### PR TITLE
const ns should be FQDN (client)

### DIFF
--- a/includes/relay-hybrid-connections-node-get-started-client.md
+++ b/includes/relay-hybrid-connections-node-get-started-client.md
@@ -17,7 +17,7 @@
     ```
 2. Add the following Relay `constants` to the `sender.js` for the Hybrid Connection connection details. Replace the placeholders in brackets with the proper values that were obtained when creating the Hybrid Connection.
    
-   1. `const ns` - The Relay namespace
+   1. `const ns` - The Relay namespace (use FQDN - e.g. `{namespace}.servicebus.windows.net`)
    2. `const path` - The name of the Hybrid Connection
    3. `const keyrule` - The name of the SAS key
    4. `const key` - The SAS key value


### PR DESCRIPTION
`const ns` should be FQDN, otherwise the listener does not know how to construct the endpoint address - here's what i mean:

`const ns = "mynamespace";`

Result (listener):

```
$ node listener.js
listening
errorError: getaddrinfo ENOTFOUND relayhc relayhc:443
errorError: getaddrinfo ENOTFOUND relayhc relayhc:443
errorError: getaddrinfo ENOTFOUND relayhc relayhc:443
```

Result (client/sender):

```
$ node sender.js
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: getaddrinfo ENOTFOUND relayhc relayhc:443
    at errnoException (dns.js:28:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:76:26)
```