### PR TITLE
Update service-fabric-networking-modes.md

### DIFF
--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -227,7 +227,23 @@ When a container service restarts or moves to another node in the cluster, the I
      </Endpoints>
    </Resources>
    ```
+   
+6. For Windows, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix in RS5). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
 
+```json
+"fabricSettings": [
+                {
+                    "name": "Setup",
+                    "parameters": [
+                    {
+                            "name": "SkipContainerNetworkResetOnReboot",
+                            "value": "true"
+                    }
+                    ]
+                }
+            ],          
+ ``` 
+ 
 ## Next steps
 * [Understand the Service Fabric application model](service-fabric-application-model.md)
 * [Learn more about the Service Fabric service manifest resources](https://docs.microsoft.com/azure/service-fabric/service-fabric-service-manifest-resources)

--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -228,7 +228,7 @@ When a container service restarts or moves to another node in the cluster, the I
    </Resources>
    ```
    
-6. For Windows, in an upcoming refresh of 6.2, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix is in an upcoming release of Windows Server). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
+6. For Windows, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack. The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
 
 ```json
 "fabricSettings": [

--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -228,7 +228,7 @@ When a container service restarts or moves to another node in the cluster, the I
    </Resources>
    ```
    
-6. For Windows, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix in RS5). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
+6. For Windows, starting from version 6.2 CU3, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix in RS5). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
 
 ```json
 "fabricSettings": [

--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -228,7 +228,7 @@ When a container service restarts or moves to another node in the cluster, the I
    </Resources>
    ```
    
-6. For Windows, starting from version 6.2 CU3, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix is in an upcoming release of Windows Server). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
+6. For Windows, in an upcoming refresh of 6.2, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix is in an upcoming release of Windows Server). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
 
 ```json
 "fabricSettings": [

--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -228,7 +228,7 @@ When a container service restarts or moves to another node in the cluster, the I
    </Resources>
    ```
    
-6. For Windows, starting from version 6.2 CU3, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix in RS5). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
+6. For Windows, starting from version 6.2 CU3, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack (fix is in an upcoming release of Windows Server). The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
 
 ```json
 "fabricSettings": [


### PR DESCRIPTION
To mitigate the issue with open network on RS3 (RDBug 12741931) - we recreate the network on VM reboot. The documentation lets users know how to bypass this default behavior, if needed.