### PR TITLE
Removing '---' characters in simpleweb.yaml

### DIFF
--- a/articles/container-service/container-service-kubernetes-windows-walkthrough.md
+++ b/articles/container-service/container-service-kubernetes-windows-walkthrough.md
@@ -100,7 +100,7 @@ After creating the cluster and connecting with `kubectl`, you can try starting a
     selector:
       app: win-webserver
     type: LoadBalancer
-  ---
+  
   apiVersion: extensions/v1beta1
   kind: Deployment
   metadata:


### PR DESCRIPTION
Removing characters included in the sample code (simpleweb.yaml) which cause errors when try to deploy in Kubernetes.