### PR TITLE
fixing typo

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-setup-oidc-azure-active-directory.md
+++ b/articles/active-directory-b2c/active-directory-b2c-setup-oidc-azure-active-directory.md
@@ -30,10 +30,10 @@ To enable sign-in for users from a specific Azure AD organization, you need to r
 4. Select **New application registration**.
 5. Enter a name for your application. For example, `Azure AD B2C App`.
 6. For the **Application type**, select `Web app / API`.
-7. For the **Sign-on URL**, enter the following URL in all lowercase letters, where `your-B2C-tenant-name` is replaced with the name of your Azure AD B2C tenant. For example, `https://fabrikam.b2clogin.com/fabrikam.b2clogin.com/oauth2/authresp`:
+7. For the **Sign-on URL**, enter the following URL in all lowercase letters, where `your-B2C-tenant-name` is replaced with the name of your Azure AD B2C tenant. For example, `https://fabrikam.b2clogin.com/fabrikam.onmicrosoft.com/oauth2/authresp`:
 
     ```
-    https://your-tenant-name.b2clogin.com/your-B2C-tenant-name.b2clogin.com/oauth2/authresp
+    https://your-tenant-name.b2clogin.com/your-B2C-tenant-name.onmicrosoft.com/oauth2/authresp
     ```
 
     All URLs should now be using [b2clogin.com](b2clogin.md).


### PR DESCRIPTION
even with b2clogin.com the path shall represent onmicrosoft.com domain. The Sign-on (redirect) URL shall be `https://your-tenant-name.b2clogin.com/your-B2C-tenant-name.*onmicrosoft*.com/oauth2/authresp` instead of `https://your-tenant-name.b2clogin.com/your-B2C-tenant-name.*b2clogin*.com/oauth2/authresp`