### PR TITLE
Removed UDP where it is not used

### DIFF
--- a/articles/active-directory/connect/active-directory-aadconnect-ports.md
+++ b/articles/active-directory/connect/active-directory-aadconnect-ports.md
@@ -31,7 +31,7 @@ This table describes the ports and protocols that are required for communication
 | MS-RPC |135 (TCP/UDP) |Used during the initial configuration of the Azure AD Connect wizard when it binds to the AD forest, and also during Password synchronization. |
 | LDAP |389 (TCP/UDP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
 | RPC | 445 (TCP/UDP) |Used by Seamless SSO to create a computer account in the AD forest. |
-| LDAP/SSL |636 (TCP/UDP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using SSL. |
+| LDAP/SSL |636 (TCP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using SSL. |
 | RPC |49152- 65535 (Random high RPC Port)(TCP/UDP) |Used during the initial configuration of Azure AD Connect when it binds to the AD forests, and during Password synchronization. See [KB929851](https://support.microsoft.com/kb/929851), [KB832017](https://support.microsoft.com/kb/832017), and [KB224196](https://support.microsoft.com/kb/224196) for more information. |
 
 ## Table 2 - Azure AD Connect and Azure AD
@@ -39,18 +39,18 @@ This table describes the ports and protocols that are required for communication
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTP |80 (TCP/UDP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
-| HTTPS |443(TCP/UDP) |Used to synchronize with Azure AD. |
+| HTTP |80 (TCP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
+| HTTPS |443 (TCP) |Used to synchronize with Azure AD. |
 
 For a list of URLs and IP addresses you need to open in your firewall, see [Office 365 URLs and IP address ranges](https://support.office.com/article/Office-365-URLs-and-IP-address-ranges-8548a211-3fe7-47cb-abb1-355ea5aa88a2).
 
 ## Table 3 - Azure AD Connect and AD FS Federation Servers/WAP
-This table describes the ports and protocols that are required for communication between the Azure AD Connect server and AD FS Federation/WAP servers.  
+This table describes the ports and protocols that are required for communication between the Azure AD Connect server and AD FS Federation/WAP servers.
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTP |80 (TCP/UDP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
-| HTTPS |443(TCP/UDP) |Used to synchronize with Azure AD. |
+| HTTP |80 (TCP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
+| HTTPS |443 (TCP) |Used to synchronize with Azure AD. |
 | WinRM |5985 |WinRM Listener |
 
 ## Table 4 - WAP and Federation Servers
@@ -58,14 +58,14 @@ This table describes the ports and protocols that are required for communication
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTPS |443(TCP/UDP) |Used for authentication. |
+| HTTPS |443 (TCP) |Used for authentication. |
 
 ## Table 5 - WAP and Users
 This table describes the ports and protocols that are required for communication between users and the WAP servers.
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTPS |443(TCP/UDP) |Used for device authentication. |
+| HTTPS |443 (TCP) |Used for device authentication. |
 | TCP |49443 (TCP) |Used for certificate authentication. |
 
 ## Table 6a & 6b - Pass-through Authentication with Single Sign On (SSO) and Password Hash Sync with Single Sign On (SSO)
@@ -95,7 +95,7 @@ This table describes the following outbound ports and protocols that are require
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTPS |443(TCP/UDP) |Outbound |
+| HTTPS |443 (TCP) |Outbound |
 | Azure Service Bus |5671 (TCP/UDP) |Outbound |
 
 ### 7b - Endpoints for Azure AD Connect Health agent for (AD FS/Sync) and Azure AD


### PR DESCRIPTION
The port list also describes whether TCP or UDP ports or both are required. The list is wrongly says UDP is required in some cases. Especially, UDP does not support TLS, so in these cases, UDP is certainly not used. Fetching CRLs over HTTP (port 80) also does not use UDP.

The remaining cases where UDP is in the list may be correct, but may also be incorrect. I have not found convincing evidence that UDP is not used in these cases.