### PR TITLE
Fixed Typo in the Export powershell link

### DIFF
--- a/articles/sql-database/sql-database-export.md
+++ b/articles/sql-database/sql-database-export.md
@@ -70,7 +70,7 @@ The newest versions of SQL Server Management Studio also provide a wizard to exp
 
 ## Export to a BACPAC file using PowerShell
 
-Use the [New-AzureRmSqlDatabaseImport](/powershell/module/azurerm.sql/new-azurermsqldatabaseexport) cmdlet to submit an export database request to the Azure SQL Database service. Depending on the size of your database, the export operation may take some time to complete.
+Use the [New-AzureRmSqlDatabaseExport](/powershell/module/azurerm.sql/new-azurermsqldatabaseexport) cmdlet to submit an export database request to the Azure SQL Database service. Depending on the size of your database, the export operation may take some time to complete.
 
  ```powershell
  $exportRequest = New-AzureRmSqlDatabaseExport -ResourceGroupName $ResourceGroupName -ServerName $ServerName `


### PR DESCRIPTION
The section related to [New-AzureRmSqlDatabaseExport] showed [New-AzureRmSqlDatabaseImport] as the link text but the link directed to the Export CmdLet.  I updated the link text to reflect the correct PowerShell command.