### PR TITLE
add heading for configuring key vault

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-via-portal.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-via-portal.md
@@ -40,7 +40,8 @@ A secure cluster is a cluster that prevents unauthorized access to management op
 
 The concepts are the same for creating secure clusters, whether the clusters are Linux clusters or Windows clusters. For more information and helper scripts for creating secure Linux clusters, please see [Creating secure clusters on Linux](service-fabric-cluster-creation-via-arm.md#secure-linux-clusters). The parameters obtained by the helper script provided can be input directly into the portal as described in the section [Create a cluster in the Azure portal](#create-cluster-portal).
 
-## Log in to Azure
+## Configure Key Vault 
+### Log in to Azure
 This guide uses [Azure PowerShell][azure-powershell]. When starting a new PowerShell session, log in to your Azure account and select your subscription before executing Azure commands.
 
 Log in to your azure account:
@@ -56,7 +57,7 @@ Get-AzureRmSubscription
 Set-AzureRmContext -SubscriptionId <guid>
 ```
 
-## Set up Key Vault
+### Set up Key Vault
 This part of the guide walks you through creating a Key Vault for a Service Fabric cluster in Azure and for Service Fabric applications. For a complete guide on Key Vault, see the [Key Vault getting started guide][key-vault-get-started].
 
 Service Fabric uses X.509 certificates to secure a cluster. Azure Key Vault is used to manage certificates for Service Fabric clusters in Azure. When a cluster is deployed in Azure, the Azure resource provider responsible for creating Service Fabric clusters pulls certificates from Key Vault and installs them on the cluster VMs.
@@ -65,7 +66,7 @@ The following diagram illustrates the relationship between Key Vault, a Service 
 
 ![Certificate installation][cluster-security-cert-installation]
 
-### Create a Resource Group
+#### Create a Resource Group
 The first step is to create a new resource group specifically for Key Vault. Putting Key Vault into its own resource group is recommended so that you can remove compute and storage resource groups - such as the resource group that has your Service Fabric cluster - without losing your keys and secrets. The resource group that has your Key Vault must be in the same region as the cluster that is using it.
 
 ```powershell
@@ -81,7 +82,7 @@ The first step is to create a new resource group specifically for Key Vault. Put
 
 ```
 
-### Create Key Vault
+#### Create Key Vault
 Create a Key Vault in the new resource group. The Key Vault **must be enabled for deployment** to allow the Service Fabric resource provider to get certificates from it and install on cluster nodes:
 
 ```powershell
@@ -122,10 +123,10 @@ If you have an existing Key Vault, you can enable it for deployment using Azure 
 ```
 
 
-## Add certificates to Key Vault
+### Add certificates to Key Vault
 Certificates are used in Service Fabric to provide authentication and encryption to secure various aspects of a cluster and its applications. For more information on how certificates are used in Service Fabric, see [Service Fabric cluster security scenarios][service-fabric-cluster-security].
 
-### Cluster and server certificate (required)
+#### Cluster and server certificate (required)
 This certificate is required to secure a cluster and prevent unauthorized access to it. It provides cluster security in a couple ways:
 
 * **Cluster authentication:** Authenticates node-to-node communication for cluster federation. Only nodes that can prove their identity with this certificate can join the cluster.
@@ -137,7 +138,7 @@ To serve these purposes, the certificate must meet the following requirements:
 * The certificate must be created for key exchange, exportable to a Personal Information Exchange (.pfx) file.
 * The certificate's subject name must match the domain used to access the Service Fabric cluster. This is required to provide SSL for the cluster's HTTPS management endpoints and Service Fabric Explorer. You cannot obtain an SSL certificate from a certificate authority (CA) for the `.cloudapp.azure.com` domain. Acquire a custom domain name for your cluster. When you request a certificate from a CA the certificate's subject name must match the custom domain name used for your cluster.
 
-### Client authentication certificates
+#### Client authentication certificates
 Additional client certificates authenticate administrators for cluster management tasks. Service Fabric has two access levels: **admin** and **read-only user**. At minimum, a single certificate for administrative access should be used. For additional user-level access, a separate certificate must be provided. For more information on access roles, see [role-based access control for Service Fabric clients][service-fabric-cluster-security-roles].
 
 You do not need to upload Client authentication certificates to Key Vault to work with Service Fabric. These certificates only need to be provided to users who are authorized for cluster management. 
@@ -147,7 +148,7 @@ You do not need to upload Client authentication certificates to Key Vault to wor
 > 
 > 
 
-### Application certificates (optional)
+#### Application certificates (optional)
 Any number of additional certificates can be installed on a cluster for application security purposes. Before creating your cluster, consider the application security scenarios that require a certificate to be installed on the nodes, such as:
 
 * Encryption and decryption of application configuration values
@@ -155,7 +156,7 @@ Any number of additional certificates can be installed on a cluster for applicat
 
 Application certificates cannot be configured when creating a cluster through the Azure portal. To configure application certificates at cluster setup time, you must [create a cluster using Azure Resource Manager][create-cluster-arm]. You can also add application certificates to the cluster after it has been created.
 
-### Formatting certificates for Azure resource provider use
+#### Formatting certificates for Azure resource provider use
 Private key files (.pfx) can be added and used directly through Key Vault. However, the Azure resource provider requires keys to be stored in a special JSON format that includes the .pfx as a base-64 encoded string and the private key password. To accommodate these requirements, keys must be placed in a JSON string and then stored as *secrets* in Key Vault.
 
 To make this process easier, a PowerShell module is [available on GitHub][service-fabric-rp-helpers]. Follow these steps to use the module:


### PR DESCRIPTION
The document appears to have 2 main components: setup key vault and create cluster in azure portal.

Setting up the key vault is not labeled as such.