### PR TITLE
Ensure ~/completions folder exists - ref #20188

### DIFF
--- a/articles/aks/istio-install.md
+++ b/articles/aks/istio-install.md
@@ -94,7 +94,7 @@ If you'd like command-line completion for the Istio `istioctl` client binary, th
 
 ```bash
 # Generate the bash completion file and source it in your current shell
-istioctl collateral --bash -o ~/completions
+mkdir -p ~/completions && istioctl collateral --bash -o ~/completions
 source ~/completions/istioctl.bash
 
 # Source the bash completion file in your .bashrc so that the command-line completions
@@ -118,7 +118,7 @@ If you'd like command-line completion for the Istio `istioctl` client binary, th
 
 ```bash
 # Generate the bash completion file and source it in your current shell
-istioctl collateral --bash -o ~/completions
+mkdir -p ~/completions && istioctl collateral --bash -o ~/completions
 source ~/completions/istioctl.bash
 
 # Source the bash completion file in your .bashrc so that the command-line completions


### PR DESCRIPTION
Update instructions to ensure that `~/completions` folder exists before generating the bash completion file for `istioctl`.

See #20188 