### PR TITLE
Missing connecting to the instances in VMSS using private IP

### DIFF
--- a/articles/virtual-machine-scale-sets/tutorial-create-and-manage-cli.md
+++ b/articles/virtual-machine-scale-sets/tutorial-create-and-manage-cli.md
@@ -117,6 +117,11 @@ SSH to your first VM instance. Specify your public IP address and port number wi
 ssh azureuser@13.92.224.66 -p 50001
 ```
 
+You can also connect the VM instance by using private IP, to get the private ip of instance will be, go to see the load balancer by consulting backend pools, then using the following command :
+ssh <username>@<PrivateIP>
+Example : ssh azureuser@100.69.0.41 
+
+
 Once logged in to the VM instance, you could perform some manual configuration changes as needed. For now, close the SSH session as normal:
 
 ```bash


### PR DESCRIPTION
It is also possible to connect to VMSS individual instance by using its private IP, you can find it at its load balancer's backend pool, then use ssh directly.  In the enterprise where its security policy doesn't allow to connect instances by using public IP in the cloud, it is important to know how to manage it.