### PR TITLE
Tweaks to template to use the string and endpoint

### DIFF
--- a/articles/azure-resource-manager/resource-manager-vscode-extension.md
+++ b/articles/azure-resource-manager/resource-manager-vscode-extension.md
@@ -176,8 +176,8 @@ This article builds on the template you created in [Create and deploy your first
          "value": "[resourceGroup().location]"
        },
        "storageUri": {
-         "type": "object",
-         "value": "[reference(concat('Microsoft.Storage/storageAccounts/',variables('storageName')))]"
+         "type": "string",
+         "value": "[reference(concat('Microsoft.Storage/storageAccounts/',variables('storageName'))).primaryEndpoints.blob]"
        }
    }
    ```
@@ -244,8 +244,8 @@ The final template is:
       "value": "[resourceGroup().location]"
     },
     "storageUri": {
-      "type": "object",
-      "value": "[reference(concat('Microsoft.Storage/storageAccounts/',variables('storageName')))]"
+      "type": "string",
+      "value": "[reference(concat('Microsoft.Storage/storageAccounts/',variables('storageName'))).primaryEndpoints.blob]"
     }
   }
 }


### PR DESCRIPTION
Tweaks to the template/tutorial to not use the object, and instead directly point to the blob endpoint and ensure consistency with the rest of the guide