### PR TITLE
Update functions-bindings-cosmosdb.md

### DIFF
--- a/articles/azure-functions/functions-bindings-cosmosdb.md
+++ b/articles/azure-functions/functions-bindings-cosmosdb.md
@@ -316,7 +316,7 @@ Here's the binding data in the *function.json* file:
 
 ```json
 {
-    "name": "inputDocument",
+    "name": "inputDocumentIn",
     "type": "documentDB",
     "databaseName": "MyDatabase",
     "collectionName": "MyCollection",
@@ -324,6 +324,16 @@ Here's the binding data in the *function.json* file:
     "partitionKey": "{queueTrigger_payload_property}",
     "connection": "MyAccount_COSMOSDB",     
     "direction": "in"
+},
+{
+    "name": "inputDocumentOut",
+    "type": "documentDB",
+    "databaseName": "MyDatabase",
+    "collectionName": "MyCollection",
+    "createIfNotExists": false,
+    "partitionKey": "{queueTrigger_payload_property}",
+    "connection": "MyAccount_COSMOSDB",
+    "direction": "out"
 }
 ```
 The [configuration](#input---configuration) section explains these properties.


### PR DESCRIPTION
The JavaScript example of the Cosmos DB input binding is not working.
As mentionned by Pragna Gopa on the thread below, an output document db binding is necessary:
https://social.msdn.microsoft.com/Forums/azure/en-US/6961888a-77bd-4a93-84cd-6ae991566774/cosmosdb-inputoutput-in-javascript?forum=AzureFunctions#answers