### PR TITLE
Update data-lake-store-performance-tuning-hive.md

### DIFF
--- a/articles/data-lake-store/data-lake-store-performance-tuning-hive.md
+++ b/articles/data-lake-store/data-lake-store-performance-tuning-hive.md
@@ -53,7 +53,7 @@ Here are the most important settings to tune for improved ADLS performance:
 
 **Set hive.exec.reducer.bytes.per.reducer** – The default value works well when the data is uncompressed.  For data that is compressed, you should reduce the size of the reducer.  
 
-**Set hive.tez.container.size** – In each node, memory is specified by yarn.nodemanager.resource.memory-mb and should be correctly set on HDI cluster by default.  For additional information on setting the appropriate memory in YARN, see this post.
+**Set hive.tez.container.size** – In each node, memory is specified by yarn.nodemanager.resource.memory-mb and should be correctly set on HDI cluster by default.  For additional information on setting the appropriate memory in YARN, see this [post](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-hive-out-of-memory-error-oom).
 
 I/O intensive workloads can benefit from more parallelism by decreasing the Tez container size. This gives the user more containers which increases concurrency.  However, some Hive queries require a significant amount of memory (e.g. MapJoin).  If the task does not have enough memory, you will get an out of memory exception during runtime.  If you receive out of memory exceptions, then you should increase the memory.   
 


### PR DESCRIPTION
Added link to Azure documentation post on Yarn memory settings. There is also this post referenced here https://blogs.msdn.microsoft.com/shanyu/2014/07/31/hadoop-yarn-memory-settings-in-hdinsight/ in the linked article but I preferred to link to the Azure documentation as the first landing page.

https://github.com/Microsoft/azure-docs/compare/master...SeanMikha:patch-1#diff-93dfe7ce1f213f1b38288650e7c77eb6