### PR TITLE
Update softDeleteMarkerValue for BIT field

### DIFF
--- a/articles/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers.md
+++ b/articles/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers.md
@@ -272,7 +272,7 @@ When using the soft-delete technique, you can specify the soft delete policy as 
         }
     }
 
-The **softDeleteMarkerValue** must be a string – use the string representation of your actual value. For example, if you have an integer column where deleted rows are marked with the value 1, use `"1"`. If you have a BIT column where deleted rows are marked with the Boolean true value or 1, use `true`.
+The **softDeleteMarkerValue** must be a string – use the string representation of your actual value. For example, if you have an integer column where deleted rows are marked with the value 1, use `"1"`. If you have a BIT column where deleted rows are marked with the Boolean true value, use the string literal `True` or `true`, the case doesn't matter.
 
 <a name="TypeMapping"></a>
 

--- a/articles/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers.md
+++ b/articles/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers.md
@@ -272,7 +272,7 @@ When using the soft-delete technique, you can specify the soft delete policy as 
         }
     }
 
-The **softDeleteMarkerValue** must be a string – use the string representation of your actual value. For example, if you have an integer column where deleted rows are marked with the value 1, use `"1"`. If you have a BIT column where deleted rows are marked with the Boolean true value, use `"True"`.
+The **softDeleteMarkerValue** must be a string – use the string representation of your actual value. For example, if you have an integer column where deleted rows are marked with the value 1, use `"1"`. If you have a BIT column where deleted rows are marked with the Boolean true value or 1, use `true`.
 
 <a name="TypeMapping"></a>
 


### PR DESCRIPTION
I have a SOFT DELETE COLUMN which is a BIT field. This field is true if the record is deleted. I tried 1, "1" and "True" but nothing worked, the documents were not removed form the search index. Then I tried true and the indexer recognized these records as deleted and removed those form the index. Wasted at least 2 hours to figure this out.

I am using AzureSQL.

![image](https://user-images.githubusercontent.com/13821125/45393165-fd2bd980-b66d-11e8-8159-67baea16eb7f.png)