### PR TITLE
Also needs 'ShowPeoplePickerSuggestionsForGuestUsers' enabled

### DIFF
--- a/articles/active-directory/b2b/o365-external-user.md
+++ b/articles/active-directory/b2b/o365-external-user.md
@@ -1,3 +1,4 @@
+
 ---
 title: Office 365 external sharing and Azure Active Directory B2B collaboration | Microsoft Docs
 description: Discusses sharing resources with external partners using O365 and Azure Active Directory B2B collaboration.
@@ -31,9 +32,13 @@ OneDrive/SharePoint Online has a separate invitation manager. Support for extern
 
 ![The OneDrive/SharePoint Online external sharing setting](media/o365-external-user/odsp-sharing-setting.png)
 
+After enabling external sharing, the ability to search for existing guest users in the SharePoint Online (SPO) people picker is OFF by default to match legacy behavior.
+You can enable this feature by using the setting 'ShowPeoplePickerSuggestionsForGuestUsers' at the tenant and site collection level. You can set the feature using the Set-SPOTenant and Set-SPOSite cmdlets, which allow members to search all existing guest users in the directory. Changes in the tenant scope do not affect already provisioned SPO sites.
+
 ## Next steps
 
 * [What is Azure AD B2B collaboration?](what-is-b2b.md)
 * [Adding a B2B collaboration user to a role](add-guest-to-role.md)
 * [Delegate B2B collaboration invitations](delegate-invitations.md)
 * [Dynamic groups and B2B collaboration](use-dynamic-groups.md)
+* [Troubleshooting Azure Active Directory B2B collaboration](troubleshoot.md)

--- a/articles/active-directory/b2b/o365-external-user.md
+++ b/articles/active-directory/b2b/o365-external-user.md
@@ -1,4 +1,3 @@
-
 ---
 title: Office 365 external sharing and Azure Active Directory B2B collaboration | Microsoft Docs
 description: Discusses sharing resources with external partners using O365 and Azure Active Directory B2B collaboration.
@@ -33,6 +32,7 @@ OneDrive/SharePoint Online has a separate invitation manager. Support for extern
 ![The OneDrive/SharePoint Online external sharing setting](media/o365-external-user/odsp-sharing-setting.png)
 
 After enabling external sharing, the ability to search for existing guest users in the SharePoint Online (SPO) people picker is OFF by default to match legacy behavior.
+
 You can enable this feature by using the setting 'ShowPeoplePickerSuggestionsForGuestUsers' at the tenant and site collection level. You can set the feature using the Set-SPOTenant and Set-SPOSite cmdlets, which allow members to search all existing guest users in the directory. Changes in the tenant scope do not affect already provisioned SPO sites.
 
 ## Next steps


### PR DESCRIPTION
I copied the block from the "troubleshooting..." B2B page because this scenario also requires 'ShowPeoplePickerSuggestionsForGuestUsers' to be enabled if you want to search external "guest" users from your SPO tenant. And, because I did just copy and paste this information, I also added a link to this at the bottom of that page (i.e. to "Troubleshooting Azure Active Directory B2B collaboration")