### PR TITLE
Remove duplication sentences

### DIFF
--- a/articles/security/blueprints/payment-processing-blueprint.md
+++ b/articles/security/blueprints/payment-processing-blueprint.md
@@ -168,8 +168,6 @@ Each of the network tiers has a dedicated network security group (NSG):
 - An NSG for management jumpbox (bastion host)
 - An NSG for the app service environment
 
-Each of the NSGs have specific ports and protocols opened for the secure and correct operation of the solution. For more information, see [PCI Guidance - Network Security Groups](#network-security-groups).
-
 Each of the NSGs have specific ports and protocols opened for the secure and
 correct working of the solution. In addition, the following configurations are enabled for each NSG:
 - Enabled [diagnostic logs and events](/azure/virtual-network/virtual-network-nsg-manage-log) are stored in storage account 


### PR DESCRIPTION
It looks like duplicate sentences. Also, the sentence has the link to themselves. This sentence is unnecessary. no additional pieces of information.