### PR TITLE
error on vscode configuration instructions

### DIFF
--- a/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
+++ b/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
@@ -131,17 +131,17 @@ Follow these steps to prepare the development environment for DevKit:
 
 1. Open **File > Preference > Settings** and add following lines to configure Arduino.
     * **Windows**:
-    ```javascript
+    ```
     "arduino.path": "C:\\Program Files (x86)\\Arduino",
     "arduino.additionalUrls": "https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/master/package_azureboard_index.json"
     ```
     * **macOS**:
-    ```javascript
+    ```
     "arduino.path": "/Applications",
     "arduino.additionalUrls": "https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/master/package_azureboard_index.json"
     ```
     * **Ubuntu**:
-    ```javascript
+    ```
     "arduino.path": "/home/{username}/Downloads/arduino-1.8.5",
     "arduino.additionalUrls": "https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/master/package_azureboard_index.json"
     ```


### PR DESCRIPTION
Maybe it is a format convention but writing "javascript" in lines 134 139 and 144 is not working and the word appears in the rendered document causing confusion to the reader and errors in vscode. I proposed to delete the word; but maybe the solution is to write properly the format instruction but I don't know what is it.