### PR TITLE
Update virtual-networks-name-resolution-ddns.md

### DIFF
--- a/articles/virtual-network/virtual-networks-name-resolution-ddns.md
+++ b/articles/virtual-network/virtual-networks-name-resolution-ddns.md
@@ -54,9 +54,6 @@ You can use the hooks that are provided by the DHCP client to create and maintai
               nsupdate $nsupdatecmds
         fi
 
-        #done
-        exit 0;
-
 You can also use the *nsupdate* command to perform secure Dynamic DNS updates. For example, when you're using a Bind DNS server, a public-private key pair is [generated](http://linux.yyz.us/nsupdate/).  The DNS server is [configured](http://linux.yyz.us/dns/ddns-server.html) with the public part of the key so that it can verify the signature on the request. You must use the *-k* option to provide the key-pair to *nsupdate* in order for the Dynamic DNS update request to be signed.
 
 When you're using a Windows DNS server, you can use Kerberos authentication with the *-g* parameter in *nsupdate* (not available in the Windows version of *nsupdate*). To do this, use *kinit* to load the credentials (e.g. from a [keytab file](http://www.itadmintools.com/2011/07/creating-kerberos-keytab-files.html)). Then *nsupdate -g* will pick up the credentials from the cache.


### PR DESCRIPTION
Removing the exit 0 from the end of the script because it kills the dhcp client and locks VM out of network.