### PR TITLE
fix the link text

### DIFF
--- a/articles/azure-signalr/index.yml
+++ b/articles/azure-signalr/index.yml
@@ -38,7 +38,7 @@ sections:
       href: /azure/azure-signalr/signalr-quickstart-azure-functions-csharp
     - image: 
         src: https://docs.microsoft.com/en-us/media/logos/logo_REST.svg
-      text: C#
+      text: REST API
       href: /azure/azure-signalr/signalr-quickstart-rest-api
 - title: Step-by-Step Tutorials
   items:


### PR DESCRIPTION
fix the link text to the REST API quickstart: 'C#' -> 'REST API'