### PR TITLE
Fixed New-AzureServicePrincipal.ps1 sample script

### DIFF
--- a/articles/automation/automation-sec-configure-azure-runas-account.md
+++ b/articles/automation/automation-sec-configure-azure-runas-account.md
@@ -192,9 +192,7 @@ The steps below will walk you through the process of executing the script.
         $KeyCredential.StartDate = $CurrentDate
         $KeyCredential.EndDate= $EndDate
         $KeyCredential.KeyId = $KeyId
-        $KeyCredential.Type = "AsymmetricX509Cert"
-        $KeyCredential.Usage = "Verify"
-        $KeyCredential.Value = $KeyValue
+        $KeyCredential.CertValue = $KeyValue
    
         # Use Key credentials
         $Application = New-AzureRmADApplication -DisplayName $ApplicationDisplayName -HomePage ("http://" + $ApplicationDisplayName) -IdentifierUris ("http://" + $KeyId) -KeyCredentials $keyCredential


### PR DESCRIPTION
the sample script that creates the Azure RunAs connection does not work anymore. The PSADKeyCredential object properties have been changed few months ago when AzureRM.Resource module was updated to v3.0.1. The sample script New-AzureServicePrincipal.ps1 needs to be updated to reflect the change:
$KeyCredential = New-Object  -TypeName Microsoft.Azure.Commands.Resources.Models.ActiveDirectory.PSADKeyCredential
$KeyCredential.StartDate = $CurrentDate
$KeyCredential.EndDate = $EndDate
$KeyCredential.KeyId = $KeyId
$KeyCredential.CertValue = $KeyValue