### PR TITLE
Password is wrong compared to samples

### DIFF
--- a/articles/iot-hub/iot-hub-security-x509-get-started.md
+++ b/articles/iot-hub/iot-hub-security-x509-get-started.md
@@ -136,7 +136,7 @@ Next, we will show you how to create a C# application to simulate the X.509 devi
     ```CSharp
     try
     {
-        var cert = new X509Certificate2(@"<absolute-path-to-your-device-pfx-file>", "123");
+        var cert = new X509Certificate2(@"<absolute-path-to-your-device-pfx-file>", "1234");
         var auth = new DeviceAuthenticationWithX509Certificate("<device-id>", cert);
         var deviceClient = DeviceClient.Create("<your-iot-hub-name>.azure-devices.net", auth, TransportType.Amqp_Tcp_Only);
 


### PR DESCRIPTION
Both in https://github.com/Azure/azure-iot-sdk-c/blob/master/tools/CACertificates/certGen.sh and https://github.com/Azure/azure-iot-sdk-c/blob/master/tools/CACertificates/CACertificateOverview.md another password is used.
The password '1234' is now in everywhere the same.