### PR TITLE
Correct typo

### DIFF
--- a/articles/logic-apps/workflow-definition-language-functions-reference.md
+++ b/articles/logic-apps/workflow-definition-language-functions-reference.md
@@ -3550,7 +3550,7 @@ These examples get the specified number of
 items from the front of these collections:
 
 ```
-take('abcde`, 3)
+take('abcde', 3)
 take(createArray(0, 1, 2, 3, 4), 3)
 ```
 


### PR DESCRIPTION
````
take('abcde`, 3)
````
should be
````
take('abcde', 3)
````