### PR TITLE
Change first link of more tutorials to not point to same page

### DIFF
--- a/articles/cognitive-services/Custom-Speech-Service/CustomSpeech-How-to-Topics/cognitive-services-custom-speech-create-endpoint.md
+++ b/articles/cognitive-services/Custom-Speech-Service/CustomSpeech-How-to-Topics/cognitive-services-custom-speech-create-endpoint.md
@@ -66,6 +66,6 @@ When the deployment is ready, the deployment name becomes a link. Selecting the 
 ## Next steps
 
 For more tutorials, see:
-* [Create a custom speech-to-text endpoint](cognitive-services-custom-speech-create-endpoint.md)
+* [Use a custom speech-to-text endpoint](cognitive-services-custom-speech-use-endpoint.md)
 * [Create a custom acoustic model](cognitive-services-custom-speech-create-acoustic-model.md)
 * [Create a custom language model](cognitive-services-custom-speech-create-language-model.md)


### PR DESCRIPTION
The first of the links to further reading points to the current page. Changed it to point to the page describing how to use a custon speech-to-text endpoint.