### PR TITLE
Fix issues with missing jar files

### DIFF
--- a/articles/iot-dps/quick-create-simulated-device-x509-java.md
+++ b/articles/iot-dps/quick-create-simulated-device-x509-java.md
@@ -36,7 +36,12 @@ Make sure to complete the steps in the [Setup IoT Hub Device Provisioning Servic
     ```cmd/sh
     git clone https://github.com/Azure/azure-iot-sdk-java.git --recursive
     ```
-
+1. Navigate to the root azure-iot-sdk-java directory and build the project to download all needed packages.
+   
+   ```cmd/sh
+   cd azure-iot-sdk-java
+   mvn install -DskipTests=true
+   ```
 1. Navigate to the certificate generator project and build the project. 
 
     ```cmd/sh


### PR DESCRIPTION
Without building the root project (as suggested in the proposed edit), required dependencies cannot be found e.g. <b>dice-provider-emulator-1.0.0.jar</b>, thus the project fails to build.