### PR TITLE
Missing word in expressroute-routing.md

### DIFF
--- a/articles/expressroute/expressroute-routing.md
+++ b/articles/expressroute/expressroute-routing.md
@@ -116,7 +116,7 @@ Routing exchange will be over eBGP protocol. EBGP sessions are established betwe
 ## Autonomous System numbers
 Microsoft uses AS 12076 for Azure public, Azure private and Microsoft peering. We have reserved ASNs from 65515 to 65520 for internal use. Both 16 and 32 bit AS numbers are supported.
 
-There are no requirements around data transfer symmetry. The forward and return paths may traverse different router pairs. Identical routes must be advertised from either sides across multiple circuit pairs belonging you. Route metrics are not required to be identical.
+There are no requirements around data transfer symmetry. The forward and return paths may traverse different router pairs. Identical routes must be advertised from either sides across multiple circuit pairs belonging to you. Route metrics are not required to be identical.
 
 ## Route aggregation and prefix limits
 We support up to 4000 prefixes advertised to us through the Azure private peering. This can be increased up to 10,000 prefixes if the ExpressRoute premium add-on is enabled. We accept up to 200 prefixes per BGP session for Azure public and Microsoft peering. 
@@ -131,7 +131,7 @@ Default routes are permitted only on Azure private peering sessions. In such a c
 
  To enable connectivity to other Azure services and infrastructure services, you must make sure one of the following items is in place:
 
-* Azure public peering is enabled to route traffic to public endpoints
+* Azure public peering is enabled to route traffic to public endpoints.
 * You use user-defined routing to allow internet connectivity for every subnet requiring Internet connectivity.
 
 > [!NOTE]


### PR DESCRIPTION
The word "to" was missing in the sentence 

> Identical routes must be advertised from either sides across multiple circuit pairs belonging **to** you.

Also added period to end of bullet-point sentence.