### PR TITLE
Update documentation for cognitive search and Azure SQL datasources

### DIFF
--- a/articles/search/cognitive-search-custom-skill-interface.md
+++ b/articles/search/cognitive-search-custom-skill-interface.md
@@ -14,7 +14,7 @@ ms.custom: seodec2018
 
 # How to add a custom skill to a cognitive search pipeline
 
-A [cognitive search indexing pipeline](cognitive-search-concept-intro.md) in Azure Search can be assembled from [predefined skills](cognitive-search-predefined-skills.md) as well as custom skills that you personally create and add to the pipeline. In this article, learn how to create a custom skill that exposes an interface allowing it to be included in a cognitive search pipeline. 
+A [cognitive search indexing pipeline](cognitive-search-concept-intro.md) in Azure Search can be assembled from [predefined skills](cognitive-search-predefined-skills.md) as well as [custom skills](cognitive-search-custom-skill-webapi.md) that you personally create and add to the pipeline. In this article, learn how to create a custom skill that exposes an interface allowing it to be included in a cognitive search pipeline. 
 
 Building a custom skill gives you a way to insert transformations unique to your content. A custom skill executes independently, applying whatever enrichment step you require. For example, you could define field-specific custom entities, build custom classification models to differentiate business and financial contracts and documents, or add a speech recognition skill to reach deeper into audio files for relevant content. For a step-by-step example, see [Example: creating a custom skill](cognitive-search-create-custom-skill-example.md).
 

--- a/articles/search/cognitive-search-custom-skill-webapi.md
+++ b/articles/search/cognitive-search-custom-skill-webapi.md
@@ -1,0 +1,145 @@
+---
+title: Custom cognitive search skill - Azure Search
+description: Extend capabilities of cognitive search skillsets by calling out to Web APIs
+services: search
+manager: pablocas
+author: luiscabrer
+
+ms.service: search
+ms.devlang: NA
+ms.workload: search
+ms.topic: conceptual
+ms.date: 01/31/2019
+ms.author: luisca
+ms.custom: seojan2018
+---
+
+#	 Custom Web API skill
+
+The **Custom Web API** skill allows you to extend the functionality of cognitive search by calling to out to a custom web api endpoint to further enhance document content extraction and any enrichments performed by predefined skills. Similar to other predefined skills a **Custom Web API** skill has inputs and outputs. Depending on the inputs (which are unconstrained), your Web API will receive a _JSON_ payload when the indexer to which this skillset is associated runs. Your Web API is expected to also return a _JSON_ payload (whose structure is dependent on any outputs defined in the skill) as a reponse along with a success status code, for the results to be treated as custom enrichments. Any other response is considered an error and no enrichments are performed.
+
+The structure of the _JSON_ payloads are described further down in this document.
+
+> [!NOTE]
+> The indexer execution will attempt to retry upto a few times for certain standard HTTP status codes returned from the Web API. These HTTP status codes are: 
+> * `503 Service Unavailable`
+> * `429 Too Many Requests`
+
+## @odata.type  
+Microsoft.Skills.Custom.WebApiSkill
+
+## Skill parameters
+
+Parameters are case-sensitive.
+
+| Parameter name	 | Description |
+|--------------------|-------------|
+| uri | The URI of the web api to which the _JSON_ payload will be sent. Only **https** URI scheme is allowed |
+| httpMethod | The method to use while sending the payload. Allowed methods are `PUT` or `POST` |
+| httpHeaders | A collection of key-value pairs where the keys represent header names and values represent header values that will be sent to your Web API along with the payload. The following headers are prohibited from being in this collection:  `Accept`, `Accept-Charset`, `Accept-Encoding`, `Content-Length`, `Content-Type`, `Cookie`, `Host`, `TE`, `Upgrade`, `Via` |
+| timeout | (Optional) When specified, indicates the timeout for the http client making the API call. It must be formatted as an XSD "dayTimeDuration" value (a restricted subset of an [ISO 8601 duration](https://www.w3.org/TR/xmlschema11-2/#dayTimeDuration) value). For example, `PT60S` for 60 seconds. If not set, a default value of 30 seconds is chosen. The timeout can be set to a maximum of 90 seconds and a minimum of 1 second. |
+| batchSize | (Optional) Indicates how many "data records" (see _JSON_ payload structure below) will be sent per API call. If not set, a default of 1000 is chosen. We recommend that you make use of this parameter to achieve a suitable tradeoff between indexing throughput and load on your API |
+
+## Skill inputs
+
+There are no "predefined" inputs for this skill. You can choose one or more fields that would be already available at the time of this skill's execution as inputs and the _JSON_ payload sent to the Web API will have different fields.
+
+## Skill outputs
+
+There are no "predefined" outputs for this skill. Depending on the response your Web API will return, add output fields so that they can be picked up from the _JSON_ response.
+
+
+##	Sample definition
+
+```json
+  {
+        "@odata.type": "#Microsoft.Skills.Custom.WebApiSkill",
+        "description": "Translator custom skill",
+        "uri": "https://contoso.translate.com",
+        "batchSize": 1,
+        "context": "/document",
+        "inputs": [
+          {
+            "name": "text",
+            "source": "/document/content"
+          },
+          {
+            "name": "targetLanguage",
+            "source": "/document/destinationLanguage"
+          }
+        ],
+        "outputs": [
+          {
+            "name": "translation",
+            "targetName": "translatedText"
+          }
+        ]
+      }
+```
+##	Sample input JSON structure
+
+This _JSON_ structure represents the payload that will be sent to your Web API.
+It will always follow these constraints:
+
+1. The top level entity is called `values` and will be an array of objects. The number of such objects will be at most the `batchSize`
+2. Each object in the `values` array will have
+    * A `recordId` property which is a **unique** string, used to identify that record.
+    * A `data` property which is a json object. The fields of the `data` property will be those specified in the `inputs` section of the skill definition. The value of those fields will be from the `source` of those fields (which could be from a field in the document, or potentially from another skill)
+
+```json
+{
+    "values": [
+      {
+        "recordId": "0",
+        "data":
+           {
+             "text": "Este es un contrato en Inglés",
+             "targetLanguage": "en"
+           }
+      }
+    ]
+}
+```
+
+##	Sample output JSON structure
+
+The "output" corresponds to the response returned from your web api. The web api should only return a _JSON_ payload (verified by looking at the `Content-Type` response header) and should satisfy the following constraints:
+
+1. There should be a top level entity called `values` which should be an array of objects.
+2. The number of objects in the array should be the same as the number of objects sent to the web api.
+3. Each object should have
+   * A `recordId` property
+   * A `data` property, which is an object where the fields are enrichments matching the fields in the `output` and whose value is considered the enrichment.
+   * An `errors` property, an array listing any errors encountered that will be added to the indexer execution history. This property is required, but can have a `null` value.
+   * A `warnings` property, an array listing any warnings encountered that will be added to the indexer execution history. This property is required, but can have a `null` value.
+4. The objects in the `values` array need not be in the same order as the objects in the `values` array sent as a request to the Web API. However, the `recordId` is used for correlation so any record in the response containing a `recordId` which was not part of the original request to the Web API will be discarded.
+
+```json
+{
+    "values": [
+        {
+            "recordId": "0",
+            "data": {
+                "translation": "This is a contract in English"
+            },
+            "errors": null,
+            "warnings": null
+        }
+    ]
+}
+
+```
+
+## Error cases
+In addition to your Web API being unavailable, or sending out non successful status codes the following are considered erroneous cases
+
+* If the Web API returns a success status code but the response `Content-Type` indicates that it is not `application/json` then the response is considered invalid and no enrichments will be performed.
+* If there are **invalid** (with `recordId` not matching those in the request, or with duplicate values) records in the response `values` array, no enrichment will be performed for **those** records.
+
+For cases when the Web API is unavailable or returns a HTTP error, a friendly error with any available details about the HTTP error will be added to the indexer execution history.
+
+## See also
+
++ [How to define a skillset](cognitive-search-defining-skillset.md)
++ [Add custom skill to cognitive search](cognitive-search-custom-skill-interface.md)
++ [Create a custom skill using the Text Translate API](cognitive-search-create-custom-skill-example.md)

--- a/articles/search/cognitive-search-defining-skillset.md
+++ b/articles/search/cognitive-search-defining-skillset.md
@@ -137,11 +137,11 @@ The next piece in the skillset is an array of skills. You can think of each skil
 
 ## Add predefined skills
 
-Let's look at the first skill, which is the predefined [named entity recognition skill](cognitive-search-skill-named-entity-recognition.md):
+Let's look at the first skill, which is the predefined [entity recognition skill](cognitive-search-skill-entity-recognition.md):
 
 ```json
     {
-      "@odata.type": "#Microsoft.Skills.Text.NamedEntityRecognitionSkill",
+      "@odata.type": "#Microsoft.Skills.Text.EntityRecognitionSkill",
       "context": "/document",
       "categories": [ "Organization" ],
       "defaultLanguageCode": "en",
@@ -150,7 +150,8 @@ Let's look at the first skill, which is the predefined [named entity recognition
           "name": "text",
           "source": "/document/content"
         }
-      ],      "outputs": [
+      ],
+      "outputs": [
         {
           "name": "organizations",
           "targetName": "organizations"
@@ -223,7 +224,7 @@ Recall the structure of the custom Bing entity search enricher:
     }
 ```
 
-This definition is a custom skill that calls a web API as part of the enrichment process. For each organization identified by named entity recognition, this skill calls a web API to find the description of that organization. The orchestration of when to call the web API and how to flow the information received is handled internally by the enrichment engine. However, the initialization necessary for calling this custom API must be provided in the JSON (such as uri, httpHeaders, and the inputs expected). For guidance in creating a custom web API for the enrichment pipeline, see [How to define a custom interface](cognitive-search-custom-skill-interface.md).
+This definition is a [custom skill](cognitive-search-custom-skill-webapi.md) that calls a web API as part of the enrichment process. For each organization identified by named entity recognition, this skill calls a web API to find the description of that organization. The orchestration of when to call the web API and how to flow the information received is handled internally by the enrichment engine. However, the initialization necessary for calling this custom API must be provided in the JSON (such as uri, httpHeaders, and the inputs expected). For guidance in creating a custom web API for the enrichment pipeline, see [How to define a custom interface](cognitive-search-custom-skill-interface.md).
 
 Notice that the "context" field is set to ```"/document/organizations/*"``` with an asterisk, meaning the enrichment step is called *for each* organization under ```"/document/organizations"```. 
 

--- a/articles/search/cognitive-search-predefined-skills.md
+++ b/articles/search/cognitive-search-predefined-skills.md
@@ -23,7 +23,7 @@ In this article, you learn about the cognitive skills provided with Azure Search
 
 ## Predefined skills
 
-Several skills are flexible in what they consume or produce. In general, most skills are based on pre-trained models, which means you cannot train the model using your own training data. For guidance on creating a custom skill, see [How to define a custom interface](cognitive-search-custom-skill-interface.md) and [Example: creating a custom skill](cognitive-search-create-custom-skill-example.md). The following table enumerates and describes the skills provided by Microsoft. 
+Several skills are flexible in what they consume or produce. In general, most skills are based on pre-trained models, which means you cannot train the model using your own training data. The following table enumerates and describes the skills provided by Microsoft. 
 
 | Skill | Description |
 |-------|-------------|
@@ -36,6 +36,10 @@ Several skills are flexible in what they consume or produce. In general, most sk
 | [Microsoft.Skills.Vision.ImageAnalysisSkill](cognitive-search-skill-image-analysis.md) | This skill uses an image detection algorithm to identify the content of an image and generate a text description. |
 | [Microsoft.Skills.Vision.OcrSkill](cognitive-search-skill-ocr.md) | Optical character recognition. |
 | [Microsoft.Skills.Util.ShaperSkill](cognitive-search-skill-shaper.md) | Maps output to a complex type (a multi-part data type, which might be used for a full name, a multi-line address, or a combination of last name and a personal identifier.) |
+| [Microsoft.Skills.Custom.WebApiSkill](cognitive-search-custom-skill-webapi.md) | Allows extensibility of cognitive search pipeline by making an HTTP call into a custom Web API |
+
+
+For guidance on creating a [custom skill](cognitive-search-custom-skill-webapi.md), see [How to define a custom interface](cognitive-search-custom-skill-interface.md) and [Example: creating a custom skill](cognitive-search-create-custom-skill-example.md).
 
 ## See also
 

--- a/articles/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers.md
+++ b/articles/search/search-howto-connecting-azure-sql-database-to-azure-search-using-indexers.md
@@ -206,6 +206,9 @@ To use this policy, create or update your data source like this:
 
 When using SQL integrated change tracking policy, do not specify a separate data deletion detection policy - this policy has built-in support for identifying deleted rows. However, for the deletes to be detected "automagically", the document key in your search index must be the same as the primary key in the SQL table. 
 
+> [!NOTE]  
+> When using [TRUNCATE TABLE](https://docs.microsoft.com/en-us/sql/t-sql/statements/truncate-table-transact-sql?view=sql-server-2017) to remove a large number of rows from a SQL table, the indexer will not be able to pick up the deleted rows due to the nature of not being able to identify individual row deletions. The indexer to which the data source is attached needs to be [reset](https://docs.microsoft.com/en-us/rest/api/searchservice/reset-indexer) to reset the change tracking state and pick up these deletions.
+
 <a name="HighWaterMarkPolicy"></a>
 
 ### High Water Mark Change Detection policy


### PR DESCRIPTION
1. Add skill reference documentation for Custom Web API skill
2. Updated links and cross document references to web api skill
    * Fixed up usage of a deprecated skill
3. Add note to Azure SQL data source indicating change tracking policy and `TRUNCATE TABLE`