### PR TITLE
Create VM from Azure Image Step Fails if image name is provided. Need…

### DIFF
--- a/articles/virtual-machines/linux/build-image-with-packer.md
+++ b/articles/virtual-machines/linux/build-image-with-packer.md
@@ -203,12 +203,12 @@ You can now create a VM from your Image with [az vm create](/cli/azure/vm#az_vm_
 az vm create \
     --resource-group myResourceGroup \
     --name myVM \
-    --image myPackerImage \
+    --image <image-id> \
     --admin-username azureuser \
     --generate-ssh-keys
 ```
 
-It takes a few minutes to create the VM. Once the VM has been created, take note of the `publicIpAddress` displayed by the Azure CLI. This address is used to access the NGINX site via a web browser.
+The <image-id> must be of the form: /subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Compute/images/<image-name>. It takes a few minutes to create the VM. Once the VM has been created, take note of the `publicIpAddress` displayed by the Azure CLI. This address is used to access the NGINX site via a web browser.
 
 To allow web traffic to reach your VM, open port 80 from the Internet with [az vm open-port](/cli/azure/vm#open-port):
 


### PR DESCRIPTION
**Create VM from Azure Image** Step Fails if **image name** is provided as currently shown in docs. The **full image id** needs to be provided.
i.e. Following command Fails
```
az vm create \
    --resource-group myResourceGroup \
    --name myVM \
    --image myPackerImage \
    --admin-username azureuser \
    --generate-ssh-keys 
```
 The Error message is 
```
Invalid image "managedPackerLinux". Use a custom image name, id, or pick one from ['CentOS', 'CoreOS', 'Debian', 'openSUSE-Leap', 'RHEL', 'SLES', 'UbuntuLTS', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1']
```

When Full Image Id is provided as shown in command command below it succeeds (subcriptiontionid, resourcegroupname and imagename need to be changed)
```azurecli
az vm create \
    --resource-group myResourceGroup \
    --name myVM \
    --image "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Compute/images/<image-name>"  \
    --admin-username azureuser \
    --generate-ssh-keys
```