### PR TITLE
(Azure CXP) fixes Refined the statement for better clarity.

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-device-writeback.md
+++ b/articles/active-directory/hybrid/how-to-connect-device-writeback.md
@@ -85,7 +85,7 @@ If the checkbox for device writeback is not enabled even though you have followe
 
 First things first:
 
-* Make sure at least one forest has Windows Server 2012R2. The device object type must be present.
+* The forest where the devices are present must have forest schema upgraded to Windows 2012 R2 level so that the device object and associated attributes are present .
 * If the installation wizard is already running, then any changes will not be detected. In this case, complete the installation wizard and run it again.
 * Make sure the account you provide in the initialization script is actually the correct user used by the Active Directory Connector. To verify this, follow these steps:
   * From the start menu, open **Synchronization Service**.

--- a/articles/active-directory/hybrid/how-to-connect-device-writeback.md
+++ b/articles/active-directory/hybrid/how-to-connect-device-writeback.md
@@ -85,7 +85,7 @@ If the checkbox for device writeback is not enabled even though you have followe
 
 First things first:
 
-* The forest where the devices are present must have forest schema upgraded to Windows 2012 R2 level so that the device object and associated attributes are present .
+* The forest where the devices are present must have the forest schema upgraded to Windows 2012 R2 level so that the device object and associated attributes are present .
 * If the installation wizard is already running, then any changes will not be detected. In this case, complete the installation wizard and run it again.
 * Make sure the account you provide in the initialization script is actually the correct user used by the Active Directory Connector. To verify this, follow these steps:
   * From the start menu, open **Synchronization Service**.


### PR DESCRIPTION
Updated the Document for a better clarification ad per feedback from the customer on this [Issue](https://github.com/MicrosoftDocs/azure-docs/issues/22165) . Updated the section [Device Writeback Troubleshooting](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-device-writeback#the-writeback-checkbox-is-still-disabled) . 

Updated "Make sure at least one forest has Windows Server 2012R2 . The device object type must be present."   ....      to   ...   "The forest where the devices are present must have forest schema upgraded to Windows 2012 R2 level so that the device object and associated attributes are present ."