### PR TITLE
Missing parameter --zookeeper to read Kafka records script

### DIFF
--- a/articles/hdinsight/kafka/apache-kafka-get-started.md
+++ b/articles/hdinsight/kafka/apache-kafka-get-started.md
@@ -179,7 +179,7 @@ Use the following steps to store records into the test topic you created earlier
 2. Use a script provided with Kafka to read records from the topic:
    
     ```bash
-    /usr/hdp/current/kafka-broker/bin/kafka-console-consumer.sh --bootstrap-server $KAFKABROKERS --topic test --from-beginning
+    /usr/hdp/current/kafka-broker/bin/kafka-console-consumer.sh --bootstrap-server $KAFKABROKERS --zookeeper $KAFKAZKHOSTS --topic test --from-beginning
     ```
    
     This command retrieves the records from the topic and displays them. Using `--from-beginning` tells the consumer to start from the beginning of the stream, so all records are retrieved.


### PR DESCRIPTION
The script kafka-console-consumer.sh requires the --zookeeper parameter which can be resolved from $KAFKAZKHOSTS