### PR TITLE
(ForumsTeam) Cannot create classic Vms from classic portal.

### DIFF
--- a/includes/virtual-machines-classic-recovery-disks-portal.md
+++ b/includes/virtual-machines-classic-recovery-disks-portal.md
@@ -53,9 +53,9 @@ Once any errors are resolved, unmount and detach the existing virtual hard disk 
 
 ## Create a VM from the original hard disk
 
-To create a VM from your original virtual hard disk, use [Azure classic portal](https://manage.windowsazure.com).
+To create a VM from your original virtual hard disk, use [Azure portal](https://portal.azure.com).
 
-1. Sign into [Azure classic portal](https://manage.windowsazure.com).
-2. At the bottom of the portal, select **New** > **Compute** > **Virtual Machine** > **From Gallery**.
+1. Sign into [Azure portal](https://portal.azure.com).
+2. At the top left of the portal, select **New** > **Compute** > **Virtual Machine** > **From Gallery**.
 3. In the **Choose an Image** section, select **My disks**, and then select the original virtual hard disk. Check the location information. This is the region where the VM must be deployed. Select the next button.
 4. In the **Virtual machine configuration** section, type the VM name and select a size for the VM.


### PR DESCRIPTION
From this document https://docs.microsoft.com/en-us/azure/virtual-machines/windows/classic/troubleshoot-recovery-disks-portal , the suggestions outlined to create classic VMs from classic portal is no more available. The document has to be updated to describe the procedure using Azure portal and also add similar suggestions/process for ARM VMs.
Specifically," Create a VM from the original hard disk" in the document.