### PR TITLE
"Secure transfer required" enabled by default

### DIFF
--- a/articles/storage/common/storage-require-secure-transfer.md
+++ b/articles/storage/common/storage-require-secure-transfer.md
@@ -15,7 +15,7 @@ The "Secure transfer required" option enhances the security of your storage acco
 
 When you use the Azure Files service, any connection without encryption fails when "Secure transfer required" is enabled. This includes scenarios that use SMB 2.1, SMB 3.0 without encryption, and some versions of the Linux SMB client. 
 
-By default, the "Secure transfer required" option is disabled.
+By default, the "Secure transfer required" option is enabled.
 
 > [!NOTE]
 > Because Azure Storage doesn't support HTTPS for custom domain names, this option is not applied when you're using a custom domain name. And classic storage accounts are not supported.


### PR DESCRIPTION
There is a recent change:

By default, the "Secure transfer required" option is enabled.