### PR TITLE
Fix Open Source Redis references

### DIFF
--- a/articles/azure-cache-for-redis/cache-faq.md
+++ b/articles/azure-cache-for-redis/cache-faq.md
@@ -79,7 +79,7 @@ The FAQs in this section cover common monitoring and troubleshooting questions. 
 * [Which Azure Cache offering is right for me?](#which-azure-cache-offering-is-right-for-me)
 
 ### What is Azure Cache for Redis?
-Azure Cache for Redis is based on the popular open-source [Azure Cache for Redis](http://redis.io). It gives you access to a secure, dedicated Azure Cache for Redis, managed by Microsoft, and accessible from any application within Azure. For a more detailed overview, see the [Azure Cache for Redis](https://azure.microsoft.com/services/cache/) product page on Azure.com.
+Azure Cache for Redis is based on the popular open-source software [Redis](https://redis.io/). It gives you access to a secure, dedicated Azure Cache for Redis, managed by Microsoft, and accessible from any application within Azure. For a more detailed overview, see the [Azure Cache for Redis](https://azure.microsoft.com/services/cache/) product page on Azure.com.
 
 ### How can I get started with Azure Cache for Redis?
 There are several ways you can get started with Azure Cache for Redis.

--- a/articles/azure-cache-for-redis/cache-overview.md
+++ b/articles/azure-cache-for-redis/cache-overview.md
@@ -20,7 +20,7 @@ ms.custom: mvc
 ---
 # What is Azure Cache for Redis
 
-Azure Cache for Redis is based on the popular open-source [Azure Cache for Redis](https://redis.io/). It is typically used as a cache to improve the performance and scalability of systems that rely heavily on backend data-stores. Performance is improved by temporarily copying frequently accessed data to fast storage located close to the application. With [Azure Cache for Redis](https://redis.io/), this fast storage is located in-memory with Azure Cache for Redis instead of being loaded from disk by a database.
+Azure Cache for Redis is based on the popular software [Redis](https://redis.io/). It is typically used as a cache to improve the performance and scalability of systems that rely heavily on backend data-stores. Performance is improved by temporarily copying frequently accessed data to fast storage located close to the application. With [Azure Cache for Redis](https://redis.io/), this fast storage is located in-memory with Azure Cache for Redis instead of being loaded from disk by a database.
 
 Azure Cache for Redis can also be used as an in-memory data structure store, distributed non-relational database, and message broker. Application performance is improved by taking advantage of the low-latency, high-throughput performance of the Redis engine.
 


### PR DESCRIPTION
In the overview and FAQ its listed "open source [Azure Cache for Redis]" with a link to the Redis hompage. It should just read "Redis" when talking about the open source product I think