### PR TITLE
Changed path where service_schema.json is stored

### DIFF
--- a/articles/machine-learning/preview/model-management-service-deploy.md
+++ b/articles/machine-learning/preview/model-management-service-deploy.md
@@ -59,20 +59,20 @@ Next, define the input variables such as a Spark dataframe, Pandas dataframe, or
 
 ```python
 inputs = {"input_array": SampleDefinition(DataTypes.NUMPY, yourinputarray)}
-generate_schema(run_func=run, inputs=inputs, filepath='service_schema.json')
+generate_schema(run_func=run, inputs=inputs, filepath='./outputs/service_schema.json')
 ```
 The following example uses a Spark dataframe:
 
 ```python
 inputs = {"input_df": SampleDefinition(DataTypes.SPARK, yourinputdataframe)}
-generate_schema(run_func=run, inputs=inputs, filepath='service_schema.json')
+generate_schema(run_func=run, inputs=inputs, filepath='./outputs/service_schema.json')
 ```
 
 The following example uses a PANDAS dataframe:
 
 ```python
 inputs = {"input_df": SampleDefinition(DataTypes.PANDAS, yourinputdataframe)}
-generate_schema(run_func=run, inputs=inputs, filepath='service_schema.json')
+generate_schema(run_func=run, inputs=inputs, filepath='./outputs/service_schema.json')
 ```
 
 ### 3. Create a score.py file


### PR DESCRIPTION
I've tried exporting it directly into the root directory, but it never actually gets saved. It seems that you must place it in the ./outputs folder, which will then appear in the in the outputs section of ML Workbench after each run.

I also cannot find any documentation about specifically **why** this is, but I've noticed that they do it on the [Iris Classification tutorial as well.](https://docs.microsoft.com/en-us/azure/machine-learning/preview/tutorial-classifying-iris-part-3)