### PR TITLE
Update maximum "Public front end IP per load balancer" to 30

### DIFF
--- a/includes/azure-virtual-network-limits.md
+++ b/includes/azure-virtual-network-limits.md
@@ -37,7 +37,7 @@ The following limits apply only for networking resources managed through Azure R
 | Public IP addresses (Static) |20 |contact support |
 | Load balancers (internal and internet facing) |100 |contact support |
 | Load balancer rules per load balancer |150 |150 |
-| Public front end IP per load balancer |10 |contact support |
+| Public front end IP per load balancer |10 |30 |
 | Private front end IP per load balancer |10 |contact support |
 | VNets peerings per Virtual Network |10 |50 |
 | Point-to-Site Root Certificates per VPN Gateway |20 |20 |


### PR DESCRIPTION
This PR updates the maximum value for `Public front end IP per load balancer` from `Contact Support` to the actual number `30`.

Per Azure Support (SR# 117022415372974) 
> "I have coordinated with my Networking team and they have informed me that the Maximum limit for front end IP per load balancer is 30"

and @colemickens here - https://github.com/Azure/acs-engine/issues/447#issuecomment-290375531
> "Please contact support to raise the limit to 30."