### PR TITLE
typo: Double word "in"

### DIFF
--- a/articles/active-directory/identity-protection/howto-sign-in-risk-policy.md
+++ b/articles/active-directory/identity-protection/howto-sign-in-risk-policy.md
@@ -76,7 +76,7 @@ If you want to require MFA for risky sign-ins, you should:
 
 1. Enable the [multi-factor authentication registration policy](#multi-factor-authentication-registration-policy) for the affected users.
 
-2. Require the affected users to log in in a non-risky session to perform an MFA registration.
+2. Require the affected users to sign-in to a non-risky session to perform an MFA registration.
 
 Completing these steps ensures that multi-factor authentication is required for a risky sign-in.
 

--- a/articles/active-directory/identity-protection/howto-sign-in-risk-policy.md
+++ b/articles/active-directory/identity-protection/howto-sign-in-risk-policy.md
@@ -76,7 +76,7 @@ If you want to require MFA for risky sign-ins, you should:
 
 1. Enable the [multi-factor authentication registration policy](#multi-factor-authentication-registration-policy) for the affected users.
 
-2. Require the affected users to sign-in to a non-risky session to perform an MFA registration.
+2. Require the affected users to sign in to a non-risky session to perform an MFA registration.
 
 Completing these steps ensures that multi-factor authentication is required for a risky sign-in.
 


### PR DESCRIPTION
Sign-in seems to be the term used in the rest of the doc so "log in" was replaced too