### PR TITLE
Updated existing connections behavior

### DIFF
--- a/articles/load-balancer/load-balancer-custom-probe-overview.md
+++ b/articles/load-balancer/load-balancer-custom-probe-overview.md
@@ -22,7 +22,7 @@ ms.author: kumud
 
 [!INCLUDE [load-balancer-basic-sku-include.md](../../includes/load-balancer-basic-sku-include.md)]
 
-Azure Load Balancer offers the capability to monitor the health of server instances by using probes. When a probe fails to respond, Load Balancer stops sending new connections to the unhealthy instance. The existing connections are not affected, and new connections are sent to healthy instances.
+Azure Load Balancer offers the capability to monitor the health of server instances by using probes. When a probe fails to respond, Load Balancer stops sending new connections to the unhealthy instance, and new connections are sent to healthy instances. If there is at least one healthy instance remaining, existing connections to failed backend instances will not be affected. If no healthy instances remain, all existing connections to unhealthy instances will be terminated.
 
 Cloud service roles (worker roles and web roles) use a guest agent for probe monitoring. TCP or HTTP custom probes must be configured when you use VMs behind Load Balancer.
 


### PR DESCRIPTION
Updated doc to reflect behavior that occurs when the final probe fails in a Load Balancer. Existing connections persist *only* if there is at least one remaining healthy instance. If all instances are unhealthy, the connections *do not* persist and are terminated immediately.