### PR TITLE
Update active-directory-b2c-ui-customization-custom.md

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-ui-customization-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-ui-customization-custom.md
@@ -127,6 +127,7 @@ Under the top-level *\<TrustFrameworkPolicy\>* tag, you should find *\<BuildingB
     <ContentDefinitions>
       <ContentDefinition Id="api.idpselections">
         <LoadUri>https://{your_storage_account}.blob.core.windows.net/customize-ui.html</LoadUri>
+        <DataUri>urn:com:microsoft:aad:b2c:elements:idpselection:1.0.0</DataUri>
       </ContentDefinition>
     </ContentDefinitions>
   </BuildingBlocks>


### PR DESCRIPTION
Must DataUri be included, in order to avoid the error "The required "DataUri element is missing from ContentDefinition"? Should we comment that we can also add RecoveryUri and Metadata, and that this last one makes necessary to add the Item DisplayName?