### PR TITLE
Replaced http://aka.ms with https://aka.ms.

### DIFF
--- a/articles/connectors/apis-list.md
+++ b/articles/connectors/apis-list.md
@@ -212,7 +212,7 @@ you can [submit connectors for Microsoft certification](../logic-apps/custom-con
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
 
 * To submit or vote on ideas for Azure Logic Apps and connectors, 
-visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 * Are the docs missing articles or details you think are important? 
 If yes, you can help by adding to the existing articles or by writing your own. 

--- a/articles/connectors/connectors-create-api-azure-event-hubs.md
+++ b/articles/connectors/connectors-create-api-azure-event-hubs.md
@@ -227,7 +227,7 @@ see the [connector's reference page](/connectors/eventhubs/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-azureblobstorage.md
+++ b/articles/connectors/connectors-create-api-azureblobstorage.md
@@ -35,7 +35,7 @@ which is an action in your logic app.
 > 
 > * If you already use API Management, you can use 
 > this service for this scenario. For more info, see 
-> [Simple enterprise integration architecture](http://aka.ms/aisarch).
+> [Simple enterprise integration architecture](https://aka.ms/aisarch).
 
 If you're new to logic apps, review 
 [What is Azure Logic Apps](../logic-apps/logic-apps-overview.md) 
@@ -171,7 +171,7 @@ see the [connector's reference page](/connectors/azureblobconnector/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-bingsearch.md
+++ b/articles/connectors/connectors-create-api-bingsearch.md
@@ -212,7 +212,7 @@ see the [connector's reference page](/connectors/bingsearch/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-box.md
+++ b/articles/connectors/connectors-create-api-box.md
@@ -57,7 +57,7 @@ see the [connector's reference page](/connectors/box/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-crmonline.md
+++ b/articles/connectors/connectors-create-api-crmonline.md
@@ -229,7 +229,7 @@ see the [connector's reference page](/connectors/crm/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-db2.md
+++ b/articles/connectors/connectors-create-api-db2.md
@@ -439,7 +439,7 @@ see the [connector's reference page](/connectors/db2/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-excel.md
+++ b/articles/connectors/connectors-create-api-excel.md
@@ -88,7 +88,7 @@ by the connectors' Swagger files, see these connector reference pages:
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-ftp.md
+++ b/articles/connectors/connectors-create-api-ftp.md
@@ -189,7 +189,7 @@ review the connector's [reference page](/connectors/ftpconnector/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-oracledatabase.md
+++ b/articles/connectors/connectors-create-api-oracledatabase.md
@@ -125,7 +125,7 @@ View any triggers and actions defined in the swagger, and also see any limits in
 
 The [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps) is a great place to ask questions, answer questions, and see what other Logic Apps users are doing. 
 
-You can help improve Logic Apps and connectors by voting and submitting your ideas at [http://aka.ms/logicapps-wish](http://aka.ms/logicapps-wish). 
+You can help improve Logic Apps and connectors by voting and submitting your ideas at [https://aka.ms/logicapps-wish](https://aka.ms/logicapps-wish). 
 
 
 ## Next steps

--- a/articles/connectors/connectors-create-api-outlook.md
+++ b/articles/connectors/connectors-create-api-outlook.md
@@ -56,7 +56,7 @@ see the [connector's reference page](/connectors/outlook/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-projectonline.md
+++ b/articles/connectors/connectors-create-api-projectonline.md
@@ -87,7 +87,7 @@ review the connector's [reference page](/connectors/projectonline/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-rss.md
+++ b/articles/connectors/connectors-create-api-rss.md
@@ -78,7 +78,7 @@ review the connector's [reference page](/connectors/rss/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-salesforce.md
+++ b/articles/connectors/connectors-create-api-salesforce.md
@@ -83,7 +83,7 @@ review the connector's [reference page](/connectors/salesforce/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-sendgrid.md
+++ b/articles/connectors/connectors-create-api-sendgrid.md
@@ -92,7 +92,7 @@ review the connector's [reference page](/connectors/sendgrid/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-servicebus.md
+++ b/articles/connectors/connectors-create-api-servicebus.md
@@ -194,7 +194,7 @@ review the connector's [reference page](/connectors/servicebus/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-sftp.md
+++ b/articles/connectors/connectors-create-api-sftp.md
@@ -124,7 +124,7 @@ review the connector's [reference page](/connectors/sftpconnector/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-sharepoint.md
+++ b/articles/connectors/connectors-create-api-sharepoint.md
@@ -115,7 +115,7 @@ review the connector's [reference page](/connectors/sharepoint/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-slack.md
+++ b/articles/connectors/connectors-create-api-slack.md
@@ -96,7 +96,7 @@ review the connector's [reference page](/connectors/slack/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-smtp.md
+++ b/articles/connectors/connectors-create-api-smtp.md
@@ -90,7 +90,7 @@ review the connector's [reference page](/connectors/smtpconnector/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-trello.md
+++ b/articles/connectors/connectors-create-api-trello.md
@@ -92,7 +92,7 @@ review the connector's [reference page](/connectors/trello/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-twilio.md
+++ b/articles/connectors/connectors-create-api-twilio.md
@@ -94,7 +94,7 @@ review the connector's [reference page](/connectors/twilio/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-twitter.md
+++ b/articles/connectors/connectors-create-api-twitter.md
@@ -115,7 +115,7 @@ review the connector's [reference page](/connectors/twitterconnector/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-wunderlist.md
+++ b/articles/connectors/connectors-create-api-wunderlist.md
@@ -97,7 +97,7 @@ review the connector's [reference page](/connectors/wunderlist/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-create-api-yammer.md
+++ b/articles/connectors/connectors-create-api-yammer.md
@@ -94,7 +94,7 @@ review the connector's [reference page](/connectors/yammer/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-native-http.md
+++ b/articles/connectors/connectors-native-http.md
@@ -112,7 +112,7 @@ see [Trigger and action types reference](../logic-apps/logic-apps-workflow-actio
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 

--- a/articles/connectors/connectors-sftp-ssh.md
+++ b/articles/connectors/connectors-sftp-ssh.md
@@ -186,7 +186,7 @@ review the connector's [reference page](/connectors/sftpconnector/).
 ## Get support
 
 * For questions, visit the [Azure Logic Apps forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=azurelogicapps).
-* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](http://aka.ms/logicapps-wish).
+* To submit or vote on feature ideas, visit the [Logic Apps user feedback site](https://aka.ms/logicapps-wish).
 
 ## Next steps
 


### PR DESCRIPTION
This PR is a simple text replacement for http://aka.ms links to the corresponding https:// link. The only targets are those files in the /articles/connectors path.