### PR TITLE
Fix incorrect package location for Log4j2

### DIFF
--- a/articles/application-insights/app-insights-java-trace-logs.md
+++ b/articles/application-insights/app-insights-java-trace-logs.md
@@ -125,7 +125,7 @@ To start getting traces, merge the relevant snippet of code to the Log4J or Logb
 
 ```XML
 
-    <Configuration packages="com.microsoft.applicationinsights.Log4j">
+    <Configuration packages="com.microsoft.applicationinsights.log4j.v2">
       <Appenders>
         <ApplicationInsightsAppender name="aiAppender" />
       </Appenders>


### PR DESCRIPTION
This fixes the incorrect package location for Log4j2 which otherwise could inhibit the users from using this Appender.

The correct location for Log4j AI appender in the code is in the package : 

**com.applicationinsights.log4j.v2**