### PR TITLE
Added missing .UseApplicationInsights() in VotingWeb

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-monitoring-aspnet.md
+++ b/articles/service-fabric/service-fabric-tutorial-monitoring-aspnet.md
@@ -100,7 +100,7 @@ Here are the steps to set up the NuGet:
     
     2. In the nested *return* statement of *CreateServiceInstanceListeners()* or *CreateServiceReplicaListeners()*, under *ConfigureServices* > *services*, in between the two Singleton services declared, add:
     `.AddSingleton<ITelemetryInitializer>((serviceProvider) => FabricTelemetryInitializerExtension.CreateFabricTelemetryInitializer(serviceContext))`.
-    This will add the *Service Context* to your telemetry, allowing you to better understand the source of your telemetry in Application Insights. Your nested *return* statement in *VotingWeb.cs* should look like this:
+    This will add the *Service Context* to your telemetry, allowing you to better understand the source of your telemetry in Application Insights. Additionally, ensure that `.UseApplicationInsights()` is being called. This call is necessary to enable Application Insights in an ASP.NET Core application. Your nested *return* statement in *VotingWeb.cs* should look like this:
     
     ```csharp
     return new WebHostBuilder()
@@ -113,6 +113,7 @@ Here are the steps to set up the NuGet:
                 .AddSingleton<ITelemetryInitializer>((serviceProvider) => FabricTelemetryInitializerExtension.CreateFabricTelemetryInitializer(serviceContext)))
         .UseContentRoot(Directory.GetCurrentDirectory())
         .UseStartup<Startup>()
+        .UseApplicationInsights()
         .UseServiceFabricIntegration(listener, ServiceFabricIntegrationOptions.None)
         .UseUrls(url)
         .Build();


### PR DESCRIPTION
Following the step by step guide will not collect information from VotingWeb because the demo code does not include a call to UseApplicationInsights(). VotingData does have it.

I think it is important to emphasis the need of calling it.

I will additionally make a PR to fix the problem in https://github.com/Azure-Samples/service-fabric-dotnet-quickstart