### PR TITLE
 Better discoverability for Python application error troubleshooting

### DIFF
--- a/articles/app-service/app-service-web-open-source-technologies-faq.md
+++ b/articles/app-service/app-service-web-open-source-technologies-faq.md
@@ -64,16 +64,7 @@ To turn on PHP logging:
 For more information, see [Enable WordPress error logs](https://blogs.msdn.microsoft.com/azureossds/2015/10/09/logging-php-errors-in-wordpress-2/).
 
 ## How do I log Python application errors in apps that are hosted in App Service?
-
-To capture Python application errors:
-
-1. In the Azure portal, in your web app, select **Settings**.
-2. On the **Settings** tab, select **Application settings**.
-3. Under **App settings**, enter the following key/value pair:
-    * Key : WSGI_LOG
-    * Value : D:\home\site\wwwroot\logs.txt (enter your choice of file name)
-
-You should now see errors in the logs.txt file in the wwwroot folder.
+[!INCLUDE [web-sites-python-troubleshooting-wsgi-error-log](../../includes/web-sites-python-troubleshooting-wsgi-error-log.md)]
 
 ## How do I change the version of the Node.js application that is hosted in App Service?
 

--- a/articles/app-service/web-sites-python-configure.md
+++ b/articles/app-service/web-sites-python-configure.md
@@ -346,6 +346,9 @@ Contents of `ptvs_virtualenv_proxy.py`:
 ## Troubleshooting - Virtual Environment
 [!INCLUDE [web-sites-python-troubleshooting-virtual-environment](../../includes/web-sites-python-troubleshooting-virtual-environment.md)]
 
+## Troubleshooting - Startup Errors
+[!INCLUDE [web-sites-python-troubleshooting-wsgi-error-log](../../includes/web-sites-python-troubleshooting-wsgi-error-log.md)]
+
 ## Next steps
 For more information, see the [Python Developer Center](/develop/python/).
 

--- a/includes/web-sites-python-troubleshooting-wsgi-error-log.md
+++ b/includes/web-sites-python-troubleshooting-wsgi-error-log.md
@@ -2,7 +2,7 @@
 title: include file
 description: include file
 services: app-service
-author: cephaslin
+author: cephalin
 ms.service: app-service
 ms.topic: include
 ms.date: 06/11/2018

--- a/includes/web-sites-python-troubleshooting-wsgi-error-log.md
+++ b/includes/web-sites-python-troubleshooting-wsgi-error-log.md
@@ -1,3 +1,15 @@
+---
+title: include file
+description: include file
+services: app-service
+author: cephaslin
+ms.service: app-service
+ms.topic: include
+ms.date: 06/11/2018
+ms.author: cephalin
+ms.custom: include file
+---
+ 
 If Python encounters an error while starting your application, only a simple error page will be returned (e.g. "The page cannot be displayed because an internal server error has occurred.").
 
 To capture Python application errors:

--- a/includes/web-sites-python-troubleshooting-wsgi-error-log.md
+++ b/includes/web-sites-python-troubleshooting-wsgi-error-log.md
@@ -1,0 +1,11 @@
+If Python encounters an error while starting your application, only a simple error page will be returned (e.g. "The page cannot be displayed because an internal server error has occurred.").
+
+To capture Python application errors:
+
+1. In the Azure portal, in your web app, select **Settings**.
+2. On the **Settings** tab, select **Application settings**.
+3. Under **App settings**, enter the following key/value pair:
+    * Key : WSGI_LOG
+    * Value : D:\home\site\wwwroot\logs.txt (enter your choice of file name)
+
+You should now see errors in the logs.txt file in the wwwroot folder.


### PR DESCRIPTION
Startup errors are a very common issue when deploying to app service due to missing dependencies, incorrect configuration, syntax errors, etc.

This PR is a two-part change intended to increase the discoverability of this common issue that users will typically experience at some point when deploying a Python app on App Service:
1. Move WSGI_LOG instructions to an include so it can be shown on both the [open-source FAQ for Web Apps](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-open-source-technologies-faq) (as it is today) as well as [Python web app configuration tutorial](https://docs.microsoft.com/en-us/azure/app-service/web-sites-python-configure)
2. Include the error message displayed by App Service message in the documentation for better discoverability. Currently, searching for [Google](https://www.google.com/search?q=python+app+service+%22The+page+cannot+be+displayed+because+an+internal+server+error+has+occurred.%22&oq=python+app+service+%22The+page+cannot+be+displayed+because+an+internal+server+error+has+occurred.%22&aqs=chrome..69i57j69i60.4407j0j7&sourceid=chrome&ie=UTF-8) or [Bing](https://www.bing.com/search?q=python+app+service+%22The+page+cannot+be+displayed+because+an+internal+server+error+has+occurred.%22&qs=n&form=QBLH&sp=-1&pq=undefined&sc=8-0&sk=&cvid=2DDBC86113FE4762A39CE82860662FDC) for `python app service "The page cannot be displayed because an internal server error has occurred."` returns no first-party docs.