### PR TITLE
[ADLA CLI 2.0] Correcting "file" to "fs" in an example's syntax

### DIFF
--- a/articles/data-lake-analytics/data-lake-analytics-get-started-cli2.md
+++ b/articles/data-lake-analytics/data-lake-analytics-get-started-cli2.md
@@ -110,8 +110,8 @@ The Azure portal provides a user interface for copying some sample data files to
 To upload files using CLI 2,0, use the following commands:
 
 ```azurecli
-az dls file upload --account "<Data Lake Store Account Name>" --source-path "<Source File Path>" --destination-path "<Destination File Path>"
-az dls file list --account "<Data Lake Store Account Name>" --path "<Path>"
+az dls fs upload --account "<Data Lake Store Account Name>" --source-path "<Source File Path>" --destination-path "<Destination File Path>"
+az dls fs list --account "<Data Lake Store Account Name>" --path "<Path>"
 ```
 
 Data Lake Analytics can also access Azure Blob storage.  For uploading data to Azure Blob storage, see [Using the Azure CLI with Azure Storage](../storage/storage-azure-cli.md).


### PR DESCRIPTION
[ADLA CLI 2.0] Correcting "file" to "fs" in an example's syntax