### PR TITLE
Remove a statement about Win32-OpenSSH

### DIFF
--- a/articles/cloud-shell/quickstart-powershell.md
+++ b/articles/cloud-shell/quickstart-powershell.md
@@ -115,7 +115,7 @@ TestVm2   westus     Succeeded         Standard_DS1_v2 WindowsServer 2016-Datace
 ```
 
 > [!NOTE]
-> You may notice that the second time when you type `dir`, the cloud shell is able to display the items much faster.
+> You may notice that the second time when you type `dir`, the Cloud Shell is able to display the items much faster.
 > This is because the child items are cached in memory for a better user experience.
 However, you can always use `dir -Force` to get fresh data.
 
@@ -254,7 +254,6 @@ mywebapp3       Running  MyResourceGroup3   {mywebapp3.azurewebsites.net...   So
 
 ## SSH
 
-[Win32-OpenSSH](https://github.com/PowerShell/Win32-OpenSSH) is available in PowerShell Cloud Shell.
 To authenticate to servers or VMs using SSH, generate the public-private key pair in Cloud Shell and
 publish the public key to `authorized_keys` on the remote machine, such as `/home/user/.ssh/authorized_keys`.
 


### PR DESCRIPTION
"Win32-OpenSSH is available in PowerShell Cloud Shell." is not valid since Cloud Shell runs on Linux.