### PR TITLE
Fix typo & delete unnecessary spaces

### DIFF
--- a/articles/stream-analytics/stream-analytics-build-an-iot-solution-using-stream-analytics.md
+++ b/articles/stream-analytics/stream-analytics-build-an-iot-solution-using-stream-analytics.md
@@ -109,8 +109,8 @@ To complete this solution, you need a Microsoft Azure subscription. If you do no
 
 Be sure to follow the steps in the "Clean up your Azure account" section at the end of this article so that you can make the best use of your Azure credit.
 
-## Deploy the sample 
-There are several resources that can easily be deployed in a resource group together with a few clicks. The solution definition is hosted in github repository at [https://github.com/Azure/azure-stream-analytics/tree/master/Samples/TollApp](https://github.com/Azure/azure-stream-analytics/tree/master/Samples/TollApp).
+## Deploy the sample
+There are several resources that can easily be deployed in a resource group together with a few clicks. The solution definition is hosted in GitHub repository at [https://github.com/Azure/azure-stream-analytics/tree/master/Samples/TollApp](https://github.com/Azure/azure-stream-analytics/tree/master/Samples/TollApp).
 
 ### Deploy the TollApp template in the Azure portal
 1. To deploy the TollApp environment to Azure, use this link to [Deploy TollApp Azure Template](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-stream-analytics%2Fmaster%2FSamples%2FTollApp%2FVSProjects%2FTollAppDeployment%2Fazuredeploy.json).
@@ -119,11 +119,11 @@ There are several resources that can easily be deployed in a resource group toge
 
 3. Choose the subscription in which the various resources are billed.
 
-4. Specify a new resource group, with a unique name, for example `MyTollBooth`. 
+4. Specify a new resource group, with a unique name, for example `MyTollBooth`.
 
 5. Select an Azure location.
 
-6. Specify an **Interval** as a number of seconds. This value is used in the sample web app, for how frequently to send data into Event Hub. 
+6. Specify an **Interval** as a number of seconds. This value is used in the sample web app, for how frequently to send data into Event Hub.
 
 7. **Check** to agree to the terms and conditions.
 
@@ -145,7 +145,7 @@ There are several resources that can easily be deployed in a resource group toge
    - One Azure Event Hub
    - Two Web Apps
 
-## Examine the sample TollApp job 
+## Examine the sample TollApp job
 1. Starting from the resource group in the previous section, select the Stream Analytics streaming job starting with the name **tollapp** (name contains random characters for uniqueness).
 
 2. On the **Overview** page of the job, notice the **Query** box to view the query syntax.
@@ -191,7 +191,7 @@ Follow these steps to start the streaming job:
 
 6. Select each id to review the JSON document. Notice each tollid, windowend time, and the count of cars from that window.
 
-7. After an additional three minutes, another set of four documents is available, one document per tollid. 
+7. After an additional three minutes, another set of four documents is available, one document per tollid.
 
 
 ## Report total time for each car
@@ -225,9 +225,9 @@ AND DATEDIFF (minute, EntryStream, ExitStream ) BETWEEN 0 AND 15
 7. On the **Start job** pane, select **Now**.
 
 ### Review the total time in the output
-Repeat the steps in the preceding section to review the CosmosDB output data from the streaming job. Review the latest JSON documents. 
+Repeat the steps in the preceding section to review the CosmosDB output data from the streaming job. Review the latest JSON documents.
 
-For example, this document shows an example car with a certain license plate, the entrytime and exit time, and the DATEDIFF calculated durationinminutes field showing the toll booth duration as two minutes: 
+For example, this document shows an example car with a certain license plate, the entrytime and exit time, and the DATEDIFF calculated durationinminutes field showing the toll booth duration as two minutes:
 ```JSON
 {
     "tollid": 4,
@@ -245,7 +245,7 @@ For example, this document shows an example car with a certain license plate, th
 ```
 
 ## Report vehicles with expired registration
-Azure Stream Analytics can use static snapshots of reference data to join with temporal data streams. To demonstrate this capability, use the following sample question. The Registration input is a static blob json file that lists the expirations of license tags. By joining on the license plate, the reference data is compared to each vehicle passing through the toll both. 
+Azure Stream Analytics can use static snapshots of reference data to join with temporal data streams. To demonstrate this capability, use the following sample question. The Registration input is a static blob json file that lists the expirations of license tags. By joining on the license plate, the reference data is compared to each vehicle passing through the toll both.
 
 If a commercial vehicle is registered with the toll company, it can pass through the toll booth without being stopped for inspection. Use the registration lookup table to identify all commercial vehicles that have expired registrations.
 
@@ -260,7 +260,7 @@ WHERE Registration.Expired = '1'
 
 1. Repeat the steps in the preceding section to update the TollApp streaming job query syntax.
 
-2. Repeat the steps in the preceding section to review the CosmosDB output data from the streaming job. 
+2. Repeat the steps in the preceding section to review the CosmosDB output data from the streaming job.
 
 Example output:
 ```json
@@ -285,26 +285,26 @@ To scale out the query to partitions, edit the query syntax to the following cod
 ```sql
 SELECT TollId, System.Timestamp AS WindowEnd, COUNT(*)AS Count
 INTO CosmosDB
-FROM EntryStream 
-TIMESTAMP BY EntryTime 
+FROM EntryStream
+TIMESTAMP BY EntryTime
 PARTITION BY PartitionId
 GROUP BY TUMBLINGWINDOW(minute,3), TollId, PartitionId
 ```
 
 To scale up the streaming job to more streaming units:
 
-1. **Stop** the current job. 
+1. **Stop** the current job.
 
 2. Update the query syntax in the **< > Query** page, and save the changes.
 
 3. Under the CONFIGURE heading on the streaming job, select **Scale**.
-   
+
 4. Slide the **Streaming units** slider from 1 to 6. Streaming units define the amount of compute power that the job can receive. Select **Save**.
 
-5. **Start** the streaming job to demonstrate the additional scale. Azure Stream Analytics distributes work across more compute resources and achieve better throughput, partitioning the work across resources using the column designated in the PARTITION BY clause. 
+5. **Start** the streaming job to demonstrate the additional scale. Azure Stream Analytics distributes work across more compute resources and achieve better throughput, partitioning the work across resources using the column designated in the PARTITION BY clause.
 
 ## Monitor the job
-The **MONITOR** area contains statistics about the running job. First-time configuration is needed to use the storage account in the same region (name toll like the rest of this document).   
+The **MONITOR** area contains statistics about the running job. First-time configuration is needed to use the storage account in the same region (name toll like the rest of this document).
 
 ![Azure Stream Analytics job monitoring](media/stream-analytics-build-an-iot-solution-using-stream-analytics/stream-analytics-job-monitoring.png)
 


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it