### PR TITLE
Update AppGW SSL Policy notes and process

### DIFF
--- a/articles/application-gateway/application-gateway-configure-ssl-policy-powershell.md
+++ b/articles/application-gateway/application-gateway-configure-ssl-policy-powershell.md
@@ -108,6 +108,8 @@ CipherSuites:
 
 ## Configure a custom SSL policy
 
+If you are planning to set a custom SSL policy, you will need to pass the following parameters: PolicyType, MinProtocolVersion, CipherSuite, and ApplicationGateway. If you attempt to pass other parameters, you will get an error when you create or update the Application Gateway. 
+
 The following example sets a custom SSL policy on an application gateway. It sets the minimum protocol version to `TLSv1_1` and enables the following cipher suites:
 
 * TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
@@ -131,6 +133,8 @@ Set-AzureRmApplicationGatewaySslPolicy -ApplicationGateway $gw -PolicyType Custo
 ```
 
 ## Create an application gateway with a pre-defined SSL policy
+
+If you are planning to set a Predefined SSL policy, you will need to pass the following parameters: PolicyType, PolicyName, and ApplicationGateway. If you attempt to pass other parameters, you will get an error when you create or update the Application Gateway.
 
 The following example creates a new application gateway with a pre-defined SSL policy.
 
@@ -168,6 +172,30 @@ $policy = New-AzureRmApplicationGatewaySslPolicy -PolicyType Predefined -PolicyN
 # Create the application gateway.
 $appgw = New-AzureRmApplicationGateway -Name appgwtest -ResourceGroupName $rg.ResourceGroupName -Location "East US" -BackendAddressPools $pool -BackendHttpSettingsCollection $poolSetting -FrontendIpConfigurations $fipconfig  -GatewayIpConfigurations $gipconfig -FrontendPorts $fp -HttpListeners $listener -RequestRoutingRules $rule -Sku $sku -SslCertificates $cert -SslPolicy $policy
 ```
+
+## Update an existing application gateway with a pre-defined SSL policy
+As with a new Application Gateway, if you are planning to set a custom SSL policy, you will need to pass the following parameters: PolicyType, MinProtocolVersion, CipherSuite, and ApplicationGateway. If you are planning to set a Predefined SSL policy, you will need to pass the following parameters: PolicyType, PolicyName, and ApplicationGateway. If you attempt to pass other parameters, you will get an error when you create or update the Application Gateway.
+
+In the following example, there are code samples for both Custom Policy and Predefined Policy. Please only use one.
+
+```powershell
+# You have to change these parameters to match your environment.
+$AppGWname = "YourAppGwName"
+$RG = "YourResourceGroupName"
+
+$AppGw = get-azurermapplicationgateway -Name $AppGWname -ResourceGroupName $RG
+
+# SSL Custom Policy
+set-azurermapplicationgatewaysslpolicy -PolicyType Custom -MinProtocolVersion TLSv1_2 -CipherSuite "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256" -ApplicationGateway $AppGw
+
+# SSL Predefined Policy
+Set-AzureRmApplicationGatewaySslPolicy -PolicyType Predefined -PolicyName "AppGwSslPolicy20170401S" -ApplicationGateway $AppGW
+
+# Update AppGW
+# The SSL policy options are not validated nor are they updated on the Application Gateway until this cmdlet is executed.
+$SetGW = Set-AzureRmApplicationGateway -ApplicationGateway $AppGW
+
+
 
 ## Next steps
 


### PR DESCRIPTION
Need to make sure users know that the AppGW SSL Policy cmdlets have parameters that cannot mix based on the PolicyType specified. Also added section for updating an AppGW since users tend to miss the Set for the AppGw, itself.