### PR TITLE
Replaced backslashes with forward slashes

### DIFF
--- a/articles/virtual-machines/windows/index.yml
+++ b/articles/virtual-machines/windows/index.yml
@@ -74,7 +74,7 @@ sections:
     - html: <a href="/azure/virtual-machines/windows/tutorial-monitoring">Monitor VMs</a>
     - html: <a href="/azure/virtual-machines/windows/tutorial-azure-security">Manage security on VMs</a>
     - html: <a href="/azure/virtual-machines/windows/tutorial-vsts-iis-cicd">Create a continuous integration pipeline with Visual Studio</a>
-    - html: <a href="/azure/virtual-machines/windows/tutorial-iis-sql">Install a SQL\IIS\.NET stack</a>
+    - html: <a href="/azure/virtual-machines/windows/tutorial-iis-sql">Install a SQL/IIS/.NET stack</a>
     - html: <a href="/azure/virtual-machines/windows/tutorial-secure-web-server">Secure a web server with SSL</a>
 - title: Free Pluralsight Video Training
   items:


### PR DESCRIPTION
Forward slashes should be used in proper grammar