### PR TITLE
Update example for listAccountSas function

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-functions-resource.md
+++ b/articles/azure-resource-manager/resource-group-template-functions-resource.md
@@ -114,11 +114,10 @@ The following [example template](https://github.com/Azure/azure-docs-json-sample
             "type": "string",
             "defaultValue": "southcentralus"
         },
-        "requestContent": {
+        "accountSasProperties": {
             "type": "object",
             "defaultValue": {
                 "signedServices": "b",
-                "signedResourceType": "c",
                 "signedPermission": "r",
                 "signedExpiry": "2018-08-20T11:00:00Z",
                 "signedResourceTypes": "s"
@@ -160,7 +159,7 @@ The following [example template](https://github.com/Azure/azure-docs-json-sample
         },
         "accountSAS": {
             "type": "object",
-            "value": "[listAccountSas(parameters('storagename'), '2018-02-01', parameters('requestContent'))]"
+            "value": "[listAccountSas(parameters('storagename'), '2018-02-01', parameters('accountSasProperties'))]"
         }
     }
 }


### PR DESCRIPTION
This PR suggests the following two changes to the example ARM template for the `listAccountSas` resource function:

 * Renaming the `requestContent` parameter to `accountSasProperties` clarifies that the object is related specifically to the account SAS; the name `requestContent` isn't clear.
 * The `signedResourceType` property is not correct [as per the documentation for this API](https://docs.microsoft.com/en-us/rest/api/storagerp/storageaccounts/listaccountsas#request-body). I removed this and left the correct `signedResourceTypes` property in place.