### PR TITLE
Update azure-stack-update-1809.md

### DIFF
--- a/articles/azure-stack/azure-stack-update-1809.md
+++ b/articles/azure-stack/azure-stack-update-1809.md
@@ -134,7 +134,7 @@ For more information about these vulnerabilities, click on the preceding links, 
 
 ### Prerequisites
 
-- Install the latest Azure Stack Hotfix for 1808 before applying 1809. For more information, see [KB 4481066 – Azure Stack Hotfix Azure Stack Hotfix 1.1808.9.117](https://support.microsoft.com/help/4481066/).
+- Install the latest Azure Stack Hotfix for 1808 before applying 1809. For more information, see [KB 4481066 – Azure Stack Hotfix Azure Stack Hotfix 1.1808.9.117](https://support.microsoft.com/help/4481066/). While Microsoft recommends the latest Hotfix avaiable, the minimun version required to install 1809 is 1.1808.5.110.
 
   > [!TIP]  
   > Subscribe to the following *RRS* or *Atom* feeds to keep up with Azure Stack Hotfixes:


### PR DESCRIPTION
Added a note that while we recommend the latest 1808 hotfix to install 1809, the 1.1808.5.110 is the min version required to install 1809.