### PR TITLE
Fixes a sample that was causing deadlocks

### DIFF
--- a/articles/key-vault/key-vault-use-from-web-application.md
+++ b/articles/key-vault/key-vault-use-from-web-application.md
@@ -110,10 +110,10 @@ Now we need code to call the Key Vault API and retrieve the secret. The followin
     // I put my GetToken method in a Utils class. Change for wherever you placed your method.
     var kv = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(Utils.GetToken));
 
-    var sec = kv.GetSecretAsync(WebConfigurationManager.AppSettings["SecretUri"]).Result.Value;
+    var sec = await kv.GetSecretAsync(WebConfigurationManager.AppSettings["SecretUri"]);
 
     //I put a variable in a Utils class to hold the secret for general  application use.
-    Utils.EncryptSecret = sec;
+    Utils.EncryptSecret = sec.Value;
 
 
 


### PR DESCRIPTION
We should never tell users to use .Result. The correct way to call asynchronous methods is with the await keyword.