### PR TITLE
PowerShell prefix removed

### DIFF
--- a/articles/active-directory/users-groups-roles/groups-settings-cmdlets.md
+++ b/articles/active-directory/users-groups-roles/groups-settings-cmdlets.md
@@ -42,7 +42,7 @@ These steps create settings at directory level, which apply to all Office 365 gr
 1. In the DirectorySettings cmdlets, you must specify the ID of the SettingsTemplate you want to use. If you do not know this ID, this cmdlet returns the list of all settings templates:
   
   ```powershell
-  PS C:> Get-AzureADDirectorySettingTemplate
+  Get-AzureADDirectorySettingTemplate
   ```
   This cmdlet call returns all templates that are available:
   


### PR DESCRIPTION
Removed PowerShell command line prefix to copy the shown cmdlet properly.