### PR TITLE
Update active-directory-aadconnectsync-feature-prevent-accidental-del…

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnectsync-feature-prevent-accidental-deletes.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-feature-prevent-accidental-deletes.md
@@ -54,10 +54,11 @@ If this was unexpected, then investigate and take corrective actions. To see whi
 
 If all the deletes are desired, then do the following:
 
-1. To temporarily disable this protection and let those deletes go through, run the PowerShell cmdlet: `Disable-ADSyncExportDeletionThreshold`. Provide an Azure AD Global Administrator account and password.
+1. To retrieve the current deletion threshold, run the PowerShell cmdlet `Get-ADSyncExportDeletionThreshold`. Provide an Azure AD Global Administrator account and password. The default value is 500.
+2. To temporarily disable this protection and let those deletes go through, run the PowerShell cmdlet: `Disable-ADSyncExportDeletionThreshold`. Provide an Azure AD Global Administrator account and password.
    ![Credentials](./media/active-directory-aadconnectsync-feature-prevent-accidental-deletes/credentials.png)
-2. With the Azure Active Directory Connector still selected, select the action **Run** and select **Export**.
-3. To re-enable the protection, run the PowerShell cmdlet: `Enable-ADSyncExportDeletionThreshold`.
+3. With the Azure Active Directory Connector still selected, select the action **Run** and select **Export**.
+4. To re-enable the protection, run the PowerShell cmdlet: `Enable-ADSyncExportDeletionThreshold -DeletionThreshold 500`. Replace 500 with the value you noticed when retrieving the current deletion threshold. Provide an Azure AD Global Administrator account and password.
 
 ## Next steps
 **Overview topics**


### PR DESCRIPTION
…etes.md

Enable-ADSyncExportDeletionThreshold can be executed without parameters, but it will prompt for the DeletionThreshold to be set anyhow. So I added some steps to retrieve the current value + properly set it.