### PR TITLE
(ForumsTeam) Update on Disk sizes and performance

### DIFF
--- a/articles/virtual-machines/windows/tutorial-manage-data-disk.md
+++ b/articles/virtual-machines/windows/tutorial-manage-data-disk.md
@@ -38,7 +38,7 @@ If you choose to install and use the PowerShell locally, this tutorial requires 
 
 When an Azure virtual machine is created, two disks are automatically attached to the virtual machine. 
 
-**Operating system disk** - Operating system disks can be sized up to 1 terabyte, and hosts the VMs operating system.  The OS disk is assigned a drive letter of *c:* by default. The disk caching configuration of the OS disk is optimized for OS performance. The OS disk **should not** host applications or data. For applications and data, use a data disk, which is detailed later in this article.
+**Operating system disk** - Operating system disks can be sized up to 4 terabyte, and hosts the VMs operating system.  The OS disk is assigned a drive letter of *c:* by default. The disk caching configuration of the OS disk is optimized for OS performance. The OS disk **should not** host applications or data. For applications and data, use a data disk, which is detailed later in this article.
 
 **Temporary disk** - Temporary disks use a solid-state drive that is located on the same Azure host as the VM. Temp disks are highly performant and may be used for operations such as temporary data processing. However, if the VM is moved to a new host, any data stored on a temporary disk is removed. The size of the temporary disk is determined by the VM size. Temporary disks are assigned a drive letter of *d:* by default.
 
@@ -78,7 +78,7 @@ Standard Storage is backed by HDDs, and delivers cost-effective storage while st
 
 ### Premium disk
 
-Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. Premium Storage supports DS-series, DSv2-series, GS-series, and FS-series VMs. Premium disks come in three types (P10, P20, P30), the size of the disk determines the disk type. When selecting, a disk size the value is rounded up to the next type. For example, if the size is below 128 GB the disk type will be P10, between 129 and 512 P20, and over 512 P30. 
+Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. Premium Storage supports DS-series, DSv2-series, GS-series, and FS-series VMs. Premium disks come in three types (P10, P20, P30, P40, P50), the size of the disk determines the disk type. When selecting, a disk size the value is rounded up to the next type. For example, if the size is below 128 GB the disk type will be P10, between 129 and 512 P20,512 for P30,P40 for 2TB and P50 4TB . 
 
 ### Premium disk performance
 


### PR DESCRIPTION
Under the section: 
Default Azure disks
Operating system disk - Operating system disks can be sized up to 1 terabyte,and hosts the VMs operating system.

It has been updated to 4TB for Azure VMs
Blog link: https://azure.microsoft.com/en-in/blog/azure-introduces-new-disks-sizes-up-to-4tb/ 

Under the section: 
VMs disk types-> Premium disk performance

It's stated that Premium disks come in three types (P10, P20, P30), the size of the disk determines the disk type. When selecting, a disk size the value is rounded up to the next type. For example, if the size is below 128 GB the disk type will be P10, between 129 and 512 P20, and over 512 P30. 
Can we update that Large Disks are currently available in all Azure regions i.e P40(2TB) and P50(4TB) including IOPS Perdisk and Disk Bandwidth.
Blog Link: https://azure.microsoft.com/en-in/blog/azure-introduces-new-disks-sizes-up-to-4tb/