### PR TITLE
Adding ASA 9.8+ to table

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-about-vpn-devices.md
+++ b/articles/vpn-gateway/vpn-gateway-about-vpn-devices.md
@@ -45,7 +45,7 @@ To help configure your VPN device, refer to the links that correspond to appropr
 | Barracuda Networks, Inc. |Barracuda NextGen Firewall X-series |Barracuda Firewall 6.5 |[Configuration guide](https://techlib.barracuda.com/BFW/ConfigAzureVPNGateway) |Not compatible |
 | Brocade            |Vyatta 5400 vRouter   |Virtual Router 6.6R3 GA|[Configuration guide](http://www1.brocade.com/downloads/documents/html_product_manuals/vyatta/vyatta_5400_manual/wwhelp/wwhimpl/js/html/wwhelp.htm#href=VPN_Site-to-Site%20IPsec%20VPN/Preface.1.1.html) |Not compatible |
 | Check Point |Security Gateway |R77.30 |[Configuration guide](https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk101275) |[Configuration guide](https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk101275) |
-| Cisco              |ASA       |8.3<br>8.4+ (IKEv2*) |[Configuration samples](https://github.com/Azure/Azure-vpn-config-samples/tree/master/Cisco/Current/ASA) |[Configuration guide*](vpn-gateway-3rdparty-device-config-cisco-asa.md) |
+| Cisco              |ASA       |8.3<br>8.4+ (IKEv2*)<br>9.8+ (IKEv2***) |[Configuration samples](https://github.com/Azure/Azure-vpn-config-samples/tree/master/Cisco/Current/ASA) |[Configuration guide*](vpn-gateway-3rdparty-device-config-cisco-asa.md) |
 | Cisco |ASR |PolicyBased: IOS 15.1<br>RouteBased: IOS 15.2 |[Configuration samples](https://github.com/Azure/Azure-vpn-config-samples/tree/master/Cisco/Current/ASR) |[Configuration samples](https://github.com/Azure/Azure-vpn-config-samples/tree/master/Cisco/Current/ASR) |
 | Cisco |ISR |PolicyBased: IOS 15.0<br>RouteBased*: IOS 15.1 |[Configuration samples](https://github.com/Azure/Azure-vpn-config-samples/tree/master/Cisco/Current/ISR) |[Configuration samples\*\*](https://github.com/Azure/Azure-vpn-config-samples/tree/master/Cisco/Current/ISR) |
 | Cisco |Meraki |N/A |Not compatible |Not compatible |
@@ -71,6 +71,8 @@ To help configure your VPN device, refer to the links that correspond to appropr
 > (*) Cisco ASA versions 8.4+ add IKEv2 support, can connect to Azure VPN gateway using custom IPsec/IKE policy with "UsePolicyBasedTrafficSelectors" option. Refer to this [how-to article](vpn-gateway-connect-multiple-policybased-rm-ps.md).
 >
 > (**) ISR 7200 Series routers only support PolicyBased VPNs.
+>
+> (***) Cisco ASA versions 9.8+ can connect to Azure VPN gateway without custom IPsec/IKE policy and don't require "UsePolicyBasedTrafficSelectors" to be enabled.
 
 ## <a name="configscripts"></a>Download VPN device configuration scripts from Azure
 


### PR DESCRIPTION
Currently ASA 9.8+ is not mentioned in the main table but only in the download configuration files section  below that table. Listing it there with the note that 9.8+ doesn't need a custom policy / usepolicybasedtrafficselectors will make it easier to be discovered as people use the main table as the reference.