### PR TITLE
Replace Self Link with Uri Factory in Documentation

### DIFF
--- a/articles/cosmos-db/secure-access-to-data.md
+++ b/articles/cosmos-db/secure-access-to-data.md
@@ -148,7 +148,7 @@ The following code sample shows how to create a permission resource, read the re
 Permission docPermission = new Permission
 {
     PermissionMode = PermissionMode.Read,
-    ResourceLink = documentCollection.SelfLink,
+    ResourceLink = UriFactory.CreateDocumentCollectionUri("db", "collection"),
     Id = "readperm"
 };
   


### PR DESCRIPTION
the documentation is inconsistent.  For the most part it uses URI Factories and not self links.  Corrects the Create Permission example to use URIFactory to be consistent with the rest of the doc