### PR TITLE
Azure Backup documentation edit

### DIFF
--- a/articles/backup/backup-azure-manage-windows-server.md
+++ b/articles/backup/backup-azure-manage-windows-server.md
@@ -210,7 +210,7 @@ From the **Actions** available at the right of the backup agent console you perf
     ![Schedule a Windows Server Backup](./media/backup-azure-manage-windows-server/modify-or-stop-a-scheduled-backup.png)
 3. If you want to add or change items, on the **Select Items to Backup** screen click **Add Items**.
 
-    You can also set **Exclusion Settings** from this page in the wizard. If you want to exclude files or file types read the procedure for adding [exclusion settings](#exclusion-settings).
+    You can also set **Exclusion Settings** from this page in the wizard. If you want to exclude files or file types read the procedure for adding [exclusion settings](#manage-exclusion-settings).
 4. Select the files and folders you want to back up and click **Okay**.
 
     ![Schedule a Windows Server Backup](./media/backup-azure-manage-windows-server/add-items-modify.png)


### PR DESCRIPTION
My name is Vikranth, from the MSDN Azure forums team.

I would like to suggest a few edits/corrections in the following documentation. 
Monitor and manage Azure recovery services vaults and servers for Windows machines.

In the highlighted steps/statement in the documentation “You can also set Exclusion Settings from this page in the wizard. If you want to exclude files or file types read the procedure for adding exclusion settings.” 
The exclusion settings, hyperlink is not pointed to the correct section. 

It is now pointing to https://docs.microsoft.com/en-us/azure/backup/backup-azure-manage-windows-server#exclusion-settings

But, it should point to this section: https://docs.microsoft.com/en-us/azure/backup/backup-azure-manage-windows-server#manage-exclusion-settings.

Requesting you to correct this section in the documentation.