### PR TITLE
Fix typo & delete unnecessary space

### DIFF
--- a/articles/api-management/api-management-policy-expressions.md
+++ b/articles/api-management/api-management-policy-expressions.md
@@ -17,181 +17,181 @@ ms.date: 11/28/2017
 ms.author: apimpm
 ---
 # API Management policy expressions
-This article discusses policy expressions syntax is C# 7. Each expression has access to the implicitly provided [context](api-management-policy-expressions.md#ContextVariables) variable and an allowed [subset](api-management-policy-expressions.md#CLRTypes) of .NET Framework types.  
+This article discusses policy expressions syntax is C# 7. Each expression has access to the implicitly provided [context](api-management-policy-expressions.md#ContextVariables) variable and an allowed [subset](api-management-policy-expressions.md#CLRTypes) of .NET Framework types.
 
 For more information:
 
 - See how to supply context information to your backend service. Use the [Set query string parameter](api-management-transformation-policies.md#SetQueryStringParameter) and [Set HTTP header](api-management-transformation-policies.md#SetHTTPheader) policies to supply this information.
-- See how to use the [Validate JWT](api-management-access-restriction-policies.md#ValidateJWT) policy to pre-authorize access to operations based on token claims.   
-- See how to use an [API Inspector](https://azure.microsoft.com/documentation/articles/api-management-howto-api-inspector/) trace to see how policies are evaluated and the results of those evaluations.  
-- See how to use expressions with the [Get from cache](api-management-caching-policies.md#GetFromCache) and [Store to cache](api-management-caching-policies.md#StoreToCache) policies to configure API Management response caching. Set a duration that matches the response caching of the backend service as specified by the backed service's `Cache-Control` directive.  
-- See how to perform content filtering. Remove data elements from the response received from the backend using the [Control flow](api-management-advanced-policies.md#choose) and [Set body](api-management-transformation-policies.md#SetBody) policies. 
-- To download the policy statements, see the [api-management-samples/policies](https://github.com/Azure/api-management-samples/tree/master/policies) github repo.  
+- See how to use the [Validate JWT](api-management-access-restriction-policies.md#ValidateJWT) policy to pre-authorize access to operations based on token claims.
+- See how to use an [API Inspector](https://azure.microsoft.com/documentation/articles/api-management-howto-api-inspector/) trace to see how policies are evaluated and the results of those evaluations.
+- See how to use expressions with the [Get from cache](api-management-caching-policies.md#GetFromCache) and [Store to cache](api-management-caching-policies.md#StoreToCache) policies to configure API Management response caching. Set a duration that matches the response caching of the backend service as specified by the backed service's `Cache-Control` directive.
+- See how to perform content filtering. Remove data elements from the response received from the backend using the [Control flow](api-management-advanced-policies.md#choose) and [Set body](api-management-transformation-policies.md#SetBody) policies.
+- To download the policy statements, see the [api-management-samples/policies](https://github.com/Azure/api-management-samples/tree/master/policies) GitHub repo.
   
   
-##  <a name="Syntax"></a> Syntax  
- Single statement expressions are enclosed in `@(expression)`, where `expression` is a well-formed C# expression statement.  
+## <a name="Syntax"></a> Syntax
+Single statement expressions are enclosed in `@(expression)`, where `expression` is a well-formed C# expression statement.
   
- Multi-statement expressions are enclosed in `@{expression}`. All code paths within multi-statement expressions must end with a `return` statement.  
+Multi-statement expressions are enclosed in `@{expression}`. All code paths within multi-statement expressions must end with a `return` statement.
   
-##  <a name="PolicyExpressionsExamples"></a> Examples  
+## <a name="PolicyExpressionsExamples"></a> Examples
   
-```  
-@(true)  
+```
+@(true)
+
+@((1+1).ToString())
+
+@("Hi There".Length)
+
+@(Regex.Match(context.Response.Headers.GetValueOrDefault("Cache-Control",""), @"max-age=(?<maxAge>\d+)").Groups["maxAge"]?.Value)
+
+@(context.Variables.ContainsKey("maxAge") ? int.Parse((string)context.Variables["maxAge"]) : 3600)
+
+@{
+  string value;
+  if (context.Request.Headers.TryGetValue("Authorization", out value))
+  {
+    return Encoding.UTF8.GetString(Convert.FromBase64String(value));
+  }
+  else
+  {
+    return null;
+  }
+}
+```
   
-@((1+1).ToString())  
-  
-@("Hi There".Length)  
-  
-@(Regex.Match(context.Response.Headers.GetValueOrDefault("Cache-Control",""), @"max-age=(?<maxAge>\d+)").Groups["maxAge"]?.Value)  
-  
-@(context.Variables.ContainsKey("maxAge") ? int.Parse((string)context.Variables["maxAge"]) : 3600)  
-  
-@{   
-  string value;   
-  if (context.Request.Headers.TryGetValue("Authorization", out value))   
-  {   
-    return Encoding.UTF8.GetString(Convert.FromBase64String(value));  
-  }   
-  else   
-  {   
-    return null;  
-  }  
-}  
-```  
-  
-##  <a name="PolicyExpressionsUsage"></a> Usage  
- Expressions can be used as attribute values or text values in any API Management [policies](api-management-policies.md) (unless the policy reference specifies otherwise).  
+## <a name="PolicyExpressionsUsage"></a>Usage
+Expressions can be used as attribute values or text values in any API Management [policies](api-management-policies.md) (unless the policy reference specifies otherwise).
   
 > [!IMPORTANT]
->  When you use policy expressions, there is only limited verification of the policy expressions when the policy is defined. Expressions are executed by the gateway at run-time, any exceptions generated by policy expressions result in a runtime error.  
+> When you use policy expressions, there is only limited verification of the policy expressions when the policy is defined. Expressions are executed by the gateway at run-time, any exceptions generated by policy expressions result in a runtime error.
   
-##  <a name="CLRTypes"></a> .NET Framework types allowed in policy expressions  
- The following table lists the .NET Framework types and their members that are allowed in policy expressions.  
+## <a name="CLRTypes"></a> .NET Framework types allowed in policy expressions
+The following table lists the .NET Framework types and their members that are allowed in policy expressions.
   
-|CLR type|Supported members|  
-|--------------|-----------------------|  
-|Newtonsoft.Json.Linq.Extensions|All|  
-|Newtonsoft.Json.Linq.JArray|All|  
-|Newtonsoft.Json.Linq.JConstructor|All|  
-|Newtonsoft.Json.Linq.JContainer|All|  
-|Newtonsoft.Json.Linq.JObject|All|  
-|Newtonsoft.Json.Linq.JProperty|All|  
-|Newtonsoft.Json.Linq.JRaw|All|  
-|Newtonsoft.Json.Linq.JToken|All|  
-|Newtonsoft.Json.Linq.JTokenType|All|  
-|Newtonsoft.Json.Linq.JValue|All|  
-|System.Collections.Generic.IReadOnlyCollection<T\>|All|  
-|System.Collections.Generic.IReadOnlyDictionary<TKey,  TValue>|All|  
-|System.Collections.Generic.ISet<TKey, TValue>|All|  
-|System.Collections.Generic.KeyValuePair<TKey,  TValue>|Key, Value|  
-|System.Collections.Generic.List<TKey, TValue>|All|  
-|System.Collections.Generic.Queue<TKey, TValue>|All|  
-|System.Collections.Generic.Stack<TKey, TValue>|All|  
-|System.Convert|All|  
-|System.DateTime|All|  
-|System.DateTimeKind|Utc|  
-|System.DateTimeOffset|All|  
-|System.Decimal|All|  
-|System.Double|All|  
-|System.Guid|All|  
-|System.IEnumerable<T\>|All|  
-|System.IEnumerator<T\>|All|  
-|System.Int16|All|  
-|System.Int32|All|  
-|System.Int64|All|  
-|System.Linq.Enumerable<T\>|All|  
-|System.Math|All|  
+|CLR type|Supported members|
+|--------------|-----------------------|
+|Newtonsoft.Json.Linq.Extensions|All|
+|Newtonsoft.Json.Linq.JArray|All|
+|Newtonsoft.Json.Linq.JConstructor|All|
+|Newtonsoft.Json.Linq.JContainer|All|
+|Newtonsoft.Json.Linq.JObject|All|
+|Newtonsoft.Json.Linq.JProperty|All|
+|Newtonsoft.Json.Linq.JRaw|All|
+|Newtonsoft.Json.Linq.JToken|All|
+|Newtonsoft.Json.Linq.JTokenType|All|
+|Newtonsoft.Json.Linq.JValue|All|
+|System.Collections.Generic.IReadOnlyCollection<T\>|All|
+|System.Collections.Generic.IReadOnlyDictionary<TKey,  TValue>|All|
+|System.Collections.Generic.ISet<TKey, TValue>|All|
+|System.Collections.Generic.KeyValuePair<TKey,  TValue>|Key, Value|
+|System.Collections.Generic.List<TKey, TValue>|All|
+|System.Collections.Generic.Queue<TKey, TValue>|All|
+|System.Collections.Generic.Stack<TKey, TValue>|All|
+|System.Convert|All|
+|System.DateTime|All|
+|System.DateTimeKind|Utc|
+|System.DateTimeOffset|All|
+|System.Decimal|All|
+|System.Double|All|
+|System.Guid|All|
+|System.IEnumerable<T\>|All|
+|System.IEnumerator<T\>|All|
+|System.Int16|All|
+|System.Int32|All|
+|System.Int64|All|
+|System.Linq.Enumerable<T\>|All|
+|System.Math|All|
 |System.MidpointRounding|All|
 |System.Net.WebUtility|All|
-|System.Nullable<T\>|All|  
-|System.Random|All|  
-|System.SByte|All|  
-|System.Security.Cryptography. HMACSHA384|All|  
-|System.Security.Cryptography. HMACSHA512|All|  
-|System.Security.Cryptography.HashAlgorithm|All|  
-|System.Security.Cryptography.HMAC|All|  
-|System.Security.Cryptography.HMACMD5|All|  
-|System.Security.Cryptography.HMACSHA1|All|  
-|System.Security.Cryptography.HMACSHA256|All|  
-|System.Security.Cryptography.KeyedHashAlgorithm|All|  
-|System.Security.Cryptography.MD5|All|  
-|System.Security.Cryptography.RNGCryptoServiceProvider|All|  
-|System.Security.Cryptography.SHA1|All|  
-|System.Security.Cryptography.SHA1Managed|All|  
-|System.Security.Cryptography.SHA256|All|  
-|System.Security.Cryptography.SHA256Managed|All|  
-|System.Security.Cryptography.SHA384|All|  
-|System.Security.Cryptography.SHA384Managed|All|  
-|System.Security.Cryptography.SHA512|All|  
-|System.Security.Cryptography.SHA512Managed|All|  
-|System.Single|All|  
-|System.String|All|  
-|System.StringSplitOptions|All|  
-|System.Text.Encoding|All|  
-|System.Text.RegularExpressions.Capture|Index, Length, Value|  
-|System.Text.RegularExpressions.CaptureCollection|Count, Item|  
-|System.Text.RegularExpressions.Group|Captures, Success|  
-|System.Text.RegularExpressions.GroupCollection|Count, Item|  
-|System.Text.RegularExpressions.Match|Empty, Groups, Result|  
-|System.Text.RegularExpressions.Regex|(Constructor),IsMatch, Match, Matches, Replace|  
-|System.Text.RegularExpressions.RegexOptions|Compiled, IgnoreCase, IgnorePatternWhitespace, Multiline, None, RightToLeft, Singleline|  
-|System.TimeSpan|All|  
-|System.Tuple|All|  
-|System.UInt16|All|  
-|System.UInt32|All|  
-|System.UInt64|All|  
-|System.Uri|All|  
-|System.Xml.Linq.Extensions|All|  
-|System.Xml.Linq.XAttribute|All|  
-|System.Xml.Linq.XCData|All|  
-|System.Xml.Linq.XComment|All|  
-|System.Xml.Linq.XContainer|All|  
-|System.Xml.Linq.XDeclaration|All|  
-|System.Xml.Linq.XDocument|All|  
-|System.Xml.Linq.XDocumentType|All|  
-|System.Xml.Linq.XElement|All|  
-|System.Xml.Linq.XName|All|  
-|System.Xml.Linq.XNamespace|All|  
-|System.Xml.Linq.XNode|All|  
-|System.Xml.Linq.XNodeDocumentOrderComparer|All|  
-|System.Xml.Linq.XNodeEqualityComparer|All|  
-|System.Xml.Linq.XObject|All|  
-|System.Xml.Linq.XProcessingInstruction|All|  
-|System.Xml.Linq.XText|All|  
-|System.Xml.XmlNodeType|All|  
+|System.Nullable<T\>|All|
+|System.Random|All|
+|System.SByte|All|
+|System.Security.Cryptography. HMACSHA384|All|
+|System.Security.Cryptography. HMACSHA512|All|
+|System.Security.Cryptography.HashAlgorithm|All|
+|System.Security.Cryptography.HMAC|All|
+|System.Security.Cryptography.HMACMD5|All|
+|System.Security.Cryptography.HMACSHA1|All|
+|System.Security.Cryptography.HMACSHA256|All|
+|System.Security.Cryptography.KeyedHashAlgorithm|All|
+|System.Security.Cryptography.MD5|All|
+|System.Security.Cryptography.RNGCryptoServiceProvider|All|
+|System.Security.Cryptography.SHA1|All|
+|System.Security.Cryptography.SHA1Managed|All|
+|System.Security.Cryptography.SHA256|All|
+|System.Security.Cryptography.SHA256Managed|All|
+|System.Security.Cryptography.SHA384|All|
+|System.Security.Cryptography.SHA384Managed|All|
+|System.Security.Cryptography.SHA512|All|
+|System.Security.Cryptography.SHA512Managed|All|
+|System.Single|All|
+|System.String|All|
+|System.StringSplitOptions|All|
+|System.Text.Encoding|All|
+|System.Text.RegularExpressions.Capture|Index, Length, Value|
+|System.Text.RegularExpressions.CaptureCollection|Count, Item|
+|System.Text.RegularExpressions.Group|Captures, Success|
+|System.Text.RegularExpressions.GroupCollection|Count, Item|
+|System.Text.RegularExpressions.Match|Empty, Groups, Result|
+|System.Text.RegularExpressions.Regex|(Constructor),IsMatch, Match, Matches, Replace|
+|System.Text.RegularExpressions.RegexOptions|Compiled, IgnoreCase, IgnorePatternWhitespace, Multiline, None, RightToLeft, Singleline|
+|System.TimeSpan|All|
+|System.Tuple|All|
+|System.UInt16|All|
+|System.UInt32|All|
+|System.UInt64|All|
+|System.Uri|All|
+|System.Xml.Linq.Extensions|All|
+|System.Xml.Linq.XAttribute|All|
+|System.Xml.Linq.XCData|All|
+|System.Xml.Linq.XComment|All|
+|System.Xml.Linq.XContainer|All|
+|System.Xml.Linq.XDeclaration|All|
+|System.Xml.Linq.XDocument|All|
+|System.Xml.Linq.XDocumentType|All|
+|System.Xml.Linq.XElement|All|
+|System.Xml.Linq.XName|All|
+|System.Xml.Linq.XNamespace|All|
+|System.Xml.Linq.XNode|All|
+|System.Xml.Linq.XNodeDocumentOrderComparer|All|
+|System.Xml.Linq.XNodeEqualityComparer|All|
+|System.Xml.Linq.XObject|All|
+|System.Xml.Linq.XProcessingInstruction|All|
+|System.Xml.Linq.XText|All|
+|System.Xml.XmlNodeType|All|
   
-##  <a name="ContextVariables"></a> Context variable  
- A variable named `context` is implicitly available in every policy [expression](api-management-policy-expressions.md#Syntax). Its members provide information pertinent to the `\request`. All of the `context` members are read-only.  
+## <a name="ContextVariables"></a> Context variable
+A variable named `context` is implicitly available in every policy [expression](api-management-policy-expressions.md#Syntax). Its members provide information pertinent to the `\request`. All of the `context` members are read-only.
   
-|Context Variable|Allowed methods, properties, and parameter values|  
-|----------------------|-------------------------------------------------------|  
-|context|Api: IApi<br /><br /> Deployment<br /><br /> Elapsed: TimeSpan - time interval between the value of Timestamp and current time<br /><br /> LastError<br /><br /> Operation<br /><br /> Product<br /><br /> Request<br /><br /> RequestId: Guid - unique request identifier<br /><br /> Response<br /><br /> Subscription<br /><br /> Timestamp: DateTime - point in time when request was received<br /><br /> Tracing: bool - indicates if tracing is on or off <br /><br /> User<br /><br /> Variables: IReadOnlyDictionary<string, object><br /><br /> void Trace(message: string)|  
-|context.Api|Id: string<br /><br /> IsCurrentRevision: bool<br /><br />  Name: string<br /><br /> Path: string<br /><br /> Revision: string<br /><br /> ServiceUrl: IUrl<br /><br /> Version: string |  
-|context.Deployment|Region: string<br /><br /> ServiceName: string<br /><br /> Certificates: IReadOnlyDictionary<string, X509Certificate2>|  
-|context.LastError|Source: string<br /><br /> Reason: string<br /><br /> Message: string<br /><br /> Scope: string<br /><br /> Section: string<br /><br /> Path: string<br /><br /> PolicyId: string<br /><br /> For more information about context.LastError, see [Error handling](api-management-error-handling-policies.md).|  
-|context.Operation|Id: string<br /><br /> Method: string<br /><br /> Name: string<br /><br /> UrlTemplate: string|  
-|context.Product|Apis: IEnumerable<IApi\><br /><br /> ApprovalRequired: bool<br /><br /> Groups: IEnumerable<IGroup\><br /><br /> Id: string<br /><br /> Name: string<br /><br /> State: enum ProductState {NotPublished, Published}<br /><br /> SubscriptionLimit: int?<br /><br /> SubscriptionRequired: bool|  
-|context.Request|Body: IMessageBody<br /><br /> Certificate: System.Security.Cryptography.X509Certificates.X509Certificate2<br /><br /> Headers: IReadOnlyDictionary<string, string[]><br /><br /> IpAddress: string<br /><br /> MatchedParameters: IReadOnlyDictionary<string, string><br /><br /> Method: string<br /><br /> OriginalUrl:IUrl<br /><br /> Url: IUrl|  
-|string context.Request.Headers.GetValueOrDefault(headerName: string, defaultValue: string)|headerName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated request header values or `defaultValue` if the header is not found.|  
-|context.Response|Body: IMessageBody<br /><br /> Headers: IReadOnlyDictionary<string, string[]><br /><br /> StatusCode: int<br /><br /> StatusReason: string|  
-|string context.Response.Headers.GetValueOrDefault(headerName: string, defaultValue: string)|headerName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated response header values or `defaultValue` if the header is not found.|  
-|context.Subscription|CreatedTime: DateTime<br /><br /> EndDate: DateTime?<br /><br /> Id: string<br /><br /> Key: string<br /><br /> Name: string<br /><br /> PrimaryKey: string<br /><br /> SecondaryKey: string<br /><br /> StartDate: DateTime?|  
-|context.User|Email: string<br /><br /> FirstName: string<br /><br /> Groups: IEnumerable<IGroup\><br /><br /> Id: string<br /><br /> Identities: IEnumerable<IUserIdentity\><br /><br /> LastName: string<br /><br /> Note: string<br /><br /> RegistrationDate: DateTime|  
-|IApi|Id: string<br /><br /> Name: string<br /><br /> Path: string<br /><br /> Protocols: IEnumerable<string\><br /><br /> ServiceUrl: IUrl<br /><br /> SubscriptionKeyParameterNames: ISubscriptionKeyParameterNames|  
-|IGroup|Id: string<br /><br /> Name: string|  
-|IMessageBody|As<T\>(preserveContent: bool = false): Where T: string, JObject, JToken, JArray, XNode, XElement, XDocument<br /><br /> The `context.Request.Body.As<T>` and `context.Response.Body.As<T>` methods are used to read a request and response message bodies in a specified type `T`. By default the method uses the original message body stream and renders it unavailable after it returns. To avoid that by having the method operate on a copy of the body stream, set the `preserveContent` parameter to `true`. Go [here](api-management-transformation-policies.md#SetBody) to see an example.|  
-|IUrl|Host: string<br /><br /> Path: string<br /><br /> Port: int<br /><br /> Query: IReadOnlyDictionary<string, string[]><br /><br /> QueryString: string<br /><br /> Scheme: string|  
-|IUserIdentity|Id: string<br /><br /> Provider: string|  
-|ISubscriptionKeyParameterNames|Header: string<br /><br /> Query: string|  
-|string IUrl.Query.GetValueOrDefault(queryParameterName: string, defaultValue: string)|queryParameterName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated query parameter values or `defaultValue` if the parameter is not found.|  
-|T context.Variables.GetValueOrDefault<T\>(variableName: string, defaultValue: T)|variableName: string<br /><br /> defaultValue: T<br /><br /> Returns variable value cast to type `T` or `defaultValue` if the variable is not found.<br /><br /> This method throws an exception if the specified type does not match the actual type of the returned variable.|  
-|BasicAuthCredentials AsBasic(input: this string)|input: string<br /><br /> If the input parameter contains a valid HTTP Basic Authentication authorization request header value, the method returns an object of type `BasicAuthCredentials`; otherwise the method returns null.|  
-|bool TryParseBasic(input: this string, result: out BasicAuthCredentials)|input: string<br /><br /> result: out BasicAuthCredentials<br /><br /> If the input parameter contains a valid HTTP Basic Authentication authorization value in the request header the method returns `true` and the result parameter contains a value of type `BasicAuthCredentials`; otherwise the method returns `false`.|  
-|BasicAuthCredentials|Password: string<br /><br /> UserId: string|  
-|Jwt AsJwt(input: this string)|input: string<br /><br /> If the input parameter contains a valid JWT token value, the method returns an object of type `Jwt`; otherwise the method returns `null`.|  
-|bool TryParseJwt(input: this string, result: out Jwt)|input: string<br /><br /> result: out Jwt<br /><br /> If the input parameter contains a valid JWT token value, the method returns `true` and the result parameter contains a value of type `Jwt`; otherwise the method returns `false`.|  
-|Jwt|Algorithm: string<br /><br /> Audience: IEnumerable<string\><br /><br /> Claims: IReadOnlyDictionary<string, string[]><br /><br /> ExpirationTime: DateTime?<br /><br /> Id: string<br /><br /> Issuer: string<br /><br /> NotBefore: DateTime?<br /><br /> Subject: string<br /><br /> Type: string|  
+|Context Variable|Allowed methods, properties, and parameter values|
+|----------------------|-------------------------------------------------------|
+|context|Api: IApi<br /><br /> Deployment<br /><br /> Elapsed: TimeSpan - time interval between the value of Timestamp and current time<br /><br /> LastError<br /><br /> Operation<br /><br /> Product<br /><br /> Request<br /><br /> RequestId: Guid - unique request identifier<br /><br /> Response<br /><br /> Subscription<br /><br /> Timestamp: DateTime - point in time when request was received<br /><br /> Tracing: bool - indicates if tracing is on or off <br /><br /> User<br /><br /> Variables: IReadOnlyDictionary<string, object><br /><br /> void Trace(message: string)|
+|context.Api|Id: string<br /><br /> IsCurrentRevision: bool<br /><br />  Name: string<br /><br /> Path: string<br /><br /> Revision: string<br /><br /> ServiceUrl: IUrl<br /><br /> Version: string |
+|context.Deployment|Region: string<br /><br /> ServiceName: string<br /><br /> Certificates: IReadOnlyDictionary<string, X509Certificate2>|
+|context.LastError|Source: string<br /><br /> Reason: string<br /><br /> Message: string<br /><br /> Scope: string<br /><br /> Section: string<br /><br /> Path: string<br /><br /> PolicyId: string<br /><br /> For more information about context.LastError, see [Error handling](api-management-error-handling-policies.md).|
+|context.Operation|Id: string<br /><br /> Method: string<br /><br /> Name: string<br /><br /> UrlTemplate: string|
+|context.Product|Apis: IEnumerable<IApi\><br /><br /> ApprovalRequired: bool<br /><br /> Groups: IEnumerable<IGroup\><br /><br /> Id: string<br /><br /> Name: string<br /><br /> State: enum ProductState {NotPublished, Published}<br /><br /> SubscriptionLimit: int?<br /><br /> SubscriptionRequired: bool|
+|context.Request|Body: IMessageBody<br /><br /> Certificate: System.Security.Cryptography.X509Certificates.X509Certificate2<br /><br /> Headers: IReadOnlyDictionary<string, string[]><br /><br /> IpAddress: string<br /><br /> MatchedParameters: IReadOnlyDictionary<string, string><br /><br /> Method: string<br /><br /> OriginalUrl:IUrl<br /><br /> Url: IUrl|
+|string context.Request.Headers.GetValueOrDefault(headerName: string, defaultValue: string)|headerName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated request header values or `defaultValue` if the header is not found.|
+|context.Response|Body: IMessageBody<br /><br /> Headers: IReadOnlyDictionary<string, string[]><br /><br /> StatusCode: int<br /><br /> StatusReason: string|
+|string context.Response.Headers.GetValueOrDefault(headerName: string, defaultValue: string)|headerName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated response header values or `defaultValue` if the header is not found.|
+|context.Subscription|CreatedTime: DateTime<br /><br /> EndDate: DateTime?<br /><br /> Id: string<br /><br /> Key: string<br /><br /> Name: string<br /><br /> PrimaryKey: string<br /><br /> SecondaryKey: string<br /><br /> StartDate: DateTime?|
+|context.User|Email: string<br /><br /> FirstName: string<br /><br /> Groups: IEnumerable<IGroup\><br /><br /> Id: string<br /><br /> Identities: IEnumerable<IUserIdentity\><br /><br /> LastName: string<br /><br /> Note: string<br /><br /> RegistrationDate: DateTime|
+|IApi|Id: string<br /><br /> Name: string<br /><br /> Path: string<br /><br /> Protocols: IEnumerable<string\><br /><br /> ServiceUrl: IUrl<br /><br /> SubscriptionKeyParameterNames: ISubscriptionKeyParameterNames|
+|IGroup|Id: string<br /><br /> Name: string|
+|IMessageBody|As<T\>(preserveContent: bool = false): Where T: string, JObject, JToken, JArray, XNode, XElement, XDocument<br /><br /> The `context.Request.Body.As<T>` and `context.Response.Body.As<T>` methods are used to read a request and response message bodies in a specified type `T`. By default the method uses the original message body stream and renders it unavailable after it returns. To avoid that by having the method operate on a copy of the body stream, set the `preserveContent` parameter to `true`. Go [here](api-management-transformation-policies.md#SetBody) to see an example.|
+|IUrl|Host: string<br /><br /> Path: string<br /><br /> Port: int<br /><br /> Query: IReadOnlyDictionary<string, string[]><br /><br /> QueryString: string<br /><br /> Scheme: string|
+|IUserIdentity|Id: string<br /><br /> Provider: string|
+|ISubscriptionKeyParameterNames|Header: string<br /><br /> Query: string|
+|string IUrl.Query.GetValueOrDefault(queryParameterName: string, defaultValue: string)|queryParameterName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated query parameter values or `defaultValue` if the parameter is not found.|
+|T context.Variables.GetValueOrDefault<T\>(variableName: string, defaultValue: T)|variableName: string<br /><br /> defaultValue: T<br /><br /> Returns variable value cast to type `T` or `defaultValue` if the variable is not found.<br /><br /> This method throws an exception if the specified type does not match the actual type of the returned variable.|
+|BasicAuthCredentials AsBasic(input: this string)|input: string<br /><br /> If the input parameter contains a valid HTTP Basic Authentication authorization request header value, the method returns an object of type `BasicAuthCredentials`; otherwise the method returns null.|
+|bool TryParseBasic(input: this string, result: out BasicAuthCredentials)|input: string<br /><br /> result: out BasicAuthCredentials<br /><br /> If the input parameter contains a valid HTTP Basic Authentication authorization value in the request header the method returns `true` and the result parameter contains a value of type `BasicAuthCredentials`; otherwise the method returns `false`.|
+|BasicAuthCredentials|Password: string<br /><br /> UserId: string|
+|Jwt AsJwt(input: this string)|input: string<br /><br /> If the input parameter contains a valid JWT token value, the method returns an object of type `Jwt`; otherwise the method returns `null`.|
+|bool TryParseJwt(input: this string, result: out Jwt)|input: string<br /><br /> result: out Jwt<br /><br /> If the input parameter contains a valid JWT token value, the method returns `true` and the result parameter contains a value of type `Jwt`; otherwise the method returns `false`.|
+|Jwt|Algorithm: string<br /><br /> Audience: IEnumerable<string\><br /><br /> Claims: IReadOnlyDictionary<string, string[]><br /><br /> ExpirationTime: DateTime?<br /><br /> Id: string<br /><br /> Issuer: string<br /><br /> NotBefore: DateTime?<br /><br /> Subject: string<br /><br /> Type: string|
 |string Jwt.Claims.GetValueOrDefault(claimName: string, defaultValue: string)|claimName: string<br /><br /> defaultValue: string<br /><br /> Returns comma-separated claim values or `defaultValue` if the header is not found.|
 |byte[] Encrypt(input: this byte[], alg: string, key:byte[], iv:byte[])|input - plaintext to be encrypted<br /><br />alg - name of a symmetric encryption algorithm<br /><br />key - encryption key<br /><br />iv - initialization vector<br /><br />Returns encrypted plaintext.|
 |byte[] Encrypt(input: this byte[], alg: System.Security.Cryptography.SymmetricAlgorithm)|input - plaintext to be encrypted<br /><br />alg - encryption algorithm<br /><br />Returns encrypted plaintext.|


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary space: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it