### PR TITLE
Was "copy data to" meant instead of "copy data from" meant in the paragraph on using Azure Cosmos DB as a sink?

### DIFF
--- a/articles/data-factory/connector-azure-cosmos-db.md
+++ b/articles/data-factory/connector-azure-cosmos-db.md
@@ -159,7 +159,7 @@ To copy data from Azure Cosmos DB, set the source type in the copy activity to *
 
 ### Azure Cosmos DB as sink
 
-To copy data from Azure Cosmos DB, set the sink type in the copy activity to **DocumentDbCollectionSink**. The following properties are supported in the copy activity **source** section:
+To copy data to Azure Cosmos DB, set the sink type in the copy activity to **DocumentDbCollectionSink**. The following properties are supported in the copy activity **source** section:
 
 | Property | Description | Required |
 |:--- |:--- |:--- |


### PR DESCRIPTION
Was "copy data to" meant instead of "copy data from" meant in the paragraph on using Azure Cosmos DB as a sink?