### PR TITLE
inconsistent content in load-balancer-troubleshoot.md

### DIFF
--- a/articles/load-balancer/load-balancer-troubleshoot.md
+++ b/articles/load-balancer/load-balancer-troubleshoot.md
@@ -125,7 +125,7 @@ Evaluate Application Gateway or other proxies (for example, nginx or haproxy) to
 ## Additional network captures
 If you decide to open a support case, collect the following information for a quicker resolution. Choose a single backend VM to perform the following tests:
 - Use Psping from one of the backend VMs within the VNet to test the probe port response (example: psping 10.0.0.4:3389) and record results. 
-- Use TCPing from one of the backend VMs within the VNet to test the probe port response (example: psping 10.0.0.4:3389) and record results.
+- Use TCPing from one of the backend VMs within the VNet to test the probe port response (example: tcping 10.0.0.4 3389) and record results.
 - If no response is received in these ping tests, run a simultaneous Netsh trace on the backend VM and the VNet test VM while you run PsPing then stop the Netsh trace. 
   
 ## Next steps


### PR DESCRIPTION
The sentence of section of Additional network captures.   the sentence i says “Using TCPing …” while the example uses “psping”, is this some kind of typo here?