### PR TITLE
Added link for Python simulated device quickstart

### DIFF
--- a/includes/iot-hub-get-started-device-selector.md
+++ b/includes/iot-hub-get-started-device-selector.md
@@ -13,3 +13,4 @@
 > * [Adafruit Feather HUZZAH ESP8266 with Arduino IDE](../articles/iot-hub/iot-hub-arduino-huzzah-esp8266-get-started.md)
 > * [Sparkfun ESP8266 Thing Dev with Arduino IDE](../articles/iot-hub/iot-hub-sparkfun-esp8266-thing-dev-get-started.md)
 > * [Adafruit Feather M0 with Arduino IDE](../articles/iot-hub/iot-hub-adafruit-feather-m0-wifi-kit-arduino-get-started.md)
+> * [iOS with Swift](../articles/iot-hub/quickstart-send-telemetry-ios.md)

--- a/includes/iot-hub-get-started-device-selector.md
+++ b/includes/iot-hub-get-started-device-selector.md
@@ -3,6 +3,7 @@
 > * [Simulated device with .NET](../articles/iot-hub/quickstart-send-telemetry-dotnet.md)
 > * [Simulated device with Java](../articles/iot-hub/quickstart-send-telemetry-java.md)
 > * [Simulated device with Node.js](../articles/iot-hub/quickstart-send-telemetry-node.md)
+> * [Simulated device with Python](../articles/iot-hub/quickstart-send-telemetry-python.md)
 > * [IoT DevKit AZ3166 with VS Code](../articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md)
 > * [Raspberry Pi with Node.js](../articles/iot-hub/iot-hub-raspberry-pi-kit-node-get-started.md)
 > * [Raspberry Pi with Python](../articles/iot-hub/iot-hub-raspberry-pi-kit-python-get-started.md)


### PR DESCRIPTION
The list was missing a link for the article about sending telemetry from a simulated device using Python. This change adds that link to the list.

As a side note, the diff says it's +2-1 but it's only +1, something about git diff seems to be measuring it improperly.