### PR TITLE
Update doc to reflect Azure AD in new portal

### DIFF
--- a/articles/app-service-mobile/app-service-mobile-how-to-configure-active-directory-authentication.md
+++ b/articles/app-service-mobile/app-service-mobile-how-to-configure-active-directory-authentication.md
@@ -45,8 +45,8 @@ You can also choose to provide configuration settings manually. This is the pref
 
 ### <a name="register"> </a>Register your application with Azure Active Directory
 1. Log on to the [Azure portal], and navigate to your application. Copy your **URL**. You will use this to configure your Azure Active Directory app.
-2. Sign in to the [Azure classic portal] and navigate to **Active Directory**.
-   
+2. Sign in to the [Azure portal] and navigate to **Azure Active Directory**
+  
     ![][2]
 3. Select your directory, and then select the **Applications** tab at the top. Click **ADD** at the bottom to create a new app registration.
 4. Click **Add an application my organization is developing**.


### PR DESCRIPTION
Azure AD is now available in the new portal at portal.azure.com. We should revise the document to also show how to set up Azure AD auth using the new portal, as there are a few pieces that are different.

I've started some changes, but there are major changes that need to be made. Navigating to directories is different (done by clicking your user in the top right of the screen and going to the new directory). Apps are under App registrations now. A few others, too.