### PR TITLE
Changing "Docker container" to "Linux container"

### DIFF
--- a/articles/service-fabric/service-fabric-deploy-container-linux.md
+++ b/articles/service-fabric/service-fabric-deploy-container-linux.md
@@ -1,6 +1,6 @@
 ---
 title: Service Fabric and Deploying Containers in Linux | Microsoft Docs
-description: Service Fabric and the use of Docker containers to deploy microservice applications. This article describes the capabilities that Service Fabric provides for containers and how to deploy a Docker container image into a cluster
+description: Service Fabric and the use of Linux containers to deploy microservice applications. This article describes the capabilities that Service Fabric provides for containers and how to deploy a Linux container image into a cluster
 services: service-fabric
 documentationcenter: .net
 author: msfussell
@@ -17,10 +17,10 @@ ms.date: 2/16/2017
 ms.author: msfussell
 
 ---
-# Deploy a Docker container to Service Fabric
+# Deploy a Linux container to Service Fabric
 > [!div class="op_single_selector"]
 > * [Deploy Windows Container](service-fabric-deploy-container.md)
-> * [Deploy Docker Container](service-fabric-deploy-container-linux.md)
+> * [Deploy Linux Container](service-fabric-deploy-container-linux.md)
 >
 >
 


### PR DESCRIPTION
Since Windows Containers are also Docker-compatible, as are these Linux Containers, it would be more consistent if they are separated by Windows and Linux