### PR TITLE
uppercase filename creates a compilation error

### DIFF
--- a/articles/hdinsight/hdinsight-storm-develop-java-topology.md
+++ b/articles/hdinsight/hdinsight-storm-develop-java-topology.md
@@ -294,7 +294,7 @@ Bolts handle the data processing. This topology uses two bolts:
 > [!NOTE]
 > Bolts can do literally anything, for example, computation, persistence, or talking to external components.
 
-Create two new files, `SplitSentence.java` and `WordCount.Java` in the `src\main\java\com\microsoft\example` directory. Use the following text as the contents for the files:
+Create two new files, `SplitSentence.java` and `WordCount.java` in the `src\main\java\com\microsoft\example` directory. Use the following text as the contents for the files:
 
 **SplitSentence**
 


### PR DESCRIPTION
If you copy/paste WordCount.Java as file name (like I did) it will not compile it and generate a compilation error