### PR TITLE
Fix yaml indentation that has broken automatic numbering

### DIFF
--- a/articles/ansible/ansible-manage-azure-dynamic-inventories.md
+++ b/articles/ansible/ansible-manage-azure-dynamic-inventories.md
@@ -131,27 +131,27 @@ The purpose of tags is to enable the ability to quickly and easily work with sub
 
 1. Insert the following code into the newly created `nginx.yml` file:
 
-```yml
----
-- name: Install and start Nginx on an Azure virtual machine
-  hosts: azure
-  become: yes
-  tasks:
-  - name: install nginx
-    apt: pkg=nginx state=installed
-    notify:
-    - start nginx
+    ```yml
+    ---
+    - name: Install and start Nginx on an Azure virtual machine
+    hosts: azure
+    become: yes
+    tasks:
+    - name: install nginx
+      apt: pkg=nginx state=installed
+      notify:
+      - start nginx
 
-  handlers:
-  - name: start nginx
-    service: name=nginx state=started
-```
+    handlers:
+    - name: start nginx
+      service: name=nginx state=started
+    ```
 
 1. Run the `nginx.yml` playbook:
 
-  ```azurecli-interactive
-  ansible-playbook -i azure_rm.py nginx.yml
-  ```
+    ```azurecli-interactive
+    ansible-playbook -i azure_rm.py nginx.yml
+    ```
 
 1. Once you run the playbook, you see results similar to the following output:
 


### PR DESCRIPTION
Fixes #10150, Updates PR #14078  - Fixed the indentation of the nginx playbook and the bash command so that the automatic numbering works correctly. 