### PR TITLE
Corrected application-gateway create command

### DIFF
--- a/articles/application-gateway/application-gateway-create-gateway-cli.md
+++ b/articles/application-gateway/application-gateway-create-gateway-cli.md
@@ -121,7 +121,9 @@ az network application-gateway create \
 --location eastus \
 --resource-group AdatumAppGatewayRG \
 --vnet-name AdatumAppGatewayVNET \
+---vnet-address-prefix 10.0.0.0/16 \
 --subnet Appgatewaysubnet \
+---subnet-address-prefix 10.0.0.0/28 \
 --servers 10.0.0.4 10.0.0.5 \
 --cert-file /mnt/c/Users/username/Desktop/application-gateway/fabrikam.pfx \
 --cert-password P@ssw0rd \

--- a/articles/application-gateway/application-gateway-create-gateway-cli.md
+++ b/articles/application-gateway/application-gateway-create-gateway-cli.md
@@ -121,9 +121,7 @@ az network application-gateway create \
 --location eastus \
 --resource-group AdatumAppGatewayRG \
 --vnet-name AdatumAppGatewayVNET \
---vnet-address-prefix 10.0.0.0/16 \
 --subnet Appgatewaysubnet \
---subnet-address-prefix 10.0.0.0/28 \
 --servers 10.0.0.4 10.0.0.5 \
 --cert-file /mnt/c/Users/username/Desktop/application-gateway/fabrikam.pfx \
 --cert-password P@ssw0rd \
@@ -131,6 +129,7 @@ az network application-gateway create \
 --sku Standard_Small \
 --http-settings-cookie-based-affinity Enabled \
 --http-settings-protocol Http \
+--public-ip-address AdatumAppGatewayPIP \
 --frontend-port 443 \
 --routing-rule-type Basic \
 --http-settings-port 80


### PR DESCRIPTION
When running "az network application-gateway create", an error is returned when vnet-address-prefix and subnet-address-prefix are specified along with vnet-name and subnet specified, so removed the two *-prefix params. Also, this doc is listed under the "Public Facing" section but it doesn't actually create a public IP, so I added --public-ip-address.