### PR TITLE
Fix architecture link bugs

### DIFF
--- a/articles/iot-accelerators/iot-accelerators-remote-monitoring-sample-walkthrough.md
+++ b/articles/iot-accelerators/iot-accelerators-remote-monitoring-sample-walkthrough.md
@@ -130,6 +130,8 @@ If you want to explore the source code and developer documentation, start with o
 
 * [Solution accelerator for Remote Monitoring with Azure IoT (.NET)](https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/wiki/).
 * [Solution accelerator for Remote Monitoring with Azure IoT (Java)](https://github.com/Azure/azure-iot-pcs-remote-monitoring-java).
-* [Solution accelerator for Remote Monitoring architecture)](https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/wiki/Architecture).
+
+Detailed solution architecture diagrams:
+* [Solution accelerator for Remote Monitoring architecture](https://github.com/Azure/azure-iot-pcs-remote-monitoring-dotnet/wiki/Architecture).
 
 For more conceptual information about the Remote Monitoring solution accelerator, see [Customize the solution accelerator](../iot-accelerators/iot-accelerators-remote-monitoring-customize.md).


### PR DESCRIPTION
Architecture diagram link was 1) listed as a GitHub repository (bug) and 2) had an extra parentheses in the text.