### PR TITLE
fix restart policy for liveness example

### DIFF
--- a/articles/container-instances/container-instances-liveness-probe.md
+++ b/articles/container-instances/container-instances-liveness-probe.md
@@ -45,7 +45,7 @@ properties:
                 - "/tmp/healthy"
         periodSeconds: 5
   osType: Linux
-  restartPolicy: Never
+  restartPolicy: Always
 tags: null
 type: Microsoft.ContainerInstance/containerGroups
 ```


### PR DESCRIPTION
never causes no restarts to occur