### PR TITLE
Avoid using cmdlet aliases

### DIFF
--- a/articles/automation/automation-hrw-run-runbooks.md
+++ b/articles/automation/automation-hrw-run-runbooks.md
@@ -141,7 +141,7 @@ The following PowerShell runbook, *Export-RunAsCertificateToHybridWorker*, expor
     Set-AzureRmContext -SubscriptionId $RunAsConnection.SubscriptionID | Write-Verbose
 
     # List automation accounts to confirm Azure Resource Manager calls are working
-    Get-AzureRmAutomationAccount | Select AutomationAccountName
+    Get-AzureRmAutomationAccount | Select-Object AutomationAccountName
 
 Save the *Export-RunAsCertificateToHybridWorker* runbook to your computer with a `.ps1` extension.  Import it into your Automation account and edit the runbook, changing the value of the variable `$Password` with your own password.  Publish and then run the runbook targeting the Hybrid Worker group that run and authenticate runbooks using the Run As account.  The job stream reports the attempt to import the certificate into the local machine store, and follows with multiple lines depending on how many Automation accounts are defined in your subscription and if authentication is successful.  
 


### PR DESCRIPTION
'Select' is an alias of 'Select-Object'. Alias can introduce possible problems and make scripts hard to maintain.