### PR TITLE
Updated PowerShell module link to MSOnline v1.0

### DIFF
--- a/articles/active-directory/authentication/concept-sspr-policy.md
+++ b/articles/active-directory/authentication/concept-sspr-policy.md
@@ -109,7 +109,7 @@ This guidance applies to other providers, such as Intune and Office 365, which a
 
 ## Set or check the password policies by using PowerShell
 
-To get started, you need to [download and install the Azure AD PowerShell module](https://docs.microsoft.com/powershell/module/Azuread/?view=azureadps-2.0). After you have it installed, you can use the following steps to configure each field.
+To get started, you need to [download and install the Azure AD (MSOnline) PowerShell module](https://docs.microsoft.com/en-us/powershell/module/msonline/?view=azureadps-1.0). After you have it installed, you can use the following steps to configure each field.
 
 ### Check the expiration policy for a password
 


### PR DESCRIPTION
Updated PowerShell module link to MSOnline v1.0 until PowerShell examples are updated to use new AzureAD v2.0 module. Submitted #16141 to rack that change.

#16124 is resolved by this PR.
