### PR TITLE
Fix powershell by adding verbose and removing brace

### DIFF
--- a/articles/network-watcher/network-watcher-troubleshoot-manage-rest.md
+++ b/articles/network-watcher/network-watcher-troubleshoot-manage-rest.md
@@ -78,8 +78,8 @@ $requestBody = @"
 }
 "@
 
-}
-armclient post "https://management.azure.com/subscriptions/${subscriptionId}/ResourceGroups/${NWresourceGroupName}/providers/Microsoft.Network/networkWatchers/${networkWatcherName}/troubleshoot?api-version=2016-03-30 "
+
+armclient post "https://management.azure.com/subscriptions/${subscriptionId}/ResourceGroups/${NWresourceGroupName}/providers/Microsoft.Network/networkWatchers/${networkWatcherName}/troubleshoot?api-version=2016-03-30" -verbose
 ```
 
 Since this operation is long running, the URI for querying the operation and the URI for the result is returned in the response header as shown in the following response:
@@ -112,7 +112,7 @@ null
 Use the operations URI to query for the progress of the operation as seen in the following example:
 
 ```powershell
-armclient get "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/8a1167b7-6768-4ac1-85dc-703c9c9b9247?api-version=2016-03-30"
+armclient get "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operations/8a1167b7-6768-4ac1-85dc-703c9c9b9247?api-version=2016-03-30" -verbose
 ```
 
 While the operation is in progress, the response shows **InProgress** as seen in the following example:
@@ -136,7 +136,7 @@ When the operation is complete the status changes to **Succeeded**.
 Once the status returned is **Succeeded**, call a GET Method on the operationResult URI to retrieve the results.
 
 ```powershell
-armclient get "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operationResults/8a1167b7-6768-4ac1-85dc-703c9c9b9247?api-version=2016-03-30"
+armclient get "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westcentralus/operationResults/8a1167b7-6768-4ac1-85dc-703c9c9b9247?api-version=2016-03-30" -verbose
 ```
 
 The following responses are examples of a typical degraded response returned when querying the results of troubleshooting a gateway. See [Understanding the results](#understanding-the-results) to get clarification on what the properties in the response mean.


### PR DESCRIPTION
Added -verbose so that you can grab the operations guid.
Removed dangling brace in powershell