### PR TITLE
Possible double-quotes in $packageUri

### DIFF
--- a/articles/app-service-web/app-service-vnet-integration-powershell.md
+++ b/articles/app-service-web/app-service-vnet-integration-powershell.md
@@ -335,6 +335,12 @@ Copy the following script and save it to a file. If you don’t want to use the 
 
         Write-Host "Retrieving VPN Package and supplying to App"
         $packageUri = Get-AzureRmVpnClientPackage -ResourceGroupName $resourceGroupName -VirtualNetworkGatewayName $vnetGatewayName -ProcessorArchitecture Amd64
+        
+        # $packageUri may contain literal double-quotes at the start and the end of the URL
+        if($packageUri.Length -gt 0 -and $packageUri.Substring(0, 1) -eq '"' -and $packageUri.Substring($packageUri.Length - 1, 1) -eq '"')
+        {
+            $packageUri = $packageUri.Substring(1, $packageUri.Length - 2)
+        }
 
         # Put the VPN client configuration package onto the App
         $PropertiesObject = @{
@@ -514,6 +520,12 @@ Copy the following script and save it to a file. If you don’t want to use the 
         # Now finish joining by getting the VPN package and giving it to the App
         Write-Host "Retrieving VPN Package and supplying to App"
         $packageUri = Get-AzureRmVpnClientPackage -ResourceGroupName $vnet.ResourceGroupName -VirtualNetworkGatewayName $gateway.Name -ProcessorArchitecture Amd64
+        
+        # $packageUri may contain literal double-quotes at the start and the end of the URL
+        if($packageUri.Length -gt 0 -and $packageUri.Substring(0, 1) -eq '"' -and $packageUri.Substring($packageUri.Length - 1, 1) -eq '"')
+        {
+            $packageUri = $packageUri.Substring(1, $packageUri.Length - 2)
+        }
 
         # Put the VPN client configuration package onto the App
         $PropertiesObject = @{


### PR DESCRIPTION
While using this article to integrate Existing Web Apps to VNETs in Azure Government, we have noticed that the Get-AzureRmVpnClientPackage cmdlet was returning a URL with literal double-quotes at the beginning and the end of the URL string. This caused the New-AzureRmResource to save the gateway configuration with a blank package Uri. Hence the change proposed tries to address identifying if the URL returned contains a literal double-quote at the beginning and the end of the URL and strips these double-quotes off before calling New-AzureRmResource.