### PR TITLE
Remove mention of read-only databases

### DIFF
--- a/articles/billing/billing-spending-limit.md
+++ b/articles/billing/billing-spending-limit.md
@@ -25,7 +25,7 @@ Spending limit in Azure exists to prevent spending over your credit amount. All 
 
 When your usage results in charges that exhaust the monthly amounts included with your subscription, the services that you deployed are disabled for the rest of that billing period. 
 
-For example, when you spend all the credit included with your subscription, Cloud Services that you deployed are removed from production and your Azure virtual machines are stopped and de-allocated. The data in your storage accounts and databases are available in a read-only manner.
+For example, when you spend all the credit included with your subscription, Cloud Services that you deployed are removed from production and your Azure virtual machines are stopped and de-allocated. The data in your storage accounts are available in a read-only manner.
 
 At the beginning of the next billing period, if your subscription offer includes credits over multiple months, your subscription would be re-enabled automatically. Then you can redeploy your Cloud Services and have full access to your storage accounts and databases.
 


### PR DESCRIPTION
Azure SQL DB Databases don't got into read-only mode when the spending limit is hit. They are disabled for login.