### PR TITLE
Changes done to SAS URLs (as applicable to Tables)

### DIFF
--- a/articles/search/search-howto-indexing-azure-tables.md
+++ b/articles/search/search-howto-indexing-azure-tables.md
@@ -58,7 +58,7 @@ You can provide the credentials for the table in one of these ways:
 
 - **Full access storage account connection string**: `DefaultEndpointsProtocol=https;AccountName=<your storage account>;AccountKey=<your account key>`. You can get the connection string from the Azure portal by navigating to the storage account blade > Settings > Keys (for Classic storage accounts) or Settings > Access keys (for Azure Resource Manager storage accounts).
 - **Storage account shared access signature** (SAS) connection string: `TableEndpoint=https://<your account>.table.core.windows.net/;SharedAccessSignature=?sv=2016-05-31&sig=<the signature>&spr=https&se=<the validity end time>&srt=co&ss=t&sp=rl`. The SAS should have the list and read permissions on containers (tables in this case) and objects (table rows).
--  **Table shared access signature**: `TableSharedAccessUri=https://<your storage account>.table.core.windows.net/<table name>?tn=<table name>&sv=2016-05-31&sig=<the signature>&se=<the validity end time>&sp=r`. The SAS should have query (read) permissions on the table.
+-  **Table shared access signature**: `ContainerSharedAccessUri=https://<your storage account>.table.core.windows.net/<table name>?tn=<table name>&sv=2016-05-31&sig=<the signature>&se=<the validity end time>&sp=r`. The SAS should have query (read) permissions on the table.
 
 For more info on storage shared access signatures, see [Using Shared Access Signatures](../storage/storage-dotnet-shared-access-signature-part-1.md).
 

--- a/articles/search/search-howto-indexing-azure-tables.md
+++ b/articles/search/search-howto-indexing-azure-tables.md
@@ -57,8 +57,8 @@ For more on the Create Datasource API, see [Create Datasource](https://msdn.micr
 You can provide the credentials for the table in one of these ways: 
 
 - **Full access storage account connection string**: `DefaultEndpointsProtocol=https;AccountName=<your storage account>;AccountKey=<your account key>`. You can get the connection string from the Azure portal by navigating to the storage account blade > Settings > Keys (for Classic storage accounts) or Settings > Access keys (for Azure Resource Manager storage accounts).
-- **Storage account shared access signature** (SAS) connection string: `TableEndpoint=https://<your account>.table.core.windows.net/;SharedAccessSignature=?sv=2016-05-31&sig=<the signature>&spr=https&se=<the validity end time>&srt=co&ss=b&sp=rl`. The SAS should have the list and read permissions on containers (tables in this case) and objects (table rows).
--  **Table shared access signature**: `ContainerSharedAccessUri=https://<your storage account>.table.core.windows.net/<table name>?sv=2016-05-31&sr=c&sig=<the signature>&se=<the validity end time>&sp=rl`. The SAS should have the list and read permissions on the table.
+- **Storage account shared access signature** (SAS) connection string: `TableEndpoint=https://<your account>.table.core.windows.net/;SharedAccessSignature=?sv=2016-05-31&sig=<the signature>&spr=https&se=<the validity end time>&srt=co&ss=t&sp=rl`. The SAS should have the list and read permissions on containers (tables in this case) and objects (table rows).
+-  **Table shared access signature**: `TableSharedAccessUri=https://<your storage account>.table.core.windows.net/<table name>?tn=<table name>&sv=2016-05-31&sig=<the signature>&se=<the validity end time>&sp=r`. The SAS should have query (read) permissions on the table.
 
 For more info on storage shared access signatures, see [Using Shared Access Signatures](../storage/storage-dotnet-shared-access-signature-part-1.md).
 


### PR DESCRIPTION
In Account SAS, the "ss" should be `t` instead of `b` for tables. In Table SAS, table name should be included in SAS (using `tn` parameter). Also in Table SAS, there's no such thing as `List` permission. There's a `Query` permission that goes as `r` in SAS.