### PR TITLE
Change New-AzureRmADServicePrincipal Parameter

### DIFF
--- a/articles/virtual-machines/windows/build-image-with-packer.md
+++ b/articles/virtual-machines/windows/build-image-with-packer.md
@@ -38,7 +38,8 @@ Packer authenticates with Azure using a service principal. An Azure service prin
 Create a service principal with [New-AzureRmADServicePrincipal](/powershell/module/azurerm.resources/new-azurermadserviceprincipal) and assign permissions for the service principal to create and manage resources with [New-AzureRmRoleAssignment](/powershell/module/azurerm.resources/new-azurermroleassignment):
 
 ```powershell
-$sp = New-AzureRmADServicePrincipal -DisplayName "Azure Packer IKF" -Password "P@ssw0rd!"
+$Secure_String_Pwd = ConvertTo-SecureString "P@ssw0rd!" -AsPlainText -Force
+$sp = New-AzureRmADServicePrincipal -DisplayName "Azure Packer IKF" -Password $Secure_String_Pwd
 Sleep 20
 New-AzureRmRoleAssignment -RoleDefinitionName Contributor -ServicePrincipalName $sp.ApplicationId
 ```


### PR DESCRIPTION
New-AzureRmADServicePrincipal cannot take a basic string for the password.  This updates to create a secure string based on the documentation here. https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertto-securestring?view=powershell-5.1