### PR TITLE
Corrected link for Pricing

### DIFF
--- a/articles/azure-functions/functions-overview.md
+++ b/articles/azure-functions/functions-overview.md
@@ -67,8 +67,8 @@ Azure Functions integrates with various Azure and 3rd-party services. These serv
 ## <a name="pricing"></a>How much does Functions cost?
 Azure Functions has two kinds of pricing plans, choose the one that best fits your needs: 
 
-* **Consumption plan** - When your function runs, Azure provides all of the necessary computational resources. You don't have to worry about resource management, and you only pay for the time that your code runs. Full pricing details are available on the [Functions Pricing page](/pricing/details/functions). 
-* **App Service plan** - Run your functions just like your web, mobile, and API apps. When you are already using App Service for your other applications, you can run your functions on the same plan at no additional cost. Full details can be found on the [App Service Pricing page](/pricing/details/app-service/).
+* **Consumption plan** - When your function runs, Azure provides all of the necessary computational resources. You don't have to worry about resource management, and you only pay for the time that your code runs. Full pricing details are available on the [Functions Pricing page](https://azure.microsoft.com/pricing/details/functions/). 
+* **App Service plan** - Run your functions just like your web, mobile, and API apps. When you are already using App Service for your other applications, you can run your functions on the same plan at no additional cost. Full details can be found on the [App Service Pricing page](https://azure.microsoft.com/pricing/details/app-service/).
 
 For more information about scaling your functions, see [How to scale Azure Functions](functions-scale.md).
 


### PR DESCRIPTION
Path for pricing was relative, however actual page exist on different subdomain.I have updated it with absolute path not adding locale in URL hence unsure if you want to accept this pull request.