### PR TITLE
Vale fixes

### DIFF
--- a/articles/data-factory/v1/data-factory-json-scripting-reference.md
+++ b/articles/data-factory/v1/data-factory-json-scripting-reference.md
@@ -3550,7 +3550,7 @@ To define an FTP linked service, set the **type** of the linked service to **Ftp
 | username |User who has access to the FTP server |No |&nbsp; |
 | password |Password for the user (username) |No |&nbsp; |
 | encryptedCredential |Encrypted credential to access the FTP server |No |&nbsp; |
-| gatewayName |Name of the Data Management Gateway gateway to connect to an on-premises FTP server |No |&nbsp; |
+| gatewayName |Name of the Data Management Gateway to connect to an on-premises FTP server |No |&nbsp; |
 | port |Port on which the FTP server is listening |No |21 |
 | enableSsl |Specify whether to use FTP over SSL/TLS channel |No |true |
 | enableServerCertificateValidation |Specify whether to enable server SSL certificate validation when using FTP over SSL/TLS channel |No |true |

--- a/includes/redis-cache-configure-stackexchange-redis-nuget.md
+++ b/includes/redis-cache-configure-stackexchange-redis-nuget.md
@@ -21,7 +21,7 @@ Type **StackExchange.Redis** or **StackExchange.Redis.StrongName** into the sear
 The NuGet package downloads and adds the required assembly references for your client application to access Azure Redis Cache with the StackExchange.Redis cache client.
 
 > [!NOTE]
-> If you have previously configured your project to use StackExchange.Redis, you can check for updates to the package from the **NuGet Package Manager**. To check for and install updated versions of the StackExchange.Redis NuGet package, click **Updates** in the the **NuGet Package Manager** window. If an update to the StackExchange.Redis NuGet package is available, you can update your project to use the updated version.
+> If you have previously configured your project to use StackExchange.Redis, you can check for updates to the package from the **NuGet Package Manager**. To check for and install updated versions of the StackExchange.Redis NuGet package, click **Updates** in the **NuGet Package Manager** window. If an update to the StackExchange.Redis NuGet package is available, you can update your project to use the updated version.
 > 
 > 
 

--- a/includes/storsimple-8000-configure-and-register-device-u2.md
+++ b/includes/storsimple-8000-configure-and-register-device-u2.md
@@ -16,7 +16,7 @@
 
 6. Type the following command: `Invoke-HcsSetupWizard`.
 
-7. A setup wizard will appear to help you configure the network settings for the device. Supply the the following information:
+7. A setup wizard will appear to help you configure the network settings for the device. Supply the following information:
    
    * IP address for the DATA 0 network interface
    * Subnet mask

--- a/includes/storsimple-configure-and-register-device-u1.md
+++ b/includes/storsimple-configure-and-register-device-u1.md
@@ -14,7 +14,7 @@
      Complete steps 5-12 to configure the minimum required network settings for your device. **These configuration steps need to be performed on the active controller of the device.** The serial console menu indicates the controller state in the banner message. If you are not connected to the active controller, disconnect and then connect to the active controller.
 5. At the command prompt, type your password. The default device password is **Password1**.
 6. Type the following command: `Invoke-HcsSetupWizard`. 
-7. A setup wizard will appear to help you configure the network settings for the device. Supply the the following information: 
+7. A setup wizard will appear to help you configure the network settings for the device. Supply the following information: 
    
    * IP address for the DATA 0 network interface
    * Subnet mask

--- a/includes/storsimple-configure-and-register-device.md
+++ b/includes/storsimple-configure-and-register-device.md
@@ -16,7 +16,7 @@
 6. Type the following command:
    
      `Invoke-HcsSetupWizard` 
-7. A setup wizard will appear to help you configure the network settings for the device. Supply the the following information: 
+7. A setup wizard will appear to help you configure the network settings for the device. Supply the following information: 
    
    * IP address for the DATA 0 network interface
    * Subnet mask

--- a/includes/virtual-machines-autoscale.md
+++ b/includes/virtual-machines-autoscale.md
@@ -2,7 +2,7 @@
 
 ## Horizontal or vertical scaling
 
-The autoscale feature of Azure Monitor only scales horizontally, which is an increase ("out") or decrease ("in") of the number of VMs. Horizontal scaling is more flexible in a cloud situation as it allows you to run potentially thousands of VMs to handle load. You scale horizontally by either automatically or manually changing the capacity (or instance count) of the the scale set. 
+The autoscale feature of Azure Monitor only scales horizontally, which is an increase ("out") or decrease ("in") of the number of VMs. Horizontal scaling is more flexible in a cloud situation as it allows you to run potentially thousands of VMs to handle load. You scale horizontally by either automatically or manually changing the capacity (or instance count) of the scale set. 
 
 Vertical scaling keeps the same number of VMs, but makes the VMs more ("up") or less ("down") powerful. Power is measured in attributes such as memory, CPU speed, or disk space. Vertical scaling is dependent on the availability of larger hardware, which quickly hits an upper limit and can vary by region. Vertical scaling also usually requires a VM to stop and restart. You scale vertically by setting a new size in the configuration of the VMs in the scale set.
 

--- a/includes/vpn-gateway-modify-lng-gateway-ip-portal-include.md
+++ b/includes/vpn-gateway-modify-lng-gateway-ip-portal-include.md
@@ -17,7 +17,7 @@ Use the example to modify a local network gateway that does not have a gateway c
 2. In the **IP address** box, modify the IP address.
 3. Click **Save** to save the settings.
 
-### <a name="gwipwithconnection"></a>To modify the local network gateway gateway IP address - existing gateway connection
+### <a name="gwipwithconnection"></a>To modify the local network gateway IP address - existing gateway connection
 
 To modify a local network gateway that has a connection, you need to first remove the connection. After the connection is removed, you can modify the gateway IP address and recreate a new connection. You can also modify the address prefixes at the same time. This results in some downtime for your VPN connection. When modifying the gateway IP address, you don't need to delete the VPN gateway. You only need to remove the connection.
  


### PR DESCRIPTION
Playing around with https://github.com/errata-ai/vale to find duplicate words.
Ran `vale includes/` with the following `.vale`
```
# This goes in a file named either `.vale` or `_vale`.

StylesPath = path/to/some/directory
MinAlertLevel = error # suggestion, warning or error

[*.{md,txt}] # Only Markdown and .txt files
# List of styles to load
BasedOnStyles = vale, Joblint
# Style.Rule = {YES, NO, suggestion, warning, error} to
# enable/disable a rule or change its level.
vale.Editorializing = NO
```
Some false positives for:
- Directory directory. EX: for C# samples, but maybe correct for `Azure Active Directory Directory Synchronization