### PR TITLE
Added notes to help first connection to Bing Visual Search API

### DIFF
--- a/articles/cognitive-services/bing-visual-search/quickstarts/python.md
+++ b/articles/cognitive-services/bing-visual-search/quickstarts/python.md
@@ -35,9 +35,10 @@ This article includes a simple console application that sends a Bing Visual Sear
 You need [Python 3](https://www.python.org/) to run this code.
 
 For this quickstart, you may use a [free trial](https://azure.microsoft.com/try/cognitive-services/?api=bing-web-search-api) subscription key or a paid subscription key.
-notes: 
-- in Azure Portal, the API is found as BingSearchv7.
-- to use the visual search functionalities, choose S9 pricing tier (in Resources > BingSearchv7 > Resource Management > Pricing tier) 
+
+> [!Note]
+> In the Azure portal, the API is found as BingSearchv7.
+> To use the visual search functionality, choose **S9 pricing tier** under **Resources** > **BingSearchv7** > **Resource Management** > **Pricing tier**.  
 
 ## Running the walkthrough
 

--- a/articles/cognitive-services/bing-visual-search/quickstarts/python.md
+++ b/articles/cognitive-services/bing-visual-search/quickstarts/python.md
@@ -38,6 +38,7 @@ For this quickstart, you may use a [free trial](https://azure.microsoft.com/try/
 
 > [!Note]
 > In the Azure portal, the API is found as BingSearchv7.
+> 
 > To use the visual search functionality, choose **S9 pricing tier** under **Resources** > **BingSearchv7** > **Resource Management** > **Pricing tier**.  
 
 ## Running the walkthrough

--- a/articles/cognitive-services/bing-visual-search/quickstarts/python.md
+++ b/articles/cognitive-services/bing-visual-search/quickstarts/python.md
@@ -35,6 +35,9 @@ This article includes a simple console application that sends a Bing Visual Sear
 You need [Python 3](https://www.python.org/) to run this code.
 
 For this quickstart, you may use a [free trial](https://azure.microsoft.com/try/cognitive-services/?api=bing-web-search-api) subscription key or a paid subscription key.
+notes: 
+- in Azure Portal, the API is found as BingSearchv7.
+- to use the visual search functionalities, choose S9 pricing tier (in Resources > BingSearchv7 > Resource Management > Pricing tier) 
 
 ## Running the walkthrough
 


### PR DESCRIPTION
The proposed changes add 2 notes regarding:
- how to find the correct API in Azure Portal (the link provided in this page doesn't work in my case as it points to a web page that requires new free trial subscription...  installing the API from Azure Portal is simpler. Also, I was initially looking for an API called visual search and took me time to realize it was included in Bing Search v7 API)
- the pricing tier configuration change that is necessary to enable visualsearch.