### PR TITLE
Update cdn-custom-ssl.md

### DIFF
--- a/articles/cdn/cdn-custom-ssl.md
+++ b/articles/cdn/cdn-custom-ssl.md
@@ -117,7 +117,7 @@ Grant Azure CDN permission to access the certificates (secrets) in your Azure Ke
 
     ![Access policy settings](./media/cdn-custom-ssl/cdn-access-policy-settings.png)
 
-2. In **Select principal**, search **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, and select **Microsoft.Azure.Cdn**.
+2. In **Select principal**, search for **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, and select **Microsoft.Azure.Cdn**.
 
 3. In **Secret permissions**, select **Get** to allow CDN to perform these permissions to get and list the certificates. 
 

--- a/articles/cdn/cdn-custom-ssl.md
+++ b/articles/cdn/cdn-custom-ssl.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Tutorial - Configure HTTPS on an Azure CDN custom domain | Microsoft Docs
 description: In this tutorial, you learn how to enable and disable HTTPS on your Azure CDN endpoint custom domain.
 services: cdn

--- a/articles/cdn/cdn-custom-ssl.md
+++ b/articles/cdn/cdn-custom-ssl.md
@@ -117,7 +117,7 @@ Grant Azure CDN permission to access the certificates (secrets) in your Azure Ke
 
     ![Access policy settings](./media/cdn-custom-ssl/cdn-access-policy-settings.png)
 
-2. In **Select principal**, search, and select **Azure CDN**.
+2. In **Select principal**, search **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, and select **Microsoft.Azure.Cdn**.
 
 3. In **Secret permissions**, select **Get** to allow CDN to perform these permissions to get and list the certificates. 
 


### PR DESCRIPTION
Please, update the cdn-access-policy-settings.png picture to remove the AzureCdn@microsoft.com reference, because it's valid only for those who are member of the @microsoft.com tenant. The better way to illustrate this screen is searching for the principal 205478c0-bd83-4e1b-a9d6-db63a3e1e1c8, that represents the Microsoft.Azure.Cdn service principal.