### PR TITLE
Add more details about adding GitHub repos to DTL

### DIFF
--- a/articles/devtest-lab/devtest-lab-add-artifact-repo.md
+++ b/articles/devtest-lab/devtest-lab-add-artifact-repo.md
@@ -42,7 +42,7 @@ To get the GitHub repository clone URL and personal access token, follow these s
 4. Select the profile image in the upper-right corner of GitHub, and select **Settings**.
 5. In the **Personal settings** menu on the left, select **Personal access tokens**.
 6. Select **Generate new token**.
-7. On the **New personal access token** page, enter a **Token description**, accept the default items in the **Select scopes**, and then choose **Generate Token**.
+7. On the **New personal access token** page, enter a **Token description**. If it's a public repo, accept the default items in the **Select scopes**; otherwise, select **repo** scope. Then choose **Generate Token**. [Read more about OAuth scopes in GitHub](https://developer.github.com/v3/oauth/#scopes).
 8. Save the generated token as you need it later.
 9. You can close GitHub now.   
 10. Continue to the [Connect your lab to the artifact repository](#connect-your-lab-to-the-artifact-repository) section.


### PR DESCRIPTION
Update step 7 to call out the difference between the required scopes of public repos and private ones.