### PR TITLE
Update to fix a minor typo on cosmos-db/serverless-computing-database

### DIFF
--- a/articles/cosmos-db/serverless-computing-database.md
+++ b/articles/cosmos-db/serverless-computing-database.md
@@ -132,7 +132,7 @@ Azure Cosmos DB is the recommended database for your serverless computing archit
 
 * **Global replication**. You can replicate Azure Cosmos DB data [around the globe](distribute-data-globally.md) to reduce latency, geo-locating your data closest to where your users are. As with all Azure Cosmos DB queries, data from event-driven triggers is read data from the Azure Cosmos DB closest to the user.
 
-If you're looking to integrate with Azure Functions to store data and don't need deep indexing or if you need to store attachments and media files, the [Azure Blog Storage trigger](../azure-functions/functions-bindings-storage-blob.md) may be a better option.
+If you're looking to integrate with Azure Functions to store data and don't need deep indexing or if you need to store attachments and media files, the [Azure Blob Storage trigger](../azure-functions/functions-bindings-storage-blob.md) may be a better option.
 
 Benefits of Azure Functions: 
 


### PR DESCRIPTION
Line#135 should be referring to Azure "Blob" storage instead of "Blog" storage.