### PR TITLE
Note about MD5 hash

### DIFF
--- a/articles/expressroute/expressroute-howto-routing-portal-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-routing-portal-resource-manager.md
@@ -38,6 +38,7 @@ This article walks you through the steps to create and manage routing configurat
 ## Configuration prerequisites
 * Make sure that you have reviewed the [prerequisites](expressroute-prerequisites.md) page, the [routing requirements](expressroute-routing.md) page, and the [workflows](expressroute-workflows.md) page before you begin configuration.
 * You must have an active ExpressRoute circuit. Follow the instructions to [Create an ExpressRoute circuit](expressroute-howto-circuit-arm.md) and have the circuit enabled by your connectivity provider before you proceed. The ExpressRoute circuit must be in a provisioned and enabled state for you to be able to run the cmdlets described below.
+* If you plan to use a shared key/MD5 hash, be sure to use this on both sides of the tunnel and limit the number of characters to a maximum of 25.
 
 These instructions only apply to circuits created with service providers offering Layer 2 connectivity services. If you are using a service provider offering managed Layer 3 services (typically an IPVPN, like MPLS), your connectivity provider will configure and manage routing for you. 
 


### PR DESCRIPTION
Should include a note somewhere for each deployment method (Portal and PS) regarding MD5 Hash/shared key.
We appear to have a limit of 25 characters even though the text box and PS will accept more. We should at least warn the users about this in our documentation until such time as PG addresses the issue.