### PR TITLE
Edit variable name in PowerShell code

### DIFF
--- a/articles/storage/blobs/storage-upload-process-images.md
+++ b/articles/storage/blobs/storage-upload-process-images.md
@@ -77,7 +77,7 @@ In this case, `<blob_storage_account>` is the name of the Blob storage account y
 ```azurecli-interactive 
 $blobStorageAccount="<blob_storage_account>"
 
-blobStorageAccountKey=$(az storage account keys list -g myResourceGroup \
+$blobStorageAccountKey=$(az storage account keys list -g myResourceGroup \
 -n $blobStorageAccount --query [0].value --output tsv) 
 
 az storage container create -n images --account-name $blobStorageAccount \


### PR DESCRIPTION
blobStorageAccountKey variable name without $ sign in PowerShell code caused error. Fixed.