### PR TITLE
Update functions-bindings-microsoft-graph.md

### DIFF
--- a/articles/azure-functions/functions-bindings-microsoft-graph.md
+++ b/articles/azure-functions/functions-bindings-microsoft-graph.md
@@ -735,6 +735,7 @@ public static async Task Run(HttpRequest req, TraceWriter log, Stream myOneDrive
         .FirstOrDefault(q => string.Compare(q.Key, "text", true) == 0)
         .Value;
     await myOneDriveFile.WriteAsync(Encoding.UTF8.GetBytes(data), 0, data.Length);
+    myOneDriveFile.Close();
     return;
 }
 ```


### PR DESCRIPTION
In File Output Binding example code sample, line of code was missing that closes file. It is crucial to close file after executing WriteAsync as it will not be saved to OneDrive otherwise (I've verified it myself and Matt's example from Build session also contains call to Close after WriteAsync)