### PR TITLE
Listening for SE gives a time window before maintenance

### DIFF
--- a/articles/virtual-machines/windows/scheduled-events.md
+++ b/articles/virtual-machines/windows/scheduled-events.md
@@ -38,7 +38,7 @@ Many applications can benefit from time to prepare for virtual machine maintenan
 - Event logging
 - Graceful shutdown 
 
-Using Scheduled Events your application can discover when maintenance will occur and trigger tasks to limit its impact.  
+Using Scheduled Events your application can discover when maintenance will occur and trigger tasks to limit its impact. Enabling scheduled events gives your virtual machine a minimum amount of time before the maintenance activity is performed. See the Event Scheduling section below for details.
 
 Scheduled Events provides events in the following use cases:
 - Platform initiated maintenance (e.g. Host OS Update)
@@ -68,7 +68,7 @@ The Scheduled Events Service is versioned. Versions are mandatory and the curren
 > Previous preview releases of scheduled events supported {latest} as the api-version. This format is no longer supported and will be deprecated in the future.
 
 ### Enabling and Disabling Scheduled Events
-Scheduled Events is enabled for your service the first time you make a request for events. You should expect a delayed response in your first call of up to two minutes.
+Scheduled Events is enabled for your service the first time you make a request for events. You should expect a delayed response in your first call of up to two minutes. You should query the endpoint periodically to detect upcoming maintenance events as well as the status of maintenance activities that are being performed.
 
 Scheduled Events is disabled for your service if it does not make a request for 24 hours.
 
@@ -107,6 +107,7 @@ In the case where there are scheduled events, the response contains an array of 
     ]
 }
 ```
+The DocumentIncarnation is an ETag and provides an easy way to inspect if the Events payload has changed since the last query.
 
 ### Event Properties
 |Property  |  Description |


### PR DESCRIPTION
Clarifying that listening for schedule events gives callers an extended timeout before maintenance is performed as this was not clear previously. Also the guidance around having to periodically query the endpoint for changes was missing. Finally highlighted that the DocumentIncarnation tag provides an easy way to detect if the events payload has changed.