### PR TITLE
azure-cli command to register a new provider feature requires arguments

### DIFF
--- a/articles/azure-resource-manager/resource-group-move-resources.md
+++ b/articles/azure-resource-manager/resource-group-move-resources.md
@@ -270,7 +270,7 @@ Register-AzureRmProviderFeature -FeatureName ManagedResourcesMove -ProviderNames
 ```
 
 ```azurecli-interactive
-az feature register Microsoft.Compute ManagedResourcesMove
+az feature register --namespace Microsoft.Compute --name ManagedResourcesMove
 ```
 
 This support means you can also move:


### PR DESCRIPTION
Running the command without specifying _namespace_ and _name_ parameters results in an error

`az feature register: error: the following arguments are required: --namespace, --name/-n`