### PR TITLE
Add missing ',' in Article "Custom Script Extension for Linux"

### DIFF
--- a/articles/virtual-machines/extensions/custom-script-linux.md
+++ b/articles/virtual-machines/extensions/custom-script-linux.md
@@ -153,7 +153,7 @@ The dos2unix conversion can be skipped by setting the skipDos2Unix to true.
 ```json
 {
   "fileUris": ["<url>"],
-  "commandToExecute": "<command-to-execute>"
+  "commandToExecute": "<command-to-execute>",
   "skipDos2Unix": true
 }
 ```


### PR DESCRIPTION
A ',' was missing in a code snippet in the page "Use the Azure Custom Script Extension Version 2 with Linux virtual machines"
https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux