### PR TITLE
Update assign-policy-definition-ps.md

### DIFF
--- a/articles/azure-policy/assign-policy-definition-ps.md
+++ b/articles/azure-policy/assign-policy-definition-ps.md
@@ -55,7 +55,7 @@ You’re now ready to identify non-compliant resources to understand the complia
 Use the following information to identify resources that aren't compliant with the policy assignment you created. Run the following commands:
 
 ```azurepowershell-interactive
-$policyAssignment = Get-AzureRmPolicyAssignment | Where-Object { $_.Properties.DisplayName -eq 'Audit Virtual Machines without Managed Disks' }
+$policyAssignment = Get-AzureRmPolicyAssignment | Where-Object { $_.Name -eq 'Audit Virtual Machines without Managed Disks' }
 $policyAssignment.PolicyAssignmentId
 ```
 


### PR DESCRIPTION
Update to https://docs.microsoft.com/en-us/azure/azure-policy/assign-policy-definition-ps

This article referenced Get-AzureRmPolicyAssignment and the example shown claimed that there is a subproperty called DisplayName.  I think that this was copied over from Get-AzureRmPolicyDefinition, because the subproperty is valid for that Cmdlet, but it is not valid for Get-AzureRmPolicyAssignment.

I first tested this using AzureRM PowerShell Module 5.7.0, so I then upgraded to the latest version, 6.0.1 and I see the same issue when using the latest version.

Instead of calling $_.Properties.DisplayName the Get-AzureRmPolicyAssignment example should just call $_.Name instead