### PR TITLE
Remove link to deploying private docker registry

### DIFF
--- a/articles/container-registry/container-registry-intro.md
+++ b/articles/container-registry/container-registry-intro.md
@@ -66,4 +66,3 @@ Developers can also push to a container registry as part of a container developm
 * [Create a container registry using the Azure CLI](container-registry-get-started-azure-cli.md)
 * [Push your first image using the Docker CLI](container-registry-get-started-docker-cli.md)
 * To build a continuous integration and deployment workflow using Visual Studio Team Services, Azure Container Service, and Azure Container Registry, see [this tutorial](../container-service/container-service-docker-swarm-setup-ci-cd.md).
-* If you want to set up your own Docker private registry in Azure (without a public endpoint), see [Deploying Your Own Private Docker Registry on Azure](../virtual-machines/virtual-machines-linux-docker-registry-in-blob-storage.md).


### PR DESCRIPTION
The link currently simply redirects to ACR, and ACR instructions are already handed in the first bullet of the next steps section.