### PR TITLE
Update ingress class selector value

### DIFF
--- a/articles/aks/http-application-routing.md
+++ b/articles/aks/http-application-routing.md
@@ -101,7 +101,7 @@ kind: Ingress
 metadata:
   name: party-clippy
   annotations:
-    kubernetes.io/ingress.class: addon-http-application-routing
+    kubernetes.io/ingress.class: addon-http-application-routing-nginx-ingress
 spec:
   rules:
   - host: party-clippy.<CLUSTER_SPECIFIC_DNS_ZONE>


### PR DESCRIPTION
Default HTTP application routing add ingress controller with "addon-http-application-routing-nginx-ingress" selector. 
Ingress resource annotations class selector should be updated as "addon-http-application-routing-nginx-ingress".