### PR TITLE
chore: Remove en-gb from azure.microsoft.com links

### DIFF
--- a/articles/sql-data-warehouse/sql-data-warehouse-partner-business-intelligence.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-partner-business-intelligence.md
@@ -89,7 +89,7 @@ To learn more about some of our other partners, see [Data Integration partners][
 [yellowfin_datasheet]:http://www.yellowfinbi.com/Document.i4?DocumentId=877299
 
 <!--Marketplace Links -->
-[birst_marketplace]:https://azure.microsoft.com/en-gb/marketplace/partners/birst/birst/
+[birst_marketplace]:https://azure.microsoft.com/marketplace/partners/birst/birst/
 <!--[clearstory_marketplace]:-->
 <!--[dell_statistica_marketplace]:https://azure.microsoft.com/marketplace/partners/dell-software/statistica-data-miner/-->
 [dundas_bi_marketplace]:https://azure.microsoft.com/marketplace/partners/dundas/dundas-bi/ 

--- a/articles/sql-data-warehouse/sql-data-warehouse-partner-data-integration.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-partner-data-integration.md
@@ -73,9 +73,9 @@ To learn more about other partners, see [Business Intelligence partners][bi_part
 
 <!--Marketplace Links -->
 [alteryx_marketplace]:https://azure.microsoft.com/marketplace/partners/alteryx/alteryx-designer/
-[attunity_marketplace]:https://azure.microsoft.com/en-gb/marketplace/partners/attunity-cloudbeam/cloudbeam-dw-byol/ 
+[attunity_marketplace]:https://azure.microsoft.com/marketplace/partners/attunity-cloudbeam/cloudbeam-dw-byol/ 
 
-<!--[bryte_systems_marketplace]:https://azure.microsoft.com/en-gb/marketplace/partners/bryte/bryteflow-cdc-free-trial/--> 
+<!--[bryte_systems_marketplace]:https://azure.microsoft.com/marketplace/partners/bryte/bryteflow-cdc-free-trial/--> 
 
 [informatica_Cloud_Services_marketplace]:https://azuremarketplace.microsoft.com/marketplace/partners/informatica/informatica-cloud-services/
 


### PR DESCRIPTION
Find/replace `https://azure.microsoft.com/en-gb/` -> `https://azure.microsoft.com/` to match link locale guidelines