### PR TITLE
Fix blockquote nested lists formatting.

### DIFF
--- a/articles/active-directory-domain-services/active-directory-ds-getting-started.md
+++ b/articles/active-directory-domain-services/active-directory-ds-getting-started.md
@@ -45,14 +45,13 @@ In the **Basics** page of the wizard, you can specify the DNS domain name for th
    > [!NOTE]
    > **Guidelines for selecting a DNS domain name**
    > * **Built-in domain name:** By default, the wizard specifies the default/built-in domain name of the directory (with a **.onmicrosoft.com** suffix) for you. If you choose to enable secure LDAP access to the managed domain over the internet, expect issues creating a public DNS record or obtaining a secure LDAP certificate from a public CA for this domain name. Microsoft owns the *.onmicrosoft.com* domain and CAs will not issue certificates vouching for this domain.
-   * **Custom domain names:** You can also type in a custom domain name. In this example, the custom domain name is *contoso100.com*.
-   * **Non-routable domain suffixes:** We generally recommend avoiding a non-routable domain name suffix. For instance, it is better to avoid creating a domain with the DNS domain name 'contoso.local'. The '.local' DNS suffix is not routable and can cause issues with DNS resolution.
-   * **Domain prefix restrictions:** The prefix of your specified domain name (for example, *contoso100* in the *contoso100.com* domain name) must contain 15 or fewer characters. You cannot create a managed domain with a prefix longer than 15 characters.
-   * **Network name conflicts:** Ensure that the DNS domain name you have chosen for the managed domain does not already exist in the virtual network. Specifically, check whether:
-       * You already have an Active Directory domain with the same DNS domain name on the virtual network.
-       * The virtual network where you plan to enable the managed domain has a VPN connection with your on-premises network. In this scenario, ensure you don't have a domain with the same DNS domain name on your on-premises network.
-       * You have an existing cloud service with that name on the virtual network.
-    >
+   > * **Custom domain names:** You can also type in a custom domain name. In this example, the custom domain name is *contoso100.com*.
+   > * **Non-routable domain suffixes:** We generally recommend avoiding a non-routable domain name suffix. For instance, it is better to avoid creating a domain with the DNS domain name 'contoso.local'. The '.local' DNS suffix is not routable and can cause issues with DNS resolution.
+   > * **Domain prefix restrictions:** The prefix of your specified domain name (for example, *contoso100* in the *contoso100.com* domain name) must contain 15 or fewer characters. You cannot create a managed domain with a prefix longer than 15 characters.
+   > * **Network name conflicts:** Ensure that the DNS domain name you have chosen for the managed domain does not already exist in the virtual network. Specifically, check whether:
+   >   * You already have an Active Directory domain with the same DNS domain name on the virtual network.
+   >   * The virtual network where you plan to enable the managed domain has a VPN connection with your on-premises network. In this scenario, ensure you don't have a domain with the same DNS domain name on your on-premises network.
+   >   * You have an existing cloud service with that name on the virtual network.
 
 2. Select the Azure **Subscription** in which you would like to create the managed domain.
 


### PR DESCRIPTION
Fix blockquote nested lists formatting in "DNS domain name" guidelines section. This fix allows GitHub's markdown interpreter to correctly interpret the intended formatting, which is a blockquote containing a list and a nested list.