### PR TITLE
Typo on "Using Azure API Management service with an internal virtual network"

### DIFF
--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -70,14 +70,14 @@ You can also enable virtual network connectivity by using PowerShell cmdlets.
 When API Management is in external virtual network mode, the DNS is managed by Azure. For internal virtual network mode, you have to manage your own routing.
 
 > [!NOTE]
-> API Management service does not listen to requests coming from IP addresses. It only responds to requests to the host name configured on its service endpoints. These endpoints include gateway, the Developer portal, the Azurethe portal, direct management endpoint, and Git.
+> API Management service does not listen to requests coming from IP addresses. It only responds to requests to the host name configured on its service endpoints. These endpoints include gateway, the Azure portal and the Developer portal, direct management endpoint, and Git.
 
 ### Access on default host names
 When you create an API Management service, named "contoso" for example, the following service endpoints are configured by default:
 
    * Gateway or proxy: contoso.azure-api.net
 
-   * the Azure portal and the Developer portal: contoso.portal.azure-api.net
+   * The Azure portal and the Developer portal: contoso.portal.azure-api.net
 
    * Direct management endpoint: contoso.management.azure-api.net
 


### PR DESCRIPTION
Fixed typo on DNS configuration document section.