### PR TITLE
Removed whitespace around properties in Policy

### DIFF
--- a/articles/active-directory/active-directory-claims-mapping.md
+++ b/articles/active-directory/active-directory-claims-mapping.md
@@ -465,7 +465,7 @@ In this example, you create a policy that adds the EmployeeID and TenantCountry 
 	1. To create the policy, run this command:  
 	 
 	 ``` powershell
-	New-AzureADPolicy -Definition @('{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":"true", "ClaimsSchema": [{"Source":"user","ID":"employeeid","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name","JwtClaimType":"name"},{"Source":"company","ID":" tenantcountry ","SamlClaimType":" http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country ","JwtClaimType":"country"}]}}') -DisplayName "ExtraClaimsExample” -Type "ClaimsMappingPolicy"
+	New-AzureADPolicy -Definition @('{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":"true", "ClaimsSchema": [{"Source":"user","ID":"employeeid","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name","JwtClaimType":"name"},{"Source":"company","ID":"tenantcountry","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country","JwtClaimType":"country"}]}}') -DisplayName "ExtraClaimsExample" -Type "ClaimsMappingPolicy"
 	```
 	
 	2. To see your new policy, and to get the policy ObjectId, run the following command:


### PR DESCRIPTION
Removed whitespace around tenantCountry property as well as SAML claim type in the first example of claims mapping policy. Also fixed missmatched quote again in the first policy.
The white space inside property names and/or values causes issues.