### PR TITLE
Added details to retrieve custom script output

### DIFF
--- a/articles/virtual-machines/windows/extensions-customscript.md
+++ b/articles/virtual-machines/windows/extensions-customscript.md
@@ -121,6 +121,25 @@ Data about the state of extension deployments can be retrieved from the Azure po
 Get-AzureRmVMExtension -ResourceGroupName myResourceGroup -VMName myVM -Name myExtensionName
 ```
 
+To see the output of the script that is executed as part of the Custom Script Execution cmdlet, add the -Status switch to the above powershell cmdlet as shown below.
+
+```powershell
+Get-AzureRmVMExtension -ResourceGroupName myResourceGroup -VMName myVM -Name myExtensionName -Status
+```
+The above cmdlet returns the output in the "Statuses" property which is a list. Expand the property to see the actual text output in the "Message" property
+
+```powershell
+(Get-AzureRmVMExtension -ResourceGroupName myResourceGroup -VMName myVM -Name myExtensionName -Status).Statuses[0].Message
+```
+
+> [!NOTE]  
+> If running the above cmdlet in an Azure Automation runbook of type "workflow", add the cmdlet within an InlineScript { } block and return the output from the block... 
+$status = InlineScript {
+(Get-AzureRmVMExtension -ResourceGroupName myResourceGroup -VMName myVM -Name myExtensionName -Status).Statuses[0].Message
+}
+>
+> 
+
 Extension execution output is logged to files found under the following directory on the target virtual machine.
 ```cmd
 C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension


### PR DESCRIPTION
1. Added the details of PowerShell cmdlets to use for retrieving the output of the script that is executed as part of the CustomScript Execution. 

2. Also added a note on how to use the same when running them inside an automation runbook of type workflow as the cmdlet doesn't return straightforward output while running in runbook of type workflow. Spent a lot of time myself to figure this out.