### PR TITLE
Update Fixed-Rate sampling sample code

### DIFF
--- a/articles/application-insights/app-insights-sampling.md
+++ b/articles/application-insights/app-insights-sampling.md
@@ -279,7 +279,7 @@ Instead of setting the sampling parameter in the .config file, you can programma
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     ...
 
-    var builder = TelemetryConfiguration.Active.GetTelemetryProcessorChainBuilder();
+    var builder = TelemetryConfiguration.Active.TelemetryProcessorChainBuilder;
     builder.UseSampling(10.0); // percentage
 
     // If you have other telemetry processors:


### PR DESCRIPTION
The sample code provided uses `GetTelemetryProcessorChainBuilder()`, but that was deprecated for the property `TelemetryProcessorChainBuilder`. This must have been missed in a previous edit, as it's used correctly elsewhere.