### PR TITLE
Missing the quote for the docker image file name

### DIFF
--- a/articles/virtual-machines/linux/docker-machine.md
+++ b/articles/virtual-machines/linux/docker-machine.md
@@ -36,7 +36,7 @@ docker-machine create -d azure \
     --azure-subscription-id $sub \
     --azure-ssh-user azureuser \
     --azure-open-port 80 \
-    --azure-size "Standard_D2_v2 \
+    --azure-size "Standard_D2_v2" \
     myvm
 ```
 


### PR DESCRIPTION
docker-machine create needs a azure instance which contains both quotes