### PR TITLE
Incorrect path name in Java job definition

### DIFF
--- a/articles/hdinsight/hdinsight-run-samples.md
+++ b/articles/hdinsight/hdinsight-run-samples.md
@@ -77,7 +77,7 @@ For the procedure of developing a Java MapReduce program, see - [Develop Java Ma
     $mrJobDefinition = New-AzureRmHDInsightMapReduceJobDefinition `
                                 -JarFile "wasbs:///example/jars/hadoop-mapreduce-examples.jar" `
                                 -ClassName "wordcount" `
-                                -Arguments "wasbs:///example/data/gutenberg/davinci.txt", "wasbs:///example/data/WordCountOutput1"
+                                -Arguments "wasbs:///example/data/gutenberg/davinci.txt", "wasbs:///example/data/WordCountOutput"
 
     # Submit the job and wait for job completion
     $cred = Get-Credential -Message "Enter the HDInsight cluster HTTP user credential:"


### PR DESCRIPTION
The Java job definition uses WordCountOutput1 as the output path name but the findstr looks in WordCountOutput