### PR TITLE
Update storage-service-encryption.md

### DIFF
--- a/articles/storage/storage-service-encryption.md
+++ b/articles/storage/storage-service-encryption.md
@@ -107,8 +107,6 @@ A: No, SSE is only supported on Resource Manager storage accounts.
 
 A: You can create a new Resource Manager storage account and copy your data using [AzCopy](storage-use-azcopy.md) from your existing classic storage account to your newly created Resource Manager storage account. 
 
-Another option is to migrate your classic storage account to a Resource Manage storage account. For more information, see [Platform Supported Migration of IaaS Resources from Classic to Resource Manager](https://azure.microsoft.com/blog/iaas-migration-classic-resource-manager/).
-
 **Q: I have an existing Resource Manager storage account. Can I enable SSE on it?**
 
 A: Yes, but only newly written blobs will be encrypted. It does not go back and encrypt data that was already present. 


### PR DESCRIPTION
Remove suggestion for migrating classic storage account to Resource Manager storage account to encrypt it's data, since it is not supported.
(I am opening this pull request since the this sentence is conflicting the docs, I will be happy if someone explains why I was able to activate the encryption on migrated storage account without getting error message)