### PR TITLE
Unit Testing Concepts & How-To for Stateful Services

### DIFF
--- a/articles/service-fabric/service-fabric-concepts-unit-testing.md
+++ b/articles/service-fabric/service-fabric-concepts-unit-testing.md
@@ -1,0 +1,58 @@
+# Unit Testing Reliable Services
+
+- [Unit Testing Reliable Services](#unit-testing-reliable-services)
+    - [Why Unit Test Reliable Services](#why-unit-test-reliable-services)
+        - [Manual Testing Methods](#manual-testing-methods)
+            - [Powershell Command Testing](#powershell-command-testing)
+            - [Load Testing](#load-testing)
+            - [Chaos Testing](#chaos-testing)
+    - [Best Practices](#best-practices)
+        - [Test End-to-End / Only Mock Infrastructure, Data, and External Processes](#test-end-to-end-only-mock-infrastructure-data-and-external-processes)
+    - [Mocking in Reliable Services](#mocking-in-reliable-services)
+
+ This article covers how to write unit tests that cover service fabric stateful service classes. To accomplish there are two primary areas that must be mocked. The first is the service fabric orchestration. This includes when a service's life cycle events, such as RunAsync and OnChangeRoleAsync, are executed. The second is the reliable collection infrastructure. 
+
+##  Why Unit Test Reliable Services 
+
+Unit testing reliable services allows a developer to automate that their service reacts in the appropriate manner to service lifecycle events. Service lifecycle event reactions can be time consuming to test manually after the service is running in a cluster. Unit tests can provide a safety check that code changes to a service do not induce an unexpected failure during lifecycle events.
+
+### Manual Testing Methods
+
+The following lists the three approaches to testing lifecylce events manually and the challenges for each
+
+
+#### Powershell Command Testing
+
+In this approach, powershell commands such as `Move-ServiceFabricPrimaryReplica` can be used to manually trigger a lifecycle event to occur. This approach is great for narrowing down root cause to a particular event that may cause a service to fail. With this approach however, the lifecylce event that causes a failure would need to be known. If the failure only occurs during load but, is not clear which event actually triggers the failure, each of these scenarios would need to be explored to determine root cause
+
+#### Load Testing
+
+Another approach is create artificial load on the cluster. This will cause service fabric to begin to rebalance services around the cluster. Rebalancing itself will execute the lifecycle events such as `OnChangeRoleAsync` to move a replica to a different node.
+
+This approach can be effective at reproducing failures that occur during certain lifecycle events. However, this is a brute-force approach. As with all brute-force approaches, if you need to know what specifically caused the service to fail, this can be extremely difficult to determine unless the service has been extensively instrumented.
+
+#### Chaos Testing
+
+An alternative brute-force approach to load testing is to use the Chaos Test. This will randomly move services around the cluster and restart nodes. While this approach is effective at surfacing failures, it, like load testing, can be difficult to track exactly what caused the failure. Extensive service instrumentation would be required to determine exact root cause.
+
+## Best Practices
+
+### Test End-to-End / Only Mock Infrastructure, Data, and External Processes
+
+The unit tests that are most effective at rooting out potential failures are those that execute all the application code. The only bits mocked are those that involve external processes (i.e. third-party api's or off-cluster azure resources), interactions with Reliable State and Collections, and the service fabric runtime executing the lifecycle events of a service. Everything else in between should be executed during a test. The following is an example of gherkin for a test that demonstrates end-to-end testing
+
+	Given stateful service named "fabric:/MyApp/MyService" is created
+	And a new replica is created as "Primary" with id "111"
+	And a new replica is created as "IdleSecondary" with id "222"
+    And a new replica is created as "IdleSecondary" with id "333"
+	And all idle secondary replicas are promoted to active secondary
+	When a request is made to add the an employee "John Smith"
+    And the active secondary replica "222" is promoted to primary
+    And a request is made to get all employees
+	Then the request should should return the "John Smith" employee
+
+This test will assert that the data being captured on one replica is available to a secondary replica when its promoted to be primary. Assuming that a reliable collection is the backing store for the employee data, Aa potential failure that could be caught with this test is if the application code did not execute `CommitAsync` on the transaction to save the new employee. In that case, the second request to get employees would not return employee added by the first request.
+
+##  Mocking in Reliable Services
+
+Mocking needs to occur both at the orchestration and data layers. The `ServiceFabric.Mocks X.X.X.X` nuget package fortunately provides mocks for both of these layers.

--- a/articles/service-fabric/service-fabric-concepts-unit-testing.md
+++ b/articles/service-fabric/service-fabric-concepts-unit-testing.md
@@ -1,44 +1,51 @@
-# Unit Testing Reliable Services
+# Unit Testing Stateful Services
 
-- [Unit Testing Reliable Services](#unit-testing-reliable-services)
-    - [Why Unit Test Reliable Services](#why-unit-test-reliable-services)
-        - [Manual Testing Methods](#manual-testing-methods)
-            - [Powershell Command Testing](#powershell-command-testing)
-            - [Load Testing](#load-testing)
-            - [Chaos Testing](#chaos-testing)
-    - [Best Practices](#best-practices)
-        - [Test End-to-End / Only Mock Infrastructure, Data, and External Processes](#test-end-to-end-only-mock-infrastructure-data-and-external-processes)
-    - [Mocking in Reliable Services](#mocking-in-reliable-services)
+- [Unit Testing Stateful Services](#unit-testing-stateful-services)
+    - [Unit Testing & Mocking](#unit-testing-mocking)
+        - [Service Fabric Considerations](#service-fabric-considerations)
+    - [Why Unit Test Stateful Services](#why-unit-test-stateful-services)
+    - [Common Practices](#common-practices)
+        - [Arrangement](#arrangement)
+            - [Use Multiple Service Instances](#use-multiple-service-instances)
+            - [Many State Manager Instances, Single Storage](#many-state-manager-instances-single-storage)
+            - [Keep Track of Cancellation Tokens](#keep-track-of-cancellation-tokens)
+            - [Test End-to-End / Only Mock Infrastructure, Data, and External Processes](#test-end-to-end-only-mock-infrastructure-data-and-external-processes)
+        - [Acting](#acting)
+            - [Mimic Service Fabric Replica Orchestration](#mimic-service-fabric-replica-orchestration)
+            - [Run Replica Role Changes](#run-replica-role-changes)
+            - [Cancel Cancellation Tokens](#cancel-cancellation-tokens)
+            - [Execute Requests Against Multiple Replicas](#execute-requests-against-multiple-replicas)
+        - [Asserting](#asserting)
+            - [Ensure Responses Match Across Replicas](#ensure-responses-match-across-replicas)
+            - [Verify Replicas That Should Serve Requests](#verify-replicas-that-should-serve-requests)
+            - [Verify Service Respects Cancellation](#verify-service-respects-cancellation)
 
- This article covers how to write unit tests that cover service fabric stateful service classes. To accomplish there are two primary areas that must be mocked. The first is the service fabric orchestration. This includes when a service's life cycle events, such as RunAsync and OnChangeRoleAsync, are executed. The second is the reliable collection infrastructure. 
+This article covers the concepts and practices of unit testing Service Fabric Stateful Services. Unit testing within Service Fabric deserves its own considerations due to the fact that the application code actively runs under multiple different contexts. In this article we will describe the practices used to ensure application code is covered under each of the different contexts it can run.
 
-##  Why Unit Test Reliable Services 
+## Unit Testing & Mocking
+*Level set what unit testing and mocking means for the context of this article. This should be the canonical definition of what unit testing and mocking is really*
 
-Unit testing reliable services allows a developer to automate that their service reacts in the appropriate manner to service lifecycle events. Service lifecycle event reactions can be time consuming to test manually after the service is running in a cluster. Unit tests can provide a safety check that code changes to a service do not induce an unexpected failure during lifecycle events.
+### Service Fabric Considerations
+*Here we will answer what is different about testing in service fabric compared to traditional application code. Examples may be that the code runs in multiple places simultaneously and any one of the instances can serve requests at any point in time.*
 
-### Manual Testing Methods
+## Why Unit Test Stateful Services 
+*Here we want to answer the question as to what this type of testing uncovers that conventional application/domain specific unit testing may not catch. Big one is the fact that their code will be running on multiple nodes simultaneously and ensuring that each of these instances are not holding state that gets out of sync with the other replica's*
 
-The following lists the three approaches to testing lifecylce events manually and the challenges for each
+## Common Practices
 
+### Arrangement
+*Add a diagram here to illustrate the arrangement of the services and state manager before executing requests.*
 
-#### Powershell Command Testing
+#### Use Multiple Service Instances
+*This will describe why testing a single instance of a service will not cover all scenarios that need to be covered. For example if there is any in memory state, using multiple instances and rotating requests to different instances will uncover issues around in-memory state becoming out of sync.*
 
-In this approach, powershell commands such as `Move-ServiceFabricPrimaryReplica` can be used to manually trigger a lifecycle event to occur. This approach is great for narrowing down root cause to a particular event that may cause a service to fail. With this approach however, the lifecylce event that causes a failure would need to be known. If the failure only occurs during load but, is not clear which event actually triggers the failure, each of these scenarios would need to be explored to determine root cause
+#### Many State Manager Instances, Single Storage
+*Each replica has its own instance of the state manager but, the underlying data should be the same across all replicas. Simulating this can be simiplified by using a singleton dictionary or queue behind the state manager mock.*
 
-#### Load Testing
+#### Keep Track of Cancellation Tokens
+*Keep a copy of the cancellation tokens fed to lifecycle hooks so that the reaction to their cancellation can be tested.*
 
-Another approach is create artificial load on the cluster. This will cause service fabric to begin to rebalance services around the cluster. Rebalancing itself will execute the lifecycle events such as `OnChangeRoleAsync` to move a replica to a different node.
-
-This approach can be effective at reproducing failures that occur during certain lifecycle events. However, this is a brute-force approach. As with all brute-force approaches, if you need to know what specifically caused the service to fail, this can be extremely difficult to determine unless the service has been extensively instrumented.
-
-#### Chaos Testing
-
-An alternative brute-force approach to load testing is to use the Chaos Test. This will randomly move services around the cluster and restart nodes. While this approach is effective at surfacing failures, it, like load testing, can be difficult to track exactly what caused the failure. Extensive service instrumentation would be required to determine exact root cause.
-
-## Best Practices
-
-### Test End-to-End / Only Mock Infrastructure, Data, and External Processes
-
+#### Test End-to-End / Only Mock Infrastructure, Data, and External Processes
 The unit tests that are most effective at rooting out potential failures are those that execute all the application code. The only bits mocked are those that involve external processes (i.e. third-party api's or off-cluster azure resources), interactions with Reliable State and Collections, and the service fabric runtime executing the lifecycle events of a service. Everything else in between should be executed during a test. The following is an example of gherkin for a test that demonstrates end-to-end testing
 
 	Given stateful service named "fabric:/MyApp/MyService" is created
@@ -53,6 +60,25 @@ The unit tests that are most effective at rooting out potential failures are tho
 
 This test will assert that the data being captured on one replica is available to a secondary replica when its promoted to be primary. Assuming that a reliable collection is the backing store for the employee data, Aa potential failure that could be caught with this test is if the application code did not execute `CommitAsync` on the transaction to save the new employee. In that case, the second request to get employees would not return employee added by the first request.
 
-##  Mocking in Reliable Services
+### Acting
+#### Mimic Service Fabric Replica Orchestration
+*Include a link to the article that already exists that documents how each method hook is invoked under different lifecycle events. The tests should invoke these same methods in the order documented.*
 
-Mocking needs to occur both at the orchestration and data layers. The `ServiceFabric.Mocks X.X.X.X` nuget package fortunately provides mocks for both of these layers.
+#### Run Replica Role Changes
+*Test scenarios where the replica that wasnt a primary becomes a primary then serves requests*
+
+#### Cancel Cancellation Tokens
+*Verify the service responds accordingly to cancellation token cancel events. Long running processes should respect tokens and shut down when the token is cancelled*
+
+#### Execute Requests Against Multiple Replicas
+*Executing the same request against multiple replica after transitioning them to primary will verify state is in sync amongst the replicas*
+
+### Asserting
+#### Ensure Responses Match Across Replicas
+*Run requests against multiple replicas and ensure the response they provide matches. This will check if the service has state that is not synced with the other replicas*
+
+#### Verify Replicas That Should Serve Requests
+*If a secondary shouldnt serve a request, verify the service will reject the request when its running on secondary*
+
+#### Verify Service Respects Cancellation
+*Assert long running processes are shut down when cancellation is tripped*

--- a/articles/service-fabric/service-fabric-concepts-unit-testing.md
+++ b/articles/service-fabric/service-fabric-concepts-unit-testing.md
@@ -1,70 +1,69 @@
-# Unit Testing Stateful Services
+---
+title: Unit testing stateful services in Azure Service Fabric | Microsoft Docs
+description: Learn about the concepts and practices of unit testing Service Fabric Stateful Services.
+services: service-fabric
+documentationcenter: .net
+author: charleszipp
+manager: timlt
+editor: vturecek
 
-- [Unit Testing Stateful Services](#unit-testing-stateful-services)
-    - [Unit Testing & Mocking](#unit-testing-mocking)
-        - [Service Fabric Considerations](#service-fabric-considerations)
-    - [Why Unit Test Stateful Services](#why-unit-test-stateful-services)
-    - [Common Practices](#common-practices)
-        - [Arrangement](#arrangement)
-            - [Use Multiple Service Instances](#use-multiple-service-instances)
-            - [Mock The State Manager](#mock-the-state-manager)
-            - [Many State Manager Instances, Single Storage](#many-state-manager-instances--single-storage)
-            - [Keep Track of Cancellation Tokens](#keep-track-of-cancellation-tokens)
-            - [Test End-to-End with Mocked Remote Resouces](#test-end-to-end-with-mocked-remote-resouces)
-        - [Acting](#acting)
-            - [Mimic Service Fabric Replica Orchestration](#mimic-service-fabric-replica-orchestration)
-            - [Run Replica Role Changes](#run-replica-role-changes)
-            - [Cancel Cancellation Tokens](#cancel-cancellation-tokens)
-            - [Execute Requests Against Multiple Replicas](#execute-requests-against-multiple-replicas)
-        - [Asserting](#asserting)
-            - [Ensure Responses Match Across Replicas](#ensure-responses-match-across-replicas)
-            - [Verify Service Respects Cancellation](#verify-service-respects-cancellation)
-            - [Verify Which Replicas Should Serve Requests](#verify-which-replicas-should-serve-requests)
+ms.assetid: 
+ms.service: service-fabric
+ms.devlang: dotnet
+ms.topic: conceptual
+ms.tgt_pltfrm: NA
+ms.workload: NA
+ms.date: 08/22/2018
+ms.author: ryanwi
 
-This article covers the concepts and practices of unit testing Service Fabric Stateful Services. Unit testing within Service Fabric deserves its own considerations due to the fact that the application code actively runs under multiple different contexts. In this article we will describe the practices used to ensure application code is covered under each of the different contexts it can run.
+---
+# Unit testing stateful services in Service Fabric
 
-## Unit Testing & Mocking
-Unit testing in the context of this article is automated testing that can be executed within the context of a test runner such as MSTest or NUnit. The unit tests within this article do not perform operations against a remote resource such as an database or RESTFul api. These remote resources are expected to be mocked. Mocking in the context of this article will fake, record, and control the return values for remote resources.
+This article covers the concepts and practices of unit testing Service Fabric Stateful Services. Unit testing within Service Fabric deserves its own considerations due to the fact that the application code actively runs under multiple different contexts. This article describes the practices used to ensure application code is covered under each of the different contexts it can run.
 
-### Service Fabric Considerations
-Unit testing a service fabric stateful service has several considerations. Firstly, the service code executes on multiple nodes but under different roles. Unit tests should evaluate the code under each role to acheive complete coverage. The different roles would be Primary, Active Secondary, Idle Secondary, and Unknown. The None role does not typically need any special coverage as service fabric considers this role to be void or null service. Secondly, each node will change its role at any given point. To acheive complete coverage, code execution path's should be tested with role changes occuring.
+## Unit testing and mocking
+Unit testing in the context of this article is automated testing that can be executed within the context of a test runner such as MSTest or NUnit. The unit tests within this article do not perform operations against a remote resource such as a database or RESTFul API. These remote resources should be mocked. Mocking in the context of this article will fake, record, and control the return values for remote resources.
 
-## Why Unit Test Stateful Services 
-Unit testing stateful services can help to uncover some common mistakes that are made that wouldnt necessarily be caught by conventional application or domain specific unit testing. For example, if the stateful service has any in-memory state, this type of testing can verify that this in-memory state is kept in sync across each replica. This type of testing can also verify that a stateful service responds to cancellation tokens passed in by the service fabric orchestration appropriately. When cancellations are triggered, the service should halt any long running and/or asynchronous operations.  
+### Service Fabric considerations
+Unit testing a service fabric stateful service has several considerations. Firstly, the service code executes on multiple nodes but under different roles. Unit tests should evaluate the code under each role to achieve complete coverage. The different roles would be Primary, Active Secondary, Idle Secondary, and Unknown. The None role does not typically need any special coverage as service fabric considers this role to be void or null service. Secondly, each node will change its role at any given point. To achieve complete coverage, code execution path's should be tested with role changes occurring.
 
-## Common Practices
+## Why unit test stateful services? 
+Unit testing stateful services can help to uncover some common mistakes that are made that would not necessarily be caught by conventional application or domain-specific unit testing. For example, if the stateful service has any in-memory state, this type of testing can verify that this in-memory state is kept in sync across each replica. This type of testing can also verify that a stateful service responds to cancellation tokens passed in by the service fabric orchestration appropriately. When cancellations are triggered, the service should halt any long running and/or asynchronous operations.  
+
+## Common practices
 
 The following section advises on the most common practices for unit testing a stateful service. It also advises what a mocking layer should have to closely align to the Service Fabric orchestration and state management. Mocking libraries do exist libraries that provide this functionality. [ServiceFabric.Mocks](https://www.nuget.org/packages/ServiceFabric.Mocks/) as of 3.3.0 or later is one such library that provides the mocking functionality recommended and follows the practices outlined below.
 
 ### Arrangement
 
-#### Use Multiple Service Instances
-Unit tests should execute multiple instances of a stateful service. This simulates what actually happens on the cluster where Service Fabric provisions multiple replicas running your service across different nodes. Each of these instances will be executing under a different context however. When running the test each instance should be primed with the role configuration expected on the cluster. For example, if the service is expected to have target replica size of 3, Service Fabric would provision 3 replicas on different nodes. One of which being the primary and the other two being Active Secondary's.
+#### Use multiple service instances
+Unit tests should execute multiple instances of a stateful service. This simulates what actually happens on the cluster where Service Fabric provisions multiple replicas running your service across different nodes. Each of these instances will be executing under a different context however. When running the test, each instance should be primed with the role configuration expected on the cluster. For example, if the service is expected to have target replica size of 3, Service Fabric would provision three replicas on different nodes. One of which being the primary and the other two being Active Secondary's.
 
-In most cases the service execution path's will vary slightly for each of these roles. For example, if the service should not accept requests from an Active Secondary, the service may have a check for this case to throw back an informative exception that indicates a request was attempte on a secondary. Having multiple instances will allow this situation to be tested.
+In most cases, the service execution path's will vary slightly for each of these roles. For example, if the service should not accept requests from an Active Secondary, the service may have a check for this case to throw back an informative exception that indicates a request was attempted on a secondary. Having multiple instances will allow this situation to be tested.
 
 Additionally, having multiple instances allows the tests to switch the roles of each of these instances to verify the responses are consistent despite the role changes.
 
-#### Mock The State Manager
-The State Manager should be treated as a remote resource and therefore mocked. When mocking the state manager, there will need to be some underlying in-memory storage for tracking what is saved to the state manager so that it can be read and verified. A simple way to acheive this is to create mock instances of each of the types of Reliable Collections. Within those mocks use a data type that closely aligns with the operations performed against that collection. The following are some suggested data types for each reliable collection
+#### Mock the state manager
+The State Manager should be treated as a remote resource and therefore mocked. When mocking the state manager, there needs to be some underlying in-memory storage for tracking what is saved to the state manager so that it can be read and verified. A simple way to achieve this is to create mock instances of each of the types of Reliable Collections. Within those mocks, use a data type that closely aligns with the operations performed against that collection. The following are some suggested data types for each reliable collection
 
 - IReliableDictionary<TKey, TValue> -> System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
 - IReliableQueue<T> -> System.Collections.Generic.Queue<T>
 - IReliableConcurrentQueue<T> -> System.Collections.Concurrent.ConcurrentQueue<T>
 
-#### Many State Manager Instances, Single Storage
-As mentioned before, the State Manager and Reliable Collections should be treated as a remote resource. Therefore, these should and will be mocked within the unit tests. However, when running multiple instances of a stateful service it will be a challenge to keep each mocked state manager in sync across different stateful service instances. When the stateful service is running on the cluster, the Service Fabric takes care of keeping each secondary replica's state manager consistent with the primary replica. Therefore, the tests should behave the same so that they can simulate role changes.
+#### Many State Manager Instances, single storage
+As mentioned before, the State Manager and Reliable Collections should be treated as a remote resource. Therefore, these resources should and will be mocked within the unit tests. However, when running multiple instances of a stateful service it will be a challenge to keep each mocked state manager in sync across different stateful service instances. When the stateful service is running on the cluster, the Service Fabric takes care of keeping each secondary replica's state manager consistent with the primary replica. Therefore, the tests should behave the same so that they can simulate role changes.
 
-A simple way this synchronization can be acheived, is to use a singleton pattern for the underlying object that stores the data written to each Reliable Collection. For example, if a stateful service is using an `IReliableDictionary<string, string>`. The mock state manager should return a mock of `IReliableDictionary<string, string>`. That mock may use a `ConcurrentDictionary<string, string>` to keep track of the key/value pairs written. The `ConcurrentDictionary<string, string>` should be a singleton used by all instances of the state managers passed to the service.
+A simple way this synchronization can be achieved, is to use a singleton pattern for the underlying object that stores the data written to each Reliable Collection. For example, if a stateful service is using an `IReliableDictionary<string, string>`. The mock state manager should return a mock of `IReliableDictionary<string, string>`. That mock may use a `ConcurrentDictionary<string, string>` to keep track of the key/value pairs written. The `ConcurrentDictionary<string, string>` should be a singleton used by all instances of the state managers passed to the service.
 
-#### Keep Track of Cancellation Tokens
-Cancellation tokens are an important yet commonly overlooked aspect of stateful services. When Service Fabric starts up a primary replica for a stateful service, a cancellation token is provided. This cancellation token is intended to signal to the service when it being removed or demoted to a different role. The stateful service should stop any long running or asynchronous operations so that Service Fabric can complete the role change workflow.
+#### Keep track of cancellation tokens
+Cancellation tokens are an important yet commonly overlooked aspect of stateful services. When Service Fabric starts up a primary replica for a stateful service, a cancellation token is provided. This cancellation token is intended to signal to the service when it is removed or demoted to a different role. The stateful service should stop any long running or asynchronous operations so that Service Fabric can complete the role change workflow.
 
 When running the unit tests, any cancellation tokens that are provided to RunAsync, ChangeRoleAsync, OpenAsync, and CloseAsync should be held during the test execution. Holding onto these tokens will allow the test to simulate a service shutdown or demotion and verify the service responds appropriately.
 
-#### Test End-to-End with Mocked Remote Resouces
-Unit tests should execute as much of the application code that can modify the state of the stateful service as possible. Its recommended that the tests be more end-to-end in nature. The only mocks that exist are to record, simulate, and/or verify remote resource interactions. This includes interactions with the State Manager and Reliable Collections. The following is an example of gherkin for a test that demonstrates end-to-end testing
+#### Test end-to-end with mocked remote resources
+Unit tests should execute as much of the application code that can modify the state of the stateful service as possible. It's recommended that the tests be more end-to-end in nature. The only mocks that exist are to record, simulate, and/or verify remote resource interactions. This includes interactions with the State Manager and Reliable Collections. The following snippet is an example of gherkin for a test that demonstrates end-to-end testing:
 
+```
 	Given stateful service named "fabric:/MyApp/MyService" is created
 	And a new replica is created as "Primary" with id "111"
 	And a new replica is created as "IdleSecondary" with id "222"
@@ -74,31 +73,32 @@ Unit tests should execute as much of the application code that can modify the st
     And the active secondary replica "222" is promoted to primary
     And a request is made to get all employees
 	Then the request should should return the "John Smith" employee
+```
 
-This test will assert that the data being captured on one replica is available to a secondary replica when its promoted to be primary. Assuming that a reliable collection is the backing store for the employee data, Aa potential failure that could be caught with this test is if the application code did not execute `CommitAsync` on the transaction to save the new employee. In that case, the second request to get employees would not return employee added by the first request.
+This test asserts that the data being captured on one replica is available to a secondary replica when it is promoted to primary. Assuming that a reliable collection is the backing store for the employee data, Aa potential failure that could be caught with this test is if the application code did not execute `CommitAsync` on the transaction to save the new employee. In that case, the second request to get employees would not return employee added by the first request.
 
 ### Acting
-#### Mimic Service Fabric Replica Orchestration
-When managing multiple service instances, the tests should intialize and tear down these services in the same manner as the Service Fabric orchestration. For example, when a service is created on a new primary replica, Service Fabric will invoke CreateServiceReplicaListener, OpenAsync, ChangeRoleAsync, and RunAsync. The lifecycle events are documented in the following articles:
+#### Mimic Service Fabric replica orchestration
+When managing multiple service instances, the tests should initialize and tear down these services in the same manner as the Service Fabric orchestration. For example, when a service is created on a new primary replica, Service Fabric will invoke CreateServiceReplicaListener, OpenAsync, ChangeRoleAsync, and RunAsync. The lifecycle events are documented in the following articles:
 
 - [Stateful Service Startup](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-lifecycle#stateful-service-startup)
 - [Stateful Service Shutdown](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-lifecycle#stateful-service-shutdown)
 - [Stateful Service Primary Swaps](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-lifecycle#stateful-service-primary-swaps)
 
-#### Run Replica Role Changes
+#### Run replica role changes
 The unit tests should change the roles of the service instances in the same manner as the Service Fabric orchestration. The role state machine is documented in the following article:
 
 [Replica Role State Machine](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-concepts-replica-lifecycle#replica-role)
 
-Simulating role changes is one of the more critical aspects of testing as it can uncover issues where the replicas state are not consistent with each other. This happens often times due to storing in-memory state in static or class level instance variables. Examples of this may be cancellation tokens, enums, and configuration objects/values. This will also ensure that the service is respecting the cancellation tokens provided during RunAsync to allow the role change to occur. This can also uncover issues that may arise if code is not written to allow an invocation of RunAsync multiple times.
+Simulating role changes is one of the more critical aspects of testing and can uncover issues where the replica's state are not consistent with each other. Inconsistent replica state can occur due to storing in-memory state in static or class level instance variables. Examples of this may be cancellation tokens, enums, and configuration objects/values. This will also ensure that the service is respecting the cancellation tokens provided during RunAsync to allow the role change to occur. Simulating role changes can also uncover issues that may arise if code is not written to allow an invocation of RunAsync multiple times.
 
-#### Cancel Cancellation Tokens
-There should exists unit tests where the cancellation token provided to RunAsync is actually cancelled. This will allow the test to verify that the service gracefully shutsdown. During this shut down any long running or asynchronous operations should be stopped. Example of a long running process that may exist on a service is one that listens for messages on a Reliable Queue. This may exist directly within RunAsync or a background thread. The implementation should include logic for exiting the operation if this cancellation token is cancelled.
+#### Cancel cancellation tokens
+There should exist unit tests where the cancellation token provided to RunAsync is canceled. This will allow the test to verify that the service gracefully shuts down. During this shut down any long running or asynchronous operations should be stopped. Example of a long running process that may exist on a service is one that listens for messages on a Reliable Queue. This may exist directly within RunAsync or a background thread. The implementation should include logic for exiting the operation if this cancellation token is canceled.
 
-If the stateful services makes use of any cache or in-memory state that should only exist on the primary, it should be disposed at this time. This is to ensure that this state is consistent if the node becomes a primary again later. Cancellation testing will allow the test to verify this state is disposed properly.
+If the stateful services make use of any cache or in-memory state that should only exist on the primary, it should be disposed at this time. This is to ensure that this state is consistent if the node becomes a primary again later. Cancellation testing will allow the test to verify this state is disposed properly.
 
-#### Execute Requests Against Multiple Replicas
-There should assert tests that execute the same request against different replica's. When pairing this with role changes, consistency issues can be uncovered. An example test may perform the following steps
+#### Execute requests against multiple replicas
+There should be assert tests that execute the same request against different replica's. When paired with role changes, consistency issues can be uncovered. An example test may perform the following steps:
 1. Execute a write request against the current primary
 2. Execute a read request that returns the data written in step 1 against current primary
 3. Promote a secondary to primary. This should also demote the current primary to secondary
@@ -109,13 +109,14 @@ In the last step, the test can assert the data returned is consistent. A potenti
 In-memory data is typically used to create secondary indexes or aggregations of data that exists in a reliable collection.
 
 ### Asserting
-#### Ensure Responses Match Across Replicas
-Unit tests should assert that a response for a given request is consistent across multiple replica after they transition to primary. This can surface potential issues where data provided in the response is either not backed by a reliable collection, or kept in-memory without a mechanism to synchornize that data across replicas. This will ensure that the service sends back consistent responses after Service Fabric rebalances or fails over to a new primary replica.
+#### Ensure responses match across replicas
+Unit tests should assert that a response for a given request is consistent across multiple replicas after they transition to primary. This can surface potential issues where data provided in the response is either not backed by a reliable collection, or kept in-memory without a mechanism to synchronize that data across replicas. This will ensure that the service sends back consistent responses after Service Fabric rebalances or fails over to a new primary replica.
 
-#### Verify Service Respects Cancellation
-Long-running or asynchronous processes that should be terminated when a cancellation token is cancelled should be verified that they actually terminated after cancellation. This will ensure that despite the replica changing roles, processes that are not intended to keep running on non-primary replica stop before the transition completes. This can also uncover issues where such a process blocks a role change or shutdown request from Service Fabric from completing.
+#### Verify service respects cancellation
+Long-running or asynchronous processes that should be terminated when a cancellation token is canceled should be verified that they actually terminated after cancellation. This will ensure that despite the replica changing roles, processes that are not intended to keep running on non-primary replica stop before the transition completes. This can also uncover issues where such a process blocks a role change or shutdown request from Service Fabric from completing.
 
-#### Verify Which Replicas Should Serve Requests
+#### Verify which replicas should serve requests
 The tests should assert the expected behavior if a request is routed to a non-primary replica. Service Fabric does provide the ability to have secondary replicas serve requests. However, writes to reliable collections can only occur from the primary replica. If your application intends for only primary replicas to serve requests or, only a subset of requests can be handled by a secondary, then the tests should assert the expected behavior for both the positive and negative cases. The negative case being a request is routed to a replica that should not handle the request and, the positive being the opposite.
 
-
+## Next steps
+Learn how to [unit test stateful services](service-fabric-how-to-unit-test-stateful-services.md).

--- a/articles/service-fabric/service-fabric-concepts-unit-testing.md
+++ b/articles/service-fabric/service-fabric-concepts-unit-testing.md
@@ -14,7 +14,7 @@ ms.topic: conceptual
 ms.tgt_pltfrm: NA
 ms.workload: NA
 ms.date: 08/22/2018
-ms.author: ryanwi
+ms.author: 
 
 ---
 # Unit testing stateful services in Service Fabric

--- a/articles/service-fabric/service-fabric-concepts-unit-testing.md
+++ b/articles/service-fabric/service-fabric-concepts-unit-testing.md
@@ -7,9 +7,10 @@
     - [Common Practices](#common-practices)
         - [Arrangement](#arrangement)
             - [Use Multiple Service Instances](#use-multiple-service-instances)
-            - [Many State Manager Instances, Single Storage](#many-state-manager-instances-single-storage)
+            - [Mock The State Manager](#mock-the-state-manager)
+            - [Many State Manager Instances, Single Storage](#many-state-manager-instances--single-storage)
             - [Keep Track of Cancellation Tokens](#keep-track-of-cancellation-tokens)
-            - [Test End-to-End / Only Mock Infrastructure, Data, and External Processes](#test-end-to-end-only-mock-infrastructure-data-and-external-processes)
+            - [Test End-to-End with Mocked Remote Resouces](#test-end-to-end-with-mocked-remote-resouces)
         - [Acting](#acting)
             - [Mimic Service Fabric Replica Orchestration](#mimic-service-fabric-replica-orchestration)
             - [Run Replica Role Changes](#run-replica-role-changes)
@@ -23,30 +24,47 @@
 This article covers the concepts and practices of unit testing Service Fabric Stateful Services. Unit testing within Service Fabric deserves its own considerations due to the fact that the application code actively runs under multiple different contexts. In this article we will describe the practices used to ensure application code is covered under each of the different contexts it can run.
 
 ## Unit Testing & Mocking
-*Level set what unit testing and mocking means for the context of this article. This should be the canonical definition of what unit testing and mocking is really*
+Unit testing in the context of this article is automated testing that can be executed within the context of a test runner such as MSTest or NUnit. The unit tests within this article do not perform operations against a remote resource such as an database or RESTFul api. These remote resources are expected to be mocked. Mocking in the context of this article will fake, record, and control the return values for remote resources.
 
 ### Service Fabric Considerations
-*Here we will answer what is different about testing in service fabric compared to traditional application code. Examples may be that the code runs in multiple places simultaneously and any one of the instances can serve requests at any point in time.*
+Unit testing a service fabric stateful service has several considerations. Firstly, the service code executes on multiple nodes but under different roles. Unit tests should evaluate the code under each role to acheive complete coverage. The different roles would be Primary, Active Secondary, Idle Secondary, and Unknown. The None role does not typically need any special coverage as service fabric considers this role to be void or null service. Secondly, each node will change its role at any given point. To acheive complete coverage, code execution path's should be tested with role changes occuring.
 
 ## Why Unit Test Stateful Services 
-*Here we want to answer the question as to what this type of testing uncovers that conventional application/domain specific unit testing may not catch. Big one is the fact that their code will be running on multiple nodes simultaneously and ensuring that each of these instances are not holding state that gets out of sync with the other replica's*
+Unit testing stateful services can help to uncover some common mistakes that are made that wouldnt necessarily be caught by conventional application or domain specific unit testing. For example, if the stateful service has any in-memory state, this type of testing can verify that this in-memory state is kept in sync across each replica. This type of testing can also verify that a stateful service responds to cancellation tokens passed in by the service fabric orchestration appropriately. When cancellations are triggered, the service should halt any long running and/or asynchronous operations.  
 
 ## Common Practices
+
+The following section advises on the most common practices for unit testing a stateful service. It also advises what a mocking layer should have to closely align to the Service Fabric orchestration and state management. Mocking libraries do exist libraries that provide this functionality. [ServiceFabric.Mocks](https://www.nuget.org/packages/ServiceFabric.Mocks/) as of 3.3.0 or later is one such library that provides the mocking functionality recommended and follows the practices outlined below.
 
 ### Arrangement
 *Add a diagram here to illustrate the arrangement of the services and state manager before executing requests.*
 
 #### Use Multiple Service Instances
-*This will describe why testing a single instance of a service will not cover all scenarios that need to be covered. For example if there is any in memory state, using multiple instances and rotating requests to different instances will uncover issues around in-memory state becoming out of sync.*
+Unit tests should execute multiple instances of a stateful service. This simulates what actually happens on the cluster where Service Fabric provisions multiple replicas running your service across different nodes. Each of these instances will be executing under a different context however. When running the test each instance should be primed with the role configuration expected on the cluster. For example, if the service is expected to have target replica size of 3, Service Fabric would provision 3 replicas on different nodes. One of which being the primary and the other two being Active Secondary's.
+
+In most cases the service execution path's will vary slightly for each of these roles. For example, if the service should not accept requests from an Active Secondary, the service may have a check for this case to throw back an informative exception that indicates a request was attempte on a secondary. Having multiple instances will allow this situation to be tested.
+
+Additionally, having multiple instances allows the tests to switch the roles of each of these instances to verify the responses are consistent despite the role changes.
+
+#### Mock The State Manager
+The State Manager should be treated as a remote resource and therefore mocked. When mocking the state manager, there will need to be some underlying in-memory storage for tracking what is saved to the state manager so that it can be read and verified. A simple way to acheive this is to create mock instances of each of the types of Reliable Collections. Within those mocks use a data type that closely aligns with the operations performed against that collection. The following are some suggested data types for each reliable collection
+
+- IReliableDictionary<TKey, TValue> -> System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>
+- IReliableQueue<T> -> System.Collections.Generic.Queue<T>
+- IReliableConcurrentQueue<T> -> System.Collections.Concurrent.ConcurrentQueue<T>
 
 #### Many State Manager Instances, Single Storage
-*Each replica has its own instance of the state manager but, the underlying data should be the same across all replicas. Simulating this can be simiplified by using a singleton dictionary or queue behind the state manager mock.*
+As mentioned before, the State Manager and Reliable Collections should be treated as a remote resource. Therefore, these should and will be mocked within the unit tests. However, when running multiple instances of a stateful service it will be a challenge to keep each mocked state manager in sync across different stateful service instances. When the stateful service is running on the cluster, the Service Fabric takes care of keeping each secondary replica's state manager consistent with the primary replica. Therefore, the tests should behave the same so that they can simulate role changes.
+
+A simple way this synchronization can be acheived, is to use a singleton pattern for the underlying object that stores the data written to each Reliable Collection. For example, if a stateful service is using an `IReliableDictionary<string, string>`. The mock state manager should return a mock of `IReliableDictionary<string, string>`. That mock may use a `ConcurrentDictionary<string, string>` to keep track of the key/value pairs written. The `ConcurrentDictionary<string, string>` should be a singleton used by all instances of the state managers passed to the service.
 
 #### Keep Track of Cancellation Tokens
-*Keep a copy of the cancellation tokens fed to lifecycle hooks so that the reaction to their cancellation can be tested.*
+Cancellation tokens are an important yet commonly overlooked aspect of stateful services. When Service Fabric starts up a primary replica for a stateful service, a cancellation token is provided. This cancellation token is intended to signal to the service when it being removed or demoted to a different role. The stateful service should stop any long running or asynchronous operations so that Service Fabric can complete the role change workflow.
 
-#### Test End-to-End / Only Mock Infrastructure, Data, and External Processes
-The unit tests that are most effective at rooting out potential failures are those that execute all the application code. The only bits mocked are those that involve external processes (i.e. third-party api's or off-cluster azure resources), interactions with Reliable State and Collections, and the service fabric runtime executing the lifecycle events of a service. Everything else in between should be executed during a test. The following is an example of gherkin for a test that demonstrates end-to-end testing
+When running the unit tests, any cancellation tokens that are provided to RunAsync, ChangeRoleAsync, OpenAsync, and CloseAsync should be held during the test execution. Holding onto these tokens will allow the test to simulate a service shutdown or demotion and verify the service responds appropriately.
+
+#### Test End-to-End with Mocked Remote Resouces
+Unit tests should execute as much of the application code that can modify the state of the stateful service as possible. Its recommended that the tests be more end-to-end in nature. The only mocks that exist are to record, simulate, and/or verify remote resource interactions. This includes interactions with the State Manager and Reliable Collections. The following is an example of gherkin for a test that demonstrates end-to-end testing
 
 	Given stateful service named "fabric:/MyApp/MyService" is created
 	And a new replica is created as "Primary" with id "111"
@@ -62,13 +80,22 @@ This test will assert that the data being captured on one replica is available t
 
 ### Acting
 #### Mimic Service Fabric Replica Orchestration
-*Include a link to the article that already exists that documents how each method hook is invoked under different lifecycle events. The tests should invoke these same methods in the order documented.*
+When managing multiple service instances, the tests should intialize and tear down these services in the same manner as the Service Fabric orchestration. For example, when a service is created on a new primary replica, Service Fabric will invoke CreateServiceReplicaListener, OpenAsync, ChangeRoleAsync, and RunAsync. The lifecycle events are documented in the following articles:
+
+*TODO: add links to https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-reliable-services-lifecycle#stateful-service-startup, shutdown, and primary swaps*
 
 #### Run Replica Role Changes
-*Test scenarios where the replica that wasnt a primary becomes a primary then serves requests*
+The unit tests should change the roles of the service instances in the same manner as the Service Fabric orchestration. The role state machine is documented in the following article:
+
+*TODO: add link https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-concepts-replica-lifecycle#replica-role*
+
+Simulating role changes is one of the more critical aspects of testing as it can uncover issues where the replicas state are not consistent with each other. This happens often times due to storing in-memory state in static or class level instance variables. Examples of this may be cancellation tokens, enums, and configuration objects/values. This will also ensure that the service is respecting the cancellation tokens provided during RunAsync to allow the role change to occur. This can also uncover issues that may arise if code is not written to allow an invocation of RunAsync multiple times.
 
 #### Cancel Cancellation Tokens
 *Verify the service responds accordingly to cancellation token cancel events. Long running processes should respect tokens and shut down when the token is cancelled*
+There should exists unit tests where the cancellation token provided to RunAsync is actually cancelled. This will allow the test to verify that the service gracefully shutsdown. During this shut down any long running or asynchronous operations should be stopped. Example of a long running process that may exist on a service is one that listens for messages on a Reliable Queue. This may exist directly within RunAsync or a background thread. The implementation should include logic for exiting the operation if this cancellation token is cancelled.
+
+If the stateful services makes use of any cache or in-memory state that should only exist on the primary, it should be disposed at this time. This is to ensure that this state is consistent if the node becomes a primary again later. Cancellation testing will allow the test to verify this state is disposed properly.
 
 #### Execute Requests Against Multiple Replicas
 *Executing the same request against multiple replica after transitioning them to primary will verify state is in sync amongst the replicas*

--- a/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
+++ b/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
@@ -1,0 +1,111 @@
+# Unit Testing Considerations in Stateful Services
+*TODO: Here highlight points to keep in mind when developing tests for stateful services. These should cover*
+1. *Each replica executes application code but under different context*
+2. *State should be synchronized between the replicas (reliable collections facilitate this easiest)*
+3. *Replica's will move and change roles. The context under which they execute is dependent on the role.*
+
+*Link back to conceptual article indicating this article assumes the consumer has read it as those concepts will be applied here.*
+
+# ServiceFabric.Mocks
+*TODO: As of version 3.3.0, this package provides an api for mocking both the orchestration of the replicas and the state management. This will be used in the examples.*
+*Add link to nuget package and github*
+
+# Setting up the Mock Orchestration & State
+As part of the arrange portion of a test, a mock replica set and state manager will be created. The replica set will then own creating an instance of the tested service for each replica. It will also own executing lifecycle events such as `OnChangeRole` and `RunAsync`. The mock state manager will ensure any operations performed against the state manager are run and kept as the actual state manager would.
+
+1. Create a service factory delegate that will instantiate the service being tested. This should be similar or same as the service factory callback typically found in `Program.cs` for a service fabric service or actor. This should follow the following signature:
+```csharp
+MyStatefulService CreateMyStatefulService(StatefulServiceContext context, IReliableStateManagerReplica2 stateManager)
+```
+2. Create an instance of `MockReliableStateManager` class. This will mock all interactions with the state manager.
+3. Create an instance of `MockStatefulServiceReplicaSet<TStatefulService>` where `TStatefulService` is the type of the service being tested. This will require the delegate created in step #1 and the state manager instantiated in #2
+4. Add Replicas to the Replica Set. Specify the role (i.e. Primary, ActiveSecondary, IdleSecondary) and the id of the replica
+> Hold on to the replica id's! These will likely be used during the act and assert portions of a unit test.
+
+```csharp
+//service factory to instruct how to create the service instance
+var serviceFactory = (StatefulServiceContext context, IReliableStateManagerReplica2 stateManager) => new MyStatefulService(context, stateManager);
+//instantiate a new mock state manager
+var stateManager = new MockReliableStateManager();
+//instantiate a new replica set with the service factory and state manager
+var replicaSet = new MockStatefulServiceReplicaSet<MyStatefulService>(CreateStatefulService, stateManager);
+//add a new Primary replica with id 1
+await replicaSet.AddReplicaAsync(ReplicaRole.Primary, 1);
+//add a new ActiveSecondary replica with id 2
+await replicaSet.AddReplicaAsync(ReplicaRole.ActiveSecondary, 2);
+//add a second ActiveSecondary replica with id 3
+await replicaSet.AddReplicaAsync(ReplicaRole.ActiveSecondary, 3);
+```
+
+# Executing Service Requests
+Service requests can be executed on a specific replica using the convience properties and lookups.
+```csharp
+const string stateName = "test";
+var payload = new Payload(StatePayload);
+
+//execute a request on the primary replica using
+await replicaSet.Primary.ServiceInstance.InsertAsync(stateName, payload);
+
+//execute a request against replica with id 2
+await replicaSet[2].ServiceInstance.InsertAsync(stateName, payload);
+
+//execute a request against one of the active secondary replicas
+await replicaSet.FirstActiveSecondary.InsertAsync(stateName, payload);
+```
+
+# Execute A Service Move
+The mock replica set exposes several convienence methods to trigger different types of service moves.
+```csharp
+//promote the first active secondary to primary
+replicaSet.PromoteNewReplicaToPrimaryAsync();
+//promote the secondary with replica id 4 to primary
+replicaSet.PromoteNewReplicaToPrimaryAsync(4);
+
+//promote the first idle secondary to an active secondary
+PromoteIdleSecondaryToActiveSecondaryAsync();
+//promote idle secodary with replica id 4 to active secondary 
+PromoteIdleSecondaryToActiveSecondaryAsync(4);
+
+//add a new replica with randomly assigned replica id and promote it to primary
+PromoteNewReplicaToPrimaryAsync()
+//add a new replica with replica id 4 and promote it to primary
+PromoteNewReplicaToPrimaryAsync(4)
+```
+
+# Putting It All Together
+The following test demonstrates setting up a 3 node replica set and verifying that the data is available from a secondary after a role change. A typical issue this may catch is if the data added during `InsertAsync` was saved either to something in-memory or to a reliable collection without running `CommitAsync`. In either case, the secondary would be out of sync with the primary. This would lead to inconsistent responses after service moves.
+
+```csharp
+[TestMethod]
+public async Task TestServiceState_InMemoryState_PromoteActiveSecondary()
+{
+    var stateManager = new MockReliableStateManager();
+    var replicaSet = new MockStatefulServiceReplicaSet<MyStatefulService>(CreateStatefulService, stateManager);
+    await replicaSet.AddReplicaAsync(ReplicaRole.Primary, 1);
+    await replicaSet.AddReplicaAsync(ReplicaRole.ActiveSecondary, 2);
+    await replicaSet.AddReplicaAsync(ReplicaRole.ActiveSecondary, 3);
+
+    const string stateName = "test";
+    var payload = new Payload(StatePayload);
+
+    //insert data
+    await replicaSet.Primary.ServiceInstance.InsertAsync(stateName, payload);
+    //promote one of the secondaries to primary
+    await replicaSet.PromoteActiveSecondaryToPrimaryAsync(2);
+    //get data
+    var payloads = (await replicaSet.Primary.ServiceInstance.GetPayloadsAsync()).ToList();
+
+    //data should match what was inserted against the primary
+    Assert.IsTrue(payloads.Count == 1);
+    Assert.IsTrue(payloads[0].Content == payload.Content);
+
+    //verify the data was saved against the reliable dictionary
+    var dictionary = await StateManager.GetOrAddAsync<IReliableDictionary<string, Payload>>(MyStatefulService.StateManagerDictionaryKey);
+    using(var tx = StateManager.CreateTransaction())
+    {
+        var payload = await dictionary.TryGetValue(stateName);
+        Assert.IsTrue(payload.HasValue);
+        Assert.IsTrue(payload.Value.Content == payload.Content);
+    }
+}
+```

--- a/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
+++ b/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
@@ -1,22 +1,41 @@
+---
+title: Develop unit tests for stateful services in Azure Service Fabric | Microsoft Docs
+description: Learn how to develop unit tests for  Service Fabric Stateful Services.
+services: service-fabric
+documentationcenter: .net
+author: charleszipp
+manager: timlt
+editor: vturecek
+
+ms.assetid: 
+ms.service: service-fabric
+ms.devlang: dotnet
+ms.topic: conceptual
+ms.tgt_pltfrm: NA
+ms.workload: NA
+ms.date: 08/22/2018
+ms.author: ryanwi
+
+---
+
 # Unit Testing Considerations in Stateful Services
-While developing unit tests for stateful services, each there are some special considerations that should be kept in mind.
-1. Each replica executes application code but under different context. If the service uses 3 replicas, the service code is executing on 3 nodes in parallel under different context/role.
-2. State stored within the stateful service should be consistent amongst all replicas. The state manager and reliable collections will provide this consistentcy out-of-the-box. However, in-memory state will need to be managed by the application code.
+Unit testing Service Fabric stateful services uncovers common mistakes that would not necessarily be caught by conventional application or domain-specific unit testing. While developing unit tests for stateful services, there are some special considerations that should be kept in mind.
+
+1. Each replica executes application code but under different context. If the service uses three replicas, the service code is executing on three nodes in parallel under different context/role.
+2. State stored within the stateful service should be consistent amongst all replicas. The state manager and reliable collections will provide this consistency out-of-the-box. However, in-memory state will need to be managed by the application code.
 3. Each replica will change roles at some point while running on the cluster. A secondary replica will become a primary, in the event that the node hosting the primary becomes unavailable or overloaded. This is natural behavior for service fabric therefore services must plan for eventually executing under a different role.
 
-This article assumes the following conceptual documentation has been read:
+This article assumes that [Unit testing stateful services in Service Fabric](service-fabric-concepts-unit-testing.md) has been read.
 
-*TODO: Link back to conceptual article indicating this article assumes the consumer has read it as those concepts will be applied here.*
-
-# ServiceFabric.Mocks
-As of version 3.3.0, [ServiceFabric.Mocks](https://www.nuget.org/packages/ServiceFabric.Mocks/) provides an api for mocking both the orchestration of the replicas and the state management. This will be used in the examples.
+## The ServiceFabric.Mocks library
+As of version 3.3.0, [ServiceFabric.Mocks](https://www.nuget.org/packages/ServiceFabric.Mocks/) provides an API for mocking both the orchestration of the replicas and the state management. This will be used in the examples.
 
 [Nuget](https://www.nuget.org/packages/ServiceFabric.Mocks/)
 [Github](https://github.com/loekd/ServiceFabric.Mocks)
 
 *ServiceFabric.Mocks is not owned or maintained by Microsoft. However, this is currently the Microsoft recommended library for unit testing stateful services.*
 
-# Setting up the Mock Orchestration & State
+## Set up the mock orchestration and state
 As part of the arrange portion of a test, a mock replica set and state manager will be created. The replica set will then own creating an instance of the tested service for each replica. It will also own executing lifecycle events such as `OnChangeRole` and `RunAsync`. The mock state manager will ensure any operations performed against the state manager are run and kept as the actual state manager would.
 
 1. Create a service factory delegate that will instantiate the service being tested. This should be similar or same as the service factory callback typically found in `Program.cs` for a service fabric service or actor. This should follow the following signature:
@@ -25,8 +44,8 @@ MyStatefulService CreateMyStatefulService(StatefulServiceContext context, IRelia
 ```
 2. Create an instance of `MockReliableStateManager` class. This will mock all interactions with the state manager.
 3. Create an instance of `MockStatefulServiceReplicaSet<TStatefulService>` where `TStatefulService` is the type of the service being tested. This will require the delegate created in step #1 and the state manager instantiated in #2
-4. Add Replicas to the Replica Set. Specify the role (i.e. Primary, ActiveSecondary, IdleSecondary) and the id of the replica
-> Hold on to the replica id's! These will likely be used during the act and assert portions of a unit test.
+4. Add Replicas to the Replica Set. Specify the role (such as Primary, ActiveSecondary, IdleSecondary) and the ID of the replica
+> Hold on to the replica IDs! These will likely be used during the act and assert portions of a unit test.
 
 ```csharp
 //service factory to instruct how to create the service instance
@@ -43,8 +62,8 @@ await replicaSet.AddReplicaAsync(ReplicaRole.ActiveSecondary, 2);
 await replicaSet.AddReplicaAsync(ReplicaRole.ActiveSecondary, 3);
 ```
 
-# Executing Service Requests
-Service requests can be executed on a specific replica using the convience properties and lookups.
+## Execute service requests
+Service requests can be executed on a specific replica using the convenience properties and lookups.
 ```csharp
 const string stateName = "test";
 var payload = new Payload(StatePayload);
@@ -59,8 +78,8 @@ await replicaSet[2].ServiceInstance.InsertAsync(stateName, payload);
 await replicaSet.FirstActiveSecondary.InsertAsync(stateName, payload);
 ```
 
-# Execute A Service Move
-The mock replica set exposes several convienence methods to trigger different types of service moves.
+## Execute a service move
+The mock replica set exposes several convenience methods to trigger different types of service moves.
 ```csharp
 //promote the first active secondary to primary
 replicaSet.PromoteNewReplicaToPrimaryAsync();
@@ -78,8 +97,8 @@ PromoteNewReplicaToPrimaryAsync()
 PromoteNewReplicaToPrimaryAsync(4)
 ```
 
-# Putting It All Together
-The following test demonstrates setting up a 3 node replica set and verifying that the data is available from a secondary after a role change. A typical issue this may catch is if the data added during `InsertAsync` was saved either to something in-memory or to a reliable collection without running `CommitAsync`. In either case, the secondary would be out of sync with the primary. This would lead to inconsistent responses after service moves.
+## Putting it all together
+The following test demonstrates setting up a three node replica set and verifying that the data is available from a secondary after a role change. A typical issue this may catch is if the data added during `InsertAsync` was saved either to something in-memory or to a reliable collection without running `CommitAsync`. In either case, the secondary would be out of sync with the primary. This would lead to inconsistent responses after service moves.
 
 ```csharp
 [TestMethod]
@@ -115,3 +134,6 @@ public async Task TestServiceState_InMemoryState_PromoteActiveSecondary()
     }
 }
 ```
+
+## Next steps
+Learn how to test [service-to-service communication](service-fabric-testability-scenarios-service-communication.md) and [simulate failures using controlled chaos](service-fabric-controlled-chaos.md).

--- a/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
+++ b/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
@@ -14,7 +14,7 @@ ms.topic: conceptual
 ms.tgt_pltfrm: NA
 ms.workload: NA
 ms.date: 08/22/2018
-ms.author: ryanwi
+ms.author: 
 
 ---
 

--- a/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
+++ b/articles/service-fabric/service-fabric-how-to-unit-test-stateful-services.md
@@ -1,14 +1,20 @@
 # Unit Testing Considerations in Stateful Services
-*TODO: Here highlight points to keep in mind when developing tests for stateful services. These should cover*
-1. *Each replica executes application code but under different context*
-2. *State should be synchronized between the replicas (reliable collections facilitate this easiest)*
-3. *Replica's will move and change roles. The context under which they execute is dependent on the role.*
+While developing unit tests for stateful services, each there are some special considerations that should be kept in mind.
+1. Each replica executes application code but under different context. If the service uses 3 replicas, the service code is executing on 3 nodes in parallel under different context/role.
+2. State stored within the stateful service should be consistent amongst all replicas. The state manager and reliable collections will provide this consistentcy out-of-the-box. However, in-memory state will need to be managed by the application code.
+3. Each replica will change roles at some point while running on the cluster. A secondary replica will become a primary, in the event that the node hosting the primary becomes unavailable or overloaded. This is natural behavior for service fabric therefore services must plan for eventually executing under a different role.
 
-*Link back to conceptual article indicating this article assumes the consumer has read it as those concepts will be applied here.*
+This article assumes the following conceptual documentation has been read:
+
+*TODO: Link back to conceptual article indicating this article assumes the consumer has read it as those concepts will be applied here.*
 
 # ServiceFabric.Mocks
-*TODO: As of version 3.3.0, this package provides an api for mocking both the orchestration of the replicas and the state management. This will be used in the examples.*
-*Add link to nuget package and github*
+As of version 3.3.0, [ServiceFabric.Mocks](https://www.nuget.org/packages/ServiceFabric.Mocks/) provides an api for mocking both the orchestration of the replicas and the state management. This will be used in the examples.
+
+[Nuget](https://www.nuget.org/packages/ServiceFabric.Mocks/)
+[Github](https://github.com/loekd/ServiceFabric.Mocks)
+
+*ServiceFabric.Mocks is not owned or maintained by Microsoft. However, this is currently the Microsoft recommended library for unit testing stateful services.*
 
 # Setting up the Mock Orchestration & State
 As part of the arrange portion of a test, a mock replica set and state manager will be created. The replica set will then own creating an instance of the tested service for each replica. It will also own executing lifecycle events such as `OnChangeRole` and `RunAsync`. The mock state manager will ensure any operations performed against the state manager are run and kept as the actual state manager would.

--- a/articles/service-fabric/toc.yml
+++ b/articles/service-fabric/toc.yml
@@ -26,10 +26,12 @@
     - name: 1- Build a .NET application
       href: service-fabric-tutorial-create-dotnet-app.md
     - name: 2- Deploy the application
-      href: service-fabric-tutorial-deploy-app-to-party-cluster.md    
-    - name: 3- Configure CI/CD
+      href: service-fabric-tutorial-deploy-app-to-party-cluster.md
+    - name: 3- Enable HTTPS
+      href: service-fabric-tutorial-dotnet-app-enable-https-endpoint.md
+    - name: 4- Configure CI/CD
       href: service-fabric-tutorial-deploy-app-with-cicd-vsts.md
-    - name: 4- Monitor and Diagnose
+    - name: 5- Monitor and Diagnose
       href: service-fabric-tutorial-monitoring-aspnet.md
   - name: Deploy a Java app
     items:
@@ -71,6 +73,16 @@
       href: service-fabric-tutorial-upgrade-cluster.md
     - name: 4- Deploy API Management with Service Fabric
       href: service-fabric-tutorial-deploy-api-management.md
+  - name: Create a standalone cluster on AWS
+    items:
+    - name: 1- Create the infrastructure on AWS
+      href: service-fabric-tutorial-standalone-create-infrastructure.md
+    - name: 2- Set up Service Fabric
+      href: service-fabric-tutorial-standalone-create-service-fabric-cluster.md
+    - name: 3- Deploy an application into the cluster
+      href: service-fabric-tutorial-standalone-install-an-application.md
+    - name: 4- Clean up your cluster and delete the infrastructure
+      href: service-fabric-tutorial-standalone-clean-up.md
 - name: Samples
   items:
   - name: Code samples
@@ -93,19 +105,22 @@
     href: service-fabric-architecture.md
   - name: Terminology
     href: service-fabric-technical-overview.md
-  - name: Building applications
-    href: service-fabric-choose-framework.md
+  - name: Building applications    
     items:
-    - name: Containers
-      href: service-fabric-containers-overview.md
+    - name: Building applications overview
+      href: service-fabric-choose-framework.md
+    - name: Containers      
       items:
+      - name: Containers overview
+        href: service-fabric-containers-overview.md
       - name: Docker compose (preview)
         href: service-fabric-docker-compose.md
       - name: Resource governance
         href: service-fabric-resource-governance.md
-    - name: Reliable Services
-      href: service-fabric-reliable-services-introduction.md
+    - name: Reliable Services      
       items:
+      - name: Reliable Services overview
+        href: service-fabric-reliable-services-introduction.md
       - name: Service partitioning
         href: service-fabric-concepts-partitioning.md
       - name: Reliable Services lifecycle - C#
@@ -127,8 +142,9 @@
       - name: Reliable Collection serialization
         href: service-fabric-reliable-services-reliable-collections-serialization.md
     - name: Reliable Actors
-      href: service-fabric-reliable-actors-introduction.md
       items:
+      - name: Reliable Actors overview
+        href: service-fabric-reliable-actors-introduction.md
       - name: Architecture
         href: service-fabric-reliable-actors-platform.md
       - name: Implementing service-level features
@@ -151,6 +167,13 @@
       href: service-fabric-application-model.md
     - name: Application and service manifests
       href: service-fabric-application-and-service-manifests.md
+    - name: Application and service manifest examples
+      href: service-fabric-manifest-examples.md
+      items:
+      - name: Reliable services application and service manifest examples
+        href: service-fabric-manifest-example-reliable-services-app.md
+      - name: Multi-container application and service manifest examples
+        href: service-fabric-manifest-example-container-app.md
     - name: Hosting model
       href: service-fabric-hosting-model.md
     - name: Application security
@@ -162,12 +185,15 @@
     - name: Availability of services
       href: service-fabric-availability-services.md       
     - name: Service communication
-      href: service-fabric-connect-and-communicate-with-services.md
       items:
+      - name: Service communication overview
+        href: service-fabric-connect-and-communicate-with-services.md
       - name: DNS service
         href: service-fabric-dnsservice.md
       - name: Reverse proxy
         href: service-fabric-reverseproxy.md
+      - name: Set up and configure reverse proxy 
+        href: service-fabric-reverseproxy-setup.md
       - name: Configure reverse proxy for secure communication
         href: service-fabric-reverseproxy-configure-secure-communication.md
       - name: Reverse proxy diagnostics
@@ -175,11 +201,13 @@
       - name: ASP.NET Core
         href: service-fabric-reliable-services-communication-aspnetcore.md
     - name: Application lifecycle
-      href: service-fabric-application-lifecycle.md
       items:
+      - name: Application lifecycle overview
+        href: service-fabric-application-lifecycle.md
       - name: Application upgrade
-        href: service-fabric-application-upgrade.md
         items:
+        - name: Application upgrade overview
+          href: service-fabric-application-upgrade.md
         - name: Configuration
           href: service-fabric-visualstudio-configure-upgrade.md
         - name: Application upgrade parameters
@@ -190,15 +218,24 @@
           href: service-fabric-application-upgrade-advanced.md
       - name: Manage applications for multiple environments
         href: service-fabric-manage-multiple-environment-app-configuration.md
-      - name: Testing apps with fault analysis
-        href: service-fabric-testability-overview.md
+      - name: Testing applications
+        items:
+          - name: Unit testing stateful services
+            href: service-fabric-concepts-unit-testing.md
+          - name: Testing apps with fault analysis
+            href: service-fabric-testability-overview.md
       - name: The ImageStoreConnectionString setting
         href: service-fabric-image-store-connection-string.md
     - name: Service resources
       href: service-fabric-service-manifest-resources.md
+    - name: Periodic backup and restore
+      items:
+      - name: Understanding periodic backup configuration
+        href: service-fabric-backuprestoreservice-configure-periodic-backup.md 
   - name: Clusters
-    href: service-fabric-deploy-anywhere.md
     items:
+    - name: Clusters overview
+      href: service-fabric-deploy-anywhere.md
     - name: Cluster security
       href: service-fabric-cluster-security.md
     - name: Scaling
@@ -212,8 +249,9 @@
       - name: Cluster networking patterns
         href: service-fabric-patterns-networking.md
     - name: Cluster resource manager
-      href: service-fabric-cluster-resource-manager-introduction.md
       items:
+      - name: Cluster resource manager overview
+        href: service-fabric-cluster-resource-manager-introduction.md
       - name: Architecture
         href: service-fabric-cluster-resource-manager-architecture.md
       - name: Describe a cluster
@@ -238,15 +276,19 @@
         href: service-fabric-cluster-resource-manager-advanced-throttling.md
       - name: Service movement
         href: service-fabric-cluster-resource-manager-movement-cost.md
+      - name: Autoscaling services
+        href: service-fabric-cluster-resource-manager-autoscaling.md
   - name: Monitoring and diagnostics
     items:
     - name: Monitoring overview
       href: service-fabric-diagnostics-overview.md
-    - name: Cluster events
+    - name: Cluster monitoring
       href: service-fabric-diagnostics-event-generation-infra.md
       items:
-      - name: Operational channel
-        href: service-fabric-diagnostics-event-generation-operational.md
+      - name: Service Fabric events
+        href: service-fabric-diagnostics-events.md
+      - name: EventStore overview
+        href: service-fabric-diagnostics-eventstore.md
       - name: Reliable Services events
         href: service-fabric-reliable-services-diagnostics.md
       - name: Reliable Actors events
@@ -261,8 +303,6 @@
       href: service-fabric-health-introduction.md
     - name: Report health events
       href: service-fabric-report-health.md
-    - name: Monitor with OMS
-      href: service-fabric-diagnostics-event-analysis-oms.md
   - name: Integration with API Management
     href: service-fabric-api-management-overview.md
 - name: How-to guides
@@ -385,6 +425,8 @@
         href: service-fabric-reliable-actors-reliabledictionarystateprovider-configuration.md    
     - name: Build an ASP.NET Core service
       href: service-fabric-add-a-web-frontend.md
+    - name: Build an Apache Tomcat server container on Linux
+      href: service-fabric-get-started-tomcat.md
     - name: Configure security
       items:
       - name: Manage application secrets
@@ -405,6 +447,12 @@
         href: service-fabric-securing-containers.md
       - name: Set up gMSA for Windows containers 
         href: service-fabric-setup-gmsa-for-windows-containers.md
+      - name: Configure certificates on Linux
+        href: service-fabric-configure-certificates-linux.md
+    - name: Configure periodic backups (Clusters on Azure)
+      href: service-fabric-backuprestoreservice-quickstart-azurecluster.md
+    - name: Configure periodic backups (Standalone Clusters)
+      href: service-fabric-backuprestoreservice-quickstart-standalonecluster.md
     - name: Migrate old Java Application to support Maven
       href: service-fabric-migrate-old-javaapp-to-use-maven.md
   - name: Work in a Windows/VS dev environment
@@ -415,6 +463,8 @@
       href: service-fabric-visualstudio-configure-secure-connections.md
     - name: Debug a .NET service in VS
       href: service-fabric-debugging-your-application.md
+    - name: Debug Windows containers with Service Fabric and VS
+      href: service-fabric-how-to-debug-windows-containers.md
     - name: Common errors and exceptions
       href: service-fabric-errors-and-exceptions.md
     - name: Monitor and diagnose locally
@@ -429,6 +479,14 @@
       href: service-fabric-debugging-your-application-java.md
     - name: Monitor and diagnose locally
       href: service-fabric-diagnostics-how-to-monitor-and-diagnose-services-locally-linux.md
+  - name: Work in a VS Code environment
+    items:
+    - name: Get started with VS Code
+      href: service-fabric-get-started-vs-code.md
+    - name: Develop C# Service Fabric applications with VS Code
+      href: service-fabric-develop-csharp-applications-with-vs-code.md
+    - name: Develop Java Service Fabric applications with VS Code
+      href: service-fabric-develop-java-applications-with-vs-code.md
   - name: Migrate from Cloud Services
     items:
     - name: Compare Cloud Services with Service Fabric
@@ -471,6 +529,8 @@
         href: service-fabric-application-upgrade-troubleshooting.md
     - name: Test applications and services
       items:
+      - name: Unit test stateful services
+        href: service-fabric-how-to-unit-test-stateful-services.md
       - name: Test service-to-service communication
         href: service-fabric-testability-scenarios-service-communication.md
       - name: Simulate failures
@@ -497,28 +557,40 @@
       items:
       - name: Create
         items:
-        - name: Azure portal
+        - name: Create in Azure portal
           href: service-fabric-cluster-creation-via-portal.md
-        - name: Azure Resource Manager
-          href: service-fabric-cluster-creation-via-arm.md
+        - name: Set up Azure Active Directory authentication
+          href: service-fabric-cluster-creation-setup-aad.md
+        - name: Create a custom cluster template
+          href: service-fabric-cluster-creation-create-template.md
+        - name: Create using Resource Manager
+          href: service-fabric-cluster-creation-via-arm.md        
+        - name: Create using certificate common name
+          href: service-fabric-create-cluster-using-cert-cn.md
       - name: Scale
         items:
-        - name: Manually
+        - name: Manually scale out
           href: service-fabric-cluster-scale-up-down.md
-        - name: Programmatically
+        - name: Programmatically scale out
           href: service-fabric-cluster-programmatic-scaling.md
+        - name: Virtual Machine Scale Set Node Type scale out
+          href: virtual-machine-scale-set-scale-node-type-scale-out.md
       - name: Upgrade
         href: service-fabric-cluster-upgrade.md
       - name: Set access control
         href: service-fabric-cluster-security-roles.md      
       - name: Open a port in the load balancer
         href: create-load-balancer-rule.md
+      - name: Change cluster certificate to common name
+        href: service-fabric-cluster-change-cert-thumbprint-to-cn.md
+      - name: Manually rollover cluster certs
+        href: service-fabric-cluster-rollover-cert-cn.md
       - name: Manage cluster certificates
         href: service-fabric-cluster-security-update-certs-azure.md
       - name: Delete
         href: service-fabric-cluster-delete.md
       - name: Remote connect to cluster node VM
-        href: service-fabric-cluster-remote-connect-to-azure-cluster-node.md
+        href: service-fabric-cluster-remote-connect-to-azure-cluster-node.md      
     - name: Standalone clusters
       items:
       - name: Create
@@ -549,36 +621,51 @@
       href: service-fabric-patch-orchestration-application-linux.md
   - name: Monitor and diagnose
     items:
-    - name: Analyze with OMS
+    - name: Monitor applications
       items:
-      - name: Set up OMS Log Analytics
-        href: service-fabric-diagnostics-oms-setup.md
-      - name: Add the OMS Agent
-        href: service-fabric-diagnostics-oms-agent.md
+      - name: Analyze with Application Insights
+        href: service-fabric-diagnostics-event-analysis-appinsights.md
+      - name: Add logging to your application
+        href: service-fabric-how-to-diagnostics-log.md
+      - name: Aggregate events with EventFlow
+        href: service-fabric-diagnostics-event-aggregation-eventflow.md    
       - name: Monitor containers
         href: service-fabric-diagnostics-oms-containers.md
-    - name: Analyze with Application Insights
-      href: service-fabric-diagnostics-event-analysis-appinsights.md
-    - name: Aggregate events - EventFlow
-      href: service-fabric-diagnostics-event-aggregation-eventflow.md
-    - name: Aggregate events - Azure Diagnostics
+    - name: Monitor clusters
       items:
-      - name: Windows
+      - name: Query EventStore APIs
+        href: service-fabric-diagnostics-eventstore-query.md      
+      - name: Windows Azure Diagnostics
         href: service-fabric-diagnostics-event-aggregation-wad.md
-      - name: Linux
-        href: service-fabric-diagnostics-event-aggregation-lad.md
-    - name: Performance monitoring with WAD
-      href: service-fabric-diagnostics-perf-wad.md
-    - name: Report and check health
-      href: service-fabric-diagnostics-how-to-report-and-check-service-health.md
-    - name: Add logging to your service
-      href: service-fabric-how-to-diagnostics-log.md
-    - name: Troubleshoot with system health reports
-      href: service-fabric-understand-and-troubleshoot-with-system-health-reports.md
-    - name: View health reports
-      href: service-fabric-view-entities-aggregated-health.md
+      - name: Linux Azure Diagnostics
+        href: service-fabric-diagnostics-event-aggregation-lad.md 
+      - name: Set up Log Analytics
+        href: service-fabric-diagnostics-oms-setup.md
+      - name: Monitor with Log Analytics
+        href: service-fabric-diagnostics-event-analysis-oms.md  
+    - name: Monitor infrastructure
+      items:
+      - name: Performance monitoring with the Log Analytics Agent
+        href: service-fabric-diagnostics-oms-agent.md
+      - name: Performance monitoring with WAD
+        href: service-fabric-diagnostics-perf-wad.md     
+    - name: Monitor health
+      items:
+      - name: Report and check health
+        href: service-fabric-diagnostics-how-to-report-and-check-service-health.md   
+      - name: Troubleshoot with system health reports
+        href: service-fabric-understand-and-troubleshoot-with-system-health-reports.md
+      - name: View health reports
+        href: service-fabric-view-entities-aggregated-health.md
     - name: Troubleshoot your local cluster
       href: service-fabric-troubleshoot-local-cluster-setup.md
+    - name: Diagnose common scenarios
+      href: service-fabric-diagnostics-common-scenarios.md
+  - name: Best practices
+    items:
+    - name: Production readiness checklist
+      href: service-fabric-production-readiness-checklist.md
+
 - name: Reference
   items:
   - name: Azure PowerShell
@@ -594,20 +681,29 @@
       href: service-fabric-sfctl-application.md
     - name: sfctl chaos
       href: service-fabric-sfctl-chaos.md
+      items:
+      - name: sfctl chaos schedule  
+        href: service-fabric-sfctl-chaos-schedule.md
     - name: sfctl cluster
       href: service-fabric-sfctl-cluster.md
     - name: sfctl compose
       href: service-fabric-sfctl-compose.md
+    - name: sfctl container
+      href: service-fabric-sfctl-container.md
     - name: sfctl is
       href: service-fabric-sfctl-is.md
     - name: sfctl node
       href: service-fabric-sfctl-node.md
     - name: sfctl partition
       href: service-fabric-sfctl-partition.md
+    - name: sfctl property
+      href: service-fabric-sfctl-property.md
     - name: sfctl replica
       href: service-fabric-sfctl-replica.md
     - name: sfctl rpm
       href: service-fabric-sfctl-rpm.md
+    - name: sfctl sa-cluster
+      href: service-fabric-sfctl-sa-cluster.md
     - name: sfctl service
       href: service-fabric-sfctl-service.md
     - name: sfctl store
@@ -618,10 +714,23 @@
     href: /dotnet/api/overview/azure/service-fabric?view=azure-dotnet
   - name: REST
     href: /rest/api/servicefabric
+  - name: Service Fabric events
+    href: service-fabric-diagnostics-event-generation-operational.md
   - name: Configure cluster settings and fabric upgrade policy
     href: service-fabric-cluster-fabric-settings.md
   - name: Service model XML schema
     href: service-fabric-service-model-schema.md
+    items:
+    - name: Elements
+      href: service-fabric-service-model-schema-elements.md
+    - name: Complex types
+      href: service-fabric-service-model-schema-complex-types.md
+    - name: Attribute groups
+      href: service-fabric-service-model-schema-attribute-groups.md
+    - name: Simple types
+      href: service-fabric-service-model-schema-simple-types.md
+    - name: Element groups
+      href: service-fabric-service-model-schema-element-groups.md
   - name: Environment variables
     href: service-fabric-environment-variables-reference.md
 - name: Resources


### PR DESCRIPTION
This PR adds two new articles centered around unit testing for stateful services. The first 'concepts' doc explains recommended practices for unit testing stateful services. The second how-to uses ServiceFabric.Mocks to demonstrate a sample implementation.