### PR TITLE
CRL (Outbound) doesn't use HTTPs

### DIFF
--- a/articles/azure-stack/azure-stack-integrate-endpoints.md
+++ b/articles/azure-stack/azure-stack-integrate-endpoints.md
@@ -74,7 +74,7 @@ Azure Stack supports only transparent proxy servers. In a deployment where a tra
 |Windows Defender|.wdcp.microsoft.com<br>.wdcpalt.microsoft.com<br>*.updates.microsoft.com<br>*.download.microsoft.com<br>https://msdl.microsoft.com/download/symbols<br>http://www.microsoft.com/pkiops/crl<br>http://www.microsoft.com/pkiops/certs<br>http://crl.microsoft.com/pki/crl/products<br>http://www.microsoft.com/pki/certs<br>https://secure.aadcdn.microsoftonline-p.com<br>|HTTPS|80<br>443|
 |NTP|     |UDP|123|
 |DNS|     |TCP<br>UDP|53|
-|CRL|     |HTTPS|443|
+|CRL|     |HTTP|80|
 |     |     |     |     |
 
 > [!Note]  


### PR DESCRIPTION
Changing outbound CRL table entry to HTTP 80.
Microsoft doesn't support retrieving CRLs over HTTP.
Look at inbound, that is correct.  

Background, CDP info (containing the CRL pointer) is on the certificate, it is engrained in Enterprise's and Public CA's certificate policies, every customers CRL endpoint will be different. The point is, infra roles must have outbound connectivity to get to that CRL and (as per our PKI requirements) the CRL must be a HTTP endpoint.  So this page is conflicting with our PKI requirement page: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-pki-certs#certificate-requirements