### PR TITLE
Update storage-using-managed-disks-template-deployments.md

### DIFF
--- a/articles/storage/storage-using-managed-disks-template-deployments.md
+++ b/articles/storage/storage-using-managed-disks-template-deployments.md
@@ -70,7 +70,7 @@ Within the virtual machine object, we need a dependency on the storage account t
             "dataDisks": [
                 {
                     "name": "datadisk1",
-                    "diskSizeGB": "1023",
+                    "diskSizeGB": 1023,
                     "lun": 0,
                     "vhd": {
                         "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))).primaryEndpoints.blob, 'vhds/datadisk1.vhd')]"
@@ -91,7 +91,7 @@ With Azure Managed Disks, the disk becomes a top-level resource and no longer re
 
 ### Default managed disk settings
 
-To create a VM with managed disks, you no longer need to create the storage account resource and can update your virtual machine resource as follows. Specifically note that the `apiVersion` reflects `2016-04-30-preview` and the `osDisk` and `dataDisks` no longer refer to a specific URI for the VHD. When deploying without specifying additional properties, the disk will use [Standard LRS storage]((storage-redundancy.md). If no name is specified, it takes the format of `<VMName>_OsDisk_1_<randomstring>` for the OS disk and `<VMName>_disk<#>_<randomstring>` for each data disk. By default, Azure disk encryption is disabled; caching is Read/Write for the OS disk and None for data disks. You may notice in the example below there is still a storage account dependency, though this is only for storage of diagnostics and is not needed for disk storage.
+To create a VM with managed disks, you no longer need to create the storage account resource and can update your virtual machine resource as follows. Specifically note that the `apiVersion` reflects `2016-04-30-preview` and the `osDisk` and `dataDisks` no longer refer to a specific URI for the VHD. When deploying without specifying additional properties, the disk will use [Standard LRS storage](storage-redundancy.md). If no name is specified, it takes the format of `<VMName>_OsDisk_1_<randomstring>` for the OS disk and `<VMName>_disk<#>_<randomstring>` for each data disk. By default, Azure disk encryption is disabled; caching is Read/Write for the OS disk and None for data disks. You may notice in the example below there is still a storage account dependency, though this is only for storage of diagnostics and is not needed for disk storage.
 
 ```
 {
@@ -118,7 +118,7 @@ To create a VM with managed disks, you no longer need to create the storage acco
             },
             "dataDisks": [
                 {
-                    "diskSizeGB": "1023",
+                    "diskSizeGB": 1023,
                     "lun": 0,
                     "createOption": "Empty"
                 }
@@ -204,8 +204,8 @@ To create managed availability sets with VMs using managed disks, add the `sku` 
     "location": "[resourceGroup().location]",
     "name": "[variables('avSetName')]",
     "properties": {
-        "PlatformUpdateDomainCount": "3",
-        "PlatformFaultDomainCount": "2"
+        "PlatformUpdateDomainCount": 3,
+        "PlatformFaultDomainCount": 2
     },
     "sku": {
         "name": "Aligned"


### PR DESCRIPTION
Fixed a few datatype typos and fixed a broken reference.   The types, using string "1023" vs. a bare integer 1023 will be accepted by the compute provider, but will fail when validated against the corresponding schema.  i.e., they forgot to define the schema as also accepting a string.   So best to do the examples the way there were intended -- bare integers.

This doc should be fixed to reflect the exact API versions usable for Managed Disks.   2016-04-30-preview is likely to fail Marketplace publishing validation due to it being more than 2 behind current and more than a year old, for instance.   Fix needed is inclusion of something like:

> ***Note:** While the examples below specify API version 2016-04-30-preview, Microsoft.Compute API version 201x-yy.zz or higher can also be used with Managed Disks.*

Thanks.  Shawn.   selliott@microsoft.com