### PR TITLE
Update active-directory-mobileanddesktopapp-ios-introduction.md

### DIFF
--- a/articles/active-directory/develop/GuidedSetups/active-directory-mobileanddesktopapp-ios-introduction.md
+++ b/articles/active-directory/develop/GuidedSetups/active-directory-mobileanddesktopapp-ios-introduction.md
@@ -9,6 +9,8 @@ At the end of this guide, your application will be able to call a protected API 
 > - XCode 8.x is required for this guide. You can download XCode [from here](https://geo.itunes.apple.com/us/app/xcode/id497799835?mt=12 "XCode Download URL").
 > - [Carthage](https://github.com/Carthage/Carthage) for package management
 
+>Important: The MSAL library is not supported by the [Microsoft Graph client library for iOS](https://github.com/microsoftgraph/msgraph-sdk-ios). You must make REST requests to the Microsoft Graph API.
+
 ### How this guide works
 
 ![How this guide works](media/active-directory-mobileanddesktopapp-ios-introduction/iosintro.png)


### PR DESCRIPTION
Developers need to know that they cannot use the MSAL library for iOS with the MS Graph client library before they read the article and try to retrofit their client library based apps with MSAL.