### PR TITLE
Add AAD and EA references

### DIFF
--- a/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
@@ -72,7 +72,7 @@ You can share an ExpressRoute circuit across multiple subscriptions. The figure 
 
 - Each of the smaller clouds within the large cloud is used to represent subscriptions that belong to different departments within an organization.
 - Each of the departments within the organization can use their own subscription for deploying their services, but they can share a single ExpressRoute circuit to connect back to your on-premises network.
-- A single department (in this example: IT) can own the ExpressRoute circuit. Other subscriptions within the organization can use the ExpressRoute circuit.
+- A single department (in this example: IT) can own the ExpressRoute circuit. Other subscriptions within the organization can use the ExpressRoute circuit and authorizations associated to the circuit, including subscriptions linked to other Azure Active Directory tenants and Enterprise Agreement enrollments. 
 
 	> [!NOTE]
 	> Connectivity and bandwidth charges for the dedicated circuit will be applied to the ExpressRoute circuit owner. All virtual networks share the same bandwidth.


### PR DESCRIPTION
ER authorizations can span outside of subscription, tenant, and EA boundaries