### PR TITLE
Updating step in Google app registration

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-setup-goog-app.md
+++ b/articles/active-directory-b2c/active-directory-b2c-setup-goog-app.md
@@ -24,7 +24,7 @@ To use a Google account as an identity provider in Azure Active Directory (Azure
 3. Enter a **Project Name**, click **Create**, and then make sure you are using the new project.
 3. Select **Credentials** in the left menu, and then select **Create credentials** > **Oauth client ID**.
 4. Select **Configure consent screen**.
-5. Select or specify a valid **Email address**, provide a **Product name shown to users**, and click **Save**.
+5. Select or specify a valid **Email address**, provide a **Product name shown to users**, add `b2clogin.com` to **Authorized domains**, and click **Save**.
 6. Under **Application type**, select **Web application**.
 7. Enter a **Name** for your application, enter `https://your-tenant-name.b2clogin.com` in **Authorized JavaScript origins**, and `https://your-tenant-name.b2clogin.com/your-tenant-name.onmicrosoft.com/oauth2/authresp` in **Authorized redirect URIs**. Replace `your-tenant-name` with the name of your tenant. You need to use all lowercase letters when entering your tenant name even if the tenant is defined with uppercase letters in Azure AD B2C.
 8. Click **Create**.


### PR DESCRIPTION
According to the "OAuth consent screen" page:

> To protect you and your users, Google only allows applications that authenticate using OAuth to use Authorized Domains. Your applications' links must be hosted on Authorized Domains.

Accordingly, Google restricts the domains used in "Authorized JavaScript origins" and "Authorized redirect URIs" to this list, and `b2clogin.com` must be added before step 8 can be completed.