### PR TITLE
Added Rails only Note

### DIFF
--- a/articles/app-service/containers/quickstart-ruby.md
+++ b/articles/app-service/containers/quickstart-ruby.md
@@ -1,7 +1,7 @@
 ---
-title: Create a Ruby App and deploy to App Service on Linux | Microsoft Docs
-description: Learn to create Ruby apps with App Service on Linux.
-keywords: azure app service, linux, oss, ruby
+title: Create a Ruby on Rails App and deploy to App Service on Linux | Microsoft Docs
+description: Learn to create a Ruby on Rails app with App Service on Linux.
+keywords: azure app service, linux, oss, ruby, rails
 services: app-service
 documentationcenter: ''
 author: SyntaxC4
@@ -18,9 +18,11 @@ ms.date: 08/24/2018
 ms.author: cfowler
 ms.custom: mvc
 ---
-# Create a Ruby App in App Service on Linux
+# Create a Ruby on Rails App in App Service on Linux
 
 [Azure App Service on Linux](app-service-linux-intro.md) provides a highly scalable, self-patching web hosting service. This quickstart shows you how to create a basic [Ruby on Rails](https://rubyonrails.org/) application that can then be deployed to Azure as a Web App on Linux.
+
+*Note: The Ruby development stack only supports Ruby on Rails at this time. If you want to use a different platform, such as Sinatra, please see the quickstart for [Web App for Containers](https://docs.microsoft.com/en-us/azure/app-service/containers/).*
 
 ![Hello-world](./media/quickstart-ruby/hello-world-updated.png)
 
@@ -43,13 +45,13 @@ git clone https://github.com/Azure-Samples/ruby-docs-hello-world
 
 Run the application locally so that you see how it should look when you deploy it to Azure. Open a terminal window, change to the `hello-world` directory, and use the `rails server` command to start the server.
 
-The first step is to install the required gems. There's a `Gemfile` included in the sample so you don't need to specify the gems to install. We'll use bundler for this, and we'll save the gems locally in a `.gems` directory. Feel free to change the name if you like:
+The first step is to install the required gems. There's a `Gemfile` included in the sample so you don't need to specify the gems to install. We'll use bundler for this:
 
 ```
-bundle install --path=.gems
+bundle install
 ```
 
-Once the gems are installed, we'll use bundler to start the app for us:
+Once the gems are installed, we'll use bundler to start the app:
 
 ```bash
 bundle exec rails server

--- a/articles/app-service/containers/quickstart-ruby.md
+++ b/articles/app-service/containers/quickstart-ruby.md
@@ -22,7 +22,8 @@ ms.custom: mvc
 
 [Azure App Service on Linux](app-service-linux-intro.md) provides a highly scalable, self-patching web hosting service. This quickstart shows you how to create a basic [Ruby on Rails](https://rubyonrails.org/) application that can then be deployed to Azure as a Web App on Linux.
 
-*Note: The Ruby development stack only supports Ruby on Rails at this time. If you want to use a different platform, such as Sinatra, please see the quickstart for [Web App for Containers](https://docs.microsoft.com/en-us/azure/app-service/containers/).*
+> [!NOTE]
+> The Ruby development stack only supports Ruby on Rails at this time. If you want to use a different platform, such as Sinatra, please see the quickstart for [Web App for Containers](https://docs.microsoft.com/azure/app-service/containers/).
 
 ![Hello-world](./media/quickstart-ruby/hello-world-updated.png)
 


### PR DESCRIPTION
Currently, WebApps for Linux only supports Ruby on Rails according to the team (have email from Yi Liao confirming limitation). I spent 7 hours yesterday trying to get a simple Sinatra service up and I have to think I won't be the only one, so I added a note here to spell that out as well as an update to the titling.

In addition, I removed the local install of the gems as it can be confusing. Seasoned Ruby devs will know how to deal with this. I did leave the gem installation bits, however.