### PR TITLE
Fix maximum number of KB for Basic tier

### DIFF
--- a/articles/cognitive-services/QnAMaker/Tutorials/choosing-capacity-qnamaker-deployment.md
+++ b/articles/cognitive-services/QnAMaker/Tutorials/choosing-capacity-qnamaker-deployment.md
@@ -33,7 +33,7 @@ The following table gives you some high-level guidelines.
 |                        | QnA Maker Management | App Service | Azure Search | Limitations                      |
 | ---------------------- | -------------------- | ----------- | ------------ | -------------------------------- |
 | Experimentation        | Free SKU             | Free Tier   | Free Tier    | Publish Up to 2 KBs, 50 MB size  |
-| Dev/Test Environment   | Standard SKU         | Shared      | Basic        | Publish Up to 4 KBs, 2 GB size    |
+| Dev/Test Environment   | Standard SKU         | Shared      | Basic        | Publish Up to 14 KBs, 2 GB size    |
 | Production Environment | Standard SKU         | Basic       | Standard     | Publish Up to 49 KBs, 25 GB size |
 
 For upgrading your QnA Maker stack, see [Upgrade your QnA Maker service](../How-To/upgrade-qnamaker-service.md).


### PR DESCRIPTION
Maximum number of KB for Basic tier should be 14.
https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/limits
https://docs.microsoft.com/en-us/azure/search/search-limits-quotas-capacity