### PR TITLE
Adding example on how to get $ckt variable

### DIFF
--- a/articles/expressroute/how-to-routefilter-powershell.md
+++ b/articles/expressroute/how-to-routefilter-powershell.md
@@ -149,6 +149,7 @@ Set-AzureRmRouteFilter -RouteFilter $routefilter
 Run the following command to attach the route filter to the ExpressRoute circuit, assuming you have only Microsoft peering:
 
 ```powershell
+$ckt = Get-AzureRmExpressRouteCircuit -Name "ExpressRouteARMCircuit" -ResourceGroupName "ExpressRouteResourceGroup"
 $ckt.Peerings[0].RouteFilter = $routefilter 
 Set-AzureRmExpressRouteCircuit -ExpressRouteCircuit $ckt
 ```


### PR DESCRIPTION
$ckt = Get-AzureRmExpressRouteCircuit -Name "ExpressRouteARMCircuit" -ResourceGroupName "ExpressRouteResourceGroup" added to clarify prerequisite variable.