### PR TITLE
change in SAS Token management

### DIFF
--- a/articles/virtual-machines/linux/diagnostic-extension.md
+++ b/articles/virtual-machines/linux/diagnostic-extension.md
@@ -78,7 +78,7 @@ sed -i "s#__DIAGNOSTIC_STORAGE_ACCOUNT__#$my_diagnostic_storage_account#g" porta
 sed -i "s#__VM_RESOURCE_ID__#$my_vm_resource_id#g" portal_public_settings.json
 
 # Build the protected settings (storage account SAS token)
-my_diagnostic_storage_account_sastoken=$(az storage account generate-sas --account-name $my_diagnostic_storage_account --expiry 9999-12-31T23:59Z --permissions wlacu --resource-types co --services bt -o tsv)
+my_diagnostic_storage_account_sastoken=$(az storage table generate-sas --account-name $my_diagnostic_storage_account --expiry 9999-12-31T23:59Z --permissions wlacu --resource-types co --services bt -o tsv)
 my_lad_protected_settings="{'storageAccountName': '$my_diagnostic_storage_account', 'storageAccountSasToken': '$my_diagnostic_storage_account_sastoken'}"
 
 # Finallly tell Azure to install and enable the extension


### PR DESCRIPTION
CRI 51437740 

There's a change in the way Azure Storage manages SAS token for Table service
Documented here https://github.com/Azure/azure-cli/issues/4827


If we use "az storage account generate-sas --services bt" - then the generated SAS token will only include Blob service (ss=b).
We need to generate the SAS token for the Table service here, so we need to use "az storage table generate-sas --services bt" and that will generate a SAS token for Table service too (ss=bt).