### PR TITLE
Fixed typo in Batch Task Output docs

### DIFF
--- a/articles/batch/batch-task-output.md
+++ b/articles/batch/batch-task-output.md
@@ -178,7 +178,7 @@ The following code snippet iterates through all of a job's tasks, prints some in
 ```csharp
 foreach (CloudTask task in myJob.ListTasks())
 {
-    foreach (TaskOutputStorage output in
+    foreach (OutputFileReference output in
         task.OutputStorage(storageAccount).ListOutputs(
             TaskOutputKind.TaskOutput))
     {


### PR DESCRIPTION
`TaskOutputStorage.ListOutputs(TaskOutputKind.TaskLog)` returns a `IEnumerable<OutputFileReference>`, rather than the original, incorrect `IEnumerable<TaskOutputStorage>`.