### PR TITLE
fix: metric alerts payload schema documentation

### DIFF
--- a/articles/azure-monitor/platform/alerts-metric-near-real-time.md
+++ b/articles/azure-monitor/platform/alerts-metric-near-real-time.md
@@ -70,6 +70,7 @@ The POST operation contains the following JSON payload and schema for all near n
 {"schemaId":"AzureMonitorMetricAlert","data":
     {
     "version": "2.0",
+    "properties": null,
     "status": "Activated",
     "context": {
     "timestamp": "2018-02-28T10:44:10.1714014Z",
@@ -77,11 +78,13 @@ The POST operation contains the following JSON payload and schema for all near n
     "name": "StorageCheck",
     "description": "",
     "conditionType": "SingleResourceMultipleMetricCriteria",
+    "severity":"3",
     "condition": {
       "windowSize": "PT5M",
       "allOf": [
         {
           "metricName": "Transactions",
+          "metricNamespace":"microsoft.storage/storageAccounts",
           "dimensions": [
             {
               "name": "AccountResourceId",


### PR DESCRIPTION
There are a number of missing properties from the Alerts Payload Schema

* added data.properties
* added data.context.severity
* added data.context.condition.allOf.metricNamespace