### PR TITLE
Provision will fail if TEMP path is incorrect

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -93,6 +93,12 @@ On the VM that you plan to upload to Azure, run all commands in the following st
     ```PowerShell
     powercfg /setactive SCHEME_MIN
     ```
+6. Ensure the TEMP and TMP path environment variables are set to default %SystemRoot%\TEMP
+    ```PowerShell
+    C:\>reg query "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" | find /i "temp"
+    TEMP    REG_EXPAND_SZ    %SystemRoot%\TEMP
+    TMP    REG_EXPAND_SZ    %SystemRoot%\TEMP
+    ```
 
 ## Check the Windows services
 Make sure that each of the following Windows services is set to the **Windows default values**. These are the minimum numbers of services that must be set up to make sure that the VM has connectivity. To reset the startup settings, run the following commands:


### PR DESCRIPTION
CRIs 63063500 and 75637687
VM provisioning failed because customers overrode the TEMP and TMP path variables.
these variables must be set to default.

Causes provisioning timeout:
C:\>reg query "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" | find /i "temp"
    TEMP    REG_SZ    D:\System2\TEMP
    TMP    REG_SZ    D:\System2\TEMP

Windows default values:
C:\>reg query "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" | find /i "temp"
    TEMP    REG_EXPAND_SZ    %SystemRoot%\TEMP
    TMP    REG_EXPAND_SZ    %SystemRoot%\TEMP