### PR TITLE
attach-os-disk param expects disk name

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-upload-vhd.md
+++ b/articles/virtual-machines/virtual-machines-linux-upload-vhd.md
@@ -91,7 +91,7 @@ Now, create your VM with [az vm create](/cli/azure/vm#create) and specify the UR
 az vm create --resource-group myResourceGroup --location westus \
     --name myVM --os-type linux \
     --admin-username azureuser --ssh-key-value ~/.ssh/id_rsa.pub \
-    --attach-os-disk https://vhdstoragezw9.blob.core.windows.net/system/Microsoft.Compute/Images/vhds/my_image-osDisk.vhd
+    --attach-os-disk myUMDiskFromVHD
 ```
 
 ### Unmanaged disks


### PR DESCRIPTION
When managed disk is used to create a VM --attach-os-disk parameter expects disk name rather than a disk URI. That's been the case for me when I created a VM from existing VHD