### PR TITLE
Fix: redisCacheLocation is no longer used by the referenced template

### DIFF
--- a/articles/redis-cache/cache-redis-cache-arm-provision.md
+++ b/articles/redis-cache/cache-redis-cache-arm-provision.md
@@ -125,7 +125,7 @@ Creates the Azure Redis Cache.
 [!INCLUDE [app-service-deploy-commands](../../includes/app-service-deploy-commands.md)]
 
 ### PowerShell
-    New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-redis-cache/azuredeploy.json -ResourceGroupName ExampleDeployGroup -redisCacheName ExampleCache -redisCacheLocation "West US"
+    New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-redis-cache/azuredeploy.json -ResourceGroupName ExampleDeployGroup -redisCacheName ExampleCache
 
 ### Azure CLI
     azure group deployment create --template-uri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-redis-cache/azuredeploy.json -g ExampleDeployGroup


### PR DESCRIPTION
See change history of https://github.com/Azure/azure-quickstart-templates/blob/master/101-redis-cache/azuredeploy.json - now it deploys to the resource group location, in line with some of their recommended best practices: "Do not use a parameter to specify the location. Use the location property of the resourceGroup instead. By using the resourceGroup().location expression for all your resources, the resources in the template will automatically be deployed in the same location as the resource group."