### PR TITLE
Changed Azure AD/AD description

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-faq.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-faq.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Azure virtual machine scale sets FAQs | Microsoft Docs
 description: Get answers to frequently asked questions about virtual machine scale sets.
 services: virtual-machine-scale-sets

--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-faq.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-faq.md
@@ -449,9 +449,9 @@ If the extension definition in the virtual machine scale set model is updated an
 
 If an existing VM is service-healed, it appears as a reboot, and the extensions are not rerun. If it is reimaged, it's like replacing the OS drive with the source image. Any specialization from the latest model, such as extensions, are run.
  
-### How do I join a virtual machine scale set to an Azure AD domain?
+### How do I join a virtual machine scale set to an Active Directory domain?
 
-To join a virtual machine scale set to an Azure Active Directory (Azure AD) domain, you can define an extension. 
+To join a virtual machine scale set to an Active Directory (AD) domain, you can define an extension. 
 
 To define an extension, use the JsonADDomainExtension property:
 


### PR DESCRIPTION
The JsonADDomainExtension joins a VM to an Active Directory domain, not an Azure AD domain. Changing this verbiage so there's not confusion as to what this capability applies to.