### PR TITLE
Change title 'Create a trial registration? to something like 'Registe…

### DIFF
--- a/articles/cost-management/quick-register-ea.md
+++ b/articles/cost-management/quick-register-ea.md
@@ -22,7 +22,7 @@ You use your Azure Enterprise Agreement to register with Azure Cost Management. 
 
 - Log in to the Azure portal at http://portal.azure.com.
 
-## Create a trial registration
+## Register with Azure Cost Management
 
 1. In the Azure portal, click **Cost Management + Billing** in the list of services.
 2. Under **Overview**, click **Cost Management**  


### PR DESCRIPTION
…r with Azure Cost Management'.

Change title 'Create a trial registration? to something like 'Register with Azure Cost Management'. 
The current title gives the idea that this will be temporary.
The same feedback applies to the articles for other types of subscriptions:
https://docs.microsoft.com/en-us/azure/cost-management/quick-register-azure-sub
https://docs.microsoft.com/en-us/azure/cost-management/quick-register-csp