### PR TITLE
Update BingVoiceOutput.md for wrong text of Service name mapping

### DIFF
--- a/articles/cognitive-services/Speech/API-Reference-REST/BingVoiceOutput.md
+++ b/articles/cognitive-services/Speech/API-Reference-REST/BingVoiceOutput.md
@@ -161,7 +161,7 @@ hi-IN|Female|"Microsoft Server Speech Text to Speech Voice (hi-IN, Kalpana, Apol
 it-IT|Male|"Microsoft Server Speech Text to Speech Voice (it-IT, Cosimo, Apollo)"
 ja-JP|Female|"Microsoft Server Speech Text to Speech Voice (ja-JP, Ayumi, Apollo)"
 ja-JP|Male|"Microsoft Server Speech Text to Speech Voice (ja-JP, Ichiro, Apollo)"
-ko-KR|Female|"Microsoft Server Speech Text to Speech Voice (ko-KR,HeamiRUS)"
+ko-KR|Female|"Microsoft Server Speech Text to Speech Voice (ko-KR, HeamiRUS)"
 pt-BR|Male|"Microsoft Server Speech Text to Speech Voice (pt-BR, Daniel, Apollo)"
 ru-RU|Female|"Microsoft Server Speech Text to Speech Voice (ru-RU, Irina, Apollo)"
 ru-RU|Male|"Microsoft Server Speech Text to Speech Voice (ru-RU, Pavel, Apollo)"


### PR DESCRIPTION
Motivations:
- Can not play voice with the Korean of Service name mapping in [Cognitive-Speech-TTS](sample link : https://github.com/Azure-Samples/Cognitive-Speech-TTS) Android sample

Modifications:
- Add space to the string for the Korean of Service name mapping
