### PR TITLE
Updated "Permitted Virtual Machines" in policy.md

### DIFF
--- a/articles/virtual-machines/windows/policy.md
+++ b/articles/virtual-machines/windows/policy.md
@@ -56,7 +56,7 @@ To ensure that virtual machines for your organization are compatible with an app
             {
               "field": "Microsoft.Compute/imageSku",
               "in": [
-                "2012-Datacenter"
+                "2012-R2-Datacenter"
               ]
             },
             {
@@ -82,6 +82,23 @@ Use a wild card to modify the preceding policy to allow any Windows Server Datac
 {
   "field": "Microsoft.Compute/imageSku",
   "like": "*Datacenter"
+}
+```
+
+Use anyOf to modify the preceding policy to allow any Windows Server 2012 R2 Datacenter or higher image:
+
+```json
+{
+  "anyOf": [
+    {
+      "field": "Microsoft.Compute/imageSku",
+      "like": "2012-R2-Datacenter*"
+    },
+    {
+      "field": "Microsoft.Compute/imageSku",
+      "like": "2016-Datacenter*"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
- Updated the incorrect `"in":` value for `"field": "Microsoft.Compute/imageSku"` from `"2012-Datacenter"` to `"2012-R2-Datacenter"` to align with example statement.
- Added an `"anyOf":` logical operator example to allow Windows Server 2012 R2 Datacenter or higher images to allow deployment.