### PR TITLE
Update storage-python-how-to-use-file-storage.md

### DIFF
--- a/articles/storage/storage-python-how-to-use-file-storage.md
+++ b/articles/storage/storage-python-how-to-use-file-storage.md
@@ -39,7 +39,7 @@ from azure.storage.file import FileService
 The following code creates a **FileService** object using the storage account name and account key.  Replace 'myaccount' and 'mykey' with your account name and key.
 
 ```python
-file_service = **FileService** (account_name='myaccount', account_key='mykey')
+file_service = FileService(account_name='myaccount', account_key='mykey')
 ```
 
 In the following code example, you can use a **FileService** object to create the share if it doesn't exist.


### PR DESCRIPTION
syntax error in line 42 of the docs file_service = **FileService** (account_name='myaccount', account_key='mykey'), should not have the asterisks I believe?