### PR TITLE
ARM P2S does not require certs to be made manually

### DIFF
--- a/articles/app-service-web/web-sites-integrate-with-vnet.md
+++ b/articles/app-service-web/web-sites-integrate-with-vnet.md
@@ -92,6 +92,7 @@ If your VNET does not have a gateway nor has Point to Site then you have to set 
 
 ##### Enabling Point to Site in a Resource Manager VNET
 To configure a Resource Manager VNET with a gateway and Point to Site, you can use either PowerShell as documented here, [Configure a Point-to-Site connection to a virtual network using PowerShell][V2VNETP2S] or use the Azure Portal as documented here, [Configure a Point-to-Site connection to a VNet using the Azure Portal][V2VNETPortal].  The UI to perform this capability is not yet available. 
+Note that you will not need to create certificates for the Point to Site configuration. This will be automatically configured when you connect your WebApp to the VNET. 
 
 ### Creating a pre-configured VNET
 If you want to create a new VNET that is configured with a gateway and Point-to-Site, then the App Service networking UI has the capability to do that but only for a Resource manager VNET.  If you wish to create a Classic VNET with a gateway and Point-to-Site then you need to do this manually through the Networking user interface. 


### PR DESCRIPTION
The links for creating a Point to Site VPN for an ARM VNET discuss the need to create and upload certs. This is not required in this case since the certs get created automatically from the webapp blade when connecting to the VNET.