### PR TITLE
fix example parameter

### DIFF
--- a/articles/service-fabric/service-fabric-docker-compose.md
+++ b/articles/service-fabric/service-fabric-docker-compose.md
@@ -62,7 +62,7 @@ Start-ServiceFabricComposeDeploymentUpgrade -DeploymentName TestContainerApp -Co
 After upgrade is accepted, the upgrade progress could be tracked using the following command:
 
 ```powershell
-Get-ServiceFabricComposeDeploymentUpgrade -Deployment TestContainerApp
+Get-ServiceFabricComposeDeploymentUpgrade -DeploymentName TestContainerApp
 ```
 
 ### Use Azure Service Fabric CLI (sfctl)


### PR DESCRIPTION
Get-ServiceFabricComposeDeploymentUpgrade example lists the alias parameter -Deployment instead of the full parameter name -DeploymentName