### PR TITLE
Update import statements for missing 'account'

### DIFF
--- a/articles/data-lake-store/data-lake-store-get-started-python.md
+++ b/articles/data-lake-store/data-lake-store-get-started-python.md
@@ -75,8 +75,8 @@ pip install azure-datalake-store
 	from msrestazure.azure_active_directory import AADTokenCredentials
 
 	## Required for Azure Data Lake Store account management
-	from azure.mgmt.datalake.store.account import DataLakeStoreAccountManagementClient
-	from azure.mgmt.datalake.store.account.models import DataLakeStoreAccount
+	from azure.mgmt.datalake.store import DataLakeStoreAccountManagementClient
+	from azure.mgmt.datalake.store.models import DataLakeStoreAccount
 
 	## Required for Azure Data Lake Store filesystem management
 	from azure.datalake.store import core, lib, multithread


### PR DESCRIPTION
Name 'account' does not exist in azure.mgmt.datalake.store. Updating code sample import statements.