### PR TITLE
Update azure-stack-kv-push-secret-into-vm.md

### DIFF
--- a/articles/azure-stack/azure-stack-kv-push-secret-into-vm.md
+++ b/articles/azure-stack/azure-stack-kv-push-secret-into-vm.md
@@ -65,12 +65,12 @@ vault as a secret.
     "dataType" :"pfx",
     "password": "$certPassword"
     }
-    @$jsonObjectBytes = [System.Text.Encoding]::UTF8.GetBytes($jsonObject)
+    "@
+    $jsonObjectBytes = [System.Text.Encoding]::UTF8.GetBytes($jsonObject)
     $jsonEncoded = [System.Convert]::ToBase64String($jsonObjectBytes)
     Switch-AzureMode -Name AzureResourceManager
     New-AzureRmResourceGroup -Name $resourceGroup -Location $location
-    New-AzureRmKeyVault -VaultName $vaultName -ResourceGroupName
-    $resourceGroup -Location $location -sku standard -EnabledForDeployment
+    New-AzureRmKeyVault -VaultName $vaultName -ResourceGroupName $resourceGroup -Location $location -sku standard -EnabledForDeployment
     $secret = ConvertTo-SecureString -String $jsonEncoded -AsPlainText -Force
     Set-AzureKeyVaultSecret -VaultName $vaultName -Name $secretName -SecretValue $secret
 


### PR DESCRIPTION
Added a " before second @ 
removed the Enter given after  New-AzureRmKeyVault -VaultName $vaultName -ResourceGroupName so $resourceGroup -Location $location -sku standard -EnabledForDeployment is on the same line where is belongs.