### PR TITLE
Add Page blob max size comparison

### DIFF
--- a/articles/azure-stack/azure-stack-acs-differences.md
+++ b/articles/azure-stack/azure-stack-acs-differences.md
@@ -38,6 +38,7 @@ considerations to keep in mind when you deploy Azure Stack. To learn about high-
 |Blob name|1,024 characters (2,048 bytes)|880 characters (1,760 bytes)
 |Block blob max size|4.75 TB (100 MB X 50,000 blocks)|50,000 X 4 MB (approx. 195 GB)
 |Page blob incremental snapshot copy|Premium and standard Azure page blobs supported|Not yet supported
+|Page blob max size|8 TB|1 TB
 |Page blob page size|512 bytes|4 KB
 |Table partition key and row key size|1,024 characters (2,048 bytes)|400 characters (800 bytes)
 


### PR DESCRIPTION
Page blob max size: Azure (8 TB) | Azure Stack (1 TB)