### PR TITLE
Remove User ID and Password for service principal

### DIFF
--- a/articles/data-factory/connector-azure-sql-data-warehouse.md
+++ b/articles/data-factory/connector-azure-sql-data-warehouse.md
@@ -128,7 +128,7 @@ To use service principal based AAD application token authentication, follow thes
         "typeProperties": {
             "connectionString": {
                 "type": "SecureString",
-                "value": "Server=tcp:<servername>.database.windows.net,1433;Database=<databasename>;User ID=<username>@<servername>;Password=<password>;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
+                "value": "Server=tcp:<servername>.database.windows.net,1433;Database=<databasename>;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
             },
             "servicePrincipalId": "<service principal id>",
             "servicePrincipalKey": {

--- a/articles/data-factory/connector-azure-sql-database.md
+++ b/articles/data-factory/connector-azure-sql-database.md
@@ -125,7 +125,7 @@ To use service principal based AAD application token authentication, follow thes
         "typeProperties": {
             "connectionString": {
                 "type": "SecureString",
-                "value": "Server=tcp:<servername>.database.windows.net,1433;Database=<databasename>;User ID=<username>@<servername>;Password=<password>;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
+                "value": "Server=tcp:<servername>.database.windows.net,1433;Database=<databasename>;Trusted_Connection=False;Encrypt=True;Connection Timeout=30"
             },
             "servicePrincipalId": "<service principal id>",
             "servicePrincipalKey": {


### PR DESCRIPTION
Remove User ID and Password from connection string when using service principal authentication is used.