### PR TITLE
Fix the fully qualified class name for the command line

### DIFF
--- a/articles/hdinsight/hdinsight-storm-deploy-monitor-topology-linux.md
+++ b/articles/hdinsight/hdinsight-storm-deploy-monitor-topology-linux.md
@@ -81,7 +81,7 @@ The HDInsight Tools can be used to submit C# or hybrid topologies to your Storm 
 
 2. Use the following command to start an example topology:
 
-        storm jar /usr/hdp/current/storm-client/contrib/storm-starter/storm-starter-topologies-*.jar storm.starter.WordCountTopology WordCount
+        storm jar /usr/hdp/current/storm-client/contrib/storm-starter/storm-starter-topologies-*.jar org.apache.storm.starter.WordCountTopology WordCount
 
     This command starts the example WordCount topology on the cluster. This topology randomly generate sentences and count the occurrence of each word in the sentences.
 


### PR DESCRIPTION
Fix the fully qualified class name for the command line by adding `org.apache.`, otherwise, when trying to find `storm.starter.WordCountTopology`, storm will complain:

    Error: Could not find or load main class storm.starter.WordCountTopology

Because what needs to be passed is

    org.apache.storm.starter.WordCountTopology

I tested this on a:

    Cluster type, HDI version
    Storm on Linux (HDI 3.6)