### PR TITLE
Added Boolean and Int as data types for custom attributes

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-custom-attr.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-custom-attr.md
@@ -32,7 +32,7 @@ Your Azure Active Directory (Azure AD) B2C directory comes with a built-in set o
 4. Provide a **Name** for the custom attribute (for example, "ShoeSize") and optionally, a **Description**. Click **Create**.
    
    > [!NOTE]
-   > Only the "String" **Data Type** is currently available.
+   > Only the "String", "Boolean" and "Int" **Data Types** are currently available.
    > 
    > 
 


### PR DESCRIPTION
Boolean and Int datatypes are allowed as custom attributes, but the documentation does not reflect that yet. 