### PR TITLE
Add "Windows" in the page title

### DIFF
--- a/articles/virtual-machines/virtual-machines-windows-sizes.md
+++ b/articles/virtual-machines/virtual-machines-windows-sizes.md
@@ -18,7 +18,7 @@ ms.date: 01/24/2017
 ms.author: cynthn
 
 ---
-# Sizes for virtual machines in Azure
+# Sizes for Windows virtual machines in Azure
 This article describes the available sizes and options for the Azure virtual machines you can use to run your Windows apps and workloads. It also provides deployment considerations to be aware of when you're planning to use these resources.  This article is also available for [Linux virtual machines](virtual-machines-linux-sizes.md?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
 > [!IMPORTANT]


### PR DESCRIPTION
While the "Windows" term exists in the browser title as well as in the address itself, it is missing in the page's effective title (which is confusing). I've added this.