### PR TITLE
Update azure-stack-acs-differences.md

### DIFF
--- a/articles/azure-stack/user/azure-stack-acs-differences.md
+++ b/articles/azure-stack/user/azure-stack-acs-differences.md
@@ -40,6 +40,7 @@ considerations to keep in mind when you deploy Azure Stack. To learn about high-
 |Managed disks|Premium and standard supported|Not yet supported
 |Blob name|1,024 characters (2,048 bytes)|880 characters (1,760 bytes)
 |Block blob max size|4.75 TB (100 MB X 50,000 blocks)|50,000 X 4 MB (approx. 195 GB)
+|Page blob snapshot copy|Backup Azure unmanaged VM disks attached to a running VM supported|Not yet supported
 |Page blob incremental snapshot copy|Premium and standard Azure page blobs supported|Not yet supported
 |Page blob max size|8 TB|1 TB
 |Page blob page size|512 bytes|4 KB


### PR DESCRIPTION
Explain live snapshot (snapshot copy a page blob which is used by a living VM as unmanaged disk) is not supported. Or at least we don't guarantee the snapshot is consist with the page blob at the time snapshot is made.