### PR TITLE
Code example attempts to initialize the list within a list and fails …

### DIFF
--- a/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
+++ b/articles/app-service-web/sendgrid-dotnet-how-to-send-email.md
@@ -89,9 +89,9 @@ The following example demonstrates how to create a fully populated email object:
 
     var recipients = new List<EmailAddress>
     {
-        new EmailAddress(){ "jeff@example.com", "Jeff Smith" },
-        new EmailAddress(){ "anna@example.com", "Anna Lidman" },
-        new EmailAddress(){ "peter@example.com", "Peter Saddow" }
+        new EmailAddress("jeff@example.com", "Jeff Smith"),
+        new EmailAddress("anna@example.com", "Anna Lidman"),
+        new EmailAddress("peter@example.com", "Peter Saddow")
     };
     msg.AddTos(recipients);
 


### PR DESCRIPTION
…with 'cannot initialize type EmailAddress with a collection initializer'

code attempts to build a collection within a collection. putting the address/name value pairs in parenthesis works fine.