### PR TITLE
Fix VM Size link text

### DIFF
--- a/articles/virtual-machines/windows/tutorial-manage-data-disk.md
+++ b/articles/virtual-machines/windows/tutorial-manage-data-disk.md
@@ -88,7 +88,7 @@ Premium disks are backed by SSD-based high-performance, low-latency disk. Perfec
 | IOPS per disk | 500 | 2,300 | 5,000 |
 Throughput per disk | 100 MB/s | 150 MB/s | 200 MB/s |
 
-While the above table identifies max IOPS per disk, a higher level of performance can be achieved by striping multiple data disks. For instance, 64 data disks can be attached to Standard_GS5 VM. If each of these disks are sized as a P30, a maximum of 80,000 IOPS can be achieved. For detailed information on max IOPS per VM, see [Linux VM sizes](./sizes.md).
+While the above table identifies max IOPS per disk, a higher level of performance can be achieved by striping multiple data disks. For instance, 64 data disks can be attached to Standard_GS5 VM. If each of these disks are sized as a P30, a maximum of 80,000 IOPS can be achieved. For detailed information on max IOPS per VM, see [VM types and sizes](./sizes.md).
 
 ## Create and attach disks
 


### PR DESCRIPTION
Link text seems to point to Linux VM Sizes, but it could point to either Windows or Linux VM sizes based on the URL. Hence changed to reflect title of the page obtained from left side menu.