### PR TITLE
Removing word "bash", restructuring sentence

### DIFF
--- a/articles/api-management/powershell-samples.md
+++ b/articles/api-management/powershell-samples.md
@@ -19,7 +19,7 @@ ms.custom: mvc
 
 # Azure PowerShell samples for API Management
 
-The following table includes links to bash scripts built using the Azure PowerShell.
+The following table contains sample scripts for working with the API Management service from PowerShell.
 
 | | |
 |-|-|


### PR DESCRIPTION
The original sentence was confusing. Use of the word `bash` is misleading, as well as the word `built`. My version is not a lot better, but more clear.