### PR TITLE
Update cdn-purge-endpoint.md

### DIFF
--- a/articles/cdn/cdn-purge-endpoint.md
+++ b/articles/cdn/cdn-purge-endpoint.md
@@ -20,7 +20,7 @@ ms.author: mazha
 # Purge an Azure CDN endpoint
 ## Overview
 Azure CDN edge nodes will cache assets until the asset's time-to-live (TTL) expires.  After the asset's TTL expires, when a client requests the asset from the edge node, the edge node will retrieve a new updated copy of the asset to serve the client request and store refresh the cache.
-
+, a
 The best practice to make sure your users always obtain the latest copy of your assets is to version your assets for each update and publish them as new URLs.  CDN will immediately retrieve the new assets for the next client requests.  Sometimes you may wish to purge cached content from all edge nodes and force them all to retrieve new updated assets.  This might be due to updates to your web application, or to quickly update assets that contain incorrect information.
 
 > [!TIP]
@@ -65,7 +65,7 @@ This tutorial walks you through purging assets from all edge nodes of an endpoin
     ![Purge button](./media/cdn-purge-endpoint/cdn-purge-button.png)
 
 > [!IMPORTANT]
-> Purge requests take approximately 2-3 minutes to process with **Azure CDN from Verizon** (Standard and Premium), and approximately 7 minutes with **Azure CDN from Akamai**.  Azure CDN has a limit of 50 concurrent purge requests at any given time. 
+> Purge requests take approximately 2-3 minutes to process with **Azure CDN from Verizon** (Standard and Premium), and approximately 7 minutes with **Azure CDN from Akamai**.  Azure CDN has a limit of 50 concurrent purge requests at any given time at the profile level. 
 > 
 > 
 

--- a/articles/cdn/cdn-purge-endpoint.md
+++ b/articles/cdn/cdn-purge-endpoint.md
@@ -20,7 +20,7 @@ ms.author: mazha
 # Purge an Azure CDN endpoint
 ## Overview
 Azure CDN edge nodes will cache assets until the asset's time-to-live (TTL) expires.  After the asset's TTL expires, when a client requests the asset from the edge node, the edge node will retrieve a new updated copy of the asset to serve the client request and store refresh the cache.
-, a
+
 The best practice to make sure your users always obtain the latest copy of your assets is to version your assets for each update and publish them as new URLs.  CDN will immediately retrieve the new assets for the next client requests.  Sometimes you may wish to purge cached content from all edge nodes and force them all to retrieve new updated assets.  This might be due to updates to your web application, or to quickly update assets that contain incorrect information.
 
 > [!TIP]


### PR DESCRIPTION
Added "at the profile level" to "Azure CDN has a limit of 50 concurrent purge requests at any given time"