### PR TITLE
Fixes syntax error in `SQL API` code example

### DIFF
--- a/articles/cosmos-db/unique-keys.md
+++ b/articles/cosmos-db/unique-keys.md
@@ -87,9 +87,8 @@ private static async Task CreateCollectionIfNotExistsAsync(string dataBase, stri
                 UniqueKeys =
                 new Collection<UniqueKey>
                 {
-                    new UniqueKey { Paths = new Collection<string> { "/firstName" , "/lastName" , "/email" }}
-                    new UniqueKey { Paths = new Collection<string> { "/address/zipCode" } },
-
+                    new UniqueKey { Paths = new Collection<string> { "/firstName" , "/lastName" , "/email" } },
+                    new UniqueKey { Paths = new Collection<string> { "/address/zipCode" } }
                 }
             };
             await client.CreateDocumentCollectionAsync(


### PR DESCRIPTION
The `CreateCollectionIfNotExistsAsync` code sample had a misplaced comma.