### PR TITLE
Clarify warm-up configuration setting

### DIFF
--- a/articles/app-service/web-sites-staged-publishing.md
+++ b/articles/app-service/web-sites-staged-publishing.md
@@ -172,10 +172,12 @@ If any errors are identified in production after a slot swap, roll the slots bac
 ## Custom warm-up before swap
 Some apps may require custom warm-up actions. The `applicationInitialization` configuration element in web.config allows you to specify custom initialization actions to be performed before a request is received. The swap operation waits for this custom warm-up to complete. Here is a sample web.config fragment.
 
-    <applicationInitialization>
-        <add initializationPage="/" hostName="[app hostname]" />
-        <add initializationPage="/Home/About" hostname="[app hostname]" />
-    </applicationInitialization>
+    <system.webServer>
+        <applicationInitialization>
+            <add initializationPage="/" hostName="[app hostname]" />
+            <add initializationPage="/Home/About" hostname="[app hostname]" />
+        </applicationInitialization>
+    </system.webServer>
 
 ## Monitor swap progress
 


### PR DESCRIPTION
This PR updates the example `web.config` fragment provided to clarify that the `applicationInitialization` setting must be placed within the `system.webServer`.