### PR TITLE
Fixing async code fragment

### DIFF
--- a/articles/azure-functions/functions-triggers-bindings.md
+++ b/articles/azure-functions/functions-triggers-bindings.md
@@ -164,7 +164,7 @@ public static Task<string> Run(WorkItem input, TraceWriter log)
 {
     string json = string.Format("{{ \"id\": \"{0}\" }}", input.Id);
     log.Info($"C# script processed queue message. Item={json}");
-    return json;
+    return Task.FromResult(json);
 }
 ```
 


### PR DESCRIPTION
The async example for a C# function does return a `string` where a `Task<string>` is expected. Changing to use `Task.FromResult` though the use of the `async` modifier would be fine too (however, it'd result in a warning of missing any `await` in the body, and I didn't want to add an `await Task.Delay(x)` to the code just to make that go away).