### PR TITLE
Fixing typo

### DIFF
--- a/articles/cosmos-db/logging.md
+++ b/articles/cosmos-db/logging.md
@@ -381,7 +381,7 @@ To learn about the meaning of the data returned by each log search, see [Interpr
 * Which operations take longer than 3 milliseconds.
 
     ```
-    AzureDiagnostics | where toint(duration_s) > 3000 and ResourceProvider=="MICROSOFT.DOCUMENTDB" and Category=="DataPlaneRequests" | summarize count() by clientIpAddress_s, TimeGenerated
+    AzureDiagnostics | where toint(duration_s) > 30000 and ResourceProvider=="MICROSOFT.DOCUMENTDB" and Category=="DataPlaneRequests" | summarize count() by clientIpAddress_s, TimeGenerated
     ```
 
 * Which agent is running the operations.


### PR DESCRIPTION
There are [10,000 ticks per millisecond (instead of 1,000)](https://msdn.microsoft.com/en-us/library/system.timespan.tickspersecond(v=vs.110).aspx)