### PR TITLE
Update ADFS Migration Guide Link

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-pta.md
+++ b/articles/active-directory/hybrid/how-to-connect-pta.md
@@ -64,7 +64,7 @@ You can combine Pass-through Authentication with the [Seamless Single Sign-On](h
 ## Next steps
 
 - [Quick Start](how-to-connect-pta-quick-start.md) - Get up and running Azure AD Pass-through Authentication.
-- [Migrate from AD FS to Pass-through Authentication](https://github.com/Identity-Deployment-Guides/Identity-Deployment-Guides/blob/master/Authentication/Migrating%20from%20Federated%20Authentication%20to%20Pass-through%20Authentication.docx) - A detailed guide to migrate from AD FS (or other federation technologies) to Pass-through Authentication.
+- [Migrate from AD FS to Pass-through Authentication](https://github.com/Identity-Deployment-Guides/Identity-Deployment-Guides/blob/master/Authentication/Migrating%20from%20Federated%20Authentication%20to%20Pass-through%20Authentication.docx?raw=true) - A detailed guide to migrate from AD FS (or other federation technologies) to Pass-through Authentication.
 - [Smart Lockout](../authentication/howto-password-smart-lockout.md) - Configure Smart Lockout capability on your tenant to protect user accounts.
 - [Current limitations](how-to-connect-pta-current-limitations.md) - Learn which scenarios are supported and which ones are not.
 - [Technical Deep Dive](how-to-connect-pta-how-it-works.md) - Understand how this feature works.


### PR DESCRIPTION
Updating the link to the migration guide docx to the raw github link, so that the user is prompted to open in word or save a copy when clicking on link. Current link takes user to the file in the github, where the user will have to click on a second link (raw file link) to view the docx.