### PR TITLE
Reference body not data in the Python requests.post call

### DIFF
--- a/articles/machine-learning/preview/model-management-consumption.md
+++ b/articles/machine-learning/preview/model-management-consumption.md
@@ -157,6 +157,6 @@ url = 'http://<service ip address>:80/api/v1/service/<service name>/score'
 api_key = 'your service key' 
 headers = {'Content-Type':'application/json', 'Authorization':('Bearer '+ api_key)}
 
-resp = requests.post(url, data, headers=headers)
+resp = requests.post(url, body, headers=headers)
 resp.text
 ```


### PR DESCRIPTION
They data variable is incorrectly referenced in the requests.post call.  It should be body since it encodes the data variable into json.