### PR TITLE
Fixed typo in B2C docs

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-configure-signup-self-asserted-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-configure-signup-self-asserted-custom.md
@@ -31,7 +31,7 @@ Gathering initial data from your users is achieved via signup/signin.  Additiona
 
 
 ## Define the claim, its display name and the user input type
-Lets ask the user for their city.  Add the following element to the `<ClaimsSchema>` element in the TrustFrameWorkExtensions policy file:
+Lets ask the user for their city.  Add the following element to the `<ClaimsSchema>` element in the TrustFrameworkBase policy file:
 
 ```xml
 <ClaimType Id="city">


### PR DESCRIPTION
In IEF - User Flows - Configure user input, the "city" claim type must be added to the `TrustFrameworkBase` file.