### PR TITLE
Optional RUNFILE and or Secure CUDA Repo for silent installs

### DIFF
--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -113,7 +113,7 @@ After the update completes, restart the VM.
 #### Installation of NVIDIA CUDA Toolkit
  Installation of NVIDIA CUDA Toolkit.
  
-	 ##### Ubuntu 16.04-LTS
+	##### Ubuntu 16.04-LTS
 	 ```bash
 	 CUDA_REPO_PKG=cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
 	 DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
@@ -137,7 +137,7 @@ After the update completes, restart the VM.
  
  [CUDA Samples](http://docs.nvidia.com/cuda/cuda-samples/#new-features-in-cuda-toolkit-8-0) can be installed in a location as follows:
  
-		 ###### Ubuntu 16.04-LTS
+	###### Ubuntu 16.04-LTS
 		 ```bash
 		 export SHARE_DATA="/data"
 		 export SAMPLES_USER="samplesuser"
@@ -145,12 +145,13 @@ After the update completes, restart the VM.
 
 		 ```
 
-		 ###### Centos 7.3
+	###### Centos 7.3
 		 In /usr/local/cuda-8.0/samples for CentOS 7.3. 
 
 		 * Just a make within each would suffice post successful provisioning.
  
  ##### Optional Unattended, silent NVIDIA Tesla Driver Install:
+  
   NVIDIA Tesla Driver Silent Install is as follows:
   
  > :grey_exclamation:
@@ -158,6 +159,7 @@ After the update completes, restart the VM.
  > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS.
  
  > **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
+	
 	###### Ubuntu 16.04-LTS
 	```bash 
 		service lightdm stop 
@@ -202,7 +204,7 @@ After the update completes, restart the VM.
 		chmod +x /etc/rc.d/rc.local
 	```
 #### Secure Installation of CUDNN
-	##### Both Ubuntu 16.04-LTS and CentOS 7.3
+ ##### Both Ubuntu 16.04-LTS and CentOS 7.3
 
 	The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
 	cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -113,7 +113,8 @@ After the update completes, restart the VM.
 #### Installation of NVIDIA CUDA Toolkit
  Installation of NVIDIA CUDA Toolkit.
  
-	##### Ubuntu 16.04-LTS
+##### Ubuntu 16.04-LTS
+
 	 ```bash
 	 CUDA_REPO_PKG=cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
 	 DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
@@ -126,7 +127,7 @@ After the update completes, restart the VM.
 	 export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/:${LIBRARY_PATH}  && export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/stubs:${LIBRARY_PATH} && \
 	 export PATH=/usr/local/cuda-8.0/bin:${PATH}
 	 ```
-	 ##### CentOS 7.3
+##### CentOS 7.3
 	  ```bash
 		wget http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-8.0.61-1.x86_64.rpm
 		rpm -i cuda-repo-rhel7-8.0.61-1.x86_64.rpm
@@ -137,15 +138,16 @@ After the update completes, restart the VM.
  
  [CUDA Samples](http://docs.nvidia.com/cuda/cuda-samples/#new-features-in-cuda-toolkit-8-0) can be installed in a location as follows:
  
-	###### Ubuntu 16.04-LTS
+###### Ubuntu 16.04-LTS
+	
 		 ```bash
 		 export SHARE_DATA="/data"
 		 export SAMPLES_USER="samplesuser"
 		 su -c "/usr/local/cuda-8.0/bin/./cuda-install-samples-8.0.sh $SHARE_DATA" $SAMPLES_USER
-
 		 ```
 
-	###### Centos 7.3
+###### Centos 7.3
+	
 		 In /usr/local/cuda-8.0/samples for CentOS 7.3. 
 
 		 * Just a make within each would suffice post successful provisioning.
@@ -177,11 +179,11 @@ After the update completes, restart the VM.
 	```
 	###### CentOS 7.3
 
-	 > :grey_exclamation:
+> :grey_exclamation:
 
-	 > Successful Installation happens on reboot.
+> Successful Installation happens on reboot.
 
-	 > **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
+> **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
 
 	```bash 
 		wget http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -110,63 +110,111 @@ After the update completes, restart the VM.
 
 * If you want to capture an image of a Linux VM on which you installed NVIDIA drivers, see [How to generalize and capture a Linux virtual machine](virtual-machines-linux-capture-image.md?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
-#### Silent and Secure installation of NVIDIA CUDA Toolkit on Ubuntu 16.04 LTS
+#### Installation of NVIDIA CUDA Toolkit
+ Installation of NVIDIA CUDA Toolkit.
  
- CUDA Toolkit may be silently and securely installed via scripts as follows
- 
- ```bash
- CUDA_REPO_PKG=cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
- DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
- export CUDA_DOWNLOAD_SUM=1f4dffe1f79061827c807e0266568731 && export CUDA_PKG_VERSION=8-0 && curl -o cuda-repo.deb -fsSL http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/${CUDA_REPO_PKG} && \
-     echo "$CUDA_DOWNLOAD_SUM  cuda-repo.deb" | md5sum -c --strict - && \
-     dpkg -i cuda-repo.deb && \
-     rm cuda-repo.deb && \
-     apt-get update -y && apt-get install -y cuda && \
-     apt-get install -y nvidia-cuda-toolkit && \
- export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/:${LIBRARY_PATH}  && export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/stubs:${LIBRARY_PATH} && \
- export PATH=/usr/local/cuda-8.0/bin:${PATH}
- ```
-
+	 ##### Ubuntu 16.04-LTS
+	 ```bash
+	 CUDA_REPO_PKG=cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
+	 DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
+	 export CUDA_DOWNLOAD_SUM=1f4dffe1f79061827c807e0266568731 && export CUDA_PKG_VERSION=8-0 && curl -o cuda-repo.deb -fsSL http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/${CUDA_REPO_PKG} && \
+	     echo "$CUDA_DOWNLOAD_SUM  cuda-repo.deb" | md5sum -c --strict - && \
+	     dpkg -i cuda-repo.deb && \
+	     rm cuda-repo.deb && \
+	     apt-get update -y && apt-get install -y cuda && \
+	     apt-get install -y nvidia-cuda-toolkit && \
+	 export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/:${LIBRARY_PATH}  && export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/stubs:${LIBRARY_PATH} && \
+	 export PATH=/usr/local/cuda-8.0/bin:${PATH}
+	 ```
+	 ##### CentOS 7.3
+	  ```bash
+		wget http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-8.0.61-1.x86_64.rpm
+		rpm -i cuda-repo-rhel7-8.0.61-1.x86_64.rpm
+		yum clean all
+		yum install -y cuda
+	 ```
 ##### CUDA Samples Install
  
  [CUDA Samples](http://docs.nvidia.com/cuda/cuda-samples/#new-features-in-cuda-toolkit-8-0) can be installed in a location as follows:
  
- ```bash
- export SHARE_DATA="/data"
- export SAMPLES_USER="samplesuser"
- su -c "/usr/local/cuda-8.0/bin/./cuda-install-samples-8.0.sh $SHARE_DATA" $SAMPLES_USER
+		 ###### Ubuntu 16.04-LTS
+		 ```bash
+		 export SHARE_DATA="/data"
+		 export SAMPLES_USER="samplesuser"
+		 su -c "/usr/local/cuda-8.0/bin/./cuda-install-samples-8.0.sh $SHARE_DATA" $SAMPLES_USER
 
- ```
+		 ```
+
+		 ###### Centos 7.3
+		 In /usr/local/cuda-8.0/samples for CentOS 7.3. 
+
+		 * Just a make within each would suffice post successful provisioning.
  
- ##### Optional Silent Install without reboot may be performed via scripts as follows:
- > [!IMPORTANT]
- > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS. **This is required only for NVIDIA Driver with DKMS (Dynamic Kernel Module Support).**
+ ##### Optional Unattended, silent NVIDIA Tesla Driver Install:
+  NVIDIA Tesla Driver Silent Install is as follows:
+  
+ > :grey_exclamation:
+ 
+ > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS.
+ 
+ > **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
+	###### Ubuntu 16.04-LTS
+	```bash 
+		service lightdm stop 
+		wget  http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
+		apt-get install -y linux-image-virtual
+		apt-get install -y linux-virtual-lts-xenial
+		apt-get install -y linux-tools-virtual-lts-xenial linux-cloud-tools-virtual-lts-xenial
+		apt-get install -y linux-tools-virtual linux-cloud-tools-virtual
+		DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
+		DEBIAN_FRONTEND=noninteractive apt-get update -y
+		DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential gcc gcc-multilib dkms g++ make binutils linux-headers-`uname -r` linux-headers-4.4.0-70-generic
+		chmod +x NVIDIA-Linux-x86_64-375.39.run
+		./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
+		DEBIAN_FRONTEND=noninteractive update-initramfs -u
+	```
+	###### CentOS 7.3
 
-```bash 
-    service lightdm stop 
-    wget  http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
-    DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
-    DEBIAN_FRONTEND=noninteractive apt-get update -y
-    apt-get install -y linux-image-virtual linux-tools-virtual linux-cloud-tools-virtual linux-virtual-lts-xenial linux-tools-virtual-lts-xenial linux-cloud-tools-virtual-lts-xenial 
-    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential gcc gcc-multilib dkms g++ make binutils linux-headers-`uname -r` linux-headers-4.4.0-70-generic
-    chmod +x NVIDIA-Linux-x86_64-375.39.run
-    ./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
-    DEBIAN_FRONTEND=noninteractive update-initramfs -u
-```
+	 > :grey_exclamation:
 
-#### Silent installation of CUDNN
+	 > Successful Installation happens on reboot.
 
-The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
-cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.
-cuDNN is part of the NVIDIA Deep Learning SDK and it can be installed silently as follows:
+	 > **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
 
- ```bash
-    export CUDNN_DOWNLOAD_SUM=a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8 && curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz -O && \
-    echo "$CUDNN_DOWNLOAD_SUM  cudnn-8.0-linux-x64-v5.1.tgz" | sha256sum -c --strict - && \
-    tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local && \
-    rm cudnn-8.0-linux-x64-v5.1.tgz && \
-    ldconfig
-  ```
+	```bash 
+		wget http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
+		yum clean all
+		yum update -y  dkms
+		yum install -y gcc make binutils gcc-c++ kernel-devel kernel-headers --disableexcludes=all
+		yum -y upgrade kernel kernel-devel
+		chmod +x NVIDIA-Linux-x86_64-375.39.run
+
+		cat >>~/install_nvidiarun.sh <<EOF
+		cd /var/lib/waagent/custom-script/download/0 && \
+		./NVIDIA-Linux-x86_64-375.39.run --silent --dkms --install-libglvnd && \
+		sed -i '$ d' /etc/rc.d/rc.local && \
+		chmod -x /etc/rc.d/rc.local
+		rm -rf ~/install_nvidiarun.sh
+		EOF
+
+		chmod +x install_nvidiarun.sh
+		echo -ne "~/install_nvidiarun.sh" >> /etc/rc.d/rc.local
+		chmod +x /etc/rc.d/rc.local
+	```
+#### Secure Installation of CUDNN
+	##### Both Ubuntu 16.04-LTS and CentOS 7.3
+
+	The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
+	cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.
+	cuDNN is part of the NVIDIA Deep Learning SDK and it can be installed  as follows:
+
+	 ```bash
+	    export CUDNN_DOWNLOAD_SUM=a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8 && curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz -O && \
+	    echo "$CUDNN_DOWNLOAD_SUM  cudnn-8.0-linux-x64-v5.1.tgz" | sha256sum -c --strict - && \
+	    tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local && \
+	    rm cudnn-8.0-linux-x64-v5.1.tgz && \
+	    ldconfig
+	  ```
 
 ## Next steps
 

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -180,7 +180,7 @@ In /usr/local/cuda-8.0/samples for CentOS 7.3.
 		./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
 		DEBIAN_FRONTEND=noninteractive update-initramfs -u
 ```
-	###### CentOS 7.3
+###### CentOS 7.3
 
 > :grey_exclamation:
 
@@ -195,7 +195,6 @@ In /usr/local/cuda-8.0/samples for CentOS 7.3.
 		yum install -y gcc make binutils gcc-c++ kernel-devel kernel-headers --disableexcludes=all
 		yum -y upgrade kernel kernel-devel
 		chmod +x NVIDIA-Linux-x86_64-375.39.run
-
 		cat >>~/install_nvidiarun.sh <<EOF
 		cd /var/lib/waagent/custom-script/download/0 && \
 		./NVIDIA-Linux-x86_64-375.39.run --silent --dkms --install-libglvnd && \
@@ -203,7 +202,6 @@ In /usr/local/cuda-8.0/samples for CentOS 7.3.
 		chmod -x /etc/rc.d/rc.local
 		rm -rf ~/install_nvidiarun.sh
 		EOF
-
 		chmod +x install_nvidiarun.sh
 		echo -ne "~/install_nvidiarun.sh" >> /etc/rc.d/rc.local
 		chmod +x /etc/rc.d/rc.local
@@ -212,9 +210,9 @@ In /usr/local/cuda-8.0/samples for CentOS 7.3.
  
  ##### Both Ubuntu 16.04-LTS and CentOS 7.3
 
-	The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
-	cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.
-	cuDNN is part of the NVIDIA Deep Learning SDK and it can be installed  as follows:
+The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
+cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.
+cuDNN is part of the NVIDIA Deep Learning SDK and it can be installed  as follows:
 
 ```bash
 	    export CUDNN_DOWNLOAD_SUM=a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8 && curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz -O && \

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -115,7 +115,7 @@ After the update completes, restart the VM.
  
 ##### Ubuntu 16.04-LTS
 
-	 ```bash
+ ```bash
 	 CUDA_REPO_PKG=cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
 	 DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
 	 export CUDA_DOWNLOAD_SUM=1f4dffe1f79061827c807e0266568731 && export CUDA_PKG_VERSION=8-0 && curl -o cuda-repo.deb -fsSL http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/${CUDA_REPO_PKG} && \
@@ -126,31 +126,34 @@ After the update completes, restart the VM.
 	     apt-get install -y nvidia-cuda-toolkit && \
 	 export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/:${LIBRARY_PATH}  && export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/stubs:${LIBRARY_PATH} && \
 	 export PATH=/usr/local/cuda-8.0/bin:${PATH}
-	 ```
+```
+
 ##### CentOS 7.3
-	  ```bash
+
+```bash
 		wget http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-8.0.61-1.x86_64.rpm
 		rpm -i cuda-repo-rhel7-8.0.61-1.x86_64.rpm
 		yum clean all
 		yum install -y cuda
-	 ```
+```
+
 ##### CUDA Samples Install
  
  [CUDA Samples](http://docs.nvidia.com/cuda/cuda-samples/#new-features-in-cuda-toolkit-8-0) can be installed in a location as follows:
  
 ###### Ubuntu 16.04-LTS
 	
-		 ```bash
+```bash
 		 export SHARE_DATA="/data"
 		 export SAMPLES_USER="samplesuser"
 		 su -c "/usr/local/cuda-8.0/bin/./cuda-install-samples-8.0.sh $SHARE_DATA" $SAMPLES_USER
-		 ```
+```
 
 ###### Centos 7.3
 	
-		 In /usr/local/cuda-8.0/samples for CentOS 7.3. 
+In /usr/local/cuda-8.0/samples for CentOS 7.3. 
 
-		 * Just a make within each would suffice post successful provisioning.
+* Just a make within each would suffice post successful provisioning.
  
  ##### Optional Unattended, silent NVIDIA Tesla Driver Install:
   
@@ -162,8 +165,8 @@ After the update completes, restart the VM.
  
  > **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
 	
-	###### Ubuntu 16.04-LTS
-	```bash 
+###### Ubuntu 16.04-LTS
+```bash 
 		service lightdm stop 
 		wget  http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
 		apt-get install -y linux-image-virtual
@@ -176,7 +179,7 @@ After the update completes, restart the VM.
 		chmod +x NVIDIA-Linux-x86_64-375.39.run
 		./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
 		DEBIAN_FRONTEND=noninteractive update-initramfs -u
-	```
+```
 	###### CentOS 7.3
 
 > :grey_exclamation:
@@ -185,7 +188,7 @@ After the update completes, restart the VM.
 
 > **This is required  for NVIDIA Driver with DKMS (Dynamic Kernel Module Support) for driver load surviving kernel updates.**
 
-	```bash 
+```bash 
 		wget http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
 		yum clean all
 		yum update -y  dkms
@@ -204,21 +207,22 @@ After the update completes, restart the VM.
 		chmod +x install_nvidiarun.sh
 		echo -ne "~/install_nvidiarun.sh" >> /etc/rc.d/rc.local
 		chmod +x /etc/rc.d/rc.local
-	```
+```
 #### Secure Installation of CUDNN
+ 
  ##### Both Ubuntu 16.04-LTS and CentOS 7.3
 
 	The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
 	cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.
 	cuDNN is part of the NVIDIA Deep Learning SDK and it can be installed  as follows:
 
-	 ```bash
+```bash
 	    export CUDNN_DOWNLOAD_SUM=a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8 && curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz -O && \
 	    echo "$CUDNN_DOWNLOAD_SUM  cudnn-8.0-linux-x64-v5.1.tgz" | sha256sum -c --strict - && \
 	    tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local && \
 	    rm cudnn-8.0-linux-x64-v5.1.tgz && \
 	    ldconfig
-	  ```
+```
 
 ## Next steps
 

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -141,8 +141,8 @@ After the update completes, restart the VM.
  ##### Optional Silent Install without reboot may be performed via scripts as follows:
  > [!IMPORTANT]
  > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS.
- 
-    ```bash 
+
+```bash 
     service lightdm stop 
     wget  http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
     DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
@@ -152,8 +152,7 @@ After the update completes, restart the VM.
     chmod +x NVIDIA-Linux-x86_64-375.39.run
     ./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
     DEBIAN_FRONTEND=noninteractive update-initramfs -u
-    
-     ```
+```
 
 #### Silent installation of CUDNN
 

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -140,7 +140,7 @@ After the update completes, restart the VM.
  
  ##### Optional Silent Install without reboot may be performed via scripts as follows:
  > [!IMPORTANT]
- > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS.
+ > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS. **This is required only for NVIDIA Driver with DKMS (Dynamic Kernel Module Support).**
 
 ```bash 
     service lightdm stop 

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -110,6 +110,64 @@ After the update completes, restart the VM.
 
 * If you want to capture an image of a Linux VM on which you installed NVIDIA drivers, see [How to generalize and capture a Linux virtual machine](virtual-machines-linux-capture-image.md?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
+#### Silent and Secure installation of NVIDIA CUDA Toolkit on Ubuntu 16.04 LTS
+ 
+ CUDA Toolkit may be silently and securely installed via scripts as follows
+ 
+ ```bash
+ CUDA_REPO_PKG=cuda-repo-ubuntu1604_8.0.61-1_amd64.deb
+ DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
+ export CUDA_DOWNLOAD_SUM=1f4dffe1f79061827c807e0266568731 && export CUDA_PKG_VERSION=8-0 && curl -o cuda-repo.deb -fsSL http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/${CUDA_REPO_PKG} && \
+     echo "$CUDA_DOWNLOAD_SUM  cuda-repo.deb" | md5sum -c --strict - && \
+     dpkg -i cuda-repo.deb && \
+     rm cuda-repo.deb && \
+     apt-get update -y && apt-get install -y cuda && \
+     apt-get install -y nvidia-cuda-toolkit && \
+ export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/:${LIBRARY_PATH}  && export LIBRARY_PATH=/usr/local/cuda-8.0/lib64/stubs:${LIBRARY_PATH} && \
+ export PATH=/usr/local/cuda-8.0/bin:${PATH}
+ ```
+
+##### CUDA Samples Install
+ 
+ [CUDA Samples](http://docs.nvidia.com/cuda/cuda-samples/#new-features-in-cuda-toolkit-8-0) can be installed in a location as follows:
+ 
+ ```bash
+ export SHARE_DATA="/data"
+ export SAMPLES_USER="samplesuser"
+ su -c "/usr/local/cuda-8.0/bin/./cuda-install-samples-8.0.sh $SHARE_DATA" $SAMPLES_USER
+
+ ```
+ 
+ ##### Optional Silent Install without reboot may be performed via scripts as follows:
+ > [!IMPORTANT]
+ > Currently, this need not be required when using secure cuda-repo-ubuntu1604_8.0.61-1_amd64.deb for Azure NC VMs running Ubuntu Server 16.04 LTS.
+ 
+    ```bash 
+    service lightdm stop 
+    wget  http://us.download.nvidia.com/XFree86/Linux-x86_64/375.39/NVIDIA-Linux-x86_64-375.39.run&lang=us&type=Tesla
+    DEBIAN_FRONTEND=noninteractive apt-mark hold walinuxagent
+    DEBIAN_FRONTEND=noninteractive apt-get update -y
+    apt-get install -y linux-image-virtual linux-tools-virtual linux-cloud-tools-virtual linux-virtual-lts-xenial linux-tools-virtual-lts-xenial linux-cloud-tools-virtual-lts-xenial 
+    DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential gcc gcc-multilib dkms g++ make binutils linux-headers-`uname -r` linux-headers-4.4.0-70-generic
+    chmod +x NVIDIA-Linux-x86_64-375.39.run
+    ./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
+    DEBIAN_FRONTEND=noninteractive update-initramfs -u
+     ```
+
+#### Silent installation of CUDNN
+
+The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated library of primitives for deep neural networks. 
+cuDNN provides highly tuned implementations for standard routines such as forward and backward convolution, pooling, normalization, and activation layers.
+cuDNN is part of the NVIDIA Deep Learning SDK and it can be installed silently as follows:
+
+ ```bash
+    export CUDNN_DOWNLOAD_SUM=a87cb2df2e5e7cc0a05e266734e679ee1a2fadad6f06af82a76ed81a23b102c8 && curl -fsSL http://developer.download.nvidia.com/compute/redist/cudnn/v5.1/cudnn-8.0-linux-x64-v5.1.tgz -O && \
+    echo "$CUDNN_DOWNLOAD_SUM  cudnn-8.0-linux-x64-v5.1.tgz" | sha256sum -c --strict - && \
+    tar -xzf cudnn-8.0-linux-x64-v5.1.tgz -C /usr/local && \
+    rm cudnn-8.0-linux-x64-v5.1.tgz && \
+    ldconfig
+  ```
+
 ## Next steps
 
 * For more information about the NVIDIA GPUs on the N-series VMs, see:

--- a/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
+++ b/articles/virtual-machines/virtual-machines-linux-n-series-driver-setup.md
@@ -152,6 +152,7 @@ After the update completes, restart the VM.
     chmod +x NVIDIA-Linux-x86_64-375.39.run
     ./NVIDIA-Linux-x86_64-375.39.run  --silent --dkms
     DEBIAN_FRONTEND=noninteractive update-initramfs -u
+    
      ```
 
 #### Silent installation of CUDNN


### PR DESCRIPTION
Deleting #874 and new pull 
# Adding optional Tesla for CUDA 8.0 RUNFILE Options for DKMS with 375.39 local run for Ubuntu Server 16.04-LTS as well as CentOS 7.3
# Optional  CUDA Repo installation which includes latest 375.39 for Ubuntu 16.04-LTS and CentOS 7.3