### PR TITLE
Fixing formatting typo in the Notes section

### DIFF
--- a/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
+++ b/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
@@ -101,7 +101,7 @@ To select the User Identifier or add user attributes, follow the steps below:
 
 8.  Under the **User attributes** section, select the unique identifier for your users in the **User Identifier** dropdown. The selected option needs to match the expected value in the application to authenticate the user.
 
- >[!NOTE}
+ >[!NOTE]
  >Azure AD select the format for the NameID attribute (User Identifier) based on the value selected or the format requested by the application in the SAML AuthRequest. For more information visit the article [Single Sign-On SAML protocol](https://docs.microsoft.com/azure/active-directory/develop/active-directory-single-sign-on-protocol-reference#authnrequest) under the section NameIDPolicy.
  >
  >


### PR DESCRIPTION
Changing } to ] in the notes section to correct formatting.