### PR TITLE
Denote instructions are for classic portal

### DIFF
--- a/articles/multi-factor-authentication/multi-factor-authentication-get-started-auth-provider.md
+++ b/articles/multi-factor-authentication/multi-factor-authentication-get-started-auth-provider.md
@@ -53,7 +53,7 @@ Use the following steps to create an Azure Multi-Factor Authentication Provider 
       * The Provider must be associated with an Azure AD directory to take advantage of the advanced features.
       * Only one Provider can be associated with any one Azure AD directory.
 
-## Create an MFA Provider
+## Create an MFA Provider - Classic Portal
 Use the following steps to create an Azure Multi-Factor Authentication Provider in the classic portal:
 
 1. Sign in to the [Azure classic portal](https://manage.windowsazure.com) as an administrator.


### PR DESCRIPTION
It took me a while to figure out why the instructions to create an MFA Provider were there twice. This change makes it clear by denoting "Classic Portal" in the section header