### PR TITLE
Update to apiVersion and clarification about type

### DIFF
--- a/articles/virtual-machines/extensions/oms-linux.md
+++ b/articles/virtual-machines/extensions/oms-linux.md
@@ -76,9 +76,9 @@ The following JSON shows the schema for the Log Analytics Agent extension. The e
 
 ```json
 {
-  "type": "extensions",
+  "type": "Microsoft.Compute/virtualMachines/extensions",
   "name": "OMSExtension",
-  "apiVersion": "2015-06-15",
+  "apiVersion": "2018-06-01",
   "location": "<location>",
   "dependsOn": [
     "[concat('Microsoft.Compute/virtualMachines/', <vm-name>)]"
@@ -97,11 +97,15 @@ The following JSON shows the schema for the Log Analytics Agent extension. The e
 }
 ```
 
+>[!NOTE]
+>The schema above assumes that it will be placed at the root level of the template. If you put it inside the virtual machine resource in the template, the `type` and `name` properties should be changed, as described [further down](#template-deployment).
+>
+
 ### Property values
 
 | Name | Value / Example |
 | ---- | ---- |
-| apiVersion | 2015-06-15 |
+| apiVersion | 2018-06-01 |
 | publisher | Microsoft.EnterpriseCloud.Monitoring |
 | type | OmsAgentForLinux |
 | typeHandlerVersion | 1.7 |
@@ -121,7 +125,7 @@ The following example assumes the VM extension is nested inside the virtual mach
 {
   "type": "extensions",
   "name": "OMSExtension",
-  "apiVersion": "2015-06-15",
+  "apiVersion": "2018-06-01",
   "location": "<location>",
   "dependsOn": [
     "[concat('Microsoft.Compute/virtualMachines/', <vm-name>)]"
@@ -146,7 +150,7 @@ When placing the extension JSON at the root of the template, the resource name i
 {
   "type": "Microsoft.Compute/virtualMachines/extensions",
   "name": "<parentVmResource>/OMSExtension",
-  "apiVersion": "2015-06-15",
+  "apiVersion": "2018-06-01",
   "location": "<location>",
   "dependsOn": [
     "[concat('Microsoft.Compute/virtualMachines/', <vm-name>)]"


### PR DESCRIPTION
Update `apiVersion` to latest, update the `type` to its full value in the initial example, and add note pointing to the differences.

Fixes [#10102](https://github.com/MicrosoftDocs/azure-docs/issues/10102).