### PR TITLE
Update howto-mfa-nps-extension.md

### DIFF
--- a/articles/active-directory/authentication/howto-mfa-nps-extension.md
+++ b/articles/active-directory/authentication/howto-mfa-nps-extension.md
@@ -12,7 +12,7 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 08/14/2017
+ms.date: 05/01/2018
 ms.author: joflore
 ms.reviewer: richagi
 ms.custom: H1Hack27Feb2017; it-pro
@@ -113,9 +113,9 @@ When you deploy the NPS extension, use these factors to evaluate which methods a
 
 You can [disable unsupported authentication methods](howto-mfa-mfasettings.md#selectable-verification-methods) in Azure.
 
-### Enable users for MFA
+### Register users for MFA
 
-Before you deploy the full NPS extension, you need to enable MFA for the users that you want to perform two-step verification. More immediately, to test the extension as you deploy it, you need at least one test account that is fully registered for Multi-Factor Authentication.
+Before you deploy and use the NPS extension, users that will be required to perform two-step verification need to be registered for MFA. More immediately, to test the extension as you deploy it, you need at least one test account that is fully registered for Multi-Factor Authentication.
 
 Use these steps to get a test account started:
 1. Sign in to [https://aka.ms/mfasetup](https://aka.ms/mfasetup) with a test account. 


### PR DESCRIPTION
Made changes to clarify that users need to be "registered" for MFA, not "enabled" for MFA since "enabled" implies that they are enabled at the user level and will require MFA for all sign-ins and not just those dictated by conditional access and NPS extension.