### PR TITLE
Fix for example, and adding deployment credentials supporting info

### DIFF
--- a/articles/app-service/containers/quickstart-ruby.md
+++ b/articles/app-service/containers/quickstart-ruby.md
@@ -82,6 +82,8 @@ Your app is now configured. Using your web browser, navigate to `http://localhos
 
 [!INCLUDE [Try Cloud Shell](../../../includes/cloud-shell-try-it.md)]
 
+[!INCLUDE [Configure deployment user](../../../includes/configure-deployment-user.md)]
+
 ## Create a Ruby web app on Azure
 
 A resource group is required to contain the assets needed for your web app. To create a resource group, use the [az group create]() command.
@@ -123,10 +125,6 @@ git add -A
 git commit -m "Initial deployment commit"
 git push azure master
 ```
-
-> [!NOTE]
-> You may be prompted for credentials When you push to Azure Master. If you have not yet set your [Deployment Credentials](../../app-service-web/app-service-deployment-credentials) in the App Service blade.
->
 
 Confirm that the remote deployment operations report success. The commands produce output similar to the following text:
 

--- a/articles/app-service/containers/quickstart-ruby.md
+++ b/articles/app-service/containers/quickstart-ruby.md
@@ -42,7 +42,7 @@ git clone https://github.com/Azure-Samples/ruby-docs-hello-world
 ## Run the application locally
 
 Run the rails server in order for the application to work. Change to the *hello-world* directory, and the `rails server` command starts the server.
-
+e
 ```bash
 cd hello-world\bin
 rails server
@@ -123,6 +123,10 @@ git add -A
 git commit -m "Initial deployment commit"
 git push azure master
 ```
+
+> [!NOTE]
+> You may be prompted for credentials When you push to Azure Master. If you have not yet set your [Deployment Credentials](../../app-service-web/app-service-deployment-credentials) in the App Service blade.
+>
 
 Confirm that the remote deployment operations report success. The commands produce output similar to the following text:
 

--- a/articles/app-service/containers/quickstart-ruby.md
+++ b/articles/app-service/containers/quickstart-ruby.md
@@ -42,7 +42,7 @@ git clone https://github.com/Azure-Samples/ruby-docs-hello-world
 ## Run the application locally
 
 Run the rails server in order for the application to work. Change to the *hello-world* directory, and the `rails server` command starts the server.
-e
+
 ```bash
 cd hello-world\bin
 rails server

--- a/articles/app-service/containers/quickstart-ruby.md
+++ b/articles/app-service/containers/quickstart-ruby.md
@@ -87,7 +87,7 @@ Your app is now configured. Using your web browser, navigate to `http://localhos
 A resource group is required to contain the assets needed for your web app. To create a resource group, use the [az group create]() command.
 
 ```azurecli-interactive
-az group create --location westeurop --name myResourceGroup
+az group create --location westeurope --name myResourceGroup
 ```
 
 Use the [az appservice plan create](https://docs.microsoft.com/cli/azure/appservice/plan#az_appservice_plan_create) command to create an app service plan for your web app.

--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -19,7 +19,7 @@ ms.author: cfowler
 ---
 # Use a custom Docker image for Azure Web App for Containers
 
-[Web App for Containers](https://azure.microsoft.com/azure/app-service-web/app-service-linux-intro.md) provides built-in Docker images on Linux with support for specific versions, such as PHP 7.0 and Node.js 4.5. Web App for Containers leverages the Docker container technology to host both built-in images and custom images as a platform as a service. In this tutorial, you will learn how to build a custom docker image for use on Web App for Containers, which is a common pattern if there isn't a built-in image for your language, or your application requires a specific configuration which isn't provided within the built-in images.
+[Web App for Containers](app-service-linux-intro.md) provides built-in Docker images on Linux with support for specific versions, such as PHP 7.0 and Node.js 4.5. Web App for Containers leverages the Docker container technology to host both built-in images and custom images as a platform as a service. In this tutorial, you will learn how to build a custom docker image for use on Web App for Containers, which is a common pattern if there isn't a built-in image for your language, or your application requires a specific configuration which isn't provided within the built-in images.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixed the location to correctly spell "westeurope", also added in a link to deployment credentials to set this up for the Git Push step.