### PR TITLE
Fixed semicolon mistake

### DIFF
--- a/articles/cosmos-db/sql-api-dotnet-application.md
+++ b/articles/cosmos-db/sql-api-dotnet-application.md
@@ -235,7 +235,7 @@ The first thing to do here is add a class that contains all the logic to connect
         using System.Configuration;
         using System.Linq.Expressions;
         using System.Threading.Tasks;
-        using System.Net
+        using System.Net;
         
     Now replace this code 
    


### PR DESCRIPTION
- Fixed mistake that a semicolon is missing in the last statement.
- cosmos-db/sql-api-dotnet-application.md (ASP.NET MVC Tutorial: Web application development with Azure Cosmos DB)