### PR TITLE
chore: Remove en-gb from MS links

### DIFF
--- a/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
+++ b/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
@@ -116,7 +116,7 @@ For initial registration, allow access to the following endpoints:
 If you can't allow connectivity by FQDN and need to specify IP ranges instead, use these options:
 
 * Allow the connector outbound access to all destinations.
-* Allow the connector outbound access to all of the [Azure datacenter IP ranges](https://www.microsoft.com/en-gb/download/details.aspx?id=41653). The challenge with using the list of Azure datacenter IP ranges is that it's updated weekly. You need to put a process in place to ensure that your access rules are updated accordingly. Only using a subset of the IP addresses may cause your configuration to break.
+* Allow the connector outbound access to all of the [Azure datacenter IP ranges](https://www.microsoft.com//download/details.aspx?id=41653). The challenge with using the list of Azure datacenter IP ranges is that it's updated weekly. You need to put a process in place to ensure that your access rules are updated accordingly. Only using a subset of the IP addresses may cause your configuration to break.
 
 #### Proxy authentication
 

--- a/articles/batch/batch-rendering-render-managers.md
+++ b/articles/batch/batch-rendering-render-managers.md
@@ -28,7 +28,7 @@ Scripts and instructions to enable Azure Batch pool VMs to be used as Qube worke
 
 Royal Render has Azure and Azure Batch integration built-in, allowing you to extend a render farm with Azure-based VMs. For a summary, see [the help files](http://www.royalrender.de/help8/index.html?Cloudrendering.html).
 
-For an example of a Royal Render customer using the Azure integration, see the [Jellyfish Pictures customer story](https://customers.microsoft.com/en-gb/story/jellyfishpictures).
+For an example of a Royal Render customer using the Azure integration, see the [Jellyfish Pictures customer story](https://customers.microsoft.com/story/jellyfishpictures).
 
 ## Using Azure with Thinkbox Deadline
 


### PR DESCRIPTION
Not all microsoft.com links redirect, but these appear to redirect to locales correctly