### PR TITLE
Update azure-stack-install-visual-studio.md

### DIFF
--- a/articles/azure-stack/azure-stack-install-visual-studio.md
+++ b/articles/azure-stack/azure-stack-install-visual-studio.md
@@ -40,9 +40,9 @@ Use Visual Studio to author and deploy Azure Resource Manager [templates](azure-
 
 1. Launch Visual Studio.
 
-2. From the **Edit** menu, select **Cloud Explorer**.
+2. From the **View** menu, select **Cloud Explorer**.
 
-3. In the new pane, select **Add Account** and sign in with your Active Directory credentials.  
+3. In the new pane, select **Add Account** and sign in with your Azure Active Directory credentials.  
     ![Screenshot of Cloud Explorer once logged in and connected to Azure Stack](./media/azure-stack-install-visual-studio/image6.png)
 
 Once logged in, you can [deploy templates](azure-stack-deploy-template-visual-studio.md) or browse available resource types and resource groups to create your own templates.  


### PR DESCRIPTION
In VS 2015 community, which is the version downloaded in this guide, Cloud Explorer is accessed from the View menu, not the Edit menu.
Slight tweak from Active Directory to Azure Active Directory.