### PR TITLE
Added remark about the workspaceId

### DIFF
--- a/articles/virtual-machines/extensions/oms-windows.md
+++ b/articles/virtual-machines/extensions/oms-windows.md
@@ -73,7 +73,7 @@ The following JSON shows the schema for the OMS Agent extension. The extension r
 | workspaceId (e.g)* | 6f680a37-00c6-41c7-a93f-1437e3462574 |
 | workspaceKey (e.g) | z4bU3p1/GrnWpQkky4gdabWXAhbWSTz70hm4m2Xt92XI+rSRgE8qVvRhsGo9TXffbrTahyrwv35W0pOqQAU7uQ== |
 
-*The workspaceId is called the consumerId in the log analytics API.
+\* The workspaceId is called the consumerId in the Log Analytics API.
 
 ## Template deployment
 

--- a/articles/virtual-machines/extensions/oms-windows.md
+++ b/articles/virtual-machines/extensions/oms-windows.md
@@ -70,8 +70,10 @@ The following JSON shows the schema for the OMS Agent extension. The extension r
 | publisher | Microsoft.EnterpriseCloud.Monitoring |
 | type | MicrosoftMonitoringAgent |
 | typeHandlerVersion | 1.0 |
-| workspaceId (e.g) | 6f680a37-00c6-41c7-a93f-1437e3462574 |
+| workspaceId (e.g)* | 6f680a37-00c6-41c7-a93f-1437e3462574 |
 | workspaceKey (e.g) | z4bU3p1/GrnWpQkky4gdabWXAhbWSTz70hm4m2Xt92XI+rSRgE8qVvRhsGo9TXffbrTahyrwv35W0pOqQAU7uQ== |
+
+*The workspaceId is called the consumerId in the log analytics API.
 
 ## Template deployment
 


### PR DESCRIPTION
The workspaceId is called the consumerId in the log analytics API. Adding this to the documentation would have saved me a lot of time.