### PR TITLE
Update ElasticSearchListener Constructor

### DIFF
--- a/articles/service-fabric/service-fabric-diagnostic-how-to-use-elasticsearch.md
+++ b/articles/service-fabric/service-fabric-diagnostic-how-to-use-elasticsearch.md
@@ -187,7 +187,7 @@ namespace Stateless1
                 ElasticSearchListener esListener = null;
                 if (configProvider.HasConfiguration)
                 {
-                    esListener = new ElasticSearchListener(configProvider);
+                    esListener = new ElasticSearchListener(configProvider, new FabricHealthReporter("ElasticSearchEventListener"));
                 }
 
                 // The ServiceManifest.XML file defines one or more service type names.


### PR DESCRIPTION
The most current version of the `ElasticSearchListener` takes [two parameters in the constructor now](https://github.com/Azure-Samples/service-fabric-dotnet-management-party-cluster/blob/master/src/Microsoft.Diagnostics.EventListeners/ElasticSearchListener.cs#L25), a `FabricConfigurationProvider` and a `FabricHealthReporter`.