### PR TITLE
Fix DSC extension version to 2.70 instead of 2.7

### DIFF
--- a/articles/automation/automation-dsc-onboarding.md
+++ b/articles/automation/automation-dsc-onboarding.md
@@ -33,7 +33,7 @@ Azure Automation DSC can be used to manage a variety of machines:
 In addition, if you are not ready to manage machine configuration from the cloud, Azure Automation DSC can also be used as a report-only endpoint. This allows you to set (push) desired configuration through DSC on-premises and view rich reporting details on node compliance with the desired state in Azure Automation.
 
 > [!NOTE]
-> Managing Azure VMs with DSC is included at no extra charge if the virtual machine DSC extension installed is greater than 2.7.  Please refer to the [**Automation pricing page**](https://azure.microsoft.com/en-us/pricing/details/automation/) for more details.
+> Managing Azure VMs with DSC is included at no extra charge if the virtual machine DSC extension installed is greater than 2.70. Please refer to the [**Automation pricing page**](https://azure.microsoft.com/en-us/pricing/details/automation/) for more details.
 
 
 The following sections outline how you can onboard each type of machine to Azure Automation DSC.


### PR DESCRIPTION
* Updated version to match portal prompts. v2.7 of DSC extension is old. DSC management with Azure Automation Services and DSC extension v2.70+ is free for Azure VMs.