### PR TITLE
Update sql-database-resource-limits.md

### DIFF
--- a/articles/sql-database/sql-database-resource-limits.md
+++ b/articles/sql-database/sql-database-resource-limits.md
@@ -109,7 +109,7 @@ You can increase or decrease the resources available to an elastic pool based on
 | Maximum | Value |
 | :--- | :--- |
 | Databases per server | 5000 |
-| Number of servers per subscription per region | 21 |
+| Number of servers per subscription per region | 20 |
 |||
 
 > [!IMPORTANT]


### PR DESCRIPTION
The "Number of servers per subscription per region" is listed as 21, whereas it has to be 20. I've gotten this confirmed with the Owner of SQL SKUs at Capacity Management, Sachin Phadke <sachinp@microsoft.com>. CSS engineer Kelvin James Aroza <Kelvin.Aroza@microsoft.com> submitted this request via CSS Content team. I am submitting the PR on his behalf.