### PR TITLE
Add Chicago location for Lightower

### DIFF
--- a/articles/expressroute/expressroute-locations.md
+++ b/articles/expressroute/expressroute-locations.md
@@ -183,7 +183,7 @@ If your connectivity provider is not listed in previous sections, you can still 
 | **[Gtt Communications Inc](https://www.gtt.net/wp-content/uploads/2017/04/EtherCloud-Data-Sheet.pdf)** |Equinix | Washington DC |
 | **[HSO](http://www.hso.co.uk/products/cloud-direct)** |Equinix | London, Slough |
 | **LGA Telecom** |Equinix |Singapore|
-| **[Lightower](http://www.lightower.com/network-solutions/cloud-connect/#microsoft-azure)** |Equinix |New York, Washington DC |
+| **[Lightower](http://www.lightower.com/network-solutions/cloud-connect/#microsoft-azure)** |Equinix | Chicago, New York, Washington DC |
 | **[Macroview Telecom](http://www.macroview.com/en/scripts/catitem.php?catid=solution&sectionid=expressroute)** |Equinix |Hong Kong |
 | **[Macquarie Telecom Group](https://macquariegovernment.com/secure-cloud/secure-cloud-exchange/)** | Megaport | Sydney |
 | **[Masergy](https://www.masergy.com/solutions/hybrid-networking/cloud-marketplace/microsoft-azure)** | Equinix | Washington DC |


### PR DESCRIPTION
Lightower, as an "additional service provider" peers through Equinix at CH1 in Chicago. From Lightower: Lightower is a C1 partner.  We connect to Azure via Equinix at 350 East Cermak, Chicago, 60 Hudson St., NY, and 21715 Filigree Ct. Ashburn, VA.  (Tom Werner, 212-324-5047, twerner@lightower.com)