### PR TITLE
Fix the language name from Java to JavaScript

### DIFF
--- a/articles/cosmos-db/tutorial-global-distribution-sql-api.md
+++ b/articles/cosmos-db/tutorial-global-distribution-sql-api.md
@@ -92,7 +92,7 @@ The current write and read endpoints are available in DocumentClient.getWriteEnd
 
 Below is a code example for NodeJS/Javascript. Python and Java will follow the same pattern.
 
-```java
+```JavaScript
 // Creating a ConnectionPolicy object
 var connectionPolicy = new DocumentBase.ConnectionPolicy();
 


### PR DESCRIPTION
## Modify the language name

The following page says "Below is a code example for NodeJS/Javascript.".
And, the code looks like JavaScript code. However, the code language name is Java. 
So, I modified the language name Java to JavaScript.

URL: https://docs.microsoft.com/en-us/azure/cosmos-db/tutorial-global-distribution-sql-api#nodejs-javascript-and-python-sdks