### PR TITLE
Refresh instructions to work with latest cordova

### DIFF
--- a/articles/active-directory/active-directory-devquickstarts-cordova.md
+++ b/articles/active-directory/active-directory-devquickstarts-cordova.md
@@ -60,19 +60,20 @@ Note that those should work both on the PC and on the Mac.
 Each target platform has different prerequisites.
 
 * To build and run Windows Tablet/PC or Phone app version
-  * [Visual Studio 2013 for Windows with Update 2 or later](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-8) (Express or another version).
+  * [Visual Studio 2013 for Windows with Update 2 or later](http://www.visualstudio.com/downloads/download-visual-studio-vs#d-express-windows-8) (Express or another version) or [Visual Studio 2015](https://www.visualstudio.com/downloads/download-visual-studio-vs#d-community).
+
 * To build and run for iOS
   
-  * Xcode 5.x or greater. Download it at http://developer.apple.com/downloads or the [Mac App Store](http://itunes.apple.com/us/app/xcode/id497799835?mt=12)
+  * Xcode 6.x or greater. Download it at http://developer.apple.com/downloads or the [Mac App Store](http://itunes.apple.com/us/app/xcode/id497799835?mt=12)
   * [ios-sim](https://www.npmjs.org/package/ios-sim) – allows you to launch iOS apps into the iOS Simulator from the command line (can be easily installed via the terminal: `npm install -g ios-sim`)
 * To build and run application for Android
   
   * Install [Java Development Kit (JDK) 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) or later. Make sure `JAVA_HOME` (Environment Variable) is correctly set according to JDK installation path (for example C:\Program Files\Java\jdk1.7.0_75).
   * Install [Android SDK](http://developer.android.com/sdk/installing/index.html?pkg=tools) and add `<android-sdk-location>\tools` location (for example, C:\tools\Android\android-sdk\tools) to your `PATH` Environment Variable.
   * Open Android SDK Manager (for example, via terminal: `android`) and install
-  * *Android 5.0.1 (API 21)* platform SDK
-  * *Android SDK Build-tools* version 19.1.0 or higher
-  * *Android Support Repository* (Extras)
+    * *Android 5.0.1 (API 21)* platform SDK
+    * *Android SDK Build-tools* version 19.1.0 or higher
+    * *Android Support Repository* (Extras)
   
   Android sdk doesn't provide any default emulator instance. Create a new one by running `android avd` from terminal and then selecting *Create...* if you want to run Android app on emulator. Recommended *Api Level* is 19 or higher, see [AVD Manager](http://developer.android.com/tools/help/avd-manager.html) for more information about Android emulator and creation options.
 
@@ -104,14 +105,19 @@ From your shell or command line, type the following command:
 There are multiple ways of creating Cordova applications. In this tutorial we will use the Cordova command line interface (CLI).
 From your shell or command line, type the following command:
 
-     cordova create DirSearchClient --copy-from="NativeClient-MultiTarget-Cordova/DirSearchClient"
+     cordova create DirSearchClient
 
-That will create the folder structure and scaffolding for the Cordova project, copying the content of the starter project in the www subfolder.
-Move to the new DirSearchClient folder.
+That will create the folder structure and scaffolding for the Cordova project.
+Move to the new DirSearchClient folder
 
     cd .\DirSearchClient
+    
+and copy the content of the starter project in the www subfolder using file manager or the following command in your shell:
 
-Add the whitelist plugin, necessary for invoking the Graph API.
+  * Windows: `xcopy ..\NativeClient-MultiTarget-Cordova\DirSearchClient www /E /Y`
+  * Mac: `cp -r  ../NativeClient-MultiTarget-Cordova/DirSearchClient/* www`
+
+Then add the whitelist plugin, necessary for invoking the Graph API.
 
      cordova plugin add cordova-plugin-whitelist
 
@@ -131,7 +137,7 @@ The application you are developing in this tutorial will provide a bare-bone dir
 The very first thing you need to do is to introduce in your code the protocol values that are used by AAD for identifying your app and the resources you target. Those values will be used to construct the token requests later on. Insert the snippet below at the very top of the index.js file.
 
 ```javascript
-    var authority = "https://login.windows.net/common",
+var authority = "https://login.windows.net/common",
     redirectUri = "http://MyDirectorySearcherApp",
     resourceUri = "https://graph.windows.net",
     clientId = "a5d92493-ae5a-4a9f-bcbf-9f1d354067d3",


### PR DESCRIPTION
- Update requirements - add VS 2015 and Xcode 6 as it's now required to build for iOS
- Update create app section - `--copy-from` flag is broken and replaced with manual template copying 
- Minor formatting fixes

This was moved from https://github.com/Azure/azure-content/pull/7815