### PR TITLE
Fix broken link and change language block type

### DIFF
--- a/articles/cognitive-services/Emotion/QuickStarts/JavaScript.md
+++ b/articles/cognitive-services/Emotion/QuickStarts/JavaScript.md
@@ -18,7 +18,7 @@ ms.author: anroth
 > Video API Preview will end on October 30th, 2017. Try the new [Video Indexer API Preview](https://azure.microsoft.com/services/cognitive-services/video-indexer/) to easily extract insights from 
 videos and to enhance content discovery experiences, such as search results, by detecting spoken words, faces, characters, and emotions. [Learn more](https://docs.microsoft.com/azure/cognitive-services/video-indexer/video-indexer-overview).
 
-This article provides information and code samples to help you quickly get started using the [Emotion API Recognize method](https://dev.projectoxford.ai/docs/services/5639d931ca73072154c1ce89/operations/563b31ea778daf121cc3a5fa) with JavaScript to recognize the emotions expressed by one or more people in an image.
+This article provides information and code samples to help you quickly get started using the [Emotion API Recognize method](https://westus.dev.cognitive.microsoft.com/docs/services/5639d931ca73072154c1ce89/operations/563b31ea778daf121cc3a5fa) with JavaScript to recognize the emotions expressed by one or more people in an image.
 
 ## Prerequisite
 * Get your free Subscription Key [here](https://azure.microsoft.com/en-us/try/cognitive-services/), or if you have an Azure Subscription create an Emotion API resource and get your Subscription Key and Endpoint there.
@@ -35,7 +35,7 @@ Copy the following and save it to a file such as `test.html`. Change the request
 
 and change the request body to the location of an image you want to use. To run the sample, drag-and-drop the file into your browser.
 
-```javascript
+```html
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
This commit changes:
- broken API documentation link to point to current Emotion API docs
- block code language type to `html`, so it's better rendered in documentation

Thanks!