### PR TITLE
Use local filesystem in AWS service fabric

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-standalone-create-service-fabric-cluster.md
+++ b/articles/service-fabric/service-fabric-tutorial-standalone-create-service-fabric-cluster.md
@@ -56,13 +56,7 @@ After updating the nodes, they appear as follows:
         }
 ```
 
-Then you need to update a couple of the properties.  On line 34, you need to modify the connection string for the diagnostic store it should look like this after modification, with your IP address replaced in `"connectionstring": "\\\\172.31.27.1\\c$\\DiagnosticsStore"`
-
-After you update the connection string be sure to create the folder.  The following command will create it, be sure to replace the ip address below with the IP address you inserted into the connection string:
-
-```powershell
-mkdir \\172.31.27.1\c$\DiagnosticsStore
-```
+Then you need to update a couple of the properties.  On line 34, you need to modify the connection string for the diagnostic store it should look like this `"connectionstring": "C:\\ProgramData\\SF\\DiagnosticsStore"`
 
 Finally, in the `nodeTypes` section of the configuration add a new section to map the ephemeral ports that windows will use.  The configuration file should like like the following:
 


### PR DESCRIPTION
The AWS tutorial does not join the machines to an Active Directory, instead electing to use the same Administrator password for all machines.

Service Fabric executables run under service accounts that do not share the same password across different machines. Setting up a file share on a single node is a bad idea because none of the other nodes will have write access to the file share. This will cause services that depend on file share access to fail at certain points, such as when updating the cluster.