### PR TITLE
Update service-fabric-diagnostic-how-to-use-elasticsearch.md

### DIFF
--- a/articles/service-fabric/service-fabric-diagnostic-how-to-use-elasticsearch.md
+++ b/articles/service-fabric/service-fabric-diagnostic-how-to-use-elasticsearch.md
@@ -187,7 +187,7 @@ namespace Stateless1
                 ElasticSearchListener esListener = null;
                 if (configProvider.HasConfiguration)
                 {
-                    esListener = new ElasticSearchListener(configProvider);
+                    esListener = new ElasticSearchListener(configProvider, new FabricHealthReporter("ElasticSearchEventListener"));
                 }
 
                 // The ServiceManifest.XML file defines one or more service type names.


### PR DESCRIPTION
Fix that's required for it to build with [today's `ElasticSearchListener`](https://github.com/Azure-Samples/service-fabric-dotnet-management-party-cluster/blob/6dc12c42a73afb97c08facd2ee6724736e1655bf/src/Microsoft.Diagnostics.EventListeners/ElasticSearchListener.cs)