### PR TITLE
Fix typo/grammar issue in "Create a new Azure API Management service instance" docs

### DIFF
--- a/articles/api-management/powershell-create-service-instance.md
+++ b/articles/api-management/powershell-create-service-instance.md
@@ -42,7 +42,7 @@ New-AzureRmResourceGroup -Name myResourceGroup -Location WestUS
 
 ## Create an API Management service
 
-This is long running operation and could take up to 15 minutes.
+This is a long running operation and could take up to 15 minutes.
 
 ```azurepowershell-interactive
 New-AzureRmApiManagement -ResourceGroupName "myResourceGroup" -Location "West US" -Name "apim-name" -Organization "myOrganization" -AdminEmail "myEmail" -Sku "Developer"


### PR DESCRIPTION
Simply added a missing **a** in a sentence. 