### PR TITLE
Remove ".NET Standard" and fix typos

### DIFF
--- a/includes/updated-for-az.md
+++ b/includes/updated-for-az.md
@@ -8,14 +8,14 @@ ms.topic: include
 > [!NOTE]
 >
 > This article has recently been updated to use commands from the new Azure PowerShell Az
-> module. This module is the new .NET Standard PowerShell module for Azure, compatible with
+> module. This module is the new PowerShell module for Azure, compatible with
 > PowerShell versions 5.x and 6. AzureRM will continue to get critical bugfix updates, but 
 > new features will be in the Az module only.
 >
-> * To learn more about the Az module and continued support for `AzureRM`,
+> * To learn more about the Az module and continued support for AzureRM module,
 >   see [Introducing the new Azure PowerShell Az module](/powershell/azure/new-azureps-module-az).
 > * The Az module is already available on Cloud Shell, with AzureRM compatibility automatically enabled.
 >   For instructions on installing the Az module, see [Install Azure PowerShell](/powershell/azure/install-az-ps).
-> * To enable the AzureRM compatibility commands, run `Enable-AzureRMAlias` after installation.
+> * To enable the AzureRM compatibility commands, run `Enable-AzureRmAlias` after installation.
 >   For more on compatibility, see [Migrate from Azure PowerShell AzureRM to Az](/powershell/azure/migrate-from-azurerm-to-az).
 

--- a/includes/updated-for-az.md
+++ b/includes/updated-for-az.md
@@ -12,7 +12,7 @@ ms.topic: include
 > PowerShell versions 5.x and 6. AzureRM will continue to get critical bugfix updates, but 
 > new features will be in the Az module only.
 >
-> * To learn more about the Az module and continued support for AzureRM module,
+> * To learn more about the Az module and continued support for the AzureRM module,
 >   see [Introducing the new Azure PowerShell Az module](/powershell/azure/new-azureps-module-az).
 > * The Az module is already available on Cloud Shell, with AzureRM compatibility automatically enabled.
 >   For instructions on installing the Az module, see [Install Azure PowerShell](/powershell/azure/install-az-ps).


### PR DESCRIPTION
Information about ".NET Standard" is unnecessary and will cause more confusion to the users than provide an important information. If someone wants to know the details, he/she will get them if they click on the provided link.