### PR TITLE
Copy Wizard Optional Ports needed to be added to the documentation

### DIFF
--- a/articles/data-factory/data-factory-data-management-gateway.md
+++ b/articles/data-factory/data-factory-data-management-gateway.md
@@ -136,6 +136,7 @@ At corporate firewall level, you need configure the following domains and outbou
 | *.servicebus.windows.net |443, 80 |Used for communication with Data Movement Service backend |
 | *.core.windows.net |443 |Used for Staged copy using Azure Blob (if configured)|
 | *.frontend.clouddatahub.net |443 |Used for communication with Data Movement Service backend |
+| *.servicebus.windows.net |9350-9354, 5671 |Optional service bus relay over TCP used by the Copy Wizard |
 
 
 At windows firewall level, these outbound ports are normally enabled. If not, you can configure the domains and ports accordingly on gateway machine.


### PR DESCRIPTION
The additional ports are not part of the initial Data Gateway Configuration steps but they are listed in the troubleshooting steps page and they generate a confusing warning to the users.