### PR TITLE
The procedure referred to a wrong cmdlet

### DIFF
--- a/articles/load-balancer/quickstart-create-basic-load-balancer-powershell.md
+++ b/articles/load-balancer/quickstart-create-basic-load-balancer-powershell.md
@@ -67,7 +67,8 @@ To allow the load balancer to monitor the status of your app, you use a health p
 
 The following example creates a TCP probe. You can also create custom HTTP probes for more fine grained health checks. When using a custom HTTP probe, you must create the health check page, such as *healthcheck.aspx*. The probe must return an **HTTP 200 OK** response for the load balancer to keep the host in rotation.
 
-To create a TCP health probe, you use [New-AzureRmLoadBalancerProbeConfig](/powershell/module/azurerm.network/add-azurermloadbalancerprobeconfig). The following example creates a health probe named *myHealthProbe* that monitors each VM on *HTTP* port *80*:
+To create a TCP health probe, you use [New-AzureRmLoadBalancerProbeConfig](/powershell/module/azurerm.network/new-azurermloadbalancerprobeconfig).
+The following example creates a health probe named *myHealthProbe* that monitors each VM on *HTTP* port *80*:
 
 ```azurepowershell-interactive
 $probe = New-AzureRmLoadBalancerProbeConfig `

--- a/articles/load-balancer/quickstart-create-basic-load-balancer-powershell.md
+++ b/articles/load-balancer/quickstart-create-basic-load-balancer-powershell.md
@@ -67,7 +67,7 @@ To allow the load balancer to monitor the status of your app, you use a health p
 
 The following example creates a TCP probe. You can also create custom HTTP probes for more fine grained health checks. When using a custom HTTP probe, you must create the health check page, such as *healthcheck.aspx*. The probe must return an **HTTP 200 OK** response for the load balancer to keep the host in rotation.
 
-To create a TCP health probe, you use [Add-AzureRmLoadBalancerProbeConfig](/powershell/module/azurerm.network/add-azurermloadbalancerprobeconfig). The following example creates a health probe named *myHealthProbe* that monitors each VM on *HTTP* port *80*:
+To create a TCP health probe, you use [New-AzureRmLoadBalancerProbeConfig](/powershell/module/azurerm.network/add-azurermloadbalancerprobeconfig). The following example creates a health probe named *myHealthProbe* that monitors each VM on *HTTP* port *80*:
 
 ```azurepowershell-interactive
 $probe = New-AzureRmLoadBalancerProbeConfig `


### PR DESCRIPTION
As far as I know, the command to create a new probe configuration is this one: "New-azurermloadbalancerprobeconfig" https://docs.microsoft.com/en-us/powershell/module/azurerm.network/new-azurermloadbalancerprobeconfig?view=azurermps-6.13.0 and no Add-azurermloadbalancerprobeconfig. In fact in the example some lines below it is used correctly