### PR TITLE
link module composition was missing

### DIFF
--- a/articles/iot-edge/how-to-create-transparent-gateway-linux.md
+++ b/articles/iot-edge/how-to-create-transparent-gateway-linux.md
@@ -187,6 +187,7 @@ Refer to the [module composition article][lnk-module-composition] for more detai
 <!-- Links -->
 [lnk-install-linux-x64]: ./how-to-install-iot-edge-linux.md
 [lnk-install-linux-arm]: ./how-to-install-iot-edge-linux-arm.md
+[lnk-module-composition]: ./module-composition.md
 [lnk-devicesdk]: ../iot-hub/iot-hub-devguide-sdks.md
 [lnk-tutorial1-win]: tutorial-simulate-device-windows.md
 [lnk-tutorial1-lin]: tutorial-simulate-device-linux.md


### PR DESCRIPTION
added ./module-composition.md to the list of links. As seen in Windows doc twin