### PR TITLE
Fix typo and delete unnecessary spaces, tab

### DIFF
--- a/articles/active-directory/manage-apps/add-application-portal.md
+++ b/articles/active-directory/manage-apps/add-application-portal.md
@@ -14,8 +14,8 @@ ms.author: barbkess
 ---
 # Quickstart: Add an application to your Azure Active Directory tenant
 
-Azure Active Directory (Azure AD) has a gallery that contains thousands of pre-integrated applications. Some of the applications your organization uses are probably in the gallery. This quickstart uses the Azure portal to add a gallery application to your Azure Active Directory (Azure AD) tenant. 
- 
+Azure Active Directory (Azure AD) has a gallery that contains thousands of pre-integrated applications. Some of the applications your organization uses are probably in the gallery. This quickstart uses the Azure portal to add a gallery application to your Azure Active Directory (Azure AD) tenant.
+
 After an application is added to your Azure AD tenant, you can:
 
 - Manage user access to the application with a conditional access policy.
@@ -36,13 +36,13 @@ To test the steps in this tutorial, we recommend using a non-production environm
 
 To add a gallery application to your Azure AD tenant:
 
-1. In the [Azure portal](https://portal.azure.com), on the left navigation panel, click **Azure Active Directory**. 
+1. In the [Azure portal](https://portal.azure.com), on the left navigation panel, click **Azure Active Directory**.
 
-2. In the **Azure Active Directory** blade, click **Enterprise applications**. 
+2. In the **Azure Active Directory** blade, click **Enterprise applications**.
 
     ![Open enterprise applications](media/add-application-portal/open-enterprise-apps.png)
 
-3. The **All applications** blade opens to show a random sample of the applications in your Azure AD tenant. 
+3. The **All applications** blade opens to show a random sample of the applications in your Azure AD tenant.
 
     ![All applications blade](media/add-application-portal/applications-blade.png)
 
@@ -51,37 +51,37 @@ To add a gallery application to your Azure AD tenant:
 
     ![New application](media/add-application-portal/new-application.png)
 
-5. To see a list of applications in the gallery, it's easiest to use the **Categories** since the icons under **Featured applications** are a random sample of gallery applications. 
+5. To see a list of applications in the gallery, it's easiest to use the **Categories** since the icons under **Featured applications** are a random sample of gallery applications.
 
     ![Search by name or category](media/add-application-portal/categories.png)
 
     To see more applications, you could click **Show more**. We don't recommend searching this way since there are thousands of applications in the gallery.
 
-6. To search for an application, under **Add from the gallery** enter the name of the application you want to add. Select the application from the results, and click **Add**. The following example shows the **Add app** form that appears after searching for GitHub.com.
+6. To search for an application, under **Add from the gallery** enter the name of the application you want to add. Select the application from the results, and click **Add**. The following example shows the **Add app** form that appears after searching for github.com.
 
-	![Add an application](media/add-application-portal/add-an-application.png)
+    ![Add an application](media/add-application-portal/add-an-application.png)
 
 6. In the application-specific form, you can change property information. For example, you can edit the name of the application to match the needs of your organization. This example uses the name **GitHub-test**.
 
 8. When you are finished making changes to the properties, click **Add**.
 
-9. A getting started page appears with the options for configuring the application for your organization. 
+9. A getting started page appears with the options for configuring the application for your organization.
 
     ![Get started menu](media/add-application-portal/get-started.png)
 
-You have finished adding your application. Feel free to take a break.  The next sections show you how to change the logo and edit other properties for your application.
+You have finished adding your application. Feel free to take a break. The next sections show you how to change the logo and edit other properties for your application.
 
 ## Find your Azure AD tenant application
 
 Let's assume you had to leave and now you're returning to continue configuring your application. The first thing you need to do is find your application.
 
-1. In the **[Azure portal](https://portal.azure.com)**, on the left navigation panel, click **Azure Active Directory**. 
+1. In the **[Azure portal](https://portal.azure.com)**, on the left navigation panel, click **Azure Active Directory**.
 
-2. In the Azure Active Directory blade, click **Enterprise applications**. 
+2. In the Azure Active Directory blade, click **Enterprise applications**.
 
 3. From the **Application Type** drop-down menu, select **All Applications**, and click **Apply**. To learn more about the viewing options, see [View tenant applications](view-applications-portal.md).
 
-4. You can now see a list of all the applications in your Azure AD tenant.  The list is a random sample. To see more applications, click **Show more** one or more times. 
+4. You can now see a list of all the applications in your Azure AD tenant. The list is a random sample. To see more applications, click **Show more** one or more times.
 
 5. To quickly find an application in your tenant, enter the application name in the search box and click **Apply**. This example finds the GitHub-test application that we added previously.
 
@@ -99,41 +99,41 @@ To edit the application properties
 
     ![Edit properties blade](media/add-application-portal/edit-properties.png)
 
-3. Take a moment to understand the sign-in options. The **Enabled for users to sign-in**, **User assignment required**, and **Visible to user** combine to determine whether users who are assigned or unassigned to the application can sign in.  They also determine if the user can see the application in the access panel. 
+3. Take a moment to understand the sign-in options. The **Enabled for users to sign-in**, **User assignment required**, and **Visible to user** combine to determine whether users who are assigned or unassigned to the application can sign in. They also determine if the user can see the application in the access panel.
 
     - **Enabled for users to sign-in** determines whether users assigned to the application can sign in.
     - **User assignment required** determines whether users who are not assigned to the application can sign in.
-    - **Visible to user** determines whether users assigned to an app can see it in the access panel and O365 launcher. 
+    - **Visible to user** determines whether users assigned to an app can see it in the access panel and O365 launcher.
 
-4. Use the following tables to help you choose the options that are best for your needs. 
+4. Use the following tables to help you choose the options that are best for your needs.
 
-     - Behavior for **assigned** users:
+    - Behavior for **assigned** users:
 
-       | Application property settings | | | Assigned-user experience | |
-       |---|---|---|---|---|
-       | Enabled for users to sign-in? | User assignment required? | Visible to users? | Can assigned users sign in? | Can assigned users see the application?* |
-       | yes | yes | yes | yes | yes  |
-       | yes | yes | no  | yes | no   |
-       | yes | no  | yes | yes | yes  |
-       | yes | no  | no  | yes | no   |
-       | no  | yes | yes | no  | no   |
-       | no  | yes | no  | no  | no   |
-       | no  | no  | yes | no  | no   |
-       | no  | no  | no  | no  | no   |
+        | Application property settings | | | Assigned-user experience | |
+        |---|---|---|---|---|
+        | Enabled for users to sign-in? | User assignment required? | Visible to users? | Can assigned users sign in? | Can assigned users see the application?* |
+        | yes | yes | yes | yes | yes  |
+        | yes | yes | no  | yes | no   |
+        | yes | no  | yes | yes | yes  |
+        | yes | no  | no  | yes | no   |
+        | no  | yes | yes | no  | no   |
+        | no  | yes | no  | no  | no   |
+        | no  | no  | yes | no  | no   |
+        | no  | no  | no  | no  | no   |
 
-     - Behavior for **unassigned** users:
-  
-       | Application property settings | | | Unassigned-user experience | |
-       |---|---|---|---|---|
-       | Enabled for users to sign-in? | User assignment required? | Visible to users? | Can unassigned users sign in? | Can unassigned users see the application?* |
-       | yes | yes | yes | no  | no   |
-       | yes | yes | no  | no  | no   |
-       | yes | no  | yes | yes | no   |
-       | yes | no  | no  | yes | no   |
-       | no  | yes | yes | no  | no   |
-       | no  | yes | no  | no  | no   |
-       | no  | no  | yes | no  | no   |
-       | no  | no  | no  | no  | no   |
+    - Behavior for **unassigned** users:
+
+        | Application property settings | | | Unassigned-user experience | |
+        |---|---|---|---|---|
+        | Enabled for users to sign-in? | User assignment required? | Visible to users? | Can unassigned users sign in? | Can unassigned users see the application?* |
+        | yes | yes | yes | no  | no   |
+        | yes | yes | no  | no  | no   |
+        | yes | no  | yes | yes | no   |
+        | yes | no  | no  | yes | no   |
+        | no  | yes | yes | no  | no   |
+        | no  | yes | no  | no  | no   |
+        | no  | no  | yes | no  | no   |
+        | no  | no  | no  | no  | no   |
 
     *Can the user see the application in the access panel and the Office 365 app launcher?
 
@@ -152,9 +152,9 @@ To use a custom logo:
 
 ## Next steps
 
-In this quickstart, you've learned how to add a gallery application to your Azure AD tenant. You learned how to edit the properties for an application. 
+In this quickstart, you've learned how to add a gallery application to your Azure AD tenant. You learned how to edit the properties for an application.
 
-Now, you're ready to configure the application for single sign-on. 
+Now, you're ready to configure the application for single sign-on.
 
 > [!div class="nextstepaction"]
 > [Configure single sign-on](configure-single-sign-on-portal.md)


### PR DESCRIPTION
* Fix typo: GitHub.com -> github.com
* Delete unnecessary spaces: As Markdown syntax, there was a large amount of half-width spaces that did not affect the display, so I deleted it
* Replace tab to space: Since tabs and half-width spaces were mixed, I unified them into one-byte space.
* Add space: Since the space for indentation was odd, it made it even.
