### PR TITLE
Update azure-stack-validate-pki-certs.md

### DIFF
--- a/articles/azure-stack/azure-stack-validate-pki-certs.md
+++ b/articles/azure-stack/azure-stack-validate-pki-certs.md
@@ -70,7 +70,7 @@ Use these steps to prepare and to validate the Azure Stack PKI certificates for 
     ```PowerShell  
     New-Item C:\Certificates -ItemType Directory
     
-    $directories = 'ACSBlob','ACSQueue','ACSTable','Admin Portal','ARM Admin','ARM Public','KeyVault','KeyVaultInternal','Public Portal'
+    $directories = 'ACSBlob','ACSQueue','ACSTable','Admin Portal','ARM Admin','ARM Public','KeyVault','KeyVaultInternal','Public Portal','Admin Extension Host','Public Extension Host'
     
     $destination = 'c:\certificates'
     


### PR DESCRIPTION
If the folders about extension host don't exist, the following error raises. This PR will fix this issue.

```
Test-AzsCertificateFolderStructure : Invalid folder structure found in certificate folder c:\certificates, ensure only required folders are present. 
Required folders: ACSBlob, ACSQueue, ACSTable, Admin Portal, ARM Admin, ARM Public, KeyVault, KeyVaultInternal, Public Portal, Admin Extension Host, Public 
Extension Host 
Invalid folders: [none] 
```