### PR TITLE
Updated download information for IP ranges

### DIFF
--- a/articles/azure-functions/ip-addresses.md
+++ b/articles/azure-functions/ip-addresses.md
@@ -54,21 +54,31 @@ az webapp show --resource-group <group_name> --name <app_name> --query possibleO
 
 ## Data center outbound IP addresses
 
-If you need to whitelist the outbound IP addresses used by your function apps, another option is to whitelist the function apps' data center (Azure region). You can [download an XML file that lists IP addresses for all Azure data centers](https://www.microsoft.com/en-us/download/details.aspx?id=41653). Then find the XML element that applies to the region that your function app runs in.
+If you need to whitelist the outbound IP addresses used by your function apps, another option is to whitelist the function apps' data center (Azure region). You can [download a JSON file that lists IP addresses for all Azure data centers](https://www.microsoft.com/en-us/download/details.aspx?id=56519). Then find the JSON fragment that applies to the region that your function app runs in.
 
-For example, this is what the Western Europe XML element might look like:
+For example, this is what the Western Europe JSON fragment might look like:
 
 ```
-  <Region Name="europewest">
-    <IpRange Subnet="13.69.0.0/17" />
-    <IpRange Subnet="13.73.128.0/18" />
-    <!-- Some IP addresses not shown here -->
-    <IpRange Subnet="213.199.180.192/27" />
-    <IpRange Subnet="213.199.183.0/24" />
-  </Region>
+{
+  "name": "AzureCloud.westeurope",
+  "id": "AzureCloud.westeurope",
+  "properties": {
+    "changeNumber": 9,
+    "region": "westeurope",
+    "platform": "Azure",
+    "systemService": "",
+    "addressPrefixes": [
+      "13.69.0.0/17",
+      "13.73.128.0/18",
+      ... Some IP addresses not shown here
+     "213.199.180.192/27",
+     "213.199.183.0/24"
+    ]
+  }
+}
 ```
 
- For information about when this file is updated and when the IP addresses change, expand the **Details** section of the [Download Center page](https://www.microsoft.com/en-us/download/details.aspx?id=41653).
+ For information about when this file is updated and when the IP addresses change, expand the **Details** section of the [Download Center page](https://www.microsoft.com/en-us/download/details.aspx?id=56519).
 
 ## Inbound IP address changes
 


### PR DESCRIPTION
The Azure IP address range file is now provided in JSON rather than XML. This change updates the page to point to handle the JSON location rather than the old XML location.