### PR TITLE
Validate P2 license requirements....

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-pass-through-authentication-smart-lockout.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-pass-through-authentication-smart-lockout.md
@@ -32,7 +32,7 @@ Smart Lockout also distinguishes between sign-ins from genuine users and from at
 Because Pass-through Authentication forwards password validation requests onto your on-premises Active Directory (AD), you need to prevent attackers from locking out your users’ AD accounts. Since you have your own AD Account Lockout policies (specifically, [**Account Lockout Threshold**](https://technet.microsoft.com/library/hh994574(v=ws.11).aspx) and [**Reset Account Lockout Counter After policies**](https://technet.microsoft.com/library/hh994568(v=ws.11).aspx)), you need to configure Azure AD’s Lockout Threshold and Lockout Duration values appropriately to filter out attacks in the cloud before they reach your on-premises AD.
 
 >[!NOTE]
->The Smart Lockout feature is free and is _on_ by default for all customers. However, modifying Azure AD’s Lockout Threshold and Lockout Duration values using Graph API needs your tenant to have at least one Azure AD Premium P2 license. You don't need an Azure AD Premium P2 license _per user_ to get the Smart Lockout feature with Pass-through Authentication.
+>The Smart Lockout feature is free and is _on_ by default for all customers. However, modifying Azure AD’s Lockout Threshold and Lockout Duration values using Graph API needs your tenant to be acticated for Azure AD Premium P2.
 
 To ensure that your users’ on-premises AD accounts are well protected, you need to ensure that:
 


### PR DESCRIPTION
The statement stating only 1 x AAD P2 license is needed to activate the feature for the tenant sounds grossly misrepresented from a licensing perspective. Similarly, we have other AAD P2 features which are tenant wide features, but our licensing policy dictates a P2 license is needed for each user using it (even though the AAD system doesn't validate which users have P2 licenses).
My point is this... if you're using a single P2 license as a mechanism to activate tenant features to be used by everyone... you're likely violating our license terms (regardless of what the technology allows you to do with 1x license)