### PR TITLE
Update expressroute-howto-circuit-classic.md

### DIFF
--- a/articles/expressroute/expressroute-howto-circuit-classic.md
+++ b/articles/expressroute/expressroute-howto-circuit-classic.md
@@ -54,11 +54,11 @@ Follow the instructions in [Getting started with Azure PowerShell cmdlets](/powe
 
 3. If you have more than one subscription, select the subscription that you want to use.
 
-    	Select-AzureRmSubscription -SubscriptionName "Replace_with_your_subscription_name"
+    	Select-AzureSubscription -SubscriptionId "Replace_with_your_subscription_id"
 
-4. Next, use the following cmdlet to add your Azure subscription to PowerShell for the classic deployment model.
+4. Confirm if the selected subscription id is set as default.
 
-		Add-AzureAccount
+		Get-AzureSubscription -default
 
 ## Create and provision an ExpressRoute circuit
 ### Step 1. Import the PowerShell modules for ExpressRoute


### PR DESCRIPTION
Customer are not able to delete the circuit because correct subscription context was not set correctly by the command mentioned in the current document. After following the proposed changes customer were successfully able to delete the circuit.