### PR TITLE
Updated PowerShell command with -AddResourceAccess

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-setup-aad.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-setup-aad.md
@@ -35,7 +35,7 @@ To simplify some of the steps involved in configuring Azure AD with a Service Fa
 4. Run `SetupApplications.ps1`, and provide the TenantId, ClusterName, and WebApplicationReplyUrl as parameters. For example:
 
 ```PowerShell
-.\SetupApplications.ps1 -TenantId '690ec069-8200-4068-9d01-5aaf188e557a' -ClusterName 'mycluster' -WebApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/Explorer/index.html'
+.\SetupApplications.ps1 -TenantId '690ec069-8200-4068-9d01-5aaf188e557a' -ClusterName 'mycluster' -WebApplicationReplyUrl 'https://mycluster.westus.cloudapp.azure.com:19080/Explorer/index.html' -AddResourceAccess
 ```
 
 > [!NOTE]


### PR DESCRIPTION
When these instructions are followed, the ServiceFabric fails to authenticate if the -AddResourceAccess switch parameter is omitted. The default guidance should include -AddResourceAccess.