### PR TITLE
Update azure-stack-rotate-secrets.md

### DIFF
--- a/articles/azure-stack/azure-stack-rotate-secrets.md
+++ b/articles/azure-stack/azure-stack-rotate-secrets.md
@@ -67,7 +67,7 @@ Running secret rotation using the instructions below will remediate these alerts
 2.  Prepare a new set of replacement external certificates. The new set matches the certificate specifications outlined in the [Azure Stack PKI certificate requirements](https://docs.microsoft.com/azure/azure-stack/azure-stack-pki-certs).
 3.  Store a back up to the certificates used for rotation in a secure backup location. If your rotation runs and then fails, replace the certificates in the file share with the backup copies before you rerun the rotation. Note, keep backup copies in the secure backup location.
 3.  Create a fileshare you can access from the ERCS VMs. The file share must be  readable and writable for the **CloudAdmin** identity.
-4.  Open a PowerShell ISE console on the ERCS VM using the **CloudAdmin** account.  Navigate to your fileshare. 
+4.  Open a PowerShell ISE console from a computer where you have access to the fileshare. Navigate to your fileshare. 
 5.  Run **[CertDirectoryMaker.ps1](http://www.aka.ms/azssecretrotationhelper)** to create the required directories for your external certificates.
 
 ## Rotating external and internal secrets


### PR DESCRIPTION
The customers can't navigate to shares from ERCS-VM or open a powershell ISE console on the ERCS-VMs. So this is not possible to do without unlocking a supportsession first.