### PR TITLE
Fixed reference to outputs

### DIFF
--- a/articles/azure-resource-manager/resource-group-linked-templates.md
+++ b/articles/azure-resource-manager/resource-group-linked-templates.md
@@ -48,7 +48,7 @@ You create a link between two templates by adding a deployment resource within t
 Like other resource types, you can set dependencies between the linked template and other resources. Therefore, when other resources require an output value from the linked template, you can make sure the linked template is deployed before them. Or, when the linked template relies on other resources, you can make sure other resources are deployed before the linked template. You can retrieve a value from a linked template with the following syntax:
 
 ```json
-"[reference('linkedTemplate').outputs.exampleProperty]"
+"[reference('linkedTemplate').outputs.exampleProperty.value]"
 ```
 
 The Resource Manager service must be able to access the linked template. You cannot specify a local file or a file that is only available on your local network for the linked template. You can only provide a URI value that includes either **http** or **https**. One option is to place your linked template in a storage account, and use the URI for that item, such as shown in the following example:


### PR DESCRIPTION
Added missing ".value". The sample as it is does not work.