### PR TITLE
Add Display Name to suggested app claims for password reset

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-policies.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-policies.md
@@ -198,7 +198,7 @@ This policy describes the experiences that the consumers  go through during pass
 
 5. Select **Identity providers**, and then select **Reset password using email address**. Click **OK**.
 
-6. Select **Application claims**. Here you choose claims that you want returned in the tokens that are sent back to your application after a successful password reset experience. For example, select **User's Object ID**.
+6. Select **Application claims**. Here you choose claims that you want returned in the tokens that are sent back to your application after a successful password reset experience. For example, select **Display Name** and **User's Object ID**.
 
 7. Select **Create**. Note that the policy that was created appears as **B2C_1_SSPR** (the **B2C\_1\_** fragment is automatically added) in the **Password reset policies** blade.
 


### PR DESCRIPTION
When completing the password reset flow the user often gets signed in. Our default ASP.NET templates display the user's display name after they get signed in, but users often forget to add display name claim to their password reset policy because the instructions don't tell suggest it.

@SaeedAkhter-MSFT 