### PR TITLE
Update sql-database-sync-data-between-sql-databases.md

### DIFF
--- a/articles/sql-database/scripts/sql-database-sync-data-between-sql-databases.md
+++ b/articles/sql-database/scripts/sql-database-sync-data-between-sql-databases.md
@@ -134,7 +134,7 @@ New-AzureRmSqlSyncMember   -ResourceGroupName $ResourceGroupName `
                             -Name $SyncMemberName `
                             -MemberDatabaseCredential $Credential `
                             -MemberDatabaseName $MemberDatabaseName `
-                            -MemberServerName $MemberServerName `
+                            -MemberServerName ($MemberServerName + ".database.windows.net" `
                             -MemberDatabaseType $MemberDatabaseType `
                             -SyncDirection $SyncDirection
 


### PR DESCRIPTION
For some reason, adding a new sync member requires the servername to be in the format of *.database.windows.net. I suspect it is a bug in the cmdlet that it doesn't fill it in if not specified, but adding it to the code here covers both scenarios.