### PR TITLE
Make sample MetricManager code compile

### DIFF
--- a/articles/application-insights/app-insights-api-custom-events-metrics.md
+++ b/articles/application-insights/app-insights-api-custom-events-metrics.md
@@ -134,7 +134,7 @@ Create an instance of MetricManager and then use it as a factory for metrics:
     var manager = new Microsoft.ApplicationInsights.Extensibility.MetricManager(telemetryClient);
 
     // For each metric that you want to use:
-    var metric1 = mgr.CreateMetric("m1", dimensions);
+    var metric1 = manager.CreateMetric("m1", dimensions);
 
     // Each time you want to record a measurement:
     metric1.Track(value);


### PR DESCRIPTION
The sample code for MetricManager has incorrect local variable name which prevents code from being used as is.