### PR TITLE
add common troubleshooting instructions for config

### DIFF
--- a/articles/application-insights/app-insights-api-filtering-sampling.md
+++ b/articles/application-insights/app-insights-api-filtering-sampling.md
@@ -332,6 +332,9 @@ What's the difference between telemetry processors and telemetry initializers?
 * TelemetryProcessors allow you to completely replace or discard a telemetry item.
 * TelemetryProcessors don't process performance counter telemetry.
 
+## Troubleshooting ApplicationInsights.config
+* Confirm that the fully qualified type name and assembly name are correct.
+* Confirm that the applicationinsights.config file is in your output directory and contains any recent changes.
 
 ## Reference docs
 * [API Overview](app-insights-api-custom-events-metrics.md)


### PR DESCRIPTION
Add common troubleshooting instructions for ApplicationInsights.config. 
This is relevant to adding new initaliziers or processors to the config.