### PR TITLE
Fix missing

### DIFF
--- a/articles/storsimple/storsimple-virtual-array-manage-alerts.md
+++ b/articles/storsimple/storsimple-virtual-array-manage-alerts.md
@@ -34,7 +34,6 @@ You can choose whether you want to be notified by email of the alert conditions 
 > [!NOTE]
 > You can enter a maximum of 20 email addresses per virtual array.
 
-
 After you enable email notification for a virtual array, members of the notification list will receive an email message each time a critical alert occurs. The messages will be sent from *storsimple-alerts-noreply@mail.windowsazure.com* and will describe the alert condition. Recipients can click **Unsubscribe** to remove themselves from the email notification list.
 
 #### To enable email notification for alerts
@@ -58,8 +57,8 @@ After you enable email notification for a virtual array, members of the notifica
       
       > [!NOTE]
       > If the test notification message can't be sent, the StorSimple Device Manager service will display an appropriate message. Click **OK**, wait a few minutes, and then try to send your test notification message again.
-      > 
-      > 
+      >
+      >
    5. At the bottom of the page, click **Save** to save your configuration. When prompted for confirmation, click **Yes**.
       
       ![Alerts test notification email sent](./media/storsimple-virtual-array-manage-alerts/alerts10.png)
@@ -97,11 +96,11 @@ Click an alert in the list to get additional details for the alert, including th
 
 You can copy the alert details to a text file if you need to send the information to Microsoft Support. After you have followed the recommendation and resolved the alert condition on-premises, you should clear the alert from the list. Select the alert from the list and then click **Clear**. To clear multiple alerts, select each alert, click any column except the **Alert** column, and then click **Clear** after you have selected all the alerts to be cleared.
 
-When you click **Clear**, you will have the opportunity to provide comments about the alert and the steps that you took to resolve the issue. 
+When you click **Clear**, you will have the opportunity to provide comments about the alert and the steps that you took to resolve the issue.
 
 ![alert comments](./media/storsimple-virtual-array-manage-alerts/alerts17.png)
 
-Some events will be cleared by the system if another event is triggered with new information. 
+Some events will be cleared by the system if another event is triggered with new information.
 
 ## Sort and review alerts
 
@@ -126,7 +125,7 @@ The following tables list some of the StorSimple alerts that you might encounter
 
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
-| Device *<device name>* is not connected to the cloud. |The named device cannot connect to the cloud. |Could not connect to the cloud. This could be due to one of the following:<ul><li>There may be a problem with the network settings on your device.</li><li>There may be a problem with the storage account credentials.</li></ul>For more information on troubleshooting connectivity issues, go to the [local web UI](storsimple-ova-web-ui-admin.md) of the device. |
+| Device *\<device name>* is not connected to the cloud. |The named device cannot connect to the cloud. |Could not connect to the cloud. This could be due to one of the following:<ul><li>There may be a problem with the network settings on your device.</li><li>There may be a problem with the storage account credentials.</li></ul>For more information on troubleshooting connectivity issues, go to the [local web UI](storsimple-ova-web-ui-admin.md) of the device. |
 
 ### Configuration alerts
 
@@ -158,9 +157,8 @@ The following tables list some of the StorSimple alerts that you might encounter
 
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
-| Password for <*device name*> will expire in <*number*> days. |Password warning. |Your password will expire in <number< days. Consider changing your password. For more information, go to [Change the StorSimple Virtual Array device administrator password](storsimple-virtual-array-change-device-admin-password.md). |
+| Password for <*device name*> will expire in <*number*> days. |Password warning. |Your password will expire in \<number> days. Consider changing your password. For more information, go to [Change the StorSimple Virtual Array device administrator password](storsimple-virtual-array-change-device-admin-password.md). |
 
 ## Next steps
 
 * [Learn about the StorSimple Virtual Array](storsimple-ova-overview.md).
-

--- a/articles/storsimple/storsimple-virtual-array-manage-alerts.md
+++ b/articles/storsimple/storsimple-virtual-array-manage-alerts.md
@@ -125,21 +125,21 @@ The following tables list some of the StorSimple alerts that you might encounter
 
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
-| Device *\<device name>* is not connected to the cloud. |The named device cannot connect to the cloud. |Could not connect to the cloud. This could be due to one of the following:<ul><li>There may be a problem with the network settings on your device.</li><li>There may be a problem with the storage account credentials.</li></ul>For more information on troubleshooting connectivity issues, go to the [local web UI](storsimple-ova-web-ui-admin.md) of the device. |
+| Device *<device name\>* is not connected to the cloud. |The named device cannot connect to the cloud. |Could not connect to the cloud. This could be due to one of the following:<ul><li>There may be a problem with the network settings on your device.</li><li>There may be a problem with the storage account credentials.</li></ul>For more information on troubleshooting connectivity issues, go to the [local web UI](storsimple-ova-web-ui-admin.md) of the device. |
 
 ### Configuration alerts
 
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
 | On-premises virtual device configuration unsupported. |Slow performance. |The current configuration may result in performance degradation. Ensure that your server meets the minimum configuration requirements. For more information, go to [StorSimple Virtual Array Requirements](storsimple-ova-system-requirements.md). |
-| You are running out of provisioned disk space on <*device name*>. |Disk space warning. |You are running low on provisioned disk space. To free up space, consider moving workloads to another volume or share or deleting data. |
+| You are running out of provisioned disk space on <*device name*\>. |Disk space warning. |You are running low on provisioned disk space. To free up space, consider moving workloads to another volume or share or deleting data. |
 
 ### Job failure alerts
 
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
-| Backup of <*device name*> couldn’t be completed. |Backup job failure. |Could not create a backup. Consider one of the following:<ul><li>Connectivity issues could be preventing the backup operation from successfully completing. Ensure that there are no connectivity issues. For more information on troubleshooting connectivity issues, go to the [local web UI](storsimple-ova-web-ui-admin.md) for your virtual device.</li><li>You have reached the available storage limit. To free up space, consider deleting any backups that are no longer needed.</li></ul> Resolve the issues, clear the alert and retry the operation. |
-| Clone of <*device name*> couldn’t be completed. |Clone job failure. |Could not create a clone. Consider one of the following:<ul><li>Your backup list may not be valid. Refresh the list to verify it is still valid.</li><li>Connectivity issues could be preventing the clone operation from successfully completing. Ensure that there are no connectivity issues.</li><li>You have reached the available storage limit. To free up space, consider deleting any backups that are no longer needed.</li></ul>Resolve the issues, clear the alert and retry the operation. |
+| Backup of <*device name*\> couldn’t be completed. |Backup job failure. |Could not create a backup. Consider one of the following:<ul><li>Connectivity issues could be preventing the backup operation from successfully completing. Ensure that there are no connectivity issues. For more information on troubleshooting connectivity issues, go to the [local web UI](storsimple-ova-web-ui-admin.md) for your virtual device.</li><li>You have reached the available storage limit. To free up space, consider deleting any backups that are no longer needed.</li></ul> Resolve the issues, clear the alert and retry the operation. |
+| Clone of <*device name*\> couldn’t be completed. |Clone job failure. |Could not create a clone. Consider one of the following:<ul><li>Your backup list may not be valid. Refresh the list to verify it is still valid.</li><li>Connectivity issues could be preventing the clone operation from successfully completing. Ensure that there are no connectivity issues.</li><li>You have reached the available storage limit. To free up space, consider deleting any backups that are no longer needed.</li></ul>Resolve the issues, clear the alert and retry the operation. |
 
 ### Networking alerts
 | Alert text | Event | More information / recommended actions |
@@ -151,13 +151,13 @@ The following tables list some of the StorSimple alerts that you might encounter
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
 | You are experiencing unexpected delays in data transfer. |Slow data transfer. |Throttling errors occur when you exceed the scalability targets of a storage service. The storage service does this to ensure that no single client or tenant can use the service at the expense of others. For more information on troubleshooting your Azure storage account, go to [Monitor, diagnose, and troubleshoot Microsoft Azure Storage](../storage/common/storage-monitoring-diagnosing-troubleshooting.md). |
-| You are running low on local reservation disk space on <*device name*>. |Slow response time. |10% of the total provisioned size for <*device name*> is reserved on the local device and you are now running low on the reserved space. The workload on <*device name*> is generating a higher rate of churn or you might have recently migrated a large amount of data. This may result in reduced performance. Consider one of the following actions to resolve this:<ul><li>Increase the cloud bandwidth to this device.</li><li>Reduce or move workloads to another volume or share.</li></ul> |
+| You are running low on local reservation disk space on <*device name*\>. |Slow response time. |10% of the total provisioned size for <*device name*\> is reserved on the local device and you are now running low on the reserved space. The workload on <*device name*\> is generating a higher rate of churn or you might have recently migrated a large amount of data. This may result in reduced performance. Consider one of the following actions to resolve this:<ul><li>Increase the cloud bandwidth to this device.</li><li>Reduce or move workloads to another volume or share.</li></ul> |
 
 ### Security alerts
 
 | Alert text | Event | More information / recommended actions |
 |:--- |:--- |:--- |
-| Password for <*device name*> will expire in <*number*> days. |Password warning. |Your password will expire in \<number> days. Consider changing your password. For more information, go to [Change the StorSimple Virtual Array device administrator password](storsimple-virtual-array-change-device-admin-password.md). |
+| Password for <*device name*\> will expire in <*number*\> days. |Password warning. |Your password will expire in <*number*\> days. Consider changing your password. For more information, go to [Change the StorSimple Virtual Array device administrator password](storsimple-virtual-array-change-device-admin-password.md). |
 
 ## Next steps
 


### PR DESCRIPTION
evi1: ![evi](https://user-images.githubusercontent.com/1207985/51512923-a4562400-1e4b-11e9-90bc-a5863e55473b.jpg)
evi2: ![evi2](https://user-images.githubusercontent.com/1207985/51512927-a91ad800-1e4b-11e9-932a-db218263787d.jpg)

evi1: It is not displayed because it does not perform escape processing.
evi2: Since it says `Password for <*device name*> will expire in <*number*> days.` on the left side. So, I think that it is typo of `Your password will expire in <number> days.`