### PR TITLE
No support for disks < 1024 MB

### DIFF
--- a/articles/site-recovery/vmware-physical-azure-support-matrix.md
+++ b/articles/site-recovery/vmware-physical-azure-support-matrix.md
@@ -164,7 +164,7 @@ Guest/server encrypted disk | No
 Guest/server NFS | No
 Guest/server SMB 3.0 | No
 Guest/server RDM | Yes<br/><br/> N/A for physical servers
-Guest/server disk > 1 TB | Yes<br/><br/>Up to 4,095 GB
+Guest/server disk > 1 TB | Yes<br/><br/>Up to 4,095 GB; disk must be larger than 1024 MB
 Guest/server disk with 4K logical and 4k physical sector size | Yes
 Guest/server disk with 4K logical and 512 bytes physical sector size | Yes
 Guest/server volume with striped disk >4 TB <br><br/>Logical volume management (LVM)| Yes


### PR DESCRIPTION
Guest Disks must be 1024 MB or greater in size for ASR to protect them.