### PR TITLE
Update refresh types in analysis-services-async-refresh page

### DIFF
--- a/articles/analysis-services/analysis-services-async-refresh.md
+++ b/articles/analysis-services/analysis-services-async-refresh.md
@@ -93,7 +93,7 @@ Specifying parameters is not required. The default is applied.
 
 |Name  |Type  |Description  |Default  |
 |---------|---------|---------|---------|
-|Type     |  Enum       |  The type of processing to perform. The types are aligned with the TMSL [refresh command](https://docs.microsoft.com/sql/analysis-services/tabular-models-scripting-language-commands/refresh-command-tmsl) types: full, clearValues, calculate, dataOnly, automatic, add, and defragment.       |   automatic      |
+|Type     |  Enum       |  The type of processing to perform. Of the TMSL [refresh command](https://docs.microsoft.com/sql/analysis-services/tabular-models-scripting-language-commands/refresh-command-tmsl) types, full, clearValues, calculate, dataOnly, automatic, and defragment are supported; add is not supported.       |   automatic      |
 |CommitMode     |  Enum       |  Determines if objects will be committed in batches or only when complete. Modes include: default, transactional, partialBatch.  |  transactional       |
 |MaxParallelism     |   Int      |  This value determines the maximum number of threads on which to run processing commands in parallel. This value aligned with the MaxParallelism property that can be set in the TMSL [Sequence command](https://docs.microsoft.com/sql/analysis-services/tabular-models-scripting-language-commands/sequence-command-tmsl) or using other methods.       | 10        |
 |RetryCount    |    Int     |   Indicates the number of times the operation will retry before failing.      |     0    |


### PR DESCRIPTION
Update analysis-services-async-refresh page to accurately reflect supported refresh types.