### PR TITLE
Fix for the storageURI output

### DIFF
--- a/articles/azure-resource-manager/resource-manager-vscode-extension.md
+++ b/articles/azure-resource-manager/resource-manager-vscode-extension.md
@@ -176,8 +176,8 @@ This article builds on the template you created in [Create and deploy your first
          "value": "[resourceGroup().location]"
        },
        "storageUri": {
-         "type": "string",
-         "value": "[reference(variables('storageName'))]"
+         "type": "object",
+         "value": "[reference(concat('Microsoft.Storage/storageAccounts/',variables('storageName')))]"
        }
    }
    ```
@@ -244,8 +244,8 @@ The final template is:
       "value": "[resourceGroup().location]"
     },
     "storageUri": {
-      "type": "string",
-      "value": "[reference(variables('storageName'))]"
+      "type": "object",
+      "value": "[reference(concat('Microsoft.Storage/storageAccounts/',variables('storageName')))]"
     }
   }
 }


### PR DESCRIPTION
In it's current format, the storageURI output breaks (Deployment failed. The template output 'storageUri' is not valid: Index (zero based) must be greater than or equal to zero and less than the size of the argument list)

This is fixed once the storageUri type is changed to "object" rather than string. I have also adjusted the value inside the reference function to use the Microsoft.Storage/storageAccounts Resource Provider.