### PR TITLE
Reference "thumbprint" as "SHA1 thumbprint"

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-create-vnet-and-linux-cluster.md
+++ b/articles/service-fabric/service-fabric-tutorial-create-vnet-and-linux-cluster.md
@@ -132,7 +132,7 @@ The [vnet-cluster.parameters.json][parameters] parameters file declares many val
 |adminPassword|Password#1234| Admin password for the cluster VMs.|
 |clusterName|mysfcluster123| Name of the cluster. |
 |location|southcentralus| Location of the cluster. |
-|certificateThumbprint|| <p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the certificate thumbprint value. For example, "6190390162C988701DB5676EB81083EA608DCCF3". </p>|
+|certificateThumbprint|| <p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the certificate SHA1 thumbprint value. For example, "6190390162C988701DB5676EB81083EA608DCCF3". </p>|
 |certificateUrlValue|| <p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the certificate URL. For example, "https://mykeyvault.vault.azure.net:443/secrets/mycertificate/02bea722c9ef4009a76c5052bcbf8346".</p>|
 |sourceVaultValue||<p>Value should be empty if creating a self-signed certificate or providing a certificate file.</p><p>To use an existing certificate previously uploaded to a key vault, fill in the source vault value. For example, "/subscriptions/333cc2c84-12fa-5778-bd71-c71c07bf873f/resourceGroups/MyTestRG/providers/Microsoft.KeyVault/vaults/MYKEYVAULT".</p>|
 


### PR DESCRIPTION
Updated the references to the certificate thumbprint to be labeled as "SHA1 thumbprint". The documentation isn't very clear as to what SHA hash to generate / use for thumbprints. Azure KeyVault outputs SHA1 hashes for the certificates, and that's fine if you use those directly with Service Fabric. However, with self-generated, self-signed certificates it's important to use SHA1 for generating the thumbprint values to use, and the documentation doesn't mention SHA1 very clearly throughout. This is a cause of confusion since it could be assumed that SHA256 thumbprints would be ok, but they are not and you'll get HTTP 403 errors if you try to use them without any kind of warning as to specifically why. Adding mention of SHA1 should help those that are having issues, or even prevent them all together.