### PR TITLE
Update tutorial-manage-data-disk.md

### DIFF
--- a/articles/virtual-machines/windows/tutorial-manage-data-disk.md
+++ b/articles/virtual-machines/windows/tutorial-manage-data-disk.md
@@ -142,10 +142,10 @@ Once a disk has been attached to the virtual machine, the operating system needs
 Create an RDP connection with the virtual machine. Open up PowerShell and run this script.
 
 ```azurepowershell
-Get-Disk | Where partitionstyle -eq 'raw' | `
-Initialize-Disk -PartitionStyle MBR -PassThru | `
-New-Partition -AssignDriveLetter -UseMaximumSize | `
-Format-Volume -FileSystem NTFS -NewFileSystemLabel "myDataDisk" -Confirm:$false
+Get-Disk | Where partitionstyle -eq 'raw' |
+    Initialize-Disk -PartitionStyle MBR -PassThru |
+    New-Partition -AssignDriveLetter -UseMaximumSize |
+    Format-Volume -FileSystem NTFS -NewFileSystemLabel "myDataDisk" -Confirm:$false
 ```
 
 ## Verify the data disk


### PR DESCRIPTION
Cleaned up example for manually configuring a raw disk in a VM by removing backticks, as they are unnecessary in this scenario due to the pipe operator providing natural line continuation.