### PR TITLE
Update virtual-machines-linux-redhat-create-upload-vhd.md to improve command format.

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-redhat-create-upload-vhd.md
+++ b/articles/virtual-machines/virtual-machines-linux-redhat-create-upload-vhd.md
@@ -54,75 +54,75 @@ This section assumes that you have already installed a RHEL image (from an ISO f
 2. Click **Connect** to open a console window for the virtual machine.
 3. Uninstall NetworkManager by running the following command:
 
-   # sudo rpm -e --nodeps NetworkManager
+        # sudo rpm -e --nodeps NetworkManager
    Note that if the package is not already installed, this command will fail with an error message. This is expected.
 4. Create a file named **network** in the `/etc/sysconfig/` directory that contains the following text:
 
-     NETWORKING=yes
-     HOSTNAME=localhost.localdomain
+        NETWORKING=yes
+        HOSTNAME=localhost.localdomain
 5. Create a file named **ifcfg-eth0** in the `/etc/sysconfig/network-scripts/` directory that contains the following text:
 
-     DEVICE=eth0
-     ONBOOT=yes
-     BOOTPROTO=dhcp
-     TYPE=Ethernet
-     USERCTL=no
-     PEERDNS=yes
-     IPV6INIT=no
+        DEVICE=eth0
+        ONBOOT=yes
+        BOOTPROTO=dhcp
+        TYPE=Ethernet
+        USERCTL=no
+        PEERDNS=yes
+        IPV6INIT=no
 6. Move (or remove) udev rules to avoid generating static rules for the Ethernet interface. These rules cause problems when you clone a virtual machine in Microsoft Azure or Hyper-V:
 
-   # sudo mkdir -m 0700 /var/lib/waagent
-   # sudo mv /lib/udev/rules.d/75-persistent-net-generator.rules /var/lib/waagent/
-   # sudo mv /etc/udev/rules.d/70-persistent-net.rules /var/lib/waagent/
+         # sudo mkdir -m 0700 /var/lib/waagent
+         # sudo mv /lib/udev/rules.d/75-persistent-net-generator.rules /var/lib/waagent/
+         # sudo mv /etc/udev/rules.d/70-persistent-net.rules /var/lib/waagent/
 7. Ensure that the network service will start at boot time by running the following command:
 
-   # sudo chkconfig network on
+        # sudo chkconfig network on
 8. Register your Red Hat subscription to enable the installation of packages from the RHEL repository by running the following command:
 
-   # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
+        # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
 9. The WALinuxAgent package `WALinuxAgent-<version>` has been pushed to the Red Hat extras repository. Enable the extras repository by running the following command:
 
-   # subscription-manager repos --enable=rhel-6-server-extras-rpms
+        # subscription-manager repos --enable=rhel-6-server-extras-rpms
 10. Modify the kernel boot line in your grub configuration to include additional kernel parameters for Azure. To do this, open `/boot/grub/menu.lst` in a text editor and ensure that the default kernel includes the following parameters:
 
-     console=ttyS0
-     earlyprintk=ttyS0
-     rootdelay=300
-     numa=off
+        console=ttyS0
+        earlyprintk=ttyS0
+        rootdelay=300
+        numa=off
 
     This will also ensure that all console messages are sent to the first serial port, which can assist Azure support with debugging issues. This will disable NUMA due to a bug in the kernel version that is used by RHEL 6.
 
     In addition to the above action, we recommend that you remove the following parameters:
 
-     rhgb quiet crashkernel=auto
+        rhgb quiet crashkernel=auto
 
     Graphical and quiet boot are not useful in a cloud environment where we want all the logs to be sent to the serial port.
 
     The crashkernel option can be left configured if desired, but note that this parameter will reduce the amount of available memory in the VM by 128 MB or more. This might be problematic on smaller VM sizes.
 11. Ensure that the SSH server is installed and configured to start at boot time. This is usually the default. Modify /etc/ssh/sshd_config to include the following line:
 
-     ClientAliveInterval 180
+        ClientAliveInterval 180
 12. Install the Azure Linux Agent by running the following command:
 
-    # sudo yum install WALinuxAgent
-    # sudo chkconfig waagent on
+        # sudo yum install WALinuxAgent
+        # sudo chkconfig waagent on
     Note that installing the WALinuxAgent package will remove the NetworkManager and NetworkManager-gnome packages if they were not already removed as described in step 2.
 13. Do not create swap space on the OS disk.
     The Azure Linux Agent can automatically configure swap space by using the local resource disk that is attached to the VM after the VM is provisioned on Azure. Note that the local resource disk is a temporary disk, and might be emptied when the VM is deprovisioned. After you install the Azure Linux Agent (see the previous step), modify the following parameters in /etc/waagent.conf appropriately:
 
-     ResourceDisk.Format=y
-     ResourceDisk.Filesystem=ext4
-     ResourceDisk.MountPoint=/mnt/resource
-     ResourceDisk.EnableSwap=y
-     ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
+        ResourceDisk.Format=y
+        ResourceDisk.Filesystem=ext4
+        ResourceDisk.MountPoint=/mnt/resource
+        ResourceDisk.EnableSwap=y
+        ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
 14. Unregister the subscription (if necessary) by running the following command:
 
-    # sudo subscription-manager unregister
+        # sudo subscription-manager unregister
 15. Run the following commands to deprovision the virtual machine and prepare it for provisioning on Azure:
 
-    # sudo waagent -force -deprovision
-    # export HISTSIZE=0
-    # logout
+        # sudo waagent -force -deprovision
+        # export HISTSIZE=0
+        # logout
 16. Click **Action > Shut Down** in Hyper-V Manager. Your Linux VHD is now ready to be uploaded to Azure.
      
 
@@ -131,63 +131,63 @@ This section assumes that you have already installed a RHEL image (from an ISO f
 2. Click **Connect** to open a console window for the virtual machine.
 3. Create a file named **network** in the `/etc/sysconfig/` directory that contains the following text:
 
-     NETWORKING=yes
-     HOSTNAME=localhost.localdomain
+        NETWORKING=yes
+        HOSTNAME=localhost.localdomain
 4. Create a file named **ifcfg-eth0** in the `/etc/sysconfig/network-scripts/` directory that contains the following text:
 
-     DEVICE=eth0
-     ONBOOT=yes
-     BOOTPROTO=dhcp
-     TYPE=Ethernet
-     USERCTL=no
-     PEERDNS=yes
-     IPV6INIT=no
+        DEVICE=eth0
+        ONBOOT=yes
+        BOOTPROTO=dhcp
+        TYPE=Ethernet
+        USERCTL=no
+        PEERDNS=yes
+        IPV6INIT=no
 5. Ensure that the network service will start at boot time by running the following command:
 
-   # sudo chkconfig network on
+        # sudo chkconfig network on
 6. Register your Red Hat subscription to enable the installation of packages from the RHEL repository by running the following command:
 
-   # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
+        # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
 7. Modify the kernel boot line in your grub configuration to include additional kernel parameters for Azure. To do this, open `/etc/default/grub` in a text editor and edit the **GRUB_CMDLINE_LINUX** parameter. For example:
 
-     GRUB_CMDLINE_LINUX="rootdelay=300
-     console=ttyS0
-     earlyprintk=ttyS0"
+        GRUB_CMDLINE_LINUX="rootdelay=300
+        console=ttyS0
+        earlyprintk=ttyS0"
 
    This will also ensure that all console messages are sent to the first serial port, which can assist Azure support with debugging issues. In addition to the above action, we recommend that you remove the following parameters:
 
-     rhgb quiet crashkernel=auto
+        rhgb quiet crashkernel=auto
 
    Graphical and quiet boot are not useful in a cloud environment where we want all the logs to be sent to the serial port.
    The crashkernel option can be left configured if desired, but note that this parameter will reduce the amount of available memory in the VM by 128 MB or more. This might be problematic on smaller VM sizes.
 8. After you are done editing `/etc/default/grub`, run the following command to rebuild the grub configuration:
 
-   # sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+        # sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 9. Ensure that the SSH server is installed and configured to start at boot time. This is usually the default. Modify `/etc/ssh/sshd_config` to include the following line:
 
-     ClientAliveInterval 180
+        ClientAliveInterval 180
 10. The WALinuxAgent package `WALinuxAgent-<version>` has been pushed to the Red Hat extras repository. Enable the extras repository by running the following command:
 
-    # subscription-manager repos --enable=rhel-7-server-extras-rpms
+        # subscription-manager repos --enable=rhel-7-server-extras-rpms
 11. Install the Azure Linux Agent by running the following command:
 
-    # sudo yum install WALinuxAgent
-    # sudo systemctl enable waagent.service
+        # sudo yum install WALinuxAgent
+        # sudo systemctl enable waagent.service
 12. Do not create swap space on the OS disk. The Azure Linux Agent can automatically configure swap space by using the local resource disk that is attached to the VM after the VM is provisioned on Azure. Note that the local resource disk is a temporary disk, and might be emptied when the VM is deprovisioned. After you install the Azure Linux Agent (see the previous step), modify the following parameters in `/etc/waagent.conf` appropriately:
 
-     ResourceDisk.Format=y
-     ResourceDisk.Filesystem=ext4
-     ResourceDisk.MountPoint=/mnt/resource
-     ResourceDisk.EnableSwap=y
-     ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
+        ResourceDisk.Format=y
+        ResourceDisk.Filesystem=ext4
+        ResourceDisk.MountPoint=/mnt/resource
+        ResourceDisk.EnableSwap=y
+        ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
 13. If you want to unregister the subscription, run the following command:
 
-    # sudo subscription-manager unregister
+        # sudo subscription-manager unregister
 14. Run the following commands to deprovision the virtual machine and prepare it for provisioning on Azure:
 
-    # sudo waagent -force -deprovision
-    # export HISTSIZE=0
-    # logout
+        # sudo waagent -force -deprovision
+        # export HISTSIZE=0
+        # logout
 15. Click **Action > Shut Down** in Hyper-V Manager. Your Linux VHD is now ready to be uploaded to Azure.
      
 
@@ -198,115 +198,115 @@ This section assumes that you have already installed a RHEL image (from an ISO f
 
    Generate an encrypted password and copy the output of the command:
 
-   # openssl passwd -1 changeme
+        # openssl passwd -1 changeme
    Set a root password with guestfish:
 
-   # guestfish --rw -a <image-name>
-   > <fs> run
-   > <fs> list-filesystems
-   > <fs> mount /dev/sda1 /
-   > <fs> vi /etc/shadow
-   > <fs> exit
-   >
-   >
+        # guestfish --rw -a <image-name>
+        > <fs> run
+        > <fs> list-filesystems
+        > <fs> mount /dev/sda1 /
+        > <fs> vi /etc/shadow
+        > <fs> exit
+        >
+        >
 
    Change the second field of the root user from “!!” to the encrypted password.
 3. Create a virtual machine in KVM from the qcow2 image, set the disk type to **qcow2**, and set the virtual network interface device model to **virtio**. Then start the virtual machine and sign in as root.
 4. Create a file named **network** in the `/etc/sysconfig/` directory that contains the following text:
 
-     NETWORKING=yes
-     HOSTNAME=localhost.localdomain
+        NETWORKING=yes
+        HOSTNAME=localhost.localdomain
 5. Create a file named **ifcfg-eth0** in the `/etc/sysconfig/network-scripts/` directory that contains the following text:
 
-     DEVICE=eth0
-     ONBOOT=yes
-     BOOTPROTO=dhcp
-     TYPE=Ethernet
-     USERCTL=no
-     PEERDNS=yes
-     IPV6INIT=no
+        DEVICE=eth0
+        ONBOOT=yes
+        BOOTPROTO=dhcp
+        TYPE=Ethernet
+        USERCTL=no
+        PEERDNS=yes
+        IPV6INIT=no
 6. Move (or remove) the udev rules to avoid generating static rules for the Ethernet interface. These rules cause problems when you clone a virtual machine in Microsoft Azure or Hyper-V:
 
-   # mkdir -m 0700 /var/lib/waagent
-   # mv /lib/udev/rules.d/75-persistent-net-generator.rules /var/lib/waagent/
-   # mv /etc/udev/rules.d/70-persistent-net.rules /var/lib/waagent/
+        # mkdir -m 0700 /var/lib/waagent
+        # mv /lib/udev/rules.d/75-persistent-net-generator.rules /var/lib/waagent/
+        # mv /etc/udev/rules.d/70-persistent-net.rules /var/lib/waagent/
 7. Ensure that the network service will start at boot time by running the following command:
 
-   # chkconfig network on
+        # chkconfig network on
 8. Register your Red Hat subscription to enable the installation of packages from the RHEL repository by running the following command:
 
-   # subscription-manager register --auto-attach --username=XXX --password=XXX
+        # subscription-manager register --auto-attach --username=XXX --password=XXX
 9. Modify the kernel boot line in your grub configuration to include additional kernel parameters for Azure. To do this, open `/boot/grub/menu.lst` in a text editor and ensure that the default kernel includes the following parameters:
 
-     console=ttyS0 earlyprintk=ttyS0 rootdelay=300 numa=off
+        console=ttyS0 earlyprintk=ttyS0 rootdelay=300 numa=off
 
    This will also ensure that all console messages are sent to the first serial port, which can assist Azure support with debugging issues. This will disable NUMA due to a bug in the kernel version that is used by RHEL 6.
 
    In addition to the above action, we recommend that you remove the following parameters:
 
-     rhgb quiet crashkernel=auto
+        rhgb quiet crashkernel=auto
 
    Graphical and quiet boot are not useful in a cloud environment where we want all the logs to be sent to the serial port.
    The crashkernel option may be left configured if desired, but note that this parameter will reduce the amount of available memory in the VM by 128 MB or more. This might be problematic on smaller VM sizes.
 10. Add Hyper-V modules into initramfs:  
 
     Edit `/etc/dracut.conf` and add content:
-    add_drivers+=”hv_vmbus hv_netvsc hv_storvsc”
+        add_drivers+=” hv_vmbus hv_netvsc hv_storvsc ”
 
     Rebuild initramfs:
 
         # dracut –f -v
 11. Uninstall cloud-init:
 
-    # yum remove cloud-init
+        # yum remove cloud-init
 12. Ensure that the SSH server is installed and configured to start at boot time:
 
-    # chkconfig sshd on
+        # chkconfig sshd on
     Modify /etc/ssh/sshd_config to include the following lines:
 
-     PasswordAuthentication yes
-     ClientAliveInterval 180
+        PasswordAuthentication yes
+        ClientAliveInterval 180
 
     Restart sshd:
 
-    # service sshd restart
+        # service sshd restart
 13. The WALinuxAgent package `WALinuxAgent-<version>` has been pushed to the Red Hat extras repository. Enable the extras repository by running the following command:
 
-    # subscription-manager repos --enable=rhel-6-server-extras-rpms
+        # subscription-manager repos --enable=rhel-6-server-extras-rpms
 14. Install the Azure Linux Agent by running the following command:
 
-    # yum install WALinuxAgent
-    # chkconfig waagent on
+        # yum install WALinuxAgent
+        # chkconfig waagent on
 15. The Azure Linux Agent can automatically configure swap space by using the local resource disk that is attached to the VM after the VM is provisioned on Azure. Note that the local resource disk is a temporary disk, and might be emptied when the VM is deprovisioned. After you install the Azure Linux Agent (see the previous step), modify the following parameters in **/etc/waagent.conf** appropriately:
 
-     ResourceDisk.Format=y
-     ResourceDisk.Filesystem=ext4
-     ResourceDisk.MountPoint=/mnt/resource
-     ResourceDisk.EnableSwap=y
-     ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
+        ResourceDisk.Format=y
+        ResourceDisk.Filesystem=ext4
+        ResourceDisk.MountPoint=/mnt/resource
+        ResourceDisk.EnableSwap=y
+        ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
 16. Unregister the subscription (if necessary) by running the following command:
 
-    # subscription-manager unregister
+        # subscription-manager unregister
 17. Run the following commands to deprovision the virtual machine and prepare it for provisioning on Azure:
 
-    # waagent -force -deprovision
-    # export HISTSIZE=0
-    # logout
+        # waagent -force -deprovision
+        # export HISTSIZE=0
+        # logout
 18. Shut down the VM in KVM.
 19. Convert the qcow2 image to VHD format.
     First convert the image to raw format:
 
-    # qemu-img convert -f qcow2 –O raw rhel-6.7.qcow2 rhel-6.7.raw
+        # qemu-img convert -f qcow2 –O raw rhel-6.7.qcow2 rhel-6.7.raw
     Make sure that the size of the raw image is aligned with 1 MB. Otherwise, round up the size to align with 1 MB:
 
-    # MB=$((1024*1024))
-    # size=$(qemu-img info -f raw --output json "rhel-6.7.raw" | \
+        # MB=$((1024*1024))
+        # size=$(qemu-img info -f raw --output json "rhel-6.7.raw" | \
                gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
-    # rounded_size=$((($size/$MB + 1)*$MB))
-    # qemu-img resize rhel-6.7.raw $rounded_size
+        # rounded_size=$((($size/$MB + 1)*$MB))
+        # qemu-img resize rhel-6.7.raw $rounded_size
     Convert the raw disk to a fixed-sized VHD:
 
-    # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-6.7.raw rhel-6.7.vhd
+        # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-6.7.raw rhel-6.7.vhd
 
 ### <a id="rhel7xkvm"> </a>Prepare a RHEL 7.1/7.2 virtual machine from KVM
 1. Download the KVM image of RHEL 7.1 (or 7.2) from the Red Hat website. We will use RHEL 7.1 as the example here.
@@ -314,117 +314,117 @@ This section assumes that you have already installed a RHEL image (from an ISO f
 
    Generate an encrypted password, and copy the output of the command:
 
-   # openssl passwd -1 changeme
+        # openssl passwd -1 changeme
    Set a root password with guestfish.
 
-   # guestfish --rw -a <image-name>
-   > <fs> run
-   > <fs> list-filesystems
-   > <fs> mount /dev/sda1 /
-   > <fs> vi /etc/shadow
-   > <fs> exit
-   >
-   >
+        # guestfish --rw -a <image-name>
+        > <fs> run
+        > <fs> list-filesystems
+        > <fs> mount /dev/sda1 /
+        > <fs> vi /etc/shadow
+        > <fs> exit
+        >
+        >
 
    Change the second field of root user from “!!” to the encrypted password.
 3. Create a virtual machine in KVM from the qcow2 image, set the disk type to **qcow2**, and set the virtual network interface device model to **virtio**. Then start the virtual machine and sign in as root.
 4. Create a file named **network** in the `/etc/sysconfig/` directory that contains the following text:
 
-     NETWORKING=yes
-     HOSTNAME=localhost.localdomain
+        NETWORKING=yes
+        HOSTNAME=localhost.localdomain
 5. Create a file named **ifcfg-eth0** in the `/etc/sysconfig/network-scripts/` directory that contains the following text:
 
-     DEVICE=eth0
-     ONBOOT=yes
-     BOOTPROTO=dhcp
-     TYPE=Ethernet
-     USERCTL=no
-     PEERDNS=yes
-     IPV6INIT=no
+        DEVICE=eth0
+        ONBOOT=yes
+        BOOTPROTO=dhcp
+        TYPE=Ethernet
+        USERCTL=no
+        PEERDNS=yes
+        IPV6INIT=no
 6. Ensure that the network service will start at boot time by running the following command:
 
-   # chkconfig network on
+        # chkconfig network on
 7. Register your Red Hat subscription to enable installation of packages from the RHEL repository by running the following command:
 
-   # subscription-manager register --auto-attach --username=XXX --password=XXX
+        # subscription-manager register --auto-attach --username=XXX --password=XXX
 8. Modify the kernel boot line in your grub configuration to include additional kernel parameters for Azure. To do this, open `/etc/default/grub` in a text editor and edit the **GRUB_CMDLINE_LINUX** parameter. For example:
 
-     GRUB_CMDLINE_LINUX="rootdelay=300
-     console=ttyS0
-     earlyprintk=ttyS0"
+        GRUB_CMDLINE_LINUX="rootdelay=300
+        console=ttyS0
+        earlyprintk=ttyS0"
 
    This will also ensure that all console messages are sent to the first serial port, which can assist Azure support with debugging issues. In addition to the above action, we recommend that you remove the following parameters:
 
-     rhgb quiet crashkernel=auto
+        rhgb quiet crashkernel=auto
 
    Graphical and quiet boot are not useful in a cloud environment where we want all the logs to be sent to the serial port.
    The crashkernel option can be left configured if desired, but note that this parameter will reduce the amount of available memory in the VM by 128 MB or more. This might be problematic on smaller VM sizes.
 9. After you are done editing `/etc/default/grub`, run the following command to rebuild the grub configuration:
 
-   # grub2-mkconfig -o /boot/grub2/grub.cfg
+        # grub2-mkconfig -o /boot/grub2/grub.cfg
 10. Add Hyper-V modules into initramfs:
 
     Edit `/etc/dracut.conf` and add content:
 
-     add_drivers+=”hv_vmbus hv_netvsc hv_storvsc”
+        add_drivers+=” hv_vmbus hv_netvsc hv_storvsc ”
 
     Rebuild initramfs:
 
-    # dracut –f -v
+        # dracut –f -v
 11. Uninstall cloud-init:
 
-    # yum remove cloud-init
+        # yum remove cloud-init
 12. Ensure that the SSH server is installed and configured to start at boot time:
 
-    # systemctl enable sshd
+        # systemctl enable sshd
     Modify /etc/ssh/sshd_config to include the following lines:
 
-     PasswordAuthentication yes
-     ClientAliveInterval 180
+        PasswordAuthentication yes
+        ClientAliveInterval 180
 
     Restart sshd:
 
-     systemctl restart sshd
+        # systemctl restart sshd
 13. The WALinuxAgent package `WALinuxAgent-<version>` has been pushed to the Red Hat extras repository. Enable the extras repository by running the following command:
 
-    # subscription-manager repos --enable=rhel-7-server-extras-rpms
+        # subscription-manager repos --enable=rhel-7-server-extras-rpms
 14. Install the Azure Linux Agent by running the following command:
 
-    # yum install WALinuxAgent
+        # yum install WALinuxAgent
     Enable the waagent service:
 
-    # systemctl enable waagent.service
+        # systemctl enable waagent.service
 15. Do not create swap space on the OS disk. The Azure Linux Agent can automatically configure swap space by using the local resource disk that is attached to the VM after the VM is provisioned on Azure. Note that the local resource disk is a temporary disk, and might be emptied when the VM is deprovisioned. After you install the Azure Linux Agent (see the previous step), modify the following parameters in `/etc/waagent.conf` appropriately:
 
-     ResourceDisk.Format=y
-     ResourceDisk.Filesystem=ext4
-     ResourceDisk.MountPoint=/mnt/resource
-     ResourceDisk.EnableSwap=y
-     ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
+        ResourceDisk.Format=y
+        ResourceDisk.Filesystem=ext4
+        ResourceDisk.MountPoint=/mnt/resource
+        ResourceDisk.EnableSwap=y
+        ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
 16. Unregister the subscription (if necessary) by running the following command:
 
-    # subscription-manager unregister
+        # subscription-manager unregister
 17. Run the following commands to deprovision the virtual machine and prepare it for provisioning on Azure:
 
-    # sudo waagent -force -deprovision
-    # export HISTSIZE=0
-    # logout
+        # sudo waagent -force -deprovision
+        # export HISTSIZE=0
+        # logout
 18. Shut down the virtual machine in KVM.
 19. Convert the qcow2 image to VHD format.
 
     First convert the image to raw format:
 
-    # qemu-img convert -f qcow2 –O raw rhel-7.1.qcow2 rhel-7.1.raw
+        # qemu-img convert -f qcow2 –O raw rhel-7.1.qcow2 rhel-7.1.raw
     Make sure that the size of the raw image is aligned with 1 MB. Otherwise, round up the size to align with 1 MB:
 
-    # MB=$((1024*1024))
-    # size=$(qemu-img info -f raw --output json "rhel-7.1.raw" | \
+        # MB=$((1024*1024))
+        # size=$(qemu-img info -f raw --output json "rhel-7.1.raw" | \
                gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
-    # rounded_size=$((($size/$MB + 1)*$MB))
-    # qemu-img resize rhel-7.1.raw $rounded_size
+        # rounded_size=$((($size/$MB + 1)*$MB))
+        # qemu-img resize rhel-7.1.raw $rounded_size
     Convert the raw disk to a fixed-sized VHD:
 
-    # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-7.1.raw rhel-7.1.vhd
+        # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-7.1.raw rhel-7.1.vhd
 
 ## Prepare a Red Hat-based virtual machine from VMware
 ### Prerequisites
@@ -437,46 +437,46 @@ This section assumes that you have already installed a RHEL virtual machine in V
 ### <a id="rhel67vmware"> </a>Prepare a RHEL 6.7 virtual machine from VMware
 1. Uninstall NetworkManager by running the following command:
 
-   # sudo rpm -e --nodeps NetworkManager
+        # sudo rpm -e --nodeps NetworkManager
    Note that if the package is not already installed, this command will fail with an error message. This is expected.
 2. Create a file named **network** in the /etc/sysconfig/ directory that contains the following text:
 
-     NETWORKING=yes
-     HOSTNAME=localhost.localdomain
+        NETWORKING=yes
+        HOSTNAME=localhost.localdomain
 3. Create a file named **ifcfg-eth0** in the /etc/sysconfig/network-scripts/ directory that contains the following text:
 
-     DEVICE=eth0
-     ONBOOT=yes
-     BOOTPROTO=dhcp
-     TYPE=Ethernet
-     USERCTL=no
-     PEERDNS=yes
-     IPV6INIT=no
+        DEVICE=eth0
+        ONBOOT=yes
+        BOOTPROTO=dhcp
+        TYPE=Ethernet
+        USERCTL=no
+        PEERDNS=yes
+        IPV6INIT=no
 4. Move (or remove) the udev rules to avoid generating static rules for the Ethernet interface. These rules cause problems when you clone a virtual machine in Microsoft Azure or Hyper-V:
 
-   # sudo mkdir -m 0700 /var/lib/waagent
-   # sudo mv /lib/udev/rules.d/75-persistent-net-generator.rules /var/lib/waagent/
-   # sudo mv /etc/udev/rules.d/70-persistent-net.rules /var/lib/waagent/
+        # sudo mkdir -m 0700 /var/lib/waagent
+        # sudo mv /lib/udev/rules.d/75-persistent-net-generator.rules /var/lib/waagent/
+        # sudo mv /etc/udev/rules.d/70-persistent-net.rules /var/lib/waagent/
 5. Ensure that the network service will start at boot time by running the following command:
 
-   # sudo chkconfig network on
+        # sudo chkconfig network on
 6. Register your Red Hat subscription to enable the installation of packages from the RHEL repository by running the following command:
 
-   # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
+        # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
 7. The WALinuxAgent package `WALinuxAgent-<version>` has been pushed to the Red Hat extras repository. Enable the extras repository by running the following command:
 
-   # subscription-manager repos --enable=rhel-6-server-extras-rpms
+        # subscription-manager repos --enable=rhel-6-server-extras-rpms
 8. Modify the kernel boot line in your grub configuration to include additional kernel parameters for Azure. To do this, open "/boot/grub/menu.lst" in a text editor and ensure that the default kernel includes the following parameters:
 
-     console=ttyS0
-     earlyprintk=ttyS0
-     rootdelay=300
-     numa=off
+        console=ttyS0
+        earlyprintk=ttyS0
+        rootdelay=300
+        numa=off
 
    This will also ensure that all console messages are sent to the first serial port, which can assist Azure support with debugging issues. This will disable NUMA due to a bug in the kernel version that is used by RHEL 6.
    In addition to the above action, we recommend that you remove the following parameters:
 
-     rhgb quiet crashkernel=auto
+        rhgb quiet crashkernel=auto
 
    Graphical and quiet boot are not useful in a cloud environment where we want all the logs to be sent to the serial port.
    The crashkernel option can be left configured if desired, but note that this parameter will reduce the amount of available memory in the VM by 128 MB or more. This might be problematic on smaller VM sizes.
@@ -484,135 +484,135 @@ This section assumes that you have already installed a RHEL virtual machine in V
 
      Edit `/etc/dracut.conf` and add content:
 
-         add_drivers+=”hv_vmbus hv_netvsc hv_storvsc”
+        add_drivers+=” hv_vmbus hv_netvsc hv_storvsc ”
 
      Rebuild initramfs:
 
          # dracut –f -v
 10. Ensure that the SSH server is installed and configured to start at boot time. This is usually the default. Modify `/etc/ssh/sshd_config` to include the following line:
 
-     ClientAliveInterval 180
+       ClientAliveInterval 180
 11. Install the Azure Linux Agent by running the following command:
 
-    # sudo yum install WALinuxAgent
-    # sudo chkconfig waagent on
+        # sudo yum install WALinuxAgent
+        # sudo chkconfig waagent on
 12. Do not create swap space on the OS disk:
 
     The Azure Linux Agent can automatically configure swap space by using the local resource disk that is attached to the VM after the VM is provisioned on Azure. Note that the local resource disk is a temporary disk, and might be emptied when the VM is deprovisioned. After you install the Azure Linux Agent (see the previous step), modify the following parameters in `/etc/waagent.conf` appropriately:
 
-     ResourceDisk.Format=y
-     ResourceDisk.Filesystem=ext4
-     ResourceDisk.MountPoint=/mnt/resource
-     ResourceDisk.EnableSwap=y
-     ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
+        ResourceDisk.Format=y
+        ResourceDisk.Filesystem=ext4
+        ResourceDisk.MountPoint=/mnt/resource
+        ResourceDisk.EnableSwap=y
+        ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
 13. Unregister the subscription (if necessary) by running the following command:
 
-    # sudo subscription-manager unregister
+        # sudo subscription-manager unregister
 14. Run the following commands to deprovision the virtual machine and prepare it for provisioning on Azure:
 
-    # sudo waagent -force -deprovision
-    # export HISTSIZE=0
-    # logout
+        # sudo waagent -force -deprovision
+        # export HISTSIZE=0
+        # logout
 15. Shut down the VM, and convert the VMDK file to a .vhd file.
 
     First convert the image to raw format:
 
-    # qemu-img convert -f vmdk –O raw rhel-6.7.vmdk rhel-6.7.raw
+        # qemu-img convert -f vmdk –O raw rhel-6.7.vmdk rhel-6.7.raw
     Make sure that the size of the raw image is aligned with 1 MB. Otherwise, round up the size to align with 1 MB:
 
-    # MB=$((1024*1024))
-    # size=$(qemu-img info -f raw --output json "rhel-6.7.raw" | \
+        # MB=$((1024*1024))
+        # size=$(qemu-img info -f raw --output json "rhel-6.7.raw" | \
              gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
-    # rounded_size=$((($size/$MB + 1)*$MB))
-    # qemu-img resize rhel-6.7.raw $rounded_size
+        # rounded_size=$((($size/$MB + 1)*$MB))
+        # qemu-img resize rhel-6.7.raw $rounded_size
     Convert the raw disk to a fixed-sized VHD:
 
-    # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-6.7.raw rhel-6.7.vhd
+        # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-6.7.raw rhel-6.7.vhd
 
 ### <a id="rhel7xvmware"> </a>Prepare a RHEL 7.1/7.2 virtual machine from VMware
 1. Create a file named **network** in the /etc/sysconfig/ directory that contains the following text:
 
-     NETWORKING=yes
-     HOSTNAME=localhost.localdomain
+        NETWORKING=yes
+        HOSTNAME=localhost.localdomain
 2. Create a file named **ifcfg-eth0** in the /etc/sysconfig/network-scripts/ directory that contains the following text:
 
-     DEVICE=eth0
-     ONBOOT=yes
-     BOOTPROTO=dhcp
-     TYPE=Ethernet
-     USERCTL=no
-     PEERDNS=yes
-     IPV6INIT=no
+        DEVICE=eth0
+        ONBOOT=yes
+        BOOTPROTO=dhcp
+        TYPE=Ethernet
+        USERCTL=no
+        PEERDNS=yes
+        IPV6INIT=no
 3. Ensure that the network service will start at boot time by running the following command:
 
-   # sudo chkconfig network on
+        # sudo chkconfig network on
 4. Register your Red Hat subscription to enable the installation of packages from the RHEL repository by running the following command:
 
-   # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
+        # sudo subscription-manager register --auto-attach --username=XXX --password=XXX
 5. Modify the kernel boot line in your grub configuration to include additional kernel parameters for Azure. To do this, open `/etc/default/grub` in a text editor and edit the **GRUB_CMDLINE_LINUX** parameter. For example:
 
-     GRUB_CMDLINE_LINUX="rootdelay=300
-     console=ttyS0
-     earlyprintk=ttyS0"
+        GRUB_CMDLINE_LINUX="rootdelay=300
+        console=ttyS0
+        earlyprintk=ttyS0"
 
    This will also ensure that all console messages are sent to the first serial port, which can assist Azure support with debugging issues. In addition to the above action, we recommend that you remove the following parameters:
 
-     rhgb quiet crashkernel=auto
+        rhgb quiet crashkernel=auto
 
    Graphical and quiet boot are not useful in a cloud environment where we want all the logs to be sent to the serial port.
    The crashkernel option can be left configured if desired, but note that this parameter will reduce the amount of available memory in the VM by 128 MB or more. This might be problematic on smaller VM sizes.
 6. After you are done editing `/etc/default/grub`, run the following command to rebuild the grub configuration:
 
-   # sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+        # sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 7. Add Hyper-V modules into initramfs:
 
    Edit `/etc/dracut.conf`, add content:
 
-     add_drivers+=”hv_vmbus hv_netvsc hv_storvsc”
+        add_drivers+=” hv_vmbus hv_netvsc hv_storvsc ”
 
    Rebuild initramfs:
 
-   # dracut –f -v
+        # dracut –f -v
 8. Ensure that the SSH server is installed and configured to start at boot time. This is usually the default. Modify `/etc/ssh/sshd_config` to include the following line:
 
-     ClientAliveInterval 180
+        ClientAliveInterval 180
 9. The WALinuxAgent package `WALinuxAgent-<version>` has been pushed to the Red Hat extras repository. Enable the extras repository by running the following command:
 
-   # subscription-manager repos --enable=rhel-7-server-extras-rpms
+        # subscription-manager repos --enable=rhel-7-server-extras-rpms
 10. Install the Azure Linux Agent by running the following command:
 
-    # sudo yum install WALinuxAgent
-    # sudo systemctl enable waagent.service
+        # sudo yum install WALinuxAgent
+        # sudo systemctl enable waagent.service
 11. Do not create swap space on the OS disk. The Azure Linux Agent can automatically configure swap space by using the local resource disk that is attached to the VM after the VM is provisioned on Azure. Note that the local resource disk is a temporary disk, and might be emptied when the VM is deprovisioned. After you install the Azure Linux Agent (see the previous step), modify the following parameters in `/etc/waagent.conf` appropriately:
 
-     ResourceDisk.Format=y
-     ResourceDisk.Filesystem=ext4
-     ResourceDisk.MountPoint=/mnt/resource
-     ResourceDisk.EnableSwap=y
-     ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
+        ResourceDisk.Format=y
+        ResourceDisk.Filesystem=ext4
+        ResourceDisk.MountPoint=/mnt/resource
+        ResourceDisk.EnableSwap=y
+        ResourceDisk.SwapSizeMB=2048    ## NOTE: set this to whatever you need it to be.
 12. If you want to unregister the subscription, run the following command:
 
-    # sudo subscription-manager unregister
+        # sudo subscription-manager unregister
 13. Run the following commands to deprovision the virtual machine and prepare it for provisioning on Azure:
 
-    # sudo waagent -force -deprovision
-    # export HISTSIZE=0
-    # logout
+        # sudo waagent -force -deprovision
+        # export HISTSIZE=0
+        # logout
 14. Shut down the VM, and convert the VMDK file to VHD format.
 
     First convert the image to raw format:
 
-    # qemu-img convert -f vmdk –O raw rhel-7.1.vmdk rhel-7.1.raw
+        # qemu-img convert -f vmdk –O raw rhel-7.1.vmdk rhel-7.1.raw
     Make sure that the size of the raw image is aligned with 1 MB. Otherwise, round up the size to align with 1 MB:
 
-    # MB=$((1024*1024))
-    # size=$(qemu-img info -f raw --output json "rhel-7.1.raw" | \
+        # MB=$((1024*1024))
+        # size=$(qemu-img info -f raw --output json "rhel-7.1.raw" | \
               gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
-    # rounded_size=$((($size/$MB + 1)*$MB))
-    # qemu-img resize rhel-7.1.raw $rounded_size
+        # rounded_size=$((($size/$MB + 1)*$MB))
+        # qemu-img resize rhel-7.1.raw $rounded_size
     Convert the raw disk to a fixed-sized VHD:
 
-    # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-7.1.raw rhel-7.1.vhd
+        # qemu-img convert -f raw -o subformat=fixed -O vpc rhel-7.1.raw rhel-7.1.vhd
 
 ## Prepare a Red Hat-based virtual machine from an ISO by using a kickstart file automatically
 ### <a id="rhel7xkickstart"> </a>Prepare a RHEL 7.1/7.2 virtual machine from a kickstart file


### PR DESCRIPTION
The command format is broken on this page, so users are hard to understand which is the command and to copy the commands. Also, some commands such as guestfish commands aren't shown due to broken format.