### PR TITLE
Update insights-how-to-scale.md

### DIFF
--- a/articles/monitoring-and-diagnostics/insights-how-to-scale.md
+++ b/articles/monitoring-and-diagnostics/insights-how-to-scale.md
@@ -30,11 +30,9 @@ You can scale in the portal, and you can also use the [REST API](https://msdn.mi
 > 
 
 ## Scaling manually
-1. In the [Azure Portal](https://portal.azure.com/), click **Browse**, then navigate to the resource you want to scale, such as a **App Service plan**.
-2. The **Scale** tile in **Operations** will tell you the status of scaling: **Off** for when you are scaling manually, **On** for when you are scaling by one or more performance metrics.
-   
-    ![Scale tile](./media/insights-how-to-scale/Insights_UsageLens.png)
-3. Clicking on the tile will take you to the **Scale** blade. At the top of the scale blade you can see a history of autoscale actions the service.
+1. In the [Azure Portal](https://portal.azure.com/), click **Browse**, then navigate to the resource you want to scale, such as an **App Service plan**.
+2. Click **Settings > Scale out (App Service plan).**
+3. At the top of the **Scale** blade you can see a history of autoscale actions of the service.
    
     ![Scale blade](./media/insights-how-to-scale/Insights_ScaleBladeDayZero.png)
    


### PR DESCRIPTION
Step 2 of "Scaling Manually" originally referred to the "Scale tile in Operations". However, it is unclear what "operations" is a reference to. Also, there is no "scale tile" by default in an App Service Plan. Instructions were modified so that users can navigate to the feature without having certain tiles configured. Also, two grammatical changes.