### PR TITLE
Adding comments about Skype for Business

### DIFF
--- a/articles/active-directory/manage-apps/tenant-restrictions.md
+++ b/articles/active-directory/manage-apps/tenant-restrictions.md
@@ -110,7 +110,10 @@ Refer to [Updated Office 365 modern authentication](https://blogs.office.com/201
 
 Tenant Restrictions is currently supported by Office 365 browser-based applications (the Office Portal, Yammer, SharePoint sites, Outlook on the Web, etc.). For thick clients (Outlook, Skype for Business, Word, Excel, PowerPoint, etc.) Tenant Restrictions can only be enforced when modern authentication is used.  
 
-Outlook and Skype for Business clients that support modern authentication may still able to use legacy protocols against tenants where modern authentication is not enabled, effectively bypassing Tenant Restrictions. Applications that use legacy protocols may be blocked by Tenant Restrictions if they contact login.microsoftonline.com, login.microsoft.com, or login.windows.net during authentication.
+Outlook and Skype for Business clients that support modern authentication may still able to use legacy protocols against tenants where modern authentication is not enabled, effectively bypassing Tenant Restrictions. Applications that use legacy protocols may be blocked by Tenant Restrictions if they contact login.microsoftonline.com, login.microsoft.com, or login.windows.net during authentication.Since Skype for Business client applications which use either modern authentication or legacy authentication are using login.microsoftonline.com, these applications are blocked by Tenant Restrictions.
+
+
+
 
 For Outlook on Windows, customers may choose to implement restrictions preventing end users from adding non-approved mail accounts to their profiles. For example, see the [Prevent adding non-default Exchange accounts](http://gpsearch.azurewebsites.net/default.aspx?ref=1) group policy setting. For Outlook on non-Windows platforms, and for Skype for Business on all platforms, full support for Tenant Restrictions is not currently available.
 


### PR DESCRIPTION
Since Skype for Business client applications which use legacy authentication are using login.microsoftonline.com, customer is asking us to  add an additional comment about it.