### PR TITLE
Correct Javascript example

### DIFF
--- a/articles/application-insights/app-insights-nodejs-quick-start.md
+++ b/articles/application-insights/app-insights-nodejs-quick-start.md
@@ -63,11 +63,11 @@ Application Insights can gather telemetry data from any internet-connected appli
    npm install applicationinsights --save
    ```
 
-3. Edit your app's first .js file and add the two lines below to the topmost part of your script. If you are using the [Node.js quickstart app](https://docs.microsoft.com/azure/app-service/app-service-web-get-started-nodejs), you would modify the index.js file. 
+3. Edit your app's first .js file and add the two lines below to the topmost part of your script. If you are using the [Node.js quickstart app](https://docs.microsoft.com/azure/app-service/app-service-web-get-started-nodejs), you would modify the index.js file. Replace &lt;instrumentation_key&gt; with your application's instrumentation key. 
 
    ```JavaScript
    const appInsights = require('applicationinsights');
-   appInsights.setup('<instrumentation_key').start();
+   appInsights.setup('<instrumentation_key>').start();
    ```
 
 4. Restart your app.


### PR DESCRIPTION
Missing closing tag in javascript example. Make it obvious that we need to replace the instrumentation_key.