### PR TITLE
Update tutorial-custom-docker-image.md

### DIFF
--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -293,12 +293,12 @@ SSH enables secure communication between a container and a client. In order for 
     ```
 
 * Make sure to [start the ssh service](https://github.com/Azure-App-Service/node/blob/master/6.9.3/startup/init_container.sh) using a shell script in */bin* directory.
- +
- +    ```bash
- +    #!/bin/bash
- +    service ssh start
- +    ```
- +    
+ 
+	```bash
+	#!/bin/bash
+	service ssh start
+	```
+     
 ### Open SSH connection to container
 
 Web App for Containers does not allow external connections to the container. SSH is available only through the Kudu site, which is accessible at `https://<app_name>.scm.azurewebsites.net`.

--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -292,7 +292,7 @@ SSH enables secure communication between a container and a client. In order for 
     EXPOSE 8000 2222
     ```
 
-* Make sure to [start the ssh service](https://github.com/Azure-App-Service/node/blob/master/6.9.3/startup/init_container.sh) using a shell script in */bin* directory.
+* Make sure to [start the ssh service](https://github.com/Azure-App-Service/node/blob/master/6.9.3/startup/init_container.sh) by using a shell script in the /bin directory.
  
 	```bash
 	#!/bin/bash

--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -290,10 +290,15 @@ SSH enables secure communication between a container and a client. In order for 
 
     ```docker
     EXPOSE 8000 2222
-
-    RUN service ssh start
     ```
 
+* Make sure to [start the ssh service](https://github.com/Azure-App-Service/node/blob/master/6.9.3/startup/init_container.sh) using a shell script in */bin* directory.
+ +
+ +    ```bash
+ +    #!/bin/bash
+ +    service ssh start
+ +    ```
+ +    
 ### Open SSH connection to container
 
 Web App for Containers does not allow external connections to the container. SSH is available only through the Kudu site, which is accessible at `https://<app_name>.scm.azurewebsites.net`.


### PR DESCRIPTION
Corrected webssh step: The "service ssh start" command needs to be run from a shell script and not a Dockerfile RUN command.