### PR TITLE
Collection name used does not match the documentation.

### DIFF
--- a/articles/documentdb/documentdb-change-feed.md
+++ b/articles/documentdb/documentdb-change-feed.md
@@ -72,7 +72,7 @@ DocumentDB provides elastic containers of storage and throughput called **collec
 ### ReadDocumentFeed API
 Let's take a brief look at how ReadDocumentFeed works. DocumentDB supports reading a feed of documents within a collection via the `ReadDocumentFeed` API. For example, the following request returns a page of documents inside the `serverlogs` collection. 
 
-	GET https://mydocumentdb.documents.azure.com/dbs/smalldb/colls/smallcoll HTTP/1.1
+	GET https://mydocumentdb.documents.azure.com/dbs/smalldb/colls/serverlogs HTTP/1.1
 	x-ms-date: Tue, 22 Nov 2016 17:05:14 GMT
 	authorization: type%3dmaster%26ver%3d1.0%26sig%3dgo7JEogZDn6ritWhwc5hX%2fNTV4wwM1u9V2Is1H4%2bDRg%3d
 	Cache-Control: no-cache


### PR DESCRIPTION
Collection name used in GET request does not match the documentation.  smallcoll should be serverlogs