### PR TITLE
Removing duplicate "Videos" Item from "Resources" section of TOC

### DIFF
--- a/articles/stream-analytics/TOC.yml
+++ b/articles/stream-analytics/TOC.yml
@@ -157,8 +157,6 @@
     href: https://azure.microsoft.com/roadmap/
   - name: Blog
     href: http://blogs.msdn.com/b/streamanalytics/
-  - name: Videos
-    href: https://azure.microsoft.com/resources/videos/index/?services=stream-analytics&sort=newest
   - name: Feedback forum
     href: http://feedback.azure.com/forums/270577-azure-stream-analytics
   - name: Forum
@@ -172,7 +170,7 @@
   - name: Stack Overflow
     href: http://stackoverflow.com/questions/tagged/azure-stream-analytics
   - name: Videos
-    href: https://azure.microsoft.com/documentation/videos/index/?services=stream-analytics
+    href: https://azure.microsoft.com/resources/videos/index/?services=stream-analytics&sort=newest
   - name: Customer case studies
     href: https://azure.microsoft.com/case-studies/?service=stream-analytics
   - name: Whitepaper - Real-time event processing


### PR DESCRIPTION
Affected Page URL: https://docs.microsoft.com/en-us/azure/stream-analytics/stream-analytics-twitter-sentiment-analysis-trends

There is duplicate "Videos" item under Resources in TOC.
 Both the "Videos" redirect to the same URL.
Removed one "Videos" item and kept the one having sort filter.