### PR TITLE
Update CosmosDB SQL API libraries table

### DIFF
--- a/articles/cosmos-db/sql-api-introduction.md
+++ b/articles/cosmos-db/sql-api-introduction.md
@@ -64,10 +64,9 @@ Azure Cosmos DB exposes resources through the REST APIs that can be called by an
 | Download | Documentation |
 | --- | --- |
 | [.NET SDK](http://go.microsoft.com/fwlink/?LinkID=402989) |[.NET library](/dotnet/api/overview/azure/cosmosdb?view=azure-dotnet) |
-| [Node.js SDK](http://go.microsoft.com/fwlink/?LinkID=402990) |[Node.js library](https://github.com/Azure/azure-cosmosdb-node) |
 | [Java SDK](http://go.microsoft.com/fwlink/?LinkID=402380) |[Java library](/java/api/com.microsoft.azure.documentdb) |
-| [JavaScript SDK](https://github.com/Azure/azure-cosmos-js) |[JavaScript library](https://github.com/Azure/azure-cosmos-js) |
-| n/a |[Server-side JavaScript SDK](https://github.com/Azure/azure-cosmosdb-js-server) |
+| [JavaScript SDK](https://www.npmjs.com/package/@azure/cosmos) |[JavaScript library](https://github.com/Azure/azure-cosmos-js) |
+| n/a |[Server-side library](https://azure.github.io/azure-cosmosdb-js-server/) |
 | [Python SDK](https://pypi.python.org/pypi/pydocumentdb) |[Python library](https://github.com/Azure/azure-cosmos-python) |
 | n/a | [API for MongoDB](mongodb-introduction.md)
 


### PR DESCRIPTION
* The Node SDK pointed to an obsolete repo (see https://github.com/Azure/azure-cosmosdb-node/issues/241)
* The Javascript SDK download pointed to the source/documentation for the package, rather than to the download on NPM
* "Server-side JavaScript SDK" was confusing when seen alongside "JavaScript SDK" and "Node.js SDK" -- the fact that there's only one server-side SDK means you can omit the "JavaScript" part.

The JS documentation may also want to point to https://docs.microsoft.com/en-us/javascript/api/%40azure/cosmos/?view=azure-node-latest, which I found much more helpful in figuring out what the API can do -- it is linked to from the repo's main README, though, so perhaps it is better to keep it pointed at the repo?