### PR TITLE
Added step to delete AAD B2C tenant

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-faqs.md
+++ b/articles/active-directory-b2c/active-directory-b2c-faqs.md
@@ -109,7 +109,8 @@ Not currently. This feature is on our roadmap. Verifying your domain in the **Do
 ### How do I delete my Azure AD B2C tenant?
 Follow these steps to delete your Azure AD B2C tenant:
 
-1. Delete all the policies in your Azure AD B2C tenant.
+1. Delete all the user flows (policies) in your Azure AD B2C tenant.
+1. Delete all the applications you registered in your Azure AD B2C tenant.
 1. Now sign in to the [Azure portal](https://portal.azure.com/) as the Subscription Administrator. (Use the same work or school account or the same Microsoft account that you used to sign up for Azure.)
 1. Switch to the Azure AD B2C tenant you want to delete.
 2. Navigate to the Active Directory menu on the left.


### PR DESCRIPTION
Registered applications must also be deleted first before you can delete the tenant.