### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/logic-apps/logic-apps-workflow-definition-language.md
+++ b/articles/logic-apps/logic-apps-workflow-definition-language.md
@@ -23,15 +23,15 @@ your workflow's underlying definition describes the actual
 logic that runs for your logic app. This description 
 follows a structure that's defined and validated 
 by the Workflow Definition Language schema, which uses 
-[JavaScript Object Notation (JSON)](https://www.json.org/). 
-  
+[JavaScript Object Notation (JSON)](https://www.json.org/).
+
 ## Workflow definition structure
 
 A workflow definition has at least one trigger that instantiates your logic app, 
-plus one or more actions that your logic app runs. 
+plus one or more actions that your logic app runs.
 
-Here is the high-level structure for a workflow definition:  
-  
+Here is the high-level structure for a workflow definition:
+
 ```json
 "definition": {
   "$schema": "<workflow-definition-language-schema-version>",
@@ -42,17 +42,17 @@ Here is the high-level structure for a workflow definition:
   "outputs": { "<workflow-output-definitions>" }
 }
 ```
-  
-| Element | Required | Description | 
-|---------|----------|-------------| 
-| definition | Yes | The starting element for your workflow definition | 
-| $schema | Only when externally referencing a workflow definition | The location for the JSON schema file that describes the Workflow Definition Language version, which you can find here: <p>`https://schema.management.azure.com/schemas/2016-06-01/Microsoft.Logic.json`</p> |   
-| contentVersion | No | The version number for your workflow definition, which is "1.0.0.0" by default. To help identify and confirm the correct definition when deploying a workflow, specify a value to use. | 
-| parameters | No | The definitions for one or more parameters that pass data into your workflow <p><p>Maximum parameters: 50 | 
-| triggers | No | The definitions for one or more triggers that instantiate your workflow. You can define more than one trigger, but only with the Workflow Definition Language, not visually through the Logic Apps Designer. <p><p>Maximum triggers: 10 | 
-| actions | No | The definitions for one or more actions to execute at workflow runtime <p><p>Maximum actions: 250 | 
-| outputs | No | The definitions for the outputs that return from a workflow run <p><p>Maximum outputs: 10 |  
-|||| 
+
+| Element | Required | Description |
+|---------|----------|-------------|
+| definition | Yes | The starting element for your workflow definition |
+| $schema | Only when externally referencing a workflow definition | The location for the JSON schema file that describes the Workflow Definition Language version, which you can find here: <p>`https://schema.management.azure.com/schemas/2016-06-01/Microsoft.Logic.json`</p> |
+| contentVersion | No | The version number for your workflow definition, which is "1.0.0.0" by default. To help identify and confirm the correct definition when deploying a workflow, specify a value to use. |
+| parameters | No | The definitions for one or more parameters that pass data into your workflow <p><p>Maximum parameters: 50 |
+| triggers | No | The definitions for one or more triggers that instantiate your workflow. You can define more than one trigger, but only with the Workflow Definition Language, not visually through the Logic Apps Designer. <p><p>Maximum triggers: 10 |
+| actions | No | The definitions for one or more actions to execute at workflow runtime <p><p>Maximum actions: 250 |
+| outputs | No | The definitions for the outputs that return from a workflow run <p><p>Maximum outputs: 10 |
+||||
 
 ## Parameters
 
@@ -62,7 +62,7 @@ Both parameter declarations and parameter values are required at deployment.
 Before you can use these parameters in other workflow sections, 
 make sure that you declare all the parameters in these sections. 
 
-Here is the general structure for a parameter definition:  
+Here is the general structure for a parameter definition:
 
 ```json
 "parameters": {
@@ -70,66 +70,66 @@ Here is the general structure for a parameter definition:
     "type": "<parameter-type>",
     "defaultValue": "<default-parameter-value>",
     "allowedValues": [ <array-with-permitted-parameter-values> ],
-    "metadata": { 
-      "key": { 
+    "metadata": {
+      "key": {
         "name": "<key-value>"
-      } 
+      }
     }
   }
 },
 ```
 
-| Element | Required | Type | Description |  
-|---------|----------|------|-------------|  
+| Element | Required | Type | Description |
+|---------|----------|------|-------------|
 | type | Yes | int, float, string, securestring, bool, array, JSON object, secureobject <p><p>**Note**: For all passwords, keys, and secrets, use the `securestring` and `secureobject` types because the `GET` operation doesn't return these types. | The type for the parameter |
-| defaultValue | No | Same as `type` | The default parameter value when no value is specified when the workflow instantiates | 
-| allowedValues | No | Same as `type` | An array with values that the parameter can accept |  
-| metadata | No | JSON object | Any other parameter details, for example, the name or a readable description for your logic app, or design-time data used by Visual Studio or other tools |  
+| defaultValue | No | Same as `type` | The default parameter value when no value is specified when the workflow instantiates |
+| allowedValues | No | Same as `type` | An array with values that the parameter can accept |
+| metadata | No | JSON object | Any other parameter details, for example, the name or a readable description for your logic app, or design-time data used by Visual Studio or other tools |
 ||||
 
-## Triggers and actions  
+## Triggers and actions
 
 In a workflow definition, the `triggers` and `actions` sections 
 define the calls that happen during your workflow's execution. 
 For syntax and more information about these sections, see 
 [Workflow triggers and actions](../logic-apps/logic-apps-workflow-actions-triggers.md).
-  
-## Outputs 
+
+## Outputs
 
 In the `outputs` section, define the data that 
 your workflow can return when finished running. 
 For example, to track a specific status or value from each run, 
-specify that the workflow output returns that data. 
+specify that the workflow output returns that data.
 
 > [!NOTE]
 > When responding to incoming requests from a service's REST API, 
 > do not use `outputs`. Instead, use the `Response` action type. 
 > For more information, see [Workflow triggers and actions](../logic-apps/logic-apps-workflow-actions-triggers.md).
 
-Here is the general structure for an output definition: 
+Here is the general structure for an output definition:
 
 ```json
 "outputs": {
-  "<key-name>": {  
-    "type": "<key-type>",  
-    "value": "<key-value>"  
+  "<key-name>": {
+    "type": "<key-type>",
+    "value": "<key-value>"
   }
-} 
+}
 ```
 
-| Element | Required | Type | Description | 
-|---------|----------|------|-------------| 
-| <*key-name*> | Yes | String | The key name for the output return value |  
-| type | Yes | int, float, string, securestring, bool, array, JSON object | The type for the output return value | 
-| value | Yes | Same as `type` | The output return value |  
-||||| 
+| Element | Required | Type | Description |
+|---------|----------|------|-------------|
+| <*key-name*> | Yes | String | The key name for the output return value |
+| type | Yes | int, float, string, securestring, bool, array, JSON object | The type for the output return value |
+| value | Yes | Same as `type` | The output return value |
+|||||
 
 To get the output from a workflow run, 
 review the logic app's run history and 
 details in the Azure portal or use the 
 [Workflow REST API](https://docs.microsoft.com/rest/api/logic/workflows). 
 You can also pass output to external systems, for example, 
-Power BI so that you can create dashboards. 
+Power BI so that you can create dashboards.
 
 <a name="expressions"></a>
 
@@ -138,9 +138,9 @@ Power BI so that you can create dashboards.
 With JSON, you can have literal values that exist at design time, for example:
 
 ```json
-"customerName": "Sophia Owen", 
-"rainbowColors": ["red", "orange", "yellow", "green", "blue", "indigo", "violet"], 
-"rainbowColorsCount": 7 
+"customerName": "Sophia Owen",
+"rainbowColors": ["red", "orange", "yellow", "green", "blue", "indigo", "violet"],
+"rainbowColorsCount": 7
 ```
 
 You can also have values that don't exist until run time. 
@@ -153,7 +153,7 @@ you can use an expression anywhere in a JSON
 string value by prefixing the expression with the at-sign (\@). 
 When evaluating an expression that represents a JSON value, 
 the expression body is extracted by removing the \@ character, 
-and always results in another JSON value. 
+and always results in another JSON value.
 
 For example, for the previously defined `customerName` property, 
 you can get the property value by using the 
@@ -161,7 +161,7 @@ you can get the property value by using the
 function in an expression and assign that value to the `accountName` property:
 
 ```json
-"customerName": "Sophia Owen", 
+"customerName": "Sophia Owen",
 "accountName": "@parameters('customerName')"
 ```
 
@@ -186,16 +186,16 @@ prefix the \@ character with another \@ character as an escape character: \@\@
 These examples show how expressions are evaluated:
 
 | JSON value | Result |
-|------------|--------| 
+|------------|--------|
 | "Sophia Owen" | Return these characters: 'Sophia Owen' |
 | "array[1]" | Return these characters: 'array[1]' |
-| "\@\@" | Return these characters as a one-character string: '\@' |   
+| "\@\@" | Return these characters as a one-character string: '\@' |
 | " \@" | Return these characters as a two-character string: ' \@' |
 |||
 
 For these examples, suppose you define "myBirthMonth" 
-equal to "January" and "myAge" equal to the number 42:  
-  
+equal to "January" and "myAge" equal to the number 42:
+
 ```json
 "myBirthMonth": "January",
 "myAge": 42
@@ -204,19 +204,19 @@ equal to "January" and "myAge" equal to the number 42:
 These examples show how the following expressions are evaluated:
 
 | JSON expression | Result |
-|-----------------|--------| 
-| "\@parameters('myBirthMonth')" | Return this string: "January" |  
-| "\@{parameters('myBirthMonth')}" | Return this string: "January" |  
-| "\@parameters('myAge')" | Return this number: 42 |  
-| "\@{parameters('myAge')}" | Return this number as a string: "42" |  
-| "My age is \@{parameters('myAge')}" | Return this string: "My age is 42" |  
-| "\@concat('My age is ', string(parameters('myAge')))" | Return this string: "My age is 42" |  
-| "My age is \@\@{parameters('myAge')}" | Return this string, which includes the expression: "My age is \@{parameters('myAge')}` | 
-||| 
+|-----------------|--------|
+| "\@parameters('myBirthMonth')" | Return this string: "January" |
+| "\@{parameters('myBirthMonth')}" | Return this string: "January" |
+| "\@parameters('myAge')" | Return this number: 42 |
+| "\@{parameters('myAge')}" | Return this number as a string: "42" |
+| "My age is \@{parameters('myAge')}" | Return this string: "My age is 42" |
+| "\@concat('My age is ', string(parameters('myAge')))" | Return this string: "My age is 42" |
+| "My age is \@\@{parameters('myAge')}" | Return this string, which includes the expression: "My age is \@{parameters('myAge')}` |
+|||
 
 When you're working visually in the Logic Apps Designer, 
 you can create expressions through the Expression builder, 
-for example: 
+for example:
 
 ![Logic Apps Designer > Expression builder](./media/logic-apps-workflow-definition-language/expression-builder.png)
 
@@ -248,15 +248,15 @@ for example, the `searchQuery` property here:
 
 In [expressions](#expressions) and [functions](#functions), 
 operators perform specific tasks, such as reference a 
-property or a value in an array. 
+property or a value in an array.
 
-| Operator | Task | 
+| Operator | Task |
 |----------|------|
-| ' | To use a string literal as input or in expressions and functions, wrap the string only with single quotation marks, for example, `'<myString>'`. Do not use double quotation marks (""), which conflict with the JSON formatting around an entire expression. For example: <p>**Yes**: length('Hello') </br>**No**: length("Hello") <p>When you pass arrays or numbers, you don't need wrapping punctuation. For example: <p>**Yes**: length([1, 2, 3]) </br>**No**: length("[1, 2, 3]") | 
-| [] | To reference a value at a specific position (index) in an array, use square brackets. For example, to get the second item in an array: <p>`myArray[1]` | 
-| . | To reference a property in an object, use the dot operator. For example, to get the `name` property for a `customer` JSON object: <p>`"@parameters('customer').name"` | 
-| ? | To reference null properties in an object without a runtime error, use the question mark operator. For example, to handle null outputs from a trigger, you can use this expression: <p>`@coalesce(trigger().outputs?.body?.<someProperty>, '<property-default-value>')` | 
-||| 
+| ' | To use a string literal as input or in expressions and functions, wrap the string only with single quotation marks, for example, `'<myString>'`. Do not use double quotation marks (""), which conflict with the JSON formatting around an entire expression. For example: <p>**Yes**: length('Hello') </br>**No**: length("Hello") <p>When you pass arrays or numbers, you don't need wrapping punctuation. For example: <p>**Yes**: length([1, 2, 3]) </br>**No**: length("[1, 2, 3]") |
+| [] | To reference a value at a specific position (index) in an array, use square brackets. For example, to get the second item in an array: <p>`myArray[1]` |
+| . | To reference a property in an object, use the dot operator. For example, to get the `name` property for a `customer` JSON object: <p>`"@parameters('customer').name"` |
+| ? | To reference null properties in an object without a runtime error, use the question mark operator. For example, to handle null outputs from a trigger, you can use this expression: <p>`@coalesce(trigger().outputs?.body?.<someProperty>, '<property-default-value>')` |
+|||
 
 <a name="functions"></a>
 
@@ -266,7 +266,7 @@ Some expressions get their values from runtime actions
 that might not yet exist when a logic app starts to run. 
 To reference or work with these values in expressions, 
 you can use [*functions*](../logic-apps/workflow-definition-language-functions-reference.md) 
-that the Workflow Definition Language provides. 
+that the Workflow Definition Language provides.
 
 ## Next steps
 

--- a/articles/logic-apps/logic-apps-workflow-definition-language.md
+++ b/articles/logic-apps/logic-apps-workflow-definition-language.md
@@ -229,7 +229,7 @@ for example, the `searchQuery` property here:
   "inputs": {
     "host": {
       "connection": {
-       "name": "@parameters('$connections')['twitter']['connectionId']"
+        "name": "@parameters('$connections')['twitter']['connectionId']"
       }
     }
   },


### PR DESCRIPTION
When copying from the web page, unnecessary one-byte space is included behind the code. Indentation is misaligned.