### PR TITLE
(AzureForums) Add a 'Note" to add app setting details

### DIFF
--- a/articles/nodejs-specify-node-version-azure-apps.md
+++ b/articles/nodejs-specify-node-version-azure-apps.md
@@ -41,6 +41,8 @@ Since 0.6.22 is not one of the versions available in the hosting environment, th
 
 ## Versioning Websites with App Settings
 If you are hosting the application in a Website, you can set the environment variable **WEBSITE_NODE_DEFAULT_VERSION** to the desired version.
+Note: You could add the app setting as part of the site resource itself, following the pattern in this [sample] (https://github.com/davidebbo/AzureWebsitesSamples/blob/331e48636a0d5b2d9b22c68961196b7040d0ab81/ARMTemplates/FunctionsWebDeploy.json#L44-L67).
+
 
 ## Versioning Cloud Services with PowerShell
 If you are hosting the application in a Cloud Service, and are deploying the application using Azure PowerShell, you can override the default Node.js version by using the **Set-AzureServiceProjectRole** PowerShell cmdlet. For example:


### PR DESCRIPTION
Ref doc: https://docs.microsoft.com/en-us/azure/nodejs-specify-node-version-azure-apps
The suggestions outlined in the document referenced, azuredeploy.json disregards WEBSITE_NODE_DEFAULT_VERSION variable during the deployment, a note could be added to inform the users to add an app setting as part of the site resource itself, as mentioned by David Ebbo in this sample: https://github.com/davidebbo/AzureWebsitesSamples/blob/331e48636a0d5b2d9b22c68961196b7040d0ab81/ARMTemplates/FunctionsWebDeploy.json#L44-L67

This request stems from the following WebApps forum thread, where this issue was discussed: https://social.msdn.microsoft.com/Forums/en-US/c2890f30-0ffa-4ec6-9f01-f5439389ac5a/inconsistent-nodejs-version-used-in-azure-documentation-bug?forum=windowsazurewebsitespreview
