### PR TITLE
Major changes to OS Drive expanding approach

### DIFF
--- a/includes/virtual-machines-common-expand-os-disk.md
+++ b/includes/virtual-machines-common-expand-os-disk.md
@@ -10,7 +10,11 @@ When you create a new virtual machine (VM) in a Resource Group by deploying an i
 > 
 
 ## Resize the OS drive
-In this article we’ll accomplish the task of resizing the OS drive using resource manager modules of [Azure Powershell](/powershell/azureps-cmdlets-docs). Open your Powershell ISE or Powershell window in administrative mode and follow the steps below:
+In this article we’ll accomplish the task of resizing the OS drive using resource manager modules of [Azure Powershell](/powershell/azureps-cmdlets-docs). We will show resizing the OS drive for both Unamanged and Managed disks since the approach to resize disks differs between both disk types.
+
+### For resizing Unmanaged Disks:
+
+Open your Powershell ISE or Powershell window in administrative mode and follow the steps below:
 
 1. Sign-in to your Microsoft Azure account in resource management mode and select your subscription as follows:
    
@@ -34,7 +38,7 @@ In this article we’ll accomplish the task of resizing the OS drive using resou
     ```Powershell
     Stop-AzureRmVM -ResourceGroupName $rgName -Name $vmName
     ```
-5. And here comes the moment we’ve been waiting for! Set the size of the OS disk to the desired value and update the VM as follows:
+5. And here comes the moment we’ve been waiting for! Set the size of the Unmanaged OS disk to the desired value and update the VM as follows:
    
    ```Powershell
    $vm.StorageProfile.OSDisk.DiskSizeGB = 1023
@@ -42,7 +46,50 @@ In this article we’ll accomplish the task of resizing the OS drive using resou
    ```
    
    > [!WARNING]
-   > The new size should be greater than the existing disk size. The maximum allowed is 2048 GB. (It is possible to expand the VHD blob beyond that size, but the OS will only be able to work with the first 2048 GB of space.)
+   > The new size should be greater than the existing disk size. The maximum allowed is 2048 GB for OS disks. (It is possible to expand the VHD blob beyond that size, but the OS will only be able to work with the first 2048 GB of space.)
+   > 
+   > 
+6. Updating the VM may take a few seconds. Once the command finishes executing, restart the VM as follows:
+   
+   ```Powershell
+   Start-AzureRmVM -ResourceGroupName $rgName -Name $vmName
+   ```
+
+### For resizing Managed Disks:
+
+Open your Powershell ISE or Powershell window in administrative mode and follow the steps below:
+
+1. Sign-in to your Microsoft Azure account in resource management mode and select your subscription as follows:
+   
+   ```Powershell
+   Login-AzureRmAccount
+   Select-AzureRmSubscription –SubscriptionName 'my-subscription-name'
+   ```
+2. Set your resource group name and VM name as follows:
+   
+   ```Powershell
+   $rgName = 'my-resource-group-name'
+   $vmName = 'my-vm-name'
+   ```
+3. Obtain a reference to your VM as follows:
+   
+   ```Powershell
+   $vm = Get-AzureRmVM -ResourceGroupName $rgName -Name $vmName
+   ```
+4. Stop the VM before resizing the disk as follows:
+   
+    ```Powershell
+    Stop-AzureRmVM -ResourceGroupName $rgName -Name $vmName
+    ```
+5. Obtain a reference to the Managed OS disk. Set the size of the Managed OS disk to the desired value and update the Disk as follows:
+   
+   ```Powershell
+   $disk= Get-AzureRmDisk -ResourceGroupName $rgName -DiskName $vm.StorageProfile.OsDisk.Name
+   $disk.DiskSizeGB = 1023
+   Update-AzureRmDisk -ResourceGroupName $rgName -Disk $disk -DiskName $disk.Name
+   ```   
+   > [!WARNING]
+   > The new size should be greater than the existing disk size. The maximum allowed is 2048 GB for OS disks. (It is possible to expand the VHD blob beyond that size, but the OS will only be able to work with the first 2048 GB of space.)
    > 
    > 
 6. Updating the VM may take a few seconds. Once the command finishes executing, restart the VM as follows:
@@ -54,7 +101,9 @@ In this article we’ll accomplish the task of resizing the OS drive using resou
 And that’s it! Now RDP into the VM, open Computer Management (or Disk Management) and expand the drive using the newly allocated space.
 
 ## Summary
-In this article, we used Azure Resource Manager modules of Powershell to expand the OS drive of an IaaS virtual machine. Reproduced below is the complete script for your reference:
+In this article, we used Azure Resource Manager modules of Powershell to expand the OS drive of an IaaS virtual machine. Reproduced below is the complete script for your reference for both Unmanaged and Managed disks:
+
+Unamanged Disks:
 
 ```Powershell
 Login-AzureRmAccount
@@ -67,17 +116,43 @@ $vm.StorageProfile.OSDisk.DiskSizeGB = 1023
 Update-AzureRmVM -ResourceGroupName $rgName -VM $vm
 Start-AzureRmVM -ResourceGroupName $rgName -Name $vmName
 ```
+Managed Disks:
+
+```Powershell
+Login-AzureRmAccount
+Select-AzureRmSubscription -SubscriptionName 'my-subscription-name'
+$rgName = 'my-resource-group-name'
+$vmName = 'my-vm-name'
+$vm = Get-AzureRmVM -ResourceGroupName $rgName -Name $vmName
+Stop-AzureRMVM -ResourceGroupName $rgName -Name $vmName
+$disk= Get-AzureRmDisk -ResourceGroupName $rgName -DiskName $vm.StorageProfile.OsDisk.Name
+$disk.DiskSizeGB = 1023
+Update-AzureRmDisk -ResourceGroupName $rgName -Disk $disk -DiskName $disk.Name
+Start-AzureRmVM -ResourceGroupName $rgName -Name $vmName
+```
 
 ## Next Steps
-Though in this article, we focused primarily on expanding the OS disk of the VM, the developed script may also be used for expanding the data disks attached to the VM by changing a single line of code. For example, to expand the first data disk attached to the VM, replace the ```OSDisk``` object of ```StorageProfile``` with ```DataDisks``` array and use a numeric index to obtain a reference to first attached data disk, as shown below:
+Though in this article, we focused primarily on expanding the Unamanged/Managed OS disk of the VM, the developed script may also be used for expanding the data disks attached to the VM. For example, to expand the first data disk attached to the VM, replace the ```OSDisk``` object of ```StorageProfile``` with ```DataDisks``` array and use a numeric index to obtain a reference to first attached data disk, as shown below:
 
+Unamanged Disk:
 ```Powershell
 $vm.StorageProfile.DataDisks[0].DiskSizeGB = 1023
 ```
+Managed Disk:
+```Powershell
+$disk= Get-AzureRmDisk -ResourceGroupName $rgName -DiskName $vm.StorageProfile.DataDisks[0].Name
+$disk.DiskSizeGB = 1023
+```
+
 Similarly you may reference other data disks attached to the VM, either by using an index as shown above or the ```Name``` property of the disk as illustrated below:
 
+Unamanged Disk:
 ```Powershell
-($vm.StorageProfile.DataDisks | Where {$_.Name -eq 'my-second-data-disk'})[0].DiskSizeGB = 1023
+($vm.StorageProfile.DataDisks | Where ({$_.Name -eq 'my-second-data-disk'}).DiskSizeGB = 1023
+```
+Manged Disk:
+```Powershell
+(Get-AzureRmDisk -ResourceGroupName $rgName -DiskName ($vm.StorageProfile.DataDisks | Where ({$_.Name -eq 'my-second-data-disk'})).Name).DiskSizeGB = 1023
 ```
 
 If you want to find out how to attach disks to an Azure Resource Manager VM, check this [article](../articles/virtual-machines/windows/attach-managed-disk-portal.md?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).


### PR DESCRIPTION
With the introduction of Managed Disks in Azure, the approach for disk resizing has changed. The way to expand Managed disk size is different from Unmanaged disks. What approach and PS code is shown in this docs article is only for expanding OS drive size for Unmanaged disks. I have added the PS approach and code for expanding OS drives size for Managed disks. I have tried to keep the flow and formatting intact as per the original, and have also added the relevant section on Data Disks pertaining to Managed disks too. There were some script errors in existing PS code and some missing Info, which I corrected.