### PR TITLE
Update luis-concept-patterns.md

### DIFF
--- a/articles/cognitive-services/LUIS/luis-concept-patterns.md
+++ b/articles/cognitive-services/LUIS/luis-concept-patterns.md
@@ -35,6 +35,7 @@ Patterns solve the following situations:
 ## Patterns solve missed entity detection
 A second issue is that LUIS doesn't find the employee name in the utterance, to return in an entity. 
 -->
+
 ## Patterns are not a guarantee of intent
 Patterns use a mix of prediction technologies. Setting an intent for a template utterance in a pattern is not a guarantee of the intent prediction but it is a strong signal. 
 


### PR DESCRIPTION
add empty line before the "Patterns are not a guarantee of intent" header, because at the rendered HTML, it's displayed inline.