### PR TITLE
Update vmware-azure-install-linux-master-target.md

### DIFF
--- a/articles/site-recovery/vmware-azure-install-linux-master-target.md
+++ b/articles/site-recovery/vmware-azure-install-linux-master-target.md
@@ -179,7 +179,7 @@ Azure Site Recovery master target server requires a specific version of the Ubun
 #### Download and install additional packages
 
 > [!NOTE]
-> Make sure that you have Internet connectivity to download and install additional packages. If you don't have Internet connectivity, you need to manually find these RPM packages and install them.
+> Make sure that you have Internet connectivity to download and install additional packages. If you don't have Internet connectivity, you need to manually find these Deb packages and install them.
 
  `apt-get install -y multipath-tools lsscsi python-pyasn1 lvm2 kpartx`
 


### PR DESCRIPTION
Just a minor fix. Replacing word "RPM" for "Deb" since Master target server is now Ubuntu-based. Therefore, correct package file format is *.deb.
RPM package file format was utilized in past versions where  CentOS was the official base Linux distribution.
I do apologize for the small fix. I just want to contribute by making sure documentation is accurate.