### PR TITLE
Fixed creating the load balancer rule description

### DIFF
--- a/articles/load-balancer/load-balancer-get-started-ilb-arm-cli.md
+++ b/articles/load-balancer/load-balancer-get-started-ilb-arm-cli.md
@@ -83,7 +83,7 @@ A health probe checks all virtual machine instances to make sure they can receiv
 
 ### Create the load balancer rule
 
-A load balancer rule defines the front-end IP configuration for the incoming traffic and the back-end IP pool to receive the traffic, along with the required source and destination port. Create a load balancer rule *myLoadBalancerRuleWeb* with [az network lb rule create](https://docs.microsoft.com/cli/azure/network/lb/rule?view=azure-cli-latest#create) for listening to port 80 in the frontend pool *myFrontEndPool* and sending load-balanced network traffic to the backend address pool *myBackEndPool* also using port 80. 
+A load balancer rule defines the front-end IP configuration for the incoming traffic and the back-end IP pool to receive the traffic, along with the required source and destination port. Create a load balancer rule *myHTTPRule* with [az network lb rule create](https://docs.microsoft.com/cli/azure/network/lb/rule?view=azure-cli-latest#create) for listening to port 80 in the frontend pool *myFrontEnd* and sending load-balanced network traffic to the backend address pool *myBackEndPool* also using port 80. 
 
 ```azurecli-interactive
   az network lb rule create \


### PR DESCRIPTION
Fixed creating the load balancer rule description to match the script as is the case in other sections of the document. Some of the variables did not match the script.