### PR TITLE
Updated argument - it is "node" not "agent"

### DIFF
--- a/articles/aks/kubernetes-walkthrough.md
+++ b/articles/aks/kubernetes-walkthrough.md
@@ -71,7 +71,7 @@ Output:
 The following example creates a cluster named *myK8sCluster* with one node.
 
 ```azurecli-interactive
-az aks create --resource-group myResourceGroup --name myK8sCluster --agent-count 1 --generate-ssh-keys
+az aks create --resource-group myResourceGroup --name myK8sCluster --node-count 1 --generate-ssh-keys
 ```
 
 After several minutes, the command completes and returns JSON-formatted information about the cluster.


### PR DESCRIPTION
Fixed argument for Azure CLI when creating AKS cluster