### PR TITLE
Removed "SNAPSHOT" designation from command

### DIFF
--- a/articles/azure-functions/functions-create-first-java-maven.md
+++ b/articles/azure-functions/functions-create-first-java-maven.md
@@ -55,7 +55,7 @@ In an empty folder, run the following command to generate the Functions project 
 mvn archetype:generate \
     -DarchetypeGroupId=com.microsoft.azure \
 	-DarchetypeArtifactId=azure-functions-archetype \
-    -DarchetypeVersion=1.0-SNAPSHOT
+    -DarchetypeVersion=1.0
 ```
 
 ### Windows (CMD)


### PR DESCRIPTION
Maven command for MacOS fails as listed, but works if you remove the SNAPSHOT and just have 1.0.