### PR TITLE
Fix typo

### DIFF
--- a/articles/storage/common/storage-redundancy-zrs.md
+++ b/articles/storage/common/storage-redundancy-zrs.md
@@ -76,7 +76,7 @@ You can request live migration through the [Azure Support portal](https://ms.por
     - **Problem Type**: Select **Data Migration**.
     - **Category**: Select **Migrate to ZRS within a region**.
     - **Title**: Type a descriptive title, for example, **ZRS account migration**.
-    - **Details**: Type additional details in the **Details** box, for example, I would like to migrate to ZRS from [LRS, GRS] in the ______ region. 
+    - **Details**: Type additional details in the **Details** box, for example, I would like to migrate to ZRS from [LRS, GRS] in the \_\_ region. 
 5. Select **Next**.
 6. Verify that the contact information is correct on the **Contact information** blade.
 7. Select **Create**.


### PR DESCRIPTION
Typo: `__` -> `\_\_`
In Markdown `__` is used for highlighting.
To simply display `__`, we need escape `\_\_`.

Even without escaping, if we look at this page , it may seem that there is no problem.

https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy-zrs#support-coverage-and-regional-availability

evi1: ![evi1](https://user-images.githubusercontent.com/1207985/49350715-6b26f080-f6f3-11e8-8803-a7bdba8f6eaf.jpg)

But, in the Japanese page, problems will arise as follows.

https://docs.microsoft.com/ja-jp/azure/storage/common/storage-redundancy-zrs#support-coverage-and-regional-availability

evi2: ![evi2](https://user-images.githubusercontent.com/1207985/49350731-7b3ed000-f6f3-11e8-8959-99199f6fa6dd.jpg)

`__` is not displayed and characters are qualified with italics.

For that reason, I'm sending a PR to correct this original English page. I will send PR to Japanese page if this PR accepts.