### PR TITLE
Update output for bulk executor changes

### DIFF
--- a/articles/stream-analytics/stream-analytics-documentdb-output.md
+++ b/articles/stream-analytics/stream-analytics-documentdb-output.md
@@ -48,7 +48,7 @@ If the incoming JSON document has an existing ID field, that field is automatica
 If you want to save <i>all</i> documents including the ones with a duplicate ID, rename the ID field in your query (with the AS keyword) and let Cosmos DB create the ID field or replace the ID with another column's value (using the AS keyword or by using the 'Document ID' setting).
 
 ## Data partitioning in Cosmos DB
-Azure Cosmos DB [unlimited](../cosmos-db/partition-data.md) containers are the recommended approach for partitioning your data, as Azure Cosmos DB automatically scales partitions based on your workload. When writing to unlimited containers, Stream Analytics uses as many parallel writers as previous query step or input partitioning scheme.
+Azure Cosmos DB [unlimited](../cosmos-db/partition-data.md) containers are the recommended approach for partitioning your data, as Azure Cosmos DB automatically scales partitions based on your workload. When writing to unlimited containers, Stream Analytics uses as many parallel writers as the previous query step or input partitioning scheme.
 > [!Note]
 > At this time, Azure Stream Analytics only supports unlimited collections with partition keys at the top level. For example, `/region` is supported. Nested partition keys (e.g. `/region/name`) are not supported. 
 

--- a/articles/stream-analytics/stream-analytics-documentdb-output.md
+++ b/articles/stream-analytics/stream-analytics-documentdb-output.md
@@ -23,17 +23,22 @@ For those who are unfamiliar with Cosmos DB, take a look at [Azure Cosmos DB’s
 The Azure Cosmos DB output in Stream Analytics enables writing your stream processing results as JSON output into your Cosmos DB collection(s). Stream Analytics doesn't create collections in your database, instead requiring you to create them upfront. This is so that the billing costs of Cosmos DB collections are controlled by you, and so that you can tune the performance, consistency, and capacity of your collections directly using the [Cosmos DB APIs](https://msdn.microsoft.com/library/azure/dn781481.aspx).
 
 > [!Note]
-> You must add 0.0.0.0 to the list of allowed IPs from you Azure Cosmos DB firewall.
+> You must add 0.0.0.0 to the list of allowed IPs from your Azure Cosmos DB firewall.
 
 Some of the Cosmos DB collection options are detailed below.
 
 ## Tune consistency, availability, and latency
 To match your application requirements, Azure Cosmos DB allows you to fine tune the database and collections and make trade-offs between consistency, availability, and latency. Depending on what levels of read consistency your scenario needs against read and write latency, you can choose a consistency level on your database account. Also by default, Azure Cosmos DB enables synchronous indexing on each CRUD operation to your collection. This is another useful option to control the write/read performance in Azure Cosmos DB. For more information, review the [change your database and query consistency levels](../cosmos-db/consistency-levels.md) article.
 
+## Using Bulk Executor API based writer
+With Job Compatibility level 1.2, Stream Analytics supports writing to CosmosDB using [bulk executor library](../cosmos-db/bulk-executor-overview.md). This enables writing to CosmosDB at higher throughput and efficiently handle throttling requests. The upsert behavior is different than before, with details explained in the next section.
+
 ## Upserts from Stream Analytics
 Stream Analytics integration with Azure Cosmos DB allows you to insert or update records in your collection based on a given Document ID column. This is also referred to as an *Upsert*.
 
-Stream Analytics uses an optimistic upsert approach, where updates are only done when insert fails with a Document ID conflict. This update is performed as a PATCH, so it enables partial updates to the document, that is, addition of new properties or replacing an existing property is performed incrementally. However, changes in the values of array properties in your JSON document result in the entire array getting overwritten, that is, the array isn't merged.
+- With Job Compatibility level 1.2, upserts behavior is to insert or REPLACE the document. This is the patch behavior supported by bulk executor CosmosDB API.
+
+- Before Compatibility level 1.2, Stream Analytics uses an optimistic upsert approach, where updates are only done when insert fails with a Document ID conflict. This update is performed as a PATCH, so it enables partial updates to the document, that is, addition of new properties or replacing an existing property is performed incrementally. However, changes in the values of array properties in your JSON document result in the entire array getting overwritten, that is, the array isn't merged.
 
 If the incoming JSON document has an existing ID field, that field is automatically used as the Document ID column in Cosmos DB and any subsequent writes are handled as such, leading to one of these situations:
 - unique IDs lead to insert
@@ -43,7 +48,7 @@ If the incoming JSON document has an existing ID field, that field is automatica
 If you want to save <i>all</i> documents including the ones with a duplicate ID, rename the ID field in your query (with the AS keyword) and let Cosmos DB create the ID field or replace the ID with another column's value (using the AS keyword or by using the 'Document ID' setting).
 
 ## Data partitioning in Cosmos DB
-Azure Cosmos DB [unlimited](../cosmos-db/partition-data.md) are the recommended approach for partitioning your data, as Azure Cosmos DB automatically scales partitions based on your workload. When writing to unlimited containers, Stream Analytics uses as many parallel writers as previous query step or input partitioning scheme.
+Azure Cosmos DB [unlimited](../cosmos-db/partition-data.md) containers are the recommended approach for partitioning your data, as Azure Cosmos DB automatically scales partitions based on your workload. When writing to unlimited containers, Stream Analytics uses as many parallel writers as previous query step or input partitioning scheme.
 > [!Note]
 > At this time, Azure Stream Analytics only supports unlimited collections with partition keys at the top level. For example, `/region` is supported. Nested partition keys (e.g. `/region/name`) are not supported. 
 


### PR DESCRIPTION
Under JC 1.2 we now support bulk executor api. This change updates the output documentation page.