### PR TITLE
Bug Fix - "Create service principal with certificate from Certificate…

### DIFF
--- a/articles/azure-resource-manager/resource-group-authenticate-service-principal.md
+++ b/articles/azure-resource-manager/resource-group-authenticate-service-principal.md
@@ -306,8 +306,8 @@ Param (
  {
     # Sleep here for a few seconds to allow the service principal application to become active (should only take a couple of seconds normally)
     Sleep 15
-    New-AzureRMRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $Application.ApplicationId | Write-Verbose -ErrorAction SilentlyContinue
-    $NewRole = Get-AzureRMRoleAssignment -ServicePrincipalName $Application.ApplicationId -ErrorAction SilentlyContinue
+    New-AzureRMRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $ServicePrincipal.ApplicationId | Write-Verbose -ErrorAction SilentlyContinue
+    $NewRole = Get-AzureRMRoleAssignment -ServicePrincipalName $ServicePrincipal.ApplicationId -ErrorAction SilentlyContinue
     $Retries++;
  }
  


### PR DESCRIPTION
… Authority"

The PS for "Create service principal with certificate from Certificate Authority" had a bug:

Use of an unspecified variable $applicationId. I believe this is a typo and should actually be $ServicePrincipal.