### PR TITLE
const ns should be FQDN

### DIFF
--- a/includes/relay-hybrid-connections-node-get-started-server.md
+++ b/includes/relay-hybrid-connections-node-get-started-server.md
@@ -12,7 +12,7 @@
     ```
 2. Add the following Relay `constants` to the `listener.js` for the Hybrid Connection connection details. Replace the placeholders in brackets with the proper values that were obtained when creating the Hybrid Connection.
    
-   1. `const ns` - The Relay namespace
+   1. `const ns` - The Relay namespace (use FQDN - e.g. `{namespace}.servicebus.windows.net`)
    2. `const path` - The name of the Hybrid Connection
    3. `const keyrule` - The name of the SAS key
    4. `const key` - The SAS key value


### PR DESCRIPTION
`const ns` should be FQDN, otherwise the listener does not know how to construct the endpoint address - here's what i mean:

`const ns = "mynamespace";`

Result:

```
$ node listener.js
listening
errorError: getaddrinfo ENOTFOUND relayhc relayhc:443
errorError: getaddrinfo ENOTFOUND relayhc relayhc:443
errorError: getaddrinfo ENOTFOUND relayhc relayhc:443
```