### PR TITLE
Copy database name correction

### DIFF
--- a/articles/sql-database/sql-database-copy.md
+++ b/articles/sql-database/sql-database-copy.md
@@ -63,7 +63,7 @@ This command copies Database1 to a new database named Database2 on the same serv
 
     -- Execute on the master database.
     -- Start copying.
-    CREATE DATABASE Database1_copy AS COPY OF Database1;
+    CREATE DATABASE Database2 AS COPY OF Database1;
 
 ### Copy a SQL database to a different server
 
@@ -73,7 +73,7 @@ This command copies Database1 on server1 to a new database named Database2 on se
 
     -- Execute on the master database of the target server (server2)
     -- Start copying from Server1 to Server2
-    CREATE DATABASE Database1_copy AS COPY OF server1.Database1;
+    CREATE DATABASE Database2 AS COPY OF server1.Database1;
 
 
 ### Monitor the progress of the copying operation


### PR DESCRIPTION
The copied database name in the code was different than that in the text describing what the code does. Fixed that by changing the name in the code. Another alternative would be to change the reference to the name in the text describing what the code does. I leave that up to you.