### PR TITLE
Corrected typo in AccountKey command sample

### DIFF
--- a/articles/cosmos-db/table-import.md
+++ b/articles/cosmos-db/table-import.md
@@ -90,7 +90,7 @@ Use the following target options when defining Azure Cosmos DB Table API as the 
 Here is a command-line sample showing how to import from Azure Table storage to Table API:
 
 ```
-dt /s:AzureTable /s.ConnectionString:DefaultEndpointsProtocol=https;AccountName=<Azure Table storage account name>;AccountKey==<Account Key>;EndpointSuffix=core.windows.net /s.Table:<Table name> /t:TableAPIBulk /t.ConnectionString:DefaultEndpointsProtocol=https;AccountName=<Azure Cosmos DB account name>;AccountKey=<Azure Cosmos DB account key>;TableEndpoint=https://<Account name>.table.cosmosdb.azure.com:443 /t.TableName:<Table name> /t.Overwrite
+dt /s:AzureTable /s.ConnectionString:DefaultEndpointsProtocol=https;AccountName=<Azure Table storage account name>;AccountKey=<Account Key>;EndpointSuffix=core.windows.net /s.Table:<Table name> /t:TableAPIBulk /t.ConnectionString:DefaultEndpointsProtocol=https;AccountName=<Azure Cosmos DB account name>;AccountKey=<Azure Cosmos DB account key>;TableEndpoint=https://<Account name>.table.cosmosdb.azure.com:443 /t.TableName:<Table name> /t.Overwrite
 ```
 <a id="table-api-preview"></a>
 ### Sample command: Source is Azure Cosmos DB Table API (preview)


### PR DESCRIPTION
In Source part of sample command there is a typo with two "=" characters: "AccountKey==<Account Key>;" should be: "AccountKey=<Account Key>;"