### PR TITLE
Parameter -TypeName is missing from the command

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-vnet-vnet-rm-ps.md
+++ b/articles/vpn-gateway/vpn-gateway-vnet-vnet-rm-ps.md
@@ -449,7 +449,7 @@ In this example, because the gateways are in the different subscriptions, we've 
   Connect to Subscription 1 before running the following example:
 
   ```powershell
-  $vnet5gw = New-Object Microsoft.Azure.Commands.Network.Models.PSVirtualNetworkGateway
+  $vnet5gw = New-Object -TypeName Microsoft.Azure.Commands.Network.Models.PSVirtualNetworkGateway
   $vnet5gw.Name = "VNet5GW"
   $vnet5gw.Id   = "/subscriptions/66c8e4f1-ecd6-47ed-9de7-7e530de23994/resourceGroups/TestRG5/providers/Microsoft.Network/virtualNetworkGateways/VNet5GW"
   $Connection15 = "VNet1toVNet5"
@@ -460,7 +460,7 @@ In this example, because the gateways are in the different subscriptions, we've 
   Connect to Subscription 5 before running the following example:
 
   ```powershell
-  $vnet1gw = New-Object Microsoft.Azure.Commands.Network.Models.PSVirtualNetworkGateway
+  $vnet1gw = New-Object -TypeName Microsoft.Azure.Commands.Network.Models.PSVirtualNetworkGateway
   $vnet1gw.Name = "VNet1GW"
   $vnet1gw.Id = "/subscriptions/b636ca99-6f88-4df4-a7c3-2f8dc4545509/resourceGroups/TestRG1/providers/Microsoft.Network/virtualNetworkGateways/VNet1GW "
   $Connection51 = "VNet5toVNet1"


### PR DESCRIPTION
Without this -TypeName parameter command will give error. Corrected command is given below
New-Object -TypeName Microsoft.Azure.Commands.Network.Models.PSVirtualNetworkGateway