### PR TITLE
Changed MachineKeySet = True to FALSE

### DIFF
--- a/articles/app-service-web/web-sites-configure-ssl-certificate.md
+++ b/articles/app-service-web/web-sites-configure-ssl-certificate.md
@@ -118,7 +118,7 @@ to generate it:
         KeyLength = 2048              ; Required minimum is 2048
         KeySpec = 1
         KeyUsage = 0xA0
-        MachineKeySet = True
+        MachineKeySet = FALSE
         ProviderName = "Microsoft RSA SChannel Cryptographic Provider"
         ProviderType = 12
         HashAlgorithm = SHA256


### PR DESCRIPTION
The default is false, and you can't import the response you get back from the CSR to the user store (as suggested by the further instructions) with this set to true.