### PR TITLE
download url corrected VS2015-> vs2017

### DIFF
--- a/articles/sql-database/sql-database-connect-query-dotnet.md
+++ b/articles/sql-database/sql-database-connect-query-dotnet.md
@@ -35,7 +35,7 @@ The steps in this section assume that you are familar with developing using .NET
 
 Visual Studio 2017 Community is a fully-featured, extensible, free IDE for creating modern applications for Android, iOS, Windows, as well as web & database applications and cloud services. You can install either the full .NET framework or just .NET core. The code snippets in the quick start work with either. If you already have Visual Studio installed on your machine, skip the next few steps.
 
-1. Download the [installer](https://go.microsoft.com/fwlink/?LinkId=691978). 
+1. Download the [Visual Studio 2017 installer](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=Community&rel=15). 
 2. Run the installer and follow the installation prompts to complete the installation.
 
 ### **Mac OS**


### PR DESCRIPTION
Old url was pointing to VS2015 update 2 download,
Corrected to point VS2017 Download.

@ajlam @jhubbard @Rick-Andreson @stevestein Please review the PR.