### PR TITLE
Fix css issue

### DIFF
--- a/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
+++ b/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
@@ -171,7 +171,7 @@ Apps can be applied to **SendGrid** email messages using methods implemented as 
 The following examples demonstrate the footer and click tracking
 filters:
 
-### Footer
+### Footer settings
     msg.SetFooterSetting(
                          true,
                          "Some Footer HTML",


### PR DESCRIPTION
Using Footer creates an id=footer value which causes a black box to be
placed around the word Footer