### PR TITLE
Update Node LTS to 8.9.3

### DIFF
--- a/articles/container-instances/container-instances-tutorial-prepare-app.md
+++ b/articles/container-instances/container-instances-tutorial-prepare-app.md
@@ -50,7 +50,7 @@ git clone https://github.com/Azure-Samples/aci-helloworld.git
 The Dockerfile provided in the sample repo shows how the container is built. It starts from an [official Node.js image][dockerhub-nodeimage] based on [Alpine Linux](https://alpinelinux.org/), a small distribution that is well suited to use with containers. It then copies the application files into the container, installs dependencies using the Node Package Manager, and finally starts the application.
 
 ```Dockerfile
-FROM node:8.2.0-alpine
+FROM node:8.9.3-alpine
 RUN mkdir -p /usr/src/app
 COPY ./app/* /usr/src/app/
 WORKDIR /usr/src/app
@@ -68,13 +68,13 @@ Output from the `docker build` command is similar to the following (truncated fo
 
 ```bash
 Sending build context to Docker daemon  119.3kB
-Step 1/6 : FROM node:8.2.0-alpine
-8.2.0-alpine: Pulling from library/node
+Step 1/6 : FROM node:8.9.3-alpine
+8.9.3-alpine: Pulling from library/node
 88286f41530e: Pull complete
 84f3a4bf8410: Pull complete
 d0d9b2214720: Pull complete
 Digest: sha256:c73277ccc763752b42bb2400d1aaecb4e3d32e3a9dbedd0e49885c71bea07354
-Status: Downloaded newer image for node:8.2.0-alpine
+Status: Downloaded newer image for node:8.9.3-alpine
  ---> 90f5ee24bee2
 ...
 Step 6/6 : CMD node /usr/src/app/index.js


### PR DESCRIPTION
I've created a PR in source app repository to update LTS version used in Docker image:
Azure-Samples/aci-helloworld/pull/2
This PR reflects the change in the PR in the documentation file, only relevant information has been updated.

Thanks!