### PR TITLE
Updated Commandlet name

### DIFF
--- a/articles/azure-stack/azure-stack-validation-report.md
+++ b/articles/azure-stack/azure-stack-validation-report.md
@@ -38,19 +38,81 @@ By default, both files are written to *C:\Users\<username>\AppData\Local\Temp\Az
 To view the report in PowerShell, supply the path to the report as a value for **-ReportPath**. This command displays the contents of the report and identifies validations that do not yet have results.
 
 For example, to view the report from a PowerShell prompt that is open to the location where the report is located, run: 
-   > `Start-AzsReadinessChecker -ReportPath .\AzsReadinessReport.json` 
+   > `Read-AzsReadinessReport -ReportPath .\AzsReadinessReport.json` 
 
-The output resembles the following image:
+The output resembles the following:
 
-![view-report](./media/azure-stack-validation-report/view-report.png)
+````PowerShell
+Reading All Validation(s) from Report C:\Contoso-AzsReadinessCheckerReport.json
+
+############### Certificate Validation Summary ###############
+
+Certificate Validation results not available.
+
+############### Registration Validation Summary ###############
+
+Azure Registration Validation results not available.
+
+############### Azure Identity Results ###############
+
+Test                          : ServiceAdministrator
+Result                        : OK
+AAD Service Admin             : admin@contoso.onmicrosoft.com
+Azure Environment             : AzureCloud
+Azure Active Directory Tenant : contoso.onmicrosoft.com
+Error Details                 : 
+
+############### Azure Identity Validation Summary ###############
+
+	Azure Identity Validation found no errors or warnings.
+
+############### Azure Stack Graph Validation Summary ###############
+
+Azure Stack Graph Validation results not available.
+
+############### Azure Stack ADFS Validation Summary ###############
+
+Azure Stack ADFS Validation results not available.
+
+############### AzsReadiness Job Summary ###############
+
+Index             : 0
+Operations        : 
+StartTime         : 2018/10/22 14:24:16
+EndTime           : 2018/10/22 14:24:19
+Duration          : 3
+PSBoundParameters : 
+````
 
 ## View the report summary
 To view a summary of the report, you can add the **-Summary** switch to the end of the PowerShell command line. For example: 
- > `Start-AzsReadinessChecker -ReportPath .\AzsReadinessReport.json -summary`  
+ > `Read-AzsReadinessReport -ReportPath .\Contoso-AzsReadinessReport.json -summary`  
 
-The summary shows validations that don't have results and indicates pass or fail for validations that are complete. The output resembles the following image:
+The summary shows validations that don't have results and indicates pass or fail for validations that are complete. The output resembles the following:
 
-![report-summary](./media/azure-stack-validation-report/report-summary.png)
+````PowerShell
+Reading All Validation(s) from Report C:\Contoso-AzsReadinessCheckerReport.json
+
+############### Certificate Validation Summary ###############
+
+    Certificate Validation found no errors or warnings.
+	
+############### Registration Validation Summary ###############
+
+	Registration Validation found no errors or warnings.
+
+############### Azure Identity Validation Summary ###############
+
+	Azure Identity Validation found no errors or warnings.
+
+############### Azure Stack Graph Validation Summary ###############
+
+Azure Stack Graph Validation results not available.
+
+############### Azure Stack ADFS Validation Summary ###############
+
+Azure Stack ADFS Validation results not available.
+````
 
 
 ## View a filtered report
@@ -58,12 +120,13 @@ To view a report that is filtered on a single type of validation, use the **-Rep
 - Certificate
 - AzureRegistration
 - AzureIdentity
+- Graph
+- ADFS
 - Jobs   
 - All  
 
 For example, to view the report summary for certificates only, use the following PowerShell command line: 
- > `Start-AzsReadinessChecker -ReportPath .\AzsReadinessReport.json -ReportSections Certificate – Summary`
+ > `Read-AzsReadinessReport -ReportPath .\Contoso-AzsReadinessReport.json -ReportSections Certificate – Summary`
 
 
 ## See also
-[Start-AzsReadinessChecker cmdlet reference](azure-stack-azsreadiness-cmdlet.md)


### PR DESCRIPTION
Replace Start-AzsReadinessChecker with Read-AzsReadinessReport
Replaced screengrabs with text representations
Removed See also -> commandlet reference (this is obsolete and needs completely re-doing.)