### PR TITLE
Move the P Query Parameter to the URL

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-access-tokens.md
+++ b/articles/active-directory-b2c/active-directory-b2c-access-tokens.md
@@ -76,7 +76,7 @@ When requesting an access token, the client application needs to specify the des
 > Currently, custom domains are not supported along with access tokens. You must use your tenantName.onmicrosoft.com domain in the request URL.
 
 ```
-https://login.microsoftonline.com/<tenantName>.onmicrosoft.com/oauth2/v2.0/authorize?p=<yourPolicyId>&client_id=<appID_of_your_client_application>&nonce=anyRandomValue&redirect_uri=<redirect_uri_of_your_client_application>&scope=https%3A%2F%2Fcontoso.onmicrosoft.com%2Fnotes%2Fread&response_type=code 
+https://login.microsoftonline.com/<tenantName>.onmicrosoft.com/<yourPolicyId>/oauth2/v2.0/authorize?client_id=<appID_of_your_client_application>&nonce=anyRandomValue&redirect_uri=<redirect_uri_of_your_client_application>&scope=https%3A%2F%2Fcontoso.onmicrosoft.com%2Fnotes%2Fread&response_type=code 
 ```
 
 To acquire multiple permissions in the same request, you can add multiple entries in the single **scope** parameter, separated by spaces. For example:


### PR DESCRIPTION
Being that `p` is a custom parameter, it fits better in the URL then the query parameters.  It is a more "standards compliant" way.