### PR TITLE
Updated quotes of powershell script

### DIFF
--- a/includes/virtual-machines-ag-listener-configure.md
+++ b/includes/virtual-machines-ag-listener-configure.md
@@ -78,7 +78,7 @@ The availability group listener is an IP address and network name that the SQL S
     ```PowerShell
     $ClusterNetworkName = "<MyClusterNetworkName>" # the cluster network name (Use Get-ClusterNetwork on Windows Server 2012 of higher to find the name)
     $IPResourceName = "<IPResourceName>" # the IP Address resource name
-    $ILBIP = “<n.n.n.n>” # the IP Address of the Internal Load Balancer (ILB). This is the static IP address for the load balancer you configured in the Azure portal.
+    $ILBIP = "<n.n.n.n>" # the IP Address of the Internal Load Balancer (ILB). This is the static IP address for the load balancer you configured in the Azure portal.
     [int]$ProbePort = <nnnnn>
     
     Import-Module FailoverClusters


### PR DESCRIPTION
Documentation uses in the powershell scripts
“ (U+201C) LEFT DOUBLE QUOTATION MARK
” (U+201D) RIGHT DOUBLE QUOTATION MARK.

I'm proposing (U+0022) instead, as the previous quotes might be a copy and paste from Microsoft Word.