### PR TITLE
Update storage-troubleshoot-linux-file-connection-problems.md

### DIFF
--- a/articles/storage/files/storage-troubleshoot-linux-file-connection-problems.md
+++ b/articles/storage/files/storage-troubleshoot-linux-file-connection-problems.md
@@ -79,7 +79,7 @@ If you cannot upgrade to the latest kernel versions, you can work around this pr
 
 ### Cause
 
-Some Linux distributions do not yet support encryption features in SMB 3.0 and users might receive a "115" error message if they try to mount Azure Files by using SMB 3.0 because of a missing feature.
+Some Linux distributions do not yet support encryption features in SMB 3.0 and users might receive a "115" error message if they try to mount Azure Files by using SMB 3.0 because of a missing feature. SMB 3.0 with full encryption is only supported at the moment when using Ubuntu 16.04 or later.
 
 ### Solution
 
@@ -100,11 +100,11 @@ To check whether caching is disabled, look for the **cache=** entry.
 
 In some scenarios, the **serverino** mount option can cause the **ls** command to run stat against every directory entry. This behavior results in performance degradation when you're listing a big directory. You can check the mount options in your **/etc/fstab** entry:
 
-`//azureuser.file.core.windows.net/cifs /cifs cifs vers=3.0,serverino,username=xxx,password=xxx,dir_mode=0777,file_mode=0777`
+`//azureuser.file.core.windows.net/cifs /cifs cifs vers=2.1,serverino,username=xxx,password=xxx,dir_mode=0777,file_mode=0777`
 
 You can also check whether the correct options are being used by running the  **sudo mount | grep cifs** command and checking its output, such as the following example output:
 
-`//mabiccacifs.file.core.windows.net/cifs on /cifs type cifs (rw,relatime,vers=3.0,sec=ntlmssp,cache=strict,username=xxx,domain=X,uid=0,noforceuid,gid=0,noforcegid,addr=192.168.10.1,file_mode=0777, dir_mode=0777,persistenthandles,nounix,serverino,mapposix,rsize=1048576,wsize=1048576,actimeo=1)`
+`//azureuser.file.core.windows.net/cifs on /cifs type cifs (rw,relatime,vers=2.1,sec=ntlmssp,cache=strict,username=xxx,domain=X,uid=0,noforceuid,gid=0,noforcegid,addr=192.168.10.1,file_mode=0777, dir_mode=0777,persistenthandles,nounix,serverino,mapposix,rsize=1048576,wsize=1048576,actimeo=1)`
 
 If the **cache=strict** or **serverino** option is not present, unmount and mount Azure Files again by running the mount command from the [documentation](../storage-how-to-use-files-linux.md). Then, recheck that the **/etc/fstab** entry has the correct options.
 


### PR DESCRIPTION
Adding disclaimer about what is currently supported when using SMB 3.0. 

Corrected examples to list 2.1 so customers do not get confused when trying 3.0 in other distros that will not work.

Red Hat for example, the mount command might work when specifying version 3.0 but that does not add encryption, so using 2.1 is the recommendation from Red Hat as its still experimental for them (this also applies to other distributions)