### PR TITLE
Include the right package

### DIFF
--- a/includes/get-client-libraries.md
+++ b/includes/get-client-libraries.md
@@ -4,7 +4,7 @@
     ```json
     {
       "require": {
-        "microsoft/azure-storage": "*"
+        "microsoft/windowsazure": "^0.5"
       }
     }
     ```


### PR DESCRIPTION
In documentation page https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-php-how-to-use-queues

You are using `WindowsAzure\Common\*` libraries which are parts from `microsoft/windowsazure` package.