### PR TITLE
Fixed the title field to say "Create"

### DIFF
--- a/articles/iot-central/quick-deploy-iot-central.md
+++ b/articles/iot-central/quick-deploy-iot-central.md
@@ -1,5 +1,5 @@
 ---
-title: Deploy an Azure IoT Central application | Microsoft Docs
+title: Create an Azure IoT Central application | Microsoft Docs
 description: Create a new Azure IoT Central application to manage refigerated vending devices. View the telemetry data generated from your simulated devices.
 author: tbhagwat3
 ms.author: tanmayb


### PR DESCRIPTION
Instead of "Deploy"

The title of the article says "Create". So the title field in the metadata area should say the same.