### PR TITLE
Fix 404 page reference in storage-blob-static-website-host.md

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website-host.md
+++ b/articles/storage/blobs/storage-blob-static-website-host.md
@@ -74,7 +74,7 @@ Next, create a Hello World web page with Visual Studio Code and deploy it to the
     ```
 
 1. Create the default error file and name it *404.html*.
-1. Open *error.html* in the editor, paste the following text into the file, and save it:
+1. Open *404.html* in the editor, paste the following text into the file, and save it:
 
     ```
     <h1>404</h1>


### PR DESCRIPTION
The rest of this document refers to `404.html`, but this one line incorrectly specifies `error.html`