### PR TITLE
Add TLS workaround for custom skills

### DIFF
--- a/articles/search/cognitive-search-create-custom-skill-example.md
+++ b/articles/search/cognitive-search-create-custom-skill-example.md
@@ -245,7 +245,7 @@ All Azure Functions created after June 30th, 2018 have disabled TLS 1.0, which i
 
 1. In the [Azure portal](https://portal.azure.com), navigate to the Resource Group, and look for the Translate Function you published. Under the **Platform features** section, you should see SSL.
 
-1. After selecting SSL, you should change the **Minimum TLS version** to 1.0. This is only a workaround, and TLS 1.2 will eventually be supported.
+1. After selecting SSL, you should change the **Minimum TLS version** to 1.0. TLS 1.2 functions are not yet supported as custom skills.
 
 ## Test the function in Azure
 

--- a/articles/search/cognitive-search-create-custom-skill-example.md
+++ b/articles/search/cognitive-search-create-custom-skill-example.md
@@ -239,6 +239,13 @@ When you are satisfied with the function behavior, you can publish it.
 
 1. In the [Azure portal](https://portal.azure.com), navigate to the Resource Group, and look for the Translate Function you published. Under the **Manage** section, you should see Host Keys. Select the **Copy** icon for the *default* host key.  
 
+## Update SSL Settings
+
+All Azure Functions created after June 30th, 2018 have disabled TLS 1.0, which is not currently compatible with custom skills.
+
+1. In the [Azure portal](https://portal.azure.com), navigate to the Resource Group, and look for the Translate Function you published. Under the **Platform features** section, you should see SSL.
+
+1. After selecting SSL, you should change the **Minimum TLS version** to 1.0. This is only a workaround, and TLS 1.2 will eventually be supported.
 
 ## Test the function in Azure
 


### PR DESCRIPTION
Unfortunately, Cognitive Search is not compatible with the recent Azure Function TLS 1.2 deadline. We are working on a fix, but I'm including information about a workaround right now