### PR TITLE
Added required AppSettings for private registry

### DIFF
--- a/articles/app-service/containers/tutorial-multi-container-app.md
+++ b/articles/app-service/containers/tutorial-multi-container-app.md
@@ -105,6 +105,14 @@ When the App Service plan has been created, the Azure CLI shows information simi
   "workerTierName": null
 }
 ```
+## Using custom images from a private registry
+
+If you're using custom images from a private registry make sure to specify the following application settings in your app service. 
+
+* DOCKER_REGISTRY_SERVER_PASSWORD
+* DOCKER_REGISTRY_SERVER_URL
+* DOCKER_REGISTRY_SERVER_USERNAME
+
 
 ## Docker Compose configuration options
 


### PR DESCRIPTION
I added the hint that you need to specify app settings to allow pulling of images from a private registry. While the settings are added automatically for single container app services it's not done automatically in a multi-container appservice.