### PR TITLE
Reference "thumbprint" as "SHA1 thumbprint"

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-create-vnet-and-windows-cluster.md
+++ b/articles/service-fabric/service-fabric-tutorial-create-vnet-and-windows-cluster.md
@@ -138,7 +138,7 @@ The [vnet-cluster.parameters.json][parameters] parameters file declares many val
 |adminPassword|Password#1234| Admin password for the cluster VMs. [Password requirements for VM](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#what-are-the-password-requirements-when-creating-a-vm)|
 |clusterName|mysfcluster123| Name of the cluster. Can contain letters and numbers only. Length can be between 3 and 23 characters.|
 |location|southcentralus| Location of the cluster. |
-|certificateThumbprint|| <p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the certificate thumbprint value. For example, "6190390162C988701DB5676EB81083EA608DCCF3"</p>. |
+|certificateThumbprint|| <p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the certificate SHA1 thumbprint value. For example, "6190390162C988701DB5676EB81083EA608DCCF3"</p>. |
 |certificateUrlValue|| <p>Value should be empty if creating a self-signed certificate or providing a certificate file. </p><p>To use an existing certificate previously uploaded to a key vault, fill in the certificate URL. For example, "https://mykeyvault.vault.azure.net:443/secrets/mycertificate/02bea722c9ef4009a76c5052bcbf8346".</p>|
 |sourceVaultValue||<p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the source vault value. For example, "/subscriptions/333cc2c84-12fa-5778-bd71-c71c07bf873f/resourceGroups/MyTestRG/providers/Microsoft.KeyVault/vaults/MYKEYVAULT".</p>|
 
@@ -223,7 +223,7 @@ Import-PfxCertificate -Exportable -CertStoreLocation Cert:\CurrentUser\My `
 
 You are now ready to connect to your secure cluster.
 
-The **Service Fabric** PowerShell module provides many cmdlets for managing Service Fabric clusters, applications, and services.  Use the [Connect-ServiceFabricCluster](/powershell/module/servicefabric/connect-servicefabriccluster) cmdlet to connect to the secure cluster. The certificate thumbprint and connection endpoint details are found in the output from the previous step.
+The **Service Fabric** PowerShell module provides many cmdlets for managing Service Fabric clusters, applications, and services.  Use the [Connect-ServiceFabricCluster](/powershell/module/servicefabric/connect-servicefabriccluster) cmdlet to connect to the secure cluster. The certificate SHA1 thumbprint and connection endpoint details are found in the output from the previous step.
 
 ```powershell
 Connect-ServiceFabricCluster -ConnectionEndpoint mysfcluster123.southcentralus.cloudapp.azure.com:19000 `


### PR DESCRIPTION
Updated the references to the certificate thumbprint to be labeled as "SHA1 thumbprint". The documentation isn't very clear as to what SHA hash to generate / use for thumbprints. Azure KeyVault outputs SHA1 hashes for the certificates, and that's fine if you use those directly with Service Fabric. However, with self-generated, self-signed certificates it's important to use SHA1 for generating the thumbprint values to use, and the documentation doesn't mention SHA1 very clearly throughout. This is a cause of confusion since it could be assumed that SHA256 thumbprints would be ok, but they are not and you'll get HTTP 403 errors if you try to use them without any kind of warning as to specifically why. Adding mention of SHA1 should help those that are having issues, or even prevent them all together.