### PR TITLE
Correct the remount instruction.

### DIFF
--- a/articles/virtual-machines/linux/mount-azure-file-storage-on-linux-using-smb.md
+++ b/articles/virtual-machines/linux/mount-azure-file-storage-on-linux-using-smb.md
@@ -135,7 +135,7 @@ For this detailed walkthrough, we create the prerequisites needed to first creat
     When you reboot the Linux VM, the mounted SMB share is unmounted during shutdown. To remount the SMB share on boot, add a line to the Linux /etc/fstab. Linux uses the fstab file to list the file systems that it needs to mount during the boot process. Adding the SMB share ensures that the File storage share is a permanently mounted file system for the Linux VM. Adding the File storage SMB share to a new VM is possible when you use cloud-init.
 
     ```bash
-    //myaccountname.file.core.windows.net/mysharename /mymountpoint cifs vers=3.0,username=myaccountname,password=StorageAccountKeyEndingIn==,dir_mode=0777,file_mode=0777
+    //myaccountname.file.core.windows.net/mystorageshare /mnt/mymountdirectory cifs vers=3.0,username=mystorageaccount,password=StorageAccountKeyEndingIn==,dir_mode=0777,file_mode=0777
     ```
 
 ## Next steps


### PR DESCRIPTION
Use the same account and share names as other example commands, and clarify specifying full path to local mount point.