### PR TITLE
Based on feedback, changed terms used for 'third-party application'

### DIFF
--- a/articles/active-directory/active-directory-coreapps-hide-third-party-app.md
+++ b/articles/active-directory/active-directory-coreapps-hide-third-party-app.md
@@ -1,6 +1,6 @@
 ---
-title: Hide a third-party application from user's experience in Azure Active Directory | Microsoft Docs
-description: How to hide a third-party application from user's experience in Azure Active Directory 
+title: Hide an application from user's experience in Azure Active Directory | Microsoft Docs
+description: How to hide an application from user's experience in Azure Active Directory 
 services: active-directory
 documentationcenter: ''
 author: billmath
@@ -17,12 +17,12 @@ ms.reviewer: asteen
 ms.custom: it-pro
 ---
 
-# Hide a third-party application from user's experience in Azure Active Directory
+# Hide an application from user's experience in Azure Active Directory
 
-If you have a third-party application (an app published by others than Microsoft) that you do not want to show up on the users’ access panels or Office 365 launchers, there is an option to hide this app tile. By hiding the app users still have permissions to the app but will not see them appear on their app launchers. You must have the appropriate permissions to manage the enterprise app, and you must be global admin for the directory.
+If you have an application that you do not want to show on users’ access panels or Office 365 launchers, there is an option to hide this app tile. This option is only available for third-party applications (apps not published by Microsoft). By hiding the app users still have permissions to the app but will not see them appear on their app launchers. You must have the appropriate permissions to manage the enterprise app, and you must be global admin for the directory.
 
-## Hiding a user's access panel
-Use the following steps to hide a user's access panel and Office 365 app launchers
+## Hiding an application from user's end user experiences
+Use the following steps to hide an application from user's access panel and Office 365 app launchers
 
 ### How do I hide an app from user’s access panel and O365 app launchers?
 


### PR DESCRIPTION
Switched out third-party with applications to be more generic and easy to understand. Within the doc we describe that this option is only for third-party apps.