### PR TITLE
Corrected path to iris_sklearn.py

### DIFF
--- a/articles/machine-learning/preview/tutorial-classifying-iris-part-2.md
+++ b/articles/machine-learning/preview/tutorial-classifying-iris-part-2.md
@@ -323,7 +323,7 @@ To execute your script in a Docker container on a remote Linux machine, you need
 3. Issue the same command as you did before in the CLI window, except this time target _myvm_:
    ```azurecli
    REM executes iris_sklearn.py in a remote Docker container
-   az ml experiment submit -c myvm .\iris_sklearn.py
+   az ml experiment submit -c myvm iris_sklearn.py
    ```
    The command executes as if you're in a `docker-python` environment, except that the execution happens on the remote Linux VM. The CLI window displays the same output information.
 


### PR DESCRIPTION
Tried running this on an ubuntu VM with *.\iris_sklearn.py* and console returns:

```
az ml experiment submit -c dv-data-sci-ubuntu .\iris_sk_learn.py
File to run does not exist.
```

Removed *./* and it works:

[Link to image of it working in console](https://www.dropbox.com/s/zbbn55jsu32eef7/Screenshot%202018-01-19%2020.12.57.png?dl=0)