### PR TITLE
Updated VM SLA URL

### DIFF
--- a/articles/virtual-machines/linux/overview.md
+++ b/articles/virtual-machines/linux/overview.md
@@ -29,7 +29,7 @@ Microsoft Azure resources are distributed across multiple geographical regions a
 * [Azure Regions](https://azure.microsoft.com/regions/)
 
 ## Availability
-Azure announced an industry leading single instance virtual machine Service Level Agreement of 99.9% provided you deploy the VM with premium storage for all disks.  In order for your deployment to qualify for the standard 99.95% VM Service Level Agreement, you still need to deploy two or more VMs running your workload inside of an availability set. An availability set ensures that your VMs are distributed across multiple fault domains in the Azure data centers as well as deployed onto hosts with different maintenance windows. The full [Azure SLA](https://azure.microsoft.com/support/legal/sla/virtual-machines/v1_0/) explains the guaranteed availability of Azure as a whole.
+Azure announced an industry leading single instance virtual machine Service Level Agreement of 99.9% provided you deploy the VM with premium storage for all disks.  In order for your deployment to qualify for the standard 99.95% VM Service Level Agreement, you still need to deploy two or more VMs running your workload inside of an availability set. An availability set ensures that your VMs are distributed across multiple fault domains in the Azure data centers as well as deployed onto hosts with different maintenance windows. The full [Azure SLA](https://azure.microsoft.com/support/legal/sla/virtual-machines/) explains the guaranteed availability of Azure as a whole.
 
 ## Managed Disks
 


### PR DESCRIPTION
Old version was hard coded to an obsolete page.  New one should redirect to the latest automatically.