### PR TITLE
Flag --show-all has been deprecated

### DIFF
--- a/articles/aks/gpu-cluster.md
+++ b/articles/aks/gpu-cluster.md
@@ -181,7 +181,7 @@ samples-tf-mnist-demo   1         1            35s
 
 Determine the pod name to view the logs by showing completed pods.
 ```
-$ kubectl get pods --selector app=samples-tf-mnist-demo --show-all
+$ kubectl get pods --selector app=samples-tf-mnist-demo 
 NAME                          READY     STATUS      RESTARTS   AGE
 samples-tf-mnist-demo-smnr6   0/1       Completed   0          4m
 ```


### PR DESCRIPTION
```$ kubectl get pods --selector app=samples-tf-mnist-demo --show-all```
When running this command, the CLI returns this warning:

```Flag --show-all has been deprecated, will be removed in an upcoming release```


If you run the command **without** --show-all, it still returns the nodes as expected:
```
 DaveVoyles@minint-55r162g  ~/Desktop  kubectl get pods --selector app=samples-tf-mnist-demo --show-all
Flag --show-all has been deprecated, will be removed in an upcoming release
NAME                          READY     STATUS      RESTARTS   AGE
samples-tf-mnist-demo-jhsgf   0/1       Completed   0          28m
 DaveVoyles@minint-55r162g ~/Desktop  kubectl get pods --selector app=samples-tf-mnist-demo
NAME                          READY     STATUS      RESTARTS   AGE
samples-tf-mnist-demo-jhsgf   0/1       Completed   0          29m```