### PR TITLE
Change on CLI arguments to create snapshot, "--source-disk" replaced …

### DIFF
--- a/articles/virtual-machines/linux/virtual-machines-linux-snapshot-copy-managed-disk.md
+++ b/articles/virtual-machines/linux/virtual-machines-linux-snapshot-copy-managed-disk.md
@@ -32,7 +32,7 @@ The following steps show how to obtain and take a snapshot of a managed OS disk 
 ```azure-cli
 # take the disk id with which to create a snapshot
 osDiskId=$(az vm show -g myResourceGroup -n myVM --query "storageProfile.osDisk.managedDisk.id" -o tsv)
-az snapshot create -g myResourceGroup --source-disk "$osDiskId" --name osDisk-backup
+az snapshot create -g myResourceGroup --source "$osDiskId" --name osDisk-backup
 ```
 
 The output should look something like:


### PR DESCRIPTION
…by "--source"

When testing, received error from CLI, see below. Fixed by using "--source" instead of "--source-disk"

az snapshot create: error: unrecognized argument: --source-disk /subscriptions/*****/resourceGroups/*****/providers/Microsoft.Compute/disks/osdisk_*****
usage: az snapshot create [-h] [--output {json,tsv,list,table,jsonc}]
                          [--verbose] [--debug] [--query JMESPATH]
                          [--sku {Premium_LRS,Standard_LRS}] --resource-group
                          RESOURCE_GROUP_NAME [--size-gb SIZE_GB]