### PR TITLE
AzureSearch_Skip and AzureSearch_SkipContent require value 'True' not…

### DIFF
--- a/articles/search/search-howto-indexing-azure-blob-storage.md
+++ b/articles/search/search-howto-indexing-azure-blob-storage.md
@@ -272,8 +272,8 @@ The configuration parameters described above apply to all blobs. Sometimes, you 
 
 | Property name | Property value | Explanation |
 | --- | --- | --- |
-| AzureSearch_Skip |"true" |Instructs the blob indexer to completely skip the blob. Neither metadata nor content extraction is attempted. This is useful when a particular blob fails repeatedly and interrupts the indexing process. |
-| AzureSearch_SkipContent |"true" |This is equivalent of `"dataToExtract" : "allMetadata"` setting described [above](#PartsOfBlobToIndex) scoped to a particular blob. |
+| AzureSearch_Skip |"True" |Instructs the blob indexer to completely skip the blob. Neither metadata nor content extraction is attempted. This is useful when a particular blob fails repeatedly and interrupts the indexing process. |
+| AzureSearch_SkipContent |"True" |This is equivalent of `"dataToExtract" : "allMetadata"` setting described [above](#PartsOfBlobToIndex) scoped to a particular blob. |
 
 ## Incremental indexing and deletion detection
 When you set up a blob indexer to run on a schedule, it re-indexes only the changed blobs, as determined by the blob's `LastModified` timestamp.


### PR DESCRIPTION
… 'true'

It appears these fields are case sensitive and require an uppercase T.