### PR TITLE
Update HDInsight domain-join instructions

### DIFF
--- a/articles/hdinsight/domain-joined/apache-domain-joined-configure.md
+++ b/articles/hdinsight/domain-joined/apache-domain-joined-configure.md
@@ -30,10 +30,6 @@ This article is the first tutorial of a series:
 * Create an HDInsight cluster connected to Azure AD (via the Azure Directory Domain Services capability) with Apache Ranger enabled.
 * Create and apply Hive policies through Apache Ranger, and allow users (for example, data scientists) to connect to Hive using ODBC-based tools, for example Excel, Tableau etc. Microsoft is working on adding other workloads, such as HBase and Storm, to Domain-joined HDInsight soon.
 
-An example of the final topology looks as follows:
-
-![Domain-joined HDInsight topology](./media/apache-domain-joined-configure/hdinsight-domain-joined-topology.png)
-
 Azure service names must be globally unique. The following names are used in this tutorial. Contoso is a fictitious name. You must replace *contoso* with a different name when you go through the tutorial. 
 
 **Names:**

--- a/articles/hdinsight/domain-joined/apache-domain-joined-configure.md
+++ b/articles/hdinsight/domain-joined/apache-domain-joined-configure.md
@@ -77,12 +77,12 @@ After creating the VNet, you will configure the Azure AD DS to use this VNet.
    * **Subnet address range**: 10.0.0.0/24
    * **Subscription**: (Select your Azure subscription.)
    * **Resource group**: contosohdirg
-   * **Location**: (Select the same location as the Azure AD VNet, i.e. contosoaadvnet.)
+   * **Location**: (Select the same location as the Azure AD VNet. For example, contosoaadvnet.)
 5. Click **Create**.
 
 **To configure DNS for the Resource Manager VNet**
 
-1. From the [Azure portal](https://portal.azure.com), click **More services** -> **Virtual networks**. Ensure not to click **Virtual networks (classic)**.
+1. From the [Azure portal](https://portal.azure.com), click **More services** > **Virtual networks**. Ensure not to click **Virtual networks (classic)**.
 2. Click **contosohdivnet**.
 3. Click **DNS servers** from the left side of the new blade.
 4. Click **Custom**, and then enter the following values:
@@ -148,7 +148,7 @@ For more information, see [Azure AD Domain Services (Preview) - Create the 'AAD 
    * **Directory name**: contosoaaddirectory
    * **DNS domain name**: This shows the default DNS name of the Azure directory. For example, contoso.onmicrosoft.com.
    * **Location**: Select your region.
-   * **Network**: Select the virtual network and subnet you created earlier, i.e. **contosohdivnet**.
+   * **Network**: Select the virtual network and subnet you created earlier. For example, **contosohdivnet**.
 3. Click **OK** from the summary page. You will see **Deployment in progress...** under notifications.
 4. Wait until **Deployment in progress...** disappears, and **IP Address** gets populated. Two IP addresses will get populated. These are the IP addresses of the domain controllers provisioned by Domain Services. Each IP address will be visible after the corresponding domain controller is provisioned and ready. Write down the two IP addresses. You will need them later.
 


### PR DESCRIPTION
Current document is outdated due to the following reasons.

- Most `Azure AD` operations (apart from creating a new `AD`) can now be done without the need to navigate to classic portal.
- `Azure AD DS` now supports `Resource Manager` `VNets` so no need to create classic `VNets` and peer them with their `RM` counterparts.
- `Azure AD DS` `LDAPS` now supports self-signed certificates.
- HDInsight premium is now supported on `Spark` and `Interactive Query clusters` as well.