### PR TITLE
Azure functions v2 is now available in GA

### DIFF
--- a/includes/functions-vstools-create.md
+++ b/includes/functions-vstools-create.md
@@ -24,7 +24,7 @@ The Azure Functions project template in Visual Studio creates a project that can
 
     | Setting      | Suggested value  | Description                      |
     | ------------ |  ------- |----------------------------------------- |
-    | **Version** | Azure Functions v1 <br />(.NET Framework) | This creates a function project that uses the version 1 runtime of Azure Functions. The version 2 runtime, which supports .NET Core, is currently in preview. For more information, see [How to target Azure Functions runtime version](../articles/azure-functions/functions-versions.md).   |
+    | **Version** | Azure Functions v1 <br />(.NET Framework) | This creates a function project that uses the version 1 runtime of Azure Functions. However, it is recommended that you should use version 2 of the runtime, which supports .NET Core (currently available in GA). For more information, see [How to target Azure Functions runtime version](../articles/azure-functions/functions-versions.md).   |
     | **Template** | HTTP trigger | This creates a function triggered by an HTTP request. |
     | **Storage account**  | Storage Emulator | An HTTP trigger doesn't use the Storage account connection. All other trigger types require a valid Storage account connection string. |
     | **Access rights** | Anonymous | The created function can be triggered by any client without providing a key. This authorization setting makes it easy to test your new function. For more information about keys and authorization, see [Authorization keys](../articles/azure-functions/functions-bindings-http-webhook.md#authorization-keys) in the [HTTP and webhook bindings](../articles/azure-functions/functions-bindings-http-webhook.md). |


### PR DESCRIPTION
Editing the create functions tutorials page where it still states that Azure Functions 2 was still in preview.

Did not change the suggested values and images as a lot of developers are still using older versions of visual studio.