### PR TITLE
Update service-fabric-containers-volume-logging-drivers.md

### DIFF
--- a/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
+++ b/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
@@ -17,10 +17,24 @@ ms.date: 8/9/2017
 ms.author: subramar
 ---
 
-# Specifying volume plugins and logging drivers for your container
+# Using Volume Plugins and Logging Drivers for your Container
 
-Service Fabric supports specifying [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) for your container service. The plugins are specified in the application manifest as shown in the following manifest:
+Service Fabric supports specifying [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) for your container service. By default, there are no [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) installed on the machines. 
 
+## Install plugin or driver
+
+This can be accompished manually by RDP/SSH-ing into the machine or through a VMSS start-up script. For instance, in order to install the Docker Volume Driver, SSH into the machine and execute:
+
+```bash
+docker plugin install --alias cloudstor:azure --grant-all-permissions docker4x/17.09.0-ce-azure1  \
+    CLOUD_PLATFORM=AZURE \
+    AZURE_STORAGE_ACCOUNT="[MY-STORAGE-ACCOUNT-NAME]" \
+    AZURE_STORAGE_ACCOUNT_KEY="[MY-STORAGE-ACCOUNT-KEY]" \
+    DEBUG=1
+```
+
+## Specify the plugin or driver in the manifest
+The plugins are specified in the application manifest as shown in the following manifest:
 
 ```xml
 ?xml version="1.0" encoding="UTF-8"?>
@@ -41,7 +55,7 @@ Service Fabric supports specifying [Docker volume plugins](https://docs.docker.c
         </LogConfig>
         <Volume Source="c:\workspace" Destination="c:\testmountlocation1" IsReadOnly="false"></Volume>
         <Volume Source="d:\myfolder" Destination="c:\testmountlocation2" IsReadOnly="true"> </Volume>
-        <Volume Source="myvolume1" Destination="c:\testmountlocation2" Driver="azurefile" IsReadOnly="true">
+        <Volume Source="myvolume1" Destination="c:\testmountlocation2" Driver="cloudstor:azure" IsReadOnly="true">
            <DriverOption Name="share" Value="models"/>
         </Volume>
        </ContainerHostPolicies>

--- a/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
+++ b/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
@@ -17,13 +17,13 @@ ms.date: 8/9/2017
 ms.author: subramar
 ---
 
-# Using Volume Plugins and Logging Drivers for your Container
+# Using Volume Plugins and Logging Drivers in your Container
 
-Service Fabric supports specifying [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) for your container service. By default, there are no [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) installed on the machines. 
+Service Fabric supports specifying [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) for your container service. 
 
-## Install plugin or driver
+## Install Volume/Logging Driver
 
-This can be accompished manually by RDP/SSH-ing into the machine or through a VMSS start-up script. For instance, in order to install the Docker Volume Driver, SSH into the machine and execute:
+If the Docker volume/logging driver is not installed on the machine, install it manually through RDP/SSH-ing into the machine or through a VMSS start-up script. For instance, in order to install the Docker Volume Driver, SSH into the machine and execute:
 
 ```bash
 docker plugin install --alias cloudstor:azure --grant-all-permissions docker4x/17.09.0-ce-azure1  \

--- a/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
+++ b/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
@@ -26,7 +26,7 @@ Service Fabric supports specifying [Docker volume plugins](https://docs.docker.c
 If the Docker volume/logging driver is not installed on the machine, install it manually through RDP/SSH-ing into the machine or through a VMSS start-up script. For instance, in order to install the Docker Volume Driver, SSH into the machine and execute:
 
 ```bash
-docker plugin install --alias cloudstor:azure --grant-all-permissions docker4x/17.09.0-ce-azure1  \
+docker plugin install --alias azure --grant-all-permissions docker4x/17.09.0-ce-azure1  \
     CLOUD_PLATFORM=AZURE \
     AZURE_STORAGE_ACCOUNT="[MY-STORAGE-ACCOUNT-NAME]" \
     AZURE_STORAGE_ACCOUNT_KEY="[MY-STORAGE-ACCOUNT-KEY]" \
@@ -55,7 +55,7 @@ The plugins are specified in the application manifest as shown in the following 
         </LogConfig>
         <Volume Source="c:\workspace" Destination="c:\testmountlocation1" IsReadOnly="false"></Volume>
         <Volume Source="d:\myfolder" Destination="c:\testmountlocation2" IsReadOnly="true"> </Volume>
-        <Volume Source="myvolume1" Destination="c:\testmountlocation2" Driver="cloudstor:azure" IsReadOnly="true">
+        <Volume Source="myvolume1" Destination="c:\testmountlocation2" Driver="azure" IsReadOnly="true">
            <DriverOption Name="share" Value="models"/>
         </Volume>
        </ContainerHostPolicies>

--- a/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
+++ b/articles/service-fabric/service-fabric-containers-volume-logging-drivers.md
@@ -17,11 +17,11 @@ ms.date: 8/9/2017
 ms.author: subramar
 ---
 
-# Using Volume Plugins and Logging Drivers in your Container
+# Using volume plugins and logging drivers in your container
 
 Service Fabric supports specifying [Docker volume plugins](https://docs.docker.com/engine/extend/plugins_volume/) and [Docker logging drivers](https://docs.docker.com/engine/admin/logging/overview/) for your container service. 
 
-## Install Volume/Logging Driver
+## Install volume/logging driver
 
 If the Docker volume/logging driver is not installed on the machine, install it manually through RDP/SSH-ing into the machine or through a VMSS start-up script. For instance, in order to install the Docker Volume Driver, SSH into the machine and execute:
 


### PR DESCRIPTION
At OpenHack, there's a lot of confusion around how to install volume/logging drivers. The instructions seem to imply using https://github.com/Azure/azurefile-dockervolumedriver, but according to this PR https://github.com/Azure/azurefile-dockervolumedriver/pull/92, it is deprecated. 

Added instructions on installing the docker4x/17.09.0-ce-azure1 driver. 

@suhuruli @mani-ramaswamy 