### PR TITLE
Update automation-linux-hrw-install.md

### DIFF
--- a/articles/automation/automation-linux-hrw-install.md
+++ b/articles/automation/automation-linux-hrw-install.md
@@ -12,7 +12,7 @@ manager: carmonm
 ---
 # How to deploy a Linux Hybrid Runbook Worker
 
-The Hybrid Runbook Worker feature of Azure Automation allows you to run runbooks directly on the computer hosting the role and against resources in the environment to manage those local resources. The Linux Hybrid Runbook Worker executes runbooks as a special user which can be elevated for running commands that need elevation. Runbooks are stored and managed in Azure Automation and then delivered to one or more designated computers. This article decribes how to install the Hybrid Runbook Worker on a Linux machine.
+The Hybrid Runbook Worker feature of Azure Automation allows you to run runbooks directly on the computer hosting the role and against resources in the environment to manage those local resources. The Linux Hybrid Runbook Worker executes runbooks as a special user which can be elevated for running commands that need elevation. Runbooks are stored and managed in Azure Automation and then delivered to one or more designated computers. This article describes how to install the Hybrid Runbook Worker on a Linux machine.
 
 ## Supported Linux Operating Systems
 


### PR DESCRIPTION
Fixed a typo in the "How to deploy a Linux Hybrid Runbook Worker" section: "decribes" -> "describes".