### PR TITLE
Fix a broken embeded video

### DIFF
--- a/articles/application-insights/app-insights-web-monitor-performance.md
+++ b/articles/application-insights/app-insights-web-monitor-performance.md
@@ -120,7 +120,7 @@ Here are a few tips for finding and diagnosing performance issues:
 [Troubleshooting][qna] - and Q & A
 
 ## Video
-[!VIDEO https://channel9.msdn.com/Series/ConnectOn-Demand/222/player]
+> [!VIDEO https://channel9.msdn.com/Series/ConnectOn-Demand/222/player]
 
 
 <!--Link references-->


### PR DESCRIPTION
The video at the bottom of page https://docs.microsoft.com/en-us/azure/application-insights/app-insights-web-monitor-performance is not shown, due to a missing blockquote.