### PR TITLE
Currently, makecert can make a cert using sha256

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-certificates-point-to-site-makecert.md
+++ b/articles/vpn-gateway/vpn-gateway-certificates-point-to-site-makecert.md
@@ -37,7 +37,6 @@ Point-to-Site connections use certificates to authenticate. This article shows y
 
 While we recommend using the [Windows 10 PowerShell steps](vpn-gateway-certificates-point-to-site.md) to create your certificates, we provide these MakeCert instructions as an optional method. The certificates that you generate using either method can be installed on [any supported client operating system](vpn-gateway-howto-point-to-site-resource-manager-portal.md#faq). However, MakeCert has the following limitations:
 
-* MakeCert cannot generate SHA-2 certificates, only SHA-1. SHA-1 certificates are still valid for Point-to-Site connections, but SHA-1 uses an encryption hash that is not as strong as SHA-2.
 * MakeCert is deprecated. This means that this tool could be removed at any point. Any certificates that you already generated using MakeCert won't be affected if MakeCert is no longer available. MakeCert is only used to generate the certificates, not as a validating mechanism.
 
 ## <a name="rootcert"></a>Create a self-signed root certificate


### PR DESCRIPTION
makecert.exe(Version 6.1.7600.16385 and above) can make a certificate using sha256(sha2) above.

Windows 7 93184 - makecert needs to support SHA2 certificates
http://bugcheck/bugs/Windows7/93184

So, it is wrong that the original sentence of "However, MakeCert can't generate SHA-2 certificates, only SHA-1."
This makes a customer confusing.