### PR TITLE
Update Python quickstart tutorial instruction

### DIFF
--- a/articles/iot-edge/tutorial-python-module.md
+++ b/articles/iot-edge/tutorial-python-module.md
@@ -225,7 +225,7 @@ You can use the Azure portal to deploy your Python module to an IoT Edge device 
 
 6. Right-click the name of your IoT Edge device, and then select **Create Deployment for IoT Edge device**. 
 
-7. Browse to the solution folder that contains the **PythonModule**. Open the config folder, select the deployment.json file, and then choose **Select Edge Deployment Manifest**.
+7. Browse to the solution folder that contains the **PythonModule**. Open the config folder, select the deployment.json file, and then choose **Create Deployment for Single Device**.
 
 8. Refresh the **Azure IoT Hub Devices** section. You should see the new **PythonModule** running along with the **TempSensor** module and the **$edgeAgent** and **$edgeHub**. 
 


### PR DESCRIPTION
'Select Edge Deployment Manifest' is no longer an option in VS Code Extension.  The latest has either 'Create Deployment for Single Device' or 'Create Deployment at Scale'.

![image](https://user-images.githubusercontent.com/23619763/44051285-49c122ec-9eee-11e8-9162-50558ac1499f.png)
