### PR TITLE
Update hdinsight-domain-joined-architecture.md

### DIFF
--- a/articles/hdinsight/hdinsight-domain-joined-architecture.md
+++ b/articles/hdinsight/hdinsight-domain-joined-architecture.md
@@ -23,17 +23,17 @@ ms.author: saurinsh
 
 The traditional Hadoop is a single-user cluster. It is suitable for most companies that have smaller application teams building large data workloads. As Hadoop gains popularity, many enterprises are moving toward a model in which clusters are managed by IT teams and multiple application teams share clusters. Thus, functionalities involving multiuser clusters are among the most requested functionalities in Azure HDInsight.
 
-Instead of building its own multiuser authentication and authorization, HDInsight relies on the most popular identity provider--Azure Active Directory (Azure AD). The powerful security functionality in Azure AD can be used to manage multiuser authorization in HDInsight. By integrating HDInsight with Azure AD, you can communicate with the clusters by using your Azure AD credentials. HDInsight maps an Azure AD user to a local Hadoop user, so all the services running on HDInsight (Ambari, Hive server, Ranger, Spark thrift server, and others) work seamlessly for the authenticated user.
+Instead of building its own multiuser authentication and authorization, HDInsight relies on the most popular identity provider-- Active Directory (AD). The powerful security functionality in AD can be used to manage multiuser authorization in HDInsight. By integrating HDInsight with AD, you can communicate with the clusters by using your AD credentials. HDInsight maps an AD user to a local Hadoop user, so all the services running on HDInsight (Ambari, Hive server, Ranger, Spark thrift server, and others) work seamlessly for the authenticated user.
 
-## Integrate HDInsight with Azure AD
+## Integrate HDInsight with AD
 
-By integrating HDInsight with Azure AD, the HDInsight cluster nodes are domain-joined to the Azure AD domain. HDInsight creates service principals for the Hadoop services running on the cluster and places them within a specified organizational unit (OU) in Azure AD. HDInsight also creates reverse DNS mappings in the Azure AD domain for the IP addresses of the nodes that are joined to the domain.
+By integrating HDInsight with AD, the HDInsight cluster nodes are domain-joined to the AD domain. HDInsight creates service principals for the Hadoop services running on the cluster and places them within a specified organizational unit (OU) in AD. HDInsight also creates reverse DNS mappings in the AD domain for the IP addresses of the nodes that are joined to the domain.
 
 You can achieve this setup by using multiple architectures. You can choose from the following architectures.
 
 **HDInsight integrated with Azure AD running on Azure IaaS**
 
-This is the simplest architecture for integrating HDInsight with Azure AD. The Azure AD domain controller runs on one (or multiple) virtual machines (VMs) in Azure. These VMs are usually in a virtual network. You set up another virtual network for the HDInsight cluster. For HDInsight to have a line of sight to Azure AD, you need to peer these virtual networks by using [VNet-to-VNet peering](../virtual-network/virtual-network-create-peering.md).
+This is the simplest architecture for integrating HDInsight with AD. The AD domain controller runs on one (or multiple) virtual machines (VMs) in Azure. These VMs are usually in a virtual network. You set up another virtual network for the HDInsight cluster. For HDInsight to have a line of sight to AD, you need to peer these virtual networks by using [VNet-to-VNet peering](../virtual-network/virtual-network-create-peering.md).
 
 ![Domain-join HDInsight cluster topology](./media/hdinsight-domain-joined-architecture/hdinsight-domain-joined-architecture_1.png)
 
@@ -41,7 +41,7 @@ This is the simplest architecture for integrating HDInsight with Azure AD. The A
 > In this architecture, you cannot use Azure Data Lake Store with the HDInsight cluster.
 
 
-Prerequisites for Azure AD:
+Prerequisites for AD:
 
 * An [organizational unit](../active-directory-domain-services/active-directory-ds-admin-guide-create-ou.md) must be created, within which you place the HDInsight cluster VMs and the service principals used by the cluster.
 * [Lightweight Directory Access Protocols](../active-directory-domain-services/active-directory-ds-admin-guide-configure-secure-ldap.md) (LDAPs) must be set up for communicating with Azure AD. The certificate used to set up LDAPS must be a real certificate (not a self-signed certificate).


### PR DESCRIPTION
Updated "Azure AD" to "AD" in several places in intro sections as well as section "**HDInsight integrated with Azure AD running on Azure IaaS**". The 2 supported options now include 1 with AD and 1 with Azure AD. Therefore, the article intro section should use the term "AD" as a generic term encompassing both. And the section with AD (not AAD) had referred erroneously to "Azure AD", so needed to be updated to "AD".