### PR TITLE
Update docker-machine.md

### DIFF
--- a/articles/virtual-machines/linux/docker-machine.md
+++ b/articles/virtual-machines/linux/docker-machine.md
@@ -18,7 +18,7 @@ ms.author: iainfou
 
 ---
 # How to use Docker Machine to create hosts in Azure
-This article details how to use [Docker Machine](https://docs.docker.com/machine/) to create hosts in Azure. The `docker-machine` command creates a Linux virtual machine (VM) in Azure then installs Docker. You can then manage your Docker hosts in Azure using the same local tools and workflows.
+This article details how to use [Docker Machine](https://docs.docker.com/machine/) to create hosts in Azure. The `docker-machine` command creates a Linux virtual machine (VM) in Azure then installs Docker. You can then manage your Docker hosts in Azure using the same local tools and workflows. To use docker-machine in Windows 10, you must use Linux bash.
 
 ## Create VMs with Docker Machine
 First, obtain your Azure subscription ID with [az account show](/cli/azure/account#show) as follows:
@@ -29,13 +29,14 @@ sub=$(az account show --query "id" -o tsv)
 
 You create Docker host VMs in Azure with `docker-machine create` by specifying *azure* as the driver. For more information, see the [Docker Azure Driver documentation](https://docs.docker.com/machine/drivers/azure/)
 
-The following example creates a VM named *myVM*, creates a user account named *azureuser*, and opens port *80* on the host VM. Follow any prompts to log in to your Azure account and grant Docker Machine permissions to create and manage resources.
+The following example creates a VM named *myVM*, based on "Standard D2 v2" plan, creates a user account named *azureuser*, and opens port *80* on the host VM. Follow any prompts to log in to your Azure account and grant Docker Machine permissions to create and manage resources.
 
 ```bash
 docker-machine create -d azure \
     --azure-subscription-id $sub \
     --azure-ssh-user azureuser \
     --azure-open-port 80 \
+    --azure-size "Standard_D2_v2 \
     myvm
 ```
 


### PR DESCRIPTION
VM Sizing is mandatory because the script use Standard A2 that is not more available. It's important specify that is necessary use bash also in Windows 10, because docker-machine is present if Docker for Windows is installed.