### PR TITLE
Update sa-create-vm-specialized.md nsg step order

### DIFF
--- a/articles/virtual-machines/windows/sa-create-vm-specialized.md
+++ b/articles/virtual-machines/windows/sa-create-vm-specialized.md
@@ -213,27 +213,9 @@ Create the vNet and subNet of the [virtual network](../../virtual-network/virtua
     $vnet = New-AzureRmVirtualNetwork -Name $vnetName -ResourceGroupName $rgName -Location $location `
         -AddressPrefix 10.0.0.0/16 -Subnet $singleSubnet
     ```    
-
-### Create a public IP address and NIC
-To enable communication with the virtual machine in the virtual network, you need a [public IP address](../../virtual-network/virtual-network-ip-addresses-overview-arm.md) and a network interface.
-
-1. Create the public IP. In this example, the public IP address name is set to **myIP**.
-   
-    ```powershell
-    $ipName = "myIP"
-    $pip = New-AzureRmPublicIpAddress -Name $ipName -ResourceGroupName $rgName -Location $location `
-        -AllocationMethod Dynamic
-    ```       
-2. Create the NIC. In this example, the NIC name is set to **myNicName**.
-   
-    ```powershell
-    $nicName = "myNicName"
-    $nic = New-AzureRmNetworkInterface -Name $nicName -ResourceGroupName $rgName `
-	-Location $location -SubnetId $vnet.Subnets[0].Id -PublicIpAddressId $pip.Id
-	```
-
 ### Create the network security group and an RDP rule
 To be able to log in to your VM using RDP, you need to have an security rule that allows RDP access on port 3389. Because the VHD for the new VM was created from an existing specialized VM, after the VM is created you can use an existing account from the source virtual machine that had permission to log on using RDP.
+This needs to be completed prior to creating the network interface it will be associated with.  
 This example sets the NSG name to **myNsg** and the RDP rule name to **myRdpRule**.
 
 ```powershell
@@ -249,6 +231,24 @@ $nsg = New-AzureRmNetworkSecurityGroup -ResourceGroupName $rgName -Location $loc
 ```
 
 For more information about endpoints and NSG rules, see [Opening ports to a VM in Azure using PowerShell](nsg-quickstart-powershell.md?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
+
+### Create a public IP address and NIC
+To enable communication with the virtual machine in the virtual network, you need a [public IP address](../../virtual-network/virtual-network-ip-addresses-overview-arm.md) and a network interface.
+
+1. Create the public IP. In this example, the public IP address name is set to **myIP**.
+   
+    ```powershell
+    $ipName = "myIP"
+    $pip = New-AzureRmPublicIpAddress -Name $ipName -ResourceGroupName $rgName -Location $location `
+        -AllocationMethod Dynamic
+    ```       
+2. Create the NIC. In this example, the NIC name is set to **myNicName**. This step also associates the Network Security Group created earlier with this NIC.
+   
+    ```powershell
+    $nicName = "myNicName"
+    $nic = New-AzureRmNetworkInterface -Name $nicName -ResourceGroupName $rgName `
+	-Location $location -SubnetId $vnet.Subnets[0].Id -PublicIpAddressId $pip.Id -NetworkSecurityGroupId $nsg.Id
+	```
 
 ### Set the VM name and size
 


### PR DESCRIPTION
The order for creation of the NSG and NIC were out of sync. The NSG was never actually being associated with the NIC, to do that it needs to be created before the NIC and then can be associated via the `-NetworkSecurityGroupId` parameter on `New-AzureRmNetworkInterface`