### PR TITLE
typo: Double word "Azure"

### DIFF
--- a/articles/active-directory/fundamentals/active-directory-architecture.md
+++ b/articles/active-directory/fundamentals/active-directory-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: What is the Azure Active Directory architecture? | Microsoft Docs
-description: Learn what an Azure Active Directory tenant is and how to manage Azure through Azure Azure Active Directory.
+description: Learn what an Azure Active Directory tenant is and how to manage Azure through Azure Active Directory.
 services: active-directory
 author: eross-msft
 manager: mtillman

--- a/articles/azure-cache-for-redis/scripts/cache-keys-ports.md
+++ b/articles/azure-cache-for-redis/scripts/cache-keys-ports.md
@@ -26,7 +26,7 @@ In this scenario, you learn how to retrieve the hostname, ports, and keys used t
 
 ## Sample script
 
-[!code-azurecli[main](../../../cli_scripts/redis-cache/cache-keys-ports/cache-keys-ports.sh "Azure Azure Cache for Redis")]
+[!code-azurecli[main](../../../cli_scripts/redis-cache/cache-keys-ports/cache-keys-ports.sh "Azure Cache for Redis")]
 
 
 ## Script explanation

--- a/articles/azure-cache-for-redis/scripts/create-cache.md
+++ b/articles/azure-cache-for-redis/scripts/create-cache.md
@@ -26,7 +26,7 @@ In this scenario, you learn how to create an Azure Cache for Redis.
 
 ## Sample script
 
-[!code-azurecli[main](../../../cli_scripts/redis-cache/create-cache/create-cache.sh "Azure Azure Cache for Redis")]
+[!code-azurecli[main](../../../cli_scripts/redis-cache/create-cache/create-cache.sh "Azure Cache for Redis")]
 
 [!INCLUDE [cli-script-clean-up](../../../includes/redis-cli-script-clean-up.md)]
 

--- a/articles/azure-cache-for-redis/scripts/create-premium-cache-cluster.md
+++ b/articles/azure-cache-for-redis/scripts/create-premium-cache-cluster.md
@@ -26,7 +26,7 @@ In this scenario, you learn how to create a 6 GB Premium tier Azure Cache for Re
 
 ## Sample script
 
-[!code-azurecli[main](../../../cli_scripts/redis-cache/create-premium-cache-cluster/create-premium-cache-cluster.sh "Azure Azure Cache for Redis")]
+[!code-azurecli[main](../../../cli_scripts/redis-cache/create-premium-cache-cluster/create-premium-cache-cluster.sh "Azure Cache for Redis")]
 
 [!INCLUDE [cli-script-clean-up](../../../includes/redis-cli-script-clean-up.md)]
 

--- a/articles/azure-cache-for-redis/scripts/delete-cache.md
+++ b/articles/azure-cache-for-redis/scripts/delete-cache.md
@@ -26,7 +26,7 @@ In this scenario, you learn how to delete an Azure Cache for Redis.
 
 ## Sample script
 
-[!code-azurecli[main](../../../cli_scripts/redis-cache/delete-cache/delete-cache.sh "Azure Azure Cache for Redis")]
+[!code-azurecli[main](../../../cli_scripts/redis-cache/delete-cache/delete-cache.sh "Azure Cache for Redis")]
 
 [!INCLUDE [cli-script-clean-up](../../../includes/redis-cli-script-clean-up.md)]
 

--- a/articles/azure-cache-for-redis/scripts/show-cache.md
+++ b/articles/azure-cache-for-redis/scripts/show-cache.md
@@ -26,7 +26,7 @@ In this scenario, you learn how to retrieve the details of an Azure Cache for Re
 
 ## Sample script
 
-[!code-azurecli[main](../../../cli_scripts/redis-cache/show-cache/show-cache.sh "Azure Azure Cache for Redis")]
+[!code-azurecli[main](../../../cli_scripts/redis-cache/show-cache/show-cache.sh "Azure Cache for Redis")]
 
 ## Script explanation
 

--- a/includes/cache-deploy-parameters.md
+++ b/includes/cache-deploy-parameters.md
@@ -7,7 +7,7 @@ ms.author: wesmc
 ---
 
 ### cacheSKUName
-The pricing tier of the new Azure Azure Cache for Redis.
+The pricing tier of the new Azure Cache for Redis.
 
     "cacheSKUName": {
       "type": "string",
@@ -17,7 +17,7 @@ The pricing tier of the new Azure Azure Cache for Redis.
       ],
       "defaultValue": "Basic",
       "metadata": {
-        "description": "The pricing tier of the new Azure Azure Cache for Redis."
+        "description": "The pricing tier of the new Azure Cache for Redis."
       }
     },
 
@@ -40,7 +40,7 @@ The family for the sku.
 
 
 ### cacheSKUCapacity
-The size of the new Azure Azure Cache for Redis instance. 
+The size of the new Azure Cache for Redis instance. 
 
     "cacheSKUCapacity": {
       "type": "int",
@@ -55,7 +55,7 @@ The size of the new Azure Azure Cache for Redis instance.
       ],
       "defaultValue": 0,
       "metadata": {
-        "description": "The size of the new Azure Azure Cache for Redis instance. "
+        "description": "The size of the new Azure Cache for Redis instance. "
       }
     }
 

--- a/includes/redis-cache-access-keys.md
+++ b/includes/redis-cache-access-keys.md
@@ -12,15 +12,15 @@ ms.custom: "include file"
 
 ### Retrieve host name, ports, and access keys by using the Azure portal
 
-When connecting to an Azure Azure Cache for Redis instance, cache clients need the host name, ports, and a key for the cache. Some clients might refer to these items by slightly different names. You can retrieve this information in the Azure portal.
+When connecting to an Azure Cache for Redis instance, cache clients need the host name, ports, and a key for the cache. Some clients might refer to these items by slightly different names. You can retrieve this information in the Azure portal.
 
 #### To retrieve the access keys and host name
 
 1. To retrieve the access keys by using the [Azure portal](https://portal.azure.com), browse to your cache and select **Access keys**. 
 
-    ![Azure Azure Cache for Redis keys](media/redis-cache-access-keys/redis-cache-keys.png)
+    ![Azure Cache for Redis keys](media/redis-cache-access-keys/redis-cache-keys.png)
 
 2. To retrieve the host name and ports, select **Properties**.
 
-    ![Azure Azure Cache for Redis properties](media/redis-cache-access-keys/redis-cache-hostname-ports.png)
+    ![Azure Cache for Redis properties](media/redis-cache-access-keys/redis-cache-hostname-ports.png)
 

--- a/includes/redis-cache-access-keys_cli.md
+++ b/includes/redis-cache-access-keys_cli.md
@@ -20,10 +20,10 @@ To retrieve the host name and ports using the Azure CLI you can call [az redis s
 
 # Retrieve the hostname, ports, and keys for contosoCache located in contosoGroup
 
-# Retrieve the hostname and ports for an Azure Azure Cache for Redis instance
+# Retrieve the hostname and ports for an Azure Cache for Redis instance
 redis=($(az redis show --name contosoCache --resource-group contosoGroup --query [hostName,enableNonSslPort,port,sslPort] --output tsv))
 
-# Retrieve the keys for an Azure Azure Cache for Redis instance
+# Retrieve the keys for an Azure Cache for Redis instance
 keys=($(az redis list-keys --name contosoCache --resource-group contosoGroup --query [primaryKey,secondaryKey] --output tsv))
 
 # Display the retrieved hostname, keys, and ports
@@ -35,4 +35,4 @@ echo "Primary Key:" ${keys[0]}
 echo "Secondary Key:" ${keys[1]}
 ```
 
-For more information about this script, see [Get the hostname, ports, and keys for Azure Azure Cache for Redis](../articles/azure-cache-for-redis/scripts/cache-keys-ports.md). For more information on Azure CLI see [Install Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) and [Get started with Azure CLI](https://docs.microsoft.com/cli/azure/get-started-with-azure-cli).
+For more information about this script, see [Get the hostname, ports, and keys for Azure Cache for Redis](../articles/azure-cache-for-redis/scripts/cache-keys-ports.md). For more information on Azure CLI see [Install Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) and [Get started with Azure CLI](https://docs.microsoft.com/cli/azure/get-started-with-azure-cli).

--- a/includes/redis-cache-browse.md
+++ b/includes/redis-cache-browse.md
@@ -12,13 +12,13 @@ ms.custom: "include file"
 
 If you did not pin your cache to the dashboard, find your cache in the [Azure portal](https://portal.azure.com) using **All services**.
 
-![Azure Azure Cache for Redis Browse Blade](media/redis-cache-browse/redis-cache-browse.png)
+![Azure Cache for Redis Browse Blade](media/redis-cache-browse/redis-cache-browse.png)
 
-To view your caches, click **All services** and search for **Azure Cache for Rediss**. 
+To view your caches, click **All services** and search for **Azure Cache for Redis**. 
 
 Select the desired cache to view and configure the settings for that cache.
 
-![Azure Azure Cache for Redis Browse Cache List](media/redis-cache-browse/redis-caches.png)
+![Azure Cache for Redis Browse Cache List](media/redis-cache-browse/redis-caches.png)
 
 You can view and configure your cache from the **Azure Cache for Redis** blade.
 

--- a/includes/redis-cache-configure-stackexchange-redis-nuget.md
+++ b/includes/redis-cache-configure-stackexchange-redis-nuget.md
@@ -25,7 +25,7 @@ Type **StackExchange.Redis** or **StackExchange.Redis.StrongName** into the sear
 
 ![StackExchange.Redis NuGet package](media/redis-cache-configure-stackexchange-redis-nuget/redis-cache-stackexchange-redis.png)
 
-The NuGet package downloads and adds the required assembly references for your client application to access Azure Azure Cache for Redis with the StackExchange.Azure Cache for Redis client.
+The NuGet package downloads and adds the required assembly references for your client application to access Azure Cache for Redis with the StackExchange.Azure Cache for Redis client.
 
 > [!NOTE]
 > If you have previously configured your project to use StackExchange.Redis, you can check for updates to the package from the **NuGet Package Manager**. To check for and install updated versions of the StackExchange.Redis NuGet package, click **Updates** in the **NuGet Package Manager** window. If an update to the StackExchange.Redis NuGet package is available, you can update your project to use the updated version.

--- a/includes/redis-cache-create.md
+++ b/includes/redis-cache-create.md
@@ -20,10 +20,10 @@ ms.custom: "include file"
     | Setting      | Suggested value  | Description |
     | ------------ |  ------- | -------------------------------------------------- |
     | **DNS name** | Globally unique name | The cache name. It must be a string between 1 and 63 characters and contain only numbers, letters, and the `-` character. The cache name cannot start or end with the `-` character, and consecutive `-` characters are not valid.  | 
-    | **Subscription** | Your subscription | The subscription under which this new Azure Azure Cache for Redis instance is created. | 
+    | **Subscription** | Your subscription | The subscription under which this new Azure Cache for Redis instance is created. | 
     | **Resource group** |  *TestResources* | Name for the new resource group in which to create your cache. By putting all the resources for an app in a group, you can manage them together. For example, deleting the resource group deletes all resources that are associated with the app. | 
     | **Location** | East US | Choose a [region](https://azure.microsoft.com/regions/) near to other services that will use your cache. |
-    | **[Pricing tier](https://azure.microsoft.com/pricing/details/cache/)** |  Basic C0 (250 MB Cache) |  The pricing tier determines the size, performance, and features that are available for the cache. For more information, see [Azure Azure Cache for Redis Overview](../articles/azure-cache-for-redis/cache-overview.md). |
+    | **[Pricing tier](https://azure.microsoft.com/pricing/details/cache/)** |  Basic C0 (250 MB Cache) |  The pricing tier determines the size, performance, and features that are available for the cache. For more information, see [Azure Cache for Redis Overview](../articles/azure-cache-for-redis/cache-overview.md). |
     | **Pin to dashboard** |  Selected | Pin the new cache to your dashboard to make    it easy to find. |
 
     ![Create cache](media/redis-cache-create/redis-cache-cache-create.png) 

--- a/includes/redis-cache-premium-create.md
+++ b/includes/redis-cache-premium-create.md
@@ -10,7 +10,7 @@ To create a premium cache, sign in to the [Azure portal](https://portal.azure.co
 ![Create cache](media/redis-cache-premium-create/redis-cache-new-cache-menu.png)
 
 > [!NOTE]
-> In addition to creating caches in the Azure portal, you can also create them using Resource Manager templates, PowerShell, or Azure CLI. For more information about creating an Azure Azure Cache for Redis, see [Create a cache](../articles/azure-cache-for-redis/cache-dotnet-how-to-use-azure-redis-cache.md#create-a-cache).
+> In addition to creating caches in the Azure portal, you can also create them using Resource Manager templates, PowerShell, or Azure CLI. For more information about creating an Azure Cache for Redis, see [Create a cache](../articles/azure-cache-for-redis/cache-dotnet-how-to-use-azure-redis-cache.md#create-a-cache).
 > 
 > 
 

--- a/includes/redis-cache-service-limits.md
+++ b/includes/redis-cache-service-limits.md
@@ -13,9 +13,9 @@ ms.author: wesmc
 | Azure Cache for Redis replicas (for high availability) |1 |
 | Shards in a premium cache with clustering |10 |
 
-Azure Azure Cache for Redis limits and sizes are different for each pricing tier. To see the pricing tiers and their associated sizes, see [Azure Azure Cache for Redis Pricing](https://azure.microsoft.com/pricing/details/cache/).
+Azure Cache for Redis limits and sizes are different for each pricing tier. To see the pricing tiers and their associated sizes, see [Azure Cache for Redis Pricing](https://azure.microsoft.com/pricing/details/cache/).
 
-For more information on Azure Azure Cache for Redis configuration limits, see [Default Redis server configuration](../articles/azure-cache-for-redis/cache-configure.md#default-redis-server-configuration).
+For more information on Azure Cache for Redis configuration limits, see [Default Redis server configuration](../articles/azure-cache-for-redis/cache-configure.md#default-redis-server-configuration).
 
-Because configuration and management of Azure Azure Cache for Redis instances is done by Microsoft, not all Redis commands are supported in Azure Azure Cache for Redis. For more information, see [Redis commands not supported in Azure Azure Cache for Redis](../articles/azure-cache-for-redis/cache-configure.md#redis-commands-not-supported-in-azure-cache-for-redis).
+Because configuration and management of Azure Cache for Redis instances is done by Microsoft, not all Redis commands are supported in Azure Cache for Redis. For more information, see [Redis commands not supported in Azure Cache for Redis](../articles/azure-cache-for-redis/cache-configure.md#redis-commands-not-supported-in-azure-cache-for-redis).
 

--- a/includes/redis-cli-script-clean-up.md
+++ b/includes/redis-cli-script-clean-up.md
@@ -7,7 +7,7 @@ ms.author: wesmc
 ---
 ## Clean up deployment 
 
-After the script sample has been run, the follow command can be used to remove the resource group, Azure Azure Cache for Redis instance, and any related resources in the resource group.
+After the script sample has been run, the follow command can be used to remove the resource group, Azure Cache for Redis instance, and any related resources in the resource group.
 
 ```azurecli
 az group delete --name contosoGroup


### PR DESCRIPTION
The product page doesn't seem to call it "Azure Azure Cache for Redis"