### PR TITLE
Add EnvironmentOverrides opening tag

### DIFF
--- a/articles/service-fabric/service-fabric-get-started-containers.md
+++ b/articles/service-fabric/service-fabric-get-started-containers.md
@@ -210,6 +210,7 @@ These environment variables can be overridden in the application manifest:
 ```xml
 <ServiceManifestImport>
   <ServiceManifestRef ServiceManifestName="Guest1Pkg" ServiceManifestVersion="1.0.0" />
+  <EnvironmentOverrides CodePackageRef="Code">
     <EnvironmentVariable Name="HttpGatewayPort" Value="19080"/>
   </EnvironmentOverrides>
   ...


### PR DESCRIPTION
The example is not compliant with the  http://schemas.microsoft.com/2011/01/fabric schema due the missing EnvironmentOverrides opening tag.