### PR TITLE
Updated healthy result status

### DIFF
--- a/articles/network-watcher/network-watcher-monitor-with-azure-automation.md
+++ b/articles/network-watcher/network-watcher-monitor-with-azure-automation.md
@@ -126,7 +126,7 @@ if($result.code -ne "Healthy")
     }
 else
     {
-    Write-Output ("Connection Status is: $($result.connectionStatus)")
+    Write-Output ("Connection Status is: $($result.code)")
     }
 ```
 


### PR DESCRIPTION
The $result object does not contain a connectionStatus property which results in an empty status when the VPN tunnel is in a healthy state.