### PR TITLE
typo: adpaters, netowrk, and varible

### DIFF
--- a/articles/databox-online/data-box-edge-deploy-connect-setup-activate.md
+++ b/articles/databox-online/data-box-edge-deploy-connect-setup-activate.md
@@ -82,7 +82,7 @@ Your dashboard displays the various settings that are required to configure and 
     - You can configure your network interface as IPv4.
 
     >[!NOTE] 
-    > We recommend that you do not switch the local IP address of the netowrk interface from static to DCHP, unless you have another IP address to connect to the device. If using one network interface and you switch to DHCP, there would be no way to determine the DHCP address. If you want to change to a DHCP address, wait until after the device has registered with the service, and then change. You can then view the IPs of all the adapters in the **Device properties** in the Azure portal for your service.
+    > We recommend that you do not switch the local IP address of the network interface from static to DCHP, unless you have another IP address to connect to the device. If using one network interface and you switch to DHCP, there would be no way to determine the DHCP address. If you want to change to a DHCP address, wait until after the device has registered with the service, and then change. You can then view the IPs of all the adapters in the **Device properties** in the Azure portal for your service.
 
 1. (Optional) In the left pane, select **Web proxy settings**, and then configure your web proxy server. Although web proxy configuration is optional, if you use a web proxy, you can configure it on this page only.
    

--- a/articles/databox-online/data-box-edge-deploy-connect-setup-activate.md
+++ b/articles/databox-online/data-box-edge-deploy-connect-setup-activate.md
@@ -82,7 +82,7 @@ Your dashboard displays the various settings that are required to configure and 
     - You can configure your network interface as IPv4.
 
     >[!NOTE] 
-    > We recommend that you do not switch the local IP address of the netowrk interface from static to DCHP, unless you have another IP address to connect to the device. If using one network interface and you switch to DHCP, there would be no way to determine the DHCP address. If you want to change to a DHCP address, wait until after the device has registered with the service, and then change. You can then view the IPs of all the adpaters in the **Device properties** in the Azure portal for your service.
+    > We recommend that you do not switch the local IP address of the netowrk interface from static to DCHP, unless you have another IP address to connect to the device. If using one network interface and you switch to DHCP, there would be no way to determine the DHCP address. If you want to change to a DHCP address, wait until after the device has registered with the service, and then change. You can then view the IPs of all the adapters in the **Device properties** in the Azure portal for your service.
 
 1. (Optional) In the left pane, select **Web proxy settings**, and then configure your web proxy server. Although web proxy configuration is optional, if you use a web proxy, you can configure it on this page only.
    

--- a/articles/databox-online/data-box-gateway-deploy-connect-setup-activate.md
+++ b/articles/databox-online/data-box-gateway-deploy-connect-setup-activate.md
@@ -82,7 +82,7 @@ You are now at the **Dashboard** of your device.
     - You can configure your network interface as IPv4.
 
     >[!NOTE] 
-    > We recommend that you do not switch the local IP address of the network interface from static to DHCP, unless you have another IP address to connect to the device. If using one network interface and you switch to DHCP, there would be no way to determine the DHCP address. If you want to change to a DHCP address, wait until after the device has registered with the service, and then change. You can then view the IPs of all the adpaters in the **Device properties** in the Azure portal for your service.
+    > We recommend that you do not switch the local IP address of the network interface from static to DHCP, unless you have another IP address to connect to the device. If using one network interface and you switch to DHCP, there would be no way to determine the DHCP address. If you want to change to a DHCP address, wait until after the device has registered with the service, and then change. You can then view the IPs of all the adapters in the **Device properties** in the Azure portal for your service.
 
 4. (Optionally) configure your web proxy server. Although web proxy configuration is optional, be aware that if you use a web proxy, you can only configure it here.
    

--- a/articles/virtual-network/virtual-networks-dmz-nsg-fw-asm.md
+++ b/articles/virtual-network/virtual-networks-dmz-nsg-fw-asm.md
@@ -418,7 +418,7 @@ This PowerShell script should be run locally on an internet connected PC or serv
         $FatalError = $true}
     Else { Write-Host "The network config file was found" -ForegroundColor Green
             If (-Not (Select-String -Pattern $DeploymentLocation -Path $NetworkConfigFile)) {
-                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation varible is correct and the network config file matches.' -ForegroundColor Yellow
+                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation variable is correct and the network config file matches.' -ForegroundColor Yellow
                 $FatalError = $true}
             Else { Write-Host "The deployment location was found in the network config file." -ForegroundColor Green}}
 

--- a/articles/virtual-network/virtual-networks-dmz-nsg-fw-asm.md
+++ b/articles/virtual-network/virtual-networks-dmz-nsg-fw-asm.md
@@ -418,7 +418,7 @@ This PowerShell script should be run locally on an internet connected PC or serv
         $FatalError = $true}
     Else { Write-Host "The network config file was found" -ForegroundColor Green
             If (-Not (Select-String -Pattern $DeploymentLocation -Path $NetworkConfigFile)) {
-                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation varible is correct and the netowrk config file matches.' -ForegroundColor Yellow
+                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation varible is correct and the network config file matches.' -ForegroundColor Yellow
                 $FatalError = $true}
             Else { Write-Host "The deployment location was found in the network config file." -ForegroundColor Green}}
 

--- a/articles/virtual-network/virtual-networks-dmz-nsg-fw-udr-asm.md
+++ b/articles/virtual-network/virtual-networks-dmz-nsg-fw-udr-asm.md
@@ -776,7 +776,7 @@ This PowerShell script should be run locally on an internet connected PC or serv
         $FatalError = $true}
     Else { Write-Host "The network config file was found" -ForegroundColor Green
             If (-Not (Select-String -Pattern $DeploymentLocation -Path $NetworkConfigFile)) {
-                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation varible is correct and the netowrk config file matches.' -ForegroundColor Yellow
+                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation varible is correct and the network config file matches.' -ForegroundColor Yellow
                 $FatalError = $true}
             Else { Write-Host "The deployment location was found in the network config file." -ForegroundColor Green}}
 

--- a/articles/virtual-network/virtual-networks-dmz-nsg-fw-udr-asm.md
+++ b/articles/virtual-network/virtual-networks-dmz-nsg-fw-udr-asm.md
@@ -776,7 +776,7 @@ This PowerShell script should be run locally on an internet connected PC or serv
         $FatalError = $true}
     Else { Write-Host "The network config file was found" -ForegroundColor Green
             If (-Not (Select-String -Pattern $DeploymentLocation -Path $NetworkConfigFile)) {
-                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation varible is correct and the network config file matches.' -ForegroundColor Yellow
+                Write-Host 'The deployment location was not found in the network config file, please check the network config file to ensure the $DeploymentLocation variable is correct and the network config file matches.' -ForegroundColor Yellow
                 $FatalError = $true}
             Else { Write-Host "The deployment location was found in the network config file." -ForegroundColor Green}}
 


### PR DESCRIPTION
Stacking a few fixes because they are all on the same lines and would hit merge conflicts submitted separately