### PR TITLE
Applying to Pen Testing no longer "required"

### DIFF
--- a/articles/security/azure-security-pen-testing.md
+++ b/articles/security/azure-security-pen-testing.md
@@ -30,7 +30,7 @@ When you pen test your applications, it might look like an attack to us. We [con
 
 What to do?
 
-When you’re ready to pen test your Azure-hosted applications, you need to let us know. Once we know that you’re going to be performing specific tests, we won’t inadvertently shut you down (such as blocking the IP address that you’re testing from), as long as your tests conform to the Azure pen testing terms and conditions.
+When you’re ready to pen test your Azure-hosted applications, you have an option to [let us know](https://portal.msrc.microsoft.com/en-us/engage/pentest). Once we know that you’re going to be performing specific tests, we won’t inadvertently shut you down (such as blocking the IP address that you’re testing from), as long as your tests conform to the Azure pen testing terms and conditions described in [Microsoft Cloud Unified Penetration Testing Rules of Engagement](https://technet.microsoft.com/en-us/mt784683).
 Standard tests you can perform include:
 
 * Tests on your endpoints to uncover the [Open Web Application Security Project (OWASP) top 10 vulnerabilities](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project)


### PR DESCRIPTION
<Source>:
Submit Azure Service Penetration Testing Notification
https://portal.msrc.microsoft.com/en-us/engage/pentest 

This form is optional. Customers are allowed to test their Azure resources without prior approval as long as they abide by the Pentest Rules of Engagement. No exceptions to the rules of engagement will be granted.

Microsoft Cloud Unified Penetration Testing Rules of Engagement
https://technet.microsoft.com/en-us/mt784683
Customers who wish to formally document upcoming penetration testing engagements against Microsoft Azure are encouraged to fill out the Azure Service Penetration Testing Notification form.


Wording of "need to" "optional" and "encouraged to" are different, so some customers wonders what is true.  It may be better if we have the same message to all documents.