### PR TITLE
typo: Double word "threat"

### DIFF
--- a/articles/mysql/TOC.yml
+++ b/articles/mysql/TOC.yml
@@ -163,7 +163,7 @@
       href: howto-troubleshoot-query-performance.md
     - name: How to use views in sys schema
       href: howto-troubleshoot-sys-schema.md
-    name: Advanced Threat Threat Protection
+    name: Advanced Threat Protection
     items:
     - name: Azure portal
       href: howto-database-threat-protection-portal.md

--- a/articles/postgresql/TOC.yml
+++ b/articles/postgresql/TOC.yml
@@ -139,7 +139,7 @@
     items:
     - name: Create alerts on metrics
       href: howto-alert-on-metric.md
-  - name: Advanced Threat Threat Protection
+  - name: Advanced Threat Protection
     items:
     - name: Azure portal
       href: howto-database-threat-protection-portal.md


### PR DESCRIPTION
Maybe it's correct, but "Advanced Threat Threat Protection" isn't used anywhere else