### PR TITLE
CentOS/RHEL script fails because $OsDiskName is empty

### DIFF
--- a/articles/virtual-network/virtual-network-create-vm-accelerated-networking.md
+++ b/articles/virtual-network/virtual-network-create-vm-accelerated-networking.md
@@ -402,8 +402,8 @@ Creating a Red Hat Enterprise Linux or CentOS 7.3 VM requires some extra steps t
 
     # Specify a URI for the location from which the new image binary large object (BLOB) is copied to start the virtual machine. 
     # Must end with ".vhd" extension
-    $destOsDiskName = "MyOsDiskName.vhd" 
-    $destOsDiskUri = "https://myexamplesa.blob.core.windows.net/vhds/" + $destOsDiskName
+    $OsDiskName = "MyOsDiskName.vhd" 
+    $destOsDiskUri = "https://myexamplesa.blob.core.windows.net/vhds/" + $OsDiskName
     
     # Define a credential object for the VM. PowerShell prompts you for a username and password.
     $Cred = Get-Credential


### PR DESCRIPTION
In Ubuntu/SLES instructions we use $OsDiskName throughout the whole script for the OS disk name.

In CentOS/RHEL instructions we define it as $destOsDiskName, but use $OsDiskName in Set-AzureRmVMOSDisk, which fails because $OsDiskName is of course empty.

Changed every reference to $destOsDiskNaname for $OsDiskName to fix it and also keep it consistent with the Ubuntu/SLES script.

Tested the changes: I have now deployed 2 VMs with the modified script.