### PR TITLE
Update Deploy the template using the parameters section

### DIFF
--- a/articles/virtual-machines/windows/ps-template.md
+++ b/articles/virtual-machines/windows/ps-template.md
@@ -196,7 +196,7 @@ Deploy the template using the parameters:
 ```powershell
 $templatePath = "https://" + $storageName + ".blob.core.windows.net/templates/CreateVMTemplate.json"
 $parametersPath = "https://" + $storageName + ".blob.core.windows.net/templates/Parameters.json"
-New-AzureRmResourceGroupDeployment -ResourceGroupName "myResourceGroup" -Name "myDeployment" -TemplateUri $templatePath -TemplateParameterUri $parameterPath 
+New-AzureRmResourceGroupDeployment -ResourceGroupName "myResourceGroup" -Name "myDeployment" -TemplateUri $templatePath -TemplateParameterUri $parametersPath 
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Parameter variable declared as $parametersPath but in command it is used as $parameterPath, due to missing "s" it is throwing error in PowerShell script execution if we copy this script. Refer declaration in the original document at line number 198 and change in line 199