### PR TITLE
additional note related to REST API env variables

### DIFF
--- a/articles/app-service/app-service-managed-service-identity.md
+++ b/articles/app-service/app-service-managed-service-identity.md
@@ -149,7 +149,7 @@ A successful 200 OK response includes a JSON body with the following properties:
 This response is the same as the [response for the AAD service-to-service access token request](../active-directory/develop/active-directory-protocols-oauth-service-to-service.md#service-to-service-access-token-response).
 
 > [!NOTE] 
-> Environment variables are set up when the process first starts, and so after enabling Managed Service Identity for your Function App you may need to wait for a period of time, or until you've redeployed your Functions, before `MSI_ENDPOINT` and `MSI_SECRET` are availale to your code.
+> Environment variables are set up when the process first starts, so after enabling Managed Service Identity for your application you may need to restart your application, or redeploy its code, before `MSI_ENDPOINT` and `MSI_SECRET` are availale to your code.
 
 ### REST protocol examples
 An example request might look like the following:

--- a/articles/app-service/app-service-managed-service-identity.md
+++ b/articles/app-service/app-service-managed-service-identity.md
@@ -148,6 +148,9 @@ A successful 200 OK response includes a JSON body with the following properties:
 
 This response is the same as the [response for the AAD service-to-service access token request](../active-directory/develop/active-directory-protocols-oauth-service-to-service.md#service-to-service-access-token-response).
 
+> [!NOTE] 
+> Environment variables are set up when the process first starts, and so after enabling Managed Service Identity for your Function App you may need to wait for a period of time, or until you've redeployed your Functions, before `MSI_ENDPOINT` and `MSI_SECRET` are availale to your code.
+
 ### REST protocol examples
 An example request might look like the following:
 ```

--- a/articles/app-service/app-service-managed-service-identity.md
+++ b/articles/app-service/app-service-managed-service-identity.md
@@ -149,7 +149,7 @@ A successful 200 OK response includes a JSON body with the following properties:
 This response is the same as the [response for the AAD service-to-service access token request](../active-directory/develop/active-directory-protocols-oauth-service-to-service.md#service-to-service-access-token-response).
 
 > [!NOTE] 
-> Environment variables are set up when the process first starts, so after enabling Managed Service Identity for your application you may need to restart your application, or redeploy its code, before `MSI_ENDPOINT` and `MSI_SECRET` are availale to your code.
+> Environment variables are set up when the process first starts, so after enabling Managed Service Identity for your application you may need to restart your application, or redeploy its code, before `MSI_ENDPOINT` and `MSI_SECRET` are available to your code.
 
 ### REST protocol examples
 An example request might look like the following:


### PR DESCRIPTION
If you enable the Managed Service Identity within the Azure Portal, and then go straight to your Azure Function and run it, you may well find that `process.env['MSI_ENDPOINT']` and `process.env['MSI_SECRET']` return `undefined` because the process within which the Function is running does not have these environment variables set up.

Restarting the Function App, and "save and run" of the function, may also not bring these variables into the process.

The note warns users that this might be a problem.