### PR TITLE
Corrected Case in the Claims in step 6

### DIFF
--- a/articles/active-directory/active-directory-saas-amazon-web-service-tutorial.md
+++ b/articles/active-directory/active-directory-saas-amazon-web-service-tutorial.md
@@ -128,8 +128,8 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 	
 	| Attribute Name  | Attribute Value | Namespace |
 	| --------------- | --------------- | --------------- |
-	| rolesessionname | user.userprincipalname | https://aws.amazon.com/SAML/Attributes |
-	| role 			  | user.assignedroles | keep it blank |
+	| RoleSessionName | user.userprincipalname | https://aws.amazon.com/SAML/Attributes |
+	| Role 			  | user.assignedroles |  https://aws.amazon.com/SAML/Attributes |
 	
 	>[!TIP]
 	>You need to configure the user provisioning in Azure AD to fetch all the roles from AWS Console. Please refer the provisioning steps below.


### PR DESCRIPTION
Corrected the case for the Claims in the table in Step 6 and added the Namespace for Role.
People copy and paste the text from this table as is and the result is it fails. Corrected so they can copy and it work first time.
In addition it seems there is a bug in Azure portal, that whilst a user can go back into a claim and change the text to use the correct case and save it, The portal does not actually commit that save in upper case. The user might not see this as they have clicked on Save assuming it has saved the changes, they then go and test it and it is still not working, causing dis satisfaction, as well as them assuming that it is another problem, whilst it is still this same one problem of case not being updated.
The only way to do it is to delete the claims and then add them in again using the correct case. Hence if this article could clearly articulate the need to copy the claims text exactly including the case, it would save a whole lot of wasted time trying to figure out what else might be wrong. 