### PR TITLE
Update log-analytics-powerbi.md

### DIFF
--- a/articles/log-analytics/log-analytics-powerbi.md
+++ b/articles/log-analytics/log-analytics-powerbi.md
@@ -20,9 +20,11 @@ ms.author: bwren
 # Export Log Analytics data to Power BI
 
 >[!NOTE]
-> If your workspace has been upgraded to the [new Log Analytics query language](log-analytics-log-search-upgrade.md), then this process for exporting Log Analytics data to Power BI will no longer work.  Any existing schedules that you created before upgrading will become disabled. 
+> If your workspace has been upgraded to the [new Log Analytics query language](log-analytics-log-search-upgrade.md), then this process for exporting Log Analytics data to Power BI will no longer work.  Any existing schedules that you created before upgrading will become disabled. You will also no longer see the ability to turn on the Power BI export capability in Settings under Preview Features, as this feature is fully released in upgraded workspaces. 
 >
 > After upgrade, Azure Log Analytics uses the same platform as Application Insights, and you use the same process to export Log Analytics queries to Power BI as [the process to export Application Insights queries to Power BI](../application-insights/app-insights-export-power-bi.md#export-analytics-queries).  You can either export the query using the Analytics console as described in that article, or you can select the **Power BI** button at the top of the screen in the Log Search portal.
+>
+> Users will need access to the Workspace Resource in Azure to use the Power BI export capabilitiy in upgraded workspaces. Without access, users will see an error message when importing the query to Power BI desktop that they do not have access.
 
 
 


### PR DESCRIPTION
PG owner for this page.

Adding 2 points to the note at the top of the page:
1) That the power bi export option is no longer in Preview settings for upgraded workspaces, as the feature is a GA feature in Search V2.
2) That users may run into access problems in the Power BI export step since this requires Azure RBAC. Many users may only have Classic Portal access to a workspace, but not have access to the subscription it is tied to, denying them access when Power BI desktop makes the ARM call using their creds to the workspace.