### PR TITLE
Added subscription_id

### DIFF
--- a/articles/app-service/containers/app-service-linux-ssh-support.md
+++ b/articles/app-service/containers/app-service-linux-ssh-support.md
@@ -120,10 +120,10 @@ If you've already run `az extension add` before, run [az extension update](/cli/
 az extension update --name webapp
 ```
 
-Open a remote connection to your app using the [az webapp remote-connection create](/cli/azure/ext/webapp/webapp/remote-connection?view=azure-cli-latest#ext-webapp-az-webapp-remote-connection-create) command. Specify _\<group\_name>_ and \_<app\_name>_ for your app, and replace \<port> with a local port number.
+Open a remote connection to your app using the [az webapp remote-connection create](/cli/azure/ext/webapp/webapp/remote-connection?view=azure-cli-latest#ext-webapp-az-webapp-remote-connection-create) command. Specify _\<subscription\_id>_, _\<group\_name>_ and \_<app\_name>_ for your app, and replace \<port> with a local port number.
 
 ```azurecli-interactive
-az webapp remote-connection create --resource-group <group_name> -n <app_name> -p <port> &
+az webapp remote-connection create --subscription <subscription_id> --resource-group <group_name> -n <app_name> -p <port> &
 ```
 
 > [!TIP]


### PR DESCRIPTION
I tested the step by step (with Mac Azure CLI Client) and for MS accounts containing multiple subscriptions it returns : 
Resource group '<group_name>' could not be found.

Specifying the subscription_id fixed it.