### PR TITLE
Fixed issue with the copy command

### DIFF
--- a/articles/app-service/app-service-web-tutorial-rest-api.md
+++ b/articles/app-service/app-service-web-tutorial-rest-api.md
@@ -81,7 +81,7 @@ When Swaggerize asks for a project name, use *ContactList*.
 1. Copy the *lib* folder into the *ContactList* folder created by `yo swaggerize`, then change directory into *ContactList*.
 
     ```bash
-    cp -r lib/ ContactList/
+    cp -r lib ContactList/
     cd ContactList
     ```
 


### PR DESCRIPTION
When running the `cp -r lib/ ContactList/` this is not the correct way to copy the directory into the other directory. The trailing slash needs to be removed so that the directory is copied and not the contents of the directory.