### PR TITLE
Update R script

### DIFF
--- a/articles/batch/tutorial-r-doazureparallel.md
+++ b/articles/batch/tutorial-r-doazureparallel.md
@@ -46,7 +46,10 @@ In the RStudio console, install the [doAzureParallel Github package](http://www.
 ```R
 # Install the devtools package  
 install.packages("devtools") 
-  
+
+# Install rAzureBatch package
+devtools::install_github("Azure/rAzureBatch") 
+
 # Install the doAzureParallel package 
 devtools::install_github("Azure/doAzureParallel") 
  


### PR DESCRIPTION
An extra R script is required: doAzureParallel now requires the rAzureBatch package. If not, the following error occurs:
ERROR: dependency 'rAzureBatch' is not available for package 'doAzureParallel'