### PR TITLE
Fix typos

### DIFF
--- a/articles/monitoring-and-diagnostics/monitoring-autoscale-get-started.md
+++ b/articles/monitoring-and-diagnostics/monitoring-autoscale-get-started.md
@@ -35,7 +35,7 @@ You can discover all the resources for which auto scale is applicable in Azure M
 
 You can use the filter pane at the top to scope down the list to select resources in a specific resource group, select specific resource types or select a specific resource.
 
-For each resource, you find find the current instance count as well as its autoscale status. The auto scale status can be
+For each resource, you will find the current instance count as well as its autoscale status. The auto scale status can be
 
 - Not configured: You have not enabled auto scale setting yet for this resource
 - Enabled: You have enabled auto scale setting for this resource
@@ -48,7 +48,7 @@ Lets now go through a simple step-by-step walkthrough to create your first autos
 - Open 'Autoscale' blade in Azure Monitor and select a resource you want to scale. (the steps below use an app service plan associated with a web app. You can [create your first ASP.NET web app in Azure in five minutes][4])
 - In the scale setting blade for the resource, notice that the current instance count is 1. Click on 'Enable autoscale'.
   ![Scale setting for new web app][5]
-- Provide a name for the scale setting, and the click on "Add a rule". Notice the scale rule options that opens as a context pane in the right hand side. By default, it sets the option to scale your instance count by 1 if the CPU percetage of the resource exceeds 70%. Leave it to its default values and click on Add.
+- Provide a name for the scale setting, and the click on "Add a rule". Notice the scale rule options that opens as a context pane in the right hand side. By default, it sets the option to scale your instance count by 1 if the CPU percentage of the resource exceeds 70%. Leave it to its default values and click on Add.
   ![Create scale setting for a web app][6]
 - You now created your first scale rule. Notice that the UX recommends best practices and states that 'It is recommended to have at least one scale in rule'. To do so, click on 'Add a rule' and set the 'Operator' to 'Less than', 'Threshold' to '20' and 'Operation' to 'Decrease count by'. You should now have a scale setting that scales out/scales in based on CPU usage.
   ![Scale based on cpu][8]
@@ -65,7 +65,7 @@ In addition to scale based on CPU always, you can also set your scale differentl
 - Click on 'Add a scale condition'
 - Setting the scale mode and the rules is the same as the default condition
 - Select 'Repeat specific days' for the schedule
-- Select the days, and the start/end time when the scale condition should be applied for the selected days.
+- Select the days, and the start/end time when the scale condition should be applied for the selected days
 
 ![Scale condition based on schedule][9]
 ## Scale differently on specific dates
@@ -74,7 +74,7 @@ In addition to scale based on CPU always, you can also set your scale differentl
 - Click on 'Add a scale condition'
 - Setting the scale mode and the rules is the same as the default condition
 - Select 'Specify start/end dates' for the schedule
-- Select the start/end dates, as well as the start/end time when the scale condition should be applied for the selected dates.
+- Select the start/end dates, as well as the start/end time when the scale condition should be applied for the selected dates
 
 ![Scale condition based on dates][10]
 
@@ -95,7 +95,7 @@ You can make changes in JSON directly, if required. These changes will get refle
 ## Disable autoscale and manually scale your instances
 There might be times when you want to disbable your current scale setting and manually scale your resource.
 
-Click on the 'Disable autocale' button at the top.
+Click on the 'Disable autoscale' button at the top.
 ![Disable autoscale][13]
 
 Note that this option disables your configuration, and you can still get back to it once you enable auto scale again. You can now set the number of instances you want to scale to manually.


### PR DESCRIPTION
Just a few typos. 
There's a mix of 'autoscale' and 'auto scale' in the document, but I decided to leave them unchanged.