### PR TITLE
Add Pillow pip install requirement.

### DIFF
--- a/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md
+++ b/articles/cognitive-services/Face/Tutorials/FaceAPIinPythonTutorial.md
@@ -55,7 +55,7 @@ Below is an example result. It's a `list` of detected faces. Each item in the li
 
 ## Draw rectangles around the faces
 
-Using the json coordinates that you received from the previous command, you can draw rectangles on the image to visually represent each face. At the top of the file, add the following:
+Using the json coordinates that you received from the previous command, you can draw rectangles on the image to visually represent each face. You will need to `pip install Pillow` to use the `PIL` imaging module.  At the top of the file, add the following:
 
 ```python
 import requests


### PR DESCRIPTION
The PIL being imported is from the Pillow module but could be confused with the now defunct PIL library not available on PyPi.  Spelling out the pip install command would help prevent confusion.