### PR TITLE
added version information for .NET class library project

### DIFF
--- a/articles/data-factory/data-factory-use-custom-activities.md
+++ b/articles/data-factory/data-factory-use-custom-activities.md
@@ -111,7 +111,7 @@ The method returns a dictionary that can be used to chain custom activities toge
      <li>Launch <b>Visual Studio 2015</b> or <b>Visual Studio 2013</b> or <b>Visual Studio 2012</b>.</li>
      <li>Click <b>File</b>, point to <b>New</b>, and click <b>Project</b>.</li>
      <li>Expand <b>Templates</b>, and select <b>Visual C#</b>. In this walkthrough, you use C#, but you can use any .NET language to develop the custom activity.</li>
-     <li>Select <b>Class Library</b> from the list of project types on the right.</li>
+     <li>Select <b>Class Library (.NET Framework)</b> from the list of project types on the right. Remeber to select version number 4.0.</li>
      <li>Enter <b>MyDotNetActivity</b> for the <b>Name</b>.</li>
      <li>Select <b>C:\ADFGetStarted</b> for the <b>Location</b>.</li>
      <li>Click <b>OK</b> to create the project.</li>


### PR DESCRIPTION
The documentation is unclear about which .NET version to use. The packaes are only compatible with .NET version 4.0 or lower. This must be made clear. 