### PR TITLE
Fix broken how to link for Kubernetes How to

### DIFF
--- a/articles/jenkins/overview.md
+++ b/articles/jenkins/overview.md
@@ -25,7 +25,7 @@ Host Jenkins in Azure to centralize your build automation and scale your deploym
  
 - [The Jenkins solution template](install-jenkins-solution-template.md) in Azure Marketplace.
 - [Azure virtual machines](/azure/virtual-machines/linux/overview). See our [tutorial](/azure/virtual-machines/linux/tutorial-jenkins-github-docker-cicd) to create a Jenkins instance on a VM.
-- On a Kubernetes cluster running in [Azure Container Service](/azure/container-service/kubernetes/container-service-kubernetes-walkthrough), see our [how-to](/azure/container-service/kubernetes/container-service-kubernetes-jenkin).
+- On a Kubernetes cluster running in [Azure Container Service](/azure/container-service/kubernetes/container-service-kubernetes-walkthrough), see our [how-to](/azure/container-service/kubernetes/container-service-kubernetes-jenkins).
 
 Monitor and manage your Azure Jenkins deployment using [Log Analytics](/azure/log-analytics/log-analytics-overview), [Operations Management Suite](/azure/operations-management-suite/operations-management-suite-overview), and the [Azure CLI] (/cli/azure/overview).
 


### PR DESCRIPTION
Adding an "s" onto the end of the URL path for the k8s how to, as it is currently broken.