### PR TITLE
Updating the OpenSSL package dir for Windows

### DIFF
--- a/articles/iot-edge/how-to-create-transparent-gateway-windows.md
+++ b/articles/iot-edge/how-to-create-transparent-gateway-windows.md
@@ -50,7 +50,7 @@ The following steps walk you through the process of creating the certificates an
          ```PowerShell
          .\vcpkg install openssl:x64-windows
          ```
-      1. Add `$VCPKGDIR\vcpkg\packages\openssl-windows_x64-windows\tools\openssl` to your `PATH` environment variable so that the `openssl.exe` file is available for invocation.
+      1. Add `$VCPKGDIR\installed\x64-windows\tools\openssl` to your `PATH` environment variable so that the `openssl.exe` file is available for invocation.
 
 1. Navigate to the directory in which you want to work. From here on we'll refer to this as $WRKDIR.  All files will be created in this directory.
    

--- a/articles/iot-edge/how-to-create-transparent-gateway-windows.md
+++ b/articles/iot-edge/how-to-create-transparent-gateway-windows.md
@@ -50,7 +50,7 @@ The following steps walk you through the process of creating the certificates an
          ```PowerShell
          .\vcpkg install openssl:x64-windows
          ```
-      1. Add `$VCPKGDIR\vcpkg\packages\openssl_x64-windows\tools\openssl` to your `PATH` environment variable so that the `openssl.exe` file is available for invocation.
+      1. Add `$VCPKGDIR\vcpkg\packages\openssl-windows_x64-windows\tools\openssl` to your `PATH` environment variable so that the `openssl.exe` file is available for invocation.
 
 1. Navigate to the directory in which you want to work. From here on we'll refer to this as $WRKDIR.  All files will be created in this directory.
    


### PR DESCRIPTION
VCPkg has introduced a breaking change by changing the OpenSSL package install directory. The changes here conform to the new path.