### PR TITLE
Fix "Too many binary messages"

### DIFF
--- a/articles/cognitive-services/translator-speech/quickstarts/csharp.md
+++ b/articles/cognitive-services/translator-speech/quickstarts/csharp.md
@@ -59,11 +59,12 @@ namespace TranslateSpeechQuickStart
 
             /* Make sure the audio file is followed by silence.
              * This lets the service know that the audio input is finished. */
-            var silence = new byte[3200000];
+            var silence = new byte[32000];
             var silence_buffer = new ArraySegment<byte>(silence);
             await client.SendAsync(silence_buffer, WebSocketMessageType.Binary, true, CancellationToken.None);
 
             Console.WriteLine("Done sending.");
+            System.Threading.Thread.Sleep(3000);
             await client.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
         }
 


### PR DESCRIPTION
This codes doesn't work. "Too many binary messages" is occured. 

First, silence buffer is too large on this WebSocket.
Seconds, WebSocket will be closed before recieving response.