### PR TITLE
Update azure service type

### DIFF
--- a/articles/traffic-manager/traffic-manager-endpoint-types.md
+++ b/articles/traffic-manager/traffic-manager-endpoint-types.md
@@ -33,8 +33,9 @@ The following sections describe each endpoint type in greater depth.
 
 Azure endpoints are used for Azure-based services in Traffic Manager. The following Azure resource types are supported:
 
-* 'Classic' IaaS VMs and PaaS cloud services.
+* PaaS cloud services.
 * Web Apps
+* Web App Slots
 * PublicIPAddress resources (which can be connected to VMs either directly or via an Azure Load Balancer). The publicIpAddress must have a DNS name assigned to be used in a Traffic Manager profile.
 
 PublicIPAddress resources are Azure Resource Manager resources. They do not exist in the classic deployment model. Thus they are only supported in Traffic Manager's Azure Resource Manager experiences. The other endpoint types are supported via both Resource Manager and the classic deployment model.


### PR DESCRIPTION
Update azure service type as Azure endpoints
For 2 reasons 
- Classic IaaS VMs have been retired 
- Adding directly distributing traffic to appropriate app service slots