### PR TITLE
Update to match current tooling

### DIFF
--- a/articles/iot-edge/how-to-deploy-modules-vscode.md
+++ b/articles/iot-edge/how-to-deploy-modules-vscode.md
@@ -125,7 +125,7 @@ You deploy modules to your device by applying the deployment manifest that you c
 
 2. Right-click on the device that you want to configure with the deployment manifest. 
 
-3. Select **Create Deployment for IoT Edge Device**. 
+3. Select **Create Deployment for Single Device**. 
 
 4. Navigate to the deployment manifest JSON file that you want to use, and click **Select Edge Deployment Manifest**. 
 


### PR DESCRIPTION
The menu entry in the VS Code extension for deployment has been changed from "Create deployment for IoT Edge Device" to "Create deployment for Single Device". Docs should match current tools.