### PR TITLE
Fix broken link to the Java app insights page

### DIFF
--- a/articles/application-insights/app-insights-proactive-performance-diagnostics.md
+++ b/articles/application-insights/app-insights-proactive-performance-diagnostics.md
@@ -20,7 +20,7 @@ ms.author: cfreeman
 
 [Application Insights](app-insights-overview.md) automatically analyzes the performance of your web application, and can warn you about potential problems. You might be reading this because you received one of our smart detection notifications.
 
-This feature requires no special setup, other than configuring your app for Application Insights (on [ASP.NET](app-insights-asp-net.md), Java(app-insights-java-get-started.md), or [Node.js](app-insights-nodejs.md), and in [web page code](app-insights-javascript.md)). It is active when your app generates enough telemetry.
+This feature requires no special setup, other than configuring your app for Application Insights (on [ASP.NET](app-insights-asp-net.md), [Java](app-insights-java-get-started.md), or [Node.js](app-insights-nodejs.md), and in [web page code](app-insights-javascript.md)). It is active when your app generates enough telemetry.
 
 ## When would I get a smart detection notification?
 


### PR DESCRIPTION
Missing parentheses caused broken link.