### PR TITLE
incorrect archetype name in java functions quickstart guide

### DIFF
--- a/articles/azure-functions/functions-create-first-java-maven.md
+++ b/articles/azure-functions/functions-create-first-java-maven.md
@@ -55,7 +55,7 @@ In an empty folder, run the following command to generate the Functions project 
 mvn archetype:generate \
     -DarchetypeGroupId=com.microsoft.azure \
 	-DarchetypeArtifactId=azure-functions-archetype \
-    -DarchetypeVersion=1.0-SNAPSHOT
+    -DarchetypeVersion=1.0
 ```
 
 ### Windows (CMD)
@@ -63,7 +63,7 @@ mvn archetype:generate \
 mvn archetype:generate ^
 	-DarchetypeGroupId=com.microsoft.azure ^
 	-DarchetypeArtifactId=azure-functions-archetype ^
-    -DarchetypeVersion=1.0-SNAPSHOT
+    -DarchetypeVersion=1.0
 ```
 
 Maven prompts you for values needed to finish generating the project. For _groupId_, _artifactId_, and _version_ values, see the [Maven naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html) reference. The _appName_ value must be unique across Azure, so Maven generates an app name based on the previously entered _artifactId_  as a default. The _packageName_ value determines the Java package for the generated function code.


### PR DESCRIPTION
fixing error:
```
The desired archetype does not exist (com.microsoft.azure:azure-functions-archetype:1.0-SNAPSHOT)
```