### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-functions/functions-reference-csharp.md
+++ b/articles/azure-functions/functions-reference-csharp.md
@@ -255,7 +255,7 @@ public async static Task ProcessQueueMessageAsync(
         Stream blobInput,
         Stream blobOutput)
 {
-    await blobInput.CopyToAsync(blobOutput, 4096, token);
+    await blobInput.CopyToAsync(blobOutput, 4096);
 }
 ```
 


### PR DESCRIPTION
Remove token argument in example code as it does not exist in this context