### PR TITLE
Fix broken links to examples in functions-bindings-timer.md

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -40,11 +40,11 @@ The timer trigger is provided in the [Microsoft.Azure.WebJobs.Extensions](https:
 
 See the language-specific example:
 
-* [C#](#trigger---c-example)
-* [C# script (.csx)](#trigger---c-script-example)
-* [F#](#trigger---f-example)
-* [JavaScript](#trigger---javascript-example)
-* [Java](#trigger---java-example)
+* [C#](#c-example)
+* [C# script (.csx)](#c-script-example)
+* [F#](#f-example)
+* [JavaScript](#javascript-example)
+* [Java](#java-example)
 
 ### C# example
 


### PR DESCRIPTION
This commit fixes currently broken links in `articles/azure-functions/functions-bindings-timer.md`

I was looking at this docs page and selected the JavaScript example, but unfortunately it seemed like the link was broken. After digging in, it looks like each of the links had an extra string prepended.