### PR TITLE
add troubleshooting note

### DIFF
--- a/articles/aks/tutorial-kubernetes-deploy-application.md
+++ b/articles/aks/tutorial-kubernetes-deploy-application.md
@@ -102,6 +102,10 @@ To see the application, browse to the external IP address.
 
 ![Image of Kubernetes cluster on Azure](media/container-service-kubernetes-tutorials/azure-vote.png)
 
+If the application did not load, it might be due to an authorization problem with your image registry.
+
+Please follow these steps to [allow access via a Kubernetes secret](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-aks#access-with-kubernetes-secret).
+
 ## Next steps
 
 In this tutorial, the Azure vote application was deployed to a Kubernetes cluster in AKS. Tasks completed include:  


### PR DESCRIPTION
When following [step 4 of this Kubernetes tutorial](https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-application), I ran into an issue with my `azure-vote-front` pod.

It led to a blank application page, even though I followed the steps in the tutorial.

After searching around for common errors, I eventually came across [this article](https://kukulinski.com/10-most-common-reasons-kubernetes-deployments-fail-part-1/) which helped me get to the root of the problem.

It was not able to properly pull the image from my private Azure image registry.

After I got it working, I noticed the comments section referenced an article that outlined the steps I followed to give Kubernetes access to my image repository.

I thought it might be valuable to include this in the documentation, to prevent others from going through the same trouble.