### PR TITLE
Clarify use of minIOWorkerThreads setting

### DIFF
--- a/articles/redis-cache/cache-faq.md
+++ b/articles/redis-cache/cache-faq.md
@@ -382,7 +382,7 @@ Given this information, we strongly recommend that customers set the minimum con
 
 How to configure this setting:
 
-* In ASP.NET, use the ["minIoThreads" configuration setting]["minIoThreads" configuration setting] under the `<processModel>` configuration element in web.config. If you are running inside of Azure WebSites, this setting is not exposed through the configuration options. However, you should still be able to configure this setting programmatically (see below) from your Application_Start method in global.asax.cs.
+* In ASP.NET, use the ["minIoThreads" or "minWorkerThreads" configuration setting]["minIoThreads" configuration setting] under the `<processModel>` configuration element in web.config. If you are running inside of Azure WebSites, this setting is not exposed through the configuration options. However, you should still be able to configure this setting programmatically (see below) from your Application_Start method in global.asax.cs.
 
   > [!NOTE] 
   > The value specified in this configuration element is a *per-core* setting. For example, if you have a 4 core machine and want your minIOThreads setting to be 200 at runtime, you would use `<processModel minIoThreads="50"/>`.


### PR DESCRIPTION
Clarify the use of the minIOWorkerThreads configuration setting to help with thread growth. This aligns with the April 19th update to https://gist.github.com/JonCole/e65411214030f0d823cb#file-threadpool-md.