### PR TITLE
Update azure cli syntax to add custom domain to app service

### DIFF
--- a/articles/app-service/app-service-web-tutorial-custom-domain.md
+++ b/articles/app-service/app-service-web-tutorial-custom-domain.md
@@ -275,10 +275,10 @@ You can automate management of custom domains with scripts, using the [Azure CLI
 The following command adds a configured custom DNS name to an App Service app. 
 
 ```bash 
-az appservice web config hostname add \
-    --webapp <app_name> \
+az webapp config hostname add \
+    --webapp-name <app_name> \
     --resource-group <resource_group_name> \ 
-    --name <fully_qualified_domain_name> 
+    --hostname <fully_qualified_domain_name> 
 ``` 
 
 For more information, see [Map a custom domain to a web app](scripts/app-service-cli-configure-custom-domain.md). 


### PR DESCRIPTION
The syntax provided didn't work for me in the Cloud Shell. The update, and what worked for me, is based on the docs at https://docs.microsoft.com/en-us/cli/azure/webapp/config/hostname?view=azure-cli-latest#az_webapp_config_hostname_add