### PR TITLE
Update azure-stack-powershell-configure-admin.md

### DIFF
--- a/articles/azure-stack/azure-stack-powershell-configure-admin.md
+++ b/articles/azure-stack/azure-stack-powershell-configure-admin.md
@@ -53,6 +53,10 @@ $KeyvaultDnsSuffix = “<Keyvault DNS suffix for your environment>”
   Add-AzureRMEnvironment `
     -Name "AzureStackAdmin" `
     -ArmEndpoint $ArmEndpoint
+    
+   Set-AzureRmEnvironment `
+  -Name "AzureStackAdmin" `
+  -GraphAudience $GraphAudience 
 
 
   # Get the Active Directory tenantId that is used to deploy Azure Stack

--- a/articles/azure-stack/azure-stack-powershell-configure-admin.md
+++ b/articles/azure-stack/azure-stack-powershell-configure-admin.md
@@ -54,10 +54,9 @@ $KeyvaultDnsSuffix = “<Keyvault DNS suffix for your environment>”
     -Name "AzureStackAdmin" `
     -ArmEndpoint $ArmEndpoint
     
-   Set-AzureRmEnvironment `
-  -Name "AzureStackAdmin" `
-  -GraphAudience $GraphAudience 
-
+  Set-AzureRmEnvironment `
+    -Name "AzureStackAdmin" `
+    -GraphAudience $GraphAudience 
 
   # Get the Active Directory tenantId that is used to deploy Azure Stack
   $TenantID = Get-AzsDirectoryTenantId `


### PR DESCRIPTION
Added
Set-AzureRmEnvironment `
  -Name "AzureStackAdmin" `
  -GraphAudience $GraphAudience
Because if this is missing then enable multi-tenancy script fails... In the documentation it refers to this chapter.