### PR TITLE
Correct system key URL for v2 runtime

### DIFF
--- a/articles/azure-functions/functions-bindings-event-grid.md
+++ b/articles/azure-functions/functions-bindings-event-grid.md
@@ -355,6 +355,14 @@ For more information about how to create a subscription, see [the blob storage q
 
 You can get the system key by using the following API (HTTP GET):
 
+#### Version 2.x runtime
+
+```
+http://{functionappname}.azurewebsites.net/admin/host/systemkeys/eventgrid_extension?code={masterkey}
+```
+
+#### Version 1.x runtime
+
 ```
 http://{functionappname}.azurewebsites.net/admin/host/systemkeys/eventgridextensionconfig_extension?code={masterkey}
 ```


### PR DESCRIPTION
The URL for retrieving the Event Grid extension's system key changed with v2, but the doc contains only the v1 URL. This adds the new URL and distinguishes it from the old URL (which remains valid for v1).

Fixes #16189