### PR TITLE
delete quotes for --vm in "az backup protection enable-for-vm"

### DIFF
--- a/articles/backup/quick-backup-vm-cli.md
+++ b/articles/backup/quick-backup-vm-cli.md
@@ -59,7 +59,7 @@ If the VM is not in the same resource group as that of vault, then myResourceGro
 az backup protection enable-for-vm \
     --resource-group myResourceGroup \
     --vault-name myRecoveryServicesVault \
-    --vm $(az vm show -g VMResourceGroup -n MyVm --query id) \
+    --vm $(az vm show -g VMResourceGroup -n MyVm --query id | tr -d '"') \
     --policy-name DefaultPolicy
 ```
 


### PR DESCRIPTION
if the VM is not in the same resource group as that of vault
execution of "az backup protection enable-for-vm" will fail
with an error "The Resource 'Microsoft.Compute/virtualMachines/"' under resource group <vault group> was not found."
because of "--vm $(az vm show -g VMResourceGroup -n MyVm --query id" returns id in double quotes.
Quotes should be deleted with tr -d '"' 
Execution is successful after this change.