### PR TITLE
Updating to LIS 4.2.2-1

### DIFF
--- a/articles/virtual-network/virtual-network-create-vm-accelerated-networking.md
+++ b/articles/virtual-network/virtual-network-create-vm-accelerated-networking.md
@@ -324,11 +324,11 @@ Creating a Red Hat Enterprise Linux or CentOS 7.3 VM requires some extra steps t
 
 1.	Provision a non-SRIOV CentOS 7.3 VM on Azure
 
-2.	Install LIS 4.2.1:
+2.	Install LIS 4.2.2:
     
     ```bash
-    wget http://download.microsoft.com/download/6/8/F/68FE11B8-FAA4-4F8D-8C7D-74DA7F2CFC8C/lis-rpms-4.2.1-1.tar.gz
-    tar -xvf lis-rpms-4.2.1-1.tar.gz
+    wget http://download.microsoft.com/download/6/8/F/68FE11B8-FAA4-4F8D-8C7D-74DA7F2CFC8C/lis-rpms-4.2.2-1.tar.gz
+    tar -xvf lis-rpms-4.2.2-1.tar.gz
     cd LISISO && sudo ./install.sh
     ```
 


### PR DESCRIPTION
Instructions for CentOS/RedHat pointed to LIS 4.2.1-1 and we're on 4.2.2-1 (and actually 4.2.1 doesn't seem to work with the current CentOS 7.3 in the marketplace)