### PR TITLE
Missing a

### DIFF
--- a/articles/active-directory/fundamentals/active-directory-get-started-premium.md
+++ b/articles/active-directory/fundamentals/active-directory-get-started-premium.md
@@ -35,7 +35,7 @@ Signing up using your Azure subscription with previously purchased and activated
 As an Azure or Office 365 subscriber, you can purchase the Azure Active Directory Premium editions online. For detailed steps, see [How to Purchase Azure Active Directory Premium - Existing Customers](https://channel9.msdn.com/Series/Azure-Active-Directory-Videos-Demos/How-to-Purchase-Azure-Active-Directory-Premium-Existing-Customer) or [How to Purchase Azure Active Directory Premium - New Customers](https://channel9.msdn.com/Series/Azure-Active-Directory-Videos-Demos/How-to-Purchase-Azure-Active-Directory-Premium-New-Customers).
 
 ## Sign up using your Enterprise Mobility + Security licensing plan
-Enterprise Mobility + Security is suite, comprised of Azure AD Premium, Azure Information Protection, and Microsoft Intune. If you already have an EMS license, you can get started with Azure AD, using one of these licensing options:
+Enterprise Mobility + Security is a suite, comprised of Azure AD Premium, Azure Information Protection, and Microsoft Intune. If you already have an EMS license, you can get started with Azure AD, using one of these licensing options:
 
 For more information about EMS, see [Enterprise Mobility + Security web site](https://www.microsoft.com/cloud-platform/enterprise-mobility-security).
 


### PR DESCRIPTION
Either "Enterprise Mobility + Security is a suite" or  "Enterprise Mobility + Security suite". I propose "is a suite"  because it's followed by a list of products.