### PR TITLE
Update container-service-kubernetes-walkthrough.md

### DIFF
--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -53,7 +53,7 @@ az group create --name=$RESOURCE_GROUP --location=$LOCATION
 Once you have a resource group, you can create a cluster in that group with:
 ```console
 DNS_PREFIX=some-unique-value
-az acs create --orchestrator-type=kubernetes --resource-group $RESOURCE_GROUP --name=my-cluster --dns-prefix=$DNS_PREFIX
+az acs create --orchestrator-type=kubernetes --resource-group $RESOURCE_GROUP --name=my-cluster --dns-prefix=$DNS_PREFIX --generate-ssh-keys
 ```
 
 Once that command is complete, you should have a working Kubernetes cluster.
@@ -67,7 +67,7 @@ az acs kubernetes install-cli
 
 Once `kubectl` is installed, you can install the credentials to connect to your cluster
 ```console
-az acs kubernetes get-credentials --dns-prefix=$DNS_PREFIX --location=$LOCATION
+az acs kubernetes get-credentials --dns-prefix=$DNS_PREFIX --location=$LOCATION --user=azureuser
 ```
 
 At this point you should be ready to access your cluster from your machine, try running:


### PR DESCRIPTION
I had a couple of issues when trying to follow this documentation.

```
> az acs create --orchestrator-type=kubernetes --resource-group=tcokub --name=tco-cluster --dns-prefix=tcokub
creating service principal.........done
waiting for AAD role to propogate.done
At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details. {
  "error": {
    "code": "InvalidParameter",
    "target": "linuxProfile.ssh.publicKeys.keyData",
    "message": "The value of parameter linuxProfile.ssh.publicKeys.keyData is invalid."
  }
}
```

So I added `--generate-ssh-keys` to fix that error.

```
> az acs kubernetes get-credentials --dns-prefix=tcokub --location=westus
Authentication failed.
Traceback (most recent call last):
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\azure\cli\main.py", line 34, in main
    cmd_result = APPLICATION.execute(args)
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\azure\cli\core\application.py", line 139, in execute
    result = expanded_arg.func(params)
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\azure\cli\core\commands\__init__.py", line 275, in _execute_command
    result = op(client, **kwargs) if client else op(**kwargs)
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\azure\cli\command_modules\acs\custom.py", line 477, in k8s_get_credentials
    '.kube/config', path_candidate)
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\azure\cli\command_modules\acs\acs_client.py", line 21, in SecureCopy
    ssh.connect(host, username=user, key_filename=os.path.join(home, '.ssh', 'id_rsa'))
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\paramiko\client.py", line 380, in connect
    look_for_keys, gss_auth, gss_kex, gss_deleg_creds, gss_host)
  File "C:\Users\tconte\AppData\Roaming\Python\Python27\site-packages\paramiko\client.py", line 621, in _auth
    raise saved_exception
AuthenticationException: Authentication failed.
```

The stack shows "username=user" which is wrong since the VMs got created with admin "azureuser". This command worked, so I modified it in the doc:

```
> az acs kubernetes get-credentials --dns-prefix=tcokub --location=westus --user=azureuser
```

Another issue was:

```
> az acs kubernetes install-cli
Connection error while attempting to download client ([Errno 13] Permission denied: 'C:\\Program Files (x86)\\kubectl.exe')
```

I had to run the command in an elevated prompt, but maybe that's a bit overkill and we should pick another download location?
