### PR TITLE
Update alerts-metric.md

### DIFF
--- a/articles/azure-monitor/platform/alerts-metric.md
+++ b/articles/azure-monitor/platform/alerts-metric.md
@@ -86,10 +86,10 @@ The previous sections described how to create, view and manage metric alert rule
     az monitor metrics alert --help
     ```
 
-3. You can create a simple metric alert rule that monitors if average Percentage CPU on a VM is greater than 70
+3. You can create a simple metric alert rule that monitors if average Percentage CPU on a VM is greater than 90
 
     ```azurecli
-    az monitor metrics alert create -n {nameofthealert} -g {ResourceGroup} --scopes {VirtualMachineResourceID} --condition "avg Percentage CPU > 90"
+    az monitor metrics alert create -n {nameofthealert} -g {ResourceGroup} --scopes {VirtualMachineResourceID} --condition "avg Percentage CPU > 90" --description {descriptionofthealert}
     ```
 
 4. You can view all the metric alerts in a resource group using the following command


### PR DESCRIPTION
The --description parameter is missing in the example, but it is a required parameter. If you do not add it the example fails.