### PR TITLE
Corrected Name param for  Get-AzureRmVM/Stop-AzureRmVM

### DIFF
--- a/articles/virtual-machines/windows/convert-disk-storage.md
+++ b/articles/virtual-machines/windows/convert-disk-storage.md
@@ -95,9 +95,9 @@ $disk = Get-AzureRmDisk -DiskName $diskName -ResourceGroupName $rgName
 $vmResource = Get-AzureRmResource -ResourceId $disk.ManagedBy
 
 # Stop and deallocate the VM before changing the storage type
-Stop-AzureRmVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name -Force
+Stop-AzureRmVM -ResourceGroupName $vm.ResourceGroupName -Name $vmResource.Name -Force
 
-$vm = Get-AzureRmVM $vmResource.ResourceGroupName -Name $vmResource.ResourceName 
+$vm = Get-AzureRmVM -ResourceGroupName $vmResource.ResourceGroupName -Name $vmResource.Name 
 
 # Change the VM size to a size that supports premium storage
 # Skip this step if converting storage from premium to standard
@@ -132,7 +132,7 @@ $vmResource = Get-AzureRmResource -ResourceId $disk.ManagedBy
 # Stop and deallocate the VM before changing the storage type
 Stop-AzureRmVM -ResourceGroupName $vmResource.ResourceGroupName -Name $vmResource.Name -Force
 
-$vm = Get-AzureRmVM $vmResource.ResourceGroupName -Name $vmResource.ResourceName 
+$vm = Get-AzureRmVM -ResourceGroupName $vmResource.ResourceGroupName -Name $vmResource.Name 
 
 # Update the storage type
 $diskUpdateConfig = New-AzureRmDiskUpdateConfig -AccountType $storageType -DiskSizeGB $disk.DiskSizeGB


### PR DESCRIPTION
The -Name parameter used by the two $vm = Get-AzureRmVM commands and the first Stop-AzureRmVM command should be $vmResource.Name rather then $vmResource.ResourceName and $vm.Name respectively. Also added -ResourceGroupName to the Get-AzureRmVM commands to make it the complete command.