### PR TITLE
Removed 's' under Session controls

### DIFF
--- a/articles/active-directory/active-directory-conditional-access-azure-portal.md
+++ b/articles/active-directory/active-directory-conditional-access-azure-portal.md
@@ -80,7 +80,7 @@ If you have more than one requirement selected in a conditional access policy, y
 ![Control](./media/active-directory-conditional-access-azure-portal/06.png)
 
 ### Session controls
-Sessions controls enable limiting experience within a cloud app. The session controls are enforced by cloud apps and rely on additional information provided by Azure AD to the app about the session.
+Session controls enable limiting experience within a cloud app. The session controls are enforced by cloud apps and rely on additional information provided by Azure AD to the app about the session.
 
 ![Control](./media/active-directory-conditional-access-azure-portal/session-control-pic.png)
 


### PR DESCRIPTION
Paragraph under Session controls had an extra 's' at the end of the first word.