### PR TITLE
Make WadCfg schema documentation more clear on Metrics element

### DIFF
--- a/articles/monitoring-and-diagnostics/azure-diagnostics-schema-1dot3-and-later.md
+++ b/articles/monitoring-and-diagnostics/azure-diagnostics-schema-1dot3-and-later.md
@@ -521,7 +521,7 @@ http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration
 
  Enables you to generate a performance counter table that is optimized for fast queries. Each performance counter that is defined in the **PerformanceCounters** element is stored in the Metrics table in addition to the Performance Counter table.  
 
- The **resourceId** attribute is required.  The resource ID of the Virtual Machine you are deploying Azure Diagnostics to. Get the **resourceID** from the [Azure portal](https://portal.azure.com). Select **Browse** -> **Resource Groups** -> **<Name\>**. Click the **Properties** tile and copy the value from the **ID** field.  
+ The **resourceId** attribute is required.  The resource ID of the Virtual Machine or Virtual Machine Scale Set you are deploying Azure Diagnostics to. Get the **resourceID** from the [Azure portal](https://portal.azure.com). Select **Browse** -> **Resource Groups** -> **<Name\>**. Click the **Properties** tile and copy the value from the **ID** field.  
 
 |Child Elements|Description|  
 |--------------------|-----------------|  


### PR DESCRIPTION
Make it more clear that resource Id should be the Id of the VM or VMSS Resource where Agent Diagnostics is deployed