### PR TITLE
Special Characters Not Showing Up

### DIFF
--- a/articles/location-based-services/quick-demo-map-app.md
+++ b/articles/location-based-services/quick-demo-map-app.md
@@ -41,7 +41,7 @@ Log in to the [Azure portal](https://portal.azure.com/).
 
 1. Download or copy the contents of the file [interactiveSearch.html](https://github.com/Azure-Samples/location-based-services-samples/blob/master/src/interactiveSearch.html).
 2. Save the contents of this file locally as **AzureMapDemo.html** and open it in a text editor.
-3. Search for the string **<insert-key>**, and replace it with the **Primary Key** value obtained in the preceding section. 
+3. Search for the string **&#60;insert-key&#62;**, and replace it with the **Primary Key** value obtained in the preceding section. 
 
 
 ## Launch the demo application for Azure Maps


### PR DESCRIPTION
The less-than and greater-than characters were causing a problem in the string "<insert-key>".  I updated the page to use the HTML number codes.