### PR TITLE
Replace the name by ID of the management group

### DIFF
--- a/articles/governance/blueprints/create-blueprint-rest-api.md
+++ b/articles/governance/blueprints/create-blueprint-rest-api.md
@@ -81,7 +81,7 @@ a role assignment on the resource group.
 
 In each REST API URI, there are variables that are used that you need to replace with your own values:
 
-- `{YourMG}` - Replace with the name of your management group
+- `{YourMG}` - Replace with the ID of your management group 
 - `{subscriptionId}` - Replace with your subscription ID
 
 1. Create the initial _blueprint_ object. The **Request Body** includes properties about the


### PR DESCRIPTION
Tested multiple times, the create blueprint or other api doesn't working with management group name instead of management group id ( literally management group display name, only for display purpose ). In some case ( default way ), the management group name and management group id can be the same, that's why most case it's working, but need clarification in documentation.