### PR TITLE
Update and fixed typo in run-command.md

### DIFF
--- a/articles/virtual-machines/linux/run-command.md
+++ b/articles/virtual-machines/linux/run-command.md
@@ -21,7 +21,7 @@ The account using Run Command must have [Contributor role](../../role-based-acce
 
 There are multiple options that can be used to access your virtual machines. Run command can run scripts on your virtual machines regardless of network connectivity and is available by default (no installation required). Run command can be used through the Azure portal, [REST API](/rest/api/compute/virtual%20machines%20run%20commands/runcommand), [Azure CLI](/cli/azure/vm/run-command?view=azure-cli-latest#az-vm-run-command-invoke), or [PowerShell](/powershell/module/azurerm.compute/invoke-azurermvmruncommand).
 
-This capability is useful in all scenarios where you want to run a script witin a virtual machines, and is one of the only ways to troubleshoot and remediate a virtual machine that is not connected to the network due to improper network or administrative user configuration.
+This capability is useful in all scenarios where you want to run a script within a virtual machines, and is one of the only ways to troubleshoot and remediate a virtual machine that is not connected to the network due to improper network or administrative user configuration.
 
 ## Restrictions
 


### PR DESCRIPTION
Fixed a typo in the Benefits section. "witin" -> "within"