### PR TITLE
Update permissions of the user on storage account

### DIFF
--- a/articles/key-vault/key-vault-overview-storage-keys-powershell.md
+++ b/articles/key-vault/key-vault-overview-storage-keys-powershell.md
@@ -89,7 +89,7 @@ Using the same PowerShell session, update the Key Vault access policy for manage
 
 ```azurepowershell-interactive
 # Give your user principal access to all storage account permissions, on your Key Vault instance
-Set-AzureRmKeyVaultAccessPolicy -VaultName $keyVaultName -UserPrincipalName $azureProfile.Context.Account.Id -PermissionsToStorage get,list,delete,set,update,regeneratekey,recover,backup,restore,purge
+Set-AzureRmKeyVaultAccessPolicy -VaultName $keyVaultName -UserPrincipalName $azureProfile.Context.Account.Id -PermissionsToStorage getsas,listsas,deletesas,setsas,regeneratekey
 ```
 
 Note that permissions for storage accounts aren't available on the storage account "Access policies" page in the Azure portal.


### PR DESCRIPTION
The permissions of this example don't allow the user to retrieve the sas definitions.
When the user will execute the PS Command Get-AzKeyVaultManagedStorageSasDefinition and don't specify "-Name" an error occured because he don't have the permission "listsas".