### PR TITLE
Fix FAQ Typo

### DIFF
--- a/articles/log-analytics/log-analytics-sql-assessment.md
+++ b/articles/log-analytics/log-analytics-sql-assessment.md
@@ -199,7 +199,7 @@ If you have recommendations that you want to ignore, you can create a text file 
 
 * Not at this time.
 
-*If another server for is discovered after I’ve added the SQL assessment solution, will it be assessed?*
+*If another server is discovered after I’ve added the SQL assessment solution, will it be assessed?*
 
 * Yes, once it is discovered it is assessed from then on, every 7 days.
 


### PR DESCRIPTION
Removed an unnecessary word from one of the questions in the FAQ section.