### PR TITLE
Added information about X-Original-Host header

### DIFF
--- a/articles/application-gateway/application-gateway-faq.md
+++ b/articles/application-gateway/application-gateway-faq.md
@@ -90,8 +90,7 @@ For example, if Application Gateway is set to three instances and no private fro
 
 Yes, Application Gateway inserts x-forwarded-for, x-forwarded-proto, and x-forwarded-port headers into the request forwarded to the backend. The format for x-forwarded-for header is a comma-separated list of IP:Port. The valid values for x-forwarded-proto are http or https. X-forwarded-port specifies the port at which the request reached at the Application Gateway.
 
-> [!NOTE]
-> Application Gateway does not currently support the X-Forwarded-Host header. In order to retrieve the original host requested by the client, please use the X-Original-Host header.
+Application Gateway also inserts X-Original-Host header which contains the original Host header with which the request arrived. This header is useful in scenarios like Azure Website integration, where the incoming host header is modified before traffic is routed to the backend.
 
 **Q. How long does it take to deploy an Application Gateway? Does my Application Gateway still work when being updated?**
 

--- a/articles/application-gateway/application-gateway-faq.md
+++ b/articles/application-gateway/application-gateway-faq.md
@@ -90,6 +90,9 @@ For example, if Application Gateway is set to three instances and no private fro
 
 Yes, Application Gateway inserts x-forwarded-for, x-forwarded-proto, and x-forwarded-port headers into the request forwarded to the backend. The format for x-forwarded-for header is a comma-separated list of IP:Port. The valid values for x-forwarded-proto are http or https. X-forwarded-port specifies the port at which the request reached at the Application Gateway.
 
+> [!NOTE]
+> Application Gateway does not currently support the X-Forwarded-Host header. In order to retrieve the original host requested by the client, please use the X-Original-Host header.
+
 **Q. How long does it take to deploy an Application Gateway? Does my Application Gateway still work when being updated?**
 
 New Application Gateway deployments can take up to 20 minutes to provision. Changes to instance size/count are not disruptive, and the gateway remains active during this time.


### PR DESCRIPTION
As per this [feedback request](https://feedback.azure.com/forums/217313-networking/suggestions/33657763-add-the-x-forwarded-host-header-to-application-gat) it would have been useful to know which header Application Gateway uses to pass through the originally requested host.

I've added details about using X-Original-Host header as opposed to the standard X-Forwarded-Host header as a note in the X-Forwarded headers question.