### PR TITLE
"New input" capture does not match the name of query

### DIFF
--- a/articles/application-insights/app-insights-code-sample-export-sql-stream-analytics.md
+++ b/articles/application-insights/app-insights-code-sample-export-sql-stream-analytics.md
@@ -213,7 +213,7 @@ Replace the default query with:
       ,A.context.location.city as city
     INTO
       AIOutput
-    FROM AIinput A
+    FROM AlIinput A
     CROSS APPLY GetElements(A.[view]) as flat
 
 


### PR DESCRIPTION
"New input" capture shows it alias as "AllInput" but SA query from clause is "AIInput" so it cause following error.

----
Stream Analytics job has validation errors: The input aiinput used in the query was not defined. 
----

So, I changed SA query as bellow.

before
    FROM AIinput A
after
    FROM AlIinput A

If input alias should be AIinput, please re-take "New input" capture and update.

Thanks
Takeshi