### PR TITLE
Fixed Temp Storage Column Header for B-series

### DIFF
--- a/includes/virtual-machines-common-b-series-burstable.md
+++ b/includes/virtual-machines-common-b-series-burstable.md
@@ -14,7 +14,7 @@ The B-series VMs are ideal for workloads that do not need the full performance o
 
 The B-series comes in the following six VM sizes:
 
-| Size          | vCPU's | Memory: GiB | Local SSD: GiB | Base CPU Perf of VM | Max CPU Perf of VM | Credits Banked / Hour | Max Banked Credits |
+| Size          | vCPU's | Memory: GiB | Temp storage (SSD) GiB | Base CPU Perf of VM | Max CPU Perf of VM | Credits Banked / Hour | Max Banked Credits |
 |---------------|--------|-------------|----------------|--------------------------------|---------------------------|-----------------------|--------------------|
 | Standard_B1s  | 1      | 1           | 4              | 10%                            | 100%                      | 6                     | 144                |
 | Standard_B1ms | 1      | 2           | 4              | 20%                            | 100%                      | 12                    | 288                |


### PR DESCRIPTION
The B-series table was showing "Local SSD:GiB" instead of "Temp storage (SSD) GiB" which is confusing. All other VM tiers use the "Temp storage (SSD) GiB" header.