### PR TITLE
Removed references to Hypernet Gateways

### DIFF
--- a/articles/network-watcher/network-watcher-troubleshoot-overview.md
+++ b/articles/network-watcher/network-watcher-troubleshoot-overview.md
@@ -84,7 +84,6 @@ The following list shows the support shows which gateways and connections are su
 |**Gateway types**   |         |
 |VPN      | Supported        |
 |ExpressRoute | Not Supported |
-|Hypernet | Not Supported|
 |**VPN types** | |
 |Route Based | Supported|
 |Policy Based | Not Supported|
@@ -92,7 +91,6 @@ The following list shows the support shows which gateways and connections are su
 |IPSec| Supported|
 |VNet2Vnet| Supported|
 |ExpressRoute| Not Supported|
-|Hypernet| Not Supported|
 |VPNClient| Not Supported|
 
 ## Log files


### PR DESCRIPTION
As Hypernet isn't a customer-facing feature, I propose we remove it from our public documentation.