### PR TITLE
Fix link to 2.3-compatible JSON settings

### DIFF
--- a/articles/virtual-machines/linux/diagnostic-extension.md
+++ b/articles/virtual-machines/linux/diagnostic-extension.md
@@ -66,7 +66,7 @@ my_diagnostic_storage_account=<your_azure_storage_account_for_storing_vm_diagnos
 az login
 
 # Download the sample Public settings. (You could also use curl or any web browser)
-wget https://github.com/Azure/azure-linux-extensions/blob/master/Diagnostic/tests/lad_2_3_compatible_portal_pub_settings.json -O portal_public_settings.json
+wget https://raw.githubusercontent.com/Azure/azure-linux-extensions/master/Diagnostic/tests/lad_2_3_compatible_portal_pub_settings.json -O portal_public_settings.json
 
 # Build the VM resource ID. Replace storage account name and resource ID in the public settings.
 my_vm_resource_id=$(az vm show -g $my_resource_group -n $my_linux_vm --query "id" -o tsv)

--- a/articles/virtual-machines/linux/diagnostic-extension.md
+++ b/articles/virtual-machines/linux/diagnostic-extension.md
@@ -37,7 +37,7 @@ You can enable this extension by using the Azure PowerShell cmdlets, Azure CLI s
 
 The Azure portal cannot be used to enable or configure LAD 3.0. Instead, it installs and configures version 2.3. Azure portal graphs and alerts work with data from both versions of the extension.
 
-These installation instructions and a [downloadable sample configuration](https://github.com/Azure/azure-linux-extensions/blob/master/Diagnostic/tests/lad_2_3_compatible_portal_pub_settings.json) configure LAD 3.0 to:
+These installation instructions and a [downloadable sample configuration](https://raw.githubusercontent.com/Azure/azure-linux-extensions/master/Diagnostic/tests/lad_2_3_compatible_portal_pub_settings.json) configure LAD 3.0 to:
 
 * capture and store the same metrics as were provided by LAD 2.3;
 * capture a useful set of file system metrics, new to LAD 3.0;
@@ -50,7 +50,8 @@ The downloadable configuration is just an example; modify it to suit your own ne
 
 * **Azure Linux Agent version 2.2.0 or later**. Most Azure VM Linux gallery images include version 2.2.7 or later. Run `/usr/sbin/waagent -version` to confirm the version installed on the VM. If the VM is running an older version of the guest agent, follow [these instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/update-agent) to update it.
 * **Azure CLI**. [Set up the Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli) environment on your machine.
-* An existing storage account to store the data and an associated SAS token that grants the needed access rights.
+* The wget command, if you don't already have it: `sudo apt-get install wget`
+* An existing Azure subscription and a storage account within it to store the data.
 
 ### Sample installation
 
@@ -64,6 +65,8 @@ my_diagnostic_storage_account=<your_azure_storage_account_for_storing_vm_diagnos
 
 # Should login to Azure first before anything else
 az login
+# Should select the subscription containing the storage account
+az account set --subscription <your_azure_subscription_id>
 
 # Download the sample Public settings. (You could also use curl or any web browser)
 wget https://raw.githubusercontent.com/Azure/azure-linux-extensions/master/Diagnostic/tests/lad_2_3_compatible_portal_pub_settings.json -O portal_public_settings.json


### PR DESCRIPTION
The link points to the GitHub page for that file; this change replaces it with a link to the raw contents of the file.