### PR TITLE
Adding notes about the requirement of the vfat driver

### DIFF
--- a/articles/virtual-machines/linux/encrypt-disks.md
+++ b/articles/virtual-machines/linux/encrypt-disks.md
@@ -21,6 +21,8 @@ ms.author: iainfou
 # How to encrypt virtual disks on a Linux VM
 For enhanced virtual machine (VM) security and compliance, virtual disks and the VM itself can be encrypted. VMs are encrypted using cryptographic keys that are secured in an Azure Key Vault. You control these cryptographic keys and can audit their use. This article details how to encrypt virtual disks on a Linux VM using the Azure CLI 2.0. You can also perform these steps with the [Azure CLI 1.0](encrypt-disks-nodejs.md?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
+NOTE: Make sure that you have the vfat driver enabled in your Linux VM. Some security practices such as CIS benchmarks ask to disable the vfat driver. That driver is required for encryption to work after the process is finished.
+
 ## Quick commands
 If you need to quickly accomplish the task, the following section details the base commands to encrypt virtual disks on your VM. More detailed information and context for each step can be found the rest of the document, [starting here](#overview-of-disk-encryption).
 
@@ -143,6 +145,7 @@ Supported scenarios and requirements for disk encryption:
 * All resources (such as Key Vault, Storage account, and VM) must be in the same Azure region and subscription.
 * Standard A, D, DS, G, GS, etc., series VMs.
 * Updating the cryptographic keys on an already encrypted Linux VM.
+* VFAT driver is enabled in the Linux VM.
 
 Disk encryption is not currently supported in the following scenarios:
 

--- a/articles/virtual-machines/linux/encrypt-disks.md
+++ b/articles/virtual-machines/linux/encrypt-disks.md
@@ -21,7 +21,8 @@ ms.author: iainfou
 # How to encrypt virtual disks on a Linux VM
 For enhanced virtual machine (VM) security and compliance, virtual disks and the VM itself can be encrypted. VMs are encrypted using cryptographic keys that are secured in an Azure Key Vault. You control these cryptographic keys and can audit their use. This article details how to encrypt virtual disks on a Linux VM using the Azure CLI 2.0. You can also perform these steps with the [Azure CLI 1.0](encrypt-disks-nodejs.md?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
 
-NOTE: Make sure that you have the vfat driver enabled in your Linux VM. Some security practices such as CIS benchmarks ask to disable the vfat driver. That driver is required for encryption to work after the process is finished.
+> [!NOTE]
+> Make sure that you have the vfat driver enabled in your Linux VM. Some security practices such as CIS benchmarks ask to disable the vfat driver. That driver is required for encryption to work after the process is finished.
 
 ## Quick commands
 If you need to quickly accomplish the task, the following section details the base commands to encrypt virtual disks on your VM. More detailed information and context for each step can be found the rest of the document, [starting here](#overview-of-disk-encryption).


### PR DESCRIPTION
Some security benchmarks, such as CIS, recommend disabling the vfat driver and that will cause problems with Azure Disk Encryption since we require that filesystem to mount the BEK volume.

In most cases if CIS is indeed installed, you can easily disable that by commenting out the line:
install vfat /bin/true