### PR TITLE
Update process to include samba-common-tools

### DIFF
--- a/articles/active-directory-domain-services/active-directory-ds-join-rhel-linux-vm.md
+++ b/articles/active-directory-domain-services/active-directory-ds-join-rhel-linux-vm.md
@@ -66,7 +66,7 @@ Here, 'contoso100.com' is the DNS domain name of your managed domain. 'contoso-r
 Next, install packages required for domain join on the virtual machine. In your SSH terminal, type the following command to install the required packages:
 
     ```
-    sudo yum install realmd sssd krb5-workstation krb5-libs
+    sudo yum install realmd sssd krb5-workstation krb5-libs samba-common-tools
     ```
 
 


### PR DESCRIPTION
Joining the domain fails with missing packages if the samba-common-tools are not installed