### PR TITLE
Added "--%" to PowerShell command.

### DIFF
--- a/includes/app-service-web-create-web-app-python-no-h.md
+++ b/includes/app-service-web-create-web-app-python-no-h.md
@@ -3,7 +3,7 @@ In the Cloud Shell, create a web app in the `myAppServicePlan` App Service plan 
 In the following example, replace `<app_name>` with a globally unique app name (valid characters are `a-z`, `0-9`, and `-`). The runtime is set to `python|3.4`. To see all supported runtimes, run [az webapp list-runtimes](/cli/azure/webapp?view=azure-cli-latest#az_webapp_list_runtimes). 
 
 ```azurecli-interactive
-az webapp create --resource-group myResourceGroup --plan myAppServicePlan --name <app_name> --runtime "python|3.4" --deployment-local-git
+az --% webapp create --resource-group myResourceGroup --plan myAppServicePlan --name <app_name> --runtime "python|3.4" --deployment-local-git
 ```
 
 When the web app has been created, the Azure CLI shows output similar to the following example:


### PR DESCRIPTION
Based on customer cases, PowerShell has a problem escaping the pipe character. By adding "--%", we can avoid this issue.