### PR TITLE
Make it explicit how to escape special characters in Text.Format function

### DIFF
--- a/articles/data-factory/data-factory-functions-variables.md
+++ b/articles/data-factory/data-factory-functions-variables.md
@@ -90,7 +90,7 @@ The following tables list all the functions in Azure Data Factory:
 | Date |StartOfDay(X) |X: DateTime |Gets the start of the day represented by the day component of parameter X.<br/><br/>Example: StartOfDay of 9/15/2013 05:10:23 PM is 9/15/2013 12:00:00 AM. |
 | DateTime |From(X) |X: String |Parse string X to a date time. |
 | DateTime |Ticks(X) |X: DateTime |Gets the ticks property of the parameter X. One tick equals 100 nanoseconds. The value of this property represents the number of ticks that have elapsed since 12:00:00 midnight, January 1, 0001. |
-| Text |Format(X) |X: String variable |Formats the text. |
+| Text |Format(X) |X: String variable |Formats the text (use `\\'` combination to escape `'` character).|
 
 > [!IMPORTANT]
 > When using a function within another function, you do not need to use **$$** prefix for the inner function. For example: $$Text.Format('PartitionKey eq \\'my_pkey_filter_value\\' and RowKey ge \\'{0:yyyy-MM-dd HH:mm:ss}\\'', Time.AddHours(SliceStart, -6)). In this example, notice that **$$** prefix is not used for the **Time.AddHours** function. 


### PR DESCRIPTION
Today I had to help a friend who couldn't figure it out because this feature hasn't been documented. There are only some examples of how to do it.