### PR TITLE
fix Russian grammar in a text sample

### DIFF
--- a/articles/cognitive-services/text-analytics/how-tos/text-analytics-how-to-language-detection.md
+++ b/articles/cognitive-services/text-analytics/how-tos/text-analytics-how-to-language-detection.md
@@ -47,7 +47,7 @@ Document size must be under 5,000 characters per document, and you can have up t
             },                
             {
                 "id": "5",
-                "text": "Этот документ находится на английском языке."
+                "text": "Этот документ на английском языке."
             }
         ]
     }


### PR DESCRIPTION
In a phrase like that the verb 'To be' should be omitted.