### PR TITLE
Wrong Step 2 in "Create a Virtual Network and a subnet for the applic…

### DIFF
--- a/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
+++ b/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
@@ -110,7 +110,7 @@ $appgatewaysubnet = New-AzureRmVirtualNetworkSubnetConfig -Name apim01 -AddressP
 Assign the address range 10.0.1.0/24 to the subnet variable to be used for API Management while creating a Virtual Network.
 
 ```powershell
-$apimsubnet = New-AzureRmVirtualNetworkSubnetConfig -Name apim01 -AddressPrefix 10.0.1.0/24
+$apimsubnet = New-AzureRmVirtualNetworkSubnetConfig -Name apim02 -AddressPrefix 10.0.1.0/24
 ```
 
 ### Step 3


### PR DESCRIPTION
…ation gateway"

Wrong line: 
$apimsubnet = New-AzureRmVirtualNetworkSubnetConfig -Name apim01 -AddressPrefix 10.0.1.0/24

Subnet name must be unique. 

The name apim01 is already used in Step 1 in "Create a Virtual Network and a subnet for the application gateway"

It cause run-time error in PowerShell console.