### PR TITLE
Make PIPNAME variable name more descriptive

### DIFF
--- a/articles/aks/ingress.md
+++ b/articles/aks/ingress.md
@@ -67,10 +67,10 @@ DNSNAME="demo-aks-ingress"
 
 # Get resource group and public ip name
 RESOURCEGROUP=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[resourceGroup]" --output tsv)
-PIPNAME=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[name]" --output tsv)
+PUBLICIPNAME=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[name]" --output tsv)
 
 # Update public ip address with dns name
-az network public-ip update --resource-group $RESOURCEGROUP --name  $PIPNAME --dns-name $DNSNAME
+az network public-ip update --resource-group $RESOURCEGROUP --name $PUBLICIPNAME --dns-name $DNSNAME
 ```
 
 The ingress controller should now be accessible through the FQDN.


### PR DESCRIPTION
Without reading the code closely, it's not entirely obvious at first sight what `PIPNAME` represents. For example, a possible tokenization of that variable name can lead to the question "What is a `PIP` and why does it have a `NAME`?" Expanding the `P` abbreviation in the variable name to `PUBLIC` makes the name more immediate and therewith makes it easier to skim the code snippet.