### PR TITLE
add [!NOTE] to help the user not click create

### DIFF
--- a/articles/app-service-web/app-service-web-tutorial-dotnet-sqldatabase.md
+++ b/articles/app-service-web/app-service-web-tutorial-dotnet-sqldatabase.md
@@ -130,6 +130,9 @@ You can also accept the automatically generated name, which is already unique.
 
 To prepare for the next step, click **Explore additional Azure services**.
 
+> [!NOTE]
+> Do not click create on this dialog to continue, you will first need to setup a SQL Server in the next step.
+
 ![Configure web app name](./media/app-service-web-tutorial-dotnet-sqldatabase/web-app-name.png)
 
 ### Create a SQL Server instance


### PR DESCRIPTION
clicking create too soon, breaks this whole sample, so I'm just adding a little note. I watched two people in a row make this same mistake. Thinking that creating the web app is a single step, but in fact it's only step 1 of 2.