### PR TITLE
Removed invalid 'image-' prefixes

### DIFF
--- a/articles/container-instances/container-instances-tutorial-deploy-app.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-app.md
@@ -47,7 +47,7 @@ az acr credential show --name <acrName> --query passwords[0].value
 To deploy your container image from the container registry with a resource request of 1 CPU core and 1GB of memory, run the following command:
 
 ```azurecli-interactive
-az container create --name aci-tutorial-app --image <acrLoginServer>/aci-tutorial-app:v1 --cpu 1 --memory 1 --image-registry-login-server <acrLoginServer> --image-registry-username <acrName> --image-registry-password <acrPassword> --ip-address public -g myResourceGroup
+az container create --name aci-tutorial-app --image <acrLoginServer>/aci-tutorial-app:v1 --cpu 1 --memory 1 --registry-login-server <acrLoginServer> --registry-username <acrName> --registry-password <acrPassword> --ip-address public -g myResourceGroup
 ```
 
 Within a few seconds, you will receive an initial response from Azure Resource Manager. To view the state of the deployment, use:


### PR DESCRIPTION
registry-login-server, registry-username, registry-password do not have the 'image-' prefix

Versions:
azure-cli (2.0.12)
...
container (0.1.7)