### PR TITLE
Improve hyperlink formatting.

### DIFF
--- a/articles/mysql/concepts-compatibility.md
+++ b/articles/mysql/concepts-compatibility.md
@@ -19,8 +19,8 @@ Azure Database for MySQL uses the world's most popular community edition of MySQ
 | **Driver** | **Links** | **Compatible Versions** | **Uncompatible Versions** | **Notes** |
 | :-------- | :------------------------ | :----------- | :---------------------- | :--------------------------------------- |
 | PHP | http://php.net/downloads.php | 5.5 5.6 7.x | 5.3 | For PHP 7.0 connection with SSL MySQLi, add MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT in the connection string. <br> ```mysqli_real_connect($conn, $host, $username, $password, $db_name, 3306, NULL, MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT);```<br> PDO set: ```PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT``` option to false.|
-| .Net | [MySqlConnector on Github]: https://github.com/mysql-net/MySqlConnector/releases <br> [Installation package from Nuget]:<br> https://www.nuget.org/packages/MySqlConnector/ | 0.27 and after | 0.26.5 and before | |
-| Nodejs |  [MySQLjs on Github]:<br> https://github.com/mysqljs/mysql/releases <br> [Installation package from NPM]:<br> Run “npm install mysql” from NPM | 2.15 | 2.14.1 and before | |
+| .Net | [MySqlConnector on GitHub](https://github.com/mysql-net/MySqlConnector) <br> [Installation package from Nuget](https://www.nuget.org/packages/MySqlConnector/) | 0.27 and after | 0.26.5 and before | |
+| Nodejs |  [MySQLjs on GitHub](https://github.com/mysqljs/mysql/releases) <br> Installation package from NPM:<br> Run `npm install mysql` from NPM | 2.15 | 2.14.1 and before | |
 | GO | https://github.com/go-sql-driver/mysql/releases | 1.3 | 1.2 and before | Use allowNativePasswords=true in the connection string |
 | Python | https://pypi.python.org/pypi/mysql-connector-python | 1.2.3, 2.0, 2.1, 2.2 | 1.2.2 and before | |
 | Java | https://downloads.mariadb.org/connector-java/ | 2.1 2.0 1.6 | 1.5.5 and before | |


### PR DESCRIPTION
Use Markdown hyperlink syntax and remove extraneous square brackets.