### PR TITLE
Update Advisor TOC.md with link to CLI documentation

### DIFF
--- a/articles/advisor/TOC.md
+++ b/articles/advisor/TOC.md
@@ -11,7 +11,8 @@
 ## [Get started with Advisor](advisor-get-started.md)
 
 # Reference
-## [REST](https://docs.microsoft.com/rest/api/advisor)
+## [REST API](https://docs.microsoft.com/rest/api/advisor)
+## [CLI](https://docs.microsoft.com/cli/azure/advisor)
 
 # Related
 ## [Security Center](https://azure.microsoft.com/services/security-center/)


### PR DESCRIPTION
Advisor recently added CLI support.  Updating the Reference section of the TOC to include a link to the CLI documentation.  I also changed the name of the 'REST' link to 'REST API' to be a bit more clear.