### PR TITLE
Update event-hubs-java-get-started-receive-eph.md

### DIFF
--- a/articles/event-hubs/event-hubs-java-get-started-receive-eph.md
+++ b/articles/event-hubs/event-hubs-java-get-started-receive-eph.md
@@ -215,7 +215,7 @@ For different types of build environments, you can explicitly obtain the latest 
     ```
 
 > [!NOTE]
-> This tutorial uses a single instance of EventProcessorHost. To increase throughput, it is recommended that you run multiple instances of EventProcessorHost. In those cases, the various instances automatically coordinate with each other in order to load balance the received events. If you want multiple receivers to each process *all* the events, you must use the **ConsumerGroup** concept. When receiving events from different machines, it might be useful to specify names for EventProcessorHost instances based on the machines (or roles) in which they are deployed.
+> This tutorial uses a single instance of EventProcessorHost. To increase throughput, it is recommended that you run multiple instances of EventProcessorHost, preferrably on separate machines.  This will provide redundancy as well.   In those cases, the various instances automatically coordinate with each other in order to load balance the received events. If you want multiple receivers to each process *all* the events, you must use the **ConsumerGroup** concept. When receiving events from different machines, it might be useful to specify names for EventProcessorHost instances based on the machines (or roles) in which they are deployed.
 > 
 > 
 


### PR DESCRIPTION
Added note clarifying that the EventProcessorHost run preferrably on separate machines.  This will provide redundancy as well.

EventProcessorHost, preferrably on separate machines.  This will provide redundancy as well.