### PR TITLE
Clarify case requirement for sign-on URL

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-setup-aad-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-setup-aad-custom.md
@@ -50,8 +50,8 @@ To enable sign-in for users from a specific Azure AD organization, you need to r
 1. Select **Web app / API** for the application type.
 1. For **Sign-on URL**, enter the following URL, where `yourtenant` is replaced by the name of your Azure AD B2C tenant (`fabrikamb2c.onmicrosoft.com`):
 
->[!NOTE]
->  The value for "yourtenant" must be all lowercase in the Sign-on URL.
+    >[!NOTE]
+    >The value for "yourtenant" must be all lowercase in the **Sign-on URL**.
 
     ```
     https://login.microsoftonline.com/te/yourtenant.onmicrosoft.com/oauth2/authresp

--- a/articles/active-directory-b2c/active-directory-b2c-setup-aad-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-setup-aad-custom.md
@@ -51,7 +51,7 @@ To enable sign-in for users from a specific Azure AD organization, you need to r
 1. For **Sign-on URL**, enter the following URL, where `yourtenant` is replaced by the name of your Azure AD B2C tenant (`fabrikamb2c.onmicrosoft.com`):
 
 >[!NOTE]
-> The value for "yourtenant" must be all lowercase in the Sign-on URL regardless of the case used within B2C.
+>  The value for "yourtenant" must be all lowercase in the Sign-on URL.
 
     ```
     https://login.microsoftonline.com/te/yourtenant.onmicrosoft.com/oauth2/authresp

--- a/articles/active-directory-b2c/active-directory-b2c-setup-aad-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-setup-aad-custom.md
@@ -50,6 +50,9 @@ To enable sign-in for users from a specific Azure AD organization, you need to r
 1. Select **Web app / API** for the application type.
 1. For **Sign-on URL**, enter the following URL, where `yourtenant` is replaced by the name of your Azure AD B2C tenant (`fabrikamb2c.onmicrosoft.com`):
 
+>[!NOTE]
+> The value for "yourtenant" must be all lowercase in the Sign-on URL regardless of the case used within B2C.
+
     ```
     https://login.microsoftonline.com/te/yourtenant.onmicrosoft.com/oauth2/authresp
     ```


### PR DESCRIPTION
Per Parakh Jain <parja@microsoft.com>, reply URL (therefore effectively sign-on URL) must contain tenant name as lower-case in order to avoid error AADSTS50011: Reply address '' specified by the request is not a valid URL. Allowed schemes: 'http,https'