### PR TITLE
typo : Double Use words

### DIFF
--- a/articles/active-directory/conditional-access/require-tou.md
+++ b/articles/active-directory/conditional-access/require-tou.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart - Require terms of use to be accepted before accessing cloud apps that are protected by Azure Active Directory conditional access | Microsoft Docs
-description: In this quickstart, you learn how you can require that your terms of use are accepted before access to selected cloud apps is granted by by Azure Active Directory conditional access.
+description: In this quickstart, you learn how you can require that your terms of use are accepted before access to selected cloud apps is granted by Azure Active Directory conditional access.
 services: active-directory
 keywords: conditional access to apps, conditional access with Azure AD, secure access to company resources, conditional access policies, terms of use
 documentationcenter: ''

--- a/articles/active-directory/privileged-identity-management/pim-resource-roles-enable-subscription-management.md
+++ b/articles/active-directory/privileged-identity-management/pim-resource-roles-enable-subscription-management.md
@@ -1,6 +1,6 @@
 ---
 title: Enable subscription management in your tenant - Azure | Microsoft Docs
-description: Learn how to enable enable subscription management in your tenant when using Azure AD Privileged Identity Management (PIM).
+description: Learn how to enable subscription management in your tenant when using Azure AD Privileged Identity Management (PIM).
 services: active-directory
 documentationcenter: ''
 author: rolyon


### PR DESCRIPTION
Fixing the typo double use of 'by' and 'enable'