### PR TITLE
Updated Metric Aggregation thread example

### DIFF
--- a/articles/application-insights/app-insights-api-custom-events-metrics.md
+++ b/articles/application-insights/app-insights-api-custom-events-metrics.md
@@ -206,10 +206,10 @@ If you are using the latest version of the SDK for ASP.NET, you can use [`Metric
         {
             name = Name;
             thread = new BackgroundWorker();
-            thread.DoWork += (o, e) => {
+            thread.DoWork += async (o, e) => {
                 while (!stop)
                 {
-                    Thread.Sleep(60000); // 1 minute
+                    await Task.Delay(60000);
                     telemetryClient.TrackMetric(this.Aggregate());
                 }
             };


### PR DESCRIPTION
In real-world scenarios running this hogs an unprecedented amount of CPU on App Services because this thread is 99% of the time idling but blocking. Letting the TPL deal with releasing the sleeping thread back to the pool maintains performance and efficiency.