### PR TITLE
Correct typo and add missing attribute

### DIFF
--- a/articles/active-directory/active-directory-saas-lessonly-tutorial.md
+++ b/articles/active-directory/active-directory-saas-lessonly-tutorial.md
@@ -140,7 +140,8 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 	| ---------------  | ----------------|
 	| urn:oid:2.5.4.42 |user.givenname |
 	| urn:oid:2.5.4.4  |user.surname |
-	| urn:oid:0.9.2342.19200300.1001.3 |user.mail |
+	| urn:oid:0.9.2342.19200300.100.1.3 |user.mail |
+	| urn:oid:1.3.6.1.4.1.5923.1.1.1.10 |user.objectid |
 
 	a. Click **Add attribute** to open the **Add Attribute** dialog.
 


### PR DESCRIPTION
## Why

There was a typo in one of the attribute names that has been causing trouble when you copy and paste from this guide for setup.

Additionally, there is a required "user id" attribute that was not documented in this guide that has also caused some pain for initial setups.

## What

Correct the attribute name that should be entered to correspond with user.mail

Add the missing user ID attribute and have it associate with user.objectid