### PR TITLE
Fixing configuration which resulted in wrong diagnostic settings name…

### DIFF
--- a/articles/monitoring-and-diagnostics/monitoring-enable-diagnostic-logs-using-template.md
+++ b/articles/monitoring-and-diagnostics/monitoring-enable-diagnostic-logs-using-template.md
@@ -77,7 +77,7 @@ For non-Compute resources, you will need to do two things:
     "resources": [
       {
         "type": "providers/diagnosticSettings",
-        "name": "Microsoft.Insights/[parameters('settingName')]",
+        "name": "[concat('Microsoft.Insights/', parameters('settingName'))]",
         "dependsOn": [
           "[/*resource Id for which Diagnostic Logs will be enabled>*/]"
         ],
@@ -207,7 +207,7 @@ Here is a full example that creates a Logic App and turns on streaming to Event 
       "resources": [
         {
           "type": "providers/diagnosticSettings",
-          "name": "Microsoft.Insights/[parameters('settingName')]",
+          "name": "[concat('Microsoft.Insights/', parameters('settingName'))]",
           "dependsOn": [
             "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
           ],


### PR DESCRIPTION
Fixing configuration which resulted in wrong diagnostic settings name: "parameters('settingName')" instead of the parameter "value"