### PR TITLE
Update tutorial-docker-python-postgresql-app.md

### DIFF
--- a/articles/app-service/containers/tutorial-docker-python-postgresql-app.md
+++ b/articles/app-service/containers/tutorial-docker-python-postgresql-app.md
@@ -152,7 +152,7 @@ When the Azure Database for PostgreSQL server is created, the Azure CLI shows in
     "size": null,
     "tier": "Basic"
   },
-  "sslEnforcement": null,
+  "sslEnforcement": enabled,
   "storageMb": 2048,
   "tags": null,
   "type": "Microsoft.DBforPostgreSQL/servers",


### PR DESCRIPTION
We need to force ssl/encryption on the postgress database.  Right now the JSON code says to disable it.  This is a bad example, we do not want people to follow that.  #Security 