### PR TITLE
Removing model import - new SDK change

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/python-tutorial.md
+++ b/articles/cognitive-services/Custom-Vision-Service/python-tutorial.md
@@ -115,7 +115,6 @@ To send an image to the prediction endpoint and retrieve the prediction, add the
 
 ```python
 from azure.cognitiveservices.vision.customvision.prediction import CustomVisionPredictionClient
-from azure.cognitiveservices.vision.customvision.prediction.prediction_endpoint import models
 
 # Now there is a trained endpoint that can be used to make a prediction
 


### PR DESCRIPTION
Removed import model "from azure.cognitiveservices.vision.customvision.prediction.prediction_endpoint import models". The new SDK change doesn't require this line and having this will break the code.