### PR TITLE
Removing SfB as unsupported

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-pass-through-authentication-current-limitations.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-pass-through-authentication-current-limitations.md
@@ -35,7 +35,6 @@ The following scenarios are fully supported:
 The following scenarios are _not_ supported:
 
 - User sign-ins into legacy Office client applications (Office 2013 or earlier). Organizations are encouraged to switch to modern authentication, if possible. Modern authentication allows for Pass-through Authentication support but also helps you secure your user accounts using [conditional access](../active-directory-conditional-access.md) features such as Multi-Factor Authentication (MFA).
-- User sign-ins into Skype for Business client applications, including Skype for Business 2016.
 - User sign-ins into PowerShell v1.0. It is recommended that you use PowerShell v2.0 instead.
 - App passwords for MFA.
 - Detection of users with [leaked credentials](../active-directory-reporting-risk-events.md#leaked-credentials).


### PR DESCRIPTION
SfB now supports Modern Authentication and is the default
https://technet.microsoft.com/en-us/library/mt803262.aspx