### PR TITLE
Fixing Article name in TOC

### DIFF
--- a/articles/cognitive-services/Speech-Service/toc.yml
+++ b/articles/cognitive-services/Speech-Service/toc.yml
@@ -103,7 +103,7 @@
       href: how-to-customize-language-model.md
     - name: Customize pronunciation
       href: how-to-customize-pronunciation.md
-    - name: Create custom Speech Recognition endpoint
+    - name: Create custom Speech-To-Text endpoint
       href: how-to-create-custom-endpoint.md
     - name: Customize voice fonts (bot brand voice)
       href: how-to-customize-voice-font.md


### PR DESCRIPTION
Fixing wrong article name `Create custom Speech Recognition endpoint` to `Create custom Speech-To-Text endpoint` as this article is about Custom STT, not recognition, and real article name is "Create a custom speech-to-text endpoint"