### PR TITLE
Remove misleading comment

### DIFF
--- a/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md
+++ b/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md
@@ -38,8 +38,6 @@ import cognitive_face as CF
 
 KEY = '<Subscription Key>'  # Replace with a valid subscription key (keeping the quotes in place).
 CF.Key.set(KEY)
-# If you need to, you can change your base API url with:
-#CF.BaseUrl.set('https://westcentralus.api.cognitive.microsoft.com/face/v1.0/')
 
 BASE_URL = 'https://westus.api.cognitive.microsoft.com/face/v1.0/'  # Replace with your regional Base URL
 CF.BaseUrl.set(BASE_URL)


### PR DESCRIPTION
If the line is uncommented, the base URL is overridden immediately below any and wouldn't work.