### PR TITLE
Eliminate looping in SSIS IR creation sections

### DIFF
--- a/articles/data-factory/tutorial-deploy-ssis-packages-azure.md
+++ b/articles/data-factory/tutorial-deploy-ssis-packages-azure.md
@@ -74,11 +74,33 @@ In this tutorial, you complete the following steps:
 
 1. Select **Author & Monitor** to open the Data Factory user interface (UI) on a separate tab. 
 
-## Provision an Azure-SSIS integration runtime
+## Create an Azure-SSIS integration runtime
+
+### From the Data Factory overview
 
 1. On the **Let's get started** page, select the **Configure SSIS Integration Runtime** tile. 
 
    !["Configure SSIS Integration Runtime" tile](./media/tutorial-create-azure-ssis-runtime-portal/configure-ssis-integration-runtime-tile.png)
+
+1. For the remaining steps to set up an Azure-SSIS IR, see the [Provision an Azure-SSIS integration runtime](#provision-an-azure-ssis-integration-runtime) section. 
+
+### From the Authoring UI
+
+1. In the Azure Data Factory UI, switch to the **Edit** tab, select **Connections**, and then switch to the **Integration Runtimes** tab to view existing integration runtimes in your data factory. 
+
+   ![Selections for viewing existing IRs](./media/tutorial-create-azure-ssis-runtime-portal/view-azure-ssis-integration-runtimes.png)
+
+1. Select **New** to create an Azure-SSIS IR. 
+
+   ![Integration runtime via menu](./media/tutorial-create-azure-ssis-runtime-portal/edit-connections-new-integration-runtime-button.png)
+
+1. In the **Integration Runtime Setup** window, select **Lift-and-shift existing SSIS packages to execute in Azure**, and then select **Next**. 
+
+   ![Specify the type of integration runtime](./media/tutorial-create-azure-ssis-runtime-portal/integration-runtime-setup-options.png)
+
+1. For the remaining steps to set up an Azure-SSIS IR, see the [Provision an Azure-SSIS integration runtime](#provision-an-azure-ssis-integration-runtime) section. 
+
+## Provision an Azure-SSIS integration runtime
 
 1. On the **General Settings** page of **Integration Runtime Setup**, complete the following steps: 
 
@@ -146,22 +168,6 @@ In this tutorial, you complete the following steps:
 1. Use the links in the **Actions** column to stop/start, edit, or delete the integration runtime. Use the last link to view JSON code for the integration runtime. The edit and delete buttons are enabled only when the IR is stopped. 
 
    ![Links in the "Actions" column](./media/tutorial-create-azure-ssis-runtime-portal/azure-ssis-ir-actions.png) 
-
-## Create an Azure-SSIS integration runtime
-
-1. In the Azure Data Factory UI, switch to the **Edit** tab, select **Connections**, and then switch to the **Integration Runtimes** tab to view existing integration runtimes in your data factory. 
-
-   ![Selections for viewing existing IRs](./media/tutorial-create-azure-ssis-runtime-portal/view-azure-ssis-integration-runtimes.png)
-
-1. Select **New** to create an Azure-SSIS IR. 
-
-   ![Integration runtime via menu](./media/tutorial-create-azure-ssis-runtime-portal/edit-connections-new-integration-runtime-button.png)
-
-1. In the **Integration Runtime Setup** window, select **Lift-and-shift existing SSIS packages to execute in Azure**, and then select **Next**. 
-
-   ![Specify the type of integration runtime](./media/tutorial-create-azure-ssis-runtime-portal/integration-runtime-setup-options.png)
-
-1. For the remaining steps to set up an Azure-SSIS IR, see the [Provision an Azure-SSIS integration runtime](#provision-an-azure-ssis-integration-runtime) section. 
 
 ## Deploy SSIS packages
 Now, use SQL Server Data Tools (SSDT) or SQL Server Management Studio (SSMS) to deploy your SSIS packages to Azure. Connect to your Azure SQL Database server that hosts the SSIS Catalog (SSISDB database). The name of Azure SQL Database server is in the format `<servername>.database.windows.net`. 


### PR DESCRIPTION
The "Provision an Azure-SSIS integration runtime" initiates creation of an SSIS IR from the Let's get started UI. The following section, "Create an Azure-SSIS integration runtime," initiates creation of an SSIS IR from the Authoring UI, but it links back up to the previous section for common steps. This causes the user to loop back to the docs which describe the Let's get started UI.

This change moves the sections which detail the two ways by which a user can initiate the experience together, and moves the common steps below.