### PR TITLE
updated limitation of reply url which is 20

### DIFF
--- a/articles/active-directory/develop/active-directory-v2-limitations.md
+++ b/articles/active-directory/develop/active-directory-v2-limitations.md
@@ -85,7 +85,7 @@ In this case, you're referring to a DNS subdomain of login.contoso.com. If you w
 
 You can add the latter two because they are subdomains of the first redirect URI, contoso.com. This limitation will be removed in an upcoming release.
 
-Also note, you can have only 20 reply url's for a particular application.
+Also note, you can have only 20 reply URLs for a particular application.
 
 To learn how to register an app in the Application Registration Portal, see [How to register an app with the v2.0 endpoint](active-directory-v2-app-registration.md).
 

--- a/articles/active-directory/develop/active-directory-v2-limitations.md
+++ b/articles/active-directory/develop/active-directory-v2-limitations.md
@@ -85,6 +85,8 @@ In this case, you're referring to a DNS subdomain of login.contoso.com. If you w
 
 You can add the latter two because they are subdomains of the first redirect URI, contoso.com. This limitation will be removed in an upcoming release.
 
+Also note, you can have only 20 reply url's for a particular application.
+
 To learn how to register an app in the Application Registration Portal, see [How to register an app with the v2.0 endpoint](active-directory-v2-app-registration.md).
 
 ## Restrictions on services and APIs


### PR DESCRIPTION
I found this 20 limitation only at the time of production release, there is no document that is this information