### PR TITLE
Updated broken links for Overview and Lifecycle

### DIFF
--- a/articles/machine-learning/team-data-science-process/index.yml
+++ b/articles/machine-learning/team-data-science-process/index.yml
@@ -24,8 +24,8 @@ sections:
   - type: list
     style: unordered
     items:
-    - html: <a href:"overview">Overview</a>
-    - html: <a href:"lifecycle">Lifecycle</a>
+    - html: <a href="overview">Overview</a>
+    - html: <a href="lifecycle">Lifecycle</a>
 
 - title: Step-by-Step Tutorials
   items:


### PR DESCRIPTION
There was a syntax error in the href for these two links