### PR TITLE
adding list of supported distros

### DIFF
--- a/articles/virtual-machines/extensions/diagnostics-linux.md
+++ b/articles/virtual-machines/extensions/diagnostics-linux.md
@@ -52,6 +52,7 @@ The downloadable configuration is just an example; modify it to suit your own ne
 * **Azure CLI**. [Set up the Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli) environment on your machine.
 * The wget command, if you don't already have it: Run `sudo apt-get install wget`.
 * An existing Azure subscription and an existing storage account within it to store the data.
+* List of supported Linux distributions is on https://github.com/Azure/azure-linux-extensions/tree/master/Diagnostic#supported-linux-distributions
 
 ### Sample installation
 


### PR DESCRIPTION
Had a CRI where LAD failed to install because of "os version: : not supported"
The doc above doesn't specify which ones are supported, so it might be a good idea to redirect users to github where this list exists.