### PR TITLE
Delete unnecessary space

### DIFF
--- a/articles/data-factory/v1/data-factory-copy-activity-fault-tolerance.md
+++ b/articles/data-factory/v1/data-factory-copy-activity-fault-tolerance.md
@@ -59,8 +59,8 @@ The following example provides a JSON definition to configure skipping the incom
     },
     "sink": {
         "type": "SqlSink",
-    },         
-    "enableSkipIncompatibleRow": true,           
+    },
+    "enableSkipIncompatibleRow": true,
     "redirectIncompatibleRowSettings": {
         "linkedServiceName": "BlobStorage",
         "path": "redirectcontainer/erroroutput"


### PR DESCRIPTION
If we copy each script from the web page, there is a large amount of unnecessary space after the code.