### PR TITLE
Use consistent language + script naming convention

### DIFF
--- a/articles/cognitive-services/Translator/languages.md
+++ b/articles/cognitive-services/Translator/languages.md
@@ -139,8 +139,8 @@ The following languages can be detected by the Detect() method. Detect () may de
 | Bulgarian |
 | Catalan |
 | Chinese |
-| Chinese_Simplified |
-| Chinese_Traditional |
+| Chinese (Simplified) |
+| Chinese (Traditional) |
 | Croatian |
 | Czech |
 | Danish |
@@ -153,7 +153,7 @@ The following languages can be detected by the Detect() method. Detect () may de
 | Galician |
 | German |
 | Greek |
-| Haitian_Creole |
+| Haitian Creole |
 | Hebrew |
 | Hindi |
 | Hungarian |
@@ -163,8 +163,8 @@ The following languages can be detected by the Detect() method. Detect () may de
 | Italian |
 | Japanese |
 | Korean |
-| Kurdish_Arabic |
-| Kurdish_Latin |
+| Kurdish (Arabic) |
+| Kurdish (Latin) |
 | Latin |
 | Latvian |
 | Lithuanian |
@@ -172,15 +172,15 @@ The following languages can be detected by the Detect() method. Detect () may de
 | Malay |
 | Maltese |
 | Norwegian |
-| Norwegian_Nynorsk |
+| Norwegian (Nynorsk) |
 | Pashto |
 | Persian |
 | Polish |
 | Portuguese |
 | Romanian |
 | Russian |
-| Serbian_Cyrillic |
-| Serbian_Latin |
+| Serbian (Cyrillic) |
+| Serbian (Latin) |
 | Slovak |
 | Slovenian |
 | Somali |
@@ -192,8 +192,8 @@ The following languages can be detected by the Detect() method. Detect () may de
 | Turkish |
 | Ukrainian |
 | Urdu |
-| Uzbek_Cyrillic |
-| Uzbek_Latin |
+| Uzbek (Cyrillic) |
+| Uzbek (Latin) |
 | Vietnamese |
 | Welsh |
 | Yiddish |


### PR DESCRIPTION
The Detect languages table is apparently showing Translator system-internal names with underscores, rather than the actual language names.  The edit changes these to proper language names according to the convention. this clarifies the ambiguity in "Haitian_Creole" -- where "Creole" is part of the name, not a script as it is in other identifiers.  I would ask that for consistency, you also show the language codes that the Detect API returns for all of these. I assume that the API returns proper ISO codes, and not these internal ids with underscores.