### PR TITLE
updated production environment instructions

### DIFF
--- a/articles/container-service/container-service-setup-ci-cd.md
+++ b/articles/container-service/container-service-setup-ci-cd.md
@@ -284,6 +284,7 @@ If you open the build definition in VSTS, you'll see something like this:
 	```
 
 	* For the label value, you can either specify the URL of your ACS agent's fully qualified domain name (FQDN), or a custom domain (for example, app.contoso.com). To find your ACS agent's FQDN, run the command `az acs list`, and check the property for `agentPoolProfiles.fqdn`. For example, `myacsagents.westus.cloudapp.azure.com`.
+	* The sample app by default is listening on port 80, for those who have their docker applications listening on other ports, for instance `port 8080` or `443`, attach the port number to the FQDN. For example, `myacsagents.westus.cloudapp.azure.com:8080`. However when you try to access the application from outside, you will need to query it at port 80.
 	* By following the filename convention docker-compose.env.*environment-name*.yml, these settings only affect the named environment (in this case, the environment named *Production*). Inspect the release definition in VSTS, each environment's deployment task is set up to read from a docker-compose file named after this convention.
 
 1. Commit and push the file to your master source repository to start another build.


### PR DESCRIPTION
docker containers listening on ports other than `port 80` need to specify that in the vhost label as `myacsagents.westus.cloudapp.azure.com:8080`.