### PR TITLE
Add missing script references for failover groups

### DIFF
--- a/articles/sql-database/scripts/sql-database-setup-geodr-failover-database-failover-group-powershell.md
+++ b/articles/sql-database/scripts/sql-database-setup-geodr-failover-database-failover-group-powershell.md
@@ -54,7 +54,9 @@ This script uses the following commands. Each command in the table links to comm
 | [Get-AzureRmSqlDatabaseReplicationLink](/powershell/module/azurerm.sql/get-azurermsqldatabasereplicationlink) | Gets the geo-replication links between an Azure SQL Database and a resource group or SQL Server. |
 | [Remove-AzureRmSqlDatabaseSecondary](/powershell/module/azurerm.sql/remove-azurermsqldatabasesecondary) | Terminates data replication between a SQL Database and the specified secondary database. |
 | [Remove-AzureRmResourceGroup](/powershell/module/azurerm.resources/remove-azurermresourcegroup) | Deletes a resource group including all nested resources. |
-|||
+| [New-AzureRMSqlDatabaseFailoverGroup](/powershell/module/azurerm.sql/new-azurermsqldatabasefailovergroup) | Creates a new Azure SQL Database Failover Group for the specified servers. |
+| [Switch-AzureRMSqlDatabaseFailoverGroup](/powershell/module/azurerm.sql/switch-azurermsqldatabasefailovergroup) | Swaps the roles of the servers in the Failover Group and switches all secondary databases to the primary role. |
+| [Get-AzureRMSqlDatabaseFailoverGroup](/powershell/module/azurerm.sql/get-azurermsqldatabasefailovergroup) | Gets a specific Azure SQL Database Failover Group or lists the Failover Groups on a server. |
 
 ## Next steps
 


### PR DESCRIPTION
There a few failover group cmdlets used in the example script but the script explanation doesn't have links for them. I am adding those missing links.