### PR TITLE
Fix broken link to "cname" anchor

### DIFF
--- a/articles/app-service-web/custom-dns-web-site-buydomains-web-app.md
+++ b/articles/app-service-web/custom-dns-web-site-buydomains-web-app.md
@@ -56,7 +56,7 @@ The app's current tier is highlighted by a blue border. Check to make sure that 
 
 ![Check pricing tier](./media/app-service-web-tutorial-custom-domain/check-pricing-tier.png)
 
-If the App Service plan is not **Free**, close the **Choose your pricing tier** page and skip to [Map a CNAME record](#cname).
+If the App Service plan is not **Free**, close the **Choose your pricing tier** page and skip to [Buy the domain](#buy-the-domain).
 
 ### Scale up the App Service plan
 


### PR DESCRIPTION
I suspect the next step should be "Buy the Domain" regardless of current tier?