### PR TITLE
Change "Central West US" to "West Central US"

### DIFF
--- a/articles/storage/storage-redundancy.md
+++ b/articles/storage/storage-redundancy.md
@@ -114,7 +114,7 @@ When you create a storage account, you select the primary region for the account
 | Germany Central |Germany Northeast |
 | Germany Northeast |Germany Central |
 | West US 2 |Central West US |
-| Central West US |West US 2 |
+| West Central US |West US 2 |
 
 For up-to-date information about regions supported by Azure, see [Azure Regions](https://azure.microsoft.com/regions/).
 

--- a/articles/storage/storage-redundancy.md
+++ b/articles/storage/storage-redundancy.md
@@ -113,7 +113,7 @@ When you create a storage account, you select the primary region for the account
 | UK South |UK West |
 | Germany Central |Germany Northeast |
 | Germany Northeast |Germany Central |
-| West US 2 |Central West US |
+| West US 2 |West Central US |
 | West Central US |West US 2 |
 
 For up-to-date information about regions supported by Azure, see [Azure Regions](https://azure.microsoft.com/regions/).


### PR DESCRIPTION
Matches convention with how "South Central US" and "North Central US" are displayed