### PR TITLE
Changed array to access 3rd element, instead of 4th

### DIFF
--- a/articles/azure-functions/functions-reference-node.md
+++ b/articles/azure-functions/functions-reference-node.md
@@ -50,7 +50,7 @@ module.exports = function(context, myTrigger, myInput, myOtherInput) {
 
 Bindings of `direction === "in"` are passed along as function arguments, which means that you can use [`arguments`](https://msdn.microsoft.com/library/87dw3w1k.aspx) to dynamically handle new inputs (for example, by using `arguments.length` to iterate over all your inputs). This functionality is convenient when you have only a trigger and no additional inputs, because you can predictably access your trigger data without referencing your `context` object.
 
-The arguments are always passed along to the function in the order in which they occur in *function.json*, even if you don't specify them in your exports statement. For example, if you have `function(context, a, b)` and change it to `function(context, a)`, you can still get the value of `b` in function code by referring to `arguments[3]`.
+The arguments are always passed along to the function in the order in which they occur in *function.json*, even if you don't specify them in your exports statement. For example, if you have `function(context, a, b)` and change it to `function(context, a)`, you can still get the value of `b` in function code by referring to `arguments[2]`.
 
 All bindings, regardless of direction, are also passed along on the `context` object (see the following script). 
 


### PR DESCRIPTION
It looks as though the array was previously trying to access the 4th element:  arguments[3]

When I believe the purpose was to access the 3rd: arguments[2]

Unless I misunderstood?