### PR TITLE
Updating supported runtime

### DIFF
--- a/articles/cosmos-db/documentdb-sdk-java.md
+++ b/articles/cosmos-db/documentdb-sdk-java.md
@@ -44,7 +44,7 @@ ms.custom: H1Hack27Feb2017
 
 <tr><td>**Web app tutorial**</td><td>[Web application development with Azure Cosmos DB](documentdb-java-application.md)</td></tr>
 
-<tr><td>**Current supported runtime**</td><td>[JDK 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html)</td></tr>
+<tr><td>**Minimum supported runtime**</td><td>[JDK 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html)</td></tr>
 </table></br>
 
 ## Release Notes


### PR DESCRIPTION
Cosmos DB supports JDK7 on-wards and reflecting the documentation accordingly.