### PR TITLE
update with supported SLA

### DIFF
--- a/articles/storage/common/storage-redundancy.md
+++ b/articles/storage/common/storage-redundancy.md
@@ -35,6 +35,7 @@ The following table provides a quick overview of the scope of durability and ava
 | Read access to your data (in a remote, geo-replicated region) in the event of region-wide unavailability | No                              | No                               | No                                   | Yes                                  |
 | Designed to provide ___ durability of objects over a given year                                          | at least 99.999999999% (11 9's) | at least 99.9999999999% (12 9's) | at least 99.99999999999999% (16 9's) | at least 99.99999999999999% (16 9's) |
 | Supported storage account types                                                                   | GPv1, GPv2, Blob                | GPv2                             | GPv1, GPv2, Blob                     | GPv1, GPv2, Blob                     |
+Supported SLA                  | at least 99.9% (99% for Cool Access Tier)                 |at least 99.9% (99% for Cool Access Tier)  | at least 99.9% (99% for Cool Access Tier)    |
 
 See [Azure Storage Pricing](https://azure.microsoft.com/pricing/details/storage/) for pricing information on the different redundancy options.
 


### PR DESCRIPTION
Updated with supported SLA, which is an important information for Azure storage , and it is easy to make readers and users confused with durability ( data loss ) and availability in case of missing.  Another reason is : there is a error ( information not aligned with each other )  about Azure storage SLA on the page : https://azure.microsoft.com/en-us/support/legal/sla/storage/v1_3/  

We guarantee that at least 99.99% (99.9% for Cool Access Tier) of the time, we will successfully process requests to read data from Read Access-Geo Redundant Storage (RA-GRS) Accounts, provided that failed attempts to read data from the primary region are retried on the secondary region.
We guarantee that at least 99.9% (99% for Cool Access Tier) of the time, we will successfully process requests to read data from Locally Redundant Storage (LRS), Zone Redundant Storage (ZRS), and Geo Redundant Storage (GRS) Accounts.
We guarantee that at least 99.9% (99% for Cool Access Tier) of the time, we will successfully process requests to write data to Locally Redundant Storage (LRS), Zone Redundant Storage (ZRS), and Geo Redundant Storage (GRS) Accounts and Read Access-Geo Redundant Storage (RA-GRS) Accounts .

Strongly recommended this page should be updated