### PR TITLE
Logic Apps - Document the disableByteOrderMark for XML Transforms

### DIFF
--- a/articles/logic-apps/logic-apps-enterprise-integration-transform.md
+++ b/articles/logic-apps/logic-apps-enterprise-integration-transform.md
@@ -74,6 +74,28 @@ You can now test your transform by making a request to the HTTP endpoint.
 * Upload existing maps  
 * Includes support for the XML format.
 
+## Adanced features
+The following features can only be accessed from the code view.
+
+### Byte Order Mark
+By default, the response from the transformation will start with the Byte Order Mark (BOM). To disable this functionality, specify `disableByteOrderMark` for the `transformOptions` property:
+
+````json
+"Transform_XML": {
+    "inputs": {
+        "content": "@{triggerBody()}",
+        "integrationAccount": {
+            "map": {
+                "name": "TestMap"
+            }
+        },
+        "transformOptions": "disableByteOrderMark"
+    },
+    "runAfter": {},
+    "type": "Xslt"
+}
+````
+
 ## Learn more
 * [Learn more about the Enterprise Integration Pack](../logic-apps/logic-apps-enterprise-integration-overview.md "Learn about Enterprise Integration Pack")  
 * [Learn more about maps](../logic-apps/logic-apps-enterprise-integration-maps.md "Learn about enterprise integration maps")  


### PR DESCRIPTION
Adds details of how to use the `disableByteOrderMark` feature in Logic App XML Transforms.