### PR TITLE
Mount location of container logs from pods

### DIFF
--- a/articles/aks/tutorial-kubernetes-monitor.md
+++ b/articles/aks/tutorial-kubernetes-monitor.md
@@ -95,6 +95,8 @@ spec:
           name: container-hostname
         - mountPath: /var/log
           name: host-log
+        - mountPath: /var/lib/docker/containers/
+          name: container-log
        livenessProbe:
         exec:
          command:
@@ -121,6 +123,9 @@ spec:
     - name: host-log
       hostPath:
        path: /var/log
+    - name: container-log
+      hostPath:
+       path: /var/lib/docker/containers/
 ```
 
 Create the DaemonSet with the following command:


### PR DESCRIPTION
The symbolic links in the /var/log/pods folder are not able to crawled because the source of those files is in /var/lib/docker/containers. Without this change, I was not able to capture my logs from inside my containers.