### PR TITLE
Add context parameter to sample definition for Image Analysis Skill

### DIFF
--- a/articles/search/cognitive-search-skill-image-analysis.md
+++ b/articles/search/cognitive-search-skill-image-analysis.md
@@ -43,6 +43,7 @@ Parameters are case-sensitive.
 ```json
 {
     "@odata.type": "#Microsoft.Skills.Vision.ImageAnalysisSkill",
+    "context": "/document/normalized_images/*",
     "visualFeatures": [
         "Tags",
         "Faces",


### PR DESCRIPTION
The sample definition for the Image Analysis Skill doesn't work as written, this change fixes that.