### PR TITLE
Update azure-stack-powershell-download.md

### DIFF
--- a/articles/azure-stack/user/azure-stack-powershell-download.md
+++ b/articles/azure-stack/user/azure-stack-powershell-download.md
@@ -37,6 +37,7 @@ To get these tools, clone the AzureStack-Tools GitHub repository or download the
 cd \
 
 # Download the tools archive
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 invoke-webrequest `
   https://github.com/Azure/AzureStack-Tools/archive/master.zip `
   -OutFile master.zip


### PR DESCRIPTION
Update to match operator documentation at https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-download to set TLS1.2, allowing download from GitHub. Alternatively, make the scripts shared between both the operator and user pages so only one needs to be updated going forward as users and operators share the same tools package.