### PR TITLE
SAML attribute names are case-sensitive

### DIFF
--- a/articles/active-directory/active-directory-saas-amazon-web-service-tutorial.md
+++ b/articles/active-directory/active-directory-saas-amazon-web-service-tutorial.md
@@ -114,8 +114,8 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 	
 	| Attribute Name  | Attribute Value | Namespace |
 	| --------------- | --------------- | --------------- |
-	| rolesessionname | user.userprincipalname | https://aws.amazon.com/SAML/Attributes |
-	| role 			  | user.assignedroles |  https://aws.amazon.com/SAML/Attributes |
+	| RoleSessionName | user.userprincipalname | https://aws.amazon.com/SAML/Attributes |
+	| Role 			  | user.assignedroles |  https://aws.amazon.com/SAML/Attributes |
 	
 	>[!TIP]
 	>You need to configure the user provisioning in Azure AD to fetch all the roles from AWS Console. Refer the provisioning steps below.


### PR DESCRIPTION
AWS SAML federation requires "Role" and "RoleSessionName" attribute. If the names are lowercase then AWS responses "Your request included an invalid SAML response" error.

- https://docs.aws.amazon.com/en_us/IAM/latest/UserGuide/troubleshoot_saml.html#troubleshoot_saml_invalid-response
- https://docs.aws.amazon.com/en_us/IAM/latest/UserGuide/troubleshoot_saml.html#troubleshoot_saml_missing-rolesessionname