### PR TITLE
Removed duplicate Program Files entry in cmds

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-recover-from-localdb-10gb-limit.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-recover-from-localdb-10gb-limit.md
@@ -61,11 +61,11 @@ The name of the database created for Azure AD Connect is **ADSync**. To perform 
 * The Sync Service account that is used as the operating context of Azure AD Connect Synchronization Service.
 * The local group ADSyncAdmins that was created during installation.
 
-1. Back up the database by copying **ADSync.mdf** and **ADSync_log.ldf** files located under `%ProgramFiles%\program files\Microsoft Azure AD Sync\Data` to a safe location.
+1. Back up the database by copying **ADSync.mdf** and **ADSync_log.ldf** files located under `%ProgramFiles%\Microsoft Azure AD Sync\Data` to a safe location.
 
 2. Start a new PowerShell session.
 
-3. Navigate to folder `%ProgramFiles%\Program Files\Microsoft SQL Server\110\Tools\Binn`.
+3. Navigate to folder `%ProgramFiles%\Microsoft SQL Server\110\Tools\Binn`.
 
 4. Start **sqlcmd** utility by running the command `./SQLCMD.EXE -S “(localdb)\.\ADSync” -U <Username> -P <Password>`, using the credential of a sysadmin or the database DBO.
 


### PR DESCRIPTION
Commands listed "program files" twice.  Removed second reference to Program Files folder since %programFiles% was specified.
i.e. %programFiles%\Program Files\ (duplicate) to just %programFiles%\