### PR TITLE
container-service-limits.md

### DIFF
--- a/includes/container-service-limits.md
+++ b/includes/container-service-limits.md
@@ -2,10 +2,11 @@
 | --- | :--- |
 | Max nodes per cluster | 100 |
 | Max pods per node ([basic networking with Kubenet][basic-networking]) | 110 |
-| Max pods per node ([advanced networking with Azure CNI][advanced-networking]) | 30 |
-| Max cluster per subscription | 20<sup>1</sup> |
+| Max pods per node ([advanced networking with Azure CNI][advanced-networking]) | 30<sup>1</sup> |
+| Max cluster per subscription | 20<sup>2</sup> |
 
-<sup>1</sup> Create an [Azure support request][azure-support] to request a limit increase.<br />
+<sup>1</sup> This value can be customized through ARM template deployment. See examples [here][arm-deployment-example].<br />
+<sup>2</sup> Create an [Azure support request][azure-support] to request a limit increase.<br />
 
 <!-- LINKS - Internal -->
 [basic-networking]: ../articles/aks/networking-overview.md#basic-networking
@@ -13,3 +14,4 @@
 
 <!-- LINKS - External -->
 [azure-support]: https://ms.portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/newsupportrequest
+[arm-deployment-example]: https://github.com/Azure/AKS/blob/master/examples/vnet/02-aks-custom-vnet.json#L64-L69


### PR DESCRIPTION
The max pods per node setting is not a hard limit and can be set via ARM deployment.  This is very important as 30 pods is very low.