### PR TITLE
Out of date sample code

### DIFF
--- a/articles/storage/storage-java-how-to-use-table-storage.md
+++ b/articles/storage/storage-java-how-to-use-table-storage.md
@@ -552,7 +552,7 @@ try
     CloudTableClient tableClient = storageAccount.createCloudTableClient();
 
     // Delete the table and all its data if it exists.
-    CloudTable cloudTable = new CloudTable("people",tableClient);
+    CloudTable cloudTable = tableClient.getTableReference("people");
     cloudTable.deleteIfExists();
 }
 catch (Exception e)


### PR DESCRIPTION
The code to delete a table is not correct. The code is creating an instance of CloudTable incorrectly. The right way to create the instance is using CloudTableClient's getTableReference method. I made the change to reflect that.