### PR TITLE
Add iothub-explorer reference in iothub-security-devguide

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-security.md
+++ b/articles/iot-hub/iot-hub-devguide-security.md
@@ -220,7 +220,7 @@ The result, which grants access to all functionality for device1, would be:
     SharedAccessSignature sr=myhub.azure-devices.net%2fdevices%2fdevice1&sig=13y8ejUk2z7PLmvtwR5RqlGBOVwiq7rQR3WZ5xZX3N4%3D&se=1456971697
 
 > [!NOTE]
-> It is possible to generate a SAS token using the .NET [device explorer][lnk-device-explorer] tool.
+> It is possible to generate a SAS token using the .NET [device explorer][lnk-device-explorer] tool or the cross-platform, node-based [iothub-explorer][lnk-iothub-explorer] command-line utility.
 > 
 > 
 
@@ -429,6 +429,7 @@ If you would like to try out some of the concepts described in this article, you
 [lnk-service-sdk]: https://github.com/Azure/azure-iot-sdk-csharp/tree/master/service
 [lnk-client-sdk]: https://github.com/Azure/azure-iot-sdk-csharp/tree/master/device
 [lnk-device-explorer]: https://github.com/Azure/azure-iot-sdk-csharp/blob/master/tools/DeviceExplorer
+[lnk-iothub-explorer]: https://github.com/azure/iothub-explorer
 
 [lnk-getstarted-tutorial]: iot-hub-csharp-csharp-getstarted.md
 [lnk-c2d-tutorial]: iot-hub-csharp-csharp-c2d.md


### PR DESCRIPTION
The iothub-security-devguide only references the .NET based tool DeviceExplorer. It's worth pointing out that iothub-explorer, which is cross-platform also allows generating SAS tokens for devices.