### PR TITLE
Update network-watcher-packet-capture-overview.md

### DIFF
--- a/articles/network-watcher/network-watcher-packet-capture-overview.md
+++ b/articles/network-watcher/network-watcher-packet-capture-overview.md
@@ -33,7 +33,7 @@ To reduce the information you capture to only the information you want, the foll
 
 |Property|Description|
 |---|---|
-|**Maximum bytes per packet (bytes)** | The number of bytes from each packet that are captured, all bytes are captured if left blank. The number of bytes from each packet that are captured, all bytes are captured if left blank. If you need only the IPv4 header – indicate 60 here |
+|**Maximum bytes per packet (bytes)** | The number of bytes from each packet that are captured, all bytes are captured if left blank. The number of bytes from each packet that are captured, all bytes are captured if left blank. If you need only the IPv4 header – indicate 34 here |
 |**Maximum bytes per session (bytes)** | Total number of bytes in that are captured, once the value is reached the session ends.|
 |**Time limit (seconds)** | Sets a time constraint on the packet capture session. The default value is 18000 seconds or 5 hours.|
 


### PR DESCRIPTION
if the customer only wants the IPv4 header, truncating at 60 bytes is wrong.
he shall truncate at 34 (includes Ethernet header 14 bytes + IPv4 header 20 bytes)

truncating at 60 bytes will also reveal 20 more bytes of TCP header and some extra bytes of application header / payload.