### PR TITLE
Update service-fabric-reliable-services-communication-remoting.md

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-communication-remoting.md
+++ b/articles/service-fabric/service-fabric-reliable-services-communication-remoting.md
@@ -27,6 +27,8 @@ Setting up remoting for a service is done in two simple steps:
 1. Create an interface for your service to implement. This interface defines the methods that will be available for a remote procedure call on your service. The methods must be task-returning asynchronous methods. The interface must implement `Microsoft.ServiceFabric.Services.Remoting.IService` to signal that the service has a remoting interface.
 2. Use a remoting listener in your service. This is an `ICommunicationListener` implementation that provides remoting capabilities. The `Microsoft.ServiceFabric.Services.Remoting.Runtime` namespace contains an extension method,`CreateServiceRemotingListener` for both stateless and stateful services that can be used to create a remoting listener using the default remoting transport protocol.
 
+Note: The `Remoting` namespace is available as a seperate nuget package called `Microsoft.ServiceFabric.Services.Remoting` 
+
 For example, the following stateless service exposes a single method to get "Hello World" over a remote procedure call.
 
 ```csharp


### PR DESCRIPTION
Attempt to make availability of the remoting namespace more clear

1. In early versions of Service Fabric the remoting namespace was included in `Microsoft.ServiceFabric.Services`
2. The nuget package for Remoting is not included in Service Fabric Visual Studio templates by default