### PR TITLE
git clone url had a typo

### DIFF
--- a/articles/app-service-web/app-service-web-tutorial-docker-python-postgresql-app.md
+++ b/articles/app-service-web/app-service-web-tutorial-docker-python-postgresql-app.md
@@ -72,7 +72,7 @@ Open the terminal window, and `CD` to a working directory.
 Run the following commands to clone the sample repository and go to the *0.1-initialapp* release.
 
 ```bash
-git clone https://github.com/Azure-Samples/docker-flask-postgres.gi
+git clone https://github.com/Azure-Samples/docker-flask-postgres.git
 cd docker-flask-postgres
 git checkout tags/0.1-initialapp
 ```


### PR DESCRIPTION
the git clone url was missing the trailing 't'.