### PR TITLE
Fix error in Network Interface example

### DIFF
--- a/articles/virtual-machines/windows/csharp.md
+++ b/articles/virtual-machines/windows/csharp.md
@@ -356,8 +356,8 @@ A virtual machine needs a network interface to communicate on the virtual networ
                 new NetworkInterfaceIPConfiguration
                   {
                     Name = nicName,
-                    PublicIPAddress = pubipResponse,
-                    Subnet = subnetResponse
+                    PublicIPAddress = publicIP,
+                    Subnet = subnet
                   }
               }
           }


### PR DESCRIPTION
There is a simple error in the CreateNetworkInterfaceAsync method where two variable names were incorrect.