### PR TITLE
ResourceName has been changed to Name property

### DIFF
--- a/articles/lab-services/devtest-lab-faq.md
+++ b/articles/lab-services/devtest-lab-faq.md
@@ -168,7 +168,7 @@ You can delete VMs from your lab in the Azure portal. You also can delete all th
     # Get the VMs from that lab.
     $labVMs = Get-AzureRmResource | Where-Object {
               $_.ResourceType -eq 'microsoft.devtestlab/labs/virtualmachines' -and
-              $_.ResourceName -like "$($lab.ResourceName)/*"}
+              $_.Name -like "$($lab.Name)/*"}
 
     # Delete the VMs.
     foreach($labVM in $labVMs)


### PR DESCRIPTION
The `Get-AzureRmResource` don't have a `ResourceName` property.  It has been renamed to `Name` property.