### PR TITLE
Fixed small spelling/grammar mistakes

### DIFF
--- a/articles/dms/tutorial-sql-server-to-managed-instance.md
+++ b/articles/dms/tutorial-sql-server-to-managed-instance.md
@@ -114,7 +114,7 @@ After the service is created, locate it within the Azure portal, open it, and th
     When a trusted certificate is not installed, SQL Server generates a self-signed certificate when the instance is started. This certificate is used to encrypt the credentials for client connections.
 
     > [!CAUTION]
-    > SSL connections that are encyopted using a self-signed certificate do not provide strong security. They are susceptible to man-in-the-middle attacks. You shoudl not rely on SSL using self-signed certificates in a production environment or on servers that are connected to the internet.
+    > SSL connections that are encrypted using a self-signed certificate does not provide strong security. They are susceptible to man-in-the-middle attacks. You should not rely on SSL using self-signed certificates in a production environment or on servers that are connected to the internet.
 
    ![Source Details](media\tutorial-sql-server-to-managed-instance\dms-source-details1.png)
 


### PR DESCRIPTION
Changed
 - "encyopted" -> "encrypted"
- "do not provide" -> "does not provide" 
- "shoudl" -> "should"