### PR TITLE
Fix typo

### DIFF
--- a/articles/machine-learning/studio/azure-ml-netsharp-reference-guide.md
+++ b/articles/machine-learning/studio/azure-ml-netsharp-reference-guide.md
@@ -383,7 +383,7 @@ The example illustrates some basic commands as follows:
 
 + The first line defines the input layer (named `Data`). When you use the  `auto` keyword, the neural network automatically includes all feature columns in the input examples. 
 + The second line creates the hidden layer. The name `H` is assigned to the hidden layer, which has 200 nodes. This layer is fully connected to the input layer.
-+ The third line defines the output layer (named `O`), which contains 10 output nodes. If the neural network is used for classification, there is one output node per class. The keyword **sigmoid** indicates that the output function is applied to the output layer.
++ The third line defines the output layer (named `Out`), which contains 10 output nodes. If the neural network is used for classification, there is one output node per class. The keyword **sigmoid** indicates that the output function is applied to the output layer.
 
 ### Define multiple hidden layers: computer vision example
 


### PR DESCRIPTION
O ->  Out

evi
```Net#
input Data auto;
hidden H [200] from Data all;
output Out [10] sigmoid from H all;  <- Out, not O
```

refs: https://github.com/MicrosoftDocs/azure-docs.ja-jp/pull/1359