### PR TITLE
Update storage-tables-scale-targets.md to better describe max properties in a table

### DIFF
--- a/includes/storage-tables-scale-targets.md
+++ b/includes/storage-tables-scale-targets.md
@@ -2,7 +2,7 @@
 |----------|---------------|
 | Max size of single table | 500 TiB |
 | Max size of a table entity | 1 MiB |
-| Max number of properties in a table entity | 252 |
+| Max number of properties in a table entity | 255 (including 3 system properties: PartitionKey, RowKey and Timestamp) |
 | Max number of stored access policies per table | 5 |
 | Maximum request rate per storage account | 20,000 transactions per second (assuming 1 KiB entity size) |
 | Target throughput for single table partition (1 KiB entities) | Up to 2000 entities per second |


### PR DESCRIPTION
 I provided feedback requesting clarification about the “Max number of properties in a table entity” listed at 252 in this section. I didn't know if the number accounted for the 3 system properties PartitionKey, RowKey and Timestamp for each entity. After some research, I found out the max number is 255 including the 3 properties mentioned above.  It would make more sense to indicate max of 255 and indicate/list the 3 properties.

@roygara provided a link to official MS documentation that corroborates this change