### PR TITLE
Fix ampersand and delete unnecessary spaces

### DIFF
--- a/articles/active-directory/develop/quickstart-v1-android.md
+++ b/articles/active-directory/develop/quickstart-v1-android.md
@@ -28,7 +28,7 @@ ms.custom: aaddev
 If you're developing an Android application, Microsoft makes it simple and straightforward to sign in Azure Active Directory (Azure AD) users. Azure AD enables your application to access user data through the Microsoft Graph or your own protected web API.
 
 The Azure AD Authentication Library (ADAL) Android library gives your app the ability to begin using the
-[Microsoft Azure Cloud](https://cloud.microsoft.com) & [Microsoft Graph API](https://developer.microsoft.com/graph) by supporting [Microsoft Azure Active Directory accounts](https://azure.microsoft.com/services/active-directory/) using industry standard OAuth 2.0 and OpenID Connect.
+[Microsoft Azure Cloud](https://cloud.microsoft.com) and [Microsoft Graph API](https://developer.microsoft.com/graph) by supporting [Microsoft Azure Active Directory accounts](https://azure.microsoft.com/services/active-directory/) using industry standard OAuth 2.0 and OpenID Connect.
 
 In this quickstart, you'll learn how to:
 
@@ -54,18 +54,18 @@ You can find the full sample code [on GitHub](https://github.com/Azure-Samples/a
 ```Java
 // Initialize your app with MSAL
 AuthenticationContext mAuthContext = new AuthenticationContext(
-        MainActivity.this, 
-        AUTHORITY, 
+        MainActivity.this,
+        AUTHORITY,
         false);
 
 
 // Perform authentication requests
 mAuthContext.acquireToken(
-    getActivity(), 
-    RESOURCE_ID, 
-    CLIENT_ID, 
-    REDIRECT_URI,  
-    PromptBehavior.Auto, 
+    getActivity(),
+    RESOURCE_ID,
+    CLIENT_ID,
+    REDIRECT_URI,
+    PromptBehavior.Auto,
     getAuthInteractiveCallback());
 
 // ...
@@ -76,7 +76,7 @@ mAuthResult.getAccessToken()
 
 ## Step 1: Register and configure your app
 
-You will need to have a native client application registered with Microsoft using the 
+You will need to have a native client application registered with Microsoft using the
 [Azure portal](https://portal.azure.com).
 
 1. Getting to app registration


### PR DESCRIPTION
Fix ampersand: & -> and

refs: https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/a/ampersand

en page: ![evi en](https://user-images.githubusercontent.com/1207985/49856545-71c01100-fe33-11e8-8bd9-6e837bf03201.jpg)
^ No problem.
ja page: ![evi ja](https://user-images.githubusercontent.com/1207985/49856548-72f13e00-fe33-11e8-835f-a7292f3f63fc.jpg)
^ But, `&` remains intact and not translated. So, this is very sad 😭 for those who read Japanese documents.

If you change from & to and.

* You can follow the Microsoft Style Guide: you win 😍
* English documents are not problem: we (people who read English documents) win 😍
* Japanese documents are no problem: we (people who read Japanese documents) win 😍

So, everyone is win and nobody loses! 😍😍😍