### PR TITLE
replaced cosmosdb_name with cosmosdb-name

### DIFF
--- a/articles/cosmos-db/create-mongodb-nodejs.md
+++ b/articles/cosmos-db/create-mongodb-nodejs.md
@@ -134,33 +134,12 @@ DB/databaseAccounts/<cosmosdb-name>",
 
 In this step, you connect your MEAN.js sample application to an Azure Cosmos DB database you just created, using a MongoDB connection string. 
 
-## Retrieve the key
-
-In order to connect to an Azure Cosmos DB database, you need the database key. Use the [az cosmosdb list-keys](/cli/azure/cosmosdb#list-keys) command to retrieve the primary key.
-
-```azurecli-interactive
-az cosmosdb list-keys --name <cosmosdb-name> --resource-group myResourceGroup
-```
-
-The Azure CLI outputs information similar to the following example. 
-
-```json
-{
-  "primaryMasterKey": "RUayjYjixJDWG5xTqIiXjC...",
-  "primaryReadonlyMasterKey": "...",
-  "secondaryMasterKey": "...",
-  "secondaryReadonlyMasterKey": "..."
-}
-```
-
-Copy the value of `primaryMasterKey` to a text editor. You need this information in the next step.
-
 <a name="devconfig"></a>
 ## Configure the connection string in your Node.js application
 
 In your MEAN.js repository, open `config/env/local-development.js`.
 
-Replace the content of this file with the following code. Be sure to also replace the two `<cosmosdb-name>` placeholders with your Azure Cosmos DB account name, and the `<primary_master_key>` placeholder with the key you copied in the previous step.
+Replace the content of this file with the following code. Be sure to also replace the two `<cosmosdb-name>` placeholders with your Azure Cosmos DB account name.
 
 ```javascript
 'use strict';
@@ -176,6 +155,24 @@ module.exports = {
 > The `ssl=true` option is important because [Azure Cosmos DB requires SSL](connect-mongodb-account.md#connection-string-requirements). 
 >
 >
+
+## Retrieve the key
+
+To connect to an Azure Cosmos DB database, you need the database key. Use the [az cosmosdb list-keys](/cli/azure/cosmosdb#list-keys) command to retrieve the primary key.
+
+```azurecli-interactive
+az cosmosdb list-keys --name <cosmosdb-name> --resource-group myResourceGroup --query "primaryMasterKey"
+```
+
+The Azure CLI outputs information similar to the following example. 
+
+```json
+"RUayjYjixJDWG5xTqIiXjC..."
+```
+
+Copy the value of `primaryMasterKey`.  
+
+In your MEAN.js repository, open `config/env/local-development.js`. Replace the `<primary_master_key>` placeholder with the key value you copied.
 
 Save your changes.
 

--- a/articles/cosmos-db/create-mongodb-nodejs.md
+++ b/articles/cosmos-db/create-mongodb-nodejs.md
@@ -88,10 +88,10 @@ az group create --name myResourceGroup --location "West Europe"
 
 Create an Azure Cosmos DB account with the [az cosmosdb create](/cli/azure/cosmosdb#create) command.
 
-In the following command, please substitute your own unique Azure Cosmos DB account name where you see the `<cosmosdb_name>` placeholder. This unique name will be used as part of your Azure Cosmos DB endpoint (`https://<cosmosdb_name>.documents.azure.com/`), so the name needs to be unique across all Azure Cosmos DB accounts in Azure. 
+In the following command, please substitute your own unique Azure Cosmos DB account name where you see the `<cosmosdb-name>` placeholder. This unique name will be used as part of your Azure Cosmos DB endpoint (`https://<cosmosdb-name>.documents.azure.com/`), so the name needs to be unique across all Azure Cosmos DB accounts in Azure. 
 
 ```azurecli-interactive
-az cosmosdb create --name <cosmosdb_name> --resource-group myResourceGroup --kind MongoDB
+az cosmosdb create --name <cosmosdb-name> --resource-group myResourceGroup --kind MongoDB
 ```
 
 The `--kind MongoDB` parameter enables MongoDB client connections.
@@ -101,17 +101,17 @@ When the Azure Cosmos DB account is created, the Azure CLI shows information sim
 ```json
 {
   "databaseAccountOfferType": "Standard",
-  "documentEndpoint": "https://<cosmosdb_name>.documents.azure.com:443/",
+  "documentEndpoint": "https://<cosmosdb-name>.documents.azure.com:443/",
   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Document
-DB/databaseAccounts/<cosmosdb_name>",
+DB/databaseAccounts/<cosmosdb-name>",
   "kind": "MongoDB",
   "location": "West Europe",
-  "name": "<cosmosdb_name>",
+  "name": "<cosmosdb-name>",
   "readLocations": [
     {
-      "documentEndpoint": "https://<cosmosdb_name>-westeurope.documents.azure.com:443/",
+      "documentEndpoint": "https://<cosmosdb-name>-westeurope.documents.azure.com:443/",
       "failoverPriority": 0,
-      "id": "<cosmosdb_name>-westeurope",
+      "id": "<cosmosdb-name>-westeurope",
       "locationName": "West Europe",
       "provisioningState": "Succeeded"
     }
@@ -120,9 +120,9 @@ DB/databaseAccounts/<cosmosdb_name>",
   "type": "Microsoft.DocumentDB/databaseAccounts",
   "writeLocations": [
     {
-      "documentEndpoint": "https://<cosmosdb_name>-westeurope.documents.azure.com:443/",
+      "documentEndpoint": "https://<cosmosdb-name>-westeurope.documents.azure.com:443/",
       "failoverPriority": 0,
-      "id": "<cosmosdb_name>-westeurope",
+      "id": "<cosmosdb-name>-westeurope",
       "locationName": "West Europe",
       "provisioningState": "Succeeded"
     }
@@ -139,7 +139,7 @@ In this step, you connect your MEAN.js sample application to an Azure Cosmos DB 
 In order to connect to an Azure Cosmos DB database, you need the database key. Use the [az cosmosdb list-keys](/cli/azure/cosmosdb#list-keys) command to retrieve the primary key.
 
 ```azurecli-interactive
-az cosmosdb list-keys --name <cosmosdb_name> --resource-group myResourceGroup
+az cosmosdb list-keys --name <cosmosdb-name> --resource-group myResourceGroup
 ```
 
 The Azure CLI outputs information similar to the following example. 
@@ -160,14 +160,14 @@ Copy the value of `primaryMasterKey` to a text editor. You need this information
 
 In your MEAN.js repository, open `config/env/local-development.js`.
 
-Replace the content of this file with the following code. Be sure to also replace the two `<cosmosdb_name>` placeholders with your Azure Cosmos DB account name, and the `<primary_master_key>` placeholder with the key you copied in the previous step.
+Replace the content of this file with the following code. Be sure to also replace the two `<cosmosdb-name>` placeholders with your Azure Cosmos DB account name, and the `<primary_master_key>` placeholder with the key you copied in the previous step.
 
 ```javascript
 'use strict';
 
 module.exports = {
   db: {
-    uri: 'mongodb://<cosmosdb_name>:<primary_master_key>@<cosmosdb_name>.documents.azure.com:10250/mean-dev?ssl=true&sslverifycertificate=false'
+    uri: 'mongodb://<cosmosdb-name>:<primary_master_key>@<cosmosdb-name>.documents.azure.com:10250/mean-dev?ssl=true&sslverifycertificate=false'
   }
 };
 ```
@@ -217,7 +217,7 @@ In your MEAN.js repository, open `config/env/production.js`.
 In the `db` object, replace the value of `uri` as show in the following example. Be sure to replace the placeholders as before.
 
 ```javascript
-'mongodb://<cosmosdb_name>:<primary_master_key>@<cosmosdb_name>.documents.azure.com:10250/mean?ssl=true&sslverifycertificate=false',
+'mongodb://<cosmosdb-name>:<primary_master_key>@<cosmosdb-name>.documents.azure.com:10250/mean?ssl=true&sslverifycertificate=false',
 ```
 
 In the terminal, commit all your changes into Git. You can copy both commands to run them together.


### PR DESCRIPTION
3 main changes in this PR ...

### placeholder name underscores

when the name is `cosmosdb_name` some folks may try the command by using this value. The underscore is not a valid character for a database account, so I propose we change this to a dash. 

See below for details ...

```
$ az cosmosdb create --name my_cosmosdb_name --resource-group myResourceGroup --kind MongoDB 
The character '_' at index 2 is not allowed in the DatabaseAccount name
ActivityId: 01fa2151-605d-11e7-9bf0-784f4394b80b
```




### making copying the keys clearer for the reader, using jmespath

When we get the keys, we tell the user to copy the primaryMasterKey from the output json in terminal.

az cosmosdb list-keys --name my-cosmosdb-name --resource-group myResourceGroup 

Instead we could tell the user to run this command which outputs just the primaryMasterKey, which makes it easier to copy and paste for the reader.

`az cosmosdb list-keys --name my-cosmosdb-name --resource-group myResourceGroup --query "primaryMasterKey"`

### making the copying work even if we use just the clipboard

we just told the user to copy the key. but then we tell them to copy another snippet of code and paste it. this means key is not retained in the clipboard's most recent value. Instead, I propose we switch the order of these to make it easier for the reader.

