### PR TITLE
Use `uri_base` for HTTPS request

### DIFF
--- a/articles/cognitive-services/Computer-vision/QuickStarts/Python.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/Python.md
@@ -563,7 +563,7 @@ body = "{'url':'https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/Atomis
 
 try:
     # Execute the REST API call and get the response.
-    conn = httplib.HTTPSConnection('westcentralus.api.cognitive.microsoft.com')
+    conn = httplib.HTTPSConnection(uri_base)
     conn.request("POST", "/vision/v1.0/ocr?%s" % params, body, headers)
     response = conn.getresponse()
     data = response.read()
@@ -617,7 +617,7 @@ body = "{'url':'https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/Atomis
 
 try:
     # Execute the REST API call and get the response.
-    conn = http.client.HTTPSConnection('westcentralus.api.cognitive.microsoft.com')
+    conn = http.client.HTTPSConnection(uri_base)
     conn.request("POST", "/vision/v1.0/ocr?%s" % params, body, headers)
     response = conn.getresponse()
     data = response.read()


### PR DESCRIPTION
Previously the code would ask user to specify their region in the `uri_base` and then proceed to ignore it by hard coding the region in the `HTTPSconnection`. This commit fixes that, by using the `uri_base`, when making the HTTPS request.