### PR TITLE
update subscription limits resources manager file

### DIFF
--- a/includes/azure-subscription-limits-azure-resource-manager.md
+++ b/includes/azure-subscription-limits-azure-resource-manager.md
@@ -1,6 +1,6 @@
 | Resource | Default Limit | Maximum Limit |
 | --- | --- | --- |
-| VMs per [subscription](../articles/billing-buy-sign-up-azure-subscription.md) |20<sup>1</sup> per Region |10,000 per Region |
+| VMs per [subscription](../articles/billing-buy-sign-up-azure-subscription.md) |10,000 <sup>1</sup> per Region |10,000 per Region |
 | VM total cores per [subscription](../articles/billing-buy-sign-up-azure-subscription.md) |20<sup>1</sup> per Region | Contact support |
 | VM per series (Dv2, F, etc.) cores per [subscription](../articles/billing-buy-sign-up-azure-subscription.md) |20<sup>1</sup> per Region | Contact support |
 | [Co-administrators](../articles/billing-add-change-azure-subscription-administrator.md) per subscription |Unlimited |Unlimited |


### PR DESCRIPTION
This is change to the azure-subscription-limits-azure-resource-manager.md
Need to update the default no of VMs per subscription. It was listed as 20 per subscription which is wrong. It should be 10,000 per code. Confirmed with the CRP dev team