### PR TITLE
Misspellings in Azure Site Recovery support matrix

### DIFF
--- a/articles/site-recovery/azure-to-azure-support-matrix.md
+++ b/articles/site-recovery/azure-to-azure-support-matrix.md
@@ -129,7 +129,7 @@ China | China East, China North
 
 **Configuration** | **Supported/Not supported** | **Remarks**
 --- | --- | ---
-Size | Any Azure VM size with atleast 2 CPU cores and 1-GB RAM | Refer to [Azure virtual machine sizes](../virtual-machines/windows/sizes.md)
+Size | Any Azure VM size with at least 2 CPU cores and 1-GB RAM | Refer to [Azure virtual machine sizes](../virtual-machines/windows/sizes.md)
 Availability sets | Supported | If you use the default option during 'Enable replication' step in portal, the availability set is auto created based on source region configuration. You can change the target availability set in 'Replicated item > Settings > Compute and Network > Availability set' any time.
 Hybrid Use Benefit (HUB) VMs | Supported | If the source VM has HUB license enabled, the Test failover or Failover VM also uses the HUB license.
 Virtual machine scale sets | Not supported |
@@ -144,8 +144,8 @@ VMs migrated using Site Recovery | Supported | If it is a VMware/Physical machin
 --- | --- | ---
 Maximum OS disk size | 2048 GB | Refer to [Disks used by VMs.](../virtual-machines/windows/about-disks-and-vhds.md#disks-used-by-vms)
 Maximum data disk size | 4095 GB | Refer to [Disks used by VMs.](../virtual-machines/windows/about-disks-and-vhds.md#disks-used-by-vms)
-Number of data disks | Upto 64 as supported by a specific Azure VM size | Refer to [Azure virtual machine sizes](../virtual-machines/windows/sizes.md)
-Temporary disk | Always excluded from replication | Temporary disk is excluded from replication always. You should not put any persistent data on temporary disk as per Azure guida nce. Refer to [Temporary disk on Azure VMs](../virtual-machines/windows/about-disks-and-vhds.md#temporary-disk) for more details.
+Number of data disks | Up to 64 as supported by a specific Azure VM size | Refer to [Azure virtual machine sizes](../virtual-machines/windows/sizes.md)
+Temporary disk | Always excluded from replication | Temporary disk is excluded from replication always. You should not put any persistent data on temporary disk as per Azure guidance. Refer to [Temporary disk on Azure VMs](../virtual-machines/windows/about-disks-and-vhds.md#temporary-disk) for more details.
 Data change rate on the disk | Maximum of 10 MBps per disk for Premium storage and 2 MBps per disk for Standard storage | If the average data change rate on the disk is beyond 10 MBps (for Premium) and 2 MBps (for Standard) continuously, replication will not catch up. However, if it is an occasional data burst and the data change rate is greater than 10 MBps (for Premium) and 2 MBps (for Standard)  for some time and comes down, replication will catch up. In this case, you might see slightly delayed recovery points.
 Disks on standard storage accounts | Supported |
 Disks on premium storage accounts | Supported | If a VM has disks spread across premium and standard storage accounts, you can select a different target storage account for each disk to ensure you have the same storage configuration in target region
@@ -170,7 +170,7 @@ General purpose V2 storage accounts (Both Hot and Cool tier) | No | Transaction 
 ## Support for Network configuration
 **Configuration** | **Supported/Not supported** | **Remarks**
 --- | --- | ---
-Network interface (NIC) | Upto maximum number of NICs supported by a specific Azure VM size | NICs are created when the VM is created as part of Test failover or Failover operation. The number of NICs on the failover VM depends on the number of NICs the source VM has at the time of enabling replication. If you add/remove NIC after enabling replication, it does not impact NIC count on the failover VM.
+Network interface (NIC) | Up to maximum number of NICs supported by a specific Azure VM size | NICs are created when the VM is created as part of Test failover or Failover operation. The number of NICs on the failover VM depends on the number of NICs the source VM has at the time of enabling replication. If you add/remove NIC after enabling replication, it does not impact NIC count on the failover VM.
 Internet Load Balancer | Supported | You need to associate the pre-configured load balancer using an azure automation script in a recovery plan.
 Internal Load balancer | Supported | You need to associate the pre-configured load balancer using an azure automation script in a recovery plan.
 Public IP| Supported | You need to associate an already existing public IP to the NIC or create one and associate to the NIC using an azure automation script in a recovery plan.


### PR DESCRIPTION
"guida nce" -> "guidance"
"atleast" -> "at least" (https://www.quora.com/What-is-the-difference-between-atleast-and-at-least)
"Upto" -> "Up to" (http://www.yourdictionary.com/upto and https://en.wiktionary.org/wiki/upto)