### PR TITLE
Skype for Business iOS is now supported

### DIFF
--- a/articles/active-directory/active-directory-certificate-based-authentication-ios.md
+++ b/articles/active-directory/active-directory-certificate-based-authentication-ios.md
@@ -41,7 +41,7 @@ This feature is available in preview in Office 365 US Government Defense and Fed
 | OneDrive |![Check][1] |
 | Outlook |![Check][1] |
 | Yammer |![Check][1] |
-| Skype for Business |Coming soon |
+| Skype for Business |![Check][1] |
 
 ## Requirements 
 


### PR DESCRIPTION
I've checked support for SfB iOS. This is supported as of 6.11 but was mentioned in 6.12.
[https://itunes.apple.com/us/app/skype-for-business-formerly-lync-2013/id605841731?mt=8](url)