### PR TITLE
Added missing azurecli syntax highlighting

### DIFF
--- a/articles/container-service/container-service-create-acs-cluster-cli.md
+++ b/articles/container-service/container-service-create-acs-cluster-cli.md
@@ -115,7 +115,7 @@ az acs scale -g acsrg1 -n acs-cluster --new-agent-count 4
 ![Image ACS scale](media/container-service-create-acs-cluster-cli/acs-scale.png)
 
 ## Delete a container service cluster
-```
+```azurecli
 az acs delete -g acsrg1 -n acs-cluster 
 ```
 *Note that this delete command does not delete all resources (network and storage) created while creating the container service. To delete all resources, it is recommended that a single ACS cluster be created per resource group and then the resource group itself be deleted when the acs cluster is no longer required to ensure that all related resources are deleted and you are not charged for them.*


### PR DESCRIPTION
The `azurecli` syntax was left off the last code block, 

![image](https://cloud.githubusercontent.com/assets/5393923/21267416/3185750a-c378-11e6-884a-2f774faf0926.png)
