### PR TITLE
Fixed `/etc/apt/sources.list` repo URLs for Jessie

### DIFF
--- a/articles/virtual-machines/linux/debian-create-upload-vhd.md
+++ b/articles/virtual-machines/linux/debian-create-upload-vhd.md
@@ -65,10 +65,10 @@ There are tools available for generating Debian VHDs for Azure, such as the [azu
 
     **Debian 8.x "Jessie"**
 
-        deb http://debian-archive.trafficmanager.net/debian jessie-backports main
-        deb-src http://debian-archive.trafficmanager.net/debian jessie-backports main
-        deb http://debian-archive.trafficmanager.net/debian-azure jessie main
-        deb-src http://debian-archive.trafficmanager.net/debian-azure jessie main
+        deb http://debian-archive.trafficmanager.net/debian jessie main
+        deb http://debian-archive.trafficmanager.net/debian-security jessie/updates main
+        deb-src http://debian-archive.trafficmanager.net/debian jessie main
+        deb-src http://debian-archive.trafficmanager.net/debian-security jessie/updates main
 
 
 1. Install the Azure Linux Agent:


### PR DESCRIPTION
The very bottom of this page: https://wiki.debian.org/Cloud/MicrosoftAzure says: 
_"On Debian Jessie images, that were created before February 2nd 2017, we included an extra repository called "debian-azure" (URL: http://debian-archive.trafficmanager.net/debian-azure) to ship an updated version of waagent. The archive signing key for that repository expired._

_This repository is not needed any more and can safely be removed from the sources.list. The updated waagent package is nowadays shipped with the debian-backports repository."_ 

I've been getting "`GPG error: ...KEYEXPIRED xxxx` errors for a month now when running `apt-get update`. I just found the "known problems" section at the bottom of that link &...well everything is fixed. No need to try and change the expiration date without a private key. 

In other words, I've been trying to figure out how to get rid of this error for a long time. Nothing except for removing the `.../debian-azure` suffixes in my `/etc/apt/sources.list` has worked.