### PR TITLE
possible syntax error in the sample code

### DIFF
--- a/articles/batch/batch-automatic-scaling.md
+++ b/articles/batch/batch-automatic-scaling.md
@@ -472,7 +472,7 @@ if (pool.AutoScaleEnabled == false)
     // We need a valid autoscale formula to enable autoscaling on the
     // pool. This formula is valid, but won't resize the pool:
     await pool.EnableAutoScaleAsync(
-        autoscaleFormula: "$TargetDedicatedNodes = {pool.CurrentDedicatedNodes};",
+        autoscaleFormula: "$TargetDedicatedNodes = $CurrentDedicatedNodes;",
         autoscaleEvaluationInterval: TimeSpan.FromMinutes(5));
 
     // Batch limits EnableAutoScaleAsync calls to once every 30 seconds.


### PR DESCRIPTION
In the documentation, ``$CurrentDedicatedNodes`` is the way to describe the current dedicated node of a pool. ``{pool.CurrentDedicatedNodes}`` seems not working here.