### PR TITLE
Add optional 'timeout' param

### DIFF
--- a/articles/cognitive-services/Academic-Knowledge/CalcHistogramMethod.md
+++ b/articles/cognitive-services/Academic-Knowledge/CalcHistogramMethod.md
@@ -32,8 +32,9 @@ Name  |Value | Required?  |Description
 **count** |Number | No<br>Default: 10 |Number of results to return.
 **offset**  |Number | No<br>Default: 0 |Index of the first result to return.
 **timeout**  |Number | No<br>Default: 1000 |Timeout in milliseconds. Only interpretations found before the timeout has elapsed are returned.
-<br>
+
 ## Response (JSON)
+
 Name | Description
 --------|---------
 **expr**  |The expr parameter from the request.
@@ -48,7 +49,7 @@ Name | Description
 **histograms[x].histogram[y].count**  |Number of matching entities with this attribute value.
 **aborted** | True if the request timed out.
 
- <br>
+
 #### Example:
 ```
 https:// westus.api.cognitive.microsoft.com/academic/v1.0/calchistogram?expr=And(Composite(AA.AuN=='jaime teevan'),Y>2012)&attributes=Y,F.FN&count=4

--- a/articles/cognitive-services/Academic-Knowledge/CalcHistogramMethod.md
+++ b/articles/cognitive-services/Academic-Knowledge/CalcHistogramMethod.md
@@ -31,6 +31,7 @@ Name  |Value | Required?  |Description
 **attributes** | Text string | No<br>default: | A comma-delimited list that specifies the attribute values that are included in the response. Attribute names are case-sensitive.
 **count** |Number | No<br>Default: 10 |Number of results to return.
 **offset**  |Number | No<br>Default: 0 |Index of the first result to return.
+**timeout**  |Number | No<br>Default: 1000 |Timeout in milliseconds. Only interpretations found before the timeout has elapsed are returned.
 <br>
 ## Response (JSON)
 Name | Description


### PR DESCRIPTION
Add optional 'timeout' param to Request Parameter table for CalcHistogram.
'timeout' is given as an option for Interpret, but not for any other endpoint. After testing, I discovered that all other endpoints actually do accept a timeout.