### PR TITLE
RBAC is on by default

### DIFF
--- a/articles/aks/kubernetes-dashboard.md
+++ b/articles/aks/kubernetes-dashboard.md
@@ -36,6 +36,9 @@ This command creates a proxy between your development system and the Kubernetes 
 
 ### For RBAC-enabled clusters
 
+> [!NOTE]
+> For new AKS clusters RBAC is enabled by default.
+
 If your AKS cluster uses RBAC, a *ClusterRoleBinding* must be created before you can correctly access the dashboard. By default, the Kubernetes dashboard is deployed with minimal read access and displays RBAC access errors. The Kubernetes dashboard does not currently support user-provided credentials to determine the level of access, rather it uses the roles granted to the service account. A cluster administrator can choose to grant additional access to the *kubernetes-dashboard* service account, however this can be a vector for privilege escalation. You can also integrate Azure Active Directory authentication to provide a more granular level of access.
 
 To create a binding, use the [kubectl create clusterrolebinding][kubectl-create-clusterrolebinding] command as shown in the following example. 


### PR DESCRIPTION
Added a note that RBAC is enabled by default on new aks clusters.