### PR TITLE
Fixed: Incorrect Client SDK Sample

### DIFF
--- a/articles/cosmos-db/programming.md
+++ b/articles/cosmos-db/programming.md
@@ -678,7 +678,7 @@ In addition to the DocumentDB API for [Node.js](documentdb-sdk-node.md) client, 
     document.Year = 1949;
 
     // execute stored procedure
-    Document createdDocument = await client.ExecuteStoredProcedureAsync<Document>(UriFactory.CreateStoredProcedureUri("db", "coll", "sproc"), document, 1920);
+    Document createdDocument = await client.ExecuteStoredProcedureAsync<Document>(UriFactory.CreateStoredProcedureUri("db", "coll", "ValidateDocumentAge"), document, 1920);
 
 
 This sample shows how to use the [DocumentDB .NET API](/dotnet/api/overview/azure/cosmosdb?view=azure-dotnet) to create a pre-trigger and create a document with the trigger enabled. 


### PR DESCRIPTION
The sample incorrectly created a Uri to a Storedprocedure named "sproc" that actually have the id "ValidateDocumentAge"