### PR TITLE
add heading for creating web app client secret

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-app-registration.md
+++ b/articles/active-directory-b2c/active-directory-b2c-app-registration.md
@@ -48,6 +48,8 @@ Log in to the [Azure portal](https://portal.azure.com/) as the Global Administra
 
 [!INCLUDE [active-directory-b2c-register-web-app](../../includes/active-directory-b2c-register-web-app.md)]
 
+### Create a web app client secret
+
 If your web application calls a web API secured by Azure AD B2C, perform these steps:
    1. Create an application secret by going to the **Keys** blade and clicking the **Generate Key** button. Make note of the **App key** value. You use the value as the application secret in your application's code.
    2. Click **API Access**, click **Add**, and select your web API and scopes (permissions).


### PR DESCRIPTION
this will allow for a direct link to creating the client secret.  The client secret is referenced in various samples like [active-directory-b2c-devquickstarts-web-api-dotnet](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-devquickstarts-web-api-dotnet) but there is no link to it and how to set it up.