### PR TITLE
Correct Ubuntu distributions and signature

### DIFF
--- a/articles/storage/common/storage-use-azcopy-linux.md
+++ b/articles/storage/common/storage-use-azcopy-linux.md
@@ -58,9 +58,8 @@ You can remove the extracted files once AzCopy on Linux is installed. Alternativ
 Add apt source for Microsoft Linux product repository and install AzCopy:
 
 ```bash
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod/ xenial main" > azure.list
-sudo cp ./azure.list /etc/apt/sources.list.d/
-apt-key adv --keyserver packages.microsoft.com --recv-keys B02C46DF417A0893
+echo deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod/ trusty main | sudo tee /etc/apt/sources.list.d/azure.list
+sudo apt-key adv --keyserver packages.microsoft.com --recv-keys EB3E94ADBE1229CF
 ```
 
 ```bash
@@ -73,9 +72,8 @@ sudo apt-get install azcopy
 Add apt source for Microsoft Linux product repository and install AzCopy:
 
 ```bash
-sudo echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod/ trusty main" > azure.list
-sudo cp ./azure.list /etc/apt/sources.list.d/
-apt-key adv --keyserver packages.microsoft.com --recv-keys B02C46DF417A0893
+echo deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod/ xenial main | sudo tee /etc/apt/sources.list.d/azure.list
+sudo apt-key adv --keyserver packages.microsoft.com --recv-keys EB3E94ADBE1229CF
 ```
 
 ```bash


### PR DESCRIPTION
Corrects the error with the Ubuntu distribution names being incorrect. 
Simplifies the command to add repository. 
Corrects the certificate thumbprint.