### PR TITLE
Fix Missing Capital Letter

### DIFF
--- a/articles/event-grid/overview.md
+++ b/articles/event-grid/overview.md
@@ -76,7 +76,7 @@ Here are some of the key features of Azure Event Grid:
 * **Pay-per-event** - Pay only for the amount you use Event Grid.
 * **High throughput** - Build high-volume workloads on Event Grid with support for millions of events per second.
 * **Built-in Events** - Get up and running quickly with resource-defined built-in events.
-* **Custom Events** - use Event Grid route, filter, and reliably deliver custom events in your app.
+* **Custom Events** - Use Event Grid route, filter, and reliably deliver custom events in your app.
 
 For a comparison of Event Grid, Event Hubs, and Service Bus, see [Choose between Azure services that deliver messages](compare-messaging-services.md).
 


### PR DESCRIPTION
As the rest of the items for  `Event Grid` Capabilities The description should start with Capital Letters.