### PR TITLE
Remove unsupported/unneeded style tag from Billing index

### DIFF
--- a/articles/billing/index.md
+++ b/articles/billing/index.md
@@ -167,7 +167,6 @@ Learn how to understand your Azure billing, monitor usage and costs, and manage 
                 <div class="card">
                     <div class="cardText">
                         <h3>Enterprise subscription: requires EA portal access</h3>
-                        <style>.p-test:after { font-family: docons; content: "\E9D0";}</style>
                         <p>
                         <a class="p-test" href="https://ea.azure.com/helpdocs/createADepartment" data-linktype="external">Manage departments<span class="docon docon-navigate-external"></span></a>
                         <br>


### PR DESCRIPTION
The style tag in the Billing index.md page was not doing anything, and was not even rendering:
![style-element-removed](https://user-images.githubusercontent.com/24712731/47314274-766c0400-d5fe-11e8-9556-0f40dc96c922.PNG)

Additionally, the style tag did not appear to be adding anything that the `.docon` style was not already providing to the span tag that followed:
![docon-class](https://user-images.githubusercontent.com/24712731/47314296-88e63d80-d5fe-11e8-91e5-885fb97f4385.PNG)
