### PR TITLE
Use static IP outside node resource group

### DIFF
--- a/articles/aks/static-ip.md
+++ b/articles/aks/static-ip.md
@@ -87,6 +87,46 @@ Create the service and deployment with the `kubectl apply` command.
 kubectl apply -f load-balancer-service.yaml
 ```
 
+## Using Static IP address outside node resource group
+
+It is possible to use a Static IP that is created outside the node resource group with Kubernetes version 1.10+.  To use an IP address outside the node resource group add an annotation to the Service definition.  Provide your own resource group name as the value to the annotation below.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-resource-group: resource-group-name
+  name: azure-load-balancer
+spec:
+  loadBalancerIP: 40.121.183.52
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: azure-load-balancer
+```
+
+## Using Static IP address outside node resource group
+
+It is possible to use a Static IP that is created outside the node resource group with Kubernetes version 1.10+.  To use an IP address outside the node resource group add an annotation to the Service definition.  Provide your own resource group name as the value to the annotation below.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-resource-group: resource-group-name
+  name: azure-load-balancer
+spec:
+  loadBalancerIP: 40.121.183.52
+  type: LoadBalancer
+  ports:
+  - port: 80
+  selector:
+    app: azure-load-balancer
+```
+
 ## Troubleshoot
 
 If the static IP address defined in the *loadBalancerIP* property of the Kubernetes service manifest does not exist, or has not been created in the node resource group, the load balancer service creation fails. To troubleshoot, review the service creation events with the [kubectl describe][kubectl-describe] command. Provide the name of the service as specified in the YAML manifest, as shown in the following example:

--- a/articles/aks/static-ip.md
+++ b/articles/aks/static-ip.md
@@ -53,7 +53,7 @@ The IP address is shown, as shown in the following condensed example output:
     "ipAddress": "40.121.183.52",
     [..]
   }
-````
+```
 
 You can later get the public IP address using the [az network public-ip list][az-network-public-ip-list] command. Specify the name of the node resource group, and then query for the *ipAddress* as shown in the following example:
 
@@ -85,26 +85,6 @@ Create the service and deployment with the `kubectl apply` command.
 
 ```console
 kubectl apply -f load-balancer-service.yaml
-```
-
-## Using Static IP address outside node resource group
-
-It is possible to use a Static IP that is created outside the node resource group with Kubernetes version 1.10+.  To use an IP address outside the node resource group add an annotation to the Service definition.  Provide your own resource group name as the value to the annotation below.
-
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-resource-group: resource-group-name
-  name: azure-load-balancer
-spec:
-  loadBalancerIP: 40.121.183.52
-  type: LoadBalancer
-  ports:
-  - port: 80
-  selector:
-    app: azure-load-balancer
 ```
 
 ## Using Static IP address outside node resource group


### PR DESCRIPTION
Needed this for keeping IP addresses across cluster creation.  I found the following annotation in the source code for the K8s azure provider implementation of the load balancer: https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/azure/azure_loadbalancer.go#L73