### PR TITLE
Update msi-tutorial-linux-vm-access-storage.md

### DIFF
--- a/articles/active-directory/pp/msi-tutorial-linux-vm-access-storage.md
+++ b/articles/active-directory/pp/msi-tutorial-linux-vm-access-storage.md
@@ -187,7 +187,7 @@ To complete these steps, you need an SSH client. If you are using Windows, you c
 4. Now use the access token to access Azure Storage, for example to read the contents of the sample file which you previously uploaded to the container. Replace the values of `<STORAGE ACCOUNT>`, `<CONTAINER NAME>`, and `<FILE NAME>` with the values you specified earlier, and `<ACCESS TOKEN>` with the token returned in the previous step.
 
    ```bash
-   curl https://<STORAGE ACCOUNT>.blob.core.windows.net/<CONTAINER NAME>/<FILE NAME>?api-version=2017-11-09 -H "Authorization: Bearer <ACCESS TOKEN>"
+   curl https://<STORAGE ACCOUNT>.blob.core.windows.net/<CONTAINER NAME>/<FILE NAME> -H "x-ms-version: 2017-11-09" -H "Authorization: Bearer <ACCESS TOKEN>"
    ```
 
    The response contains the contents of the file:


### PR DESCRIPTION
Curl doesn’t translate the query parameter “?api-version=2017-11-09” in the URL into the header. Adding -H “x-ms-version: 2017-11-09” to curl command makes it work.