### PR TITLE
Added free tier for availability of IoT Edge

### DIFF
--- a/articles/iot-edge/how-iot-edge-works.md
+++ b/articles/iot-edge/how-iot-edge-works.md
@@ -23,7 +23,7 @@ ms.custom:
 Azure IoT Edge moves cloud analytics and custom business logic to devices so that your organization can focus on business insights instead of data management. Enable your solution to truly scale by configuring your IoT software, deploying it to devices via standard containers, and monitoring it all from the cloud.
 
 >[!NOTE]
->Azure IoT Edge is only available in the standard tier of IoT Hub. For more information about the basic and standard tiers, see [How to choose the right IoT Hub tier](../iot-hub/iot-hub-scaling.md).
+>Azure IoT Edge is available in the free and standard tier of IoT Hub. The free tier is for testing and evaluation only. For more information about the basic and standard tiers, see [How to choose the right IoT Hub tier](../iot-hub/iot-hub-scaling.md).
 
 Analytics drives business value in IoT solutions, but not all analytics needs to be in the cloud. If you want a device to respond to emergencies as quickly as possible, you can perform anomaly detection on the device itself. Similarly, if you want to reduce bandwidth costs and avoid transferring terabytes of raw data, you can perform data cleaning and aggregation locally. Then send the insights to the cloud. 
 


### PR DESCRIPTION
The free tier is also supporting IoT Edge (next to standard tier). 
The text is taken from: "IoT Hub also offers a free tier that is meant for testing and evaluation. It has all the capabilities of the standard tier, but limited messaging allowances. You cannot upgrade from the free tier to either basic or standard."