### PR TITLE
Streaming with ACL required arguments

### DIFF
--- a/articles/app-service/web-sites-enable-diagnostic-log.md
+++ b/articles/app-service/web-sites-enable-diagnostic-log.md
@@ -177,17 +177,17 @@ To see a list of available paths, use the -ListPath parameter.
 ### Streaming with Azure Command-Line Interface
 To stream logging information, open a new command prompt, PowerShell, Bash, or Terminal session and enter the following command:
 
-    azure site log tail webappname
+    az webapp log tail --name webappname --resource-group myResourceGroup
 
 This will connect to the web app named 'webappname' and begin streaming information to the window as log events occur on the web app. Any information written to files ending in .txt, .log, or .htm that are stored in the /LogFiles directory (d:/home/logfiles) will be streamed to the local console.
 
 To filter specific events, such as errors, use the **--Filter** parameter. For example:
 
-    azure site log tail webappname --filter Error
+    az webapp log tail --name webappname --resource-group myResourceGroup --filter Error
 
 To filter specific log types, such as HTTP, use the **--Path** parameter. For example:
 
-    azure site log tail webappname --path http
+    az webapp log tail --name webappname --resource-group myResourceGroup --path http
 
 > [!NOTE]
 > If you have not installed the Azure Command-Line Interface, or have not configured it to use your Azure Subscription, see [How to Use Azure Command-Line Interface](../cli-install-nodejs.md).


### PR DESCRIPTION
az: error: argument _command_package: invalid choice: site
az webapp log tail: error: (--resource-group --name | --ids) are required