### PR TITLE
Clarify what is considered a 3rd-party dependency for Java Function Packaging

### DIFF
--- a/articles/azure-functions/functions-reference-java.md
+++ b/articles/azure-functions/functions-reference-java.md
@@ -86,6 +86,8 @@ with the corresponding `function.json`:
 
 Azure Functions supports the use of third-party libraries. By default, all dependencies specified in your project `pom.xml` file will be automatically bundled during the `mvn package` goal. For libraries not specified as dependencies in the `pom.xml` file, place them in a `lib` directory in the function's root directory. Dependencies placed in the `lib` directory will be added to the system class loader at runtime.
 
+The `com.microsoft.azure.functions:azure-functions-java-library` dependency is provided on the classpath by default, and does not need to be included in the `lib` directory.
+
 ## Data type support
 
 You can use any data types in Java for the input and output data, including native types; customized Java types and specialized Azure types defined in `azure-functions-java-library` package. The Azure Functions runtime attempts convert the input received into the type requested by your code.


### PR DESCRIPTION
The dependencies specified for inclusion in the lib directory were previously phrased as "third party dependencies". This usually refers to any libraries in a project, which would include the Azure Java library. I noticed when working with the Maven example that it included all dependencies except the Azure Java library. Since the function is running within Azure, I assume this is due to it being provided automatically. 

This change adds a line clarifying that the Azure Java library is provided and its omission from the lib directory is expected.