### PR TITLE
Update encrypt-disks.md

### DIFF
--- a/articles/virtual-machines/linux/encrypt-disks.md
+++ b/articles/virtual-machines/linux/encrypt-disks.md
@@ -59,8 +59,9 @@ Set permissions on your Key Vault with [az keyvault set-policy](/cli/azure/keyva
 
 ```azurecli
 az keyvault set-policy --name $keyvault_name --spn $sp_id \
-  --key-permissions all \
-  --secret-permissions all
+  --key-permissions encrypt decrypt wrapKey unwrapKey sign verify get list create update im
+port delete backup restore recover purge \
+  --secret-permissions get list set delete backup restore recover purge
 ```
 
 Create a VM with [az vm create](/cli/azure/vm#create) and attach a 5Gb data disk. Only certain marketplace images support disk encryption. The following example creates a VM named `myVM` using a **CentOS 7.2n** image:


### PR DESCRIPTION
There is some disconnect about the "az keyvault set-policy" command.

The original articles asks us to use:
--key-permissions all
--secret-permissions all

However, the CLI available on the portal does not have all as a parameter nor does the documentation lists that:
https://docs.microsoft.com/en-us/cli/azure/keyvault#set-policy

Older versions of CLI 2.0 (206+dev) for instance did have an all option, that is not true on CLI 2.0.9.

It might be safer to just add all the options separated by space to avoid confusion.