### PR TITLE
Updated array example for strings

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-functions-array.md
+++ b/articles/azure-resource-manager/resource-group-template-functions-array.md
@@ -73,7 +73,7 @@ The following [example template](https://github.com/Azure/azure-docs-json-sample
         },
         "stringToConvert": {
             "type": "string",
-            "defaultValue": "a"
+            "defaultValue": "efgh"
         },
         "objectToConvert": {
             "type": "object",
@@ -104,7 +104,7 @@ The output from the preceding example with the default values is:
 | Name | Type | Value |
 | ---- | ---- | ----- |
 | intOutput | Array | [1] |
-| stringOutput | Array | ["a"] |
+| stringOutput | Array | ["efgh"] |
 | objectOutput | Array | [{"a": "b", "c": "d"}] |
 
 To deploy this example template with Azure CLI, use:


### PR DESCRIPTION
Changed example for array() to make it clear that, given a string argument, it won't create an array of individual characters but an array with one element - the string itself.