### PR TITLE
No need for the reader to have GitHub account

### DIFF
--- a/articles/azure-functions/functions-create-first-azure-function-azure-cli-linux.md
+++ b/articles/azure-functions/functions-create-first-azure-function-azure-cli-linux.md
@@ -25,7 +25,6 @@ The following steps are supported on a Mac, Windows, or Linux computer.
 
 To complete this quickstart, you need:
 
-+ An active [GitHub](https://github.com) account. 
 + An active Azure subscription.
 
 [!INCLUDE [quickstarts-free-trial-note](../../includes/quickstarts-free-trial-note.md)]


### PR DESCRIPTION
The way the quickstart is worded, it does not require the reader to use their own GitHub account, so I think this requirement should be removed from the documentation.

Another option would be to add wording that references the reader's GitHub account...

The _deployment-source-url_ parameter is a sample repository in GitHub that contains a "Hello World" HTTP triggered function. You can replace this URL with your own GitHub repository that contains your function code.