### PR TITLE
Fix deprecated usage: how-to-deploy-modules-cli.md

### DIFF
--- a/articles/iot-edge/how-to-deploy-modules-cli.md
+++ b/articles/iot-edge/how-to-deploy-modules-cli.md
@@ -107,7 +107,7 @@ Change directories into the folder where your deployment manifest is saved. If y
 Use the following command to apply the configuration to an IoT Edge device:
 
    ```cli
-   az iot hub apply-configuration --device-id [device id] --hub-name [hub name] --content [file path]
+   az iot edge set-modules --device-id [device id] --hub-name [hub name] --content [file path]
    ```
 
 The device id parameter is case-sensitive. The content parameter points to the deployment manifest file that you saved. 


### PR DESCRIPTION
While following the how-to guide at https://docs.microsoft.com/en-us/azure/iot-edge/how-to-deploy-modules-cli, you run into a deprecation warning for `az iot hub apply-configuration`.

The embedded image already uses the correct `az iot edge set-modules` instead.

This commit fixes the command in the text, too.