### PR TITLE
Correct max request length in HTTP bindings trigger docs

### DIFF
--- a/articles/azure-functions/functions-bindings-http-webhook.md
+++ b/articles/azure-functions/functions-bindings-http-webhook.md
@@ -533,7 +533,7 @@ Webhook authorization is handled by the webhook receiver component, part of the 
 
 ## Trigger - limits
 
-The HTTP request length is limited to 100K (102,400) bytes, and the URL length is limited to 4k (4,096) bytes. These limits are specified by the `httpRuntime` element of the runtime's [Web.config file](https://github.com/Azure/azure-webjobs-sdk-script/blob/v1.x/src/WebJobs.Script.WebHost/Web.config).
+The HTTP request length is limited to 100MB (104,857,600 bytes), and the URL length is limited to 4kB (4,096 bytes). These limits are specified by the `httpRuntime` element of the runtime's [Web.config file](https://github.com/Azure/azure-webjobs-sdk-script/blob/v1.x/src/WebJobs.Script.WebHost/Web.config).
 
 If a function that uses the HTTP trigger doesn't complete within about 2.5 minutes, the gateway will timeout and return an HTTP 502 error. The function will continue running but will be unable to return an HTTP response. For long-running functions, we recommend that you follow async patterns and return a location where you can ping the status of the request. For information about how long a function can run, see [Scale and hosting - Consumption plan](functions-scale.md#consumption-plan). 
 

--- a/articles/azure-functions/functions-bindings-http-webhook.md
+++ b/articles/azure-functions/functions-bindings-http-webhook.md
@@ -533,7 +533,7 @@ Webhook authorization is handled by the webhook receiver component, part of the 
 
 ## Trigger - limits
 
-The HTTP request length is limited to 100MB (104,857,600 bytes), and the URL length is limited to 4kB (4,096 bytes). These limits are specified by the `httpRuntime` element of the runtime's [Web.config file](https://github.com/Azure/azure-webjobs-sdk-script/blob/v1.x/src/WebJobs.Script.WebHost/Web.config).
+The HTTP request length is limited to 100MB (104,857,600 bytes), and the URL length is limited to 4KB (4,096 bytes). These limits are specified by the `httpRuntime` element of the runtime's [Web.config file](https://github.com/Azure/azure-webjobs-sdk-script/blob/v1.x/src/WebJobs.Script.WebHost/Web.config).
 
 If a function that uses the HTTP trigger doesn't complete within about 2.5 minutes, the gateway will timeout and return an HTTP 502 error. The function will continue running but will be unable to return an HTTP response. For long-running functions, we recommend that you follow async patterns and return a location where you can ping the status of the request. For information about how long a function can run, see [Scale and hosting - Consumption plan](functions-scale.md#consumption-plan). 
 


### PR DESCRIPTION
This value was incorrect; you'll note that in the docs for `<httpRuntime>`, `maxRequestLength` is specified in kB while the other values are in bytes (or 'characters'):

https://msdn.microsoft.com/en-us/library/e1f13641(v=vs.100).aspx