### PR TITLE
Update names and API versions for VM extension resources

### DIFF
--- a/articles/azure-monitor/platform/collect-custom-metrics-guestos-resource-manager-vm.md
+++ b/articles/azure-monitor/platform/collect-custom-metrics-guestos-resource-manager-vm.md
@@ -70,7 +70,7 @@ Add this Managed Service Identity (MSI) extension to the template at the top of 
     {
         "type": "Microsoft.Compute/virtualMachines/extensions",
         "name": "WADExtensionSetup",
-        "apiVersion": "2015-05-01-preview",
+        "apiVersion": "2017-12-01",
         "location": "[resourceGroup().location]",
         "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]" ],
@@ -140,7 +140,7 @@ Add the following configuration to enable the Diagnostics extension on a Windows
 {
             "type": "extensions",
             "name": "Microsoft.Insights.VMDiagnosticsSettings",
-            "apiVersion": "2015-05-01-preview",
+            "apiVersion": "2017-12-01",
             "location": "[resourceGroup().location]",
             "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/articles/azure-monitor/platform/collect-custom-metrics-guestos-resource-manager-vm.md
+++ b/articles/azure-monitor/platform/collect-custom-metrics-guestos-resource-manager-vm.md
@@ -138,8 +138,8 @@ Add the following configuration to enable the Diagnostics extension on a Windows
 //Start of section to add
 "resources": [
 {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmName'), '/', 'Microsoft.Insights.VMDiagnosticsSettings')]",
+            "type": "extensions",
+            "name": "Microsoft.Insights.VMDiagnosticsSettings",
             "apiVersion": "2017-12-01",
             "location": "[resourceGroup().location]",
             "dependsOn": [

--- a/articles/azure-monitor/platform/collect-custom-metrics-guestos-resource-manager-vm.md
+++ b/articles/azure-monitor/platform/collect-custom-metrics-guestos-resource-manager-vm.md
@@ -69,7 +69,7 @@ Add this Managed Service Identity (MSI) extension to the template at the top of 
 // Add this code directly below.
     {
         "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "WADExtensionSetup",
+        "name": "[concat(variables('vmName'), '/', 'WADExtensionSetup')]",
         "apiVersion": "2017-12-01",
         "location": "[resourceGroup().location]",
         "dependsOn": [
@@ -138,8 +138,8 @@ Add the following configuration to enable the Diagnostics extension on a Windows
 //Start of section to add
 "resources": [
 {
-            "type": "extensions",
-            "name": "Microsoft.Insights.VMDiagnosticsSettings",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(variables('vmName'), '/', 'Microsoft.Insights.VMDiagnosticsSettings')]",
             "apiVersion": "2017-12-01",
             "location": "[resourceGroup().location]",
             "dependsOn": [


### PR DESCRIPTION
Two-segment name is required for the managed identity (WAD) extension and both extensions are no longer in preview so the API versions should be updated accordingly. Thanks.