### PR TITLE
Flag --disable-nodejs-remote-modules was removed from build script

### DIFF
--- a/articles/iot-hub/iot-hub-linux-iot-edge-get-started.md
+++ b/articles/iot-hub/iot-hub-linux-iot-edge-get-started.md
@@ -30,7 +30,7 @@ Open a shell and run the following commands to install the prerequisite packages
 
 ```bash
 sudo apt-get update
-sudo apt-get install curl build-essential libcurl4-openssl-dev git cmake libssl-dev uuid-dev valgrind libglib2.0-dev libtool autoconf
+sudo apt-get install curl build-essential libcurl4-openssl-dev git cmake pkg-config libssl-dev uuid-dev valgrind libglib2.0-dev libtool autoconf
 ```
 
 In the shell, run the following command to clone the Azure IoT Edge GitHub repository to your local machine:
@@ -50,7 +50,7 @@ You can now build the IoT Edge runtime and samples on your local machine:
 1. Run the build script as follows:
 
     ```sh
-    tools/build.sh --disable-nodejs-remote-modules --disable-native-remote-modules
+    tools/build.sh --disable-native-remote-modules
     ```
 
 This script uses the **cmake** utility to create a folder called **build** in the root folder of your local copy of the **iot-edge** repository and generate a makefile. The script then builds the solution, skipping unit tests and end to end tests. If you want to build and run the unit tests, add the `--run-unittests` parameter. If you want to build and run the end to end tests, add the `--run-e2e-tests`.


### PR DESCRIPTION
A recent change removed this flag, so you cannot pass it to the Windows build script anymore. Node.js remote modules are now disabled by default.

Also, added pkg-config to the list of dependencies to `apt-get`. This package was also added to `doc/devbox_setup.md` in the `Azure/iot-edge` repo.