### PR TITLE
Clarify MSGEN version requirements for Python

### DIFF
--- a/articles/genomics/quickstart-run-genomics-workflow-portal.md
+++ b/articles/genomics/quickstart-run-genomics-workflow-portal.md
@@ -55,8 +55,9 @@ Users need to install both Python and the Microsoft Genomics Python client in th
 
 ### Install Python
 
-The Microsoft Genomics Python client is compatible with Python 2.7. We recommend using version 2.7.12 or later; 2.7.14 is the suggested version. You can find the download [here](https://www.python.org/downloads/). 
+The Microsoft Genomics Python client is compatible with Python 2.7. 12 or later 2.7.xx version; 2.7.15 is the latest version at the time of this writing; 2.7.14 is the suggested version. You can find the download [here](https://www.python.org/downloads/). 
 
+NOTE: Python 3.x isn't compatible with Python 2.7.xx.  MSGen is a Python 2.7 application. When running MSGen, make sure that your active Python environment is using a 2.7.xx version of Python. You may get errors when trying to use MSGen with a 3.x version of Python.
 
 ### Install the Microsoft Genomics client
 


### PR DESCRIPTION
One of our users tried to follow this guide using a version 3.x series of Python. He had to engage with the development team to understand that MSGEN did not support 3.X version of Python since it is a 2.7 Python application. Clarifying the Install Python section in this troubleshooting guide to alleviate future misinterpretations by customers.