### PR TITLE
Fixed typo in example to match rest of doc: rbac-virtualkubelet.yaml

### DIFF
--- a/articles/aks/virtual-kubelet.md
+++ b/articles/aks/virtual-kubelet.md
@@ -54,7 +54,7 @@ subjects:
 Apply the binding with [kubectl apply][kubectl-apply] and specify your *rbac-virtualkubelet.yaml* file, as shown in the following example:
 
 ```
-$ kubectl apply -f rbac-virtual-kubelet.yaml
+$ kubectl apply -f rbac-virtualkubelet.yaml
 
 clusterrolebinding.rbac.authorization.k8s.io/virtual-kubelet created
 ```


### PR DESCRIPTION
The document refers to a file named: `rbac-virtualkubelet.yaml` in the prose here:

```
A ClusterRoleBinding must also be created for the Virtual Kubelet. To create a binding, create a file named rbac-virtualkubelet.yaml and paste the following definition:
```

And here:

```
Apply the binding with kubectl apply and specify your rbac-virtualkubelet.yaml file, as shown in the following example:
```

While the example has an extra `-` in the file name:

```
kubectl apply -f rbac-virtual-kubelet.yaml
```

Fixed the typo by removing the extra "-".

