### PR TITLE
Azure AD Connect: Fix spacing for Microsoft docs

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-connectors.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-connectors.md
@@ -13,14 +13,11 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 09/07/2016
+ms.date: 01/09/2017
 ms.author: billmath
 
 ---
 # Azure AD Connect sync: Synchronization Service Manager
-| [Operations](active-directory-aadconnectsync-service-manager-ui-operations.md) | [Connectors](active-directory-aadconnectsync-service-manager-ui-connectors.md) | [Metaverse Designer](active-directory-aadconnectsync-service-manager-ui-mvdesigner.md) | [Metaverse Search](active-directory-aadconnectsync-service-manager-ui-mvsearch.md) |
-| --- | --- | --- | --- |
-|  | | | |
 
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/connectors.png)
 
@@ -42,7 +39,7 @@ The Connectors tab is used to manage all systems the sync engine is connected to
 | [Search Connector Space](#search-connector-space) |Used to find objects and to [Follow an object and its data through the system](#follow-an-object-and-its-data-through-the-system). |
 
 ### Delete
-The delete action is used for two different things.
+The delete action is used for two different things.  
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/connectordelete.png)
 
 The option **Delete connector space only** removes all data, but keep the configuration.
@@ -63,8 +60,8 @@ The search connector space action is useful to find objects and troubleshoot dat
 
 Start by selecting a **scope**. You can search based on data (RDN, DN, Anchor, Sub-Tree), or state of the object (all other options).  
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cssearchscope.png)  
-If you for example do a Sub-Tree search, you get all objects in one OU.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cssearchsubtree.png)
+If you for example do a Sub-Tree search, you get all objects in one OU.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cssearchsubtree.png)  
 From this grid you can select an object, select **properties**, and [follow it](#follow-an-object-and-its-data-through-the-system) from the source connector space, through the metaverse, and to the target connector space.
 
 ## Follow an object and its data through the system
@@ -72,18 +69,18 @@ When you are troubleshooting a problem with data, follow an object from the sour
 
 ### Connector Space Object Properties
 **Import**  
-When you open a cs object, there are several tabs at the top. The **Import** tab shows the data that is staged after an import.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/csimport.png)
+When you open a cs object, there are several tabs at the top. The **Import** tab shows the data that is staged after an import.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/csimport.png)  
 The **Old Value** shows what currently is stored in the system and the **New Value** what has been received from the source system and has not been applied yet. In this case, since there is a synchronization error, the change cannot be applied.
 
 **Error**  
 The error page is only visible if there is a problem with the object. See the details on the operations page for more information on how to [troubleshoot synchronization errors](active-directory-aadconnectsync-service-manager-ui-operations.md#troubleshoot-errors-in-operations-tab).
 
 **Lineage**  
-The lineage tab shows how the connector space object is related to the metaverse object. You can see when the Connector last imported a change from the connected system and which rules applied to populate data in the metaverse.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cslineage.png)
-In the **Action** column, you can see there is one **Inbound** sync rule with the action **Provision**. That indicates that as long as this connector space object is present, the metaverse object remains. If the list of sync rules instead shows a sync rule with direction **Outbound** and **Provision**, it indicates that this object is deleted when the metaverse object is deleted.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cslineageout.png)
+The lineage tab shows how the connector space object is related to the metaverse object. You can see when the Connector last imported a change from the connected system and which rules applied to populate data in the metaverse.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cslineage.png)  
+In the **Action** column, you can see there is one **Inbound** sync rule with the action **Provision**. That indicates that as long as this connector space object is present, the metaverse object remains. If the list of sync rules instead shows a sync rule with direction **Outbound** and **Provision**, it indicates that this object is deleted when the metaverse object is deleted.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/cslineageout.png)  
 You can also see in the **PasswordSync** column that the inbound connector space can contribute changes to the password since one sync rule has the value **True**. This password is then sent to Azure AD through the outbound rule.
 
 From the lineage tab, you can get to the metaverse by clicking [Metaverse Object Properties](#metaverse-object-properties).
@@ -91,9 +88,9 @@ From the lineage tab, you can get to the metaverse by clicking [Metaverse Object
 At the bottom of all tabs are two buttons: **Preview** and **Log**.
 
 **Preview**  
-The preview page is used to synchronize one single object. It is useful if you are troubleshooting some customer sync rules and want to see the effect of a change on a single object. You can select between **Full Sync** and **Delta sync**. You can also select between **Generate Preview**, which only keeps the change in memory, and **Commit Preview**, which stages all changes to target connector spaces.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/preview1.png)
-You can inspect the object and which rule applied for a particular attribute flow.
+The preview page is used to synchronize one single object. It is useful if you are troubleshooting some customer sync rules and want to see the effect of a change on a single object. You can select between **Full Sync** and **Delta sync**. You can also select between **Generate Preview**, which only keeps the change in memory, and **Commit Preview**, which stages all changes to target connector spaces.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/preview1.png)  
+You can inspect the object and which rule applied for a particular attribute flow.  
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/preview2.png)
 
 **Log**  
@@ -101,11 +98,11 @@ The Log page is used to see the password sync status and history.
 
 ### Metaverse Object Properties
 **Attributes**  
-On the attributes tab, you can see the values and which Connector contributed it.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/mvattributes.png)
+On the attributes tab, you can see the values and which Connector contributed it.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/mvattributes.png)  
 **Connectors**  
-The Connectors tab shows all connector spaces that have a representation of the object.
-![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/mvconnectors.png)
+The Connectors tab shows all connector spaces that have a representation of the object.  
+![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/mvconnectors.png)  
 This tab also allows you to navigate to the [connector space object](#connector-space-object-properties).
 
 ## Next steps

--- a/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-mvdesigner.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-mvdesigner.md
@@ -13,14 +13,11 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 09/07/2016
+ms.date: 01/09/2017
 ms.author: billmath
 
 ---
 # Azure AD Connect sync: Synchronization Service Manager
-| [Operations](active-directory-aadconnectsync-service-manager-ui-operations.md) | [Connectors](active-directory-aadconnectsync-service-manager-ui-connectors.md) | [Metaverse Designer](active-directory-aadconnectsync-service-manager-ui-mvdesigner.md) | [Metaverse Search](active-directory-aadconnectsync-service-manager-ui-mvsearch.md) |
-| --- | --- | --- | --- |
-|  | | | |
 
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/mvdesigner.png)
 
@@ -30,4 +27,3 @@ For most customers, there is nothing to configure here.
 Learn more about the [Azure AD Connect sync](active-directory-aadconnectsync-whatis.md) configuration.
 
 Learn more about [Integrating your on-premises identities with Azure Active Directory](active-directory-aadconnect.md).
-

--- a/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-mvsearch.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-mvsearch.md
@@ -13,14 +13,11 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 09/07/2016
+ms.date: 01/09/2017
 ms.author: billmath
 
 ---
 # Azure AD Connect sync: Synchronization Service Manager
-| [Operations](active-directory-aadconnectsync-service-manager-ui-operations.md) | [Connectors](active-directory-aadconnectsync-service-manager-ui-connectors.md) | [Metaverse Designer](active-directory-aadconnectsync-service-manager-ui-mvdesigner.md) | [Metaverse Search](active-directory-aadconnectsync-service-manager-ui-mvsearch.md) |
-| --- | --- | --- | --- |
-|  | | | |
 
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/mvsearch.png)
 
@@ -32,4 +29,3 @@ In the search results, select an object and **Properties** to see the [metaverse
 Learn more about the [Azure AD Connect sync](active-directory-aadconnectsync-whatis.md) configuration.
 
 Learn more about [Integrating your on-premises identities with Azure Active Directory](active-directory-aadconnect.md).
-

--- a/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-operations.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui-operations.md
@@ -13,14 +13,11 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 09/07/2016
+ms.date: 01/09/2016
 ms.author: billmath
 
 ---
 # Azure AD Connect sync: Synchronization Service Manager
-| [Operations](active-directory-aadconnectsync-service-manager-ui-operations.md) | [Connectors](active-directory-aadconnectsync-service-manager-ui-connectors.md) | [Metaverse Designer](active-directory-aadconnectsync-service-manager-ui-mvdesigner.md) | [Metaverse Search](active-directory-aadconnectsync-service-manager-ui-mvsearch.md) |
-| --- | --- | --- | --- |
-|  | | | |
 
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/operations.png)
 
@@ -59,4 +56,3 @@ If the error itself does not give enough information, then it is time to look at
 Learn more about the [Azure AD Connect sync](active-directory-aadconnectsync-whatis.md) configuration.
 
 Learn more about [Integrating your on-premises identities with Azure Active Directory](active-directory-aadconnect.md).
-

--- a/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-service-manager-ui.md
@@ -13,14 +13,11 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 09/07/2016
+ms.date: 01/09/2017
 ms.author: billmath
 
 ---
 # Azure AD Connect sync: Synchronization Service Manager
-| [Operations](active-directory-aadconnectsync-service-manager-ui-operations.md) | [Connectors](active-directory-aadconnectsync-service-manager-ui-connectors.md) | [Metaverse Designer](active-directory-aadconnectsync-service-manager-ui-mvdesigner.md) | [Metaverse Search](active-directory-aadconnectsync-service-manager-ui-mvsearch.md) |
-| --- | --- | --- | --- |
-|  | | | |
 
 ![Sync Service Manager](./media/active-directory-aadconnectsync-service-manager-ui/ssmui.png)
 
@@ -35,4 +32,3 @@ Click the links at the top of this topic to learn more about the different tabs 
 Learn more about the [Azure AD Connect sync](active-directory-aadconnectsync-whatis.md) configuration.
 
 Learn more about [Integrating your on-premises identities with Azure Active Directory](active-directory-aadconnect.md).
-


### PR DESCRIPTION
With the move to Microsoft docs, need to fix the wrapping around pictures. Adding more explicit line brakes.