### PR TITLE
download the app's skeleton as a .zip file link updated

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-devquickstarts-web-node.md
+++ b/articles/active-directory-b2c/active-directory-b2c-devquickstarts-web-node.md
@@ -29,7 +29,7 @@ You need to:
 3. Use Passport to issue sign-in and sign-out requests to Azure AD.
 4. Print user data.
 
-The code for this tutorial [is maintained on GitHub](https://github.com/AzureADQuickStarts/B2C-WebApp-OpenIDConnect-NodeJS). To follow along, you can [download the app's skeleton as a .zip file](https://github.com/AzureADQuickStarts/B2C-WebApp-OpenIDConnect-NodeJS/archive/skeleton.zip). You can also clone the skeleton:
+The code for this tutorial [is maintained on GitHub](https://github.com/AzureADQuickStarts/B2C-WebApp-OpenIDConnect-NodeJS). To follow along, you can [download the app's skeleton as a .zip file](https://github.com/AzureADQuickStarts/B2C-WebApp-OpenIDConnect-NodeJS/archive/master.zip). You can also clone the skeleton:
 
 ```git clone --branch skeleton https://github.com/AzureADQuickStarts/B2C-WebApp-OpenIDConnect-NodeJS.git```
 


### PR DESCRIPTION
download the app's skeleton as a .zip file link was pointing wrong url. It's updated with correct link.