### PR TITLE
Fix Azure CLI 2.0 command to stream log files

### DIFF
--- a/articles/azure-functions/functions-monitoring.md
+++ b/articles/azure-functions/functions-monitoring.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Monitor Azure Functions
 description: Learn how to use Azure Application Insights with Azure Functions for monitoring function execution.
 services: functions

--- a/articles/azure-functions/functions-monitoring.md
+++ b/articles/azure-functions/functions-monitoring.md
@@ -554,7 +554,7 @@ For Azure CLI 2.0, use the following commands to sign in, choose your subscripti
 az login
 az account list
 az account set <subscriptionNameOrId>
-az appservice web log tail --resource-group <resource group name> --name <function app name>
+az webapp log tail --resource-group <resource group name> --name <function app name>
 ```
 
 For Azure PowerShell, use the following commands to add your Azure account, choose your subscription, and stream log files:


### PR DESCRIPTION
The Azure CLI 2.0 documentation for streaming log files incorrectly uses `az appservice ...`, the command for interacting with **app service plans** (not web or function apps).

The correct command is documented here: https://docs.microsoft.com/en-us/cli/azure/webapp/log?view=azure-cli-latest#az-webapp-log-tail