### PR TITLE
Alligned tenant property with Data Lake Store Gen1

### DIFF
--- a/articles/data-factory/transform-data-using-data-lake-analytics.md
+++ b/articles/data-factory/transform-data-using-data-lake-analytics.md
@@ -54,7 +54,7 @@ Use service principal authentication by specifying the following properties:
 | :---------------------- | :--------------------------------------- | :------- |
 | **servicePrincipalId**  | Specify the application's client ID.     | Yes      |
 | **servicePrincipalKey** | Specify the application's key.           | Yes      |
-| **tenant**              | Specify the tenant information (tenant ID) under which your application resides. You can retrieve it by hovering the mouse in the upper-right corner of the Azure portal. | Yes      |
+| **tenant**              | Specify the tenant information (domain name or tenant ID) under which your application resides. You can retrieve it by hovering the mouse in the upper-right corner of the Azure portal. | Yes      |
 
 **Example: Service principal authentication**
 ```json
@@ -70,7 +70,7 @@ Use service principal authentication by specifying the following properties:
                 "value": "<service principal key>",
                 "type": "SecureString"
             },
-            "tenant": "<tenant ID>",
+            "tenant": "<tenant info, e.g. microsoft.onmicrosoft.com>",
             "subscriptionId": "<optional, subscription id of ADLA>",
             "resourceGroupName": "<optional, resource group name of ADLA>"
         },

--- a/articles/data-factory/transform-data-using-data-lake-analytics.md
+++ b/articles/data-factory/transform-data-using-data-lake-analytics.md
@@ -54,7 +54,7 @@ Use service principal authentication by specifying the following properties:
 | :---------------------- | :--------------------------------------- | :------- |
 | **servicePrincipalId**  | Specify the application's client ID.     | Yes      |
 | **servicePrincipalKey** | Specify the application's key.           | Yes      |
-| **tenant**              | Specify the tenant information (domain name or tenant ID) under which your application resides. You can retrieve it by hovering the mouse in the upper-right corner of the Azure portal. | Yes      |
+| **tenant**              | Specify the tenant information (tenant ID) under which your application resides. You can retrieve it by hovering the mouse in the upper-right corner of the Azure portal. | Yes      |
 
 **Example: Service principal authentication**
 ```json


### PR DESCRIPTION
The description of the `tenant` stated incorrectly that domain name is an valid option.
But at this moment the U-SQL Activity only accepts *tenant ID* as option.