### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-databricks/databricks-stream-from-eventhubs.md
+++ b/articles/azure-databricks/databricks-stream-from-eventhubs.md
@@ -363,7 +363,7 @@ After you have finished running the tutorial, you can terminate the cluster. To 
 
 ![Stop a Databricks cluster](./media/databricks-stream-from-eventhubs/terminate-databricks-cluster.png "Stop a Databricks cluster")
 
-If you do not manually terminate the cluster it will automatically stop, provided you selected the **Terminate after __ minutes of inactivity** checkbox while creating the cluster. In such a case, the cluster will automatically stop if it has been inactive for the specified time.
+If you do not manually terminate the cluster it will automatically stop, provided you selected the **Terminate after \_\_ minutes of inactivity** checkbox while creating the cluster. In such a case, the cluster will automatically stop if it has been inactive for the specified time.
 
 ## Next steps
 In this tutorial, you learned how to:


### PR DESCRIPTION
## Typo: `__` -> `\_\_`. Same as #18853.

In Markdown `__` is used for highlighting. To simply display `__`, we need escape `\_\_`.

Even without escaping, if we look at this page, it may seem that there is no problem.

https://docs.microsoft.com/en-us/azure/azure-databricks/databricks-stream-from-eventhubs

![evi1](https://user-images.githubusercontent.com/1207985/48521439-d7ae8c80-e8b7-11e8-9d7a-0e0e070683a2.jpg)

But, in the Japanese page, problems will arise as follows.

https://docs.microsoft.com/ja-jp/azure/azure/azure-databricks/databricks-stream-from-eventhubs

![evi2](https://user-images.githubusercontent.com/1207985/48521448-ded59a80-e8b7-11e8-93ec-04ea44a08e02.jpg)

I send a PR for the correction of the Japanese page at https://github.com/MicrosoftDocs/azure-docs.ja-jp/pull/816, but the label "Source Issue (= original text's issue)" It was pasted.
For that reason, I'm sending a PR to correct this original English page.