### PR TITLE
Adding a custom class to the table

### DIFF
--- a/articles/active-directory/active-directory-token-and-claims.md
+++ b/articles/active-directory/active-directory-token-and-claims.md
@@ -45,6 +45,7 @@ eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIyZDRkMTFhMi1mODE0LTQ2YTctODkwYS0y
 > 
 
 #### Claims in id_tokens
+> [!div class="mx-codeBreakAll"]
 | JWT Claim | Name | Description |
 | --- | --- | --- |
 | `appid` |Application ID |Identifies the application that is using the token to access a resource. The application can act as itself or on behalf of a user. The application ID typically represents an application object, but it can also represent a service principal object in Azure AD. <br><br> **Example JWT Value**: <br> `"appid":"15CB020F-3984-482A-864D-1D92265E8268"` |


### PR DESCRIPTION
Adding this custom class wrapper will break the lines of code so the table no longer breaks out of the center content column.