### PR TITLE
Conn string approach for notification hub fails with error

### DIFF
--- a/articles/azure-functions/functions-bindings-notification-hubs.md
+++ b/articles/azure-functions/functions-bindings-notification-hubs.md
@@ -73,8 +73,8 @@ You can also manually add a connection string for an existing hub by adding a co
 
 1. On the **Function app** blade of the Azure portal, click **Function App Settings > Go to App Service settings**.
 2. In the **Settings** blade, click **Application Settings**.
-3. Scroll down to the **Connection strings** section, and add a named entry for *DefaultFullSharedAccessSignature* value for your notification hub. Change the type to **Custom**.
-4. Reference your connection string name in the output bindings. Similar to **MyHubConnectionString** used in the example above.
+3. Scroll down to the **App settings ** section, and add a named entry for *DefaultFullSharedAccessSignature* value for your notification hub.
+4. Reference your App setting string name in the output bindings. Similar to **MyHubConnectionString** used in the example above.
 
 ## APNS native notifications with C# queue triggers
 This example shows how to use types defined in the [Microsoft Azure Notification Hubs Library](https://www.nuget.org/packages/Microsoft.Azure.NotificationHubs/) to send a native APNS notification. 


### PR DESCRIPTION
**Please don't accept PR without security review from dev team**
The Connection string approach detailed in the document fails with "Microsoft.Azure.WebJobs.Host: 'DefaultFullSharedAccessSignature' does not resolve to a value."  If adding the connection string to App settings instead of Connection strings the steps succeed.