### PR TITLE
(ForumsTeam) Azure Stack - Incorrect link hyperlinked

### DIFF
--- a/articles/azure-stack/azure-stack-key-features.md
+++ b/articles/azure-stack/azure-stack-key-features.md
@@ -141,5 +141,5 @@ In-development builds will provide the following benefits:
 - Other improvements
 
 ## Next steps
-[Deploy Azure Stack Development Kit](azure-stack-deploy.md)
+[Deploy Azure Stack Development Kit](https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-run-powershell-script)
 


### PR DESCRIPTION
Ref: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-key-features
The "Next steps' section in this doc, points to "Azure Stack deployment prerequisites" which instead should point to "Deploy the Azure Stack Development Kit"