### PR TITLE
New line fix

### DIFF
--- a/articles/application-insights/app-insights-monitor-web-app-availability.md
+++ b/articles/application-insights/app-insights-monitor-web-app-availability.md
@@ -211,6 +211,7 @@ The X out of Y locations alert rule is enabled by default in the [new unified al
 > [!NOTE]
 > * Configure the action groups to receive notifications when the alert triggers by following the steps above. Without this step, you will only receive in-portal notifications when the rule triggers.
 >
+
 ### Alert on availability metrics
 Using the [new unified alerts](https://docs.microsoft.com/azure/monitoring-and-diagnostics/monitoring-overview-unified-alerts), you can alert on segmented aggregate availability and test duration metrics as well:
 


### PR DESCRIPTION
The missing new line makes the page less nicer in app-insights-monitor-web-app-availability.md

"Alert on availability metrics" title is getting into the note well.

![image](https://user-images.githubusercontent.com/1004579/48076750-28eabc00-e1e6-11e8-84db-c509c3d8807d.png)
