### PR TITLE
Clarify Ls-Series caching policy

### DIFF
--- a/includes/virtual-machines-common-sizes-storage.md
+++ b/includes/virtual-machines-common-sizes-storage.md
@@ -26,7 +26,7 @@ ACU: 180-240
 | Standard_L32s <sup>1</sup> | 32   | 256  | 5,630 | 64   | 160,000 / 1,600   | 40,000 / 1,000     | 8 / 20,000 | 
  
 
-The maximum disk throughput  possible with Ls-series VMs may be limited by the number, size, and striping of any attached disks. For details, see [Premium Storage: High-performance storage for Azure virtual machine workloads](../articles/virtual-machines/windows/premium-storage.md). 
+The maximum disk throughput possible with Ls-series VMs may be limited by the number, size, and striping of any attached disks. For details, see [Premium Storage: High-performance storage for Azure virtual machine workloads](../articles/virtual-machines/windows/premium-storage.md). Ls-series VMs are targeted at workloads with high local storage use and typically only use attached disks for initial loading and logging, as caching is ineffective in these cases the Ls-series does not support host caching for attached disks, disks must be attached in uncached mode. 
 
 <sup>1</sup> Instance is isolated to hardware dedicated to a single customer.
 


### PR DESCRIPTION
Updated discussion on disk throughput to clarify that Ls attached disks are not cached (and why).