### PR TITLE
Typo in active-directory-b2b-code-samples.md

### DIFF
--- a/articles/active-directory/active-directory-b2b-code-samples.md
+++ b/articles/active-directory/active-directory-b2b-code-samples.md
@@ -102,7 +102,7 @@ namespace SampleInviteApp
         /// <summary>
         /// Client secret of the application.
         /// </summary>
-        private static readonly string TestAppClientSecret = @"
+        private static readonly string TestAppClientSecret = @"";
  
         /// <summary>
         /// This is the email address of the user you want to invite.


### PR DESCRIPTION
Missing closing quote and line terminator.