### PR TITLE
Removed Cloud Shell quickstart as it doesn't work with this sample.

### DIFF
--- a/articles/app-service-web/app-service-web-get-started-nodejs.md
+++ b/articles/app-service-web/app-service-web-get-started-nodejs.md
@@ -37,8 +37,6 @@ To complete this quickstart:
 
 [!INCLUDE [quickstarts-free-trial-note](../../includes/quickstarts-free-trial-note.md)]
 
-[!INCLUDE [cloud-shell-try-it.md](../../includes/cloud-shell-try-it.md)]
-
 If you choose to install and use the CLI locally, this topic requires that you are running the Azure CLI version 2.0 or later. Run `az --version` to find the version. If you need to install or upgrade, see [Install Azure CLI 2.0]( /cli/azure/install-azure-cli). 
 
 ## Download the sample


### PR DESCRIPTION
Would recommend reviewing all samples that have had Cloud Shell included as its use means some steps in the remainder of the quick start / lab / demo are invalid.