### PR TITLE
endpoint ownership --> endpoint validity

### DIFF
--- a/articles/event-grid/security-authentication.md
+++ b/articles/event-grid/security-authentication.md
@@ -22,7 +22,7 @@ Azure Event Grid has three types of authentication:
 
 Webhooks are one of many ways to receive events in real time from Azure Event Grid. Every time there is a new event ready to be delivered, the Event Grid Webhook seeds an HTTP request to the configured HTTP endpoint with the event in the body.
 
-When you register your own WebHook endpoint with Event Grid, it sends you a POST request with a simple validation code in order to prove endpoint ownership. Your app needs to respond by echoing back the validation code. Event Grid does not deliver events to WebHook endpoints that have not passed the validation.
+When you register your own WebHook endpoint with Event Grid, it sends you a POST request with a simple validation code in order to prove endpoint validity. Your app needs to respond by echoing back the validation code. Event Grid does not deliver events to WebHook endpoints that have not passed the validation.
 
 ### Validation details
 


### PR DESCRIPTION
This mechanism does not really prove ownership. It just ensures that the endpoint passes the AEG handshake. This is simply a technical nit-pick.