### PR TITLE
Update outdated link

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
@@ -75,5 +75,5 @@ If you want to route your device-to-cloud messages to custom endpoints, see [Use
 [lnk-d2c-tutorial]: tutorial-routing.md
 [lnk-event-hub-partitions]: ../event-hubs/event-hubs-features.md#partitions
 [lnk-servicebus-sdk]: https://www.nuget.org/packages/WindowsAzure.ServiceBus
-[lnk-eventprocessorhost]: https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-dotnet-standard-getstarted-receive-eph
+[lnk-eventprocessorhost]: https://docs.microsoft.com/azure/event-hubs/event-hubs-dotnet-standard-getstarted-receive-eph
 [lnk-amqp]: https://www.amqp.org/

--- a/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
@@ -75,5 +75,5 @@ If you want to route your device-to-cloud messages to custom endpoints, see [Use
 [lnk-d2c-tutorial]: tutorial-routing.md
 [lnk-event-hub-partitions]: ../event-hubs/event-hubs-features.md#partitions
 [lnk-servicebus-sdk]: https://www.nuget.org/packages/WindowsAzure.ServiceBus
-[lnk-eventprocessorhost]: http://blogs.msdn.com/b/servicebus/archive/2015/01/16/event-processor-host-best-practices-part-1.aspx
+[lnk-eventprocessorhost]: https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-dotnet-standard-getstarted-receive-eph
 [lnk-amqp]: https://www.amqp.org/


### PR DESCRIPTION
The link for "Event Hubs Event Processor Host" was pointing to a 3.5y old blog post that wasn't very helpful and contained outdated links. I am proposing to link to the respective Event Hubs .NET getting started topic instead.