### PR TITLE
Download and install the IoT Edge script was corrupted

### DIFF
--- a/articles/iot-edge/quickstart.md
+++ b/articles/iot-edge/quickstart.md
@@ -123,7 +123,7 @@ Use PowerShell to download and install the IoT Edge runtime. Use the device conn
 2. Download and install the IoT Edge service on your device. 
 
    ```powershell
-   . {Invoke-WebRequest -useb aka.ms/iotedge-win} | Invoke-Expression; `
+   . {Invoke-WebRequest -useb aka.ms/iotedge-win} | Invoke-Expression; 
    Install-SecurityDaemon -Manual -ContainerOs Linux
    ```
 


### PR DESCRIPTION
Just like the script for removing, an unwanted character corrupted the script.
Removing that character fixed the script.