### PR TITLE
Update howto-connection-string.md

### DIFF
--- a/articles/mysql/howto-connection-string.md
+++ b/articles/mysql/howto-connection-string.md
@@ -19,6 +19,7 @@ This document lists all connection string types supported by Azure Database for 
 
 - Please refer to document [How to configure SSL](./howto-configure-ssl.md) to obtain the cert
 - {your_host} = <servername>.mysql.database.azure.com
+- {your_user}@{servername} = userID format for authentication correctly.  Using just the userID will cause the authentication to fail.
 
 ## ADO.NET
 ```ado.net


### PR DESCRIPTION
It's not immediately clear that you need to use userID@servername as the format for any user account that authenticates to this server.  I spent two days trying to troubleshoot why I couldn't connect to the server with my webapp while I could use MySQL Workbench to connect with the user account.  Specifying userID@servername is what solved this problem for me.