### PR TITLE
Update IoTHubClient_LL_DoWork frequency recommended value

### DIFF
--- a/articles/iot-hub/iot-hub-device-sdk-c-iothubclient.md
+++ b/articles/iot-hub/iot-hub-device-sdk-c-iothubclient.md
@@ -86,7 +86,7 @@ The first three lines create the message, and the last line sends the event. How
 while (1)
 {
     IoTHubClient_LL_DoWork(iotHubClientHandle);
-    ThreadAPI_Sleep(1000);
+    ThreadAPI_Sleep(100);
 }
 ```
 
@@ -104,7 +104,7 @@ IOTHUB_CLIENT_STATUS status;
 while ((IoTHubClient_LL_GetSendStatus(iotHubClientHandle, &status) == IOTHUB_CLIENT_OK) && (status == IOTHUB_CLIENT_SEND_STATUS_BUSY))
 {
     IoTHubClient_LL_DoWork(iotHubClientHandle);
-    ThreadAPI_Sleep(1000);
+    ThreadAPI_Sleep(100);
 }
 ```
 


### PR DESCRIPTION
Usually we recommend running IoTHubClient_LL_DoWork every one hundred milliseconds, not every second. 
The sample should reflect that recommended value.