### PR TITLE
fixed typo's in twin query samples

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-query-language.md
+++ b/articles/iot-hub/iot-hub-devguide-query-language.md
@@ -163,13 +163,13 @@ SELECT * FROM devices.modules
 We don't allow join between the devices and devices.modules collections. If you want to query module twins across devices, you do do it based on tags. This query will return all module twins across all devices with the scanning status:
 
 ```sql
-Select * from devices.modules where reported.properties.status = 'scanning'
+Select * from devices.modules where properties.reported.status = 'scanning'
 ```
 
 This query will return all module twins with the scanning status, but only on the specified subset of devices.
 
 ```sql
-Select * from devices.modules where reported.properties.status = 'scanning' and deviceId IN ('device1', 'device2')  
+Select * from devices.modules where properties.reported.status = 'scanning' and deviceId IN ('device1', 'device2')  
 ```
 
 ### C# example


### PR DESCRIPTION
properties.reported.status was backwards as reported.properties.status in two of the twin query examples.