### PR TITLE
Set-Service -Name termService -StartupType Manual

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -106,7 +106,7 @@ Set-Service -Name iphlpsvc -StartupType Automatic
 Set-Service -Name netlogon -StartupType Manual
 Set-Service -Name netman -StartupType Manual
 Set-Service -Name nsi -StartupType Automatic
-Set-Service -Name termService -StartupType Manual
+Set-Service -Name termService -StartupType Automatic
 Set-Service -Name MpsSvc -StartupType Automatic
 Set-Service -Name RemoteRegistry -StartupType Automatic
 ```


### PR DESCRIPTION
Hello. The service termService should be set to Automatic so people can connect to their VM. This Manual setting has generated cases due to errors during RDP attempts. Is there a good reason to set it Manual?
Thank you!