### PR TITLE
Updated to fix linux SSH key invalid error

### DIFF
--- a/articles/virtual-machines/linux/openshift-get-started.md
+++ b/articles/virtual-machines/linux/openshift-get-started.md
@@ -119,10 +119,10 @@ Use the `appId` value from the service principal you created earlier for the `aa
 az group deployment create --name myOpenShiftCluster \
       --template-uri https://raw.githubusercontent.com/Microsoft/openshift-origin/master/azuredeploy.json \
       --params \ 
-        openshiftMasterPublicIpDnsLabel=myopenshiftmaster \
-        infraLbPublicIpDnsLabel=myopenshiftlb \
-        openshiftPassword=Pass@word!
-        sshPublicKey=~/.ssh/openshift_rsa.pub \
+        [openshiftMasterPublicIpDnsLabel=myopenshiftmaster] \
+        [infraLbPublicIpDnsLabel=myopenshiftlb] \
+        openshiftPassword=Pass@word! \
+        sshPublicKey="ssh-rsa AA... user@account.com" \
         keyVaultResourceGroup=myResourceGroup \
         keyVaultName=myKeyVault \
         keyVaultSecret=OpenShiftKey \


### PR DESCRIPTION
1. Added \ character at end of password input.

2. Updated to include full SSH key inside argument rather than the path to the SSH key.

3. Square brackets have been added for these things (optional arguments)
- openshiftMasterPublicIpDnsLabel=myopenshiftmaster
- infraLbPublicIpDnsLabel=myopenshiftlb
As they weren't required in our case.