### PR TITLE
Disclose SDK temporary storage

### DIFF
--- a/articles/application-insights/app-insights-data-retention-privacy.md
+++ b/articles/application-insights/app-insights-data-retention-privacy.md
@@ -129,7 +129,7 @@ Yes, we use https to send data to the portal from nearly all SDKs, including web
 Yes, certain Telemetry Channels will persist data locally if an endpoint cannot be reached. Please review below to see which frameworks and telemetry channels are affected.
 
 
-Telemetry channels that utilize local storage create temp files in the TEMP or APPDATA directories which are restricted to the specific account running your application. This may happen when an endpoint was temporary unavailable or you hit the throttling limit. Once this issue is resolved, the telemetry channel will resume sending all the new and persisted data.
+Telemetry channels that utilize local storage create temp files in the TEMP or APPDATA directories which are restricted to the specific account running your application. This may happen when an endpoint was temporarily unavailable or you hit the throttling limit. Once this issue is resolved, the telemetry channel will resume sending all the new and persisted data.
 
 
 This persisted data is **not encrypted** and it is strongly recommended to restructure your data collection policy to disable the collection of private data. (See [How to export and delete private data](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-customer-data#how-to-export-and-delete-private-data) for more information.)

--- a/articles/application-insights/app-insights-data-retention-privacy.md
+++ b/articles/application-insights/app-insights-data-retention-privacy.md
@@ -177,7 +177,7 @@ services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel () {
 
 (See [AspNetCore Custom Configuration](https://github.com/Microsoft/ApplicationInsights-aspnetcore/wiki/Custom-Configuration) for more information. )
 
-### NodeJS
+### Node.js
 
 By default `%TEMP%/appInsights-node{INSTRUMENTATION KEY}` is used for persisting data. Permissions to access this folder are restricted to the current user and Administrators. (See [implementation](https://github.com/Microsoft/ApplicationInsights-node.js/blob/develop/Library/Sender.ts) here.)
 

--- a/articles/application-insights/app-insights-data-retention-privacy.md
+++ b/articles/application-insights/app-insights-data-retention-privacy.md
@@ -132,7 +132,7 @@ Yes, certain Telemetry Channels will persist data locally if an endpoint cannot 
 Telemetry channels that utilize local storage create temp files in the TEMP or APPDATA directories which are restricted to the specific account running your application. This may happen when an endpoint was temporarily unavailable or you hit the throttling limit. Once this issue is resolved, the telemetry channel will resume sending all the new and persisted data.
 
 
-This persisted data is **not encrypted** and it is strongly recommended to restructure your data collection policy to disable the collection of private data. (See [How to export and delete private data](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-customer-data#how-to-export-and-delete-private-data) for more information.)
+This persisted data is **not encrypted** and it is strongly recommended to restructure your data collection policy to disable the collection of private data. (See [How to export and delete private data](https://docs.microsoft.com/azure/application-insights/app-insights-customer-data#how-to-export-and-delete-private-data) for more information.)
 
 
 If a customer needs to configure this directory with specific security requirements it can be configured per framework. Please make sure that the process running your application has write access to this directory, but also make sure this directory is protected to avoid telemetry being read by unintended users.

--- a/articles/application-insights/app-insights-data-retention-privacy.md
+++ b/articles/application-insights/app-insights-data-retention-privacy.md
@@ -179,7 +179,11 @@ services.AddSingleton(typeof(ITelemetryChannel), new ServerTelemetryChannel () {
 
 ### NodeJS
 
-The local folder can be overridden by changing the runtime value of the static variable `Sender.TEMPDIR_PREFIX` found in [Sender.ts](https://github.com/Microsoft/ApplicationInsights-node.js/blob/7a1ecb91da5ea0febf5ceab13d6a4bf01a63933d/Library/Sender.ts#L384). This value controls the subfolder within the TEMP directory.
+By default `%TEMP%/appInsights-node{INSTRUMENTATION KEY}` is used for persisting data. Permissions to access this folder are restricted to the current user and Administrators. (See [implementation](https://github.com/Microsoft/ApplicationInsights-node.js/blob/develop/Library/Sender.ts) here.)
+
+The folder prefix `appInsights-node` can be overridden by changing the runtime value of the static variable `Sender.TEMPDIR_PREFIX` found in [Sender.ts](https://github.com/Microsoft/ApplicationInsights-node.js/blob/7a1ecb91da5ea0febf5ceab13d6a4bf01a63933d/Library/Sender.ts#L384).
+
+
 
 ## How do I send data to Application Insights using TLS 1.2?
 


### PR DESCRIPTION
This document addresses an SDL concern:
Our telemetry channel persists data to a local storage, without calling out that this storage is not encrypted.
This could have implications for customers considering PII or HIPAA and they need to be made aware of this storage.