### PR TITLE
Remove redundant `az network public-ip list` call

### DIFF
--- a/articles/aks/ingress.md
+++ b/articles/aks/ingress.md
@@ -65,12 +65,11 @@ IP="51.145.155.210"
 # Name to associate with public IP address
 DNSNAME="demo-aks-ingress"
 
-# Get resource group and public ip name
-RESOURCEGROUP=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[resourceGroup]" --output tsv)
-PUBLICIPNAME=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[name]" --output tsv)
+# Get the resource-id of the public ip
+PUBLICIPID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[id]" --output tsv)
 
 # Update public ip address with dns name
-az network public-ip update --resource-group $RESOURCEGROUP --name $PUBLICIPNAME --dns-name $DNSNAME
+az network public-ip update --ids $PUBLICIPID --dns-name $DNSNAME
 ```
 
 The ingress controller should now be accessible through the FQDN.


### PR DESCRIPTION
The current version of the AKS ingress example makes two `az network public-ip list` calls to uniquely identify the public IP resource: one to grab the resource group of the public IP and one to grab the resource name of the public IP. These two calls can be replaced by a single call to fetch the resource ID of the public IP.