### PR TITLE
Update quickstart.experimental.md

### DIFF
--- a/articles/iot-edge/quickstart.experimental.md
+++ b/articles/iot-edge/quickstart.experimental.md
@@ -84,8 +84,9 @@ The instructions in this section configure the IoT Edge runtime with Linux conta
   Expand-Archive .\iotedged-windows.zip C:\ProgramData\iotedge -f
   Move-Item c:\ProgramData\iotedge\iotedged-windows\* C:\ProgramData\iotedge\ -Force
   rmdir C:\ProgramData\iotedge\iotedged-windows
-  $env:Path += ";C:\ProgramData\iotedge"
-  SETX /M PATH "$env:Path"
+  $sysenv = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment"
+  $path = (Get-ItemProperty -Path $sysenv -Name Path).Path + ";C:\ProgramData\iotedge"
+  Set-ItemProperty -Path $sysenv -Name Path -Value $path
   ```
 
 3. Install the vcruntime.


### PR DESCRIPTION
The Windows quickstart instructs users to update their system PATH environment variable using `SETX /M PATH "$env:Path"`. This is problematic because `$env:Path` is an aggregation of system _and user_ paths, so the command appends more than was intended; the resulting **system** PATH ends up looking like this: `<old system PATH>;<user-local PATH>;C:\ProgramData\iotedge`.

This change updates the docs with powershell commands that surgically target the system path in the registry, rather than using `SETX`.