### PR TITLE
Incorrect value of Standard_F1 max data disk IOPS

### DIFF
--- a/articles/azure-stack/user/azure-stack-vm-sizes.md
+++ b/articles/azure-stack/user/azure-stack-vm-sizes.md
@@ -104,7 +104,7 @@ General purpose VM sizes provide a balanced CPU-to-memory ratio. They are used f
 
 |Size     |vCPU     |Memory (GiB) | Temp storage (GiB)  | Max OS disk throughput (IOPS) | Max temp storage throughput (IOPS) | Max data disks / throughput (IOPS) | Max NICs / expected network bandwidth (Mbps) |
 |-----------------|----|----|-----|----|------|------------|---------|
-|**Standard_F1**  |1   |2   |16   |500 |3000  |4 / 4x400   |2 / 750  |
+|**Standard_F1**  |1   |2   |16   |500 |3000  |4 / 4x500   |2 / 750  |
 |**Standard_F2**  |2   |4   |32   |500 |6000  |8 / 8x500   |2 / 1500 |
 |**Standard_F4**  |4   |8   |64   |500 |12000 |16 / 16x500 |4 / 3000 |
 |**Standard_F8**  |8   |16  |128  |500 |24000 |32 / 32x500 |8 / 6000 |


### PR DESCRIPTION
Max data disk throughput (IOPS) of Standard_F1 should be "4 / 4x500".