### PR TITLE
Resolve URL formatting

### DIFF
--- a/articles/active-directory/active-directory-add-company-branding.md
+++ b/articles/active-directory/active-directory-add-company-branding.md
@@ -36,7 +36,7 @@ Typically, if you need browser-based access to your cloud apps and services that
 
 If you have applied changes to your sign-in page, it can take up to an hour for the changes to appear.
 
-A branded sign-in page only appears when you visit a service with a tenant-specific URL such as [https://outlook.com/**contoso**.com](https://outlook.com/contoso.com), or [https://mail.**contoso**.com](https://mail.contoso.com).
+A branded sign-in page only appears when you visit a service with a tenant-specific URL such as `https://outlook.com/**contoso**.com`, or `https://mail.**contoso**.com`.
 
 When you visit a service with non-tenant specific URLs (e.g.: https://mail.office365.com), a non-branded sign-in page appears. in this case, your branding appears once you have entered your user ID or you have selected a user tile.
 

--- a/articles/active-directory/active-directory-add-company-branding.md
+++ b/articles/active-directory/active-directory-add-company-branding.md
@@ -36,7 +36,7 @@ Typically, if you need browser-based access to your cloud apps and services that
 
 If you have applied changes to your sign-in page, it can take up to an hour for the changes to appear.
 
-A branded sign-in page only appears when you visit a service with a tenant-specific URL such as `https://outlook.com/**contoso**.com`, or `https://mail.**contoso**.com`.
+A branded sign-in page only appears when you visit a service with a tenant-specific URL such as https&#58;&#47;&#47;outlook&#46;com&#47;**contoso**&#46;com, or https&#58;&#47;&#47;mail&#46;**contoso**&#46;com.
 
 When you visit a service with non-tenant specific URLs (e.g.: https://mail.office365.com), a non-branded sign-in page appears. in this case, your branding appears once you have entered your user ID or you have selected a user tile.
 

--- a/articles/active-directory/active-directory-add-company-branding.md
+++ b/articles/active-directory/active-directory-add-company-branding.md
@@ -36,7 +36,7 @@ Typically, if you need browser-based access to your cloud apps and services that
 
 If you have applied changes to your sign-in page, it can take up to an hour for the changes to appear.
 
-A branded sign-in page only appears when you visit a service with a tenant-specific URL such as https://outlook.com/**contoso**.com, or https://mail.**contoso**.com.
+A branded sign-in page only appears when you visit a service with a tenant-specific URL such as [https://outlook.com/**contoso**.com](https://outlook.com/contoso.com), or [https://mail.**contoso**.com](https://mail.contoso.com).
 
 When you visit a service with non-tenant specific URLs (e.g.: https://mail.office365.com), a non-branded sign-in page appears. in this case, your branding appears once you have entered your user ID or you have selected a user tile.
 


### PR DESCRIPTION
Markdown was seeing asterisks (for bold) prior to the slash in a URL as part of the URL and not parsing them as formatting. Converted the link to an actual link format which fixes this.

_Was:_
![image](https://cloud.githubusercontent.com/assets/5036744/20950423/c3ad0184-bc73-11e6-845f-2734894fbe5a.png)

_Now:_
![image](https://cloud.githubusercontent.com/assets/5036744/20950437/d09a8b28-bc73-11e6-932d-6c34519a57cb.png)
