### PR TITLE
Added an example for getting more detailed output

### DIFF
--- a/articles/automation/automation-runbook-output-and-messages.md
+++ b/articles/automation/automation-runbook-output-and-messages.md
@@ -184,6 +184,11 @@ The following example starts a sample runbook and then waits for it to complete.
 
     Get-AzureRmAutomationJobOutput -ResourceGroupName "ResourceGroup01" `
     –AutomationAccountName "MyAutomationAccount" -Id $job.JobId –Stream Output
+    
+    # For more detailed job output, pipe the output of Get-AzureRmAutomationJobOutput to Get-AzureRmAutomationJobOutputRecord
+    Get-AzureRmAutomationJobOutput -ResourceGroupName "ResourceGroup01" `
+    –AutomationAccountName "MyAutomationAccount" -Id $job.JobId –Stream Any | Get-AzureRmAutomationJobOutputRecord
+    
 
 ### Graphical Authoring
 For graphical runbooks, extra logging is available in the form of activity-level tracing.  There are two levels of tracing: Basic and Detailed.  In Basic tracing, you can see the start and end time of each activity in the runbook plus information related to any activity retries, such as number of attempts and start time of the activity.  In Detailed tracing, you get Basic tracing plus input and output data for each activity.  Note that currently the trace records are written using the verbose stream, so you must enable Verbose logging when you enable tracing.  For graphical runbooks with tracing enabled there is no need to log progress records, because the Basic tracing serves the same purpose and is more informative.


### PR DESCRIPTION
The output of Get-AzureRmAutomationJobOutput will cut the status message string off at a certain character count indicating it has done so with an ellipses. In order to get the full text of that message you must call Get-AzureRmAutomationJobOutputRecord.

It took me I dunno, an hour to discover (which isn't bad) but I figured I can probably help cut that down a smidge