### PR TITLE
Turkey ISO code is TR or TUR, not TU

### DIFF
--- a/articles/cognitive-services/Computer-vision/FAQ.md
+++ b/articles/cognitive-services/Computer-vision/FAQ.md
@@ -41,7 +41,7 @@ Supported languages include:
 | Danish (da-DK)  | Dutch (nl-NL)     | English           | Finnish (fi-FI)            |French (fr-FR)
 | German (de-DE)  | Greek (el-GR)     | Hungarian (hu-HU) | Italian (it-IT)            | Japanese (ja-JP)
 | Korean (ko-KR)  | Norwegian (nb-NO) | Polish (pl-PL)    | Portuguese (pt-BR) (pt-PT) | Russian (ru-RU)
-| Spanish (es-ES)	| Swedish (sv-SV)	  | Turkish (tr-TU)   |                            |
+| Spanish (es-ES)	| Swedish (sv-SV)	  | Turkish (tr-TR)   |                            |
 
 -----
 


### PR DESCRIPTION
It's either a possible typo or intended. Please have a look, thanks!