### PR TITLE
Update terraform-create-complete-vm to avoid name conflict

### DIFF
--- a/articles/virtual-machines/terraform-create-complete-vm.md
+++ b/articles/virtual-machines/terraform-create-complete-vm.md
@@ -125,9 +125,14 @@ resource "azurerm_network_interface" "helloterraformnic" {
 The previous script snippets create a public IP and a network interface that makes use of the public IP created. Note the references to subnet_id and public_ip_address_id. Terraform has built-in intelligence to understand that the network interface has a dependency on the resources that need to be created before the creation of the network interface.
 
 ~~~~
+# create a random id
+resource "random_id" "randomId" {
+  byte_length = 4
+}
+
 # create storage account
 resource "azurerm_storage_account" "helloterraformstorage" {
-    name = "helloterraformstorage"
+    name                = "tfstorage${random_id.randomId.hex}"
     resource_group_name = "${azurerm_resource_group.helloterraform.name}"
     location = "westus"
     account_type = "Standard_LRS"


### PR DESCRIPTION
Added a random hex id to the storage account name so it doesn't conflict (`helloterraformstorage` is already taken)

See comment: https://docs.microsoft.com/en-us/azure/virtual-machines/terraform-create-complete-vm