### PR TITLE
Link for Azure Devops Services is broken

### DIFF
--- a/includes/virtual-machines-common-infrastructure-automation.md
+++ b/includes/virtual-machines-common-infrastructure-automation.md
@@ -17,7 +17,7 @@ To create and manage Azure virtual machines (VMs) in a consistent manner at scal
     - [Azure Automation](#azure-automation) can perform actions across your Azure and on-premises infrastructure.
 
 - Automate application deployment and delivery
-    - Examples include [Azure DevOps Services](#visual-studio-team-services) and [Jenkins](#jenkins).
+    - Examples include [Azure DevOps Services](#azure-devops-services) and [Jenkins](#jenkins).
 
 ## Ansible
 [Ansible](https://www.ansible.com/) is an automation engine for configuration management, VM creation, or application deployment. Ansible uses an agent-less model, typically with SSH keys, to authenticate and manage target machines. Configuration tasks are defined in playbooks, with a number of Ansible modules available to carry out specific tasks. For more information, see [How Ansible works](https://www.ansible.com/how-ansible-works).


### PR DESCRIPTION
Azure Devops Services link is pointing to
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/infrastructure-automation#visual-studio-team-services
Instead it should point to
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/infrastructure-automation#azure-devops-services