### PR TITLE
Changed DN examples to reflect current Azure ADDS

### DIFF
--- a/articles/active-directory-domain-services/active-directory-ds-ldaps-bind-lockdown.md
+++ b/articles/active-directory-domain-services/active-directory-ds-ldaps-bind-lockdown.md
@@ -34,8 +34,8 @@ Next, bind to the managed domain. Click **Connection** and click **Bind...** in 
 Select **View**, and then select **Tree** in the menu. Leave the Base DN field blank, and click OK. Navigate to the container that you want to search, right-click the container, and select Search.
 
 > [!TIP]
-> - Users and groups synchronized from Azure AD are stored in the **AADDC Users** container. The search path for this container looks like ```CN=AADDC\ Users,DC=CONTOSO100,DC=COM```.
-> - Computer accounts for computers joined to the managed domain are stored in the **AADDC Computers** container. The search path for this container looks like ```CN=AADDC\ Computers,DC=CONTOSO100,DC=COM```.
+> - Users and groups synchronized from Azure AD are stored in the **AADDC Users** organizational unit. The search path for this organizational unit looks like ```OU=AADDC Users,DC=CONTOSO100,DC=COM```.
+> - Computer accounts for computers joined to the managed domain are stored in the **AADDC Computers** organizational unit. The search path for this organizational unit looks like ```OU=AADDC Computers,DC=CONTOSO100,DC=COM```.
 >
 >
 


### PR DESCRIPTION
The DN strings used in this article did not reflect what AADDS actually uses in a production Azure environment. The entities "AADDC Users" and "AADDC Computers" are Organizational Units, not Containers. The related fields have been changed from CN to OU and related notes have also been changed to reflect this. 

I've attached a screenshot from LDP.exe to confirm this, we only just deployed AADDS to our tenant a couple of days ago and this is how it was setup.

https://user-images.githubusercontent.com/3991905/45258896-a5dbef80-b375-11e8-92da-11de36d2cd79.PNG