### PR TITLE
Update storage-use-azcopy-linux.md

### DIFF
--- a/articles/storage/storage-use-azcopy-linux.md
+++ b/articles/storage/storage-use-azcopy-linux.md
@@ -22,8 +22,11 @@ AzCopy on Linux is a command-line utility designed for copying data to and from 
 
 There are two versions of AzCopy that you can download. AzCopy on Linux is built with .NET Core Framework, which targets Linux platforms offering POSIX style command-line options. [AzCopy on Windows](storage-use-azcopy.md) is built with .NET Framework, and offers Windows style command-line options. This article covers AzCopy on Linux.
 
+
 ## Download and install AzCopy
 ### Installation on Linux
+
+The article includes commands for various releases of Ubuntu.  Use the `lsb_release -a` command to confirm your distribution release and codename. 
 
 AzCopy on Linux requires .NET Core framework on the platform. See the installation instructions on the [.NET Core](https://www.microsoft.com/net/core#linuxubuntu) page.
 
@@ -34,7 +37,7 @@ As an example, let's install .NET Core on Ubuntu 16.10. For the latest installat
 sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ yakkety main" > /etc/apt/sources.list.d/dotnetdev.list' 
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
 sudo apt-get update
-sudo apt-get install dotnet-dev-1.0.3
+sudo apt-get install dotnet-dev-1.0.4
 ```
 
 Once you have installed .NET Core, download and install AzCopy.


### PR DESCRIPTION
Updated dotnet to 1.0.4 as the latest version recommended on the https://www.microsoft.com/net/core#linuxubuntu page.  Also added paragraph showing lsb_release -a command to help user determine which release of Ubuntu they are using so that they can navigate to the right section.  The dotnet and azcopy sections could still do with a little more tidying.