### PR TITLE
M27749: Possible typo "five" at line 154

### DIFF
--- a/articles/cognitive-services/Speech-Service/prepare-transcription.md
+++ b/articles/cognitive-services/Speech-Service/prepare-transcription.md
@@ -151,7 +151,7 @@ Apply the following normalization to your text before importing it.
 *   Decimal point should be "," and not "."
 *   Time separator between hours and minutes should be ":" and not ".": 12:00 Uhr
 *   Abbreviations such as 'ca.' aren't replaced. We recommend you use the full form.
-*   The five main mathematical operators are removed: +, -, \*, /. We recommend replacing them with their literal form: plus, minus, mal, geteilt.
+*   The four main mathematical operators are removed: +, -, \*, /. We recommend replacing them with their literal form: plus, minus, mal, geteilt.
 *   Same applies for comparison operators (=, <, >) - gleich, kleiner als, grösser als
 *   Use fractions, such as 3/4, in word form (such as 'drei viertel' instead of ¾)
 *   Replace the € symbol with the word form "Euro"


### PR DESCRIPTION
Hello, @panosper,
Translator has reported possible source content issue. 
"Change ""five"" to ""four"", since there are only four operators being referenced."

Please review and merge the suggested proposed file change to avoid this error. If you make related fix in another PR, then share your PR number, so we can confirm and close this PR.

Many thanks in advance.