### PR TITLE
Adding command to remove external dns pod

### DIFF
--- a/articles/dev-spaces/troubleshooting.md
+++ b/articles/dev-spaces/troubleshooting.md
@@ -72,9 +72,10 @@ azds list-uris
 
 If a URL is in the *Pending* state, that means that Dev Spaces is still waiting for DNS registration to complete. Sometimes, it takes a few minutes for this to happen. Dev Spaces also opens a localhost tunnel for each service, which you can use while waiting on DNS registration.
 
-If a URL remains in the *Pending* state for more than 5 minutes, it may indicate a problem with the nginx ingress controller that is responsible for acquiring the public endpoint. You can use the following command to delete the pod running the nginx controller. It will be recreated automatically.
+If a URL remains in the *Pending* state for more than 5 minutes, it may indicate a problem with the external DNS pod that creates the public endpoint and/or the nginx ingress controller pod that acquires the public endpoint. You can use the following commands to delete these pods. They will be recreated automatically.
 
 ```cmd
+kubectl delete pod -n kube-system -l app=addon-http-application-routing-external-dns
 kubectl delete pod -n kube-system -l app=addon-http-application-routing-nginx-ingress
 ```
 


### PR DESCRIPTION
Adding an additional command that removes the external DNS pod in addition to the nginx ingress controller, since either (or both) can cause this issue.