### PR TITLE
Update automation-create-runas-account.md

### DIFF
--- a/articles/automation/automation-create-runas-account.md
+++ b/articles/automation/automation-create-runas-account.md
@@ -149,16 +149,12 @@ Depending on the configuration option you select, the script creates the followi
 		$keyValue = [System.Convert]::ToBase64String($PfxCert.GetRawCertData())
 		$KeyId = (New-Guid).Guid
 
-		$KeyCredential = New-Object  Microsoft.Azure.Commands.Resources.Models.ActiveDirectory.PSADKeyCredential
-		$KeyCredential.StartDate = $CurrentDate
-		$KeyCredential.EndDate = Get-Date $PfxCert.GetExpirationDateString()
-		$KeyCredential.EndDate = $KeyCredential.EndDate.AddDays(-1)
-		$KeyCredential.KeyId = $KeyId
-		$KeyCredential.CertValue  = $keyValue
+		$keyCredEndDate = Get-Date $PfxCert.GetExpirationDateString()
+                $keyCredEndDate = $keyCredEndDate.AddDays(-1)
 
 		# Use key credentials and create an Azure AD application
-		$Application = New-AzureRmADApplication -DisplayName $ApplicationDisplayName -HomePage ("http://" + $applicationDisplayName) -IdentifierUris ("http://" + $KeyId) -KeyCredentials $KeyCredential
-		$ServicePrincipal = New-AzureRMADServicePrincipal -ApplicationId $Application.ApplicationId
+		$Application = New-AzureRmADApplication -DisplayName $ApplicationDisplayName -HomePage ("http://" + $applicationDisplayName) -IdentifierUris ("http://" + $KeyId)
+		$ServicePrincipal = New-AzureRMADServicePrincipal -ApplicationId $Application.ApplicationId -CertValue $keyValue -StartDate $CurrentDate -EndDate $keyCredEndDate
 		$GetServicePrincipal = Get-AzureRmADServicePrincipal -ObjectId $ServicePrincipal.Id
 
 		# Sleep here for a few seconds to allow the service principal application to become active (ordinarily takes a few seconds)


### PR DESCRIPTION
Made alterations to the New-RunAsAccount.ps1 script due to changes in latest AzureRM powershell modules (v4.4.1).

The following object no longer exists:
Microsoft.Azure.Commands.Resources.Models.ActiveDirectory.PSADKeyCredential

Therefore, the key credential variables should be supplied as parameters to the New-AzureRMADServicePrincipal CmdLet.

Note - Not sure if $KeyId is still required, but left it in due to it being used as the -IdentifierUris parameter to the New-AzureRmADApplication CmdLet.

See discussion https://github.com/Azure/azure-powershell/issues/4491 for how I arrived at my solution.