### PR TITLE
Update automation-windows-hrw-install.md

### DIFF
--- a/articles/automation/automation-windows-hrw-install.md
+++ b/articles/automation/automation-windows-hrw-install.md
@@ -64,7 +64,7 @@ Perform the following steps to automate the installation and configuration of th
 3. From the PowerShell command-line shell, navigate to the folder, which contains the script you downloaded and execute it changing the values for parameters *-AutomationAccountName*, *-ResourceGroupName*, *-HybridGroupName*, *-SubscriptionId*, and *-WorkspaceName*.
 
      > [!NOTE] 
-     > You are prompted to authenticate with Azure after you execute the script.  You **must** sign in with an account that is a member of the Subscription Admins role and co-administrator of the subscription.  
+     > You are prompted to authenticate with Azure after you execute the script. This requires JavaScript to be enabled on your browser. As well, you **must** sign in with an account that is a member of the Subscription Admins role and co-administrator of the subscription.  
      >  
     
         .\New-OnPremiseHybridWorker.ps1 -AutomationAccountName <NameofAutomationAccount> `


### PR DESCRIPTION
The login prompt that comes up for accessing the subscript won't work on Window Server browser unless JavaScript is enabled (which is not by default for security).

Performing this on Window Server 2016 server I am giving this response:
![image](https://user-images.githubusercontent.com/11204251/43777705-36d4bbb4-9a19-11e8-834d-f8bb6d88fccd.png)

I don't know if it would be best state that you basically need to ensure IE Enhanced Security Configuration is turned off for administrators?
