### PR TITLE
Fixed parameter in example code.

### DIFF
--- a/articles/log-analytics/log-analytics-agent-windows.md
+++ b/articles/log-analytics/log-analytics-agent-windows.md
@@ -120,7 +120,7 @@ To retrieve the product code from the agent install package directly, you can us
 	    $OPSINSIGHTS_WS_KEY = Get-AutomationVariable -Name "OPSINSIGHTS_WS_KEY"
 
 	    Import-DscResource -ModuleName xPSDesiredStateConfiguration
-        Import-DscResource –ModuleName PSDesiredStateConfiguration
+        Import-DscResource -ModuleName PSDesiredStateConfiguration
 
 	    Node OMSnode {
 		    Service OIService


### PR DESCRIPTION
"–ModuleName" in the example code was using the wrong dash "–" instead of "-" which could cause problems if example is copied and pasted.