### PR TITLE
Update active-directory-certificate-based-authentication-ios.md

### DIFF
--- a/articles/active-directory/active-directory-certificate-based-authentication-ios.md
+++ b/articles/active-directory/active-directory-certificate-based-authentication-ios.md
@@ -41,6 +41,7 @@ This feature is available in preview in Office 365 US Government Defense and Fed
 | OneDrive |![Check][1] |
 | Outlook |![Check][1] |
 | Yammer |![Check][1] |
+| Microsoft Teams ||![Check][1] |
 | Skype for Business |![Check][1] |
 
 ## Requirements 


### PR DESCRIPTION
Adding "Microsoft Team" as an Office mobile application that has Azure Active Directory certificate-based authentication on iOS