### PR TITLE
fix: metric alerts payload schema documentation

### DIFF
--- a/articles/azure-monitor/platform/alerts-metric-near-real-time.md
+++ b/articles/azure-monitor/platform/alerts-metric-near-real-time.md
@@ -77,11 +77,13 @@ The POST operation contains the following JSON payload and schema for all near n
     "name": "StorageCheck",
     "description": "",
     "conditionType": "SingleResourceMultipleMetricCriteria",
+    "severity":"3",
     "condition": {
       "windowSize": "PT5M",
       "allOf": [
         {
           "metricName": "Transactions",
+          "metricNamespace":"microsoft.storage/storageAccounts",
           "dimensions": [
             {
               "name": "AccountResourceId",


### PR DESCRIPTION
Add missing properties to Metric Alert payload Schema 

* added data.context.severity
* added data.context.condition.allOf.metricNamespace