### PR TITLE
Removed duplicate code

### DIFF
--- a/articles/iot-edge/tutorial-csharp-module.md
+++ b/articles/iot-edge/tutorial-csharp-module.md
@@ -164,13 +164,8 @@ The environment file stores the credentials for your container registry and shar
 
     // Read the TemperatureThreshold value from the module twin's desired properties
     var moduleTwin = await ioTHubModuleClient.GetTwinAsync();
-    var moduleTwinCollection = moduleTwin.Properties.Desired;
-    try {
-        temperatureThreshold = moduleTwinCollection["TemperatureThreshold"];
-    } catch(ArgumentOutOfRangeException e) {
-        Console.WriteLine($"Property TemperatureThreshold not exist: {e.Message}"); 
-    }
-
+    OnDesiredPropertiesUpdate(moduleTwin.Properties.Desired, ioTHubModuleClient);
+    
     // Attach a callback for updates to the module twin's desired properties.
     await ioTHubModuleClient.SetDesiredPropertyUpdateCallbackAsync(OnDesiredPropertiesUpdate, null);
 


### PR DESCRIPTION
In the init method, a part of the OnDesiredPropertiesUpdate was duplicated.
Just executing OnDesiredPropertiesUpdate() with the right properties makes more sense. And now the same exception handling is in place too.