### PR TITLE
typo: Portugese -> Portuguese

### DIFF
--- a/articles/cognitive-services/Content-Moderator/language-support.md
+++ b/articles/cognitive-services/Content-Moderator/language-support.md
@@ -62,7 +62,7 @@ ms.author: sajagtap
 | Old (Persian) | Hebrew
 | Pashto | Hindi
 | Polish | Hungarian
-| Portugese | Icelandic
+| Portuguese | Icelandic
 | Punjabi | Igbo
 | Rejang | Indonesian
 | Russian | Inuktitut


### PR DESCRIPTION
Aside: Displaying this as a table when the rows don't mean anything seems odd.