### PR TITLE
Update link for the Printable Markdown Cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can create reusable content sections to be included in one or more articles.
 All the articles in this repository use GitHub flavored markdown.  Here's a list of resources.
 
 * [Markdown basics](https://help.github.com/articles/markdown-basics/)
-* [Printable markdown cheatsheet](./contributor-guide/media/documents/markdown-cheatsheet.pdf?raw=true)
+* [Printable markdown cheatsheet](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf)
 
 
 ## Labels


### PR DESCRIPTION
It looks like cheatsheet was removed with commit https://github.com/MicrosoftDocs/azure-docs/commit/337eb2f45e2671d1bde43bdb4719b874d50f0b63 so updating the reference to the official GitHub markdown cheatsheet to match the markdown basics.