### PR TITLE
Removing unnecessary styles

### DIFF
--- a/articles/cosmos-db/documentdb-nodejs-application.md
+++ b/articles/cosmos-db/documentdb-nodejs-application.md
@@ -501,19 +501,6 @@ Now let’s turn our attention to building the user interface so a user can actu
           padding: 50px;
           font: 14px "Lucida Grande", Helvetica, Arial, sans-serif;
         }
-        a {
-          color: #00B7FF;
-        }
-        .well label {
-          display: block;
-        }
-        .well input {
-          margin-bottom: 5px;
-        }
-        .btn {
-          margin-top: 5px;
-          border: outset 1px #C8C8C8;
-        }
    
     Save and close this **style.css** file.
 


### PR DESCRIPTION
Removing styles that are unnecessary for modern browsers with Bootstrap. We could probably do away with these styles altogether and just use Bootstrap containers, but this is ok too.

I do **NOT** know if this breaks compatibility in older browsers (IE 11 and lower). It's been a long time since I had to consider that someone might be on an old browser version.