### PR TITLE
Add a link to Logic Apps for Managed Identity

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/overview.md
+++ b/articles/active-directory/managed-identities-azure-resources/overview.md
@@ -113,6 +113,7 @@ Learn how to use a managed identity with other Azure services:
 
 * [Azure App Service](/azure/app-service/app-service-managed-service-identity)
 * [Azure Functions](/azure/app-service/app-service-managed-service-identity)
+* [Azure Logic Apps](/azure/logic-apps/create-managed-service-identity)
 * [Azure Service Bus](../../service-bus-messaging/service-bus-managed-service-identity.md)
 * [Azure Event Hubs](../../event-hubs/event-hubs-managed-service-identity.md)
 * [Azure API Management](../../api-management/api-management-howto-use-managed-service-identity.md)


### PR DESCRIPTION
Logic Apps has recently added the Managed Identity capability. But this page is missing the link to that page. Therefore, I added it.