### PR TITLE
Azure App Service Deployment Credentials Link Fix

### DIFF
--- a/articles/app-service/app-service-deploy-ftp.md
+++ b/articles/app-service/app-service-deploy-ftp.md
@@ -109,4 +109,4 @@ enables version control, package restore, MSBuild, and more.
 
 ## More Resources
 
-* [Azure App Service Deployment Credentials](app-service-deploy-ftp.md)
+* [Azure App Service Deployment Credentials](https://docs.microsoft.com/en-us/azure/app-service/app-service-deployment-credentials)

--- a/articles/app-service/app-service-deploy-ftp.md
+++ b/articles/app-service/app-service-deploy-ftp.md
@@ -109,4 +109,4 @@ enables version control, package restore, MSBuild, and more.
 
 ## More Resources
 
-* [Azure App Service Deployment Credentials](https://docs.microsoft.com/en-us/azure/app-service/app-service-deployment-credentials)
+* [Azure App Service Deployment Credentials](app-service-deployment-credentials.md)


### PR DESCRIPTION
Fixed href link in from `app-service-deploy-ftp.md` to `https://docs.microsoft.com/en-us/azure/app-service/app-service-deployment-credentials`

Closes #15884