### PR TITLE
Repaired script for Removing the IoT Edge runtime.

### DIFF
--- a/articles/iot-edge/quickstart.md
+++ b/articles/iot-edge/quickstart.md
@@ -224,7 +224,7 @@ If you want to remove the installations from your device, use the following comm
 Remove the IoT Edge runtime.
 
    ```powershell
-   . {Invoke-WebRequest -useb aka.ms/iotedge-win} | Invoke-Expression; `
+   . {Invoke-WebRequest -useb aka.ms/iotedge-win} | Invoke-Expression;
    Uninstall-SecurityDaemon
    ```
 


### PR DESCRIPTION
The script was corrupted by an unwanted character. Now it works again.