### PR TITLE
Update sql-database-business-continuity.md

### DIFF
--- a/articles/sql-database/sql-database-business-continuity.md
+++ b/articles/sql-database/sql-database-business-continuity.md
@@ -117,7 +117,7 @@ If you are using active geo-replication and auto-failover groups as your recover
 > 
 
 ### Perform a geo-restore
-If you are using the automated backups with geo-redundant storage (enabled by default), you can recover the database using [geo-restore](sql-database-disaster-recovery.md#recover-using-geo-restore). Recovery usually takes place within 12 hours - with data loss of up to one hour determined by when the last hourly differential backup was taken and replicated. Until the recovery completes, the database is unable to record any transactions or respond to any queries. Note, geo-restore only restores the database to the last available point in time.
+If you are using the automated backups with geo-redundant storage (enabled by default), you can recover the database using [geo-restore](sql-database-disaster-recovery.md#recover-using-geo-restore). Recovery usually takes place within 12 hours - with data loss of up to one hour determined by when the last log backup was taken and replicated. Until the recovery completes, the database is unable to record any transactions or respond to any queries. Note, geo-restore only restores the database to the last available point in time.
 
 > [!NOTE]
 > If the data center comes back online before you switch your application over to the recovered database, you can cancel the recovery.  


### PR DESCRIPTION
The original document mentions that geo replication of last hourly differential backup controls data loss for geo-restored db. There 2 things wrong with this statement. 

1. Differential backups don't happen every hour.
2. Last log backup that is geo-replicated will determine data loss in case db is geo-restored. 