### PR TITLE
typo: behand -> behind

### DIFF
--- a/articles/media-services/previous/media-services-build-smooth-streaming-apps.md
+++ b/articles/media-services/previous/media-services-build-smooth-streaming-apps.md
@@ -504,7 +504,7 @@ You have completed lesson 2.  In this lesson you added a slider to application.
 Smooth Streaming is capable to stream content with multiple language audio tracks that are selectable by the viewers.  In this lesson, you will enable viewers to select streams. This lesson contains the following procedures:
 
 1. Modify the XAML file
-2. Modify the code behand file
+2. Modify the code behind file
 3. Compile and test the application
 
 **To modify the XAML file**


### PR DESCRIPTION
FYI, looks like the typo made it to a bunch of the localized versions