### PR TITLE
(Azure CXP) fixes Editing Grammatical Errors

### DIFF
--- a/articles/active-directory/saas-apps/sharepoint-on-premises-tutorial.md
+++ b/articles/active-directory/saas-apps/sharepoint-on-premises-tutorial.md
@@ -110,14 +110,14 @@ To configure Azure AD single sign-on with SharePoint on-premises, perform the fo
     `https://<YourSharePointServerURL>/_trust/default.aspx`
 
 	> [!NOTE]
-	> These values are not real. You may require to update these values with the actual Sign-On URL, Identifier and Reply URL. Contact [SharePoint on-premises Client support team](https://support.office.com/) to get these values. You may also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+	> These values are not real. Update these values with the actual Sign-On URL, Identifier, and Reply URL. Contact [SharePoint on-premises Client support team](https://support.office.com/) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 5. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, click **Download** to download the **Certificate (Base64)** from the given options as per your requirement and save it on your computer.
 
 	![The Certificate download link](common/certificatebase64.png)
 
     > [!Note]
-	> Please note down the file path where you have downloaded the certificate file, as you would need to use it later in the PowerShell script for configuration.
+    > Note the file path where you downloaded the certificate file. You need the file later in the PowerShell script for the configuration.
 
 6. On the **Set up SharePoint on-premises** section, copy the appropriate URL(s) as per your requirement. For **Single Sign-On Service URL**, use a value of the following pattern: `https://login.microsoftonline.com/_my_directory_id_/wsfed` 
 
@@ -174,7 +174,7 @@ To configure Azure AD single sign-on with SharePoint on-premises, perform the fo
 	![Configuring your authentication provider](./media/sharepoint-on-premises-tutorial/fig10-configauthprovider.png)
 
 	> [!NOTE]
-	> Some of the external users will not be able to use this single sign-on integration as their UPN will have mangled value, something like `MYEMAIL_outlook.com#ext#@TENANT.onmicrosoft.com`. Soon we will allow custom app config on how to handle the UPN depending on the user type. After that all your guest users should be able to use SSO seamlessly as the organization employees.
+	> Some external users won't be able to use this single sign-on integration as their UPN will have a mangled value like `MYEMAIL_outlook.com#ext#@TENANT.onmicrosoft.com`. Soon we will allow custom app configuration to handle the UPN depending on the user type. After that all your guest users should be able to use SSO seamlessly as the organization employees.
 
 ### Create an Azure AD test user
 

--- a/articles/active-directory/saas-apps/sharepoint-on-premises-tutorial.md
+++ b/articles/active-directory/saas-apps/sharepoint-on-premises-tutorial.md
@@ -110,14 +110,14 @@ To configure Azure AD single sign-on with SharePoint on-premises, perform the fo
     `https://<YourSharePointServerURL>/_trust/default.aspx`
 
 	> [!NOTE]
-	> These values are not real. Update these values with the actual Sign-On URL, Identifier and Reply URL. Contact [SharePoint on-premises Client support team](https://support.office.com/) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+	> These values are not real. You may require to update these values with the actual Sign-On URL, Identifier and Reply URL. Contact [SharePoint on-premises Client support team](https://support.office.com/) to get these values. You may also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 5. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, click **Download** to download the **Certificate (Base64)** from the given options as per your requirement and save it on your computer.
 
 	![The Certificate download link](common/certificatebase64.png)
 
     > [!Note]
-	> Please note down the file path to which you have downloaded the certificate file, as you need to use it later in the PowerShell script for configuration.
+	> Please note down the file path where you have downloaded the certificate file, as you would need to use it later in the PowerShell script for configuration.
 
 6. On the **Set up SharePoint on-premises** section, copy the appropriate URL(s) as per your requirement. For **Single Sign-On Service URL**, use a value of the following pattern: `https://login.microsoftonline.com/_my_directory_id_/wsfed` 
 
@@ -174,7 +174,7 @@ To configure Azure AD single sign-on with SharePoint on-premises, perform the fo
 	![Configuring your authentication provider](./media/sharepoint-on-premises-tutorial/fig10-configauthprovider.png)
 
 	> [!NOTE]
-	> Some of the external users will not able to use this single sign-on integration as their UPN will have mangled value something like `MYEMAIL_outlook.com#ext#@TENANT.onmicrosoft.com`. Soon we will allow customers app config on how to handle the UPN depending on the user type. After that all your guest users should be able to use SSO seamlessly as the organization employees.
+	> Some of the external users will not be able to use this single sign-on integration as their UPN will have mangled value, something like `MYEMAIL_outlook.com#ext#@TENANT.onmicrosoft.com`. Soon we will allow custom app config on how to handle the UPN depending on the user type. After that all your guest users should be able to use SSO seamlessly as the organization employees.
 
 ### Create an Azure AD test user
 


### PR DESCRIPTION
Edited the Note after step 4 in the section [Configure Azure AD single Sign-on](https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/sharepoint-on-premises-tutorial#configure-azure-ad-single-sign-on) for better grammar as pointed out by the customer on this [issue](https://github.com/MicrosoftDocs/azure-docs/issues/21908)

Updated "Update these values... "    to      "You may require to update these values with the actual Sign-On URL, .... " 
Updated "You can .. "    to     "You May ... "
Updated "Please note down the file path to which"     to      "Please note down the file path where "  and in the same line "as you need "      to     "as you would need  "

Edited the NOTE after [section 2.e](https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/sharepoint-on-premises-tutorial#configure-sharepoint-on-premises-single-sign-on)

Updated "Some of the external users will not able"    to      "Some of the external users will not be able  " 
Updated "Soon we will allow customer app config"      to     "Soon we will allow custom app config.. "