### PR TITLE
Modify AppId editing example to match starter pack

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-get-started-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-get-started-custom.md
@@ -153,7 +153,7 @@ Add the application IDs to the extensions file (`TrustFrameworkExtensions.xml`):
 2. Replace both instances of `IdentityExperienceFrameworkAppId` with the application ID of the Identity Experience Framework application that you created earlier. Here is an example:
 
    ```xml
-   <Item Key="client_id">8322dedc-cbf4-43bc-8bb6-141d16f0f489</Item>
+   <Item Key="IdTokenAudience">8322dedc-cbf4-43bc-8bb6-141d16f0f489</Item>
    ```
 3. Replace both instances of `ProxyIdentityExperienceFrameworkAppId` with the application ID of the Proxy Identity Experience Framework application that you created earlier.
 4. Save your extensions file.


### PR DESCRIPTION
Downloadable starter pack indicates that when configuring local accounts the IdentityExperienceFrameworkAppId value should be used as IdTokenAudience (and resourceID) within the login-NonInteractive section of TrustFrameworkExtensions; however, the example on this page could be read to indicate that the IdentityExperienceFrameworkAppId  value should be used for client_id, causing confusion.