### PR TITLE
Update to "To get Azure private peering details" section

### DIFF
--- a/articles/expressroute/expressroute-howto-routing-arm.md
+++ b/articles/expressroute/expressroute-howto-routing-arm.md
@@ -290,7 +290,7 @@ You can get configuration details by using the following example:
 ```powershell
 $ckt = Get-AzureRmExpressRouteCircuit -Name "ExpressRouteARMCircuit" -ResourceGroupName "ExpressRouteResourceGroup"
 
-Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePrivatePeering" -Circuit $ckt
+Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePrivatePeering" -ExpressRouteCircuit $ckt
 ```
 
 ### <a name="updateprivate"></a>To update Azure private peering configuration


### PR DESCRIPTION
Invalid PowerShell command syntax, change "-Circuit" to "-ExpressRouteCircuit" 

Get-AzureRmExpressRouteCircuitPeeringConfig [-Name <String>] -ExpressRouteCircuit <PSExpressRouteCircuit> [-DefaultProfile <IAzureContextContainer>] [<CommonParameters>]

https://docs.microsoft.com/en-us/powershell/module/azurerm.network/get-azurermexpressroutecircuitpeeringconfig?view=azurermps-4.4.1&viewFallbackFrom=azurermps-4.4.0

---------------

Current-
Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePrivatePeering" -Circuit $ckt

Change to -
Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePrivatePeering" -ExpressRouteCircuit $ckt