### PR TITLE
add SSH public key prerequisite

### DIFF
--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -23,7 +23,7 @@ ms.author: anhowe
 # Microsoft Azure Container Service Engine - Kubernetes Walkthrough
 
 ## Prerequisites
-This walkthrough assumes that you have the ['azure-cli' command line tool](https://github.com/azure/azure-cli#installation) installed.
+This walkthrough assumes that you have the ['azure-cli' command line tool](https://github.com/azure/azure-cli#installation) installed and have created [SSH public key](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) at `~/.ssh/id_rsa.pub`.
 
 ## Overview
 
@@ -56,6 +56,10 @@ DNS_PREFIX=some-unique-value
 SERVICE_NAME=any-acs-service-name
 az acs create --orchestrator-type=kubernetes --resource-group $RESOURCE_GROUP --name=$SERVICE_NAME --dns-prefix=$DNS_PREFIX
 ```
+
+> [!NOTE]
+> azure-cli will upload `~/.ssh/id_rsa.pub` to the Linux VMs.
+>
 
 Once that command is complete, you should have a working Kubernetes cluster.
 


### PR DESCRIPTION
The walkthrough actually requires users to have SSH public key which is not mentioned. Hence adding this back.