### PR TITLE
Update vmware-azure-install-linux-master-target.md

### DIFF
--- a/articles/site-recovery/vmware-azure-install-linux-master-target.md
+++ b/articles/site-recovery/vmware-azure-install-linux-master-target.md
@@ -55,7 +55,7 @@ The following supported Ubuntu kernels are supported.
 Take the following the steps to install the Ubuntu 16.04.2 64-bit
 operating system.
 
-1.   Go to the [download link](https://www.ubuntu.com/download/server/thank-you?version=16.04.2&architecture=amd64), choose the closest mirror anddownload an Ubuntu 16.04.2 minimal 64-bit ISO.
+1.   Go to the [download link](http://old-releases.ubuntu.com/releases/16.04.2/ubuntu-16.04.2-server-amd64.iso), choose the closest mirror anddownload an Ubuntu 16.04.2 minimal 64-bit ISO.
 Keep an Ubuntu 16.04.2 minimal 64-bit ISO in the DVD drive and start the system.
 
 1.  Select **English** as your preferred language, and then select **Enter**.


### PR DESCRIPTION
The download link for ‘Ubuntu 16.04.2 64-bit operating system’ is broken.
Several Customers are having trouble finding the correct Ubuntu images with supported kernel versions if they have less Linux expertise.
I'm submitting this patch with new URL link to old archive image 'ubuntu-16.04.2-server-amd64.iso'.