### PR TITLE
Fix the name of WEBSITE_NODE_DEFAULT_VERSION setting

### DIFF
--- a/articles/azure-functions/functions-reference-node.md
+++ b/articles/azure-functions/functions-reference-node.md
@@ -268,7 +268,7 @@ The following table shows the Node.js version used by each major version of the 
 | Functions version | Node.js version | 
 |---|---|
 | 1.x | 6.11.2 (locked by the runtime) |
-| 2.x  |>=8.4.0 with current LTS 8.9.4 recommended. Set the version by using the WEBSITE_DEFAULT_NODE_VERSION [app setting](functions-how-to-use-azure-function-app-settings.md#settings).|
+| 2.x  |>=8.4.0 with current LTS 8.9.4 recommended. Set the version by using the WEBSITE_NODE_DEFAULT_VERSION [app setting](functions-how-to-use-azure-function-app-settings.md#settings).|
 
 You can see the current version that the runtime is using by printing `process.version` from any function.
 


### PR DESCRIPTION
WEBSITE_NODE_DEFAULT_VERSION is the correct name as per https://docs.microsoft.com/en-us/azure/azure-functions/functions-app-settings#websitenodedefaultversion