### PR TITLE
Removed reference of UseExistingDatabase switch from install sql delegation

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-install-existing-database.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-existing-database.md
@@ -54,6 +54,10 @@ Important notes to take note of before you proceed:
 2.	Once the MSI installation completes, the Azure AD Connect wizard starts with the Express mode setup. Close the screen by clicking the Exit icon.
 ![Welcome](./media/how-to-connect-install-existing-database/db1.png)
 3.	Start a new command prompt or PowerShell session. Navigate to folder <drive>\program files\Microsoft Azure AD Connect. Run command .\AzureADConnect.exe /useexistingdatabase to start the Azure AD Connect wizard in “Use existing database” setup mode.
+
+>[!NOTE]
+>The switch **/UseExistingDatabase** should only be used when the DB already contains data from a previous AADC installation. For instance, when the Customer is moving from a localDB to a full SQL Server, or when the AADC server was rebuilt and they restored a SQL backup of the ADSync database from a previous installation of AADC. If you have created an empty database and use it for installation then skip this step.
+
 ![PowerShell](./media/how-to-connect-install-existing-database/db2.png)
 4.	You are greeted with the Welcome to Azure AD Connect screen. Once you agree to the license terms and privacy notice, click **Continue**.
 ![Welcome](./media/how-to-connect-install-existing-database/db3.png)

--- a/articles/active-directory/hybrid/how-to-connect-install-existing-database.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-existing-database.md
@@ -55,8 +55,8 @@ Important notes to take note of before you proceed:
 ![Welcome](./media/how-to-connect-install-existing-database/db1.png)
 3.	Start a new command prompt or PowerShell session. Navigate to folder <drive>\program files\Microsoft Azure AD Connect. Run command .\AzureADConnect.exe /useexistingdatabase to start the Azure AD Connect wizard in “Use existing database” setup mode.
 
->[!NOTE]
->The switch **/UseExistingDatabase** should only be used when the DB already contains data from a previous AADC installation. For instance, when the Customer is moving from a localDB to a full SQL Server, or when the AADC server was rebuilt and they restored a SQL backup of the ADSync database from a previous installation of AADC. If you have created an empty database and use it for installation then skip this step.
+> [!NOTE]
+> Use the switch **/UseExistingDatabase** only when the database already contains data from an earlier Azure AD Connect installation. For instance, when you are moving from a local database to a full SQL Server database or when the Azure AD Connect server was rebuilt and you restored a SQL backup of the ADSync database from an earlier installation of Azure AD Connect. If you created an empty database and use it for installation, skip this step.
 
 ![PowerShell](./media/how-to-connect-install-existing-database/db2.png)
 4.	You are greeted with the Welcome to Azure AD Connect screen. Once you agree to the license terms and privacy notice, click **Continue**.

--- a/articles/active-directory/hybrid/how-to-connect-install-sql-delegation.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-sql-delegation.md
@@ -49,10 +49,7 @@ To provision the database out of band and install Azure AD Connect with database
 ## Additional information
 Once the database is provisioned, the Azure AD Connect administrator can install and configure on-premises synchronization at their convenience.  
 
-The **/UseExistingDatabase** flag is required when using a pre-created database.  It is not only used in recovery situations.
-
-In addition to supporting new installations of Azure AD Connect, this feature also enables delegation for any scenario related to the **/UseExistingDatabase** flag.  For more information on installing Azure AD Connect with an existing database, see [Install Azure AD Connect using an existing ADSync database](how-to-connect-install-existing-database.md)
-
+For more information on installing Azure AD Connect with an existing database, see [Install Azure AD Connect using an existing ADSync database](how-to-connect-install-existing-database.md)
 
 ## Next steps
 - [Getting started with Azure AD Connect using express settings](how-to-connect-install-express.md)


### PR DESCRIPTION
1. Removed reference of UseExistingDatabase switch from install sql delegation.
2. Updated documentation for installing from existing database.

@billmath - Please review this document.