### PR TITLE
Updating API Management + AAD B2C instructions

### DIFF
--- a/articles/api-management/api-management-howto-aad-b2c.md
+++ b/articles/api-management/api-management-howto-aad-b2c.md
@@ -28,20 +28,20 @@ Azure Active Directory B2C is a cloud identity management solution for consumer-
 
 ## Authorize developer accounts by using Azure Active Directory B2C
 
-1. To get started, click **Publisher portal** in the Azure portal for your API Management service. This takes you to the API Management publisher portal.
-
-   ![Publisher portal][api-management-management-console]
+1. To get started, sign in to the [Azure portal](https://portal.azure.com) and locate your API Management instance.
 
    > [!NOTE]
    > If you haven't yet created an API Management service instance, see [Create an API Management service instance][Create an API Management service instance] in the [Get started with Azure API Management tutorial][Get started with Azure API Management].
 
-2. On the **API Management** menu, click **Security**. On the **Identities** tab, choose **Azure Active Directory B2C**.
+2. Under **SECURITY**, select **Identities**. Click **+Add** at the top.
 
-  ![External identities 1][api-management-howto-aad-b2c-security-tab]
+   The **Add identity provider** pane appears on the right. Choose **Azure Active Directory B2C**.
+    
+   ![Add AAD B2C as identity provider][api-management-howto-add-b2c-identity-provider]
 
-3. Make a note of the **Redirect URL** and switch over to Azure Active Directory B2C in the Azure portal.
+3. Copy the **Redirect URL** and switch over to your Azure Active Directory B2C tenant in the Azure portal.
 
-  ![External identities 2][api-management-howto-aad-b2c-security-tab-reply-url]
+  ![AAD B2C identity provider redirect URL][api-management-howto-copy-b2c-identity-provider-redirect-url]
 
 4. Click the **Applications** button.
 
@@ -122,9 +122,8 @@ Azure Active Directory B2C is a cloud identity management solution for consumer-
 
 
 
-
-[api-management-howto-aad-b2c-security-tab]: ./media/api-management-howto-aad-b2c/api-management-b2c-security-tab.PNG
-[api-management-howto-aad-b2c-security-tab-reply-url]: ./media/api-management-howto-aad-b2c/api-management-b2c-security-tab-reply-url.PNG
+[api-management-howto-add-b2c-identity-provider]: ./media/api-management-howto-aad-b2c/api-management-add-b2c-identity-provider.PNG
+[api-management-howto-copy-b2c-identity-provider-redirect-url]: ./media/api-management-b2c-identity-provider-redirect-url.PNG
 [api-management-howto-aad-b2c-portal-menu]: ./media/api-management-howto-aad-b2c/api-management-b2c-portal-menu.PNG
 [api-management-howto-aad-b2c-add-button]: ./media/api-management-howto-aad-b2c/api-management-b2c-add-button.PNG
 [api-management-howto-aad-b2c-app-details]: ./media/api-management-howto-aad-b2c/api-management-b2c-app-details.PNG

--- a/articles/api-management/api-management-howto-aad-b2c.md
+++ b/articles/api-management/api-management-howto-aad-b2c.md
@@ -39,11 +39,11 @@ Azure Active Directory B2C is a cloud identity management solution for consumer-
     
    ![Add AAD B2C as identity provider][api-management-howto-add-b2c-identity-provider]
 
-3. Copy the **Redirect URL** and switch over to your Azure Active Directory B2C tenant in the Azure portal.
+3. Copy the **Redirect URL**.
 
   ![AAD B2C identity provider redirect URL][api-management-howto-copy-b2c-identity-provider-redirect-url]
 
-4. Click the **Applications** button.
+4. In a new tab, access your Azure Active Directory B2C tenant in the Azure portal and open the **Applications** blade.
 
   ![Register a new application 1][api-management-howto-aad-b2c-portal-menu]
 
@@ -51,7 +51,7 @@ Azure Active Directory B2C is a cloud identity management solution for consumer-
 
   ![Register a new application 2][api-management-howto-aad-b2c-add-button]
 
-6. In the **New application** blade, enter a name for the application. Choose **Yes** under **Web App/Web API**, and choose **Yes** under **Allow implicit flow**. Then copy the **Redirect URL** from the **Azure Active Directory B2C** section of the **Identities** tab in the publisher portal, and paste it into the **Reply URL** text box.
+6. In the **New application** blade, enter a name for the application. Choose **Yes** under **Web App/Web API**, and choose **Yes** under **Allow implicit flow**. Then paste the **Redirect URL** copied in step 3 into the **Reply URL** text box.
 
   ![Register a new application 3][api-management-howto-aad-b2c-app-details]
 
@@ -63,15 +63,15 @@ Azure Active Directory B2C is a cloud identity management solution for consumer-
 
   ![Application ID 1][api-management-howto-aad-b2c-app-id]
 
-9. Switch back to the publisher portal and paste the ID into the **Client Id** text box.
+9. Switch back to the API Management **Add identity provider** pane and paste the ID into the **Client Id** text box.
 
   ![Application ID 2][api-management-howto-aad-b2c-client-id]
 
-10. Switch back to the Azure portal, click the **Keys** button, and then click **Generate key**. Click **Save** to save the configuration and display the **App key**. Copy the key to the clipboard.
+10. Switch back to the B2C app registration, click the **Keys** button, and then click **Generate key**. Click **Save** to save the configuration and display the **App key**. Copy the key to the clipboard.
 
   ![App key 1][api-management-howto-aad-b2c-app-key]
 
-11. Switch back to the publisher portal and paste the key into the **Client Secret** text box.
+11. Switch back to the API Management **Add identity provider** pane and paste the key into the **Client Secret** text box.
 
   ![App key 2][api-management-howto-aad-b2c-client-secret]
 
@@ -79,7 +79,7 @@ Azure Active Directory B2C is a cloud identity management solution for consumer-
 
   ![Allowed tenant][api-management-howto-aad-b2c-allowed-tenant]
 
-13. Specify the **Signup Policy** and **Signin Policy**. Optionally, you can also provide the **Profile Editing Policy** and **Password Reset Policy**.
+13. Specify the **Signup Policy** and **Signin Policy** from the B2C Tenant policies. Optionally, you can also provide the **Profile Editing Policy** and **Password Reset Policy**.
 
   ![Policies][api-management-howto-aad-b2c-policies]
 


### PR DESCRIPTION
Current instructions use functionality in the Publisher Portal, which has been moved to the Azure Portal. These image files need to be added to the media folder:
![api-management-add-b2c-identity-provider](https://user-images.githubusercontent.com/12376867/46640369-7826c980-cb20-11e8-84b8-68ce011d6ade.png)
![api-management-b2c-identity-provider-redirect-url](https://user-images.githubusercontent.com/12376867/46640372-79f08d00-cb20-11e8-9eb1-213979c5e522.png)

