### PR TITLE
Streaming not .NET logs to blob storage

### DIFF
--- a/articles/app-service/web-sites-enable-diagnostic-log.md
+++ b/articles/app-service/web-sites-enable-diagnostic-log.md
@@ -59,6 +59,11 @@ When you enable **application diagnostics**, you also choose the **Level**. This
 
 For **Application logging**, you can turn on the file system option temporarily for debugging purposes. This option turns off automatically in 12 hours. You can also turn on the blob storage option to select a blob container to write logs to.
 
+> [!NOTE]
+> Currently only .NET application logs can be written to the blob storage. Java, PHP, Node.js, Python application logs can only be stored on the file system (without code modifications to write logs to external storage).
+>
+>
+
 For **Web server logging**, you can select **storage** or **file system**. Selecting **storage** allows you to select a storage account, and then a blob container that the logs are written to. 
 
 If you store logs on the file system, the files can be accessed by FTP, or downloaded as a Zip archive by using Azure CLI.


### PR DESCRIPTION
I think it should be explicitly mentioned in the documentation that log streaming from app service container to blob storage works only for C# applications.
I've spent quite a lot of a time trying different configurations to stream webapp logs to storage account before found out (with the help of the Azure support) that it is impossible for java application (and works only for .NET apps).