### PR TITLE
Update documentdb-time-to-live.md

### DIFF
--- a/articles/documentdb/documentdb-time-to-live.md
+++ b/articles/documentdb/documentdb-time-to-live.md
@@ -70,7 +70,7 @@ You are able to configure a default time to live at a collection level. To set t
     DocumentCollection collectionDefinition = new DocumentCollection();
     collectionDefinition.Id = "orders";
     collectionDefinition.PartitionKey.Paths.Add("/customerId");
-    collectionDefinition.DefaultTimeToLive = 90 * 60 * 24; // expire all documents after 90 days
+    collectionDefinition.DefaultTimeToLive = 90 * 60 * 60 * 24; // expire all documents after 90 days
     
     DocumentCollection ttlEnabledCollection = await client.CreateDocumentCollectionAsync(
         "/dbs/salesdb",


### PR DESCRIPTION
Fixed calculation of 90 days, which was missing the "seconds" multiply