### PR TITLE
New CLI command to list resource types

### DIFF
--- a/articles/azure-resource-manager/move-support-resources.md
+++ b/articles/azure-resource-manager/move-support-resources.md
@@ -31,7 +31,7 @@ Get-AzureRmResource -ResourceGroupName demogroup | Select Name, ResourceType | F
 For Azure CLI, use:
 
 ```azurecli-interactive
-az resource list -g demogroup --query '[].{name:name, reourcetype:type}'
+az resource list -g demogroup --query '[].{name:name, resourceType:type}' --output table
 ```
 
 The resource type is returned in the format `<resource-provider>/<resource-type-name>`. So, the value `Microsoft.OperationalInsights/workspaces` has a resource provider of **Microsoft.OperationalInsights** and resource type name of **workspaces**.


### PR DESCRIPTION
Previous command had a typo in the cosmetic name, and didn't specify tabular output.  The new command better matches the PowerShell equivalent above.