### PR TITLE
Fixing few Critical Bugs in the documentation after testing

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-upload-vhd.md
+++ b/articles/virtual-machines/virtual-machines-linux-upload-vhd.md
@@ -222,19 +222,19 @@ az disk create --resource-group myResourceGroup --name myManagedDisk \
   --source https://mystorageaccount.blob.core.windows.net/mydisks/myDisk.vhd
 ```
 
-Obtain the URI of the managed disk you created with [az disk list](/cli/azure/disk/list):
+Obtain the ID of the managed disk you created with [az disk list](/cli/azure/disk/list):
 
 ```azurecli
 az disk list --resource-group myResourceGroup \
-  --query '[].{Name:name,URI:creationData.sourceUri}' --output table
+  --query [].{Name:name,ID:id} --output table
 ```
 
 The output is similar to the following example:
 
 ```azurecli
-Name               URI
+Name               ID
 -----------------  ----------------------------------------------------------------------------------------------------
-myUMDiskFromVHD    https://vhdstoragezw9.blob.core.windows.net/system/Microsoft.Compute/Images/vhds/my_image-osDisk.vhd
+myManagedDisk    /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk
 ```
 
 Now, create your VM with [az vm create](/cli/azure/vm#create) and specify the URI of your managed disk (`--image`). The following example creates a VM named `myVM` using the managed disk created from your uploaded VHD:
@@ -243,7 +243,7 @@ Now, create your VM with [az vm create](/cli/azure/vm#create) and specify the UR
 az vm create --resource-group myResourceGroup --location westus \
     --name myVM --os-type linux \
     --admin-username azureuser --ssh-key-value ~/.ssh/id_rsa.pub \
-    --attach-os-disk https://vhdstoragezw9.blob.core.windows.net/system/Microsoft.Compute/Images/vhds/my_image-osDisk.vhd
+    --attach-os-disk /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk
 ```
 
 ### Azure 2.0 - unmanaged disks


### PR DESCRIPTION
Changing the name in az disk list command to be consistent with "az disk create". 
Also to create a VM with Managed Disks you need to provide the ID. URI works only for Unmanaged Disks. Updating the az disk list and "az vm create" commands to reflect this in the "Azure CLI 2.0 - Azure Managed Disks" section. 
Also, the quotes in the value for --query in "az disk list" command are not correct. Azure CLI provides result only when the single quotes are not provided.