### PR TITLE
Azure AD Connect: Fix list of Geos for PDL

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnectsync-feature-preferreddatalocation.md
+++ b/articles/active-directory/connect/active-directory-aadconnectsync-feature-preferreddatalocation.md
@@ -12,12 +12,12 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 01/30/2018
+ms.date: 01/31/2018
 ms.author: billmath
 
 ---
 # Azure AD Connect sync: Configure preferred data location for Office 365 resources
-The purpose of this topic is to walk you through how to configure PreferredDataLocation in Azure AD Connect Sync. When a customer uses Multi-Geo capabilities in Office 365, this attribute is used to designate the geo-location of the user’s Office 365 data.
+The purpose of this topic is to walk you through how to configure PreferredDataLocation in Azure AD Connect Sync. When a customer uses Multi-Geo capabilities in Office 365, this attribute is used to designate the geo-location of the user’s Office 365 data. The terms **region** and **Geo** are used interchangeable.
 
 > [!IMPORTANT]
 > Multi-Geo is currently in preview. If you would like to join the preview program, please contact your Microsoft representative.
@@ -25,36 +25,41 @@ The purpose of this topic is to walk you through how to configure PreferredDataL
 >
 
 ## Enable synchronization of PreferredDataLocation
-By default, Office 365 resources for your users are located in the same region as your Azure AD tenant. For example, if your tenant is located in North America then the users Exchange mailboxes are also located in North America. For a multi-national organization this might not be optimal. By setting the attribute preferredDataLocation the user's region can be defined.
+By default, Office 365 resources for your users are located in the same geo as your Azure AD tenant. For example, if your tenant is located in North America then the users Exchange mailboxes are also located in North America. For a multi-national organization this might not be optimal. By setting the attribute preferredDataLocation the user's geo can be defined.
 
-By settings this attribute, you can have the user's Office 365 resources, such as the mailbox and OneDrive, in the same region as the user and still have one tenant for your entire organization.
+By settings this attribute, you can have the user's Office 365 resources, such as the mailbox and OneDrive, in the same geo as the user and still have one tenant for your entire organization.
 
 > [!IMPORTANT]
 > To be eligible for Multi-Geo, you must have at least 5000 seats in your Office 365 subscription
 >
 >
 
-The regions in Office 365 available for Multi-Geo are:
+A list of all Geos for Office 365 can be found in [where is your data located](https://aka.ms/datamaps).
 
-| Region | Description |
+The geos in Office 365 available for Multi-Geo are:
+
+| Geo | preferredDataLocation value |
 | --- | --- |
-| NAM | North America |
-| EUR | Europe |
-| APC | Asia Pacific |
-| JPN | Japan |
-| AUS | Australia |
-| CAN | Canada |
-| GBR | Great Britain |
-| LAM | Latin America |
+| Asia Pacific | APC |
+| Australia | AUS |
+| Canada | CAN |
+| European Union | EUR |
+| India | IND |
+| Japan | JPN |
+| South Korea | KOR |
+| United Kingdom | GBR |
+| United States | NAM |
 
-Not all Office 365 workloads supports the use of setting a user's region.
+* If a geo is not listed in this table, for example South America, then it cannot be used for Multi-Geo.
+* India and South Korea geos are only available to customers with billing addresses and licenses purchased in those geos.
+* Not all Office 365 workloads supports the use of setting a user's geo.
 
 Azure AD Connect supports synchronization of the **PreferredDataLocation** attribute for **User** objects in version 1.1.524.0 and after. More specifically, following changes have been introduced:
 
 * The schema of the object type **User** in the Azure AD Connector is extended to include PreferredDataLocation attribute, which is of type single-valued string.
 * The schema of the object type **Person** in the Metaverse is extended to include PreferredDataLocation attribute, which is of type string and is single-valued.
 
-By default, the PreferredDataLocation attribute is not enabled for synchronization. This feature is intended for larger organizations and not everyone would benefit from it. You must also identify an attribute to hold the Office 365 region for your users since there is no PreferredDataLocation attribute in on-premises Active Directory. This is going to be different for each organization.
+By default, the PreferredDataLocation attribute is not enabled for synchronization. This feature is intended for larger organizations and not everyone would benefit from it. You must also identify an attribute to hold the Office 365 geo for your users since there is no PreferredDataLocation attribute in on-premises Active Directory. This is going to be different for each organization.
 
 > [!IMPORTANT]
 > Currently, Azure AD allows the PreferredDataLocation attribute on both synchronized User objects and cloud User objects to be directly configured using Azure AD PowerShell. Once you have enabled synchronization of the PreferredDataLocation attribute, you must stop using Azure AD PowerShell to configure the attribute on **synchronized User objects** as Azure AD Connect will override them based on the source attribute values in on-premises Active Directory.
@@ -241,13 +246,13 @@ Re-enable the built-in sync scheduler:
 ## Step 8: Verify the result
 It is now time to verify the configuration and enable it for your users.
 
-1. Add the region to the selected attribute on a user. The list of available regions can be found in [this table](#enable-synchronization-of-preferreddatalocation).  
+1. Add the geo to the selected attribute on a user. The list of available geo can be found in [this table](#enable-synchronization-of-preferreddatalocation).  
 ![AD attribute added to a user](./media/active-directory-aadconnectsync-feature-preferreddatalocation/preferreddatalocation-adattribute.png)
 2. Wait for the attribute to be synchronized to Azure AD.
 3. Using Exchange Online PowerShell, verify that the mailbox region has been set correctly.  
 ![Mailbox region set on a user in Exchange Online](./media/active-directory-aadconnectsync-feature-preferreddatalocation/preferreddatalocation-mailboxregion.png)  
-Assuming your tenant has been marked to be able to use this feature, the mailbox is moved to the correct region. This can be verified by looking at the server name where the mailbox is located.
-4. To verify that this setting has been effective over many mailboxes, use the script in the [Technet gallery](https://gallery.technet.microsoft.com/office/PowerShell-Script-to-a6bbfc2e). This script also has a list of all Office 365 datacenters server prefixes and which region it is located in. It can be used as a reference in the previous step to verify the location of the mailbox.
+Assuming your tenant has been marked to be able to use this feature, the mailbox is moved to the correct geo. This can be verified by looking at the server name where the mailbox is located.
+4. To verify that this setting has been effective over many mailboxes, use the script in the [Technet gallery](https://gallery.technet.microsoft.com/office/PowerShell-Script-to-a6bbfc2e). This script also has a list of all Office 365 datacenters server prefixes and which geo it is located in. It can be used as a reference in the previous step to verify the location of the mailbox.
 
 ## Next steps
 


### PR DESCRIPTION
- Replacing "region" with "geo" by request from Office 365 marketing. In PowerShell the term is "region" so it has to still be region in those cases.
- Updating the list of geos to what actually is and will be supported.

That should be it. No known TODOs for this topic at present.