### PR TITLE
Update resource-group-move-resources.md

### DIFF
--- a/articles/azure-resource-manager/resource-group-move-resources.md
+++ b/articles/azure-resource-manager/resource-group-move-resources.md
@@ -134,9 +134,15 @@ The services that currently do not enable moving a resource are:
 * Security
 * Virtual Machines with certificate stored in Key Vault
 * Virtual Machines with Managed Disks
+* Availability sets with Virtual Machines with Managed Disks
+* Virtual Machine Scale Sets with Managed Disks
+* Managed Disks
+* Images created from Managed Disks
+* Snapshots created from Managed Disks
 * Virtual Machines Scale Sets
 * Virtual Networks (classic) - see [Classic deployment limitations](#classic-deployment-limitations)
 * VPN Gateway
+* Virtual Machines created from Marketplace resources - cannot be moved across subscriptions. Resource needs to be deprovisioned in the current subscription and deployed again in the new subscription
 
 ## App Service limitations
 When working with App Service apps, you cannot move only an App Service plan. To move App Service apps, your options are:


### PR DESCRIPTION
got the following from Vikram (PM on Managed Disks):

Please note that none of these resources can be moved across RGs either within the same subscription or different subscription:
•VMs with managed disk
•Availability sets with VMs with managed disks
•VM Scale Sets with managed disks
•Images
•Disks
•Snapshots

and that from Sean Zimmerman (PM on Marketplace)

Due to downstream limitations 3rd party resources cannot be moved across subscriptions.  The resource will need to be deprovisioned in the current subscription and deployed again in the new subscription.