### PR TITLE
Updated the restriction to map a custom domain

### DIFF
--- a/articles/azure-functions/scripts/functions-cli-configure-custom-domain.md
+++ b/articles/azure-functions/scripts/functions-cli-configure-custom-domain.md
@@ -20,7 +20,7 @@ ms.custom: mvc
 ---
 # Map a custom domain to a function app
 
-This sample script creates a function app with related resources, and then maps `www.<yourdomain>` to it. To map to a custom domain, your function app must be created in an App Service plan and not in a consumption plan. Azure Functions only supports mapping a custom domain using an A record.
+This sample script creates a function app with related resources, and then maps `www.<yourdomain>` to it. Azure Functions supports mapping a custom domain using a CNAME record. A records are not supported for Consumption Functions Apps.
 
 [!INCLUDE [quickstarts-free-trial-note](../../../includes/quickstarts-free-trial-note.md)]
 


### PR DESCRIPTION
I can set a custom domain using a CNAME record to function app in the both case of consumption plan and App Service plan, but I can NOT set a custom domain using an A record.
I think this document is mistaken. So I changed it.

> To map to a custom domain, your function app must be created in an App Service plan and not in a consumption plan. Azure Functions only supports mapping a custom domain using an A record.