### PR TITLE
Fix Broken Link to Service Fabric Containers samples on https://docs.microsoft.com/azure/

### DIFF
--- a/articles/containers/index.yml
+++ b/articles/containers/index.yml
@@ -80,7 +80,7 @@ sections:
     style: unordered
     items:
     - html: <a href="https://azure.microsoft.com/resources/samples/app-service-java-deploy-image-from-acr-to-linux/">Getting Started with Appservice - Manage Linux Web App With Container Registry - in Java</a>
-    - html: <a href="https://azure.microsoft.com/resources/samples/service-fabric-dotnet-containers/">Service Fabric Container Samples</a>
+    - html: <a href="https://docs.microsoft.com/azure/service-fabric/service-fabric-containers-overview/">Service Fabric Container Samples</a>
     - html: <a href="https://azure.microsoft.com/resources/samples/container-service-python-manage/">Deploy and connect to a Docker container in an Azure cluster</a>
 - title: Step-by-Step Tutorials
   items:


### PR DESCRIPTION
The link to Service Fabric Container Samples is broken. Here is a proposed fix with a working URI that points to a doc with both Service Fabric container overview information as well as links to related samples...