### PR TITLE
"two-step verification" -> "password reset"

### DIFF
--- a/articles/active-directory/user-help/security-info-setup-email.md
+++ b/articles/active-directory/user-help/security-info-setup-email.md
@@ -42,7 +42,7 @@ Depending on your organization’s settings, you may be prompted to add an email
 
 3. In the **Keep your account secure** page, select **Done**.
 
-    Your security info is updated to use your email address to verify your identity when using two-step verification.
+    Your security info is updated to use your email address to verify your identity when using password reset.
 
 ## Additional security info options
 


### PR DESCRIPTION
The sentence reads: "Your security info is updated to use your email address to verify your identity when using two-step verification." I had a customer ask me how to set up the email method for two-step verification. There are two other articles that confirm that the email method is only available during Azure AD SSPR / password reset.

What are authentication methods? "Email address - SSPR Only"
https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-authentication-methods

Security info (preview) overview  "Set up security info to use email - Describes how to set up your email address to help you reset your password."
https://docs.microsoft.com/en-us/azure/active-directory/user-help/user-help-security-info-overview

Propose to change "two-step verification" to "password reset" so that this article is consistent with the other two, and does not imply that customers can use email as a second factor during MFA.