### PR TITLE
Removed Invalid Section

### DIFF
--- a/articles/azure-stack/azure-stack-usage-reporting.md
+++ b/articles/azure-stack/azure-stack-usage-reporting.md
@@ -93,10 +93,6 @@ For Azure Stack multinode, Enterprise Agreement (EA) and CSP subscriptions are s
 
 In the Azure Stack Development Kit, usage data reporting requires subscriptions that are created in the global Azure system. Subscriptions created in one of the sovereign clouds (the Azure Government, Azure Germany, and Azure China clouds) cannot be registered with Azure, so they don’t support usage data reporting.
 
-## How can users identify Azure Stack usage data in the Azure billing portal?
-
-Users can see the Azure Stack usage data in the usage details file. To know about how to get the usage details file, refer to the [download usage file from the Azure Account Center article](https://docs.microsoft.com/azure/billing/billing-download-azure-invoice-daily-usage-date#download-usage-from-the-account-center-csv). The usage details file contains the Azure Stack meters that identify Azure Stack storage and VMs. All resources used in Azure Stack are reported under the region named “Azure Stack.”
-
 ## Why doesn’t the usage reported in Azure Stack match the report generated from Azure Account Center?
 
 There is always a delay between the usage data reported by the Azure Stack usage APIs and the usage data reported  by the Azure Account Center. This delay is the time required to upload usage data from Azure Stack to Azure commerce. Due to this delay, usage that occurs shortly before midnight may show up in Azure the following day. If you use the [Azure Stack Usage APIs](azure-stack-provider-resource-api.md), and compare the results to the usage reported in the Azure billing portal, you can see a difference.


### PR DESCRIPTION
Removed "How can users identify Azure Stack usage data in the Azure billing portal?" section as the information supplied is not true. There is no way for Azure Stack tenants to view Azure Stack usage data through the Azure account center.