### PR TITLE
(ForumsTeam) Incorrect url hyperlinked

### DIFF
--- a/articles/cloud-services/cloud-services-troubleshoot-deployment-problems.md
+++ b/articles/cloud-services/cloud-services-troubleshoot-deployment-problems.md
@@ -80,6 +80,6 @@ For more information on how to troubleshoot for this problem, see the blog post 
 >
 
 ## Next steps
-View more [troubleshooting articles](https://azure.microsoft.com/documentation/articles/?tag=top-support-issue&product=cloud-services) for cloud services.
+View more [troubleshooting articles](https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-allocation-failures) for cloud services.
 
 To learn how to troubleshoot cloud service role issues by using Azure PaaS computer diagnostics data, see [Kevin Williamson's blog series](http://blogs.msdn.com/b/kwill/archive/2013/08/09/windows-azure-paas-compute-diagnostics-data.aspx).


### PR DESCRIPTION
The hyperlink [troubleshooting articles] in the "Next steps" section points to generic Microsoft Azure Documentation url, but not to Cloud Service troubleshooting docs. Kindly fix this issue.
Could be redirected to these links instead: 
https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-allocation-failures
https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-troubleshoot-roles-that-fail-start