### PR TITLE
Update durable-functions-eternal-orchestrations.md

### DIFF
--- a/articles/azure-functions/durable-functions-eternal-orchestrations.md
+++ b/articles/azure-functions/durable-functions-eternal-orchestrations.md
@@ -48,7 +48,7 @@ public static async Task Run(
     DateTime nextCleanup = context.CurrentUtcDateTime.AddHours(1);
     await context.CreateTimer<string>(nextCleanup);
 
-    context.ContinueAsNew();
+    context.ContinueAsNew(null);
 }
 ```
 


### PR DESCRIPTION
`ContinueAsNew` requires a parameter; I'm guessing this is supposed to be `(null)` here.