### PR TITLE
Update tutorial-csharp-module.md to read Module Twin desired property on startup

### DIFF
--- a/articles/iot-edge/tutorial-csharp-module.md
+++ b/articles/iot-edge/tutorial-csharp-module.md
@@ -103,11 +103,19 @@ The following steps show you how to create an IoT Edge module based on .NET core
     }
     ```
 
-8. In the **Init** method, the code creates and configures a **DeviceClient** object. This object allows the module to  connect to the local Azure IoT Edge runtime to send and receive messages. The connection string used in the **Init** method is supplied to the module by IoT Edge runtime. After creating the **DeviceClient**, the code registers a callback for receiving messages from the IoT Edge hub via the **input1** endpoint. Replace the `SetInputMessageHandlerAsync` method with a new one, and add a `SetDesiredPropertyUpdateCallbackAsync` method for desired properties updates. To make this change, replace the last line of the **Init** method with the following code:
+8. In the **Init** method, the code creates and configures a **DeviceClient** object. This object allows the module to  connect to the local Azure IoT Edge runtime to send and receive messages. The connection string used in the **Init** method is supplied to the module by IoT Edge runtime. After creating the **DeviceClient**, the code reads the TemperatureThreshold from the Module Twin's desired properties and registers a callback for receiving messages from the IoT Edge hub via the **input1** endpoint. Replace the `SetInputMessageHandlerAsync` method with a new one, and add a `SetDesiredPropertyUpdateCallbackAsync` method for desired properties updates. To make this change, replace the last line of the **Init** method with the following code:
 
     ```csharp
     // Register callback to be called when a message is received by the module
     // await ioTHubModuleClient.SetImputMessageHandlerAsync("input1", PipeMessage, iotHubModuleClient);
+
+    // Read TemperatureThreshold from Module Twin Desired Properties
+    var deviceTwin = await ioTHubModuleClient.GetTwinAsync();
+    var twinCollection = deviceTwin.Properties.Desired;
+    if (twinCollection["TemperatureThreshold"] != null)
+    {
+        temperatureThreshold = twinCollection["TemperatureThreshold"];
+    }
 
     // Attach callback for Twin desired properties updates
     await ioTHubModuleClient.SetDesiredPropertyUpdateCallbackAsync(onDesiredPropertiesUpdate, null);

--- a/articles/iot-edge/tutorial-csharp-module.md
+++ b/articles/iot-edge/tutorial-csharp-module.md
@@ -110,11 +110,11 @@ The following steps show you how to create an IoT Edge module based on .NET core
     // await ioTHubModuleClient.SetImputMessageHandlerAsync("input1", PipeMessage, iotHubModuleClient);
 
     // Read TemperatureThreshold from Module Twin Desired Properties
-    var deviceTwin = await ioTHubModuleClient.GetTwinAsync();
-    var twinCollection = deviceTwin.Properties.Desired;
-    if (twinCollection["TemperatureThreshold"] != null)
+    var moduleTwin = await ioTHubModuleClient.GetTwinAsync();
+    var moduleTwinCollection = moduleTwin.Properties.Desired;
+    if (moduleTwinCollection["TemperatureThreshold"] != null)
     {
-        temperatureThreshold = twinCollection["TemperatureThreshold"];
+        temperatureThreshold = moduleTwinCollection["TemperatureThreshold"];
     }
 
     // Attach callback for Twin desired properties updates


### PR DESCRIPTION
The sample code does not pick up the Module Twin's desired property "TemperatureThreshold" when the module starts, only when the desired property is updated while the module is running and onDesiredPropertiesUpdate() is fired. Reading the desired property from the Module Twin in the Init() method resolves this issue.