### PR TITLE
Update IoTHub X.509 client certificate documentation

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-security.md
+++ b/articles/iot-hub/iot-hub-devguide-security.md
@@ -329,7 +329,7 @@ The [Azure IoT device SDK for .NET][lnk-client-sdk] (version 1.0.11+) supports t
 
 ### C\# Support
 The class **DeviceAuthenticationWithX509Certificate** supports the creation of 
- **DeviceClient** instances using an X.509 certificate.
+ **DeviceClient** instances using an X.509 certificate. The X.509 certificate must be in the PFX (also called PKCS #12) format which includes the private key. 
 
 Here is a sample code snippet:
 


### PR DESCRIPTION
Update X.509 client certificate documentation to reflect the fact the device client needs to provided teh X.509 client cert in the PFX format containing the private key as well.