### PR TITLE
columnMappings format for Copy Activity

### DIFF
--- a/articles/data-factory/copy-activity-schema-and-type-mapping.md
+++ b/articles/data-factory/copy-activity-schema-and-type-mapping.md
@@ -121,7 +121,6 @@ The following JSON defines a copy activity in a pipeline. The columns from sourc
         {
             "type": "TabularTranslator",
             "columnMappings": "UserId: MyUserId, Group:MyGroup, Name:MyName"
-            }
         }
     }
 }

--- a/articles/data-factory/copy-activity-schema-and-type-mapping.md
+++ b/articles/data-factory/copy-activity-schema-and-type-mapping.md
@@ -120,11 +120,7 @@ The following JSON defines a copy activity in a pipeline. The columns from sourc
         "translator":
         {
             "type": "TabularTranslator",
-            "columnMappings": 
-            {
-                "UserId": "MyUserId",
-                "Group": "MyGroup",
-                "Name": "MyName"
+            "columnMappings": "UserId: MyUserId, Group:MyGroup, Name:MyName"
             }
         }
     }


### PR DESCRIPTION
Difference in documentation and current format for representing column mapping  for source and sink in Copy Activity in DataFactory.