### PR TITLE
Remove improper Docker references (ARM)

### DIFF
--- a/articles/iot-edge/how-to-install-iot-edge-linux-arm.md
+++ b/articles/iot-edge/how-to-install-iot-edge-linux-arm.md
@@ -22,11 +22,9 @@ This article lists the steps to install the Azure IoT Edge runtime on a Linux AR
 
 ## Install the container runtime
 
-Azure IoT Edge relies on a [OCI-compatible][lnk-oci] container runtime (e.g. Docker). If you already have Docker CE/EE installed on your Edge device, you can continue to use it for development and testing with Azure IoT Edge. 
+Azure IoT Edge relies on a [OCI-compatible][lnk-oci] container runtime. For production scenarios, it is highly recommended you use the [Moby-based][lnk-moby] engine provided below. It is the only container engine officially supported with Azure IoT Edge. Docker CE/EE container images are compatible with the Moby-based runtime.
 
-For production scenarios, it is highly recommended you use the [Moby-based][lnk-moby] engine provided below. It is the only container engine officially supported with Azure IoT Edge. Docker CE/EE container images are fully compatible with the Moby runtime.
-
-Commands below install both moby engine and command-line interface (CLI). The CLI is useful for development but optional for production deployments.
+Commands below install both the Moby-based engine and command-line interface (CLI). The CLI is useful for development but optional for production deployments.
 
 ```cmd/sh
 


### PR DESCRIPTION
Docker CE/EE licenses prevent embedding of those Docker products in other services/products, such as Azure IoT Edge, which is why the moby solution was adopted. This PR removes references to that effect, and to Docker as a general technology (the Docker mark references Docker, Inc).