### PR TITLE
Adding complex password for pfx as a requirement.

### DIFF
--- a/articles/azure-stack/azure-stack-pki-certs.md
+++ b/articles/azure-stack/azure-stack-pki-certs.md
@@ -38,6 +38,7 @@ The following list describes the certificate requirements that are needed to dep
 - The certificate pfx files must have a value "Digital Signature" and "KeyEncipherment" in its “Key Usage" field.
 - The certificate pfx files must have the values “Server Authentication (1.3.6.1.5.5.7.3.1)” and “Client Authentication (1.3.6.1.5.5.7.3.2)” in the "Enhanced Key Usage" field.
 - The passwords to all certificate pfx files must be the same at the time of deployment
+- Password to the certificate pfx has to be a complex password.
 - Ensure that the Subject Names and Subject Alternative Names of all certificates match the specifications described in this article to avoid failed deployments.
 
 > [!NOTE]


### PR DESCRIPTION
Today during an Azure Stack deployment we found out that the pfx certificates should have a complex password. Otherwise, deployment fails.