### PR TITLE
Permissions and SQL elastic pool

### DIFF
--- a/articles/advisor/advisor-overview.md
+++ b/articles/advisor/advisor-overview.md
@@ -40,9 +40,6 @@ The Advisor dashboard displays personalized recommendations for all your subscri
 
   ![Advisor recommendation types](./media/advisor-overview/advisor-dashboard.png)
 
-> [!NOTE]
-> To use Azure Advisor with a subscription, a subscription *Owner* must launch the Advisor dashboard.  This action registers the subscription with Advisor.  From that point on, any subscription *Owner*, *Contributor*, or *Reader* can access the Advisor recommendations for the subscription. 
-
 You can click a category to display the list of recommendations within that category, and select a recommendation to learn more about it.  You can also learn about actions that you can perform to take advantage of an opportunity or resolve an issue.
 
 ![Advisor recommendation category](./media/advisor-overview/advisor-ha-category-example.png) 
@@ -60,11 +57,11 @@ You can also view Advisor recommendations through the virtual machine resource i
 
 ### What permissions do I need to access Advisor?
 
-To obtain Advisor recommendations for a subscription, you must first register your subscription with Advisor. A subscription is registered when a subscription *Owner* launches the Advisor dashboard. This is a one-time operation. After the subscription is registered, you can access Advisor recommendations as *Owner*, *Contributor*, or *Reader* of a subscription.
+You can access Advisor recommendations as *Owner*, *Contributor*, or *Reader* of a subscription.
 
 ### What resources does Advisor provide recommendations for?
 
-Advisor provides recommendations for virtual machines, availability sets, application gateways, App Services, SQL servers, SQL databases, and Redis Cache.
+Advisor provides recommendations for virtual machines, availability sets, application gateways, App Services, SQL databases, and Redis Cache.
 
 ### Can I postpone or dismiss a recommendation?
 


### PR DESCRIPTION
It is no longer required for an Owner to visit Advisor first to register
- removed note
- updated FAQ

Removed SQL Elastic Pool cost recommendation
- removed SQL server from resources listed in FAQ question "What resources does Advisor provide recommendations for?"