### PR TITLE
Wrong URL in "To deploy any service configuration changes to the API …

### DIFF
--- a/articles/api-management/api-management-configuration-repository-git.md
+++ b/articles/api-management/api-management-configuration-repository-git.md
@@ -155,7 +155,7 @@ Once your local changes are committed and pushed to the server repository, you c
 
 ![Deploy][api-management-configuration-deploy]
 
-For information on performing this operation using the REST API, see [Deploy Git changes to configuration database using the REST API](https://msdn.microsoft.com/library/dn781420.aspx#DeployChanges).
+For information on performing this operation using the REST API, see [Deploy Git changes to configuration database using the REST API](https://docs.microsoft.com/en-us/rest/api/apimanagement/tenantconfiguration).
 
 ## File and folder structure reference of local Git repository
 The files and folders in the local git repository contain the configuration information about the service instance.


### PR DESCRIPTION
…Management service instance"

URL in "Deploy Git changes to configuration database using the REST API" is not correct. It should be redirected to https://docs.microsoft.com/en-us/rest/api/apimanagement/tenantconfiguration Because this document describes how to deploy service configuration changes to the configuration database of API Management service instance (This operation applies changes from the specified Git branch to the configuration database).