### PR TITLE
(AzureForums) Rename the section Deploy the Azure Stack Development Kit

### DIFF
--- a/articles/azure-stack/azure-stack-key-features.md
+++ b/articles/azure-stack/azure-stack-key-features.md
@@ -141,5 +141,5 @@ In-development builds will provide the following benefits:
 - Other improvements
 
 ## Next steps
-[Deploy Azure Stack Development Kit](azure-stack-deploy.md)
+[Azure Stack deployment prerequisites](azure-stack-deploy.md)
 


### PR DESCRIPTION
Kindly rename the section "Deploy Azure Stack Development Kit" to "Azure Stack deployment prerequisites" under the "Next steps" section.