### PR TITLE
Update application-gateway-configure-redirect-powershell.md

### DIFF
--- a/articles/application-gateway/application-gateway-configure-redirect-powershell.md
+++ b/articles/application-gateway/application-gateway-configure-redirect-powershell.md
@@ -223,7 +223,7 @@ $fipconfig = New-AzureRmApplicationGatewayFrontendIPConfig -Name 'fip01' -Public
 $listener = New-AzureRmApplicationGatewayHttpListener -Name listener01 -Protocol Http -FrontendIPConfiguration $fipconfig -FrontendPort $fp 
 
 # Create the redirect configuration that will point traffic to the 
-$redirectconfig = New-AzureRmApplicationGatewayRedirectConfiguration -Name myredirect -RedirectType Temporary -TargetUrl "http://bing.com" -IncludePath $true -IncludeQueryString $true
+$redirectconfig = New-AzureRmApplicationGatewayRedirectConfiguration -Name myredirect -RedirectType Temporary -TargetUrl "http://bing.com"
 
 #Create a load balancer routing rule that configures the load balancer behavior. In this example, a basic round robin rule is created.
 $rule = New-AzureRmApplicationGatewayRequestRoutingRule -Name rule01 -RuleType Basic -HttpListener $listener -RedirectConfiguration $redirectconfig 


### PR DESCRIPTION
Remove "-IncludePath $true -IncludeQueryString $true"

> The following example redirects traffic coming into the application gateway to an external website (bing.com). When using the `TargetUrl` switch the `IncludePath` and `IncludeQuery` switches are not allowed.