### PR TITLE
Avoid Couldn't destroy threadgroup exception

### DIFF
--- a/articles/hdinsight/hdinsight-storm-develop-java-topology.md
+++ b/articles/hdinsight/hdinsight-storm-develop-java-topology.md
@@ -193,6 +193,7 @@ For Storm topologies, the [Exec Maven Plugin](http://mojo.codehaus.org/exec-mave
     <includePluginDependencies>false</includePluginDependencies>
     <classpathScope>compile</classpathScope>
     <mainClass>${storm.topology}</mainClass>
+    <cleanupDaemonThreads>false</cleanupDaemonThreads> 
     </configuration>
 </plugin>
 ```


### PR DESCRIPTION
Adding this cleanupDaemonThreads will make sure maven does not shut down the deamon threads, making the sample exit cleanly