### PR TITLE
Add attributes for publicatios extend metadata

### DIFF
--- a/articles/cognitive-services/Academic-Knowledge/PaperEntityAttributes.md
+++ b/articles/cognitive-services/Academic-Knowledge/PaperEntityAttributes.md
@@ -56,6 +56,9 @@ S.U		| Source URL
 VFN		| Venue Full Name - full name of the Journal or Conference
 VSN		| Venue Short Name - short name of the Journal or Conference
 V		| Volume - journal volume
+BV		| Journal Name
+BT		| 
+PB		| Journal Abreviations
 I 		| Issue - journal issue
 FP		| FirstPage - first page of paper
 LP 		| LastPage - last page of paper


### PR DESCRIPTION
I notice when publications are published in a journal, there are other attributes that are not in the docs (_BV, BT, PB_).  I don't know exactly what means each attribute, but I added some description;  they are mostly related with journals meta data.

Here is an example of the extended meta data for this [publication](https://academic.microsoft.com/#/detail/992652367). This is the query executed. 

`
https://westus.api.cognitive.microsoft.com/academic/v1.0/evaluate?expr=Id=992652367&attributes=Id,Ti,L,Y,D,CC,ECC,AA.AuN,AA.AuId,AA.AfN,AA.AfId,AA.S,F.FN,F.FId,J.JN.J.JId,C.CN,C.CId,RId,W,E&
`

{"BV":"The Journal of Academic Librarianship","BT":"a","PB":"JAI"}