### PR TITLE
Updated links to Azure Functions and Web Apps

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website.md
+++ b/articles/storage/blobs/storage-blob-static-website.md
@@ -12,9 +12,9 @@ ms.component: blobs
 ---
 
 # Static website hosting in Azure Storage (Preview)
-Azure Storage now offers static website hosting (Preview), enabling you to deploy cost-effective and scalable modern web applications on Azure. On a static website, webpages contain static content and JavaScript or other client-side code. By contrast, dynamic websites depend on server-side code, and can be hosted using [Azure Web Apps](/app-service/app-service-web-overview.md).
+Azure Storage now offers static website hosting (Preview), enabling you to deploy cost-effective and scalable modern web applications on Azure. On a static website, webpages contain static content and JavaScript or other client-side code. By contrast, dynamic websites depend on server-side code, and can be hosted using [Azure Web Apps](/azure/app-service/app-service-web-overview).
 
-As deployments shift toward elastic, cost-effective models, the ability to deliver web content without the need for server management is critical. The introduction of static website hosting in Azure Storage makes this possible, enabling rich backend capabilities with serverless architectures leveraging [Azure Functions](/azure-functions/functions-overview.md) and other PaaS services.
+As deployments shift toward elastic, cost-effective models, the ability to deliver web content without the need for server management is critical. The introduction of static website hosting in Azure Storage makes this possible, enabling rich backend capabilities with serverless architectures leveraging [Azure Functions](/azure/azure-functions/functions-overview) and other PaaS services.
 
 ## How does it work?
 When you enable static websites on your storage account, a new web service endpoint is created of the form `<account-name>.<zone-name>.web.core.windows.net`.
@@ -82,6 +82,6 @@ Yes, the web endpoint is case sensitive just like the blob endpoint.
 ## Next steps
 * [Using the Azure CDN to access blobs with custom domains over HTTPS](storage-https-custom-domain-cdn.md)
 * [Configure a custom domain name for your blob or web endpoint](storage-custom-domain-name.md)
-* [Azure Functions](/azure-functions/functions-overview.md)
-* [Azure Web Apps](/app-service/app-service-web-overview.md)
+* [Azure Functions](/azure/azure-functions/functions-overview)
+* [Azure Web Apps](/azure/app-service/app-service-web-overview)
 * [Build your first serverless web app](https://aka.ms/static-serverless-webapp)


### PR DESCRIPTION
The links to the Azure Functions and Azure Web Apps overviews were redirecting to a 404, I've updated those links as follows: 
Lines 15 and 86 - Azure Web Apps : Added /azure/ and removed .md extension. 
Lines 16 and 85 - Azure Functions: Added /azure/ and removed .md extension.