### PR TITLE
Fixed retry block syntax from { to (

### DIFF
--- a/articles/api-management/api-management-advanced-policies.md
+++ b/articles/api-management/api-management-advanced-policies.md
@@ -333,7 +333,7 @@ This topic provides a reference for the following API Management policies. For i
 ```xml  
   
 <retry  
-    condition="@{context.Response.StatusCode == 500}"  
+    condition="@(context.Response.StatusCode == 500)"  
     count="10"  
     interval="10"  
     max-interval="100"  


### PR DESCRIPTION
The <retry> example block has a curly brace instead of a parenthesis inside the condition statement, which throws an error in API Management.  I fixed this and changed it to parenthesis.