### PR TITLE
Added a second troubleshooting step for 401s

### DIFF
--- a/articles/aks/aad-integration.md
+++ b/articles/aks/aad-integration.md
@@ -216,8 +216,8 @@ aks-nodepool1-79590246-2   Ready     agent     1h        v1.9.9
 
 Once complete, the authentication token is cached. You are only reprompted to log in when the token has expired or the Kubernetes config file re-created.
 
-If you are seeing an authorization error message after signing in successfully, check:
-1. The user you are signing in as is not a Guest in the Azure AD (this is often the case if you are using a federated login from a different directory)
+If you are seeing an authorization error message after signing in successfully, check whether:
+1. The user you are signing in as is not a Guest in the Azure AD instance (this is often the case if you are using a federated login from a different directory).
 2. The user is not a member of more than 200 groups.
 
 ```console

--- a/articles/aks/aad-integration.md
+++ b/articles/aks/aad-integration.md
@@ -216,7 +216,9 @@ aks-nodepool1-79590246-2   Ready     agent     1h        v1.9.9
 
 Once complete, the authentication token is cached. You are only reprompted to log in when the token has expired or the Kubernetes config file re-created.
 
-If you are seeing an authorization error message after signing in successfully, check that the user you are signing in as is not a Guest in the Azure AD (this is often the case if you are using a federated login from a different directory).
+If you are seeing an authorization error message after signing in successfully, check:
+1. The user you are signing in as is not a Guest in the Azure AD (this is often the case if you are using a federated login from a different directory)
+2. The user is not a member of more than 200 groups.
 
 ```console
 error: You must be logged in to the server (Unauthorized)


### PR DESCRIPTION
Please reach out to copowell internally on this - there is more that can be done to fix this doc regarding a case we had open.

User had more than 200 groups (distribution and security) and they were receiving 401s since the token didn't contain the authorized group GUID. The fix was to change the groupMembershipClaims property in the appManifest for the Kubernetes API in AAD from "All" to "SecurityGroup".