### PR TITLE
Azure AD Connect: clarify a name in different C versions

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnectsync-configure-filtering.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-configure-filtering.md
@@ -249,7 +249,7 @@ In this example, you change the filtering so that only users that have both thei
 1. Sign in to the server that is running Azure AD Connect sync by using an account that is a member of the **ADSyncAdmins** security group.
 2. Start **Synchronization Rules Editor** from the **Start** menu.
 3. Under **Rules Type**, click **Outbound**.
-4. Find the rule named **Out to AAD – User Join**, and click **Edit**.
+4. Depending on the version of Connect you use, either find the rule named **Out to AAD – User Join** or **Out to AAD - User Join SOAInAD**, and click **Edit**.
 5. In the pop-up, answer **Yes** to create a copy of the rule.
 6. On the **Description** page, change **Precedence** to an unused value, such as 50.
 7. Click **Scoping filter** on the left-hand navigation, and then click **Add clause**. In **Attribute**, select **mail**. In **Operator**, select **ENDSWITH**. In **Value**, type **@contoso.com**, and then click **Add clause**. In **Attribute**, select **userPrincipalName**. In **Operator**, select **ENDSWITH**. In **Value**, type **@contoso.com**.


### PR DESCRIPTION
This rule will have different names depending on the Connect version. Need to fix an earlier fix (which I don't think I reviewed) so it is correct for all currently supported versions of Connect.