### PR TITLE
Updated HDI article with terminology, corrected supportability statement

### DIFF
--- a/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
+++ b/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
@@ -20,32 +20,32 @@ Domain-joined clusters provide the multi-user enterprise security capabilities o
 In this article, you learn how to configure a Domain-joined HDInsight cluster using Azure Active Directory Domain Services.
 
 > [!NOTE]
-> Active Directory on Azure IaaS VMs is no longer supported.
+> Creating a Domain-joined HDInsight cluster requires Azure Active Directory Domain Services. Creating a Domain-joined HDInsight cluster using Active Directory hosted in Azure IaaS virtual machines is no longer supported.
 
 ## Create Azure ADDS
 
-You need to create an Azure AD DS before you can create an HDInsight cluster. To create an Azure ADDS, see [Enable Azure Active Directory Domain Services using the Azure portal](../../active-directory-domain-services/active-directory-ds-getting-started.md). 
+You need to create an Azure AD Domain Services (AAD-DS) before you can create an HDInsight cluster. To create an AAD-DS instace, see [Enable Azure Active Directory Domain Services using the Azure portal](../../active-directory-domain-services/active-directory-ds-getting-started.md). 
 
 > [!NOTE]
-> Only the tenant administrators have the privileges to create domain services. If you use Azure Data Lake Storage (ADLS) as the default storage for HDInsight, then make sure the default Azure AD tenant for ADLS is same as the domain for the HDInsight cluster. For this set up to work with Azure Data Lake Store, multi-factor authentication needs to be disabled for users that will have access to the cluster.
+> Only the tenant administrators have the privileges to create an AAD-DS instance. If you use Azure Data Lake Storage (ADLS) as the default storage for HDInsight, then make sure the default Azure AD tenant for ADLS is same as the domain for the HDInsight cluster. For this set up to work with Azure Data Lake Store, multi-factor authentication needs to be disabled for users that will have access to the cluster.
 
-After the AAD domain service has been provisioned, you need to create a service account in AAD (which will be synced to AAD-DS) with the right permissions to create the HDInsight cluster. If this service account already exists, you need to reset it's password and wait until it syncs to AAD-DS (This reset will result in creation of the kerberos password hash and it could take up to 30 min). This service account should have the following privillages:
+After the AAD-DS instance has been provisioned, you need to create a service account in AAD (which will be synced to AAD-DS) with the right permissions to create the HDInsight cluster. If this service account already exists, you need to reset it's password and wait until it syncs to AAD-DS (This reset will result in creation of the kerberos password hash and it could take up to 30 min). This service account should have the following privillages:
 
 - Join machines to the domain and place machine principals within the OU that you specify during cluster creation.
 - Create service principals within the OU that you specify during cluster creation.
 
-You must enable Secure LDAP for Azure AD Domain Services Managed Domain. To enable Secure LDAP, see [Configure secure LDAP (LDAPS) for an Azure AD Domain Services managed domain](../../active-directory-domain-services/active-directory-ds-admin-guide-configure-secure-ldap.md).
+You must enable Secure LDAP for AAD-DS. To enable Secure LDAP, see [Configure secure LDAP (LDAPS) for an Azure AD Domain Services managed domain](../../active-directory-domain-services/active-directory-ds-admin-guide-configure-secure-ldap.md).
 
 ## Create a Domain-joined HDInsight cluster
 
-The next step is to create the HDInsight cluster using the AAD DS and the service account created in the previous section.
+The next step is to create the HDInsight cluster using the AAD-DS and the service account created in the previous section.
 
-It is easier to place both the Azure AD domain service and the HDInsight cluster in the same Azure virtual network(VNet). In case they are in different VNets, you must peer both VNets. For more information, see [Virtual network peering](../../virtual-network/virtual-network-peering-overview.md).
+It is easier to place both the AAD-DS and the HDInsight cluster in the same Azure virtual network(VNet). In case they are in different VNets, you must peer both VNets. For more information, see [Virtual network peering](../../virtual-network/virtual-network-peering-overview.md).
 
 When you create a domain-joined HDInsight cluster, you must supply the following parameters:
 
-- **Domain name**: The domain-name that is associated with Azure AD DS. For example, contoso.onmicrosoft.com
-- **Domain user name**: The service account in the Azure AD DC that is created in the previous section. For example, hdiadmin@contoso.onmicrosoft.com. This domain user will be the administrator of this domain-joined HDInsight cluster.
+- **Domain name**: The domain-name that is associated with AAD-DS. For example, contoso.onmicrosoft.com
+- **Domain user name**: The service account in the managed domain that is created in the previous section. For example, hdiadmin@contoso.onmicrosoft.com. This domain user will be the administrator of this domain-joined HDInsight cluster.
 - **Domain password**: The password of the service account.
 - **Organization Unit**: The distinguished name of the OU that you want to use with HDInsight cluster. For example: OU=HDInsightOU,DC=contoso,DC=onmicrosohift,DC=com. If this OU does not exist, HDInsight cluster attempts to create this OU. 
 - **LDAPS URL**: For example, ldaps://contoso.onmicrosoft.com:636

--- a/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
+++ b/articles/hdinsight/domain-joined/apache-domain-joined-configure-using-azure-adds.md
@@ -24,7 +24,7 @@ In this article, you learn how to configure a Domain-joined HDInsight cluster us
 
 ## Create Azure ADDS
 
-You need to create an Azure AD Domain Services (AAD-DS) before you can create an HDInsight cluster. To create an AAD-DS instace, see [Enable Azure Active Directory Domain Services using the Azure portal](../../active-directory-domain-services/active-directory-ds-getting-started.md). 
+You need to create an Azure AD Domain Services (AAD-DS) before you can create an HDInsight cluster. To create an AAD-DS instance, see [Enable Azure Active Directory Domain Services using the Azure portal](../../active-directory-domain-services/active-directory-ds-getting-started.md). 
 
 > [!NOTE]
 > Only the tenant administrators have the privileges to create an AAD-DS instance. If you use Azure Data Lake Storage (ADLS) as the default storage for HDInsight, then make sure the default Azure AD tenant for ADLS is same as the domain for the HDInsight cluster. For this set up to work with Azure Data Lake Store, multi-factor authentication needs to be disabled for users that will have access to the cluster.


### PR DESCRIPTION
Current article makes it seem as though Active Directory on IaaS VMs is not supported, it is. However, it is not supported to use to configured a Domain-joined HDInsight cluster. Also corrected to use AAD-DS consistently in the document.