### PR TITLE
Update active-directory-federation-sha256-guidance.md

### DIFF
--- a/articles/active-directory/active-directory-federation-sha256-guidance.md
+++ b/articles/active-directory/active-directory-federation-sha256-guidance.md
@@ -20,7 +20,7 @@ ms.author: anandy
 ---
 # Change signature hash algorithm for Office 365 replying party trust
 ## Overview
-Azure Active Directory Federation Services (AD FS) signs its tokens to Microsoft Azure Active Directory to ensure that they cannot be tampered with. This signature can be based on SHA1 or SHA256. Azure Active Directory now supports tokens signed with an SHA256 algorithm, and we recommend setting the token-signing algorithm to SHA256 for the highest level of security. This article describes the steps needed to set the token-signing algorithm to the more secure SHA256 level.
+Active Directory Federation Services (AD FS) signs its tokens to Microsoft Azure Active Directory to ensure that they cannot be tampered with. This signature can be based on SHA1 or SHA256. Azure Active Directory now supports tokens signed with an SHA256 algorithm, and we recommend setting the token-signing algorithm to SHA256 for the highest level of security. This article describes the steps needed to set the token-signing algorithm to the more secure SHA256 level.
 
 ## Change the token-signing algorithm
 After you have set the signature algorithm with one of the two processes below, AD FS signs the tokens for Office 365 relying party trust with SHA256. You don't need to make any extra configuration changes, and this change has no impact on your ability to access Office 365 or other Azure AD applications.


### PR DESCRIPTION
The first line of the article: "Azure Active Directory Federation Services (AD FS) signs its tokens" should be "Active Directory Federation Services (AD FS) signs its tokens". There's no product that's called Azure Active Directory Federation Services. It might confuse people as to which product/service is issueing tokens.