### PR TITLE
Updated the install command for the CentOS.

### DIFF
--- a/articles/virtual-machines/linux/update-agent.md
+++ b/articles/virtual-machines/linux/update-agent.md
@@ -44,7 +44,7 @@ sudo apt-get install walinuxagent
 And on CentOS, type:
 
 ```bash
-sudo yum install waagent
+sudo yum install WALinuxAgent
 ```
 
 For Oracle Linux, make sure that the `Addons` repository is enabled. Choose to edit the file `/etc/yum.repos.d/public-yum-ol6.repo`(Oracle Linux 6) or `/etc/yum.repos.d/public-yum-ol7.repo`(Oracle Linux), and change the line `enabled=0` to `enabled=1` under **[ol6_addons]** or **[ol7_addons]** in this file.


### PR DESCRIPTION
Tested on CentOS 7.3 vm on Azure.
The "waagent" package doesn't exist in the repo any-longer and was replaced by "WALinuxAgent" .
