### PR TITLE
fix schema url

### DIFF
--- a/articles/virtual-machines/windows/ps-template.md
+++ b/articles/virtual-machines/windows/ps-template.md
@@ -161,7 +161,7 @@ In this step, you create a template file that deploys the resources and a parame
 
     ```json
     {
-      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
       "contentVersion": "1.0.0.0",
       "parameters": {
       "adminUserName": { "value": "azureuser" },


### PR DESCRIPTION
The schema url used in the example parameters.json is wrong, it is pointing to the template schema instead of the parameters schema.