### PR TITLE
improve Content-Length

### DIFF
--- a/articles/cognitive-services/QnAMaker/Quickstarts/nodejs.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/nodejs.md
@@ -102,7 +102,7 @@ let post = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};
@@ -301,7 +301,7 @@ let patch = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};
@@ -502,7 +502,7 @@ let post = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};
@@ -614,7 +614,7 @@ let put = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};
@@ -890,7 +890,7 @@ let post = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Authorization' : 'EndpointKey ' + endpoint_key,
 		}
 	};
@@ -1252,7 +1252,7 @@ let http_delete = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};
@@ -1465,7 +1465,7 @@ let patch = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};
@@ -1695,7 +1695,7 @@ let put = function (path, content, callback) {
 		path : path,
 		headers : {
 			'Content-Type' : 'application/json',
-			'Content-Length' : content.length,
+			'Content-Length' : Buffer.byteLength(content),
 			'Ocp-Apim-Subscription-Key' : subscriptionKey,
 		}
 	};


### PR DESCRIPTION
Using `content.length` occurs an error 'Parameter is null' , when `content` includes Chinese, Japanese or Korean characters.