### PR TITLE
signalr bindings for functions to toc

### DIFF
--- a/articles/azure-signalr/TOC.yml
+++ b/articles/azure-signalr/TOC.yml
@@ -32,6 +32,8 @@
     href: signalr-internals.md
   - name: Scale ASP.NET Core SignalR
     href: signalr-overview-scale-aspnet-core.md
+  - name: SignalR Service bindings for Azure Functions
+    href: https://docs.microsoft.com/azure/azure-functions/functions-bindings-signalr-service
   - name: Build Real-time Apps with Azure Functions
     href: signalr-overview-azure-functions.md
   - name: Access key rotation


### PR DESCRIPTION
We'd like to strengthen the association between the SignalR Service and the Azure Functions bindings for SignalR Service, so this PR adds a link in the SignalR Service TOC to the Azure Functions article on the SignalR Service bindings for Functions. 