### PR TITLE
Change Management Group  ID with Name in docs and portal

### DIFF
--- a/articles/azure-resource-manager/management-groups-create.md
+++ b/articles/azure-resource-manager/management-groups-create.md
@@ -34,8 +34,8 @@ You can create the management group by using the portal, PowerShell, or Azure CL
 
     ![Main Group](media/management-groups/main.png)
 4.  Fill in the management group ID field.
-    - The **Management Group ID** is the directory unique identifier that is used to submit commands on this management group. This identifier is not editable after creation as it is used throughout the Azure system to identify this group.
-    - The display name field is the name that is displayed within the Azure portal. A separate display name is an optional field when creating the management group and can be changed at any time.  
+    - The **Management Group Name** is the directory unique identifier that is used to submit commands on this management group. This identifier is not editable after creation as it is used throughout the Azure system to identify this group.
+    - The **display name** field is the name that is displayed within the Azure portal. A separate display name is an optional field when creating the management group and can be changed at any time.  
 
     ![Create](media/management-groups/create_context_menu.png)  
 5.  Select **Save**


### PR DESCRIPTION
Hi team,
Management Group ID seems to be confusing. In all Azure resources the resource name is the resource unique identifier and we cannot change it later. The management groups seem to work the same way, so why not simply call it Management group name? It would also be consisting with nomenclature used in powershell and CLI (group name).
Thanks.