### PR TITLE
http to https for airline source data

### DIFF
--- a/articles/hdinsight/r-server/r-server-get-started.md
+++ b/articles/hdinsight/r-server/r-server-get-started.md
@@ -262,7 +262,7 @@ You can submit a job using scaleR functions. Here is an example of the commands 
 	dir.create(source)
 
 	# Download data to the tmp folder.
-	remoteDir <- "http://packages.revolutionanalytics.com/datasets/AirOnTimeCSV2012"
+	remoteDir <- "https://packages.revolutionanalytics.com/datasets/AirOnTimeCSV2012"
 	download.file(file.path(remoteDir, "airOT201201.csv"), file.path(source, "airOT201201.csv"))
 	download.file(file.path(remoteDir, "airOT201202.csv"), file.path(source, "airOT201202.csv"))
 	download.file(file.path(remoteDir, "airOT201203.csv"), file.path(source, "airOT201203.csv"))


### PR DESCRIPTION
In Step 3 script, the remoteDir command has an http url. This will automatic redirect to https, and the resulting downloaded file will be the redirect output, not the file. Changed http prefix to https