### PR TITLE
Adding Instance metadata access via Puppet module example documentation

### DIFF
--- a/articles/virtual-machines/linux/instance-metadata-service.md
+++ b/articles/virtual-machines/linux/instance-metadata-service.md
@@ -392,6 +392,7 @@ Bash       | https://github.com/Microsoft/azureimds/blob/master/IMDSSample.sh
 Perl       | https://github.com/Microsoft/azureimds/blob/master/IMDSSample.pl
 Java       | https://github.com/Microsoft/azureimds/blob/master/imdssample.java
 Visual Basic | https://github.com/Microsoft/azureimds/blob/master/IMDSSample.vb
+Puppet | https://github.com/keirans/azuremetadata
     
 
 ## FAQ

--- a/articles/virtual-machines/windows/instance-metadata-service.md
+++ b/articles/virtual-machines/windows/instance-metadata-service.md
@@ -392,6 +392,7 @@ Bash       | https://github.com/Microsoft/azureimds/blob/master/IMDSSample.sh
 Perl       | https://github.com/Microsoft/azureimds/blob/master/IMDSSample.pl
 Java       | https://github.com/Microsoft/azureimds/blob/master/imdssample.java
 Visual Basic | https://github.com/Microsoft/azureimds/blob/master/IMDSSample.vb
+Puppet | https://github.com/keirans/azuremetadata
     
 
 ## FAQ


### PR DESCRIPTION
As per issue [5799](https://github.com/MicrosoftDocs/azure-docs/issues/5799), this PR adds a link to the Azure metadata module on Github and the Puppet forge that I currently maintain until there is native Puppet / Facter support.  

