### PR TITLE
Update tutorial-simulate-device-linux.md

### DIFF
--- a/articles/iot-edge/tutorial-simulate-device-linux.md
+++ b/articles/iot-edge/tutorial-simulate-device-linux.md
@@ -35,6 +35,11 @@ This tutorial uses your computer or virtual machine like an Internet of Things d
 
 * Python pip, to install the IoT Edge runtime.
    * Linux: `sudo apt-get install python-pip`.
+     * _Note that on certain distributions (e.g., Raspbian), you might also need to upgrade certain pip packages and install additional dependencies:_
+     ```
+     sudo pip install --upgrade setuptools pip
+     sudo apt-get install python2.7-dev libffi-dev libssl-dev
+     ```
    * MacOS: `sudo easy_install pip`.
 * Docker, to run the IoT Edge modules
    * [Install Docker for Linux][lnk-docker-ubuntu] and make sure that it's running. 


### PR DESCRIPTION
Raspbian has some additional prerequisites, which are not documented here. They are documented on [pypi](https://pypi.python.org/pypi/azure-iot-edge-runtime-ctl), but are not very discoverable. We've had requests to add the information to this document so more people will see it.