### PR TITLE
python3 : `print(x)` & python2 : `print x`

### DIFF
--- a/articles/automation/automation-first-runbook-textual-python2.md
+++ b/articles/automation/automation-first-runbook-textual-python2.md
@@ -55,6 +55,7 @@ You start by creating a simple runbook that outputs the text *Hello World*.
 Now you add a simple command to print the text "Hello World":
 
 ```python
+from __future__ import print_statement
 print("Hello World!")
 ```
 
@@ -150,6 +151,7 @@ To work with Azure VMs, create an instance of the
 Use the Compute client to start the VM. Add the following code to the runbook:
 
 ```python
+from __future__ import print_statement
 # Initialize the compute management client with the RunAs credential and specify the subscription to work against.
 compute_client = ComputeManagementClient(
 azure_credential,


### PR DESCRIPTION
Fixed minor but breaking syntax issues RE: python2 compatibility for users who copy/paste.