### PR TITLE
Fix nonunified

### DIFF
--- a/articles/virtual-machines/linux/tutorial-build-deploy-jenkins.md
+++ b/articles/virtual-machines/linux/tutorial-build-deploy-jenkins.md
@@ -39,7 +39,7 @@ to a [deployment group](https://docs.microsoft.com/azure/devops/pipelines/releas
 ## Before you begin
 
 * You need access to a Jenkins server. If you have not yet created a Jenkins server,
-  see [Create a Jenkins master on an Azure virtual machine](https://docs.microsoft.com/azure/jenkins/install-jenkins-solution-template). 
+  see [Create a Jenkins master on an Azure Virtual Machine](https://docs.microsoft.com/azure/jenkins/install-jenkins-solution-template). 
 
 * Sign in to your Azure DevOps Services organization (**https://{yourorganization}.visualstudio.com**). 
   You can get a [free Azure DevOps Services organization](https://go.microsoft.com/fwlink/?LinkId=307137&clcid=0x409&wt.mc_id=o~msft~vscom~home-vsts-hero~27308&campaign=o~msft~vscom~home-vsts-hero~27308).

--- a/articles/virtual-machines/linux/tutorial-build-deploy-jenkins.md
+++ b/articles/virtual-machines/linux/tutorial-build-deploy-jenkins.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorial - CI/CD from Jenkins to Azure VMs with Azure DevOps Services | Microsoft Docs
-description: In this tutorial, you learn how to set up continuous integration (CI) and continuous deployment (CD) of a Node.js app by using Jenkins to Azure VMs from Release Management in Visual Studio Team Services or Microsoft Team Foundation Server
+description: In this tutorial, you learn how to set up continuous integration (CI) and continuous deployment (CD) of a Node.js app by using Jenkins to Azure VMs from Release Management in Azure DevOps or Azure DevOps Server
 author: tomarcher
 manager: jpconnock
 tags: azure-resource-manager


### PR DESCRIPTION
* The previous name(Visual Studio Team Services, Microsoft Team Foundation Server) and the new name (Azure DevOps, Azure DevOps Server) are mixed. So, I unified it into a new name.
* Typo: Azure virtual machine -> Azure Virtual Machine