### PR TITLE
Add section with TLS/SSL detail

### DIFF
--- a/articles/iot-hub/iot-hub-mqtt-support.md
+++ b/articles/iot-hub/iot-hub-mqtt-support.md
@@ -73,6 +73,34 @@ If a device cannot use the device SDKs, it can still connect to the public devic
 
 For MQTT connect and disconnect packets, IoT Hub issues an event on the **Operations Monitoring** channel with additional information that can help you to troubleshoot connectivity issues.
 
+### TLS/SSL configuration
+
+To use the MQTT protocol directly, your client *must* connect over TLS/SSL. Attempts to skip this will fail with connection errors.
+
+In order to establish a TLS connection, you may need to download and reference the DigiCert Baltimore Root Certificate. This is the certificate that Azure uses to secure the connection, and can be found in the [Azure-iot-sdk-c repository][lnk-sdk-c-certs]. More information about these certificates can be found on [Digicert's website][lnk-digicert-root-certs].
+
+An example of how to implement this using the Python version of the [Paho MQTT library][lnk-paho] by the Eclipse Foundation might look like this:
+
+```
+from paho.mqtt import client as mqtt
+import ssl
+  
+path_to_root_cer = "...local\\path\\to\\digicert.cer"
+device_id = "<device id from device registry>"
+sas_token = "<generated SAS token>
+subdomain = "<iothub subdomain>"
+
+client = mqtt.Client(client_id=device_id, protocol=mqtt.MQTTv311)
+
+client.username_pw_set(username=subdomain+".azure-devices.net/" + device_id, password=sas_token)
+
+client.tls_set(ca_certs=path_to_root_cert, certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_TLSv1, ciphers=None)
+client.tls_insecure_set(False)
+
+client.connect(subdomain+".azure-devices.net", port=8883)
+```
+
+
 ### Sending device-to-cloud messages
 After making a successful connection, a device can send messages to IoT Hub using `devices/{device_id}/messages/events/` or `devices/{device_id}/messages/events/{property_bag}` as a **Topic Name**. The `{property_bag}` element enables the device to send messages with additional properties in a url-encoded format. For example:
 
@@ -235,3 +263,6 @@ To further explore the capabilities of IoT Hub, see:
 [lnk-quotas]: iot-hub-devguide-quotas-throttling.md
 [lnk-devguide-twin-reconnection]: iot-hub-devguide-device-twins.md#device-reconnection-flow
 [lnk-devguide-twin]: iot-hub-devguide-device-twins.md
+[lnk-sdk-c-certs]: https://github.com/Azure/azure-iot-sdk-c/blob/master/certs/certs.c
+[lnk-digicert-root-certs]: https://www.digicert.com/digicert-root-certificates.htm
+[lnk-paho]: https://pypi.python.org/pypi/paho-mqtt

--- a/articles/iot-hub/iot-hub-mqtt-support.md
+++ b/articles/iot-hub/iot-hub-mqtt-support.md
@@ -79,7 +79,15 @@ To use the MQTT protocol directly, your client *must* connect over TLS/SSL. Atte
 
 In order to establish a TLS connection, you may need to download and reference the DigiCert Baltimore Root Certificate. This is the certificate that Azure uses to secure the connection, and can be found in the [Azure-iot-sdk-c repository][lnk-sdk-c-certs]. More information about these certificates can be found on [Digicert's website][lnk-digicert-root-certs].
 
-An example of how to implement this using the Python version of the [Paho MQTT library][lnk-paho] by the Eclipse Foundation might look like this:
+An example of how to implement this using the Python version of the [Paho MQTT library][lnk-paho] by the Eclipse Foundation might look like the following.
+
+First, install the Paho library from your command-line environment:
+
+```
+>pip install paho-mqtt
+```
+
+Then, implement the client in a Python script:
 
 ```
 from paho.mqtt import client as mqtt
@@ -87,7 +95,7 @@ import ssl
   
 path_to_root_cer = "...local\\path\\to\\digicert.cer"
 device_id = "<device id from device registry>"
-sas_token = "<generated SAS token>
+sas_token = "<generated SAS token>"
 subdomain = "<iothub subdomain>"
 
 client = mqtt.Client(client_id=device_id, protocol=mqtt.MQTTv311)


### PR DESCRIPTION
Add a section under "Using the MQTT protocol directly" describing how to configure a client for TLS/SSL, including links to where to get the necessary certificates, as well as example (python) code for establishing MQTT connections.