### PR TITLE
M28802: Clarification about API names

### DIFF
--- a/articles/cognitive-services/Face/APIReference.md
+++ b/articles/cognitive-services/Face/APIReference.md
@@ -1,3 +1,5 @@
+<!-- Linguist question: Please confirm that the following are API names and should be left as is: "Person Management, LargePersonGroup/PersonGroup Management, LargeFaceList/FaceList Management, and Face Algorithms" -->
+
 ---
 title: API Reference for the Face API Service | Microsoft Docs
 titleSuffix: "Microsoft Cognitive Services"


### PR DESCRIPTION
Hello, @SteveMSFT,  
Translator has a question regarding some API names. 
Please confirm that the following are API names and should be left as is: "Person Management, LargePersonGroup/PersonGroup Management, LargeFaceList/FaceList Management, and Face Algorithms"

Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.