### PR TITLE
Fix typo

### DIFF
--- a/articles/data-factory/concepts-pipelines-activities.md
+++ b/articles/data-factory/concepts-pipelines-activities.md
@@ -94,7 +94,7 @@ Here is how a pipeline is defined in JSON format:
 
 Tag | Description | Type | Required
 --- | ----------- | ---- | --------
-name | Name of the pipeline. Specify a name that represents the action that the pipeline performs. <br/><ul><li>Maximum number of characters: 140</li><li>Must start with a letter, number, or an underscore (_)</li><li>Following characters are not allowed: “.”, “+”, “?”, “/”, “<”,”>”,”*”,”%”,”&”,”:”,”\”</li></ul> | String | Yes
+name | Name of the pipeline. Specify a name that represents the action that the pipeline performs. <br/><ul><li>Maximum number of characters: 140</li><li>Must start with a letter, number, or an underscore (\_)</li><li>Following characters are not allowed: “.”, “+”, “?”, “/”, “<”,”>”,”*”,”%”,”&”,”:”,”\”</li></ul> | String | Yes
 description | Specify the text describing what the pipeline is used for. | String | No
 activities | The **activities** section can have one or more activities defined within it. See the [Activity JSON](#activity-json) section for details about the activities JSON element. | Array | Yes
 parameters | The **parameters** section can have one or more parameters defined within the pipeline, making your pipeline flexible for reuse. | List | No
@@ -127,7 +127,7 @@ Following table describes properties in the activity JSON definition:
 
 Tag | Description | Required
 --- | ----------- | ---------
-name | Name of the activity. Specify a name that represents the action that the activity performs. <br/><ul><li>Maximum number of characters: 55</li><li>Must start with a letter number, or an underscore (_)</li><li>Following characters are not allowed: “.”, “+”, “?”, “/”, “<”,”>”,”*”,”%”,”&”,”:”,”\” | Yes</li></ul>
+name | Name of the activity. Specify a name that represents the action that the activity performs. <br/><ul><li>Maximum number of characters: 55</li><li>Must start with a letter number, or an underscore (\_)</li><li>Following characters are not allowed: “.”, “+”, “?”, “/”, “<”,”>”,”*”,”%”,”&”,”:”,”\” | Yes</li></ul>
 description | Text describing what the activity or is used for | Yes
 type | Type of the activity. See the [Data Movement Activities](#data-movement-activities), [Data Transformation Activities](#data-transformation-activities), and [Control Activities](#control-activities) sections for different types of activities. | Yes
 linkedServiceName | Name of the linked service used by the activity.<br/><br/>An activity may require that you specify the linked service that links to the required compute environment. | Yes for HDInsight Activity, Azure Machine Learning Batch Scoring Activity, Stored Procedure Activity. <br/><br/>No for all others
@@ -191,7 +191,7 @@ Control activities have the following top-level structure:
 
 Tag | Description | Required
 --- | ----------- | --------
-name | Name of the activity. Specify a name that represents the action that the activity performs.<br/><ul><li>Maximum number of characters: 55</li><li>Must start with a letter number, or an underscore (_)</li><li>Following characters are not allowed: “.”, “+”, “?”, “/”, “<”,”>”,”*”,”%”,”&”,”:”,”\” | Yes</li><ul>
+name | Name of the activity. Specify a name that represents the action that the activity performs.<br/><ul><li>Maximum number of characters: 55</li><li>Must start with a letter number, or an underscore (\_)</li><li>Following characters are not allowed: “.”, “+”, “?”, “/”, “<”,”>”,”*”,”%”,”&”,”:”,”\” | Yes</li><ul>
 description | Text describing what the activity or is used for | Yes
 type | Type of the activity. See the [data movement activities](#data-movement-activities), [data transformation activities](#data-transformation-activities), and [control activities](#control-activities) sections for different types of activities. | Yes
 typeProperties | Properties in the typeProperties section depend on each type of activity. To see type properties for an activity, click links to the activity in the previous section. | No


### PR DESCRIPTION
Typo: `_` -> `\_`
In Markdown `_` is used for highlighting. To simply display `_`, we need escape `\_`. Even without escaping, if we look at this page , it may seem that there is no problem.

https://docs.microsoft.com/en-us/azure/data-factory/concepts-pipelines-activities#control-activity

![en](https://user-images.githubusercontent.com/1207985/50415245-54406d80-085d-11e9-9d30-499a3d8e1b9d.jpg)

But, in the Japanese page, problems will arise as follows.

https://docs.microsoft.com/ja-jp/azure/data-factory/concepts-pipelines-activities#control-activity

![ja](https://user-images.githubusercontent.com/1207985/50415247-56a2c780-085d-11e9-8c5a-17a74d2645b3.jpg)

`_` is not displayed and characters are qualified with italics.

For that reason, I'm sending a Pull Request(PR) to correct this original English page. I will send PR to Japanese page if this PR accepts.