### PR TITLE
Change naming to reflect VS naming

### DIFF
--- a/articles/service-fabric/service-fabric-get-started.md
+++ b/articles/service-fabric/service-fabric-get-started.md
@@ -44,7 +44,7 @@ The following operating system versions are supported for development:
 
 ## Install the SDK and tools
 ### To use Visual Studio 2017
-Service Fabric Tools are part of the Azure Development and Management workload in Visual Studio 2017. Enable this workload as part of your Visual Studio installation.
+Service Fabric Tools are part of the Azure Development workload in Visual Studio 2017. Enable this workload as part of your Visual Studio installation.
 In addition, you need to install the Microsoft Azure Service Fabric SDK, using Web Platform Installer.
 
 * [Install the Microsoft Azure Service Fabric SDK][core-sdk]


### PR DESCRIPTION
The latest version of VS 2017 (15.5.1) calls this Azure Development, not Azure Development and Management. See screenshot below.
![vs azure development snapshot](https://user-images.githubusercontent.com/17129954/33962046-1105490e-e005-11e7-9e53-244ec269602a.jpg)
