### PR TITLE
Incorrect claim rule

### DIFF
--- a/articles/active-directory/active-directory-conditional-access-no-modern-authentication.md
+++ b/articles/active-directory/active-directory-conditional-access-no-modern-authentication.md
@@ -96,7 +96,7 @@ To effectively protect access to Exchange Online from Exchange ActiveSync, you c
 
         @RuleName = "Block Exchange ActiveSync"
         c1:[Type == "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-application", Value == "Microsoft.Exchange.ActiveSync"]
-        => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit", Value = "false");
+        => issue(Type = "http://schemas.microsoft.com/authorization/claims/deny", Value = "true");
 
 
 


### PR DESCRIPTION
Line 99: => issue(Type = "http://schemas.microsoft.com/authorization/claims/permit", Value = "false"); will actually issue a Permit claim.
I suggest => issue(Type = "http://schemas.microsoft.com/authorization/claims/deny", Value = "true"); which will effectively issue a Deny claim and block the access at the ADFS level according to what the bullet point above is mentioning: "- Block Exchange ActiveSync by using Active Directory Federation Services (AD FS) rules."