### PR TITLE
Flag --disable-nodejs-remote-modules was removed from build script

### DIFF
--- a/articles/iot-hub/iot-hub-windows-iot-edge-get-started.md
+++ b/articles/iot-hub/iot-hub-windows-iot-edge-get-started.md
@@ -49,7 +49,7 @@ You can now build the IoT Edge runtime and samples on your local machine:
 1. Run the build script as follows:
 
     ```cmd
-    tools\build.cmd --disable-nodejs-remote-modules --disable-native-remote-modules
+    tools\build.cmd --disable-native-remote-modules
     ```
 
 This script creates a Visual Studio solution file and builds the solution. You can find the Visual Studio solution in the **build** folder in your local copy of the **iot-edge** repository. If you want to build and run the unit tests, add the `--run-unittests` parameter. If you want to build and run the end to end tests, add the `--run-e2e-tests`.


### PR DESCRIPTION
A recent change removed this flag, so you cannot pass it to the Windows build script anymore. Node.js remote modules are now disabled by default.