### PR TITLE
Fixed broken links

### DIFF
--- a/articles/cognitive-services/Face/index.md
+++ b/articles/cognitive-services/Face/index.md
@@ -21,43 +21,43 @@ ms.author: carolz
 <p style="margin-top: 6px; margin-bottom: 6px;">Detect and identify faces using:</p>
 <div class="ico48Case">
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/CSharp">
+        <a href="/articles/cognitive-services/Face/QuickStarts/CSharp.md">
             <img src="media/index/logo_Csharp.svg" alt="">
             <span>C&#35;</span>
         </a>
     </div>
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/curl">
+        <a href="/articles/cognitive-services/Face/QuickStarts/curl.md">
             <img src="media/index/logo_curl.svg" alt="">
             <span>cURL</span>
         </a>
     </div>
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/Java">
+        <a href="/articles/cognitive-services/Face/QuickStarts/Java.md">
             <img src="media/index/logo_java.svg" alt="">
             <span>Java</span>
         </a>
     </div>
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/JavaScript">
+        <a href="/articles/cognitive-services/Face/QuickStarts/JavaScript.md">
             <img src="media/index/logo_js.svg" alt="">
             <span>JavaScript</span>
         </a>
     </div>
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/PHP">
+        <a href="/articles/cognitive-services/Face/QuickStarts/PHP.md">
             <img src="media/index/logo_php.svg" alt="">
             <span>PHP</span>
         </a>
     </div>
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/Python">
+        <a href="/articles/cognitive-services/Face/QuickStarts/Python.md">
             <img src="media/index/logo_python.svg" alt="">
             <span>Python</span>
         </a>
     </div>
     <div class="ico48Link">
-        <a href="/azure/cognitive-services/Face/QuickStarts/Ruby">
+        <a href="/articles/cognitive-services/Face/QuickStarts/Ruby.md">
             <img src="media/index/logo_ruby.svg" alt="">
             <span>Ruby</span>
         </a>
@@ -67,9 +67,9 @@ ms.author: carolz
 <h2 style="margin-top: 36px">Step-by-Step Tutorials</h2>
 <p>Develop applications using the Face API:</p>
 <ol>
-    <li><a href="/azure/cognitive-services/Face/Tutorials/FaceAPIinCSharpTutorial">C&#35; Tutorial</a></li>
-    <li><a href="/azure/cognitive-services/Face/Tutorials/FaceAPIinJavaForAndroidTutorial">Java for Android Tutorial</a></li>
-    <li><a href="/azure/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial">Python Tutorial</a></li>
+    <li><a href="/articles/cognitive-services/Face/Tutorials/FaceAPIinCSharpTutorial.md">C&#35; Tutorial</a></li>
+    <li><a href="/articles/cognitive-services/Face/Tutorials/FaceAPIinJavaForAndroidTutorial.md">Java for Android Tutorial</a></li>
+    <li><a href="/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md">Python Tutorial</a></li>
 </ol>
 
 <h2 style="margin-top: 36px">Reference</h2>
@@ -80,7 +80,7 @@ ms.author: carolz
                 <div class="card">
                     <div class="cardText">
                         <h3>APIs</h3>
-                        <p><a href="/azure/cognitive-services/face/apireference">API Reference</a></p>
+                        <p><a href="/articles/cognitive-services/Face/APIReference.md">API Reference</a></p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Most of the links were pointing to articles inside of https://github.com/MicrosoftDocs/azure-docs/blob/master/azure/cognitive-services/Face/Tutorials/, but these were resulting in 404s. All links using /azure/cognitive-services have now been updated to use /articles/cognitive-services instead. Additionally, the .md extension missing from these links were added.