### PR TITLE
Update sql-data-warehouse-manage-monitor.md

### DIFF
--- a/articles/sql-data-warehouse/sql-data-warehouse-manage-monitor.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-manage-monitor.md
@@ -266,7 +266,6 @@ FROM sys.dm_pdw_nodes_os_performance_counters
 WHERE 
 instance_name like 'Distribution_%' 
 AND counter_name = 'Log File(s) Used Size (KB)'
-AND counter_name = 'Target Server Memory (KB)'
 ```
 ## Monitor transaction log rollback
 If your queries are failing or taking a long time to proceed, you can check and monitor if you have any transactions rolling back.


### PR DESCRIPTION
removed AND condition or query would return empty results. Also checking memory (using OR instead of AND) wouldn't make sense in a check for transaction log size