### PR TITLE
Adding notice for previously rotated systems

### DIFF
--- a/articles/azure-stack/azure-stack-rotate-secrets.md
+++ b/articles/azure-stack/azure-stack-rotate-secrets.md
@@ -39,7 +39,7 @@ Infrastructure service certificates for external-facing services that are provid
     - ADFS<sup>*</sup>
     - Graph<sup>*</sup>
 
-    > <sup>*</sup> Only applicable if the environment’s identity provider is Active Directory Federated Services (AD FS).
+   <sup>*</sup> Only applicable if the environment’s identity provider is Active Directory Federated Services (AD FS).
 
 > [!NOTE]
 > All other secure keys and strings, including BMC and switch passwords, user and administrator account passwords are still manually updated by the administrator. 
@@ -51,7 +51,7 @@ In order to maintain the integrity of the Azure Stack infrastructure, operators 
 Azure Stack supports secret rotation with external certificates from a new Certificate Authority (CA) in the following contexts:
 
 |Installed Certificate CA|CA to Rotate To|Supported|Azure Stack Versions Supported|
-|-----|-----|-----|-----|-----|
+|-----|-----|-----|-----|
 |From Self-Signed|To Enterprise|Not Supported||
 |From Self-Signed|To Self-Signed|Not Supported||
 |From Self-Signed|To Public<sup>*</sup>|Supported|1803 & Later|
@@ -75,8 +75,9 @@ When secrets are within 30 days of expiration, the following alerts are generate
 Running secret rotation using the instructions below will remediate these alerts.
 
 ## Pre-steps for secret rotation
-    > [!IMPORTANT]  
-    > Ensure secret rotation hasn't been previously successfully executed on your environment. If secret rotation has already been performed update to Azure Stack version 1807 or later prior to rotating secrets. 
+
+   > [!IMPORTANT]  
+   > Ensure secret rotation hasn't been previously successfully executed on your environment. If secret rotation has already been performed update to Azure Stack version 1807 or later prior to rotating secrets. 
 1.  Notify your users of any maintenance operations. Schedule normal maintenance windows, as much as possible,  during non-business hours. Maintenance operations may affect both user workloads and portal operations.
     > [!note]  
     > The next steps only apply when rotating Azure Stack external secrets.
@@ -155,7 +156,6 @@ The Start-SecretRotation cmdlet rotates the infrastructure secrets of an Azure S
 | -- | -- | -- | -- | -- | -- |
 | PfxFilesPath | String  | False  | Named  | None  | The fileshare path to the **\Certificates** directory containing all external network endpoint certificates. Only required when rotating internal and external secrets. End directory must be **\Certificates**. |
 | CertificatePassword | SecureString | False  | Named  | None  | The password for all certificates provided in the -PfXFilesPath. Required value if PfxFilesPath is provided when both internal and external secrets are rotated. |
-|
 
 ### Examples
  

--- a/articles/azure-stack/azure-stack-rotate-secrets.md
+++ b/articles/azure-stack/azure-stack-rotate-secrets.md
@@ -75,13 +75,11 @@ When secrets are within 30 days of expiration, the following alerts are generate
 Running secret rotation using the instructions below will remediate these alerts.
 
 ## Pre-steps for secret rotation
-
+    > [!IMPORTANT]  
+    > Ensure secret rotation hasn't been previously successfully executed on your environment. If secret rotation has already been performed update to Azure Stack version 1807 or later prior to rotating secrets. 
 1.  Notify your users of any maintenance operations. Schedule normal maintenance windows, as much as possible,  during non-business hours. Maintenance operations may affect both user workloads and portal operations.
-
     > [!note]  
     > The next steps only apply when rotating Azure Stack external secrets.
-
-2. Ensure secret rotation hasn't been successfully executed on your environment within the past month. At this point in time Azure Stack only supports secret rotation once per month. 
 3. Prepare a new set of replacement external certificates. The new set matches the certificate specifications outlined in the [Azure Stack PKI certificate requirements](https://docs.microsoft.com/azure/azure-stack/azure-stack-pki-certs).
 4.  Store a back up to the certificates used for rotation in a secure backup location. If your rotation runs and then fails, replace the certificates in the file share with the backup copies before you rerun the rotation. Note, keep backup copies in the secure backup location.
 5.  Create a fileshare you can access from the ERCS VMs. The file share must be  readable and writable for the **CloudAdmin** identity.


### PR DESCRIPTION
All customers who have previously rotated secrets on their Azure Stack environments must update to version 1807 or later prior to rotation.