### PR TITLE
Fix typeHandlerVersion

### DIFF
--- a/articles/monitoring-and-diagnostics/metrics-store-custom-guestos-resource-manager-vm.md
+++ b/articles/monitoring-and-diagnostics/metrics-store-custom-guestos-resource-manager-vm.md
@@ -148,7 +148,7 @@ Add the following configuration to enable the Diagnostics extension on a Windows
             "properties": { 
             "publisher": "Microsoft.Azure.Diagnostics", 
             "type": "IaaSDiagnostics", 
-            "typeHandlerVersion": "1.4", 
+            "typeHandlerVersion": "1.12", 
             "autoUpgradeMinorVersion": true, 
             "settings": { 
                 "WadCfg": { 


### PR DESCRIPTION
Documentation states that the typeHandlerVersion needs to be at least 1.5. In the sample code on the page 1.4 is referenced and the Azure Monitor Sink is not supported in that version. Fixes #19376.