### PR TITLE
Fix API reference in docs for setting instrumentation key

### DIFF
--- a/articles/application-insights/app-insights-java-get-started.md
+++ b/articles/application-insights/app-insights-java-get-started.md
@@ -167,7 +167,7 @@ You can also [set it in code](app-insights-api-custom-events-metrics.md#ikey):
 
 ```Java
 
-    telemetryClient.InstrumentationKey = "...";
+    telemetryClient.getContext().setInstrumentationKey("...");
 ```
 
 ## 4. Add an HTTP filter


### PR DESCRIPTION
The docs appear to reference the C# API rather than the Java API. However, the URL linked above the code snippet - https://docs.microsoft.com/en-us/azure/application-insights/app-insights-api-custom-events-metrics#ikey - does not even have a Java section, and I recommend that this be rectified as well.