### PR TITLE
Fixes an issue with certificate issuance, ingress creation

### DIFF
--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -119,7 +119,7 @@ metadata:
   name: letsencrypt-staging
 spec:
   acme:
-    server: https://acme-staging-v01.api.letsencrypt.org/directory
+    server: https://acme-staging.api.letsencrypt.org/directory
     email: user@contoso.com
     privateKeySecretRef:
       name: letsencrypt-staging

--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -38,7 +38,7 @@ To create the ingress controller, use `Helm` to install *nginx-ingress*. For add
 > The following example installs the ingress controller in the `kube-system` namespace. You can specify a different namespace for your own environment if desired. If your AKS cluster is not RBAC enabled, add `--set rbac.create=false` to the commands.
 
 ```console
-helm install stable/nginx-ingress --namespace kube-system --set controller.replicaCount=2
+helm install stable/nginx-ingress --namespace kube-system --set rbac.create=true --set controller.replicaCount=2
 ```
 
 During the installation, an Azure public IP address is created for the ingress controller. This public IP address is static for the life-span of the ingress controller. If you delete the ingress controller, the public IP address assignment is lost. If you then create an additional ingress controller, a new public IP address is assigned. If you wish to retain the use of the public IP address, you can instead [create an ingress controller with a static public IP address][aks-ingress-static-tls].
@@ -82,7 +82,7 @@ The ingress controller is now accessible through the FQDN.
 The NGINX ingress controller supports TLS termination. There are several ways to retrieve and configure certificates for HTTPS. This article demonstrates using [cert-manager][cert-manager], which provides automatic [Lets Encrypt][lets-encrypt] certificate generation and management functionality.
 
 > [!NOTE]
-> This article uses the `staging` environment for Let's Encrypt. In production deployments, use `letsencrypt-prod` and `https://acme-v02.api.letsencrypt.org/directory` in the resource definitions and when installing the Helm chart.
+> This article uses the `staging` environment for Let's Encrypt. In production deployments, use `letsencrypt-prod` and `https://acme.api.letsencrypt.org/directory` in the resource definitions and when installing the Helm chart.
 
 To install the cert-manager controller in an RBAC-enabled cluster, use the following `helm install` command:
 
@@ -119,7 +119,7 @@ metadata:
   name: letsencrypt-staging
 spec:
   acme:
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-staging.api.letsencrypt.org/directory
     email: user@contoso.com
     privateKeySecretRef:
       name: letsencrypt-staging

--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -82,7 +82,7 @@ The ingress controller is now accessible through the FQDN.
 The NGINX ingress controller supports TLS termination. There are several ways to retrieve and configure certificates for HTTPS. This article demonstrates using [cert-manager][cert-manager], which provides automatic [Lets Encrypt][lets-encrypt] certificate generation and management functionality.
 
 > [!NOTE]
-> This article uses the `staging` environment for Let's Encrypt. In production deployments, use `letsencrypt-prod` and `https://acme.api.letsencrypt.org/directory` in the resource definitions and when installing the Helm chart.
+> This article uses the `staging` environment for Let's Encrypt. In production deployments, use `letsencrypt-prod` and `https://acme-v01.api.letsencrypt.org/directory` in the resource definitions and when installing the Helm chart.
 
 To install the cert-manager controller in an RBAC-enabled cluster, use the following `helm install` command:
 
@@ -119,7 +119,7 @@ metadata:
   name: letsencrypt-staging
 spec:
   acme:
-    server: https://acme-staging.api.letsencrypt.org/directory
+    server: https://acme-staging-v01.api.letsencrypt.org/directory
     email: user@contoso.com
     privateKeySecretRef:
       name: letsencrypt-staging


### PR DESCRIPTION
Cluster Issuer with Let's Encrypt v2 endpoints do not appear to work with cert-manager. Downgrading to v1 endpoints resolves the issue.

Also, the ingress creation needs to explicitly enable RBAC for RBAC enabled clusters.