### PR TITLE
adls root permissions note for sdk

### DIFF
--- a/articles/data-lake-store/data-lake-store-service-to-service-authenticate-using-active-directory.md
+++ b/articles/data-lake-store/data-lake-store-service-to-service-authenticate-using-active-directory.md
@@ -76,6 +76,9 @@ When programmatically logging in, you need the ID for your application. If the a
     ![Assign permissions to group](./media/data-lake-store-authenticate-using-active-directory/adl.acl.5.png "Assign permissions to group")
 
 > [!NOTE]
+> If you plan on restricting your Azure Active Directory application to a specific folder, you will also need to to give that same Azure Active directory application **Execute** permisison to the root to enable file creation access via the .NET SDK.
+
+> [!NOTE]
 > If you want to use the SDKs to create a Data Lake Store account, you must assign the Azure AD web application as a role to the Resource Group in which you create the Data Lake Store account.
 > 
 >


### PR DESCRIPTION
Added note stating that you must give your Azure AD application 'execute' permissions to the root in order to write files to any of the folders you gave it access to via the SDK. This is also noted in an old MSDN Forum post located here: https://social.msdn.microsoft.com/Forums/azure/en-US/ecf3ed13-3812-456f-ab84-bc7a4da5ad26/azure-data-lake-storage-acls-and-azure-active-directory-applications?forum=AzureDataLake