### PR TITLE
Add check for `existsSync`

### DIFF
--- a/articles/app-service-api/app-service-api-nodejs-api-app.md
+++ b/articles/app-service-api/app-service-api-nodejs-api-app.md
@@ -134,6 +134,9 @@ Change directory to the *start* folder, then run `yo swaggerize`. Swaggerize cre
     var swaggerize = require('swaggerize-express');
     var swaggerUi = require('swaggerize-ui'); 
     var path = require('path');
+    var fs = require("fs");
+    
+    fs.existsSync = fs.existsSync || require('path').existsSync;
 
     var app = express();
 


### PR DESCRIPTION
The API application will throw a 500 error once published. Including `fs.existsSync` as suggested by @aussieviking fixes this issue. Not entirely sure why this is the case. Perhaps there is a more desirable fix than this one.