### PR TITLE
Remove usage of single quote

### DIFF
--- a/articles/virtual-machines/windows/extensions-customscript.md
+++ b/articles/virtual-machines/windows/extensions-customscript.md
@@ -136,7 +136,7 @@ When executing the `commandToExecute` command, the extension will have set this 
 
 Since the absolute download path may vary over time, it is better to opt for relative script/file paths in the `commandToExecute` string, whenever possible. For example:
 ```json
-	"commandToExecute": "powershell.exe . . . -File './scripts/myscript.ps1'"
+	"commandToExecute": "powershell.exe . . . -File \"./scripts/myscript.ps1\""
 ```
 
 Path information after the first URI segment is retained for files downloaded via the `fileUris` property list.  As shown in the table below, downloaded files are mapped into download subdirectories to reflect the structure of the `fileUris` values.  


### PR DESCRIPTION
- As discussed in this Stack Overflow question:

https://stackoverflow.com/questions/49131353/powershell-script-is-not-executing-when-using-azurerm-virtual-machine-extension

The usage of single quotes in the commandToExecute section of the JSON causes the script not to be executed, with the error:

`Processing -File ''test.ps1'' failed because the file does not have a '.ps1' extension. Specify a valid Windows PowerShell script file name, and then try again.`

I have changed this section to use an escaped double quote, rather than a single quote.