### PR TITLE
Added explicit instructions for module name

### DIFF
--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -94,7 +94,7 @@ The Azure IoT Edge extension for Visual Studio Code that you installed in the pr
    2. Provide a name for your solution or accept the default **EdgeSolution**.
    3. Choose **Azure Functions - C#** as the module template. 
    4. Name your module **CSharpFunction**. 
-   5. Specify the Azure container registry that you created in the previous section as the image repository for your first module. Replace **localhost:5000** with the login server value that you copied. The final string looks like \<registry name\>.azurecr.io/csharpfunction.
+   5. Specify the Azure container registry that you created in the previous section as the image repository for your first module. Replace **localhost:5000** with the login server value that you copied. Make sure that you append the module name (eg. /csharpfunction) to the string. The final string looks like \<registry name\>.azurecr.io/csharpfunction.
 
    ![Provide Docker image repository](./media/tutorial-deploy-function/repository.png)
 

--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -94,7 +94,7 @@ The Azure IoT Edge extension for Visual Studio Code that you installed in the pr
    2. Provide a name for your solution or accept the default **EdgeSolution**.
    3. Choose **Azure Functions - C#** as the module template. 
    4. Name your module **CSharpFunction**. 
-   5. Specify the Azure container registry that you created in the previous section as the image repository for your first module. Replace **localhost:5000** with the login server value that you copied. Make sure that you append the module name (eg. /csharpfunction) to the string. The final string looks like \<registry name\>.azurecr.io/csharpfunction.
+   5. Specify the Azure container registry that you created in the previous section as the image repository for your first module. Replace **localhost:5000** with the login server value that you copied. Make sure that the module name (eg. /csharpfunction) is left intact as part of the string. The final string looks like \<registry name\>.azurecr.io/csharpfunction.
 
    ![Provide Docker image repository](./media/tutorial-deploy-function/repository.png)
 

--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -94,7 +94,7 @@ The Azure IoT Edge extension for Visual Studio Code that you installed in the pr
    2. Provide a name for your solution or accept the default **EdgeSolution**.
    3. Choose **Azure Functions - C#** as the module template. 
    4. Name your module **CSharpFunction**. 
-   5. Specify the Azure container registry that you created in the previous section as the image repository for your first module. Replace **localhost:5000** with the login server value that you copied. Make sure that the module name (eg. /csharpfunction) is left intact as part of the string. The final string looks like \<registry name\>.azurecr.io/csharpfunction.
+   5. Specify the Azure container registry that you created in the previous section as the image repository for your first module. Replace **localhost:5000** with the login server value that you copied. Make sure that the module name (for example, /csharpfunction) is left intact as part of the string. The final string looks like \<registry name\>.azurecr.io/csharpfunction.
 
    ![Provide Docker image repository](./media/tutorial-deploy-function/repository.png)
 


### PR DESCRIPTION
Added a sentence "Make sure that you append the module name (eg. /csharpfunction) to the string." to explicitly state that the module name is required as part of the string.