### PR TITLE
Correcting CORS in own app vs CORS in Web App

### DIFF
--- a/articles/app-service/app-service-web-tutorial-rest-api.md
+++ b/articles/app-service/app-service-web-tutorial-rest-api.md
@@ -189,7 +189,7 @@ Congratulations, you're running an API in Azure App Service with CORS support.
 You can use your own CORS utilities instead of App Service CORS for more flexibility. For example, you may want to specify different allowed origins for different routes or methods. Since App Service CORS lets you specify one set of accepted origins for all API routes and methods, you would want to use your own CORS code. See how ASP.NET Core does it at [Enabling Cross-Origin Requests (CORS)](/aspnet/core/security/cors).
 
 > [!NOTE]
-> Don't try to use App Service CORS and your own CORS code together. When used together, App Service CORS takes precedence and your own CORS code has no effect.
+> Don't try to use App Service CORS and your own CORS code together. When used together, your own CORS code takes precedence and App Service CORS has no effect.
 >
 >
 


### PR DESCRIPTION
When used together, CORS defined in own application, takes precedence over App Service Apps CORS, not the other way around.
(Tested with a Spring Boot application, where the CORS where defined at controllers level).