### PR TITLE
fixing wrong link

### DIFF
--- a/articles/service-fabric/service-fabric-choose-framework.md
+++ b/articles/service-fabric/service-fabric-choose-framework.md
@@ -42,7 +42,7 @@ Reliable Services can also be stateful, exclusive to Service Fabric, where state
 ## ASP.NET Core
 ASP.NET Core is a new open-source and cross-platform framework for building modern cloud-based Internet-connected applications, such as web apps, IoT apps, and mobile backends. Service Fabric integrates with ASP.NET Core so you can write both stateless and stateful ASP.NET Core applications that take advantage of Reliable Collections and Service Fabric's advanced orchestration capabilities.
 
-[Learn more about ASP.NET Core in Service Fabric](service-fabric-reliable-services-communication-aspnetcore.md) or get started by [writing your first ASP.NET Core Service Fabric application](service-fabric-reliable-services-communication-aspnetcore.md).
+[Learn more about ASP.NET Core in Service Fabric](service-fabric-reliable-services-communication-aspnetcore.md) or get started by [writing your first ASP.NET Core Service Fabric application](service-fabric-tutorial-create-dotnet-app.md).
 
 ## Reliable Actors
 Built on top of Reliable Services, the Reliable Actor framework is an application framework that implements the Virtual Actor pattern, based on the actor design pattern. The Reliable Actor framework uses independent units of compute and state with single-threaded execution called actors. The Reliable Actor framework provides built-in communication for actors and pre-set state persistence and scale-out configurations.


### PR DESCRIPTION
Both links in this sentence were pointing to the same content, the latter one was clearly wrong. Replacing it with the right link to related tutorial.