### PR TITLE
(Azure CXP) fixes Updated the Article for Typo

### DIFF
--- a/articles/active-directory/users-groups-roles/groups-dynamic-membership.md
+++ b/articles/active-directory/users-groups-roles/groups-dynamic-membership.md
@@ -345,7 +345,7 @@ The following device attributes can be used.
  accountEnabled | true false | (device.accountEnabled -eq true)
  displayName | any string value |(device.displayName -eq "Rob Iphone”)
  deviceOSType | any string value | (device.deviceOSType -eq "iPad") -or (device.deviceOSType -eq "iPhone")
- deviceOSVersion | any string value | (device.OSVersion -eq "9.1")
+ deviceOSVersion | any string value | (device.deviceOSVersion -eq "9.1")
  deviceCategory | a valid device category name | (device.deviceCategory -eq "BYOD")
  deviceManufacturer | any string value | (device.deviceManufacturer -eq "Samsung")
  deviceModel | any string value | (device.deviceModel -eq "iPad Air")


### PR DESCRIPTION
The section for [Rules for Devices](https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/groups-dynamic-membership#rules-for-devices) have an example entry which has wrong syntax . deviceOSversion . It must be (device.deviceOSVersion -eq "9.1") rather than "" (device.OSVersion -eq "9.1") "" . This is done after verifying in lab and as per [this issue](https://github.com/MicrosoftDocs/azure-docs/issues/21710)