### PR TITLE
wrong syntax

### DIFF
--- a/articles/virtual-machines/windows/capture-image-resource.md
+++ b/articles/virtual-machines/windows/capture-image-resource.md
@@ -124,7 +124,7 @@ If you only want to create an image of the OS disk, you can also create an image
 2. Get the VM.
 
    ```azurepowershell-interactive
-   $vm = Get-AzureRmVm -Name myVM -ResourceGroupName $rgName
+   $vm = Get-AzureRmVm -Name $vmName -ResourceGroupName $rgName
    ```
 
 3. Get the ID of the managed disk.


### PR DESCRIPTION
VM Name is coming from $vmName
Executing current PS script will fail because there's no VM called "MyVM"

$vmName = "VMBaseRG54415109"
$rgName = "RG54415109"
$location = "WestEurope"
#$snapshotName = "mySnapshot"
$imageName = "myImage54415109"
$vm = Get-AzureRmVm -Name myVM -ResourceGroupName $rgName
Get-AzureRmVm : The Resource 'Microsoft.Compute/virtualMachines/myVM' under resource group 'RG54415109' was not found.
ErrorCode: ResourceNotFound
ErrorMessage: The Resource 'Microsoft.Compute/virtualMachines/myVM' under resource group 'RG54415109' was not found.
StatusCode: 404
ReasonPhrase: Not Found