### PR TITLE
clean-up in Thrid-Party Storage Clients on "Azure Storage Client Tools"

### DIFF
--- a/articles/storage/storage-explorers.md
+++ b/articles/storage/storage-explorers.md
@@ -220,32 +220,4 @@ We have not verified the functionality or quality claimed by the following third
     <td></td>
     <td></td>
   </tr>
-  <tr>
-    <td><a href="http://storageexplorer.codeplex.com/">Azure Web Storage Explorer</a></td>
-    <td>X</td>
-    <td>X</td>
-    <td></td>
-    <td>X</td>
-    <td>X</td>
-    <td></td>
-    <td>Y</td>
-    <td>X</td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
-  <tr>
-    <td><a href="https://zudio.co/">Zudio</a></td>
-    <td>X</td>
-    <td>X</td>
-    <td></td>
-    <td>X</td>
-    <td>X</td>
-    <td>X</td>
-    <td>Trial</td>
-    <td>X</td>
-    <td></td>
-    <td></td>
-    <td></td>
-  </tr>
 </table>


### PR DESCRIPTION
* removed "Azure Web Storage Explorer" because its a duplicate of "Azure Storage Explorer"
* removed Zudio because its 404