### PR TITLE
NarrowAzureTrafficSelectors is difficult to understand

### DIFF
--- a/includes/vpn-gateway-device-configuration-scripts.md
+++ b/includes/vpn-gateway-device-configuration-scripts.md
@@ -21,5 +21,5 @@
 |Ubiquiti| EdgeRouter| EdgeOS v1.10x RouteBased BGP|
 
 > [!NOTE]
-> (*) Required: NarrowAzureTrafficSelectors and CustomAzurePolicies (IKE/IPsec)
+> (*) Required: NarrowAzureTrafficSelectors (enable UsePolicyBasedTrafficSelectors option) and CustomAzurePolicies (IKE/IPsec)
 >


### PR DESCRIPTION
NarrowAzureTrafficSelectors means to enable UsePolicyBasedTrafficSelectors so I hope to add some word into this sentence, E.g (enable UsePolicyBasedTrafficSelectors option)