### PR TITLE
Update azure-stack-app-service-deploy.md

### DIFF
--- a/articles/azure-stack/azure-stack-app-service-deploy.md
+++ b/articles/azure-stack/azure-stack-app-service-deploy.md
@@ -13,7 +13,7 @@ ms.workload: app-service
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: article
-ms.date: 05/18/2018
+ms.date: 05/22/2018
 ms.author: anwestg
 
 ---
@@ -63,6 +63,10 @@ To deploy App Service resource provider, follow these steps:
         * If you're using Azure Active Directory (Azure AD), enter the Azure AD admin account and password that you provided when you deployed Azure Stack. Click **Sign In**.
         * If you're using Active Directory Federation Services (AD FS), provide your admin account. For example, cloudadmin@azurestack.local. Enter your password, and click **Sign In**.
     2. In the **Azure Stack Subscriptions** box, select the **Default Provider Subscription**.
+    > [!NOTE]
+    > App Service can only be deployed into the **Default Provider Subscription** at this time.  In a future update App Service will deploy into the new Metering Subscription introduced in Azure Stack 1804 and all existing deployments will be migrated to this new subscription also.
+    >
+    >
     3. In the **Azure Stack Locations** box, select the location that corresponds to the region you're deploying to. For example, select **local** if your deploying to the Azure Stack Development Kit.
 
     ![App Service Installer][3]


### PR DESCRIPTION
Additional note to cover why the default provider subscription is only available for deployments instead of allowing customers to select alternative subscriptions that were introduced in 1804