### PR TITLE
Removes superfluous commas from the REST sample

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-deploy-rest.md
+++ b/articles/azure-resource-manager/resource-group-template-deploy-rest.md
@@ -61,12 +61,12 @@ Your template can be either a local file or an external file that is available t
             "properties": {
               "templateLink": {
                 "uri": "http://mystorageaccount.blob.core.windows.net/templates/template.json",
-                "contentVersion": "1.0.0.0",
+                "contentVersion": "1.0.0.0"
               },
               "mode": "Incremental",
               "parametersLink": {
                 "uri": "http://mystorageaccount.blob.core.windows.net/templates/parameters.json",
-                "contentVersion": "1.0.0.0",
+                "contentVersion": "1.0.0.0"
               }
             }
           }


### PR DESCRIPTION
The demonstration PUT body has superfluous commas before two '}' which presents as errors when the content is used in Postman and when run through a JSON linter.