### PR TITLE
Connect to virtual machine - #4 - formatting fix

### DIFF
--- a/articles/virtual-machines/windows/quick-create-portal.md
+++ b/articles/virtual-machines/windows/quick-create-portal.md
@@ -61,11 +61,11 @@ Create a remote desktop connection to the virtual machine. These directions tell
 	
 2. In the **Connect to virtual machine** page, keep the default options to connect by DNS name over port 3389 and click **Download RDP file**.
 
-2. Open the downloaded RDP file and click **Connect** when prompted. 
+3. Open the downloaded RDP file and click **Connect** when prompted. 
 
-3. In the **Windows Security** window, select **More choices** and then **Use a different account**. Type the username as *vmname*\*username*, enter password you created for the virtual machine, and then click **OK**.
+4. In the **Windows Security** window, select **More choices** and then **Use a different account**. Type the username as *vmname*\\*username*, enter password you created for the virtual machine, and then click **OK**.
 
-4. You may receive a certificate warning during the sign-in process. Click **Yes** or **Continue** to create the connection.
+5. You may receive a certificate warning during the sign-in process. Click **Yes** or **Continue** to create the connection.
 
 ## Install web server
 


### PR DESCRIPTION
Fixed the Markdown formatting for Connect to virtual machine #4 so that the backslash in "vmname\username" is rendered correctly.

also fixed the numbering of these same items.