### PR TITLE
consistency of names in image vs guide

### DIFF
--- a/includes/virtual-machines-ag-listener-configure.md
+++ b/includes/virtual-machines-ag-listener-configure.md
@@ -59,7 +59,7 @@ The availability group listener is an IP address and network name that the SQL S
 
     b. On the **Resources** tab, right-click the client access point resource under **Server Name**, and then click **Properties**. 
 
-   ![IP Resource](./media/virtual-machines-ag-listener-configure/98-dependencies.png) 
+   ![IP Resource](./media/virtual-machines-ag-listener-configure/98-dependencies.png)
 
     c. Click the **Dependencies** tab. Verify that the IP address is a dependency. If it is not, set a dependency on the IP address. If there are multiple resources listed, verify that the IP addresses have OR, not AND, dependencies. Click **OK**. 
 


### PR DESCRIPTION
line 62 would require an image change, is it refers to "AG1Group" instead of "AG1".
The guide only mentions "AG1" in earlier sections, and there is an introduction of a new parameter which breaks consistency. Proposed edited image uploaded below.
![98-dependencies](https://user-images.githubusercontent.com/24219457/37717191-06bb5710-2d5b-11e8-9ebf-3cefc77d0330.png)
