### PR TITLE
Updated guidance-compute-n-tier-vm-linux.md RG name to fix failed deployments

### DIFF
--- a/articles/guidance/guidance-compute-n-tier-vm-linux.md
+++ b/articles/guidance/guidance-compute-n-tier-vm-linux.md
@@ -144,7 +144,7 @@ A deployment for this reference architecture is available on [GitHub][github-fol
    [!["Deploy To Azure"][1]][2]
 2. Once the link has opened in the Azure portal, enter the follow values: 
    
-   * The **Resource group** name is already defined in the parameter file, so select **Create New** and enter `ra-ntier-sql-network-rg` in the text box.
+   * The **Resource group** name is already defined in the parameter file, so select **Create New** and enter `ra-ntier-cassandra-rg` in the text box.
    * Select the region from the **Location** drop down box.
    * Do not edit the **Template Root Uri** or the **Parameter Root Uri** text boxes.
    * Review the terms and conditions, then click the **I agree to the terms and conditions stated above** checkbox.


### PR DESCRIPTION
The Deployment Steps section instructs the user to click the `Deploy to Azure` button and then name the new resource group `ra-ntier-sql-network-rg`.  However, doing so will cause a failed deployment.

In the [ARM Template](https://github.com/mspnp/reference-architectures/tree/master/guidance-compute-n-tier)'s 6 parameter files, they use `ra-ntier-cassandra-rg` as a hardcoded resource group name, resulting in a mismatch between the documentation and the template file.

Swapping in instructions to use the updated resource group name results in a successful template deployment. 

* [1](https://github.com/mspnp/reference-architectures/blob/master/guidance-compute-n-tier/parameters/linux/businessTier.parameters.json#L96)
* [2](https://github.com/mspnp/reference-architectures/blob/master/guidance-compute-n-tier/parameters/linux/dataTier.parameters.json#L64)
* [3](https://github.com/mspnp/reference-architectures/blob/master/guidance-compute-n-tier/parameters/linux/managementTierJumpbox.parameters.json#L54)
* [4](https://github.com/mspnp/reference-architectures/blob/master/guidance-compute-n-tier/parameters/linux/managementTierOps.parameters.json#L64)
* [5](https://github.com/mspnp/reference-architectures/blob/master/guidance-compute-n-tier/parameters/linux/networkSecurityGroups.parameters.json#L8)
* [6](https://github.com/mspnp/reference-architectures/blob/master/guidance-compute-n-tier/parameters/linux/networkSecurityGroups.parameters.json#L8)