### PR TITLE
fix: add path for suggested perf counter

### DIFF
--- a/articles/service-fabric/service-fabric-diagnostics-event-generation-perf.md
+++ b/articles/service-fabric/service-fabric-diagnostics-event-generation-perf.md
@@ -74,7 +74,7 @@ In the applications you are deploying to your cluster, if you are using Reliable
 
 If you use Reliable Services, we similarly have `Service Fabric Service` and `Service Fabric Service Method` counter categories that you should collect counters from. 
 
-If you use Reliable Collections, we recommend adding the `Avg. Transaction ms/Commit` from the `Service Fabric Transactional Replicator` to collect the average commit latency per transaction metric.
+If you use Reliable Collections, we recommend adding the `Avg. Transaction ms/Commit` from the `Service Fabric Transactional Replicator` (`\Service Fabric Replicator(*)\Avg. Commit ms/Operation`) to collect the average commit latency per transaction metric.
 
 
 ## Next steps


### PR DESCRIPTION
The name and path for the perf counter are not the same. Tbh, I'm not entirely certain if the original perf counter mentioned `Avg. Transaction ms/Commit` is the same as `\Service Fabric Replicator()\Avg. Commit ms/Operation`

On an ASF node:
```
PS C:\Users\adminuser> (Get-Counter -ListSet "Service Fabric Replicator").Paths
\Service Fabric Replicator()\Enqueued Bytes/Sec
\Service Fabric Replicator()\Enqueued Operations/Sec
\Service Fabric Replicator()\Current Role
\Service Fabric Replicator()\% Replication Queue Usage
\Service Fabric Replicator()\Avg. Cleanup ms/Operation
\Service Fabric Replicator()\Avg. Complete ms/Operation
\Service Fabric Replicator()\Avg. Commit ms/Operation
\Service Fabric Replicator()# Operations Replication Queue
\Service Fabric Replicator(*)# Bytes Replication Queue
```