### PR TITLE
fixed bug/typo from CTRL+\ to correct CTRL+`

### DIFF
--- a/articles/app-service-web/app-service-web-tutorial-dotnet-sqldatabase.md
+++ b/articles/app-service-web/app-service-web-tutorial-dotnet-sqldatabase.md
@@ -170,7 +170,7 @@ Visual Studio lets you explorer and manage your new SQL Database easily in the *
 
 ### Create a database connection
 
-Open **SQL Server Object Explorer** by typing `Ctrl`+`\`, `Ctrl`+`S`.
+Open **SQL Server Object Explorer** by typing `Ctrl`+`` ` ``, `Ctrl`+`S`.
 
 At the top of **SQL Server Object Explorer**, click the **Add SQL Server** button.
 


### PR DESCRIPTION
The markup for escaping of CTRL+` is tricky, because the ` is used for kb highlights in the md. for future reference, `` ` `` (double tick, space, tick, space, double tick) is the correct mark down.