### PR TITLE
Remove  dotnet restore

### DIFF
--- a/articles/app-service/containers/quickstart-dotnetcore.md
+++ b/articles/app-service/containers/quickstart-dotnetcore.md
@@ -61,7 +61,6 @@ Run the application locally so that you see how it should look when you deploy i
 Restore the NuGet packages and run the app.
 
 ```bash
-dotnet restore
 dotnet run
 ```
 


### PR DESCRIPTION
we don't need this command since donnet restore is alredy run  as part of Processing post-creation actions.