### PR TITLE
Update storage-use-azcopy-linux.md

### DIFF
--- a/articles/storage/common/storage-use-azcopy-linux.md
+++ b/articles/storage/common/storage-use-azcopy-linux.md
@@ -562,7 +562,7 @@ azcopy \
 	--sync-copy
 ```
 
-When copying from File Storage to Blob Storage, the default blob type is block blob, user can specify option `/BlobType:page` to change the destination blob type.
+When copying from File Storage to Blob Storage, the default blob type is block blob, user can specify option `--blob-type page` to change the destination blob type. Available types are `page | block | append`.
 
 Note that `--sync-copy` might generate additional egress cost comparing to asynchronous copy. The recommended approach is to use this option in an Azure VM, that is in the same region as your source storage account to avoid egress cost.
 


### PR DESCRIPTION
Fixing typo about BlobType parameter. There is no /BlobType in azcopy for Linux, there is --blob-type:

According to the help from the command itself:
azcopy --help | grep -i page
--blob-type <page | block | append>