### PR TITLE
update - upgrade permissions - SQL Server

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-accounts-permissions.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-accounts-permissions.md
@@ -97,7 +97,7 @@ When you upgrade from one version of Azure AD Connect to a new release, you need
 | --- | --- | --- |
 | User running the installation wizard |Administrator of the local server |Update binaries. |
 | User running the installation wizard |Member of ADSyncAdmins |Make changes to Sync Rules and other configuration. |
-| User running the installation wizard |If you use a full SQL server: DBO (or similar) of the sync engine database |Make database level changes, such as updating tables with new columns. |
+| User running the installation wizard |If you use a full SQL server: Sysadmin (or similar) of the database instance hosting the sync engine database |Make database level changes, such as updating tables with new columns. |
 
 ## More about the created accounts
 ### Active Directory account


### PR DESCRIPTION
Verified sysadmin permissions requirements when upgrading two staging servers from 1.1.443.0 to 1.1.561.0.

-Upgrade failed when only DBO permissions were granted to user running Installation wizard during upgrade
-Upgrade succeeded when sysadmin permissions were granted to user running Installation wizard during upgrade (DBO permissions were already in place)

Recommend internal testing to repro