### PR TITLE
Updated References to Resources

### DIFF
--- a/articles/search/search-get-started-java.md
+++ b/articles/search/search-get-started-java.md
@@ -6,7 +6,7 @@ author: jj09
 manager: jlembicz
 ms.service: search
 ms.topic: conceptual
-ms.date: 07/14/2016
+ms.date: 08/26/2018
 ms.author: jjed
 
 ---
@@ -23,9 +23,9 @@ To run this sample, you must have an Azure Search service, which you can sign up
 
 We used the following software to build and test this sample:
 
-* [Eclipse IDE for Java EE Developers](https://eclipse.org/downloads/packages/eclipse-ide-java-ee-developers/lunar). Be sure to download the EE version. One of the verification steps requires a feature that is found only in this edition.
-* [JDK 8u40](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-* [Apache Tomcat 8.0](http://tomcat.apache.org/download-80.cgi)
+* [Eclipse IDE for Java EE Developers](https://www.eclipse.org/downloads/packages/release/photon/r/eclipse-ide-java-ee-developers). Be sure to download the EE version. One of the verification steps requires a feature that is found only in this edition.
+* [JDK 8u181](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+* [Apache Tomcat 8.5.33](https://tomcat.apache.org/download-80.cgi#8.5.33)
 
 ## About the data
 This sample application uses data from the [United States Geological Services (USGS)](http://geonames.usgs.gov/domestic/download_data.htm), filtered on the state of Rhode Island to reduce the dataset size. We'll use this data to build a search application that returns landmark buildings such as hospitals and schools, as well as geological features like streams, lakes, and summits.
@@ -46,7 +46,7 @@ The following list describes the files that are relevant to this sample.
 * SearchServiceHelper.java: A helper class that provides static methods
 * Document.java: Provides the data model
 * config.properties: Sets the Search service URL and api-key
-* Pom.xml: A Maven dependency
+* pom.xml: A Maven dependency
 
 <a id="sub-2"></a>
 


### PR DESCRIPTION
- Edited pom file name from Pom.xml to pom.xml
- Update Tomcat version to 8.5.x
- Updated reference to JDK version from 8u40 to 8u181
- Updated Eclipse reference from lunar to photon

Tomcat 8.0.x has reached end-of-life and is no longer supported. Changed to 8.5.x
JDK 8u40 is about 3 years old. Updated to latest JDK version
Eclipse Lunar is an older version of Eclipse. Updated to latest version Photon
Renamed Pom.xml to pom.xml (actual file name is case sensitive)