### PR TITLE
Fix table on azure-storage-limits.md

### DIFF
--- a/includes/azure-storage-limits.md
+++ b/includes/azure-storage-limits.md
@@ -17,7 +17,6 @@
 | Max size of a file in a file share |1 TB |
 | Max number of files in a file share |Only limit is the 5 TB total capacity of the file share |
 | Max IOPS per share |1000 |
-
 | Max number of stored access policies per container, file share, table, or queue |5 |
 | Maximum request rate per storage account |Blobs: 20,000 requests per second<sup>2</sup> for blobs of any valid size<sup>3</sup> <br />Files: 20,000 requests per second <sup>2</sup> for files of any valid size<sup>3</sup> <br />Queues: 20,000 messages per second (assuming 1 KB message size)<br />Tables: 20,000 transactions per second (assuming 1 KB entity size) |
 | Target throughput for single blob |Up to 60 MB per second, or up to 500 requests per second |


### PR DESCRIPTION
Table is not rendered correctly on https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#storage-limits 
The bottom half of the table is broken.