### PR TITLE
WebJobs AccessRights Warning

### DIFF
--- a/articles/app-service-web/websites-dotnet-webjobs-sdk-service-bus.md
+++ b/articles/app-service-web/websites-dotnet-webjobs-sdk-service-bus.md
@@ -151,7 +151,7 @@ The following features were added in release 1.1:
 * A `MessageProcessor` strategy pattern allows you to specify a processor per queue/topic.
 * Message processing concurrency is supported by default. 
 * Easy customization of `OnMessageOptions` via `ServiceBusConfiguration.MessageOptions`.
-* Allow [AccessRights](https://github.com/Azure/azure-webjobs-sdk-samples/blob/master/BasicSamples/ServiceBus/Functions.cs#L71) to be specified on `ServiceBusTriggerAttribute`/`ServiceBusAttribute` (for scenarios where you might not have Manage rights). 
+* Allow [AccessRights](https://github.com/Azure/azure-webjobs-sdk-samples/blob/master/BasicSamples/ServiceBus/Functions.cs#L71) to be specified on `ServiceBusTriggerAttribute`/`ServiceBusAttribute` (for scenarios where you might not have Manage rights). Note that Azure WebJobs is unable to automatically provision non-existent queues and topics without Manage AccessRights.
 
 ## <a id="queues"></a>Related topics covered by the storage queues how-to article
 For information about WebJobs SDK scenarios not specific to Service Bus, see [How to use Azure queue storage with the WebJobs SDK](websites-dotnet-webjobs-sdk-storage-queues-how-to.md). 


### PR DESCRIPTION
Add information warning that webjobs is unable to provision queues/topics if it does not have Manage AccessRights.