### PR TITLE
Added cross-subscription Traffic Manager endpoints

### DIFF
--- a/articles/traffic-manager/traffic-manager-powershell-arm.md
+++ b/articles/traffic-manager/traffic-manager-powershell-arm.md
@@ -202,6 +202,18 @@ $child = Get-AzureRmTrafficManagerEndpoint -Name child -ResourceGroupName MyRG
 New-AzureRmTrafficManagerEndpoint -Name child-endpoint -ProfileName parent -ResourceGroupName MyRG -Type NestedEndpoints -TargetResourceId $child.Id -EndpointStatus Enabled -EndpointLocation "North Europe" -MinChildEndpoints 2
 ```
 
+## Adding endpoints from another subscription
+
+Traffic Manager can work with endpoints from different subscriptions. You need to switch to the subscription with the endpoint you want to add to retrieve the needed input to Traffic Manager. Then you need to switch to the subscriptions with the Traffic Manager profile, and add the encpoint to it. The below example shows how to do this with a public IP address.
+
+```powershell
+Set-AzureRmContext -SubscriptionId $EndpointSubscription
+$ip = Get-AzureRmPublicIpAddress -Name $IpAddresName -ResourceGroupName $EndpointRG
+
+Set-AzureRmContext -SubscriptionId $trafficmanagerSubscription
+New-AzureRmTrafficManagerEndpoint -Name $EndpointName -ProfileName $ProfileName -ResourceGroupName $TrafficManagerRG -Type AzureEndpoints -TargetResourceId $ip.Id -EndpointStatus Enabled
+```
+
 ## Update a Traffic Manager Endpoint
 
 There are two ways to update an existing Traffic Manager endpoint:


### PR DESCRIPTION
Added an example PowerShell script showing how to add endpoints to a Traffic Manager Profile across different subscriptions.