### PR TITLE
Wrong link target for next step link.

### DIFF
--- a/articles/network-watcher/network-watcher-visualize-nsg-flow-logs-power-bi.md
+++ b/articles/network-watcher/network-watcher-visualize-nsg-flow-logs-power-bi.md
@@ -116,7 +116,7 @@ Feel free to customize this template for your needs. There are many numerous way
 
 ## Next Steps
 
-Learn how to visualize your NSG flow logs with the Elastick Stack by visiting [Visualize network traffic patterns to and from your VMs using open source tools](network-watcher-using-open-source-tools.md)
+Learn how to visualize your NSG flow logs with the Elastick Stack by visiting [Visualize Azure Network Watcher NSG flow logs using open source tools](network-watcher-visualize-nsg-flow-logs-open-source-tools.md)
 
 [1]: ./media/network-watcher-visualize-nsg-flow-logs-power-bi/figure1.png
 [2]: ./media/network-watcher-visualize-nsg-flow-logs-power-bi/figure2.png


### PR DESCRIPTION
Corrected the link at the bottom. It pointed to an article about analyzing a packet trace while the wording suggested it would linke to the Elastic article to visualize the NSG log data.