### PR TITLE
Example broken

### DIFF
--- a/articles/virtual-machines/windows/convert-disk-storage.md
+++ b/articles/virtual-machines/windows/convert-disk-storage.md
@@ -127,10 +127,10 @@ $storageType = 'StandardSSD_LRS'
 $disk = Get-AzureRmDisk -DiskName $diskName -ResourceGroupName $rgName
 
 # Get parent VM resource
-$vmResource = Get-AzureRmResource -ResourceId $disk.diskId
+$vmResource = Get-AzureRmResource -ResourceId $disk.ManagedBy
 
 # Stop and deallocate the VM before changing the storage type
-Stop-AzureRmVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force
+Stop-AzureRmVM -ResourceGroupName $vmResource.ResourceGroupName -Name $vmResource.Name -Force
 
 $vm = Get-AzureRmVM $vmResource.ResourceGroupName -Name $vmResource.ResourceName 
 


### PR DESCRIPTION
Several incorrect variable references in the example were fixed