### PR TITLE
docker-machine more optimal values, fix acs kubernetes get creds

### DIFF
--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -49,7 +49,8 @@ az resource group create --name=$RESOURCE_GROUP --location=$LOCATION
 Once you have a resource group, you can create a cluster in that group with:
 ```console
 DNS_PREFIX=some-unique-value
-az acs create --orchestrator-type=kubernetes --resource-group $RESOURCE_GROUP --name=my-cluster --dns-prefix=$DNS_PREFIX
+SERVICE_NAME=any-acs-service-name
+az acs create --orchestrator-type=kubernetes --resource-group $RESOURCE_GROUP --name=$SERVICE_NAME --dns-prefix=$DNS_PREFIX
 ```
 
 Once that command is complete, you should have a working Kubernetes cluster.
@@ -61,9 +62,9 @@ Once that command is complete, you should have a working Kubernetes cluster.
 az acs kubernetes install-cli
 ```
 
-Once `kubectl` is installed, you can install the credentials to connect to your cluster
+Once `kubectl` is installed, running the below command will download the master kubernetes cluster configuration to the ~/.kube/config file
 ```console
-az acs kubernetes get-credentials --dns-prefix=$DNS_PREFIX --location=$LOCATION
+az acs kubernetes get-credentials --resource-group=$RESOURCE_GROUP --name=$SERVICE_NAME
 ```
 
 At this point you should be ready to access your cluster from your machine, try running:

--- a/articles/vs-azure-tools-docker-machine-azure-config.md
+++ b/articles/vs-azure-tools-docker-machine-azure-config.md
@@ -24,7 +24,7 @@ to create new Linux VMs, configured with the Docker daemon, running in Azure.
 
 **Note:** 
 
-* *This article depends on docker-machine version 0.7.0 or greater*
+* *This article depends on docker-machine version 0.9.0-rc2 or greater*
 * *Windows Containers will be supported through docker-machine in the near future*
 
 ## Create VMs with Docker Machine
@@ -44,10 +44,15 @@ or the [Azure Portal](https://portal.azure.com) to retrieve your Azure Subscript
 Type `docker-machine create --driver azure` to see the options and their default values.
 You can also see the [Docker Azure Driver documentation](https://docs.docker.com/machine/drivers/azure/) for more info. 
 
-The following example relies upon the default values, but it does optionally open port 80 on the VM for internet access. 
+The following example relies upon the [default values](https://github.com/docker/machine/blob/master/drivers/azure/azure.go#L22), but it does optionally set these values: 
+
+* azure-dns for the name associated with the public IP and certificates generated.  The VM can then safely stop, release the dynamic IP, and give the ability to reconnect after vm starts again with a new IP.  The name prefix needs to be unique for that region  UNIQUE_DNSNAME_PREFIX.westus.cloudapp.azure.com.
+* open port 80 on the VM for outbound internet access
+* size of the VM to utilize faster premium storage
+* premium storage used for the vm disk
 
 ```
-docker-machine create -d azure --azure-subscription-id <Your AZURE_SUBSCRIPTION_ID> --azure-open-port 80 mydockerhost
+docker-machine create -d azure --azure-subscription-id <Your AZURE_SUBSCRIPTION_ID> --azure-dns <Your UNIQUE_DNSNAME_PREFIX> --azure-open-port 80 --azure-size Standard_DS1_v2 --azure-storage-type "Premium_LRS" mydockerhost 
 ```
 
 ## Choose a docker host with docker-machine


### PR DESCRIPTION
Biggest reason is for azure-dns now being present and premium storage / DS VMs provides better experience at very similar cost