### PR TITLE
Updates

### DIFF
--- a/articles/iot-edge/how-to-create-transparent-gateway.md
+++ b/articles/iot-edge/how-to-create-transparent-gateway.md
@@ -78,10 +78,10 @@ You can use the sample Powershell and Bash scripts described in [Managing CA Cer
 
 ### Bash
 
-Create the new device certificate:
+Create the new device certificate.  **DO NOT** name the `myGatewayCAName` to be the same as your gateway host's name.  Doing so will cause client certification against these certs to fail.
 
    ```bash
-   ./certGen.sh create_edge_device_certificate myGateway
+   ./certGen.sh create_edge_device_certificate myGatewayCAName
    ```
 
 New files are created: .\certs\new-edge-device.* contains the public key and PFX, and .\private\new-edge-device.key.pem contains the device's private key.
@@ -89,6 +89,7 @@ New files are created: .\certs\new-edge-device.* contains the public key and PFX
 In the `certs` directory, run the following command to get the full chain of the device public key:
 
    ```bash
+   cd ./certs
    cat ./new-edge-device.cert.pem ./azure-iot-test-only.intermediate.cert.pem ./azure-iot-test-only.root.ca.cert.pem > ./new-edge-device-full-chain.cert.pem
    ```
 
@@ -121,11 +122,11 @@ Provide the device and certificate information to the IoT Edge runtime.
 In Linux, using the Bash output:
 
    ```bash
-   sudo iotedgectl setup --connection-string {device connection string}
-        --edge-hostname {gateway hostname, e.g. mygateway.contoso.com}
-        --device-ca-cert-file {full path}/certs/new-edge-device.cert.pem
-        --device-ca-chain-cert-file {full path}/certs/new-edge-device-full-chain.cert.pem
-        --device-ca-private-key-file {full path}/private/new-edge-device.key.pem
+   sudo iotedgectl setup --connection-string {device connection string} \
+        --edge-hostname {gateway hostname, e.g. mygateway.contoso.com} \
+        --device-ca-cert-file {full path}/certs/new-edge-device.cert.pem \
+        --device-ca-chain-cert-file {full path}/certs/new-edge-device-full-chain.cert.pem \
+        --device-ca-private-key-file {full path}/private/new-edge-device.key.pem \
         --owner-ca-cert-file {full path}/certs/azure-iot-test-only.root.ca.cert.pem
    ```
 


### PR DESCRIPTION
Make easier to copy/paste and more critically clarify certificate naming practices.