### PR TITLE
Update "Reset the password" instructions for linux

### DIFF
--- a/articles/virtual-machines/linux/classic/reset-access.md
+++ b/articles/virtual-machines/linux/classic/reset-access.md
@@ -62,7 +62,7 @@ You will need to do the following:
 2. Run this command, substituting the name of your virtual machine for **myVM**.
 
 	```   
-        azure vm extension set myVM VMAccessForLinux Microsoft.OSTCExtensions 1.* –-private-config-path PrivateConf.json
+        azure vm extension set myResourceGroup myVM VMAccessForLinux Microsoft.OSTCExtensions 1.4 –-private-config-path PrivateConf.json
 	```
 
 ## <a name="sshkeyresetcli"></a>Reset the SSH key


### PR DESCRIPTION
I tested the updated command with the azure cloud shell. Without a resource group specified, I got the following error:

```
"+ Looking up the VM "VMAccessForLinux"
error:   Resource group 'myVM' could not be found.
error:   Error information has been recorded to /home/myName/.azure/azure.err
error:   vm extension set command failed"
```

Without changing "1.*" to "1.4", I got:
```
info:    Executing command vm extension set
+ Looking up the VM "myVM"
+ Installing extension "VMAccessForLinux", VM: "myVM"
error:   The value of parameter typeHandlerVersion is invalid.
error:   Error information has been recorded to /home/myName/.azure/azure.err
error:   vm extension set command failed
```

After my suggested edits, the command has been stuck at the following stage for at least 10 minutes:
```
info:    Executing command vm extension set
+ Looking up the VM "myVM"
- Installing extension "VMAccessForLinux", VM: "myVM"
```

Someone should probably look into this further to see if it's still even possible to reset a password on a linux VM. The other sections probably also need similar updates.