### PR TITLE
Fix load balancer setup example error

### DIFF
--- a/articles/load-balancer/load-balancer-get-started-internet-arm-cli.md
+++ b/articles/load-balancer/load-balancer-get-started-internet-arm-cli.md
@@ -128,7 +128,7 @@ This example creates the following items.
 2. Create a load balancer rule.
 
     ```azurecli
-        azure network lb rule create --resource-group nrprg nrplb --lb-name lbrule --protocol tcp --frontend-port 80 --backend-port 80 --frontend-ip-name NRPfrontendpool --backend-address-pool-name NRPbackendpool
+        azure network lb rule create --resource-group nrprg --lb-name nrplb --name lbrule --protocol tcp --frontend-port 80 --backend-port 80 --frontend-ip-name NRPfrontendpool --backend-address-pool-name NRPbackendpool
     ```
 
 3. Create a health probe.


### PR DESCRIPTION
The value of `--lb-name` was misplaced in front of the option, where `lbrule` should be placed after another option `--name`.