### PR TITLE
Fixes in Kubernetes Walkthrough for Azure Container Services (wrong command lines)

### DIFF
--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -46,7 +46,7 @@ To create your cluster, you first need to create a resource group in a specific 
 ```console
 RESOURCE_GROUP=my-resource-group
 LOCATION=westus
-az resource group create --name=$RESOURCE_GROUP --location=$LOCATION
+az group create --name=$RESOURCE_GROUP --location=$LOCATION
 ```
 
 ### Create a cluster

--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -53,7 +53,8 @@ az group create --name=$RESOURCE_GROUP --location=$LOCATION
 Once you have a resource group, you can create a cluster in that group with:
 ```console
 DNS_PREFIX=some-unique-value
-az acs create --orchestrator-type=kubernetes --resource-group $RESOURCE_GROUP --name=my-cluster --dns-prefix=$DNS_PREFIX
+CLUSTER_NAME=my-cluster
+az acs create --orchestrator-type=kubernetes --resource-group=$RESOURCE_GROUP --name=$CLUSTER_NAME --dns-prefix=$DNS_PREFIX
 ```
 
 Once that command is complete, you should have a working Kubernetes cluster.
@@ -67,7 +68,7 @@ az acs kubernetes install-cli
 
 Once `kubectl` is installed, you can install the credentials to connect to your cluster
 ```console
-az acs kubernetes get-credentials --dns-prefix=$DNS_PREFIX --location=$LOCATION
+az acs kubernetes get-credentials --name=$CLUSTER_NAME --dns-prefix=$DNS_PREFIX --resource-group=$RESOURCE_GROUP
 ```
 
 At this point you should be ready to access your cluster from your machine, try running:


### PR DESCRIPTION
Creating a Resource Group via azure-cli 2.0 is not done with `az resource group create`. The `resource` command does not know "create". It's `az group create`.