### PR TITLE
Fix azure-mgmt-datalake-store link to docs

### DIFF
--- a/articles/data-lake-store/data-lake-store-get-started-python.md
+++ b/articles/data-lake-store/data-lake-store-get-started-python.md
@@ -41,7 +41,7 @@ Learn how to use the Python SDK for Azure Data Lake Store to perform basic accou
 To work with Data Lake Store using Python, you need to install three modules.
 
 * The `azure-mgmt-resource` module, which includes Azure modules for Active Directory, etc.
-* The `azure-mgmt-datalake-store` module, which includes the Azure Data Lake Store account management operations. For more information on this module, see [Azure Data Lake Store Management module reference](http://azure-sdk-for-python.readthedocs.io/en/latest/sample_azure-mgmt-datalake-store.html).
+* The `azure-mgmt-datalake-store` module, which includes the Azure Data Lake Store account management operations. For more information on this module, see [Azure Data Lake Store Management module reference](http://azure-sdk-for-python.readthedocs.io/sample_azure-mgmt-datalake-store.html).
 * The `azure-datalake-store` module, which includes the Azure Data Lake Store filesystem operations. For more information on this module, see [Azure Data Lake Store Filesystem module reference](http://azure-datalake-store.readthedocs.io/en/latest/).
 
 Use the following commands to install the modules.


### PR DESCRIPTION
The link for Azure Management for Data Lake Store leads to a 404 page on readthedocs.  I found the correct page and have provided the updated link.