### PR TITLE
Unification of description

### DIFF
--- a/articles/data-factory/tutorial-copy-data-tool.md
+++ b/articles/data-factory/tutorial-copy-data-tool.md
@@ -19,7 +19,7 @@ ms.author: jingwang
 > * [Version 1](v1/data-factory-copy-data-from-azure-blob-storage-to-sql-database.md)
 > * [Current version](tutorial-copy-data-tool.md)
 
-In this tutorial, you use the Azure portal to create a data factory. Then, you use the Copy Data tool to create a pipeline that copies data from Azure Blob storage to a SQL database. 
+In this tutorial, you use the Azure portal to create a data factory. Then, you use the Copy Data tool to create a pipeline that copies data from Azure Blob storage to a SQL database.
 
 > [!NOTE]
 > If you're new to Azure Data Factory, see [Introduction to Azure Data Factory](introduction.md).
@@ -72,45 +72,45 @@ Prepare your Blob storage and your SQL database for the tutorial by performing t
 
 ## Create a data factory
 
-1. On the left menu, select **+ New** > **Data + Analytics** > **Data Factory**: 
-   
-   ![New data factory creation](./media/tutorial-copy-data-tool/new-azure-data-factory-menu.png)
-1. On the **New data factory** page, under **Name**, enter **ADFTutorialDataFactory**. 
-      
-     ![New data factory](./media/tutorial-copy-data-tool/new-azure-data-factory.png)
- 
-   The name for your data factory must be _globally unique_. You might receive the following error message:
-   
-   ![New data factory error message](./media/tutorial-copy-data-tool/name-not-available-error.png)
+1. On the left menu, select **+ New** > **Data + Analytics** > **Data Factory**:
+    
+    ![New data factory creation](./media/tutorial-copy-data-tool/new-azure-data-factory-menu.png)
+1. On the **New data factory** page, under **Name**, enter **ADFTutorialDataFactory**.
+    
+    ![New data factory](./media/tutorial-copy-data-tool/new-azure-data-factory.png)
 
-   If you receive an error message about the name value, enter a different name for the data factory. For example, use the name _**yourname**_**ADFTutorialDataFactory**. For the naming rules for Data Factory artifacts, see [Data Factory naming rules](naming-rules.md).
-1. Select the Azure **subscription** in which to create the new data factory. 
+    The name for your data factory must be _globally unique_. You might receive the following error message:
+    
+    ![New data factory error message](./media/tutorial-copy-data-tool/name-not-available-error.png)
+
+    If you receive an error message about the name value, enter a different name for the data factory. For example, use the name _**yourname**_**ADFTutorialDataFactory**. For the naming rules for Data Factory artifacts, see [Data Factory naming rules](naming-rules.md).
+1. Select the Azure **subscription** in which to create the new data factory.
 1. For **Resource Group**, take one of the following steps:
-     
+    
     a. Select **Use existing**, and select an existing resource group from the drop-down list.
 
-    b. Select **Create new**, and enter the name of a resource group. 
-         
+    b. Select **Create new**, and enter the name of a resource group.
+    
     To learn about resource groups, see [Use resource groups to manage your Azure resources](../azure-resource-manager/resource-group-overview.md).
 
 1. Under **version**, select **V2** for the version.
 1. Under **location**, select the location for the data factory. Only supported locations are displayed in the drop-down list. The data stores (for example, Azure Storage and SQL Database) and computes (for example, Azure HDInsight) that are used by your data factory can be in other locations and regions.
-1. Select **Pin to dashboard**. 
+1. Select **Pin to dashboard**.
 1. Select **Create**.
 1. On the dashboard, the **Deploying Data Factory** tile shows the process status.
 
 	![Deploying data factory tile](media/tutorial-copy-data-tool/deploying-data-factory.png)
 1. After creation is finished, the **Data Factory** home page is displayed.
-   
+    
     ![Data factory home page](./media/tutorial-copy-data-tool/data-factory-home-page.png)
-1. To launch the Azure Data Factory user interface (UI) in a separate tab, select the **Author & Monitor** tile. 
+1. To launch the Azure Data Factory user interface (UI) in a separate tab, select the **Author & Monitor** tile.
 
 ## Use the Copy Data tool to create a pipeline
 
-1. On the **Let's get started** page, select the **Copy Data** tile to launch the Copy Data tool. 
+1. On the **Let's get started** page, select the **Copy Data** tile to launch the Copy Data tool.
 
-   ![Copy Data tool tile](./media/tutorial-copy-data-tool/copy-data-tool-tile.png)
-1. On the **Properties** page, under **Task name**, enter **CopyFromBlobToSqlPipeline**. Then select **Next**. The Data Factory UI creates a pipeline with the specified task name. 
+    ![Copy Data tool tile](./media/tutorial-copy-data-tool/copy-data-tool-tile.png)
+1. On the **Properties** page, under **Task name**, enter **CopyFromBlobToSqlPipeline**. Then select **Next**. The Data Factory UI creates a pipeline with the specified task name.
 
     ![Properties page](./media/tutorial-copy-data-tool/copy-data-tool-properties-page.png)
 1. On the **Source data store** page, complete the following steps:
@@ -139,7 +139,7 @@ Prepare your Blob storage and your SQL database for the tutorial by performing t
 
     b. Click **Next** to move to next step.
 
-1. On the **File format settings** page, notice that the tool automatically detects the column and row delimiters. Select **Next**. You also can preview data and view the schema of the input data on this page. 
+1. On the **File format settings** page, notice that the tool automatically detects the column and row delimiters. Select **Next**. You also can preview data and view the schema of the input data on this page.
 
     ![File format settings](./media/tutorial-copy-data-tool/file-format-settings-page.png)
 1. On the **Destination data store** page, completes the following steps:
@@ -152,7 +152,7 @@ Prepare your Blob storage and your SQL database for the tutorial by performing t
 
     ![Select Azure SQL DB](./media/tutorial-copy-data-tool/select-azure-sql-db.png)
 
-    c. On the **New Linked Service** page, select your server name and DB name from the dropdown list, and specify the username and password, then select **Finish**.    
+    c. On the **New Linked Service** page, select your server name and DB name from the dropdown list, and specify the username and password, then select **Finish**.
 
     ![Configure Azure SQL DB](./media/tutorial-copy-data-tool/config-azure-sql-db.png)
 
@@ -160,23 +160,23 @@ Prepare your Blob storage and your SQL database for the tutorial by performing t
 
     ![Select sink linked service](./media/tutorial-copy-data-tool/select-sink-linked-service.png)
 
-1. On the **Table mapping** page, select the **[dbo].[emp]** table, and then select **Next**. 
+1. On the **Table mapping** page, select the **[dbo].[emp]** table, and then select **Next**.
 
     ![Table mapping](./media/tutorial-copy-data-tool/table-mapping.png)
 1. On the **Schema mapping** page, notice that the first and second columns in the input file are mapped to the **FirstName** and **LastName** columns of the **emp** table. Select **Next**.
 
     ![Schema mapping page](./media/tutorial-copy-data-tool/schema-mapping.png)
-1. On the **Settings** page, select **Next**. 
+1. On the **Settings** page, select **Next**.
 1. On the **Summary** page, review the settings, and then select **Next**.
 
     ![Summary page](./media/tutorial-copy-data-tool/summary-page.png)
 1. On the **Deployment page**, select **Monitor** to monitor the pipeline (task).
 
     ![Deployment page](./media/tutorial-copy-data-tool/deployment-page.png)
-1. Notice that the **Monitor** tab on the left is automatically selected. The **Actions** column includes links to view activity run details and to rerun the pipeline. Select **Refresh** to refresh the list. 
+1. Notice that the **Monitor** tab on the left is automatically selected. The **Actions** column includes links to view activity run details and to rerun the pipeline. Select **Refresh** to refresh the list.
 
     ![Monitor pipeline runs](./media/tutorial-copy-data-tool/pipeline-monitoring.png)
-1. To view the activity runs that are associated with the pipeline run, select the **View Activity Runs** link in the **Actions** column. For details about the copy operation, select the **Details** link (eyeglasses icon) in the **Actions** column. To go back to the **Pipeline Runs** view, select the **Pipelines** link at the top. To refresh the view, select **Refresh**. 
+1. To view the activity runs that are associated with the pipeline run, select the **View Activity Runs** link in the **Actions** column. For details about the copy operation, select the **Details** link (eyeglasses icon) in the **Actions** column. To go back to the **Pipeline Runs** view, select the **Pipelines** link at the top. To refresh the view, select **Refresh**.
 
     ![Monitor activity runs](./media/tutorial-copy-data-tool/activity-monitoring.png)
 
@@ -189,14 +189,14 @@ Prepare your Blob storage and your SQL database for the tutorial by performing t
 1. Select the **Author** tab on the left to switch to the editor mode. You can update the linked services, datasets, and pipelines that were created via the tool by using the editor. For details on editing these entities in the Data Factory UI, see [the Azure portal version of this tutorial](tutorial-copy-data-portal.md).
 
 ## Next steps
-The pipeline in this sample copies data from Blob storage to a SQL database. You learned how to: 
+The pipeline in this sample copies data from Blob storage to a SQL database. You learned how to:
 
 > [!div class="checklist"]
 > * Create a data factory.
 > * Use the Copy Data tool to create a pipeline.
 > * Monitor the pipeline and activity runs.
 
-Advance to the following tutorial to learn how to copy data from on-premises to the cloud: 
+Advance to the following tutorial to learn how to copy data from on-premises to the cloud:
 
 > [!div class="nextstepaction"]
 >[Copy data from on-premises to the cloud](tutorial-hybrid-copy-data-tool.md)


### PR DESCRIPTION
Same as #21485 

Since this file(and articles/data-factory/concepts-pipeline-execution-triggers.md) is different from the others, the description is unified.

description: `Select the version of Data Factory service you are using:`
file list:
- articles/data-factory/concepts-datasets-linked-services.md
- articles/data-factory/connector-amazon-redshift.md
- articles/data-factory/connector-amazon-simple-storage-service.md
- articles/data-factory/connector-azure-blob-storage.md
- articles/data-factory/connector-azure-cosmos-db.md
- etc...