### PR TITLE
Update active-directory-devquickstarts-dotnet.md

### DIFF
--- a/articles/active-directory/develop/active-directory-devquickstarts-dotnet.md
+++ b/articles/active-directory/develop/active-directory-devquickstarts-dotnet.md
@@ -44,6 +44,7 @@ To enable your app to get tokens, you'll first need to register it in your Azure
 
 1. Sign in to the [Azure portal](https://portal.azure.com).
 2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+2a. If you have no Directory list, your tenant is microsoft.onmicrosoft.com.
 3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
 4. Click on **App registrations** and choose **Add**.
 5. Follow the prompts and create a new **Native Client Application**.


### PR DESCRIPTION
Following the path of least resistance means not creating a tenant -- so you get assigned to the default one, microsoft.com (aka microsoft.onmicrosoft.com).