### PR TITLE
Update build-image-with-packer.md

### DIFF
--- a/articles/virtual-machines/windows/build-image-with-packer.md
+++ b/articles/virtual-machines/windows/build-image-with-packer.md
@@ -107,8 +107,8 @@ Create a file named *windows.json* and paste the following content. Enter your o
     "type": "powershell",
     "inline": [
       "Add-WindowsFeature Web-Server",
-      "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
-      "& $Env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /shutdown /quiet"
+      "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit",
+      "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
     ]
   }]
 }


### PR DESCRIPTION
It is generally not sufficient to call sysprep, and then exit.  To ensure a reliable build, one should wait for sysprep to complete before returning from the provisioner.  I updated the document to match the advice I give in the Azure examples, and in Packer's own documentation.