### PR TITLE
Update template-uri for the linux version

### DIFF
--- a/articles/service-fabric-mesh/service-fabric-mesh-quickstart-deploy-container.md
+++ b/articles/service-fabric-mesh/service-fabric-mesh-quickstart-deploy-container.md
@@ -47,7 +47,7 @@ Create your application in the resource group using the `az mesh deployment crea
 az mesh deployment create --resource-group myResourceGroup --template-uri https://raw.githubusercontent.com/Azure-Samples/service-fabric-mesh/master/templates/helloworld/helloworld.linux.json --parameters "{'location': {'value': 'eastus'}}" 
 ```
 
-The preceding command deploys a Linux application using [mesh_rp.linux.json template](https://sfmeshsamples.blob.core.windows.net/templates/helloworld/mesh_rp.linux.json). If you want to deploy a Windows application, use [mesh_rp.windows.json template](https://sfmeshsamples.blob.core.windows.net/templates/helloworld/mesh_rp.windows.json). Windows container images are larger than Linux container images and may take more time to deploy.
+The preceding command deploys a Linux application using [linux.json template](https://raw.githubusercontent.com/Azure-Samples/service-fabric-mesh/master/templates/helloworld/helloworld.linux.json). If you want to deploy a Windows application, use [windows.json template](https://raw.githubusercontent.com/Azure-Samples/service-fabric-mesh/master/templates/helloworld/helloworld.windows.json). Windows container images are larger than Linux container images and may take more time to deploy.
 
 This command will produce a JSON snippet that is shown below. Under the ```outputs``` section of the JSON output, copy the ```publicIPAddress``` property.
 

--- a/articles/service-fabric-mesh/service-fabric-mesh-quickstart-deploy-container.md
+++ b/articles/service-fabric-mesh/service-fabric-mesh-quickstart-deploy-container.md
@@ -44,7 +44,7 @@ az group create --name myResourceGroup --location eastus
 Create your application in the resource group using the `az mesh deployment create` command.  Run the following:
 
 ```azurecli-interactive
-az mesh deployment create --resource-group myResourceGroup --template-uri https://raw.githubusercontent.com/Azure-Samples/service-fabric-mesh/master/templates/helloworld/mesh_rp.linux.json --parameters "{'location': {'value': 'eastus'}}" 
+az mesh deployment create --resource-group myResourceGroup --template-uri https://raw.githubusercontent.com/Azure-Samples/service-fabric-mesh/master/templates/helloworld/helloworld.linux.json --parameters "{'location': {'value': 'eastus'}}" 
 ```
 
 The preceding command deploys a Linux application using [mesh_rp.linux.json template](https://sfmeshsamples.blob.core.windows.net/templates/helloworld/mesh_rp.linux.json). If you want to deploy a Windows application, use [mesh_rp.windows.json template](https://sfmeshsamples.blob.core.windows.net/templates/helloworld/mesh_rp.windows.json). Windows container images are larger than Linux container images and may take more time to deploy.


### PR DESCRIPTION
The template link changed on Azure samples Github repo, so we have to update it.
https://github.com/Azure-Samples/service-fabric-mesh/blob/master/templates/helloworld/helloworld.linux.json