### PR TITLE
Fixing Documentation Bug - Adding newline before the URLs for Azure G…

### DIFF
--- a/includes/site-recovery-URLS.md
+++ b/includes/site-recovery-URLS.md
@@ -1,5 +1,6 @@
 ``*.accesscontrol.windows.net``: Used for access control and identity management<br/><br/>``\*.backup.windowsazure.com``: Used for replication data transfer and orchestration <br/><br/> ``\*.blob.core.windows.net``: Used for access to the storage account that stores replicated data<br/><br/> ``\*.hypervrecoverymanager.windowsazure.com``: Used for replication management operations and orchestration<br.><br/>
-``time.nist.gov`` and ``time.windows.com``: Used to check time synchronization between system and global time
+``time.nist.gov`` and ``time.windows.com``: Used to check time synchronization between system and global time.
+<br/><br/>
 
 URLs for Azure Government Cloud:
 


### PR DESCRIPTION
…overnment Cloud which is causing confusions in the main article

This is causing issues when included in the main article. The resulting text is confusing and changes the semantics. It seems a continuation of the text of the previous sentence. Check the URLs section in Prerequisites section in below article here: https://docs.microsoft.com/en-us/azure/site-recovery/site-recovery-vmm-to-vmm