### PR TITLE
Updated the app scopping query

### DIFF
--- a/articles/log-analytics/log-analytics-cross-workspace-search.md
+++ b/articles/log-analytics/log-analytics-cross-workspace-search.md
@@ -122,7 +122,6 @@ applicationsScoping
 | where success == 'False'
 | parse SourceApp with * '(' applicationName ')' * 
 | summarize count() by applicationName, bin(timestamp, 1h) 
-| sort by count_ desc 
 | render timechart
 ```
 ![Timechart](media/log-analytics-cross-workspace-search/chart.png)


### PR DESCRIPTION
Removed the sort since it's not required when bin and timechart are used. I kept it from the time I looked at the results in table.