### PR TITLE
Adding underscore to StorageType variable

### DIFF
--- a/articles/virtual-machines/windows/convert-disk-storage.md
+++ b/articles/virtual-machines/windows/convert-disk-storage.md
@@ -43,7 +43,7 @@ $rgName = 'yourResourceGroup'
 $vmName = 'yourVM'
 
 # Choose between StandardLRS and PremiumLRS based on your scenario
-$storageType = 'PremiumLRS'
+$storageType = 'Premium_LRS'
 
 # Premium capable size
 # Required only if converting storage from standard to premium
@@ -85,7 +85,7 @@ $diskName = 'yourDiskName'
 # resource group that contains the managed disk
 $rgName = 'yourResourceGroupName'
 # Choose between StandardLRS and PremiumLRS based on your scenario
-$storageType = 'PremiumLRS'
+$storageType = 'Premium_LRS'
 # Premium capable size 
 $size = 'Standard_DS2_v2'
 


### PR DESCRIPTION
Powershell throws an error if there is no '_' between 'Premium' and 'LRS' Example: Premium_LRS