### PR TITLE
Update update-infrastructure-redhat.md

### DIFF
--- a/articles/virtual-machines/linux/update-infrastructure-redhat.md
+++ b/articles/virtual-machines/linux/update-infrastructure-redhat.md
@@ -131,12 +131,12 @@ This procedure is provided for reference only. RHEL PAYG images already have the
    
     - For RHEL 6:
         ```bash
-        curl -o azureclient.rpm https://rhui-1.microsoft.com/pulp/repos/microsoft-azure-rhel6/rhui-azure-rhel6-2.1-32.noarch.rpm 
+        curl -o azureclient.rpm https://rhui-1.microsoft.com/pulp/repos/microsoft-azure-rhel6/rhui-azure-rhel6-2.2-74.noarch.rpm
         ```
     
     - For RHEL 7:
         ```bash
-        curl -o azureclient.rpm https://rhui-1.microsoft.com/pulp/repos/microsoft-azure-rhel7/rhui-azure-rhel7-2.1-19.noarch.rpm  
+        curl -o azureclient.rpm https://rhui-1.microsoft.com/pulp/repos/microsoft-azure-rhel7/rhui-azure-rhel7-2.2-74.noarch.rpm 
         ```
 
    b. Verify.


### PR DESCRIPTION
The RHUI rpm certificates have changed and the new RPMs are available to fix the certificate expired errors.

I have proposed a change to the document.