### PR TITLE
Update ASP.NET Core support

### DIFF
--- a/articles/application-insights/app-insights-profiler.md
+++ b/articles/application-insights/app-insights-profiler.md
@@ -21,8 +21,7 @@ ms.author: cfreeman
 
 Find out how much time is spent in each method in your live web application by using the profiling tool of [Azure Application Insights](app-insights-overview.md). It shows you detailed profiles of live requests that were served by your app, and highlights the 'hot path' that is using the most time. It automatically selects examples that have different response times. The profiler uses various techniques to minimize overhead.
 
-The profiler currently works for ASP.NET web apps running on Azure App Services, in at least the Basic pricing tier. (If you're using ASP.NET Core, the target framework must be `.NetCoreApp`.)
-
+The profiler currently works for ASP.NET web apps running on Azure App Services, in at least the Basic pricing tier. 
 
 <a id="installation"></a>
 ## Enable the profiler
@@ -231,8 +230,7 @@ When you configure the profiler, the following updates are made to the Web App's
 
 ## <a id="aspnetcore"></a>ASP.NET Core Support
 
-ASP.NET Core 1.1.2 applications targeting to AI SDK 2.0 or higher would work with the Profiler. 
-
+ASP.NET Core application needs to install Microsoft.ApplicationInsights.AspNetCore Nuget package 2.1.0-beta6 or higher to work with the Profiler. We no longer support the lower versions after 6/27/2017.
 
 ## Next steps
 


### PR DESCRIPTION
ASP.NET Core needs to have the 2.1.0-beta6 AI SDK to work with profiler after 6/27/2017. The change will enable the support for both ASP.NET CORE 1.x and 2.x applications.

@mscawa @pharring 