### PR TITLE
Changing the link in PCS documentation to correct IOT docs

### DIFF
--- a/articles/iot-suite/iot-suite-what-is-azure-iot.md
+++ b/articles/iot-suite/iot-suite-what-is-azure-iot.md
@@ -27,5 +27,5 @@ Now that you have learned about the typical IoT Architecture, explore the differ
 To find out more about the individual Azure IoT services, see:
 
 * [What is Azure IoT Suite?](iot-suite-what-are-preconfigured-solutions.md)
-* [What is Microsoft IoT Central?](https://www.microsoft.com/internet-of-things/iot-central-saas-solutions)
+* [What is Microsoft IoT Central?](https://docs.microsoft.com/en-us/microsoft-iot-central/overview-iot-central)
 * [What is Azure IoT Hub?](../iot-hub/iot-hub-what-is-iot-hub.md)

--- a/articles/iot-suite/iot-suite-what-is-azure-iot.md
+++ b/articles/iot-suite/iot-suite-what-is-azure-iot.md
@@ -27,5 +27,5 @@ Now that you have learned about the typical IoT Architecture, explore the differ
 To find out more about the individual Azure IoT services, see:
 
 * [What is Azure IoT Suite?](iot-suite-what-are-preconfigured-solutions.md)
-* [What is Microsoft IoT Central?](https://docs.microsoft.com/en-us/microsoft-iot-central/overview-iot-central)
+* [What is Microsoft IoT Central?](https://docs.microsoft.com/microsoft-iot-central/overview-iot-central)
 * [What is Azure IoT Hub?](../iot-hub/iot-hub-what-is-iot-hub.md)


### PR DESCRIPTION
The previous link just pointed to the actual site of iot central and not the overview of their documentation (like the other links on the page do)