### PR TITLE
Text skewed after Max IOPS per share

### DIFF
--- a/articles/azure-subscription-service-limits.md
+++ b/articles/azure-subscription-service-limits.md
@@ -286,4 +286,3 @@ For SQL Database limits, see [SQL Database Resource Limits](sql-database/sql-dat
 [Virtual Machine and Cloud Service Sizes for Azure](virtual-machines/linux/sizes.md?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json)
 
 [Sizes for Cloud Services](cloud-services/cloud-services-sizes-specs.md)
-


### PR DESCRIPTION
Looks like 'Storage' gets skewed and no longer follows format after 'Max IOPS per share'. Also... how do you edit these documents in a friendly way outside of the Git raw text editor. Apologies else I'd give the edit a try