### PR TITLE
SF cluster VM size requirements for Gold

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-capacity.md
+++ b/articles/service-fabric/service-fabric-cluster-capacity.md
@@ -62,7 +62,7 @@ The durability tier is used to indicate to the system the privileges that your V
 
 This privilege is expressed in the following values:
 
-* Gold - The infrastructure Jobs can be paused for a duration of 2 hours per UD
+* Gold - The infrastructure Jobs can be paused for a duration of 2 hours per UD.  Gold durability level currently requires D15_V2 or G5 size VMs.
 * Silver - The infrastructure Jobs can be paused for a duration of 30 minutes per UD (This is currently not enabled for use. Once enabled this will be available on all standard VMs of single core and above).
 * Bronze - No privileges. This is the default.
 


### PR DESCRIPTION
Adding D15_V2 and G5  as the required VM sizes for Gold durability level