### PR TITLE
No -Name Parameter

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-deploy.md
+++ b/articles/azure-resource-manager/resource-group-template-deploy.md
@@ -131,7 +131,7 @@ If your template includes a parameter with the same name as one of the parameter
 To test your template and parameter values without actually deploying any resources, use [Test-​Azure​Rm​Resource​Group​Deployment](/powershell/module/azurerm.resources/test-azurermresourcegroupdeployment). 
 
 ```powershell
-Test-AzureRmResourceGroupDeployment -Name ExampleDeployment -ResourceGroupName ExampleResourceGroup `
+Test-AzureRmResourceGroupDeployment -ResourceGroupName ExampleResourceGroup `
   -TemplateFile c:\MyTemplates\storage.json -storageAccountType Standard_GRS
 ```
 


### PR DESCRIPTION
Test-AzureRmResourceGroupDeployment doesn't have a -Name Parameter. 

Running the code snippet specified results in:
![image](https://user-images.githubusercontent.com/5795530/38148047-ca1184f0-3422-11e8-998f-546f72ef9628.png)


The documentation of Test-AzureRmResourceGroupDeployment doesnt mention a -Name parameter either:
[https://github.com/Azure/azure-powershell/blob/preview/src/ResourceManager/Resources/Commands.Resources/help/Test-AzureRmResourceGroupDeployment.md](https://github.com/Azure/azure-powershell/blob/preview/src/ResourceManager/Resources/Commands.Resources/help/Test-AzureRmResourceGroupDeployment.md)