### PR TITLE
More specific navigation to locate Azure AD tenant

### DIFF
--- a/includes/active-directory-protocols-getting-started.md
+++ b/includes/active-directory-protocols-getting-started.md
@@ -19,7 +19,8 @@ ms.author: priyamo
 First, you need to register your application with your Azure Active Directory (Azure AD) tenant. This will give you an Application ID for your application, as well as enable it to receive tokens.
 
 * Sign in to the [Azure portal](https://portal.azure.com).
-* Choose your Azure AD tenant by clicking on your account in the top right corner of the page.
+* Choose your Azure AD tenant by clicking on your account in the top right corner of the page, followed by clicking on the **Switch Directory** navigation and then select the appropriate tenant. 
+  * Skip this step, if you've only one Azure AD tenant under your account or if you've already selected the appropriate Azure AD tenant.
 * In the left hand navigation pane, click on **Azure Active Directory**.
 * Click on **App Registrations** and click on **New application registration**.
 * Follow the prompts and create a new application. It doesn't matter if it is a web application or a native application for this tutorial, but if you'd like specific examples for web applications or native applications, check out our [quickstarts](../articles/active-directory/develop/active-directory-developers-guide.md).


### PR DESCRIPTION
The previous content suggested selecting Azure AD tenant by just clicking users account in the top right, which is a bit confusing, specially who just started using the portal.  The new changes suggests a more specific walk through to locate the target Azure AD tenant.