### PR TITLE
Update open IP address rule

### DIFF
--- a/articles/sql-database/sql-database-firewall-configure.md
+++ b/articles/sql-database/sql-database-firewall-configure.md
@@ -156,7 +156,7 @@ The following example sets a server-level firewall rule using PowerShell:
 ```powershell
 New-AzureRmSqlServerFirewallRule -ResourceGroupName "myResourceGroup" `
     -ServerName $servername `
-    -FirewallRuleName "AllowSome" -StartIpAddress "0.0.0.0" -EndIpAddress "0.0.0.0"
+    -FirewallRuleName "AllowSome" -StartIpAddress "0.0.0.0" -EndIpAddress "255.255.255.255"
 ```
 
 > [!TIP]


### PR DESCRIPTION
As Azure has a update about 'enable access to all the Azure serivces' which is equal to 0.0.0.0 starting IP and 0.0.0.0 as ending IP. So we cannot add this in the firewall rule as temporary testing purposes. 

The right way to open the server to all IP addresses is to set up a firewall rule using 0.0.0.0 as the starting IP address range and using 255.255.255.255 as the ending IP address range. Although, it is not recommended.

Ref doc url for my pull request:
https://docs.microsoft.com/en-us/azure/sql-database/sql-database-troubleshoot-common-connection-issues