### PR TITLE
Handle SSL in connection string

### DIFF
--- a/articles/postgresql/connect-csharp.md
+++ b/articles/postgresql/connect-csharp.md
@@ -113,7 +113,7 @@ namespace Driver
             //
             string connString =
                 String.Format(
-                    "Server={0}; User Id={1}; Database={2}; Port={3}; Password={4};",
+                    "Server={0}; User Id={1}; Database={2}; Port={3}; Password={4}; SSL Mode=Prefer; Trust Server Certificate=true",
                     Host,
                     User,
                     DBname,


### PR DESCRIPTION
By default Azure hosted postgres servers require SSL. Without these connection string settings you will get an exception when trying to query the server.