### PR TITLE
Removing emotional bot reference

### DIFF
--- a/articles/cognitive-services/Text-Analytics/quick-start.md
+++ b/articles/cognitive-services/Text-Analytics/quick-start.md
@@ -146,5 +146,4 @@ Refer to the [Text Analytics Overview](overview.md#supported-languages) for deta
 ## Next steps
 Congratulations! You have now completed using text analytics on your data. You may now wish to look into using a tool such as [Power BI](//powerbi.microsoft.com) to visualize your data. You can also use the insights to provide a streaming view of what customers are saying.
 
-To see how Text Analytics capabilities, such as sentiment, can be used as part of a bot, see the [Emotional Bot](http://docs.botframework.com/en-us/bot-intelligence/language/#example-emotional-bot) example on the Bot Framework site.
 


### PR DESCRIPTION
Let's remove this... that is not an example... and that document does not add much additional value. 
Also, the link would probably be https://docs.microsoft.com/en-us/bot-framework/cognitive-services-bot-intelligence-overview#language-understanding  if we do want to keep it as a reference.