### PR TITLE
Fix table formatting

### DIFF
--- a/articles/devtest-lab/devtest-lab-artifact-author.md
+++ b/articles/devtest-lab/devtest-lab-artifact-author.md
@@ -72,7 +72,7 @@ You define parameters will the following structure.
 | Element name | Required? | Description |
 | --- | --- | --- |
 | type |Yes |Type of parameter value. See the list below for the allowed types: |
-| displayName    Yes |Name of the parameter that is displayed to a user in the lab. | |
+| displayName |Yes |Name of the parameter that is displayed to a user in the lab. | |
 | description |Yes |Description of the parameter that is displayed in the lab. |
 
 The allowed types are:


### PR DESCRIPTION
The 'Artifact parameters' section contained a malformed table.