### PR TITLE
Fixed vars in metricResourceUri

### DIFF
--- a/articles/monitoring-and-diagnostics/insights-autoscale-common-metrics.md
+++ b/articles/monitoring-and-diagnostics/insights-autoscale-common-metrics.md
@@ -123,7 +123,8 @@ Get-AzureRmMetricDefinition -ResourceId <resource_id> | Format-Table -Property N
 | \PhysicalDisk\TransfersPerSecond |CountPerSecond |
 | \PhysicalDisk\ReadsPerSecond |CountPerSecond |
 | \PhysicalDisk\WritesPerSecond |CountPerSecond |
-| \PhysicalDisk\AverageReadTime |Seconds || \PhysicalDisk\AverageWriteTime |Seconds |
+| \PhysicalDisk\AverageReadTime |Seconds |
+| \PhysicalDisk\AverageWriteTime |Seconds |
 | \PhysicalDisk\AverageTransferTime |Seconds |
 | \PhysicalDisk\AverageDiskQueueLength |Count |
 | \NetworkInterface\BytesTransmitted |Bytes |

--- a/articles/monitoring-and-diagnostics/insights-autoscale-common-metrics.md
+++ b/articles/monitoring-and-diagnostics/insights-autoscale-common-metrics.md
@@ -123,8 +123,7 @@ Get-AzureRmMetricDefinition -ResourceId <resource_id> | Format-Table -Property N
 | \PhysicalDisk\TransfersPerSecond |CountPerSecond |
 | \PhysicalDisk\ReadsPerSecond |CountPerSecond |
 | \PhysicalDisk\WritesPerSecond |CountPerSecond |
-| \PhysicalDisk\AverageReadTime |Seconds |
-| \PhysicalDisk\AverageWriteTime |Seconds |
+| \PhysicalDisk\AverageReadTime |Seconds || \PhysicalDisk\AverageWriteTime |Seconds |
 | \PhysicalDisk\AverageTransferTime |Seconds |
 | \PhysicalDisk\AverageDiskQueueLength |Count |
 | \NetworkInterface\BytesTransmitted |Bytes |
@@ -167,7 +166,7 @@ For example, with a Classic Storage Account the autoscale setting metricTrigger 
 ```
 "metricName": "ApproximateMessageCount",
  "metricNamespace": "",
- "metricResourceUri": "/subscriptions/s1/resourceGroups/rg1/providers/Microsoft.ClassicStorage/storageAccounts/mystorage/services/queue/queues/mystoragequeue"
+ "metricResourceUri": "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RES_GROUP_NAME/providers/Microsoft.ClassicStorage/storageAccounts/STORAGE_ACCOUNT_NAME/services/queue/queues/QUEUE_NAME"
  ```
 
 For a (non-classic) storage account, the metricTrigger would include:
@@ -175,7 +174,7 @@ For a (non-classic) storage account, the metricTrigger would include:
 ```
 "metricName": "ApproximateMessageCount",
 "metricNamespace": "",
-"metricResourceUri": "/subscriptions/s1/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/mystorage/services/queue/queues/mystoragequeue"
+"metricResourceUri": "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RES_GROUP_NAME/providers/Microsoft.Storage/storageAccounts/STORAGE_ACCOUNT_NAME/services/queue/queues/QUEUE_NAME"
 ```
 
 ## Commonly used Service Bus metrics
@@ -186,7 +185,7 @@ For VM scale sets, you can update the Autoscale setting in the Resource Manager 
 ```
 "metricName": "MessageCount",
  "metricNamespace": "",
-"metricResourceUri": "/subscriptions/s1/resourceGroups/rg1/providers/Microsoft.ServiceBus/namespaces/mySB/queues/myqueue"
+"metricResourceUri": "/subscriptions/SUBSCRIPTION_ID/resourceGroups/RES_GROUP_NAME/providers/Microsoft.ServiceBus/namespaces/SB_NAMESPACE/queues/QUEUE_NAME"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Less than ideal names for variables. Fixed.