### PR TITLE
Delete unnecessary space in script

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-audit-logs.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-audit-logs.md
@@ -18,7 +18,7 @@ ms.component: B2C
 Azure Active Directory B2C (Azure AD B2C) emits audit logs containing activity information about B2C resources, issued tokens, and administrator access. This article provides a brief overview of the information available through audit logs and instructions on how to access this data for your Azure AD B2C tenant.
 
 > [!IMPORTANT]
-> Audit logs are only retained for seven days. Plan to download and store your logs using one of the methods shown below if you require a longer retention period. 
+> Audit logs are only retained for seven days. Plan to download and store your logs using one of the methods shown below if you require a longer retention period.
 
 ## Overview of activities available in the B2C category of audit logs
 The **B2C** category in audit logs contains the following types of activities:
@@ -40,7 +40,7 @@ The example below shows the data captured when a user signs in with an external 
 
 ## Accessing audit logs through the Azure Portal
 1. Go to the [Azure portal](https://portal.azure.com). Make sure you are in your B2C directory.
-2. Click on **Azure Active Directory** in the favorites bar on the left 
+2. Click on **Azure Active Directory** in the favorites bar on the left
     
     ![Audit Logs - AAD button](./media/active-directory-b2c-reference-audit-logs/audit-logs-portal-aad.png)
 
@@ -53,14 +53,14 @@ The example below shows the data captured when a user signs in with an external 
 
     ![Audit Logs - Category](./media/active-directory-b2c-reference-audit-logs/audit-logs-portal-category.png)
 
-You will see a list of activities logged over the last seven days. 
+You will see a list of activities logged over the last seven days.
 - Use the **Activity Resource Type** dropdown to filter by the activity types outlined above
 - Use the **Date Range** dropdown to filter the date range of the activities shown
 - If you click on a specific row in the list, a contextual box on the right will show you additional attributes associated with the activity
 - Click on **Download** to download the activities as a csv file
 
 ## Accessing audit logs through the Azure AD reporting API
-Audit logs are published to the same pipeline as other activities for Azure Active Directory, so they can be accessed through the [Azure Active Directory reporting API](https://docs.microsoft.com/azure/active-directory/active-directory-reporting-api-audit-reference). 
+Audit logs are published to the same pipeline as other activities for Azure Active Directory, so they can be accessed through the [Azure Active Directory reporting API](https://docs.microsoft.com/azure/active-directory/active-directory-reporting-api-audit-reference).
 
 ### Prerequisites
 To authenticate to the Azure AD reporting API you first need to register an application. Make sure to follow the steps in [Prerequisites to access the Azure AD reporting APIs](https://azure.microsoft.com/documentation/articles/active-directory-reporting-api-getting-started/).
@@ -79,7 +79,7 @@ The following script provides an example of using PowerShell to query the Azure 
 # Constants
 $ClientID       = "your-client-application-id-here"       # Insert your application's Client ID, a Globally Unique ID (registered by Global Admin)
 $ClientSecret   = "your-client-application-secret-here"   # Insert your application's Client Key/Secret string
-$loginURL       = "https://login.microsoftonline.com"     
+$loginURL       = "https://login.microsoftonline.com"
 $tenantdomain   = "your-b2c-tenant.onmicrosoft.com"       # AAD B2C Tenant; for example, contoso.onmicrosoft.com
 $resource       = "https://graph.windows.net"             # Azure AD Graph API resource URI
 $7daysago       = "{0:s}" -f (get-date).AddDays(-7) + "Z" # Use 'AddMinutes(-5)' to decrement minutes, for example
@@ -90,13 +90,13 @@ $body       = @{grant_type="client_credentials";resource=$resource;client_id=$Cl
 $oauth      = Invoke-RestMethod -Method Post -Uri $loginURL/$tenantdomain/oauth2/token?api-version=1.0 -Body $body
 
 # Parse audit report items, save output to file(s): auditX.json, where X = 0 thru n for number of nextLink pages
-if ($oauth.access_token -ne $null) {   
+if ($oauth.access_token -ne $null) {
     $i=0
     $headerParams = @{'Authorization'="$($oauth.token_type) $($oauth.access_token)"}
-    $url = 'https://graph.windows.net/' + $tenantdomain + '/activities/audit?api-version=beta&$filter=category eq ''B2C''and activityDate gt ' + $7daysago 
+    $url = 'https://graph.windows.net/' + $tenantdomain + '/activities/audit?api-version=beta&$filter=category eq ''B2C''and activityDate gt ' + $7daysago
 
     # loop through each query page (1 through n)
-    Do{
+    Do {
         # display each event on the console window
         Write-Output "Fetching data using Uri: $url"
         $myReport = (Invoke-WebRequest -UseBasicParsing -Headers $headerParams -Uri $url)
@@ -114,4 +114,3 @@ if ($oauth.access_token -ne $null) {
     Write-Host "ERROR: No Access Token"
 }
 ```
-


### PR DESCRIPTION
If we copy each script from the web page, there is a large amount of unnecessary space after the code.