### PR TITLE
Clarify NSG considerations

### DIFF
--- a/articles/application-gateway/application-gateway-probe-overview.md
+++ b/articles/application-gateway/application-gateway-probe-overview.md
@@ -92,7 +92,7 @@ The following table provides definitions for the properties of a custom health p
 
 If there is a network security group (NSG) on an application gateway subnet, port ranges 65503-65534 must be opened on the application gateway subnet for inbound traffic. These ports are required for the backend health API to work.
 
-Additionally, outbound Internet connectivity can't be blocked, and traffic from the AzureLoadBalancer tag must be allowed.
+Additionally, outbound Internet connectivity can't be blocked, and inbound traffic coming from the AzureLoadBalancer tag must be allowed.
 
 ## Next steps
 After learning about Application Gateway health monitoring, you can configure a [custom health probe](application-gateway-create-probe-portal.md) in the Azure portal or a [custom health probe](application-gateway-create-probe-ps.md) using PowerShell and the Azure Resource Manager deployment model.


### PR DESCRIPTION
Explicitly mention that *inbound* traffic from AzureLoadBalancer must be allowed.