### PR TITLE
typo: Encypted -> Encrypted

### DIFF
--- a/articles/media-services/previous/media-services-dotnet-upload-files.md
+++ b/articles/media-services/previous/media-services-dotnet-upload-files.md
@@ -50,7 +50,7 @@ When you create assets, you can specify the following encryption options:
   
     If your asset is storage encrypted, you must configure asset delivery policy. For more information, see [Configuring asset delivery policy](media-services-dotnet-configure-asset-delivery-policy.md).
 
-If you specify for your asset to be encrypted with a **CommonEncrypted** option, or an **EnvelopeEncypted** option, you need to associate your asset with a **ContentKey**. For more information, see [How to create a ContentKey](media-services-dotnet-create-contentkey.md). 
+If you specify for your asset to be encrypted with a **CommonEncrypted** option, or an **EnvelopeEncrypted** option, you need to associate your asset with a **ContentKey**. For more information, see [How to create a ContentKey](media-services-dotnet-create-contentkey.md). 
 
 If you specify for your asset to be encrypted with a **StorageEncrypted** option, the Media Services SDK for .NET creates a **StorateEncrypted** **ContentKey** for your asset.
 

--- a/articles/storage/files/storage-files-faq.md
+++ b/articles/storage/files/storage-files-faq.md
@@ -293,7 +293,7 @@ This article answers common questions about Azure Files features and functionali
     
     If you need a file snapshot feature, let us know at [Azure Files UserVoice](https://feedback.azure.com/forums/217298-storage/category/180670-files).
 
-* <a id="encypted-snapshots"></a>
+* <a id="encrypted-snapshots"></a>
 **Can I create share snapshots of an encrypted file share?**  
     You can take a share snapshot of Azure file shares that have encryption at rest enabled. You can restore files from a share snapshot to an encrypted file share. If your share is encrypted, your share snapshot also is encrypted.
 


### PR DESCRIPTION

Updated the anchor typo since the article is new and didn't seem to have
references