### PR TITLE
Adding resource: npm pkg for video indexer

### DIFF
--- a/articles/cognitive-services/video-indexer/toc.yml
+++ b/articles/cognitive-services/video-indexer/toc.yml
@@ -31,3 +31,5 @@
   items:
   - name: Azure Roadmap
     href: https://azure.microsoft.com/roadmap/
+  - name: Video Indexer Node.js module
+    href: https://www.npmjs.com/package/video-indexer 


### PR DESCRIPTION
I've created a Node.js wrapper for Video Indexer and would love to make the resource available to other developers. It can be installed via npm (`npm install video-indexer`), and the source is available at https://github.com/hxlnt/video-indexer. 