### PR TITLE
Added a note regarding Standard load balancer requirement for VMs not…

### DIFF
--- a/articles/virtual-machines/windows/sql/virtual-machines-windows-portal-sql-availability-group-dr.md
+++ b/articles/virtual-machines/windows/sql/virtual-machines-windows-portal-sql-availability-group-dr.md
@@ -81,7 +81,7 @@ To create a replica in a remote data center, do the following steps:
    - Include a backend pool consisting of only the virtual machines in the same region as the load balancer.
    - Use a TCP port probe specific to the IP address.
    - Have a load balancing rule specific to the SQL Server in the same region.  
-   - Be a Standard Load Balancer if the virtual machines in the backend pool are not part of either a single availability set or virtual machine scale set. For additional information review [Azure Load Balancer Standard overview](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-overview)
+   - Be a Standard Load Balancer if the virtual machines in the backend pool are not part of either a single availability set or virtual machine scale set. For additional information review [Azure Load Balancer Standard overview](https://docs.microsoft.com/azure/load-balancer/load-balancer-standard-overview).
 
 1. [Add Failover Clustering feature to the new SQL Server](virtual-machines-windows-portal-sql-availability-group-prereq.md#add-failover-clustering-features-to-both-sql-server-vms).
 

--- a/articles/virtual-machines/windows/sql/virtual-machines-windows-portal-sql-availability-group-dr.md
+++ b/articles/virtual-machines/windows/sql/virtual-machines-windows-portal-sql-availability-group-dr.md
@@ -81,6 +81,7 @@ To create a replica in a remote data center, do the following steps:
    - Include a backend pool consisting of only the virtual machines in the same region as the load balancer.
    - Use a TCP port probe specific to the IP address.
    - Have a load balancing rule specific to the SQL Server in the same region.  
+   - Be a Standard Load Balancer if the virtual machines in the backend pool are not part of either a single availability set or virtual machine scale set. For additional information review [Azure Load Balancer Standard overview](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-overview)
 
 1. [Add Failover Clustering feature to the new SQL Server](virtual-machines-windows-portal-sql-availability-group-prereq.md#add-failover-clustering-features-to-both-sql-server-vms).
 


### PR DESCRIPTION
… part of availability set or scale set.

We worked on a case with the customer wherein customer just had one VM in each subnet and neither was part of availability set. This was preventing connections from remote regions to fail when using ILB/Listener. Resolution was to implement standard ILB.