### PR TITLE
fix menu item path

### DIFF
--- a/articles/application-insights/quick-monitor-portal.md
+++ b/articles/application-insights/quick-monitor-portal.md
@@ -51,7 +51,7 @@ If you don't have an Azure subscription, create a [free](https://azure.microsoft
 
 Application Insights gathers telemetry data for your application regardless of where it's running. Use the following steps to start viewing this data.
 
-1. Open Application Insights by clicking **Project** -> **Application Insights** -> **Search Debug Session Telemetry**.  You see the telemetry from your current session.<BR><br>![Telemetry in Visual Studio](./media/quick-monitor-portal/telemetry-in-vs.png)
+1. Open Application Insights by clicking **View** -> **Other Windows** -> **Application Insights Search**.  You see the telemetry from your current session.<BR><br>![Telemetry in Visual Studio](./media/quick-monitor-portal/telemetry-in-vs.png)
 
 2. Click on the first request in the list (GET Home/Index in this example) to see the request details. Notice that the status code and response time are both included along with other valuable information about the request.<br><br>![Response details in Visual Studio](media/quick-monitor-portal/request-details.png)
 


### PR DESCRIPTION
Following the steps of this quickstart the "Search Debug Session" menu item does not exist. Instead the user needs to go to "Application Insights Search" via View->Other Windows.