### PR TITLE
Removed references to graph endpoint

### DIFF
--- a/articles/azure-stack/user/azure-stack-powershell-configure-user.md
+++ b/articles/azure-stack/user/azure-stack-powershell-configure-user.md
@@ -43,7 +43,6 @@ Based on the type of your Azure Stack deployment (Azure AD or AD FS), run one of
 Make sure you replace the following script variables with values from your Azure Stack configuration:
 
 * AAD tenantName
-* GraphAudience endpoint
 * ArmEndpoint
 
 ### Azure Active Directory (AAD) based deployments
@@ -56,18 +55,10 @@ Make sure you replace the following script variables with values from your Azure
   # For Azure Stack development kit, this value is set to https://management.local.azurestack.external. To get this value for Azure Stack integrated systems, contact your service provider.
   $ArmEndpoint = "<Resource Manager endpoint for your environment>"
 
-  # For Azure Stack development kit, this value is set to https://graph.windows.net/. To get this value for Azure Stack integrated systems, contact your service provider.
-  $GraphAudience = "<GraphAudience endpoint for your environment>"
-
   # Register an AzureRM environment that targets your Azure Stack instance
   Add-AzureRMEnvironment `
     -Name "AzureStackUser" `
     -ArmEndpoint $ArmEndpoint
-
-  # Set the GraphEndpointResourceId value
-  Set-AzureRmEnvironment `
-    -Name "AzureStackUser" `
-    -GraphAudience $GraphAudience
 
   # Get the Active Directory tenantId that is used to deploy Azure Stack
   $TenantID = Get-AzsDirectoryTenantId `
@@ -90,19 +81,10 @@ Make sure you replace the following script variables with values from your Azure
   # For Azure Stack development kit, this value is set to https://management.local.azurestack.external. To get this value for Azure Stack integrated systems, contact your service provider.
   $ArmEndpoint = "<Resource Manager endpoint for your environment>"
 
-  # For Azure Stack development kit, this value is set to https://graph.local.azurestack.external/. To get this value for Azure Stack integrated systems, contact your service provider.
-  $GraphAudience = "<GraphAudience endpoint for your environment>"
-
   # Register an AzureRM environment that targets your Azure Stack instance
   Add-AzureRMEnvironment `
     -Name "AzureStackUser" `
     -ArmEndpoint $ArmEndpoint
-
-  # Set the GraphEndpointResourceId value
-  Set-AzureRmEnvironment `
-    -Name "AzureStackUser" `
-    -GraphAudience $GraphAudience `
-    -EnableAdfsAuthentication:$true
 
   # Get the Active Directory tenantId that is used to deploy Azure Stack
   $TenantID = Get-AzsDirectoryTenantId `


### PR DESCRIPTION
Earlier version of AzureRm.Profile didn't set GraphAudience correctly - soi that had to be done manually - that has been fixed for some time and is no longer necessary.