### PR TITLE
Missing set of env port

### DIFF
--- a/articles/cloud-services/cloud-services-nodejs-chat-app-socketio.md
+++ b/articles/cloud-services/cloud-services-nodejs-chat-app-socketio.md
@@ -85,12 +85,13 @@ server.js file:
          , nib = require('nib')
        //, sio = require('..//..//lib//socket.io'); //Original
          , sio = require('socket.io');                //Updated
+         var port = process.env.PORT || 3000;         //Updated
 3. To ensure the application listens on the correct port, open
    server.js in Notepad or your favorite editor, and then change the
    following line by replacing **3000** with **process.env.port** as shown below:
    
-       //app.listen(3000, function () {            //Original
-       app.listen(process.env.port, function () {  //Updated
+       //app.listen(3000, function () {            //Original
+       app.listen(process.env.port, function () {  //Updated
          var addr = app.address();
          console.log('   app listening on http://' + addr.address + ':' + addr.port);
        });


### PR DESCRIPTION
According to this: hhttps://docs.microsoft.com/en-us/azure/app-service-web/web-sites-nodejs-chat-app-socketio#modify-appjs-and-install-modules beside updating path to socket.io lib, the default port should be set as well.