### PR TITLE
Update configure-authentication-for-federated-users-portal.md

### DIFF
--- a/articles/active-directory/manage-apps/configure-authentication-for-federated-users-portal.md
+++ b/articles/active-directory/manage-apps/configure-authentication-for-federated-users-portal.md
@@ -180,7 +180,7 @@ New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"AccelerateToFe
 The following policy auto-accelerates users to an AD FS sign-in screen there is more than one federated domain in your tenant. If you have more than one federated domain that authenticates users for applications, you need specify the domain to auto-accelerate.
 
 ``` powershell
-New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"AccelerateToFederatedDomain`":true, "PreferredDomain":"federated.example.edu"}}") -DisplayName MultiDomainAutoAccelerationPolicy -Type HomeRealmDiscoveryPolicy
+New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"AccelerateToFederatedDomain`":true, `"PreferredDomain`":`"federated.example.edu`"}}") -DisplayName MultiDomainAutoAccelerationPolicy -Type HomeRealmDiscoveryPolicy
 ```
 
 To create a policy to enable username/password authentication for federated users directly with Azure Active Directory for specific applications, run the following command:


### PR DESCRIPTION
editing line 183 to fix the sample (adding escape character before double-quotes in 4 places)