### PR TITLE
Changed 'code file' to 'score' file

### DIFF
--- a/articles/machine-learning/preview/model-management-service-deploy.md
+++ b/articles/machine-learning/preview/model-management-service-deploy.md
@@ -131,7 +131,7 @@ az ml model register --model [path to model file] --name [model name]
 Following command helps create a manifest for the model,
 
 ```
-az ml manifest create --manifest-name [your new manifest name] -f [path to code file] -r [runtime for the image, e.g. spark-py]
+az ml manifest create --manifest-name [your new manifest name] -f [path to score file] -r [runtime for the image, e.g. spark-py]
 ```
 You can add a previously registered model to the manifest by using argument `--model-id` or `-i` in the command shown above. Multiple models can be specified with additional -i arguments.
 


### PR DESCRIPTION
The iris tutorial docs calls it a *'score'* file, which I think makes more sense. When I saw *'code'* I wasn't sure if it needed my main.py file (ex: linear_reg.py) or the score.

[The iris tutorial clarified that.](https://docs.microsoft.com/en-us/azure/machine-learning/preview/tutorial-classifying-iris-part-3)

I'm still not sure if I need the model ID generated from the previous step, though. The iris tutorial says you do, but this does not. 

EX: "To create a manifest, use the following command and provide the model ID output from the previous step:"

```az ml manifest create --manifest-name <new manifest name> -f score_iris.py -r python -i <model ID> -s service_schema.json```

The ```-i <model ID>``` step/param is missing from these instructions, but is present in the iris tutorial. Not sure if needed.