### PR TITLE
Correct ARM Template for Azure file share example

### DIFF
--- a/articles/container-instances/container-instances-mounting-azure-files-volume.md
+++ b/articles/container-instances/container-instances-mounting-azure-files-volume.md
@@ -111,11 +111,14 @@ To define the volumes you want to make available for mounting, add a `volumes` a
         "properties": {
           "image": "seanmckenna/aci-hellofiles",
           "resources": {
-            "request": {
+            "requests": {
               "cpu": 1,
               "memoryInGb": 1.5
             }
           },
+          "ports": [{
+            "port": 80
+          }],
           "volumeMounts": [{
             "name": "myvolume",
             "mountPath": "/aci/logs/"
@@ -123,12 +126,19 @@ To define the volumes you want to make available for mounting, add a `volumes` a
         }  
       }],
       "osType": "Linux",
+      "ipAddress": {
+        "type": "Public",
+        "ports": [{
+          "protocol": "tcp",
+          "port": "80"
+        }]
+      },
       "volumes": [{
         "name": "myvolume",
         "azureFile": {
-            "shareName": "acishare",
-            "storageAccountName": "[parameters('storageaccountname')]",
-            "storageAccountKey": "[parameters('storageaccountkey')]"
+          "shareName": "acishare",
+          "storageAccountName": "[parameters('storageaccountname')]",
+          "storageAccountKey": "[parameters('storageaccountkey')]"
         }
       }]
     }
@@ -174,7 +184,13 @@ With the template defined, you can create the container and mount its volume usi
 az group deployment create --name hellofilesdeployment --template-file azuredeploy.json --parameters @azuredeploy.parameters.json --resource-group myResourceGroup
 ```
 
-Once the container starts up, you can manage files in the share at the mount path that you specified.
+Once the container starts up, you can use the simple web app deployed via the **seanmckenna/aci-hellofiles** image, to the manage files in the Azure file share at the mount path that you specified. Obtain the ip address for the web app via the following:
+
+```azurecli-interactive
+az container show --resource-group myResourceGroup --name hellofiles -o table
+```
+
+You can use a tool like the [Microsoft Azure Storage Explorer](http://storageexplorer.com) to retrieve and inspect the file writen to the file share.
 
 >[!NOTE]
 > To learn more about using Azure Resource Manager templates, parameter files, and deploying with the Azure CLI, see [Deploy resources with Resource Manager templates and Azure CLI](../azure-resource-manager/resource-group-template-deploy-cli.md).


### PR DESCRIPTION
The azuredeploy.json file had invalid resources node and also was missing the port definitions so that a user could access the web app to interact with the Azure file share.

I added some additional context around obtaining the ip address of the running container so that a user could load the web app into their browser and write content to the Azure file share. I also added guidance on an easy method to retrieve and inspect the files written by the web app.