### PR TITLE
Fix Anomaly Detection API Parameter Capitalization

### DIFF
--- a/articles/machine-learning/team-data-science-process/apps-anomaly-detection-api.md
+++ b/articles/machine-learning/team-data-science-process/apps-anomaly-detection-api.md
@@ -120,7 +120,7 @@ More detailed information on these input parameters is listed in the table below
 
 | Input Parameters | Description | Default Setting | Type | Valid Range | Suggested Range |
 | --- | --- | --- | --- | --- | --- |
-| detectors.historyWindow |History (in # of data points) used for  anomaly score computation |500 |integer |10-2000 |Time-series dependent |
+| detectors.historywindow |History (in # of data points) used for  anomaly score computation |500 |integer |10-2000 |Time-series dependent |
 | detectors.spikesdips | Whether to detect only spikes, only dips, or both |Both |enumerated |Both, Spikes, Dips |Both |
 | bileveldetector.sensitivity |Sensitivity for bidirectional level change detector. |3.25 |double |None |3.25-5 (Lesser values mean more sensitive) |
 | trenddetector.sensitivity |Sensitivity for positive trend detector. |3.25 |double |None |3.25-5 (Lesser values mean more sensitive) |
@@ -159,7 +159,7 @@ More detailed information on these input parameters is listed in the table below
 | preprocess.aggregationInterval |Aggregation interval in seconds for aggregating input time series |0 (no aggregation is performed) |integer |0: skip aggregation, > 0 otherwise |5 minutes to 1 day, time-series dependent |
 | preprocess.aggregationFunc |Function used for aggregating data into the specified AggregationInterval |mean |enumerated |mean, sum, length |N/A |
 | preprocess.replaceMissing |Values used to impute missing data |lkv (last known value) |enumerated |zero, lkv, mean |N/A |
-| detectors.historyWindow |History (in # of data points) used for  anomaly score computation |500 |integer |10-2000 |Time-series dependent |
+| detectors.historywindow |History (in # of data points) used for  anomaly score computation |500 |integer |10-2000 |Time-series dependent |
 | detectors.spikesdips | Whether to detect only spikes, only dips, or both |Both |enumerated |Both, Spikes, Dips |Both |
 | bileveldetector.sensitivity |Sensitivity for bidirectional level change detector. |3.25 |double |None |3.25-5 (Lesser values mean more sensitive) |
 | postrenddetector.sensitivity |Sensitivity for positive trend detector. |3.25 |double |None |3.25-5 (Lesser values mean more sensitive) |


### PR DESCRIPTION
The `detectors.historywindow` parameter was incorrectly camel-cased to `detectors.historyWindow` in the tables.