### PR TITLE
Should NOT deploy insecure .NET 4

### DIFF
--- a/articles/log-analytics/log-analytics-ad-assessment.md
+++ b/articles/log-analytics/log-analytics-ad-assessment.md
@@ -35,7 +35,7 @@ After you've added the solution and an assessment is completed, summary informat
 Use the following information to install and configure the solutions.
 
 * Agents must be installed on domain controllers that are members of the domain to be evaluated.
-* The Active Directory Assessment solution requires .NET Framework 4 installed on each computer that has an OMS agent.
+* The Active Directory Assessment solution requires a supported version of .NET Framework 4 (4.5.2 or above) installed on each computer that has an OMS agent.
 * Add the Active Directory Assessment solution to your OMS workspace using the process described in [Add Log Analytics solutions from the Solutions Gallery](log-analytics-add-solutions.md).  There is no further configuration required.
 
   > [!NOTE]


### PR DESCRIPTION
Someone was blogging about how you should install .NET Framework 4.0 Full to get this to work. That's been end of life / unsupported / insecure for over a year. Clarified you need a supported version (4.5.2 or above).