### PR TITLE
MaxDataDiskCount is lower for Classic RDFE VMs

### DIFF
--- a/includes/virtual-machines-common-sizes-general.md
+++ b/includes/virtual-machines-common-sizes-general.md
@@ -173,4 +173,4 @@ In the classic deployment model, some VM size names are slightly different in CL
 |A4\Basic_A4|8|14 GB|2| 240 GB |16|16x300|
 
 
-Please note that the number of Data Disks for Classic VMs might be lower than the number of Data Disks for ARM VMs.
+Note that the number of Data Disks for Classic VMs might be lower than the number of Data Disks for Azure Resource Manager VMs.

--- a/includes/virtual-machines-common-sizes-general.md
+++ b/includes/virtual-machines-common-sizes-general.md
@@ -121,6 +121,8 @@ ACU: 160
 
 ACU: 100
 
+
+
 | Size            | vCPU | Memory: GiB | Temp storage (SSD) GiB | Max temp storage throughput: IOPS / Read MBps / Write MBps | Max data disks / throughput: IOPS | Max NICs / Expected network bandwidth (Mbps) | 
 |-----------------|-----------|-------------|----------------|----------------------------------------------------------|-----------------------------------|------------------------------|
 | Standard_A1_v2  | 1         | 2           | 10             | 1000 / 20 / 10                                           | 2 / 2x500               | 2 / 250                 |
@@ -169,3 +171,6 @@ In the classic deployment model, some VM size names are slightly different in CL
 |A2\Basic_A2|2|3.5 GB|2| 60 GB|4|4x300|
 |A3\Basic_A3|4|7 GB|2| 120 GB |8|8x300|
 |A4\Basic_A4|8|14 GB|2| 240 GB |16|16x300|
+
+
+Please note that the number of Data Disks for Classic VMs might be lower than the number of Data Disks for ARM VMs.


### PR DESCRIPTION
CRIs 57005309 - 58844713 - 53789825 ...

Customers with Classic VMs are reporting that MaxDataDiskCount is 2x lower that what's written in the doc. Confirmed in Source Code. They would get errors like the one below if they try to add another Data Disk
Too many data disks specified for virtual machine netserv. The maximum number of data disks currently permitted is 4. The current number of data disks is 4. The operation is attempting to add 1 additional data disks

In order to stop them opening cases / CRIs, we need to update the doc.