### PR TITLE
Update hdinsight-hbase-tutorial-get-started-linux.md

### DIFF
--- a/articles/hdinsight/hdinsight-hbase-tutorial-get-started-linux.md
+++ b/articles/hdinsight/hdinsight-hbase-tutorial-get-started-linux.md
@@ -157,7 +157,7 @@ You can query data in HBase tables by using Hive. This section creates a Hive ta
         TBLPROPERTIES ('hbase.table.name' = 'Contacts');
 4. Run the following HiveQL script to query the data in the HBase table:
    
-         SELECT count(*) FROM hbasecontacts;
+         SELECT count(rowkey) FROM hbasecontacts;
 
 ## Use HBase REST APIs using Curl
 > [!NOTE]


### PR DESCRIPTION
When I follow the steps above to connect to HBase via Hive, this command does not work for me:  SELECT count(*) FROM hbasecontacts; 
It always only returns '0'. When I change the command to for example SELECT count(rowkey) FROM hbasecontacts; the correct count is returned.