### PR TITLE
Updated sproc, trigger and udf snippets

### DIFF
--- a/articles/documentdb/documentdb-programming.md
+++ b/articles/documentdb/documentdb-programming.md
@@ -60,7 +60,7 @@ Let’s start with a simple stored procedure that returns a “Hello World” re
 
     var helloWorldStoredProc = {
         id: "helloWorld",
-        body: function () {
+        serverScript: function () {
             var context = getContext();
             var response = context.getResponse();
 
@@ -102,7 +102,7 @@ The next snippet shows how to use the context object to interact with DocumentDB
 
     var createDocumentStoredProc = {
         id: "createMyDocument",
-        body: function createMyDocument(documentToCreate) {
+        serverScript: function createMyDocument(documentToCreate) {
             var context = getContext();
             var collection = context.getCollection();
 
@@ -158,8 +158,8 @@ In DocumentDB, JavaScript is hosted in the same memory space as the database. He
 
     // JavaScript source code
     var exchangeItemsSproc = {
-        name: "exchangeItems",
-        body: function (playerId1, playerId2) {
+        id: "exchangeItems",
+        serverScript: function (playerId1, playerId2) {
             var context = getContext();
             var collection = context.getCollection();
             var response = context.getResponse();
@@ -295,8 +295,8 @@ Below is an example of a stored procedure that is written to bulk-import documen
 DocumentDB provides triggers that are executed or triggered by an operation on a document. For example, you can specify a pre-trigger when you are creating a document – this pre-trigger will run before the document is created. The following is an example of how pre-triggers can be used to validate the properties of a document that is being created:
 
     var validateDocumentContentsTrigger = {
-        name: "validateDocumentContents",
-        body: function validate() {
+        id: "validateDocumentContents",
+        serverScript: function validate() {
             var context = getContext();
             var request = context.getRequest();
 
@@ -366,8 +366,8 @@ Post-triggers, like pre-triggers, are associated with an operation on a document
 The following example shows post-triggers in action:
 
     var updateMetadataTrigger = {
-        name: "updateMetadata",
-        body: function updateMetadata() {
+        id: "updateMetadata",
+        serverScript: function updateMetadata() {
             var context = getContext();
             var collection = context.getCollection();
             var response = context.getResponse();
@@ -439,8 +439,8 @@ User-defined functions (UDFs) are used to extend the DocumentDB SQL query langua
 The following sample creates a UDF to calculate income tax based on rates for various income brackets, and then uses it inside a query to find all people who paid more than $20,000 in taxes.
 
     var taxUdf = {
-        name: "tax",
-        body: function tax(income) {
+        id: "tax",
+        serverScript: function tax(income) {
 
             if(income == undefined) 
                 throw 'no input';


### PR DESCRIPTION
`name` and `body` properties across all definitions were not compatible with the SDK's API, renamed to `id` and `serverScript`