### PR TITLE
Update howto-configure-ssl.md

### DIFF
--- a/articles/mysql/howto-configure-ssl.md
+++ b/articles/mysql/howto-configure-ssl.md
@@ -54,7 +54,7 @@ To establish a secure connection to Azure Database for MySQL over SSL from your 
 ```php
 $conn = mysqli_init();
 mysqli_ssl_set($conn,NULL,NULL, "/var/www/html/BaltimoreCyberTrustRoot.crt.pem", NULL, NULL) ; 
-mysqli_real_connect($conn, 'mydemoserver.mysql.database.azure.com', 'myadmin@mydemoserver', 'yourpassword', 'quickstartdb', 3306, MYSQLI_CLIENT_SSL, MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT);
+mysqli_real_connect($conn, 'mydemoserver.mysql.database.azure.com', 'myadmin@mydemoserver', 'yourpassword', 'quickstartdb', 3306, MYSQLI_CLIENT_SSL);
 if (mysqli_connect_errno($conn)) {
 die('Failed to connect to MySQL: '.mysqli_connect_error());
 }


### PR DESCRIPTION
Removed superfluous connection option "MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT" for PHP sample.
None of the other samples instruct MySQL and PHP to ignore the server cert.
This was required during the preview as the certs didn't match (unless you used the underlying real hostname of the MySQL instance).