### PR TITLE
Added recommendation about using SHA1 thumbprint.

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-security.md
+++ b/articles/service-fabric/service-fabric-cluster-security.md
@@ -88,6 +88,7 @@ Some important things to consider:
 * To create certificates for clusters that are running production workloads, use a correctly configured Windows Server certificate service, or one from an approved [certificate authority (CA)](https://en.wikipedia.org/wiki/Certificate_authority).
 * Never use any temporary or test certificates that you create by using tools like MakeCert.exe in a production environment.
 * You can use a self-signed certificate, but only in a test cluster. Do not use a self-signed certificate in production.
+* When generating the certificate thumbprint, be sure to generate a SHA1 thumbprint. SHA1 is what's used when configuring the Client and Cluster certificate thumbprints.
 
 ### Cluster and server certificate (required)
 These certificates (one primary and optionally a secondary) are required to secure a cluster and prevent unauthorized access to it. These certificates provide cluster and server authentication.


### PR DESCRIPTION
Added recommendation about using SHA1 thumbprint. The documentation isn't very clear as to what SHA hash to generate / use for thumbprints. Azure KeyVault outputs SHA1 hashes for the certificates, and that's fine if you use those directly with Service Fabric. However, with self-generated, self-signed certificates it's important to use SHA1 for generating the thumbprint values to use, and the documentation doesn't mention SHA1 very clearly throughout. This is a cause of confusion since it could be assumed that SHA256 thumbprints would be ok, but they are not and you'll get HTTP 403 errors if you try to use them without any kind of warning as to specifically why. Adding mention of SHA1 should help those that are having issues, or even prevent them all together.