### PR TITLE
no azure.mgmt.datalake.store.account module

### DIFF
--- a/articles/data-lake-analytics/data-lake-analytics-get-started-python.md
+++ b/articles/data-lake-analytics/data-lake-analytics-get-started-python.md
@@ -63,8 +63,8 @@ The azure-datalake-store module includes the Azure Data Lake Store filesystem op
 		from azure.mgmt.resource.resources.models import ResourceGroup
 
 		## Required for Azure Data Lake Store account management
-		from azure.mgmt.datalake.store.account import DataLakeStoreAccountManagementClient
-		from azure.mgmt.datalake.store.account.models import DataLakeStoreAccount
+		from azure.mgmt.datalake.store import DataLakeStoreAccountManagementClient
+		from azure.mgmt.datalake.store.models import DataLakeStoreAccount
 
 		## Required for Azure Data Lake Store filesystem management
 		from azure.datalake.store import core, lib, multithread


### PR DESCRIPTION
no `azure.mgmt.datalake.store.account` and `azure.mgmt.datalake.store.account.models` module, the folder structure in SDK repository has changed to `azure.mgmt.datalake.store` and  `azure.mgmt.datalake.store.models`