### PR TITLE
Application Insights - update new proxy settings

### DIFF
--- a/articles/application-insights/app-insights-troubleshoot-faq.md
+++ b/articles/application-insights/app-insights-troubleshoot-faq.md
@@ -251,15 +251,36 @@ Allow your web server to send telemetry to our endpoints https://dc.services.vis
 
 ### Proxy
 
-Route traffic from your server to a gateway on your intranet, by setting this in ApplicationInsights.config:
+Route traffic from your server to a gateway on your intranet, by overwritting these settings in the example ApplicationInsights.config.
+If these sections are not present in your config, these classes will be using the default values shown in the example below.
 
-```XML
-<TelemetryChannel>
-    <EndpointAddress>your gateway endpoint</EndpointAddress>
-</TelemetryChannel>
+#### Example ApplicationInsights.config:
+```xml
+<ApplicationInsights>
+    ...
+    <TelemetryChannel>
+         <EndpointAddress>https://dc.services.visualstudio.com/v2/track</EndpointAddress>
+    </TelemetryChannel>
+    ...
+    <ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights">
+        <ProfileQueryEndpoint>https://dc.services.visualstudio.com/api/profiles/{0}/appId</ProfileQueryEndpoint>
+    </ApplicationIdProvider>
+    ...
+</ApplicationInsights>
 ```
 
-Your gateway should route the traffic to https://dc.services.visualstudio.com:443/v2/track
+Your gateway should route the traffic to https://dc.services.visualstudio.com:443
+
+Replace the values above with: `http://<your.gateway.address>/<relative path>`
+ 
+Example: 
+```
+http://<your.gateway.endpoint>/v2/track 
+http://<your.gateway.endpoint>/api/profiles/{0}/apiId
+```
+
+
+
 
 ## Can I run Availability web tests on an intranet server?
 

--- a/articles/application-insights/app-insights-troubleshoot-faq.md
+++ b/articles/application-insights/app-insights-troubleshoot-faq.md
@@ -252,7 +252,7 @@ Allow your web server to send telemetry to our endpoints https://dc.services.vis
 ### Proxy
 
 Route traffic from your server to a gateway on your intranet, by overwritting these settings in the example ApplicationInsights.config.
-If these sections are not present in your config, these classes will be using the default values shown in the example below.
+If these "Endpoint" properties are not present in your config, these classes will be using the default values shown in the example below.
 
 #### Example ApplicationInsights.config:
 ```xml
@@ -268,6 +268,8 @@ If these sections are not present in your config, these classes will be using th
     ...
 </ApplicationInsights>
 ```
+
+_Note ApplicationIdProvider is available starting in v2.6.0_
 
 Your gateway should route the traffic to https://dc.services.visualstudio.com:443
 


### PR DESCRIPTION
This is to address: https://github.com/Microsoft/ApplicationInsights-dotnet/issues/777

The new configuration ApplicationIdProvider was added in 2.6.0.
This PR is to document that this is one more endpoint that would need to be overwritten in a proxy scenario.


Please label this PR as "application-insights".
@Dmitry-Matveev or @SergeyKanzhelev from my team to review.
@mrbullwinkle to sign off.