### PR TITLE
Fix typo and delete unnecessary spaces

### DIFF
--- a/articles/hdinsight/hdinsight-hadoop-create-linux-clusters-with-secure-transfer-storage.md
+++ b/articles/hdinsight/hdinsight-hadoop-create-linux-clusters-with-secure-transfer-storage.md
@@ -12,34 +12,34 @@ ms.date: 07/24/2018
 ---
 # Create Apache Hadoop cluster with secure transfer storage accounts in Azure HDInsight
 
-The [Secure transfer required](../storage/common/storage-require-secure-transfer.md) feature enhances the security of your Azure Storage account by enforcing all requests to your account through a secure connection. This feature and the wasbs scheme are only supported by HDInsight cluster version 3.6 or newer. 
+The [Secure transfer required](../storage/common/storage-require-secure-transfer.md) feature enhances the security of your Azure Storage account by enforcing all requests to your account through a secure connection. This feature and the wasbs scheme are only supported by HDInsight cluster version 3.6 or newer.
 
 ## Prerequisites
 Before you begin this tutorial, you must have:
 
 * **Azure subscription**: To create a free one-month trial account, browse to [azure.microsoft.com/free](https://azure.microsoft.com/free).
 * **An Azure Storage account with secure transfer enabled**. For the instructions, see [Create a storage account](../storage/common/storage-quickstart-create-account.md) and [Require secure transfer](../storage/common/storage-require-secure-transfer.md).
-* **A Blob container on the storage account**. 
+* **A Blob container on the storage account**.
 
 ## Create cluster
 
 [!INCLUDE [delete-cluster-warning](../../includes/hdinsight-delete-cluster-warning.md)]
 
 
-In this section, you create a Hadoop cluster in HDInsight using an [Azure Resource Manager template](../azure-resource-manager/resource-group-template-deploy.md). The template is located in [Github](https://azure.microsoft.com/resources/templates/101-hdinsight-linux-with-existing-default-storage-account/). Resource Manager template experience is not required for following this tutorial. For other cluster creation methods and understanding the properties used in this tutorial, see [Create HDInsight clusters](hdinsight-hadoop-provision-linux-clusters.md).
+In this section, you create a Hadoop cluster in HDInsight using an [Azure Resource Manager template](../azure-resource-manager/resource-group-template-deploy.md). The template is located in [GitHub](https://azure.microsoft.com/resources/templates/101-hdinsight-linux-with-existing-default-storage-account/). Resource Manager template experience is not required for following this tutorial. For other cluster creation methods and understanding the properties used in this tutorial, see [Create HDInsight clusters](hdinsight-hadoop-provision-linux-clusters.md).
 
-1. Click the following image to sign in to Azure and open the Resource Manager template in the Azure portal. 
-   
+1. Click the following image to sign in to Azure and open the Resource Manager template in the Azure portal.
+
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-hdinsight-linux-with-existing-default-storage-account%2Fazuredeploy.json" target="_blank"><img src="./media/hdinsight-hadoop-linux-tutorial-get-started/deploy-to-azure.png" alt="Deploy to Azure"></a>
 
 2. Follow the instructions to create the cluster with the following specifications: 
 
-    - Specify HDInsight version 3.6.  Version 3.6 or newer is required.
+    - Specify HDInsight version 3.6. Version 3.6 or newer is required.
     - Specify a secure transfer enabled storage account.
     - Use short name for the storage account.
-    - Both the storage account and the blob container must be created beforehand. 
+    - Both the storage account and the blob container must be created beforehand.
 
-      For the instructions, see [Create cluster](hadoop/apache-hadoop-linux-tutorial-get-started.md#create-cluster). 
+      For the instructions, see [Create cluster](hadoop/apache-hadoop-linux-tutorial-get-started.md#create-cluster).
 
 If you use script action to provide your own configuration files, you must use wasbs in the following settings:
 
@@ -53,7 +53,7 @@ There are several options to add additional secure transfer enabled storage acco
 
 - Modify the Azure Resource Manager template in the last section.
 - Create a cluster using the [Azure portal](https://portal.azure.com) and specify linked storage account.
-- Use script action to add additional secure transfer enabled storage accounts to an existing HDInsight cluster.  For more information, see [Add additional storage accounts to HDInsight](hdinsight-hadoop-add-storage.md).
+- Use script action to add additional secure transfer enabled storage accounts to an existing HDInsight cluster. For more information, see [Add additional storage accounts to HDInsight](hdinsight-hadoop-add-storage.md).
 
 ## Next steps
 In this tutorial, you have learned how to create an HDInsight cluster, and enable secure transfer to the storage accounts.
@@ -75,7 +75,7 @@ To learn more about creating or managing an HDInsight cluster, see the following
 * To learn about managing your Linux-based HDInsight cluster, see [Manage HDInsight clusters using Ambari](hdinsight-hadoop-manage-ambari.md).
 * To learn more about the options you can select when creating an HDInsight cluster, see [Creating HDInsight on Linux using custom options](hdinsight-hadoop-provision-linux-clusters.md).
 * If you are familiar with Linux, and Apache Hadoop, but want to know specifics about Hadoop on the HDInsight, see [Working with HDInsight on Linux](hdinsight-hadoop-linux-information.md). This article provides information such as:
-  
+
   * URLs for services hosted on the cluster, such as [Apache Ambari](https://ambari.apache.org/) and [WebHCat](https://cwiki.apache.org/confluence/display/Hive/WebHCat)
   * The location of [Apache Hadoop](https://hadoop.apache.org/) files and examples on the local file system
   * The use of Azure Storage (WASB) instead of [Apache Hadoop HDFS](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html) as the default data store


### PR DESCRIPTION
* typo: Github -> GitHub
* delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it