### PR TITLE
URL for /images/ example was pointing to /video/

### DIFF
--- a/articles/application-gateway/tutorial-url-route-cli.md
+++ b/articles/application-gateway/tutorial-url-route-cli.md
@@ -242,7 +242,7 @@ az network public-ip show \
 
 ![Test base URL in application gateway](./media/tutorial-url-route-cli/application-gateway-nginx.png)
 
-Change the URL to http://&lt;ip-address&gt;:8080/video/test.html, substituting your IP address for &lt;ip-address&gt;, and you should see something like the following example:
+Change the URL to http://&lt;ip-address&gt;:8080/images/test.html, substituting your IP address for &lt;ip-address&gt;, and you should see something like the following example:
 
 ![Test images URL in application gateway](./media/tutorial-url-route-cli/application-gateway-nginx-images.png)
 


### PR DESCRIPTION
Looks like a simple copy/paste error where `/video/` was left in a place where it should have been `/images`.