### PR TITLE
Remove text specifying that app service plan can only be shared by ap…

### DIFF
--- a/articles/app-service/azure-web-sites-web-hosting-plans-in-depth-overview.md
+++ b/articles/app-service/azure-web-sites-web-hosting-plans-in-depth-overview.md
@@ -30,7 +30,7 @@ App Service plans define:
 - SKU (Free, Shared, Basic, Standard, Premium)
 
 Web Apps, Mobile Apps, API Apps, Function Apps (or Functions), in [Azure App Service](http://go.microsoft.com/fwlink/?LinkId=529714) 
-all run in an App Service plan.  Apps in the same subscription, region, and resource group can share an App Service plan. 
+all run in an App Service plan.  Apps in the same subscription, and region can share an App Service plan. 
 
 All applications assigned to an **App Service plan** share the resources defined by it. This sharing saves money when hosting multiple apps in a single App Service plan.
 


### PR DESCRIPTION
…ps w/in same resource group

It is possible to have apps share an App Service Plan that is in a different resource group.

Scenario:
Resource Group: resourcegroup-01
App Service Plan: plan-in-resourcegroup-01
Web App: webapp-in-resourcegroup-01

New API App...
Resource Group: resourcegroup-02
API App: apiapp-in-resourcegroup-02
App Service Plan: plan-in-resourcegroup-01