### PR TITLE
Fix broken 404 URL link for #14980

### DIFF
--- a/articles/automation/automation-scenario-source-control-integration-with-VSTS.md
+++ b/articles/automation/automation-scenario-source-control-integration-with-VSTS.md
@@ -41,7 +41,7 @@ Create a [secure variable](automation-variables.md) in your automation account t
 
 ![](media/automation-scenario-source-control-integration-with-VSTS/VSTSTokenVariable.png)
 
-Import the runbook that syncs your runbooks or configurations into the automation account. You can use the [Azure DevOps sample runbook](https://www.powershellgallery.com/packages/Sync-VSTS/1.0/DisplayScript) or the [Azure DevOps with Git sample runbook](https://www.powershellgallery.com/packages/Sync-VSTSGit/1.0/DisplayScript) from the PowerShellGallery.com depending on if you use Azure DevOps source control or Azure DevOps with Git and deploy to your automation account.
+Import the runbook that syncs your runbooks or configurations into the automation account. You can use the [Azure DevOps sample runbook](https://www.powershellgallery.com/packages/Sync-VSTS) or the [Azure DevOps with Git sample runbook](https://www.powershellgallery.com/packages/Sync-VSTSGit) from the [PowerShell Gallery](https://www.powershellgallery.com) depending on if you use Azure DevOps source control or Azure DevOps with Git and deploy to your automation account.
 
 ![](media/automation-scenario-source-control-integration-with-VSTS/VSTSPowerShellGallery.png)
 


### PR DESCRIPTION
Updated the "Azure DevOps sample runbook" and "Azure DevOps with Git sample runbook" URL to the published package URL in order to resolve #14980 so that there is no dependency to package versioning when a new version is released by AzureAutomation team.