### PR TITLE
Fix dead link

### DIFF
--- a/articles/lab-services/devtest-lab-integrate-ci-cd-vsts.md
+++ b/articles/lab-services/devtest-lab-integrate-ci-cd-vsts.md
@@ -134,7 +134,7 @@ The next stage of the deployment is to create the VM to use as the "golden image
 1. In the release pipeline, select **Add tasks** and then, on the **Deploy** tab, add an *Azure PowerShell* task. Configure the task as follows:
 
    > [!NOTE]
-   > To collect the details of the DevTest Labs VM, see [Deploy: Azure PowerShell](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzurePowerShell) and execute the script.
+   > To collect the details of the DevTest Labs VM, see [Deploy: Azure PowerShell](https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShellV3) and execute the script.
 
    a. For **Azure Connection Type**, select **Azure Resource Manager**.
 


### PR DESCRIPTION
`https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzurePowerShell` redirects to `https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShell`.
But `https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShell` does not exist(404).
URLs close to `https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShell` are `https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShellV2` and `https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShellV3`.
I fix it to `https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/AzurePowerShellV3` because I thought that the latest one would be preferable.