### PR TITLE
Update active-directory-b2c-reference-oauth-code.md

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-oauth-code.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oauth-code.md
@@ -196,7 +196,8 @@ grant_type=refresh_token&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=90
 | Parameter | Required? | Description |
 | --- | --- | --- |
 | p |Required |The policy that was used to acquire the original refresh token. You cannot use a different policy in this request. Note that you add this parameter to the *query string*, not in the POST body. |
-| client_id |Recommended |The application ID assigned to your app in the [Azure portal](https://portal.azure.com). |
+| client_id |Required |The application ID assigned to your app in the [Azure portal](https://portal.azure.com). |
+| client_secret |Required |The client_secret associated to your client_id in the [Azure portal](https://portal.azure.com). |
 | grant_type |Required |The type of grant. For this leg of the authorization code flow, the grant type must be `refresh_token`. |
 | scope |Recommended |A space-separated list of scopes. A single scope value indicates to Azure AD both of the permissions that are being requested. Using the client ID as the scope indicates that your app needs an access token that can be used against your own service or web API, represented by the same client ID.  The `offline_access` scope indicates that your app will need a refresh token for long-lived access to resources.  You also can use the `openid` scope to request an ID token from Azure AD B2C. |
 | redirect_uri |Optional |The redirect URI of the application where you received the authorization code. |


### PR DESCRIPTION
When refreshing a token it required me to provide both a client_id and a client_secret in order to properly execute the refresh token flow. The documentation however only mentioned the client_id. Performing the request as described in the current iteration of the documentation caused a 400 Bad request with a message requesting a client_secret to be provided.

After adding the client_secret to the requests data it worked and I was able to successfully refresh the token.

I added the client_secret to the documentation to make sure others can avoid this small issue.