### PR TITLE
TTL in seconds, not minutes

### DIFF
--- a/articles/active-directory/fundamentals/add-custom-domain.md
+++ b/articles/active-directory/fundamentals/add-custom-domain.md
@@ -59,10 +59,10 @@ After you create your directory, you can add your custom domain name.
 ## Add your DNS information to the domain registrar
 After you add your custom domain name to Azure AD, you must return to your domain registrar and add the Azure AD DNS information from your copied TXT file. Creating this TXT record for your domain "verifies" ownership of your domain name.
 
--  Go back to your domain registrar, create a new TXT record for your domain based on your copied DNS information, set the **TTL** (time to live) to 60 minutes, and then save the information.
+-  Go back to your domain registrar, create a new TXT record for your domain based on your copied DNS information, set the **TTL** (time to live) to 60 seconds, and then save the information.
 
     >[!Important]
-    >You can register as many domain names as you want. However, each domain gets its own TXT record from Azure AD. Be careful when entering your TXT file information at the domain registrar. If you enter the wrong, or duplicate information by mistake, you'll have to wait until the TTL times out (60 minutes) before you can try again.
+    >You can register as many domain names as you want. However, each domain gets its own TXT record from Azure AD. Be careful when entering your TXT file information at the domain registrar. If you enter the wrong, or duplicate information by mistake, you'll have to wait until the TTL times out (60 seconds) before you can try again.
 
 ## Verify your custom domain name
 After you register your custom domain name, you need to make sure it's valid in Azure AD. The propagation from your domain registrar to Azure AD can be instantaneous or it can take up to a few days, depending on your domain registrar.


### PR DESCRIPTION
The screenshot  shows TTL 60, and the instructions are to set TTL to 60 minutes. DNS TTL standard uses seconds as unit, so either the screenshot is wrong or the instructions are. If Azure AD checks the TXT record just once to validate domain ownership, I propose to change the instructions to use 60 (seconds).

If the check will be performed at a regular interval (you don't want de overhead of a check every minute) , then use 3600 seconds (1 hour) and discard/modify this patch.