### PR TITLE
Replace 'subscriptionKey' with 'key' in ruby.md

### DIFF
--- a/articles/cognitive-services/Bing-Spell-Check/quickstarts/ruby.md
+++ b/articles/cognitive-services/Bing-Spell-Check/quickstarts/ruby.md
@@ -26,7 +26,7 @@ You must have a [Cognitive Services API account](https://docs.microsoft.com/azur
 
 1. Create a new Ruby project in your favorite IDE.
 2. Add the code provided below.
-3. Replace the `subscriptionKey` value with an access key valid for your subscription.
+3. Replace the `key` value with an access key valid for your subscription.
 4. Run the program.
 
 ```ruby


### PR DESCRIPTION
Hello 👋 I was following the guides at https://docs.microsoft.com/en-us/azure/cognitive-services/bing-spell-check/quickstarts/ruby and noticed that we mention `subscriptionKey` in the guide, but it doesn't exist in the code. It's called `key` instead, so fixing it.