### PR TITLE
Add step to ensure database name matches

### DIFF
--- a/articles/cosmos-db/create-sql-api-dotnet.md
+++ b/articles/cosmos-db/create-sql-api-dotnet.md
@@ -117,9 +117,13 @@ Now go back to the Azure portal to get your connection string information and co
 
     `<add key="endpoint" value="FILLME" />`
 
-4. Then copy your PRIMARY KEY value from the portal and make it the value of the authKey in web.config. You've now updated your app with all the info it needs to communicate with Azure Cosmos DB. 
+4. Then copy your PRIMARY KEY value from the portal and make it the value of the authKey in web.config. 
 
     `<add key="authKey" value="FILLME" />`
+    
+5. Then update the database value to match the name of the database you have created earlier. You've now updated your app with all the info it needs to communicate with Azure Cosmos DB. 
+
+    `<add key="database" value="Tasks" />`    
     
 ## Run the web app
 1. In Visual Studio, right-click on the project in **Solution Explorer** and then click **Manage NuGet Packages**. 


### PR DESCRIPTION
The suggested name for the database throughout this quickstart is "Tasks", however, the sample app sets it to "ToDoList", so it won't work out of the box. Took my a while to figure out why it's not working and finally noticed the naming mismatch. I don't want to change the sample app code, because other tutorials use it as well. Making this doc change seems like safest bet, as it also covers the scenario where users pick an arbitrary name for their database.