### PR TITLE
"... app settings" can cause confusion

### DIFF
--- a/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
+++ b/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
@@ -25,7 +25,7 @@ To begin, go to the [Azure portal](http://portal.azure.com) and sign in to your 
 
 ![Function app overview in the Azure portal](./media/functions-how-to-use-azure-function-app-settings/azure-function-app-main.png)
 
-## <a name="manage-app-service-settings"></a>Function app settings tab
+## <a name="manage-app-service-settings"></a>Settings tab
 
 ![Function app overview in the Azure portal.](./media/functions-how-to-use-azure-function-app-settings/azure-function-app-settings-tab.png)
 


### PR DESCRIPTION
I realize that "Function app settings" are the settings for the function app. However, as you can see from this answer in SO (https://stackoverflow.com/a/47636326/84395), they are being read as the Function's "App Settings" (i.e. Application Settings).

To remove confusion, just name this section based on the name of the tab