### PR TITLE
Add next steps to point to a related walk through

### DIFF
--- a/articles/aks/kubernetes-walkthrough.md
+++ b/articles/aks/kubernetes-walkthrough.md
@@ -266,7 +266,7 @@ In this quickstart, pre-created container images were used to create a Kubernete
 
 ## Next steps
 
-In this quickstart, you deployed a Kubernetes cluster and deployed a multi-container application to it.
+In this quickstart, you deployed a Kubernetes cluster and deployed a multi-container application to it.  [Access the Kubernetes web dashboard][kubernetes-dashboard] for the cluster you just created.
 
 To learn more about AKS, and walk through a complete code to deployment example, continue to the Kubernetes cluster tutorial.
 
@@ -295,3 +295,4 @@ To learn more about AKS, and walk through a complete code to deployment example,
 [azure-portal]: https://portal.azure.com
 [kubernetes-deployment]: concepts-clusters-workloads.md#deployments-and-yaml-manifests
 [kubernetes-service]: concepts-network.md#services
+[kubernetes-dashboard]: kubernetes-dashboard.md


### PR DESCRIPTION
We have had customers call in with support cases having issues connecting to the kubernetes dashboard, added a line in next steps section to send customers along to complete needed steps there.