### PR TITLE
Broken hyperlink returns 404 (create linux vhd)

### DIFF
--- a/articles/virtual-machines/linux/endorsed-distros.md
+++ b/articles/virtual-machines/linux/endorsed-distros.md
@@ -19,7 +19,7 @@ ms.author: szark
 
 ---
 # Linux on distributions endorsed by Azure
-Partners provide Linux images in the Azure Marketplace. We are working with various Linux communities to add even more flavors to the Endorsed Distribution list. In the meantime, for distributions that are not available from the Marketplace, you can always bring your own Linux by following the guidelines at [Creating and uploading a virtual hard disk that contains the Linux operating system](classic/create-upload-vhd.md?toc=%2fazure%2fvirtual-machines%2flinux%2fclassic%2ftoc.json).
+Partners provide Linux images in the Azure Marketplace. We are working with various Linux communities to add even more flavors to the Endorsed Distribution list. In the meantime, for distributions that are not available from the Marketplace, you can always bring your own Linux by following the guidelines at [Create &and upload a virtual hard disk that contains the Linux operating system](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic).
 
 ## Supported distributions and versions
 The following table lists the Linux distributions and versions that are supported on Azure. Refer to [Support for Linux images in Microsoft Azure](https://support.microsoft.com/help/2941892/support-for-linux-and-open-source-technology-in-azure) for more detailed information about support for Linux and open source technology in Azure.

--- a/articles/virtual-machines/linux/endorsed-distros.md
+++ b/articles/virtual-machines/linux/endorsed-distros.md
@@ -19,7 +19,7 @@ ms.author: szark
 
 ---
 # Linux on distributions endorsed by Azure
-Partners provide Linux images in the Azure Marketplace. We are working with various Linux communities to add even more flavors to the Endorsed Distribution list. In the meantime, for distributions that are not available from the Marketplace, you can always bring your own Linux by following the guidelines at [Create &and upload a virtual hard disk that contains the Linux operating system](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic).
+Partners provide Linux images in the Azure Marketplace. We are working with various Linux communities to add even more flavors to the Endorsed Distribution list. In the meantime, for distributions that are not available from the Marketplace, you can always bring your own Linux by following the guidelines at [Create and upload a virtual hard disk that contains the Linux operating system](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic).
 
 ## Supported distributions and versions
 The following table lists the Linux distributions and versions that are supported on Azure. Refer to [Support for Linux images in Microsoft Azure](https://support.microsoft.com/help/2941892/support-for-linux-and-open-source-technology-in-azure) for more detailed information about support for Linux and open source technology in Azure.


### PR DESCRIPTION
The hyper link for creating and uploading vhd is broken and points to "classic/create-upload-vhd.md?toc=%2fazure%2fvirtual-machines%2flinux%2fclassic%2ftoc.json"

I have updated the doc to point to https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic