### PR TITLE
Adding missing quotes

### DIFF
--- a/articles/virtual-network/virtual-network-multiple-ip-addresses-powershell.md
+++ b/articles/virtual-network/virtual-network-multiple-ip-addresses-powershell.md
@@ -86,7 +86,7 @@ The steps that follow explain how to create an example VM with multiple IP addre
 	
 	```powershell
 	$IpConfigName2 = "IPConfig-2"
-	$IPAddress     = 10.0.0.5
+	$IPAddress     = "10.0.0.5"
 	$myPublicIp2   = New-AzureRmPublicIpAddress -Name "myPublicIp2" -ResourceGroupName $myResourceGroup `
 	-Location $location -AllocationMethod Static
 	$IpConfig2     = New-AzureRmNetworkInterfaceIpConfig -Name $IpConfigName2 `


### PR DESCRIPTION
There are missing quotes when assigning the static IP address for IP Configurations 2.