### PR TITLE
Update wording (visible -> invisible) of comment

### DIFF
--- a/articles/storage/storage-dotnet-how-to-use-queues.md
+++ b/articles/storage/storage-dotnet-how-to-use-queues.md
@@ -161,7 +161,7 @@ CloudQueue queue = queueClient.GetQueueReference("myqueue");
 CloudQueueMessage message = queue.GetMessage();
 message.SetMessageContent("Updated contents.");
 queue.UpdateMessage(message,
-    TimeSpan.FromSeconds(60.0),  // Make it visible for another 60 seconds.
+    TimeSpan.FromSeconds(60.0),  // Make the message invisible to other consumers for another 60 seconds.
     MessageUpdateFields.Content | MessageUpdateFields.Visibility);
 ```
 


### PR DESCRIPTION
Updated the wording of the comment to avoid confusion line 164.  The existing comment "Make the message visible" is inaccurate and indicates the message will again be visible in the queue after the call.  The line of code in fact extends the period to which the message will be invisible to other clients for an additional 60 seconds.