### PR TITLE
Removing references to graph search API

### DIFF
--- a/articles/cognitive-services/Academic-Knowledge/toc.yml
+++ b/articles/cognitive-services/Academic-Knowledge/toc.yml
@@ -34,18 +34,8 @@
         href: SimilarityMethod.md
   - name: Query expression syntax
     href: QueryExpressionSyntax.md
-  - name: Graph traversal
-    items:
-      - name: Lambda search syntax
-        href: LambdaSearchSyntax.md
-      - name: Graph search method
-        href: GraphSearchMethod.md
-      - name: JSON Search Syntax
-        href: JSONSearchSyntax.md
 - name: Reference
   items:
-    - name: API Reference
-      href: https://westus.dev.cognitive.microsoft.com/docs/services/56332331778daf02acc0a50b/operations/565d9001ca73072048922d97
     - name: Labs API reference
       href: https://dev.labs.cognitive.microsoft.com/docs/services/56332331778daf02acc0a50b/operations/565d9001ca73072048922d97
 - name: Resources


### PR DESCRIPTION
Removing references to graph search API as it has been completely decommissioned, plus removing defunct API reference link