### PR TITLE
typo: E>xample -> Example

### DIFF
--- a/articles/cognitive-services/Content-Moderator/video-transcript-moderation-review-tutorial-dotnet.md
+++ b/articles/cognitive-services/Content-Moderator/video-transcript-moderation-review-tutorial-dotnet.md
@@ -237,7 +237,7 @@ The code performs the following steps:
 
 - Checks to make sure the configuration in `App.config` contains all necessary data
 - Checks to make sure the `ffmpeg` binary is present
-- Builds the output filename by appending `_c.mp4` to the base name of the file (such as `Example.mp4` -> `E>xample_c.mp4`)
+- Builds the output filename by appending `_c.mp4` to the base name of the file (such as `Example.mp4` -> `Example_c.mp4`)
 - Builds a command-line string to perform the conversion
 - Starts an `ffmpeg` process using the command line
 - Waits for the video to be processed


### PR DESCRIPTION

Text mentions that it should just be the base with an appended _c.mp4