### PR TITLE
Fix typo : VMWare -> VMware on various pages

### DIFF
--- a/articles/azure-government/documentation-government-services-monitoringandmanagement.md
+++ b/articles/azure-government/documentation-government-services-monitoringandmanagement.md
@@ -63,7 +63,7 @@ The following Site Recovery features are not currently available in Azure Govern
 
 | Site Recovery | Classic | Resource Manager |
 | --- | --- | --- |
-| VMWare/Physical  | GA | GA |
+| VMware/Physical  | GA | GA |
 | Hyper-V | GA | GA |
 | Site to Site | GA | GA |
 

--- a/articles/azure-monitor/toc.yml
+++ b/articles/azure-monitor/toc.yml
@@ -562,7 +562,7 @@
         href: ../monitoring/monitoring-solution-agenthealth.md?toc=/azure/azure-monitor/toc.json
       - name: Capacity and performance
         href: ../log-analytics/log-analytics-capacity.md?toc=/azure/azure-monitor/toc.json
-      - name: VMWare Analytics
+      - name: VMware Analytics
         href: ../log-analytics/log-analytics-vmware.md?toc=/azure/azure-monitor/toc.json
       - name: Wire Data
         href: ../log-analytics/log-analytics-wire-data.md?toc=/azure/azure-monitor/toc.json

--- a/articles/backup/backup-azure-dpm-introduction.md
+++ b/articles/backup/backup-azure-dpm-introduction.md
@@ -164,7 +164,7 @@ After creating the Azure Backup vault, an agent should be installed on each of y
 14. When using Data Protection Manager, you can modify the settings specified during the registration workflow by clicking the **Configure** option by selecting **Online** under the **Management** Tab.
 
 ## Requirements (and limitations)
-* DPM can be running as a physical server or a Hyper-V virtual machine installed on System Center 2012 SP1 or System Center 2012 R2. It can also be running as an Azure virtual machine running on System Center 2012 R2 with at least DPM 2012 R2 Update Rollup 3 or a Windows virtual machine in VMWare running on System Center 2012 R2 with at least Update Rollup 5.
+* DPM can be running as a physical server or a Hyper-V virtual machine installed on System Center 2012 SP1 or System Center 2012 R2. It can also be running as an Azure virtual machine running on System Center 2012 R2 with at least DPM 2012 R2 Update Rollup 3 or a Windows virtual machine in VMware running on System Center 2012 R2 with at least Update Rollup 5.
 * If you’re running DPM with System Center 2012 SP1 you should install Update Roll up 2 for System Center Data Protection Manager SP1. This is required before you can install the Azure Backup Agent.
 * The DPM server should have Windows PowerShell and .Net Framework 4.5 installed.
 * DPM can back up most workloads to Azure Backup. For a full list of what’s supported see the Azure Backup support items below.

--- a/articles/migrate/contoso-migration-rehost-linux-vm-mysql.md
+++ b/articles/migrate/contoso-migration-rehost-linux-vm-mysql.md
@@ -48,7 +48,7 @@ The IT Leadership team has worked closely with business partners to understand w
 
 The Contoso cloud team has pinned down goals for this migration, in order to determine the best migration method:
 
-- After migration, the app in Azure should have the same performance capabilities as it does today in their on-premises VMWare environment.  The app will remain as critical in the cloud as it is on-premises. 
+- After migration, the app in Azure should have the same performance capabilities as it does today in their on-premises VMware environment.  The app will remain as critical in the cloud as it is on-premises. 
 - Contoso doesn’t want to invest in this app.  It's important to the business, but in its current form Contoso simply want to move it safely to the cloud.
 - Having completed a couple of Windows app migrations, Contoso wants to learn how to use a Linux-based infrastructure in Azure.
 - Contoso wants to minimize database admin tasks after the application is moved to the cloud.

--- a/articles/virtual-machines/linux/create-upload-centos.md
+++ b/articles/virtual-machines/linux/create-upload-centos.md
@@ -294,7 +294,7 @@ Preparing a CentOS 7 virtual machine for Azure is very similar to CentOS 6, howe
    
         # sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 
-10. If building the image from **VMWare, VirtualBox or KVM:** Ensure the Hyper-V drivers are included in the initramfs:
+10. If building the image from **VMware, VirtualBox or KVM:** Ensure the Hyper-V drivers are included in the initramfs:
    
    Edit `/etc/dracut.conf`, add content:
    


### PR DESCRIPTION
Hi !

I found some typo on VMware written some time "VMWare" instead of "VMware" 
