### PR TITLE
Add China East 2 / China North 2 to region pairing doc

### DIFF
--- a/articles/best-practices-availability-paired-regions.md
+++ b/articles/best-practices-availability-paired-regions.md
@@ -1,4 +1,4 @@
-| China |China North |China East|---
+---
 title: 'Business continuity and disaster recovery (BCDR): Azure Paired Regions | Microsoft Docs'
 description: Learn about Azure regional pairing, to ensure that applications are resilient during data center failures.
 author: rayne-wiselman

--- a/articles/best-practices-availability-paired-regions.md
+++ b/articles/best-practices-availability-paired-regions.md
@@ -1,4 +1,4 @@
----
+| China |China North |China East|---
 title: 'Business continuity and disaster recovery (BCDR): Azure Paired Regions | Microsoft Docs'
 description: Learn about Azure regional pairing, to ensure that applications are resilient during data center failures.
 author: rayne-wiselman
@@ -28,6 +28,7 @@ Figure 1 – Azure regional pairs
 | Brazil |Brazil South 2 |South Central US |
 | Canada |Canada Central |Canada East |
 | China |China North |China East|
+| China |China North 2 |China East 2|
 | Europe |North Europe |West Europe |
 | France |France Central|France South|
 | Germany |Germany Central |Germany Northeast |


### PR DESCRIPTION
A customer raised a Service Request with CSS that was escalated to an ICM, with the question of, "what's the paired region for China East 2"?  The ICM provided the answer of China North 2.  This doc update will allow customers to answer this question in the future, without involving CSS and PG.