### PR TITLE
Remove invalid comma in ASA code sample

### DIFF
--- a/articles/stream-analytics/stream-analytics-streaming-unit-consumption.md
+++ b/articles/stream-analytics/stream-analytics-streaming-unit-consumption.md
@@ -87,7 +87,7 @@ The state size of a temporal join is proportional to the number of events in the
 
 The number of unmatched events in the join affect the memory utilization for the query. The following query is looking to find the ad impressions that generate clicks:
 
-    SELECT id
+    SELECT clicks.id
     FROM clicks 
     INNER JOIN impressions ON impressions.id = clicks.id AND DATEDIFF(hour, impressions, clicks) between 0 AND 10.
 
@@ -95,10 +95,10 @@ In this example, it is possible that lots of ads are shown and few people click 
 
 To remediate this, send events to Event Hub partitioned by the join keys (id in this case), and scale out the query by allowing the system to process each input partition separately using  **PARTITION BY** as shown:
 
-    SELECT id
+    SELECT clicks.id
     FROM clicks PARTITION BY PartitionId
     INNER JOIN impressions PARTITION BY PartitionId 
-    ON impression.PartitionId = clocks.PartitionId AND impressions.id = clicks.id AND DATEDIFF(hour, impressions, clicks) between 0 AND 10 
+    ON impression.PartitionId = clicks.PartitionId AND impressions.id = clicks.id AND DATEDIFF(hour, impressions, clicks) between 0 AND 10 
 </code>
 
 Once the query is partitioned out, it is spread out over multiple nodes. As a result the number of events coming into each node is reduced thereby reducing the size of the state kept in the join window. 

--- a/articles/stream-analytics/stream-analytics-streaming-unit-consumption.md
+++ b/articles/stream-analytics/stream-analytics-streaming-unit-consumption.md
@@ -89,7 +89,7 @@ The number of unmatched events in the join affect the memory utilization for the
 
     SELECT id
     FROM clicks 
-    INNER JOIN, impressions ON impressions.id = clicks.id AND DATEDIFF(hour, impressions, clicks) between 0 AND 10.
+    INNER JOIN impressions ON impressions.id = clicks.id AND DATEDIFF(hour, impressions, clicks) between 0 AND 10.
 
 In this example, it is possible that lots of ads are shown and few people click on it and it is required to keep all the events in the time window. Memory consumed is proportional to the window size and event rate. 
 


### PR DESCRIPTION
Fix extra comma in code sample (`INNER JOIN, impressions` -> `INNER JOIN impressions`)