### PR TITLE
Add a Python example of cognitive rest-api

### DIFF
--- a/articles/cognitive-services/Speech/GetStarted/GetStartedREST.md
+++ b/articles/cognitive-services/Speech/GetStarted/GetStartedREST.md
@@ -165,6 +165,30 @@ using (FileStream fs = new FileStream(YOUR_AUDIO_FILE, FileMode.Open, FileAccess
 }
 ```
 
+# [Python](#tab/Python)
+
+```py
+import requests
+import json
+
+# Modify the parameters as you want
+recogMode = 'interactive'
+language = 'en-US'
+outputFormat = 'detailed'
+apiKey = 'YOUR_SUBSCRIPTION_KEY'
+audioFilePath = 'YOUR_AUDIO_FILE'
+
+apiURL = 'https://speech.platform.bing.com/speech/recognition/'+ recogMode + '/cognitiveservices/v1?language=' + language + '&format=' + outputFormat
+
+requestHeader = {
+        'Ocp-Apim-Subscription-Key' : apiKey,
+        'Content-type' : 'audio/wav; codec=audio/pcm; samplerate=16000'
+}
+
+requestBody = open(audioFilePath, 'rb').read()
+response = requests.post(apiURL, data=requestBody, headers=requestHeader)
+```
+
 ---
 
 ## Process the speech recognition response
@@ -210,6 +234,13 @@ using (WebResponse response = request.GetResponse())
     Console.WriteLine(responseString);
     Console.ReadLine();
 }
+```
+
+# [Python](#tab/Python)
+
+```py
+# show the response in JSON format
+json.loads(response.content.decode('utf-8'))
 ```
 
 ---

--- a/articles/cognitive-services/Speech/How-to/how-to-authentication.md
+++ b/articles/cognitive-services/Speech/How-to/how-to-authentication.md
@@ -127,6 +127,25 @@ curl -v -X POST "https://api.cognitive.microsoft.com/sts/v1.0/issueToken" -H "Co
     }
 ```
 
+# [Python](#tab/Python)
+```py
+import json
+import requests
+
+apiKey = 'YOUR_SUBSCRIPTION_KEY'
+apiURL = 'https://api.cognitive.microsoft.com/sts/v1.0/issueToken'
+
+requestHeader = {
+        'Content-type' : 'application/x-www-form-urlencoded',
+        'Content-Length' : '0',
+        'Ocp-Apim-Subscription-Key' : apiKey
+}
+
+response = requests.post(apiURL, headers=requestHeader)
+
+print(response.content.decode('utf-8'))
+```
+
 ---
 
 The following is a sample POST request:

--- a/articles/cognitive-services/Speech/How-to/how-to-authentication.md
+++ b/articles/cognitive-services/Speech/How-to/how-to-authentication.md
@@ -128,22 +128,18 @@ curl -v -X POST "https://api.cognitive.microsoft.com/sts/v1.0/issueToken" -H "Co
 ```
 
 # [Python](#tab/Python)
+
 ```py
-import json
 import requests
-
 apiKey = 'YOUR_SUBSCRIPTION_KEY'
-apiURL = 'https://api.cognitive.microsoft.com/sts/v1.0/issueToken'
-
-requestHeader = {
+tockenURL = 'https://api.cognitive.microsoft.com/sts/v1.0/issueToken'
+fetchTockenHeader = {
         'Content-type' : 'application/x-www-form-urlencoded',
         'Content-Length' : '0',
         'Ocp-Apim-Subscription-Key' : apiKey
 }
-
-response = requests.post(apiURL, headers=requestHeader)
-
-print(response.content.decode('utf-8'))
+tockenResponse = requests.post(tockenURL, headers=fetchTockenHeader)
+OAuthTocken=tockenResponse.content.decode('utf-8')
 ```
 
 ---
@@ -237,6 +233,26 @@ using (fs = new FileStream(audioFile, FileMode.Open, FileAccess.Read))
         requestStream.Flush();
     }
 }
+```
+
+# [Python](#tab/Python)
+
+```py
+import json
+recogMode = 'interactive'
+language = 'en-US'
+outputFormat = 'detailed'
+apiURL = 'https://speech.platform.bing.com/speech/recognition/'+ recogMode + '/cognitiveservices/v1?language=' + language + '&format=' + outputFormat
+audioFilePath = 'YOUR_AUDIO_FILE'
+
+requestHeader = {
+        'Authorization' : 'Bearer ' + OAuthTocken,
+        'Content-type' : 'audio/wav; codec=audio/pcm; samplerate=16000'
+}
+
+requestBody = open(audioFilePath, 'rb').read()
+response = requests.post(apiURL, data=requestBody, headers=requestHeader)
+responseJson = json.loads(response.content.decode('utf-8'))
 ```
 
 ---


### PR DESCRIPTION
I have written the example code for Python 3.x

This code requested the api using the post of the request package, and did not include the header and processing associated with the 'chunked transfer'.