### PR TITLE
Add using directives to C# module tutorial

### DIFF
--- a/articles/iot-edge/tutorial-csharp-module.md
+++ b/articles/iot-edge/tutorial-csharp-module.md
@@ -76,6 +76,14 @@ The following steps show you how to create an IoT Edge module based on .NET core
 
    ![Open Program.cs][1]
 
+6. At the top of the **FilterModule** namespace, add three `using` statements for types used later on:
+
+    ```csharp
+    using System.Collections.Generic;     // for KeyValuePair<>
+    using Microsoft.Azure.Devices.Shared; // for TwinCollection
+    using Newtonsoft.Json;                // for JsonConvert
+    ```
+
 6. Add the `temperatureThreshold` variable to the **Program** class. This variable sets the value that the measured temperature must exceed in order for the data to be sent to IoT Hub. 
 
     ```csharp


### PR DESCRIPTION
The C# module tutorial makes use of 3 types whose namespaces aren't already referenced by the `aziotedgemodule` template code. So if you follow the tutorial, paste all the code into your own project as instructed, and build, you'll get compiler errors. I've added a step that instructs the reader to add the right namespace `using` directives.