### PR TITLE
Update location with "[resourceGroup().location]"

### DIFF
--- a/articles/load-balancer/load-balancer-standard-availability-zones.md
+++ b/articles/load-balancer/load-balancer-standard-availability-zones.md
@@ -73,7 +73,7 @@ Use the following script to create a zone-redundant frontend IP address for your
             "apiVersion": "2017-08-01",
             "type": "Microsoft.Network/loadBalancers",
             "name": "load_balancer_standard",
-            "location": "region",
+            "location": "[resourceGroup().location]",
             "sku":
             {
                 "name": "Standard"
@@ -107,7 +107,7 @@ Use the following script to create a zonal Standard Public IP address in Availab
             "apiVersion": "2017-08-01",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "public_ip_standard",
-            "location": "region",
+            "location": "[resourceGroup().location]",
             "zones": [ "1" ],
             "sku":
             {


### PR DESCRIPTION
Update location with "[resourceGroup().location]" because region is not validated, created confusion to readers in terms of utilisation