### PR TITLE
Update key-vault-subscription-move-fix.md

### DIFF
--- a/articles/key-vault/key-vault-subscription-move-fix.md
+++ b/articles/key-vault/key-vault-subscription-move-fix.md
@@ -28,9 +28,10 @@ When you create a new key vault in a subscription, it is automatically tied to t
 For example, if you have key vault 'myvault' in a subscription that has been moved from tenant A to tenant B, here's how to change the tenant ID for this key vault and remove old access policies.
 
 <pre>
+$Select-AzureRmSubscription -SubscriptionId YourSubscriptionID
 $vaultResourceId = (Get-AzureRmKeyVault -VaultName myvault).ResourceId
 $vault = Get-AzureRmResource –ResourceId $vaultResourceId -ExpandProperties
-$vault.Properties.TenantId = (Get-AzureRmContext).Tenant.TenantId
+$vault.Properties.TenantId = (Get-AzureRmContext).Tenant.Id
 $vault.Properties.AccessPolicies = @()
 Set-AzureRmResource -ResourceId $vaultResourceId -Properties $vault.Properties
 </pre>


### PR DESCRIPTION
Added `Select-AzureRmSubscription -SubscriptionId YourSubscriptionID` because without it `Get-AzureRmKeyVault` fails silently.

Also fixed `(Get-AzureRmContext).Tenant.TenantId` command to the correct `(Get-AzureRmContext).Tenant.Id`