### PR TITLE
Updating sample in Functions Monitoring topic

### DIFF
--- a/articles/azure-functions/functions-monitoring.md
+++ b/articles/azure-functions/functions-monitoring.md
@@ -402,12 +402,13 @@ namespace functionapp0915
             // Track a Dependency
             var dependency = new DependencyTelemetry
                 {
-                    Name = "Test Dependency",
-                    Target = "swapi.co/api/planets/1/",
+                    Name = "GET api/planets/1/",
+                    Target = "swapi.co",
+                    Data = "https://swapi.co/api/planets/1/",
                     Timestamp = start,
                     Duration = DateTime.UtcNow - start,
                     Success = true
-                };            
+                };
             UpdateTelemetryContext(dependency.Context, context, userName);
             telemetry.TrackDependency(dependency);
             

--- a/articles/azure-functions/functions-monitoring.md
+++ b/articles/azure-functions/functions-monitoring.md
@@ -350,6 +350,7 @@ Here's an example of C# code that uses the [custom telemetry API](../application
 using System;
 using System.Net;
 using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.WebJobs;
 using System.Net.Http;
@@ -387,25 +388,44 @@ namespace functionapp0915
 
             // Set name to query string or body data
             name = name ?? data?.name;
-
-            telemetry.Context.Operation.Id = context.InvocationId.ToString();
-            telemetry.Context.Operation.Name = "cs-http";
-            if (!String.IsNullOrEmpty(name))
-            {
-                telemetry.Context.User.Id = name;
-            }
-            telemetry.TrackEvent("Function called");
-            telemetry.TrackMetric("Test Metric", DateTime.Now.Millisecond);
-            telemetry.TrackDependency("Test Dependency", 
-                "swapi.co/api/planets/1/", 
-                start, DateTime.UtcNow - start, true);
-
+         
+            // Track an Event
+            var evt = new EventTelemetry("Function called");
+            UpdateTelemetryContext(evt.Context, context, userName);
+            telemetry.TrackEvent(evt);
+            
+            // Track a Metric
+            var metric = new MetricTelemetry("Test Metric", DateTime.Now.Millisecond);
+            UpdateTelemetryContext(metric.Context, context, userName);
+            telemetry.TrackMetric(metric);
+            
+            // Track a Dependency
+            var dependency = new DependencyTelemetry
+                {
+                    Name = "Test Dependency",
+                    Target = "swapi.co/api/planets/1/",
+                    Timestamp = start,
+                    Duration = DateTime.UtcNow - start,
+                    Success = true
+                };            
+            UpdateTelemetryContext(dependency.Context, context, userName);
+            telemetry.TrackDependency(dependency);
+            
             return name == null
                 ? req.CreateResponse(HttpStatusCode.BadRequest, 
                     "Please pass a name on the query string or in the request body")
                 : req.CreateResponse(HttpStatusCode.OK, "Hello " + name);
         }
-    }
+        
+        // This correllates all telemetry with the current Function invocation
+        private static void UpdateTelemetryContext(TelemetryContext context, ExecutionContext functionContext, string userName)
+        {
+            context.Operation.Id = functionContext.InvocationId.ToString();
+            context.Operation.ParentId = functionContext.InvocationId.ToString();
+            context.Operation.Name = functionContext.FunctionName;
+            context.User.Id = userName;
+        }
+    }    
 }
 ```
 


### PR DESCRIPTION
The current code doesn't isn't recommended as it is modifying the static client's Context, which is used by every function invocation. This version keeps the context contained to the Telemetry themselves so it works across many invocations.