### PR TITLE
typo in FUNCTIONS_WORKER_RUNTIME

### DIFF
--- a/articles/azure-functions/functions-run-local.md
+++ b/articles/azure-functions/functions-run-local.md
@@ -182,7 +182,7 @@ The file local.settings.json stores app settings, connection strings, and settin
 {
   "IsEncrypted": false,
   "Values": {
-    "FUNCTIONS\_WORKER\_RUNTIME": "<language worker>",
+    "FUNCTIONS_WORKER_RUNTIME": "<language worker>",
     "AzureWebJobsStorage": "<connection-string>",
     "AzureWebJobsDashboard": "<connection-string>",
     "MyBindingConnection": "<binding-connection-string>"


### PR DESCRIPTION
The FUNCTIONS_WORKER_RUNTIME setting name should not have backslashes in it