### PR TITLE
Change API definition source to Function instead of Internal to sync with actual display

### DIFF
--- a/articles/azure-functions/functions-api-definition-getting-started.md
+++ b/articles/azure-functions/functions-api-definition-getting-started.md
@@ -41,7 +41,7 @@ This document guides you through the step by step process of creating an OpenAPI
 
 ## <a name="enable"></a>Enabling API Definition Support
 1. Navigate to `your function name` > `API Definition (preview)`
-1. Set `API Definition Source` to `Internal`
+1. Set `API Definition Source` to `Function`
   1. This step enables a suite of OpenAPI options for your Function App, including an endpoint to host an OpenAPI file from your Function App's domain, an inline copy of the [OpenAPI Editor](http://editor.swagger.io), and a quickstart definition generator.
 ![Enabled Definition](./media/functions-api-definition-getting-started/enabledefinition.png)
 


### PR DESCRIPTION
**Description**:
In the doc section of Azure Functions of `How to` -> `Develop` -> `Create an Open API definition` there is a subtle difference on the instruction and the actual screen of Azure Functions API definition.  

Change API definition source to Function instead of Internal to reflect the actual picture of Azure Functions API definition screenshot,

![image](https://cloud.githubusercontent.com/assets/8773147/25352674/0bbbbf9c-2957-11e7-88f3-91b387e107b8.png)
Currently, actual doc says this:

![image](https://cloud.githubusercontent.com/assets/8773147/25352722/321c2b86-2957-11e7-9578-aaf0e6271ecd.png)

Even the screenshot in the current doc shows `Function`, not `Internal`.
This PR is actually a small change, to change Internal to Function.