### PR TITLE
Nested groups are not supported

### DIFF
--- a/articles/active-directory/saas-apps/aws-multi-accounts-tutorial.md
+++ b/articles/active-directory/saas-apps/aws-multi-accounts-tutorial.md
@@ -316,6 +316,9 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 
 	![Configure Single Sign-On Add](./media/aws-multi-accounts-tutorial/graph-explorer-new5.png)
 
+> [!Note]
+> Please note that nested groups are not supported when assigning groups.
+
 28. To assign the role to the group, select the role and click on **Assign** button in the bottom of the page.
 
 	![Configure Single Sign-On Add](./media/aws-multi-accounts-tutorial/graph-explorer-new6.png)

--- a/articles/active-directory/saas-apps/aws-multi-accounts-tutorial.md
+++ b/articles/active-directory/saas-apps/aws-multi-accounts-tutorial.md
@@ -317,7 +317,7 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 	![Configure Single Sign-On Add](./media/aws-multi-accounts-tutorial/graph-explorer-new5.png)
 
 > [!Note]
-> Please note that nested groups are not supported when assigning groups.
+> Nested groups are not supported when assigning groups.
 
 28. To assign the role to the group, select the role and click on **Assign** button in the bottom of the page.
 


### PR DESCRIPTION
Azure support ticket raised after nested groups proved that they did not work when assigning permissions.  Support engineer directed me towards this open feature request: https://feedback.azure.com/forums/169401-azure-active-directory/suggestions/15718164-add-support-for-nested-groups-in-azure-ad-app-acc
In the mean time we should acknowledge nested groups are not supported.