### PR TITLE
Add note about the service account's UPN suffix.

### DIFF
--- a/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
+++ b/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
@@ -55,8 +55,8 @@ When you create a domain-joined HDInsight cluster, you must supply the following
 - **LDAPS URL**: For example, ldaps://contoso.onmicrosoft.com:636
 - **Access user group**: The security groups whose users you want to sync to the cluster. For example, HiveUsers. If you want to specify multiple user groups, separate them by comma ‘,’.
  
-[!NOTE]
-Since Apache Zeppelin uses the domain name to authenticate the administrative service account, the service account MUST have the same domain name as its UPN suffix for Apache Zeppelin to function properly.
+> [!NOTE]
+> Since Apache Zeppelin uses the domain name to authenticate the administrative service account, the service account MUST have the same domain name as its UPN suffix for Apache Zeppelin to function properly.
  
 The following screenshot shows the configurations in the Azure portal:
 

--- a/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
+++ b/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
@@ -55,6 +55,9 @@ When you create a domain-joined HDInsight cluster, you must supply the following
 - **LDAPS URL**: For example, ldaps://contoso.onmicrosoft.com:636
 - **Access user group**: The security groups whose users you want to sync to the cluster. For example, HiveUsers. If you want to specify multiple user groups, separate them by comma ‘,’.
  
+[!NOTE]
+Since Apache Zeppelin uses the domain name to authenticate the administrative service account, the service account MUST have the same domain name as its UPN suffix for Apache Zeppelin to function properly.
+ 
 The following screenshot shows the configurations in the Azure portal:
 
 ![Azure HDInsight domain-joined Active Directory Domain Services configuration](./media/apache-domain-joined-configure-using-azure-adds/hdinsight-domain-joined-configuration-azure-aads-portal.png).


### PR DESCRIPTION
In the version of Shiro that's currently being used in Zeppelin the DefaultLdapContextFactory being used in AbstractLdapRealm which ActiveDirectoryRealm is inheriting is using the following code to get its LDAP context. As a result if the privileged AD account has a different UPN suffix from the domain specified all Zeppelin authentication requests will fail. 


    public LdapContext getLdapContext(String username, String password) throws NamingException {
        if (username != null && principalSuffix != null) {
            username += principalSuffix;
        }
        return getLdapContext((Object) username, password);
    }