### PR TITLE
Remove mention of `identity` from VM instance metadata service

### DIFF
--- a/articles/virtual-machines/windows/instance-metadata-service.md
+++ b/articles/virtual-machines/windows/instance-metadata-service.md
@@ -308,7 +308,6 @@ subnet/prefix | Subnet prefix, example 24 | 2017-04-02
 ipv6/ipAddress | Local IPv6 address of the VM | 2017-04-02 
 macAddress | VM mac address | 2017-04-02 
 scheduledevents | See [Scheduled Events](scheduled-events.md) | 2017-08-01
-identity | (Preview) Managed identities for Azure resources. See [acquire an access token](../../active-directory/managed-identities-azure-resources/how-to-use-vm-token.md) | 2018-02-01
 
 ## Example scenarios for usage  
 


### PR DESCRIPTION
As confirmed in #15282, this feature does not actually exist:

> Currently there is no way to list the identities assigned to a VM from the Instance metadata service endpoint. The way to list the identities assigned to a VM are to perform a GET on Azure for the VM resource. The payload response will contain the “identity” property which will list the assigned identities within either the “identityIds” or “userAssignedIdentities” sub-property, depending on the API version used.