### PR TITLE
Updated the AzCopy paramter in Windows

### DIFF
--- a/articles/storage/common/storage-use-azcopy-migrate-on-premises-data.md
+++ b/articles/storage/common/storage-use-azcopy-migrate-on-premises-data.md
@@ -66,7 +66,7 @@ You can use AzCopy to upload all files in a folder to Blob storage on [Windows](
         --recursive
 
 # [Windows](#tab/windows)
-    AzCopy /Source:C:\myfolder /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey: key /S
+    AzCopy /Source:C:\myfolder /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey:<key> /S
 ---
 
 Replace `<key>` and `key` with your account key. In the Azure portal, you can retrieve your account key by selecting **Access keys** under **Settings** in your storage account. Select a key, and paste it into the AzCopy command. If the specified destination container does not exist, AzCopy creates it and uploads the file into it. Update the source path to your data directory, and replace **myaccount** in the destination URL with your storage account name.
@@ -87,7 +87,7 @@ If you only want to copy source resources that do not exist in the destination, 
     --exclude-older
 
 # [Windows](#tab/windows)
-    AzCopy /Source:C:\myfolder /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey: key /S /XO
+    AzCopy /Source:C:\myfolder /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey:<key> /S /XO
 ---
 
 ## Create a scheduled task or cron job 
@@ -100,7 +100,7 @@ Copy the AzCopy command to a text editor. Update the parameter values of the AzC
 
 # [Windows](#tab/windows)
     cd C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy
-    AzCopy /Source: C:\myfolder  /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey: key /V /XO /XN >C:\Path\to\logfolder\azcopy%date:~-4,4%%date:~-7,2%%date:~-10,2%%time:~-11,2%%time:~-8,2%%time:~-5,2%.log
+    AzCopy /Source: C:\myfolder  /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey:<key> /V /XO /XN >C:\Path\to\logfolder\azcopy%date:~-4,4%%date:~-7,2%%date:~-10,2%%time:~-11,2%%time:~-8,2%%time:~-5,2%.log
 ---
 
 AzCopy is run with the verbose `--verbose` (Linux) or `/V` (Windows) option. The output is redirected into a log file. 


### PR DESCRIPTION
The some of customer confuse during copy and past operation by this tutorial coused by there is white-space in key. Here looks better to easy understand how to use AzCopy command tool.

AzCopy /Source:C:\myfolder /Dest:https://myaccount.blob.core.windows.net/mycontainer /DestKey:<key> /S /XO