### PR TITLE
fix broken TOC links

### DIFF
--- a/articles/azure-monitor/toc.yml
+++ b/articles/azure-monitor/toc.yml
@@ -821,7 +821,7 @@
       - name: Azure PowerShell samples
         href: ../monitoring-and-diagnostics/insights-powershell-samples.md?toc=/azure/azure-monitor/toc.json
       - name: PowerShell cmdlets
-        href: ../log-analytics/log-analytics-powershell-workspace-configuration.md?toc=/azure%monitoring-and-diagnostics/toc.json
+        href: ../log-analytics/log-analytics-powershell-workspace-configuration.md?toc=/azure/monitoring-and-diagnostics/toc.json
       - name: Applications
         items:
         - name: Create Application Insights resources 
@@ -835,13 +835,13 @@
     - name: Azure CLI samples
       href: ../monitoring-and-diagnostics/insights-cli-samples.md?toc=/azure/azure-monitor/toc.json
     - name: Resource Manager templates
-      href: ../log-analytics/log-analytics-template-workspace-configuration.md?toc=/azure%monitoring-and-diagnostics/toc.json
+      href: ../log-analytics/log-analytics-template-workspace-configuration.md?toc=/azure/monitoring-and-diagnostics/toc.json
     - name: API
       items:  
       - name: Walkthrough using REST API
         href: ../monitoring-and-diagnostics/monitoring-rest-api-walkthrough.md?toc=/azure/azure-monitor/toc.json
       - name: Alert API
-        href: ../log-analytics/log-analytics-api-alerts.md?toc=/azure%monitoring-and-diagnostics/toc.json
+        href: ../log-analytics/log-analytics-api-alerts.md?toc=/azure/monitoring-and-diagnostics/toc.json
     - name: Applications
       items:
       - name: Automate with Microsoft Flow


### PR DESCRIPTION
Currently these links open with a blank TOC.

Before:
![image](https://user-images.githubusercontent.com/12844147/47535523-a4578e00-d907-11e8-8896-1ac90b307a47.png)

After:
![image](https://user-images.githubusercontent.com/12844147/47535543-b9ccb800-d907-11e8-9e79-0aba6e8a2585.png)
