### PR TITLE
Fix a typo: key management is not supported

### DIFF
--- a/articles/documentdb/documentdb-nosql-database-encryption-at-rest.md
+++ b/articles/documentdb/documentdb-nosql-database-encryption-at-rest.md
@@ -52,7 +52,7 @@ A: Microsoft has a set of internal guidelines, which DocumentDB follows.  While 
 ### Q: Can I use my own encryption keys?
 A: Azure Cosmos DB is a PaaS service and we have worked hard to keep the service easy to use.  We have noticed this question is
 often asked as a proxy question for meeting a compliance like PCI-DSS.  As part of building this feature we have worked with compliance auditors to ensure customers using Azure Cosmos DB meeting their requirements without needing to manage keys themselves.
-This is why we currently do offer users the option to burden themselves with key management.
+This is why we currently do not offer users the option to burden themselves with key management.
 
 
 ### Q: What regions have encryption turned on?


### PR DESCRIPTION
Docs had an error in them, key management is not supported.