### PR TITLE
Fixed Temp Storage Column Header for Fsv2-series

### DIFF
--- a/includes/virtual-machines-common-sizes-compute.md
+++ b/includes/virtual-machines-common-sizes-compute.md
@@ -16,7 +16,7 @@ The Fs-series provides all the advantages of the F-series, in addition to Premiu
 
 ACU: 195 - 210
 
-| Size             | vCPU's | Memory: GiB | Local SSD: GiB | Max data disks | Max cached and temp storage throughput: IOPS / MBps (cache size in GiB) | Max NICs / Expected network bandwidth (Mbps) |
+| Size             | vCPU's | Memory: GiB | Temp storage (SSD) GiB | Max data disks | Max cached and temp storage throughput: IOPS / MBps (cache size in GiB) | Max NICs / Expected network bandwidth (Mbps) |
 |------------------|--------|-------------|----------------|----------------|-----------------------------------------------------------------------|------------------------------------------------|
 | Standard_F2s_v2  | 2      | 4           | 16             | 4              | 4000 (32)                                                             | Moderate                                       |
 | Standard_F4s_v2  | 4      | 8           | 32             | 8              | 8000 (64)                                                             | Moderate                                       |


### PR DESCRIPTION
The Fsv2-series was showing "Local SSD:GiB" instead of "Temp storage (SSD) GiB" which is confusing. All other F-series and other VM tiers use the "Temp storage (SSD) GiB" header.