### PR TITLE
Correct H1 formatting

### DIFF
--- a/articles/cognitive-services/Welcome.md
+++ b/articles/cognitive-services/Welcome.md
@@ -1,5 +1,5 @@
 ---
-title: What is Microsoft Cognitive Services? - Documentation | Microsoft Docs
+title: What is Microsoft Cognitive Services? | Microsoft Docs
 description: Microsoft Cognitive Services is a set of APIs, SDKs, and services that you can use with Microsoft Azure that make applications more intelligent, engaging, and discoverable.
 services: cognitive-services
 author: irvingk
@@ -12,7 +12,7 @@ ms.date: 01/02/2017
 ms.author: irvingk 
 ---
 
-## What is Cognitive Services?
+# What is Cognitive Services?
 
 Microsoft Cognitive Services (formerly Project Oxford) are a set of APIs, SDKs and services available to developers to make their applications more intelligent, engaging and discoverable. Microsoft Cognitive Services expands on Microsoft’s evolving portfolio of machine learning APIs and enables developers to easily add intelligent features – such as emotion and video detection; facial, speech and vision recognition; and speech and language understanding – into their applications. Our vision is for more personal computing experiences and enhanced productivity aided by systems that increasingly can see, hear, speak, understand and even begin to reason.
 


### PR DESCRIPTION
Remove "Documentation" from page title - not needed, adds noise