### PR TITLE
Remove ClearDB References

### DIFF
--- a/articles/app-service/app-service-web-open-source-technologies-faq.md
+++ b/articles/app-service/app-service-web-open-source-technologies-faq.md
@@ -26,20 +26,6 @@ This article has answers to frequently asked questions (FAQs) about issues with 
 
 [!INCLUDE [support-disclaimer](../../includes/support-disclaimer.md)]
 
-## My ClearDB database is down. How do I resolve this?
-
-For database-related issues, contact [ClearDB support](https://www.cleardb.com/developers/help/support). 
-
-For answers to common questions about ClearDB, see [ClearDB FAQs](https://docs.microsoft.com/azure/store-cleardb-faq/).
-
-## Why wasn't my ClearDB database migrated during my subscription migration?
-
-When you perform resource migration across subscriptions, some limitations apply. A ClearDB MySQL database is a third-party service and is not migrated during an Azure subscription migration.
-
-If you don't manage the migration of your MySQL database before you migrate your Azure resources, your ClearDB MySQL database might be unavailable. To avoid this, first, manually migrate your ClearDB database, and then migrate the Azure subscription for your web app.
-
-For more information, see [FAQs for ClearDB MySQL databases with Azure App Service](https://docs.microsoft.com/azure/store-cleardb-faq/).
-
 ## How do I turn on PHP logging to troubleshoot PHP issues?
 
 To turn on PHP logging:

--- a/articles/billing/billing-how-to-pay-by-invoice.md
+++ b/articles/billing/billing-how-to-pay-by-invoice.md
@@ -23,7 +23,7 @@ You can change the payment method for your Azure subscription to invoice by subm
 
 > [!IMPORTANT]
 > * Invoice pay is only available for business accounts.
-> * [Third party and external services](billing-understand-your-azure-marketplace-charges.md) cannot be purchased or paid for using invoice pay. If your subscription contains resources from external services like ClearDB or SendGrid, they need be deleted before changing to invoice pay. To purchase external services after switching to invoice pay, you need a separate subscription with a credit or debit card.
+> * [Third party and external services](billing-understand-your-azure-marketplace-charges.md) cannot be purchased or paid for using invoice pay. If your subscription contains resources from external services like SendGrid, they need be deleted before changing to invoice pay. To purchase external services after switching to invoice pay, you need a separate subscription with a credit or debit card.
 > * Once you switch to invoice pay, you can't switch back to credit or debit card payment.
 
 ## Request pay by invoice

--- a/articles/billing/billing-understand-your-azure-marketplace-charges.md
+++ b/articles/billing/billing-understand-your-azure-marketplace-charges.md
@@ -19,7 +19,7 @@ ms.author: adpick
 ms.custom: H1Hack27Feb2017
 ---
 # Understand your Azure billing for external service charges
-External services are published by third party software vendors in the Azure marketplace. For example, ClearDB and SendGrid are external services that you can purchase in Azure, but are not published by Microsoft.
+External services are published by third party software vendors in the Azure marketplace. For example, SendGrid is an external services that you can purchase in Azure, but is not published by Microsoft.
 
 When you provision a new external service or resource, a warning is shown:
 

--- a/articles/role-based-access-control/built-in-roles.md
+++ b/articles/role-based-access-control/built-in-roles.md
@@ -58,8 +58,7 @@ The following table provides brief descriptions of the built-in roles. Click the
 | [Classic Network Contributor](#classic-network-contributor) | Lets you manage classic networks, but not access to them. |
 | [Classic Storage Account Contributor](#classic-storage-account-contributor) | Lets you manage classic storage accounts, but not access to them. |
 | [Classic Storage Account Key Operator Service Role](#classic-storage-account-key-operator-service-role) | Classic Storage Account Key Operators are allowed to list and regenerate keys on Classic Storage Accounts |
-| [Classic Virtual Machine Contributor](#classic-virtual-machine-contributor) | Lets you manage classic virtual machines, but not access to them, and not the virtual network or storage account they’re connected to. |
-| [ClearDB MySQL DB Contributor](#cleardb-mysql-db-contributor) | Lets you manage ClearDB MySQL databases, but not access to them. |
+| [Classic Virtual Machine Contributor](#classic-virtual-machine-contributor) | Lets you manage classic virtual machines, but not access to them, and not the virtual network or storage account they’re connected to.|
 | [Cosmos DB Account Reader Role](#cosmos-db-account-reader-role) | Can read Azure Cosmos DB account data. See [DocumentDB Account Contributor](#documentdb-account-contributor) for managing Azure Cosmos DB accounts. |
 | [Data Box Contributor](#data-box-contributor) | Lets you manage everything under Data Box Service except giving access to others. |
 | [Data Box Operator](#data-box-operator) | Lets you manage Data Box Service except creating order or editing order details and giving access to others. |
@@ -649,21 +648,6 @@ The following table provides brief descriptions of the built-in roles. Click the
 > | Microsoft.Resources/deployments/* | Create and manage resource group deployments |
 > | Microsoft.Resources/subscriptions/resourceGroups/read | Gets or lists resource groups. |
 > | Microsoft.Support/* | Create and manage support tickets |
-
-## ClearDB MySQL DB Contributor
-> [!div class="mx-tableFixed"]
-> | | |
-> | --- | --- |
-> | **Description** | Lets you manage ClearDB MySQL databases, but not access to them. |
-> | **Id** | 9106cda0-8a86-4e81-b686-29a22c54effe |
-> | **Actions** |  |
-> | Microsoft.Authorization/*/read | Read roles and role assignments |
-> | Microsoft.Insights/alertRules/* | Create and manage alert rules |
-> | Microsoft.ResourceHealth/availabilityStatuses/read | Gets the availability statuses for all resources in the specified scope |
-> | Microsoft.Resources/deployments/* | Create and manage resource group deployments |
-> | Microsoft.Resources/subscriptions/resourceGroups/read | Gets or lists resource groups. |
-> | Microsoft.Support/* | Create and manage support tickets |
-> | successbricks.cleardb/databases/* | Create and manage ClearDB MySQL databases |
 
 ## Cosmos DB Account Reader Role
 > [!div class="mx-tableFixed"]


### PR DESCRIPTION
ClearDB is no longer a partner available in Azure. This removes references to them in the docs. The service was deprecated and shut down for all customers in June.