### PR TITLE
Updated outdated references to 'documentdb'

### DIFF
--- a/articles/azure-functions/scripts/functions-cli-create-function-app-connect-to-cosmos-db.md
+++ b/articles/azure-functions/scripts/functions-cli-create-function-app-connect-to-cosmos-db.md
@@ -49,7 +49,7 @@ This script uses the following commands. Each command in the table links to comm
 | [az group create](https://docs.microsoft.com/cli/azure/group#az_group_create) | Create a resource group with location |
 | [az storage account create](https://docs.microsoft.com/cli/azure/storage/account) | Create a storage account |
 | [az functionapp create](https://docs.microsoft.com/cli/azure/functionapp#az_functionapp_create) | Create a new function app |
-| [az documentdb create](https://docs.microsoft.com/cli/azure/documentdb#az_documentdb_create) | Create documentdb database |
+| [az cosmosdb create](https://docs.microsoft.com/cli/azure/cosmosdb#az_cosmosdb_create) | Create cosmosdb database |
 | [az group delete](https://docs.microsoft.com/cli/azure/group#az_group_delete) | Clean up |
 
 ## Next steps


### PR DESCRIPTION
Replaced outdated references to 'documentdb' with 'cosmosdb' along with the correct link to the cosmosdb-create cli docs.