### PR TITLE
Update azure-stack-node-actions.md

### DIFF
--- a/articles/azure-stack/azure-stack-node-actions.md
+++ b/articles/azure-stack/azure-stack-node-actions.md
@@ -145,9 +145,9 @@ When you run the repair action, you need to specify the BMC IP address.
 To run the repair action through PowerShell:
 
   ````PowerShell
-  Repair-AzsScaleUnitNode -Location <RegionName> -Name <NodeName> -BMCIPAddress <BMCIPAddress>
+  Repair-AzsScaleUnitNode -Location <RegionName> -Name <NodeName> -BMCIPv4Address <BMCIPv4Address>
   ````
 
 ## Next steps
 
-To learn more about the Azure Stack Fabric administrator module, see [Azs.Fabric.Admin](https://docs.microsoft.com/powershell/module/azs.fabric.admin/?view=azurestackps-1.4.0).
+To learn more about the Azure Stack Fabric administrator module, see [Azs.Fabric.Admin](https://docs.microsoft.com/powershell/module/azs.fabric.admin/?view=azurestackps-1.5.0).


### PR DESCRIPTION
Correct parameter on Repair-AzsScaleUnitNode: BMCIPv4Address instead of BMCIPAddress.
Update link to additional documentation to point to current version: 1.5.0 instead of 1.4.0.