### PR TITLE
Update example of individual certs

### DIFF
--- a/articles/azure-stack/azure-stack-pki-certs.md
+++ b/articles/azure-stack/azure-stack-pki-certs.md
@@ -30,7 +30,7 @@ Azure Stack has a public infrastructure network using externally accessible publ
 ## Certificate requirements
 The following list describes the certificate requirements that are needed to deploy Azure Stack: 
 - Certificates must be issued from either an internal Certificate Authority or a Public Certificate Authority. If a public certificate authority is used, it must be included in the base operating system image as part of the Microsoft Trusted Root Authority Program. You can find the full list here: https://gallery.technet.microsoft.com/Trusted-Root-Certificate-123665ca 
-- The certificate can be a single wild card certificate covering all name spaces in the Subject Alternative Name (SAN) field. Alternatively, you can use individual certificates using wild cards for endpoints such as storage and Key Vault where they are required. 
+- The certificate can be a single wild card certificate covering all name spaces in the Subject Alternative Name (SAN) field. Alternatively, you can use individual certificates using wild cards for endpoints such as acs and Key Vault where they are required. 
 - The certificate signature algorithm cannot be SHA1, as it must be stronger. 
 - The certificate format must be PFX, as both the public and private keys are required for Azure Stack installation. 
 - The certificate pfx files must have a value "Digital Signature" and "KeyEncipherment" in its “Key Usage" field.


### PR DESCRIPTION
current wording is confusing for customers. They may thing you can provide single certs for blob, table, and/or queue storage which is NOT supported. You need a single cert for acs all-up (as covered in the mandatory certs table)