### PR TITLE
Update MetaData Links of Local Account SignIn

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-password-change-custom.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-password-change-custom.md
@@ -81,8 +81,8 @@ Add the following claims provider to your extensions policy.
             <Item Key="UserMessageIfInvalidPassword">Your password is incorrect</Item>
             <Item Key="UserMessageIfOldPasswordUsed">Looks like you used an old password</Item>
             <Item Key="ProviderName">https://sts.windows.net/</Item>
-            <Item Key="METADATA">https://login.microsoftonline.com/{tenant}.onmicrosoft.com/.well-known/openid-configuration</Item>
-            <Item Key="authorization_endpoint">https://login.microsoftonline.com/{tenant}.onmicrosoft.com/oauth2/token</Item>
+            <Item Key="METADATA">https://login.microsoftonline.com/{tenant}/.well-known/openid-configuration</Item>
+            <Item Key="authorization_endpoint">https://login.microsoftonline.com/{tenant}/oauth2/token</Item>
             <Item Key="response_types">id_token</Item>
             <Item Key="response_mode">query</Item>
             <Item Key="scope">email openid</Item>


### PR DESCRIPTION
Making [documentation](https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-password-change-custom#add-a-password-change-claims-provider-with-its-supporting-elements) on par with the code samples

* Refers and fixes  #16955

Issue introduced between these commits - 
[Updating references to login.microsoftonline to b2clogin.com](https://github.com/MicrosoftDocs/azure-docs/commit/7a310fee8cdb95dc2833badaf6e0f9cc2666909a#diff-7760e66615f852f125ffda18119b1d8b)
[Fixing doc](https://github.com/MicrosoftDocs/azure-docs/commit/ff8dda14b6db3c2887cbe5572e12b0ef8c33f87a#diff-7760e66615f852f125ffda18119b1d8b)

Code sample - 
https://github.com/Azure-Samples/active-directory-b2c-custom-policy-starterpack/blob/master/scenarios/password-change/TrustFrameworkExtensions.xml#L38