### PR TITLE
clearer documentation on preview cluster.

### DIFF
--- a/articles/service-fabric/service-fabric-docker-compose.md
+++ b/articles/service-fabric/service-fabric-docker-compose.md
@@ -22,7 +22,7 @@ ms.author: subramar
 
 Docker uses the [docker-compose.yml](https://docs.docker.com/compose) file for defining multi-container applications. To make it easy for customers familiar with Docker to orchestrate existing container applications on Service Fabric, we've included preview support for Docker Compose natively in the platform. Service Fabric can accept version 3(+) of `docker-compose.yml` files. Since this support is in preview, only a subset of Compose directives are supported. For example, application upgrades aren't supported. However, you can always remove and deploy applications instead of upgrading them.  
 
-To use this preview, you need to install the preview SDK (version 255.255.x.x) through the portal. 
+To use this preview, you need to create your cluster with the preview SDK (version 255.255.x.x) through the portal. 
 
 > [!NOTE]
 > This feature is in preview and not supported.


### PR DESCRIPTION
Documentation isn't clear on how to get a SF cluster with version 255.*. Altered the documentation so it's clear that you need to create a new cluster with the preview version. Also see question and answer at the bottom of this article, which also indicates that previous explanation wasn't clear.