### PR TITLE
Fixed description for link

### DIFF
--- a/articles/key-vault/key-vault-secure-your-key-vault.md
+++ b/articles/key-vault/key-vault-secure-your-key-vault.md
@@ -233,7 +233,7 @@ This example depicts a simple scenario. Real life scenarios may be more complex 
   Link to Key access control reference documentation.
 * [Secret access control](https://msdn.microsoft.com/library/azure/dn903623.aspx#BKMK_SecretAccessControl)
   
-  Link to Key access control reference documentation.
+  Link to Secret access control reference documentation.
 * [Set](https://msdn.microsoft.com/library/mt603625.aspx) and [Remove](https://msdn.microsoft.com/library/mt619427.aspx) key vault access policy using PowerShell
   
   Links to reference documentation for PowerShell cmdlets to manage key vault access policy.


### PR DESCRIPTION
Description text was wrong, for 'Secret Access Control' link. Fixed.
Please cancel old PR1911