### PR TITLE
Change stop to deallocate for stopping VMs

### DIFF
--- a/articles/virtual-network/create-vm-accelerated-networking-cli.md
+++ b/articles/virtual-network/create-vm-accelerated-networking-cli.md
@@ -223,7 +223,7 @@ If you have created a VM without Accelerated Networking, it is possible to enabl
 First stop/deallocate the VM or, if an Availability Set, all the VMs in the Set:
 
 ```azurecli
-az vm stop \
+az vm deallocate \
     --resource-group myResourceGroup \
     --name myVM
 ```


### PR DESCRIPTION
Please use deallocate instead of stop to actually deallocate the VM to upgrade it to accelerated networking. Using stop leaves the VM in running state and doesn't actually gets deallocated