### PR TITLE
Update Virtual Network type table

### DIFF
--- a/articles/api-management/api-management-using-with-vnet.md
+++ b/articles/api-management/api-management-using-with-vnet.md
@@ -106,7 +106,7 @@ When an API Management service instance is hosted in a VNET, the ports in the fo
 | Source / Destination Port(s) | Direction | Transport protocol | Source / Destination | Purpose (*) | Virtual Network type |
 | --- | --- | --- | --- | --- | --- |
 | * / 80, 443 |Inbound |TCP |INTERNET / VIRTUAL_NETWORK|Client communication to API Management|External |
-| * / 3443 |Inbound |TCP |INTERNET / VIRTUAL_NETWORK|Management endpoint for Azure portal and Powershell |Internal |
+| * / 3443 |Inbound |TCP |INTERNET / VIRTUAL_NETWORK|Management endpoint for Azure portal and Powershell |External & Internal |
 | * / 80, 443 |Outbound |TCP |VIRTUAL_NETWORK / INTERNET|**Dependency on Azure Storage**, Azure Service Bus, and Azure Active Directory (where applicable).|External & Internal |
 | * / 1433 |Outbound |TCP |VIRTUAL_NETWORK / SQL|**Access to Azure SQL endpoints** |External & Internal |
 | * / 5672 |Outbound |TCP |VIRTUAL_NETWORK / INTERNET|Dependency for Log to Event Hub policy and monitoring agent |External & Internal |


### PR DESCRIPTION
The port TCP 3443 must be configured either if the virtual network type is External or Internal. Changed from "Internal" to "External & Internal".
Same issue documented in the link below:
https://github.com/MicrosoftDocs/azure-docs/issues/6518