### PR TITLE
fix syntax highlighting for csharp code

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw-secure-basic.md
+++ b/articles/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw-secure-basic.md
@@ -73,7 +73,7 @@ Add the `ClientAuthMiddleware.cs` class under the *App_Start* folder. To do so:
 
 3. Open the *App_Start\ClientAuthMiddleware.cs* file, and replace the file content with following code:
 
-    ```C#
+    ```csharp
     
     using Microsoft.Owin;
     using System;
@@ -191,7 +191,7 @@ Add an OWIN startup class named `Startup.cs` to the API. To do so:
 
 2. Open the *Startup.cs* file, and replace the file content with following code:
 
-    ```C#
+    ```csharp
     using Microsoft.Owin;
     using Owin;
     

--- a/articles/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw-secure-cert.md
+++ b/articles/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw-secure-cert.md
@@ -178,7 +178,7 @@ Replace the certificate's **Subject name**, **Issuer name**, and **Certificate t
 ### 6.2 Add the IsValidClientCertificate function
 Open the *Controllers\IdentityController.cs* file, and then add to the `Identity` controller class the following function: 
 
-```C#
+```csharp
 private bool IsValidClientCertificate()
 {
     string ClientCertificateSubject = ConfigurationManager.AppSettings["ClientCertificate:Subject"];
@@ -280,7 +280,7 @@ In the preceding sample code, we accept the certificate as valid only if all the
 ### 6.3 Call the IsValidClientCertificate function
 Open the *Controllers\IdentityController.cs* file and then, at the beginning of the `SignUp()` function, add the following code snippet: 
 
-```C#
+```csharp
 if (IsValidClientCertificate() == false)
 {
     return Content(HttpStatusCode.Conflict, new B2CResponseContent("Your client certificate is not valid", HttpStatusCode.Conflict));

--- a/articles/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw.md
+++ b/articles/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw.md
@@ -85,7 +85,7 @@ Create a model that represents input claims by doing the following:
 
 3. Name the class `InputClaimsModel`, and then add the following properties to the `InputClaimsModel` class:
 
-    ```C#
+    ```csharp
     namespace Contoso.AADB2C.API.Models
     {
         public class InputClaimsModel
@@ -99,7 +99,7 @@ Create a model that represents input claims by doing the following:
 
 4. Create a new model, `OutputClaimsModel`, and then add the following properties to the `OutputClaimsModel` class:
 
-    ```C#
+    ```csharp
     namespace Contoso.AADB2C.API.Models
     {
         public class OutputClaimsModel
@@ -111,7 +111,7 @@ Create a model that represents input claims by doing the following:
 
 5. Create one more model, `B2CResponseContent`, which you use to throw input-validation error messages. Add the following properties to the `B2CResponseContent` class, provide the missing references, and then save the file:
 
-    ```C#
+    ```csharp
     namespace Contoso.AADB2C.API.Models
     {
         public class B2CResponseContent
@@ -149,7 +149,7 @@ In the web API, a _controller_ is an object that handles HTTP requests. The cont
 
 4. If the *IdentityController.cs* file is not open already, double-click it, and then replace the code in the file with the following code:
 
-    ```C#
+    ```csharp
     using Contoso.AADB2C.API.Models;
     using Newtonsoft.Json;
     using System;

--- a/articles/active-directory-b2c/active-directory-b2c-devquickstarts-graph-dotnet.md
+++ b/articles/active-directory-b2c/active-directory-b2c-devquickstarts-graph-dotnet.md
@@ -134,7 +134,7 @@ Any request to the Graph API requires an access token for authentication. `B2CGr
 
 When `B2CGraphClient` runs, it creates an instance of the `B2CGraphClient` class. The constructor for this class sets up an ADAL authentication scaffolding:
 
-```C#
+```csharp
 public B2CGraphClient(string clientId, string clientSecret, string tenant)
 {
     // The client_id, client_secret, and tenant are provided in Program.cs, which pulls the values from App.config
@@ -153,7 +153,7 @@ public B2CGraphClient(string clientId, string clientSecret, string tenant)
 
 We'll use the `B2C Get-User` command as an example. When `B2C Get-User` is invoked without any additional inputs, the CLI calls the `B2CGraphClient.GetAllUsers(...)` method. This method calls `B2CGraphClient.SendGraphGetRequest(...)`, which submits an HTTP GET request to the Graph API. Before `B2CGraphClient.SendGraphGetRequest(...)` sends the GET request, it first gets an access token by using ADAL:
 
-```C#
+```csharp
 public async Task<string> SendGraphGetRequest(string api, string query)
 {
     // First, use ADAL to acquire a token by using the app's identity (the credential)
@@ -187,7 +187,7 @@ There are two important things to note:
 
 Both of these details are handled in the `B2CGraphClient.SendGraphGetRequest(...)` method:
 
-```C#
+```csharp
 public async Task<string> SendGraphGetRequest(string api, string query)
 {
     ...

--- a/articles/active-directory-b2c/active-directory-b2c-devquickstarts-native-dotnet.md
+++ b/articles/active-directory-b2c/active-directory-b2c-devquickstarts-native-dotnet.md
@@ -70,7 +70,7 @@ PM> Install-Package Microsoft.Identity.Client -IncludePrerelease
 ### Enter your B2C details
 Open the file `Globals.cs` and replace each of the property values with your own. This class is used throughout `TaskClient` to reference commonly used values.
 
-```C#
+```csharp
 public static class Globals
 {
     ...
@@ -91,7 +91,7 @@ public static class Globals
 ### Create the PublicClientApplication
 The primary class of MSAL is `PublicClientApplication`. This class represents your application in the Azure AD B2C system. When the app initalizes, create an instance of `PublicClientApplication` in `MainWindow.xaml.cs`. This can be used throughout the window.
 
-```C#
+```csharp
 protected async override void OnInitialized(EventArgs e)
 {
     base.OnInitialized(e);
@@ -109,7 +109,7 @@ protected async override void OnInitialized(EventArgs e)
 ### Initiate a sign-up flow
 When a user opts to signs up, you want to initiate a sign-up flow that uses the sign-up policy you created. By using MSAL, you just call `pca.AcquireTokenAsync(...)`. The parameters you pass to `AcquireTokenAsync(...)` determine which token you receive, the policy used in the authentication request, and more.
 
-```C#
+```csharp
 private async void SignUp(object sender, RoutedEventArgs e)
 {
     AuthenticationResult result = null;
@@ -160,7 +160,7 @@ private async void SignUp(object sender, RoutedEventArgs e)
 ### Initiate a sign-in flow
 You can initiate a sign-in flow in the same way that you initiate a sign-up flow. When a user signs in, make the same call to MSAL, this time by using your sign-in policy:
 
-```C#
+```csharp
 private async void SignIn(object sender = null, RoutedEventArgs args = null)
 {
     AuthenticationResult result = null;
@@ -175,7 +175,7 @@ private async void SignIn(object sender = null, RoutedEventArgs args = null)
 ### Initiate an edit-profile flow
 Again, you can execute an edit-profile policy in the same fashion:
 
-```C#
+```csharp
 private async void EditProfile(object sender, RoutedEventArgs e)
 {
     AuthenticationResult result = null;
@@ -191,7 +191,7 @@ In all of these cases, MSAL either returns a token in `AuthenticationResult` or 
 ### Check for tokens on app start
 You can also use MSAL to keep track of the user's sign-in state.  In this app, we want the user to remain signed in even after they close the app & re-open it.  Back inside the `OnInitialized` override, use MSAL's `AcquireTokenSilent` method to check for cached tokens:
 
-```C#
+```csharp
 AuthenticationResult result = null;
 try
 {
@@ -230,7 +230,7 @@ catch (MsalException ex)
 ## Call the task API
 You have now used MSAL to execute policies and get tokens.  When you want to use one these tokens to call the task API, you can again use MSAL's `AcquireTokenSilent` method to check for cached tokens:
 
-```C#
+```csharp
 private async void GetTodoList()
 {
     AuthenticationResult result = null;
@@ -275,7 +275,7 @@ private async void GetTodoList()
 
 When the call to `AcquireTokenSilentAsync(...)` succeeds and a token is found in the cache, you can add the token to the `Authorization` header of the HTTP request. The task web API will use this header to authenticate the request to read the user's to-do list:
 
-```C#
+```csharp
     ...
     // Once the token has been returned by MSAL, add it to the http authorization header, before making the call to access the To Do list service.
     httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", result.Token);
@@ -288,7 +288,7 @@ When the call to `AcquireTokenSilentAsync(...)` succeeds and a token is found in
 ## Sign the user out
 Finally, you can use MSAL to end a user's session with the app when the user selects **Sign out**.  When using MSAL, this is accomplished by clearing all of the tokens from the token cache:
 
-```C#
+```csharp
 private void SignOut(object sender, RoutedEventArgs e)
 {
     // Clear any remnants of the user's session.

--- a/articles/active-directory-b2c/active-directory-b2c-ui-customization-custom-dynamic.md
+++ b/articles/active-directory-b2c/active-directory-b2c-ui-customization-custom-dynamic.md
@@ -101,7 +101,7 @@ Your custom HTML5 template is based on the Azure AD B2C built-in HTML5 template.
 
 7. For this walkthrough, we remove the reference to layout-page. Add the following code snippet to _unified.cshtml_:
 
-    ```C#
+    ```csharp
     @{
         Layout = null;
     }
@@ -260,7 +260,7 @@ Modify the HomeController `unified` method to accept the campaignId parameter. T
 
 1. Open the *Controllers\HomeController.cs* file, and then change the `unified` method by adding the following code snippet:
 
-    ```C#
+    ```csharp
     public IActionResult unified(string campaignId)
     {
         // If campaign ID is Hawaii, show Hawaii background

--- a/articles/active-directory/develop/active-directory-conditional-access-developer.md
+++ b/articles/active-directory/develop/active-directory-conditional-access-developer.md
@@ -105,7 +105,7 @@ The claims challenge is inside the ```WWW-Authenticate``` header, which can be p
 
 The ```WWW-Authenticate``` header does have a unique structure and is not trivial to parse in order to extract values.  Here's a short method to help.
 
-```C#
+```csharp
         /// <summary>
         /// This method extracts the claims value from the 403 error response from MS Graph. 
         /// </summary>

--- a/articles/active-directory/develop/active-directory-devquickstarts-dotnet.md
+++ b/articles/active-directory/develop/active-directory-devquickstarts-dotnet.md
@@ -71,7 +71,7 @@ The basic principle behind ADAL is that whenever your app needs an access token,
 
 * In the `DirectorySearcher` project, open `MainWindow.xaml.cs` and locate the `MainWindow()` method.  The first step is to initialize your app's `AuthenticationContext` - ADAL's primary class.  This is where you pass ADAL the coordinates it needs to communicate with Azure AD and tell it how to cache tokens.
 
-```C#
+```csharp
 public MainWindow()
 {
     InitializeComponent();
@@ -84,7 +84,7 @@ public MainWindow()
 
 * Now locate the `Search(...)` method, which will be invoked when the user clicks the "Search" button in the app's UI.  This method makes a GET request to the Azure AD Graph API to query for users whose UPN begins with the given search term.  But in order to query the Graph API, you need to include an access_token in the `Authorization` header of the request - this is where ADAL comes in.
 
-```C#
+```csharp
 private async void Search(object sender, RoutedEventArgs e)
 {
     // Validate the Input String
@@ -118,7 +118,7 @@ private async void Search(object sender, RoutedEventArgs e)
 * Notice that the `AuthenticationResult` object contains a `UserInfo` object that can be used to collect information your app may need.  In the DirectorySearcher, `UserInfo` is used to customize the app's UI with the user's id.
 * When the user clicks the "Sign Out" button, we want to ensure that the next call to `AcquireTokenAsync(...)` will ask the user to sign in.  With ADAL, this is as easy as clearing the token cache:
 
-```C#
+```csharp
 private void SignOut(object sender = null, RoutedEventArgs args = null)
 {
     // Clear the token cache
@@ -130,7 +130,7 @@ private void SignOut(object sender = null, RoutedEventArgs args = null)
 
 * However, if the user does not click the "Sign Out" button, you will want to maintain the user's session for the next time they run the DirectorySearcher.  When the app launches, you can check ADAL's token cache for an existing token and update the UI accordingly.  In the `CheckForCachedToken()` method, make another call to `AcquireTokenAsync(...)`, this time passing in the `PromptBehavior.Never` parameter.  `PromptBehavior.Never` will tell ADAL that the user should not be prompted for sign in, and ADAL should instead throw an exception if it is unable to return a token.
 
-```C#
+```csharp
 public async void CheckForCachedToken() 
 {
     // As the application starts, try to get an access token without prompting the user.  If one exists, show the user as signed in.

--- a/articles/active-directory/develop/active-directory-devquickstarts-webapi-dotnet.md
+++ b/articles/active-directory/develop/active-directory-devquickstarts-webapi-dotnet.md
@@ -70,7 +70,7 @@ To validate incoming requests and tokens, you need to set up your application to
 
 3. Change the class declaration to `public partial class Startup`. We’ve already implemented part of this class for you in another file. In the `Configuration(…)` method, make a call to `ConfgureAuth(…)` to set up authentication for your web app.
 
-    ```C#
+    ```csharp
     public partial class Startup
     {
         public void Configuration(IAppBuilder app)
@@ -82,7 +82,7 @@ To validate incoming requests and tokens, you need to set up your application to
 
 4. Open the file `App_Start\Startup.Auth.cs` and implement the `ConfigureAuth(…)` method. The parameters that you provide in `WindowsAzureActiveDirectoryBearerAuthenticationOptions` will serve as coordinates for your app to communicate with Azure AD.
 
-    ```C#
+    ```csharp
     public void ConfigureAuth(IAppBuilder app)
     {
         app.UseWindowsAzureActiveDirectoryBearerAuthentication(
@@ -96,7 +96,7 @@ To validate incoming requests and tokens, you need to set up your application to
 
 5. Now you can use `[Authorize]` attributes to help protect your controllers and actions with JSON Web Token (JWT) bearer authentication. Decorate the `Controllers\TodoListController.cs` class with an authorize tag. This will force the user to sign in before accessing that page.
 
-    ```C#
+    ```csharp
     [Authorize]
     public class TodoListController : ApiController
     {
@@ -106,7 +106,7 @@ To validate incoming requests and tokens, you need to set up your application to
 
 6. A common requirement for web APIs is to validate the "scopes" present in the token. This ensures that the user has consented to the permissions required to access the To Do List Service.
 
-    ```C#
+    ```csharp
     public IEnumerable<TodoItem> Get()
     {
         // user_impersonation is the default permission exposed by applications in Azure AD

--- a/articles/active-directory/develop/active-directory-devquickstarts-windowsphone.md
+++ b/articles/active-directory/develop/active-directory-devquickstarts-windowsphone.md
@@ -90,7 +90,7 @@ The basic principle behind ADAL is that whenever your app needs an access token,
 
 * The first step is to initialize your app’s `AuthenticationContext` - ADAL’s primary class.  This is where you pass ADAL the coordinates it needs to communicate with Azure AD and tell it how to cache tokens.
 
-```C#
+```csharp
 public MainPage()
 {
     ...
@@ -102,7 +102,7 @@ public MainPage()
 
 * Now locate the `Search(...)` method, which will be invoked when the user cliks the "Search" button in the app's UI.  This method makes a GET request to the Azure AD Graph API to query for users whose UPN begins with the given search term.  But in order to query the Graph API, you need to include an access_token in the `Authorization` header of the request - this is where ADAL comes in.
 
-```C#
+```csharp
 private async void Search(object sender, RoutedEventArgs e)
 {
     ...
@@ -125,7 +125,7 @@ private async void Search(object sender, RoutedEventArgs e)
 ```
 * If interactive authentication is necessary, ADAL will use Windows Phone's Web Authentication Broker (WAB) and [continuation model](http://www.cloudidentity.com/blog/2014/06/16/adal-for-windows-phone-8-1-deep-dive/) to display the Azure AD sign in page.  When the user signs in, your app needs to pass ADAL the results of the WAB interaction.  This is as simple as implementing the `ContinueWebAuthentication` interface:
 
-```C#
+```csharp
 // This method is automatically invoked when the application
 // is reactivated after an authentication interaction through WebAuthenticationBroker.
 public async void ContinueWebAuthentication(WebAuthenticationBrokerContinuationEventArgs args)
@@ -138,7 +138,7 @@ public async void ContinueWebAuthentication(WebAuthenticationBrokerContinuationE
 
 * Now it's time to use the `AuthenticationResult` that ADAL returned to your app.  In the `QueryGraph(...)` callback, attach the access_token you acquired to the GET request in the Authorization header:
 
-```C#
+```csharp
 private async void QueryGraph(AuthenticationResult result)
 {
     if (result.Status != AuthenticationStatus.Success)
@@ -155,13 +155,13 @@ private async void QueryGraph(AuthenticationResult result)
 ```
 * You can also use the `AuthenticationResult` object to display information about the user in your app. In the `QueryGraph(...)` method, use the result to show the user's ID on the page:
 
-```C#
+```csharp
 // Update the Page UI to represent the signed in user
 ActiveUser.Text = result.UserInfo.DisplayableId;
 ```
 * Finally, you can use ADAL to sign the user out of hte application as well.  When the user clicks the "Sign Out" button, we want to ensure that the next call to `AcquireTokenSilentAsync(...)` will fail.  With ADAL, this is as easy as clearing the token cache:
 
-```C#
+```csharp
 private void SignOut()
 {
     // Clear session state from the token cache.

--- a/articles/active-directory/develop/active-directory-devquickstarts-windowsstore.md
+++ b/articles/active-directory/develop/active-directory-devquickstarts-windowsstore.md
@@ -86,7 +86,7 @@ The basic principle behind ADAL is that whenever the app needs an access token, 
 
 1. Initialize the app’s `AuthenticationContext`, which is the primary class of ADAL. This action passes ADAL the coordinates it needs to communicate with Azure AD and tell it how to cache tokens.
 
-    ```C#
+    ```csharp
     public MainPage()
     {
         ...
@@ -97,7 +97,7 @@ The basic principle behind ADAL is that whenever the app needs an access token, 
 
 2. Locate the `Search(...)` method, which is invoked when users click the **Search** button on the app's UI. This method makes a get request to the Azure AD Graph API to query for users whose UPN begins with the given search term. To query the Graph API, include an access token in the request's **Authorization** header. This is where ADAL comes in.
 
-    ```C#
+    ```csharp
     private async void Search(object sender, RoutedEventArgs e)
     {
         ...
@@ -120,20 +120,20 @@ The basic principle behind ADAL is that whenever the app needs an access token, 
     When the app requests a token by calling `AcquireTokenAsync(...)`, ADAL attempts to return a token without asking the user for credentials. If ADAL determines that the user needs to sign in to get a token, it displays a sign-in dialog box, collects the user's credentials, and returns a token after authentication succeeds. If ADAL is unable to return a token for any reason, the *AuthenticationResult* status is an error.
 3. Now it's time to use the access token you just acquired. Also in the `Search(...)` method, attach the token to the Graph API get request in the **Authorization** header:
 
-    ```C#
+    ```csharp
     // Add the access token to the Authorization header of the call to the Graph API, and call the Graph API.
     httpClient.DefaultRequestHeaders.Authorization = new HttpCredentialsHeaderValue("Bearer", result.AccessToken);
 
     ```
 4. You can use the `AuthenticationResult` object to display information about the user in the app, such as the user's ID:
 
-    ```C#
+    ```csharp
     // Update the page UI to represent the signed-in user
     ActiveUser.Text = result.UserInfo.DisplayableId;
     ```
 5. You can also use ADAL to sign users out of the app. When the user clicks the **Sign Out** button, ensure that the next call to `AcquireTokenAsync(...)` shows a sign-in view. With ADAL, this action is as easy as clearing the token cache:
 
-    ```C#
+    ```csharp
     private void SignOut()
     {
         // Clear session state from the token cache.

--- a/articles/active-directory/develop/active-directory-devquickstarts-xamarin.md
+++ b/articles/active-directory/develop/active-directory-devquickstarts-xamarin.md
@@ -95,7 +95,7 @@ Almost all of the app's authentication logic lies in `DirectorySearcher.SearchBy
 
 1. Open DirectorySearcher.cs, and then add a new parameter to the `SearchByAlias(...)` method. `IPlatformParameters` is the contextual parameter that encapsulates the platform-specific objects that ADAL needs to perform the authentication.
 
-    ```C#
+    ```csharp
     public static async Task<List<User>> SearchByAlias(string alias, IPlatformParameters parent)
     {
     ```
@@ -104,7 +104,7 @@ Almost all of the app's authentication logic lies in `DirectorySearcher.SearchBy
 This action passes ADAL the coordinates it needs to communicate with Azure AD.
 3. Call `AcquireTokenAsync(...)`, which accepts the `IPlatformParameters` object and invokes the authentication flow that's necessary to return a token to the app.
 
-    ```C#
+    ```csharp
     ...
         AuthenticationResult authResult = null;
         try
@@ -123,7 +123,7 @@ This action passes ADAL the coordinates it needs to communicate with Azure AD.
     `AcquireTokenAsync(...)` first attempts to return a token for the requested resource (the Graph API in this case) without prompting users to enter their credentials (via caching or refreshing old tokens). As necessary, it shows users the Azure AD sign-in page before acquiring the requested token.
 4. Attach the access token to the Graph API request in the **Authorization** header:
 
-    ```C#
+    ```csharp
     ...
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authResult.AccessToken);
     ...
@@ -134,12 +134,12 @@ That's all for the `DirectorySearcher` PCL and the app's identity-related code. 
 ### Android
 1. In MainActivity.cs, add a call to `SearchByAlias(...)` in the button click handler:
 
-    ```C#
+    ```csharp
     List<User> results = await DirectorySearcher.SearchByAlias(searchTermText.Text, new PlatformParameters(this));
     ```
 2. Override the `OnActivityResult` lifecycle method to forward any authentication redirects back to the appropriate method. ADAL provides a helper method for this in Android:
 
-    ```C#
+    ```csharp
     ...
     protected override void OnActivityResult(int requestCode, Result resultCode, Intent data)
     {
@@ -152,7 +152,7 @@ That's all for the `DirectorySearcher` PCL and the app's identity-related code. 
 ### Windows Desktop
 In MainWindow.xaml.cs, make a call to `SearchByAlias(...)` by passing a `WindowInteropHelper` in the desktop's `PlatformParameters` object:
 
-```C#
+```csharp
 List<User> results = await DirectorySearcher.SearchByAlias(
   SearchTermText.Text,
   new PlatformParameters(PromptBehavior.Auto, this.Handle));
@@ -161,7 +161,7 @@ List<User> results = await DirectorySearcher.SearchByAlias(
 #### iOS
 In DirSearchClient_iOSViewController.cs, the iOS `PlatformParameters` object takes a reference to the View Controller:
 
-```C#
+```csharp
 List<User> results = await DirectorySearcher.SearchByAlias(
   SearchTermText.Text,
   new PlatformParameters(PromptBehavior.Auto, this.Handle));
@@ -170,7 +170,7 @@ List<User> results = await DirectorySearcher.SearchByAlias(
 ### Windows Universal
 In Windows Universal, open MainPage.xaml.cs, and then implement the `Search` method. This method uses a helper method in a shared project to update UI as necessary.
 
-```C#
+```csharp
 ...
 List<User> results = await DirectorySearcherLib.DirectorySearcher.SearchByAlias(SearchTermText.Text, new PlatformParameters(PromptBehavior.Auto, false));
 ...

--- a/articles/active-directory/develop/active-directory-v2-devquickstarts-dotnet-api.md
+++ b/articles/active-directory/develop/active-directory-v2-devquickstarts-dotnet-api.md
@@ -66,7 +66,7 @@ PM> Install-Package Microsoft.IdentityModel.Protocol.Extensions -ProjectName Tod
 * Add an OWIN Startup class to the TodoListService project called `Startup.cs`.  Right click on the project --> **Add** --> **New Item** --> Search for “OWIN”.  The OWIN middleware will invoke the `Configuration(…)` method when your app starts.
 * Change the class declaration to `public partial class Startup` - we’ve already implemented part of this class for you in another file.  In the `Configuration(…)` method, make a call to ConfgureAuth(…) to set up authentication for your web app.
 
-```C#
+```csharp
 public partial class Startup
 {
     public void Configuration(IAppBuilder app)
@@ -78,7 +78,7 @@ public partial class Startup
 
 * Open the file `App_Start\Startup.Auth.cs` and implement the `ConfigureAuth(…)` method, which will set up the Web API to accept tokens from the v2.0 endpoint.
 
-```C#
+```csharp
 public void ConfigureAuth(IAppBuilder app)
 {
         var tvps = new TokenValidationParameters
@@ -115,7 +115,7 @@ public void ConfigureAuth(IAppBuilder app)
 
 * Now you can use `[Authorize]` attributes to protect your controllers and actions with OAuth 2.0 bearer authentication.  Decorate the `Controllers\TodoListController.cs` class with an authorize tag.  This will force the user to sign in before accessing that page.
 
-```C#
+```csharp
 [Authorize]
 public class TodoListController : ApiController
 {
@@ -123,7 +123,7 @@ public class TodoListController : ApiController
 
 * When an authorized caller successfully invokes one of the `TodoListController` APIs, the action might need access to information about the caller.  OWIN provides access to the claims inside the bearer token via the `ClaimsPrincipal` object.  
 
-```C#
+```csharp
 public IEnumerable<TodoItem> Get()
 {
     // You can use the ClaimsPrincipal to access information about the

--- a/articles/active-directory/develop/active-directory-v2-devquickstarts-dotnet-web.md
+++ b/articles/active-directory/develop/active-directory-v2-devquickstarts-dotnet-web.md
@@ -61,7 +61,7 @@ Here, we'll configure the OWIN middleware to use the OpenID Connect authenticati
 3. Add an "OWIN Startup Class" to the project called `Startup.cs`  Right click on the project --> **Add** --> **New Item** --> Search for "OWIN".  The OWIN middleware will invoke the `Configuration(...)` method when your app starts.
 4. Change the class declaration to `public partial class Startup` - we've already implemented part of this class for you in another file.  In the `Configuration(...)` method, make a call to ConfigureAuth(...) to set up authentication for your web app  
 
-        ```C#
+        ```csharp
         [assembly: OwinStartup(typeof(Startup))]
         
         namespace TodoList_WebApp
@@ -78,7 +78,7 @@ Here, we'll configure the OWIN middleware to use the OpenID Connect authenticati
 
 5. Open the file `App_Start\Startup.Auth.cs` and implement the `ConfigureAuth(...)` method.  The parameters you provide in `OpenIdConnectAuthenticationOptions` will serve as coordinates for your app to communicate with Azure AD.  You'll also need to set up Cookie Authentication - the OpenID Connect middleware uses cookies underneath the covers.
 
-        ```C#
+        ```csharp
         public void ConfigureAuth(IAppBuilder app)
                      {
                              app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
@@ -115,7 +115,7 @@ Your app is now properly configured to communicate with the v2.0 endpoint using 
 
 - You can use authorize tags in your controllers to require that user signs in before accessing a certain page.  Open `Controllers\HomeController.cs`, and add the `[Authorize]` tag to the About controller.
         
-        ```C#
+        ```csharp
         [Authorize]
         public ActionResult About()
         {
@@ -124,7 +124,7 @@ Your app is now properly configured to communicate with the v2.0 endpoint using 
 
 - You can also use OWIN to directly issue authentication requests from within your code.  Open `Controllers\AccountController.cs`.  In the SignIn() and SignOut() actions, issue OpenID Connect challenge and sign-out requests, respectively.
 
-        ```C#
+        ```csharp
         public void SignIn()
         {
             // Send an OpenID Connect sign-in request.
@@ -175,7 +175,7 @@ When authenticating users with OpenID Connect, the v2.0 endpoint returns an id_t
 
 - Open the `Controllers\HomeController.cs` file.  You can access the user's claims in your controllers via the `ClaimsPrincipal.Current` security principal object.
 
-        ```C#
+        ```csharp
         [Authorize]
         public ActionResult About()
         {

--- a/articles/active-directory/develop/active-directory-v2-devquickstarts-webapp-webapi-dotnet.md
+++ b/articles/active-directory/develop/active-directory-v2-devquickstarts-webapp-webapi-dotnet.md
@@ -65,7 +65,7 @@ Now configure the OWIN middleware to use the [OpenID Connect authentication prot
 * Open the file `App_Start\Startup.Auth.cs` and add `using` statements for the libraries from above.
 * In the same file, implement the `ConfigureAuth(...)` method.  The parameters you provide in `OpenIDConnectAuthenticationOptions` will serve as coordinates for your app to communicate with Azure AD.
 
-```C#
+```csharp
 public void ConfigureAuth(IAppBuilder app)
 {
     app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
@@ -113,7 +113,7 @@ In the `AuthorizationCodeReceived` notification, we want to use [OAuth 2.0 in ta
 * And add another `using` statement to the `App_Start\Startup.Auth.cs` file for MSAL.
 * Now add a new method, the `OnAuthorizationCodeReceived` event handler.  This handler will use MSAL to acquire an access token to the To-Do List API, and will store the token in MSAL's token cache for later:
 
-```C#
+```csharp
 private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedNotification notification)
 {
         string userObjectId = notification.AuthenticationTicket.Identity.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier").Value;
@@ -141,7 +141,7 @@ Now it's time to actually use the access_token you acquired in step 3.  Open the
     `using Microsoft.Identity.Client;`
 * In the `Index` action, use MSAL's `AcquireTokenSilentAsync` method to get an access_token that can be used to read data from the To-Do List service:
 
-```C#
+```csharp
 // ...
 string userObjectID = ClaimsPrincipal.Current.FindFirst("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier").Value;
 string tenantID = ClaimsPrincipal.Current.FindFirst("http://schemas.microsoft.com/identity/claims/tenantid").Value;
@@ -157,7 +157,7 @@ result = await app.AcquireTokenSilentAsync(new string[] { Startup.clientId });
 * The sample then adds the resulting token to the HTTP GET request as the `Authorization` header, which the To-Do List service uses to authenticate the request.
 * If the To-Do List service returns a `401 Unauthorized` response, the access_tokens in MSAL have become invalid for some reason.  In this case, you should drop any access_tokens from the MSAL cache and show the user a message that they may need to sign in again, which will restart the token acquisition flow.
 
-```C#
+```csharp
 // ...
 // If the call failed with access denied, then drop the current access token from the cache,
 // and show the user an error indicating they might need to sign-in again.
@@ -172,7 +172,7 @@ if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
 
 * Similarly, if MSAL is unable to return an access_token for any reason, you should instruct the user to sign in again.  This is as simple as catching any `MSALException`:
 
-```C#
+```csharp
 // ...
 catch (MsalException ee)
 {

--- a/articles/active-directory/develop/active-directory-v2-devquickstarts-wpf.md
+++ b/articles/active-directory/develop/active-directory-v2-devquickstarts-wpf.md
@@ -66,7 +66,7 @@ The basic principle behind MSAL is that whenever your app needs an access token,
 
 * In the `TodoListClient` project, open `MainWindow.xaml.cs` and locate the `OnInitialized(...)` method.  The first step is to initialize your app's `PublicClientApplication` - MSAL's primary class representing native applications.  This is where you pass MSAL the coordinates it needs to communicate with Azure AD and tell it how to cache tokens.
 
-```C#
+```csharp
 protected override async void OnInitialized(EventArgs e)
 {
         base.OnInitialized(e);
@@ -79,7 +79,7 @@ protected override async void OnInitialized(EventArgs e)
 
 * When the app starts up, we want to check and see if the user is already signed into the app.  However, we don't want to invoke a sign-in UI just yet - we'll make the user click "Sign In" to do so.  Also in the `OnInitialized(...)` method:
 
-```C#
+```csharp
 // As the app starts, we want to check to see if the user is already signed in.
 // You can do so by trying to get a token from MSAL, using the method
 // AcquireTokenSilent.  This forces MSAL to throw an exception if it cannot
@@ -116,7 +116,7 @@ catch (MsalException ex)
 
 * If the user is not signed in and they click the "Sign In" button, we want to invoke a login UI and have the user enter their credentials.  Implement the Sign-In button handler:
 
-```C#
+```csharp
 private async void SignIn(object sender = null, RoutedEventArgs args = null)
 {
         // TODO: Sign the user out if they clicked the "Clear Cache" button
@@ -164,7 +164,7 @@ catch (MsalException ex)
 
 * If the user successfully signs-in, MSAL will receive and cache a token for you, and you can proceed to call the `GetTodoList()` method with confidence.  All that's left to get a user's tasks is to implement the `GetTodoList()` method.
 
-```C#
+```csharp
 private async void GetTodoList()
 {
 
@@ -216,7 +216,7 @@ httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("
 
 - When the user is done managing their To-Do List, they may finally sign out of the app by clicking the "Clear Cache" button.
 
-```C#
+```csharp
 private async void SignIn(object sender = null, RoutedEventArgs args = null)
 {
         // If the user clicked the 'clear cache' button,

--- a/articles/api-management/api-management-howto-disaster-recovery-backup-restore.md
+++ b/articles/api-management/api-management-howto-disaster-recovery-backup-restore.md
@@ -65,7 +65,7 @@ Click **Delegated Permissions** beside the newly added **Windows** **Azure Servi
 
 Prior to invoking the APIs that generate the backup and restore it, it is necessary to get a token. The following example uses the [Microsoft.IdentityModel.Clients.ActiveDirectory](https://www.nuget.org/packages/Microsoft.IdentityModel.Clients.ActiveDirectory) nuget package to retrieve the token.
 
-```c#
+```csharp
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System;
 
@@ -108,7 +108,7 @@ Once the values are specified, the code example should return a token similar to
 
 Before calling the backup and restore operations described in the following sections, set the authorization request header for your REST call.
 
-```c#
+```csharp
 request.Headers.Add(HttpRequestHeader.Authorization, "Bearer " + token);
 ```
 

--- a/articles/api-management/api-management-howto-protect-backend-with-aad.md
+++ b/articles/api-management/api-management-howto-protect-backend-with-aad.md
@@ -78,13 +78,13 @@ The Web API in this example implements a basic calculator service using a model 
 
 Add the following `using` statement to the top of the `CalcInput.cs` file.
 
-```c#
+```csharp
 using Newtonsoft.Json;
 ```
 
 Replace the generated class with the following code.
 
-```c#
+```csharp
 public class CalcInput
 {
     [JsonProperty(PropertyName = "a")]
@@ -101,7 +101,7 @@ Right-click **Controllers** in **Solution Explorer** and choose **Add**->**Contr
 
 Add the following `using` statement to the top of the `CalcController.cs` file.
 
-```c#
+```csharp
 using System.IO;
 using System.Web;
 using APIMAADDemo.Models;
@@ -109,7 +109,7 @@ using APIMAADDemo.Models;
 
 Replace the generated controller class with the following code. This code implements the `Add`, `Subtract`, `Multiply`, and `Divide` operations of the Basic Calculator API.
 
-```c#
+```csharp
 [Authorize]
 public class CalcController : ApiController
 {

--- a/articles/api-management/api-management-howto-setup-delegation.md
+++ b/articles/api-management/api-management-howto-setup-delegation.md
@@ -128,7 +128,7 @@ These code samples show how to take the *delegation validation key*, which is se
 
 **C# code to generate hash of returnUrl**
 
-```c#
+```csharp
 using System.Security.Cryptography;
 
 string key = "delegation validation key";

--- a/articles/api-management/api-management-log-to-eventhub-sample.md
+++ b/articles/api-management/api-management-log-to-eventhub-sample.md
@@ -162,7 +162,7 @@ In this sample, we use the `EventProcessorHost` for simplicity, however it may n
 ### IEventProcessor
 The central concept when using `EventProcessorHost` is to create an implementation of the `IEventProcessor` interface, which contains the method `ProcessEventAsync`. The essence of that method is shown here:
 
-```c#
+```csharp
 async Task IEventProcessor.ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages)
 {
 
@@ -189,7 +189,7 @@ A list of EventData objects are passed into the method and we iterate over that 
 ### HttpMessage
 The `HttpMessage` instance contains three pieces of data:
 
-```c#
+```csharp
 public class HttpMessage
 {
    public Guid MessageId { get; set; }
@@ -212,7 +212,7 @@ For this sample, I decided it would be interesting to push the HTTP Request over
 
 The `IHttpMessageProcessor` implementation looks like this,
 
-```c#
+```csharp
 public class RunscopeHttpMessageProcessor : IHttpMessageProcessor
 {
    private HttpClient _HttpClient;

--- a/articles/application-insights/app-insights-analytics-import.md
+++ b/articles/application-insights/app-insights-analytics-import.md
@@ -193,7 +193,7 @@ This code uses the [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.J
 
 ### Classes
 
-```C#
+```csharp
 namespace IngestionClient 
 { 
     using System; 
@@ -352,7 +352,7 @@ namespace IngestionClient
 
 Use this code for each blob. 
 
-```C#
+```csharp
    AnalyticsDataSourceClient client = new AnalyticsDataSourceClient(); 
 
    var ingestionRequest = new AnalyticsDataSourceIngestionRequest("iKey", "sourceId", "blobUrlWithSas"); 

--- a/articles/application-insights/app-insights-analytics-tour.md
+++ b/articles/application-insights/app-insights-analytics-tour.md
@@ -537,7 +537,7 @@ If your application attaches [custom dimensions (properties) and custom measurem
 
 For example, if your app includes:
 
-```C#
+```csharp
 
     var dimensions = new Dictionary<string, string>
                      {{"p1", "v1"},{"p2", "v2"}};
@@ -610,7 +610,7 @@ If you use [TrackEvent()](app-insights-api-custom-events-metrics.md#trackevent) 
 
 Let's take an example where your app code contains these lines:
 
-```C#
+```csharp
 
     telemetry.TrackEvent("Query",
        new Dictionary<string,string> {{"query", sqlCmd}},

--- a/articles/application-insights/app-insights-api-custom-events-metrics.md
+++ b/articles/application-insights/app-insights-api-custom-events-metrics.md
@@ -155,7 +155,7 @@ To send a single metric value:
 
 *C#, Java*
 
-```C#
+```csharp
     var sample = new MetricTelemetry();
     sample.Name = "metric name";
     sample.Value = 42.3;
@@ -175,7 +175,7 @@ Here is an example of aggregating code:
 
 *C#*
 
-```C#
+```csharp
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -419,7 +419,7 @@ When tracking telemetry manually, the easiest way to ensure telemetry correlatio
 
 *C#*
 
-```C#
+```csharp
 // Establish an operation context and associated telemetry item:
 using (var operation = telemetryClient.StartOperation<RequestTelemetry>("operationName"))
 {
@@ -573,7 +573,7 @@ If [sampling](app-insights-sampling.md) is in operation, the itemCount property 
 ## TrackDependency
 Use the TrackDependency call to track the response times and success rates of calls to an external piece of code. The results appear in the dependency charts in the portal.
 
-```C#
+```csharp
 var success = false;
 var startTime = DateTime.UtcNow;
 var timer = System.Diagnostics.Stopwatch.StartNew();
@@ -910,7 +910,7 @@ To *dynamically stop and start* the collection and transmission of telemetry:
 
 *C#*
 
-```C#
+```csharp
 
     using  Microsoft.ApplicationInsights.Extensibility;
 

--- a/articles/application-insights/app-insights-api-filtering-sampling.md
+++ b/articles/application-insights/app-insights-api-filtering-sampling.md
@@ -119,7 +119,7 @@ You can pass string values from the .config file by providing public named prope
 
 **Alternatively,** you can initialize the filter in code. In a suitable initialization class - for example AppStart in Global.asax.cs - insert your processor into the chain:
 
-```C#
+```csharp
 
     var builder = TelemetryConfiguration.Active.TelemetryProcessorChainBuilder;
     builder.Use((next) => new SuccessfulDependencyFilter(next));
@@ -163,7 +163,7 @@ Filter out bots and web tests. Although Metrics Explorer gives you the option to
 #### Failed authentication
 Filter out requests with a "401" response.
 
-```C#
+```csharp
 
 public void Process(ITelemetry item)
 {
@@ -221,7 +221,7 @@ If you provide a telemetry initializer, it is called whenever any of the Track*(
 
 *C#*
 
-```C#
+```csharp
 
     using System;
     using Microsoft.ApplicationInsights.Channel;
@@ -272,7 +272,7 @@ In ApplicationInsights.config:
 
 *Alternatively,* you can instantiate the initializer in code, for example in Global.aspx.cs:
 
-```C#
+```csharp
     protected void Application_Start()
     {
         // ...

--- a/articles/application-insights/app-insights-asp-net-dependencies.md
+++ b/articles/application-insights/app-insights-asp-net-dependencies.md
@@ -175,7 +175,7 @@ You can write code that sends dependency information, using the same [TrackDepen
 
 For example, if you build your code with an assembly that you didn't write yourself, you could time all the calls to it, to find out what contribution it makes to your response times. To have this data displayed in the dependency charts in Application Insights, send it using `TrackDependency`.
 
-```C#
+```csharp
 
             var startTime = DateTime.UtcNow;
             var timer = System.Diagnostics.Stopwatch.StartNew();

--- a/articles/application-insights/app-insights-cloudservices.md
+++ b/articles/application-insights/app-insights-cloudservices.md
@@ -113,7 +113,7 @@ In Visual Studio, configure the Application Insights SDK for each cloud app proj
 
     In a suitable startup function, set the instrumentation key from the configuration setting in the .cscfg file:
  
-    ```C#
+    ```csharp
    
      TelemetryConfiguration.Active.InstrumentationKey = RoleEnvironment.GetConfigurationSettingValue("APPINSIGHTS_INSTRUMENTATIONKEY");
     ```

--- a/articles/application-insights/app-insights-configuration-with-applicationinsights-config.md
+++ b/articles/application-insights/app-insights-configuration-with-applicationinsights-config.md
@@ -245,7 +245,7 @@ If you want to set the key dynamically - for example if you want to send results
 
 To set the key for all instances of TelemetryClient, including standard telemetry modules, set the key in TelemetryConfiguration.Active. Do this in an initialization method, such as global.aspx.cs in an ASP.NET service:
 
-```C#
+```csharp
 
     protected void Application_Start()
     {
@@ -258,7 +258,7 @@ To set the key for all instances of TelemetryClient, including standard telemetr
 
 If you just want to send a specific set of events to a different resource, you can set the key for a specific TelemetryClient:
 
-```C#
+```csharp
 
     var tc = new TelemetryClient();
     tc.Context.InstrumentationKey = "----- my key ----";

--- a/articles/application-insights/app-insights-sampling.md
+++ b/articles/application-insights/app-insights-sampling.md
@@ -124,7 +124,7 @@ Remove the `AdaptiveSamplingTelemetryProcessor` node from the .config file.
 
 *C#*
 
-```C#
+```csharp
 
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -241,7 +241,7 @@ Instead of setting the sampling parameter in the .config file, you can programma
 
 *C#*
 
-```C#
+```csharp
 
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;

--- a/articles/application-insights/app-insights-snapshot-debugger.md
+++ b/articles/application-insights/app-insights-snapshot-debugger.md
@@ -79,7 +79,7 @@ The following environments are supported:
 
 3. Modify your application's `Startup` class to add and configure the Snapshot Collector's telemetry processor.
 
-   ```C#
+   ```csharp
    using Microsoft.ApplicationInsights.SnapshotCollector;
    using Microsoft.Extensions.Options;
    ...
@@ -137,7 +137,7 @@ The following environments are supported:
 2. Add the [Microsoft.ApplicationInsights.SnapshotCollector](http://www.nuget.org/packages/Microsoft.ApplicationInsights.SnapshotCollector) NuGet package in your app.
 
 3. Snapshots are collected only on exceptions that are reported to Application Insights. You may need to modify your code to report them. The exception handling code depends on the structure of your application, but an example is below:
-    ```C#
+    ```csharp
    TelemetryClient _telemetryClient = new TelemetryClient();
 
    void ExampleRequest()
@@ -288,7 +288,7 @@ Follow these steps to configure your Cloud Service role with a dedicated local r
 ```
 
 2. Modify your role's `OnStart` method to add an environment variable that points to the `SnapshotStore` local resource.
-```C#
+```csharp
    public override bool OnStart()
    {
        Environment.SetEnvironmentVariable("SNAPSHOTSTORE", RoleEnvironment.GetLocalResource("SnapshotStore").RootPath);

--- a/articles/application-insights/app-insights-usage-overview.md
+++ b/articles/application-insights/app-insights-usage-overview.md
@@ -107,7 +107,7 @@ Events can be logged from the client side of the app:
 
 Or from the server side:
 
-```C#
+```csharp
     var tc = new Microsoft.ApplicationInsights.TelemetryClient();
     tc.TrackEvent("CreatedAccount", new Dictionary<string,string> {"AccountType":account.Type}, null);
     ...
@@ -138,7 +138,7 @@ In the Application Insights portal, filter and split your data on the property v
 
 To do this, [set up a telemetry initializer](app-insights-api-filtering-sampling.md##add-properties-itelemetryinitializer):
 
-```C#
+```csharp
 
 
     // Telemetry initializer class
@@ -153,7 +153,7 @@ To do this, [set up a telemetry initializer](app-insights-api-filtering-sampling
 
 In the web app initializer such as Global.asax.cs:
 
-```C#
+```csharp
 
     protected void Application_Start()
     {

--- a/articles/application-insights/app-insights-usage-retention.md
+++ b/articles/application-insights/app-insights-usage-retention.md
@@ -52,7 +52,7 @@ It's good practice to code custom events that represent key business actions, an
 
 Or in ASP.NET server code:
 
-```C#
+```csharp
    telemetry.TrackEvent("won game");
 ```
 

--- a/articles/application-insights/app-insights-usage-send-user-context.md
+++ b/articles/application-insights/app-insights-usage-send-user-context.md
@@ -49,7 +49,7 @@ Create a telemetry initializer, as described in detail [here](https://docs.micro
 
 This example sets the user ID to an identifier that expires after the session. If possible, use a user ID that persists across sessions.
 
-```C#
+```csharp
 
     using System;
     using System.Web;

--- a/articles/application-insights/app-insights-windows-desktop.md
+++ b/articles/application-insights/app-insights-windows-desktop.md
@@ -45,7 +45,7 @@ ms.author: mbullwin
 6. Run your app, and see the telemetry in the resource you created in the Azure Portal.
 
 ## <a name="telemetry"></a>Example code
-```C#
+```csharp
 
     public partial class Form1 : Form
     {

--- a/articles/application-insights/application-insights-console.md
+++ b/articles/application-insights/application-insights-console.md
@@ -29,7 +29,7 @@ You need a subscription with [Microsoft Azure](http://azure.com). Sign in with a
 * Install latest [Microsoft.ApplicationInsights](https://www.nuget.org/packages/Microsoft.ApplicationInsights) package.
 * Set the instrumentation key in your code before tracking any telemetry (or set APPINSIGHTS_INSTRUMENTATIONKEY environment variable). After that, you should be able to manually track telemetry and see it on the Azure portal
 
-```C#
+```csharp
 TelemetryConfiguration.Active.InstrumentationKey = " *your key* ";
 var telemetryClient = new TelemetryClient();
 telemetryClient.TrackTrace("Hello World!");
@@ -43,13 +43,13 @@ You may initialize and configure Application Insights from the code or using `Ap
 
 By default, Application Insights SDK looks for `ApplicationInsights.config` file in the working directory when `TelemetryConfiguration` is being created
 
-```C#
+```csharp
 TelemetryConfiguration config = TelemetryConfiguration.Active; // Read ApplicationInsights.config file if present
 ```
 
 You may also specify path to the config file.
 
-```C#
+```csharp
 TelemetryConfiguration configuration = TelemetryConfiguration.CreateFromConfiguration("ApplicationInsights.config");
 ```
 
@@ -88,7 +88,7 @@ You may get a full example of the config file by installing latest version of [M
 
 * During application start-up create and configure `DependencyTrackingTelemetryModule` instance - it must be singleton and must be preserved for application lifetime.
 
-```C#
+```csharp
 var module = new DependencyTrackingTelemetryModule();
 
 // prevent Correlation Id to be sent to certain endpoints. You may add other domains as needed.
@@ -107,7 +107,7 @@ module.Initialize(configuration);
 
 * Add common telemetry initializers
 
-```C#
+```csharp
 // stamps telemetry with correlation identifiers
 TelemetryConfiguration.Active.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
 
@@ -119,7 +119,7 @@ TelemetryConfiguration.Active.TelemetryInitializers.Add(new HttpDependenciesPars
 
 #### Full example
 
-```C#
+```csharp
 static void Main(string[] args)
 {
     TelemetryConfiguration configuration = TelemetryConfiguration.Active;

--- a/articles/azure-functions/functions-openapi-definition.md
+++ b/articles/azure-functions/functions-openapi-definition.md
@@ -59,7 +59,7 @@ This tutorial uses an HTTP triggered function that takes two parameters: the est
 
 1. Replace the contents of the run.csx file with the following code, then click **Save**:
 
-    ```c#
+    ```csharp
     using System.Net;
 
     const double revenuePerkW = 0.12; 

--- a/articles/cognitive-services/Bing-Image-Search/quickstarts/csharp.md
+++ b/articles/cognitive-services/Bing-Image-Search/quickstarts/csharp.md
@@ -35,7 +35,7 @@ To run this application, follow these steps.
 2. Replace the `accessKey` value with an access key valid for your subscription.
 3. Run the program.
 
-```c#
+```csharp
 using System;
 using System.Text;
 using System.Net;

--- a/articles/cognitive-services/Bing-News-Search/csharp.md
+++ b/articles/cognitive-services/Bing-News-Search/csharp.md
@@ -33,7 +33,7 @@ The [Bing News Search API](https://docs.microsoft.com/rest/api/cognitiveservices
 1. Replace the `accessKey` value with an access key valid for your subscription.
 1. Run the program.
 
-```c#
+```csharp
 using System;
 using System.Text;
 using System.Net;

--- a/articles/cognitive-services/Bing-Video-Search/csharp.md
+++ b/articles/cognitive-services/Bing-Video-Search/csharp.md
@@ -33,7 +33,7 @@ The [Bing Video Search API](https://docs.microsoft.com/rest/api/cognitiveservice
 1. Replace the `accessKey` value with an access key valid for your subscription.
 1. Run the program.
 
-```c#
+```csharp
 using System;
 using System.Text;
 using System.Net;

--- a/articles/cognitive-services/Bing-Web-Search/quickstarts/csharp.md
+++ b/articles/cognitive-services/Bing-Web-Search/quickstarts/csharp.md
@@ -35,7 +35,7 @@ To run this application, follow these steps.
 3. Replace the `accessKey` value with an access key valid for your subscription.
 4. Run the program.
 
-```c#
+```csharp
 using System;
 using System.Text;
 using System.Net;

--- a/articles/cognitive-services/Computer-vision/QuickStarts/CSharp.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/CSharp.md
@@ -41,7 +41,7 @@ With the [Analyze Image method](https://westcentralus.dev.cognitive.microsoft.co
 
 Create a new Console solution in Visual Studio, then replace Program.cs with the following code. Change the `uriBase` to use the location where you obtained your subscription keys, and replace the `subscriptionKey` value with your valid subscription key.
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Net.Http;
@@ -290,7 +290,7 @@ The Domain-Specific Model is a model trained to identify a specific set of objec
 
 Create a new Console solution in Visual Studio, then replace Program.cs with the following code. Change the `uriBase` to use the location where you obtained your subscription keys, and replace the `subscriptionKey` value with your valid subscription key.
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Net.Http;
@@ -492,7 +492,7 @@ Use the [Get Thumbnail method](https://westcentralus.dev.cognitive.microsoft.com
 
 Create a new Console solution in Visual Studio, then replace Program.cs with the following code. Change the `uriBase` to use the location where you obtained your subscription keys, and replace the `subscriptionKey` value with your valid subscription key.
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Net.Http;
@@ -699,7 +699,7 @@ Use the [Optical Character Recognition (OCR) method](https://westcentralus.dev.c
 
 Create a new Console solution in Visual Studio, then replace Program.cs with the following code. Change the `uriBase` to use the location where you obtained your subscription keys, and replace the `subscriptionKey` value with your valid subscription key.
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Net.Http;
@@ -955,7 +955,7 @@ Use the [RecognizeText method](https://westus.dev.cognitive.microsoft.com/docs/s
 
 Create a new Console solution in Visual Studio, then replace Program.cs with the following code. Change the `uriBase` to use the location where you obtained your subscription keys, and replace the `subscriptionKey` value with your valid subscription key.
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Linq;

--- a/articles/cognitive-services/Custom-Vision-Service/use-prediction-api.md
+++ b/articles/cognitive-services/Custom-Vision-Service/use-prediction-api.md
@@ -27,7 +27,7 @@ After you train your model, you can obtain a URL that you can use to test images
 
 ### Test an image in C#
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Net.Http;

--- a/articles/cognitive-services/Face/QuickStarts/CSharp.md
+++ b/articles/cognitive-services/Face/QuickStarts/CSharp.md
@@ -40,7 +40,7 @@ The sample is written in C# using the Face API client library.
 1. Run the program.
 1. Enter the path to an image on your hard drive.
 
-```c#
+```csharp
 using System;
 using System.IO;
 using System.Net.Http;
@@ -315,7 +315,7 @@ create a person group with specified personGroupId, name, and user-provided user
 
 Create a new Console solution in Visual Studio, then replace Program.cs with the following code. Change the `string uri` to use the region where you obtained your subscription keys, and replace the "Ocp-Apim-Subscription-Key" value with your valid subscription key.
 
-```c#
+```csharp
 using System;
 using System.Net.Http.Headers;
 using System.Net.Http;

--- a/articles/cognitive-services/Translator/transform-text.md
+++ b/articles/cognitive-services/Translator/transform-text.md
@@ -43,7 +43,7 @@ string sentence;   // transformed text
 
 ## Example 
 
-```C#
+```csharp
 using System;
 using System.Text;
 using System.Net;

--- a/articles/cognitive-services/Translator/word-alignment.md
+++ b/articles/cognitive-services/Translator/word-alignment.md
@@ -39,7 +39,7 @@ You will not receive alignment information in the following cases:
 
 
 
-```C#
+```csharp
 
  
 

--- a/articles/cognitive-services/text-analytics/quickstarts/csharp.md
+++ b/articles/cognitive-services/text-analytics/quickstarts/csharp.md
@@ -48,7 +48,7 @@ You must also have the [endpoint and access key](../How-tos/text-analytics-how-t
 1. Replace the location in `client.AzureRegion` (currently `AzureRegions.Westus`) to the region you signed up for.
 1. Run the program.
 
-```c#
+```csharp
 using System;
 using Microsoft.Azure.CognitiveServices.Language.TextAnalytics;
 using Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models;

--- a/articles/cosmos-db/change-feed-hl7-fhir-logic-apps.md
+++ b/articles/cosmos-db/change-feed-hl7-fhir-logic-apps.md
@@ -106,7 +106,7 @@ We are using the [`CreateDocumentChangeFeedQuery`](https://msdn.microsoft.com/li
 
 **Source for the API app**
 
-```C#
+```csharp
 
 	using System.Collections.Generic;
 	using System.Linq;

--- a/articles/cosmos-db/performance-levels.md
+++ b/articles/cosmos-db/performance-levels.md
@@ -144,7 +144,7 @@ Another option for changing your collections' performance levels is through the 
 
 Here is a code snippet for changing the collection throughput to 5,000 request units per second:
     
-```C#
+```csharp
     //Fetch the resource to be updated
     Offer offer = client.CreateOfferQuery()
                       .Where(r => r.ResourceLink == collection.SelfLink)    

--- a/articles/cosmos-db/performance-tips.md
+++ b/articles/cosmos-db/performance-tips.md
@@ -57,7 +57,7 @@ So if you're asking "How can I improve my database performance?" consider the fo
 
      The Connectivity Mode is configured during the construction of the DocumentClient instance with the ConnectionPolicy parameter. If Direct Mode is used, the Protocol can also be set within the ConnectionPolicy parameter.
 
-    ```C#
+    ```csharp
     var serviceEndpoint = new Uri("https://contoso.documents.net");
     var authKey = new "your authKey from the Azure portal";
     DocumentClient client = new DocumentClient(serviceEndpoint, authKey,
@@ -157,7 +157,7 @@ So if you're asking "How can I improve my database performance?" consider the fo
 
     Cosmos DB’s indexing policy also allows you to specify which document paths to include or exclude from indexing by leveraging Indexing Paths (IndexingPolicy.IncludedPaths and IndexingPolicy.ExcludedPaths). The use of indexing paths can offer improved write performance and lower index storage for scenarios in which the query patterns are known beforehand, as indexing costs are directly correlated to the number of unique paths indexed.  For example, the following code shows how to exclude an entire section of the documents (a.k.a. a subtree) from indexing using the "*" wildcard.
 
-    ```C#
+    ```csharp
     var collection = new DocumentCollection { Id = "excludedPathCollection" };
     collection.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/*" });
     collection.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/nonIndexedContent/*");
@@ -179,7 +179,7 @@ So if you're asking "How can I improve my database performance?" consider the fo
 
     To measure the overhead of any operation (create, update, or delete), inspect the [x-ms-request-charge](https://docs.microsoft.com/rest/api/documentdb/common-documentdb-rest-response-headers) header (or the equivalent RequestCharge property in ResourceResponse<T> or FeedResponse<T> in the .NET SDK) to measure the number of request units consumed by these operations.
 
-    ```C#
+    ```csharp
     // Measure the performance (request units) of writes
     ResourceResponse<Document> response = await client.CreateDocumentAsync(collectionSelfLink, myDocument);
     Console.WriteLine("Insert of document consumed {0} request units", response.RequestCharge);

--- a/articles/cosmos-db/set-throughput.md
+++ b/articles/cosmos-db/set-throughput.md
@@ -57,7 +57,7 @@ The following table lists the throughput available for containers:
 
 ## To set the throughput by using the SQL API for .NET
 
-```C#
+```csharp
 // Fetch the offer of the collection whose throughput needs to be updated
 Offer offer = client.CreateOfferQuery()
     .Where(r => r.ResourceLink == collection.SelfLink)    

--- a/articles/data-factory/transform-data-using-dotnet-custom-activity.md
+++ b/articles/data-factory/transform-data-using-dotnet-custom-activity.md
@@ -199,7 +199,7 @@ When the activity is executed, referenceObjects and extendedProperties are store
 
 Following sample code demonstrate how the SampleApp.exe can access the required information from JSON files: 
 
-```C#
+```csharp
 using Newtonsoft.Json;
 using System;
 using System.IO;

--- a/articles/data-lake-analytics/data-lake-analytics-u-sql-programmability-guide.md
+++ b/articles/data-lake-analytics/data-lake-analytics-u-sql-programmability-guide.md
@@ -902,7 +902,7 @@ User-defined aggregates are any aggregation-related functions that are not shipp
 
 The user-defined aggregate base class definition is as follows:
 
-```c#
+```csharp
     [SqlUserDefinedAggregate]
     public abstract class IAggregate<T1, T2, TResult> : IAggregate
     {
@@ -1481,7 +1481,7 @@ OUTPUT @rs0 TO @output_file USING new USQL_Programmability.HTMLOutputter(isHeade
 
 To avoid creating an instance of the object in base script, we can create a function wrapper, as shown in our earlier example:
 
-```c#
+```csharp
         // Define the factory classes
         public static class Factory
         {
@@ -1797,7 +1797,7 @@ CROSS APPLY new MyNameSpace.MyApplier (parameter: “value”) AS alias([columns
 
 Or with the invocation of a wrapper factory method:
 
-```c#
+```csharp
 	CROSS APPLY MyNameSpace.MyApplier (parameter: “value”) AS alias([columns types]…);
 ```
 
@@ -1875,7 +1875,7 @@ Example: 	[`SqlUserDefinedCombiner(Mode=CombinerMode.Left)`]
 
 The main programmability objects are:
 
-```c#
+```csharp
 	public override IEnumerable<IRow> Combine(IRowset left, IRowset right,
 		IUpdatableRow output
 ```

--- a/articles/hdinsight/hbase/apache-hbase-rest-sdk.md
+++ b/articles/hdinsight/hbase/apache-hbase-rest-sdk.md
@@ -34,7 +34,7 @@ The HBase .NET SDK is provided as a NuGet package, which can be installed from t
 
 To use the SDK, instantiate a new `HBaseClient` object, passing in `ClusterCredentials` composed of the `Uri` to your cluster, and the Hadoop user name and password.
 
-```c#
+```csharp
 var credentials = new ClusterCredentials(new Uri("https://CLUSTERNAME.azurehdinsight.net"), "USERNAME", "PASSWORD");
 client = new HBaseClient(credentials);
 ```
@@ -49,7 +49,7 @@ The data is physically stored in *HFiles*. A single HFile contains data for one 
 
 To create a new table, specify a `TableSchema` and columns. The following code checks whether the table 'RestSDKTable` already exists - if not, the table is created.
 
-```c#
+```csharp
 if (!client.ListTablesAsync().Result.name.Contains("RestSDKTable"))
 {
     // Create the table
@@ -67,7 +67,7 @@ This new table has two column families, t1 and t2. Since column families are sto
 
 To delete a table:
 
-```c#
+```csharp
 await client.DeleteTableAsync("RestSDKTable");
 ```
 
@@ -75,7 +75,7 @@ await client.DeleteTableAsync("RestSDKTable");
 
 To insert data, you specify a unique row key as the row identifier. All data is stored in a `byte[]` array. The following code defines and adds the `title`, `director`, and `release_date` columns to the t1 column family, as these columns are the most frequently accessed. The `description` and `tagline` columns are added to the t2 column family. You can partition your data into column families as needed.
 
-```c#
+```csharp
 var key = "fifth_element";
 var row = new CellSet.Row { key = Encoding.UTF8.GetBytes(key) };
 var value = new Cell
@@ -123,7 +123,7 @@ HBase implements BigTable, so the data format looks like the following:
 
 To read data from an HBase table, pass the table name and row key to the `GetCellsAsync` method to return the `CellSet`.
 
-```c#
+```csharp
 var key = "fifth_element";
 
 var cells = await client.GetCellsAsync("RestSDKTable", key);
@@ -137,7 +137,7 @@ Console.WriteLine(Encoding.UTF8.GetString(cells.rows[0].values
 
 In this case, the code returns only the first matching row, as there should only be one row for a unique key. The returned value is changed into `string` format from the `byte[]` array. You can also convert the value to other types, such as an integer for the movie's release date:
 
-```c#
+```csharp
 var releaseDateField = cells.rows[0].values
     .Find(c => Encoding.UTF8.GetString(c.column) == "t1:release_date");
 int releaseDate = 0;
@@ -154,7 +154,7 @@ Console.WriteLine(releaseDate);
 
 HBase uses `scan` to retrieve one or more rows. This example requests multiple rows in batches of 10, and retrieves data whose key values are between 25 and 35. After retrieving all rows, delete the scanner to clean up resources.
 
-```c#
+```csharp
 var tableName = "mytablename";
 
 // Assume the table has integer keys and we want data between keys 25 and 35

--- a/articles/hdinsight/hbase/apache-hbase-using-phoenix-query-server-rest-sdk.md
+++ b/articles/hdinsight/hbase/apache-hbase-using-phoenix-query-server-rest-sdk.md
@@ -36,7 +36,7 @@ Microsoft .NET driver for Apache Phoenix Query Server is provided as a NuGet pac
 
 To begin using the library, instantiate a new `PhoenixClient` object, passing in `ClusterCredentials` containing the `Uri` to your cluster and the cluster's Hadoop user name and password.
 
-```c#
+```csharp
 var credentials = new ClusterCredentials(new Uri("https://CLUSTERNAME.azurehdinsight.net/"), "USERNAME", "PASSWORD");
 client = new PhoenixClient(credentials);
 ```
@@ -47,7 +47,7 @@ Replace CLUSTERNAME with your HDInsight HBase cluster name, and USERNAME and PAS
 
 To send one or more requests to PQS, you need to include a unique connection identifier to associate the request(s) with the connection.
 
-```c#
+```csharp
 string connId = Guid.NewGuid().ToString();
 ```
 
@@ -57,7 +57,7 @@ Each example first makes a call to the `OpenConnectionRequestAsync` method, pass
 
 To call  `ConnectionSyncRequestAsync`,  pass in a `ConnectionProperties` object.
 
-```c#
+```csharp
 ConnectionProperties connProperties = new ConnectionProperties
 {
     HasAutoCommit = true,
@@ -99,7 +99,7 @@ HBase, like any other RDBMS, stores data in tables. Phoenix uses standard SQL qu
 
 This example and all subsequent examples, use the instantiated `PhoenixClient` object as defined in [Instantiate a new PhoenixClient object](#instantiate-new-phoenixclient-object).
 
-```c#
+```csharp
 string connId = Guid.NewGuid().ToString();
 RequestOptions options = RequestOptions.GetGatewayDefaultOptions();
 
@@ -169,13 +169,13 @@ The preceding example creates a new table named `Customers` using the `IF NOT EX
 
 This example shows an individual data insert, referencing a `List<string>` collection of American state and territory abbreviations:
 
-```c#
+```csharp
 var states = new List<string> { "AL", "AK", "AS", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FM", "FL", "GA", "GU", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MH", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "MP", "OH", "OK", "OR", "PW", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VI", "VA", "WA", "WV", "WI", "WY" };
 ```
 
 The table's `StateProvince` column value will be used in a subsequent select operation.
 
-```c#
+```csharp
 string connId = Guid.NewGuid().ToString();
 RequestOptions options = RequestOptions.GetGatewayDefaultOptions();
 options.TimeoutMillis = 300000;
@@ -286,7 +286,7 @@ The structure for executing an insert statement is similar to creating a new tab
 
 The following code is nearly identical to the code for inserting data individually. This example uses the `UpdateBatch` object in a call to `ExecuteBatchRequestAsync`, rather than repeatedly calling `ExecuteRequestAsync` with a prepared statement.
 
-```c#
+```csharp
 string connId = Guid.NewGuid().ToString();
 RequestOptions options = RequestOptions.GetGatewayDefaultOptions();
 options.TimeoutMillis = 300000;
@@ -404,7 +404,7 @@ This example shows how to reuse one connection to execute multiple queries:
 2. Use a total row count select statement to retrieve the single scalar result.
 3. Execute a select statement that returns the total number of customers per state or territory.
 
-```c#
+```csharp
 string connId = Guid.NewGuid().ToString();
 RequestOptions options = RequestOptions.GetGatewayDefaultOptions();
 

--- a/articles/iot-hub/iot-hub-devguide-security.md
+++ b/articles/iot-hub/iot-hub-devguide-security.md
@@ -192,7 +192,7 @@ def generate_sas_token(uri, key, policy_name, expiry=3600):
 
 The functionality in C# to generate a security token is:
 
-```C#
+```csharp
 using System;
 using System.Globalization;
 using System.Net;

--- a/articles/media-services/media-services-media-encoder-premium-workflow-multiplefilesinput.md
+++ b/articles/media-services/media-services-media-encoder-premium-workflow-multiplefilesinput.md
@@ -44,7 +44,7 @@ The configuration string to set in the encoding task uses an XML document that l
 
 The following is the C# code that reads the XML configuration from a file, update it with the right video filename and passes it to the task in a job:
 
-```c#
+```csharp
 string premiumConfiguration = ReadAllText(@"D:\home\site\wwwroot\Presets\SetRuntime.xml").Replace("VideoFileName", myVideoFileName);
 
 // Declare a new job.
@@ -412,7 +412,7 @@ Then, paste the following XML data. You need to specify the name of the video fi
 
 If you use the .NET SDK to create and run the task, this XML data has to be passed as the configuration string.
 
-```c#
+```csharp
 public ITask AddNew(string taskName, IMediaProcessor mediaProcessor, string configuration, TaskOptions options);
 ```
 

--- a/articles/monitoring-and-diagnostics/azure-diagnostics-troubleshooting.md
+++ b/articles/monitoring-and-diagnostics/azure-diagnostics-troubleshooting.md
@@ -151,7 +151,7 @@ If you are thinking about contacting support, the first thing they might ask you
 ## Diagnostics data tables not found
 The tables in Azure storage that hold ETW events are named by using the following code:
 
-```C#
+```csharp
         if (String.IsNullOrEmpty(eventDestination)) {
             if (e == "DefaultEvents")
                 tableName = "WADDefault" + MD5(provider);

--- a/articles/redis-cache/cache-how-to-troubleshoot.md
+++ b/articles/redis-cache/cache-how-to-troubleshoot.md
@@ -191,7 +191,7 @@ This error message contains metrics that can help point you to the cause and pos
 ### Steps to investigate
 1. As a best practice make sure you are using the following pattern to connect when using the StackExchange.Redis client.
 
-    ```c#
+    ```csharp
 	private static Lazy<ConnectionMultiplexer> lazyConnection = new Lazy<ConnectionMultiplexer>(() =>
 	{
 	    return ConnectionMultiplexer.Connect("cachename.redis.cache.windows.net,abortConnect=false,ssl=true,password=...");

--- a/articles/redis-cache/cache-migrate-to-redis.md
+++ b/articles/redis-cache/cache-migrate-to-redis.md
@@ -122,7 +122,7 @@ In Managed Cache Service, connections to the cache were handled by the `DataCach
 
 Add the following using statement to the top of any file from which you want to access the cache.
 
-```c#
+```csharp
 using StackExchange.Redis
 ```
 
@@ -135,7 +135,7 @@ If this namespace doesn’t resolve, be sure that you have added the StackExchan
 
 To connect to an Azure Redis Cache instance, call the static `ConnectionMultiplexer.Connect` method and pass in the endpoint and key. One approach to sharing a `ConnectionMultiplexer` instance in your application is to have a static property that returns a connected instance, similar to the following example. This provides a thread-safe way to initialize only a single connected `ConnectionMultiplexer` instance. In this example `abortConnect` is set to false, which means that the call will succeed even if a connection to the cache is not established. One key feature of `ConnectionMultiplexer` is that it will automatically restore connectivity to the cache once the network issue or other causes are resolved.
 
-```c#
+```csharp
 private static Lazy<ConnectionMultiplexer> lazyConnection = new Lazy<ConnectionMultiplexer>(() =>
 {
     return ConnectionMultiplexer.Connect("contoso5.redis.cache.windows.net,abortConnect=false,ssl=true,password=...");
@@ -154,7 +154,7 @@ The cache endpoint, keys, and ports can be obtained from the **Redis Cache** bla
 
 Once the connection is established, return a reference to the Redis cache database by calling the `ConnectionMultiplexer.GetDatabase` method. The object returned from the `GetDatabase` method is a lightweight pass-through object and does not need to be stored.
 
-```c#
+```csharp
 IDatabase cache = Connection.GetDatabase();
 
 // Perform cache operations using the cache object...
@@ -175,7 +175,7 @@ When calling `StringGet`, if the object exists, it is returned, and if it does n
 
 To specify the expiration of an item in the cache, use the `TimeSpan` parameter of `StringSet`.
 
-```c#
+```csharp
 cache.StringSet("key1", "value1", TimeSpan.FromMinutes(90));
 ```
 

--- a/articles/redis-cache/cache-web-app-howto.md
+++ b/articles/redis-cache/cache-web-app-howto.md
@@ -99,7 +99,7 @@ For more information about this package, see the [EntityFramework](https://www.n
     ![Add model class][cache-model-add-class-dialog]
 3. Replace the `using` statements at the top of the `Team.cs` file with the following `using` statements.
 
-	```c#
+	```csharp
 	using System;
 	using System.Collections.Generic;
 	using System.Data.Entity;
@@ -109,7 +109,7 @@ For more information about this package, see the [EntityFramework](https://www.n
 
 1. Replace the definition of the `Team` class with the following code snippet that contains an updated `Team` class definition as well as some other Entity Framework helper classes. For more information on the code first approach to Entity Framework that's used in this tutorial, see [Code first to a new database](https://msdn.microsoft.com/data/jj193542).
 
-	```c#
+	```csharp
 	public class Team
 	{
 	    public int ID { get; set; }
@@ -223,7 +223,7 @@ For more information about this package, see the [EntityFramework](https://www.n
     ![Global.asax.cs][cache-global-asax]
 6. Add the following two `using` statements at the top of the file under the other `using` statements.
 
-	```c#
+	```csharp
 	using System.Data.Entity;
 	using ContosoTeamStats.Models;
 	```
@@ -231,7 +231,7 @@ For more information about this package, see the [EntityFramework](https://www.n
 
 1. Add the following line of code at the end of the `Application_Start` method.
 
-	```c#
+	```csharp
 	Database.SetInitializer<TeamContext>(new TeamInitializer());
 	```
 
@@ -241,7 +241,7 @@ For more information about this package, see the [EntityFramework](https://www.n
     ![RouteConfig.cs][cache-RouteConfig-cs]
 2. Replace `controller = "Home"` in the following code in the `RegisterRoutes` method with `controller = "Teams"` as shown in the following example.
 
-	```c#
+	```csharp
 	routes.MapRoute(
 	    name: "Default",
 	    url: "{controller}/{action}/{id}",
@@ -293,14 +293,14 @@ In this section of the tutorial, you'll configure the sample application to stor
     ![Teams controller][cache-teamscontroller]
 4. Add the following two `using` statements to **TeamsController.cs**.
 
-	```c#   
+	```csharp   
 	using System.Configuration;
 	using StackExchange.Redis;
 	```
 
 5. Add the following two properties to the `TeamsController` class.
 
-	```c#   
+	```csharp   
 	// Redis Connection string info
 	private static Lazy<ConnectionMultiplexer> lazyConnection = new Lazy<ConnectionMultiplexer>(() =>
 	{
@@ -348,14 +348,14 @@ In this sample, team statistics can be retrieved from the database or from the c
 
 1. Add the following `using` statements to the `TeamsController.cs` file at the top with the other `using` statements.
 
-	```c#   
+	```csharp   
 	using System.Diagnostics;
 	using Newtonsoft.Json;
 	```
 
 2. Replace the current `public ActionResult Index()` method implementation with the following implementation.
 
-    ```c#
+    ```csharp
     // GET: Teams
     public ActionResult Index(string actionType, string resultType)
     {
@@ -414,7 +414,7 @@ In this sample, team statistics can be retrieved from the database or from the c
    
     The `PlayGames` method updates the team statistics by simulating a season of games, saves the results to the database, and clears the now outdated data from the cache.
 
-    ```c#
+    ```csharp
     void PlayGames()
     {
         ViewBag.msg += "Updating team statistics. ";
@@ -433,7 +433,7 @@ In this sample, team statistics can be retrieved from the database or from the c
 
     The `RebuildDB` method reinitializes the database with the default set of teams, generates statistics for them, and clears the now outdated data from the cache.
 
-    ```c#
+    ```csharp
     void RebuildDB()
     {
         ViewBag.msg += "Rebuilding DB. ";
@@ -448,7 +448,7 @@ In this sample, team statistics can be retrieved from the database or from the c
 
     The `ClearCachedTeams` method removes any cached team statistics from the cache.
 
-    ```c#
+    ```csharp
     void ClearCachedTeams()
     {
         IDatabase cache = Connection.GetDatabase();
@@ -463,7 +463,7 @@ In this sample, team statistics can be retrieved from the database or from the c
    
     The `GetFromDB` method reads the team statistics from the database.
    
-    ```c#
+    ```csharp
     List<Team> GetFromDB()
     {
         ViewBag.msg += "Results read from DB. ";
@@ -477,7 +477,7 @@ In this sample, team statistics can be retrieved from the database or from the c
 
     The `GetFromList` method reads the team statistics from cache as a serialized `List<Team>`. If there is a cache miss, the team statistics are read from the database and then stored in the cache for next time. In this sample we're using JSON.NET serialization to serialize the .NET objects to and from the cache. For more information, see [How to work with .NET objects in Azure Redis Cache](cache-dotnet-how-to-use-azure-redis-cache.md#work-with-net-objects-in-the-cache).
 
-    ```c#
+    ```csharp
     List<Team> GetFromList()
     {
         List<Team> teams = null;
@@ -505,7 +505,7 @@ In this sample, team statistics can be retrieved from the database or from the c
 
     The `GetFromSortedSet` method reads the team statistics from a cached sorted set. If there is a cache miss, the team statistics are read from the database and stored in the cache as a sorted set.
 
-    ```c#
+    ```csharp
     List<Team> GetFromSortedSet()
     {
         List<Team> teams = null;
@@ -542,7 +542,7 @@ In this sample, team statistics can be retrieved from the database or from the c
 
     The `GetFromSortedSetTop5` method reads the top 5 teams from the cached sorted set. It starts by checking the cache for the existence of the `teamsSortedSet` key. If this key is not present, the `GetFromSortedSet` method is called to read the team statistics and store them in the cache. Next, the cached sorted set is queried for the top 5 teams which are returned.
 
-    ```c#
+    ```csharp
     List<Team> GetFromSortedSetTop5()
     {
         List<Team> teams = null;
@@ -575,7 +575,7 @@ The scaffolding code that was generated as part of this sample includes methods 
 
 1. Browse to the `Create(Team team)` method in the `TeamsController` class. Add a call to the `ClearCachedTeams` method, as shown in the following example.
 
-    ```c#
+    ```csharp
     // POST: Teams/Create
     // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
     // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
@@ -600,7 +600,7 @@ The scaffolding code that was generated as part of this sample includes methods 
 
 1. Browse to the `Edit(Team team)` method in the `TeamsController` class. Add a call to the `ClearCachedTeams` method, as shown in the following example.
 
-    ```c#
+    ```csharp
     // POST: Teams/Edit/5
     // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
     // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
@@ -624,7 +624,7 @@ The scaffolding code that was generated as part of this sample includes methods 
 
 1. Browse to the `DeleteConfirmed(int id)` method in the `TeamsController` class. Add a call to the `ClearCachedTeams` method, as shown in the following example.
 
-    ```c#
+    ```csharp
     // POST: Teams/Delete/5
     [HttpPost, ActionName("Delete")]
     [ValidateAntiForgeryToken]

--- a/articles/security/azure-security-threat-modeling-tool-authentication.md
+++ b/articles/security/azure-security-threat-modeling-tool-authentication.md
@@ -372,7 +372,7 @@ The `<netMsmqBinding/>` element of the WCF configuration file below instructs WC
 | **Steps** | <p>The TokenReplayCache property allows developers to define a token replay cache, a store that can be used for saving tokens for the purpose of verifying that no token can be used more than once.</p><p>This is a measure against a common attack, the aptly called token replay attack: an attacker intercepting the token sent at sign-in might try to send it to the app again (“replay” it) for establishing a new session. E.g., In OIDC code-grant flow, after successful user authentication, a request to "/signin-oidc" endpoint of the relying party is made with "id_token", "code" and "state" parameters.</p><p>The relying party validates this request and establishes a new session. If an adversary captures this request and replays it, he/she can establish a successful session and spoof the user. The presence of the nonce in OpenID Connect can limit but not fully eliminate the circumstances in which the attack can be successfully enacted. To protect their applications, developers can provide an implementation of ITokenReplayCache and assign an instance to TokenReplayCache.</p>|
 
 ### Example
-```C#
+```csharp
 // ITokenReplayCache defined in ADAL
 public interface ITokenReplayCache
 {
@@ -383,7 +383,7 @@ bool TryFind(string securityToken);
 
 ### Example
 Here is a sample implementation of the ITokenReplayCache interface. (Please customize and implement your project-specific caching framework)
-```C#
+```csharp
 public class TokenReplayCache : ITokenReplayCache
 {
     private readonly ICacheProvider cache; // Your project-specific cache provider
@@ -407,7 +407,7 @@ public class TokenReplayCache : ITokenReplayCache
 }
 ```
 The implemented cache has to be referenced in OIDC options via the "TokenValidationParameters" property as follows.
-```C#
+```csharp
 OpenIdConnectOptions openIdConnectOptions = new OpenIdConnectOptions
 {
     AutomaticAuthenticate = true,
@@ -455,7 +455,7 @@ Please note that to test the effectiveness of this configuration, login into you
 | **Steps** | <ul><li>**Generic:** Authenticate the device using Transport Layer Security (TLS) or IPSec. Infrastructure should support using pre-shared key (PSK) on those devices that cannot handle full asymmetric cryptography. Leverage Azure AD, Oauth.</li><li>**C#:** When creating a DeviceClient instance, by default, the Create method creates a DeviceClient instance that uses the AMQP protocol to communicate with IoT Hub. To use the HTTPS protocol, use the override of the Create method that enables you to specify the protocol. If you use the HTTPS protocol, you should also add the `Microsoft.AspNet.WebApi.Client` NuGet package to your project to include the `System.Net.Http.Formatting` namespace.</li></ul>|
 
 ### Example
-```C#
+```csharp
 static DeviceClient deviceClient;
 
 static string deviceKey = "{device key}";

--- a/articles/security/azure-security-threat-modeling-tool-authorization.md
+++ b/articles/security/azure-security-threat-modeling-tool-authorization.md
@@ -398,7 +398,7 @@ return result;
 | **Steps** | <p>Role information for the application users can be derived from Azure AD or ADFS claims if the application relies on them as Identity provider or the application itself might provided it. In any of these cases, the custom authorization implementation should validate the user role information.</p><p>Role information for the application users can be derived from Azure AD or ADFS claims if the application relies on them as Identity provider or the application itself might provided it. In any of these cases, the custom authorization implementation should validate the user role information.</p>
 
 ### Example
-```C#
+```csharp
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
 public class ApiAuthorizeAttribute : System.Web.Http.AuthorizeAttribute
 {
@@ -429,7 +429,7 @@ public bool ValidateRoles(actionContext)
 }
 ```
 All the controllers and action methods which needs to protected should be decorated with above attribute.
-```C#
+```csharp
 [ApiAuthorize]
 public class CustomController : ApiController
 {

--- a/articles/security/azure-security-threat-modeling-tool-communication-security.md
+++ b/articles/security/azure-security-threat-modeling-tool-communication-security.md
@@ -212,7 +212,7 @@ This rule works by returning an HTTP status code of 301 (permanent redirect) whe
 | **Steps** | <p>Certificate pinning defends against Man-In-The-Middle (MITM) attacks. Pinning is the process of associating a host with their expected X509 certificate or public key. Once a certificate or public key is known or seen for a host, the certificate or public key is associated or 'pinned' to the host. </p><p>Thus, when an adversary attempts to do SSL MITM attack, during SSL handshake the key from attacker's server will be different from the pinned certificate's key, and the request will be discarded, thus preventing MITM Certificate pinning can be achieved by implementing ServicePointManager's `ServerCertificateValidationCallback` delegate.</p>|
 
 ### Example
-```C#
+```csharp
 using System;
 using System.Net;
 using System.Net.Security;
@@ -341,7 +341,7 @@ string GetData(int value);
 
 ### Example 
 The following code shows a Web API authentication filter that checks for SSL: 
-```C#
+```csharp
 public class RequireHttpsAttribute : AuthorizationFilterAttribute
 {
     public override void OnAuthorization(HttpActionContext actionContext)
@@ -361,7 +361,7 @@ public class RequireHttpsAttribute : AuthorizationFilterAttribute
 }
 ```
 Add this filter to any Web API actions that require SSL: 
-```C#
+```csharp
 public class ValuesController : ApiController
 {
     [RequireHttps]

--- a/articles/security/azure-security-threat-modeling-tool-configuration-management.md
+++ b/articles/security/azure-security-threat-modeling-tool-configuration-management.md
@@ -44,7 +44,7 @@ ms.author: rodsan
 
 ### Example
 Example policy: 
-```C#
+```csharp
 Content-Security-Policy: default-src 'self'; script-src 'self' www.google-analytics.com 
 ```
 This policy allows scripts to load only from the web application’s server and google analytics server. Scripts loaded from any other site will be rejected. When CSP is enabled on a website, the following features are automatically disabled to mitigate XSS attacks. 
@@ -109,7 +109,7 @@ Example: var str="alert(1)"; eval(str);
 
 ### Example
 The X-FRAME-OPTIONS header can be set via IIS web.config. Web.config code snippet for sites that should never be framed: 
-```C#
+```csharp
     <system.webServer>
         <httpProtocol>
             <customHeader>
@@ -121,7 +121,7 @@ The X-FRAME-OPTIONS header can be set via IIS web.config. Web.config code snippe
 
 ### Example
 Web.config code for sites that should only be framed by pages in the same domain: 
-```C#
+```csharp
     <system.webServer>
         <httpProtocol>
             <customHeader>
@@ -156,7 +156,7 @@ If access to Web.config is available, then CORS can be added through the followi
 
 ### Example
 If access to web.config is not available, then CORS can be configured by adding the following CSharp code: 
-```C#
+```csharp
 HttpContext.Response.AppendHeader("Access-Control-Allow-Origin", "http://example.com")
 ```
 
@@ -224,7 +224,7 @@ Add the header in the web.config file if the application is hosted by Internet I
 
 ### Example
 Add the header through the global Application\_BeginRequest 
-```C#
+```csharp
 void Application_BeginRequest(object sender, EventArgs e)
 {
 this.Response.Headers["X-Content-Type-Options"] = "nosniff";
@@ -233,7 +233,7 @@ this.Response.Headers["X-Content-Type-Options"] = "nosniff";
 
 ### Example
 Implement custom HTTP module 
-```C#
+```csharp
 public class XContentTypeOptionsModule : IHttpModule
 {
 #region IHttpModule Members
@@ -260,7 +260,7 @@ application.Response.Headers.Add("X-Content-Type-Options ", "nosniff");
 ### Example
 You can enable the required header only for specific pages by adding it to individual responses: 
 
-```C#
+```csharp
 this.Response.Headers["X-Content-Type-Options"] = "nosniff";
 ```
 
@@ -299,7 +299,7 @@ this.Response.Headers["X-Content-Type-Options"] = "nosniff";
 
 ### Example
 In the App_Start/WebApiConfig.cs, add the following code to the WebApiConfig.Register method 
-```C#
+```csharp
 using System.Web.Http;
 namespace WebService
 {
@@ -323,7 +323,7 @@ namespace WebService
 ### Example
 EnableCors attribute can be applied to action methods in a controller as follows: 
 
-```C#
+```csharp
 public class ResourcesController : ApiController
 {
   [EnableCors("http://localhost:55912", // Origin
@@ -363,7 +363,7 @@ Please note that it is critical to ensure that the list of origins in EnableCors
 
 ### Example
 To disable CORS on a particular method in a class, the DisableCors attribute can be used as shown below: 
-```C#
+```csharp
 [EnableCors("http://example.com", "Accept, Origin, Content-Type", "POST")]
 public class ResourcesController : ApiController
 {
@@ -398,7 +398,7 @@ Enabling CORS with middleware: To enable CORS for the entire application add the
 
 ### Example
 The first is to call UseCors with a lambda. The lambda takes a CorsPolicyBuilder object: 
-```C#
+```csharp
 public void Configure(IApplicationBuilder app)
 {
     app.UseCors(builder =>
@@ -410,7 +410,7 @@ public void Configure(IApplicationBuilder app)
 
 ### Example
 The second is to define one or more named CORS policies, and then select the policy by name at run time. 
-```C#
+```csharp
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddCors(options =>
@@ -434,7 +434,7 @@ Enabling CORS in MVC: Developers can alternatively use MVC to apply specific COR
 
 ### Example
 Per action: To specify a CORS policy for a specific action add the [EnableCors] attribute to the action. Specify the policy name. 
-```C#
+```csharp
 public class HomeController : Controller
 {
     [EnableCors("AllowSpecificOrigin")] 
@@ -446,7 +446,7 @@ public class HomeController : Controller
 
 ### Example
 Per controller: 
-```C#
+```csharp
 [EnableCors("AllowSpecificOrigin")]
 public class HomeController : Controller
 {
@@ -454,7 +454,7 @@ public class HomeController : Controller
 
 ### Example
 Globally: 
-```C#
+```csharp
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddMvc();
@@ -468,7 +468,7 @@ Please note that it is critical to ensure that the list of origins in EnableCors
 
 ### Example
 To disable CORS for a controller or action, use the [DisableCors] attribute. 
-```C#
+```csharp
 [DisableCors]
     public IActionResult About()
     {

--- a/articles/security/azure-security-threat-modeling-tool-exception-management.md
+++ b/articles/security/azure-security-threat-modeling-tool-exception-management.md
@@ -73,7 +73,7 @@ Disable debugging information in the service. This can be accomplished by removi
 
 ### Example
 To control the status code returned by the API, `HttpResponseException` can be used as shown below: 
-```C#
+```csharp
 public Product GetProduct(int id)
 {
     Product item = repository.Get(id);
@@ -87,7 +87,7 @@ public Product GetProduct(int id)
 
 ### Example
 For further control on the exception response, the `HttpResponseMessage` class can be used as shown below: 
-```C#
+```csharp
 public Product GetProduct(int id)
 {
     Product item = repository.Get(id);
@@ -107,7 +107,7 @@ To catch unhandled exceptions that are not of the type `HttpResponseException`, 
 
 ### Example
 Here is a filter that converts `NotImplementedException` exceptions into HTTP status code `501, Not Implemented`: 
-```C#
+```csharp
 namespace ProductStore.Filters
 {
     using System;
@@ -135,7 +135,7 @@ There are several ways to register a Web API exception filter:
 
 ### Example
 To apply the filter to a specific action, add the filter as an attribute to the action: 
-```C#
+```csharp
 public class ProductsController : ApiController
 {
     [NotImplExceptionFilter]
@@ -148,7 +148,7 @@ public class ProductsController : ApiController
 ### Example
 To apply the filter to all of the actions on a `controller`, add the filter as an attribute to the `controller` class: 
 
-```C#
+```csharp
 [NotImplExceptionFilter]
 public class ProductsController : ApiController
 {
@@ -158,14 +158,14 @@ public class ProductsController : ApiController
 
 ### Example
 To apply the filter globally to all Web API controllers, add an instance of the filter to the `GlobalConfiguration.Configuration.Filters` collection. Exception filters in this collection apply to any Web API controller action. 
-```C#
+```csharp
 GlobalConfiguration.Configuration.Filters.Add(
     new ProductStore.NotImplExceptionFilterAttribute());
 ```
 
 ### Example
 For model validation, the model state can be passed to CreateErrorResponse method as shown below: 
-```C#
+```csharp
 public HttpResponseMessage PostProduct(Product item)
 {
     if (!ModelState.IsValid)
@@ -223,7 +223,7 @@ Check the links in the references section for additional details about exception
 | **Steps** | Application should fail safely. Any method that returns a Boolean value, based on which certain decision is made, should have exception block carefully created. There are lot of logical errors due to which security issues creep in, when the exception block is written carelessly.|
 
 ### Example
-```C#
+```csharp
         public static bool ValidateDomain(string pathToValidate, Uri currentUrl)
         {
             try

--- a/articles/security/azure-security-threat-modeling-tool-input-validation.md
+++ b/articles/security/azure-security-threat-modeling-tool-input-validation.md
@@ -40,7 +40,7 @@ ms.author: rodsan
 
 ### Example 
 
-```C#
+```csharp
 XsltSettings settings = new XsltSettings();
 settings.EnableScript = true; // WRONG: THIS SHOULD BE SET TO false
 ```
@@ -48,14 +48,14 @@ settings.EnableScript = true; // WRONG: THIS SHOULD BE SET TO false
 ### Example
 If you are using using MSXML 6.0, XSLT scripting is disabled by default; however, you must ensure that it has not been explicitly enabled through the XML DOM object property AllowXsltScript. 
 
-```C#
+```csharp
 doc.setProperty("AllowXsltScript", true); // WRONG: THIS SHOULD BE SET TO false
 ```
 
 ### Example
 If you are using MSXML 5 or below, XSLT scripting is enabled by default and you must explicitly disable it. Set the XML DOM object property AllowXsltScript to false. 
 
-```C#
+```csharp
 doc.setProperty("AllowXsltScript", false); // CORRECT. Setting to false disables XSLT scripting.
 ```
 
@@ -142,7 +142,7 @@ this.Response.Headers[""X-Content-Type-Options""] = ""nosniff"";
 ### Example
 For .NET Framework code, you can use the following approaches:
 
-```C#
+```csharp
 XmlTextReader reader = new XmlTextReader(stream);
 reader.ProhibitDtd = true;
 
@@ -160,7 +160,7 @@ Note that the default value of `ProhibitDtd` in `XmlReaderSettings` is true, but
 ### Example
 To disable entity resolution for XmlDocuments, use the `XmlDocument.Load(XmlReader)` overload of the Load method and set the appropriate properties in the XmlReader argument to disable resolution, as illustrated in the following code: 
 
-```C#
+```csharp
 XmlReaderSettings settings = new XmlReaderSettings();
 settings.ProhibitDtd = true;
 XmlReader reader = XmlReader.Create(stream, settings);
@@ -171,7 +171,7 @@ doc.Load(reader);
 ### Example
 If disabling entity resolution is not possible for your application, set the XmlReaderSettings.MaxCharactersFromEntities property to a reasonable value according to your application's needs. This will limit the impact of potential exponential expansion DoS attacks. The following code provides an example of this approach: 
 
-```C#
+```csharp
 XmlReaderSettings settings = new XmlReaderSettings();
 settings.ProhibitDtd = false;
 settings.MaxCharactersFromEntities = 1000;
@@ -181,7 +181,7 @@ XmlReader reader = XmlReader.Create(stream, settings);
 ### Example
 If you need to resolve inline entities but do not need to resolve external entities, set the XmlReaderSettings.XmlResolver property to null. For example: 
 
-```C#
+```csharp
 XmlReaderSettings settings = new XmlReaderSettings();
 settings.ProhibitDtd = false;
 settings.MaxCharactersFromEntities = 1000;
@@ -215,7 +215,7 @@ Note that in MSXML6, ProhibitDTD is set to true (disabling DTD processing) by de
 ### Example
 For the last point regarding file format signature validation, refer to the class below for details: 
 
-```C#
+```csharp
         private static Dictionary<string, List<byte[]>> fileSignature = new Dictionary<string, List<byte[]>>
                     {
                     { ".DOC", new List<byte[]> { new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 } } },
@@ -331,7 +331,7 @@ For the last point regarding file format signature validation, refer to the clas
 ### Example 
 The following code shows how to use type safe parameters with the SqlParameterCollection when calling a stored procedure. 
 
-```C#
+```csharp
 using System.Data;
 using System.Data.SqlClient;
 
@@ -371,7 +371,7 @@ In the preceding code example, the input value cannot be longer than 11 characte
 
 ### Example
 
-```C#
+```csharp
 * Encoder.HtmlEncode 
 * Encoder.HtmlAttributeEncode 
 * Encoder.JavaScriptEncode 
@@ -463,7 +463,7 @@ Don't use `innerHtml`; instead use `innerText`. Similarly, instead of `$("#elm")
 ### Example
 For example, the following configuration will throw a RegexMatchTimeoutException, if the processing takes more than 5 seconds: 
 
-```C#
+```csharp
 <httpRuntime targetFramework="4.5" defaultRegexMatchTimeout="00:00:05" />
 ```
 
@@ -481,7 +481,7 @@ For example, the following configuration will throw a RegexMatchTimeoutException
 ### Example
 Following is an insecure example: 
 
-```C#
+```csharp
 <div class="form-group">
             @Html.Raw(Model.AccountConfirmText)
         </div>
@@ -506,7 +506,7 @@ Do not use `Html.Raw()` unless you need to display markup. This method does not 
 ### Example
 Following is an example of insecure dynamic Stored Procedure: 
 
-```C#
+```csharp
 CREATE PROCEDURE [dbo].[uspGetProductsByCriteria]
 (
   @productName nvarchar(200) = NULL,
@@ -533,7 +533,7 @@ AS
 
 ### Example
 Following is the same stored procedure implemented securely: 
-```C#
+```csharp
 CREATE PROCEDURE [dbo].[uspGetProductsByCriteriaSecure]
 (
              @productName nvarchar(200) = NULL,
@@ -566,7 +566,7 @@ AS
 ### Example
 The following code demonstrates the same: 
 
-```C#
+```csharp
 using System.ComponentModel.DataAnnotations;
 
 namespace MyApi.Models
@@ -587,7 +587,7 @@ namespace MyApi.Models
 ### Example
 In the action method of the API controllers, validity of the model has to be explicitly checked as shown below: 
 
-```C#
+```csharp
 namespace MyApi.Controllers
 {
     public class ProductsController : ApiController
@@ -634,7 +634,7 @@ namespace MyApi.Controllers
 ### Example
 The following code shows how to use type safe parameters with the SqlParameterCollection when calling a stored procedure. 
 
-```C#
+```csharp
 using System.Data;
 using System.Data.SqlClient;
 

--- a/articles/security/azure-security-threat-modeling-tool-sensitive-data.md
+++ b/articles/security/azure-security-threat-modeling-tool-sensitive-data.md
@@ -94,7 +94,7 @@ ms.author: rodsan
 
 ### Example
 This may be implemented through a filter. Following example may be used: 
-```C#
+```csharp
 public override void OnActionExecuting(ActionExecutingContext filterContext)
         {
             if (filterContext == null || (filterContext.HttpContext != null && filterContext.HttpContext.Response != null && filterContext.HttpContext.Response.IsRequestBeingRedirected))
@@ -142,7 +142,7 @@ public override void OnActionExecuting(ActionExecutingContext filterContext)
 | **Steps** | The autocomplete attribute specifies whether a form should have autocomplete on or off. When autocomplete is on, the browser automatically complete values based on values that the user has entered before. For example, when a new name and password is entered in a form and the form is submitted, the browser asks if the password should be saved.Thereafter when the form is displayed, the name and password are filled in automatically or are completed as the name is entered. An attacker with local access could obtain the clear text password from the browser cache. By default autocomplete is enabled, and it must explicitly be disabled. |
 
 ### Example
-```C#
+```csharp
 <form action="Login.aspx" method="post " autocomplete="off" >
       Social Security Number: <input type="text" name="ssn" />
       <input type="submit" value="Submit" />    
@@ -351,7 +351,7 @@ cacheLocation: 'localStorage', // enable this for IE, as sessionStorage does not
 
 ### Example
 Intune can be configured with following security policies to safeguard sensitive data: 
-```C#
+```csharp
 Require encryption on mobile device    
 Require encryption on storage cards
 Allow screen capture
@@ -359,7 +359,7 @@ Allow screen capture
 
 ### Example
 If the application is not an enterprise application, then use platform provided keystore, keychains to store encryption keys, using which cryptographic operation may be performed on the file system. Following code snippet shows how to access key from keychain using xamarin: 
-```C#
+```csharp
         protected static string EncryptionKey
         {
             get

--- a/articles/security/azure-security-threat-modeling-tool-session-management.md
+++ b/articles/security/azure-security-threat-modeling-tool-session-management.md
@@ -41,13 +41,13 @@ ms.author: rodsan
 | **Steps** | If the application relies on access token issued by Azure AD, the logout event handler should call |
 
 ### Example
-```C#
+```csharp
 HttpContext.GetOwinContext().Authentication.SignOut(OpenIdConnectAuthenticationDefaults.AuthenticationType, CookieAuthenticationDefaults.AuthenticationType)
 ```
 
 ### Example
 It should also destroy user's session by calling Session.Abandon() method. Following method shows secure implementation of user logout:
-```C#
+```csharp
     [HttpPost]
         [ValidateAntiForgeryToken]
         public void LogOff()
@@ -98,7 +98,7 @@ It should also destroy user's session by calling Session.Abandon() method. Follo
 | **Steps** | If the application relies on STS token issued by ADFS, the logout event handler should call WSFederationAuthenticationModule.FederatedSignOut() method to log out the user. Also the current session should be destroyed, and the session token value should be reset and nullified.|
 
 ### Example
-```C#
+```csharp
         [HttpPost, ValidateAntiForgeryToken]
         [Authorization]
         public ActionResult SignOut(string redirectUrl)
@@ -158,7 +158,7 @@ It should also destroy user's session by calling Session.Abandon() method. Follo
 | **Steps** | Cookies are normally only accessible to the domain for which they were scoped. Unfortunately, the definition of "domain" does not include the protocol so cookies that are created over HTTPS are accessible over HTTP. The "secure" attribute indicates to the browser that the cookie should only be made available over HTTPS. Ensure that all cookies set over HTTPS use the **secure** attribute. The requirement can be enforced in the web.config file by setting the requireSSL attribute to true. It is the preferred approach because it will enforce the **secure** attribute for all current and future cookies without the need to make any additional code changes.|
 
 ### Example
-```C#
+```csharp
 <configuration>
   <system.web>
     <httpCookies requireSSL="true"/>
@@ -177,7 +177,7 @@ The setting is enforced even if HTTP is used to access the application. If HTTP 
 | **Steps** | When the web application is the Relying Party, and the IdP is ADFS server, the FedAuth token's secure attribute can be configured by setting requireSSL to True in `system.identityModel.services` section of web.config:|
 
 ### Example
-```C#
+```csharp
   <system.identityModel.services>
     <federationConfiguration>
       <!-- Set requireSsl=true; domain=application domain name used by FedAuth cookies (Ex: .gdinfra.com); -->
@@ -271,7 +271,7 @@ Following configuration shows the correct configuration:
 | **Steps** | Anti-CSRF and ASP.NET MVC forms - Use the `AntiForgeryToken` helper method on Views; put an `Html.AntiForgeryToken()` into the form, for example,|
 
 ### Example
-```C#
+```csharp
 @using (Html.BeginForm("UserProfile", "SubmitUpdate")) { 
     @Html.ValidationSummary(true) 
     @Html.AntiForgeryToken()
@@ -279,7 +279,7 @@ Following configuration shows the correct configuration:
 ```
 
 ### Example
-```C#
+```csharp
 <form action="/UserProfile/SubmitUpdate" method="post">
     <input name="__RequestVerificationToken" type="hidden" value="saTFWpkKN0BYazFtN6c4YbZAmsEwG0srqlUqqloi/fVgeV2ciIFVmelvzwRZpArs" />
     <!-- rest of form goes here -->
@@ -303,7 +303,7 @@ Assuming all is well, the request goes through as normal. But if not, then an au
 
 ### Example
 Anti-CSRF and AJAX: The form token can be a problem for AJAX requests, because an AJAX request might send JSON data, not HTML form data. One solution is to send the tokens in a custom HTTP header. The following code uses Razor syntax to generate the tokens, and then adds the tokens to an AJAX request. 
-```C#
+```csharp
 <script>
     @functions{
         public string TokenHeaderValue()
@@ -328,7 +328,7 @@ Anti-CSRF and AJAX: The form token can be a problem for AJAX requests, because a
 
 ### Example
 When you process the request, extract the tokens from the request header. Then call the AntiForgery.Validate method to validate the tokens. The Validate method throws an exception if the tokens are not valid.
-```C#
+```csharp
 void ValidateRequestHeader(HttpRequestMessage request)
 {
     string cookieToken = "";
@@ -359,7 +359,7 @@ void ValidateRequestHeader(HttpRequestMessage request)
 
 ### Example
 Here's the code you need to have in all of your pages:
-```C#
+```csharp
 void Page_Init (object sender, EventArgs e) {
    ViewStateUserKey = Session.SessionID;
    :
@@ -433,7 +433,7 @@ void Page_Init (object sender, EventArgs e) {
 
 ### Example
 Also the ADFS issued SAML claim token's lifetime should be set to 15 minutes, by executing the following powershell command on the ADFS server:
-```C#
+```csharp
 Set-ADFSRelyingPartyTrust -TargetName “<RelyingPartyWebApp>” -ClaimsProviderName @(“Active Directory”) -TokenLifetime 15 -AlwaysRequireAuthentication $true
 ```
 
@@ -493,7 +493,7 @@ Set-ADFSRelyingPartyTrust -TargetName “<RelyingPartyWebApp>” -ClaimsProvider
 
 ### Example
 When you process the request, extract the tokens from the request header. Then call the AntiForgery.Validate method to validate the tokens. The Validate method throws an exception if the tokens are not valid.
-```C#
+```csharp
 void ValidateRequestHeader(HttpRequestMessage request)
 {
     string cookieToken = "";
@@ -515,7 +515,7 @@ void ValidateRequestHeader(HttpRequestMessage request)
 
 ### Example
 Anti-CSRF and ASP.NET MVC forms - Use the AntiForgeryToken helper method on Views; put an Html.AntiForgeryToken() into the form, for example,
-```C#
+```csharp
 @using (Html.BeginForm("UserProfile", "SubmitUpdate")) { 
     @Html.ValidationSummary(true) 
     @Html.AntiForgeryToken()
@@ -525,7 +525,7 @@ Anti-CSRF and ASP.NET MVC forms - Use the AntiForgeryToken helper method on View
 
 ### Example
 The example above will output something like the following:
-```C#
+```csharp
 <form action="/UserProfile/SubmitUpdate" method="post">
     <input name="__RequestVerificationToken" type="hidden" value="saTFWpkKN0BYazFtN6c4YbZAmsEwG0srqlUqqloi/fVgeV2ciIFVmelvzwRZpArs" />
     <!-- rest of form goes here -->

--- a/articles/service-fabric/service-fabric-add-a-web-frontend.md
+++ b/articles/service-fabric/service-fabric-add-a-web-frontend.md
@@ -88,7 +88,7 @@ Let's start by creating the interface to act as the contract between the statefu
 
 4. In the class library, create an interface with a single method, `GetCountAsync`, and extend the interface from `Microsoft.ServiceFabric.Services.Remoting.IService`. The remoting interface must derive from this interface to indicate that it is a Service Remoting interface.
    
-    ```c#
+    ```csharp
     using Microsoft.ServiceFabric.Services.Remoting;
     using System.Threading.Tasks;
         
@@ -111,7 +111,7 @@ Now that we have defined the interface, we need to implement it in the stateful 
     ![Adding a reference to the class library project in the stateful service][vs-add-class-library-reference]
 2. Locate the class that inherits from `StatefulService`, such as `MyStatefulService`, and extend it to implement the `ICounter` interface.
    
-    ```c#
+    ```csharp
     using MyStatefulService.Interface;
    
     ...
@@ -123,7 +123,7 @@ Now that we have defined the interface, we need to implement it in the stateful 
     ```
 3. Now implement the single method that is defined in the `ICounter` interface, `GetCountAsync`.
    
-    ```c#
+    ```csharp
     public async Task<long> GetCountAsync()
     {
         var myDictionary = 
@@ -147,7 +147,7 @@ In this case, we replace the existing `CreateServiceReplicaListeners` method and
 
 The `CreateServiceRemotingListener` extension method on the `IService` interface allows you to easily create a `ServiceRemotingListener` with all default settings. To use this extension method, ensure you have the `Microsoft.ServiceFabric.Services.Remoting.Runtime` namespace imported. 
 
-```c#
+```csharp
 using Microsoft.ServiceFabric.Services.Remoting.Runtime;
 
 ...
@@ -173,7 +173,7 @@ Our stateful service is now ready to receive traffic from other services over RP
 
 4. In the **Controllers** folder, open the `ValuesController` class. Note that the `Get` method currently just returns a hard-coded string array of "value1" and "value2"--which matches what we saw earlier in the browser. Replace this implementation with the following code:
    
-    ```c#
+    ```csharp
     using MyStatefulService.Interface;
     using Microsoft.ServiceFabric.Services.Client;
     using Microsoft.ServiceFabric.Services.Remoting.Client;

--- a/articles/service-fabric/service-fabric-cloud-services-migration-worker-role-stateless-service.md
+++ b/articles/service-fabric/service-fabric-cloud-services-migration-worker-role-stateless-service.md
@@ -53,7 +53,7 @@ Worker Role and Service Fabric service APIs offer similar entry points:
 | Open listener for client requests |N/A |<ul><li> `CreateServiceInstanceListener()` for stateless</li><li>`CreateServiceReplicaListener()` for stateful</li></ul> |
 
 ### Worker Role
-```C#
+```csharp
 
 using Microsoft.WindowsAzure.ServiceRuntime;
 
@@ -78,7 +78,7 @@ namespace WorkerRole1
 ```
 
 ### Service Fabric Stateless Service
-```C#
+```csharp
 
 using System.Collections.Generic;
 using System.Threading;
@@ -135,7 +135,7 @@ Each of these packages can be independently versioned and upgraded. Similar to C
 #### Cloud Services
 Configuration settings from ServiceConfiguration.*.cscfg can be accessed through `RoleEnvironment`. These settings are globally available to all role instances in the same Cloud Service deployment.
 
-```C#
+```csharp
 
 string value = RoleEnvironment.GetConfigurationSettingValue("Key");
 
@@ -146,7 +146,7 @@ Each service has its own individual configuration package. There is no built-in 
 
 Configuration settings are accesses within each service instance through the service's `CodePackageActivationContext`.
 
-```C#
+```csharp
 
 ConfigurationPackage configPackage = this.Context.CodePackageActivationContext.GetConfigurationPackageObject("Config");
 
@@ -167,7 +167,7 @@ using (StreamReader reader = new StreamReader(Path.Combine(configPackage.Path, "
 #### Cloud Services
 The `RoleEnvironment.Changed` event is used to notify all role instances when a change occurs in the environment, such as a configuration change. This is used to consume configuration updates without recycling role instances or restarting a worker process.
 
-```C#
+```csharp
 
 RoleEnvironment.Changed += RoleEnvironmentChanged;
 
@@ -188,7 +188,7 @@ Each of the three package types in a service - Code, Config, and Data - have eve
 
 These events are available to consume changes in service packages without restarting the service instance.
 
-```C#
+```csharp
 
 this.Context.CodePackageActivationContext.ConfigurationPackageModifiedEvent +=
                     this.CodePackageActivationContext_ConfigurationPackageModifiedEvent;

--- a/articles/service-fabric/service-fabric-cluster-programmatic-scaling.md
+++ b/articles/service-fabric/service-fabric-cluster-programmatic-scaling.md
@@ -55,7 +55,7 @@ A service principal can be created with the following steps:
 
 The fluent compute library can log in using these credentials as follows (note that core fluent Azure types like `IAzure` are in the [Microsoft.Azure.Management.Fluent](https://www.nuget.org/packages/Microsoft.Azure.Management.Fluent/) package):
 
-```C#
+```csharp
 var credentials = new AzureCredentials(new ServicePrincipalLoginInformation {
                 ClientId = AzureClientId,
                 ClientSecret = 
@@ -77,7 +77,7 @@ Once logged in, scale set instance count can be queried via `AzureClient.Virtual
 ## Scaling out
 Using the fluent Azure compute SDK, instances can be added to the virtual machine scale set with just a few calls -
 
-```C#
+```csharp
 var scaleSet = AzureClient.VirtualMachineScaleSets.GetById(ScaleSetId);
 var newCapacity = (int)Math.Min(MaximumNodeCount, scaleSet.Capacity + 1);
 scaleSet.Update().WithCapacity(newCapacity).Apply(); 
@@ -93,7 +93,7 @@ Scaling in is similar to scaling out. The actual virtual machine scale set chang
 
 Preparing the node for shutdown involves finding the node to be removed (the most recently added node) and deactivating it. For non-seed nodes, newer nodes can be found by comparing `NodeInstanceId`. 
 
-```C#
+```csharp
 using (var client = new FabricClient())
 {
 	var mostRecentLiveNode = (await client.QueryManager.GetNodeListAsync())
@@ -107,7 +107,7 @@ Seed nodes are different and don't necessarily follow the convention that greate
 
 Once the node to be removed is found, it can be deactivated and removed using the same `FabricClient` instance and the `IAzure` instance from earlier.
 
-```C#
+```csharp
 var scaleSet = AzureClient.VirtualMachineScaleSets.GetById(ScaleSetId);
 
 // Remove the node from the Service Fabric cluster
@@ -132,7 +132,7 @@ scaleSet.Update().WithCapacity(newCapacity).Apply();
 
 As with scaling out, PowerShell cmdlets for modifying virtual machine scale set capacity can also be used here if a scripting approach is preferable. Once the virtual machine instance is removed, Service Fabric node state can be removed.
 
-```C#
+```csharp
 await client.ClusterManager.RemoveNodeStateAsync(mostRecentLiveNode.NodeName);
 ```
 

--- a/articles/service-fabric/service-fabric-reliable-services-notifications.md
+++ b/articles/service-fabric/service-fabric-reliable-services-notifications.md
@@ -54,7 +54,7 @@ To register for transaction notifications and/or state manager notifications, yo
 A common place to register with these event handlers is the constructor of your stateful service. 
 When you register on the constructor, you won't miss any notification that's caused by a change during the lifetime of **IReliableStateManager**.
 
-```C#
+```csharp
 public MyService(StatefulServiceContext context)
     : base(MyService.EndpointName, context, CreateReliableStateManager(context))
 {
@@ -74,7 +74,7 @@ It also contains the transaction property that provides a reference to the trans
 
 Following is an example **TransactionChanged** event handler.
 
-```C#
+```csharp
 private void OnTransactionChangedHandler(object sender, NotifyTransactionChangedEventArgs e)
 {
     if (e.Action == NotifyTransactionChangedAction.Commit)
@@ -96,7 +96,7 @@ You use the action property in **NotifyStateManagerChangedEventArgs** to cast **
 
 Following is an example **StateManagerChanged** notification handler.
 
-```C#
+```csharp
 public void OnStateManagerChangedHandler(object sender, NotifyStateManagerChangedEventArgs e)
 {
     if (e.Action == NotifyStateManagerChangedAction.Rebuild)
@@ -123,7 +123,7 @@ To get Reliable Dictionary notifications, you need to register with the **Dictio
 A common place to register with these event handlers is in the **ReliableStateManager.StateManagerChanged** add notification.
 Registering when **IReliableDictionary** is added to **IReliableStateManager** ensures that you won't miss any notifications.
 
-```C#
+```csharp
 private void ProcessStateManagerSingleEntityNotification(NotifyStateManagerChangedEventArgs e)
 {
     var operation = e as NotifyStateManagerSingleEntityChangedEventArgs;
@@ -149,7 +149,7 @@ private void ProcessStateManagerSingleEntityNotification(NotifyStateManagerChang
 The preceding code sets the **IReliableNotificationAsyncCallback** interface, along with **DictionaryChanged**. 
 Because **NotifyDictionaryRebuildEventArgs** contains an **IAsyncEnumerable** interface--which needs to be enumerated asynchronously--rebuild notifications are fired through **RebuildNotificationAsyncCallback** instead of **OnDictionaryChangedHandler**.
 
-```C#
+```csharp
 public async Task OnDictionaryRebuildNotificationHandlerAsync(
     IReliableDictionary<TKey, TValue> origin,
     NotifyDictionaryRebuildEventArgs<TKey, TValue> rebuildNotification)
@@ -179,7 +179,7 @@ Use the action property in **NotifyDictionaryChangedEventArgs** to cast **Notify
 * **NotifyDictionaryChangedAction.Update**: **NotifyDictionaryItemUpdatedEventArgs**
 * **NotifyDictionaryChangedAction.Remove**: **NotifyDictionaryItemRemovedEventArgs**
 
-```C#
+```csharp
 public void OnDictionaryChangedHandler(object sender, NotifyDictionaryChangedEventArgs<TKey, TValue> e)
 {
     switch (e.Action)

--- a/articles/service-fabric/service-fabric-reliable-services-quick-start.md
+++ b/articles/service-fabric/service-fabric-reliable-services-quick-start.md
@@ -186,7 +186,7 @@ Reliable Collections can store any .NET type, including your custom types, with 
 The Reliable State Manager manages Reliable Collections for you. You can simply ask the Reliable State Manager for a reliable collection by name at any time and at any place in your service. The Reliable State Manager ensures that you get a reference back. We don't recommended that you save references to reliable collection instances in class member variables or properties. Special care must be taken to ensure that the reference is set to an instance at all times in the service lifecycle. The Reliable State Manager handles this work for you, and it's optimized for repeat visits.
 
 ### Transactional and asynchronous operations
-```C#
+```csharp
 using (ITransaction tx = this.StateManager.CreateTransaction())
 {
     var result = await myDictionary.TryGetValueAsync(tx, "Counter-1");

--- a/articles/service-fabric/service-fabric-reliable-services-reliable-collections-serialization.md
+++ b/articles/service-fabric/service-fabric-reliable-services-reliable-collections-serialization.md
@@ -56,7 +56,7 @@ Among other reasons, custom serializers are commonly more efficient than generic
 [IReliableStateManager.TryAddStateSerializer<T>](https://docs.microsoft.com/dotnet/api/microsoft.servicefabric.data.ireliablestatemanager.tryaddstateserializer--1?Microsoft_ServiceFabric_Data_IReliableStateManager_TryAddStateSerializer__1_Microsoft_ServiceFabric_Data_IStateSerializer___0__) is used to register a custom serializer for the given type T.
 This registration should happen in the construction of the StatefulServiceBase to ensure that before recovery starts, all Reliable Collections have access to the relevant serializer to read their persisted data.
 
-```C#
+```csharp
 public StatefulBackendService(StatefulServiceContext context)
   : base(context)
   {
@@ -83,7 +83,7 @@ A custom serializer needs to implement the [IStateSerializer<T>](https://docs.mi
 
 Following is an example custom type called OrderKey that contains four properties
 
-```C#
+```csharp
 public class OrderKey : IComparable<OrderKey>, IEquatable<OrderKey>
 {
     public byte Warehouse { get; set; }
@@ -102,7 +102,7 @@ public class OrderKey : IComparable<OrderKey>, IEquatable<OrderKey>
 Following is an example implementation of IStateSerializer<OrderKey>.
 Note that Read and Write overloads that take in baseValue, call their respective overload for forwards compatibility.
 
-```C#
+```csharp
 public class OrderKeySerializer : IStateSerializer<OrderKey>
 {
   OrderKey IStateSerializer<OrderKey>.Read(BinaryReader reader)

--- a/articles/service-fabric/service-fabric-securing-containers.md
+++ b/articles/service-fabric/service-fabric-securing-containers.md
@@ -50,7 +50,7 @@ Alternatively, if you already have the certificates in the required form and wou
 
 The container service or process is responsible for importing the certificate files into the container. To import the certificate, you can use `setupentrypoint.sh` scripts or execute custom code within the container process. Sample code in C# for importing the PFX file follows:
 
-```c#
+```csharp
     string certificateFilePath = Environment.GetEnvironmentVariable("Certificates_MyServicePackage_NodeContainerService.Code_MyCert1_PFX");
     string passwordFilePath = Environment.GetEnvironmentVariable("Certificates_MyServicePackage_NodeContainerService.Code_MyCert1_Password");
     X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);

--- a/articles/sql-data-warehouse/sql-data-warehouse-connect-overview.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-connect-overview.md
@@ -40,12 +40,12 @@ Azure SQL Data Warehouse supports [ADO.NET][ADO.NET], [ODBC][ODBC], [PHP][PHP], 
 > 
 
 ### ADO.NET connection string example
-```C#
+```csharp
 Server=tcp:{your_server}.database.windows.net,1433;Database={your_database};User ID={your_user_name};Password={your_password_here};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
 ```
 
 ### ODBC connection string example
-```C#
+```csharp
 Driver={SQL Server Native Client 11.0};Server=tcp:{your_server}.database.windows.net,1433;Database={your_database};Uid={your_user_name};Pwd={your_password_here};Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;
 ```
 

--- a/articles/sql-data-warehouse/sql-data-warehouse-connection-strings.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-connection-strings.md
@@ -22,12 +22,12 @@ ms.author: anvang;barbkess
 You can connect to SQL Data Warehouse with several different application protocols such as, [ADO.NET][ADO.NET], [ODBC][ODBC], [PHP][PHP] and [JDBC][JDBC]. Below are some examples of connections strings for each protocol.  You can also use the Azure portal to build your connection string.  To build your connection string using the Azure portal, navigate to your database blade, under *Essentials* click on *Show database connection strings*.
 
 ## Sample ADO.NET connection string
-```C#
+```csharp
 Server=tcp:{your_server}.database.windows.net,1433;Database={your_database};User ID={your_user_name};Password={your_password_here};Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;
 ```
 
 ## Sample ODBC connection string
-```C#
+```csharp
 Driver={SQL Server Native Client 11.0};Server=tcp:{your_server}.database.windows.net,1433;Database={your_database};Uid={your_user_name};Pwd={your_password_here};Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;
 ```
 

--- a/articles/stream-analytics/stream-analytics-with-azure-functions.md
+++ b/articles/stream-analytics/stream-analytics-with-azure-functions.md
@@ -60,7 +60,7 @@ Follow the [Real-time fraud detection](stream-analytics-real-time-fraud-detectio
 
 2. Browse to the **run.csx** function. Update it with the following code. (Make sure to replace “\<your redis cache connection string goes here\>” with the Azure Redis Cache primary connection string that you retrieved in the previous section.)  
 
-   ```c#
+   ```csharp
    using System;
    using System.Net;
    using System.Threading.Tasks;
@@ -111,7 +111,7 @@ Follow the [Real-time fraud detection](stream-analytics-real-time-fraud-detectio
 
    When Stream Analytics receives the "HTTP Request Entity Too Large" exception from the function, it reduces the size of the batches it sends to Functions. In your function, use the following code to check that Stream Analytics doesn’t send oversized batches. Make sure that the maximum batch count and size values used in the function are consistent with the values entered in the Stream Analytics portal.
 
-   ```c#
+   ```csharp
    if (dataArray.ToString().Length > 262144)
       {        
         return new HttpResponseMessage(HttpStatusCode.RequestEntityTooLarge);


### PR DESCRIPTION
set c# language to `csharp` so that the docs site correctly shows syntax highlighting.