### PR TITLE
Added libtool installation

### DIFF
--- a/articles/iot-hub/iot-hub-iot-edge-physical-device.md
+++ b/articles/iot-hub/iot-hub-iot-edge-physical-device.md
@@ -280,7 +280,7 @@ At the time of writing, IoT Edge only supports BLE modules in gateways running o
 Install dependencies for Azure IoT Edge:
 
 ```sh
-sudo apt-get install cmake uuid-dev curl libcurl4-openssl-dev libssl-dev
+sudo apt-get install cmake uuid-dev curl libcurl4-openssl-dev libssl-dev libtool
 ```
 
 Use the following commands to clone IoT Edge and all its submodules to your home directory:


### PR DESCRIPTION
The ./tools/build.sh was failing due to missing the libtool library.  I suggest adding libtool to the sudo apt-get installation