### PR TITLE
Add new adaptive sampling tags

### DIFF
--- a/articles/application-insights/app-insights-sampling.md
+++ b/articles/application-insights/app-insights-sampling.md
@@ -100,6 +100,14 @@ In [ApplicationInsights.config](app-insights-configuration-with-applicationinsig
 * `<InitialSamplingPercentage>100</InitialSamplingPercentage>`
   
     The value assigned when the app has just started. Don't reduce this while you're debugging. 
+    
+* `<ExcludedTypes>Trace;Exception</ExcludedTypes>`
+  
+    A semi-colon delimited list of types that you do not want to be sampled. Possible types are "Dependency", "Event", "Exception", "PageView", "Request", "Trace". The types specified in the tag will not be sampled; however, the types that are not specified will be sampled. **Available since version 2.2.0**
+
+* `<IncludedTypes>Request;Dependency</IncludedTypes>`
+  
+    A semi-colon delimited list of types that you want to be sampled. Possible types are "Dependency", "Event", "Exception", "PageView", "Request", "Trace". The types specified in the tag will be sampled; however, the types that are not specified will not be sampled. **Available since version 2.2.0**
 
 ### Alternative: configure adaptive sampling in code
 Instead of adjusting sampling in the .config file, you can use code. This allows you to specify a callback function that is invoked whenever the sampling rate is re-evaluated. You could use this, for example, to find out what sampling rate is being used.


### PR DESCRIPTION
Since version 2.2.0 we can specify specific types for sampling. Updating the document to reflect the release notes for [2.2.0-beta1](https://github.com/Microsoft/ApplicationInsights-dotnet/releases/tag/v2.2.0-beta1) and [2.2.0-beta2](https://github.com/Microsoft/ApplicationInsights-dotnet/releases/tag/v2.2.0-beta2)