### PR TITLE
Change %RoleRoot% to %PathToApp1Install%

### DIFF
--- a/articles/cloud-services/cloud-services-startup-tasks-common.md
+++ b/articles/cloud-services/cloud-services-startup-tasks-common.md
@@ -344,7 +344,7 @@ The simplest way to detect that a task has already run is to create a file in th
 
 ```cmd
 REM   If Task1_Success.txt exists, then Application 1 is already installed.
-IF EXIST "%RoleRoot%\Task1_Success.txt" (
+IF EXIST "%PathToApp1Install%\Task1_Success.txt" (
   ECHO Application 1 is already installed. Exiting. >> "%TEMP%\StartupLog.txt" 2>&1
   GOTO Finish
 )
@@ -357,7 +357,7 @@ IF %ERRORLEVEL% EQU 0 (
   REM   The application installed without error. Create a file to indicate that the task
   REM   does not need to be run again.
 
-  ECHO This line will create a file to indicate that Application 1 installed correctly. > "%RoleRoot%\Task1_Success.txt"
+  ECHO This line will create a file to indicate that Application 1 installed correctly. > "%PathToApp1Install%\Task1_Success.txt"
 
 ) ELSE (
   REM   An error occurred. Log the error and exit with the error code.


### PR DESCRIPTION
This script has bug as  %RoleRoot%  may change.
E.g.  when first time the cloud instance starts,  %RoleRoot% could be "E:\", next time %RoleRoot% could be "F:\".  as a result, the task will be run twice.