### PR TITLE
Corrected --name parameter to correct value

### DIFF
--- a/articles/container-service/container-service-connect.md
+++ b/articles/container-service/container-service-connect.md
@@ -67,7 +67,7 @@ get the credentials is with the `az acs kubernetes get-credentials` command. Pas
 
 
 ```azurecli
-az acs kubernetes get-credentials --resource-group=<cluster-resource-group> --name=<cluster-name>
+az acs kubernetes get-credentials --resource-group=<cluster-resource-group> --name=containerservice-<cluster-resource-group>
 ```
 
 This command downloads the cluster credentials to `$HOME/.kube/config`, where `kubectl` expects it to be located.


### PR DESCRIPTION
Based on the new quickstart template the cluster-name is the concatenation of containerservice-<cluster-resource-group>

https://github.com/Azure/azure-quickstart-templates/blob/master/101-acs-swarm/azuredeploy.json