### PR TITLE
Update app-insights-annotations.md

### DIFF
--- a/articles/application-insights/app-insights-annotations.md
+++ b/articles/application-insights/app-insights-annotations.md
@@ -65,7 +65,7 @@ You need to get a separate API key for each VSTS release template.
    
     Paste your API key to the ApiKey variable definition.
    
-    ![In the Team Services window, select the Configuration tab and click Add Variable. Set the name to ApiKey and into the Value, paste the key you just generated.](./media/app-insights-annotations/50.png)
+    ![In the Team Services window, select the Configuration tab and click Add Variable. Set the name to ApiKey and into the Value, paste the key you just generated, and click the lock icon.](./media/app-insights-annotations/50.png)
 7. Finally, **Save** the release definition.
 
 


### PR DESCRIPTION
I added a note to click the "lock" icon in VSTS release variables so the ApiKey is not visible to future editors of the release definition.