### PR TITLE
Added note regarding SAS and ARM

### DIFF
--- a/articles/virtual-machines/linux/diagnostic-extension.md
+++ b/articles/virtual-machines/linux/diagnostic-extension.md
@@ -131,6 +131,10 @@ storageAccountSasToken | An [Account SAS token](https://azure.microsoft.com/blog
 mdsdHttpProxy | (optional) HTTP proxy information needed to enable the extension to connect to the specified storage account and endpoint.
 sinksConfig | (optional) Details of alternative destinations to which metrics and events can be delivered. The specific details of each data sink supported by the extension are covered in the sections that follow.
 
+
+> [!NOTE]
+> When deploying the extension with an Azure deployment template the storage account and SAS token must be created beforehand and then passed to the template. You cannot deploy a VM, Storage account and configure the extension in a single template as there, currently, isn't support for creating a SAS token within a template.
+
 You can easily construct the required SAS token through the Azure portal.
 
 1. Select the general-purpose storage account to which you want the extension to write

--- a/articles/virtual-machines/linux/diagnostic-extension.md
+++ b/articles/virtual-machines/linux/diagnostic-extension.md
@@ -133,7 +133,7 @@ sinksConfig | (optional) Details of alternative destinations to which metrics an
 
 
 > [!NOTE]
-> When deploying the extension with an Azure deployment template the storage account and SAS token must be created beforehand and then passed to the template. You cannot deploy a VM, Storage account and configure the extension in a single template as there, currently, isn't support for creating a SAS token within a template.
+> When deploying the extension with an Azure deployment template, the storage account and SAS token must be created beforehand and then passed to the template. You can't deploy a VM, storage account, and configure the extension in a single template. Creating a SAS token within a template is not currently supported.
 
 You can easily construct the required SAS token through the Azure portal.
 


### PR DESCRIPTION
Based on [discussion here](https://github.com/Azure/azure-linux-extensions/issues/503)

Add note to clarify limitations around SAS token generation and the implications for configuring the Linux Azure Diagnostics extension in ARM. 