### PR TITLE
Fix typo and delete unnecessary spaces

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-attached-disks.md
@@ -22,7 +22,7 @@ ms.author: manayar
 To expand your available storage, Azure [virtual machine scale sets](/azure/virtual-machine-scale-sets/) support VM instances with attached data disks. You can attach data disks when the scale set is created, or to an existing scale set.
 
 > [!NOTE]
->  When you create a scale set with attached data disks, you need to mount and format the disks from within a VM to use them (just like for standalone Azure VMs). A convenient way to complete this process is to use a Custom Script Extension that calls a script to partition and format all the data disks on a VM. For examples of this, see [Azure CLI](tutorial-use-disks-cli.md#prepare-the-data-disks) [Azure PowerShell](tutorial-use-disks-powershell.md#prepare-the-data-disks).
+> When you create a scale set with attached data disks, you need to mount and format the disks from within a VM to use them (just like for standalone Azure VMs). A convenient way to complete this process is to use a Custom Script Extension that calls a script to partition and format all the data disks on a VM. For examples of this, see [Azure CLI](tutorial-use-disks-cli.md#prepare-the-data-disks) [Azure PowerShell](tutorial-use-disks-powershell.md#prepare-the-data-disks).
 
 
 ## Create and manage disks in a scale set
@@ -35,7 +35,7 @@ The rest of this article outlines specific use cases such as Service Fabric clus
 
 
 ## Create a Service Fabric cluster with attached data disks
-Each [node type](../service-fabric/service-fabric-cluster-nodetypes.md) in a [Service Fabric](/azure/service-fabric) cluster running in Azure is backed by a virtual machine scale set.  Using an Azure Resource Manager template, you can attach data disks to the scale set(s) that make up the Service Fabric cluster. You can use an [existing template](https://github.com/Azure-Samples/service-fabric-cluster-templates) as a starting point. In the template, include a _dataDisks_ section in the _storageProfile_ of the _Microsoft.Compute/virtualMachineScaleSets_ resource(s) and deploy the template. The following example attaches a 128 GB data disk:
+Each [node type](../service-fabric/service-fabric-cluster-nodetypes.md) in a [Service Fabric](/azure/service-fabric) cluster running in Azure is backed by a virtual machine scale set. Using an Azure Resource Manager template, you can attach data disks to the scale set(s) that make up the Service Fabric cluster. You can use an [existing template](https://github.com/Azure-Samples/service-fabric-cluster-templates) as a starting point. In the template, include a _dataDisks_ section in the _storageProfile_ of the _Microsoft.Compute/virtualMachineScaleSets_ resource(s) and deploy the template. The following example attaches a 128 GB data disk:
 
 ```json
 "dataDisks": [
@@ -47,19 +47,19 @@ Each [node type](../service-fabric/service-fabric-cluster-nodetypes.md) in a [Se
 ]
 ```
 
-You can automatically partition, format, and mount the data disks when the cluster is deployed.  Add a custom script extension to the _extensionProfile_ of the _virtualMachineProfile_ of the scale set(s).
+You can automatically partition, format, and mount the data disks when the cluster is deployed. Add a custom script extension to the _extensionProfile_ of the _virtualMachineProfile_ of the scale set(s).
 
 To automatically prepare the data disk(s) in a Windows cluster, add the following:
 
 ```json
 {
-    "name": "customScript",    
-    "properties": {    
-        "publisher": "Microsoft.Compute",    
-        "type": "CustomScriptExtension",    
-        "typeHandlerVersion": "1.8",    
-        "autoUpgradeMinorVersion": true,    
-        "settings": {    
+    "name": "customScript",
+    "properties": {
+        "publisher": "Microsoft.Compute",
+        "type": "CustomScriptExtension",
+        "typeHandlerVersion": "1.8",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
         "fileUris": [
             "https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/prepare_vm_disks.ps1"
         ],
@@ -89,7 +89,7 @@ To automatically prepare the data disk(s) in a Linux cluster, add the following:
 
 
 ## Adding pre-populated data disks to an existing scale set
-Data disks specified in the scale set model are always empty. However, you may attach an existing data disk to a specific VM in a scale set. This feature is in preview, with examples on [github](https://github.com/Azure/vm-scale-sets/tree/master/preview/disk). If you wish to propagate data across all VMs in the scale set, you may duplicate your data disk and attach it to each VM in the scale set, you may create a custom image that contains the data and provision the scale set from this custom image, or you may use Azure Files or a similar data storage offering.
+Data disks specified in the scale set model are always empty. However, you may attach an existing data disk to a specific VM in a scale set. This feature is in preview, with examples on [GitHub](https://github.com/Azure/vm-scale-sets/tree/master/preview/disk). If you wish to propagate data across all VMs in the scale set, you may duplicate your data disk and attach it to each VM in the scale set, you may create a custom image that contains the data and provision the scale set from this custom image, or you may use Azure Files or a similar data storage offering.
 
 
 ## Additional notes


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it