### PR TITLE
Update resource-manager-tag-resources.md

### DIFF
--- a/includes/resource-manager-tag-resources.md
+++ b/includes/resource-manager-tag-resources.md
@@ -7,7 +7,7 @@
 3. To add a tag, type a key and value, or select an existing one from the dropdown menu. Select **Save**.
 
      ![Add new tag](./media/resource-manager-tag-resources/tag-resources.png)
-3. To view all the resources with a tag value, select **>** (More services), and filter by **Tags**. Select **Tags** from the available options.
+3. To view all the resources with a tag value, select **>** (More services), and enter the word **Tags** into the filter text box. Select **Tags** from the available options.
    
      ![Find tags via the Browse hub](./media/resource-manager-tag-resources/browse-tags.png)
 4. You see a summary of the tags in your subscriptions.


### PR DESCRIPTION
Made a minor change to the wording of step 4: "To view all the resources with a tag value". The existing phrase "filter by Tags" is confusing, as there is a filter drop down next to the text box with the choices "by category" and "by name". But the instructions are not to use the filter drop-down, but to enter the word "tags" into the text box.