### PR TITLE
Location inconsistency in AKS quickstart doc

### DIFF
--- a/articles/aks/kubernetes-walkthrough.md
+++ b/articles/aks/kubernetes-walkthrough.md
@@ -47,7 +47,7 @@ Output:
 ```json
 {
   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup",
-  "location": "westeurope",
+  "location": "westus2",
   "managedBy": null,
   "name": "myResourceGroup",
   "properties": {


### PR DESCRIPTION
The output of a command which specified westus2 gives back westeurope according to the docs. Seems incorrect.