### PR TITLE
Update install command for sfctl on ubuntu

### DIFF
--- a/articles/service-fabric/service-fabric-cli.md
+++ b/articles/service-fabric/service-fabric-cli.md
@@ -67,7 +67,7 @@ sudo apt-get install python3-pip
 Then, to install the Service Fabric CLI for just your installation of Python 3.6, run the following command:
 
 ```bash
-python3.6 -m pip install sfctl
+sudo pip3 install sfctl
 sfctl -h
 ```
 


### PR DESCRIPTION
The install command provided was incorrect and did not work for me and I had to use the pip3 command to install sfctl. Additionally, this was confirmed by one other new hire doing this onboarding process as well.