### PR TITLE
Fixed link to Twitter Application MAnagement

### DIFF
--- a/articles/azure-databricks/databricks-stream-from-eventhubs.md
+++ b/articles/azure-databricks/databricks-stream-from-eventhubs.md
@@ -107,7 +107,7 @@ In this section, you create an Azure Databricks workspace using the Azure portal
 
 To receive a stream of tweets, you create an application in Twitter. Follow the instructions create a Twitter application and record the values that you need to complete this tutorial.
 
-1. From a web browser, go to [Twitter Application Management](http://twitter.com/app), and select **Create New App**.
+1. From a web browser, go to [Twitter Application Management](https://apps.twitter.com/), and select **Create New App**.
 
     ![Create Twitter application](./media/databricks-stream-from-eventhubs/databricks-create-twitter-app.png "Create Twitter application")
 


### PR DESCRIPTION
The link that should point to Twitter Application Management in reality pointed to the user @app. This correction fixes that and points to the "Applications"  page of Twitter where you can create Twitter apps.