### PR TITLE
Adding info on restarting nginx controller

### DIFF
--- a/articles/dev-spaces/troubleshooting.md
+++ b/articles/dev-spaces/troubleshooting.md
@@ -57,6 +57,26 @@ In Visual Studio:
 2. Change the settings for **MSBuild project build output verbosity** to **Detailed** or **Diagnostic**.
 
     ![Screenshot of Tools Options dialog](media/common/VerbositySetting.PNG)
+    
+## DNS name resolution fails for a public URL associated with a Dev Spaces service
+
+When this happens, you might see a "Page cannot be displayed" or "This site cannot be reached" error in your web browser when attempting to connect to the public URL associated with a Dev Spaces service.
+
+### Try:
+
+You can use the following command to list out all URLs associated with your Dev Spaces services:
+
+    ```cmd
+    azds list-uris
+    ```
+
+If a URL is in the *Pending* state, that means that Dev Spaces is still waiting for DNS registration to complete. Sometimes, it takes a few minutes for this to happen. Dev Spaces also opens a localhost tunnel for each service, which you can use while waiting on DNS registration.
+
+If a URL remains in the *Pending* state for more than 5 minutes, it may indicate a problem with the nginx ingress controller that is responsible for DNS registration. You can use the following command to delete the pod running the nginx controller. It will be recreated automatically.
+
+    ```cmd
+    kubectl delete pod -n kube-system -l app=addon-http-application-routing-nginx-ingress
+    ```
 
 ## Error 'Required tools and configurations are missing'
 

--- a/articles/dev-spaces/troubleshooting.md
+++ b/articles/dev-spaces/troubleshooting.md
@@ -72,7 +72,7 @@ You can use the following command to list out all URLs associated with your Dev 
 
 If a URL is in the *Pending* state, that means that Dev Spaces is still waiting for DNS registration to complete. Sometimes, it takes a few minutes for this to happen. Dev Spaces also opens a localhost tunnel for each service, which you can use while waiting on DNS registration.
 
-If a URL remains in the *Pending* state for more than 5 minutes, it may indicate a problem with the nginx ingress controller that is responsible for DNS registration. You can use the following command to delete the pod running the nginx controller. It will be recreated automatically.
+If a URL remains in the *Pending* state for more than 5 minutes, it may indicate a problem with the nginx ingress controller that is responsible for acquiring the public endpoint. You can use the following command to delete the pod running the nginx controller. It will be recreated automatically.
 
     ```cmd
     kubectl delete pod -n kube-system -l app=addon-http-application-routing-nginx-ingress

--- a/articles/dev-spaces/troubleshooting.md
+++ b/articles/dev-spaces/troubleshooting.md
@@ -66,17 +66,17 @@ When this happens, you might see a "Page cannot be displayed" or "This site cann
 
 You can use the following command to list out all URLs associated with your Dev Spaces services:
 
-    ```cmd
-    azds list-uris
-    ```
+```cmd
+azds list-uris
+```
 
 If a URL is in the *Pending* state, that means that Dev Spaces is still waiting for DNS registration to complete. Sometimes, it takes a few minutes for this to happen. Dev Spaces also opens a localhost tunnel for each service, which you can use while waiting on DNS registration.
 
 If a URL remains in the *Pending* state for more than 5 minutes, it may indicate a problem with the nginx ingress controller that is responsible for acquiring the public endpoint. You can use the following command to delete the pod running the nginx controller. It will be recreated automatically.
 
-    ```cmd
-    kubectl delete pod -n kube-system -l app=addon-http-application-routing-nginx-ingress
-    ```
+```cmd
+kubectl delete pod -n kube-system -l app=addon-http-application-routing-nginx-ingress
+```
 
 ## Error 'Required tools and configurations are missing'
 


### PR DESCRIPTION
Adding troubleshooting information on how to restart (delete/recreate) the nginx ingress controller when it gets "stuck"