### PR TITLE
Update command to delete a vault by force

### DIFF
--- a/articles/backup/backup-azure-delete-vault.md
+++ b/articles/backup/backup-azure-delete-vault.md
@@ -84,7 +84,7 @@ To delete a Recovery Services vault:
    ```powershell
    ARMClient.exe delete /subscriptions/<subscriptionID>/resourceGroups/<resourcegroupname>/providers/Microsoft.RecoveryServices/vaults/<recovery services vault name>?api-version=2015-03-15
    ```
-If there are error messages citing "Vault cannot be deleted as there are existing resources within this vault", such as containers that need to be unregistered first, use this command which will force delete the containers as well.
+The vault must be empty before you can delete it. Otherwise you get an error citing "Vault cannot be deleted as there are existing resources within this vault". The following command demonstrates how to remove a container within a vault:
 
    ```powershell
    ARMClient.exe delete /subscriptions/<subscriptionID>/resourceGroups/<resourcegroupname>/providers/Microsoft.RecoveryServices/vaults/<recovery services vault name>/registeredIdentities/<container name>?api-version=2016-06-01

--- a/articles/backup/backup-azure-delete-vault.md
+++ b/articles/backup/backup-azure-delete-vault.md
@@ -84,7 +84,7 @@ To delete a Recovery Services vault:
    ```powershell
    ARMClient.exe delete /subscriptions/<subscriptionID>/resourceGroups/<resourcegroupname>/providers/Microsoft.RecoveryServices/vaults/<recovery services vault name>?api-version=2015-03-15
    ```
-The vault must be empty before you can delete it. Otherwise you get an error citing "Vault cannot be deleted as there are existing resources within this vault". The following command demonstrates how to remove a container within a vault:
+   The vault must be empty before you can delete it. Otherwise you get an error citing "Vault cannot be deleted as there are existing resources within this vault". The following command demonstrates how to remove a container within a vault:
 
    ```powershell
    ARMClient.exe delete /subscriptions/<subscriptionID>/resourceGroups/<resourcegroupname>/providers/Microsoft.RecoveryServices/vaults/<recovery services vault name>/registeredIdentities/<container name>?api-version=2016-06-01

--- a/articles/backup/backup-azure-delete-vault.md
+++ b/articles/backup/backup-azure-delete-vault.md
@@ -84,6 +84,12 @@ To delete a Recovery Services vault:
    ```powershell
    ARMClient.exe delete /subscriptions/<subscriptionID>/resourceGroups/<resourcegroupname>/providers/Microsoft.RecoveryServices/vaults/<recovery services vault name>?api-version=2015-03-15
    ```
+If there are error messages citing "Vault cannot be deleted as there are existing resources within this vault", such as containers that need to be unregistered first, use this command which will force delete the containers as well.
+
+   ```powershell
+   ARMClient.exe delete /subscriptions/<subscriptionID>/resourceGroups/<resourcegroupname>/providers/Microsoft.RecoveryServices/vaults/<recovery services vault name>/registeredIdentities/<container name>?api-version=2016-06-01
+   ```
+   
 1. Sign in to your subscription in the Azure portal and verify the vault is deleted.
 
 


### PR DESCRIPTION
The current ARMClient.exe command that uses api-version=2015-03-15 does not work in some reported cases such as no available means to delete the container. The api-version=2016-06-01 command with the added element of registeredIdentities/<container name> works. Thus adding the api-version=2016-06-01 command to the doc page as well.