### PR TITLE
Fixed link to key-vault get-started in service fabric documentation

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-security.md
+++ b/articles/service-fabric/service-fabric-cluster-security.md
@@ -81,7 +81,7 @@ Users who are assigned the Administrator role have full access to management cap
 Set the Administrator and User client roles when you create the cluster. Assign roles by providing separate identities (for example, by using certificates or Azure AD) for each role type. For more information about default access control settings and how to change default settings, see [Role-Based Access Control for Service Fabric clients](service-fabric-cluster-security-roles.md).
 
 ## X.509 certificates and Service Fabric
-X.509 digital certificates commonly are used to authenticate clients and servers. They also are used to encrypt and digitally sign messages. Service Fabric uses X.509 certificates to secure a cluster and provide application security features. For more information about X.509 digital certificates, see [Working with certificates](http://msdn.microsoft.com/library/ms731899.aspx). You use [Key Vault][key-vault-get-started] to manage certificates for Service Fabric clusters in Azure.
+X.509 digital certificates commonly are used to authenticate clients and servers. They also are used to encrypt and digitally sign messages. Service Fabric uses X.509 certificates to secure a cluster and provide application security features. For more information about X.509 digital certificates, see [Working with certificates](http://msdn.microsoft.com/library/ms731899.aspx). You use [Key Vault](../key-vault/key-vault-get-started.md) to manage certificates for Service Fabric clusters in Azure.
 
 Some important things to consider:
 


### PR DESCRIPTION
Link was broken. Now it's not.