### PR TITLE
Update Docker for windows proxy configuration

### DIFF
--- a/articles/iot-edge/how-to-configure-proxy-support.md
+++ b/articles/iot-edge/how-to-configure-proxy-support.md
@@ -68,7 +68,7 @@ Refer to the Docker documentation to configure the Docker daemon with environmen
 Choose the article that applies to your Docker version: 
 
 * [Docker](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
-* [Docker for Windows](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-docker/configure-docker-daemon#proxy-configuration)
+* [Docker for Windows](https://docs.microsoft.com/virtualization/windowscontainers/manage-docker/configure-docker-daemon#proxy-configuration)
 
 ### IoT Edge daemon
 

--- a/articles/iot-edge/how-to-configure-proxy-support.md
+++ b/articles/iot-edge/how-to-configure-proxy-support.md
@@ -68,7 +68,7 @@ Refer to the Docker documentation to configure the Docker daemon with environmen
 Choose the article that applies to your Docker version: 
 
 * [Docker](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
-* [Docker for Windows](https://docs.docker.com/docker-for-windows/#proxies)
+* [Docker for Windows](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-docker/configure-docker-daemon#proxy-configuration)
 
 ### IoT Edge daemon
 


### PR DESCRIPTION
Switched out the link from Docker's docs to Microsoft's docs. The Docker docs rely on Docker CE and the GUI to configure the proxy, but we need to have the Docker EE command line version. @kgremban  @alextnewman