### PR TITLE
Fixing typos and missing instructions in Desktop and SPA Tutorials

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-quickstarts-desktop-app.md
+++ b/articles/active-directory-b2c/active-directory-b2c-quickstarts-desktop-app.md
@@ -95,10 +95,6 @@ The application includes the Azure AD access token in the request to the protect
 
 You have successfully used your Azure AD B2C user account to make an authorized call an Azure AD B2C protected web API.
 
-## Clean up resources
-
-You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C quickstarts or tutorials. When no longer needed, you can [delete your Azure AD B2C tenant](active-directory-b2c-faqs.md#how-do-i-delete-my-azure-ad-b2c-tenant).
-
 ## Next steps
 
 The next step is to create your own Azure AD B2C tenant and configure the sample to run using your tenant. 

--- a/articles/active-directory-b2c/active-directory-b2c-quickstarts-spa.md
+++ b/articles/active-directory-b2c/active-directory-b2c-quickstarts-spa.md
@@ -90,10 +90,6 @@ Click the **Call Web API** button to have your display name returned from the We
 
 The sample single-page app includes an Azure AD access token in the request to the protected web API resource to perform the operation to return the JSON object.
 
-## Clean up resources
-
-You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C quickstarts or tutorials. When no longer needed, you can [delete your Azure AD B2C tenant](active-directory-b2c-faqs.md#how-do-i-delete-my-azure-ad-b2c-tenant).
-
 ## Next steps
 
 In this quickstart, you used an Azure AD B2C enabled sample ASP.NET app to sign in with a custom login page, sign in with a social identity provider, create an Azure AD B2C account, and call a web API protected by Azure AD B2C. 

--- a/articles/active-directory-b2c/active-directory-b2c-quickstarts-web-app.md
+++ b/articles/active-directory-b2c/active-directory-b2c-quickstarts-web-app.md
@@ -109,10 +109,6 @@ Azure Active Directory B2C provides functionality to allow users to update their
 
 You have successfully used your Azure AD B2C user account to make an authorized call an Azure AD B2C protected web API.
 
-## Clean up resources
-
-You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C quickstarts or tutorials. When no longer needed, you can [delete your Azure AD B2C tenant](active-directory-b2c-faqs.md#how-do-i-delete-my-azure-ad-b2c-tenant).
-
 ## Next steps
 
 In this quickstart, you used an Azure AD B2C enabled sample ASP.NET app to sign in with a custom login page, sign in with a social identity provider, create an Azure AD B2C account, and call a web API protected by Azure AD B2C. 

--- a/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app-webapi.md
+++ b/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app-webapi.md
@@ -132,6 +132,16 @@ var policyName = "B2C_1_SiUpIn";  // Sign-in / sign-up policy name
 ### Configure the desktop app
 
 1. Open the `active-directory-b2c-wpf` solution from [Authenticate users with Azure Active Directory B2C in a desktop app tutorial](active-directory-b2c-tutorials-desktop-app.md) in Visual Studio.
+2. In the `active-directory-b2c-wpf` project, open the **App.xaml.cs** file.
+3. Update the **ApiScopes** variable with the *scope* you created earlier:
+
+    ```C#
+    public static string[] ApiScopes = { "https://<your-tenant-name>.onmicrosoft.com/demoapi/demo.read" };
+    ```
+4. Change the **ApiEndpoint** variable to point to your Node.js Web API `hello` endpoint running locally a:
+    ```C#
+    public static string ApiEndpoint = "http://localhost:5000/hello";
+    ```
 
 ## Run the sample
 

--- a/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app-webapi.md
+++ b/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app-webapi.md
@@ -137,7 +137,7 @@ var policyName = "B2C_1_SiUpIn";  // Sign-in / sign-up policy name
 
 Run the Node.js web API:
 
-1. Launch a Node.js command prompt.
+1. Launch a **Node.js command prompt**.
 2. Change to the directory containing the Node.js sample. For example `cd c:\active-directory-b2c-javascript-nodejs-webapi`
 3. Run the following commands:
     ```

--- a/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app-webapi.md
+++ b/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app-webapi.md
@@ -61,7 +61,7 @@ Log in to the [Azure portal](https://portal.azure.com/) as the global administra
 
 Registered APIs are displayed in the applications list for the Azure AD B2C tenant. Select your web API from the list. The web API's property pane is displayed.
 
-![Web API properties](./media/active-directory-b2c-tutorials-web-api/b2c-web-api-properties.png)
+![Web API properties](media/active-directory-b2c-tutorials-desktop-app-webapi/b2c-web-api-properties.png)
 
 Make note of the **Application Client ID**. The ID uniquely identifies the API and is needed when configuring the API later in the tutorial.
 
@@ -79,7 +79,7 @@ Click **Published scopes (Preview)**.
 
 To configure scopes for the API, add the following entries. 
 
-![scopes defined in web api](media/active-directory-b2c-tutorials-web-api/scopes-defined-in-web-api.png)
+![scopes defined in web api](media/active-directory-b2c-tutorials-desktop-app-webapi/scopes-defined-in-web-api.png)
 
 | Setting      | Suggested value  | Description                                        |
 | ------------ | ------- | -------------------------------------------------- |
@@ -101,7 +101,7 @@ To call a protected web API from an app, you need to grant your app permissions 
 
 4. In the **Select Scopes** dropdown, select the scopes you defined in the web API registration.
 
-    ![selecting scopes for app](media/active-directory-b2c-tutorials-web-api/selecting-scopes-for-app.png)
+    ![selecting scopes for app](media/active-directory-b2c-tutorials-desktop-app-webapi/selecting-scopes-for-app.png)
 
 5. Click **OK**.
 

--- a/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app.md
+++ b/articles/active-directory-b2c/active-directory-b2c-tutorials-desktop-app.md
@@ -183,4 +183,4 @@ You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C tutor
 In this tutorial, you learned how to create an Azure AD B2C tenant, create policies, and update the sample desktop app to use your Azure AD B2C tenant. Continue to the next tutorial to learn how to register, configure, and call a protected web API from a desktop app.
 
 > [!div class="nextstepaction"]
-> 
+> [Tutorial: Use Azure Active Directory B2C to protect an ASP.NET web API from a desktop app](active-directory-b2c-tutorials-desktop-app-webapi.md)

--- a/articles/active-directory-b2c/active-directory-b2c-tutorials-spa.md
+++ b/articles/active-directory-b2c/active-directory-b2c-tutorials-spa.md
@@ -193,7 +193,7 @@ You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C tutor
 
 ## Next steps
 
-In this tutorial, you learned how to create an Azure AD B2C tenant, create policies, and update the sample single page app to use your Azure AD B2C tenant. Continue to the next tutorial to learn how to register, configure, and call a protected web API from a desktop app.
+In this tutorial, you learned how to create an Azure AD B2C tenant, create policies, and update the sample single page app to use your Azure AD B2C tenant. Continue to the next tutorial to learn how to register, configure, and call a protected web API from a single page app.
 
 > [!div class="nextstepaction"]
-> 
+> [Tutorial: Use Azure Active Directory B2C to protect an ASP.NET web API from a single page app](active-directory-b2c-tutorials-spa-webapi.md)

--- a/articles/active-directory-b2c/active-directory-b2c-tutorials-spa.md
+++ b/articles/active-directory-b2c/active-directory-b2c-tutorials-spa.md
@@ -141,8 +141,6 @@ To change the app settings:
     var applicationConfig = {
         clientID: '<Application ID for your SPA obtained from portal app registration>',
         authority: "https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/B2C_1_SiUpIn",
-        b2cScopes: ["https://fabrikamb2c.onmicrosoft.com/demoapi/demo.read"],
-        webApi: 'https://fabrikamb2chello.azurewebsites.net/hello',
     };
     ```
 


### PR DESCRIPTION
Adding Link/Button to Desktop & SPA tutorials to be consistent with WebApp tutorial.
Updating Next Step description typo in SPA tutorial.