### PR TITLE
Adding missing external endpoints

### DIFF
--- a/articles/application-insights/app-insights-ip-addresses.md
+++ b/articles/application-insights/app-insights-ip-addresses.md
@@ -31,6 +31,7 @@ You need to open some outgoing ports in your server's firewall to allow the Appl
 | --- | --- | --- | --- |
 | Telemetry |dc.services.visualstudio.com<br/>dc.applicationinsights.microsoft.com |40.114.241.141<br/>104.45.136.42<br/>40.84.189.107<br/>168.63.242.221<br/>52.167.221.184<br/>52.169.64.244 |443 |
 | Live Metrics Stream |rt.services.visualstudio.com<br/>rt.applicationinsights.microsoft.com |23.96.28.38<br/>13.92.40.198 |443 |
+| Internal Telemetry |breeze.aimon.applicationinsights.io |52.161.11.71 |443 |
 
 ## Status Monitor
 Status Monitor Configuration - needed only when making changes.
@@ -199,6 +200,7 @@ US : VA-Ashburn
 | --- | --- | --- | --- |
 | API |api.applicationinsights.io<br/>api1.applicationinsights.io<br/>api2.applicationinsights.io<br/>api3.applicationinsights.io<br/>api4.applicationinsights.io<br/>api5.applicationinsights.io |13.82.26.252<br/>40.76.213.73 |80,443 |
 | API docs |dev.applicationinsights.io<br/>dev.applicationinsights.microsoft.com<br/>dev.aisvc.visualstudio.com<br/>www.applicationinsights.io<br/>www.applicationinsights.microsoft.com<br/>www.aisvc.visualstudio.com |13.82.24.149<br/>40.114.82.10 |80,443 |
+| Internal API |aigs.aisvc.visualstudio.com<br/>aigs1.aisvc.visualstudio.com<br/>aigs2.aisvc.visualstudio.com<br/>aigs3.aisvc.visualstudio.com<br/>aigs4.aisvc.visualstudio.com<br/>aigs5.aisvc.visualstudio.com<br/>aigs6.aisvc.visualstudio.com |dynamic|443 |
 
 ## Application Insights Analytics
 
@@ -209,6 +211,20 @@ US : VA-Ashburn
 | Media CDN | applicationanalyticsmedia.azureedge.net | dynamic | 80,443 |
 
 Note: *.applicationinsights.io domain is owned by Application Insights team.
+
+## Application Insights Azure Portal Extension
+
+| Purpose | URI | IP | Ports |
+| --- | --- | --- | --- |
+| Application Insights Extension | stamp2.app.insightsportal.visualstudio.com | dynamic | 80,443 |
+| Application Insights Extension CDN | insightsportal-prod2-cdn.aisvc.visualstudio.com<br/>insightsportal-prod2-asiae-cdn.aisvc.visualstudio.com<br/>insightsportal-cdn-aimon.applicationinsights.io | dynamic | 80,443 |
+
+## Application Insights SDKs
+
+| Purpose | URI | IP | Ports |
+| --- | --- | --- | --- |
+| Application Insights JS SDK CDN | az416426.vo.msecnd.net | dynamic | 80,443 |
+| Application Insights Java SDK | aijavasdk.blob.core.windows.net | dynamic | 80,443 |
 
 ## Profiler
 


### PR DESCRIPTION
Multiple missing endpoints were added to external documentation, which need to be added to customers firewall rules:
- Internal Telemetry Endpoint (required for application insights team to get telemetry)
- Internal API endpoints (which are used to bypass ARM and should be white listed by customers)
- Extra section for Application Insights Azure Portal Extension
- Extra section for Application Insights SDKs