### PR TITLE
Rename old service name

### DIFF
--- a/articles/logic-apps/logic-apps-create-deploy-template.md
+++ b/articles/logic-apps/logic-apps-create-deploy-template.md
@@ -201,7 +201,7 @@ Name your logic app, and choose **Add**.
 ## Deploy a logic app template
 
 You can deploy your template by using any tools like PowerShell,
-REST API, [Azure DevOps Release Management](#team-services),
+REST API, [Azure DevOps Azure Pipelines](#team-services),
 and template deployment through the Azure portal.
 Also, to store the values for parameters,
 we recommend that you create a
@@ -220,12 +220,12 @@ There's an example script on GitHub under the
 [LogicAppConnectionAuth](https://github.com/logicappsio/LogicAppConnectionAuth) project.
 
 <a name="team-services"></a>
-## Azure DevOps Release Management
+## Azure DevOps Azure Pipelines
 
-A common scenario for deploying and managing an environment is to use a tool like Release Management in Azure DevOps,
+A common scenario for deploying and managing an environment is to use a tool like Azure Pipelines in Azure DevOps,
 with a logic app deployment template. Azure DevOps includes a [Deploy Azure Resource Group](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/DeployAzureResourceGroup) task that you can add to any build or release pipeline. You need to have a [service principal](https://blogs.msdn.microsoft.com/visualstudioalm/2015/10/04/automating-azure-resource-group-deployment-using-a-service-principal-in-visual-studio-online-buildrelease-management/) for authorization to deploy, and then you can generate the release pipeline.
 
-1. In Release Management, select **Empty** so that you create an empty pipeline.
+1. In Azure Pipelines, select **Empty** so that you create an empty pipeline.
 
     ![Create empty pipeline][1]
 


### PR DESCRIPTION
Release Management -> Azure Pipelines

When Visual Studio Team Services(VSTS) was renamed to Azure DevOps, the tool called Release Management is gone.
The element of Release Management is replaced by Azure Pipelines.