### PR TITLE
Remove SAML 2.0 as option

### DIFF
--- a/articles/active-directory/develop/active-directory-devhowto-appsource-certified.md
+++ b/articles/active-directory/develop/active-directory-devhowto-appsource-certified.md
@@ -18,7 +18,7 @@ ms.author: skwan;bryanla
 
 ---
 # How to get AppSource Certified for Azure Active Directory (AD)
-To receive AppSource certification for Azure AD, your application must implement the multi-tenant sign in pattern with Azure AD using the OpenID Connect, OAuth 2.0, or SAML 2.0 protocols. 
+To receive AppSource certification for Azure AD, your application must implement the multi-tenant sign in pattern with Azure AD using the OpenID Connect or OAuth 2.0 protocols. 
 
 If you’re not familiar with Azure AD sign-in or multi-tenant application development:
 


### PR DESCRIPTION
Using the usual Azure AD custom app integration path with SAML 2.0 does not work with AppSource because it requires admin intervention.  All AppSource apps need to be user-consentable.  User consent with SAML 2.0 is possible but we do not have published guidance today on how to do it.  Removing SAML 2.0 as an option until we have that guidance published.