### PR TITLE
Fix in parallel processing code snippet

### DIFF
--- a/articles/application-insights/application-insights-custom-operations-tracking.md
+++ b/articles/application-insights/application-insights-custom-operations-tracking.md
@@ -458,7 +458,6 @@ Disposing operation causes operation to be stopped, so you may do it instead of 
 
 ```csharp
 var firstOperation = telemetryClient.StartOperation<DependencyTelemetry>("task 1");
-var firstOperation = telemetryClient.StartOperation<DependencyTelemetry>("task 1");
 var firstTask = RunMyTaskAsync();
 
 var secondOperation = telemetryClient.StartOperation<DependencyTelemetry>("task 2");


### PR DESCRIPTION
Simple fix to the parallel processing code snippet that has the same line twice.

```C#
var firstOperation = telemetryClient.StartOperation<DependencyTelemetry>("task 1");
var firstOperation = telemetryClient.StartOperation<DependencyTelemetry>("task 1");
```