### PR TITLE
Changing SDK name to reflect version

### DIFF
--- a/articles/cloud-services/cloud-services-guestos-update-matrix.md
+++ b/articles/cloud-services/cloud-services-guestos-update-matrix.md
@@ -71,7 +71,7 @@ The June Guest OS has released.
 .NET Framework installed: 3.5, 4.7.2
 
 > [!NOTE]
-> The Windows Azure SDK for .NET 3.0 can be downloaded [here][Windows Azure SDK].
+> The Windows Azure SDK for .NET - 3.0 can be downloaded [here][Windows Azure SDK].
 >
 
 | Configuration string | Release date | Disable date |


### PR DESCRIPTION
Added the hyphen back in to clarify SDK version "Windows Azure SDK for .NET - 3.0"