### PR TITLE
metrics-store-custom-rest-api: JSON and URL fix

### DIFF
--- a/articles/monitoring-and-diagnostics/metrics-store-custom-rest-api.md
+++ b/articles/monitoring-and-diagnostics/metrics-store-custom-rest-api.md
@@ -45,7 +45,7 @@ Save the access token from the response.
     
     ```json
     { 
-        "time": "2018-09-13T16:34:20”, 
+        "time": "2018-09-13T16:34:20", 
         "data": { 
             "baseData": { 
                 "metric": "QueueDepth", 
@@ -77,7 +77,7 @@ Save the access token from the response.
     - **AccessToken**. Paste the token that you acquired previously.
 
     ```Shell 
-    curl -X POST curl -X POST https://<azureRegion>.monitoring.azure.com/<resourceId> /metrics -H "Content-Type: application/json" -H "Authorization: Bearer <AccessToken>" -d @custommetric.json 
+    curl -X POST curl -X POST https://<azureRegion>.monitoring.azure.com/<resourceId>/metrics -H "Content-Type: application/json" -H "Authorization: Bearer <AccessToken>" -d @custommetric.json 
     ```
 1. Change the timestamp and values in the JSON file. 
 1. Repeat the previous two steps a few times, so you have data for several minutes.


### PR DESCRIPTION
Fixed incorrect quote in the JSON sample.
Fixed /metrics URL by removing the extra space.