### PR TITLE
Increased key size for Security World

### DIFF
--- a/articles/key-vault/key-vault-hsm-protected-keys.md
+++ b/articles/key-vault/key-vault-hsm-protected-keys.md
@@ -252,7 +252,7 @@ If you are using Thales nShield Edge, to change the mode: 1. Use the Mode button
 Start a command prompt and run the Thales new-world program.
 
    ```cmd
-    new-world.exe --initialize --cipher-suite=DLf1024s160mRijndael --module=1 --acs-quorum=2/3
+    new-world.exe --initialize --cipher-suite=DLf3072s256mRijndael --module=1 --acs-quorum=2/3
    ```
 
 This program creates a **Security World** file at %NFAST_KMDATA%\local\world, which corresponds to the C:\ProgramData\nCipher\Key Management Data\local folder. You can use different values for the quorum but in our example, you’re prompted to enter three blank cards and pins for each one. Then, any two cards give full access to the security world. These cards become the **Administrator Card Set** for the new security world.


### PR DESCRIPTION
In accordance with Thales documentation, increased DSA key size from 1024 bit to 3072 bit and AES key size from 160 to 256 bit