### PR TITLE
Removed "Core Analytics" check from Akamai

### DIFF
--- a/articles/cdn/cdn-overview.md
+++ b/articles/cdn/cdn-overview.md
@@ -66,7 +66,7 @@ There are three Azure CDN products:  **Azure CDN Standard from Akamai**, **Azure
 | [Token authentication](cdn-token-auth.md)|  |  |**&#x2713;**| 
 | [DDOS protection](https://www.us-cert.gov/ncas/tips/ST04-015) |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; __Analytics and Reporting__ |
-| [Core analytics](cdn-analyze-usage-patterns.md) | **&#x2713;** |**&#x2713;** |**&#x2713;** |
+| [Core analytics](cdn-analyze-usage-patterns.md) | |**&#x2713;** |**&#x2713;** |
 | [Advanced HTTP reports](cdn-advanced-http-reports.md) | | |**&#x2713;** |
 | [Real-time stats](cdn-real-time-stats.md) | | |**&#x2713;** |
 | [Real-time alerts](cdn-real-time-alerts.md) | | |**&#x2713;** |


### PR DESCRIPTION
Does Akamai support "Core Analytics"?
https://docs.microsoft.com/en-us/azure/cdn/cdn-analyze-usage-patterns
This feature is available with Azure CDN from Verizon products (Standard and Premium). **It is not supported on Azure CDN from Akamai.** For a comparison of CDN features, see Azure CDN Overview.