### PR TITLE
Fixing typo. Trace node is not self closing

### DIFF
--- a/articles/api-management/api-management-advanced-policies.md
+++ b/articles/api-management/api-management-advanced-policies.md
@@ -871,7 +871,7 @@ Note the use of [properties](api-management-howto-properties.md) as values of th
 
 ```xml
 
-<trace source="arbitrary string literal"/>
+<trace source="arbitrary string literal">
     <!-- string expression or literal -->
 </trace>
 


### PR DESCRIPTION
I tested this in APIM and found that the documented syntax is invalid.
 - An error is thrown if the end trace node is used with the self closing node *as documented*:
 `<trace source="arbitrary string literal"/>test</trace>`
 - An error is thrown if only the self closing node is used:
 `<trace source="arbitrary string literal"/>`

Based on my testing, trace only works without the extra slash:
`<trace source="arbitrary string literal">test</trace>`
This is my purposed fix.

As a side note, more examples might be helpful as well, such as a trace for a policy expression.
Thanks!
Tom