### PR TITLE
Using data disk has issues with data not persisted

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
@@ -101,7 +101,7 @@ Then select _PUT_ to apply the changes to your scale set. This example would wor
 > [!NOTE]
 > When you make a change to a scale set definition such as adding or removing a data disk, it applies to all newly created VMs, but only applies to existing VMs if the _upgradePolicy_ property is set to "Automatic". If it is set to "Manual", you need to manually apply the new model to existing VMs. You can do this in the portal, using the _Update-AzureRmVmssInstance_ PowerShell command, or using the _az vmss update-instances_ CLI command.
 
-## Adding pre-poluated data disks to an existent scale set 
+## Adding pre-populated data disks to an existent scale set 
 > When you add disks to an existent scale set model, by design, the disk will always be created empty. This scenario also includes new instances created by the scale set. This behaviour is because the scaleset definition has an empty data disk. In order to create pre-populated data drives for an existent scale set model, you can choose either of next two options:
 
 * Copy data from the instance 0 VM to the data disk(s) in the other VMs by running a custom script.

--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
@@ -95,20 +95,21 @@ You can also add a disk by adding a new entry to the _dataDisks_ property in the
     }          
 ]
 ```
-> [!NOTE]
-> When you add disks to an existent scale set, by design, the disk always will be created empty. This scenario also includes new instances created byt the scale set. This behaviour is because the scaleset definition has an empty data disk. This behaviour can be resolved  with either of the two options:
-
-> Copy data from the instance 0 VM to the data disks in the other VMs by running a custom script.
-> Create a managed image with the OS Disk plus Data Disk (with the required data) and create a new scaleset with the image. This way every new VM created will have a data disk that that is provided in the definition of the scaleset. Since this definition will refer to an image with a data disk that has customized data, every virtual machine on the scaleset will automatically come up with these changes.
-
-> The way to create a custom image can be found here: [Create a managed image of a generalized VM in Azure](/azure/virtual-machines/windows/capture-image-resource/) 
-
-> The user needs to capture the instance 0 VM which has the required data, and then use that vhd for the image definition.
 
 Then select _PUT_ to apply the changes to your scale set. This example would work as long as you are using a VM size which supports more than two attached data disks.
 
 > [!NOTE]
 > When you make a change to a scale set definition such as adding or removing a data disk, it applies to all newly created VMs, but only applies to existing VMs if the _upgradePolicy_ property is set to "Automatic". If it is set to "Manual", you need to manually apply the new model to existing VMs. You can do this in the portal, using the _Update-AzureRmVmssInstance_ PowerShell command, or using the _az vmss update-instances_ CLI command.
+
+## Adding pre-poluated data disks to an existent scale set 
+> When you add disks to an existent scale set model, by design, the disk will always be created empty. This scenario also includes new instances created by the scale set. This behaviour is because the scaleset definition has an empty data disk. In order to create pre-populated data drives for an existent scale set model, you can choose either of next two options:
+
+* Copy data from the instance 0 VM to the data disk(s) in the other VMs by running a custom script.
+* Create a managed image with the OS disk plus data disk (with the required data) and create a new scaleset with the image. This way every new VM created will have a data disk that that is provided in the definition of the scaleset. Since this definition will refer to an image with a data disk that has customized data, every virtual machine on the scaleset will automatically come up with these changes.
+
+> The way to create a custom image can be found here: [Create a managed image of a generalized VM in Azure](/azure/virtual-machines/windows/capture-image-resource/) 
+
+> The user needs to capture the instance 0 VM which has the required data, and then use that vhd for the image definition.
 
 ## Removing a data disk from a scale set
 You can remove a data disk from a VM scale set using Azure CLI _az vmss disk detach_ command. For example the following command removes the disk defined at lun 2:

--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
@@ -95,6 +95,16 @@ You can also add a disk by adding a new entry to the _dataDisks_ property in the
     }          
 ]
 ```
+> [!NOTE]
+> When you add disks to an existent scale set, by design, the disk always will be created empty. This scenario also includes new instances created byt the scale set. This behaviour is because the scaleset definition has an empty data disk. This behaviour can be resolved  with either of the two options:
+
+> Copy data from the instance 0 VM to the data disks in the other VMs by running a custom script.
+> Create a managed image with the OS Disk plus Data Disk (with the required data) and create a new scaleset with the image. This way every new VM created will have a data disk that that is provided in the definition of the scaleset. Since this definition will refer to an image with a data disk that has customized data, every virtual machine on the scaleset will automatically come up with these changes.
+
+> The way to create a custom image can be found here: [Create a managed image of a generalized VM in Azure](/azure/virtual-machines/windows/capture-image-resource/) 
+
+> The user needs to capture the instance 0 VM which has the required data, and then use that vhd for the image definition.
+
 Then select _PUT_ to apply the changes to your scale set. This example would work as long as you are using a VM size which supports more than two attached data disks.
 
 > [!NOTE]


### PR DESCRIPTION
•	Scenario: 
o	VMSS using managed data disk is having issues with data not being persisted
•	Repro:
o	Customer has created a VMSS  with managed disks using a gallery image CentOS.
o	Customer then followed the article https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks to attached a data disk to VMSS.
o	Data disk he attached was an empty data disk.
o	Now he goes and updates this disk  on the VM instance in the VMSS and then mounts this data disk (instance _0)
o	Later customer tried to put some data on the disk  by logging in to the instance. 
o	Customer realized when a new instance is created, that data disk is coming empty.