### PR TITLE
The out param for BrokeredMessage was incorrect

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus.md
+++ b/articles/azure-functions/functions-bindings-service-bus.md
@@ -214,7 +214,7 @@ In C# and F#, Azure Functions can create a Service Bus queue message from any of
   Functions deserializes the object into a JSON message. If the output value is null when the function exits, Functions creates the message with a null object.
 * `string` - Parameter definition looks like `out string paraName` (C#). If the parameter value is non-null when the function exits, Functions creates a message.
 * `byte[]` - Parameter definition looks like `out byte[] paraName` (C#). If the parameter value is non-null when the function exits, Functions creates a message.
-* `BrokeredMessage` Parameter definition looks like `out byte[] paraName` (C#). If the parameter value is non-null when the function exits, Functions creates a message.
+* `BrokeredMessage` Parameter definition looks like `out BrokeredMessage paraName` (C#). If the parameter value is non-null when the function exits, Functions creates a message.
 
 For creating multiple messages in a C# function, you can use `ICollector<T>` or `IAsyncCollector<T>`. A message is created when you call the `Add` method.
 


### PR DESCRIPTION
BrokeredMessage out was incorrectly "out byte[] paraName"