### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/cognitive-services/Translator/migrate-to-v3.md
+++ b/articles/cognitive-services/Translator/migrate-to-v3.md
@@ -36,19 +36,19 @@ The following list of V2 and V3 methods identifies the V3 methods and APIs that 
 
 | V2 API Method   | V3 API Compatibility |
 |:----------- |:-------------|
-| Translate     | [Translate](reference/v3-0-translate.md)          |
-| TranslateArray      | [Translate](reference/v3-0-translate.md)        |
-| GetLanguageNames      | [Languages](reference/v3-0-languages.md)         |
-| GetLanguagesForTranslate     | [Languages](reference/v3-0-languages.md)       |
-| GetLanguagesForSpeak      | [Microsoft Speech Service](https://docs.microsoft.com/azure/cognitive-services/speech-service/language-support#text-to-speech)         |
-| Speak     | [Microsoft Speech Service](https://docs.microsoft.com/azure/cognitive-services/speech-service/text-to-speech)          |
-| Detect     | [Detect](reference/v3-0-detect.md)         |
-| DetectArray     | [Detect](reference/v3-0-detect.md)         |
-| AddTranslation     | [Microsoft Translator Hub API](https://hub.microsofttranslator.com/Help/Download/Microsoft%20Translator%20Hub%20API%20Guide.pdf)         |
-| AddTranslationArray    | [Microsoft Translator Hub API](https://hub.microsofttranslator.com/Help/Download/Microsoft%20Translator%20Hub%20API%20Guide.pdf)          |
-| BreakSentences      | [BreakSentence](reference/v3-0-break-sentence.md)       |
-| GetTranslations      | Feature is no longer supported         |
-| GetTranslationsArray      | Feature is no longer supported         |
+| `Translate`     | [Translate](reference/v3-0-translate.md)          |
+| `TranslateArray`      | [Translate](reference/v3-0-translate.md)        |
+| `GetLanguageNames`      | [Languages](reference/v3-0-languages.md)         |
+| `GetLanguagesForTranslate`     | [Languages](reference/v3-0-languages.md)       |
+| `GetLanguagesForSpeak`      | [Microsoft Speech Service](https://docs.microsoft.com/azure/cognitive-services/speech-service/language-support#text-to-speech)         |
+| `Speak`     | [Microsoft Speech Service](https://docs.microsoft.com/azure/cognitive-services/speech-service/text-to-speech)          |
+| `Detect`     | [Detect](reference/v3-0-detect.md)         |
+| `DetectArray`     | [Detect](reference/v3-0-detect.md)         |
+| `AddTranslation`     | [Microsoft Translator Hub API](https://hub.microsofttranslator.com/Help/Download/Microsoft%20Translator%20Hub%20API%20Guide.pdf)         |
+| `AddTranslationArray`    | [Microsoft Translator Hub API](https://hub.microsofttranslator.com/Help/Download/Microsoft%20Translator%20Hub%20API%20Guide.pdf)          |
+| `BreakSentences`      | [BreakSentence](reference/v3-0-break-sentence.md)       |
+| `GetTranslations`      | Feature is no longer supported         |
+| `GetTranslationsArray`      | Feature is no longer supported         |
 
 ## Move to JSON format
 
@@ -70,12 +70,12 @@ Microsoft Translator V3 is priced in the same way V2 was priced; per character, 
 
 | V3 Method   | Characters Counted for Billing |
 |:----------- |:-------------|
-| Languages     | No characters submitted, none counted, no charge.          |
-| Translate     | Count is based on how many characters are submitted for translation, and how many languages the characters are translated into. 50 characters submitted, and 5 languages requested will be 50x5.           |
-| Transliterate     | Number of characters submitted for transliteration are counted.         |
-| Dictionary lookup & example     | Number of characters submitted for Dictionary lookup and examples are counted.         |
-| BreakSentence     | No Charge.       |
-| Detect     | No Charge.      |
+| `Languages`     | No characters submitted, none counted, no charge.          |
+| `Translate`     | Count is based on how many characters are submitted for translation, and how many languages the characters are translated into. 50 characters submitted, and 5 languages requested will be 50x5.           |
+| `Transliterate`     | Number of characters submitted for transliteration are counted.         |
+| `Dictionary lookup & example`     | Number of characters submitted for Dictionary lookup and examples are counted.         |
+| `BreakSentence`     | No Charge.       |
+| `Detect`     | No Charge.      |
 
 ## V3 End Points
 
@@ -83,22 +83,21 @@ Global
 
 * api.cognitive.microsofttranslator.com
 
-
 ## V3 API text translations methods
 
-[Languages](reference/v3-0-languages.md)
+[`Languages`](reference/v3-0-languages.md)
 
-[Translate](reference/v3-0-translate.md)
+[`Translate`](reference/v3-0-translate.md)
 
-[Transliterate](reference/v3-0-transliterate.md)
+[`Transliterate`](reference/v3-0-transliterate.md)
 
-[BreakSentence](reference/v3-0-break-sentence.md)
+[`BreakSentence`](reference/v3-0-break-sentence.md)
 
-[Detect](reference/v3-0-detect.md)
+[`Detect`](reference/v3-0-detect.md)
 
-[Dictionary/lookup](reference/v3-0-dictionary-lookup.md)
+[`Dictionary/lookup`](reference/v3-0-dictionary-lookup.md)
 
-[Dictionary/example](reference/v3-0-dictionary-examples.md)
+[`Dictionary/example`](reference/v3-0-dictionary-examples.md)
 
 ## Compatibility and customization
 
@@ -127,7 +126,6 @@ You are using Version 3 of the Translator Text API If you are using the api.cogn
 * You are using Version 2 of the Translator Text API If you are using the api.microsofttranslator.com endpoint.
 
 No version of the Translator API creates a record of your translations. Your translations are never shared with anyone. More information on the [Translator No-Trace](http://www.aka.ms/NoTrace) webpage.
-
 
 ## Links
 


### PR DESCRIPTION
Machine translation is incorrectly translated no matter how many times the localization version mistranslation (translating the method name) is modified.
Evidence: https://github.com/changeworld/azure-docs.ja-jp/commits/live/articles/cognitive-services/Translator/migrate-to-v3.md

In the following files, it was made not to make mistranslation by putting proper names in "`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md

This change(enclose method name by "`")  has no negative effect on the English version.
Please accept this change so that method names are not mistranslated in each language in each localized version.
🙏