### PR TITLE
Update azure-stack-start-and-stop.md

### DIFF
--- a/articles/azure-stack/azure-stack-start-and-stop.md
+++ b/articles/azure-stack/azure-stack-start-and-stop.md
@@ -61,7 +61,7 @@ Start Azure Stack with the following steps. Follow these steps regardless of how
 
 ## Troubleshoot startup and shutdown of Azure Stack
 
-Perform the following steps if the infrastructure and tenant services don't successfully start after you power on your Azure Stack environment. 
+Perform the following steps if the infrastructure and tenant services don't successfully start 2 hours after you power on your Azure Stack environment. 
 
 1. Open a Privileged Endpoint Session from a machine with network access to the Azure Stack ERCS VMs.
 


### PR DESCRIPTION
Adding a time limit before troubleshooting actions should be performed. Taking startup tshooting actions before 2 hours could be detrimental to automated startup routine.