### PR TITLE
Fix missing

### DIFF
--- a/articles/active-directory-b2c/technicalprofiles.md
+++ b/articles/active-directory-b2c/technicalprofiles.md
@@ -93,7 +93,7 @@ The **TechnicalProfile** contains the following elements:
 | OutputClaimsTransformations | 0:1 | A list of previously defined references to claims transformations that should be executed after the claims are received from the claims provider. |
 | ValidationTechnicalProfiles | 0:n | A list of references to other technical profiles that the technical profile uses for validation purposes. For more information, see [validation technical profile](validation-technical-profile.md)|
 | SubjectNamingInfo | 0:1 | Controls the production of the subject name in tokens where the subject name is specified separately from claims. For example, OAuth or SAML.  |
-| IncludeClaimsFromTechnicalProfile | 0:1 | An identifier of a technical profile from which you want all of the input and output claims to be added to this technical profile. The referenced technical profile must be defined in the same policy file. | 
+| IncludeClaimsFromTechnicalProfile | 0:1 | An identifier of a technical profile from which you want all of the input and output claims to be added to this technical profile. The referenced technical profile must be defined in the same policy file. |
 | IncludeTechnicalProfile |0:1 | An identifier of a technical profile from which you want all data to be added to this technical profile. The referenced technical profile must exist in the same policy file. |
 | UseTechnicalProfileForSessionManagement | 0:1 | A different technical profile to be used for session management. |
 |EnabledForUserJourneys| 0:1 |Controls if the technical profile is executed in a user journey.  |
@@ -164,7 +164,7 @@ The **InputClaims** element contains the following element:
 | ------- | ----------- | ----------- |
 | InputClaim | 1:n | An expected input claim type. |
 
-#### InputClaim 
+#### InputClaim
 
 The **InputClaim** element contains the following attributes:
 
@@ -182,7 +182,7 @@ The **PersistedClaims** element contains the following elements:
 | ------- | ----------- | ----------- |
 | PersistedClaim | 1:n | The claim type to persist. |
 
-#### PersistedClaim 
+#### PersistedClaim
 
 The **PersistedClaim** element contains the following attributes:
 
@@ -200,7 +200,7 @@ The **OutputClaims** element contains the following element:
 | ------- | ----------- | ----------- |
 | OutputClaim | 1:n | An expected output claim type. |
 
-#### OutputClaim 
+#### OutputClaim
 
 The **OutputClaim** element contains the following attributes:
 
@@ -271,9 +271,9 @@ The **UseTechnicalProfileForSessionManagement** element contains the following a
 The **ClaimsProviderSelections** in a user journey defines the list of claims provider selection options and their order. With the **EnabledForUserJourneys** element  you filter, which claims provider is available to the user. The **EnabledForUserJourneys** element contains one of the following values:
 
 - **Always**, execute the technical profile.
-- **Never**, skip the technical profile. 
-- **OnClaimsExistence** execute only when a certain claim, specified in the technical profile exists. 
-- **OnItemExistenceInStringCollectionClaim**, execute only when an item exists in a string collection claim. 
+- **Never**, skip the technical profile.
+- **OnClaimsExistence** execute only when a certain claim, specified in the technical profile exists.
+- **OnItemExistenceInStringCollectionClaim**, execute only when an item exists in a string collection claim.
 - **OnItemAbsenceInStringCollectionClaim** execute only when an item does not exist in a string collection claim.
 
 Using **OnClaimsExistence**, **OnItemExistenceInStringCollectionClaim** or **OnItemAbsenceInStringCollectionClaim**, requires you to provide the following metadata: **ClaimTypeOnWhichToEnable** specifies the claim's type that is to be evaluated, **ClaimValueOnWhichToEnable** specifies the value that is to be compared.
@@ -285,22 +285,10 @@ The following technical profile is executed only if the **identityProviders** st
   <DisplayName>Unlink Facebook</DisplayName>
 ...
     <Metadata>
-        <Item Key="ClaimTypeOnWhichToEnable">identityProviders</Item>
-        <Item Key="ClaimValueOnWhichToEnable">facebook.com</Item>
-    </Metadata>        
+      <Item Key="ClaimTypeOnWhichToEnable">identityProviders</Item>
+      <Item Key="ClaimValueOnWhichToEnable">facebook.com</Item>
+    </Metadata>
 ...
   <EnabledForUserJourneys>OnItemExistenceInStringCollectionClaim</EnabledForUserJourneys>
-</TechnicalProfile>  
+</TechnicalProfile>
 ```
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
When copying from the web page, unnecessary half-width spaces are mixed behind the code. Indentation is misaligned.