### PR TITLE
add note about refresh and id tokens

### DIFF
--- a/articles/active-directory/develop/active-directory-v2-protocols-oauth-code.md
+++ b/articles/active-directory/develop/active-directory-v2-protocols-oauth-code.md
@@ -167,9 +167,8 @@ A successful token response will look like:
 | token_type |Indicates the token type value. The only type that Azure AD supports is Bearer |
 | expires_in |How long the access token is valid (in seconds). |
 | scope |The scopes that the access_token is valid for. |
-| refresh_token |An OAuth 2.0 refresh token. The  app can use this token acquire additional access tokens after the current access token expires.  Refresh_tokens are long-lived, and can be used to retain access to resources for extended periods of time.  For more detail, refer to the [v2.0 token reference](active-directory-v2-tokens.md). |
-| id_token |An unsigned JSON Web Token (JWT). The  app can base64Url decode the segments of this token to request information about the user who signed in. The  app can cache the values and display them, but it should not rely on them for any authorization or security boundaries.  For more information about id_tokens see the [v2.0 endpoint token reference](active-directory-v2-tokens.md). |
-
+| refresh_token |An OAuth 2.0 refresh token. The  app can use this token acquire additional access tokens after the current access token expires.  Refresh_tokens are long-lived, and can be used to retain access to resources for extended periods of time.  For more detail, refer to the [v2.0 token reference](active-directory-v2-tokens.md). <br> **Note:** Only provided if `offline_access` scope was requested. |
+| id_token |An unsigned JSON Web Token (JWT). The  app can base64Url decode the segments of this token to request information about the user who signed in. The  app can cache the values and display them, but it should not rely on them for any authorization or security boundaries.  For more information about id_tokens see the [v2.0 endpoint token reference](active-directory-v2-tokens.md). <br> **Note:** Only provided if `openid` scope was requested. |
 #### Error response
 Error responses will look like:
 
@@ -275,8 +274,8 @@ A successful token response will look like:
 | token_type |Indicates the token type value. The only type that Azure AD supports is Bearer |
 | expires_in |How long the access token is valid (in seconds). |
 | scope |The scopes that the access_token is valid for. |
-| refresh_token |A new OAuth 2.0 refresh token. You should replace the old refresh token with this newly acquired refresh token to ensure your refresh tokens remain valid for as long as possible. |
-| id_token |An unsigned JSON Web Token (JWT). The  app can base64Url decode the segments of this token to request information about the user who signed in. The  app can cache the values and display them, but it should not rely on them for any authorization or security boundaries.  For more information about id_tokens see the [v2.0 endpoint token reference](active-directory-v2-tokens.md). |
+| refresh_token |A new OAuth 2.0 refresh token. You should replace the old refresh token with this newly acquired refresh token to ensure your refresh tokens remain valid for as long as possible. <br> **Note:** Only provided if `offline_access` scope was requested. |
+| id_token |An unsigned JSON Web Token (JWT). The  app can base64Url decode the segments of this token to request information about the user who signed in. The  app can cache the values and display them, but it should not rely on them for any authorization or security boundaries.  For more information about id_tokens see the [v2.0 endpoint token reference](active-directory-v2-tokens.md). <br> **Note:** Only provided if `openid` scope was requested. |
 
 #### Error response
 ```


### PR DESCRIPTION
It seems like the `refresh_token` is only provided if the `offline_access` scope was requested and `id_token` is only provided if the `openid` scope was requested.

 It was incredibly confusing that the responses I was getting back did not match the response in the docs, I assumed that I was constructing my request incorrectly but an hour and some googling later I realized I needed those scopes.