### PR TITLE
Import-*HostingServiceCert examples have two typos

### DIFF
--- a/articles/azure-stack/azure-stack-extension-host-prepare.md
+++ b/articles/azure-stack/azure-stack-extension-host-prepare.md
@@ -88,9 +88,9 @@ Use a computer that can connect to the Azure Stack privileged endpoint for the n
 
     $CloudAdminCred = Get-Credential -UserName <Privileged endpoint credentials> -Message "Enter the cloud domain credentials to access the privileged endpoint."
 
-    [Byte[]] $AdminHostingCertContent = [Byte[]](Get-Content c:\certificate\myadminhostingcertificate.pfx -Encoding Byte)
+    [Byte[]]$AdminHostingCertContent = [Byte[]](Get-Content c:\certificate\myadminhostingcertificate.pfx -Encoding Byte)
 
-    Invoke-Command -ComputeName <PrivilegedEndpoint computer name> `
+    Invoke-Command -ComputerName <PrivilegedEndpoint computer name> `
     -Credential $CloudAdminCred `
     -ConfigurationName "PrivilegedEndpoint" `
     -ArgumentList @($AdminHostingCertContent, $CertPassword) `
@@ -105,9 +105,9 @@ Use a computer that can connect to the Azure Stack privileged endpoint for the n
 
     $CloudAdminCred = Get-Credential -UserName <Privileged endpoint credentials> -Message "Enter the cloud domain credentials to access the privileged endpoint."
 
-    [Byte[]] $HostingCertContent = [Byte[]](Get-Content c:\certificate\myhostingcertificate.pfx  -Encoding Byte)
+    [Byte[]]$HostingCertContent = [Byte[]](Get-Content c:\certificate\myhostingcertificate.pfx  -Encoding Byte)
 
-    Invoke-Command -ComputeName <PrivilegedEndpoint computer name> `
+    Invoke-Command -ComputerName <PrivilegedEndpoint computer name> `
     -Credential $CloudAdminCred `
     -ConfigurationName "PrivilegedEndpoint" `
     -ArgumentList @($HostingCertContent, $CertPassword) `


### PR DESCRIPTION
These two examples must be fixed, the current form is invalid:
"-ComputeName" should be "-ComputerName"
and 
"[Byte[]] $HostingCertContent" should be "[Byte[]]$HostingCertContent"

Additionally (the current version is valid syntax):
[Byte[]]$HostingCertContent = [Byte[]](Get-Content c:\certificate\myhostingcertificate.pfx  -Encoding Byte)
could be shortened to:
[Byte[]]$HostingCertContent = Get-Content c:\certificate\myhostingcertificate.pfx -Encoding Byte
Note: "  -Encoding" currently has two leading spaces and only needs one.