### PR TITLE
Simplifying the description of Scripts

### DIFF
--- a/articles/service-fabric/service-fabric-create-your-first-application-in-visual-studio.md
+++ b/articles/service-fabric/service-fabric-create-your-first-application-in-visual-studio.md
@@ -61,7 +61,7 @@ A Service Fabric application can contain one or more services, each with a speci
     The application project does not contain any code directly. Instead, it references a set of service projects. In addition, it contains three other types of content:
    
    * **Publish profiles**: Used to manage tooling preferences for different environments.
-   * **Scripts**: Includes a PowerShell script for deploying/upgrading your application. Visual Studio uses the script behind-the-scenes by Visual Studio. The script can also be invoked directly at the command line.
+   * **Scripts**: Includes a PowerShell script for deploying/upgrading your application. Visual Studio uses the script behind-the-scenes. The script can also be invoked directly at the command line.
    * **Application definition**: Includes the application manifest under *ApplicationPackageRoot*. Associated application parameter files are under *ApplicationParameters*, which define the application and allow you to configure it specifically for a given environment.
      
      For an overview of the contents of the service project, see [Getting started with Reliable Services](service-fabric-reliable-services-quick-start.md).


### PR DESCRIPTION
"Visual Studio uses the script behind-the-scenes by Visual Studio" sounds weird to me, I think the "by Visual Studio" should be removed. The original sentence sounds like a mix of "Visual Studio uses the script behind-the-scenes" and "The script is used behind-the-scenes by Visual Studio".