### PR TITLE
update add NIC(s)

### DIFF
--- a/articles/virtual-machines/windows/change-availability-set.md
+++ b/articles/virtual-machines/windows/change-availability-set.md
@@ -143,8 +143,8 @@ The following script provides an example of gathering the required information, 
     }
 
     #Add NIC(s)
-    foreach ($nic in $OriginalVM.NetworkInterfaceIDs) {
-        Add-AzureRmVMNetworkInterface -VM $NewVM -Id $nic
+    foreach ($nic in $OriginalVM.NetworkProfile.NetworkInterfaces) {
+        Add-AzureRmVMNetworkInterface -VM $NewVM -Id $nic.Id
     }
 
     #Create the VM


### PR DESCRIPTION
Newer versions of Azure powershell don't expose networkinterfaceIDs directly anymore, but have them under the networkprofile.