### PR TITLE
consistency with Identity Provider dropdown

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-devquickstarts-web-dotnet-susi.md
+++ b/articles/active-directory-b2c/active-directory-b2c-devquickstarts-web-dotnet-susi.md
@@ -57,7 +57,7 @@ In Azure AD B2C, every user experience is defined by a [policy](active-directory
 
 ### Add your identity providers
 
-From your settings, select **Identity Providers** and choose User ID Sign up or Email signup.
+From your settings, select **Identity Providers** and choose Username signup or Email signup.
 
 ### Create a sign-up and sign-in policy
 


### PR DESCRIPTION
the identity dropdown for local accounts has 'email' and 'username'.

also, in the same sentence 'sign up' and 'signup' were used.  made them consistent