### PR TITLE
PowerShell script for uninstall; typo fixed

### DIFF
--- a/articles/iot-edge/how-to-install-iot-edge-windows.md
+++ b/articles/iot-edge/how-to-install-iot-edge-windows.md
@@ -214,7 +214,7 @@ iotedge list
 If you want to remove the IoT Edge installation from your Windows device, use the following command from an administrative PowerShell window. This command removes the IoT Edge runtime, along with your existing configuration and the Moby engine data. 
 
 ```PowerShell
-. {Invoke-WebRequest} -useb aka.ms/iotedge-win} | Invoke-Expression; `
+. {Invoke-WebRequest -useb aka.ms/iotedge-win} | Invoke-Expression; `
 Uninstall-SecurityDaemon -DeleteConfig -DeleteMobyDataRoot
 ```
 


### PR DESCRIPTION
The PowerShell uninstall script for iot edge did not run. 
I compared it with the same script at https://docs.microsoft.com/en-us/azure/iot-edge/quickstart#clean-up-resources 
Fixed a typo.