### PR TITLE
SAS Url "st", "se" must contain full date-time spec

### DIFF
--- a/articles/marketplace-publishing/marketplace-publishing-vm-image-creation.md
+++ b/articles/marketplace-publishing/marketplace-publishing-vm-image-creation.md
@@ -445,9 +445,9 @@ Following are the steps for generating SAS URL by using Azure CLI
 
     b. **`<Storage Account Key>`**: Give your storage account key
 
-    c. **`<Permission Start Date>`**: To safeguard for UTC time, select the day before the current date. For example, if the current date is October 26, 2016, then value should be 10/25/2016. If using Azure CLI 2.0 (az command) ensure to provide both date and time in the Start and End Dates, for example, 10-25-2016T00:00:00Z.
+    c. **`<Permission Start Date>`**: To safeguard for UTC time, select the day before the current date. For example, if the current date is October 26, 2016, then value should be 10/25/2016. If using Azure CLI 2.0 (az command), provide both the date and time in the Start and End Dates, for example: 10-25-2016T00:00:00Z.
 
-    d. **`<Permission End Date>`**: Select a date that is at least 3 weeks after the **Start Date**. Then value should be **11/02/2016**. If using Azure CLI 2.0 (az command) ensure to provide both date and time in the Start and End Dates, for example, 11-02-2016T00:00:00Z.
+    d. **`<Permission End Date>`**: Select a date that is at least 3 weeks after the **Start Date**. The value should be **11/02/2016**. If using Azure CLI 2.0 (az command), provide both the date and time in the Start and End Dates, for example: 11-02-2016T00:00:00Z.
 
     Following is the example code after updating proper parameters
 
@@ -455,7 +455,7 @@ Following are the steps for generating SAS URL by using Azure CLI
           azure storage container list vhds -c $conn
           azure storage container sas create vhds rl 11/02/2016 -c $conn --start 10/25/2016  
 
-4.	Open Powershell editor with “Run as Administrator” mode and open file in step #3. Or use any other script editor on your OS.
+4.	Open Powershell editor with “Run as Administrator” mode and open file in step #3. You can use any script editor that is available on your OS.
 
 5.	Run the script and it will provide you the SAS URL for container level access
 
@@ -519,7 +519,7 @@ After you have created your offer and SKU, you should enter the image details as
 |Failure in copying images - “sp=rl” not in SAS url|Failure: Copying Images. Not able to download blob using provided SAS Uri|Update the SAS Url with permissions set as “Read” & “List|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
 |Failure in copying images - SAS url have white spaces in vhd name|Failure: Copying Images. Not able to download blob using provided SAS Uri.|Update the SAS Url without white spaces|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
 |Failure in copying images – SAS Url Authorization error|Failure: Copying Images. Not able to download blob due to authorization error|Regenerate the SAS Url|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
-|Failure in copying images – SAS Url "st" and "se" parameters do not have full date-time specification|Failure: Copying Images. Not able to download blob due to incorrect SAS Url |SAS Url Start and End Date parameters ("st", "se") are required to have full date-time specification such as 11-02-2017T00:00:00Z and not just date or shortened versions of time. It is possible to run into this using Azure CLI 2.0 (az command). Ensure to provide full date-time spec and regenerate the SAS Url|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
+|Failure in copying images – SAS Url "st" and "se" parameters do not have full date-time specification|Failure: Copying Images. Not able to download blob due to incorrect SAS Url |SAS Url Start and End Date parameters ("st", "se") are required to have full date-time specification, such as 11-02-2017T00:00:00Z, and not only the date or shortened versions for the time. It is possible to encounter this scenario using Azure CLI 2.0 (az command). Be sure to provide the full date-time specification and regenerate the SAS Url.|[https://azure.microsoft.com/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
 
 ## Next step
 After you are done with the SKU details, you can move forward to the [Azure Marketplace marketing content guide][link-pushstaging]. In that step of the publishing process, you provide the marketing content, pricing, and other information necessary prior to **Step 3: Testing your VM offer in staging**, where you test various use-case scenarios before deploying the offer to the Azure Marketplace for public visibility and purchase.  

--- a/articles/marketplace-publishing/marketplace-publishing-vm-image-creation.md
+++ b/articles/marketplace-publishing/marketplace-publishing-vm-image-creation.md
@@ -433,7 +433,7 @@ Following are the steps for generating SAS URL by using Azure CLI
 
 2.	Once it is downloaded, please install
 
-3.	Create a PowerShell file with following code and save it in local
+3.	Create a PowerShell (or other script executable) file with following code and save it locally
 
           $conn="DefaultEndpointsProtocol=https;AccountName=<StorageAccountName>;AccountKey=<Storage Account Key>"
           azure storage container list vhds -c $conn
@@ -445,9 +445,9 @@ Following are the steps for generating SAS URL by using Azure CLI
 
     b. **`<Storage Account Key>`**: Give your storage account key
 
-    c. **`<Permission Start Date>`**: To safeguard for UTC time, select the day before the current date. For example, if the current date is October 26, 2016, then value should be 10/25/2016
+    c. **`<Permission Start Date>`**: To safeguard for UTC time, select the day before the current date. For example, if the current date is October 26, 2016, then value should be 10/25/2016. If using Azure CLI 2.0 (az command) ensure to provide both date and time in the Start and End Dates, for example, 10-25-2016T00:00:00Z.
 
-    d. **`<Permission End Date>`**: Select a date that is at least 3 weeks after the **Start Date**. Then value should be **11/02/2016**.
+    d. **`<Permission End Date>`**: Select a date that is at least 3 weeks after the **Start Date**. Then value should be **11/02/2016**. If using Azure CLI 2.0 (az command) ensure to provide both date and time in the Start and End Dates, for example, 11-02-2016T00:00:00Z.
 
     Following is the example code after updating proper parameters
 
@@ -455,7 +455,7 @@ Following are the steps for generating SAS URL by using Azure CLI
           azure storage container list vhds -c $conn
           azure storage container sas create vhds rl 11/02/2016 -c $conn --start 10/25/2016  
 
-4.	Open Powershell editor with “Run as Administrator” mode and open file in step #3.
+4.	Open Powershell editor with “Run as Administrator” mode and open file in step #3. Or use any other script editor on your OS.
 
 5.	Run the script and it will provide you the SAS URL for container level access
 
@@ -519,7 +519,7 @@ After you have created your offer and SKU, you should enter the image details as
 |Failure in copying images - “sp=rl” not in SAS url|Failure: Copying Images. Not able to download blob using provided SAS Uri|Update the SAS Url with permissions set as “Read” & “List|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
 |Failure in copying images - SAS url have white spaces in vhd name|Failure: Copying Images. Not able to download blob using provided SAS Uri.|Update the SAS Url without white spaces|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
 |Failure in copying images – SAS Url Authorization error|Failure: Copying Images. Not able to download blob due to authorization error|Regenerate the SAS Url|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
-
+|Failure in copying images – SAS Url "st" and "se" parameters do not have full date-time specification|Failure: Copying Images. Not able to download blob due to incorrect SAS Url |SAS Url Start and End Date parameters ("st", "se") are required to have full date-time specification such as 11-02-2017T00:00:00Z and not just date or shortened versions of time. It is possible to run into this using Azure CLI 2.0 (az command). Ensure to provide full date-time spec and regenerate the SAS Url|[https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/](https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-shared-access-signature-part-1/)|
 
 ## Next step
 After you are done with the SKU details, you can move forward to the [Azure Marketplace marketing content guide][link-pushstaging]. In that step of the publishing process, you provide the marketing content, pricing, and other information necessary prior to **Step 3: Testing your VM offer in staging**, where you test various use-case scenarios before deploying the offer to the Azure Marketplace for public visibility and purchase.  


### PR DESCRIPTION
If one generates SAS Url using Azure CLI 2.0, it is possible to generate _valid_ SAS Url with date-only specification.

`az storage container generate-sas --connection-string $conn --name vhds --permissions rl --start '2017-08-01' --expiry '2017-08-20'`

This will trip AzCopy on later stages (it is a bug in AzCopy - reported and acknowledged on AzCopy doc page) while the URL is correct. Azure CLI 1.0 (azure command) always added time into "st", "se" even if not specified on the parameter.

It is required to use full date time like this:

`az storage container generate-sas --connection-string $conn --name vhds --permissions rl --start '2017-08-01T00:00:00Z' --expiry '2017-08-20T00:00:00Z'`

Added respective comments in CLI section and entry in SAS Url troubleshooting table.