### PR TITLE
Update DOS code formatting in numbered list

### DIFF
--- a/articles/azure-stack/azure-stack-app-service-before-you-get-started.md
+++ b/articles/azure-stack/azure-stack-app-service-before-you-get-started.md
@@ -153,22 +153,22 @@ For Azure Stack Development Kit deployments only, you can use the [example Azure
 When you use the Azure Resource Manager template, the users are already created.
 
 1. Run the following commands to create the FileShareOwner and FileShareUser accounts. Replace `<password>` with your own values.
-``` DOS
-net user FileShareOwner <password> /add /expires:never /passwordchg:no
-net user FileShareUser <password> /add /expires:never /passwordchg:no
-```
+    ``` DOS
+    net user FileShareOwner <password> /add /expires:never /passwordchg:no
+    net user FileShareUser <password> /add /expires:never /passwordchg:no
+    ```
 2. Set the passwords for the accounts to never expire by running the following WMIC commands:
-``` DOS
-WMIC USERACCOUNT WHERE "Name='FileShareOwner'" SET PasswordExpires=FALSE
-WMIC USERACCOUNT WHERE "Name='FileShareUser'" SET PasswordExpires=FALSE
-```
+    ``` DOS
+    WMIC USERACCOUNT WHERE "Name='FileShareOwner'" SET PasswordExpires=FALSE
+    WMIC USERACCOUNT WHERE "Name='FileShareUser'" SET PasswordExpires=FALSE
+    ```
 3. Create the local groups FileShareUsers and FileShareOwners, and add the accounts in the first step to them:
-``` DOS
-net localgroup FileShareUsers /add
-net localgroup FileShareUsers FileShareUser /add
-net localgroup FileShareOwners /add
-net localgroup FileShareOwners FileShareOwner /add
-```
+    ``` DOS
+    net localgroup FileShareUsers /add
+    net localgroup FileShareUsers FileShareUser /add
+    net localgroup FileShareOwners /add
+    net localgroup FileShareOwners FileShareOwner /add
+    ```
 
 ### Provision the content share
 


### PR DESCRIPTION
Attempting to fix the way that the DOS code is formatted in the numbered list.  On the MS site it loses the newlines and the DOS tag for the code.