### PR TITLE
Updated URL for Configuring Alternate Login ID

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-get-started-custom.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-get-started-custom.md
@@ -92,7 +92,7 @@ Review every domain marked **Not Added** and **Not Verified**. Make sure those d
 > When you enable Pass-through Authentication you must have at least one verified domain in order to continue through the wizard.
 
 > [!WARNING]
-> Using an Alternate ID is not compatible with all Office 365 workloads. For more information, refer to [Configuring Alternate Login ID](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configuring-alternate-login-id).
+> Using an Alternate ID is not compatible with all Office 365 workloads. For more information, refer to [Configuring Alternate Login ID](https://docs.microsoft.com/windows-server/identity/ad-fs/operations/configuring-alternate-login-id).
 >
 >
 

--- a/articles/active-directory/connect/active-directory-aadconnect-get-started-custom.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-get-started-custom.md
@@ -92,7 +92,7 @@ Review every domain marked **Not Added** and **Not Verified**. Make sure those d
 > When you enable Pass-through Authentication you must have at least one verified domain in order to continue through the wizard.
 
 > [!WARNING]
-> Using an Alternate ID is not compatible with all Office 365 workloads. For more information, refer to [Configuring Alternate Login ID](https://technet.microsoft.com/library/dn659436.aspx).
+> Using an Alternate ID is not compatible with all Office 365 workloads. For more information, refer to [Configuring Alternate Login ID](https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configuring-alternate-login-id).
 >
 >
 


### PR DESCRIPTION
Previous link was pointing to outdated article on Technet.
Updated it with docs.microsoft.com address.
I guess it is good to update this URL for all languages, not only English.