### PR TITLE
Make this note more meaningful.

### DIFF
--- a/includes/functions-local-settings-note.md
+++ b/includes/functions-local-settings-note.md
@@ -1,2 +1,2 @@
 >[!Note]
-> We recommend that you use an Azure Storage account when developing locally. Use of the Azure Storage Emulator is not supported by Azure Functions tools.
+> Use of the Azure Storage Emulator is not supported by Azure Functions tools when developing locally.


### PR DESCRIPTION
Saying
> We recommend that you use an Azure Storage account when developing locally. 

and then after that
> Use of the Azure Storage Emulator is not supported by Azure Functions tools.

Makes no sense. When a storage account is required, it's required. No need to "recommend". What makes sense is to clearly indicate that emulated account is a no-go.