### PR TITLE
Add DSv3 and Dv3 VMs to lists of general-purpose VM sizes

### DIFF
--- a/articles/virtual-machines/linux/sizes.md
+++ b/articles/virtual-machines/linux/sizes.md
@@ -24,7 +24,7 @@ This article describes the available sizes and options for the Azure virtual mac
 
 | Type                     | Sizes           |    Description       |
 |--------------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| [General purpose](sizes-general.md)          | DSv2, Dv2, DS, D, Av2, A0-7,  | Balanced CPU-to-memory ratio. Ideal for testing and development, small to medium databases, and low to medium traffic web servers. |
+| [General purpose](sizes-general.md)          | DSv3, Dv3, DSv2, Dv2, DS, D, Av2, A0-7,  | Balanced CPU-to-memory ratio. Ideal for testing and development, small to medium databases, and low to medium traffic web servers. |
 | [Compute optimized](sizes-compute.md)        | Fs, F             | High CPU-to-memory ratio. Good for medium traffic web servers, network appliances, bath processes, and application servers.        |
 | [Memory optimized](sizes-memory.md)         | M, GS, G, DSv2, DS, Dv2, D   | High memory-to-core ratio. Great for relational database servers, medium to large caches, and in-memory analytics.                 |
 | [Storage optimized](sizes-storage.md)        | Ls                | High disk throughput and IO. Ideal for Big Data, SQL, and NoSQL databases.                                                         |

--- a/articles/virtual-machines/windows/sizes.md
+++ b/articles/virtual-machines/windows/sizes.md
@@ -25,7 +25,7 @@ This article describes the available sizes and options for the Azure virtual mac
 
 | Type                     | Sizes           |    Description       |
 |--------------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| [General purpose](sizes-general.md)          | DSv2, Dv2, DS, D, Av2, A0-7 | Balanced CPU-to-memory ratio. Ideal for testing and development, small to medium databases, and low to medium traffic web servers. |
+| [General purpose](sizes-general.md)          | DSv3, Dv3, DSv2, Dv2, DS, D, Av2, A0-7 | Balanced CPU-to-memory ratio. Ideal for testing and development, small to medium databases, and low to medium traffic web servers. |
 | [Compute optimized](sizes-compute.md)        | Fs, F             | High CPU-to-memory ratio. Good for medium traffic web servers, network appliances, batch processes, and application servers.        |
 | [Memory optimized](../virtual-machines-windows-sizes-memory.md)         | M, GS, G, DSv2, DS, Dv2, D   | High memory-to-core ratio. Great for relational database servers, medium to large caches, and in-memory analytics.                 |
 | [Storage optimized](../virtual-machines-windows-sizes-storage.md)        | Ls                | High disk throughput and IO. Ideal for Big Data, SQL, and NoSQL databases.                                                         |

--- a/includes/virtual-machines-common-sizes-general.md
+++ b/includes/virtual-machines-common-sizes-general.md
@@ -5,9 +5,37 @@
 
 - D-series VMs are designed to run applications that demand higher compute power and temporary disk performance. D-series VMs provide faster processors, a higher memory-to-core ratio, and a solid-state drive (SSD) for the temporary disk. For details, see the announcement on the Azure blog, [New D-Series Virtual Machine Sizes](https://azure.microsoft.com/blog/2014/09/22/new-d-series-virtual-machine-sizes/).
 
-- Dv2-series, a follow-on to the original D-series, features a more powerful CPU. The Dv2-series CPU is about 35% faster than the D-series CPU. It is based on the latest generation 2.4 GHz Intel Xeon® E5-2673 v3 (Haswell) processor, and with the Intel Turbo Boost Technology 2.0, can go up to 3.1 GHz. The Dv2-series has the same memory and disk configurations as the D-series.
+- Dv2-series, a follow-on to the original D-series, features a more powerful CPU. The Dv2-series CPU is about 35% faster than the D-series CPU. It is based on a 2.4 GHz Intel Xeon® E5-2673 v3 (Haswell) processor, and with the Intel Turbo Boost Technology 2.0, can go up to 3.1 GHz. The Dv2-series has the same memory and disk configurations as the D-series.
+
+- Dv3-series VMs are based on the latest generation 2.3 GHz Intel Xeon® E5-2673 v4 (Broadwell) processor and can achieve 3.5GHz with Intel Turbo Boost Technology 2.0.
 
 - The basic tier sizes are primarily for development workloads and other applications that don't require load balancing, auto-scaling, or memory-intensive virtual machines. For information about VM sizes that are more appropriate for production applications, see (Sizes for virtual machines)[virtual-machines-size-specs.md] and for VM pricing information, see [Virtual Machines Pricing](https://azure.microsoft.com/pricing/details/virtual-machines/).
+
+## DSv3-series
+
+ACU: ?-?
+
+| Size | CPU cores | Memory: GiB | Local SSD: GiB | Max data disks | Max cached and local disk throughput: IOPS / MBps (cache size in GiB) | Max uncached disk throughput: IOPS / MBps | Max NICs / Expected network performance (Mbps) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Standard_DS2_v3 |2 |8 |? |? |? |? |? |
+| Standard_DS4_v3 |4 |16 |? |? |? |? |? |
+| Standard_DS8_v3 |8 |32 |? |? |? |? |? |
+| Standard_DS16_v3 |16 |64 |? |? |? |? |? |
+| Standard_DS32_v3 |32 |128 |? |? |? |? |? |
+| Standard_DS64_v3 |64 |256 |? |? |? |? |? &#8224;|
+
+## Dv3-series
+
+ACU: ?-?
+
+| Size | CPU cores | Memory: GiB | Local SSD: GiB | Max data disks | Max cached and local disk throughput: IOPS / MBps (cache size in GiB) | Max uncached disk throughput: IOPS / MBps | Max NICs / Expected network performance (Mbps) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Standard_D2_v3 |2 |8 |? |? |? |? |? |
+| Standard_D4_v3 |4 |16 |? |? |? |? |? |
+| Standard_D8_v3 |8 |32 |? |? |? |? |? |
+| Standard_D16_v3 |16 |64 |? |? |? |? |? |
+| Standard_D32_v3 |32 |128 |? |? |? |? |? |
+| Standard_D64_v3 |64 |256 |? |? |? |? |? &#8224;|
 
 ## DSv2-series
 


### PR DESCRIPTION
The new DSv3 and Dv3 sizes listed on the [Pricing pages](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/windows) are currently missing from the reference documentation. Note this PR is incomplete---much of the tables' details still need to be filled in by someone from the Azure team who knows the detailed specs.