### PR TITLE
fix CLI call for azure login

### DIFF
--- a/articles/app-service-web/storage-nodejs-use-table-storage-web-site.md
+++ b/articles/app-service-web/storage-nodejs-use-table-storage-web-site.md
@@ -459,7 +459,7 @@ In this step, you will download a file containing information about your subscri
 
 1. Enter the following command:
    
-        azure account download
+        azure login
    
     This command launches a browser and navigates to the download page. If prompted, log in with the account associated with your Azure subscription.
    


### PR DESCRIPTION
the call `azure account download` is now obsolete and should instead use `azure login`