### PR TITLE
Added missing word

### DIFF
--- a/articles/cosmos-db/sql-api-sql-query-reference.md
+++ b/articles/cosmos-db/sql-api-sql-query-reference.md
@@ -2440,7 +2440,7 @@ JOIN n IN food.nutrients
  ``` 
  
 ####  <a name="bk_trim"></a> TRIM  
- Returns a string expression after it removes leading blanks.  
+ Returns a string expression after it removes leading and trailing blanks.  
   
  **Syntax**  
   


### PR DESCRIPTION
Forgot to mention TRIM takes off both leading and traililng spaces. @mimig1