### PR TITLE
Propose to delete below 2 points

### DIFF
--- a/articles/active-directory/develop/active-directory-configurable-token-lifetimes.md
+++ b/articles/active-directory/develop/active-directory-configurable-token-lifetimes.md
@@ -82,8 +82,6 @@ A token lifetime policy is a type of policy object that contains token lifetime 
 | Multi-Factor Session Token Max Age |MaxAgeSessionMultiFactor<sup>3</sup> |Session tokens (persistent and nonpersistent) |Until-revoked |10 minutes |Until-revoked<sup>1</sup> |
 
 * <sup>1</sup>365 days is the maximum explicit length that can be set for these attributes.
-* <sup>2</sup>If  **MaxAgeSessionSingleFactor** is not set, this value takes the **MaxAgeSingleFactor** value. If neither parameter is set, the property takes the default value (until-revoked).
-* <sup>3</sup>If  **MaxAgeSessionMultiFactor** is not set, this value takes the **MaxAgeMultiFactor** value. If neither parameter is set, the property takes the default value (until-revoked).
 
 ### Exceptions
 | Property | Affects | Default |


### PR DESCRIPTION
* <sup>2</sup>If  **MaxAgeSessionSingleFactor** is not set, this value takes the **MaxAgeSingleFactor** value. If neither parameter is set, the property takes the default value (until-revoked).
* <sup>3</sup>If  **MaxAgeSessionMultiFactor** is not set, this value takes the **MaxAgeMultiFactor** value. If neither parameter is set, the property takes the default value (until-revoked).

Reason:
Tested setting MaxAgeSingleFactor and MaxAgeMultiFactor doesn't impact on MaxAgeSessionSingleFactor and MaxAgeSessionMultiFactor value when we do not set value for this two.