### PR TITLE
Doc improvements

### DIFF
--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -155,13 +155,13 @@ kubectl get pods
 Using your pod name, you can run a remote command on your pod.  For example:
 
 ```console
-kubectl exec nginx-701339712-retbj date
+kubectl exec <pod name> date
 ```
 
 You can also get a fully interactive session using the `-it` flags:
 
 ```console
-kubectl exec nginx-701339712-retbj -it bash
+kubectl exec <pod name> -it bash
 ```
 
 ![Remote session inside a container](media/container-service-kubernetes-walkthrough/kubernetes-remote.png)

--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -79,7 +79,7 @@ az acs kubernetes install-cli
 Once `kubectl` is installed, run the following command to download the master Kubernetes cluster configuration to the ~/.kube/config file:
 
 ```console
-az acs kubernetes get-credentials --resource-group=$RESOURCE_GROUP --name=$SERVICE_NAME
+az acs kubernetes get-credentials --resource-group=$RESOURCE_GROUP --name=$CLUSTER_NAME
 ```
 
 At this point you should be ready to access your cluster from your machine. Try running:

--- a/articles/container-service/container-service-kubernetes-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-walkthrough.md
@@ -140,7 +140,7 @@ To see the Kubernetes web interface, you can use:
 ```console
 kubectl proxy
 ```
-This runs a simple authenticated proxy on localhost, which you can use to view the [Kubernetes web UI](http://localhost:8001/ui). For more information, see [Using the Kubernetes web UI with Azure Container Service](container-service-kubernetes-ui.md).
+This runs a simple authenticated proxy on localhost, which you can use to view the Kubernetes web UI running on [http://localhost:8001/ui](http://localhost:8001/ui). For more information, see [Using the Kubernetes web UI with Azure Container Service](container-service-kubernetes-ui.md).
 
 ![Image of Kubernetes dashboard](media/container-service-kubernetes-walkthrough/kubernetes-dashboard.png)
 


### PR DESCRIPTION
First of all, I have to say great job. This document was super easy to follow and got me started with a Kubernetes cluster fast.

I made some minor changes that I got stuck on while I was going through the instructions. Feel free to reject or cherry pick them as you see fit.

There are three other things that I wanted your input on:
1. Is there a way to give the path to the public/private key pair?

2. What if my private key `id_rsa` is encrypted? Is there a way for the Azure-Cli to ask for the password to the private key?
I ended up decrypting my private key using `openssl rsa -in enc_id_rsa -out id_rsa` command.

3. By default there is no `watch` command on macOS. We should either have the users to install it using `brew install watch` or just give them a heads up that that's the case. They can then keep running the `kubectl get svc` command till the `pending` status resolves to an ip address