### PR TITLE
Update baseline-protection.md

### DIFF
--- a/articles/active-directory/conditional-access/baseline-protection.md
+++ b/articles/active-directory/conditional-access/baseline-protection.md
@@ -52,7 +52,8 @@ This baseline policy provides you with the option to exclude users and groups. Y
 
 ## Enable a baseline policy 
 
-While baseline policies are in preview, they are by default not activated. You need to manually enable a policy if you want to activate it. As soon as this feature has reached general availability, the policies are by default activated. The planned behavior change is the reason why you have in addition to activate and deactivate a third option to set the state of a policy: **Automatically enable policy in the future**. By selecting this option, you let Microsoft decide when to activate a policy.      
+While baseline policies are in preview, they are by default not activated. You need to manually enable a policy if you want to activate it. If you explicitly enable the baseline policies at the preview stage, they will remain active when this feature reaches general availability. The planned behavior change is the reason why you have in addition to activate and deactivate a third option to set the state of a policy: **Automatically enable policy in the future**. By selecting this option, you can leave the policies disabled during preview, but have Microsoft enable them automatically when this feature reaches general availability.
+If you do not explicitly enable baseline policies now, and do not select the **Automatically enable policy in the future** option, the policies will remain disabled when this feature reaches general availability.
 
 
 **To enable a baseline policy:**  

--- a/articles/active-directory/conditional-access/baseline-protection.md
+++ b/articles/active-directory/conditional-access/baseline-protection.md
@@ -52,8 +52,7 @@ This baseline policy provides you with the option to exclude users and groups. Y
 
 ## Enable a baseline policy 
 
-While baseline policies are in preview, they are by default not activated. You need to manually enable a policy if you want to activate it. If you explicitly enable the baseline policies at the preview stage, they will remain active when this feature reaches general availability. The planned behavior change is the reason why you have in addition to activate and deactivate a third option to set the state of a policy: **Automatically enable policy in the future**. By selecting this option, you can leave the policies disabled during preview, but have Microsoft enable them automatically when this feature reaches general availability.
-If you do not explicitly enable baseline policies now, and do not select the **Automatically enable policy in the future** option, the policies will remain disabled when this feature reaches general availability.
+While baseline policies are in preview, they are by default not activated. You need to manually enable a policy if you want to activate it. If you explicitly enable the baseline policies at the preview stage, they will remain active when this feature reaches general availability. The planned behavior change is the reason why, in addition to activate and deactivate, you have a third option to set the state of a policy: **Automatically enable policy in the future**. By selecting this option, you can leave the policies disabled during preview, but have Microsoft enable them automatically when this feature reaches general availability. If you do not explicitly enable baseline policies now, and do not select the **Automatically enable policy in the future** option, the policies will remain disabled when this feature reaches general availability.
 
 
 **To enable a baseline policy:**  


### PR DESCRIPTION
Clarifying per note from Nitika Gupta.
"If you set the policy to “Do not use policy”, it will not be enabled automatically. We highly recommend customers to enable the policy immediately since this is a key security recommendation."
@MarkusVi is on this communication that was intended to answer #10990.