### PR TITLE
Update network-watcher-packet-capture-manage-portal.md

### DIFF
--- a/articles/network-watcher/network-watcher-packet-capture-manage-portal.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-portal.md
@@ -58,8 +58,10 @@ Navigate to the [Azure portal](https://portal.azure.com) and click **Networking*
 The overview page shows a list of all packet captures that exist no matter the state.
 
 > [!NOTE]
-> Packet capture requires inbound connectivity from Azure platform (168.63.129.16).
-> Packet capture requires outbound connectivity to the storage account over port 443.
+> Packet capture requires following conectivity.
+> * Outbound connectivity to the storage account over port 443.
+> * Inbound and Outbound connectivity to 169.254.169.254
+> * Inbound and Outbound connectivity to 168.63.129.16
 
 ![packet capture overview screen][1]
 

--- a/articles/network-watcher/network-watcher-packet-capture-manage-portal.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-portal.md
@@ -58,7 +58,8 @@ Navigate to the [Azure portal](https://portal.azure.com) and click **Networking*
 The overview page shows a list of all packet captures that exist no matter the state.
 
 > [!NOTE]
-> Packet capture requires connectivity to the storage account over port 443.
+> Packet capture requires inbound connectivity from Azure platform (168.63.129.16).
+> Packet capture requires outbound connectivity to the storage account over port 443.
 
 ![packet capture overview screen][1]
 


### PR DESCRIPTION
When I block inbound traffic from 168.63.129.16, I can't capture packets.
Therefore, NetworkWatcher need to allow inbound traffic from 168.63.129.16.

Error
![image](https://user-images.githubusercontent.com/16984569/35721265-7d861c78-0834-11e8-8b36-6a3eea883245.png)

NSG settings
![image](https://user-images.githubusercontent.com/16984569/35721311-aff0fc8c-0834-11e8-9f0d-a28964cba269.png)
