### PR TITLE
Updated disk signal from "sdc" to "sdd" to real.

### DIFF
--- a/articles/virtual-machines/linux/attach-disk-portal.md
+++ b/articles/virtual-machines/linux/attach-disk-portal.md
@@ -85,59 +85,79 @@ dmesg | grep SCSI
 The output is similar to the following example:
 
 ```bash
-[    0.294784] SCSI subsystem initialized
-[    0.573458] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 252)
-[    7.110271] sd 2:0:0:0: [sda] Attached SCSI disk
-[    8.079653] sd 3:0:1:0: [sdb] Attached SCSI disk
-[ 1828.162306] sd 5:0:0:0: [sdc] Attached SCSI disk
+[    0.344460] SCSI subsystem initialized
+[    0.819969] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 247)
+[    1.057449] sd 1:0:1:0: [sdb] Attached SCSI disk
+[    1.101998] sd 0:0:0:0: [sda] Attached SCSI disk
+[    1.253212] sd 3:0:0:1: [sdd] Attached SCSI disk
+[    1.318284] sd 3:0:0:0: [sdc] Attached SCSI disk
+[   11.339570] Loading iSCSI transport class v2.0-870.
 ```
-
-Here, *sdc* is the disk that we want. Partition the disk with `fdisk`, make it a primary disk on partition 1, and accept the other defaults. The following example starts the `fdisk` process on */dev/sdc*:
+You can confirm current disk mount status using `df -h` command.
 
 ```bash
-sudo fdisk /dev/sdc
+df -h
+```
+
+The output is similar to the following example:
+
+``` bash
+Filesystem      Size  Used Avail Use% Mounted on
+udev             28G     0   28G   0% /dev
+tmpfs           5.6G  9.0M  5.5G   1% /run
+/dev/sda1        49G   37G   12G  76% /
+tmpfs            28G     0   28G   0% /dev/shm
+tmpfs           5.0M     0  5.0M   0% /run/lock
+tmpfs            28G     0   28G   0% /sys/fs/cgroup
+/dev/sdc1        99G   14G   80G  15% /data
+/dev/sdb1       335G   67M  318G   1% /mnt
+tmpfs           5.6G     0  5.6G   0% /run/user/1003
+```
+
+Here, you can see the gap of mounted disk and not. Here, *sdd* is the disk that we want. Partition the disk with `fdisk`, make it a primary disk on partition 1, and accept the other defaults. The following example starts the `fdisk` process on */dev/sdd*:
+
+```bash
+sudo fdisk /dev/sdd
 ```
 
 Use the `n` command to add a new partition. In this example, we also choose `p` for a primary partition and accept the rest of the default values. The output will be similar to the following example:
 
 ```bash
-Device contains neither a valid DOS partition table, nor Sun, SGI or OSF disklabel
-Building a new DOS disklabel with disk identifier 0x2a59b123.
+Welcome to fdisk (util-linux 2.27.1).
 Changes will remain in memory only, until you decide to write them.
-After that, of course, the previous content won't be recoverable.
+Be careful before using the write command.
 
-Warning: invalid flag 0x0000 of partition table 4 will be corrected by w(rite)
+Device does not contain a recognized partition table.
+Created a new DOS disklabel with disk identifier 0xbb806b11.
 
 Command (m for help): n
-Partition type:
+Partition type
    p   primary (0 primary, 0 extended, 4 free)
-   e   extended
+   e   extended (container for logical partitions)
 Select (default p): p
 Partition number (1-4, default 1): 1
-First sector (2048-10485759, default 2048):
-Using default value 2048
-Last sector, +sectors or +size{K,M,G} (2048-10485759, default 10485759):
-Using default value 10485759
+First sector (2048-2145386495, default 2048):
+Last sector, +sectors or +size{K,M,G,T,P} (2048-2145386495, default 2145386495):
+
+Created a new partition 1 of type 'Linux' and of size 1023 GiB.
 ```
 
 Print the partition table by typing `p` and then use `w` to write the table to disk and exit. The output should look similar to the following example:
 
 ```bash
 Command (m for help): p
-
-Disk /dev/sdc: 5368 MB, 5368709120 bytes
-255 heads, 63 sectors/track, 652 cylinders, total 10485760 sectors
-Units = sectors of 1 * 512 = 512 bytes
+Disk /dev/sdd: 1023 GiB, 1098437885952 bytes, 2145386496 sectors
+Units: sectors of 1 * 512 = 512 bytes
 Sector size (logical/physical): 512 bytes / 512 bytes
 I/O size (minimum/optimal): 512 bytes / 512 bytes
-Disk identifier: 0x2a59b123
+Disklabel type: dos
+Disk identifier: 0xbb806b11
 
-   Device Boot      Start         End      Blocks   Id  System
-/dev/sdc1            2048    10485759     5241856   83  Linux
+Device     Boot Start        End    Sectors  Size Id Type
+/dev/sdd1        2048 2145386495 2145384448 1023G 83 Linux
 
 Command (m for help): w
-The partition table has been altered!
-
+The partition table has been altered.
 Calling ioctl() to re-read partition table.
 Syncing disks.
 ```
@@ -145,28 +165,20 @@ Syncing disks.
 Now, write a file system to the partition with the `mkfs` command. Specify your filesystem type and the device name. The following example creates an *ext4* filesystem on the */dev/sdc1* partition that was created in the preceding steps:
 
 ```bash
-sudo mkfs -t ext4 /dev/sdc1
+sudo mkfs -t ext4 /dev/sdd1
 ```
 
 The output is similar to the following example:
 
 ```bash
-mke2fs 1.42.9 (4-Feb-2014)
-Discarding device blocks: done
-Filesystem label=
-OS type: Linux
-Block size=4096 (log=2)
-Fragment size=4096 (log=2)
-Stride=0 blocks, Stripe width=0 blocks
-327680 inodes, 1310464 blocks
-65523 blocks (5.00%) reserved for the super user
-First data block=0
-Maximum filesystem blocks=1342177280
-40 block groups
-32768 blocks per group, 32768 fragments per group
-8192 inodes per group
+mke2fs 1.42.13 (17-May-2015)
+Creating filesystem with 268173056 4k blocks and 67043328 inodes
+Filesystem UUID: a26cbd10-75bf-497d-bed3-877833b833b3
 Superblock backups stored on blocks:
-    32768, 98304, 163840, 229376, 294912, 819200, 884736
+        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
+        4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968,
+        102400000, 214990848
+
 Allocating group tables: done
 Writing inode tables: done
 Creating journal (32768 blocks): done
@@ -182,7 +194,7 @@ sudo mkdir /datadrive
 Use `mount` to then mount the filesystem. The following example mounts the */dev/sdc1* partition to the */datadrive* mount point:
 
 ```bash
-sudo mount /dev/sdc1 /datadrive
+sudo mount /dev/sdd1 /datadrive
 ```
 
 To ensure that the drive is remounted automatically after a reboot, it must be added to the */etc/fstab* file. It is also highly recommended that the UUID (Universally Unique IDentifier) is used in */etc/fstab* to refer to the drive rather than just the device name (such as, */dev/sdc1*). If the OS detects a disk error during boot, using the UUID avoids the incorrect disk being mounted to a given location. Remaining data disks would then be assigned those same device IDs. To find the UUID of the new drive, use the `blkid` utility:
@@ -197,6 +209,7 @@ The output looks similar to the following example:
 /dev/sda1: UUID="11111111-1b1b-1c1c-1d1d-1e1e1e1e1e1e" TYPE="ext4"
 /dev/sdb1: UUID="22222222-2b2b-2c2c-2d2d-2e2e2e2e2e2e" TYPE="ext4"
 /dev/sdc1: UUID="33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e" TYPE="ext4"
+/dev/sdd1: UUID="44444444-4b4b-4c4c-4d4d-4e4e4e4e4e4e" TYPE="ext4"
 ```
 
 > [!NOTE]
@@ -208,10 +221,10 @@ Next, open the */etc/fstab* file in a text editor as follows:
 sudo vi /etc/fstab
 ```
 
-In this example, use the UUID value for the */dev/sdc1* device that was created in the previous steps, and the mountpoint of */datadrive*. Add the following line to the end of the */etc/fstab* file:
+In this example, use the UUID value for the */dev/sd1* device that was created in the previous steps, and the mountpoint of */datadrive*. Add the following line to the end of the */etc/fstab* file:
 
 ```bash
-UUID=33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext4   defaults,nofail   1   2
+UUID=44444444-4b4b-4c4c-4d4d-4e4e4e4e4e4e   /datadrive   ext4   defaults,nofail   1   2
 ```
 
 > [!NOTE]
@@ -227,7 +240,7 @@ There are two ways to enable TRIM support in your Linux VM. As usual, consult yo
 * Use the `discard` mount option in */etc/fstab*, for example:
 
     ```bash
-    UUID=33333333-3b3b-3c3c-3d3d-3e3e3e3e3e3e   /datadrive   ext4   defaults,discard   1   2
+    UUID=44444444-4b4b-4c4c-4d4d-4e4e4e4e4e4e   /datadrive   ext4   defaults,discard   1   2
     ```
 * In some cases, the `discard` option may have performance implications. Alternatively, you can run the `fstrim` command manually from the command line, or add it to your crontab to run regularly:
   


### PR DESCRIPTION
Some linux begginer customer really confuse that current disk structure and document is different. To avoid confusion, let's use "sdd" instead of "sdc".

Here is full output from my consode today (2018/07/31) in Data Science VM.
-----------------------------------------------

**********************************************************************
* Welcome to the Linux Data Science Virtual Machine on Azure!        *
*                                                                    *
* For more information on available tools and features,              *
* visit http://aka.ms/dsvm/discover.                                 *
**********************************************************************

Last login: Tue Jul 31 07:52:43 2018 from 167.220.232.141
dahatake@dahatakedataset:~$ dmesg | grep SCSI
[    0.344460] SCSI subsystem initialized
[    0.819969] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 247)
[    1.057449] sd 1:0:1:0: [sdb] Attached SCSI disk
[    1.101998] sd 0:0:0:0: [sda] Attached SCSI disk
[    1.253212] sd 3:0:0:1: [sdd] Attached SCSI disk
[    1.318284] sd 3:0:0:0: [sdc] Attached SCSI disk
[   11.339570] Loading iSCSI transport class v2.0-870.
dahatake@dahatakedataset:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev             28G     0   28G   0% /dev
tmpfs           5.6G  9.0M  5.5G   1% /run
/dev/sda1        49G   37G   12G  76% /
tmpfs            28G     0   28G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs            28G     0   28G   0% /sys/fs/cgroup
/dev/sdc1        99G   14G   80G  15% /data
/dev/sdb1       335G   67M  318G   1% /mnt
tmpfs           5.6G     0  5.6G   0% /run/user/1003
dahatake@dahatakedataset:~$ sudo fdisk /dev/sdd

Welcome to fdisk (util-linux 2.27.1).
Changes will remain in memory only, until you decide to write them.
Be careful before using the write command.

Device does not contain a recognized partition table.
Created a new DOS disklabel with disk identifier 0xbb806b11.

Command (m for help): n
Partition type
   p   primary (0 primary, 0 extended, 4 free)
   e   extended (container for logical partitions)
Select (default p): p
Partition number (1-4, default 1): 1
First sector (2048-2145386495, default 2048):
Last sector, +sectors or +size{K,M,G,T,P} (2048-2145386495, default 2145386495):

Created a new partition 1 of type 'Linux' and of size 1023 GiB.

Command (m for help): p
Disk /dev/sdd: 1023 GiB, 1098437885952 bytes, 2145386496 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0xbb806b11

Device     Boot Start        End    Sectors  Size Id Type
/dev/sdd1        2048 2145386495 2145384448 1023G 83 Linux

Command (m for help): w
The partition table has been altered.
Calling ioctl() to re-read partition table.
Syncing disks.

dahatake@dahatakedataset:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev             28G     0   28G   0% /dev
tmpfs           5.6G  9.0M  5.5G   1% /run
/dev/sda1        49G   37G   12G  76% /
tmpfs            28G     0   28G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs            28G     0   28G   0% /sys/fs/cgroup
/dev/sdc1        99G   14G   80G  15% /data
/dev/sdb1       335G   67M  318G   1% /mnt
tmpfs           5.6G     0  5.6G   0% /run/user/1003
dahatake@dahatakedataset:~$ sudo mkfs -t ext4 /dev/sdd1
mke2fs 1.42.13 (17-May-2015)
Creating filesystem with 268173056 4k blocks and 67043328 inodes
Filesystem UUID: a26cbd10-75bf-497d-bed3-877833b833b3
Superblock backups stored on blocks:
        32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
        4096000, 7962624, 11239424, 20480000, 23887872, 71663616, 78675968,
        102400000, 214990848

Allocating group tables: done
Writing inode tables: done
Creating journal (32768 blocks): done
Writing superblocks and filesystem accounting information: done

dahatake@dahatakedataset:~$ sudo mkdir /datadrive
dahatake@dahatakedataset:~$ sudo mount /dev/sdd1 /datadrive
dahatake@dahatakedataset:~$ sudo -i blkid
/dev/sdb1: UUID="b5716a5b-8065-428a-bbc6-068405442077" TYPE="ext4" PARTUUID="1884922b-01"
/dev/sda1: LABEL="cloudimg-rootfs" UUID="75604357-9029-4b6f-8c13-6201b689c664" TYPE="ext4" PARTUUID="49ec635a-01"
/dev/sdc1: UUID="c84f09a4-f02f-4715-8345-68392d080214" TYPE="ext4" PARTUUID="deff768d-01"
/dev/sdd1: UUID="a26cbd10-75bf-497d-bed3-877833b833b3" TYPE="ext4" PARTUUID="bb806b11-01"
dahatake@dahatakedataset:~$ sudo vi /etc/fstab
dahatake@dahatakedataset:~$