### PR TITLE
Rename IoT Toolkit to IoT Hub Toolkit

### DIFF
--- a/articles/iot-edge/TOC.yml
+++ b/articles/iot-edge/TOC.yml
@@ -205,7 +205,7 @@
     href: https://azure.microsoft.com/roadmap/?category=iot
   - name: Azure IoT Edge for VS Code
     href: https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-edge
-  - name: Azure IoT Toolkit for VS Code
+  - name: Azure IoT Hub Toolkit for VS Code
     href: https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit
   - name: DeviceExplorer tool
     href: https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer

--- a/articles/iot-edge/deploy-modbus-gateway.md
+++ b/articles/iot-edge/deploy-modbus-gateway.md
@@ -91,7 +91,7 @@ View the data coming through the modbus module:
 docker logs -f modbus
 ```
 
-You can also view the telemetry the device is sending by using the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit).
+You can also view the telemetry the device is sending by using the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension).
 
 ## Next steps
 

--- a/articles/iot-edge/quickstart-linux.experimental.md
+++ b/articles/iot-edge/quickstart-linux.experimental.md
@@ -197,7 +197,7 @@ View the messages being sent from the tempSensor module:
 
 The temperature sensor module may be waiting to connect to Edge Hub if the last line you see in the log is `Using transport Mqtt_Tcp_Only`. Try killing the module and letting the Edge Agent restart it. You can kill it with the command `sudo docker stop tempSensor`.
 
-You can also watch the messages arrive at your IoT hub by using the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit). 
+You can also watch the messages arrive at your IoT hub by using the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension). 
 
 ## Clean up resources
 

--- a/articles/iot-edge/quickstart-linux.md
+++ b/articles/iot-edge/quickstart-linux.md
@@ -254,7 +254,7 @@ View the messages being sent from the tempSensor module:
 
 The temperature sensor module may be waiting to connect to Edge Hub if the last line you see in the log is `Using transport Mqtt_Tcp_Only`. Try killing the module and letting the Edge Agent restart it. You can kill it with the command `sudo docker stop tempSensor`.
 
-You can also watch the messages arrive at your IoT hub by using the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit). 
+You can also watch the messages arrive at your IoT hub by using the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension). 
 
 ## Clean up resources
 

--- a/articles/iot-edge/quickstart.md
+++ b/articles/iot-edge/quickstart.md
@@ -195,7 +195,7 @@ iotedge logs tempSensor -f
 
   ![View the data from your module](./media/quickstart/iotedge-logs.png)
 
-You can also watch the messages arrive at your IoT hub by using the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit). 
+You can also watch the messages arrive at your IoT hub by using the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension). 
 
 ## Clean up resources
 

--- a/articles/iot-edge/troubleshoot.md
+++ b/articles/iot-edge/troubleshoot.md
@@ -142,7 +142,7 @@ Replace `env: {}` with:
 
 Save the file and restart the IoT Edge security manager.
 
-You can also check the messages being sent between IoT Hub and the IoT Edge devices. View these messages by using the [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) extension for Visual Studio Code. For more information, see [Handy tool when you develop with Azure IoT](https://blogs.msdn.microsoft.com/iotdev/2017/09/01/handy-tool-when-you-develop-with-azure-iot/).
+You can also check the messages being sent between IoT Hub and the IoT Edge devices. View these messages by using the [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) extension (formerly Azure IoT Toolkit extension) for Visual Studio Code. For more information, see [Handy tool when you develop with Azure IoT](https://blogs.msdn.microsoft.com/iotdev/2017/09/01/handy-tool-when-you-develop-with-azure-iot/).
 
 ### Restart containers
 After investigating the logs and messages for information, you can try restarting containers:

--- a/articles/iot-edge/tutorial-c-module.md
+++ b/articles/iot-edge/tutorial-c-module.md
@@ -331,7 +331,7 @@ You can see the full container image address with tag in the VS Code integrated 
 
 ## Deploy and run the solution
 
-In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Toolkit extension for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
+In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Hub Toolkit extension (formerly Azure IoT Toolkit extension) for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
 
 1. In the VS Code command palette, run **Azure IoT Hub: Select IoT Hub**.
 

--- a/articles/iot-edge/tutorial-csharp-module.md
+++ b/articles/iot-edge/tutorial-csharp-module.md
@@ -308,7 +308,7 @@ You can see the full container image address with tag in the VS Code integrated 
 
 ## Deploy and run the solution
 
-In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Toolkit extension for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
+In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Hub Toolkit extension (formerly Azure IoT Toolkit extension) for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
 
 1. In the VS Code command palette, run **Azure IoT Hub: Select IoT Hub**. 
 

--- a/articles/iot-edge/tutorial-deploy-machine-learning.md
+++ b/articles/iot-edge/tutorial-deploy-machine-learning.md
@@ -169,7 +169,7 @@ If you perform these commands on a Linux device, you may need to use `sudo` for 
 
 ### View data arriving at your IoT hub
 
-You can view the device-to-cloud messages that your IoT hub receives by using the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit).
+You can view the device-to-cloud messages that your IoT hub receives by using the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension).
 
 The following steps show you how to set up Visual Studio Code to monitor device-to-cloud messages that arrive at your IoT hub. 
 

--- a/articles/iot-edge/tutorial-java-module.md
+++ b/articles/iot-edge/tutorial-java-module.md
@@ -254,7 +254,7 @@ You can see the full container image address with tag in the VS Code integrated 
 
 ## Deploy and run the solution
 
-In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Toolkit extension for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
+In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Hub Toolkit extension (formerly Azure IoT Toolkit extension) for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
 
 1. In the VS Code command palette, run the command **Azure: Sign in** and follow the instructions to sign in your Azure account. If you're already signed in, you can skip this step.
 

--- a/articles/iot-edge/tutorial-node-module.md
+++ b/articles/iot-edge/tutorial-node-module.md
@@ -218,7 +218,7 @@ You can see the full container image address with tag in the `docker build` comm
 
 ## Deploy and run the solution
 
-In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Toolkit extension for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
+In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Hub Toolkit extension (formerly Azure IoT Toolkit extension) for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
 
 1. In the VS Code command palette, run **Azure IoT Hub: Select IoT Hub**. 
 

--- a/articles/iot-edge/tutorial-python-module.md
+++ b/articles/iot-edge/tutorial-python-module.md
@@ -240,7 +240,7 @@ You can see the full container image address with tag in the `docker build` comm
 
 ## Deploy and run the solution
 
-In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Toolkit extension for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
+In the quickstart article that you used to set up your IoT Edge device, you deployed a module by using the Azure portal. You can also deploy modules using the Azure IoT Hub Toolkit extension (formerly Azure IoT Toolkit extension) for Visual Studio Code. You already have a deployment manifest prepared for your scenario, the **deployment.json** file. All you need to do now is select a device to receive the deployment.
 
 1. In the VS Code command palette, run **Azure IoT Hub: Select IoT Hub**. 
 

--- a/articles/iot-hub/TOC.yml
+++ b/articles/iot-hub/TOC.yml
@@ -229,7 +229,7 @@
       items:
       - name: Use Azure portal
         href: iot-hub-create-through-portal.md
-      - name: Use Azure IoT Toolkit for VS Code
+      - name: Use Azure IoT Hub Toolkit for VS Code
         href: iot-hub-create-use-iot-toolkit.md
       - name: Use Azure PowerShell
         href: iot-hub-create-using-powershell.md
@@ -299,7 +299,7 @@
         href: iot-hub-arduino-iot-devkit-az3166-door-monitor.md
     - name: Extended IoT scenarios
       items:
-      - name: Manage cloud device messaging with Azure IoT Toolkit for VS Code
+      - name: Manage cloud device messaging with Azure IoT Hub Toolkit for VS Code
         href: iot-hub-vscode-iot-toolkit-cloud-device-messaging.md
       - name: Data Visualization in Power BI
         href: iot-hub-live-data-visualization-in-power-bi.md
@@ -307,7 +307,7 @@
         href: iot-hub-live-data-visualization-in-web-apps.md
       - name: Weather forecast using Azure Machine Learning
         href: iot-hub-weather-forecast-machine-learning.md
-      - name: Device management with Azure IoT Toolkit for VS Code
+      - name: Device management with Azure IoT Hub Toolkit for VS Code
         href: iot-hub-device-management-iot-toolkit.md
       - name: Device management with IoT extension for Azure CLI
         href: iot-hub-device-management-iot-extension-azure-cli-2-0.md
@@ -391,7 +391,7 @@
     href: iot-hub-customer-data-requests.md
   - name: Azure Roadmap
     href: https://azure.microsoft.com/roadmap/?category=iot
-  - name: Azure IoT Toolkit
+  - name: Azure IoT Hub Toolkit
     href: https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit
   - name: DeviceExplorer tool
     href: https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer

--- a/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
+++ b/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
@@ -227,9 +227,9 @@ The sample application is running successfully when you see the following result
 
 ### View the telemetry received by Azure IoT Hub
 
-You can use [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) to monitor device-to-cloud (D2C) messages in IoT Hub.
+You can use [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit) to monitor device-to-cloud (D2C) messages in IoT Hub.
 
-1. In Visual Studio Code, look for **Azure IoT Toolkit** in the extension marketplace and install it.
+1. In Visual Studio Code, look for **Azure IoT Hub Toolkit** in the extension marketplace and install it.
 
 1. Log in [Azure portal](https://portal.azure.com/), find the IoT Hub you created.
     ![Azure portal](media/iot-hub-arduino-devkit-az3166-get-started/getting-started/azure-iot-hub-portal.png)

--- a/articles/iot-hub/iot-hub-create-use-iot-toolkit.md
+++ b/articles/iot-hub/iot-hub-create-use-iot-toolkit.md
@@ -1,6 +1,6 @@
 ---
-title: Create an Azure IoT Hub using Azure IoT Toolkit for VS Code | Microsoft Docs
-description: How to use Azure IoT Toolkit for VS Code to create an IoT hub.
+title: Create an Azure IoT Hub using Azure IoT Hub Toolkit for VS Code | Microsoft Docs
+description: How to use Azure IoT Hub Toolkit for VS Code to create an IoT hub.
 author: formulahendry
 ms.service: iot-hub
 services: iot-hub
@@ -9,11 +9,11 @@ ms.date: 07/30/2018
 ms.author: junhan
 ---
 
-# Create an IoT hub using the Azure IoT Toolkit for Visual Studio Code
+# Create an IoT hub using the Azure IoT Hub Toolkit for Visual Studio Code
 
 [!INCLUDE [iot-hub-resource-manager-selector](../../includes/iot-hub-resource-manager-selector.md)]
 
-This article shows you how to use the [Azure IoT Toolkit for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) to create an Azure IoT hub. 
+This article shows you how to use the [Azure IoT Hub Toolkit for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit) to create an Azure IoT hub. 
 
 To complete this article, you need the following:
 
@@ -21,7 +21,7 @@ To complete this article, you need the following:
 
 - [Visual Studio Code](https://code.visualstudio.com/)
 
-- [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)
+- [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)
 
 ## Create an IoT hub
 
@@ -51,10 +51,10 @@ To complete this article, you need the following:
 
 ## Next steps
 
-Now you have deployed an IoT hub using the Azure IoT Toolkit for Visual Studio Code. To explore further, check out the following articles:
+Now you have deployed an IoT hub using the Azure IoT Hub Toolkit for Visual Studio Code. To explore further, check out the following articles:
 
-* [Use the Azure IoT Toolkit extension for Visual Studio Code to send and receive messages between your device and an IoT Hub](iot-hub-vscode-iot-toolkit-cloud-device-messaging.md).
+* [Use the Azure IoT Hub Toolkit extension for Visual Studio Code to send and receive messages between your device and an IoT Hub](iot-hub-vscode-iot-toolkit-cloud-device-messaging.md).
 
-* [Use the Azure IoT Toolkit extension for Visual Studio Code for Azure IoT Hub device management](iot-hub-device-management-iot-toolkit.md)
+* [Use the Azure IoT Hub Toolkit extension for Visual Studio Code for Azure IoT Hub device management](iot-hub-device-management-iot-toolkit.md)
 
-* [See the Azure IoT Toolkit wiki page](https://github.com/microsoft/vscode-azure-iot-toolkit/wiki).
+* [See the Azure IoT Hub Toolkit wiki page](https://github.com/microsoft/vscode-azure-iot-toolkit/wiki).

--- a/articles/iot-hub/iot-hub-devguide-device-twins.md
+++ b/articles/iot-hub/iot-hub-devguide-device-twins.md
@@ -377,4 +377,4 @@ To try out some of the concepts described in this article, see the following IoT
 
 * [How to use the device twin](iot-hub-node-node-twin-getstarted.md)
 * [How to use device twin properties](tutorial-device-twins.md)
-* [Device management with Azure IoT Toolkit for VS Code](iot-hub-device-management-iot-toolkit.md)
+* [Device management with Azure IoT Hub Toolkit for VS Code](iot-hub-device-management-iot-toolkit.md)

--- a/articles/iot-hub/iot-hub-devguide-direct-methods.md
+++ b/articles/iot-hub/iot-hub-devguide-direct-methods.md
@@ -198,4 +198,4 @@ Now you have learned how to use direct methods, you may be interested in the fol
 If you would like to try out some of the concepts described in this article, you may be interested in the following IoT Hub tutorial:
 
 * [Use direct methods](quickstart-control-device-node.md)
-* [Device management with Azure IoT Toolkit for VS Code](iot-hub-device-management-iot-toolkit.md)
+* [Device management with Azure IoT Hub Toolkit for VS Code](iot-hub-device-management-iot-toolkit.md)

--- a/articles/iot-hub/iot-hub-devguide-glossary.md
+++ b/articles/iot-hub/iot-hub-devguide-glossary.md
@@ -35,8 +35,8 @@ There are _device SDKs_ available for multiple languages that enable you to crea
 ## Azure IoT service SDKs
 There are _service SDKs_ available for multiple languages that enable you to create [back-end apps](#back-end-app) that interact with an IoT hub. The IoT Hub tutorials show you how to use these service SDKs. You can find the source code and further information about the service SDKs in this GitHub [repository](https://github.com/Azure/azure-iot-sdks).
 
-## Azure IoT Toolkit
-The [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) is a cross-platform, open-source Visual Studio Code extension that helps you manage Azure IoT Hub and devices in VS Code. With Azure IoT Toolkit, IoT developers could develop IoT project in VS Code with ease.
+## Azure IoT Hub Toolkit
+The [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit) is a cross-platform, open-source Visual Studio Code extension that helps you manage Azure IoT Hub and devices in VS Code. With Azure IoT Hub Toolkit, IoT developers could develop IoT project in VS Code with ease.
 
 ## Azure portal
 The [Microsoft Azure portal](https://portal.azure.com) is a central place where you can provision and manage your Azure resources. It organizes its content using _blades_.

--- a/articles/iot-hub/iot-hub-devguide-security.md
+++ b/articles/iot-hub/iot-hub-devguide-security.md
@@ -87,7 +87,7 @@ HTTPS implements authentication by including a valid token in the **Authorizatio
 Username (DeviceId is case-sensitive):
 `iothubname.azure-devices.net/DeviceId`
 
-Password (You can generate a SAS token with the [device explorer](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/tools/DeviceExplorer) tool, the CLI extension command [az iot hub generate-sas-token](/cli/azure/ext/azure-cli-iot-ext/iot/hub?view=azure-cli-latest#ext-azure-cli-iot-ext-az-iot-hub-generate-sas-token), or the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)):
+Password (You can generate a SAS token with the [device explorer](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/tools/DeviceExplorer) tool, the CLI extension command [az iot hub generate-sas-token](/cli/azure/ext/azure-cli-iot-ext/iot/hub?view=azure-cli-latest#ext-azure-cli-iot-ext-az-iot-hub-generate-sas-token), or the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension)):
 
 `SharedAccessSignature sr=iothubname.azure-devices.net%2fdevices%2fDeviceId&sig=kPszxZZZZZZZZZZZZZZZZZAhLT%2bV7o%3d&se=1487709501`
 
@@ -268,7 +268,7 @@ The result, which grants access to all functionality for device1, would be:
 `SharedAccessSignature sr=myhub.azure-devices.net%2fdevices%2fdevice1&sig=13y8ejUk2z7PLmvtwR5RqlGBOVwiq7rQR3WZ5xZX3N4%3D&se=1456971697`
 
 > [!NOTE]
-> It's possible to generate a SAS token with the [device explorer](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/tools/DeviceExplorer) tool, the CLI extension command [az iot hub generate-sas-token](/cli/azure/ext/azure-cli-iot-ext/iot/hub?view=azure-cli-latest#ext-azure-cli-iot-ext-az-iot-hub-generate-sas-token), or the [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit).
+> It's possible to generate a SAS token with the [device explorer](https://github.com/Azure/azure-iot-sdk-csharp/blob/master/tools/DeviceExplorer) tool, the CLI extension command [az iot hub generate-sas-token](/cli/azure/ext/azure-cli-iot-ext/iot/hub?view=azure-cli-latest#ext-azure-cli-iot-ext-az-iot-hub-generate-sas-token), or the [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit).
 
 ### Use a shared access policy
 

--- a/articles/iot-hub/iot-hub-device-management-iot-toolkit.md
+++ b/articles/iot-hub/iot-hub-device-management-iot-toolkit.md
@@ -1,6 +1,6 @@
 ---
-title: Azure IoT device management with Azure IoT Toolkit extension for Visual Studio Code | Microsoft Docs
-description: Use the Azure IoT Toolkit extension for Visual Studio Code for Azure IoT Hub device management, featuring the Direct methods and the Twin's desired properties management options.
+title: Azure IoT device management with Azure IoT Hub Toolkit extension for Visual Studio Code | Microsoft Docs
+description: Use the Azure IoT Hub Toolkit extension for Visual Studio Code for Azure IoT Hub device management, featuring the Direct methods and the Twin's desired properties management options.
 author: formulahendry
 ms.service: iot-hub
 services: iot-hub
@@ -10,11 +10,11 @@ ms.date: 8/3/2018
 ms.author: junhan
 ---
 
-# Use Azure IoT Toolkit extension for Visual Studio Code for Azure IoT Hub device management
+# Use Azure IoT Hub Toolkit extension for Visual Studio Code for Azure IoT Hub device management
 
 ![End-to-end diagram](media/iot-hub-get-started-e2e-diagram/2.png)
 
-[Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) is a useful Visual Studio Code extension that makes IoT Hub management easier. It comes with management options that you can use to perform various tasks.
+[Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit) is a useful Visual Studio Code extension that makes IoT Hub management easier. It comes with management options that you can use to perform various tasks.
 
 [!INCLUDE [iot-hub-basic](../../includes/iot-hub-basic-whole.md)]
 
@@ -31,18 +31,18 @@ Device twins are JSON documents that store device state information (metadata, c
 
 ## What you learn
 
-You learn using Azure IoT Toolkit extension for Visual Studio Code with various management options on your development machine.
+You learn using Azure IoT Hub Toolkit extension for Visual Studio Code with various management options on your development machine.
 
 ## What you do
 
-Run Azure IoT Toolkit extension for Visual Studio Code with various management options.
+Run Azure IoT Hub Toolkit extension for Visual Studio Code with various management options.
 
 ## What you need
 
 * An active Azure subscription.
 * An Azure IoT hub under your subscription.
 * [Visual Studio Code](https://code.visualstudio.com/)
-* [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)
+* [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)
 
 ## Sign in to access your IoT hub
 
@@ -65,7 +65,7 @@ Run Azure IoT Toolkit extension for Visual Studio Code with various management o
 
 2. Enter the method name and payload in input box.
 
-3. Results will be shown in **OUTPUT** > **Azure IoT Toolkit** view.
+3. Results will be shown in **OUTPUT** > **Azure IoT Hub Toolkit** view.
 
 ## Read device twin
 
@@ -89,10 +89,10 @@ To send a message from your IoT hub to your device, follow these steps:
 
 2. Enter the message in input box.
 
-3. Results will be shown in **OUTPUT** > **Azure IoT Toolkit** view.
+3. Results will be shown in **OUTPUT** > **Azure IoT Hub Toolkit** view.
 
 ## Next steps
 
-You've learned how to use Azure IoT Toolkit extension for Visual Studio Code with various management options.
+You've learned how to use Azure IoT Hub Toolkit extension for Visual Studio Code with various management options.
 
 [!INCLUDE [iot-hub-get-started-next-steps](../../includes/iot-hub-get-started-next-steps.md)]

--- a/articles/iot-hub/iot-hub-device-sdk-c-intro.md
+++ b/articles/iot-hub/iot-hub-device-sdk-c-intro.md
@@ -70,11 +70,11 @@ There are several open source tools to help you manage your IoT hub.
 
 * A Windows application called [device explorer](https://github.com/Azure/azure-iot-sdk-csharp/tree/master/tools/DeviceExplorer).
 
-* A cross-platform Visual Studio Code extension called [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit).
+* A cross-platform Visual Studio Code extension called [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit).
 
 * A cross-platform Python CLI called [the IoT extension for Azure CLI](https://github.com/Azure/azure-iot-cli-extension).
 
-This tutorial uses the graphical *device explorer* tool. You can use the *Azure IoT Toolkit extension for VS Code* if you develop in VS Code. You can also use the *the IoT extension for Azure CLI 2.0* tool if you prefer to use a CLI tool.
+This tutorial uses the graphical *device explorer* tool. You can use the *Azure IoT Hub Toolkit extension for VS Code* if you develop in VS Code. You can also use the *the IoT extension for Azure CLI 2.0* tool if you prefer to use a CLI tool.
 
 The device explorer tool uses the Azure IoT service libraries to perform various functions on IoT Hub, including adding devices. If you use the device explorer tool to add a device, you get a connection string for your device. You need this connection string to run the sample applications.
 

--- a/articles/iot-hub/iot-hub-mqtt-support.md
+++ b/articles/iot-hub/iot-hub-mqtt-support.md
@@ -76,9 +76,9 @@ If a device cannot use the device SDKs, it can still connect to the public devic
 
   For more information about how to generate SAS tokens, see the device section of [Using IoT Hub security tokens][lnk-sas-tokens].
 
-  When testing, you can also use the cross-platform [Azure IoT Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) or the [Device Explorer][lnk-device-explorer] tool to quickly generate a SAS token that you can copy and paste into your own code:
+  When testing, you can also use the cross-platform [Azure IoT Hub Toolkit extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit extension) or the [Device Explorer][lnk-device-explorer] tool to quickly generate a SAS token that you can copy and paste into your own code:
 
-For Azure IoT Toolkit:
+For Azure IoT Hub Toolkit:
 
   1. Expand the **AZURE IOT HUB DEVICES** tab in the bottom left corner of Visual Studio Code.
   2. Right-click your device and select **Generate SAS Token for Device**.

--- a/articles/iot-hub/iot-hub-raspberry-pi-kit-c-get-started.md
+++ b/articles/iot-hub/iot-hub-raspberry-pi-kit-c-get-started.md
@@ -204,6 +204,6 @@ You should see the following output that shows the sensor data and the messages 
 
 ## Next steps
 
-You’ve run a sample application to collect sensor data and send it to your IoT hub. To see the messages that your Raspberry Pi has sent to your IoT hub or send messages to your Raspberry Pi, see the [Use Azure IoT Toolkit extension for Visual Studio Code to send and receive messages between your device and IoT Hub](iot-hub-vscode-iot-toolkit-cloud-device-messaging.md).
+You’ve run a sample application to collect sensor data and send it to your IoT hub. To see the messages that your Raspberry Pi has sent to your IoT hub or send messages to your Raspberry Pi, see the [Use Azure IoT Hub Toolkit extension for Visual Studio Code to send and receive messages between your device and IoT Hub](iot-hub-vscode-iot-toolkit-cloud-device-messaging.md).
 
 [!INCLUDE [iot-hub-get-started-next-steps](../../includes/iot-hub-get-started-next-steps.md)]

--- a/articles/iot-hub/iot-hub-raspberry-pi-kit-node-get-started.md
+++ b/articles/iot-hub/iot-hub-raspberry-pi-kit-node-get-started.md
@@ -235,6 +235,6 @@ You should see the following output that shows the sensor data and the messages 
 
 ## Next steps
 
-You’ve run a sample application to collect sensor data and send it to your IoT hub. To see the messages that your Raspberry Pi has sent to your IoT hub or send messages to your Raspberry Pi, see the [Use Azure IoT Toolkit extension for Visual Studio Code to send and receive messages between your device and IoT Hub](iot-hub-vscode-iot-toolkit-cloud-device-messaging.md).
+You’ve run a sample application to collect sensor data and send it to your IoT hub. To see the messages that your Raspberry Pi has sent to your IoT hub or send messages to your Raspberry Pi, see the [Use Azure IoT Hub Toolkit extension for Visual Studio Code to send and receive messages between your device and IoT Hub](iot-hub-vscode-iot-toolkit-cloud-device-messaging.md).
 
 [!INCLUDE [iot-hub-get-started-next-steps](../../includes/iot-hub-get-started-next-steps.md)]

--- a/articles/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging.md
+++ b/articles/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging.md
@@ -1,6 +1,6 @@
 ---
-title: Manage Azure IoT Hub cloud device messaging with Azure IoT Toolkit extension for Visual Studio Code | Microsoft Docs
-description: Learn how to use Azure IoT Toolkit extension for Visual Studio Code to monitor device to cloud messages and send cloud to device messages in Azure IoT Hub.
+title: Manage Azure IoT Hub cloud device messaging with Azure IoT Hub Toolkit extension for Visual Studio Code | Microsoft Docs
+description: Learn how to use Azure IoT Hub Toolkit extension for Visual Studio Code to monitor device to cloud messages and send cloud to device messages in Azure IoT Hub.
 author: formulahendry
 ms.service: iot-hub
 services: iot-hub
@@ -10,29 +10,29 @@ ms.date: 7/20/2018
 ms.author: junhan
 ---
 
-# Use Azure IoT Toolkit extension for Visual Studio Code to send and receive messages between your device and IoT Hub
+# Use Azure IoT Hub Toolkit extension for Visual Studio Code to send and receive messages between your device and IoT Hub
 
 ![End-to-end diagram](media/iot-hub-get-started-e2e-diagram/2.png)
 
-[Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) is a useful Visual Studio Code extension that makes IoT Hub management easier. This article focuses on how to use Azure IoT Toolkit extension for Visual Studio Code to send and receive messages between your device and your IoT hub.
+[Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) (formerly Azure IoT Toolkit) is a useful Visual Studio Code extension that makes IoT Hub management easier. This article focuses on how to use Azure IoT Hub Toolkit extension for Visual Studio Code to send and receive messages between your device and your IoT hub.
 
 [!INCLUDE [iot-hub-basic](../../includes/iot-hub-basic-partial.md)]
 
 ## What you will learn
 
-You learn how to use Azure IoT Toolkit extension for Visual Studio Code to monitor device-to-cloud messages and to send cloud-to-device messages. Device-to-cloud messages could be sensor data that your device collects and then sends to your IoT hub. Cloud-to-device messages could be commands that your IoT hub sends to your device to blink an LED that is connected to your device.
+You learn how to use Azure IoT Hub Toolkit extension for Visual Studio Code to monitor device-to-cloud messages and to send cloud-to-device messages. Device-to-cloud messages could be sensor data that your device collects and then sends to your IoT hub. Cloud-to-device messages could be commands that your IoT hub sends to your device to blink an LED that is connected to your device.
 
 ## What you will do
 
-- Use Azure IoT Toolkit extension for Visual Studio Code to monitor device-to-cloud messages.
-- Use Azure IoT Toolkit extension for Visual Studio Code to send cloud-to-device messages.
+- Use Azure IoT Hub Toolkit extension for Visual Studio Code to monitor device-to-cloud messages.
+- Use Azure IoT Hub Toolkit extension for Visual Studio Code to send cloud-to-device messages.
 
 ## What you need
 
 - An active Azure subscription.
 - An Azure IoT hub under your subscription.
 - [Visual Studio Code](https://code.visualstudio.com/)
-- [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)
+- [Azure IoT Hub Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)
 
 ## Sign in to access your IoT hub
 
@@ -50,7 +50,7 @@ You learn how to use Azure IoT Toolkit extension for Visual Studio Code to monit
 To monitor messages that are sent from your device to your IoT hub, follow these steps:
 
 1. Right-click your device and select **Start Monitoring D2C Message**.
-1. The monitored messages will be shown in **OUTPUT** > **Azure IoT Toolkit** view.
+1. The monitored messages will be shown in **OUTPUT** > **Azure IoT Hub Toolkit** view.
 1. To stop monitoring, right-click the **OUTPUT** view and select **Stop Monitoring D2C Message**.
 
 ## Send cloud-to-device messages
@@ -59,7 +59,7 @@ To send a message from your IoT hub to your device, follow these steps:
 
 1. Right-click your device and select **Send C2D Message to Device**. 
 1. Enter the message in input box.
-1. Results will be shown in **OUTPUT** > **Azure IoT Toolkit** view.
+1. Results will be shown in **OUTPUT** > **Azure IoT Hub Toolkit** view.
 
 ## Next steps
 

--- a/includes/iot-hub-get-started-extended.md
+++ b/includes/iot-hub-get-started-extended.md
@@ -16,9 +16,9 @@ Use other Azure services and tools. When you have connected your device to IoT H
 
 | Scenario                                                   | Azure service or tool              |
 |----------------------------------------------------------- |------------------------------------|
-| [Manage IoT Hub messages](../articles/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging.md)                  | VS Code Azure IoT Toolkit extension|
+| [Manage IoT Hub messages](../articles/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging.md)                  | VS Code Azure IoT Hub Toolkit extension|
 | [Manage your IoT device](../articles/iot-hub/iot-hub-device-management-iot-extension-azure-cli-2-0.md)                        | Azure CLI and the IoT extension    |
-| [Manage your IoT device](../articles/iot-hub/iot-hub-device-management-iot-toolkit.md)                | VS Code Azure IoT Toolkit extension|
+| [Manage your IoT device](../articles/iot-hub/iot-hub-device-management-iot-toolkit.md)                | VS Code Azure IoT Hub Toolkit extension|
 | [Save IoT Hub messages to Azure storage](../articles/iot-hub/iot-hub-store-data-in-azure-table-storage.md)  | Azure table storage                |
 | [Visualize sensor data](../articles/iot-hub/iot-hub-live-data-visualization-in-power-bi.md)                      | Microsoft Power BI                 |
 | [Visualize sensor data](../articles/iot-hub/iot-hub-live-data-visualization-in-web-apps.md)                      | Azure Web Apps                     |

--- a/includes/iot-hub-get-started-next-steps.md
+++ b/includes/iot-hub-get-started-next-steps.md
@@ -12,7 +12,7 @@
 
 To continue to get started with Azure IoT Hub and to explore other IoT scenarios, see the following:
 
-- [Manage cloud device messaging with Azure IoT Toolkit extension for Visual Studio Code](../articles/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging.md)
+- [Manage cloud device messaging with Azure IoT Hub Toolkit extension for Visual Studio Code](../articles/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging.md)
 
 - [Save your Azure IoT hub messages to Azure data storage](../articles/iot-hub/iot-hub-store-data-in-azure-table-storage.md)
 
@@ -22,6 +22,6 @@ To continue to get started with Azure IoT Hub and to explore other IoT scenarios
 
 - [Forecast weather by using the sensor data from your IoT hub in Azure Machine Learning](../articles/iot-hub/iot-hub-weather-forecast-machine-learning.md)
 
-- [Manage devices with Azure IoT Toolkit extension for Visual Studio Code](../articles/iot-hub/iot-hub-device-management-iot-toolkit.md)
+- [Manage devices with Azure IoT Hub Toolkit extension for Visual Studio Code](../articles/iot-hub/iot-hub-device-management-iot-toolkit.md)
 
 - [Use ​​Logic ​​Apps for remote monitoring and notifications](../articles/iot-hub/iot-hub-monitoring-notifications-with-azure-logic-apps.md)

--- a/includes/iot-hub-resource-manager-selector.md
+++ b/includes/iot-hub-resource-manager-selector.md
@@ -7,7 +7,7 @@ ms.author: dobett
 ---
 > [!div class="op_single_selector"]
 > * [Azure portal](../articles/iot-hub/iot-hub-create-through-portal.md)
-> * [Azure IoT Toolkit for VS Code](../articles/iot-hub/iot-hub-create-use-iot-toolkit.md)
+> * [Azure IoT Hub Toolkit for VS Code](../articles/iot-hub/iot-hub-create-use-iot-toolkit.md)
 > * [PowerShell](../articles/iot-hub/iot-hub-create-using-powershell.md)
 > * [Azure CLI](../articles/iot-hub/iot-hub-create-using-cli.md)
 > * [PowerShell with template](../articles/iot-hub/iot-hub-rm-template-powershell.md)


### PR DESCRIPTION
The [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) extension has been renamed to Azure IoT Hub Toolkit, update the old names in existing documents.