### PR TITLE
Data flow should be outbound, not inbound

### DIFF
--- a/articles/azure-monitor/platform/log-analytics-agent.md
+++ b/articles/azure-monitor/platform/log-analytics-agent.md
@@ -73,10 +73,10 @@ The information below list the proxy and firewall configuration information requ
 
 |Agent Resource|Ports |Direction |Bypass HTTPS inspection|
 |------|---------|--------|--------|   
-|*.ods.opinsights.azure.com |Port 443 |Inbound and outbound|Yes |  
-|*.oms.opinsights.azure.com |Port 443 |Inbound and outbound|Yes |  
-|*.blob.core.windows.net |Port 443 |Inbound and outbound|Yes |  
-|*.azure-automation.net |Port 443 |Inbound and outbound|Yes |  
+|*.ods.opinsights.azure.com |Port 443 |Outbound|Yes |  
+|*.oms.opinsights.azure.com |Port 443 |Outbound|Yes |  
+|*.blob.core.windows.net |Port 443 |Outbound|Yes |  
+|*.azure-automation.net |Port 443 |Outbound|Yes |  
 
 
 If you plan to use the Azure Automation Hybrid Runbook Worker to connect to and register with the Automation service to use runbooks in your environment, it must have access to the port number and the URLs described in [Configure your network for the Hybrid Runbook Worker](../../automation/automation-hybrid-runbook-worker.md#network-planning). 


### PR DESCRIPTION
From the following doc: https://docs.microsoft.com/en-us/azure/azure-monitor/platform/om-agents#network
The information below list the proxy and firewall configuration information required for the Operations Manager agent, management servers, and Operations console to communicate with Log Analytics. Traffic from each component is outbound from your network to the Log Analytics service. 

The visio/diagram in this article only shows traffic flowing outbound as well.