### PR TITLE
Update tolerations for the Windows kubelet

### DIFF
--- a/articles/aks/virtual-kubelet.md
+++ b/articles/aks/virtual-kubelet.md
@@ -178,7 +178,9 @@ spec:
       nodeSelector:
         kubernetes.io/hostname: virtual-kubelet-virtual-kubelet-win
       tolerations:
-      - key: azure.com/aci
+      - key: virtual-kubelet.io/provider
+        operator: Equal
+        value: azure
         effect: NoSchedule
 ```
 


### PR DESCRIPTION
azure.com is the old namespace, not used anymore with the Windows virtual kubelet.

With the previous tolerations, the pod can't get schedule on the virtual windows kubelet node.