### PR TITLE
Fix subtle PowerShell code issues

### DIFF
--- a/articles/storage/files/storage-sync-files-deployment-guide.md
+++ b/articles/storage/files/storage-sync-files-deployment-guide.md
@@ -196,7 +196,7 @@ if ($resourceGroups -notcontains $resourceGroup) {
 # it enables subsequent AFS cmdlets to be executed with minimal 
 # repetition of parameters or separate authentication 
 Login-AzureRmStorageSync `
-    –SubscriptionId $subID `
+    -SubscriptionId $subID `
     -ResourceGroupName $resourceGroup `
     -TenantId $tenantID `
     -Location $region
@@ -298,7 +298,7 @@ if ($fileShare -eq $null) {
 New-AzureRmStorageSyncCloudEndpoint `
     -StorageSyncServiceName $storageSyncName `
     -SyncGroupName $syncGroupName ` 
-    -StorageAccountResourceId $storageAccount.Id
+    -StorageAccountResourceId $storageAccount.Id `
     -StorageAccountShareName $fileShare.Name
 ```
 


### PR DESCRIPTION
Replace – (en dash) with - (hyphen) and add missing backtick on multi-line command