### PR TITLE
Syntax issue: active-directory-groups-dynamic-membership-azure-portal.md

### DIFF
--- a/articles/active-directory/active-directory-groups-dynamic-membership-azure-portal.md
+++ b/articles/active-directory/active-directory-groups-dynamic-membership-azure-portal.md
@@ -109,7 +109,7 @@ is equivalent to:
 
 If you want to compare the value of a user attribute against a number of different values you can use the -In or -notIn operators. Here is an example using the -In operator:
 ```
-	user.department -In [ "50001", "50002", "50003", “50005”, “50006”, “50007”, “50008”, “50016”, “50020”, “50024”, “50038”, “50039”, “51100” ]
+   user.department -In ["50001","50002","50003",“50005”,“50006”,“50007”,“50008”,“50016”,“50020”,“50024”,“50038”,“50039”,“51100”]
 ```
 Note the use of the "[" and "]" at the beginning and end of the list of values. This condition evaluates to True of the value of user.department equals one of the values in the list.
 


### PR DESCRIPTION
The example for -in/-notIn has spaces between list items, actual implementation requires that no spaces be present.