### PR TITLE
Add --registry-login-server parameter to sample

### DIFF
--- a/articles/container-instances/container-instances-using-azure-container-registry.md
+++ b/articles/container-instances/container-instances-using-azure-container-registry.md
@@ -29,7 +29,7 @@ The Azure Container Registry is an Azure-based, private registry, for Docker con
 The Azure CLI includes commands for creating and managing containers in Azure Container Instances. If you specify a private image in the `create` command, you can also specify the image registry password required to authenticate with the container registry.
 
 ```azurecli-interactive
-az container create --name myprivatecontainer --image mycontainerregistry.azurecr.io/mycontainerimage:v1 --registry-password myRegistryPassword --resource-group myresourcegroup
+az container create --name myprivatecontainer --image mycontainerregistry.azurecr.io/mycontainerimage:v1 --registry-password myRegistryPassword --registry-login-server myregistryloginserver --resource-group myresourcegroup 
 ```
 
 The `create` command also supports specifying the `registry-login-server` and `registry-username`. However, the login server for the Azure Container Registry is always *registryname*.azurecr.io and the default username is *registryname*, so these values are inferred from the image name if not explicitly provided.


### PR DESCRIPTION
The parameter --registry-login-server should be added to the sample snippet. Without providing it the sample kept failing for me.