### PR TITLE
Fix openshift-ansible path in post-deployment.md

### DIFF
--- a/articles/virtual-machines/linux/openshift-post-deployment.md
+++ b/articles/virtual-machines/linux/openshift-post-deployment.md
@@ -323,11 +323,11 @@ If you used the OCP Resource Manager template and metrics and logging weren't en
 On the first master node (Origin) or bastion node (OCP), SSH by using the credentials provided during deployment. Issue the following command:
 
 ```bash
-ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml \
+ansible-playbook $HOME/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml \
 -e openshift_metrics_install_metrics=True \
 -e openshift_metrics_cassandra_storage_type=dynamic
 
-ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
+ansible-playbook $HOME/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
 -e openshift_logging_install_logging=True \
 -e openshift_hosted_logging_storage_kind=dynamic
 ```
@@ -337,10 +337,10 @@ ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cl
 On the first master node (Origin) or bastion node (OCP), SSH by using the credentials provided during deployment. Issue the following command:
 
 ```bash
-ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml \
+ansible-playbook $HOME/openshift-ansible/playbooks/byo/openshift-cluster/openshift-metrics.yml \
 -e openshift_metrics_install_metrics=True 
 
-ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
+ansible-playbook $HOME/openshift-ansible/playbooks/byo/openshift-cluster/openshift-logging.yml \
 -e openshift_logging_install_logging=True 
 ```
 


### PR DESCRIPTION
* Following the docs and the deployOpenShift.sh script, the path to openshift-ansible is in home dir of the $SUDOUSER.