### PR TITLE
Removed extraneous back quote

### DIFF
--- a/articles/virtual-machines/windows/extensions-oms.md
+++ b/articles/virtual-machines/windows/extensions-oms.md
@@ -148,7 +148,7 @@ Set-AzureRmVMExtension -ExtensionName "Microsoft.EnterpriseCloud.Monitoring" `
     -TypeHandlerVersion 1.0 `
     -Settings $PublicSettings `
     -ProtectedSettings $ProtectedSettings `
-    -Location WestUS ` 
+    -Location WestUS 
 ```
 
 ## Troubleshoot and support


### PR DESCRIPTION
Set-AzureRmVMExtensions code had an unnecessary trailing back quote after the Location parameter.