### PR TITLE
Add Win10 Dependency to Speech-Service Java howto

### DIFF
--- a/articles/cognitive-services/Speech-Service/quickstart-java-jre.md
+++ b/articles/cognitive-services/Speech-Service/quickstart-java-jre.md
@@ -37,6 +37,9 @@ sudo apt-get update
 sudo apt-get install build-essential libssl1.0.0 libcurl3 libasound2 wget
 ```
 
+If you're running Windows (64-bit) please ensure you have installed Microsoft Visual C++ Redistributable.
+* [VC 2015 Runtime Redistributable Update 3](https://www.microsoft.com/en-us/download/confirmation.aspx?id=52685)
+
 ## Create and configure project
 
 [!INCLUDE [](../../../includes/cognitive-services-speech-service-quickstart-java-create-proj.md)]

--- a/articles/cognitive-services/Speech-Service/quickstart-java-jre.md
+++ b/articles/cognitive-services/Speech-Service/quickstart-java-jre.md
@@ -37,8 +37,9 @@ sudo apt-get update
 sudo apt-get install build-essential libssl1.0.0 libcurl3 libasound2 wget
 ```
 
-If you're running Windows (64-bit) please ensure you have installed Microsoft Visual C++ Redistributable.
-* [VC 2015 Runtime Redistributable Update 3](https://www.microsoft.com/en-us/download/confirmation.aspx?id=52685)
+If you're running Windows (64-bit) please ensure you have installed Microsoft Visual C++ Redistributable for your platform.
+* [Download Microsoft Visual C++ Redistributable for Visual Studio 2017](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads)
+
 
 ## Create and configure project
 


### PR DESCRIPTION
Customers were having issues running the tutorial (or any jar with this installed) on Azure VMs without the run time installed. Adding documentation stating the dependency.

The error was: UnsatisifedLinkError, similar to: https://github.com/Azure-Samples/cognitive-services-speech-sdk/issues/112