### PR TITLE
Updating icon for .NET + VS Code quickstart

### DIFF
--- a/articles/dev-spaces/index.yml
+++ b/articles/dev-spaces/index.yml
@@ -30,7 +30,7 @@ sections:
       text: Java
       href: quickstart-java.md
     - image: 
-        src: https://docs.microsoft.com/media/logos/logo_NETcore.svg
+        src: https://docs.microsoft.com/en-us/media/logos/logo_vs-code.svg
       text: .NET and VS Code
       href: quickstart-netcore.md
     - image: 


### PR DESCRIPTION
The icon is currently a non-standard .NET Core icon. The .NET team asked us to change it to something standard. The VS Code icon makes more sense than the standard .NET icon in this context, since there's another .NET Core tutorial that is VS-only and uses the VS icon, so the .NET Core + VS Code tutorial should use the VS Code icon.

Icon is located here: https://docs.microsoft.com/en-us/media/logos/logo_vs-code.svg