### PR TITLE
Modify "user name" to "email"

### DIFF
--- a/includes/app-service-api-configure-local-git.md
+++ b/includes/app-service-api-configure-local-git.md
@@ -2,8 +2,8 @@ Configure local Git deployment to the API app with the [az webapp source-control
 
 App Service supports several ways to deploy content to a web app, such as FTP, local Git, GitHub, Visual Studio Team Services, and Bitbucket. For this quickstart, you deploy by using local Git. That means you deploy by using a Git command to push from a local repository to a repository in Azure.  
 
-Use the script below to set the account-level deployment credentials you'll use when pushing the code, making sure to include your own values for the user name and password.   
+Use the script below to set the account-level deployment credentials you'll use when pushing the code, making sure to include your own values for the email and password.   
 
 ```azurecli-interactive
-az webapp deployment user set --user-name <desired user name> --password <desired password>
+az webapp deployment user set --user-name <desired email> --password <desired password>
 ```


### PR DESCRIPTION
In my testing, using a plain string as a username in this step returns a 403. It appears that the username must be formatted as an email address. Changed the documentation to reflect that.