### PR TITLE
Missing step for migration to resource manager

### DIFF
--- a/articles/backup/backup-azure-backup-ibiza-faq.md
+++ b/articles/backup/backup-azure-backup-ibiza-faq.md
@@ -36,5 +36,6 @@ Recovery Services vaults support both models.  You can back up a VM created in t
 Backups of classic VMs in backup vault won't migrate automatically to recovery services vault when you migrate the VMs from classic to Resource Manager mode. Please follow these steps for migration of VM backups:
 
 1. In backup vault, go to **Protected Items** tab and select the VM. Click on [Stop Protection](backup-azure-manage-vms-classic.md#stop-protecting-virtual-machines). Leave *Delete associated backup data* option **unchecked**.
-2. Migrate the virtual machine from classic mode to Resource Manager mode. Make sure that storage and network corresponding to virtual machine are also migrated to Resource Manager mode.
-3. Create a recovery services vault and configure backup on the migrated virtual machine using **Backup** action on top of vault dashboard. Learn More on how to [enable backup in recovery services vault](backup-azure-vms-first-look-arm.md)
+2. In the [Azure portal](https://portal.azure.com), go to the **Extensions** menu for the VM and uninstall the **VMSnapshot/VMSnapshotLinux** extension.
+3. Migrate the virtual machine from classic mode to Resource Manager mode. Make sure that storage and network corresponding to virtual machine are also migrated to Resource Manager mode.
+4. Create a recovery services vault and configure backup on the migrated virtual machine using **Backup** action on top of vault dashboard. Learn More on how to [enable backup in recovery services vault](backup-azure-vms-first-look-arm.md)


### PR DESCRIPTION
Found out that the Azure recovery services extension must be uninstalled for the migration validation to succeed as per the below article
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/migration-classic-resource-manager-errors