### PR TITLE
remove TOC entries that are redirected

### DIFF
--- a/articles/azure-monitor/toc.yml
+++ b/articles/azure-monitor/toc.yml
@@ -697,16 +697,6 @@
     items:
     - name: Alerts
       items:
-      - name: Create alert rules
-        items:
-        - name: Configure new metric or log alerts in Azure portal
-          href: ../monitoring-and-diagnostics/monitor-alerts-unified-usage.md?toc=/azure/azure-monitor/toc.json
-        - name: Configure classic alerts in Azure portal
-          href: ../monitoring-and-diagnostics/insights-alerts-portal.md?toc=/azure/azure-monitor/toc.json   
-        - name: Configure classic alerts with CLI
-          href: ../monitoring-and-diagnostics/insights-alerts-command-line-interface.md?toc=/azure/azure-monitor/toc.json
-        - name: Configure classic alerts with Azure PowerShell
-          href: ../monitoring-and-diagnostics/insights-alerts-powershell.md?toc=/azure/azure-monitor/toc.json
       - name: Use metric alerts
         items:
         - name: Create, view and manage metric alerts in Azure Monitor


### PR DESCRIPTION
These were removed previously in https://github.com/MicrosoftDocs/azure-docs-pr/pull/53912 but somehow found their way back in. They are all redirecting to https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/alert-metric-classic?toc=%2Fazure%2Fazure-monitor%2Ftoc.json anyway so they shouldn't be in the TOC.