### PR TITLE
Update automation-create-runas-account.md

### DIFF
--- a/articles/automation/automation-create-runas-account.md
+++ b/articles/automation/automation-create-runas-account.md
@@ -14,7 +14,7 @@ manager: carmonm
 # Update your Automation account authentication with Run As accounts 
 You can update your existing Automation account from the Azure portal or use PowerShell if:
 
-* You create an Automation account in the Portal but decline to create the Run As account.
+* You create an Automation account but do not create the Run As account.
 * You already use an Automation account to manage Resource Manager resources and you want to update the account to include the Run As account for runbook authentication.
 * You already use an Automation account to manage classic resources and you want to update it to use the Classic Run As account instead of creating a new account and migrating your runbooks and assets to it.   
 

--- a/articles/automation/automation-create-runas-account.md
+++ b/articles/automation/automation-create-runas-account.md
@@ -14,7 +14,7 @@ manager: carmonm
 # Update your Automation account authentication with Run As accounts 
 You can update your existing Automation account from the Azure portal or use PowerShell if:
 
-* You create an Automation account but decline to create the Run As account.
+* You create an Automation account in the Portal but decline to create the Run As account.
 * You already use an Automation account to manage Resource Manager resources and you want to update the account to include the Run As account for runbook authentication.
 * You already use an Automation account to manage classic resources and you want to update it to use the Classic Run As account instead of creating a new account and migrating your runbooks and assets to it.   
 


### PR DESCRIPTION
This is stated:
"You create an Automation account but decline to create the Run As account."

As far as I can figure out this is only true for the Portal. New-AzureRmAutomationAccount does not allow you to create a Run As Account.