### PR TITLE
Make endpoint key description more clear

### DIFF
--- a/articles/cognitive-services/QnAMaker/How-To/metadata-generateanswer-usage.md
+++ b/articles/cognitive-services/QnAMaker/How-To/metadata-generateanswer-usage.md
@@ -52,7 +52,7 @@ You call GenerateAnswer with an HTTP POST request. For sample code that shows ho
     - **QnAMaker endpoint** (string): The hostname of the endpoint deployed in your Azure subscription.
 - **Request headers**
     - **Content-Type** (string): The media type of the body sent to the API.
-    - **Authorization** (string): Your endpoint key (EndpointKey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+    - **Authorization** (string): Your endpoint key (EndpointKey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
 - **Request body**
     - **question** (string): A user question to be queried against your knowledge base.
     - **top** (optional, integer): The number of ranked results to include in the output. The default value is 1.

--- a/articles/cognitive-services/QnAMaker/How-To/metadata-generateanswer-usage.md
+++ b/articles/cognitive-services/QnAMaker/How-To/metadata-generateanswer-usage.md
@@ -52,7 +52,7 @@ You call GenerateAnswer with an HTTP POST request. For sample code that shows ho
     - **QnAMaker endpoint** (string): The hostname of the endpoint deployed in your Azure subscription.
 - **Request headers**
     - **Content-Type** (string): The media type of the body sent to the API.
-    - **Authorization** (string): Your endpoint key.
+    - **Authorization** (string): Your endpoint key (EndpointKey xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
 - **Request body**
     - **question** (string): A user question to be queried against your knowledge base.
     - **top** (optional, integer): The number of ranked results to include in the output. The default value is 1.


### PR DESCRIPTION
It took me some 15 minutes to understand that the word "EndpointKey" has to be in the header value for Authorization in addition to the key itself. This should make it transparent.