### PR TITLE
Remove "Windows only" from direct mode perf tips

### DIFF
--- a/articles/cosmos-db/performance-tips.md
+++ b/articles/cosmos-db/performance-tips.md
@@ -39,7 +39,7 @@ So if you're asking "How can I improve my database performance?" consider the fo
 
    * Direct Mode
 
-     Direct mode supports connectivity through TCP and HTTPS protocols. Currently, direct is supported in .NET Standard 2.0 for Windows platform only. When using Direct Mode, there are two protocol options available:
+     Direct mode supports connectivity through TCP and HTTPS protocols. Currently, direct is supported in .NET Standard 2.0. When using Direct Mode, there are two protocol options available:
 
     * TCP
     * HTTPS


### PR DESCRIPTION
As of the [2.0.0 .NET client][1], direct mode is supported on
non-Windows clients, so the performance tip note about direct mode only
working on Windows can be removed.

[1]: https://github.com/Azure/azure-cosmosdb-dotnet/blob/master/changelog.md#changes-in-200-