### PR TITLE
Update service-bus-nodejs-how-to-use-queues.md

### DIFF
--- a/articles/service-bus-messaging/service-bus-nodejs-how-to-use-queues.md
+++ b/articles/service-bus-messaging/service-bus-nodejs-how-to-use-queues.md
@@ -59,7 +59,7 @@ var azure = require('azure');
 ```
 
 ### Set up an Azure Service Bus connection
-The Azure module reads the environment variables AZURE\_SERVICEBUS\_NAMESPACE and AZURE\_SERVICEBUS\_ACCESS\_KEY to obtain information required to connect to Service Bus. If these environment variables are not set, you must specify the account information when calling **createServiceBusService**.
+The Azure module reads the environment variable AZURE\_SERVICEBUS\_CONNECTION\_STRING to obtain information required to connect to Service Bus. If this environment variables is not set, you must specify the account information when calling **createServiceBusService**.
 
 For an example of setting the environment variables in a configuration file for an Azure Cloud Service, see [Node.js Cloud Service with Storage][Node.js Cloud Service with Storage].
 


### PR DESCRIPTION
This updates the doc to use the `AZURE_SERVICEBUS_CONNECTION_STRING` environment variable instead of the `AZURE_SERVICEBUS_NAMESPACE` and `AZURE_SERVICEBUS_ACCESS_KEY`. If you only specify those two envrinment variables, you get a DNS resolution error from inside the SDK. I _think_ you need to also specify `AZURE_SERVICEBUS_ISSUER` if you specify `AZURE_SERVICEBUS_NAMESPACE` and `AZURE_SERVICEBUS_ACCESS_KEY`, but I was not able to get it to work. This way is much simpler, and is verified to work as of this writing.