### PR TITLE
Change suggested PS module import command

### DIFF
--- a/articles/virtual-machines/virtual-machines-windows-aws-to-azure.md
+++ b/articles/virtual-machines/virtual-machines-windows-aws-to-azure.md
@@ -31,7 +31,7 @@ Before uploading any VHD to Azure, you should follow [Prepare a Windows VHD or V
 If you use PowerShell, make sure that you have the latest version of the AzureRM.Compute PowerShell module. Run the following command to install it.
 
 ```powershell
-Install-Module AzureRM.Compute -RequiredVersion 2.6.0
+Install-Module AzureRM.Compute -MinimumVersion 2.6.0
 ```
 For more information, see [Azure PowerShell Versioning](https://docs.microsoft.com/powershell/azureps-cmdlets-docs/#azure-powershell-versioning).
 


### PR DESCRIPTION
The suggested import-module command can break when a subsequent module version comes out (e.g., 2.7.0).  Forcing a load of 2.6.0 is overly specific. Instead, we should suggest the -MinimumVersion option as the user really needs 2.6.0 or higher.

selliott@microsoft.com