### PR TITLE
Fixed description of how ARM template expressions work

### DIFF
--- a/articles/azure-resource-manager/resource-group-authoring-templates.md
+++ b/articles/azure-resource-manager/resource-group-authoring-templates.md
@@ -52,7 +52,7 @@ In its simplest structure, a template contains the following elements:
 We examine the sections of the template in greater detail later in this topic.
 
 ## Expressions and functions
-The basic syntax of the template is JSON. However, expressions and functions extend the JSON that is available in the template. With expressions, you create values that are not strict literal values. Expressions are enclosed with brackets `[` and `]`, and are evaluated when the template is deployed. Expressions can appear anywhere in a JSON string value and always return another JSON value. If you need to use a literal string that starts with a bracket `[`, you must use two brackets `[[`.
+The basic syntax of the template is JSON. However, expressions and functions extend the JSON values available within the template.  Expressions are written within JSON string literals whose first and last characters are the brackets: `[` and `]`, respectively. The value of the expression is evaluated when the template is deployed.   While written as a string literal, the result of evaluating the expression can be of a different JSON type, such as an array or integer, depending on the actual expression.  Note that to have a literal string starting with a bracket `[`, but not have it interpreted as an expression, add an extra bracket to start the string with `[[`.
 
 Typically, you use expressions with functions to perform operations for configuring the deployment. Just like in JavaScript, function calls are formatted as **functionName(arg1,arg2,arg3)**. You reference properties by using the dot and [index] operators.
 


### PR DESCRIPTION
Removed text indicating that `[ ]` expressions can occur anywhere within a string literal.  In fact, the first character of the string must be the opening bracket.   In reality, that must also be followed by the name of a built-in function, but that would be confusing at this point in the doc.   Also reworded the paragraph for clarify.

There should ultimately be further text added to clarify that template expressions are only evaluated in literals occurring on the "value" side of key/value entries.  For example, you can't say
```json  
       "[variables('myKeyName')]" : "some value" 
```
because ARM template processing doesn't look for expressions on the left-hand-side.

selliott@microsoft.com