### PR TITLE
Update active-directory-b2c-devquickstarts-api-dotnet.md

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-devquickstarts-api-dotnet.md
+++ b/articles/active-directory-b2c/active-directory-b2c-devquickstarts-api-dotnet.md
@@ -37,7 +37,7 @@ Next, you need to create a web API app in your B2C directory. This gives Azure A
 * Include a **web app** or **web API** in the application.
 * Use the **Redirect URI** `https://localhost:44332/` for the web app. This is the default location of the web app client for this code sample.
 * Copy the **Application ID** that is assigned to your app. You'll need it later.
-* Enter an app identifier into **App ID URI**.
+* Enter an app identifier into **App ID URI**. Copy the full **App ID URI**. You'll need it later.
 * Add permissions through the **Published scopes** menu.
 
   [!INCLUDE [active-directory-b2c-devquickstarts-v2-apps](../../includes/active-directory-b2c-devquickstarts-v2-apps.md)]
@@ -80,6 +80,7 @@ Our sample is configured to use the policies and client ID of our demo tenant. I
     * `ida:SignUpSignInPolicyId` with your "Sign-up or Sign-in" policy name
     * `ida:EditProfilePolicyId` with your "Edit Profile" policy name
     * `ida:ResetPasswordPolicyId` with your "Reset Password" policy name
+    * `api:ApiIdentifier` with your "App ID URI"
 
 
 ## Secure the API


### PR DESCRIPTION
Add instructions for updating api:ApiIdentifier in the TaskWebApp web.config. The original value points to "https://fabrikamb2c.onmicrosoft.com/tasks/". If this value is not changed to the developer's API URI, the access token will be null, causing an Unauthorized error when running the [active-directory-b2c-dotnet-webapp-and-webapi](https://github.com/Azure-Samples/active-directory-b2c-dotnet-webapp-and-webapi) sample.