### PR TITLE
Update SetDesiredPropertyUpdateCallback to SetDesiredPropertyUpdateCa…

### DIFF
--- a/articles/iot-hub/iot-hub-csharp-csharp-twin-how-to-configure.md
+++ b/articles/iot-hub/iot-hub-csharp-csharp-twin-how-to-configure.md
@@ -196,7 +196,7 @@ In this section, you create a .NET console app that connects to your hub as **my
             InitTelemetry();
 
             Console.WriteLine("Wait for desired telemetry...");
-            Client.SetDesiredPropertyUpdateCallback(OnDesiredPropertyChanged, null).Wait();
+            Client.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertyChanged, null).Wait();
             Console.ReadKey();
         }
         catch (AggregateException ex)


### PR DESCRIPTION
…llbackAsync

Due to SetDesiredPropertyUpdateCallback is obsolete, we should use the updated version.

[Obsolete("Please use SetDesiredPropertyUpdateCallbackAsync.")]
        public Task SetDesiredPropertyUpdateCallback(DesiredPropertyUpdateCallback callback, object userContext);