### PR TITLE
-Password parameter needs secure-string

### DIFF
--- a/articles/azure-resource-manager/resource-group-authenticate-service-principal.md
+++ b/articles/azure-resource-manager/resource-group-authenticate-service-principal.md
@@ -53,7 +53,8 @@ To create a service principal with the Contributor role for your subscription, u
 
 ```powershell
 Login-AzureRmAccount
-$sp = New-AzureRmADServicePrincipal -DisplayName exampleapp -Password "{provide-password}"
+$password = convertto-securestring {provide-password} -asplaintext -force
+$sp = New-AzureRmADServicePrincipal -DisplayName exampleapp -Password $password
 Sleep 20
 New-AzureRmRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $sp.ApplicationId
 ```


### PR DESCRIPTION
-Password needs secure-string or we should use -p. Please find the error below which we got when using -Password.

New-AzureRmADServicePrincipal : Cannot bind parameter 'Password'. Cannot convert the "xxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyy" value of type "System.String" to type "System.Security.SecureString".