### PR TITLE
Update documentdb-nosql-local-emulator.md

### DIFF
--- a/articles/documentdb/documentdb-nosql-local-emulator.md
+++ b/articles/documentdb/documentdb-nosql-local-emulator.md
@@ -73,7 +73,7 @@ You can download and install the Azure Cosmos DB Emulator from the [Microsoft Do
 
 The Azure Cosmos DB Emulator can be run on Docker for Windows. The Emulator does not work on Docker for Oracle Linux.
 
-Once you have [Docker for Windows](https://www.docker.com/docker-windows) installed, you can pull the Emulator image from Docker Hub by running the following command from your favorite shell (cmd.exe, PowerShell, etc.).
+Once you have [Docker for Windows](https://www.docker.com/docker-windows) installed and switched to Windows containers, you can pull the Emulator image from Docker Hub by running the following command from your favorite shell (cmd.exe, PowerShell, etc.).
 
 ```      
 docker pull microsoft/azure-documentdb-emulator 
@@ -82,7 +82,7 @@ To start the image, run the following commands.
 
 ``` 
 md %LOCALAPPDATA%\DocumentDBEmulatorCert 2>nul
-docker run -v %LOCALAPPDATA%\DocumentDBEmulatorCert:c:\DocumentDBEmulator\DocumentDBEmulatorCert -P -t -i microsoft/azure-documentdb-emulator 
+docker run -v %LOCALAPPDATA%\DocumentDBEmulatorCert:c:\DocumentDBEmulator\DocumentDBEmulatorCert -P -t -i -m 2GB microsoft/azure-documentdb-emulator 
 ```
 
 The response looks similar to the following:


### PR DESCRIPTION
When following the instructions for running the emulator on Docker for Windows on my Windows 10 machine, I had two issue:
- After installing Docker, the default setting is to use Linux Containers, so I had to switch to Windows containers
- The default memory size of the container (that on Windows 10 use Hyper-V isolation) is 1GB and causes an out-of-memory error (see [Running docker rans out of memory #254](https://github.com/Azure/azure-documentdb-dotnet/issues/254) ).