### PR TITLE
Updated PowerShell sample to fix timestamp

### DIFF
--- a/articles/log-analytics/log-analytics-data-collector-api.md
+++ b/articles/log-analytics/log-analytics-data-collector-api.md
@@ -224,8 +224,8 @@ $SharedKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # Specify the name of the record type that you'll be creating
 $LogType = "MyRecordType"
 
-# Specify a field with the created time for the records
-$TimeStampField = "DateValue"
+# You can use an optional field to specify the timestamp from the data. If the time field is not specified, Log Analytics assumes the time is the message ingestion time
+$TimeStampField = ""
 
 
 # Create two records with the same set of properties to create


### PR DESCRIPTION
Using the PowerShell sample, the dates of the records were being coded to a date in 2016 and not showing up in recent searches. To replicate the C# sample, update the comment and blanked the date field so the record shows up with a time generated of the ingestion time.