### PR TITLE
Service Fabric: Moved mac quickstarts to use docker build.

### DIFF
--- a/articles/service-fabric/service-fabric-get-started-mac.md
+++ b/articles/service-fabric/service-fabric-get-started-mac.md
@@ -41,13 +41,7 @@ Azure Service Fabric doesn't run natively on Mac OS X. To run a local Service Fa
 ## Create a local container and set up Service Fabric
 To set up a local Docker container and have a Service Fabric cluster running on it, perform the following steps:
 
-1. Pull the Service Fabric onebox container image from the Docker hub repository. By default, this will pull the image with the latest version of Service Fabric. For particular revisions, please visit the [Docker Hub](https://hub.docker.com/r/microsoft/service-fabric-onebox/) page.
-
-    ```bash
-    docker pull microsoft/service-fabric-onebox
-    ```
-
-2. Update the Docker daemon configuration on your host with the following settings and restart the Docker daemon: 
+1. Update the Docker daemon configuration on your host with the following settings and restart the Docker daemon: 
 
     ```json
     {
@@ -63,12 +57,47 @@ To set up a local Docker container and have a Service Fabric cluster running on 
     >
     >The recommended approach is to directly modify the daemon configuration settings in Docker. Select the **Docker icon**, and then select **Preferences** > **Daemon** > **Advanced**.
     >
+    >We recommend increasing the resources allocated to docker when testing large complex applications, this can be changed by selecting **Docker icon**, and then select **Advanced** then adjusting the number of cores and memory as required.
 
-3. Start a Service Fabric onebox container instance and use the image that you pulled down in the first step:
+2. In a new directory create a file called `.Dockerfile` to build your Service Fabric Image:
 
-    ```bash
-    docker run -itd -p 19080:19080 --name sfonebox microsoft/service-fabric-onebox
+    ```dockerfile
+    FROM servicefabricoss/service-fabric-onebox
+    WORKDIR /home/ClusterDeployer
+    RUN ./setup.sh
+    #Generate the local
+    RUN locale-gen en_US.UTF-8
+    #Set environment variables
+    ENV LANG=en_US.UTF-8
+    ENV LANGUAGE=en_US:en
+    ENV LC_ALL=en_US.UTF-8
+    EXPOSE 19080 19000 80 443
+    #Start SSH before running the cluster
+    CMD /etc/init.d/ssh start && ./run.sh
     ```
+
+    >[!NOTE]
+    >You can adapt this file to add additional programs or dependencies into your container.
+    >For example, adding `RUN apt-get install nodejs -y` will allow support for `nodejs` applications as guest executables.
+    
+    >[!TIP]
+    > By default, this will pull the image with the latest version of Service Fabric. For particular revisions, please visit the [Docker Hub](https://hub.docker.com/r/microsoft/service-fabric-onebox/) page
+
+3. To build your reusable image from the `.Dockerfile` open a terminal and `cd` to the directly holding your `.Dockerfile` then run:
+
+    ```bash 
+    docker build -t mysfcluster .
+    ```
+    
+    >[!NOTE]
+    >This operation will take some time but is only needed once. Currently, due to legal constrains, we are unable to distribute a pre-build image. 
+
+4. Now you can quickly start a local copy of Service Fabric, whenever you need it, by running:
+
+    ```bash 
+    docker run --name sftestcluster -d -p 19080:19080 -p 19000:19000 -p 25100-25200:25100-25200 mysfcluster
+    ```
+
     >[!TIP]
     >Provide a name for your container instance so it can be handled in a more readable manner. 
     >
@@ -77,20 +106,20 @@ To set up a local Docker container and have a Service Fabric cluster running on 
     >`docker run -itd -p 19080:19080 -p 8080:8080 --name sfonebox microsoft/service-fabric-onebox`
     >
 
-4. Log on to the Docker container in interactive SSH mode:
+5. The cluster will take a short amount of time to start, you can view logs using the following command or jump to the dashboard to view the clusters health [http://localhost:19080](http://localhost:19080):
 
-    ```bash
-    docker exec -it sfonebox bash
+    ```bash 
+    docker logs sftestcluster
     ```
 
-5. Run the setup script to fetch the required dependencies and start the cluster on the container:
 
-    ```bash
-    ./setup.sh     # Fetches and installs the dependencies required for Service Fabric to run
-    ./run.sh       # Starts the local cluster
+
+6. When your done you can stop and cleanup the container with this command:
+
+    ```bash 
+    docker rm -f sftestcluster
     ```
 
-6. After step 5 is complete, browse to `http://localhost:19080` from your Mac. You should see the Service Fabric explorer.
 
 ## Set up the Service Fabric CLI (sfctl) on your Mac
 

--- a/articles/service-fabric/service-fabric-get-started-mac.md
+++ b/articles/service-fabric/service-fabric-get-started-mac.md
@@ -57,12 +57,12 @@ To set up a local Docker container and have a Service Fabric cluster running on 
     >
     >The recommended approach is to directly modify the daemon configuration settings in Docker. Select the **Docker icon**, and then select **Preferences** > **Daemon** > **Advanced**.
     >
-    >We recommend increasing the resources allocated to docker when testing large complex applications, this can be changed by selecting **Docker icon**, and then select **Advanced** then adjusting the number of cores and memory as required.
+    >We recommend increasing the resources allocated to Docker when testing large applications. This can be done by selecting the **Docker Icon**, then selecting **Advanced** to adjust the number of cores and memory.
 
 2. In a new directory create a file called `.Dockerfile` to build your Service Fabric Image:
 
     ```dockerfile
-    FROM servicefabricoss/service-fabric-onebox
+    FROM microsoft/service-fabric-onebox
     WORKDIR /home/ClusterDeployer
     RUN ./setup.sh
     #Generate the local
@@ -90,7 +90,7 @@ To set up a local Docker container and have a Service Fabric cluster running on 
     ```
     
     >[!NOTE]
-    >This operation will take some time but is only needed once. Currently, due to legal constrains, we are unable to distribute a pre-build image. 
+    >This operation will take some time but is only needed once.
 
 4. Now you can quickly start a local copy of Service Fabric, whenever you need it, by running:
 


### PR DESCRIPTION
As discussed with @suhuruli this moves to using a docker build file to simplify the setup and starting of a cluster on Mac using docker. 