### PR TITLE
Update tutorial-classifying-iris-part-2.md

### DIFF
--- a/articles/machine-learning/preview/tutorial-classifying-iris-part-2.md
+++ b/articles/machine-learning/preview/tutorial-classifying-iris-part-2.md
@@ -222,7 +222,7 @@ Azure ML allows you to easily configure additional execution environments such a
    az account list -o table
    
    REM set the current Azure subscription to the one you want to use.
-   az set account -s <subscriptionId>
+   az account set -s <subscriptionId>
    
    REM verify your current subscription is set correctly
    az account show


### PR DESCRIPTION
az set account -s "test"
az: error: argument _command_package: invalid choice: set

Results in error, correct usage is az account set -s "test "