### PR TITLE
Use Command section "Display Name" replaced

### DIFF
--- a/articles/iot-central/tutorial-define-device-type.md
+++ b/articles/iot-central/tutorial-define-device-type.md
@@ -337,8 +337,8 @@ You use _commands_ to enable an operator to run commands directly on the device.
     | Display Name         | Echo Command    |
     | Field Name           | echo            |
     | Default Timeout      | 30              |
-    | Display Name         | Display Text    |
-    | Display Type         | text            |  
+    | Display Type         | text            |
+    | Description          | Device Command  |  
 
 You can add additional inputs to the command by clicking **+** for inputs.
 


### PR DESCRIPTION
"Display Name"  appearing twice in "Use Command" section, while "Description" was missing. Corrected as per app
