### PR TITLE
Corrects broken "C# Sample Code" link

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-actors-lifecycle.md
+++ b/articles/service-fabric/service-fabric-reliable-actors-lifecycle.md
@@ -147,7 +147,7 @@ Note that an actor cannot call delete on itself from one of its actor methods be
 * [Actor reentrancy](service-fabric-reliable-actors-reentrancy.md)
 * [Actor diagnostics and performance monitoring](service-fabric-reliable-actors-diagnostics.md)
 * [Actor API reference documentation](https://msdn.microsoft.com/library/azure/dn971626.aspx)
-* [C# Sample code](https://github.com/Azure/servicefabric-samples)
+* [C# Sample code](https://github.com/Azure-Samples/service-fabric-dotnet-getting-started)
 * [Java Sample code](http://github.com/Azure-Samples/service-fabric-java-getting-started)
 
 <!--Image references-->


### PR DESCRIPTION
I believe I found the correct link. The current link leads to a 404.