### PR TITLE
Update PS Syntax for Get-AzureRmExpressRouteCircuitPeeringConfig

### DIFF
--- a/articles/expressroute/expressroute-troubleshooting-expressroute-overview.md
+++ b/articles/expressroute/expressroute-troubleshooting-expressroute-overview.md
@@ -216,12 +216,12 @@ A sample response, for a successfully configured private peering, is:
 To get the Azure public peering configuration details, use the following commands:
 
 	$ckt = Get-AzureRmExpressRouteCircuit -ResourceGroupName "Test-ER-RG" -Name "Test-ER-Ckt"
-	Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePublicPeering" -Circuit $ckt
+	Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePublicPeering" -ExpressRouteCircuit $ckt
 
 To get the Microsoft peering configuration details, use the following commands:
 
 	$ckt = Get-AzureRmExpressRouteCircuit -ResourceGroupName "Test-ER-RG" -Name "Test-ER-Ckt"
-	Get-AzureRmExpressRouteCircuitPeeringConfig -Name "MicrosoftPeering" -Circuit $ckt
+	Get-AzureRmExpressRouteCircuitPeeringConfig -Name "MicrosoftPeering" -ExpressRouteCircuit $ckt
 
 If a peering is not configured, there would be an error message. A sample response, when the stated peering (Azure Public peering in this example) is not configured within the circuit:
 


### PR DESCRIPTION
Invalid PowerShell command syntax, change "-Circuit" to "-ExpressRouteCircuit" for both examples of Get-AzureRmExpressRouteCircuitPeeringConfig, Public and Microsoft Peering

Get-AzureRmExpressRouteCircuitPeeringConfig [-Name ] -ExpressRouteCircuit [-DefaultProfile ] []

https://docs.microsoft.com/en-us/powershell/module/azurerm.network/get-azurermexpressroutecircuitpeeringconfig?view=azurermps-4.4.1&viewFallbackFrom=azurermps-4.4.0

Correct Syntax for examples - 
Get-AzureRmExpressRouteCircuitPeeringConfig -Name "AzurePublicPeering" -ExpressRouteCircuit $ckt
Get-AzureRmExpressRouteCircuitPeeringConfig -Name "MicrosoftPeering" -ExpressRouteCircuit $ckt