### PR TITLE
Fixed LuisModelUrl

### DIFF
--- a/articles/cognitive-services/LUIS/luis-nodejs-tutorial-build-bot-framework-sample.md
+++ b/articles/cognitive-services/LUIS/luis-nodejs-tutorial-build-bot-framework-sample.md
@@ -119,7 +119,7 @@ var luisAppId = process.env.LuisAppId;
 var luisAPIKey = process.env.LuisAPIKey;
 var luisAPIHostName = process.env.LuisAPIHostName || 'westus.api.cognitive.microsoft.com';
 
-const LuisModelUrl = 'https://' + luisAPIHostName + '/luis/v2.0/apps/' + luisAppId + '&subscription-key=' + luisAPIKey;
+const LuisModelUrl = 'https://' + luisAPIHostName + '/luis/v2.0/apps/' + luisAppId + '?subscription-key=' + luisAPIKey;
 
 // Main dialog with LUIS
 var recognizer = new builder.LuisRecognizer(LuisModelUrl);


### PR DESCRIPTION
Luis expects `?subscription-key` instead of `&subscription-key`, which otherwise results in a 404 error