### PR TITLE
Wrong P4 and P6 sizes

### DIFF
--- a/articles/storage/storage-premium-storage-performance.md
+++ b/articles/storage/storage-premium-storage-performance.md
@@ -216,7 +216,7 @@ Azure Premium Storage offers seven disk sizes currently. Each disk size has a di
 
 | Premium Disks Type  | P4    | P6    | P10   | P20   | P30   | P40   | P50   | 
 |---------------------|-------|-------|-------|-------|-------|-------|-------|
-| Disk size           | 128 GB| 512 GB| 128 GB| 512 GB            | 1024 GB (1 TB)    | 2048 GB (2 TB)    | 4095 GB (4 TB)    | 
+| Disk size           | 32 GB | 64 GB | 128 GB| 512 GB            | 1024 GB (1 TB)    | 2048 GB (2 TB)    | 4095 GB (4 TB)    | 
 | IOPS per disk       | 120   | 240   | 500   | 2300              | 5000              | 7500              | 7500              | 
 | Throughput per disk | 25 MB per second  | 50 MB per second  | 100 MB per second | 150 MB per second | 200 MB per second | 250 MB per second | 250 MB per second | 
 


### PR DESCRIPTION
P4 and P6 disks are respectively 32 GB and 64 GB of size.
see here: 
https://azure.microsoft.com/it-it/blog/azure-introduces-new-disks-sizes-up-to-4tb/