### PR TITLE
Fix typo

### DIFF
--- a/articles/data-lake-analytics/data-lake-analytics-u-sql-get-started.md
+++ b/articles/data-lake-analytics/data-lake-analytics-u-sql-get-started.md
@@ -221,4 +221,4 @@ For advanced aggregation scenarios, see the U-SQL reference documentation for [a
 
 ## Next steps
 * [Overview of Microsoft Azure Data Lake Analytics](data-lake-analytics-overview.md)
-* [Develop U-SQL scripts using Data Lake Tools for Visual Studio](data-lake-analytics-data-lake-tools-get-started.md)
+* [Develop U-SQL scripts by using Data Lake Tools for Visual Studio](data-lake-analytics-data-lake-tools-get-started.md)


### PR DESCRIPTION
In this file, it is written "Develop U - SQL scripts using Data Lake Tools for Visual Studio".
However, the linked "https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/data-lake-analytics/data-lake-analytics-data-lake-tools-get-started.md", it is written "Develop U-SQL scripts by using Data Lake Tools for Visual Studio", orthographical variants.

In thinking as sentences, I thought that "by using" is reasonable as I thought that I emphasized the means.