### PR TITLE
Indent code block to fix page formatting

### DIFF
--- a/articles/app-service-web/app-service-web-staged-publishing-realworld-scenarios.md
+++ b/articles/app-service-web/app-service-web-staged-publishing-realworld-scenarios.md
@@ -161,7 +161,7 @@ In this section, you will learn how to set up a deployment workflow by using slo
     * prefix. Only numbers, letters, and underscores please!
     */
     $table_prefix = getenv('DB_PREFIX');
-```
+    ```
 
 #### Use relative paths
 One last thing to configure in the WordPress app is relative paths. WordPress stores URL information in the database. This storage makes moving content from one environment to another more difficult. You need to update the database every time you move from local to stage or stage to production environments. To reduce the risk of issues that can be caused with deploying a database every time you deploy from one environment to another, use the [Relative Root links plugin](https://wordpress.org/plugins/root-relative-urls/), which you can install by using the WordPress administrator dashboard.


### PR DESCRIPTION
Bottom half of page was displaying actual markdown code due to indentation issue.
![screen shot 2017-03-29 at 10 26 47 am](https://cloud.githubusercontent.com/assets/877536/24462711/4a869de8-146a-11e7-92cc-0085715806d2.png)
