### PR TITLE
Typo 'Devlop'

### DIFF
--- a/articles/iot-edge/how-to-develop-csharp-module.md
+++ b/articles/iot-edge/how-to-develop-csharp-module.md
@@ -69,7 +69,7 @@ There are four items within the solution:
 
 * A **deployment.template.json** file lists your new module along with a sample **tempSensor** module that simulates data you can use for testing. For more information about how deployment manifests work, see [Learn how to use deployment manifests to deploy modules and establish routes](module-composition.md). 
 
-## Devlop your module
+## Develop your module
 
 The default Azure Function code that comes with the solution is located at **modules** > **\<your module name\>** > **Program.cs**. The module and the deployment.template.json file are set up so that you can build the solution, push it to your container registry, and deploy it to a device to start testing without touching any code. The module is built to simply take input from a source (in this case, the tempSensor module that simulates data) and pipe it to IoT Hub. 
 


### PR DESCRIPTION
in 'how-to-develop-csharp-module' should be 'Develop'