### PR TITLE
Update logic-apps-limits-and-config.md

### DIFF
--- a/articles/logic-apps/logic-apps-limits-and-config.md
+++ b/articles/logic-apps/logic-apps-limits-and-config.md
@@ -112,7 +112,8 @@ These are limits for artifacts added to integration Account
 |Schema|8MB|You can use [blob URI](logic-apps-enterprise-integration-schemas.md) to upload files larger than 2 MB |
 |Map (XSLT file)|2MB| |
 |Runtime endpoint read calls per 5 minutes |60,000|Can distribute workload across multiple accounts as needed|
-|Runtime endpoint invoke calls per 5 minutes |90,000|Can distribute workload across multiple accounts as needed|
+|Runtime endpoint invoke calls per 5 minutes |45,000|Can distribute workload across multiple accounts as needed|
+|Runtime endpoint tracking calls per 5 minutes |45,000|Can distribute workload across multiple accounts as needed|
 |Runtime endpoint blocking concurrent calls |~1,000|Decrease number of concurrent requests or reduce the duration as needed|
 
 ### B2B protocols (AS2, X12, EDIFACT) message size


### PR DESCRIPTION
Updated the Integration account limits. The runtime endpoint invoke has been reduced from 90K to 45K. Also, added a new limit for runtime tracking calls.