### PR TITLE
updates peering type to AzurePublicPeering in public peering section

### DIFF
--- a/articles/expressroute/expressroute-howto-routing-arm.md
+++ b/articles/expressroute/expressroute-howto-routing-arm.md
@@ -264,7 +264,7 @@ You can get configuration details using the following cmdlet
 ### To update Azure public peering configuration
 You can update any part of the configuration using the following cmdlet
 
-    Set-AzureRmExpressRouteCircuitPeeringConfig  -Name "MicrosoftPeering" -ExpressRouteCircuit $ckt -PeeringType MicrosoftPeering -PeerASN 100 -PrimaryPeerAddressPrefix "123.0.0.0/30" -SecondaryPeerAddressPrefix "123.0.0.4/30" -VlanId 600 
+    Set-AzureRmExpressRouteCircuitPeeringConfig  -Name "AzurePublicPeering" -ExpressRouteCircuit $ckt -PeeringType AzurePublicPeering -PeerASN 100 -PrimaryPeerAddressPrefix "123.0.0.0/30" -SecondaryPeerAddressPrefix "123.0.0.4/30" -VlanId 600 
 
     Set-AzureRmExpressRouteCircuit -ExpressRouteCircuit $ckt
 


### PR DESCRIPTION
The update public peering section mentions MicrosoftPeering as Name and PeeringType which is not correct.
This should be AzurePublicPeering.