### PR TITLE
Troubleshooting connecting to an ERCS vm

### DIFF
--- a/articles/azure-stack/azure-stack-privileged-endpoint.md
+++ b/articles/azure-stack/azure-stack-privileged-endpoint.md
@@ -73,7 +73,8 @@ We recommend that you connect to the privileged endpoint only from the hardware 
 
       - **User name**: Specify the CloudAdmin account, in the format **&lt;*Azure Stack domain*&gt;\cloudadmin**. (For ASDK, the user name is **azurestack\cloudadmin**.)
       - **Password**: Enter the same password that was provided during installation for the AzureStackAdmin domain administrator account.
-    NOTE: If unable to connect to the ERCS endpoint, try steps 1 & 2 again with the ip address of an ERCS vm you haven't already tried to connect to.
+    > [!NOTE]
+    > If you are unable to connect to the ERCS endpoint, try steps one and two again with the IP address of an ERCS VM to which you haven't already tried to connect.
     
 3.	After you connect, the prompt will change to **[*IP address or ERCS VM name*]: PS>** or to **[azs-ercs01]: PS>**, depending on the environment. From here, run `Get-Command` to view the list of available cmdlets.
 

--- a/articles/azure-stack/azure-stack-privileged-endpoint.md
+++ b/articles/azure-stack/azure-stack-privileged-endpoint.md
@@ -73,6 +73,7 @@ We recommend that you connect to the privileged endpoint only from the hardware 
 
       - **User name**: Specify the CloudAdmin account, in the format **&lt;*Azure Stack domain*&gt;\cloudadmin**. (For ASDK, the user name is **azurestack\cloudadmin**.)
       - **Password**: Enter the same password that was provided during installation for the AzureStackAdmin domain administrator account.
+    NOTE: If unable to connect to the ERCS endpoint, try steps 1 & 2 again with the ip address of an ERCS vm you haven't already tried to connect to.
     
 3.	After you connect, the prompt will change to **[*IP address or ERCS VM name*]: PS>** or to **[azs-ercs01]: PS>**, depending on the environment. From here, run `Get-Command` to view the list of available cmdlets.
 


### PR DESCRIPTION
If admins can't connect to an ERCS vm it may be down, in which case they should try to connect to one of the remaining two ERCS instances.