### PR TITLE
Browser option is now supported

### DIFF
--- a/articles/active-directory/active-directory-conditional-access-technical-reference.md
+++ b/articles/active-directory/active-directory-conditional-access-technical-reference.md
@@ -218,8 +218,6 @@ This setting applies to the following client apps:
 - The **Require approved client app** requirement:
 
     - Only supports the iOS and Android for [device platform condition](#device-platforms-condition).
-
-    - Does not support the **Browser** option for the [client apps condition](#supported-browsers).
     
     - Supersedes the **Mobile apps and desktop clients** option for the [client apps condition](#supported-mobile-apps-and-desktop-clients) when that option is selected.
 


### PR DESCRIPTION
I've tested it several time in different situations and tenants. Since the change of the approved app list which now includes Microsoft Intune Managed Browser the Browser option is supported. I'll give an example, if we want to block browser access from native browsers like Safari or Chrome to enforce the users to use the managed browser we need to build a CA policy for approved app list and check both Browser and Mobile apps and desktop clients. Then this scenario is covered. If we leave browser unchecked, then Safari and Chrome are still working and we do not get the message: "You must use the Intune Managed Browser application before you can access this resource."