### PR TITLE
Fix command to create AKS cluster

### DIFF
--- a/articles/aks/kubernetes-walkthrough.md
+++ b/articles/aks/kubernetes-walkthrough.md
@@ -68,7 +68,7 @@ Output:
 Use the [az aks create][az-aks-create] command to create an AKS cluster. The following example creates a cluster named *myAKSCluster* with one node.
 
 ```azurecli-interactive
-az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 1 --generate-ssh-keys
+az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 1 --generate-ssh-keys --kubernetes-version 1.9.2
 ```
 
 After several minutes, the command completes and returns JSON-formatted information about the cluster.


### PR DESCRIPTION
Running the `az aks create` command listed in the tutorial fails on the latest azure-cli (version 2.0.31) with the following error:

```
Deployment failed. Correlation ID: {some-uuid}. PutControlPlane error
```

This is likely related to https://github.com/Azure/AKS/issues/38

Specifying a particular kubernetes version fixes the issue and the cluster is created as expected.