### PR TITLE
Updating the modbus URL to MCR URL

### DIFF
--- a/articles/iot-edge/deploy-modbus-gateway.md
+++ b/articles/iot-edge/deploy-modbus-gateway.md
@@ -30,7 +30,7 @@ This article assumes that you're using Modbus TCP protocol. For more information
 If you want to test the Modbus gateway functionality, Microsoft has a sample module that you can use. To use the sample module, go to the [Run the solution](#run-the-solution) section and enter the following as the Image URI: 
 
 ```URL
-microsoft/azureiotedge-modbus-tcp:GA-preview-amd64
+mcr.microsoft.com/azureiotedge/modbus:1.0
 ```
 
 If you want to create your own module and customize it for your environment, there is an open source [Azure IoT Edge Modbus module](https://github.com/Azure/iot-edge-modbus) project on Github. Follow the guidance in that project to create your own container image. If you create your own container image, refer to [Develop and deploy a C# IoT Edge module](tutorial-csharp-module.md) for instructions on publishing container images to a registry, and deploying a custom module to your device. 
@@ -43,7 +43,7 @@ If you want to create your own module and customize it for your environment, the
 4. Add the Modbus module:
    1. Click **Add** and select **IoT Edge module**.
    2. In the **Name** field, enter "modbus".
-   3. In the **Image** field, enter the image URI of the sample container: `microsoft/azureiotedge-modbus-tcp:GA-preview-amd64`.
+   3. In the **Image** field, enter the image URI of the sample container: `mcr.microsoft.com/azureiotedge/modbus:1.0`.
    4. Check the **Enable** box to update the module twin's desired properties.
    5. Copy the following JSON into the text box. Change the value of **SlaveConnection** to the IPv4 address of your Modbus device.
 


### PR DESCRIPTION
Modbus container is no longer in preview + is now onboarded to MCR. Updating the URLs to reflect this change