### PR TITLE
Use h1 for heading

### DIFF
--- a/articles/active-directory/develop/GuidedSetups/active-directory-mobileanddesktopapp-windowsdesktop-configure-arp.md
+++ b/articles/active-directory/develop/GuidedSetups/active-directory-mobileanddesktopapp-windowsdesktop-configure-arp.md
@@ -19,7 +19,7 @@ ms.custom: aaddev
 
 ---
 
-## Add the application’s registration information to your app
+# Add the application’s registration information to your app
 In this step, you need to add the Application Id to your project.
 
 1.	Open `App.xaml.cs` and replace the line containing the `ClientId` with:


### PR DESCRIPTION
To be consistent with other articles on docs.microsoft.com, use h1 for heading text.