### PR TITLE
Docker version should be 17.06 in the Powershell script

### DIFF
--- a/articles/iot-edge/how-to-install-iot-core.md
+++ b/articles/iot-edge/how-to-install-iot-core.md
@@ -48,7 +48,7 @@ The Azure IoT Edge Runtime can run even on tiny Single Board Computer (SBC) devi
    * Python 3.6
    * The IoT Edge control script (iotedgectl.exe)
 
-You may see informational output from the iotedgectl.exe tool in red in the remote PowerShell window. This doesn't necessarily indicate errors. 
+You may see informational output from the iotedgectl.exe tool in green in the remote PowerShell window. This doesn't necessarily indicate errors. 
 
 ## Next steps
 


### PR DESCRIPTION
1. The output from iotedgectl.exe tool in green (not red) in the remote PowerShell window.
2. Docker version should be "17.06", not "17.09" in the Powershell script, which can be downloaded by "https://aka.ms/iotedgewin".