### PR TITLE
Specify that az sf is still supported for ARM operations

### DIFF
--- a/articles/service-fabric/service-fabric-application-lifecycle-sfctl.md
+++ b/articles/service-fabric/service-fabric-application-lifecycle-sfctl.md
@@ -172,6 +172,8 @@ When an application upgrade is in progress, the status can be retrieved using th
 Finally, if an upgrade is in progress and needs to be canceled, you can use
 the `sfctl application upgrade-rollback` to roll back the upgrade.
 
+NOTE - We recommend using sfctl for cluster management, howerver, for ARM, SF CLI - https://docs.microsoft.com/en-us/cli/azure/sf/cluster?view=azure-cli-latest (az sf) can still be used. 
+
 ## Next steps
 
 * [Service Fabric CLI basics](service-fabric-cli.md)


### PR DESCRIPTION
Discussed with Mani and we concluded that it is good for customer to know that we still support "az sf" for ARM operations. They might get confused with the usage of sfctl and az sf.