### PR TITLE
Update service-fabric-diagnostics-how-to-report-and-check-service-hea…

### DIFF
--- a/articles/service-fabric/service-fabric-diagnostics-how-to-report-and-check-service-health.md
+++ b/articles/service-fabric/service-fabric-diagnostics-how-to-report-and-check-service-health.md
@@ -104,8 +104,8 @@ The Service Fabric project templates in Visual Studio contain sample code. The f
     if (!result.HasValue)
     {
        var replicaHealthReport = new StatefulServiceReplicaHealthReport(
-            this.ServiceInitializationParameters.PartitionId,
-            this.ServiceInitializationParameters.ReplicaId,
+            this.Context.PartitionId,
+            this.Context.ReplicaId,
             new HealthInformation("ServiceCode", "StateDictionary", HealthState.Error));
         fabricClient.HealthManager.ReportHealth(replicaHealthReport);
     }


### PR DESCRIPTION
…lth.md

StatefulService does not have a ServiceInitializationParameters property so the code as written does not compile. Instead, the Context property must be used to retrieve the PartitionId and ReplicaId.