### PR TITLE
Correcting terraform example code

### DIFF
--- a/articles/terraform/terraform-create-vm-cluster-module.md
+++ b/articles/terraform/terraform-create-vm-cluster-module.md
@@ -70,7 +70,7 @@ output "vm_public_name" {
     value = "${module.mycompute.public_ip_dns_name}"
 }
 
-output = "vm_public_ip" {
+output "vm_public_ip" {
     value = "${module.mycompute.public_ip_address}"
 }
 


### PR DESCRIPTION
Looks as though there is an incorrect "=" placed on the output "vm_public_ip" line, which causes terraform init to fail.