### PR TITLE
Current quickstart-create-databricks-account documentation doesn't work out of the box

### DIFF
--- a/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
+++ b/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
@@ -115,7 +115,7 @@ Before you begin with this section, you must complete the following prerequisite
 
 Enter the following code into a notebook cell:
 
-    %sh wget -P /tmp https://github.com/Azure/usql/blob/master/Examples/Samples/Data/json/radiowebsite/small_radio_json.json
+    %sh wget -P /tmp https://raw.githubusercontent.com/Azure/usql/master/Examples/Samples/Data/json/radiowebsite/small_radio_json.json
 
 In the cell, press `Shift` + `Enter` to run the code.
 

--- a/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
+++ b/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
@@ -137,7 +137,7 @@ Perform the following tasks to run a Spark SQL job on the data.
     CREATE TABLE radio_sample_data
     USING json
     OPTIONS (
-     path  "abfss://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/<PATH>/small_radio_json.json"
+     path  "abfss://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/small_radio_json.json"
     )
     ```
 

--- a/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
+++ b/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
@@ -101,7 +101,7 @@ In this section, you create a notebook in Azure Databricks workspace and then ru
     ```scala
     spark.conf.set("fs.azure.account.key.<ACCOUNT_NAME>.dfs.core.windows.net", "<ACCOUNT_KEY>") 
     spark.conf.set("fs.azure.createRemoteFileSystemDuringInitialization", "true")
-    dbutils.fs.ls("abfs://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/")
+    dbutils.fs.ls("abfss://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/")
     spark.conf.set("fs.azure.createRemoteFileSystemDuringInitialization", "false") 
     ```
 
@@ -121,7 +121,7 @@ In the cell, press `Shift` + `Enter` to run the code.
 
 Now in a new cell below this one, enter the following code (replace **FILE_SYSTEM** and **ACCOUNT_NAME** with the same values you used earlier:
 
-    dbutils.fs.cp("file:///tmp/small_radio_json.json", "abfs://<FILE_SYSTEM>@<ACCOUNT_NAME>.dfs.core.windows.net/")
+    dbutils.fs.cp("file:///tmp/small_radio_json.json", "abfss://<FILE_SYSTEM>@<ACCOUNT_NAME>.dfs.core.windows.net/")
 
 In the cell, press `Shift` + `Enter` to run the code.
 
@@ -137,7 +137,7 @@ Perform the following tasks to run a Spark SQL job on the data.
     CREATE TABLE radio_sample_data
     USING json
     OPTIONS (
-     path  "abfs://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/<PATH>/small_radio_json.json"
+     path  "abfss://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/<PATH>/small_radio_json.json"
     )
     ```
 

--- a/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
+++ b/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
@@ -137,7 +137,7 @@ Perform the following tasks to run a Spark SQL job on the data.
     CREATE TABLE radio_sample_data
     USING json
     OPTIONS (
-     path  "abfss://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/small_radio_json.json"
+     path  "abfss://<FILE_SYSTEM_NAME>@<ACCOUNT_NAME>.dfs.core.windows.net/<PATH>/small_radio_json.json"
     )
     ```
 


### PR DESCRIPTION
All the documentation here: https://docs.azuredatabricks.net/spark/latest/data-sources/azure/azure-datalake-gen2.html points to ABFSS.

I tried using it without the SSL after providing it with the previous tutorial: https://docs.microsoft.com/en-us/azure/storage/data-lake-storage/quickstart-create-account 

And I can't seem to be able to make it work. I get the following error:
```logs
java.io.IOException: abfs://coolcontainername.dfs.core.windows.net has invalid authority.
	at shaded.databricks.org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.execute(AzureBlobFileSystem.java:637)
	at shaded.databricks.org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.execute(AzureBlobFileSystem.java:623)
	at shaded.databricks.org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.createFileSystem(AzureBlobFileSystem.java:563)
	at shaded.databricks.org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem.initialize(AzureBlobFileSystem.java:130)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2669)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:370)
	at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295)
	at com.databricks.backend.daemon.dbutils.FSUtils$.getFS(DBUtilsCore.scala:192)
	at com.databricks.backend.daemon.dbutils.FSUtils$.ls(DBUtilsCore.scala:64)
	at com.databricks.dbutils_v1.impl.DbfsUtilsImpl.ls(DbfsUtilsImpl.scala:33)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$$iw$$iw$$iw$$iw$$iw$$iw.<init>(command-2171967119197342:2)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$$iw$$iw$$iw$$iw$$iw.<init>(command-2171967119197342:48)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$$iw$$iw$$iw$$iw.<init>(command-2171967119197342:50)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$$iw$$iw$$iw.<init>(command-2171967119197342:52)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$$iw$$iw.<init>(command-2171967119197342:54)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$$iw.<init>(command-2171967119197342:56)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read.<init>(command-2171967119197342:58)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$.<init>(command-2171967119197342:62)
	at line1135342bbba44ac9b430a0701cfd9bb057.$read$.<clinit>(command-2171967119197342)
	at line1135342bbba44ac9b430a0701cfd9bb057.$eval$.$print$lzycompute(<notebook>:7)
	at line1135342bbba44ac9b430a0701cfd9bb057.$eval$.$print(<notebook>:6)
```