### PR TITLE
Update Default Tags to match ARM behaviour

### DIFF
--- a/articles/virtual-network/virtual-networks-nsg.md
+++ b/articles/virtual-network/virtual-networks-nsg.md
@@ -62,8 +62,8 @@ The figure above shows how NSG rules are processed.
 ### Default Tags
 Default tags are system-provided identifiers to address a category of IP addresses. You can use default tags in the **source address prefix** and **destination address prefix** properties of any rule. There are three default tags you can use.
 
-* **VIRTUAL_NETWORK:** This default tag denotes all of your network address space. It includes the virtual network address space (CIDR ranges defined in Azure) as well as all connected on-premises address spaces and connected Azure VNets (local networks).
-* **AZURE_LOADBALANCER:** This default tag denotes Azure’s Infrastructure load balancer. This will translate to an Azure datacenter IP where Azure’s health probes originate.
+* **VIRTUAL_NETWORK** (**VirtualNetwork** if using Azure Resource Manager): This default tag denotes all of your network address space. It includes the virtual network address space (CIDR ranges defined in Azure) as well as all connected on-premises address spaces and connected Azure VNets (local networks).
+* **AZURE_LOADBALANCER** (**AzureLoadBalancer** if using Azure Resource Manager): This default tag denotes Azure’s Infrastructure load balancer. This will translate to an Azure datacenter IP where Azure’s health probes originate.
 * **INTERNET:** This default tag denotes the IP address space that is outside the virtual network and reachable by public Internet. This range includes [Azure owned public IP space](https://www.microsoft.com/download/details.aspx?id=41653) as well.
 
 ### Default Rules


### PR DESCRIPTION
If you're using Azure Resource Manager, the Default Tags have subtly different names - as https://docs.microsoft.com/en-us/rest/api/network/create-or-update-a-network-security-rule shows, the canonical names are `VirtualNetwork`, `AzureLoadBalancer` and `Internet`. Due to ARM apparently being case insensitive, it will accept `INTERNET` as documented in this page, but not `VIRTUAL_NETWORK` or `AZURE_LOADBALANCER` due to the underscores.

This caused me to run into a mystifying error when I tried to create an NSG using these default tags, and I'm not the first to be confused by this as you can see from https://github.com/Azure/azure-powershell/issues/391#issuecomment-188118549

Since the top of this page recommends using ARM, the page should at the very least mention the Default Tag names required by ARM. (Arguably, it should put them first, and mention parenthetically that if you're working in the world of Classic, the older SHOUTING_CAPS_WITH_UNDERSCORES names should be used instead. But I wanted to propose as minimal a change as possible.)