### PR TITLE
Update Marketplace search term for AKS

### DIFF
--- a/articles/aks/intro-kubernetes.md
+++ b/articles/aks/intro-kubernetes.md
@@ -38,7 +38,7 @@ With Azure handling the management of the nodes in your AKS cluster, you no long
 The goal of AKS is to provide a container hosting environment by using open-source tools and technologies that are popular among customers today. To this end, we expose the standard Kubernetes API endpoints. By using these standard endpoints, you can leverage any software that is capable of talking to a Kubernetes cluster. For example, you might choose [kubectl][kubectl-overview], [helm][helm], or [draft][draft].
 
 ## Creating a Kubernetes cluster using Azure Kubernetes Service (AKS)
-To begin using AKS, deploy an AKS cluster with the [Azure CLI][aks-quickstart] or via the portal (search the Marketplace for **Azure Kubernetes Service**). If you are an advanced user who needs more control over the Azure Resource Manager templates, use the open-source [acs-engine][acs-engine] project to build your own custom Kubernetes cluster and deploy it via the `az` CLI.
+To begin using AKS, deploy an AKS cluster with the [Azure CLI][aks-quickstart] or via the portal (search the Marketplace for **Kubernetes Service**). If you are an advanced user who needs more control over the Azure Resource Manager templates, use the open-source [acs-engine][acs-engine] project to build your own custom Kubernetes cluster and deploy it via the `az` CLI.
 
 ### Using Kubernetes
 Kubernetes automates deployment, scaling, and management of containerized applications. It has a rich set of features including:


### PR DESCRIPTION
Searching for "Azure Kubernetes Service" gives incorrect result. AKS seem to have been renamed "Kubernetes Service" in Marketplace (at least when searching).