### PR TITLE
Fix link to page Get started guide for Azure developers

### DIFF
--- a/articles/guides/developer/azure-developer-guide.md
+++ b/articles/guides/developer/azure-developer-guide.md
@@ -204,7 +204,7 @@ want to select your region to meet the legal requirements for distributing your 
 
 Although unlikely, it’s not impossible for an entire datacenter to go offline because of an event such as a natural disaster or Internet failure. It’s a best practice to host vital business applications in more than one datacenter to provide maximum availability. Using multiple regions can also reduce latency for global users and provide additional opportunities for flexibility when updating applications.
 
-Some services, such as Virtual Machine and App Services, use [Azure Traffic Manager](../../traffic-manager/traffic-manager-overview.md) to enable multi-region support with failover between regions to support high-availability enterprise applications. For an example, see [Azure reference architecture: Web application with high availability](../../guidance/guidance-web-apps-multi-region.md).
+Some services, such as Virtual Machine and App Services, use [Azure Traffic Manager](../../traffic-manager/traffic-manager-overview.md) to enable multi-region support with failover between regions to support high-availability enterprise applications. For an example, see [Azure reference architecture: Run a web application in multiple regions](https://docs.microsoft.com/azure/architecture/reference-architectures/app-service-web-app/multi-region).
 
 >**When to use**: When you have enterprise and high-availability applications that benefit from failover and replication.
 


### PR DESCRIPTION
Article **Get started guide for Azure developers** in [Multi-region apps](https://docs.microsoft.com/en-us/azure/guides/developer/azure-developer-guide#multi-region-apps) contains at link not available in the following text: _Azure reference architecture: Web application with high availability_

article it's in another [project](https://github.com/mspnp/architecture-center/blob/master/docs/reference-architectures/app-service-web-app/multi-region.md)