### PR TITLE
Updated link to Java SDK

### DIFF
--- a/articles/event-grid/sdk-overview.md
+++ b/articles/event-grid/sdk-overview.md
@@ -21,7 +21,7 @@ The management SDKs enable you to create, update, and delete event grid topics a
 
 * [.NET](https://www.nuget.org/packages/Microsoft.Azure.Management.EventGrid)
 * [Go](https://github.com/Azure/azure-sdk-for-go)
-* [Java](https://mvnrepository.com/artifact/com.microsoft.azure.eventgrid-2018-01-01/azure-mgmt-eventgrid)
+* [Java](https://search.maven.org/#search%7Cga%7C1%7Cazure-mgmt-eventgrid)
 * [Node](https://www.npmjs.com/package/azure-arm-eventgrid)
 * [Python](https://pypi.python.org/pypi/azure-mgmt-eventgrid)
 * [Ruby](https://rubygems.org/gems/azure_mgmt_event_grid)


### PR DESCRIPTION
The previous link to the Java SDK was pointing to a specific version of the SDK. We now have an additional Java SDK for the newer API version, hence updating the link.