### PR TITLE
Move co-locate Q/A closer to umanaged support Q/A

### DIFF
--- a/includes/virtual-machines-faq-for-disks.md
+++ b/includes/virtual-machines-faq-for-disks.md
@@ -96,6 +96,10 @@ Customers can take a snapshot of their managed disks and then use the snapshot t
 
 Yes, both unmanaged and managed disks are supported. We recommend that you use managed disks for new workloads and migrate your current workloads to managed disks.
 
+**Can I co-locate unmanaged and managed disks on the same VM?**
+
+No.
+
 **If I create a 128-GB disk and then increase the size to 130 GiB, will I be charged for the next disk size (256 GiB)?**
 
 Yes.
@@ -119,10 +123,6 @@ No. You can't update the computer name property. The new VM inherits it from the
 **Where can I find sample Azure Resource Manager templates to create VMs with managed disks?**
 * [List of templates using Managed Disks](https://github.com/Azure/azure-quickstart-templates/blob/master/managed-disk-support-list.md)
 * https://github.com/chagarw/MDPP
-
-**Can I co-locate unmanaged and managed disks on the same VM?**
-
-No.
 
 **When creating a disk from a blob, is there any continually existing relationship with that source blob?**
 


### PR DESCRIPTION
The wording the **Are unmanaged disks still supported?** almost suggests that a VM can support both, with the Q/A about exactly hat being buried to far down the list, it is entire possible to assume that both are supported on the same VM. Moving the the 2 Q/As closer together alleviates that confusion.