### PR TITLE
Updating the link to the GitHub

### DIFF
--- a/articles/app-service/containers/quickstart-custom-docker-image.md
+++ b/articles/app-service/containers/quickstart-custom-docker-image.md
@@ -39,7 +39,7 @@ Create a [web app](../app-service-web-overview.md) in the `myAppServicePlan` App
 az webapp create --resource-group myResourceGroup --plan myAppServicePlan --name <app name> --deployment-container-image-name elnably/dockerimagetest
 ```
 
-In the preceding command, `--deployment-container-image-name` points to the public Docker Hub image [https://hub.docker.com/r/elnably/dockerimagetest/](https://hub.docker.com/r/elnably/dockerimagetest/). You can inspect its content at [https://github.com/rachelappel/docker-image](https://github.com/rachelappel/docker-image).
+In the preceding command, `--deployment-container-image-name` points to the public Docker Hub image [https://hub.docker.com/r/elnably/dockerimagetest/](https://hub.docker.com/r/elnably/dockerimagetest/). You can inspect its content at [https://github.com/ahmedelnably/dockerimagetest](https://github.com/ahmedelnably/dockerimagetest).
 
 When the web app has been created, the Azure CLI shows output similar to the following example:
 


### PR DESCRIPTION
Updating the link to the GitHub repository containing the content for the docker container.

The original link is not the one on which the container https://hub.docker.com/r/elnably/dockerimagetest is build upon.