### PR TITLE
Update integrate with azure change

### DIFF
--- a/articles/aks/integrate-azure.md
+++ b/articles/aks/integrate-azure.md
@@ -48,7 +48,7 @@ helm install svc-cat/catalog --name catalog --namespace catalog --set controller
 If your cluster is not RBAC-enabled, run this command.
 
 ```azurecli-interactive
-helm install svc-cat/catalog --name catalog --namespace catalog --set rbacEnable=false --set apiserver.auth.enabled=false --set controllerManager.healthcheck.enabled=false
+helm install svc-cat/catalog --name catalog --namespace catalog --set rbacEnable=false --set controllerManager.healthcheck.enabled=false
 ```
 
 After the Helm chart has been run, verify that `servicecatalog` appears in the output of the following command:


### PR DESCRIPTION
Removing --set apiserver.auth.enabled=false from the non-RBAC cluster instructions. We got a couple of issues w/r/t to this line, it seems to cause issues and removing it works correctly.