### PR TITLE
Fix typo

### DIFF
--- a/articles/hdinsight/hadoop/apache-hadoop-develop-deploy-java-mapreduce-linux.md
+++ b/articles/hdinsight/hadoop/apache-hadoop-develop-deploy-java-mapreduce-linux.md
@@ -249,7 +249,7 @@ Use the following command to upload the jar file to the HDInsight headnode:
    scp target/wordcountjava-1.0-SNAPSHOT.jar USERNAME@CLUSTERNAME-ssh.azurehdinsight.net:
    ```
 
-    Replace __USERNAME__ with your SSH user name for the cluster. Replace __CLUSTERNAME__ with the HDInsight cluster name.
+Replace __USERNAME__ with your SSH user name for the cluster. Replace __CLUSTERNAME__ with the HDInsight cluster name.
 
 This command copies the files from the local system to the head node. For more information, see [Use SSH with HDInsight](../hdinsight-hadoop-linux-use-ssh-unix.md).
 


### PR DESCRIPTION
Originally, the display is incorrect because there is an indent by unnecessary one-byte space in the part which must be "Replace USERNAME with your SSH user name for the cluster. Replace CLUSTERNAME with the HDInsight cluster name."

evi: ![evi](https://user-images.githubusercontent.com/1207985/47327414-2a759980-d6a8-11e8-877b-40159173a20b.jpg)

