### PR TITLE
Set enabled=1 for Oracle Linux 7 repository example

### DIFF
--- a/articles/virtual-machines/linux/update-agent.md
+++ b/articles/virtual-machines/linux/update-agent.md
@@ -377,7 +377,7 @@ name=Oracle Linux $releasever Add ons ($basearch)
 baseurl=http://public-yum.oracle.com/repo/OracleLinux/OL7/addons/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
 gpgcheck=1
-enabled=0
+enabled=1
 ```
 
 Then type:


### PR DESCRIPTION
In the example [ol7_addons] section provided, enabled variable is set to 0, but this needs to be 1 so the repository is enabled and has the desired outcome.