### PR TITLE
Add build info to the instructions.

### DIFF
--- a/articles/cosmos-db/create-graph-nodejs.md
+++ b/articles/cosmos-db/create-graph-nodejs.md
@@ -123,7 +123,9 @@ module.exports = config;
 
 2. Run `npm install gremlin` to install required npm modules.
 
-3. Replace the contents of the `node_modules\gremlin` folder with the source code from [the Cosmos DB Gremlin fork](https://github.com/CosmosDB/gremlin-javascript), which has support for SSL and SASL, which are required for Azure Cosmos DB, but not currently supported by the driver (temporarily until the changes are accepted in the driver).
+3. Replace the contents of the `node_modules\gremlin` folder with the source code from [the Cosmos DB Gremlin fork](https://github.com/CosmosDB/gremlin-javascript), which has support for SSL and SASL, which are required for Azure Cosmos DB, but not currently supported by the driver (temporarily until the changes are accepted in the driver). Once you've checked out the repo locally run `npm install` then `npm run build` before you copy it over. 
+
+
 
 4. Run `node app.js` in a terminal to start your node application.
 


### PR DESCRIPTION
Fix: It's not clear on reading this that you need to build before copying over to the node_modules\gremlin folder. 