### PR TITLE
Corrected grep command for Debian 8

### DIFF
--- a/articles/virtual-machines/linux/update-agent.md
+++ b/articles/virtual-machines/linux/update-agent.md
@@ -117,7 +117,7 @@ This version of Debian does not have a version >= 2.0.16, therefore AutoUpdate i
 #### Check your current package version
 
 ```bash
-apt list --installed | grep walinuxagent
+apt list --installed | grep waagent
 ```
 
 #### Update package cache


### PR DESCRIPTION
Changed Debian 8 grep to reference the correct name of 'waagent' instead of 'walinuxagent'.