### PR TITLE
Update tutorial-kubernetes-prepare-acr.md

### DIFF
--- a/articles/aks/tutorial-kubernetes-prepare-acr.md
+++ b/articles/aks/tutorial-kubernetes-prepare-acr.md
@@ -76,7 +76,7 @@ tiangolo/uwsgi-nginx-flask   flask               788ca94b2313        9 months ag
 
 Each container image needs to be tagged with the loginServer name of the registry. This tag is used for routing when pushing container images to an image registry.
 
-To get the loginServer name, run the following command.
+Use the [az acr list][az-acr-list] command to get the loginServer name.
 
 ```azurecli
 az acr list --resource-group myResourceGroup --query "[].{acrLoginServer:loginServer}" --output table
@@ -167,6 +167,7 @@ Advance to the next tutorial to learn about deploying a Kubernetes cluster in Az
 
 <!-- LINKS - internal -->
 [az-acr-create]: /cli/azure/acr#create
+[az-acr-list]: /cli/azure/acr#list
 [az-acr-login]: https://docs.microsoft.com/cli/azure/acr#az_acr_login
 [az-acr-repository-list]: /cli/azure/acr/repository#list
 [az-acr-repository-show-tags]: /cli/azure/acr/repository#show-tags


### PR DESCRIPTION
updated the reference to point to "az acr list" link, as well following the convention on the links internal for point the right site.