### PR TITLE
dead link

### DIFF
--- a/articles/cognitive-services/translator-speech/quickstarts/csharp.md
+++ b/articles/cognitive-services/translator-speech/quickstarts/csharp.md
@@ -19,7 +19,7 @@ This article shows you how to use the Microsoft Translator Speech API to transla
 
 You will need [Visual Studio 2017](https://www.visualstudio.com/downloads/) to run this code on Windows. (The free Community Edition will work.)
 
-You will need a .wav file named "speak.wav" in the same folder as the executable you compile from the code below. This .wav file should be in standard PCM, 16bit, 16kHz, mono format. You can obtain such a .wav file from the [Translator Text Speak API](http://docs.microsofttranslator.com/text-translate.html#!/default/get_Speak).
+You will need a .wav file named "speak.wav" in the same folder as the executable you compile from the code below. This .wav file should be in standard PCM, 16bit, 16kHz, mono format. 
 
 You must have a [Cognitive Services API account](https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account) with **Microsoft Translator Speech API**. You will need a paid subscription key from your [Azure dashboard](https://portal.azure.com/#create/Microsoft.CognitiveServices).
 


### PR DESCRIPTION
We cannot obtain such a .wav file from the Translator Text Speak API. Because it is dead link.