### PR TITLE
Fix syntax issues in service-fabric-assign-policy-to-endpoint.md

### DIFF
--- a/articles/service-fabric/service-fabric-assign-policy-to-endpoint.md
+++ b/articles/service-fabric/service-fabric-assign-policy-to-endpoint.md
@@ -23,9 +23,9 @@ If you apply a run-as policy and the service manifest declares HTTP endpoint res
 
 ```xml
 <Policies>
-   <RunAsPolicy CodePackageRef="Code" UserRef="Customer1" />
-   <!--SecurityAccessPolicy is needed if RunAsPolicy is defined and the Endpoint is http -->
-   <SecurityAccessPolicy ResourceRef="EndpointName" PrincipalRef="Customer1" />
+  <RunAsPolicy CodePackageRef="Code" UserRef="Customer1" />
+  <!--SecurityAccessPolicy is needed if RunAsPolicy is defined and the Endpoint is http -->
+  <SecurityAccessPolicy ResourceRef="EndpointName" PrincipalRef="Customer1" />
 </Policies>
 ```
 
@@ -33,12 +33,12 @@ For an HTTPS endpoint, also indicate the name of the certificate to return to th
 
 ```xml
 <Policies>
-   <RunAsPolicy CodePackageRef="Code" UserRef="Customer1" />
+  <RunAsPolicy CodePackageRef="Code" UserRef="Customer1" />
   <!--SecurityAccessPolicy is needed if RunAsPolicy is defined and the Endpoint is http -->
-   <SecurityAccessPolicy ResourceRef="EndpointName" PrincipalRef="Customer1" />
+  <SecurityAccessPolicy ResourceRef="EndpointName" PrincipalRef="Customer1" />
   <!--EndpointBindingPolicy is needed if the EndpointName is secured with https -->
   <EndpointBindingPolicy EndpointRef="EndpointName" CertificateRef="Cert1" />
-</Policies
+</Policies>
 ```
 
 > [!WARNING] 


### PR DESCRIPTION
There was a missing closing `>` symbol in the XML, and the whitespace was inconsistent.  I have fixed both issues.