### PR TITLE
Fix typo and delete unnecessary spaces

### DIFF
--- a/articles/machine-learning/studio/retrain-a-classic-web-service.md
+++ b/articles/machine-learning/studio/retrain-a-classic-web-service.md
@@ -18,27 +18,27 @@ ms.topic: article
 ms.date: 04/19/2017
 ---
 # Retrain a Classic Azure Machine Learning Studio web service
-The Predictive Web Service you deployed is the default scoring endpoint. Default endpoints are kept in sync with the original training and scoring experiments, and therefore the trained model for the default endpoint cannot be replaced. To retrain the web service, you must add a new endpoint to the web service. 
+The Predictive Web Service you deployed is the default scoring endpoint. Default endpoints are kept in sync with the original training and scoring experiments, and therefore the trained model for the default endpoint cannot be replaced. To retrain the web service, you must add a new endpoint to the web service.
 
 ## Prerequisites
-You must have set up a training experiment and a predictive experiment as shown in [Retrain Machine Learning models programmatically](retrain-models-programmatically.md). 
+You must have set up a training experiment and a predictive experiment as shown in [Retrain Machine Learning models programmatically](retrain-models-programmatically.md).
 
 > [!IMPORTANT]
-> The predictive experiment must be deployed as a Classic machine learning web service. 
-> 
-> 
+> The predictive experiment must be deployed as a Classic machine learning web service.
+>
+>
 
 For additional information on Deploying web services, see [Deploy an Azure Machine Learning web service](publish-a-machine-learning-web-service.md).
 
 ## Add a new endpoint
-The Predictive Web Service that you deployed contains a default scoring endpoint that is kept in sync with the original training and scoring experiments trained model. To update your web service to with a new trained model, you must create a new scoring endpoint. 
+The Predictive Web Service that you deployed contains a default scoring endpoint that is kept in sync with the original training and scoring experiments trained model. To update your web service to with a new trained model, you must create a new scoring endpoint.
 
 To create a new scoring endpoint, on the Predictive Web Service that can be updated with the trained model:
 
 > [!NOTE]
 > Be sure you are adding the endpoint to the Predictive Web Service, not the Training Web Service. If you have correctly deployed both a Training and a Predictive Web Service, you should see two separate web services listed. The Predictive Web Service should end with "[predictive exp.]".
-> 
-> 
+>
+>
 
 There are two ways in which you can add a new end point to a web service:
 
@@ -46,7 +46,7 @@ There are two ways in which you can add a new end point to a web service:
 2. Use the Microsoft Azure Web Services portal
 
 ### Programmatically add an endpoint
-You can add scoring endpoints using the sample code provided in this [github repository](https://github.com/hning86/azuremlps#add-amlwebserviceendpoint).
+You can add scoring endpoints using the sample code provided in this [GitHub repository](https://github.com/hning86/azuremlps#add-amlwebserviceendpoint).
 
 ### Use the Microsoft Azure Web Services portal to add an endpoint
 1. In Machine Learning Studio, on the left navigation column, click Web Services.


### PR DESCRIPTION
* typo: github -> GitHub
* delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it