### PR TITLE
Proposed remove step 1

### DIFF
--- a/articles/vpn-gateway/point-to-site-vpn-client-configuration-azure-cert.md
+++ b/articles/vpn-gateway/point-to-site-vpn-client-configuration-azure-cert.md
@@ -83,6 +83,7 @@ Azure does not provide mobileconfig file for native Azure certificate authentica
 
 Use the following steps to configure the native VPN client on Mac for certificate authentication. You have to complete these steps on every Mac that will connect to Azure:
 
+This step 1 is not necessary and can cause confusion. Importing a PFX in MAC already imports the Client Cert as well as populates the Root Certificate.
 1. Import the **VpnServerRoot** root certificate to your Mac. This can be done by copying the file over to your Mac and double-clicking on it.  
 Click **Add** to import.
 


### PR DESCRIPTION
Proposed remove Step 1 which is not necessary. That can cause confusion as this certificate is a Public Commercial Certificate (DigiCert Global Root CA) and is not related for native Azure certificate authentication which requires only self sign PFX and Root CA certificates.