### PR TITLE
Added notes about config names case sensitity

### DIFF
--- a/articles/automation/automation-dsc-onboarding.md
+++ b/articles/automation/automation-dsc-onboarding.md
@@ -57,6 +57,7 @@ $AutomationAccountName = ""
 $AutomationAccountResourceGroup = ""
 
 # fill in the name of a Node Configuration in Azure Automation DSC, for this VM to conform to
+# NOTE: DSC Node Configuration names are case sensitive in the portal.
 $NodeConfigName = ""
 
 # get Azure Automation DSC registration info
@@ -106,6 +107,9 @@ $VM = Set-AzureVMExtension `
 
 $VM | Update-AzureVM
 ```
+
+> [!NOTE]
+> Dsc Node Configuration names are case sensitive in the portal. If the case is mismatched the node will not show up under DSC Nodes.
 
 ## Azure virtual machines
 
@@ -200,6 +204,9 @@ To generically onboard any machine to Azure Automation DSC, a [DSC metaconfigura
 1. Open the PowerShell ISE as an administrator in a machine in your local environment. The machine must have the latest version of [WMF 5](http://aka.ms/wmf5latest) installed.
 2. Copy the following script locally. This script contains a PowerShell DSC configuration for creating metaconfigurations, and a command to kick off the metaconfiguration creation.
 
+> [!NOTE]
+> Dsc Node Configuration names are case sensitive in the portal. If the case is mismatched the node will not show up under DSC Nodes.
+
     ```powershell
     # The DSC configuration that will generate metaconfigurations
     [DscLocalConfigurationManager()]
@@ -291,6 +298,7 @@ To generically onboard any machine to Azure Automation DSC, a [DSC metaconfigura
     }
 
     # Create the metaconfigurations
+    # NOTE: DSC Node Configuration names are case sensitive in the portal.
     # TODO: edit the below as needed for your use case
     $Params = @{
         RegistrationUrl = '<fill me in>';


### PR DESCRIPTION
The configuration names are case sensitive in the portal. A node will not show up under the DSC nodes if it has been assigned a DSC Configuration name with mismatched cases.