### PR TITLE
Replace deprecated command

### DIFF
--- a/includes/app-service-web-create-web-app.md
+++ b/includes/app-service-web-create-web-app.md
@@ -7,7 +7,7 @@ The web app provides a hosting space for your code and provides a URL to view th
 In the following command, replace *\<app_name>* with a unique name. If `<app_name>` is not unique, you get the error message "Website with given name <app_name> already exists." The default URL of the web app is `https://<app_name>.azurewebsites.net`. 
 
 ```azurecli-interactive
-az appservice web create --name <app_name> --resource-group myResourceGroup --plan myAppServicePlan
+az webapp create --name <app_name> --resource-group myResourceGroup --plan myAppServicePlan
 ```
 
 When the web app has been created, the Azure CLI shows information similar to the following example:


### PR DESCRIPTION
Command az appservice web create is deprecating and will be removed
in future releases. Use 'az webapp create' instead according to cli warning.