### PR TITLE
Correction: Automatic validation takes longer than a "few minutes"

### DIFF
--- a/articles/cdn/cdn-custom-ssl.md
+++ b/articles/cdn/cdn-custom-ssl.md
@@ -176,7 +176,7 @@ For more information about CNAME records, see [Create the CNAME DNS record](http
 
 If your CNAME record is in the correct format, DigiCert automatically verifies your custom domain name and creates a dedicated certificate for your domain name. DigitCert won't send you a verification email and you won't need to approve your request. The certificate is valid for one year and will be auto-renewed before it expires. Proceed to [Wait for propagation](#wait-for-propagation). 
 
-Automatic validation typically takes a few mins. If you don’t see your domain validated within an hour, open a support ticket.
+Automatic validation typically takes a few hours. If you don’t see your domain validated in 24 hours, open a support ticket.
 
 >[!NOTE]
 >If you have a Certificate Authority Authorization (CAA) record with your DNS provider, it must include DigiCert as a valid CA. A CAA record allows domain owners to specify with their DNS providers which CAs are authorized to issue certificates for their domain. If a CA receives an order for a certificate for a domain that has a CAA record and that CA is not listed as an authorized issuer, it is prohibited from issuing the certificate to that domain or subdomain. For  information about managing CAA records, see [Manage CAA records](https://support.dnsimple.com/articles/manage-caa-record/). For a CAA record tool, see [CAA Record Helper](https://sslmate.com/caa/).


### PR DESCRIPTION
Softened the note that automatic validation takes a few minutes, because it doesn't (tried with several domains from different providers and two different subscriptions). Goal of this proposed change is to correct developer's expectations, prevent frustration and reduce the number of unnecessary support requests - the validation can in reality take several hours, I would say that "next day" is usually a good time to turn to support.