### PR TITLE
Updated TrustedHosts commands

### DIFF
--- a/articles/site-recovery/hyper-v-deployment-planner-run.md
+++ b/articles/site-recovery/hyper-v-deployment-planner-run.md
@@ -53,7 +53,7 @@ Open the output file in Notepad, and then copy the names of all VMs that you wan
 
 #### Store the list of VMs in a file
 ```
-ASRDeploymentPlanner.exe -Operation GetVMlist -ServerListFile “E:\Hyper-V_ProfiledData\ServerList.txt" -User Hyper-VUser1 -OutputFile "E:\Hyper-V_ProfiledData\VMListFile.txt"
+ASRDeploymentPlanner.exe -Operation GetVMlist -ServerListFile "E:\Hyper-V_ProfiledData\ServerList.txt" -User Hyper-VUser1 -OutputFile "E:\Hyper-V_ProfiledData\VMListFile.txt"
 ```
 
 #### Store the list of VMs at the default location (-Directory path)


### PR DESCRIPTION
Correct a non-standard quote mark that was in the ASRDeploymentPlanner.exe 'Store the list of VMs in a file' example command line.