### PR TITLE
flask run command incorrectly contained the "db" param

### DIFF
--- a/articles/app-service-web/app-service-web-tutorial-docker-python-postgresql-app.md
+++ b/articles/app-service-web/app-service-web-tutorial-docker-python-postgresql-app.md
@@ -93,7 +93,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 cd app
 FLASK_APP=app.py DBHOST="localhost" DBUSER="manager" DBNAME="eventregistration" DBPASS="supersecretpass" flask db upgrade
-FLASK_APP=app.py DBHOST="localhost" DBUSER="manager" DBNAME="eventregistration" DBPASS="supersecretpass" flask db run
+FLASK_APP=app.py DBHOST="localhost" DBUSER="manager" DBNAME="eventregistration" DBPASS="supersecretpass" flask run
 ```
 
 When the app is fully loaded, you see something similar to the following message:


### PR DESCRIPTION
flask run command incorrectly contained the "db" param