### PR TITLE
Change the partition key to match the code sample

### DIFF
--- a/includes/cosmos-db-create-graph.md
+++ b/includes/cosmos-db-create-graph.md
@@ -12,6 +12,6 @@ You can now use the Data Explorer tool in the Azure portal to create a graph dat
     Graph id|sample-graph|The ID for your new graph. Graph names have the same character requirements as database IDs.
     Storage capacity| 10 GB|Leave the default value. This is the storage capacity of the database.
     Throughput|400 RUs|Leave the default value. You can scale up the throughput later if you want to reduce latency.
-    Partition key|/userid|A partition key that distributes data evenly to each partition. Selecting the correct partition key is important in creating a performant graph. For more information, see [Designing for partitioning](../articles/cosmos-db/partition-data.md#designing-for-partitioning).
+    Partition key|/firstName|A partition key that distributes data evenly to each partition. Selecting the correct partition key is important in creating a performant graph. For more information, see [Designing for partitioning](../articles/cosmos-db/partition-data.md#designing-for-partitioning).
 
 3. After the form is filled out, select **OK**.


### PR DESCRIPTION
If you're using [this sample](https://github.com/Azure-Samples/azure-cosmos-db-graph-dotnet-getting-started) to follow along with [this article](https://docs.microsoft.com/en-us/azure/cosmos-db/create-graph-dotnet), the suggested partition key of `userId ` doesn't exist in the sample data. This change is to make `firstName` the partition key, which does exist.