### PR TITLE
fixed cli error

### DIFF
--- a/articles/service-bus-messaging/service-bus-quickstart-cli.md
+++ b/articles/service-bus-messaging/service-bus-quickstart-cli.md
@@ -55,7 +55,7 @@ az servicebus queue create --resource-group myResourceGroup \
 # Get the connection string for the namespace
 connectionString=$(az servicebus namespace authorization-rule keys list \
    --resource-group myResourceGroup \
-   --namespace-name  $namespaceName \
+   --namespace-name $namespaceName \
    --name RootManageSharedAccessKey \
    --query primaryConnectionString --output tsv)
 ```


### PR DESCRIPTION
The cli for # Get the connection string for the namespace was failing due to double space when creating the connection string variable