### PR TITLE
Fixs the SearchString parameter for Get-AzureRmADServicePrincipal

### DIFF
--- a/articles/key-vault/key-vault-ovw-storage-keys.md
+++ b/articles/key-vault/key-vault-ovw-storage-keys.md
@@ -94,15 +94,11 @@ accountSasCredential.UpdateSASToken(sasToken);
 
 ### Setup for role-based access control (RBAC) permissions
 
-Key Vault needs permissions to *list* and *regenerate* keys for a storage account. Set up these permissions using the following steps:
+The Azure Key Vault application identity needs permissions to *list* and *regenerate* keys for a storage account. Set up these permissions using the following steps:
 
-- Get ObjectId of Key Vault: 
+- Get ObjectId of Azure Key Vault Identity: 
 
     `Get-AzureRmADServicePrincipal -ServicePrincipalName cfa8b339-82a2-471a-a3c9-0fc0be7a4093`
-    
-     or
-     
-    `Get-AzureRmADServicePrincipal -SearchString "Azure Key Vault"`
 
 - Assign Storage Key Operator role to Azure Key Vault Identity: 
 
@@ -126,14 +122,14 @@ The following statements are givens for this working example.
 ### Get a service principal
 
 ```powershell
-Get-AzureRmADServicePrincipal -ServicePrincipalName cfa8b339-82a2-471a-a3c9-0fc0be7a4093
+$yourKeyVaultServicePrincipalId = (Get-AzureRmADServicePrincipal -ServicePrincipalName cfa8b339-82a2-471a-a3c9-0fc0be7a4093).Id
 ```
 
-The output of the preceding command will include your  ServicePrincipal, which we'll call *yourServicePrincipalId*. 
+The output of the preceding command will include your  ServicePrincipal, which we'll call *yourKeyVaultServicePrincipalId*. 
 
 ### Set permissions
 
-Make sure you have your storage permissions set to *all*. You can get yourUserPrincipalId and set permissions on the vault using the following commands.
+Make sure you have your storage permissions set to *all*. You can get yourKeyVaultServicePrincipalId and set permissions on the vault using the following commands.
 
 ```powershell
 Get-AzureRmADUser -SearchString "your name"
@@ -141,7 +137,7 @@ Get-AzureRmADUser -SearchString "your name"
 Now search for your name and get the related ObjectId, which you will use in setting permissions on the vault.
 
 ```powershell
-Set-AzureRmKeyVaultAccessPolicy -VaultName 'yourtest1' -ObjectId yourUserPrincipalId -PermissionsToStorage all
+Set-AzureRmKeyVaultAccessPolicy -VaultName 'yourtest1' -ObjectId $yourKeyVaultServicePrincipalId -PermissionsToStorage all
 ```
 
 ### Allow access
@@ -149,7 +145,7 @@ Set-AzureRmKeyVaultAccessPolicy -VaultName 'yourtest1' -ObjectId yourUserPrincip
 You need to give the Key Vault service access to the storage accounts, before you can create a managed storage account and SAS definitions.
 
 ```powershell
-New-AzureRmRoleAssignment -ObjectId yourServicePrincipalId -RoleDefinitionName 'Storage Account Key Operator Service Role' -Scope '/subscriptions/subscriptionId/resourceGroups/yourresgroup1/providers/Microsoft.Storage/storageAccounts/yourtest1'
+New-AzureRmRoleAssignment -ObjectId $yourKeyVaultServicePrincipalId -RoleDefinitionName 'Storage Account Key Operator Service Role' -Scope '/subscriptions/subscriptionId/resourceGroups/yourresgroup1/providers/Microsoft.Storage/storageAccounts/yourtest1'
 ```
 
 ### Create storage account

--- a/articles/key-vault/key-vault-ovw-storage-keys.md
+++ b/articles/key-vault/key-vault-ovw-storage-keys.md
@@ -102,7 +102,7 @@ Key Vault needs permissions to *list* and *regenerate* keys for a storage accoun
     
      or
      
-    `Get-AzureRmADServicePrincipal -SearchString "AzureKeyVault"`
+    `Get-AzureRmADServicePrincipal -SearchString "Azure Key Vault"`
 
 - Assign Storage Key Operator role to Azure Key Vault Identity: 
 


### PR DESCRIPTION
The service Principal for Azure Kay Vault has spaces.