### PR TITLE
Inaccurate maximum number of data disks for ds2_v2

### DIFF
--- a/includes/virtual-machines-common-sizes-general.md
+++ b/includes/virtual-machines-common-sizes-general.md
@@ -68,9 +68,9 @@ ACU: 210-250
 | Size | vCPU | Memory: GiB | Temp storage (SSD) GiB | Max data disks | Max cached and temp storage throughput: IOPS / MBps (cache size in GiB) | Max uncached disk throughput: IOPS / MBps | Max NICs / Expected network bandwidth (Mbps) |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Standard_DS1_v2 |1 |3.5 |7 |4 |4,000 / 32 (43) |3,200 / 48 |2 / 750 |
-| Standard_DS2_v2 |2 |7 |14 |8 |8,000 / 64 (86) |6,400 / 96 |2 / 1500 |
+| Standard_DS2_v2 |2 |7 |14 |4 |8,000 / 64 (86) |6,400 / 96 |2 / 1500 |
 | Standard_DS3_v2 |4 |14 |28 |16 |16,000 / 128 (172) |12,800 / 192 |4 / 3000 |
-| Standard_DS4_v2 |8 |28 |56 |32 |32,000 / 256 (344) |25,600 / 384 |8 / 6000 |
+| Standard_DS4_v2 |8 |28 |56 |16 |32,000 / 256 (344) |25,600 / 384 |8 / 6000 |
 | Standard_DS5_v2 |16 |56 |112 |64 |64,000 / 512 (688) |51,200 / 768 |8 / 6000 - 12000 &#8224;|
 
 


### PR DESCRIPTION
We have a few incidents related to the accuracy of this document. 
Id 54096227: Unable to attach new disks beyond 32 for Standard_GS4 Virtual Machine. 
Accurate number is 32 (This is not included in this PR)
Id 53789825: The VM size is ds2_v2 promo which says it supports 8 data disks - maximum number of data disks currently permitted is 4.
Accurate number is 4.
-	DS2_v2_Promo has 2 vCPUs and 4 data disks
-	DS4_v2_Promo has 8 vCPUs and 16 data disks 

I have sent email to related the PM(Meagan McCrory <memccror@microsoft.com> and Jon Beck ).  Meagan confirmed that the numbers are not accurate. But I haven't seen changes been made in this Doc, which blocks me to close the incidents.