### PR TITLE
add note for ServiceBus package inclusion

### DIFF
--- a/articles/azure-functions/functions-bindings-event-hubs.md
+++ b/articles/azure-functions/functions-bindings-event-hubs.md
@@ -364,8 +364,7 @@ The [host.json](functions-host-json.md#eventhub) file contains settings that con
 
 Use the Event Hubs output binding to write events to an event stream. You must have send permission to an event hub to write events to it.
 
-> [!NOTE]
-> Ensure the required package references are in place: [Functions 1.x](#packages---functions-1.x) or [Functions 2.x](#packages---functions-2.x) 
+Ensure the required package references are in place: [Functions 1.x](#packages---functions-1.x) or [Functions 2.x](#packages---functions-2.x) 
 
 ## Output - example
 

--- a/articles/azure-functions/functions-bindings-event-hubs.md
+++ b/articles/azure-functions/functions-bindings-event-hubs.md
@@ -364,6 +364,9 @@ The [host.json](functions-host-json.md#eventhub) file contains settings that con
 
 Use the Event Hubs output binding to write events to an event stream. You must have send permission to an event hub to write events to it.
 
+> [!NOTE]
+> Ensure the required package references are in place: [Functions 1.x](#packages---functions-1.x) or [Functions 2.x](#packages---functions-2.x) 
+
 ## Output - example
 
 See the language-specific example:


### PR DESCRIPTION
When working in Visual Studio, if you create an event hubs trigger project, you get the package references that you need (Microsoft.Azure.WebJobs.ServiceBus, etc). 

However, if you want a function triggered some other way (for example queue storage) and want to output to event hub, the package reference isn't there. This PR adds a note to the section on usage of event hubs for output, reminding the user to add these references.