### PR TITLE
Wording clarification

### DIFF
--- a/includes/cloud-shell-persisting-shell-storage-introblock.md
+++ b/includes/cloud-shell-persisting-shell-storage-introblock.md
@@ -19,7 +19,7 @@ When you use basic settings and select only a subscription, Cloud Shell creates 
 The file share mounts as `clouddrive` in your `$Home` directory. This is a one-time action, and the file share mounts automatically in subsequent sessions. 
 
 > [!NOTE]
-> For security, each user should provision their own storage.  For role-based access control (RBAC), users must have contributor access or above.
+> For security, each user should provision their own storage account.  For role-based access control (RBAC), users must have contributor access or above at the storage account level.
 
 In Bash, the file share also contains a 5-GB image that is created for you which automatically persists data in your `$Home` directory. 
 


### PR DESCRIPTION
Added clarification on note about security.  One storage account for each user.  Could be confused with one storage account with multiple file shares