### PR TITLE
Correct Incorrect Variable Name

### DIFF
--- a/includes/active-directory-develop-guidedsetup-javascriptspa-use.md
+++ b/includes/active-directory-develop-guidedsetup-javascriptspa-use.md
@@ -86,7 +86,7 @@ function acquireTokenRedirectCallBack(errorDesc, token, error, tokenType)
 {
  if(tokenType === "access_token")
  {
-     callMSGraph(applicationConfig.graphEndpoint, accessToken, graphAPICallback);
+     callMSGraph(applicationConfig.graphEndpoint, token, graphAPICallback);
  } else {
      console.log("token type is:"+tokenType);
  }


### PR DESCRIPTION
The acquireTokenRedirectCallBack function parameters include token, yet within the function the name accessToken was used.