### PR TITLE
Service health alerts does not send resource health events

### DIFF
--- a/articles/monitoring-and-diagnostics/monitoring-activity-log-alerts-on-service-notifications.md
+++ b/articles/monitoring-and-diagnostics/monitoring-activity-log-alerts-on-service-notifications.md
@@ -29,6 +29,9 @@ You can receive an alert when Azure sends service health notifications to your A
 - The status of the notification (active vs. resolved).
 - The level of the notifications (informational, warning, error).
 
+> [!NOTE]
+> Service health notifications does not send an alert regarding resource health events.
+
 You also can configure who the alert should be sent to:
 
 - Select an existing action group.


### PR DESCRIPTION
Currently we do not have a feature to send resource health notifications.
(Still in development)

And service health notification documented here does not include resource health events.
So I added a note because current documentation may confuse customers that service health notifications can notify resource health events.