### PR TITLE
Add missing parameter to 'az container create'

### DIFF
--- a/articles/container-instances/container-instances-tutorial-deploy-app.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-app.md
@@ -52,7 +52,7 @@ az acr credential show --name <acrName> --query "passwords[0].value"
 Now, use the [az container create][az-container-create] command to deploy the container. Replace `<acrLoginServer>` and `<acrPassword>` with the values you obtained from the previous two commands. Replace `<acrName>` with the name of your container registry.
 
 ```azurecli
-az container create --resource-group myResourceGroup --name aci-tutorial-app --image <acrLoginServer>/aci-tutorial-app:v1 --cpu 1 --memory 1 --registry-username <acrName> --registry-password <acrPassword> --dns-name-label aci-demo --ports 80
+az container create --resource-group myResourceGroup --name aci-tutorial-app --image <acrLoginServer>/aci-tutorial-app:v1 --cpu 1 --memory 1 --registry-login-server <acrLoginServer> --registry-username <acrName> --registry-password <acrPassword> --dns-name-label aci-demo --ports 80
 ```
 
 Within a few seconds, you should receive an initial response from Azure. The `--dns-name-label` value must be unique within the Azure region you create the container instance. Modify the value in the preceding command if you receive a **DNS name label** error message when you execute the command.


### PR DESCRIPTION
The command didn't work for me until I added `--registry-login-server <acrLoginServer>`
This field also seems to be mandatory in portal.azure.com