### PR TITLE
Update tutorial to set BaseURL for api region

### DIFF
--- a/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md
+++ b/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md
@@ -38,10 +38,13 @@ import cognitive_face as CF
 KEY = 'subscription key'  # Replace with a valid subscription key (keeping the quotes in place).
 CF.Key.set(KEY)
 
+BASE_URL = 'https://westus.api.cognitive.microsoft.com/face/v1.0/' # Replace with cognitive api url for region associated with subscription (westus, eastus2, etc.) include trailing slash (keeping the quotes in place).
+CF.BaseUrl.set(BASE_URL)
+
 # You can use this example JPG or replace the URL below with your own URL to a JPEG image.
 img_url = 'https://raw.githubusercontent.com/Microsoft/Cognitive-Face-Windows/master/Data/detection1.jpg'
 result = CF.face.detect(img_url)
-print result
+print result # or print(result) for Python 3
 ```
 
 Below is an example result. It's a `list` of detected faces. Each item in the list is a `dict` instance where `faceId` is a unique ID for the detected face and `faceRectangle` describes the postion of the detected face. A face ID expires in 24 hours.


### PR DESCRIPTION
Update tutorial to instruct users to set the BaseURL corresponding to the region associated with their subscription. Remind users to include trailing slash in urls.

```
BASE_URL = 'https://westus.api.cognitive.microsoft.com/face/v1.0/'
CF.BaseUrl.set(BASE_URL)
```