### PR TITLE
Include "or stopped/deallocated"

### DIFF
--- a/includes/virtual-network-deploy-static-pip-intro-include.md
+++ b/includes/virtual-network-deploy-static-pip-intro-include.md
@@ -1,4 +1,4 @@
-You can create virtual machines (VMs) in Azure and expose them to the public Internet by using a public IP address. By default, Public IPs are dynamic and the address associated to them may change when the VM is deleted. To guarantee that the VM always uses the same public IP address, you need to create a static Public IP. 
+You can create virtual machines (VMs) in Azure and expose them to the public Internet by using a public IP address. By default, Public IPs are dynamic and the address associated to them may change when the VM is deleted or stopped/deallocated. To guarantee that the VM always uses the same public IP address, you need to create a static Public IP. 
 
 Before you can implement static Public IPs in VMs, it is necessary to understand when you can use static Public IPs, and how they are used. Read the [IP addressing overview](../articles/virtual-network/virtual-network-ip-addresses-overview-arm.md) to learn more about IP addressing in Azure.
 


### PR DESCRIPTION
Customers lose these dynamic IPs all the time when they just stop a VM. Would like to have this documented for reference.