### PR TITLE
az network dns zone export -g <resource group> -z <zone name> -f <zon…

### DIFF
--- a/articles/dns/dns-import-export.md
+++ b/articles/dns/dns-import-export.md
@@ -173,7 +173,7 @@ After you have verified that the zone has been imported correctly, you need to u
 The format of the Azure CLI command to import a DNS zone is:
 
 ```azurecli
-az network dns zone export -g <resource group> -z <zone name> -f <zone file name>
+az network dns zone export -g <resource group> -n <zone name> -f <zone file name>
 ```
 
 Values:


### PR DESCRIPTION
…e file name> will throw an error

az network dns zone export -g <resource group> -z <zone name> -f <zone file name> will throw an error "az : ERROR: az network dns zone export: error: the following arguments are required: --name/-n"

The -z should be changed to -n