### PR TITLE
Fix typo & delete unnecessary spaces

### DIFF
--- a/articles/stream-analytics/stream-analytics-manage-job.md
+++ b/articles/stream-analytics/stream-analytics-manage-job.md
@@ -1,6 +1,6 @@
 ---
 title: "Tutorial: Create and manage a Stream Analytics job using Azure portal"
-description: This tutorial provides an end-to-end demonstration of how to use Azure Stream Analytics to analyze fraudulent calls in a phone call stream. 
+description: This tutorial provides an end-to-end demonstration of how to use Azure Stream Analytics to analyze fraudulent calls in a phone call stream.
 services: stream-analytics
 author: mamccrea
 ms.author: mamccrea
@@ -21,10 +21,10 @@ This tutorial teaches how to analyze phone call data using Azure Stream Analytic
 In this tutorial, you learn how to:
 
 > [!div class="checklist"]
-> * Generate sample phone call data and send it to Azure Event Hubs  
+> * Generate sample phone call data and send it to Azure Event Hubs
 > * Create a Stream Analytics job
-> * Configure job input and output  
-> * Define a query to filter fraudulent calls  
+> * Configure job input and output
+> * Define a query to filter fraudulent calls
 > * Test and start the job
 > * Visualize results in Power BI
 
@@ -32,22 +32,22 @@ In this tutorial, you learn how to:
 
 Before you start, make sure you have the following:
 
-* If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/).  
-* Log in to the [Azure portal](https://portal.azure.com/).  
+* If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/).
+* Log in to the [Azure portal](https://portal.azure.com/).
 * Download the phone call event generator app [TelcoGenerator.zip](https://download.microsoft.com/download/8/B/D/8BD50991-8D54-4F59-AB83-3354B69C8A7E/TelcoGenerator.zip) from the Microsoft Download Center or get the source code from [GitHub](https://aka.ms/azure-stream-analytics-telcogenerator).
 * You will need Power BI account.
 
-## Create an Azure Event Hub 
+## Create an Azure Event Hub
 
 Before Stream Analytics can analyze the fraudulent calls data stream, the data needs to be sent to Azure. In this tutorial, you will send data to Azure by using  [Azure Event Hubs](https://docs.microsoft.com/azure/event-hubs/event-hubs-what-is-event-hubs).
 
 Use the following steps to create an Event Hub and send call data to that Event Hub:
 
-1. Log in to the [Azure portal](https://portal.azure.com/).  
-2. Select **Create a resource** > **Internet of Things** > **Event Hubs**.  
+1. Log in to the [Azure portal](https://portal.azure.com/).
+2. Select **Create a resource** > **Internet of Things** > **Event Hubs**.
 
    ![Create an Azure Event Hub in the portal](media/stream-analytics-manage-job/find-event-hub-resource.png)
-3. Fill out the **Create Namespace** pane with the following values:  
+3. Fill out the **Create Namespace** pane with the following values:
 
    |**Setting**  |**Suggested value** |**Description**  |
    |---------|---------|---------|
@@ -56,11 +56,11 @@ Use the following steps to create an Event Hub and send call data to that Event 
    |Resource group     |   MyASADemoRG      |  Select **Create New** and enter a new resource-group name for your account.       |
    |Location     |   West US2      |    Location where the event hub namespace can be deployed.     |
 
-4. Use default options on the remaining settings and select **Create**.  
+4. Use default options on the remaining settings and select **Create**.
 
    ![Create event hub namespace in Azure portal](media/stream-analytics-manage-job/create-event-hub-namespace.png)
 
-5. When the namespace has finished deploying, go to **All resources** and find *myEventHubsNS* in the list of Azure resources. Select *myEventHubsNS* to open it.  
+5. When the namespace has finished deploying, go to **All resources** and find *myEventHubsNS* in the list of Azure resources. Select *myEventHubsNS* to open it.
 6. Next select **+Event Hub** and enter the **Name** as *MyEventHub* or a different name of your choice. Use the default options on the remaining settings and select **Create**. Then wait for the deployment to succeed.
 
    ![Event Hub configuration in Azure portal](media/stream-analytics-manage-job/create-event-hub-portal.png)
@@ -71,7 +71,7 @@ Before an application can send data to Azure Event Hubs, the event hub must have
 
 1. Navigate to the event hub you created in the previous step,*MyEventHub*. Select **Shared access policies** under **Settings**, and then select **+ Add**.
 
-2. Name the policy **MyPolicy** and ensure **Manage** is checked. Then select **Create**.  
+2. Name the policy **MyPolicy** and ensure **Manage** is checked. Then select **Create**.
 
    ![Create event hub shared access policy](media/stream-analytics-manage-job/create-event-hub-access-policy.png)
 
@@ -79,11 +79,11 @@ Before an application can send data to Azure Event Hubs, the event hub must have
 
    ![Save the shared access policy connection string](media/stream-analytics-manage-job/save-connection-string.png)
 
-4. Paste the connection string into a text editor. You need this connection string in the next section.  
+4. Paste the connection string into a text editor. You need this connection string in the next section.
 
    The connection string looks as follows:
 
-   `Endpoint=sb://<Your event hub namespace>.servicebus.windows.net/;SharedAccessKeyName=<Your shared access policy name>;SharedAccessKey=<generated key>;EntityPath=<Your event hub name>` 
+   `Endpoint=sb://<Your event hub namespace>.servicebus.windows.net/;SharedAccessKeyName=<Your shared access policy name>;SharedAccessKey=<generated key>;EntityPath=<Your event hub name>`
 
    Notice that the connection string contains multiple key-value pairs separated with semicolons: **Endpoint**, **SharedAccessKeyName**, **SharedAccessKey**, and **EntityPath**.
 
@@ -91,15 +91,15 @@ Before an application can send data to Azure Event Hubs, the event hub must have
 
 Before you start the TelcoGenerator app, you should configure it to send data to the Azure Event Hubs you created earlier.
 
-1. Extract the contents of [TelcoGenerator.zip](https://download.microsoft.com/download/8/B/D/8BD50991-8D54-4F59-AB83-3354B69C8A7E/TelcoGenerator.zip) file.  
-2. Open the `TelcoGenerator\TelcoGenerator\telcodatagen.exe.config` file in a text editor of your choice (There is more than one .config file, so be sure that you open the right one.)  
+1. Extract the contents of [TelcoGenerator.zip](https://download.microsoft.com/download/8/B/D/8BD50991-8D54-4F59-AB83-3354B69C8A7E/TelcoGenerator.zip) file.
+2. Open the `TelcoGenerator\TelcoGenerator\telcodatagen.exe.config` file in a text editor of your choice (There is more than one .config file, so be sure that you open the right one.)
 
 3. Update the <appSettings> element in the config file with the following details:
 
-   * Set the value of the *EventHubName* key to the value of the EntityPath in the connection string.  
+   * Set the value of the *EventHubName* key to the value of the EntityPath in the connection string.
    * Set the value of the *Microsoft.ServiceBus.ConnectionString* key to the connection string without the EntityPath value.
 
-4. Save the file.  
+4. Save the file.
 5. Next open a command window and change to the folder where you unzipped the TelcoGenerator application. Then enter the following command:
 
    ```cmd
@@ -107,8 +107,8 @@ Before you start the TelcoGenerator app, you should configure it to send data to
    ```
 
    This command takes the following parameters:
-   * Number of call data records per hour.  
-   * Percentage of fraud probability, which is how often the app should simulate a fraudulent call. The value 0.2 means that about 20% of the call records will look fraudulent.  
+   * Number of call data records per hour.
+   * Percentage of fraud probability, which is how often the app should simulate a fraudulent call. The value 0.2 means that about 20% of the call records will look fraudulent.
    * Duration in hours, which is the number of hours that the app should run. You can also stop the app any time by ending the process (**Ctrl+C**) at the command line.
 
    After a few seconds, the app starts displaying phone call records on the screen as it sends them to the event hub. The phone call data contains the following fields:
@@ -126,11 +126,11 @@ Before you start the TelcoGenerator app, you should configure it to send data to
 
 Now that you have a stream of call events, you can create a Stream Analytics job that reads data from the event hub.
 
-1. To create a Stream Analytics job, navigate to the [Azure portal](https://portal.azure.com/).  
+1. To create a Stream Analytics job, navigate to the [Azure portal](https://portal.azure.com/).
 
 2. Select **Create a resource** > **Internet of Things** > **Stream Analytics job**.
 
-3. Fill out the **New Stream Analytics job** pane with the following values:  
+3. Fill out the **New Stream Analytics job** pane with the following values:
 
    |**Setting**  |**Suggested value**  |**Description**  |
    |---------|---------|---------|
@@ -139,7 +139,7 @@ Now that you have a stream of call events, you can create a Stream Analytics job
    |Resource group   |   MyASADemoRG      |   Select **Use existing** and enter a new resource-group name for your account.      |
    |Location   |    West US2     |   	Location where the job can be deployed. It's recommended to place the job and the event hub in the same region for best performance and so that you don't pay to transfer data between regions.      |
    |Hosting environment    | Cloud        |     Stream Analytics jobs can be deployed to cloud or edge. Cloud allows you to deploy to Azure Cloud, and Edge allows you to deploy to an IoT edge device.    |
-   |Streaming units     |    1	     |   	Streaming units represent the computing resources that are required to execute a job. By default, this value is set to 1. To learn about scaling streaming units, see [understanding and adjusting streaming units](stream-analytics-streaming-unit-consumption.md) article.      |   
+   |Streaming units     |    1	     |   	Streaming units represent the computing resources that are required to execute a job. By default, this value is set to 1. To learn about scaling streaming units, see [understanding and adjusting streaming units](stream-analytics-streaming-unit-consumption.md) article.      |
 
 4. Use default options on the remaining settings, select **Create** and wait for the deployment to succeed.
 
@@ -149,11 +149,11 @@ Now that you have a stream of call events, you can create a Stream Analytics job
 
 The next step is to define an input source for the job to read data using the event hub you created in the previous section.
 
-1. From the Azure portal, open the **All resources** pane, and find the *ASATutorial* Stream Analytics job.  
+1. From the Azure portal, open the **All resources** pane, and find the *ASATutorial* Stream Analytics job.
 
-2. In the **Job Topology** section of the Stream Analytics job pane, select the **Inputs** option.  
+2. In the **Job Topology** section of the Stream Analytics job pane, select the **Inputs** option.
 
-3. Select **+ Add stream input** and **Event hub**. Fill out the pane with the following values:  
+3. Select **+ Add stream input** and **Event hub**. Fill out the pane with the following values:
 
    |**Setting**  |**Suggested value**  |**Description**  |
    |---------|---------|---------|
@@ -167,25 +167,25 @@ The next step is to define an input source for the job to read data using the ev
 
    ![Configure Azure Stream Analytics input](media/stream-analytics-manage-job/configure-stream-analytics-input.png)
 
-## Configure job output 
+## Configure job output
 
 The last step is to define an output sink for the job where it can write the transformed data. In this tutorial, you output and visualize data with Power BI.
 
-1. From the Azure portal open **All resources** pane, and the *ASATutorial* Stream Analytics job.  
+1. From the Azure portal open **All resources** pane, and the *ASATutorial* Stream Analytics job.
 
-2. In the **Job Topology** section of the Stream Analytics job pane, select the **Outputs** option.  
+2. In the **Job Topology** section of the Stream Analytics job pane, select the **Outputs** option.
 
-3. Select **+ Add** > **Power BI**. Then fill the form with the following details and select **Authorize**:  
+3. Select **+ Add** > **Power BI**. Then fill the form with the following details and select **Authorize**:
 
    |**Setting**  |**Suggested value**  |
    |---------|---------|---------|
    |Output alias  |  MyPBIoutput  |
-   |Dataset name  |   ASAdataset  | 
-   |Table name |  ASATable  | 
+   |Dataset name  |   ASAdataset  |
+   |Table name |  ASATable  |
 
-   ![Configure Stream Analytics output](media/stream-analytics-manage-job/configure-stream-analytics-output.png)  
+   ![Configure Stream Analytics output](media/stream-analytics-manage-job/configure-stream-analytics-output.png)
 
-4. When you select **Authorize**, a pop-up window opens and you are asked to provide credentials to authenticate to your Power BI account. Once the authorization is successful, **Save** the settings. 
+4. When you select **Authorize**, a pop-up window opens and you are asked to provide credentials to authenticate to your Power BI account. Once the authorization is successful, **Save** the settings.
 
 ## Define a query to analyze input data
 
@@ -193,9 +193,9 @@ The next step is to create a transformation that analyzes data in real time. You
 
 In this example, fraudulent calls are made from the same user within five seconds but in separate locations. For example, the same user can't legitimately make a call from the US and Australia at the same time. To define the transformation query for your Stream Analytics job:
 
-1. From the Azure portal open the **All resources** pane and navigate to the **ASATutorial** Stream Analytics job you created earlier.  
+1. From the Azure portal open the **All resources** pane and navigate to the **ASATutorial** Stream Analytics job you created earlier.
 
-2. In the **Job Topology** section of the Stream Analytics job pane, select the **Query** option. The query window lists the inputs and outputs that are configured for the job, and lets you create a query to transform the input stream.  
+2. In the **Job Topology** section of the Stream Analytics job pane, select the **Query** option. The query window lists the inputs and outputs that are configured for the job, and lets you create a query to transform the input stream.
 
 3. Replace the existing query in the editor with the following query, which performs a self-join on a 5-second interval of call data:
 
@@ -210,11 +210,11 @@ In this example, fraudulent calls are made from the same user within five second
    GROUP BY TumblingWindow(Duration(second, 1))
    ```
 
-   To check for fraudulent calls, you can self-join the streaming data based on the `CallRecTime` value. You can then look for call records where the `CallingIMSI` value (the originating number) is the same, but the `SwitchNum` value (country of origin) is different. When you use a JOIN operation with streaming data, the join must provide some limits on how far the matching rows can be separated in time. Because the streaming data is endless, the time bounds for the relationship are specified within the **ON** clause of the join using the [DATEDIFF](https://msdn.microsoft.com/azure/stream-analytics/reference/datediff-azure-stream-analytics) function. 
+   To check for fraudulent calls, you can self-join the streaming data based on the `CallRecTime` value. You can then look for call records where the `CallingIMSI` value (the originating number) is the same, but the `SwitchNum` value (country of origin) is different. When you use a JOIN operation with streaming data, the join must provide some limits on how far the matching rows can be separated in time. Because the streaming data is endless, the time bounds for the relationship are specified within the **ON** clause of the join using the [DATEDIFF](https://msdn.microsoft.com/azure/stream-analytics/reference/datediff-azure-stream-analytics) function.
 
-   This query is just like a normal SQL join except for the **DATEDIFF** function. The **DATEDIFF** function used in this query is specific to Stream Analytics, and it must appear within the `ON...BETWEEN` clause.  
+   This query is just like a normal SQL join except for the **DATEDIFF** function. The **DATEDIFF** function used in this query is specific to Stream Analytics, and it must appear within the `ON...BETWEEN` clause.
 
-4. **Save** the query.  
+4. **Save** the query.
 
    ![Define Stream Analytics query in portal](media/stream-analytics-manage-job/define-stream-analytics-query.png)
 
@@ -222,41 +222,41 @@ In this example, fraudulent calls are made from the same user within five second
 
 You can test a query from the query editor using sample data. Run the following steps to test the query:
 
-1. Make sure that the TelcoGenerator app is running and producing phone call records.  
+1. Make sure that the TelcoGenerator app is running and producing phone call records.
 
-2. In the **Query** pane, select the dots next to the *CallStream* input and then select **Sample data from input**. 
+2. In the **Query** pane, select the dots next to the *CallStream* input and then select **Sample data from input**.
 
-3. Set **Minutes** to 3 and select **OK**. Three minutes worth of data is then sampled from the input stream and you are notified when the sample data is ready. You can view the status of sampling from the notification bar. 
+3. Set **Minutes** to 3 and select **OK**. Three minutes worth of data is then sampled from the input stream and you are notified when the sample data is ready. You can view the status of sampling from the notification bar.
 
    The sample data is stored temporarily and is available while you have the query window open. If you close the query window, the sample data is discarded, and you'll have to create a new set of sample data if you want to test. Alternatively, you can use a sample data JSON file from [GitHub](https://github.com/Azure/azure-stream-analytics/blob/master/Sample%20Data/telco.json), and then upload that JSON file to use as sample data for the *CallStream* input.
 
    ![Visual of how to sample input data for Stream Analytics](media/stream-analytics-manage-job/sample-input-data-asa.png)
 
-4. Select **Test** to test the query. You should see the following results:  
+4. Select **Test** to test the query. You should see the following results:
 
    ![Out put from Stream Analytics query test](media/stream-analytics-manage-job/sample-test-output-restuls.png)
 
 ## Start the job and visualize output
 
-1. To start the job, navigate to the **Overview** pane of your job and select **Start**.  
+1. To start the job, navigate to the **Overview** pane of your job and select **Start**.
 
-2. Select **Now** for job output start time and select **Start**. You can view the job status in the notification bar.  
+2. Select **Now** for job output start time and select **Start**. You can view the job status in the notification bar.
 
-3. Once the job succeeds, navigate to [Power BI](https://powerbi.com/) and sign in with your work or school account. If the Stream Analytics job query is outputting results, the *ASAdataset* dataset you created exists under the **Datasets** tab.  
+3. Once the job succeeds, navigate to [Power BI](https://powerbi.com/) and sign in with your work or school account. If the Stream Analytics job query is outputting results, the *ASAdataset* dataset you created exists under the **Datasets** tab.
 
-4. From your Power BI workspace, select **+ Create** to create a new dashboard named *Fraudulent Calls*.  
+4. From your Power BI workspace, select **+ Create** to create a new dashboard named *Fraudulent Calls*.
 
-5. At the top of the window, select **Add tile**. Then select **Custom Streaming Data** and **Next**. Choose the **ASAdataset** under **Your Datasets**. Select **Card** from the **Visualization type** dropdown, and add **fraudulentcalls** to **Fields**. Select **Next** to enter a name for the tile, and then select **Apply** to create the tile.  
+5. At the top of the window, select **Add tile**. Then select **Custom Streaming Data** and **Next**. Choose the **ASAdataset** under **Your Datasets**. Select **Card** from the **Visualization type** dropdown, and add **fraudulentcalls** to **Fields**. Select **Next** to enter a name for the tile, and then select **Apply** to create the tile.
 
    ![Create Power BI dashboard tiles](media/stream-analytics-manage-job/create-power-bi-dashboard-tiles.png)
 
 6. Follow the step 5 again with the following options:
-   * When you get to Visualization Type, select Line chart.  
-   * Add an axis and select **windowend**.  
-   * Add a value and select **fraudulentcalls**.  
-   * For **Time window to display**, select the last 10 minutes.  
+   * When you get to Visualization Type, select Line chart.
+   * Add an axis and select **windowend**.
+   * Add a value and select **fraudulentcalls**.
+   * For **Time window to display**, select the last 10 minutes.
 
-7. Your dashboard should look like the example below once both tiles are added. Notice that, if your event hub sender application and Streaming Analytics application are running, your PowerBI dashboard periodically updates as new data arrives.  
+7. Your dashboard should look like the example below once both tiles are added. Notice that, if your event hub sender application and Streaming Analytics application are running, your PowerBI dashboard periodically updates as new data arrives.
 
    ![View results in Power BI dashboard](media/stream-analytics-manage-job/power-bi-results-dashboard.png)
 
@@ -264,12 +264,12 @@ You can test a query from the query editor using sample data. Run the following 
 
 For this part of the tutorial, you'll use a sample [ASP.NET](https://asp.net/) web application created by the PowerBI team to embed your dashboard. For more information about embedding dashboards, see [embedding with Power BI](https://docs.microsoft.com/power-bi/developer/embedding) article.
 
-To set up the application, go to the [PowerBI-Developer-Samples](https://github.com/Microsoft/PowerBI-Developer-Samples) Github repository and follow the instructions under the **User Owns Data** section (use the redirect and homepage URLs under the **integrate-dashboard-web-app** subsection). Since we are using the Dashboard example, use the **integrate-dashboard-web-app** sample code located in the [GitHub repository](https://github.com/Microsoft/PowerBI-Developer-Samples/tree/master/User%20Owns%20Data/integrate-dashboard-web-app).
+To set up the application, go to the [PowerBI-Developer-Samples](https://github.com/Microsoft/PowerBI-Developer-Samples) GitHub repository and follow the instructions under the **User Owns Data** section (use the redirect and homepage URLs under the **integrate-dashboard-web-app** subsection). Since we are using the Dashboard example, use the **integrate-dashboard-web-app** sample code located in the [GitHub repository](https://github.com/Microsoft/PowerBI-Developer-Samples/tree/master/User%20Owns%20Data/integrate-dashboard-web-app).
 Once you've got the application running in your browser, follow these steps to embed the dashboard you created earlier into the web page:
 
-1. Select **Sign in to Power BI**, which grants the application access to the dashboards in your PowerBI account.  
+1. Select **Sign in to Power BI**, which grants the application access to the dashboards in your PowerBI account.
 
-2. Select the **Get Dashboards** button, which displays your account's Dashboards in a table. Find the name of the dashboard you created earlier, **powerbi-embedded-dashboard**, and copy the corresponding **EmbedUrl**.  
+2. Select the **Get Dashboards** button, which displays your account's Dashboards in a table. Find the name of the dashboard you created earlier, **powerbi-embedded-dashboard**, and copy the corresponding **EmbedUrl**.
 
 3. Finally, paste the **EmbedUrl** into the corresponding text field and select **Embed Dashboard**. You can now view the same dashboard embedded within a web application.
 


### PR DESCRIPTION
* typo: Github -> GitHub
* delete unnecessary space: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it