### PR TITLE
Fixed doc reference to telemetry microservice

### DIFF
--- a/articles/iot-suite/iot-suite-remote-monitoring-sample-walkthrough.md
+++ b/articles/iot-suite/iot-suite-remote-monitoring-sample-walkthrough.md
@@ -100,7 +100,7 @@ The [telemetry-agent](https://github.com/Azure/telemetry-agent-dotnet) microserv
 
 The alarms are stored in Cosmos DB.
 
-The `telemetry-agent` microservice enables the solution portal to read the telemetry sent from the devices. The solution portal also uses this service to:
+The [telemetry](https://github.com/Azure/device-telemetry-dotnet) microservice enables the solution portal to read the telemetry sent from the devices. The solution portal also uses this service to:
 
 * Define monitoring rules such as the thresholds that trigger alarms
 * Retrieve the list of past alarms.


### PR DESCRIPTION
Had no reference to repository and was referring to "telemetry-agent" instead of "telemetry"