### PR TITLE
Fixing the issue when build_grammar with BLOB files

### DIFF
--- a/articles/cognitive-services/KES/GettingStarted.md
+++ b/articles/cognitive-services/KES/GettingStarted.md
@@ -105,7 +105,7 @@ The grammar specifies the set of natural language queries that the service can i
 <grammar root="GetPapers">
 
   <!-- Import academic data schema-->
-  <import schema="academic.schema" name="academic"/>
+  <import schema="Academic.schema" name="academic"/>
 
   <!-- Define root rule-->
   <rule id="GetPapers">


### PR DESCRIPTION
I had no trouble when build locally. However, when I uploaded Academic.schema as-is and executed `kes.exe build_grammar`, the command failed with:

```
Input XML: https://xxxxxx.blob.core.windows.net/manual1/Academic.xml
Output Grammar: https://xxxxxx.blob.core.windows.net/manual1/Academic.grammar
ERROR: The grammar https://xxxxxx.blob.core.windows.net/manual1/Academic.xml imports the schema 'academic.schema', but it is not found at http://xxxxxx.blob.core.windows.net/manual1/academic.schema
```

This is the fix for the issue.