### PR TITLE
ER Circuit - connectivity capabilities

### DIFF
--- a/articles/site-recovery/site-recovery-azure-to-azure-networking-guidance.md
+++ b/articles/site-recovery/site-recovery-azure-to-azure-networking-guidance.md
@@ -167,8 +167,8 @@ Follow these guidelines for connections between the target location and the on-p
 Follow these best practices for ExpressRoute configuration:
 
 - You need to create an ExpressRoute circuit in both the source and target regions. Then you need to create a connection between:
-  - The source virtual network and the ExpressRoute circuit.
-  - The target virtual network and the ExpressRoute circuit.
+  - The source virtual network and both ExpressRoute circuits.
+  - The target virtual network and both ExpressRoute circuits.
 
 - As part of ExpressRoute standard, you can create circuits in the same geopolitical region. To create ExpressRoute circuits in different geopolitical regions, Azure ExpressRoute Premium is required, which involves an incremental cost. (If you are already using ExpressRoute Premium, there is no extra cost.) For more details, see the [ExpressRoute locations document](../expressroute/expressroute-locations.md#azure-regions-to-expressroute-locations-within-a-geopolitical-region) and [ExpressRoute pricing](https://azure.microsoft.com/pricing/details/expressroute/).
 


### PR DESCRIPTION
Not sure the goal or intent of the first 'ER best practices' bullet point...
By connecting Vnet 1 to ER Circuit 1... and Vnet 2 to ER Circuit 2... that alone doesn't peer them together unless on-premises is handling that routing. If so, that intention should be made clear.

Else what I'm proposing is a 'mesh' whereby a VNet has a connection to both ER circuits that way if 1 circuit goes down, there is still a connectivity path.