### PR TITLE
Update heading for ASE firewall integration topic

### DIFF
--- a/articles/app-service/environment/firewall-integration.md
+++ b/articles/app-service/environment/firewall-integration.md
@@ -16,7 +16,7 @@ ms.author: ccompy
 
 ---
 
-# App Service Environment certificates overview 
+# Locking down Azure App Service Environment outbound traffic 
 
 The App Service Environment (ASE) has a number of external dependencies that it requires access to in order to function properly. The ASE lives in the customer Azure Virtual Network (VNet). Customers must allow the ASE dependency traffic, which is a problem for customers that want to lock down all egress from their VNet.
 


### PR DESCRIPTION
The current heading (App Service Environment certificates overview) doesn't match the content. I'm proposing that the title of the article (Locking down Azure App Service Environment outbound traffic) be used instead.