### PR TITLE
Removed references to 'round robin' for Traffic Manager

### DIFF
--- a/articles/traffic-manager/traffic-manager-configure-weighted-routing-method.md
+++ b/articles/traffic-manager/traffic-manager-configure-weighted-routing-method.md
@@ -19,10 +19,10 @@ ms.author: kumud
 
 # Configure the weighted traffic routing method in Traffic Manager
 
-A common traffic routing method pattern is to provide a set of identical endpoints, which include cloud services and websites, and send traffic to each in a round-robin fashion. The following steps outline how to configure this type of traffic routing method.
+A common traffic routing method pattern is to provide a set of identical endpoints, which include cloud services and websites, and send traffic to each equally. The following steps outline how to configure this type of traffic routing method.
 
 > [!NOTE]
-> Azure Web App already provides round-robin load balancing functionality for websites within an Azure Region (contains multiple datacenters). Traffic Manager allows you to specify round-robin traffic routing method for websites in different datacenters.
+> Azure Web App already provides round-robin load balancing functionality for websites within an Azure Region (which may comprise multiple datacenters). Traffic Manager allows you to distribute traffic across websites in different datacenters.
 
 ## To configure the weighted traffic routing method
 


### PR DESCRIPTION
Traffic Manager does not support round-robin traffic distribution. Removed wording that implies that it does.