### PR TITLE
Add Lightower as a provider in Chicago

### DIFF
--- a/articles/expressroute/expressroute-locations-providers.md
+++ b/articles/expressroute/expressroute-locations-providers.md
@@ -146,7 +146,7 @@ If your connectivity provider is not listed in previous sections, you can still 
 | **Location** | **Exchange** | **Connectivity Providers** |
 | --- | --- | --- |
 | **Amsterdam** | Equinix, Telecity | Eurofiber , Fastweb S.p.A, Nianet |
-| **Chicago** | Equinix | Windstream |
+| **Chicago** | Equinix | Lightower, Windstream |
 | **Dallas** | Equinix, Megaport | C3ntro Telecom, Cox Business, Data Foundry, Transtelco |
 | **Frankfurt** | Telecity | Nianet, QSC AG |
 | **Hong Kong** | Equinix | Macroview Telecom |


### PR DESCRIPTION
Lightower, as an "additional service provider" peers through Equinix at CH1 in Chicago. From Lightower: Lightower is a C1 partner.  We connect to Azure via Equinix at 350 East Cermak, Chicago, 60 Hudson St., NY, and 21715 Filigree Ct. Ashburn, VA.  (Tom Werner, 212-324-5047, twerner@lightower.com)