### PR TITLE
Error creating the device enrollment entry

### DIFF
--- a/articles/iot-dps/how-to-connect-mxchip-iot-devkit.md
+++ b/articles/iot-dps/how-to-connect-mxchip-iot-devkit.md
@@ -68,13 +68,13 @@ A typical unique device secret is a 64-character string, as seen in the followin
 ```
 19e25a259d0c2be03a02d416c05c48ccd0cc7d1743458aae1cb488b074993eae
 ```
-
+c
 Each of two characters is used as the Hex value in the security calculation. The preceding sample UDS is resolved to: `0x19`, `0xe2`, `0x5a`, `0x25`, `0x9d`, `0x0c`, `0x2b`, `0xe0`, `0x3a`, `0x02`, `0xd4`, `0x16`, `0xc0`, `0x5c`, `0x48`, `0xcc`, `0xd0`, `0xcc`, `0x7d`, `0x17`, `0x43`, `0x45`, `0x8a`, `0xae`, `0x1c`, `0xb4`, `0x88`, `0xb0`, `0x74`, `0x99`, `0x3e`, `0xae`.
 
 To save a unique device secret on the DevKit:
 
 1. Open the serial monitor by using a tool such as Putty. See [Use configuration mode](https://microsoft.github.io/azure-iot-developer-kit/docs/use-configuration-mode/) for details.
-
+c
 2. With the DevKit connected to your computer, hold down the **A** button, and then press and release the **Reset** button to enter configuration mode. The screen shows the DevKit ID and Configuration.
 
 3. Take the sample UDS string and change one or more characters to other values between `0` and `f` for your own UDS.
@@ -119,6 +119,10 @@ To save a unique device secret on the DevKit:
    - leave the rest as default and click **Save**
 
    ![Upload certificate](./media/how-to-connect-mxchip-iot-devkit/upload-cert.png)
+
+  > [!NOTE]
+  > If you have an error with this message: {"message":"BadRequest:{\r\n \"errorCode\": 400004,\r\n \"trackingId\": \"1b82d826-ccb4-4e54-91d3-0b25daee8974\",\r\n \"message\": \"The certificate is not a valid base64 string value\",\r\n \"timestampUtc\": \"2018-05-09T13:52:42.7122256Z\"\r\n}"} you should open the certificate file **.pem** as text (open with Notepad or any text editor) and delete the lines "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
+
 
 ## Start the DevKit
 

--- a/articles/iot-dps/how-to-connect-mxchip-iot-devkit.md
+++ b/articles/iot-dps/how-to-connect-mxchip-iot-devkit.md
@@ -68,13 +68,13 @@ A typical unique device secret is a 64-character string, as seen in the followin
 ```
 19e25a259d0c2be03a02d416c05c48ccd0cc7d1743458aae1cb488b074993eae
 ```
-c
+
 Each of two characters is used as the Hex value in the security calculation. The preceding sample UDS is resolved to: `0x19`, `0xe2`, `0x5a`, `0x25`, `0x9d`, `0x0c`, `0x2b`, `0xe0`, `0x3a`, `0x02`, `0xd4`, `0x16`, `0xc0`, `0x5c`, `0x48`, `0xcc`, `0xd0`, `0xcc`, `0x7d`, `0x17`, `0x43`, `0x45`, `0x8a`, `0xae`, `0x1c`, `0xb4`, `0x88`, `0xb0`, `0x74`, `0x99`, `0x3e`, `0xae`.
 
 To save a unique device secret on the DevKit:
 
 1. Open the serial monitor by using a tool such as Putty. See [Use configuration mode](https://microsoft.github.io/azure-iot-developer-kit/docs/use-configuration-mode/) for details.
-c
+
 2. With the DevKit connected to your computer, hold down the **A** button, and then press and release the **Reset** button to enter configuration mode. The screen shows the DevKit ID and Configuration.
 
 3. Take the sample UDS string and change one or more characters to other values between `0` and `f` for your own UDS.
@@ -121,7 +121,14 @@ c
    ![Upload certificate](./media/how-to-connect-mxchip-iot-devkit/upload-cert.png)
 
   > [!NOTE]
-  > If you have an error with this message: {"message":"BadRequest:{\r\n \"errorCode\": 400004,\r\n \"trackingId\": \"1b82d826-ccb4-4e54-91d3-0b25daee8974\",\r\n \"message\": \"The certificate is not a valid base64 string value\",\r\n \"timestampUtc\": \"2018-05-09T13:52:42.7122256Z\"\r\n}"} you should open the certificate file **.pem** as text (open with Notepad or any text editor) and delete the lines "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----"
+  > If you have an error with this message:
+  >
+  > `{"message":"BadRequest:{\r\n \"errorCode\": 400004,\r\n \"trackingId\": \"1b82d826-ccb4-4e54-91d3-0b25daee8974\",\r\n \"message\": \"The certificate is not a valid base64 string value\",\r\n \"timestampUtc\": \"2018-05-09T13:52:42.7122256Z\"\r\n}"}`
+  >
+  > Open the certificate file **.pem** as text (open with Notepad or any text editor), and delete the lines:
+  >
+  > `"-----BEGIN CERTIFICATE-----"` and `"-----END CERTIFICATE-----"`.
+  >
 
 
 ## Start the DevKit


### PR DESCRIPTION
When the Device enrollment entry is being created, you can get an error: The certificate is not a valid base64 string value.
It can be fixed if you delete the first and the last line in the certificate file.