### PR TITLE
Update notification-hubs-nodejs-push-notification-tutorial.md

### DIFF
--- a/articles/notification-hubs/notification-hubs-nodejs-push-notification-tutorial.md
+++ b/articles/notification-hubs/notification-hubs-nodejs-push-notification-tutorial.md
@@ -93,7 +93,7 @@ The **NotificationHubService** object exposes the following object instances for
 ### How to: Send push notifications to Android applications
 The **GcmService** object provides a **send** method that can be used to send push notifications to Android applications. The **send** method accepts the following parameters:
 
-* **Tags** - the tag identifier. If no tag is provided, the notification will be sent to al clients.
+* **Tags** - the tag identifier. If no tag is provided, the notification will be sent to all clients.
 * **Payload** - the message's JSON or raw string payload.
 * **Callback** - the callback function.
 


### PR DESCRIPTION
I think the notification should be sent to "all clients" instead of "al clients".