### PR TITLE
Fix typo and delete unnecessary spaces

### DIFF
--- a/articles/hdinsight/kafka/apache-kafka-producer-consumer-api.md
+++ b/articles/hdinsight/kafka/apache-kafka-producer-consumer-api.md
@@ -45,7 +45,7 @@ The following environment variables may be set when you install Java and the JDK
 
 * `JAVA_HOME` - should point to the directory where the JDK is installed.
 * `PATH` - should contain the following paths:
-  
+
     * `JAVA_HOME` (or the equivalent path).
     * `JAVA_HOME\bin` (or the equivalent path).
     * The directory where Maven is installed.
@@ -88,7 +88,7 @@ The important things to understand in the `pom.xml` file are:
 
 ### Producer.java
 
-The producer communicates with the Kafka broker hosts (worker nodes) and sends data to a Kafka topic. The following code snippet from is from the [Producer.java](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started/blob/master/Producer-Consumer/src/main/java/com/microsoft/example/Producer.java) file from the [github repository](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started) and shows how to set the producer properties:
+The producer communicates with the Kafka broker hosts (worker nodes) and sends data to a Kafka topic. The following code snippet from is from the [Producer.java](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started/blob/master/Producer-Consumer/src/main/java/com/microsoft/example/Producer.java) file from the [GitHub repository](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started) and shows how to set the producer properties:
 
 ```java
 Properties properties = new Properties();
@@ -141,11 +141,11 @@ The [Run.java](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started
     This command creates a directory named `target`, that contains a file named `kafka-producer-consumer-1.0-SNAPSHOT.jar`.
 
 3. Use the following commands to copy the `kafka-producer-consumer-1.0-SNAPSHOT.jar` file to your HDInsight cluster:
-   
+
     ```bash
     scp ./target/kafka-producer-consumer-1.0-SNAPSHOT.jar SSHUSER@CLUSTERNAME-ssh.azurehdinsight.net:kafka-producer-consumer.jar
     ```
-   
+
     Replace **SSHUSER** with the SSH user for your cluster, and replace **CLUSTERNAME** with the name of your cluster. When prompted enter the password for the SSH user.
 
 ## <a id="run"></a> Run the example
@@ -186,11 +186,11 @@ The [Run.java](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started
     ```
 
 4. Once the producer has finished, use the following command to read from the topic:
-   
+
     ```bash
     java -jar kafka-producer-consumer.jar consumer test $KAFKABROKERS
     ```
-   
+
     The records read, along with a count of records, is displayed.
 
 5. Use __Ctrl + C__ to exit the consumer.
@@ -200,7 +200,7 @@ The [Run.java](https://github.com/Azure-Samples/hdinsight-kafka-java-get-started
 Kafka consumers use a consumer group when reading records. Using the same group with multiple consumers results in load balanced reads from a topic. Each consumer in the group receives a portion of the records.
 
 The consumer application accepts a parameter that is used as the group ID. For example, the following command starts a consumer using a group ID of `mygroup`:
-   
+
 ```bash
 java -jar kafka-producer-consumer.jar consumer test $KAFKABROKERS mygroup
 ```


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it