### PR TITLE
Child resource reference construction - update

### DIFF
--- a/articles/azure-resource-manager/resource-manager-template-child-resource.md
+++ b/articles/azure-resource-manager/resource-manager-template-child-resource.md
@@ -26,6 +26,9 @@ The format of the child resource name is: `{parent-resource-name}/{child-resourc
 
 However, you specify the type and name in a template differently based on whether it is nested within the parent resource, or on its own at the top level. This topic shows how to handle both approaches.
 
+*Note:* When constructing a fully-qualified reference to a resource, perhaps for use within a "dependsOn", the order in which to combine segments from the type and name strings as above is not simply a concatenation of the two.  Instead, after the namespace, use a sequence of *type/name* pairs in least to most specific order: `{resource-provider-namespace}/{parent-resource-type}/{parent-resource-name}[/{child-resource-type}/{child-resource-name}]*`. 
+For example, use `Microsoft.Compute/virtualMachines/myVM/extensions/myExt`, not  `Microsoft.Compute/virtualMachines/extensions/myVM/myExt`.
+
 ## Nested child resource
 The easiest way to define a child resource is to nest it within the parent resource. The following example shows a SQL database nested within in a SQL Server.
 


### PR DESCRIPTION
Clarify that when creating references to child resources, you can't simply concatenate namespace/types/names, but must instead use namespace, followed by ordered pairs of type/name values.

selliott.