### PR TITLE
Update navigation steps

### DIFF
--- a/articles/cost-management/tutorial-export-acm-data.md
+++ b/articles/cost-management/tutorial-export-acm-data.md
@@ -41,7 +41,7 @@ Sign in to the Azure portal at [https://portal.azure.com](https://portal.azure.c
 
 ## Create a daily export
 
-Cost Management + Billing &gt; select a subscription or resource group in a subscription &gt; Export &gt; **Add**.
+Cost Management + Billing &gt; Cost Management &gt; select a subscription or resource group in a subscription &gt; Export &gt; **Add**.
 
 Type a name for the export and specify the subscription, Azure storage account, container, and the file storage directory or blob container, then click **Create**.
 


### PR DESCRIPTION
Today the exports option is only available below the "Cost Management" blade. Added a step explicitely saying you have to navigate in that blade as this wasn't clear from the instructions.