### PR TITLE
We need to add outbound access to the CRL

### DIFF
--- a/articles/azure-stack/azure-stack-integrate-endpoints.md
+++ b/articles/azure-stack/azure-stack-integrate-endpoints.md
@@ -70,6 +70,7 @@ Azure Stack supports only transparent proxy servers. In a deployment where a tra
 |Windows Defender|.wdcp.microsoft.com<br>.wdcpalt.microsoft.com<br>*.updates.microsoft.com<br>*.download.microsoft.com<br>https://msdl.microsoft.com/download/symbols<br>http://www.microsoft.com/pkiops/crl<br>http://www.microsoft.com/pkiops/certs<br>http://crl.microsoft.com/pki/crl/products<br>http://www.microsoft.com/pki/certs<br>https://secure.aadcdn.microsoftonline-p.com<br>|HTTPS|80<br>443|
 |NTP|     |UDP|123|
 |DNS|     |TCP<br>UDP|53|
+|CRL|     |HTTPS|443|
 |     |     |     |     |
 
 


### PR DESCRIPTION
The customer needs to allow outbound https access to whatever CRL is on their external certificates, this could be a public CRL or an internal Enterprise CRL, only they would know my examining their certificates.