### PR TITLE
lack of kafka "Default node configuration and virtual machine sizes f…

### DIFF
--- a/articles/hdinsight/hdinsight-component-versioning.md
+++ b/articles/hdinsight/hdinsight-component-versioning.md
@@ -226,28 +226,28 @@ The following tables list the default virtual machine (VM) sizes for HDInsight c
 
 * All supported regions except Brazil South and Japan West:
 
-  | Cluster type | Hadoop | HBase | Interactive Query | Storm | Spark | ML Server |
-  | --- | --- | --- | --- | --- | --- | --- |
-  | Head: default VM size |D3 v2 |D3 v2 | D13, D14 |A4 v2 |D12 v2 |D12 v2 |
-  | Head: recommended VM sizes |D3 v2, D4 v2, D12 v2 |D3 v2, D4 v2, D12 v2  | D13, D14 |A4 v2, A8 v2, A2m v2 |D12 v2, D13 v2, D14 v2 |D12 v2, D13 v2, D14 v2 |
-  | Worker: default VM size |D3 v2 |D3 v2  | D13, D14 |D3 v2 |Windows: D12 v2; Linux: D4 v2 |Windows: D12 v2; Linux: D4 v2 |
-  | Worker: recommended VM sizes |D3 v2, D4 v2, D12 v2 |D3 v2, D4 v2, D12 v2  | D13, D14 |D3 v2, D4 v2, D12 v2 |Windows: D12 v2, D13 v2, D14 v2; Linux: D4 v2, D12 v2, D13 v2, D14 v2 |Windows: D12 v2, D13 v2, D14 v2; Linux: D4 v2, D12 v2, D13 v2, D14 v2 |
-  | ZooKeeper: default VM size | |A4 v2 | |A2 v2 | | |
-  | ZooKeeper: recommended VM sizes | |A4 v2, A8 v2, A2m v2 | | A2 v2, A4 v2, A8 v2 | | |
-  | Edge: default VM size | | | | | |Windows: D12 v2; Linux: D4 v2 |
-  | Edge: recommended VM size | | | | | |Windows: D12 v2, D13 v2, D14 v2; Linux: D4 v2, D12 v2, D13 v2, D14 v2 |
+  | Cluster type | Hadoop | HBase | Interactive Query | Storm | Spark | ML Server | Kafka
+  | --- | --- | --- | --- | --- | --- | --- | --- |
+  | Head: default VM size |D3 v2 |D3 v2 | D13, D14 |A4 v2 |D12 v2 |D12 v2 |D3 v2|
+  | Head: recommended VM sizes |D3 v2, D4 v2, D12 v2 |D3 v2, D4 v2, D12 v2  | D13, D14 |A4 v2, A8 v2, A2m v2 |D12 v2, D13 v2, D14 v2 |D12 v2, D13 v2, D14 v2 | |
+  | Worker: default VM size |D3 v2 |D3 v2  | D13, D14 |D3 v2 |Windows: D12 v2; Linux: D4 v2 |Windows: D12 v2; Linux: D4 v2 |D3 v2|
+  | Worker: recommended VM sizes |D3 v2, D4 v2, D12 v2 |D3 v2, D4 v2, D12 v2  | D13, D14 |D3 v2, D4 v2, D12 v2 |Windows: D12 v2, D13 v2, D14 v2; Linux: D4 v2, D12 v2, D13 v2, D14 v2 |Windows: D12 v2, D13 v2, D14 v2; Linux: D4 v2, D12 v2, D13 v2, D14 v2 ||
+  | ZooKeeper: default VM size | |A4 v2 | |A2 v2 | | |A3|
+  | ZooKeeper: recommended VM sizes | |A4 v2, A8 v2, A2m v2 | | A2 v2, A4 v2, A8 v2 | | ||
+  | Edge: default VM size | | | | | |Windows: D12 v2; Linux: D4 v2 ||
+  | Edge: recommended VM size | | | | | |Windows: D12 v2, D13 v2, D14 v2; Linux: D4 v2, D12 v2, D13 v2, D14 v2 ||
 * Brazil South and Japan West only (no v2 sizes):
 
-  | Cluster type | Hadoop | HBase | Interactive Query |Storm | Spark | ML Server |
-  | --- | --- | --- | --- | --- | --- | --- |
-  | Head: default VM size |D3 |D3  | D13, D14 |A3 |D12 |D12 |
-  | Head: recommended VM sizes |D3, D4, D12 |D3, D4, D12  | D13, D14 |A3, A4, A5 |D12, D13, D14 |D12, D13, D14 |
-  | Worker: default VM size |D3 |D3  | D13, D14 |D3 |Windows: D12; Linux: D4 |Windows: D12; Linux: D4 |
-  | Worker: recommended VM sizes |D3, D4, D12 |D3, D4, D12  | D13, D14 |D3, D4, D12 |Windows: D12, D13, D14; Linux: D4, D12, D13, D14 |Windows: D12, D13, D14; Linux: D4, D12, D13, D14 |
-  | ZooKeeper: default VM size | |A2 | | A2 | | |
-  | ZooKeeper: recommended VM sizes | |A2, A3, A4 | |A2, A3, A4 | | |
-  | Edge: default VM sizes | | | | | |Windows: D12; Linux: D4 |
-  | Edge: recommended VM sizes | | | | | |Windows: D12, D13, D14; Linux: D4, D12, D13, D14 |
+  | Cluster type | Hadoop | HBase | Interactive Query |Storm | Spark | ML Server | Kafka |
+  | --- | --- | --- | --- | --- | --- | --- | --- |
+  | Head: default VM size |D3 |D3  | D13, D14 |A3 |D12 |D12 |D3 |
+  | Head: recommended VM sizes |D3, D4, D12 |D3, D4, D12  | D13, D14 |A3, A4, A5 |D12, D13, D14 |D12, D13, D14 ||
+  | Worker: default VM size |D3 |D3  | D13, D14 |D3 |Windows: D12; Linux: D4 |Windows: D12; Linux: D4 |D3 |
+  | Worker: recommended VM sizes |D3, D4, D12 |D3, D4, D12  | D13, D14 |D3, D4, D12 |Windows: D12, D13, D14; Linux: D4, D12, D13, D14 |Windows: D12, D13, D14; Linux: D4, D12, D13, D14 ||
+  | ZooKeeper: default VM size | |A2 | | A2 | | | A3 |
+  | ZooKeeper: recommended VM sizes | |A2, A3, A4 | |A2, A3, A4 | | | |
+  | Edge: default VM sizes | | | | | |Windows: D12; Linux: D4 ||
+  | Edge: recommended VM sizes | | | | | |Windows: D12, D13, D14; Linux: D4, D12, D13, D14 ||
 
 > [!NOTE]
 > - Head is known as *Nimbus* for the Storm cluster type.


### PR DESCRIPTION
…or clusters" information

I add Kafka Default node configuration and virtual machine sizes for clusters into Tables. I check Azure Portal and filled default VM size, but I didn't find recommended VM size. So, could you please add recommended VM size into that table?