### PR TITLE
Update max entity num

### DIFF
--- a/articles/cognitive-services/LUIS/Add-entities.md
+++ b/articles/cognitive-services/LUIS/Add-entities.md
@@ -15,7 +15,7 @@ ms.author: cahann
 # Add Entities
 Entities are key data in your application’s domain. An entity represents a class including a collection of similar objects (places, things, people, events or concepts). Entities describe information relevant to the intent, and sometimes they are essential for your app to perform its task. For example, a News Search app may include entities such as “topic”, “source”, “keyword” and “publishing date”, which are key data to search for news. In a travel booking app, the “location”, “date”, "airline", "travel class" and "tickets" are key information for flight booking (relevant to the "Bookflight" intent). So, we'll add them as entities. 
 
-You do not need to create entities for every concept in your app, but only for those required for the app to take action. You can add up to **10** entities in a single LUIS app. 
+You do not need to create entities for every concept in your app, but only for those required for the app to take action. You can add up to **30** entities in a single LUIS app. 
 
 You can add, edit or delete entities in your app through the **Entities list** on the **Entities** page. Luis offers many types of entities; prebuilt entities, custom machine learned entities and close list entities.
 


### PR DESCRIPTION
After the test, maybe entity should update from `10` to `30`.
When I uploaded app, the tip showed:
```
{
  "error": {
    "code": "BadArgument",
    "message": "An application cannot have more than 30 entity extractors."
  }
}
```