### PR TITLE
wrong P4 and P6 disk size

### DIFF
--- a/includes/azure-storage-limits-vm-disks-managed.md
+++ b/includes/azure-storage-limits-vm-disks-managed.md
@@ -10,7 +10,7 @@
 
 | Premium Disks Type  | P4    | P6    | P10   | P20   | P30   | P40   | P50   | 
 |---------------------|-------|-------|-------|-------|-------|-------|-------|
-| Disk size           | 128 GB| 512 GB| 128 GB| 512 GB            | 1024 GB (1 TB)    | 2048 GB (2 TB)    | 4095 GB (4 TB)    | 
+| Disk size           | 32 GB | 64 GB | 128 GB| 512 GB            | 1024 GB (1 TB)    | 2048 GB (2 TB)    | 4095 GB (4 TB)    | 
 | IOPS per disk       | 120   | 240   | 500   | 2300              | 5000              | 7500              | 7500              | 
 | Throughput per disk | 25 MB/sec | 50 MB/sec  | 100 MB/sec | 150 MB/sec | 200 MB/sec | 250 MB/sec | 250 MB/sec |
 


### PR DESCRIPTION
P4 and P6 are respectively large 32GB and 64GB.
See here: [https://docs.microsoft.com/en-us/azure/storage/storage-premium-storage#scalability-and-performance-targets](url)