### PR TITLE
Fixed broken link for an overview of MS AML

### DIFF
--- a/articles/machine-learning/studio/studio-overview-diagram.md
+++ b/articles/machine-learning/studio/studio-overview-diagram.md
@@ -43,7 +43,7 @@ Download the **Microsoft Azure Machine Learning Studio Capabilities Overview** d
 
 
 ## More help with Machine Learning Studio
-* For an overview of Microsoft Azure Machine Learning, see [Introduction to machine learning on Microsoft Azure](what-is-machine-learning.md)
+* For an overview of Microsoft Azure Machine Learning, see [Introduction to machine learning on Microsoft Azure](../service/overview-what-is-azure-ml.md)
 * For an overview of Machine Learning Studio, see [What is Azure Machine Learning Studio?](what-is-ml-studio.md).
 * For a detailed discussion of the machine learning algorithms available in Machine Learning Studio, see [How to choose algorithms for Microsoft Azure Machine Learning](algorithm-choice.md).
 


### PR DESCRIPTION
There is no "what-is-machine-learning.md" file in the studio folder, that's why link to MS AML overview returns 404 error code. Instead there is an overview of AML in the sister Service folder, where the link has been redirected.