### PR TITLE
Fixing syntax error in Azure AD token sample

### DIFF
--- a/articles/sql-database/sql-database-aad-authentication-configure.md
+++ b/articles/sql-database/sql-database-aad-authentication-configure.md
@@ -345,7 +345,7 @@ Sample connection string:
 ```c#
 string ConnectionString =@"Data Source=n9lxnyuzhv.database.windows.net; Initial Catalog=testdb;"
 SqlConnection conn = new SqlConnection(ConnectionString);
-connection.AccessToken = "Your JWT token"
+conn.AccessToken = "Your JWT token"
 conn.Open();
 ```
 


### PR DESCRIPTION
Aligning the variable names within the Azure AD Token sample.