### PR TITLE
Update deviceOwnership from Corporate to Company

### DIFF
--- a/articles/active-directory/users-groups-roles/groups-dynamic-membership.md
+++ b/articles/active-directory/users-groups-roles/groups-dynamic-membership.md
@@ -349,7 +349,7 @@ The following device attributes can be used.
  deviceCategory | a valid device category name | (device.deviceCategory -eq "BYOD")
  deviceManufacturer | any string value | (device.deviceManufacturer -eq "Samsung")
  deviceModel | any string value | (device.deviceModel -eq "iPad Air")
- deviceOwnership | Personal, Corporate, Unknown | (device.deviceOwnership -eq "Corporate")
+ deviceOwnership | Personal, Company, Unknown | (device.deviceOwnership -eq "Company")
  domainName | any string value | (device.domainName -eq "contoso.com")
  enrollmentProfileName | Apple Device Enrollment Profile or Windows Autopilot profile name | (device.enrollmentProfileName -eq "DEP iPhones")
  isRooted | true false | (device.isRooted -eq true)
@@ -357,6 +357,9 @@ The following device attributes can be used.
  deviceId | a valid Azure AD device ID | (device.deviceId -eq "d4fe7726-5966-431c-b3b8-cddc8fdb717d")
  objectId | a valid Azure AD object ID |  (device.objectId -eq 76ad43c9-32c5-45e8-a272-7b58b58f596d")
  systemLabels | any string matching the Intune device property for tagging Modern Workplace devices | (device.systemLabels -contains “M365Managed”)
+
+> [!Note]  
+> For the deviceOwnership when creating Dynamic Groups for devices you need to set the value equal to "Company". On Intune the device ownership is represented instead as Corporate. Refer to [OwnerTypes](https://docs.microsoft.com/en-us/intune/reports-ref-devices#ownertypes) for more details. 
 
 ## Next steps
 


### PR DESCRIPTION
The value "corporate" do not create any results for Dynamic groups in Azure AD, this value is applicable for Intune. 
The correct value for the group is "Company"