### PR TITLE
Update local-emulator.md

### DIFF
--- a/articles/cosmos-db/local-emulator.md
+++ b/articles/cosmos-db/local-emulator.md
@@ -81,7 +81,7 @@ You can download and install the Azure Cosmos DB Emulator from the [Microsoft Do
 
 The Azure Cosmos DB Emulator can be run on Docker for Windows. The Emulator does not work on Docker for Oracle Linux.
 
-Once you have [Docker for Windows](https://www.docker.com/docker-windows) installed, you can pull the Emulator image from Docker Hub by running the following command from your favorite shell (cmd.exe, PowerShell, etc.).
+Once you have [Docker for Windows](https://www.docker.com/docker-windows) installed and switched to Windows containers, you can pull the Emulator image from Docker Hub by running the following command from your favorite shell (cmd.exe, PowerShell, etc.).
 
 ```      
 docker pull microsoft/azure-cosmosdb-emulator 
@@ -90,7 +90,7 @@ To start the image, run the following commands.
 
 ``` 
 md %LOCALAPPDATA%\CosmosDBEmulatorCert 2>nul
-docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:c:\CosmosDBEmulator\CosmosDBEmulatorCert -P -t -i microsoft/azure-cosmosdb-emulator 
+docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:c:\CosmosDBEmulator\CosmosDBEmulatorCert -P -t -i -m 2GB microsoft/azure-cosmosdb-emulator 
 ```
 
 The response looks similar to the following:


### PR DESCRIPTION
When following the instructions for running the emulator on Docker for Windows on my Windows 10 machine, I had two issue:
- After installing Docker, the default setting is to use Linux Containers, so I had to switch to Windows containers
- The default memory size of the container (that on Windows 10 use Hyper-V isolation) is 1GB and causes an out-of-memory error (see [Running docker rans out of memory #254](Azure/azure-documentdb-dotnet#254) ).
Note that this is the same PR I did on May, 22 2017 (#1815) but I had to create this new PR due to the changes happened from Document DB and Cosmos DB files.