### PR TITLE
Update storage-quickstart-blobs-dotnet.md

### DIFF
--- a/articles/storage/blobs/storage-quickstart-blobs-dotnet.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-dotnet.md
@@ -163,6 +163,7 @@ do
     {
         Console.WriteLine(item.Uri);
     }
+    blobContinuationToken = results.ContinuationToken;
 } while (blobContinuationToken != null);
 ```
 


### PR DESCRIPTION
The `blobContinuationToken` was never updated during the do-while loop for the "List the blobs in a container" section. Adding a `blobContinuationToken = results.ContinuationToken;` from inside of the loop so the loop does not run forever.