### PR TITLE
Update example with IQueryable note.

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-table.md
+++ b/articles/azure-functions/functions-bindings-storage-table.md
@@ -101,6 +101,9 @@ public class TableStorage
 }
 ```
 
+  > [!NOTE]
+  > `IQueryable` isn't supported in the [Functions v2 runtime](functions-versions.md). An alternative is to [use a CloudTable paramName method parameter](https://stackoverflow.com/questions/48922485/binding-to-table-storage-in-v2-azure-functions-using-cloudtable) to read the table by using the Azure Storage SDK. If you try to bind to `CloudTable` and get an error message, make sure that you have a reference to [the correct Storage SDK version](#azure-storage-sdk-version-in-functions-1x).
+
 ### Input - C# script example 1
 
 The following example shows a table input binding in a *function.json* file and [C# script](functions-reference-csharp.md) code that uses the binding. The function uses a queue trigger to read a single table row. 


### PR DESCRIPTION
Copied note on lack of `IQueryable` support in Functions v2 to the example section.