### PR TITLE
Change explanation of environment variables for ServiceBus

### DIFF
--- a/articles/service-bus-messaging/service-bus-nodejs-how-to-use-topics-subscriptions.md
+++ b/articles/service-bus-messaging/service-bus-nodejs-how-to-use-topics-subscriptions.md
@@ -68,7 +68,7 @@ var azure = require('azure');
 ```
 
 ### Set up a Service Bus connection
-The Azure module reads the environment variables `AZURE_SERVICEBUS_NAMESPACE` and `AZURE_SERVICEBUS_ACCESS_KEY` for information required to connect to Service Bus. If these environment variables are not set, you must specify the account information when calling `createServiceBusService`.
+The Azure module reads the environment variable `AZURE_SERVICEBUS_CONNECTION_STRING` for the connection string that you obtained from the earlier step, "Obtain the credentials". If this environment variable is not set, you must specify the account information when calling `createServiceBusService`.
 
 For an example of setting the environment variables for an Azure Cloud Service, see [Node.js Cloud Service with Storage][Node.js Cloud Service with Storage].
 


### PR DESCRIPTION
`/service-bus-nodejs-how-to-use-topics-subscriptions.md`

Change the article to suggest using the variable `AZURE_SERVICEBUS_CONNECTION_STRING`.

If a previous step, the developer is told how to obtain the connection string but later is told to use two different environment variables and now how to parse the connection string into those variables.

`servicebussettings.js` supports obtaining the entire connection string from the environment variable `AZURE_SERVICEBUS_CONNECTION_STRING`.  Changing the documentation to suggest using this variable makes sense given the instructions earlier in the article explain how to obtain the entire connection string.

See https://github.com/Azure/azure-sdk-for-node/blob/master/lib/common/lib/services/servicebussettings.js#L244 : 

```js
  } else if (process.env[EnvironmentVariables.AZURE_SERVICEBUS_CONNECTION_STRING]) {
    connectionString = process.env[EnvironmentVariables.AZURE_SERVICEBUS_CONNECTION_STRING];
```