### PR TITLE
Update instructions to ensure script action runs on head + worker nodes

### DIFF
--- a/articles/hdinsight/hdinsight-apache-spark-microsoft-cognitive-toolkit.md
+++ b/articles/hdinsight/hdinsight-apache-spark-microsoft-cognitive-toolkit.md
@@ -66,7 +66,7 @@ For instructions on how to use the Azure Portal to run script action, see [Custo
 
 * For **Bash script URI**, enter `https://raw.githubusercontent.com/Azure-Samples/hdinsight-pyspark-cntk-integration/master/cntk-install.sh`.
 
-* Make sure you run the script only on the Head and Worker nodes. Clear the checkboxes for Zookeeper and Edge nodes.
+* Make sure you run the script only on the head and worker nodes and clear all the other checkboxes.
 
 * Click **Create**.
 

--- a/articles/hdinsight/hdinsight-apache-spark-microsoft-cognitive-toolkit.md
+++ b/articles/hdinsight/hdinsight-apache-spark-microsoft-cognitive-toolkit.md
@@ -66,7 +66,7 @@ For instructions on how to use the Azure Portal to run script action, see [Custo
 
 * For **Bash script URI**, enter `https://raw.githubusercontent.com/Azure-Samples/hdinsight-pyspark-cntk-integration/master/cntk-install.sh`.
 
-* Make sure you run the script only on the headnode. Clear the checkboxes for Worker node and Zookeeper node.
+* Make sure you run the script only on the Head and Worker nodes. Clear the checkboxes for Zookeeper and Edge nodes.
 
 * Click **Create**.
 


### PR DESCRIPTION
The documentation asks you to not run the script action on worker nodes which is incorrect. It should be run on head and worker nodes but not on ZK and edge nodes.