### PR TITLE
Update log-analytics-template-workspace-configuration.md

### DIFF
--- a/articles/log-analytics/log-analytics-template-workspace-configuration.md
+++ b/articles/log-analytics/log-analytics-template-workspace-configuration.md
@@ -415,9 +415,33 @@ The following template sample illustrates how to:
     }
   ],
   "outputs": {
-    "workspaceOutput": {
-      "value": "[reference(concat('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName')), '2015-11-01-preview')]",
-      "type": "object"
+    "workspaceName": {
+      "type": "string",
+      "value": "[parameters('workspaceName')]"
+    },
+    "provisioningState": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2015-11-01-preview').provisioningState]"
+    },
+    "source": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2015-11-01-preview').source]"
+    },
+    "customerId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2015-11-01-preview').customerId]"
+    },
+    "pricingTier": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2015-11-01-preview').sku.name]"
+    },
+    "retentionInDays": {
+      "type": "int",
+      "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2015-11-01-preview').retentionInDays]"
+    },
+    "portalUrl": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2015-11-01-preview').portalUrl]"
     }
   }
 }


### PR DESCRIPTION
Updated the `"outputs":{ }` from returning an object value to itemize values.

It is a better ARM Template example to demonstrate the WorkspaceProperties object keys and values documented in [Microsoft.OperationalInsights/workspaces template reference](https://docs.microsoft.com/en-in/azure/templates/microsoft.operationalinsights/workspaces?view=azureadps-1.0#WorkspaceProperties) for API Version (2015-11-01-preview).