### PR TITLE
Added section for cross OS test (Windows / Linux)

### DIFF
--- a/articles/virtual-network/virtual-network-bandwidth-testing.md
+++ b/articles/virtual-network/virtual-network-bandwidth-testing.md
@@ -130,6 +130,38 @@ ntttcp -s10.0.0.4 -t 300
  
 Test length defaults to 60 seconds if no time parameter is given
 
+## Testing between VMs running Windows and LINUX:
+
+On this scenarios we should enable the no-sync mode so the test can run. This is done by using the **-N flag** for Linux, and **-ns flag** for Windows.
+
+#### From Linux to Windows:
+
+Receiver <Windows>:
+
+``` bash
+ntttcp -r -m <2 x nr cores>,*,<Windows server IP>
+```
+
+Sender <Linux> :
+
+``` bash
+ntttcp -s -m <2 x nr cores>,*,<Windows server IP> -N -t 300
+```
+
+#### From Windows to Linux:
+
+Receiver <Linux>:
+
+``` bash 
+ntttcp -r -m <2 x nr cores>,*,<Linux server IP>
+```
+
+Sender <Windows>:
+
+``` bash
+ntttcp -s -m <2 x nr cores>,*,<Linux  server IP> -ns -t 300
+```
+
 ## Next steps
 * Depending on results, there may be room to [Optimize network throughput machines](virtual-network-optimize-network-bandwidth.md) for your scenario.
 * Learn more wtih [Azure Virtual Network frequently asked questions (FAQ)](virtual-networks-faq.md)


### PR DESCRIPTION
In the cross OS scenario, we need to add the flags N or ns on the sender, so we can enable the no-sync mode. If we don't do it, the tests won't start.