### PR TITLE
Corrects resource naming format

### DIFF
--- a/articles/azure-resource-manager/resource-group-overview.md
+++ b/articles/azure-resource-manager/resource-group-overview.md
@@ -77,7 +77,7 @@ When creating a resource group, you need to provide a location for that resource
 ## Resource providers
 Each resource provider offers a set of resources and operations for working with an Azure service. For example, if you want to store keys and secrets, you work with the **Microsoft.KeyVault** resource provider. This resource provider offers a resource type called **vaults** for creating the key vault. 
 
-The name of a resource type is in the format: **{resource-provider}/{resource-type}**. For example, the key vault type is **Microsoft.KeyVault\vaults**.
+The name of a resource type is in the format: **{resource-provider}/{resource-type}**. For example, the key vault type is **Microsoft.KeyVault/vaults**.
 
 Before getting started with deploying your resources, you should gain an understanding of the available resource providers. Knowing the names of resource providers and resources helps you define resources you want to deploy to Azure. Also, you need to know the valid locations and API versions for each resource type. For more information, see [Resource providers and types](resource-manager-supported-services.md).
 


### PR DESCRIPTION
Corrects resource type naming format example from Microsoft.KeyVault\vaults to Microsoft.KeyVault/vaults.