### PR TITLE
Update service-fabric-diagnostics-event-generation-perf.md

### DIFF
--- a/articles/service-fabric/service-fabric-diagnostics-event-generation-perf.md
+++ b/articles/service-fabric/service-fabric-diagnostics-event-generation-perf.md
@@ -72,7 +72,7 @@ Service Fabric generates a substantial amount of custom performance counters. If
 
 In the applications you are deploying to your cluster, if you are using Reliable Actors, add countes from `Service Fabric Actor` and `Service Fabric Actor Method` categories (see [Service Fabric Reliable Actors Diagnostics](service-fabric-reliable-actors-diagnostics.md)).
 
-If you use Reliable Services, we similarly have `Service Fabric Service` and `Service Fabric Service Method` counter categories that you should collect counters from. 
+If you use Service Remoting, we similarly have `Service Fabric Service` and `Service Fabric Service Method` counter categories that you should collect counters from. 
 
 If you use Reliable Collections, we recommend adding the `Avg. Transaction ms/Commit` from the `Service Fabric Transactional Replicator` to collect the average commit latency per transaction metric.
 


### PR DESCRIPTION
These perf counters are for Service Remoting only apparently.