### PR TITLE
Clarifying Parameter for Blob Content Action

### DIFF
--- a/articles/connectors/connectors-create-api-azureblobstorage.md
+++ b/articles/connectors/connectors-create-api-azureblobstorage.md
@@ -136,7 +136,7 @@ provide the necessary information for the action.
   
       ![Select folder](./media/connectors-create-api-azureblobstorage/action-select-folder.png)
 
-   2. Browse until you find the file that you want and select that file. For the selected file, please use the **Id** field from the   blob metadata that was returned from the previous blob storage trigger.
+   2. Find and select the file you want based on the blob's **Id** number. You can find this **Id** number in the blob's metadata that is returned by the previously-described blob storage trigger.
 
 5. When you're done, on the designer toolbar, choose **Save**.
 To test your logic app, make sure that the selected folder contains a blob.

--- a/articles/connectors/connectors-create-api-azureblobstorage.md
+++ b/articles/connectors/connectors-create-api-azureblobstorage.md
@@ -136,7 +136,7 @@ provide the necessary information for the action.
   
       ![Select folder](./media/connectors-create-api-azureblobstorage/action-select-folder.png)
 
-   2. Browse until you find the file that you want and select that file.
+   2. Browse until you find the file that you want and select that file. For the selected file, please use the **Id** field from the   blob metadata that was returned from the previous blob storage trigger.
 
 5. When you're done, on the designer toolbar, choose **Save**.
 To test your logic app, make sure that the selected folder contains a blob.


### PR DESCRIPTION
Added a clarifying sentence to use ID paramater in the Blob field of the "Get Blob Content" Action, as name with path do not work here.