### PR TITLE
Add --script-root and --prefix switch

### DIFF
--- a/articles/azure-functions/functions-run-local.md
+++ b/articles/azure-functions/functions-run-local.md
@@ -261,6 +261,7 @@ func host start
 | **`--timeout -t`** | The timeout for the Functions host to start, in seconds. Default: 20 seconds.|
 | **`--useHttps`** | Bind to https://localhost:{port} rather than to http://localhost:{port}. By default, this option creates a trusted certificate on your computer.|
 | **`--pause-on-error`** | Pause for additional input before exiting the process. Useful when launching Azure Functions Core Tools from an integrated development environment (IDE).|
+| **`--script-root --prefix`** | Specify the script root path (where the host.json, local.settings.json, and function.json files are). For example, `--script-root MyProject/bin/Debug/netstandard2.0` for a precompiled function.|
 
 When the Functions host starts, it outputs the URL of HTTP-triggered functions:
 


### PR DESCRIPTION
I was trying to run some precompiled Functions on a Mac without an IDE. I didn't want to have to navigate to the build output folder every time so searched and found https://github.com/Azure/azure-functions-core-tools/commit/50323beaaef1ad61dd0d4c13d7fe606d7cfec51c. I confirmed both of these switches work with [Azure Functions Core Tools 2.0.1-beta.28](https://github.com/Azure/azure-functions-core-tools/releases/tag/2.0.1-beta.28).