### PR TITLE
Clarify default route breaks public comms for vnet

### DIFF
--- a/includes/vpn-gateway-bpg-faq-include.md
+++ b/includes/vpn-gateway-bpg-faq-include.md
@@ -28,7 +28,7 @@ Azure VPN gateway will advertise the following routes to your on-premises BGP de
 ### Can I advertise default route (0.0.0.0/0) to Azure VPN gateways?
 Yes.
 
-Please note this will force all VNet traffic towards your on-premises VPN network and will prevent public communication to the resources in your VNet, such as Virtual Machines, on their Azure public IP addresses.
+Please note this will force all VNet egress traffic towards your on-premises site, and will prevent the VNet VMs from accepting public communication from the Internet directly, such RDP or SSH from the Internet to the VMs.
 
 ### Can I advertise the exact prefixes as my Virtual Network prefixes?
 

--- a/includes/vpn-gateway-bpg-faq-include.md
+++ b/includes/vpn-gateway-bpg-faq-include.md
@@ -28,6 +28,8 @@ Azure VPN gateway will advertise the following routes to your on-premises BGP de
 ### Can I advertise default route (0.0.0.0/0) to Azure VPN gateways?
 Yes.
 
+Please note this will force all VNet traffic towards your on-premises VPN network and will prevent public communication to the resources in your VNet, such as Virtual Machines, on their Azure public IP addresses.
+
 ### Can I advertise the exact prefixes as my Virtual Network prefixes?
 
 No, advertising the same prefixes as any one of your Virtual Network address prefixes will be blocked or filtered by the Azure platform. However you can advertise a prefix that is a superset of what you have inside your Virtual Network. 


### PR DESCRIPTION
Just had a customer case and we have no clarification about this. I think it would be good to clarify beforehand and avoid customer pain.