### PR TITLE
Update app-service-web-arm-from-github-provision.md

### DIFF
--- a/articles/app-service-web/app-service-web-arm-from-github-provision.md
+++ b/articles/app-service-web/app-service-web-arm-from-github-provision.md
@@ -100,7 +100,7 @@ Instead of hard-coding the repository URL, you can add a parameter for the repos
 [!INCLUDE [app-service-deploy-commands](../../includes/app-service-deploy-commands.md)]
 
 ### PowerShell
-    New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-web-app-github-deploy/azuredeploy.json -siteName ExampleSite -hostingPlanName ExamplePlan -siteLocation "West US" -ResourceGroupName ExampleDeployGroup
+    New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-web-app-github-deploy/azuredeploy.json -siteName ExampleSite -hostingPlanName ExamplePlan -ResourceGroupName ExampleDeployGroup
 
 ### Azure CLI
 


### PR DESCRIPTION
removed sitelocation from the powershell command, as that is not supported in the provided JSON file and will cause the command to throw an exception.