### PR TITLE
Minor typo in ttl doc. "is" instead of "in"

### DIFF
--- a/articles/cosmos-db/time-to-live.md
+++ b/articles/cosmos-db/time-to-live.md
@@ -46,7 +46,7 @@ The above logic can be shown in the following matrix:
 | --- |:--- |:--- |:--- |
 | TTL Missing on document |Nothing to override at document level since both the document and collection have no concept of TTL. |No documents in this collection will expire. |The documents in this collection will expire when interval n elapses. |
 | TTL = -1 on document |Nothing to override at the document level since the collection doesn’t define the DefaultTTL property that a document can override. TTL on a document is un-interpreted by the system. |No documents in this collection will expire. |The document with TTL=-1 in this collection will never expire. All other documents will expire after "n" interval. |
-| TTL = n on document |Nothing to override at the document level. TTL on a document in un-interpreted by the system. |The document with TTL = n will expire after interval n, in seconds. Other documents will inherit interval of -1 and never expire. |The document with TTL = n will expire after interval n, in seconds. Other documents will inherit "n" interval from the collection. |
+| TTL = n on document |Nothing to override at the document level. TTL on a document is un-interpreted by the system. |The document with TTL = n will expire after interval n, in seconds. Other documents will inherit interval of -1 and never expire. |The document with TTL = n will expire after interval n, in seconds. Other documents will inherit "n" interval from the collection. |
 
 ## Configuring TTL
 By default, time to live is disabled by default in all Cosmos DB collections and on all documents. TTL can be set programmatically or in the Azure portal, in the **Settings** section for the collection. 


### PR DESCRIPTION
Minor typo in ttl doc.. "is" instead of "in"