### PR TITLE
Fixed SendGrid documentation to identify the required Nuget pkg version

### DIFF
--- a/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
+++ b/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
@@ -71,7 +71,8 @@ To install the SendGrid NuGet package in your application, do the following:
    results list.
    
    ![SendGrid NuGet package][SendGrid-NuGet-package]
-5. Click **Install** to complete the installation, and then close this
+5. Select **version 6.3.4** of the Nuget package from the version dropdown to be able to work with the object model and APIs demonstrated in this article
+6. Click **Install** to complete the installation, and then close this
    dialog.
 
 SendGrid's .NET class library is called **SendGridMail**. It contains


### PR DESCRIPTION
In this issue: https://github.com/sendgrid/sendgrid-csharp/issues/317? the author of the SendGrid package points to this page https://github.com/sendgrid/sendgrid-csharp/blob/master/TROUBLESHOOTING.md#v2 which says that version 6.3.4 of the Nuget package is required to be able to work with the SendGrid object model demonstrated in this article