### PR TITLE
Remove subcategory on left column

### DIFF
--- a/articles/virtual-network/virtual-networks-create-nsg-arm-template.md
+++ b/articles/virtual-network/virtual-networks-create-nsg-arm-template.md
@@ -187,3 +187,4 @@ To deploy the ARM template by using the Azure CLI, follow the steps below.
    * **-f (or --template-file)**. Path to your ARM template file.
    * **-e (or --parameters-file)**. Path to your ARM parameters file.
 
+Proposing removing sub category called "Without application security groups" on left unless it means something


### PR DESCRIPTION
I can't figure out why Portal and Template sections are in a subcategory called "Without application security groups." Is this an edit mistake?

The content suggested was clearly not intended to be added to the doc. I just didn't know the right way to submit this type of edit. 