### PR TITLE
Updated Step 7 of "Provision the simulated device"

### DIFF
--- a/articles/iot-dps/quick-create-simulated-device-tpm-csharp.md
+++ b/articles/iot-dps/quick-create-simulated-device-tpm-csharp.md
@@ -77,7 +77,7 @@ Make sure to complete the steps in the [Set up IoT Hub Device Provisioning Servi
 
    On successful enrollment, the *Registration ID* of your device will appear in the list under the *Individual Enrollments* tab. 
 
-6. Click Enter to enroll the simulated device. Notice the messages that simulate the device booting and connecting to the Device Provisioning Service to get your IoT hub information. 
+6. Press Enter in the command window (that displayed the **_Endorsement Key_**,  the **_Registration ID_**, and a suggested **_Device ID_**)  to enroll the simulated device. Notice the messages that simulate the device booting and connecting to the Device Provisioning Service to get your IoT hub information. 
 
 1. Verify that the device has been provisioned. On successful provisioning of the simulated device to the IoT hub linked with your provisioning service, the device ID appears on the hub's **IoT Devices** blade. 
 


### PR DESCRIPTION
Step 7 under "Provision the simulated device" is unclear regarding the Enter command. Added an extended explanation.