### PR TITLE
Update virtual-machines-common-sizes-memory.md

### DIFF
--- a/includes/virtual-machines-common-sizes-memory.md
+++ b/includes/virtual-machines-common-sizes-memory.md
@@ -29,16 +29,14 @@ Ev3-series instances are based on the 2.3 GHz Intel XEON ® E5-2673 v4 (Broadwel
 
 Data disk storage is billed separately from virtual machines. To use premium storage disks, use the ESv3 sizes. The pricing and billing meters for ESv3 sizes are the same as Ev3-series. 
 
-| Size             | CPU cores | Memory: GiB | Local SSD: GiB | Max data disks | Max cached and local disk throughput: IOPS / MBps (cache size in GiB) | Max uncached disk throughput: IOPS / MBps | Max NICs / Expected network performance (Mbps) |
-|------------------|-----------|-------------|----------------|----------------|-----------------------------------------------------------------------|-------------------------------------------|------------------------------------------------|
-| Standard_E2_v3  | 2         | 16          | 32             | 4              | 4,000 / 32 (50)                                                       | 3,200 / 48                                | 2 / moderate                                   |
-| Standard_E4_v3  | 4         | 32          | 64             | 8              | 8,000 / 64 (100)                                                      | 6,400 / 96                                | 2 / moderate                                   |
-| Standard_E8_v3  | 8         | 64          | 128            | 16             | 16,000 / 128 (200)                                                    | 12,800 / 192                              | 4 / high                                       |
-| Standard_E16_v3 | 16        | 128         | 256            | 32             | 32,000 / 256 (400)                                                    | 25,600 / 384                              | 8 / high                                       |
-| Standard_E32_v3 | 32        | 256         | 512            | 32             | 64,000 / 512 (800)                                                    | 51,200 / 768                              | 8 / extremely high                             |
-| Standard_E64_v3 | 64        | 432         | 864            | 32             | 128,000/1024 (1600)                                                   | 80,000 / 1200                             | 8 / extremely high                             |
-
-
+| Size             | CPU cores | Memory: GiB | Local SSD: GiB | Max data disks | Max local disk throughput: IOPS / Read MBps / Write MBps| Max NICs / Expected network performance (Mbps) |
+|------------------|-----------|-------------|----------------|----------------|-----------------------------------------------------------------------|-------------------------------------------|
+|Standard_E2_v3 	|2 	|16 	|50 	|4 	|3000/46/23 	|2 / moderate|
+|Standard_E4_v3 	|4 	|32 	|100 	|8 	|6000/93/46 	|2 / moderate|
+|Standard_E8_v3 	|8 	|64 	|200 	|16 	|12000/187/93 	|4 / high|
+|Standard_E16_v3 	|16 	|128 	|400 	|32 	|24000/375/187 	|8 / high|
+|Standard_E32_v3 	|32 	|256 	|800 	|32 	|48000/750/375 	|8 / extremely high|
+|Standard_E64_v3 	|64 	|432 	|1600 	|32 	|96000/1000/500 	|8 / extremely high|
 ## M-series*
 
 ACU: 160-180


### PR DESCRIPTION
update virtual-machines-common-sizes-memory.md to fix incorrect performance numbers for standard_E3 types.  Used perf numbers from blog post @ https://azure.microsoft.com/en-us/blog/introducing-the-new-dv3-and-ev3-vm-sizes/