### PR TITLE
Clarifying required url parameter format

### DIFF
--- a/articles/service-fabric/service-fabric-api-management-quick-start.md
+++ b/articles/service-fabric/service-fabric-api-management-quick-start.md
@@ -200,7 +200,7 @@ Request body:
 }
 ```
 
-The **url** parameter here is a fully-qualified service name of a service in your cluster that all requests are routed to by default if no service name is specified in a backend policy. You may use a fake service name, such as "fabric:/fake/service" if you do not intend to have a fallback service.
+The **url** parameter here is a fully-qualified service name of a service in your cluster that all requests are routed to by default if no service name is specified in a backend policy. You may use a fake service name, such as "fabric:/fake/service" if you do not intend to have a fallback service. Be aware, the **url** must be in the format "fabric:/app/service" even if it is a fake fallback service.
 
 Refer to the API Management [backend API reference documentation](https://docs.microsoft.com/rest/api/apimanagement/apimanagementrest/azure-api-management-rest-api-contract-reference#a-namebackenda-backend) for more details on each field.
 


### PR DESCRIPTION
Although I think the current text does imply to use this format - it is easy to miss. The POST request will still return a 201 so you don't hit any issues until you try to configure a policy.