### PR TITLE
Minor grammar change and remove outdated reference

### DIFF
--- a/articles/load-balancer/load-balancer-distribution-mode.md
+++ b/articles/load-balancer/load-balancer-distribution-mode.md
@@ -28,7 +28,7 @@ Figure 1 - 5-tuple distribution
 
 ## Source IP affinity mode
 
-We have another distribution mode called Source IP Affinity (also known as session affinity or client IP affinity). Azure Load Balancer can be configured to use a 2-tuple (Source IP, Destination IP) or 3-tuple (Source IP, Destination IP, Protocol) to map traffic to the available servers. By using Source IP affinity, connections initiated from the same client computer goes to the same DIP endpoint.
+We have another distribution mode called Source IP Affinity (also known as session affinity or client IP affinity). Azure Load Balancer can be configured to use a 2-tuple (Source IP, Destination IP) or 3-tuple (Source IP, Destination IP, Protocol) to map traffic to the available servers. By using Source IP affinity, connections initiated from the same client computer go to the same DIP endpoint.
 
 The following diagram illustrates a 2-tuple configuration. Notice how the 2-tuple runs through the load balancer to virtual machine 1 (VM1) which is then backed up by VM2 and VM3.
 
@@ -92,7 +92,7 @@ Set-AzureLoadBalancedEndpoint -ServiceName MyService -LBSetName LBSet1 -Protocol
 
 ### Cloud Service configuration to change distribution mode
 
-You can leverage the Azure SDK for .NET 2.5 (to be released in November) to update your Cloud Service. Endpoint settings for Cloud Services are made in the .csdef. In order to update the load balancer distribution mode for a Cloud Services deployment, a deployment upgrade is required.
+You can leverage the Azure SDK for .NET 2.5 to update your Cloud Service. Endpoint settings for Cloud Services are made in the .csdef. In order to update the load balancer distribution mode for a Cloud Services deployment, a deployment upgrade is required.
 Here is an example of .csdef changes for endpoint settings:
 
 ```xml


### PR DESCRIPTION
Removed outdated reference to future release of Azure SDK (this was released more than a year ago) and fixed one grammatical error.