### PR TITLE
Update dailyMessageQuotaUsed metric description

### DIFF
--- a/articles/monitoring-and-diagnostics/monitoring-supported-metrics.md
+++ b/articles/monitoring-and-diagnostics/monitoring-supported-metrics.md
@@ -506,7 +506,7 @@ Azure Monitor provides several ways to interact with metrics, including charting
 |jobs.completed|Completed jobs|Count|Total|The count of all completed jobs.|No Dimensions|
 |jobs.failed|Failed jobs|Count|Total|The count of all failed jobs.|No Dimensions|
 |d2c.telemetry.ingress.sendThrottle|Number of throttling errors|Count|Total|Number of throttling errors due to device throughput throttles|No Dimensions|
-|dailyMessageQuotaUsed|Total number of messages used|Count|Average|Number of total messages used today|No Dimensions|
+|dailyMessageQuotaUsed|Total number of messages used|Count|Average|Number of total messages used today. This is cumulative value that is being reset to zero at 00:00 UTC.|No Dimensions|
 
 ## Microsoft.Devices/provisioningServices
 

--- a/articles/monitoring-and-diagnostics/monitoring-supported-metrics.md
+++ b/articles/monitoring-and-diagnostics/monitoring-supported-metrics.md
@@ -506,7 +506,7 @@ Azure Monitor provides several ways to interact with metrics, including charting
 |jobs.completed|Completed jobs|Count|Total|The count of all completed jobs.|No Dimensions|
 |jobs.failed|Failed jobs|Count|Total|The count of all failed jobs.|No Dimensions|
 |d2c.telemetry.ingress.sendThrottle|Number of throttling errors|Count|Total|Number of throttling errors due to device throughput throttles|No Dimensions|
-|dailyMessageQuotaUsed|Total number of messages used|Count|Average|Number of total messages used today. This is cumulative value that is being reset to zero at 00:00 UTC.|No Dimensions|
+|dailyMessageQuotaUsed|Total number of messages used|Count|Average|Number of total messages used today. This is a cumulative value that is reset to zero at 00:00 UTC every day.|No Dimensions|
 
 ## Microsoft.Devices/provisioningServices
 


### PR DESCRIPTION
Adding more explanation to the most confusing value - dailyMessageQuotaUsed. Which is a cumulative value holding the total number of messages used since 00:00 UTC up to the point of time being asked. It cannot be split into time grains (each time grain will hold the cumulative daily value, and not the time slice value).