### PR TITLE
Change server.js location for api.json

### DIFF
--- a/articles/app-service-api/app-service-api-nodejs-api-app.md
+++ b/articles/app-service-api/app-service-api-nodejs-api-app.md
@@ -129,7 +129,7 @@ While App Service supports many ways to deploy your code to an API app, this tut
         app.use(bodyParser.json());
    
         app.use(swaggerize({
-            api: path.resolve('./config/api.json'), // third change
+            api: path.resolve('./config/swagger.json'), // third change
             handlers: path.resolve('./handlers'),
             docspath: '/swagger' // fourth change
         }));


### PR DESCRIPTION
I just ran through the process from scratch and got the following error:
```
Error: Cannot find module '/mnt/c/Users/thfalgou/dev/git/tmp/app-service-api-node-contact-list/start/ContactList/config/api.json'
```

It appears that when running through the swaggerize yeoman project creation, that it converts the api.json to swagger.json when it copies the file over. 
```
root@THFALGOUSP4:~/dev/git/tmp/app-service-api-node-contact-list/start/ContactList# ll config
total 8
drwxrwxrwx 2 root root    0 Jan  4 16:45 ./
drwxrwxrwx 2 root root    0 Jan  4 16:49 ../
-rwxrwxrwx 1 root root 2465 Jan  4 16:38 swagger.json*
```