### PR TITLE
Update text regarding providing root cert

### DIFF
--- a/articles/azure-stack/azure-stack-sql-resource-provider-deploy.md
+++ b/articles/azure-stack/azure-stack-sql-resource-provider-deploy.md
@@ -68,7 +68,7 @@ You must create one (or more) instances of SQL Server and/or provide access to e
     | 1710: 1.0.171028.1 | [SQL RP version 1.1.8.0](https://aka.ms/azurestacksqlrp1710) |
   
 
-4. The Azure Stack root certificate is retrieved from the privileged endpoint. For the Azure Stack SDK, a self-signed certificate is created as part of this process. For integrated systems, you must provide an appropriate certificate.
+4. Provide the required certificate. For the Azure Stack SDK, a self-signed certificate is created as part of this process, no additional certificate is required. For integrated systems, you must provide an appropriate certificate.
 
    To provide your own certificate, place a .pfx file in the **DependencyFilesLocalPath** as follows:
 


### PR DESCRIPTION
Feedback from MediaCloud. This statement is confusing "The Azure Stack root certificate is retrieved from the privileged endpoint.". The customer assumed they needed to provide the root cert of the solution. Jeff Goldner confirmed this is handled by the script so the information is not required in document.