### PR TITLE
Updated the links to open in new tab

### DIFF
--- a/articles/virtual-machines/windows/quick-create-portal.md
+++ b/articles/virtual-machines/windows/quick-create-portal.md
@@ -23,11 +23,11 @@ ms.custom: mvc
 
 Azure virtual machines can be created through the Azure portal. This method provides a browser-based user interface for creating and configuring virtual machines and all related resources. This quickstart steps through creating a virtual machine and installing a webserver on the VM.
 
-If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin.
+If you don't have an Azure subscription, create a <a href="https://azure.microsoft.com/free/?WT.mc_id=A261C142F" target="_blank">free account</a> before you begin.
 
 ## Log in to Azure
 
-Log in to the Azure portal at http://portal.azure.com.
+Log in to the Azure portal at <a href="http://portal.azure.com" target="_blank">http://portal.azure.com</a> .
 
 ## Create virtual machine
 


### PR DESCRIPTION
Changed the links for "free account" and Azure portal to open in the new page. Markdown does not have this feature yet, so changed to normal html. The links opening in a new tab let's the reader be on the documentation page and the reader does not need to go back to the documentation if they need to follow the subsequent sections.