### PR TITLE
Typo : undestand and explaination

### DIFF
--- a/articles/cloud-services/cloud-services-custom-domain-name-portal.md
+++ b/articles/cloud-services/cloud-services-custom-domain-name-portal.md
@@ -28,7 +28,7 @@ When you create a Cloud Service, Azure assigns it to a subdomain of **cloudapp.n
 
 However, you can also expose your application on your own domain name, such as **contoso.com**. This article explains how to reserve or configure a custom domain name for Cloud Service web roles.
 
-Do you already undestand what CNAME and A records are? [Jump past the explaination](#add-a-cname-record-for-your-custom-domain).
+If you already understand what CNAME and A records are, you can [skip the explanation](#add-a-cname-record-for-your-custom-domain).
 
 > [!NOTE]
 > The procedures in this task apply to Azure Cloud Services. For App Services, see [this](../app-service-web/web-sites-custom-domain-name.md). For storage accounts, see [this](../storage/storage-custom-domain-name.md).


### PR DESCRIPTION
Replace 
  Do you already undestand what CNAME and A records are? [Jump past the explaination].
With
  If you already understand what CNAME and A records are, you can [skip the explanation]