### PR TITLE
typo: Double word "data"

### DIFF
--- a/articles/azure-monitor/platform/log-standard-properties.md
+++ b/articles/azure-monitor/platform/log-standard-properties.md
@@ -87,7 +87,7 @@ The **\_IsBillable** property specifies whether ingested data is billable. Data 
 To get a list of computers sending billed data types, use the following query:
 
 > [!NOTE]
-> Use queries with `union withsource = tt *` sparingly as scans across data data types are expensive to execute. 
+> Use queries with `union withsource = tt *` sparingly as scans across data types are expensive to execute. 
 
 ```Kusto
 union withsource = tt * 

--- a/articles/azure-monitor/platform/manage-cost-storage.md
+++ b/articles/azure-monitor/platform/manage-cost-storage.md
@@ -164,7 +164,7 @@ To get a list of computers sending **billed data types** (some data types are fr
 | where computerName != ""
 | summarize TotalVolumeBytes=sum(_BilledSize) by computerName`
 
-Use these `union withsource = tt *` queries sparingly as scans across data data typres are expensive to execute. 
+Use these `union withsource = tt *` queries sparingly as scans across data types are expensive to execute. 
 
 This can be extended to return the count of computers per hour that are sending billed data types:
 


### PR DESCRIPTION

Also "typres" -> "types"