### PR TITLE
Corrected a typo in a resource name.

### DIFF
--- a/articles/virtual-machines/linux/terraform-create-complete-vm.md
+++ b/articles/virtual-machines/linux/terraform-create-complete-vm.md
@@ -105,7 +105,7 @@ resource "azurerm_public_ip" "myterraformpublicip" {
 Network Security Groups control the flow of network traffic in and out of your VM. The following section creates a network security group named *myNetworkSecurityGroup* and defines a rule to allow SSH traffic on TCP port 22:
 
 ```tf
-resource "azurerm_network_security_group" "temyterraformpublicipnsg" {
+resource "azurerm_network_security_group" "myterraformnsg" {
     name                = "myNetworkSecurityGroup"
     location            = "eastus"
     resource_group_name = "${azurerm_resource_group.myterraformgroup.name}"


### PR DESCRIPTION
The resource name for NSG should be "myterraformnsg", not "temyterraformpublicipnsg", which is same as the name in the complete script in the later part of the document.