### PR TITLE
Remove reference to functions v2 being in preview from linux documentation

### DIFF
--- a/articles/azure-functions/functions-create-first-azure-function-azure-cli-linux.md
+++ b/articles/azure-functions/functions-create-first-azure-function-azure-cli-linux.md
@@ -15,7 +15,7 @@ manager: jeconnoc
 
 # Create your first function running on Linux using the Azure CLI (preview)
 
-Azure Functions lets you host your functions on Linux in a default Azure App Service container. You can also [bring your own custom container](functions-create-function-linux-custom-image.md). This functionality is currently in preview and requires [the Functions 2.0 runtime](functions-versions.md), which is also in preview.
+Azure Functions lets you host your functions on Linux in a default Azure App Service container. You can also [bring your own custom container](functions-create-function-linux-custom-image.md). This functionality is currently in preview and requires [the Functions 2.0 runtime](functions-versions.md).
 
 This quickstart topic walks you through how to use Azure Functions with the Azure CLI to create your first function app on Linux hosted on the default App Service container. The function code itself is deployed to the image from a GitHub sample repository.    
 

--- a/articles/azure-functions/functions-create-function-linux-custom-image.md
+++ b/articles/azure-functions/functions-create-function-linux-custom-image.md
@@ -15,7 +15,7 @@ manager: jeconnoc
 
 # Create a function on Linux using a custom image (preview)
 
-Azure Functions lets you host your functions on Linux in your own custom container. You can also [host on a default Azure App Service container](functions-create-first-azure-function-azure-cli-linux.md). This functionality is currently in preview and requires [the Functions 2.0 runtime](functions-versions.md), which is also in preview.
+Azure Functions lets you host your functions on Linux in your own custom container. You can also [host on a default Azure App Service container](functions-create-first-azure-function-azure-cli-linux.md). This functionality is currently in preview and requires [the Functions 2.0 runtime](functions-versions.md).
 
 In this tutorial, you learn how to deploy a function app as a custom Docker image. This pattern is useful when you need to customize the built-in App Service container image. You may want to use a custom image when your functions need a specific language version or require a specific dependency or configuration that isn't provided within the built-in image.
 


### PR DESCRIPTION
Hi,

Functions v2 went out of GA during Ignite, and this commit removes a remaining reference to the functions v2 runtime being in preview.