### PR TITLE
Updated documentation on FreeBSD

### DIFF
--- a/articles/virtual-machines/virtual-machines/virtual-machines-freebsd-intro-on-azure.md
+++ b/articles/virtual-machines/virtual-machines/virtual-machines-freebsd-intro-on-azure.md
@@ -22,11 +22,22 @@ ms.author: kyliel
 This topic provides an overview of running a FreeBSD virtual machine in Azure.
 
 ## Overview
-FreeBSD for Microsoft Azure is an advanced computer operating system used to power modern servers, desktops, and embedded platforms. The FreeBSD 10.3 image is provided by Microsoft Corporation and is available in Azure. It is based on the FreeBSD 10.3 release, and Azure VM Guest Agent [2.1.4](https://github.com/Azure/WALinuxAgent/releases/tag/v2.1.4) is installed. The agent is responsible for communication between the FreeBSD VM and the Azure fabric for operations, such as provisioning the VM on first use (user name, password, host name, etc.) and enabling functionality for selective VM extensions.
-As for future versions of FreeBSD, the strategy is to stay current and make the latest releases available shortly after they are released by the FreeBSD release engineering team. The upcoming release is [FreeBSD 11](https://www.freebsd.org/releases/11.0R/schedule.html).
+FreeBSD for Microsoft Azure is an advanced computer operating system used to power modern servers, desktops, and embedded platforms.
+
+Microsoft Corporation is making images of FreeBSD available on Azure with the [Azure VM Guest Agent](https://github.com/Azure/WALinuxAgent/) pre-configured. Currently, the following FreeBSD versions are offered as images by Microsoft:
+
+- FreeBSD 10.3-RELEASE
+- FreeBSD 11.0-RELEASE
+
+The agent is responsible for communication between the FreeBSD VM and the Azure fabric for operations such as provisioning the VM on first use (user name, password or SSH key, host name, etc.) and enabling functionality for selective VM extensions.
+
+As for future versions of FreeBSD, the strategy is to stay current and make the latest releases available shortly after they are published by the FreeBSD release engineering team.
 
 ## Deploying a FreeBSD virtual machine
-Deploying a FreeBSD virtual machine is a straightforward process using an image from the [Azure Marketplace](https://azure.microsoft.com/marketplace/partners/microsoft/freebsd103/).
+Deploying a FreeBSD virtual machine is a straightforward process using an image from the Azure Marketplace:
+
+- [FreeBSD 10.3 on the Azure Marketplace](https://azure.microsoft.com/marketplace/partners/microsoft/freebsd103/)
+- [FreeBSD 11.0 on the Azure Marketplace](https://azure.microsoft.com/marketplace/partners/microsoft/freebsd110/)
 
 ## VM extensions for FreeBSD
 Following are supported VM extensions in FreeBSD.
@@ -55,19 +66,17 @@ The [CustomScript](https://github.com/Azure/azure-linux-extensions/tree/master/C
 
 ## Authentication: user names, passwords, and SSH keys
 When you're creating a FreeBSD virtual machine by using the Azure portal, you must provide a user name, password, or SSH public key.
-User names for deploying a FreeBSD virtual machine on Azure must not match names of system accounts (UID <100) already present in the virtual machine ("root," for example).
-Currently, only the RSA SSH key is supported. A multiline SSH key must begin with "---- BEGIN SSH2 PUBLIC KEY
-----" and end with "---- END SSH2 PUBLIC KEY ----".
+User names for deploying a FreeBSD virtual machine on Azure must not match names of system accounts (UID <100) already present in the virtual machine ("root", for example).
+Currently, only the RSA SSH key is supported. A multiline SSH key must begin with `---- BEGIN SSH2 PUBLIC KEY ----` and end with `---- END SSH2 PUBLIC KEY ----`.
 
 ## Obtaining superuser privileges
 The user account that is specified during virtual machine instance deployment on Azure is a privileged account. The package of sudo was installed in the published FreeBSD image.
 After you're logged in through this user account, you can run commands as root by using the command syntax.
 
-    # sudo <COMMAND>
+    $ sudo <COMMAND>
 
-You can optionally obtain a root shell by using sudo -s.
+You can optionally obtain a root shell by using `sudo -s`.
 
 ## Next steps
-* Go to [Azure Marketplace](https://azure.microsoft.com/marketplace/partners/microsoft/freebsd103/) to create a FreeBSD VM.
+* Go to [Azure Marketplace](https://azure.microsoft.com/marketplace/partners/microsoft/freebsd110/) to create a FreeBSD VM.
 * If you want to bring your own FreeBSD to Azure, refer to [Create and upload a FreeBSD VHD to Azure](../virtual-machines-linux-classic-freebsd-create-upload-vhd.md?toc=%2fazure%2fvirtual-machines%2flinux%2fclassic%2ftoc.json).
-

--- a/articles/virtual-machines/virtual-machines/virtual-machines-freebsd-intro-on-azure.md
+++ b/articles/virtual-machines/virtual-machines/virtual-machines-freebsd-intro-on-azure.md
@@ -77,6 +77,9 @@ After you're logged in through this user account, you can run commands as root b
 
 You can optionally obtain a root shell by using `sudo -s`.
 
+## Known issues
+There is currently an outstanding issues with FreeBSD 11.0 on Hyper-V (and Azure) that may cause VMs to fail to boot if the operating system is patched using `freebsd-update`. The [proposed patch](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=212721) is included in the FreeBSD images on the Azure Marketplace; however, it has not been merged upstream by the FreeBSD team, so running `freebsd-update` will replace the kernel with an unpatched one. It is recommended that users on Azure do not install patches for FreeBSD 11.0 until the fix is merged upstream.
+
 ## Next steps
 * Go to [Azure Marketplace](https://azure.microsoft.com/marketplace/partners/microsoft/freebsd110/) to create a FreeBSD VM.
 * If you want to bring your own FreeBSD to Azure, refer to [Create and upload a FreeBSD VHD to Azure](../virtual-machines-linux-classic-freebsd-create-upload-vhd.md?toc=%2fazure%2fvirtual-machines%2flinux%2fclassic%2ftoc.json).


### PR DESCRIPTION
There's currently an outstanding issue (as discussed with @squillace ) with FreeBSD 11.0 VMs running on Azure if patches are installed using `freebsd-update`. I'm suggesting an addition to the documentation to make this clear.

With the occasion, I'm also updating the page to include FreeBSD 11.0.