### PR TITLE
Fix star character encoding

### DIFF
--- a/articles/log-analytics/log-analytics-search-reference.md
+++ b/articles/log-analytics/log-analytics-search-reference.md
@@ -294,7 +294,7 @@ You can omit the logical operator for the top-level filter arguments. In this ca
 | system "Windows Server" OR Severity:1 |system AND ("Windows Server" OR Severity:1) |
 
 ### Wildcarding
-The query language supports using the (*\*) character to  represent one or more characters for a value in a query.
+The query language supports using the ( \* ) character to  represent one or more characters for a value in a query.
 
 Examples:
 


### PR DESCRIPTION
Fix star character encoding while explaining the usage of wildcards in queries