### PR TITLE
Updated max P2S to remove quota increase note

### DIFF
--- a/includes/vpn-gateway-table-gwtype-aggtput-include.md
+++ b/includes/vpn-gateway-table-gwtype-aggtput-include.md
@@ -12,12 +12,11 @@
 
 |**SKU**   | **S2S/VNet-to-VNet<br>Tunnels** | **P2S<br>Connections** | **Aggregate<br>Throughput Benchmark** |
 |---       | ---                             | ---                    | ---                         |
-|**VpnGw1**| Max. 30                         | Max. 128*              | 650 Mbps                    |
-|**VpnGw2**| Max. 30                         | Max. 128*              | 1 Gbps                      |
-|**VpnGw3**| Max. 30                         | Max. 128*              | 1.25 Gbps                   |
+|**VpnGw1**| Max. 30                         | Max. 128               | 650 Mbps                    |
+|**VpnGw2**| Max. 30                         | Max. 128               | 1 Gbps                      |
+|**VpnGw3**| Max. 30                         | Max. 128               | 1.25 Gbps                   |
 |**Basic** | Max. 10                         | Max. 128               | 100 Mbps                    | 
 
-*Contact support if additional connections are needed
 - Aggregate Throughput Benchmark is based on measurements of multiple tunnels aggregated through a single gateway. It is not a guaranteed throughput due to Internet traffic conditions and your application behaviors.
 
 - Pricing information can be found on the [Pricing](https://azure.microsoft.com/pricing/details/vpn-gateway) page.


### PR DESCRIPTION
As of now, P2S is maxed out at 128 per VPNGW (SSTP & IKEv2) with no option to be raised. I suggest we remove that asterisk regarding support quota increases, as it's not currently possible.

If this has changed, I then suggest we update our docs everywhere to reflect it, taking care to note that SSTP limits will be different than IKEv2 limits.

References:
https://docs.microsoft.com/en-us/azure/vpn-gateway/point-to-site-about#faqcert 
"We support up to 128 VPN clients to be able to connect to a virtual network at the same time."
"There is no change in the maximum number of SSTP connections supported on a gateway with RADIUS authentication. It remains 128. The maximum number of connections supported is 128, irrespective of whether the gateway is configured for SSTP, IKEv2, or both."