### PR TITLE
Fix alerts dimension operator in sample

### DIFF
--- a/articles/monitoring-and-diagnostics/monitoring-create-metric-alerts-with-templates.md
+++ b/articles/monitoring-and-diagnostics/monitoring-create-metric-alerts-with-templates.md
@@ -403,12 +403,12 @@ Save and modify the json below as advancedmetricalert.parameters.json for the pu
                     "dimensions": [
                         {
                             "name":"ResponseType",
-                            "operator": "Includes",
+                            "operator": "Include",
                             "values": ["Success"]
                         },
                         {
                             "name":"ApiName",
-                            "operator": "Includes",
+                            "operator": "Include",
                             "values": ["GetBlob"]
                         }
                     ],
@@ -424,7 +424,7 @@ Save and modify the json below as advancedmetricalert.parameters.json for the pu
                 "dimensions": [
                     {
                         "name":"ApiName",
-                        "operator": "Includes",
+                        "operator": "Include",
                         "values": ["GetBlob"]
                     }
                 ],


### PR DESCRIPTION
As per a conversation with Microsoft Azure Support, the documentation is currently incorrectly stating that the dimension operator is `Includes` when it should actually be `Include`.