### PR TITLE
Change misspelled proxy.json to proxies.json

### DIFF
--- a/articles/azure-functions/functions-proxies.md
+++ b/articles/azure-functions/functions-proxies.md
@@ -103,7 +103,7 @@ For example, a back-end URL of *https://%ORDER_PROCESSING_HOST%/api/orders* woul
 
 ## <a name="debugProxies"></a>Troubleshoot Proxies
 
-By adding the flag `"debug":true` to any proxy in your `proxy.json` you will enable debug logging. Logs are stored in `D:\home\LogFiles\Application\Proxies\DetailedTrace` and accessible through the advanced tools (kudu). Any HTTP responses will also contain a `Proxy-Trace-Location` header with a URL to access the log file.
+By adding the flag `"debug":true` to any proxy in your `proxies.json` you will enable debug logging. Logs are stored in `D:\home\LogFiles\Application\Proxies\DetailedTrace` and accessible through the advanced tools (kudu). Any HTTP responses will also contain a `Proxy-Trace-Location` header with a URL to access the log file.
 
 You can debug a proxy from the client side by adding a `Proxy-Trace-Enabled` header set to `true`. This will also log a trace to the file system, and return the trace URL as a header in the response.
 
@@ -111,7 +111,7 @@ You can debug a proxy from the client side by adding a `Proxy-Trace-Enabled` hea
 
 For security reasons you may not want to allow anyone calling your service to generate a trace. They will not be able to access the trace contents without your login credentials, but generating the trace consumes resources and exposes that you are using Function Proxies.
 
-Disable traces altogether by adding `"debug":false` to any particular proxy in your `proxy.json`.
+Disable traces altogether by adding `"debug":false` to any particular proxy in your `proxies.json`.
 
 ## Advanced configuration
 


### PR DESCRIPTION
If named proxy.json the proxy will not be created and cannot be created in portal since it is read only.