### PR TITLE
(ForumsTeam) Renamed the link name

### DIFF
--- a/articles/virtual-network/virtual-networks-name-resolution-ddns.md
+++ b/articles/virtual-network/virtual-networks-name-resolution-ddns.md
@@ -1,4 +1,4 @@
----
+ ---
 title: Using Dynamic DNS to register hostnames
 description: This page gives details on how to set up Dynamic DNS to register hostnames in your own DNS servers.
 services: dns
@@ -23,7 +23,7 @@ ms.author: garbrad
 When your custom DNS servers are hosted as Azure VMs you can forward hostname queries for the same vnet to Azure to resolve hostnames. If you do not wish to use this route, you can register your VM hostnames in your DNS server using Dynamic DNS.  Azure doesn't have the ability (e.g. credentials) to directly create records in your DNS servers, so alternative arrangements are often needed. Here are some common scenarios with alternatives.
 
 ## Windows clients
-Non-domain-joined Windows clients attempt unsecured Dynamic DNS (DDNS) updates when they boot or when their IP address changes. The DNS name is the hostname plus the primary DNS suffix. Azure leaves the primary DNS suffix blank, but you can set this in the VM, via the [UI](https://technet.microsoft.com/library/cc794784.aspx) or [by using automation](https://social.technet.microsoft.com/forums/windowsserver/3720415a-6a9a-4bca-aa2a-6df58a1a47d7/change-primary-dns-suffix).
+Non-domain-joined Windows clients attempt unsecured Dynamic DNS (DDNS) updates when they boot or when their IP address changes. The DNS name is the hostname plus the primary DNS suffix. Azure leaves the primary DNS suffix blank, but you can set this in the VM, via the [UI](https://technet.microsoft.com/library/cc794784.aspx) or [by using automation as discussed here](https://social.technet.microsoft.com/forums/windowsserver/3720415a-6a9a-4bca-aa2a-6df58a1a47d7/change-primary-dns-suffix).
 
 Domain-joined Windows clients register their IP addresses with the domain controller by using secure Dynamic DNS. The domain-join process sets the primary DNS suffix on the client and creates and maintains the trust relationship.
 


### PR DESCRIPTION
Under Windows client section "by using automation" link is taking to TechNet forum thread. I feel either we should change the link with appropriate article/blog/doc or we can change the name of link as by using automation as discussed here. I have changed the link name accordingly. Kindly review it once and do the needful.