### PR TITLE
typo: Update quickstart-create-mysql-server-database-using-azure-cli.md

### DIFF
--- a/articles/mysql/quickstart-create-mysql-server-database-using-azure-cli.md
+++ b/articles/mysql/quickstart-create-mysql-server-database-using-azure-cli.md
@@ -59,7 +59,7 @@ By default, SSL connections between your server and client applications are enfo
 The following example disables enforcing SSL on your MySQL server.
  
  ```azurecli-interactive
- az mysql server update --resource-group myresourcegroup --name myserver4demo -g -n --ssl-enforcement Disabled
+ az mysql server update --resource-group myresourcegroup --name myserver4demo --ssl-enforcement Disabled
  ```
 
 ## Get the connection information


### PR DESCRIPTION
In section `Configure SSL settings` there is a typo in the Azure CLI prompt.
It is: `az mysql server update --resource-group myresourcegroup --name myserver4demo -g -n --ssl-enforcement Disabled`
It should be: `az mysql server update --resource-group myresourcegroup --name myserver4demo --ssl-enforcement Disabled`
(remove the redundant `-n` and `-g` CLI parameters)