### PR TITLE
Update hpcpack-cluster-node-autogrowshrink.md

### DIFF
--- a/articles/virtual-machines/windows/classic/hpcpack-cluster-node-autogrowshrink.md
+++ b/articles/virtual-machines/windows/classic/hpcpack-cluster-node-autogrowshrink.md
@@ -180,7 +180,7 @@ By default HPC Pack grows 1% extra nodes for MPI jobs (**ExtraNodesGrowRatio** i
     Set-HpcClusterProperty -ExtraNodesGrowRatio 10
 
 ### SOA example
-By default, **SoaJobGrowThreshold** is set to 50000 and **SoaRequestsPerCore** is set to 200000. If you submit one SOA job with 70000 requests, there is one queued task and incoming requests are 70000. In this case HPC Pack grows 1 core for the queued task, and for incoming requests, grows (70000 - 50000)/20000 = 1 core, so in total grows 2 cores for this SOA job.
+By default, **SoaJobGrowThreshold** is set to 50000 and **SoaRequestsPerCore** is set to 20000. If you submit one SOA job with 70000 requests, there is one queued task and incoming requests are 70000. In this case HPC Pack grows 1 core for the queued task, and for incoming requests, grows (70000 - 50000)/20000 = 1 core, so in total grows 2 cores for this SOA job.
 
 ## Run the AzureAutoGrowShrink.ps1 script
 ### Prerequisites


### PR DESCRIPTION
In the  'SOA example' the default value of '200,000' carried an extra zero. Updated to show '20,000'

**Sidenote: If the calculation would result in a partial core what happens?
Using example numbers:
70,001 requests sent (70,001 - 50,000)/20,000 = 1.00005
89,999 requests sent (89,999 - 50,000)/20,000 = 1.99995
In each case would it truncate, always round up/down, round up if '>1.5+' cores?
