### PR TITLE
Updated IoT edge configuration steps

### DIFF
--- a/articles/iot-edge/tutorial-deploy-stream-analytics.md
+++ b/articles/iot-edge/tutorial-deploy-stream-analytics.md
@@ -134,7 +134,9 @@ Using the three elements of input, output, and query, this section creates a job
 
 To prepare your Stream Analytics job to be deployed on an IoT Edge device, you need to associate the job with a container in a storage account. When you go to deploy your job, the job definition is exported to the storage container. 
 
-1. Under **Configure**, select **IoT Edge settings**.
+1. Under **Configure**, select **Storage account settings**.
+
+1. Select **Add storage account**. 
 
 1. Select your **Storage account** from the drop-down menu.
 


### PR DESCRIPTION
The steps to configure the IoT Edge settings have changed. "IoT edge settings" is not longer an option and is replaced by "Storage account settings"