### PR TITLE
Updated local network gateway prefix guidance

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-bgp-resource-manager-ps.md
+++ b/articles/vpn-gateway/vpn-gateway-bgp-resource-manager-ps.md
@@ -163,7 +163,7 @@ $BGPPeerIP5 = "10.52.255.254"
 A couple of things to note regarding the local network gateway parameters:
 
 * The local network gateway can be in the same or different location and resource group as the VPN gateway. This example shows them in different resource groups in different locations.
-* The minimum prefix you need to declare for the local network gateway is the host address of your BGP Peer IP address on your VPN device. In this case, it's a /32 prefix of "10.52.255.254/32".
+* The prefix you need to declare for the local network gateway is the host address of your BGP Peer IP address on your VPN device. In this case, it's a /32 prefix of "10.52.255.254/32".
 * As a reminder, you must use different BGP ASNs between your on-premises networks and Azure VNet. If they are the same, you need to change your VNet ASN if your on-premises VPN device already uses the ASN to peer with other BGP neighbors.
 
 Before you continue, make sure you are still connected to Subscription 1.


### PR DESCRIPTION
Updated guidance for local network gateway to specifically state the prefix must be the BGP peer address only (/32).  Previous reference to "minimum prefix" is ambiguous and adding additional prefixes can cause undesired results - specifically advertising on-premises prefixes as originating from Azure VNET.