### PR TITLE
Update apiVersion of deployment

### DIFF
--- a/articles/aks/autoscaler.md
+++ b/articles/aks/autoscaler.md
@@ -228,7 +228,7 @@ subjects:
     namespace: kube-system
 
 ---
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Changed from extension/v1 to apps/v1.

When trying to deploy using extension/v1, I'm getting the following error:
error: unable to recognize "cluster_autoscaler.yaml": no matches for kind "Deployment" in version "extensions/v1"
