### PR TITLE
Update to LinkedIn Learning configuration tutorial

### DIFF
--- a/articles/active-directory/saas-apps/linkedinlearning-tutorial.md
+++ b/articles/active-directory/saas-apps/linkedinlearning-tutorial.md
@@ -107,7 +107,7 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 
 	![Configure Single Sign-On](./media/linkedinlearning-tutorial/tutorial_linkedin_admin_01.png)
 
-1. Click **OR Click Here to load and copy individual fields from the form** and copy **Entity Id** and **Assertion Consumer Access (ACS) Url**
+1. Click **OR Click Here to load and copy individual fields from the form** and copy **Entity Id** and **Assertion Consumer Service (ACS) Url**
 
 	![Configure Single Sign-On](./media/linkedinlearning-tutorial/tutorial_linkedin_admin_03.png)
 
@@ -117,9 +117,9 @@ In this section, you enable Azure AD single sign-on in the Azure portal and conf
 
     a. In the **Identifier** textbox, enter the **Entity ID** copied from LinkedIn Portal 
 
-	b. In the **Reply URL** textbox, enter the **Assertion Consumer Access (ACS) Url** copied from LinkedIn Portal
+	b. In the **Reply URL** textbox, enter the **Assertion Consumer Service (ACS) Url** copied from LinkedIn Portal
 
-1. If you want to configure SSO in **SP Initiated**, then click Show Advanced URL setting option in the configuration section and configure the sign-on URL with the following pattern:
+1. If you want to configure SSO in **SP Initiated**, then click Show Advanced URL setting option in the configuration section where you will specify your sign-on URL.  To create your login Url copy the **Assertion Consumer Service (ACS) Url** and replace /saml/ with /login/.   Once that has been done, the sign-on URL should have the following pattern:
 
 	`https://www.linkedin.com/checkpoint/enterprise/login/<AccountId>?application=learning&applicationInstanceId=<InstanceId>`
 


### PR DESCRIPTION
Adjusted to use proper terminology (ACS is Assertion Consumer Service, not Assertion Consumer Access) and provide instructions on how to create SSO login URL.