### PR TITLE
Match workspace name

### DIFF
--- a/articles/log-analytics/log-analytics-cross-workspace-search.md
+++ b/articles/log-analytics/log-analytics-cross-workspace-search.md
@@ -33,7 +33,7 @@ Identifying a workspace can be accomplished one of several ways:
 
 * Resource name - is a human-readable name of the workspace, sometimes referred to as *component name*. 
 
-    `workspace("contosoretail").Update | count`
+    `workspace("contosoretail-it").Update | count`
  
     >[!NOTE]
     >Identifying a workspace by name assumes uniqueness across all accessible subscriptions. If you have multiple applications with the specified name, the query fails because of the ambiguity. In this case, you must use one of the other identifiers.
@@ -54,7 +54,7 @@ Identifying a workspace can be accomplished one of several ways:
 
     For example:
     ``` 
-    workspace("/subscriptions/e427519-5645-8x4e-1v67-3b84b59a1985/resourcegroups/ContosoAzureHQ/providers/Microsoft.OperationalInsights/workspaces/contosoretail").Update | count
+    workspace("/subscriptions/e427519-5645-8x4e-1v67-3b84b59a1985/resourcegroups/ContosoAzureHQ/providers/Microsoft.OperationalInsights/workspaces/contosoretail-it").Update | count
     ```
 
 ### Identifying an application


### PR DESCRIPTION
The workspace is named "contosoretail-it", but it is being referenced as "contosoretail"