### PR TITLE
Fix typo & unified service name

### DIFF
--- a/articles/automation/source-control-integration.md
+++ b/articles/automation/source-control-integration.md
@@ -17,12 +17,12 @@ Source control allows you to keep your runbooks in your Automation account are u
 Azure Automation supports 3 types of source control:
 
 * GitHub
-* Visual Studio Team Services (Git)
-* Visual Studio Team Services (TFVC)
+* Azure DevOps (Git)
+* Azure DevOps (TFVC)
 
 ## Pre-requisites
 
-* A source control repository (GitHub or Visual Studio Team Services)
+* A source control repository (GitHub or Azure DevOps)
 * The correct [permissions](#personal-access-token-permissions) to the source control repository
 * A [Run-As Account and connection](manage-runas-account.md)
 
@@ -44,7 +44,7 @@ On the **Source Control Summary** page, fill out the information and click **Sav
 |Property  |Description  |
 |---------|---------|
 |Source control name     | A friendly name for the source control        |
-|Source control type     | The type of source control source. Available options are:</br> Github</br>Visual Studio Team Services (Git)</br> Visual Studio Team Services (TFVC)        |
+|Source control type     | The type of source control source. Available options are:</br> Github</br>Azure DevOps (Git)</br> Azure DevOps (TFVC)        |
 |Repository     | The name of the repository or project. This value is pulled from the source control repository. Example: $/ContosoFinanceTFVCExample         |
 |Branch     | The branch to pull the source files from. Branch targeting is not available for the TFVC source control type.          |
 |Folder path     | The folder that contains the runbooks to sync. Example: /Runbooks         |

--- a/articles/automation/source-control-integration.md
+++ b/articles/automation/source-control-integration.md
@@ -12,7 +12,7 @@ manager: carmonm
 ---
 # Source control integration in Azure Automation
 
-Source control allows you to keep your runbooks in your Automation account are up-to-date with your scripts in your GitHub or Azure Dev Ops source control repository. Source control allows you to easily collaborate with your team, track changes, and roll back to earlier versions of your runbooks. For example, source control allows you to sync different branches in source control to your development, test or production Automation accounts. This makes it easy to promote code that has been tested in your development environment to your production Automation account.
+Source control allows you to keep your runbooks in your Automation account are up-to-date with your scripts in your GitHub or Azure DevOps source control repository. Source control allows you to easily collaborate with your team, track changes, and roll back to earlier versions of your runbooks. For example, source control allows you to sync different branches in source control to your development, test or production Automation accounts. This makes it easy to promote code that has been tested in your development environment to your production Automation account.
 
 Azure Automation supports 3 types of source control:
 


### PR DESCRIPTION
* Typo: Azure Dev Ops -> Azure DevOps
* The previous name(Visual Studio Team Services) and the new name (Azure DevOps) are mixed. So, I unified it into a new name.