### PR TITLE
Do not explicitely suggest customer to manually break leases

### DIFF
--- a/articles/storage/storage-cannot-delete-storage-account-container-vhd.md
+++ b/articles/storage/storage-cannot-delete-storage-account-container-vhd.md
@@ -135,4 +135,3 @@ A "Stopped (deallocated)" status releases the computer resources, such as the CP
 
 ## Next steps
 * [Delete a storage account](storage-create-storage-account.md#delete-a-storage-account)
-* [How to break the locked lease of blob storage in Microsoft Azure (PowerShell)](https://gallery.technet.microsoft.com/scriptcenter/How-to-break-the-locked-c2cd6492)


### PR DESCRIPTION
Do we know who signed off that public link to https://gallery.technet.microsoft.com/scriptcenter/How-to-break-the-locked-c2cd6492 ?
in CSS, we generally don't advise customer to use it, as it causes more harm than good and can lead to orphaned VMs or even data loss (if lease is broken, then nothing prevents to delete the VHD with VM running...)