### PR TITLE
Remove reader NOTE

### DIFF
--- a/articles/app-service/containers/app-service-linux-java.md
+++ b/articles/app-service/containers/app-service-linux-java.md
@@ -170,9 +170,6 @@ customize the `CATALINA_OPTS` environment variable that is read in by Tomcat at 
 
 Or set the environment variables in the "Application Settings" blade in the Azure portal.
 
->[!NOTE]
-> If you are using Azure Database for Postgres, replace `ssl=true` with `sslmode=require` in the JDBC connection string.
-
 Next, determine if the data source should be available to one application or to all applications running on the Tomcat servlet.
 
 #### For application-level data sources: 


### PR DESCRIPTION
The database team updated the connection string, so the reader note is no longer required