### PR TITLE
Typo in steps 2 and 3 - PowerShell Commands

### DIFF
--- a/articles/active-directory/application-proxy-office365-app-launcher.md
+++ b/articles/active-directory/application-proxy-office365-app-launcher.md
@@ -72,7 +72,7 @@ Obtain the ObjectID of the app, and then search for the app by its home page.
 3. Find the app based on its home page URL. You can find the URL in the portal by going to **Azure Active Directory** > **Enterprise applications** > **All applications**. This example uses *sharepoint-iddemo*.
 
     ```
-    Get-AzureADApplications | where { $_.Homepage -like “sharepoint-iddemo” } | fl DisplayName, Homepage, ObjectID
+    Get-AzureADApplication | where { $_.Homepage -like “sharepoint-iddemo” } | fl DisplayName, Homepage, ObjectID
     ```
 4. You should get a result that's similar to the one shown here. Copy the ObjectID GUID to use in the next secion.
 
@@ -89,7 +89,7 @@ In the same PowerShell module that you used for step 1, do the following:
 1. Confirm that you have the correct app, and replace *8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4* with the GUID (ObjectID) that you copied in the preceding step.
 
     ```
-    Get-AzureADApplication -AppObjectId 8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4.
+    Get-AzureADApplication -ObjectId 8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4.
     ```
 
  Now that you've confirmed the app, you're ready to update the home page, as follows.


### PR DESCRIPTION
Typo in step 1.3 PowerShell Command (no S at the end of the command)

Original: Get-AzureADApplications
Fixed:  Get-AzureADApplication

Typo in step 2.1 - PowerShell Command (no 'App')

Original: Get-AzureADApplication -AppObjectId
Fixed:  Get-AzureADApplication -ObjectId