### PR TITLE
Removed comma from bindings json example

### DIFF
--- a/articles/azure-functions/functions-triggers-bindings.md
+++ b/articles/azure-functions/functions-triggers-bindings.md
@@ -345,7 +345,7 @@ For example, the following *function.json* uses a property called `BlobName` fro
       "name": "info",
       "type": "httpTrigger",
       "direction": "in",
-      "webHookType": "genericJson",
+      "webHookType": "genericJson"
     },
     {
       "name": "blobContents",


### PR DESCRIPTION
The comma was making the JSON invalid. removed it