### PR TITLE
Replace link that directs incorrectly

### DIFF
--- a/articles/azure-stack/azure-stack-app-service-before-you-get-started.md
+++ b/articles/azure-stack/azure-stack-app-service-before-you-get-started.md
@@ -31,7 +31,7 @@ Azure App Service on Azure Stack has a number of pre-requisite steps that must b
 
 ## Download the Azure App Service on Azure Stack helper scripts
 
-1. Download the [App Service on Azure Stack deployment helper scripts](http://aka.ms/appsvconmasrc1helper).
+1. Download the [App Service on Azure Stack deployment helper scripts](https://appserviceonazurestack.blob.core.windows.net/rtm-62-2-40/AppServiceHelperScripts.zip).
 2. Extract the files from the helper scripts zip file. The following files and folder structure appear:
   - Create-AppServiceCerts.ps1
   - Create-AADIdentityApp.ps1


### PR DESCRIPTION
Replace the link http://aka.ms/appsvconmasrc1helper as it does not direct the customer correctly to the files. It sends you here instead: https://docs.microsoft.com/en-us/azure/azure-stack/

I found the correct download path to be https://appserviceonazurestack.blob.core.windows.net/rtm-62-2-40/AppServiceHelperScripts.zip 

Else, please provide the correct link to the customer and update the doc. 

Thanks :) 

-Micah