### PR TITLE
Updated Terraform azurerm_resource_group argument

### DIFF
--- a/articles/virtual-machines/linux/terraform-create-complete-vm.md
+++ b/articles/virtual-machines/linux/terraform-create-complete-vm.md
@@ -348,10 +348,11 @@ resource "random_id" "randomId" {
 
 # Create storage account for boot diagnostics
 resource "azurerm_storage_account" "mystorageaccount" {
-    name                = "diag${random_id.randomId.hex}"
-    resource_group_name = "${azurerm_resource_group.myterraformgroup.name}"
-    location            = "East US"
-    account_type        = "Standard_LRS"
+    name                        = "diag${random_id.randomId.hex}"
+    resource_group_name         = "${azurerm_resource_group.myterraformgroup.name}"
+    location                    = "East US"
+    account_tier                = "Standard"
+    account_replication_type    = "LRS"
 
     tags {
         environment = "Terraform Demo"


### PR DESCRIPTION
terraform provider for Microsoft Azure has deprecated the account_type parameter.  I replaced option with account_tier, and account_replication_type.

##############
Error provided
##############
terraform plan
Warning: azurerm_storage_account.mystorageaccount: "account_type": [DEPRECATED] This field has been split into `account_tier` and `account_replication_type`
Error: azurerm_storage_account.mystorageaccount: "account_replication_type": required field is not set
Error: azurerm_storage_account.mystorageaccount: "account_tier": required field is not set