### PR TITLE
Added some words to clear up the first sentence

### DIFF
--- a/articles/azure-functions/functions-create-storage-queue-triggered-function.md
+++ b/articles/azure-functions/functions-create-storage-queue-triggered-function.md
@@ -20,7 +20,7 @@ ms.custom: mvc, cc996988-fb4f-47
 ---
 # Create a function triggered by Azure Queue storage
 
-Learn how to create a function triggered when messages are submitted to an Azure Storage queue.
+Learn how to create a function that is triggered when messages are submitted to an Azure Storage queue.
 
 ![View message in the logs.](./media/functions-create-storage-queue-triggered-function/function-app-in-portal-editor.png)
 


### PR DESCRIPTION
I started to read the article and was confused by the wording of the first sentence. I added "that is" to clear it up and make it more grammatically correct. The description of the article uses "that is" similarly.