### PR TITLE
Add another point in note about using more than one subscription

### DIFF
--- a/articles/sql-database/sql-database-vnet-service-endpoint-rule-overview.md
+++ b/articles/sql-database/sql-database-vnet-service-endpoint-rule-overview.md
@@ -115,6 +115,7 @@ You have the option of using [role-based access control (RBAC)][rbac-what-is-813
 > In some cases the Azure SQL Database and the VNet-subnet are in different subscriptions. In these cases you must ensure the following configurations:
 > - Both subscriptions must be in the same Azure Active Directory tenant.
 > - The user has the required permissions to initiate operations, such as enabling service endpoints and adding a VNet-subnet to the given Server.
+> - Both subscriptions must have the Microsoft.Sql provider registered.
 
 ## Limitations
 


### PR DESCRIPTION
Add a new point on the note that talk about using more than one subscription.
It's required to have the Microsoft.Sql provider registered on both subscriptions or else customer get an error talking about not having authorization.