### PR TITLE
Add note to imageAction docs on parsingMode limitation

### DIFF
--- a/articles/search/cognitive-search-concept-image-scenarios.md
+++ b/articles/search/cognitive-search-concept-image-scenarios.md
@@ -28,10 +28,12 @@ You cannot turn off image normalization. Skills that iterate over images expect 
 
 | Configuration Parameter | Description |
 |--------------------|-------------|
-| imageAction	| Set to "none" if no action should be taken when embedded images or image files are encountered. <br/>Set to either "generateNormalizedImages" to generate an array of normalized images as part of document cracking. These images will be exposed in the *normalized_images* field. <br/>The default is "none." This configuration is only pertinent to blob data sources, when "dataToExtract" is set to "contentAndMetadata." |
+| imageAction	| Set to "none" if no action should be taken when embedded images or image files are encountered. <br/>Set to "generateNormalizedImages" to generate an array of normalized images as part of document cracking. These images will be exposed in the *normalized_images* field. <br/>The default is "none." This configuration is only pertinent to blob data sources, when "dataToExtract" is set to "contentAndMetadata." |
 |  normalizedImageMaxWidth | The maximum width (in pixels) for normalized images generated. The default is 2000.|
 |  normalizedImageMaxHeight | The maximum height (in pixels) for normalized images generated. The default is 2000.|
 
+> [!NOTE]
+> If you set the *imageAction* property to anything other than "none", you will not be able to set the *parsingMode* property to anything other than "default".  You may only set one of these two properties to a non-default value in your indexer configuration.
 
 The default of 2000 pixels for the normalized images maximum width and height is based on the maximum sizes supported by the [OCR skill](cognitive-search-skill-ocr.md) and the [image analysis skill](cognitive-search-skill-image-analysis.md). If you increase the maximum limits, processing could fail on the larger images.
 


### PR DESCRIPTION
Adds a note to the docs saying that you cannot use imageAction and parsingMode at the same time within your indexer configuration definition.  Also fixed up a small typo I noticed.