### PR TITLE
Rename old service name

### DIFF
--- a/articles/migrate/toc.yml
+++ b/articles/migrate/toc.yml
@@ -42,7 +42,7 @@
       href: contoso-migration-refactor-web-app-sql.md
     - name: 10. Contoso-Refactor a Linux app on Azure Web Apps and Azure MySQL
       href: contoso-migration-refactor-linux-app-service-mysql.md
-    - name: 11. Contoso-Migrate TFS to VSTS
+    - name: 11. Contoso-Migrate TFS to Azure DevOps Services
       href: contoso-migration-tfs-vsts.md
     - name: 12. Contoso-Rearchitect an app on Azure Containers and Azure SQL Database
       href: contoso-migration-rearchitect-container-sql.md


### PR DESCRIPTION
VSTS -> Azure DevOps Services

refs: https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/migrate/contoso-migration-tfs-vsts.md
`Contoso migration: Refactor a Team Foundation Server deployment to Azure DevOps Services`, for that reason, I unified it from the old service name to the new service name.