### PR TITLE
add step for Select-AzureRmSubscription

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-deploy.md
+++ b/articles/azure-resource-manager/resource-group-template-deploy.md
@@ -41,6 +41,8 @@ The following example creates a resource group, and deploys a template from your
 
 ```powershell
 Login-AzureRmAccount
+
+Select-AzureRmSubscription -SubscriptionName <yourSubscriptionName>
  
 New-AzureRmResourceGroup -Name ExampleResourceGroup -Location "South Central US"
 New-AzureRmResourceGroupDeployment -Name ExampleDeployment -ResourceGroupName ExampleResourceGroup `


### PR DESCRIPTION
Added the step to set the current subscription context in the case that the user has many (which I did). The deploy command won't find a pre-existing ResourceGroup if it exists in a different subscription that the context set by Login-AzureRmAccount.