### PR TITLE
Fixed invalid json

### DIFF
--- a/articles/hdinsight/hdinsight-apache-spark-resource-manager.md
+++ b/articles/hdinsight/hdinsight-apache-spark-resource-manager.md
@@ -81,7 +81,7 @@ For applications running in the Jupyter notebook, you can use the `%%configure` 
 The snippet below shows how to change the configuration for an application running in Jupyter.
 
     %%configure
-    {"executorMemory": "3072M", "executorCores": 4, “numExecutors”:10}
+    {"executorMemory": "3072M", "executorCores": 4, "numExecutors":10}
 
 Configuration parameters must be passed in as a JSON string and must be on the next line after the magic, as shown in the example column.
 


### PR DESCRIPTION
Right double quotation mark (&#8221;) is not a valid json quotation mark. Jupyter could not parse this json object. 
Fixed to be the standard quotation mark (&#34;)