### PR TITLE
Update load-balancer-ipv6-overview.md

### DIFF
--- a/articles/load-balancer/load-balancer-ipv6-overview.md
+++ b/articles/load-balancer/load-balancer-ipv6-overview.md
@@ -69,6 +69,8 @@ Limitations
 * Network Security Group (NSG) protection for IPv4 is supported in dual-stack (IPv4+IPv6) deployments. NSGs do not apply to the IPv6 endpoints.
 * The IPv6 endpoint on the VM is not exposed directly to the internet. It is behind a load balancer. Only the ports specified in the load balancer rules are accessible over IPv6.
 * Changing the IdleTimeout parameter for IPv6 is **not currently supported**. The default is four minutes.
+* Changing the loadDistributionMethod parameter for IPv6 is **not currently supported**.
+* Setting the static IPv6 address is **not currently supported**.
 
 ## Next steps
 


### PR DESCRIPTION
I got  following errors when creating loadbalancer with IPv6.
These issue is looks like limitation at this time.

> Failed to save load balancer rule 'lbrulev6'. Error: Cannot specify loadDistributionMethod 'SourceIPProtocol' for a load balancer rule '/subscriptions/49dde45f-5712-44b2-b0ab-296bde83af6b/resourceGroups/shuda0710/providers/Microsoft.Network/loadBalancers/shuda0710/loadBalancingRules/lbrulev6' with frontend ipConfiguration '/subscriptions/49dde45f-5712-44b2-b0ab-296bde83af6b/resourceGroups/shuda0710/providers/Microsoft.Network/loadBalancers/shuda0710/frontendIPConfigurations/LoadBalancerIPv6FrontEnd' referring to an IPv6 PublicIp..

> Cannot specify publicIpAllocationMethod as Static for IPv6 PublicIp '/subscriptions/49dde45f-5712-44b2-b0ab-296bde83af6b/resourceGroups/shuda0710/providers/Microsoft.Network/publicIPAddresses/v6address'. (Code: CannotSpecifyPublicIpAllocationMethodAsStaticForIpV6PublicIp)
