### PR TITLE
Added a missing parenthesis

### DIFF
--- a/articles/active-directory/active-directory-licensing-group-advanced.md
+++ b/articles/active-directory/active-directory-licensing-group-advanced.md
@@ -158,7 +158,7 @@ During the preview period of an Azure AD release, PowerShell cannot be used to f
   function UserHasLicenseAssignedFromGroup
   {
     Param([Microsoft.Online.Administration.User]$user, [string]$skuId)
-     foreach($license in $user.Licenses
+     foreach($license in $user.Licenses)
      {
         #we look for the specific license SKU in all licenses assigned to the user
         if ($license.AccountSkuId -ieq $skuId)


### PR DESCRIPTION
PowerShell script had a missing parenthesis which results in compilation errors when copied and pasted from the document.