### PR TITLE
Clarifying restrictions on `FunctionName` attribute

### DIFF
--- a/articles/azure-functions/functions-dotnet-class-library.md
+++ b/articles/azure-functions/functions-dotnet-class-library.md
@@ -58,7 +58,7 @@ public static class SimpleExample
 } 
 ```
 
-The `FunctionName` attribute marks the method as a function entry point. The name must be unique within a project. Project templates often create a method named `Run`, but the method name can be any valid C# method name.
+The `FunctionName` attribute marks the method as a function entry point. The name must be unique within a project, start with a letter and only comtain letters, numbers, `_` and `-`, up to 127 characters in length. Project templates often create a method named `Run`, but the method name can be any valid C# method name.
 
 The trigger attribute specifies the trigger type and binds input data to a method parameter. The example function is triggered by a queue message, and the queue message is passed to the method in the `myQueueItem` parameter.
 


### PR DESCRIPTION
I hit this issue when creating a function name and found the regex [in the codebase](https://github.com/Azure/azure-functions-host/blob/12d79dc69076b717d4f3421719a509257f91935e/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs#L36) which the update is based on.