### PR TITLE
Orcas Gen5 on Central US and Gen4 on West Europe are disabled.

### DIFF
--- a/articles/mysql/concepts-pricing-tiers.md
+++ b/articles/mysql/concepts-pricing-tiers.md
@@ -40,7 +40,7 @@ Compute resources are provided as vCores, which represent the logical CPU of the
 
 | **Azure region** | **Gen 4** | **Gen 5** |
 |:---|:----------:|:--------------------:|
-| Central US |  | X |
+| Central US | X |  |
 | East US | X | X |
 | East US 2 | X | X |
 | North Central US | X |  |
@@ -51,7 +51,7 @@ Compute resources are provided as vCores, which represent the logical CPU of the
 | Canada East | X | X |
 | Brazil South | X | X |
 | North Europe | X | X |
-| West Europe | X | X |
+| West Europe |  | X |
 | UK West |  | X |
 | UK South |  | X |
 | East Asia | X |  |

--- a/articles/postgresql/concepts-pricing-tiers.md
+++ b/articles/postgresql/concepts-pricing-tiers.md
@@ -41,7 +41,7 @@ Compute resources are provided as vCores, which represent the logical CPU of the
 
 | **Azure region** | **Gen 4** | **Gen 5** |
 |:---|:----------:|:--------------------:|
-| Central US |  | X |
+| Central US | X |  |
 | East US | X | X |
 | East US 2 | X | X |
 | North Central US | X |  |
@@ -52,7 +52,7 @@ Compute resources are provided as vCores, which represent the logical CPU of the
 | Canada East | X | X |
 | Brazil South | X | X |
 | North Europe | X | X |
-| West Europe | X | X |
+| West Europe |  | X |
 | UK West |  | X |
 | UK South |  | X |
 | East Asia | X |  |


### PR DESCRIPTION
Orcas Gen5 on Central US and Gen4 on West Europe are disabled.