### PR TITLE
Multiple errors - Set-AzureADApplication now supports -Homepage flag

### DIFF
--- a/articles/active-directory/application-proxy-office365-app-launcher.md
+++ b/articles/active-directory/application-proxy-office365-app-launcher.md
@@ -106,17 +106,17 @@ In the same PowerShell module that you used for step 1, do the following:
 3. Set the home page URL to the value that you want. The value must be a subdomain path of the published app. For example, if you change the home page URL from *https://sharepoint-iddemo.msappproxy.net/* to *https://sharepoint-iddemo.msappproxy.net/hybrid/*, app users will go directly to the custom home page.
 
     ```
-    $appnew.Homepage = “https://sharepoint-iddemo.msappproxy.net/hybrid/”
+    $homepage = “https://sharepoint-iddemo.msappproxy.net/hybrid/”
     ```
 4. Make the update by using the GUID (ObjectID) that you copied in "Step 1: Find the ObjectID of the app."
 
     ```
-    Set-AzureADApplication -AppObjectId 8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4 - Application $appnew
+    Set-AzureADApplication -ObjectId 8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4 -Homepage $homepage
     ```
 5. To confirm that the change was successful, restart the app.
 
     ```
-    Get-AzureADApplication -AppObjectId 8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4
+    Get-AzureADApplication -ObjectId 8af89bfa-eac6-40b0-8a13-c2c4e3ee22a4
     ```
 
 >[!NOTE]


### PR DESCRIPTION
Set-AzureADApplication now supports the -Homepage flag

Updated Steps 2.3 and 2.4 to set variable to the desired Homepage value and registered the value using the -Homepage flag