### PR TITLE
Replaced command for 'activating AD DS powershell'

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-feature-device-writeback.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-feature-device-writeback.md
@@ -44,7 +44,7 @@ Use the following steps to prepare for using device writeback.
 1. From the machine where Azure AD Connect is installed, launch PowerShell in elevated mode.
 2. If the Active Directory PowerShell module is NOT installed, install it using the following command:
    
-   `Install-WindowsFeature –Name AD-Domain-Services –IncludeManagementTools`
+   `Add-WindowsFeature RSAT-AD-PowerShell`
 3. If the Azure Active Directory PowerShell module is NOT installed, then download and install it from [Azure Active Directory Module for Windows PowerShell (64-bit version)](http://go.microsoft.com/fwlink/p/?linkid=236297). This component has a dependency on the sign-in assistant, which is installed with Azure AD Connect.
 4. With enterprise admin credentials, run the following commands and then exit PowerShell.
    


### PR DESCRIPTION
As previously submitted here (https://github.com/Microsoft/azure-docs/pull/156), but since that file has been shelled to just a redirect, I've copied the pull request to the new file...

Its not a good idea to get people to run 'Install-WindowsFeature –Name AD-Domain-Services –IncludeManagementTools' just to install the management tools... this will install AD DS on that server! And since this is the AAD Connect server, that's not ideal! I've replaced it instead with Add-WindowsFeature RSAT-AD-PowerShell which instead just does exactly as it says on the tin.