### PR TITLE
use right terms of VM in Azure and AWS

### DIFF
--- a/articles/automation/automation-dsc-onboarding.md
+++ b/articles/automation/automation-dsc-onboarding.md
@@ -6,7 +6,6 @@ ms.service: automation
 ms.component: dsc
 author: georgewallace
 ms.author: gwallace
-ms.date: 03/16/2018
 ms.topic: conceptual
 manager: carmonm
 ---
@@ -18,8 +17,7 @@ Like [PowerShell Desired State Configuration](https://technet.microsoft.com/libr
 
 Azure Automation DSC can be used to manage a variety of machines:
 
-* Azure virtual machines ( classic )
-* Azure virtual machines ( Azure Resource Manager )
+* Azure virtual machines ( deployed both in classic and Azure Resource Manager deployment model )
 * Amazon Web Services (AWS) EC2 instances 
 * Physical/virtual Windows machines on-premises, or in a cloud other than Azure/AWS
 * Physical/virtual Linux machines on-premises, in Azure, or in a cloud other than Azure

--- a/articles/automation/automation-dsc-onboarding.md
+++ b/articles/automation/automation-dsc-onboarding.md
@@ -18,9 +18,8 @@ Like [PowerShell Desired State Configuration](https://technet.microsoft.com/libr
 
 Azure Automation DSC can be used to manage a variety of machines:
 
-* Azure virtual machines (classic)
-* Azure virtual machines
-* Amazon Web Services (AWS) virtual machines
+* Azure virtual machines ( both classic VMs and ARM VMs)
+* Amazon Web Services (AWS) EC2 instances 
 * Physical/virtual Windows machines on-premises, or in a cloud other than Azure/AWS
 * Physical/virtual Linux machines on-premises, in Azure, or in a cloud other than Azure
 

--- a/articles/automation/automation-dsc-onboarding.md
+++ b/articles/automation/automation-dsc-onboarding.md
@@ -18,7 +18,8 @@ Like [PowerShell Desired State Configuration](https://technet.microsoft.com/libr
 
 Azure Automation DSC can be used to manage a variety of machines:
 
-* Azure virtual machines ( both classic VMs and ARM VMs)
+* Azure virtual machines ( classic )
+* Azure virtual machines ( Azure Resource Manager )
 * Amazon Web Services (AWS) EC2 instances 
 * Physical/virtual Windows machines on-premises, or in a cloud other than Azure/AWS
 * Physical/virtual Linux machines on-premises, in Azure, or in a cloud other than Azure

--- a/articles/automation/automation-dsc-onboarding.md
+++ b/articles/automation/automation-dsc-onboarding.md
@@ -7,6 +7,7 @@ ms.component: dsc
 author: georgewallace
 ms.author: gwallace
 ms.topic: conceptual
+ms.date: 07/20/2018
 manager: carmonm
 ---
 # Onboarding machines for management by Azure Automation DSC


### PR DESCRIPTION
use right terms of VM in Azure and AWS:
in Azure,  virtual machine called : Azure classic virtual machine, ARM virtual machine
in AWS,  it is EC2 instances ( not virtual machine, even through is the same thing )