### PR TITLE
Removed extra phrase "choose the"

### DIFF
--- a/articles/monitoring-and-diagnostics/insights-autoscale-best-practices.md
+++ b/articles/monitoring-and-diagnostics/insights-autoscale-best-practices.md
@@ -80,7 +80,7 @@ In this case
 5. The next time autoscale checks, the CPU continues to fall to 50. It estimates again -  50 x 3 instance = 150 / 2 instances = 75, which is below the scale-out threshold of 80, so it scales in successfully to 2 instances.
 
 ### Considerations for scaling threshold values for special metrics
- For special metrics such as Storage or Service Bus Queue length metric, the threshold is the average number of messages available per current number of instances. Carefully choose the choose the threshold value for this metric.
+ For special metrics such as Storage or Service Bus Queue length metric, the threshold is the average number of messages available per current number of instances. Carefully choose the threshold value for this metric.
 
 Let's illustrate it with an example to ensure you understand the behavior better.
 


### PR DESCRIPTION
Removed extra phrase "choose the" from section Considerations for scaling threshold values for special metrics