### PR TITLE
Add Delve client application

### DIFF
--- a/articles/active-directory/conditional-access/technical-reference.md
+++ b/articles/active-directory/conditional-access/technical-reference.md
@@ -224,6 +224,7 @@ This setting applies to the following client apps:
 - Microsoft To-Do
 - Microsoft Stream
 - Microsoft Edge
+- Microsoft Delve
 
 
 


### PR DESCRIPTION
Hi 👋 from the team that owns Delve's mobile applications. As the application is controlled by the conditional access policy settings, it seems it's an omission from the documentation here. 