### PR TITLE
Clarification on rule req'd for SNAT

### DIFF
--- a/articles/load-balancer/load-balancer-outbound-connections.md
+++ b/articles/load-balancer/load-balancer-outbound-connections.md
@@ -43,7 +43,7 @@ You can use [Log Analytics for Load Balancer](load-balancer-monitor-log.md) and 
 
 ## Load-balanced VM with no Instance Level Public IP address
 
-In this scenario, the VM is part of an Azure Load Balancer pool.  The VM does not have a public IP address assigned to it. The Load Balancer resource must be configured with a rule to link the public IP frontend with the backend pool.  If you do not complete this configuration, the behavior is as described in the preceding section for [Standalone VM with no Instance Level Public IP](load-balancer-outbound-connections.md#standalone-vm-with-no-instance-level-public-ip-address).
+In this scenario, the VM is part of an Azure Load Balancer pool.  The VM does not have a public IP address assigned to it. The Load Balancer resource must be configured with an inbound load balancer rule to create a link between the public IP frontend with the backend pool.  If you do not complete this configuration, the behavior is as described in the preceding section for [Standalone VM with no Instance Level Public IP](load-balancer-outbound-connections.md#standalone-vm-with-no-instance-level-public-ip-address). 
 
 When the load-balanced VM creates an outbound flow, Azure translates the private source IP address of the outbound flow to the public IP address of the public Load Balancer frontend. Azure uses Source Network Address Translation (SNAT) to perform this function. Ephemeral ports of the Load Balancer's public IP address are used to distinguish individual flows originated by the VM. SNAT dynamically allocates ephemeral ports when outbound flows are created. In this context, the ephemeral ports used for SNAT are referred to as SNAT ports.
 
@@ -94,3 +94,4 @@ Azure uses an algorithm to determine the number of SNAT ports available based on
 Outbound connections have a 4-minute idle timeout.  This is not adjustable.
 
 It is important to remember that the number of SNAT ports available does not translate directly to number of connections. Refer preceding sections for specifics on when and how SNAT ports are allocated and [how to manage this exhaustible resource](#snatexhaust).
+	


### PR DESCRIPTION
This requires clarification to point out that the rule must be inbound. People are using this pattern to ensure a consistent outbound public IP for traffic in order to satisfy IPv4 whitelisting requirements to connect to other private systems. There is potential for confusion where an inbound rule - regardles of whether it's needed or if it's even valid - is required to enable outbound SNAT.