### PR TITLE
Fix az acs kubernetes browse syntax

### DIFF
--- a/articles/container-service/container-service-kubernetes-ui.md
+++ b/articles/container-service/container-service-kubernetes-ui.md
@@ -54,7 +54,7 @@ $ az acs kubernetes install-cli
 You can launch the Kubernetes web UI by running:
 
 ```console
-$ az acs kubernetes browse
+$ az acs kubernetes browse -g [Resource Group] -n [Container service instance name]
 ```
 
 This should open a web browser configured to talk to a secure proxy connecting your


### PR DESCRIPTION
Calling "az acs kubernetes browse" as suggested in this doc gives this output:

```
C:\Scratch>az acs kubernetes browse
az acs kubernetes browse: error: the following arguments are required: --name/-n, --resource-group/-g
usage: az acs kubernetes browse [-h] [--output {json,tsv,table,jsonc}]
                                [--verbose] [--debug] [--query JMESPATH]
                                --name NAME --resource-group RESOURCE_GROUP
                                [--disable-browser]
                                [--ssh-key-file SSH_KEY_FILE]
```

This small update tries to clarify that it's necessary to specify the resource group and name of the ACS to connect to for 'az acs kubernetes browse' to work.