### PR TITLE
Changed "Device identity" to "Module Identity"

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-identity-registry.md
+++ b/articles/iot-hub/iot-hub-devguide-identity-registry.md
@@ -202,7 +202,7 @@ Device identities are represented as JSON documents with the following propertie
 
 ## Module identity properties
 
-Device identities are represented as JSON documents with the following properties:
+Module identities are represented as JSON documents with the following properties:
 
 | Property | Options | Description |
 | --- | --- | --- |


### PR DESCRIPTION
In "Module Identify Properties", the first sentence implies that the section is about device identity properties, not module properties. It might well have been a copy-n-paste error since the previous section is called "Device Identity Properties" and starts with the same sentence.