### PR TITLE
Update link to imperative bindings

### DIFF
--- a/articles/azure-functions/functions-triggers-bindings.md
+++ b/articles/azure-functions/functions-triggers-bindings.md
@@ -405,7 +405,7 @@ module.exports = function (context, info) {
 
 ## Configuring binding data at runtime
 
-In C# and other .NET languages, you can use an imperative binding pattern, as opposed to the declarative bindings in *function.json*. Imperative binding is useful when binding parameters need to be computed at runtime rather than design time. To learn more, see [Binding at runtime via imperative bindings](functions-triggers-bindings.md#imperative-bindings) in the C# developer reference.
+In C# and other .NET languages, you can use an imperative binding pattern, as opposed to the declarative bindings in *function.json*. Imperative binding is useful when binding parameters need to be computed at runtime rather than design time. To learn more, see [Binding at runtime via imperative bindings](functions-reference-csharp.md#binding-at-runtime-via-imperative-bindings) in the C# developer reference.
 
 ## Next steps
 For more information on a specific binding, see the following articles:


### PR DESCRIPTION
The link to the imperative bindings section was not working and hence has been updated to the link given in a comment given in the article

(Link given by Matthew here: https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings#binding-expressions-and-patterns)