### PR TITLE
Update service-fabric-choose-framework.md

### DIFF
--- a/articles/service-fabric/service-fabric-choose-framework.md
+++ b/articles/service-fabric/service-fabric-choose-framework.md
@@ -56,7 +56,7 @@ Service Fabric integrates with [ASP.NET Core](service-fabric-reliable-services-c
 
 [Reliable Services overview](service-fabric-reliable-services-introduction.md)
 
-[Reliable Services overview](service-fabric-reliable-actors-introduction.md)
+[Reliable Actors overview](service-fabric-reliable-actors-introduction.md)
 
 [Service Fabric and ASP.NET Core ](service-fabric-reliable-services-communication-aspnetcore.md)
 


### PR DESCRIPTION
There is an error on text for link "service-fabric-reliable-actors-introduction.md" at the end of the page. It must be "Reliable Actors overview", not "Reliable Services overview"