### PR TITLE
Add subscription-level ARM template

### DIFF
--- a/articles/governance/blueprints/overview.md
+++ b/articles/governance/blueprints/overview.md
@@ -80,7 +80,7 @@ as artifacts:
 |Resource  | Hierarchy options| Description  |
 |---------|---------|---------|
 |Resource Groups     | Subscription | Create a new resource group for use by other artifacts within the blueprint.  These placeholder resource groups enable you to organize resources exactly the way you want them structured and provides a scope limiter for included policy and role assignment artifacts and Azure Resource Manager templates.         |
-|Azure Resource Manager template      | Resource Group | Templates are used to compose complex environments. Example environments: a SharePoint farm, Azure Automation State Configuration, or a Log Analytics workspace. |
+|Azure Resource Manager template      | Subscription, Resource Group | Templates are used to compose complex environments. Example environments: a SharePoint farm, Azure Automation State Configuration, or a Log Analytics workspace. |
 |Policy Assignment     | Subscription, Resource Group | Allows assignment of a policy or initiative to the subscription the blueprint is assigned to. The policy or initiative must be within the scope of the blueprint (in the blueprint management group or below). If the policy or initiative has parameters, these parameters are assigned at creation of the blueprint or during blueprint assignment.       |
 |Role Assignment   | Subscription, Resource Group | Add an existing user or group to a built-in role to make sure the right people always have the right access to your resources. Role assignments can be defined for the entire subscription or nested to a specific resource group included in the blueprint. |
 


### PR DESCRIPTION
This PR updates the Azure Blueprints documentation to clarify that subscription-level ARM templates are supported in addition to resource group-level ARM templates.