### PR TITLE
Discrepancy in default cache setting for Data Disk

### DIFF
--- a/includes/virtual-machines-common-premium-storage-performance.md
+++ b/includes/virtual-machines-common-premium-storage-performance.md
@@ -239,7 +239,7 @@ It is important to enable cache on the right set of disks. Whether you should en
 | **Disk Type** | **Default Cache Setting** |
 | --- | --- |
 | OS disk |ReadWrite |
-| Data disk |None |
+| Data disk |ReadOnly |
 
 Following are the recommended disk cache settings for data disks,
 


### PR DESCRIPTION
The document had conflicting information on the default setting for the Host Caching setting for Premium Data Disks. The text stated it was ReadOnly, however the Table showed it as None. I validated in the portal and when I created a new premium data disk it created as ReadOnly.