### PR TITLE
Update Supported OS to include Windows Server 2016

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-certificates-point-to-site.md
+++ b/articles/vpn-gateway/vpn-gateway-certificates-point-to-site.md
@@ -1,6 +1,6 @@
 ---
 title: 'Generate and export certificates for Point-to-Site: PowerShell: Azure | Microsoft Docs'
-description: This article contains steps to create a self-signed root certificate, export the public key, and generate client certificates using PowerShell on Windows 10.
+description: This article contains steps to create a self-signed root certificate, export the public key, and generate client certificates using PowerShell on Windows 10 or Windows Server 2016.
 services: vpn-gateway
 documentationcenter: na
 author: cherylmc
@@ -18,9 +18,9 @@ ms.date: 08/09/2017
 ms.author: cherylmc
 
 ---
-# Generate and export certificates for Point-to-Site connections using PowerShell on Windows 10
+# Generate and export certificates for Point-to-Site connections using PowerShell on Windows 10 or Windows Server 2016
 
-Point-to-Site connections use certificates to authenticate. This article shows you how to create a self-signed root certificate and generate client certificates using PowerShell on Windows 10. If you are looking for Point-to-Site configuration steps, such as how to upload root certificates, select one of the 'Configure Point-to-Site' articles from the following list:
+Point-to-Site connections use certificates to authenticate. This article shows you how to create a self-signed root certificate and generate client certificates using PowerShell on Windows 10 or Windows Server 2016. If you are looking for Point-to-Site configuration steps, such as how to upload root certificates, select one of the 'Configure Point-to-Site' articles from the following list:
 
 > [!div class="op_single_selector"]
 > * [Create self-signed certificates - PowerShell](vpn-gateway-certificates-point-to-site.md)
@@ -32,15 +32,15 @@ Point-to-Site connections use certificates to authenticate. This article shows y
 > 
 
 
-You must perform the steps in this article on a computer running Windows 10. The PowerShell cmdlets that you use to generate certificates are part of the Windows 10 operating system and do not work on other versions of Windows. The Windows 10 computer is only needed to generate the certificates. Once the certificates are generated, you can upload them, or install them on any supported client operating system. 
+You must perform the steps in this article on a computer running Windows 10 or Windows Server 2016. The PowerShell cmdlets that you use to generate certificates are part of the operating system and do not work on other versions of Windows. The Windows 10 or Windows Server 2016 computer is only needed to generate the certificates. Once the certificates are generated, you can upload them, or install them on any supported client operating system. 
 
-If you do not have access to a Windows 10 computer, you can use [MakeCert](vpn-gateway-certificates-point-to-site-makecert.md) to generate certificates. The certificates that you generate using either method can be installed on any [supported](vpn-gateway-howto-point-to-site-resource-manager-portal.md#faq) client operating system.
+If you do not have access to a Windows 10 or Windows Server 2016 computer, you can use [MakeCert](vpn-gateway-certificates-point-to-site-makecert.md) to generate certificates. The certificates that you generate using either method can be installed on any [supported](vpn-gateway-howto-point-to-site-resource-manager-portal.md#faq) client operating system.
 
 ## <a name="rootcert"></a>Create a self-signed root certificate
 
 Use the New-SelfSignedCertificate cmdlet to create a self-signed root certificate. For additional parameter information, see [New-SelfSignedCertificate](https://technet.microsoft.com/itpro/powershell/windows/pkiclient/new-selfsignedcertificate).
 
-1. From a computer running Windows 10, open a Windows PowerShell console with elevated privileges.
+1. From a computer running Windows 10 or Windows Server 2016, open a Windows PowerShell console with elevated privileges.
 2. Use the following example to create the self-signed root certificate. The following example creates a self-signed root certificate named 'P2SRootCert' that is automatically installed in 'Certificates-Current User\Personal\Certificates'. You can view the certificate by opening *certmgr.msc*, or *Manage User Certificates*.
 
   ```powershell


### PR DESCRIPTION
At the time of Authorship, Windows 10 was the only supported OS to leverage the New-SelfSignedCertificate.  The current New-SelfSignedCertificate documentation indicates the commandlet now works on both Windows 10 and Windows Server 2016.  I have personally tested each of the example commandlets on Windows Server 2016 and each worked without modification.  

This is a significant distinction as it allows certificates to be created on trusted Windows Server 2016 VMs running in Azure.  It is difficult to provision Windows 10 VMs in Azure.  It also allows the possibility to more completely automate the process via PowerShell and minimize the dependency on MakeCert.