### PR TITLE
Typo fix terraform-create-complete-vm.md

### DIFF
--- a/articles/virtual-machines/linux/terraform-create-complete-vm.md
+++ b/articles/virtual-machines/linux/terraform-create-complete-vm.md
@@ -109,7 +109,7 @@ resource "azurerm_network_security_group" "temyterraformpublicipnsg" {
     name                = "myNetworkSecurityGroup"
     location            = "eastus"
     resource_group_name = "${azurerm_resource_group.myterraformgroup.name}"
-    ;
+    
     security_rule {
         name                       = "SSH"
         priority                   = 1001


### PR DESCRIPTION
Getting rid of a random errand semi-colon.

Maybe no one has ever gotten this far in the page to notice.