### PR TITLE
Fixing PaaS cloud service static IP address table

### DIFF
--- a/articles/virtual-network/virtual-network-ip-addresses-overview-classic.md
+++ b/articles/virtual-network/virtual-network-ip-addresses-overview-classic.md
@@ -138,9 +138,8 @@ The table below shows each resource type with the possible allocation methods (d
 
 | Resource | Dynamic | Static | Multiple IP addresses |
 | --- | --- | --- | --- |
-| VM (in a *standalone* cloud service) |Yes |Yes |Yes |
-| PaaS role instance (in a *standalone* cloud service) |Yes |No |Yes |
-| VM or PaaS role instance (in a VNet) |Yes |Yes |Yes |
+| VM (in a *standalone* cloud service or VNet) |Yes |Yes |Yes |
+| PaaS role instance (in a *standalone* cloud service or VNet) |Yes |No |No |
 | Internal load balancer front end |Yes |Yes |Yes |
 | Application gateway front end |Yes |Yes |Yes |
 


### PR DESCRIPTION
PaaS Cloud Services cannot have static DIPs or multiple DIPs.  This article was correct when originally published, but the change https://github.com/MicrosoftDocs/azure-docs/commit/a1e93b2f8cebec326ed425bc9fc0070e97deb2f9#diff-f9782756ab1ca3f72ee0b08c2282b2b9 changed several tables and introduced some errors for PaaS cloud service role instances in respect to private IP addresses.