### PR TITLE
One of the templates was missing a '}'

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-functions-resource.md
+++ b/articles/azure-resource-manager/resource-group-template-functions-resource.md
@@ -123,6 +123,7 @@ The following [example template](https://github.com/Azure/azure-docs-json-sample
                 "signedExpiry": "2018-08-20T11:00:00Z",
                 "signedResourceTypes": "s"
             }
+        }
     },
     "resources": [
         {


### PR DESCRIPTION
Added a '}' as one of the templates missing it.