### PR TITLE
name change

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website.md
+++ b/articles/storage/blobs/storage-blob-static-website.md
@@ -105,7 +105,7 @@ Methods available for deploying content to a storage container include the follo
 
 - [AzCopy](../common/storage-use-azcopy.md)
 - [Storage Explorer](https://azure.microsoft.com/features/storage-explorer/)
-- [Visual Studio Team System](https://code.visualstudio.com/tutorials/static-website/deploy-VSTS)
+- [Azure Pipelines](https://code.visualstudio.com/tutorials/static-website/deploy-VSTS)
 - [Visual Studio Code extension](https://code.visualstudio.com/tutorials/static-website/getting-started)
 
 In all cases, make sure you copy files to the *$web* container.


### PR DESCRIPTION
"Visual Studio Team Services" is now "Azure DevOps". In this case, since it's a CI/CD scenario, we prefer the more specific "Azure Pipelines".