### PR TITLE
Fix small typo: "PHP" -> "Node.js"

### DIFF
--- a/articles/app-service-web/app-service-web-get-started-nodejs.md
+++ b/articles/app-service-web/app-service-web-get-started-nodejs.md
@@ -134,7 +134,7 @@ The Node.js sample code is running in an Azure App Service web app.
 
 ![Sample app running in Azure](media/app-service-web-get-started-nodejs-poc/hello-world-in-browser.png)
 
-**Congratulations!** You've deployed your first PHP app to App Service.
+**Congratulations!** You've deployed your first Node.js app to App Service.
 
 ## Update and redeploy the code
 


### PR DESCRIPTION
Instead of 
"Congratulations! You've deployed your first PHP app to App Service."
should be 
"Congratulations! You've deployed your first Node.js app to App Service."