### PR TITLE
Corrected the wrong language name under Transliteration

### DIFF
--- a/articles/cognitive-services/Translator/language-support.md
+++ b/articles/cognitive-services/Translator/language-support.md
@@ -102,7 +102,7 @@ The Transliterate method supports the following languages. In the "To/From", "<-
 | Hindi | hi | Devanagari | <--> | Latin |
 | Japanese | ja | Japanese | <--> | Latin |
 | Kannada | kn | Kannada | --> | Latin |
-| Malasian | ml | Malayalam | --> | Latin |
+| Malayalam | ml | Malayalam | --> | Latin |
 | Marathi | mr | Devanagari | --> | Latin |
 | Oriya | or | Oriya | <--> | Latin |
 | Punjabi | pa | Gurmukhi | <--> | Latin  |


### PR DESCRIPTION
ISO 639-1 code 'ml' has 'Malayalam' as the ISO Language name(https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes), but in this document it was mentioned as Malasian, which is wrong and making alot of confusions. Corrected it.