### PR TITLE
Add missing url scheme in authentication sample

### DIFF
--- a/includes/mobile-windows-universal-dotnet-authenticate-app-with-token.md
+++ b/includes/mobile-windows-universal-dotnet-authenticate-app-with-token.md
@@ -49,7 +49,7 @@
                 {
                     // Login with the identity provider.
                     user = await App.MobileService
-                        .LoginAsync(provider);
+                        .LoginAsync(provider, "{url_scheme_of_your_app}");
    
                     // Create and store the user credentials.
                     credential = new PasswordCredential(provider.ToString(),


### PR DESCRIPTION
In the Azure.Mobile.Client v4.x API, the LoginAsync method does not contain an overload that only takes in one parameter.
  