### PR TITLE
Small wording change

### DIFF
--- a/articles/postgresql/concepts-supported-versions.md
+++ b/articles/postgresql/concepts-supported-versions.md
@@ -25,7 +25,7 @@ Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/stat
 Refer to the [PostgreSQL documentation](https://www.postgresql.org/docs/9.5/static/release-9-5-14.html) to learn about improvements and fixes in this minor version.
 
 ## Managing updates and upgrades
-Azure Database for PostgreSQL automatically manages minor version patches. Currently, major version upgrade is not supported. For example, upgrading from PostgreSQL 9.5 to PostgreSQL 9.6 is not supported. If you would like to upgrade to the next major version, take a [dump and restore](./howto-migrate-using-dump-and-restore.md) it to a server that was created with the new engine version.
+Azure Database for PostgreSQL automatically manages minor version patches. Currently, major version upgrade is not supported. For example, upgrading from PostgreSQL 9.5 to PostgreSQL 9.6 is not supported. If you would like to upgrade to the next major version, create a database [dump and restore](./howto-migrate-using-dump-and-restore.md) it to a server that was created with the new engine version.
 
 ## Next steps
 For information about the support of different PostgreSQL extensions, see [PostgreSQL Extensions](concepts-extensions.md).


### PR DESCRIPTION
It was pointed out to me that "take a dump" should probably be phrased differently after I pasted it into an email.