### PR TITLE
Update redhat-create-upload-vhd.md

### DIFF
--- a/articles/virtual-machines/linux/redhat-create-upload-vhd.md
+++ b/articles/virtual-machines/linux/redhat-create-upload-vhd.md
@@ -35,7 +35,7 @@ This section assumes that you have already obtained an ISO file from the Red Hat
 * Kernel support for mounting Universal Disk Format (UDF) file systems is required. At first boot on Azure, the UDF-formatted media that is attached to the guest passes the provisioning configuration to the Linux virtual machine. The Azure Linux Agent must be able to mount the UDF file system to read its configuration and provision the virtual machine.
 * Versions of the Linux kernel that are earlier than 2.6.37 do not support non-uniform memory access (NUMA) on Hyper-V with larger virtual machine sizes. This issue primarily impacts older distributions that use the upstream Red Hat 2.6.32 kernel and was fixed in RHEL 6.6 (kernel-2.6.32-504). Systems that run custom kernels that are older than 2.6.37 or RHEL-based kernels that are older than 2.6.32-504 must set the `numa=off` boot parameter on the kernel command line in grub.conf. For more information, see Red Hat [KB 436883](https://access.redhat.com/solutions/436883).
 * Do not configure a swap partition on the operating system disk. The Linux Agent can be configured to create a swap file on the temporary resource disk.  More information about this can be found in the following steps.
-* All VHDs must have sizes that are multiples of 1 MB.
+* The raw image size must be aligned to a megabyte boundary.
 
 ### Prepare a RHEL 6 virtual machine from Hyper-V Manager
 


### PR DESCRIPTION
The raw image needs to be aligned on the megabyte boundary, the VHD is made of a raw disk image followed by a VHD footer (512 bytes), therefore if the raw image is aligned to a  megabyte boundary the VHD file cannot be.
 
If the raw image is not aligned on the megabyte boundary you will not be able to convert it to a managed disk, you will get a “Only blobs formatted as VHDs can be imported” error. If the VHD size is a multiple of 1 MB, that means the raw image is not and your will get the error.