### PR TITLE
Update api-management-howto-integrate-internal-vnet-appgateway.md

### DIFF
--- a/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
+++ b/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
@@ -109,7 +109,7 @@ $appgatewaysubnet = New-AzureRmVirtualNetworkSubnetConfig -Name appgateway01 -Ad
 Assign the address range 10.0.1.0/24 to the subnet variable to be used for api management while creating a virtual network.
 
 ```powershell
-$apimsubnet = New-AzureRmVirtualNetworkSubnetConfig -Name appgateway01 -AddressPrefix 10.0.1.0/24
+$apimsubnet = New-AzureRmVirtualNetworkSubnetConfig -Name apim01 -AddressPrefix 10.0.1.0/24
 ```
 
 ### Step 3


### PR DESCRIPTION
Second subnet must have a different name (otherwise trying to create the vnet with two subnets will throw an error).