### PR TITLE
Update "Clean up resources" container runtime

### DIFF
--- a/articles/iot-edge/quickstart-linux.md
+++ b/articles/iot-edge/quickstart-linux.md
@@ -287,7 +287,8 @@ Delete the containers that were created on your device by the IoT Edge runtime. 
 Remove the container runtime.
 
    ```bash
-   sudo apt-get remove --purge moby
+   sudo apt-get remove --purge moby-cli
+   sudo apt-get remove --purge moby-engine
    ```
 
 ## Next steps


### PR DESCRIPTION
The container runtime packages are "moby-cli" and "moby-engine". Changed the bash command to remove them