### PR TITLE
fix source image value for docker tag command: specifying source image + tag name

### DIFF
--- a/articles/container-service/container-service-tutorial-kubernetes-app-update.md
+++ b/articles/container-service/container-service-tutorial-kubernetes-app-update.md
@@ -104,7 +104,7 @@ az acr list --resource-group myResourceGroup --query "[].{acrLoginServer:loginSe
 Use [docker tag](https://docs.docker.com/engine/reference/commandline/tag/) to tag the image, making sure to update the command with your ACR login server or public registry hostname.
 
 ```bash
-docker tag azure-vote-front <acrLoginServer>/azure-vote-front:v2
+docker tag azure-vote-front:v2 <acrLoginServer>/azure-vote-front:v2
 ```
 
 Push the image to your registry. Replace `<acrLoginServer>` with your ACR login server name or public registry hostname.


### PR DESCRIPTION
In tagging "<acrLoginServer>/azure-vote-front:v2" to source image, tag name ('v2' in this example) should also be added, otherwise docker command use default tag ('latest').  Therefore, the following a command in the article is not correct. 
```
docker tag azure-vote-front <acrLoginServer>/azure-vote-front:v2
```

Instead, tag name 'v2' should be added to source image like this:
```
docker tag azure-vote-front:v2 <acrLoginServer>/azure-vote-front:v2
```