### PR TITLE
Fix sql query syntax in iot-hub-devguide-query-language

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-query-language.md
+++ b/articles/iot-hub/iot-hub-devguide-query-language.md
@@ -171,7 +171,7 @@ This query will return all module twins with the scanning status, but only on th
 ```sql
 Select * from devices.modules 
   where properties.reported.status = 'scanning' 
-  and deviceId IN ('device1', 'device2')  
+  and deviceId IN ['device1', 'device2']
 ```
 
 ### C# example


### PR DESCRIPTION
Fixed sql query syntax (`IN [...]` instead of `IN (...)`), see correct syntax on line 107