### PR TITLE
[WIP] Find unattached nics

### DIFF
--- a/articles/virtual-machines/linux/find-unattached-nics.md
+++ b/articles/virtual-machines/linux/find-unattached-nics.md
@@ -23,7 +23,7 @@ When you delete a virtual machine in Azure, the NICs attached to it are not dele
 
 ## Find and delete unattached NICs
 
-The following script shows you how to find unattached NICs by using the *virtualMachine* property. It loops through all the NICs in a subscription and checks if the *virtualMachine* property is null to find unattached NICs. *virtualMachine* property stores the MAC address of the interface when it's attached to a VM.
+The following script shows you how to find unattached NICs by using the *virtualMachine* property. It loops through all the NICs in a subscription and checks if the *virtualMachine* property is null to find unattached NICs. *virtualMachine* property stores the id and the resource group of the virtual machine the NIC is attached to.
 
 We highly recommend you to first run the script by setting the *deleteUnattachedNics* variable to 0 to view all the unattached NICs. After reviewing the unattached NICs, run the script by setting *deleteUnattachedNics* to 1 to delete all the unattached NICs.
 

--- a/articles/virtual-machines/linux/find-unattached-nics.md
+++ b/articles/virtual-machines/linux/find-unattached-nics.md
@@ -1,0 +1,48 @@
+---
+title: Find and delete unattached Azure NICs | Microsoft Docs
+description: How to find and delete unattached Azure NICs, by using Azure CLI
+services: virtual-machines-linux
+documentationcenter: ''
+author: gpetrousov
+manager: ''
+editor: ''
+tags: azure-resource-manager
+
+ms.assetid: 
+ms.service: virtual-machines-linux
+ms.workload: infrastructure-services
+ms.tgt_pltfrm: vm-linux
+ms.devlang: na
+ms.topic: article
+ms.date: 01/10/2017
+ms.author: gpetrousov
+---
+# Find and delete unattached Azure NICs
+When you delete a virtual machine in Azure, the nics attached to it are not deleted by default. Creating and deleting multiple VMs may cause the existance of many unused NICs which are still using the internal IPs and thus taking address space in the subnet. Use this article to find and delete all the unattached NICs and clean the address space.
+
+
+## Find and delete unattached NICs
+
+The following script shows you how to find unattached NICs by using the *macAddress* property. It loops through all the NICs in a subscription and checks if the *macAddress* property is null to find unattached NICs. *macAddress* property stores the MAC address of the interface when it's attached to a VM.
+
+We highly recommend you to first run the script by setting the *deleteUnattachedNics* variable to 0 to view all the unattached NICs. After reviewing the unattached NICs, run the script by setting *deleteUnattachedNics* to 1 to delete all the unattached NICs.
+
+ ```azurecli
+
+# Set deleteUnattachedNics=1 if you want to delete unattached Nics
+# Set deleteUnattachedNics=0 if you want to see the Id of the unattached Nics
+deleteUnattachedNics=0
+
+unattachedNicsIds=$(az network nic list --query '[?macAddress==`null`].[id]' -o tsv)
+for id in ${unattachedNicsIds[@]}
+do
+   if (( $deleteUnattachedNics == 1 ))
+   then
+
+       echo "Deleting unattached Nic with Id: "$id
+       az network nic delete --ids $id
+       echo "Deleted unattached Nic with Id: "$id
+   else
+       echo $id
+   fi
+done

--- a/articles/virtual-machines/linux/find-unattached-nics.md
+++ b/articles/virtual-machines/linux/find-unattached-nics.md
@@ -18,7 +18,7 @@ ms.date: 01/10/2017
 ms.author: gpetrousov
 ---
 # Find and delete unattached Azure NICs
-When you delete a virtual machine in Azure, the nics attached to it are not deleted by default. Creating and deleting multiple VMs may cause the existance of many unused NICs which are still using the internal IPs and thus taking address space in the subnet. Use this article to find and delete all the unattached NICs and clean the address space.
+When you delete a virtual machine in Azure, the NICs attached to it are not deleted by default. Creating and deleting multiple VMs may cause the existence of many unused NICs which are still occupying the internal IPs and thus taking address space in the subnet. Use this article to find and delete all the unattached NICs and clean the address space.
 
 
 ## Find and delete unattached NICs
@@ -29,8 +29,8 @@ We highly recommend you to first run the script by setting the *deleteUnattached
 
  ```azurecli
 
-# Set deleteUnattachedNics=1 if you want to delete unattached Nics
-# Set deleteUnattachedNics=0 if you want to see the Id of the unattached Nics
+# Set deleteUnattachedNics=1 if you want to delete unattached NICs
+# Set deleteUnattachedNics=0 if you want to see the Id(s) of the unattached NICs
 deleteUnattachedNics=0
 
 unattachedNicsIds=$(az network nic list --query '[?macAddress==`null`].[id]' -o tsv)

--- a/articles/virtual-machines/linux/find-unattached-nics.md
+++ b/articles/virtual-machines/linux/find-unattached-nics.md
@@ -23,7 +23,7 @@ When you delete a virtual machine in Azure, the NICs attached to it are not dele
 
 ## Find and delete unattached NICs
 
-The following script shows you how to find unattached NICs by using the *macAddress* property. It loops through all the NICs in a subscription and checks if the *macAddress* property is null to find unattached NICs. *macAddress* property stores the MAC address of the interface when it's attached to a VM.
+The following script shows you how to find unattached NICs by using the *virtualMachine* property. It loops through all the NICs in a subscription and checks if the *virtualMachine* property is null to find unattached NICs. *virtualMachine* property stores the MAC address of the interface when it's attached to a VM.
 
 We highly recommend you to first run the script by setting the *deleteUnattachedNics* variable to 0 to view all the unattached NICs. After reviewing the unattached NICs, run the script by setting *deleteUnattachedNics* to 1 to delete all the unattached NICs.
 
@@ -33,15 +33,15 @@ We highly recommend you to first run the script by setting the *deleteUnattached
 # Set deleteUnattachedNics=0 if you want to see the Id(s) of the unattached NICs
 deleteUnattachedNics=0
 
-unattachedNicsIds=$(az network nic list --query '[?macAddress==`null`].[id]' -o tsv)
+unattachedNicsIds=$(az network nic list --query '[?virtualMachine==`null`].[id]' -o tsv)
 for id in ${unattachedNicsIds[@]}
 do
    if (( $deleteUnattachedNics == 1 ))
    then
 
-       echo "Deleting unattached Nic with Id: "$id
+       echo "Deleting unattached NIC with Id: "$id
        az network nic delete --ids $id
-       echo "Deleted unattached Nic with Id: "$id
+       echo "Deleted unattached NIC with Id: "$id
    else
        echo $id
    fi


### PR DESCRIPTION
Story:
During a cleanup process that I was performing on our Azure infrastructure, I found a useful article on how to delete unattached disk https://docs.microsoft.com/en-us/azure/virtual-machines/linux/find-unattached-disks

Issue:
Also, during this process, I discovered several unattached NICs which are the remainders of deleted VMs. Unfortunately, I did not find a similar article to the above to delete unattached NICs.

Suggestion:
I created an article similar to the above where I describe how to delete unattached NICs.