### PR TITLE
try to fix xml display for 'Add a claim definition to the Extension p…

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-create-custom-attributes-profile-edit-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-create-custom-attributes-profile-edit-custom.md
@@ -128,7 +128,7 @@ For every TechnicalProfile that will read or write extension attributes you must
    </TechnicalProfile>
  </RelyingParty>
  ```
-3. Add a claim definition to the Extension policy file  `TrustFrameworkExtensions.xml` inside the ``<ClaimsSchema>`` element as shown below.
+3. Add a claim definition to the Extension policy file  `TrustFrameworkExtensions.xml` inside the `<ClaimsSchema>` element as shown below.
 ```xml
 <ClaimsSchema>
 		<ClaimType Id="extension_loyaltyId">


### PR DESCRIPTION
…olicy file'

the XML is not showing up in the docs properly.  I'm not sure this will fix it but I don't think there is supposed to be double tildes here.  Maybe that is causing the problem