### PR TITLE
Added Note for PORT check

### DIFF
--- a/articles/app-service/app-service-web-get-started-nodejs.md
+++ b/articles/app-service/app-service-web-get-started-nodejs.md
@@ -43,6 +43,9 @@ Download the sample Node.js project from [https://github.com/Azure-Samples/nodej
 
 In a terminal window, navigate to the root directory of the sample Node.js project (the one that contains _index.js_).
 
+> [!NOTE]
+> You don't need to use our sample app, you can use your own Node code if you want. Be aware, however, that the PORT for your app will be set at runtime by Azure, and is available as `process.env.PORT`. If you're using express, be sure that you have a check on startup (`app.listen`) for `process.env.PORT || 3000`. If you don't do this and your port doesn't match what is set at runtime by Azure, you will see a `Service Unavailable` message. 
+
 ## Run the app locally
 
 Run the application locally so that you see how it should look when you deploy it to Azure. Open a terminal window and use the `npm start` script to launch the built in Node.js HTTP server.


### PR DESCRIPTION
If people want to play along and do things themselves, they might just `npm init` their own solution, add express, then [grab this boilerplate code](https://expressjs.com/en/starter/hello-world.html). This is a bit easier than downloading, unzipping, etc. which is exactly what I did yesterday.

The problem I encountered was a classic Node pit of fail that I've fallen into many times: *forgetting to set the port properly*. The code they give you for the boilerplate is:

```js
const express = require('express')
const app = express()

app.get('/', (req, res) => res.send('Hello World!'))

app.listen(3000, () => console.log('Example app listening on port 3000!'))
```

The code *should* be:

```js
const express = require('express')
const app = express()

app.get('/', (req, res) => res.send('Hello World!'));

const port = process.env.PORT || 3000;
app.listen(port, () => console.log('Example app listening on port ' + port))
```

The note I added addresses this and will hopefully prevent people from wondering why their Node app doesn't run.