### PR TITLE
Update Azure Data Disk size to 4TB

### DIFF
--- a/articles/storage/storage-decide-blobs-files-disks.md
+++ b/articles/storage/storage-decide-blobs-files-disks.md
@@ -65,7 +65,7 @@ The following table compares Azure Files with Azure Data Disks.
 |Authentication|Built-in|Set up with net use|  
 |Cleanup|Automatic|Manual|  
 |Access using REST|Files within the VHD cannot be accessed|Files stored in a share can be accessed|  
-|Max Size|1 TB disk|5 TB File Share and 1 TB file within share|  
+|Max Size|4 TB disk|5 TB File Share and 1 TB file within share|  
 |Max 8KB IOps|500 IOps|1000 IOps|  
 |Throughput|Up to 60 MB/s per Disk|Up to 60 MB/s per File Share|  
 


### PR DESCRIPTION
Changed max Azure Data Disk size to 4TB to reflect recent increase from 1TB to 4TB (4095GB).