### PR TITLE
typo: behaviour -> behavior

### DIFF
--- a/articles/postgresql/concepts-monitoring.md
+++ b/articles/postgresql/concepts-monitoring.md
@@ -8,7 +8,7 @@ ms.topic: conceptual
 ms.date: 11/05/2018
 ---
 # Monitor and tune
-Monitoring data about your servers helps you troubleshoot and optimize for your workload. Azure Database for PostgreSQL provides various monitoring options to provide insight into the behaviour of your server.
+Monitoring data about your servers helps you troubleshoot and optimize for your workload. Azure Database for PostgreSQL provides various monitoring options to provide insight into the behavior of your server.
 
 ## Metrics
 Azure Database for PostgreSQL provides various metrics that give insight into the behavior of the resources supporting the PostgreSQL server. Each metric is emitted at a one-minute frequency, and has up to 30 days of history. You can configure alerts on the metrics. For step by step guidance, see [How to set up alerts](howto-alert-on-metric.md). Other tasks include setting up automated actions, performing advanced analytics, and archiving history. For more information, see the [Azure Metrics Overview](../monitoring-and-diagnostics/monitoring-overview-metrics.md).

--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -260,7 +260,7 @@ When a container service restarts or moves to another node in the cluster, the I
    </Resources>
    ```
    
-6. For Windows, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack. The default behaviour is to recreate the network. If this behaviour needs to be turned off, the following configuration can be used followed by a config upgrade.
+6. For Windows, a VM reboot will cause the open network to be recreated. This is to mitigate an underlying issue in the networking stack. The default behavior is to recreate the network. If this behavior needs to be turned off, the following configuration can be used followed by a config upgrade.
 
 ```json
 "fabricSettings": [


### PR DESCRIPTION

Correct CA/UK spelling, but US spelling is used in this repo