### PR TITLE
Fix typo & delete unnecessary space and tab

### DIFF
--- a/articles/machine-learning/team-data-science-process/group-manager-tasks.md
+++ b/articles/machine-learning/team-data-science-process/group-manager-tasks.md
@@ -45,10 +45,10 @@ This tutorial uses abbreviated names for repositories and directories. These def
 - **LR1** and **LR2**: The local directories on your machine that you clone R1 and R2 to, respectively.
 
 ### Pre-requisites for cloning repositories and checking code in and out
- 
-- Git must be installed on your machine. If you are using a Data Science Virtual Machine (DSVM), Git has been pre-installed and you are good to go. Otherwise, see the [Platforms and tools appendix](platforms-and-tools.md#appendix).  
-- If you are using a **Windows DSVM**, you need to have [Git Credential Manager (GCM)](https://github.com/Microsoft/Git-Credential-Manager-for-Windows) installed on your machine. In the README.md file, scroll down to the **Download and Install** section and click the *latest installer*. This step takes you to the latest installer page. Download the .exe installer from here and run it. 
-- If you are using **Linux DSVM**, create an SSH public key on your DSVM and add it to your group Azure DevOps Services. For more information about SSH, see the **Create SSH public key** section in the [Platforms and tools appendix](platforms-and-tools.md#appendix). 
+
+- Git must be installed on your machine. If you are using a Data Science Virtual Machine (DSVM), Git has been pre-installed and you are good to go. Otherwise, see the [Platforms and tools appendix](platforms-and-tools.md#appendix).
+- If you are using a **Windows DSVM**, you need to have [Git Credential Manager (GCM)](https://github.com/Microsoft/Git-Credential-Manager-for-Windows) installed on your machine. In the README.md file, scroll down to the **Download and Install** section and click the *latest installer*. This step takes you to the latest installer page. Download the .exe installer from here and run it.
+- If you are using **Linux DSVM**, create an SSH public key on your DSVM and add it to your group Azure DevOps Services. For more information about SSH, see the **Create SSH public key** section in the [Platforms and tools appendix](platforms-and-tools.md#appendix).
 
 
 ## 1. Create Account on Azure DevOps Services
@@ -56,36 +56,36 @@ This tutorial uses abbreviated names for repositories and directories. These def
 The Azure DevOps Services hosts the following repositories:
 
 - **group common repositories**: General-purpose repositories that can be adopted by multiple teams within a group for multiple data science projects. For example, the *GroupProjectTemplate* and *GroupUtilities* repositories.
-- **team repositories**:  Repositories for specific teams within a group. These repositories are specific for a team's need, and can be adopted by multiple projects executed by that team, but not general enough to be useful to multiple teams within a data science group. 
+- **team repositories**:  Repositories for specific teams within a group. These repositories are specific for a team's need, and can be adopted by multiple projects executed by that team, but not general enough to be useful to multiple teams within a data science group.
 - **project repositories**: Repositories available for specific projects. Such repositories may not be general enough to be useful to multiple projects performed by a team, and to multiple teams in a data science group.
 
 
 ### Setting up the Azure DevOps Services Sign into your Microsoft account
-	
-Go to [Visual Studio online](https://www.visualstudio.com/), click **Sign in** in the upper right corner and sign into your Microsoft account. 
-	
+
+Go to [Visual Studio online](https://www.visualstudio.com/), click **Sign in** in the upper right corner and sign into your Microsoft account.
+
 ![1](./media/group-manager-tasks/login.PNG)
 
-If you do not have a Microsoft account, click **Sign up now** to create a Microsoft account, and then sign in using this account. 
+If you do not have a Microsoft account, click **Sign up now** to create a Microsoft account, and then sign in using this account.
 
-If your organization has a Visual Studio/MSDN subscription, click the green **Sign in with your work or school account** box and sign in with the credentials associated with this subscription. 
-		
+If your organization has a Visual Studio/MSDN subscription, click the green **Sign in with your work or school account** box and sign in with the credentials associated with this subscription.
+
 ![2](./media/group-manager-tasks/signin.PNG)
 
 
-		
-After you sign in, click **Create New Account** in the upper right corner as shown in the following image:
-		
-![3](./media/group-manager-tasks/create-account-1.PNG)
-		
-Fill in the information for the Azure DevOps Services that you want to create in the **Create your account** wizard with the following values: 
 
-- **Server URL**: Replace *mysamplegroup* with your own *server name*. The URL of your server is going to be: *https://\<servername\>.visualstudio.com*. 
+After you sign in, click **Create New Account** in the upper right corner as shown in the following image:
+
+![3](./media/group-manager-tasks/create-account-1.PNG)
+
+Fill in the information for the Azure DevOps Services that you want to create in the **Create your account** wizard with the following values:
+
+- **Server URL**: Replace *mysamplegroup* with your own *server name*. The URL of your server is going to be: *https://\<servername\>.visualstudio.com*.
 - **Manage code using:** Select **_Git_**.
-- **Project name:** Enter *GroupCommon*. 
+- **Project name:** Enter *GroupCommon*.
 - **Organize work using:** Choose *Agile*.
-- **Host your projects in:** Choose a geo location. In this example, we choose *South Central US*. 
-		
+- **Host your projects in:** Choose a geo location. In this example, we choose *South Central US*.
+
 ![4](./media/group-manager-tasks/fill-in-account-information.png)
 
 >[AZURE.NOTE] If you see the following pop-up window after you click **Create new account**, then you need to click **Change details** to display all the fields itemized.
@@ -93,27 +93,27 @@ Fill in the information for the Azure DevOps Services that you want to create in
 ![5](./media/group-manager-tasks/create-account-2.png)
 
 
-Click **Continue**. 
+Click **Continue**.
 
 ## 2. GroupCommon Project
 
 The **GroupCommon** page (*https://\<servername\>.visualstudio.com/GroupCommon*) opens after your Azure DevOps Services is created.
-							
+
 ![6](./media/group-manager-tasks/server-created-2.PNG)
 
 ## 3. Create the GroupUtilities (R2) repository
 
 To create the **GroupUtilities** (R2) repository under Azure DevOps Services:
 
-- To open the **Create a new repository** wizard, click **New repository** on the **Version Control** tab of your project. 
+- To open the **Create a new repository** wizard, click **New repository** on the **Version Control** tab of your project.
 
-![7](./media/group-manager-tasks/create-grouputilities-repo-1.png) 
+![7](./media/group-manager-tasks/create-grouputilities-repo-1.png)
 
-- Select *Git* as the **Type**, and enter *GroupUtilities* as the **Name**, and then click **Create**. 
+- Select *Git* as the **Type**, and enter *GroupUtilities* as the **Name**, and then click **Create**.
 
 ![8](./media/group-manager-tasks/create-grouputilities-repo-2.png)
-				
-Now you should see two Git repositories **GroupProjectTemplate** and **GroupUtilities** in the left column of the **Version Control** page: 
+
+Now you should see two Git repositories **GroupProjectTemplate** and **GroupUtilities** in the left column of the **Version Control** page:
 
 ![9](./media/group-manager-tasks/two-repo-under-groupCommon.PNG)
 
@@ -123,28 +123,28 @@ Now you should see two Git repositories **GroupProjectTemplate** and **GroupUtil
 The setup of the repositories for the Azure DevOps group server consists of two tasks:
 
 - Rename the default **GroupCommon** repository***GroupProjectTemplate***.
-- Create the **GroupUtilities** repository on the Azure DevOps Services under project **GroupCommon**. 
+- Create the **GroupUtilities** repository on the Azure DevOps Services under project **GroupCommon**.
 
 Instructions for the first task are contained in this section after remarks on naming conventions or our repositories and directories. The instructions for the second task are contained in the following section for step 4.
 
 ### Rename the default GroupCommon repository
 
 To rename the default **GroupCommon** repository as *GroupProjectTemplate* (referred as **R1** in this tutorial):
-	
-- Click **Collaborate on code** on the **GroupCommon** project page. This takes you to the default Git repository page of the project **GroupCommon**. Currently, this Git repository is empty. 
+
+- Click **Collaborate on code** on the **GroupCommon** project page. This takes you to the default Git repository page of the project **GroupCommon**. Currently, this Git repository is empty.
 
 ![10](./media/group-manager-tasks/rename-groupcommon-repo-3.png)
-		
-- Click **GroupCommon** on the top left corner (highlighted with a red box in the following figure) on the Git repository page of **GroupCommon** and select **Manage repositories** (highlighted with a green box in the following figure). This  procedure brings up the **CONTROL PANEL**. 
-- Select the **Version Control** tab of your project. 
+
+- Click **GroupCommon** on the top left corner (highlighted with a red box in the following figure) on the Git repository page of **GroupCommon** and select **Manage repositories** (highlighted with a green box in the following figure). This  procedure brings up the **CONTROL PANEL**.
+- Select the **Version Control** tab of your project.
 
 ![11](./media/group-manager-tasks/rename-groupcommon-repo-4.png)
 
-- Click the **...** to the right of the **GroupCommon** repository on the left panel, and select **Rename repository**. 
+- Click the **...** to the right of the **GroupCommon** repository on the left panel, and select **Rename repository**.
 
 ![12](./media/group-manager-tasks/rename-groupcommon-repo-5.png)
-		
-- In the **Rename the GroupCommon repository** wizard that pops up, enter *GroupProjectTemplate* in the **Repository name** box, and then click **Rename**. 
+
+- In the **Rename the GroupCommon repository** wizard that pops up, enter *GroupProjectTemplate* in the **Repository name** box, and then click **Rename**.
 
 ![13](./media/group-manager-tasks/rename-groupcommon-repo-6.png)
 
@@ -168,36 +168,36 @@ The seeding procedure uses the directories on your local DSVM as intermediate st
 
 ### Clone G1 & G2 repositories to your local DSVM
 
-In this step, you clone the Team Data Science Process (TDSP) ProjectTemplate repository (G1) and Utilities (G2) from the TDSP github repositories to folders in your local DSVM as LG1 and LG2:
+In this step, you clone the Team Data Science Process (TDSP) ProjectTemplate repository (G1) and Utilities (G2) from the TDSP GitHub repositories to folders in your local DSVM as LG1 and LG2:
 
-- Create a directory to serve as the root directory to host all your clones of the repositories. 
-	-  In the Windows DSVM, create a directory *C:\GitRepos\TDSPCommon*. 
-	-  In the Linux DSVM, create a directory *GitRepos\TDSPCommon* in your home directory. 
+- Create a directory to serve as the root directory to host all your clones of the repositories.
+	-  In the Windows DSVM, create a directory *C:\GitRepos\TDSPCommon*.
+	-  In the Linux DSVM, create a directory *GitRepos\TDSPCommon* in your home directory.
 
 - Run the following set of commands from the *GitRepos\TDSPCommon* directory.
 
 	`git clone https://github.com/Azure/Azure-TDSP-ProjectTemplate`<br>
 	`git clone https://github.com/Azure/Azure-TDSP-Utilities`
-        
+
 ![14](./media/group-manager-tasks/two-folder-cloned-from-TDSP-windows.PNG)
 
-- Using our abbreviated repository names, this is what these scripts have achieved: 
+- Using our abbreviated repository names, this is what these scripts have achieved:
 	- G1 - cloned into -> LG1
 	- G2 - cloned into -> LG2
-- After the cloning is completed, you should be able to see two directories, _ProjectTemplate_ and _Utilities_, under **GitRepos\TDSPCommon** directory. 
+- After the cloning is completed, you should be able to see two directories, _ProjectTemplate_ and _Utilities_, under **GitRepos\TDSPCommon** directory.
 
 ### Clone R1 & R2 repositories to your local DSVM
 
 In this step, you clone the GroupProjectTemplate repository (R1) and GroupUtilities repository (R2) on local directories (referred as LR1 and LR2, respectively) under **GitRepos\GroupCommon** on your DSVM.
 
-- To get the URLs of the R1 and R2 repositories, go to your **GroupCommon** home page on Azure DevOps Services. This usually has the URL *https://\<Your Azure DevOps Services Name\>.visualstudio.com/GroupCommon*. 
-- Click **CODE**. 
-- Choose the **GroupProjectTemplate** and **GroupUtilities** repositories. Copy and save each of the URLs (HTTPS for Windows; SSH for Linux) from the **Clone URL** element, in turn, for use in the following scripts:  
+- To get the URLs of the R1 and R2 repositories, go to your **GroupCommon** home page on Azure DevOps Services. This usually has the URL *https://\<Your Azure DevOps Services Name\>.visualstudio.com/GroupCommon*.
+- Click **CODE**.
+- Choose the **GroupProjectTemplate** and **GroupUtilities** repositories. Copy and save each of the URLs (HTTPS for Windows; SSH for Linux) from the **Clone URL** element, in turn, for use in the following scripts:
 
 ![15](./media/group-manager-tasks/find_https_ssh_2.PNG)
 
 - Change into the **GitRepos\GroupCommon** directory on your Windows or Linux DSVM and run one of the following sets of commands to clone R1 and R2 into that directory.
-		
+
 Here are the Windows and Linux scripts:
 
 	# Windows DSVM
@@ -214,9 +214,9 @@ Here are the Windows and Linux scripts:
 
 ![17](./media/group-manager-tasks/clone-two-empty-group-reo-linux-2.PNG)
 
->[AZURE.NOTE] Expect to receive warning messages that LR1 and LR2 are empty. 	
+>[AZURE.NOTE] Expect to receive warning messages that LR1 and LR2 are empty.
 
-- Using our abbreviated repository names, this is what these scripts have achieved: 
+- Using our abbreviated repository names, this is what these scripts have achieved:
 	- R1 - cloned into -> LR1
 	- R2 - cloned into -> LR2	
 
@@ -225,12 +225,12 @@ Here are the Windows and Linux scripts:
 
 Next, in your local machine, copy the content of ProjectTemplate and Utilities directories (except the metadata in the .git directories) under GitRepos\TDSPCommon to your GroupProjectTemplate and GroupUtilities directories under **GitRepos\GroupCommon**. Here are the two tasks to complete in this step:
 
-- Copy the files in GitRepos\TDSPCommon\ProjectTemplate (**LG1**) to GitRepos\GroupCommon\GroupProjectTemplate (**LR1**) 
-- Copy the files in GitRepos\TDSPCommon\Utilities (**LG2** to GitRepos\GroupCommon\Utilities (**LR2**). 
+- Copy the files in GitRepos\TDSPCommon\ProjectTemplate (**LG1**) to GitRepos\GroupCommon\GroupProjectTemplate (**LR1**)
+- Copy the files in GitRepos\TDSPCommon\Utilities (**LG2** to GitRepos\GroupCommon\Utilities (**LR2**).
 
-To achieve these two tasks, run the following scripts in PowerShell console (Windows) or Shell script console (Linux). You are prompted to input the complete paths to LG1, LR1, LG2, and LR2. The paths that you input are validated. If you input a directory that does not exist, you are asked to input it again. 
+To achieve these two tasks, run the following scripts in PowerShell console (Windows) or Shell script console (Linux). You are prompted to input the complete paths to LG1, LR1, LG2, and LR2. The paths that you input are validated. If you input a directory that does not exist, you are asked to input it again.
 
-	# Windows DSVM		
+	# Windows DSVM
 	
     wget "https://raw.githubusercontent.com/Azure/Azure-MachineLearning-DataScience/master/Misc/TDSP/tdsp_local_copy_win.ps1" -outfile "tdsp_local_copy_win.ps1"
     .\tdsp_local_copy_win.ps1 1
@@ -247,9 +247,9 @@ Now you can see that files in directories LG1 and LG1 (except files in the .git 
     bash tdsp_local_copy_linux.sh 1
 
 ![20](./media/group-manager-tasks/copy-two-folder-to-group-folder-linux-2.PNG)
-		
+
 Now you see that the files in the two folders (except files in the .git directory) are copied to GroupProjectTemplate and GroupUtilities respectively.
-	
+
 ![21](./media/group-manager-tasks/copy-two-folder-to-group-folder-linux.PNG)
 
 - Using our abbreviated repository names, this is what these scripts have achieved:
@@ -258,11 +258,11 @@ Now you see that the files in the two folders (except files in the .git director
 
 ### Option to customize the contents of LR1 & LR2
 	
-If you want to customize the contents of LR1 and LR2 to meet the specific needs of your group, this is the stage of the procedure where that is appropriate. You can modify the template documents, change the directory structure, and add existing utilities that your group has developed or that are helpful for your entire group. 
+If you want to customize the contents of LR1 and LR2 to meet the specific needs of your group, this is the stage of the procedure where that is appropriate. You can modify the template documents, change the directory structure, and add existing utilities that your group has developed or that are helpful for your entire group.
 
 ### Add the contents in LR1 & LR2 to R1 & R2 on group server
 
-Now, you need to add the contents in LR1 and LR2 to repositories R1 and R2. Here are the git bash commands you can run in either Windows PowerShell or Linux. 
+Now, you need to add the contents in LR1 and LR2 to repositories R1 and R2. Here are the git bash commands you can run in either Windows PowerShell or Linux.
 
 Run the following commands from the GitRepos\GroupCommon\GroupProjectTemplate directory:
 
@@ -287,10 +287,10 @@ Finally, change to the **GitRepos\GroupCommon\GroupUtilities** directory and run
 	git push
 
 >[AZURE.NOTE] If this is the first time you commit to a Git repository, you need to configure global parameters *user.name* and *user.email* before you run the `git commit` command. Run the following two commands:
-		
+
 	git config --global user.name <your name>
 	git config --global user.email <your email address>
- 
+
 >If you are committing to multiple Git repositories, use the same name and email address when you commit to each of them. Using the same name and email address proves convenient later on when you build PowerBI dashboards to track your Git activities on multiple repositories.
 
 
@@ -302,7 +302,7 @@ Finally, change to the **GitRepos\GroupCommon\GroupUtilities** directory and run
 
 From your group Azure DevOps Services's homepage, click the **gear icon** next to your user name in the upper right corner, then select the **Security** tab. You can add members to your group here with various permissions.
 
-![24](./media/group-manager-tasks/add_member_to_group.PNG) 
+![24](./media/group-manager-tasks/add_member_to_group.PNG)
 
 
 ## Next steps


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary space and tab: As Markdown syntax, there was a large amount of half-width spaces and tab that did not affect the display, so I deleted it
