### PR TITLE
removed '.json' extension from service_schema.json

### DIFF
--- a/articles/machine-learning/preview/tutorial-classifying-iris-part-3.md
+++ b/articles/machine-learning/preview/tutorial-classifying-iris-part-3.md
@@ -190,7 +190,7 @@ Now you're ready to create the real-time web service.
 1. To create a real-time web service, use the following command:
 
    ```azurecli
-   az ml service create realtime -f score_iris.py --model-file model.pkl -s service_schema.json -n irisapp -r python --collect-model-data true -c aml_config\conda_dependencies.yml
+   az ml service create realtime -f score_iris.py --model-file model.pkl -s service_schema -n irisapp -r python --collect-model-data true -c aml_config\conda_dependencies.yml
    ```
    This command generates a web service ID you can use later.
 
@@ -240,7 +240,7 @@ First, register the model. Then generate the manifest, build the Docker image, a
    To create a manifest, use the following command and provide the model ID output from the previous step:
 
    ```azurecli
-   az ml manifest create --manifest-name <new manifest name> -f score_iris.py -r python -i <model ID> -s service_schema.json
+   az ml manifest create --manifest-name <new manifest name> -f score_iris.py -r python -i <model ID> -s service_schema
    ```
    This command generates a manifest ID.
 


### PR DESCRIPTION
If you pass in service_schema.json, the CLI throws an error:

```
{
    "Azure-cli-ml Version": "0.1.0a27.post3",
    "Error": "Error resolving dependency: no such file or directory service_schema.json"
}
```

*EX:* ```az ml manifest create --manifest-name mymanifest -f score.py -r python -s service_schema.json ```


However, if I run it *without* the .json:
```
az ml manifest create --manifest-name mymanifest -f score.py -r python -s service_schema     
```
RETURNS:
```
No model information provided, skipping model creation
Creating new driver at /var/folders/zg/wfn9qp9s5ys5qhjvxnk342k40000gn/T/tmpns10c73l.py
 score.py
 service_schema
Successfully created manifest
Id: 682eb200-f613-4d6e-8c01-b0991b68ecd3
More information: 'az ml manifest show -i 682eb200-f613-4d6e-8c01-b0991b68ecd3'
```