### PR TITLE
Added another point specific to MQTT Protocol for clarity

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-messages-c2d.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-c2d.md
@@ -39,7 +39,7 @@ When the IoT Hub service sends a message to a device, the service sets the messa
 A device can also choose to:
 
 * *Reject* the message, which causes IoT Hub to set it to the **Deadlettered** state. Devices that connect over the MQTT protocol cannot reject cloud-to-device messages.
-* *Abandon* the message, which causes IoT Hub to put the message back in the queue, with the state set to **Enqueued**.
+* *Abandon* the message, which causes IoT Hub to put the message back in the queue, with the state set to **Enqueued**. Devices that connect over the MQTT protocol cannot abandon cloud-to-device messages.
 
 A thread could fail to process a message without notifying IoT Hub. In this case, messages automatically transition from the **Invisible** state back to the **Enqueued** state after a *visibility (or lock) timeout*. The default value of this timeout is one minute.
 


### PR DESCRIPTION
As per the MQTT Source code (https://github.com/Azure/azure-iot-sdk-csharp/blob/master/device/Microsoft.Azure.Devices.Client/Transport/Mqtt/MqttTransportHandler.cs), a device connecting to IoT Hub using MQTT Protocol cannot Reject **_AND Abandon_** the message either. Since it was not explicitly mentioned in the documentation, I've just added that point as well for more clarity.