### PR TITLE
Updated broken links to get and set cmdlets

### DIFF
--- a/articles/automation/automation-runbook-settings.md
+++ b/articles/automation/automation-runbook-settings.md
@@ -33,7 +33,7 @@ You can change settings for a runbook in the Azure portal from the **Settings** 
 3. Click the name of a runbook and you are directed to the settings blade for the runbook. From here you can specify or modify tags, the runbook description, configure logging and tracing settings, and access support tools to help you solve problems.     
 
 ### Changing runbook settings with Windows PowerShell
-You can use the [Set-AzureRmAutomationRunbook](https://msdn.microsoft.com/library/mt603786.aspx) cmdlet to change the settings for a runbook. If you want to specify multiple tags, you can either provide an array or a single string with comma delimited values to the Tags parameter. You can get the current tags with the [Get-AzureRmAutomationRunbook](https://msdn.microsoft.com/library/mt603728.aspx).
+You can use the [Set-AzureRmAutomationRunbook](https://docs.microsoft.com/en-us/powershell/module/azurerm.automation/set-azurermautomationrunbook) cmdlet to change the settings for a runbook. If you want to specify multiple tags, you can either provide an array or a single string with comma delimited values to the Tags parameter. You can get the current tags with the [Get-AzureRmAutomationRunbook](https://docs.microsoft.com/en-us/powershell/module/azurerm.automation/get-azurermautomationrunbook).
 
 The following sample commands show how to set the properties for a runbook. This sample adds three tags to the existing tags and specifies that verbose records should be logged.
 

--- a/articles/automation/automation-runbook-settings.md
+++ b/articles/automation/automation-runbook-settings.md
@@ -33,7 +33,7 @@ You can change settings for a runbook in the Azure portal from the **Settings** 
 3. Click the name of a runbook and you are directed to the settings blade for the runbook. From here you can specify or modify tags, the runbook description, configure logging and tracing settings, and access support tools to help you solve problems.     
 
 ### Changing runbook settings with Windows PowerShell
-You can use the [Set-AzureRmAutomationRunbook](https://docs.microsoft.com/en-us/powershell/module/azurerm.automation/set-azurermautomationrunbook) cmdlet to change the settings for a runbook. If you want to specify multiple tags, you can either provide an array or a single string with comma delimited values to the Tags parameter. You can get the current tags with the [Get-AzureRmAutomationRunbook](https://docs.microsoft.com/en-us/powershell/module/azurerm.automation/get-azurermautomationrunbook).
+You can use the [Set-AzureRmAutomationRunbook](/powershell/module/azurerm.automation/set-azurermautomationrunbook) cmdlet to change the settings for a runbook. If you want to specify multiple tags, you can either provide an array or a single string with comma delimited values to the Tags parameter. You can get the current tags with the [Get-AzureRmAutomationRunbook](/powershell/module/azurerm.automation/get-azurermautomationrunbook).
 
 The following sample commands show how to set the properties for a runbook. This sample adds three tags to the existing tags and specifies that verbose records should be logged.
 


### PR DESCRIPTION
Links to "set-azurermautomationrunbook" and "get-azurermautomationrunbook" cmdlets were broken.
I've updated the 2 URLs to point to related pages at docs.microsoft.com