### PR TITLE
Fix typo in "querying all instances" example

### DIFF
--- a/articles/azure-functions/durable/durable-functions-instance-management.md
+++ b/articles/azure-functions/durable/durable-functions-instance-management.md
@@ -185,7 +185,7 @@ public static async Task Run(
     [OrchestrationClient] DurableOrchestrationClient client,
     ILogger log)
 {
-    IList<DurableOrchestrationStatus> instances = await starter.GetStatusAsync(); // You can pass CancellationToken as a parameter.
+    IList<DurableOrchestrationStatus> instances = await client.GetStatusAsync(); // You can pass CancellationToken as a parameter.
     foreach (var instance in instances)
     {
         log.LogInformation(JsonConvert.SerializeObject(instance));


### PR DESCRIPTION
Fix Incorrect code in C# example of "Querying all instances" #23357