### PR TITLE
Added A8/A9 series

### DIFF
--- a/articles/virtual-machines/virtual-machines-availability-set-supportability.md
+++ b/articles/virtual-machines/virtual-machines-availability-set-supportability.md
@@ -33,3 +33,5 @@ Series & Availability Set|Second VM|A|Av2|D|Dv2|Dv3|
 |Dv3||OK|OK|OK|OK|OK|
 
 All other series could not be in the same availability set because they require a specific hardware.
+
+A8/A9 VM size can't be mixed due to requirment on dedicated RDMA backend network.


### PR DESCRIPTION
A8 /A9 can’t share same cluster due to RDMA network card.

https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-hpc
*For MPI applications, dedicated RDMA backend network is enabled by FDR InfiniBand network, which delivers ultra-low-latency and high bandwidth.