### PR TITLE
Change Default Value for deleteUnattachedVHDs

### DIFF
--- a/articles/virtual-machines/windows/find-unattached-disks.md
+++ b/articles/virtual-machines/windows/find-unattached-disks.md
@@ -79,7 +79,7 @@ Unmanaged disks are VHD files that are stored as [page blobs](/rest/api/storages
    
 # Set deleteUnattachedVHDs=1 if you want to delete unattached VHDs
 # Set deleteUnattachedVHDs=0 if you want to see the Uri of the unattached VHDs
-$deleteUnattachedVHDs=1
+$deleteUnattachedVHDs=0
 
 $storageAccounts = Get-AzureRmStorageAccount
 


### PR DESCRIPTION
The default value for deleteUnattachedVHDs should be set to 0 so if someone copies the script it doesn't delete anything by default.