### PR TITLE
Correction for User uploaded/copied .VHD as Source

### DIFF
--- a/includes/storage-about-vhds-and-disks-windows-and-linux.md
+++ b/includes/storage-about-vhds-and-disks-windows-and-linux.md
@@ -5,7 +5,7 @@ The VHDs used in Azure are .vhd files stored as page blobs in a standard or prem
 
 Azure supports the fixed disk VHD format. The fixed format lays the logical disk out linearly within the file, so that disk offset X is stored at blob offset X. A small footer at the end of the blob describes the properties of the VHD. Often, the fixed format wastes space because most disks have large unused ranges in them. However, Azure stores .vhd files in a sparse format, so you receive the benefits of both the fixed and dynamic disks at the same time. For more details, see [Getting started with virtual hard disks](https://technet.microsoft.com/library/dd979539.aspx).
 
-All .vhd files in Azure that you want to use as a source to create disks or images are read-only. When you create a disk or image, Azure makes copies of the .vhd files. These copies can be read-only or read-and-write, depending on how you use the VHD.
+All .vhd files in Azure that you want to use as a source to create disks or images are read-only, except the .vhd files uploaded or copied to Azure storage by the user (which can be either read-write or read-only). When you create a disk or image, Azure makes copies of the source .vhd files. These copies can be read-only or read-and-write, depending on how you use the VHD.
 
 When you create a virtual machine from an image, Azure creates a disk for the virtual machine that is a copy of the source .vhd file. To protect against accidental deletion, Azure places a lease on any source .vhd file that’s used to create an image, an operating system disk, or a data disk.
 


### PR DESCRIPTION
The .VHD files uploaded to Azure or copied to an Azure storage account by the user, which are used as a source to create disks or Images, are not necessarily read-only. Proposed changes regarding same in the relevant text section.