### PR TITLE
Correct misspell in service fabric content roadmap

### DIFF
--- a/articles/service-fabric/service-fabric-content-roadmap.md
+++ b/articles/service-fabric/service-fabric-content-roadmap.md
@@ -69,7 +69,7 @@ Within a partition, stateless named services have instances while stateful named
 ## Stateless and stateful microservices for Service Fabric
 Service Fabric enables you to build applications that consist of microservices or containers. Stateless microservices (such as protocol gateways and web proxies) do not maintain a mutable state outside a request and its response from the service. Azure Cloud Services worker roles are an example of a stateless service. Stateful microservices (such as user accounts, databases, devices, shopping carts, and queues) maintain a mutable, authoritative state beyond the request and its response. Today's Internet-scale applications consist of a combination of stateless and stateful microservices. 
 
-A key differentation with Service Fabric is its strong focus on building stateful services, either with the [built in programming models ](service-fabric-choose-framework.md) or with containerized stateful services. The [application scenarios](service-fabric-application-scenarios.md) describe the scenarios where stateful services are used.
+A key differentiation with Service Fabric is its strong focus on building stateful services, either with the [built in programming models ](service-fabric-choose-framework.md) or with containerized stateful services. The [application scenarios](service-fabric-application-scenarios.md) describe the scenarios where stateful services are used.
 
 Why have stateful microservices along with stateless ones? The two main reasons are:
 


### PR DESCRIPTION
Update service-fabric-content-roadmap.md.
* "differentation" should be "differentiation"  
[Documentation Link](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-content-roadmap#stateless-and-stateful-microservices-for-service-fabric)