### PR TITLE
Prevent PostgreSQL connection leaks

### DIFF
--- a/articles/postgresql/connect-go.md
+++ b/articles/postgresql/connect-go.md
@@ -210,6 +210,7 @@ func main() {
 	sql_statement := "SELECT * from inventory;"
 	rows, err := db.Query(sql_statement)
 	checkError(err)
+	defer rows.Close()
 
 	for rows.Next() {
 		switch err := rows.Scan(&id, &name, &quantity); err {


### PR DESCRIPTION
I propose to add `rows.Close()` into `postgresql/connect-go.md` to make it better sample code. The current code is works good but it have a possibility of a connection leaks in other use-cases.