### PR TITLE
[Web Apps on Linux] Updating runtime stacks

### DIFF
--- a/articles/app-service-web/app-service-linux-intro.md
+++ b/articles/app-service-web/app-service-linux-intro.md
@@ -34,6 +34,7 @@ Web App on Linux currently supports the following application stacks:
 	* 6.2
 	* 6.6
 	* 6.9
+	* 6.10
 * PHP
 	* 5.6
 	* 7.0


### PR DESCRIPTION
This PR simply adds Node.js v6.10 to the list of available runtime stacks for Web Apps on Linux.