### PR TITLE
update container-service-tutorial-kubernetes-deploy-cluster.md

### DIFF
--- a/articles/container-service/kubernetes/container-service-tutorial-kubernetes-deploy-cluster.md
+++ b/articles/container-service/kubernetes/container-service-tutorial-kubernetes-deploy-cluster.md
@@ -70,6 +70,13 @@ To configure kubectl to connect to your Kubernetes cluster, run the [az acs kube
 ```azurecli-interactive 
 az acs kubernetes get-credentials --resource-group myResourceGroup --name myK8SCluster
 ```
+Troubleshooting Notes: At this point, if the above command gives authenication failed error, then check whether the ssh key file [id_rsa (two files - id_rsa.pub and id_rsa.] is available in the ~/.ssh/ folder. Try creating a new SSH Key and add the SSH key to the VMs. To generate and add new SSH Key, type 
+ssh-keygen -t rsa 
+Enter the filename(<private_key_file_name>) to save the ssh key. Example: Enter ~/.ssh/id_rsa. This will generate two files [one for public key and private key].
+Type eval $(ssh-agent -s), to run the ssh-agent in background.
+Then, type ssh-add ~/.ssh/<private_key_file_name> Example:ssh-add ~/.ssh/id_rsa 
+If the cluster VMs are created with portal, you can also configure the ssh public key for the VMs through the portal via Reset option and try the above steps with the same ssh key to connect to the cluster.
+
 
 To verify the connection to your cluster, run the [kubectl get nodes](https://kubernetes.io/docs/user-guide/kubectl/v1.6/#get) command.
 


### PR DESCRIPTION
az acs kubernetes get-credentials --resource-group myResourceGroup --name myK8SCluster command, gives out authentication failed error. If previous commands on creating kubernetes cluster gives some errors, then ssh key is not getting properly configured, giving out authentication failed errors, when connecting to the cluster. 
Scenario I have received authentication issue : Tried creating the kubernetes cluster with the az acs create --orchestrator-type kubernetes command and received errors that deployment is failed while provisioning cluster in master VM. Please see the error screenshot.

![acs k8scluster deployment failed](https://user-images.githubusercontent.com/20502019/31585954-e68c4182-b1e7-11e7-9392-8353d1b7e92a.png)

I have created new kubernetes cluster through portal with ssh key set through the portal to the master VM. Once az acs get-credentials command is executed, I received the authentication failed errors,  and fixed the same, by resetting and adding the ssh key to the ssh agent in the machine, where you are trying to connect to the cluster.

Provided troubleshooting notes, to fix the issue and proceed with next command mentioned in the tutorial. 