### PR TITLE
Cleaned up code example

### DIFF
--- a/articles/azure-resource-manager/resource-manager-samples-powershell-deploy.md
+++ b/articles/azure-resource-manager/resource-manager-samples-powershell-deploy.md
@@ -34,106 +34,60 @@ This script deploys a Resource Manager template to a resource group in your subs
 
  .DESCRIPTION
     Deploys an Azure Resource Manager template
-
- .PARAMETER subscriptionId
-    The subscription id where the template will be deployed.
-
- .PARAMETER resourceGroupName
-    The resource group where the template will be deployed. Can be the name of an existing or a new resource group.
-
- .PARAMETER resourceGroupLocation
-    Optional, a resource group location. If specified, will try to create a new resource group in this location. If not specified, assumes resource group is existing.
-
- .PARAMETER deploymentName
-    The deployment name.
-
- .PARAMETER templateFilePath
-    Optional, path to the template file. Defaults to template.json.
-
- .PARAMETER parametersFilePath
-    Optional, path to the parameters file. Defaults to parameters.json. If file is not found, will prompt for parameter values based on template.
 #>
 
-param(
- [Parameter(Mandatory=$True)]
- [string]
- $subscriptionId,
+param (
+    [Parameter(Mandatory)]
+    #The subscription id where the template will be deployed.
+    [string]$SubscriptionId,  
 
- [Parameter(Mandatory=$True)]
- [string]
- $resourceGroupName,
+    [Parameter(Mandatory)]
+    #The resource group where the template will be deployed. Can be the name of an existing or a new resource group.
+    [string]$ResourceGroupName, 
 
- [string]
- $resourceGroupLocation,
+    #Optional, a resource group location. If specified, will try to create a new resource group in this location. If not specified, assumes resource group is existing.
+    [string]$ResourceGroupLocation, 
 
- [Parameter(Mandatory=$True)]
- [string]
- $deploymentName,
+    #The deployment name.
+    [Parameter(Mandatory)]
+    [string]$DeploymentName,    
 
- [string]
- $templateFilePath = "template.json",
+    #Path to the template file. Defaults to template.json.
+    [string]$TemplateFilePath = "template.json",  
 
- [string]
- $parametersFilePath = "parameters.json"
+    #Path to the parameters file. Defaults to parameters.json. If file is not found, will prompt for parameter values based on template.
+    [string]$ParametersFilePath = "parameters.json"
 )
 
-<#
-.SYNOPSIS
-    Registers RPs
-#>
-Function RegisterRP {
-    Param(
-        [string]$ResourceProviderNamespace
-    )
-
-    Write-Host "Registering resource provider '$ResourceProviderNamespace'";
-    Register-AzureRmResourceProvider -ProviderNamespace $ResourceProviderNamespace;
-}
-
-#******************************************************************************
-# Script body
-# Execution begins here
-#******************************************************************************
 $ErrorActionPreference = "Stop"
 
-# sign in
-Write-Host "Logging in...";
-Login-AzureRmAccount;
+# Login to Azure and select subscription
+Write-Output "Logging in"
+Login-AzureRmAccount
+Write-Output "Selecting subscription '$SubscriptionId'"
+Select-AzureRmSubscription -SubscriptionID $SubscriptionId
 
-# select subscription
-Write-Host "Selecting subscription '$subscriptionId'";
-Select-AzureRmSubscription -SubscriptionID $subscriptionId;
-
-# Register RPs
-$resourceProviders = @();
-if($resourceProviders.length) {
-    Write-Host "Registering resource providers"
-    foreach($resourceProvider in $resourceProviders) {
-        RegisterRP($resourceProvider);
+# Create or check for existing resource group
+$resourceGroup = Get-AzureRmResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+if ( -not $ResourceGroup ) {
+    Write-Output "Could not find resource group '$ResourceGroupName' - will create it"
+    if ( -not $ResourceGroupLocation ) {
+        $ResourceGroupLocation = Read-Host -Prompt 'Enter location for resource group'
     }
-}
-
-#Create or check for existing resource group
-$resourceGroup = Get-AzureRmResourceGroup -Name $resourceGroupName -ErrorAction SilentlyContinue
-if(!$resourceGroup)
-{
-    Write-Host "Resource group '$resourceGroupName' does not exist. To create a new resource group, please enter a location.";
-    if(!$resourceGroupLocation) {
-        $resourceGroupLocation = Read-Host "resourceGroupLocation";
-    }
-    Write-Host "Creating resource group '$resourceGroupName' in location '$resourceGroupLocation'";
+    Write-Output "Creating resource group '$ResourceGroupName' in location '$ResourceGroupLocation'"
     New-AzureRmResourceGroup -Name $resourceGroupName -Location $resourceGroupLocation
 }
-else{
-    Write-Host "Using existing resource group '$resourceGroupName'";
+else {
+    Write-Output "Using existing resource group '$ResourceGroupName'"
 }
 
 # Start the deployment
-Write-Host "Starting deployment...";
-if(Test-Path $parametersFilePath) {
-    New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath -TemplateParameterFile $parametersFilePath;
-} else {
-    New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath;
+Write-Output "Starting deployment"
+if ( Test-Path $ParametersFilePath ) {
+    New-AzureRmResourceGroupDeployment -ResourceGroupName $ResourceGroupName -TemplateFile $TemplateFilePath -TemplateParameterFile $ParametersFilePath
+}
+else {
+    New-AzureRmResourceGroupDeployment -ResourceGroupName $ResourceGroupName -TemplateFile $TemplateFilePath
 }
 ``` 
 


### PR DESCRIPTION
- Introduced new parameter capitalization, congruent to community guidelines and best practices
- Re-organized parameter help info
- Normalized indentation and bracketing scheme, previously inconsistent
- Removed code that could never run and improperly named function (RegisterRp function could never run in code as written)
- Removed unnecessary semicolons
- Adjusted how a user is prompted for a resource group location if the resource group is not found