### PR TITLE
Add note about not deleting App_Data for App Insights Profiler

### DIFF
--- a/articles/application-insights/app-insights-profiler.md
+++ b/articles/application-insights/app-insights-profiler.md
@@ -38,6 +38,8 @@ In [https://portal.azure.com](https://portal.azure.com), open the Application In
 
 If you need to stop or restart the profiler, you'll find it **in the App Service resource**, in **Web Jobs**. To delete it, look under **Extensions**.
 
+If you use WebDeploy to deploy changes to your web application, ensure that you exclude the **App_Data** folder from being deleted during deployment. Otherwise, the profiler extension's files will be deleted when you next deploy the web application to Azure.
+
 ## Viewing profiler data
 
 Open the Performance blade and scroll down to the operation list.


### PR DESCRIPTION
Add a note to the user about ensuring that the ```App_Data``` folder is not deleted during subsequent deployments of their web application.

I found this the hard way the first time I updated my website after installing the profiler when the MSDeploy steps in VSTS failed:

```
2017-04-09T15:20:12.5980432Z Info: Deleting file (.\App_Data\jobs\continuous\ApplicationInsightsProfiler\ApplicationInsightsProfiler.exe).
2017-04-09T15:20:12.5980432Z Info: Deleting file (.\App_Data\jobs\continuous\ApplicationInsightsProfiler\ApplicationInsightsProfiler.exe.config).
2017-04-09T15:20:14.5668151Z Info: Deleting directory (.\App_Data\jobs\continuous\ApplicationInsightsProfiler).
2017-04-09T15:20:14.5824409Z Info: Deleting directory (.\App_Data\jobs\continuous).
2017-04-09T15:20:14.5824409Z Info: Deleting directory (.\App_Data\jobs).
2017-04-09T15:20:16.9574714Z ##[error]Failed to deploy App Service.
2017-04-09T15:20:16.9574714Z ##[error]Error: (4/9/2017 3:20:14 PM) An error occurred when the request was processed on the remote computer.
2017-04-09T15:20:16.9574714Z Error: An error was encountered when processing operation 'Delete Directory' on 'D:\home\site\wwwroot\App_Data\jobs'.
```