### PR TITLE
Fixing broken link to ARM

### DIFF
--- a/articles/load-balancer/load-balancer-outbound-connections.md
+++ b/articles/load-balancer/load-balancer-outbound-connections.md
@@ -31,7 +31,7 @@ There are multiple [outbound scenarios](#scenarios). You can combine these scena
 
 ## <a name="scenarios"></a>Scenario overview
 
-Azure Load Balancer and related resources are explicitly defined when you're using [Azure Resource Manager](#arm).  Azure currently provides three different methods to achieve outbound connectivity for Azure Resource Manager resources. 
+Azure Load Balancer and related resources are explicitly defined when you're using [Azure Resource Manager](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview).  Azure currently provides three different methods to achieve outbound connectivity for Azure Resource Manager resources. 
 
 | Scenario | Method | IP protocols | Description |
 | --- | --- | --- | --- |

--- a/articles/load-balancer/load-balancer-outbound-connections.md
+++ b/articles/load-balancer/load-balancer-outbound-connections.md
@@ -31,7 +31,7 @@ There are multiple [outbound scenarios](#scenarios). You can combine these scena
 
 ## <a name="scenarios"></a>Scenario overview
 
-Azure Load Balancer and related resources are explicitly defined when you're using [Azure Resource Manager](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview).  Azure currently provides three different methods to achieve outbound connectivity for Azure Resource Manager resources. 
+Azure Load Balancer and related resources are explicitly defined when you're using [Azure Resource Manager](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-overview).  Azure currently provides three different methods to achieve outbound connectivity for Azure Resource Manager resources. 
 
 | Scenario | Method | IP protocols | Description |
 | --- | --- | --- | --- |


### PR DESCRIPTION
There is no anchor link like `name="arm"` in this page, and yet this link refers to `#arm`. I also don't see a corollary anchor about Azure Resource Manager anywhere within this document, so I don't think it's a case of a misnamed link. It would appear that the most natural document that the link would intend to bring a reader to would be the ARM overview page, which is a totally separate page. At least, that's where I ended up going to when I was reading this page and wanted to know more about ARM.