### PR TITLE
Update service-fabric-reliable-services-reliable-collections-guidelin…

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
+++ b/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
@@ -23,7 +23,7 @@ This section provides guidelines for using Reliable State Manager and Reliable C
 The guidelines are organized as simple recommendations prefixed with the terms *Do*, *Consider*, *Avoid* and *Do not*.
 
 * Do not modify an object of custom type returned by read operations (for example, `TryPeekAsync` or `TryGetValueAsync`). Reliable Collections, just like Concurrent Collections, return a reference to the objects and not a copy.
-* Do deep copy the returned object of a custom type before modifying it. Since structs and built-in types are pass-by-value, you do not need to do a deep copy on them.
+* Do deep copy the returned object of a custom type before modifying it. Since structs and built-in types are pass-by-value, you do not need to do a deep copy on them unless they contain reference-typed fields or properties that you intend to modify.
 * Do not use `TimeSpan.MaxValue` for time-outs. Time-outs should be used to detect deadlocks.
 * Do not use a transaction after it has been committed, aborted, or disposed.
 * Do not use an enumeration outside of the transaction scope it was created in.


### PR DESCRIPTION
…es.md

Clarify that deep copying of structs may be necessary because structs can contain non-struct members.