### PR TITLE
Create password on demand

### DIFF
--- a/articles/automation/automation-hrw-run-runbooks.md
+++ b/articles/automation/automation-hrw-run-runbooks.md
@@ -109,9 +109,10 @@ The following PowerShell runbook, *Export-RunAsCertificateToHybridWorker*, expor
 
     [OutputType([string])] 
 
-    # Set the password used for this certificate
-    $Password = "YourStrongPasswordForTheCert"
-
+    # Generate the password used for this certificate
+    Add-Type -AssemblyName System.Web -ErrorAction SilentlyContinue | Out-Null
+    $Password = [System.Web.Security.Membership]::GeneratePassword(25, 10)
+    
     # Stop on errors
     $ErrorActionPreference = 'stop'
 


### PR DESCRIPTION
Do not store the password in cleartext. Since the password is temporary it can be generated on runtime.