### PR TITLE
Update reference to "ACR Identity" to "AKS Identity"

### DIFF
--- a/articles/aks/tutorial-kubernetes-deploy-cluster.md
+++ b/articles/aks/tutorial-kubernetes-deploy-cluster.md
@@ -82,7 +82,7 @@ At tutorial completion, you have an AKS cluster ready for workloads. In subseque
 
 ## Configure ACR authentication
 
-Authentication needs to be configured between the AKS cluster and the ACR registry. This involves granting the ACS identity the proper rights to pull images from the ACR registry.
+Authentication needs to be configured between the AKS cluster and the ACR registry. This involves granting the AKS identity the proper rights to pull images from the ACR registry.
 
 First, get the ID of the service principal configured for AKS. Update the resource group name and AKS cluster name to match your environment.
 


### PR DESCRIPTION
Fixed incorrect reference to ACS identity to now refer to AKS identity.