### PR TITLE
Fix typo

### DIFF
--- a/articles/logic-apps/logic-apps-workflow-actions-triggers.md
+++ b/articles/logic-apps/logic-apps-workflow-actions-triggers.md
@@ -2992,7 +2992,7 @@ see [Secure sensitive information](#secure-info).
 "authentication": {
    "audience": "https://management.core.windows.net/",
    "clientId": "34750e0b-72d1-4e4f-bbbe-664f6d04d411",
-   "secret": "hcqgkYc9ebgNLA5c+GDg7xl9ZJMD88TmTJiJBgZ8dFo="
+   "secret": "hcqgkYc9ebgNLA5c+GDg7xl9ZJMD88TmTJiJBgZ8dFo=",
    "tenant": "72f988bf-86f1-41af-91ab-2d7cd011db47",
    "type": "ActiveDirectoryOAuth"
 }

--- a/articles/logic-apps/logic-apps-workflow-actions-triggers.md
+++ b/articles/logic-apps/logic-apps-workflow-actions-triggers.md
@@ -190,10 +190,10 @@ inside the inbox for an Office 365 Outlook account:
       "method": "get",
       "path": "/Mail/OnNewEmail",
       "queries": {
-          "fetchOnlyWithAttachment": false,
-          "folderPath": "Inbox",
-          "importance": "Any",
-          "includeAttachments": false
+         "fetchOnlyWithAttachment": false,
+         "folderPath": "Inbox",
+         "importance": "Any",
+         "includeAttachments": false
       }
    },
    "recurrence": {
@@ -218,7 +218,7 @@ and waits for the endpoint to respond. For more information, see
    "type": "ApiConnectionWebhook",
    "inputs": {
       "body": {
-          "NotificationUrl": "@{listCallbackUrl()}"
+         "NotificationUrl": "@{listCallbackUrl()}"
       },
       "host": {
          "connection": {
@@ -279,9 +279,9 @@ endpoint to respond when a new email arrives.
       },
       "path": "/MailSubscription/$subscriptions",
       "queries": {
-          "folderPath": "Inbox",
-          "hasAttachment": "Any",
-          "importance": "Any"
+         "folderPath": "Inbox",
+         "hasAttachment": "Any",
+         "importance": "Any"
       }
    },
    "splitOn": "@triggerBody()?['value']"
@@ -783,15 +783,15 @@ so you can create a trigger like this example:
 ``` json
 "HTTP_Debatch": {
    "type": "Http",
-    "inputs": {
-        "uri": "https://mydomain.com/myAPI",
-        "method": "GET"
-    },
+   "inputs": {
+      "uri": "https://mydomain.com/myAPI",
+      "method": "GET"
+   },
    "recurrence": {
       "frequency": "Second",
       "interval": 1
-    },
-    "splitOn": "@triggerBody()?.Rows"
+   },
+   "splitOn": "@triggerBody()?.Rows"
 }
 ```
 
@@ -972,8 +972,8 @@ plus a reference to a valid connection.
       "retryPolicy": "<retry-behavior>",
       "queries": { "<query-parameters>" },
       "<other-action-specific-properties>"
-    },
-    "runAfter": {}
+   },
+   "runAfter": {}
 }
 ```
 
@@ -1018,8 +1018,8 @@ Office 365 Outlook connector, which is a Microsoft-managed API:
       },
       "method": "POST",
       "path": "/Mail"
-    },
-    "runAfter": {}
+   },
+   "runAfter": {}
 }
 ```
 
@@ -1159,8 +1159,8 @@ This action calls a previously created
 "<Azure-function-name>": {
    "type": "Function",
    "inputs": {
-     "function": {
-        "id": "<Azure-function-ID>"
+      "function": {
+         "id": "<Azure-function-ID>"
       },
       "method": "<method-type>",
       "headers": { "<header-content>" },
@@ -1216,15 +1216,15 @@ created "GetProductID" function:
 "GetProductID": {
    "type": "Function",
    "inputs": {
-     "function": {
-        "id": "/subscriptions/<XXXXXXXXXXXXXXXXXXXX>/resourceGroups/myLogicAppResourceGroup/providers/Microsoft.Web/sites/InventoryChecker/functions/GetProductID"
+      "function": {
+         "id": "/subscriptions/<XXXXXXXXXXXXXXXXXXXX>/resourceGroups/myLogicAppResourceGroup/providers/Microsoft.Web/sites/InventoryChecker/functions/GetProductID"
       },
       "method": "POST",
       "headers": {
-          "x-ms-date": "@utcnow()"
-       },
+         "x-ms-date": "@utcnow()"
+      },
       "body": {
-          "Product_ID": "@variables('ProductID')"
+         "Product_ID": "@variables('ProductID')"
       }
    },
    "runAfter": {}
@@ -1347,9 +1347,9 @@ easily reference the data in that output.
    "type": "ParseJson",
    "inputs": {
       "content": "<JSON-source>",
-         "schema": { "<JSON-schema>" }
-      },
-      "runAfter": {}
+      "schema": { "<JSON-schema>" }
+   },
+   "runAfter": {}
 },
 ```
 
@@ -1591,8 +1591,8 @@ all the objects in the output array.
    "inputs": {
       "from": <array>,
       "select": {
-          "<key-name>": "<expression>",
-          "<key-name>": "<expression>"
+         "<key-name>": "<expression>",
+         "<key-name>": "<expression>"
       }
    },
    "runAfter": {}
@@ -1809,7 +1809,7 @@ and "Description", and adds the word "Organic" to the values in the "Description
             "value": "@concat('Organic ', item().Product_Name)"
          }
       ]
-    },
+   },
    "runAfter": {}
 },
 ```
@@ -1834,11 +1834,11 @@ including sequential loops.
 "Terminate": {
    "type": "Terminate",
    "inputs": {
-       "runStatus": "<status>",
-       "runError": {
-            "code": "<error-code-or-name>",
-            "message": "<error-message>"
-       }
+      "runStatus": "<status>",
+      "runError": {
+         "code": "<error-code-or-name>",
+         "message": "<error-message>"
+      }
    },
    "runAfter": {}
 }
@@ -1876,8 +1876,8 @@ and returns the status, an error code, and an error message:
             "code": "Unexpected response",
             "message": "The service received an unexpected response. Please try again."
         }
-   },
-   "runAfter": {}
+    },
+    "runAfter": {}
 }
 ```
 
@@ -2080,8 +2080,8 @@ Learn [how to create "for each" loops](../logic-apps/logic-apps-control-flow-loo
       "concurrency": {
          "repetitions": <count>
       }
-    },
-    "operationOptions": "<operation-option>"
+   },
+   "operationOptions": "<operation-option>"
 }
 ```
 
@@ -2120,7 +2120,7 @@ to a person who reviews the attachment.
                "Body": "@base64ToString(items('For_each')?['Content'])",
                "Subject": "Review attachment",
                "To": "Sophie.Owen@contoso.com"
-                },
+            },
             "host": {
                "connection": {
                   "id": "@parameters('$connections')['office365']['connectionId']"
@@ -2293,13 +2293,13 @@ runs the default actions. Learn
    "cases": {
       "Case": {
          "actions": {
-           "<action-name>": { "<action-definition>" }
+            "<action-name>": { "<action-definition>" }
          },
          "case": "<matching-value>"
       },
       "Case_2": {
          "actions": {
-           "<action-name>": { "<action-definition>" }
+            "<action-name>": { "<action-definition>" }
          },
          "case": "<matching-value>"
       }
@@ -2470,7 +2470,7 @@ the specified URL until one of these conditions is met:
 * The loop has run for one hour.
 
 ```json
- "Run_until_loop_succeeds_or_expires": {
+"Run_until_loop_succeeds_or_expires": {
     "type": "Until",
     "actions": {
         "Http": {
@@ -2931,8 +2931,8 @@ see [Secure sensitive information](#secure-info).
          "username": "@parameters('userNameParam')",
          "password": "@parameters('passwordParam')"
       }
-  },
-  "runAfter": {}
+   },
+   "runAfter": {}
 }
 ```
 
@@ -3022,8 +3022,8 @@ in your trigger or action definition. Here is an example
          "username": "@parameters('userNameParam')",
          "password": "@parameters('passwordParam')"
       }
-  },
-  "runAfter": {}
+   },
+   "runAfter": {}
 }
 ```
 

--- a/articles/logic-apps/logic-apps-workflow-actions-triggers.md
+++ b/articles/logic-apps/logic-apps-workflow-actions-triggers.md
@@ -37,15 +37,15 @@ Here are the general trigger categories:
 * A *push* trigger, which creates a subscription to an endpoint 
 and provides a *callback URL* so the endpoint can notify the 
 trigger when the specified event happens or data is available. 
-The trigger then waits for the endpoint's response before firing. 
+The trigger then waits for the endpoint's response before firing.
 
-Triggers have these top-level elements, although some are optional:  
-  
+Triggers have these top-level elements, although some are optional:
+
 ```json
 "<trigger-name>": {
    "type": "<trigger-type>",
    "inputs": { "<trigger-inputs>" },
-   "recurrence": { 
+   "recurrence": {
       "frequency": "<time-unit>",
       "interval": <number-of-time-units>
    },
@@ -58,52 +58,52 @@ Triggers have these top-level elements, although some are optional:
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*trigger-name*> | String | The name for the trigger | 
-| <*trigger-type*> | String | The trigger type such as "Http" or "ApiConnection" | 
-| <*trigger-inputs*> | JSON Object | The inputs that define the trigger's behavior | 
-| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" | 
-| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*trigger-name*> | String | The name for the trigger |
+| <*trigger-type*> | String | The trigger type such as "Http" or "ApiConnection" |
+| <*trigger-inputs*> | JSON Object | The inputs that define the trigger's behavior |
+| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" |
+| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*array-with-conditions*> | Array | An array that contains one or more [conditions](#trigger-conditions) that determine whether to run the workflow. Available only for triggers. | 
-| <*runtime-config-options*> | JSON Object | You can change trigger runtime behavior by setting `runtimeConfiguration` properties. For more information, see [Runtime configuration settings](#runtime-config-options). | 
-| <*splitOn-expression*> | String | For triggers that return an array, you can specify an expression that [splits or *debatches*](#split-on-debatch) array items into multiple workflow instances for processing. | 
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*array-with-conditions*> | Array | An array that contains one or more [conditions](#trigger-conditions) that determine whether to run the workflow. Available only for triggers. |
+| <*runtime-config-options*> | JSON Object | You can change trigger runtime behavior by setting `runtimeConfiguration` properties. For more information, see [Runtime configuration settings](#runtime-config-options). |
+| <*splitOn-expression*> | String | For triggers that return an array, you can specify an expression that [splits or *debatches*](#split-on-debatch) array items into multiple workflow instances for processing. |
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
 ## Trigger types list
 
-Each trigger type has a different interface and inputs that define the trigger's behavior. 
+Each trigger type has a different interface and inputs that define the trigger's behavior.
 
 ### Built-in triggers
 
-| Trigger type | Description | 
-|--------------|-------------| 
-| [**HTTP**](#http-trigger) | Checks or *polls* any endpoint. This endpoint must conform to a specific trigger contract either by using a "202" asynchronous pattern or by returning an array. | 
+| Trigger type | Description |
+|--------------|-------------|
+| [**HTTP**](#http-trigger) | Checks or *polls* any endpoint. This endpoint must conform to a specific trigger contract either by using a "202" asynchronous pattern or by returning an array. |
 | [**HTTPWebhook**](#http-webhook-trigger) | Creates a callable endpoint for your logic app but calls the specified URL to register or unregister. |
-| [**Recurrence**](#recurrence-trigger) | Fires based on a defined schedule. You can set a future date and time for firing this trigger. Based on the frequency, you can also specify times and days for running your workflow. | 
-| [**Request**](#request-trigger)  | Creates a callable endpoint for your logic app and is also known as a "manual" trigger. For example, see [Call, trigger, or nest workflows with HTTP endpoints](../logic-apps/logic-apps-http-endpoint.md). | 
-||| 
+| [**Recurrence**](#recurrence-trigger) | Fires based on a defined schedule. You can set a future date and time for firing this trigger. Based on the frequency, you can also specify times and days for running your workflow. |
+| [**Request**](#request-trigger)  | Creates a callable endpoint for your logic app and is also known as a "manual" trigger. For example, see [Call, trigger, or nest workflows with HTTP endpoints](../logic-apps/logic-apps-http-endpoint.md). |
+|||
 
 ### Managed API triggers
 
-| Trigger type | Description | 
-|--------------|-------------| 
-| [**ApiConnection**](#apiconnection-trigger) | Checks or *polls* an endpoint by using [Microsoft-managed APIs](../connectors/apis-list.md). | 
-| [**ApiConnectionWebhook**](#apiconnectionwebhook-trigger) | Creates a callable endpoint for your logic app by calling [Microsoft-managed APIs](../connectors/apis-list.md) to subscribe and unsubscribe. | 
-||| 
+| Trigger type | Description |
+|--------------|-------------|
+| [**ApiConnection**](#apiconnection-trigger) | Checks or *polls* an endpoint by using [Microsoft-managed APIs](../connectors/apis-list.md). |
+| [**ApiConnectionWebhook**](#apiconnectionwebhook-trigger) | Creates a callable endpoint for your logic app by calling [Microsoft-managed APIs](../connectors/apis-list.md) to subscribe and unsubscribe. |
+|||
 
 ## Triggers - Detailed reference
 
 <a name="apiconnection-trigger"></a>
 
-### APIConnection trigger  
+### APIConnection trigger
 
 This trigger checks or *polls* an endpoint by using 
 [Microsoft-managed APIs](../connectors/apis-list.md) 
@@ -125,7 +125,7 @@ behavior depends on whether or not sections are included.
       "retryPolicy": { "<retry-behavior>" },
       "queries": { "<query-parameters>" }
    },
-   "recurrence": { 
+   "recurrence": {
       "frequency": "<time-unit>",
       "interval": <number-of-time-units>
    },
@@ -142,36 +142,36 @@ behavior depends on whether or not sections are included.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*APIConnection_trigger_name*> | String | The name for the trigger | 
-| <*connection-name*> | String | The name for the connection to the managed API that the workflow uses | 
-| <*method-type*> | String | The HTTP method for communicating with the managed API: "GET", "PUT", "POST", "PATCH", "DELETE" | 
-| <*api-operation*> | String | The API operation to call | 
-| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" | 
-| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*APIConnection_trigger_name*> | String | The name for the trigger |
+| <*connection-name*> | String | The name for the connection to the managed API that the workflow uses |
+| <*method-type*> | String | The HTTP method for communicating with the managed API: "GET", "PUT", "POST", "PATCH", "DELETE" |
+| <*api-operation*> | String | The API operation to call |
+| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" |
+| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
-| <*query-parameters*> | JSON Object | Any query parameters to include with the API call. For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. | 
-| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). | 
-| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |
+| <*query-parameters*> | JSON Object | Any query parameters to include with the API call. For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. |
+| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). |
+| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). |
 | <*splitOn-expression*> | String | For triggers that return arrays, this expression references the array to use so that you can create and run a workflow instance for each array item, rather than use a "for each" loop. <p>For example, this expression represents an item in the array returned within the trigger's body content: `@triggerbody()?['value']` |
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
 ||||
 
 *Outputs*
- 
+
 | Element | Type | Description |
-|---------|------|-------------| 
-| headers | JSON Object | The headers from the response | 
-| body | JSON Object | The body from the response | 
-| status code | Integer | The status code from the response | 
-|||| 
+|---------|------|-------------|
+| headers | JSON Object | The headers from the response |
+| body | JSON Object | The body from the response |
+| status code | Integer | The status code from the response |
+||||
 
 *Example*
 
@@ -185,7 +185,7 @@ inside the inbox for an Office 365 Outlook account:
       "host": {
          "connection": {
             "name": "@parameters('$connections')['office365']['connectionId']"
-         }     
+         }
       },
       "method": "get",
       "path": "/Mail/OnNewEmail",
@@ -241,23 +241,23 @@ and waits for the endpoint to respond. For more information, see
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*connection-name*> | String | The name for the connection to the managed API that the workflow uses | 
-| <*body-content*> | JSON Object | Any message content to send as payload to the managed API | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*connection-name*> | String | The name for the connection to the managed API that the workflow uses |
+| <*body-content*> | JSON Object | Any message content to send as payload to the managed API |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
-| <*query-parameters*> | JSON Object | Any query parameters to include with the API call <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. | 
-| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). | 
-| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |
+| <*query-parameters*> | JSON Object | Any query parameters to include with the API call <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. |
+| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). |
+| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). |
 | <*splitOn-expression*> | String | For triggers that return arrays, this expression references the array to use so that you can create and run a workflow instance for each array item, rather than use a "for each" loop. <p>For example, this expression represents an item in the array returned within the trigger's body content: `@triggerbody()?['value']` |
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
 *Example*
 
@@ -270,7 +270,7 @@ endpoint to respond when a new email arrives.
    "type": "ApiConnectionWebhook",
    "inputs": {
       "body": {
-         "NotificationUrl": "@{listCallbackUrl()}" 
+         "NotificationUrl": "@{listCallbackUrl()}"
       },
       "host": {
          "connection": {
@@ -324,64 +324,64 @@ The endpoint's response determines whether the workflow runs.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*method-type*> | String | The HTTP method to use for polling the specified endpoint: "GET", "PUT", "POST", "PATCH", "DELETE" | 
-| <*endpoint-URL*> | String | The HTTP or HTTPS URL for the endpoint to poll <p>Maximum string size: 2 KB | 
-| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" | 
-| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*method-type*> | String | The HTTP method to use for polling the specified endpoint: "GET", "PUT", "POST", "PATCH", "DELETE" |
+| <*endpoint-URL*> | String | The HTTP or HTTPS URL for the endpoint to poll <p>Maximum string size: 2 KB |
+| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" |
+| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
+| Value | Type | Description |
+|-------|------|-------------|
 | <*header-content*> | JSON Object | The headers to send with the request <p>For example, to set the language and type for a request: <p>`"headers": { "Accept-Language": "en-us", "Content-Type": "application/json" }` |
-| <*body-content*> | String | The message content to send as payload with the request | 
+| <*body-content*> | String | The message content to send as payload with the request |
 | <*authentication-method*> | JSON Object | The method the request uses for authentication. For more information, see [Scheduler Outbound Authentication](../scheduler/scheduler-outbound-authentication.md). Beyond Scheduler, the `authority` property is supported. When not specified, the default value is `https://login.windows.net`, but you can use a different value, such as`https://login.windows\-ppe.net`. |
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |  
- <*query-parameters*> | JSON Object | Any query parameters to include with the request <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the request. | 
-| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). | 
-| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | 
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
+ <*query-parameters*> | JSON Object | Any query parameters to include with the request <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the request. |
+| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). |
+| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). |
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
 *Outputs*
 
 | Element | Type | Description |
-|---------|------|-------------| 
-| headers | JSON Object | The headers from the response | 
-| body | JSON Object | The body from the response | 
-| status code | Integer | The status code from the response | 
-|||| 
+|---------|------|-------------|
+| headers | JSON Object | The headers from the response |
+| body | JSON Object | The body from the response |
+| status code | Integer | The status code from the response |
+||||
 
 *Requirements for incoming requests*
 
 To work well with your logic app, the endpoint must 
 conform to a specific trigger pattern or contract, 
-and recognize these properties:  
-  
-| Response | Required | Description | 
-|----------|----------|-------------| 
-| Status code | Yes | The "200 OK" status code starts a run. Any other status code doesn't start a run. | 
-| Retry-after header | No | The number of seconds until the logic app polls the endpoint again | 
-| Location header | No | The URL to call at the next polling interval. If not specified, the original URL is used. | 
-|||| 
+and recognize these properties:
+
+| Response | Required | Description |
+|----------|----------|-------------|
+| Status code | Yes | The "200 OK" status code starts a run. Any other status code doesn't start a run. |
+| Retry-after header | No | The number of seconds until the logic app polls the endpoint again |
+| Location header | No | The URL to call at the next polling interval. If not specified, the original URL is used. |
+||||
 
 *Example behaviors for different requests*
 
-| Status code | Retry after | Behavior | 
+| Status code | Retry after | Behavior |
 |-------------|-------------|----------|
-| 200 | {none} | Run the workflow, then check again for more data after the defined recurrence. | 
-| 200 | 10 seconds | Run the workflow, then check again for more data after 10 seconds. |  
-| 202 | 60 seconds | Don't trigger the workflow. The next attempt happens in one minute, subject to the defined recurrence. If the defined recurrence is less than one minute, the retry-after header takes precedence. Otherwise, the defined recurrence is used. | 
-| 400 | {none} | Bad request, don't run the workflow. If no `retryPolicy` is defined, then the default policy is used. After the number of retries has been reached, the trigger checks again for data after the defined recurrence. | 
-| 500 | {none}| Server error, don't run the workflow. If no `retryPolicy` is defined, then the default policy is used. After the number of retries has been reached, the trigger checks again for data after the defined recurrence. | 
-|||| 
+| 200 | {none} | Run the workflow, then check again for more data after the defined recurrence. |
+| 200 | 10 seconds | Run the workflow, then check again for more data after 10 seconds. |
+| 202 | 60 seconds | Don't trigger the workflow. The next attempt happens in one minute, subject to the defined recurrence. If the defined recurrence is less than one minute, the retry-after header takes precedence. Otherwise, the defined recurrence is used. |
+| 400 | {none} | Bad request, don't run the workflow. If no `retryPolicy` is defined, then the default policy is used. After the number of retries has been reached, the trigger checks again for data after the defined recurrence. |
+| 500 | {none}| Server error, don't run the workflow. If no `retryPolicy` is defined, then the default policy is used. After the number of retries has been reached, the trigger checks again for data after the defined recurrence. |
+||||
 
 <a name="http-webhook-trigger"></a>
 
-### HTTPWebhook trigger  
+### HTTPWebhook trigger
 
 This trigger makes your logic app callable by creating an endpoint 
 that can register a subscription by calling the specified endpoint URL. 
@@ -392,7 +392,7 @@ an outgoing request automatically makes the call to cancel the subscription.
 For more information, see [Endpoint subscriptions](#subscribe-unsubscribe).
 
 You can also specify [asynchronous limits](#asynchronous-limits) on an **HTTPWebhook** trigger.
-The trigger's behavior depends on the sections that you use or omit. 
+The trigger's behavior depends on the sections that you use or omit.
 
 ```json
 "HTTP_Webhook": {
@@ -430,34 +430,34 @@ both the `"subscribe"` and `"unsubscribe"` objects.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*method-type*> | String | The HTTP method to use for the subscription request: "GET", "PUT", "POST", "PATCH", or "DELETE" | 
-| <*endpoint-subscribe-URL*> | String | The endpoint URL where to send the subscription request | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*method-type*> | String | The HTTP method to use for the subscription request: "GET", "PUT", "POST", "PATCH", or "DELETE" |
+| <*endpoint-subscribe-URL*> | String | The endpoint URL where to send the subscription request |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*method-type*> | String | The HTTP method to use for the cancellation request: "GET", "PUT", "POST", "PATCH", or "DELETE" | 
-| <*endpoint-unsubscribe-URL*> | String | The endpoint URL where to send the cancellation request | 
-| <*body-content*> | String | Any message content to send in the subscription or cancellation request | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*method-type*> | String | The HTTP method to use for the cancellation request: "GET", "PUT", "POST", "PATCH", or "DELETE" |
+| <*endpoint-unsubscribe-URL*> | String | The endpoint URL where to send the cancellation request |
+| <*body-content*> | String | Any message content to send in the subscription or cancellation request |
 | <*authentication-method*> | JSON Object | The method the request uses for authentication. For more information, see [Scheduler Outbound Authentication](../scheduler/scheduler-outbound-authentication.md). |
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
-| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). | 
-| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | 
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |
+| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). |
+| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). |
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
-*Outputs* 
+*Outputs*
 
 | Element | Type | Description |
-|---------|------|-------------| 
-| headers | JSON Object | The headers from the response | 
-| body | JSON Object | The body from the response | 
-| status code | Integer | The status code from the response | 
-|||| 
+|---------|------|-------------|
+| headers | JSON Object | The headers from the response |
+| body | JSON Object | The body from the response |
+| status code | Integer | The status code from the response |
+||||
 
 *Example*
 
@@ -493,7 +493,7 @@ technology articles.
 
 <a name="recurrence-trigger"></a>
 
-### Recurrence trigger  
+### Recurrence trigger
 
 This trigger runs based on the specified recurrence schedule 
 and provides an easy way for creating a regularly running workflow. 
@@ -508,11 +508,11 @@ and provides an easy way for creating a regularly running workflow.
       "timeZone": "<time-zone>",
       "schedule": {
          // Applies only when frequency is Day or Week. Separate values with commas.
-         "hours": [ <one-or-more-hour-marks> ], 
+         "hours": [ <one-or-more-hour-marks> ],
          // Applies only when frequency is Day or Week. Separate values with commas.
-         "minutes": [ <one-or-more-minute-marks> ], 
+         "minutes": [ <one-or-more-minute-marks> ],
          // Applies only when frequency is Week. Separate values with commas.
-         "weekDays": [ "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday" ] 
+         "weekDays": [ "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday" ]
       }
    },
    "runtimeConfiguration": {
@@ -527,25 +527,25 @@ and provides an easy way for creating a regularly running workflow.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" | 
-| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*time-unit*> | String | The unit of time that describes how often the trigger fires: "Second", "Minute", "Hour", "Day", "Week", "Month" |
+| <*number-of-time-units*> | Integer | A value that specifies how often the trigger fires based on the frequency, which is the number of time units to wait until the trigger fires again <p>Here are the minimum and maximum intervals: <p>- Month: 1-16 months </br>- Day: 1-500 days </br>- Hour: 1-12,000 hours </br>- Minute: 1-72,000 minutes </br>- Second: 1-9,999,999 seconds<p>For example, if the interval is 6, and the frequency is "Month", the recurrence is every 6 months. |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*start-date-time-with-format-YYYY-MM-DDThh:mm:ss*> | String | The start date and time in this format: <p>YYYY-MM-DDThh:mm:ss if you specify a time zone <p>-or- <p>YYYY-MM-DDThh:mm:ssZ if you don't specify a time zone <p>So for example, if you want September 18, 2017 at 2:00 PM, then specify "2017-09-18T14:00:00" and specify a time zone such as "Pacific Standard Time", or specify "2017-09-18T14:00:00Z" without a time zone. <p>**Note:** This start time must follow the [ISO 8601 date time specification](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) in [UTC date time format](https://en.wikipedia.org/wiki/Coordinated_Universal_Time), but without a [UTC offset](https://en.wikipedia.org/wiki/UTC_offset). If you don't specify a time zone, you must add the letter "Z" at the end without any spaces. This "Z" refers to the equivalent [nautical time](https://en.wikipedia.org/wiki/Nautical_time). <p>For simple schedules, the start time is the first occurrence, while for complex schedules, the trigger doesn't fire any sooner than the start time. For more information about start dates and times, see [Create and schedule regularly running tasks](../connectors/connectors-native-recurrence.md). | 
-| <*time-zone*> | String | Applies only when you specify a start time because this trigger doesn't accept [UTC offset](https://en.wikipedia.org/wiki/UTC_offset). Specify the time zone that you want to apply. | 
-| <*one-or-more-hour-marks*> | Integer or integer array | If you specify "Day" or "Week" for `frequency`, you can specify one or more integers from 0 to 23, separated by commas, as the hours of the day when you want to run the workflow. <p>For example, if you specify "10", "12" and "14", you get 10 AM, 12 PM, and 2 PM as the hour marks. | 
-| <*one-or-more-minute-marks*> | Integer or integer array | If you specify "Day" or "Week" for `frequency`, you can specify one or more integers from 0 to 59, separated by commas, as the minutes of the hour when you want to run the workflow. <p>For example, you can specify "30" as the minute mark and using the previous example for hours of the day, you get 10:30 AM, 12:30 PM, and 2:30 PM. | 
-| weekDays | String or string array | If you specify "Week" for `frequency`, you can specify one or more days, separated by commas, when you want to run the workflow: "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", and "Sunday" | 
-| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). | 
-| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | 
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*start-date-time-with-format-YYYY-MM-DDThh:mm:ss*> | String | The start date and time in this format: <p>YYYY-MM-DDThh:mm:ss if you specify a time zone <p>-or- <p>YYYY-MM-DDThh:mm:ssZ if you don't specify a time zone <p>So for example, if you want September 18, 2017 at 2:00 PM, then specify "2017-09-18T14:00:00" and specify a time zone such as "Pacific Standard Time", or specify "2017-09-18T14:00:00Z" without a time zone. <p>**Note:** This start time must follow the [ISO 8601 date time specification](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) in [UTC date time format](https://en.wikipedia.org/wiki/Coordinated_Universal_Time), but without a [UTC offset](https://en.wikipedia.org/wiki/UTC_offset). If you don't specify a time zone, you must add the letter "Z" at the end without any spaces. This "Z" refers to the equivalent [nautical time](https://en.wikipedia.org/wiki/Nautical_time). <p>For simple schedules, the start time is the first occurrence, while for complex schedules, the trigger doesn't fire any sooner than the start time. For more information about start dates and times, see [Create and schedule regularly running tasks](../connectors/connectors-native-recurrence.md). |
+| <*time-zone*> | String | Applies only when you specify a start time because this trigger doesn't accept [UTC offset](https://en.wikipedia.org/wiki/UTC_offset). Specify the time zone that you want to apply. |
+| <*one-or-more-hour-marks*> | Integer or integer array | If you specify "Day" or "Week" for `frequency`, you can specify one or more integers from 0 to 23, separated by commas, as the hours of the day when you want to run the workflow. <p>For example, if you specify "10", "12" and "14", you get 10 AM, 12 PM, and 2 PM as the hour marks. |
+| <*one-or-more-minute-marks*> | Integer or integer array | If you specify "Day" or "Week" for `frequency`, you can specify one or more integers from 0 to 59, separated by commas, as the minutes of the hour when you want to run the workflow. <p>For example, you can specify "30" as the minute mark and using the previous example for hours of the day, you get 10:30 AM, 12:30 PM, and 2:30 PM. |
+| weekDays | String or string array | If you specify "Week" for `frequency`, you can specify one or more days, separated by commas, when you want to run the workflow: "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", and "Sunday" |
+| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). |
+| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). |
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
 *Example 1*
 
@@ -610,7 +610,7 @@ see [Create and schedule regularly running tasks](../connectors/connectors-nativ
 This trigger makes your logic app callable by creating an endpoint that can accept incoming requests. 
 For this trigger, provide a JSON schema that describes and validates the payload or inputs 
 that the trigger receives from the incoming request. The schema also makes trigger properties 
-easier to reference from later actions in the workflow. 
+easier to reference from later actions in the workflow.
 
 To call this trigger, you must use the `listCallbackUrl` API, which is described in the 
 [Workflow Service REST API](https://docs.microsoft.com/rest/api/logic/workflows). 
@@ -626,7 +626,7 @@ To learn how to use this trigger as an HTTP endpoint, see
       "relativePath": "<relative-path-for-accepted-parameter>",
       "schema": {
          "type": "object",
-         "properties": { 
+         "properties": {
             "<property-name>": {
                "type": "<property-type>"
             }
@@ -646,23 +646,23 @@ To learn how to use this trigger as an HTTP endpoint, see
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*property-name*> | String | The name of a property in the JSON schema, which describes the payload | 
-| <*property-type*> | String | The property's type | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*property-name*> | String | The name of a property in the JSON schema, which describes the payload |
+| <*property-type*> | String | The property's type |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
+| Value | Type | Description |
+|-------|------|-------------|
 | <*method-type*> | String | The method that incoming requests must use to call your logic app: "GET", "PUT", "POST", "PATCH", "DELETE" |
-| <*relative-path-for-accepted-parameter*> | String | The relative path for the parameter that your endpoint's URL can accept | 
-| <*required-properties*> | Array | One or more properties that require values | 
-| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). | 
-| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | 
-| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| <*relative-path-for-accepted-parameter*> | String | The relative path for the parameter that your endpoint's URL can accept |
+| <*required-properties*> | Array | One or more properties that require values |
+| <*max-runs*> | Integer | By default, logic app workflow instances run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change trigger concurrency](#change-trigger-concurrency). |
+| <*max-runs-queue*> | Integer | When your logic app is already running the maximum number of instances, which you can change based on the `runtimeConfiguration.concurrency.runs` property, any new runs are put into this queue up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change the default limit, see [Change waiting runs limit](#change-waiting-runs). |
+| <*operation-option*> | String | You can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
 *Example*
 
@@ -682,7 +682,7 @@ a schema that validates input from the incoming request:
             "customerName": {
                "type": "String"
             },
-            "customerAddress": { 
+            "customerAddress": {
                "type": "Object",
                "properties": {
                   "streetAddress": {
@@ -730,9 +730,9 @@ When an expression references a trigger's status code,
 the trigger's default behavior is replaced. So, if you 
 want the trigger to fire for more than one status code, 
 such as the "200" and "201" status code, you must include 
-this expression as your condition: 
+this expression as your condition:
 
-`@or(equals(triggers().code, 200),equals(triggers().code, 201))` 
+`@or(equals(triggers().code, 200),equals(triggers().code, 201))`
 
 <a name="split-on-debatch"></a>
 
@@ -745,7 +745,7 @@ Debatching splits up the array items and starts a new logic app instance
 that runs for each array item. This approach is useful, for example, 
 when you want to poll an endpoint that might return multiple new items between polling intervals.
 For the maximum number of array items that **SplitOn** can process in a single logic app run, 
-see [Limits and configuration](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). 
+see [Limits and configuration](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits).
 
 > [!NOTE]
 > You can't use **SplitOn** with a synchronous response pattern. 
@@ -755,17 +755,17 @@ see [Limits and configuration](../logic-apps/logic-apps-limits-and-config.md#loo
 If your trigger's Swagger file describes a payload that is an array, 
 the **SplitOn** property is automatically added to your trigger. 
 Otherwise, add this property inside the response payload that has 
-the array you want to debatch. 
+the array you want to debatch.
 
 *Example*
 
-Suppose you have an API that returns this response: 
-  
+Suppose you have an API that returns this response:
+
 ```json
 {
    "Status": "Succeeded",
-   "Rows": [ 
-      { 
+   "Rows": [
+      {
          "id": 938109380,
          "name": "customer-name-one"
       },
@@ -776,7 +776,7 @@ Suppose you have an API that returns this response:
    ]
 }
 ```
- 
+
 Your logic app only needs the content from the array in `Rows`, 
 so you can create a trigger like this example:
 
@@ -798,7 +798,7 @@ so you can create a trigger like this example:
 > [!NOTE]
 > If you use the `SplitOn` command, you can't get the properties that are outside the array. 
 > So for this example, you can't get the `status` property in the response returned from the API.
-> 
+>
 > To avoid a failure if the `Rows` property doesn't exist, 
 > this example uses the `?` operator.
 
@@ -829,16 +829,16 @@ So, your trigger outputs look like these examples:
 ## Actions overview
 
 Azure Logic Apps provides various action types - each with 
-different inputs that define an action's unique behavior. 
+different inputs that define an action's unique behavior.
 
 Actions have these high-level elements, though some are optional:
 
 ```json
 "<action-name>": {
    "type": "<action-type>",
-   "inputs": { 
+   "inputs": {
       "<input-name>": { "<input-value>" },
-      "retryPolicy": "<retry-behavior>" 
+      "retryPolicy": "<retry-behavior>"
    },
    "runAfter": { "<previous-trigger-or-action-status>" },
    "runtimeConfiguration": { "<runtime-config-options>" },
@@ -848,29 +848,29 @@ Actions have these high-level elements, though some are optional:
 
 *Required*
 
-| Value | Type | Description | 
+| Value | Type | Description |
 |-------|------|-------------|
-| <*action-name*> | String | The name for the action | 
-| <*action-type*> | String | The action type, for example, "Http" or "ApiConnection"| 
-| <*input-name*> | String | The name for an input that defines the action's behavior | 
-| <*input-value*> | Various | The input value, which can be a string, integer, JSON object, and so on | 
-| <*previous-trigger-or-action-status*> | JSON Object | The name and resulting status for the trigger or action that must run immediately before this current action can run | 
-|||| 
+| <*action-name*> | String | The name for the action |
+| <*action-type*> | String | The action type, for example, "Http" or "ApiConnection"|
+| <*input-name*> | String | The name for an input that defines the action's behavior |
+| <*input-value*> | Various | The input value, which can be a string, integer, JSON object, and so on |
+| <*previous-trigger-or-action-status*> | JSON Object | The name and resulting status for the trigger or action that must run immediately before this current action can run |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
+| Value | Type | Description |
 |-------|------|-------------|
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](#retry-policies). | 
-| <*runtime-config-options*> | JSON Object | For some actions, you can change the action's behavior at run time by setting `runtimeConfiguration` properties. For more information, see [Runtime configuration settings](#runtime-config-options). | 
-| <*operation-option*> | String | For some actions, you can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). | 
-|||| 
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](#retry-policies). |
+| <*runtime-config-options*> | JSON Object | For some actions, you can change the action's behavior at run time by setting `runtimeConfiguration` properties. For more information, see [Runtime configuration settings](#runtime-config-options). |
+| <*operation-option*> | String | For some actions, you can change the default behavior by setting the `operationOptions` property. For more information, see [Operation options](#operation-options). |
+||||
 
 ## Action types list
 
-Here are some commonly used action types: 
+Here are some commonly used action types:
 
-* [Built-in action types](#built-in-actions) such as these examples and more: 
+* [Built-in action types](#built-in-actions) such as these examples and more:
 
   * [**HTTP**](#http-action) for calling endpoints over HTTP or HTTPS
 
@@ -900,31 +900,31 @@ and help you organize workflow execution
 
 ### Built-in actions
 
-| Action type | Description | 
-|-------------|-------------| 
-| [**Compose**](#compose-action) | Creates a single output from inputs, which can have various types. | 
-| [**Function**](#function-action) | Calls an Azure Function. | 
-| [**HTTP**](#http-action) | Calls an HTTP endpoint. | 
-| [**Join**](#join-action) | Creates a string from all the items in an array and separates those items with a specified delimiter character. | 
-| [**Parse JSON**](#parse-json-action) | Creates user-friendly tokens from properties in JSON content. You can then reference those properties by including the tokens in your logic app. | 
-| [**Query**](#query-action) | Creates an array from items in another array based on a condition or filter. | 
-| [**Response**](#response-action) | Creates a response to an incoming call or request. | 
-| [**Select**](#select-action) | Creates an array with JSON objects by transforming items from another array based on the specified map. | 
-| [**Table**](#table-action) | Creates a CSV or HTML table from an array. | 
-| [**Terminate**](#terminate-action) | Stops an actively running workflow. | 
-| [**Wait**](#wait-action) | Pauses your workflow for a specified duration or until the specified date and time. | 
-| [**Workflow**](#workflow-action) | Nests a workflow inside another workflow. | 
-||| 
+| Action type | Description |
+|-------------|-------------|
+| [**Compose**](#compose-action) | Creates a single output from inputs, which can have various types. |
+| [**Function**](#function-action) | Calls an Azure Function. |
+| [**HTTP**](#http-action) | Calls an HTTP endpoint. |
+| [**Join**](#join-action) | Creates a string from all the items in an array and separates those items with a specified delimiter character. |
+| [**Parse JSON**](#parse-json-action) | Creates user-friendly tokens from properties in JSON content. You can then reference those properties by including the tokens in your logic app. |
+| [**Query**](#query-action) | Creates an array from items in another array based on a condition or filter. |
+| [**Response**](#response-action) | Creates a response to an incoming call or request. |
+| [**Select**](#select-action) | Creates an array with JSON objects by transforming items from another array based on the specified map. |
+| [**Table**](#table-action) | Creates a CSV or HTML table from an array. |
+| [**Terminate**](#terminate-action) | Stops an actively running workflow. |
+| [**Wait**](#wait-action) | Pauses your workflow for a specified duration or until the specified date and time. |
+| [**Workflow**](#workflow-action) | Nests a workflow inside another workflow. |
+|||
 
 <a name="managed-api-actions"></a>
 
 ### Managed API actions
 
-| Action type | Description | 
-|-------------|-------------|  
-| [**ApiConnection**](#apiconnection-action) | Calls an HTTP endpoint by using a [Microsoft-managed API](../connectors/apis-list.md). | 
-| [**ApiConnectionWebhook**](#apiconnectionwebhook-action) | Works like HTTP Webhook but uses a [Microsoft-managed API](../connectors/apis-list.md). | 
-||| 
+| Action type | Description |
+|-------------|-------------| 
+| [**ApiConnection**](#apiconnection-action) | Calls an HTTP endpoint by using a [Microsoft-managed API](../connectors/apis-list.md). |
+| [**ApiConnectionWebhook**](#apiconnectionwebhook-action) | Works like HTTP Webhook but uses a [Microsoft-managed API](../connectors/apis-list.md). |
+|||
 
 <a name="control-workflow-actions"></a>
 
@@ -937,14 +937,14 @@ you can reference the `@body('Http')` expression from anywhere in the workflow.
 However, actions that exist inside a control workflow action can only "run after" 
 other actions that are in the same control workflow structure.
 
-| Action type | Description | 
-|-------------|-------------| 
-| [**ForEach**](#foreach-action) | Run the same actions in a loop for every item in an array. | 
-| [**If**](#if-action) | Run actions based on whether the specified condition is true or false. | 
-| [**Scope**](#scope-action) | Run actions based on the group status from a set of actions. | 
-| [**Switch**](#switch-action) | Run actions organized into cases when values from expressions, objects, or tokens match the values specified by each case. | 
-| [**Until**](#until-action) | Run actions in a loop until the specified condition is true. | 
-|||  
+| Action type | Description |
+|-------------|-------------|
+| [**ForEach**](#foreach-action) | Run the same actions in a loop for every item in an array. |
+| [**If**](#if-action) | Run actions based on whether the specified condition is true or false. |
+| [**Scope**](#scope-action) | Run actions based on the group status from a set of actions. |
+| [**Switch**](#switch-action) | Run actions organized into cases when values from expressions, objects, or tokens match the values specified by each case. |
+| [**Until**](#until-action) | Run actions in a loop until the specified condition is true. |
+|||
 
 ## Actions - Detailed reference
 
@@ -955,7 +955,7 @@ other actions that are in the same control workflow structure.
 This action sends an HTTP request to a 
 [Microsoft-managed API](../connectors/apis-list.md) 
 and requires information about the API and parameters 
-plus a reference to a valid connection. 
+plus a reference to a valid connection.
 
 ``` json
 "<action-name>": {
@@ -965,7 +965,7 @@ plus a reference to a valid connection.
          "connection": {
             "name": "@parameters('$connections')['<api-name>']['connectionId']"
          },
-         "<other-action-specific-input-properties>"        
+         "<other-action-specific-input-properties>"
       },
       "method": "<method-type>",
       "path": "/<api-operation>",
@@ -979,23 +979,23 @@ plus a reference to a valid connection.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*action-name*> | String | The name of the action provided by the connector | 
-| <*api-name*> | String | The name of the Microsoft-managed API that is used for the connection | 
-| <*method-type*> | String | The HTTP method for calling the API: "GET", "PUT", "POST", "PATCH", or "DELETE" | 
-| <*api-operation*> | String | The API operation to call | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*action-name*> | String | The name of the action provided by the connector |
+| <*api-name*> | String | The name of the Microsoft-managed API that is used for the connection |
+| <*method-type*> | String | The HTTP method for calling the API: "GET", "PUT", "POST", "PATCH", or "DELETE" |
+| <*api-operation*> | String | The API operation to call |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action | 
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
-| <*query-parameters*> | JSON Object | Any query parameters to include with the API call. <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. | 
-| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action |
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |
+| <*query-parameters*> | JSON Object | Any query parameters to include with the API call. <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. |
+| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action |
+||||
 
 *Example*
 
@@ -1065,26 +1065,26 @@ both the `"subscribe"` and `"unsubscribe"` objects.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*action-name*> | String | The name of the action provided by the connector | 
-| <*method-type*> | String | The HTTP method to use for subscribing or unsubscribing from an endpoint: "GET", "PUT", "POST", "PATCH", or "DELETE" | 
-| <*api-subscribe-URL*> | String | The URI to use for subscribing to the API | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*action-name*> | String | The name of the action provided by the connector |
+| <*method-type*> | String | The HTTP method to use for subscribing or unsubscribing from an endpoint: "GET", "PUT", "POST", "PATCH", or "DELETE" |
+| <*api-subscribe-URL*> | String | The URI to use for subscribing to the API |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*api-unsubscribe-URL*> | String | The URI to use for unsubscribing from the API | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*api-unsubscribe-URL*> | String | The URI to use for unsubscribing from the API |
 | <*header-content*> | JSON Object | Any headers to send in the request <p>For example, to set the language and type on a request: <p>`"headers": { "Accept-Language": "en-us", "Content-Type": "application/json" }` |
-| <*body-content*> | JSON Object | Any message content to send in the request | 
+| <*body-content*> | JSON Object | Any message content to send in the request |
 | <*authentication-method*> | JSON Object | The method the request uses for authentication. For more information, see [Scheduler Outbound Authentication](../scheduler/scheduler-outbound-authentication.md). |
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
-| <*query-parameters*> | JSON Object | Any query parameters to include with the API call <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. | 
-| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action | 
-| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action | 
-|||| 
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |
+| <*query-parameters*> | JSON Object | Any query parameters to include with the API call <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. |
+| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action |
+| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action |
+||||
 
 You can also specify limits on an **ApiConnectionWebhook** action 
 in the same way as [HTTP asynchronous limits](#asynchronous-limits).
@@ -1097,7 +1097,7 @@ This action creates a single output from multiple inputs,
 including expressions. Both the output and inputs can 
 have any type that Azure Logic Apps natively supports, 
 such as arrays, JSON objects, XML, and binary.
-You can then use the action's output in other actions. 
+You can then use the action's output in other actions.
 
 ```json
 "Compose": {
@@ -1107,12 +1107,12 @@ You can then use the action's output in other actions.
 },
 ```
 
-*Required* 
+*Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*inputs-to-compose*> | Any | The inputs for creating a single output | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*inputs-to-compose*> | Any | The inputs for creating a single output |
+||||
 
 *Example 1*
 
@@ -1165,7 +1165,7 @@ This action calls a previously created
       "method": "<method-type>",
       "headers": { "<header-content>" },
       "body": { "<body-content>" },
-      "queries": { "<query-parameters>" } 
+      "queries": { "<query-parameters>" }
    },
    "runAfter": {}
 }
@@ -1173,21 +1173,21 @@ This action calls a previously created
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------|  
-| <*Azure-function-ID*> | String | The resource ID for the Azure function you want to call. Here is the format for this value:<p>"/subscriptions/<*Azure-subscription-ID*>/resourceGroups/<*Azure-resource-group*>/providers/Microsoft.Web/sites/<*Azure-function-app-name*>/functions/<*Azure-function-name*>" | 
-| <*method-type*> | String | The HTTP method to use for calling the function: "GET", "PUT", "POST", "PATCH", or "DELETE" <p>If not specified, the default is the "POST" method. | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*Azure-function-ID*> | String | The resource ID for the Azure function you want to call. Here is the format for this value:<p>"/subscriptions/<*Azure-subscription-ID*>/resourceGroups/<*Azure-resource-group*>/providers/Microsoft.Web/sites/<*Azure-function-app-name*>/functions/<*Azure-function-name*>" |
+| <*method-type*> | String | The HTTP method to use for calling the function: "GET", "PUT", "POST", "PATCH", or "DELETE" <p>If not specified, the default is the "POST" method. |
 ||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------|  
+| Value | Type | Description |
+|-------|------|-------------|
 | <*header-content*> | JSON Object | Any headers to send with the call <p>For example, to set the language and type on a request: <p>`"headers": { "Accept-Language": "en-us", "Content-Type": "application/json" }` |
-| <*body-content*> | JSON Object | Any message content to send in the request | 
-| <*query-parameters*> | JSON Object | Any query parameters to include with the API call <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. | 
-| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action | 
-| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action | 
+| <*body-content*> | JSON Object | Any message content to send in the request |
+| <*query-parameters*> | JSON Object | Any query parameters to include with the API call <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. |
+| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action |
+| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action |
 ||||
 
 When you save your logic app, the Logic Apps engine 
@@ -1195,7 +1195,7 @@ performs these checks on the referenced function:
 
 * Your workflow must have access to the function.
 
-* Your workflow can use only a standard HTTP trigger or generic JSON webhook trigger. 
+* Your workflow can use only a standard HTTP trigger or generic JSON webhook trigger.
 
   The Logic Apps engine gets and caches the trigger's URL, 
   which is used at runtime. However, if any operation 
@@ -1205,7 +1205,7 @@ performs these checks on the referenced function:
 
 * The function can't have any route defined.
 
-* Only "function" and "anonymous" authorization levels are allowed. 
+* Only "function" and "anonymous" authorization levels are allowed.
 
 *Example*
 
@@ -1220,10 +1220,10 @@ created "GetProductID" function:
         "id": "/subscriptions/<XXXXXXXXXXXXXXXXXXXX>/resourceGroups/myLogicAppResourceGroup/providers/Microsoft.Web/sites/InventoryChecker/functions/GetProductID"
       },
       "method": "POST",
-      "headers": { 
+      "headers": {
           "x-ms-date": "@utcnow()"
        },
-      "body": { 
+      "body": {
           "Product_ID": "@variables('ProductID')"
       }
    },
@@ -1236,7 +1236,7 @@ created "GetProductID" function:
 ### HTTP action
 
 This action sends a request to the specified endpoint and 
-checks the response to determine whether the workflow should run. 
+checks the response to determine whether the workflow should run.
 
 ```json
 "HTTP": {
@@ -1251,23 +1251,23 @@ checks the response to determine whether the workflow should run.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*method-type*> | String | The method to use for sending the request: "GET", "PUT", "POST", "PATCH", or "DELETE" | 
-| <*HTTP-or-HTTPS-endpoint-URL*> | String | The HTTP or HTTPS endpoint to call. Maximum string size: 2 KB | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*method-type*> | String | The method to use for sending the request: "GET", "PUT", "POST", "PATCH", or "DELETE" |
+| <*HTTP-or-HTTPS-endpoint-URL*> | String | The HTTP or HTTPS endpoint to call. Maximum string size: 2 KB |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
+| Value | Type | Description |
+|-------|------|-------------|
 | <*header-content*> | JSON Object | Any headers to send with the request <p>For example, to set the language and type: <p>`"headers": { "Accept-Language": "en-us", "Content-Type": "application/json" }` |
-| <*body-content*> | JSON Object | Any message content to send in the request | 
-| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). | 
-| <*query-parameters*> | JSON Object | Any query parameters to include with the request <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. | 
-| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action | 
-| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action | 
-|||| 
+| <*body-content*> | JSON Object | Any message content to send in the request |
+| <*retry-behavior*> | JSON Object | Customizes the retry behavior for intermittent failures, which have the 408, 429, and 5XX status code, and any connectivity exceptions. For more information, see [Retry policies](../logic-apps/logic-apps-exception-handling.md#retry-policies). |
+| <*query-parameters*> | JSON Object | Any query parameters to include with the request <p>For example, the `"queries": { "api-version": "2018-01-01" }` object adds `?api-version=2018-01-01` to the call. |
+| <*other-action-specific-input-properties*> | JSON Object | Any other input properties that apply to this specific action |
+| <*other-action-specific-properties*> | JSON Object | Any other properties that apply to this specific action |
+||||
 
 *Example*
 
@@ -1289,7 +1289,7 @@ by sending a request to the specified endpoint:
 ### Join action
 
 This action creates a string from all the items in an array 
-and separates those items with the specified delimiter character. 
+and separates those items with the specified delimiter character.
 
 ```json
 "Join": {
@@ -1304,18 +1304,18 @@ and separates those items with the specified delimiter character.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*array*> | Array | The array or expression that provides the source items. If you specify an expression, enclose that expression with double quotes. | 
-| <*delimiter*> | Single character string | The character that separates each item in the string | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*array*> | Array | The array or expression that provides the source items. If you specify an expression, enclose that expression with double quotes. |
+| <*delimiter*> | Single character string | The character that separates each item in the string |
+||||
 
 *Example*
 
 Suppose you have a previously created "myIntegerArray" 
-variable that contains this integer array: 
+variable that contains this integer array:
 
-`[1,2,3,4]` 
+`[1,2,3,4]`
 
 This action definition gets the values from the variable by using the `variables()` 
 function in an expression and creates this string with those values, 
@@ -1340,7 +1340,7 @@ This action creates user-friendly fields or *tokens* from the properties in JSON
 You can then access those properties in your logic app by using the tokens instead. 
 For example, when you want to use JSON output from services such as Azure Service Bus 
 and Azure Cosmos DB, you can include this action in your logic app so that you can more 
-easily reference the data in that output. 
+easily reference the data in that output.
 
 ```json
 "Parse_JSON": {
@@ -1355,16 +1355,16 @@ easily reference the data in that output.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*JSON-source*> | JSON Object | The JSON content you want to parse | 
-| <*JSON-schema*> | JSON Object | The JSON schema that describes the underlying the JSON content, which the action uses for parsing the source JSON content. <p>**Tip**: In Logic Apps Designer, you can either provide the schema or provide a sample payload so that the action can generate the schema. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*JSON-source*> | JSON Object | The JSON content you want to parse |
+| <*JSON-schema*> | JSON Object | The JSON schema that describes the underlying the JSON content, which the action uses for parsing the source JSON content. <p>**Tip**: In Logic Apps Designer, you can either provide the schema or provide a sample payload so that the action can generate the schema. |
+||||
 
 *Example*
 
 This action definition creates these tokens that you can use in your logic app 
-workflow but only in actions that run following the **Parse JSON** action: 
+workflow but only in actions that run following the **Parse JSON** action:
 
 `FirstName`, `LastName`, and `Email`
 
@@ -1408,7 +1408,7 @@ You can also provide this JSON content as the sample payload for generating the 
 
 ```json
 "content": {
-   "Member": { 
+   "Member": {
       "FirstName": "Sophie",
       "LastName": "Owen",
       "Email": "Sophie.Owen@contoso.com"
@@ -1460,11 +1460,11 @@ based on a specified condition or filter.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
+| Value | Type | Description |
+|-------|------|-------------|
 | <*array*> | Array | The array or expression that provides the source items. If you specify an expression, enclose that expression with double quotes. |
 | <*condition-or-filter*> | String | The condition used for filtering items in the source array <p>**Note**: If no values satisfy the condition, then the action creates an empty array. |
-|||| 
+||||
 
 *Example*
 
@@ -1483,9 +1483,9 @@ values greater than the specified value, which is two:
 
 <a name="response-action"></a>
 
-### Response action  
+### Response action
 
-This action creates the payload for the response to an HTTP request. 
+This action creates the payload for the response to an HTTP request.
 
 ```json
 "Response" {
@@ -1502,18 +1502,18 @@ This action creates the payload for the response to an HTTP request.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*response-status-code*> | Integer | The HTTP status code that is sent to the incoming request. The default code is "200 OK", but the code can be any valid status code that starts with 2xx, 4xx, or 5xx, but not with 3xxx. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*response-status-code*> | Integer | The HTTP status code that is sent to the incoming request. The default code is "200 OK", but the code can be any valid status code that starts with 2xx, 4xx, or 5xx, but not with 3xxx. |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*response-headers*> | JSON Object | One or more headers to include with the response | 
-| <*response-body*> | Various | The response body, which can be a string, JSON object, or even binary content from a previous action | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*response-headers*> | JSON Object | One or more headers to include with the response |
+| <*response-body*> | Various | The response body, which can be a string, JSON object, or even binary content from a previous action |
+||||
 
 *Example*
 
@@ -1540,7 +1540,7 @@ specified status code, message body, and message headers:
 
 *Restrictions*
 
-Unlike other actions, the **Response** action has special restrictions: 
+Unlike other actions, the **Response** action has special restrictions:
 
 * Your workflow can use the **Response** action only when the 
 workflow starts with an HTTP request trigger, 
@@ -1548,7 +1548,7 @@ meaning your workflow must be triggered by an HTTP request.
 
 * Your workflow can use the **Response** action anywhere *except* 
 inside **Foreach** loops, **Until** loops, including sequential loops, 
-and parallel branches. 
+and parallel branches.
 
 * The original HTTP request gets your workflow's response only when all 
 actions required by the **Response** action are finished within the 
@@ -1583,30 +1583,30 @@ you can add or remove properties and their values across those objects.
 The `select` property specifies at least one key-value pair that 
 define the map for transforming items in the source array. 
 A key-value pair represents a property and its value across 
-all the objects in the output array. 
+all the objects in the output array.
 
 ```json
 "Select": {
    "type": "Select",
    "inputs": {
       "from": <array>,
-      "select": { 
+      "select": {
           "<key-name>": "<expression>",
-          "<key-name>": "<expression>"        
+          "<key-name>": "<expression>"
       }
    },
    "runAfter": {}
 },
 ```
 
-*Required* 
+*Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*array*> | Array | The array or expression that provides the source items. Make sure you enclose an expression with double quotes. <p>**Note**: If the source array is empty, the action creates an empty array. | 
-| <*key-name*> | String | The property name assigned to the result from <*expression*> <p>To add a new property across all objects in the output array, provide a <*key-name*> for that property and an <*expression*> for the property value. <p>To remove a property from all objects in the array, omit the <*key-name*> for that property. | 
-| <*expression*> | String | The expression that transforms the item in the source array and assigns the result to <*key-name*> | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*array*> | Array | The array or expression that provides the source items. Make sure you enclose an expression with double quotes. <p>**Note**: If the source array is empty, the action creates an empty array. |
+| <*key-name*> | String | The property name assigned to the result from <*expression*> <p>To add a new property across all objects in the output array, provide a <*key-name*> for that property and an <*expression*> for the property value. <p>To remove a property from all objects in the array, omit the <*key-name*> for that property. |
+| <*expression*> | String | The expression that transforms the item in the source array and assigns the result to <*key-name*> |
+||||
 
 The **Select** action creates an array as output, 
 so any action that wants to use this output must either accept an array, 
@@ -1621,15 +1621,15 @@ action in your other actions.
 This action definition creates a JSON object array from an integer array. 
 The action iterates through the source array, 
 gets each integer value by using the `@item()` expression, 
-and assigns each value to the "`number`" property in each JSON object: 
+and assigns each value to the "`number`" property in each JSON object:
 
 ```json
 "Select": {
    "type": "Select",
    "inputs": {
       "from": [ 1, 2, 3 ],
-      "select": { 
-         "number": "@item()" 
+      "select": {
+         "number": "@item()"
       }
    },
    "runAfter": {}
@@ -1692,7 +1692,7 @@ column headers and values. For example, this array
 includes the "ID" and "Product_Name" properties that 
 this action can use for the column header names:
 
-`[ {"ID": 0, "Product_Name": "Apples"}, {"ID": 1, "Product_Name": "Oranges"} ]` 
+`[ {"ID": 0, "Product_Name": "Apples"}, {"ID": 1, "Product_Name": "Oranges"} ]`
 
 ```json
 "Create_<CSV | HTML>_table": {
@@ -1700,7 +1700,7 @@ this action can use for the column header names:
    "inputs": {
       "format": "<CSV | HTML>",
       "from": <array>,
-      "columns": [ 
+      "columns": [
          {
             "header": "<column-name>",
             "value": "<column-value>"
@@ -1708,20 +1708,20 @@ this action can use for the column header names:
          {
             "header": "<column-name>",
             "value": "<column-value>"
-         } 
+         }
       ]
    },
    "runAfter": {}
 }
 ```
 
-*Required* 
+*Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <CSV *or* HTML>| String | The format for the table you want to create | 
-| <*array*> | Array | The array or expression that provides the source items for the table <p>**Note**: If the source array is empty, the action creates an empty table. | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <CSV *or* HTML>| String | The format for the table you want to create |
+| <*array*> | Array | The array or expression that provides the source items for the table <p>**Note**: If the source array is empty, the action creates an empty table. |
+||||
 
 *Optional*
 
@@ -1730,22 +1730,22 @@ When `header-value` pairs have the same header name,
 their values appear in the same column under that header name. 
 Otherwise, each unique header defines a unique column.
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*column-name*> | String | The header name for a column | 
-| <*column-value*> | Any | The value in that column | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*column-name*> | String | The header name for a column |
+| <*column-value*> | Any | The value in that column |
+||||
 
 *Example 1*
 
 Suppose you have a previously created "myItemArray" 
-variable that currently contains this array: 
+variable that currently contains this array:
 
 `[ {"ID": 0, "Product_Name": "Apples"}, {"ID": 1, "Product_Name": "Oranges"} ]`
 
 This action definition creates a CSV table from the "myItemArray" variable. 
 The expression used by the `from` property gets the array from 
-"myItemArray" by using the `variables()` function: 
+"myItemArray" by using the `variables()` function:
 
 ```json
 "Create_CSV_table": {
@@ -1758,19 +1758,19 @@ The expression used by the `from` property gets the array from
 }
 ```
 
-Here is the CSV table that this action creates: 
+Here is the CSV table that this action creates:
 
 ```
-ID,Product_Name 
-0,Apples 
-1,Oranges 
+ID,Product_Name
+0,Apples
+1,Oranges
 ```
 
 *Example 2*
 
 This action definition creates an HTML table from the "myItemArray" variable. 
 The expression used by the `from` property gets the array from 
-"myItemArray" by using the `variables()` function: 
+"myItemArray" by using the `variables()` function:
 
 ```json
 "Create_HTML_table": {
@@ -1783,7 +1783,7 @@ The expression used by the `from` property gets the array from
 }
 ```
 
-Here is the HTML table that this action creates: 
+Here is the HTML table that this action creates:
 
 <table><thead><tr><th>ID</th><th>Product_Name</th></tr></thead><tbody><tr><td>0</td><td>Apples</td></tr><tr><td>1</td><td>Oranges</td></tr></tbody></table>
 
@@ -1799,7 +1799,7 @@ and "Description", and adds the word "Organic" to the values in the "Description
    "inputs": {
       "format": "HTML",
       "from": "@variables('myItemArray')",
-      "columns": [ 
+      "columns": [
          {
             "header": "Stock_ID",
             "value": "@item().ID"
@@ -1814,7 +1814,7 @@ and "Description", and adds the word "Organic" to the values in the "Description
 },
 ```
 
-Here is the HTML table that this action creates: 
+Here is the HTML table that this action creates:
 
 <table><thead><tr><th>Stock_ID</th><th>Description</th></tr></thead><tbody><tr><td>0</td><td>Organic Apples</td></tr><tr><td>1</td><td>Organic Oranges</td></tr></tbody></table>
 
@@ -1828,7 +1828,7 @@ and returns the specified status. For example, you can use the
 **Terminate** action when your logic app must exit completely 
 from an error state. This action doesn't affect already completed 
 actions and can't appear inside **Foreach** and **Until** loops, 
-including sequential loops. 
+including sequential loops.
 
 ```json
 "Terminate": {
@@ -1846,21 +1846,21 @@ including sequential loops.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
+| Value | Type | Description |
+|-------|------|-------------|
 | <*status*> | String | The status to return for the run: "Failed", "Cancelled", or "Succeeded" |
-|||| 
+||||
 
 *Optional*
 
 The properties for the "runStatus" object apply only 
 when the "runStatus" property is set to "Failed" status.
 
-| Value | Type | Description | 
-|-------|------|-------------| 
+| Value | Type | Description |
+|-------|------|-------------|
 | <*error-code-or-name*> | String | The code or name for the error |
-| <*error-message*> | String | The message or text that describes the error and any actions the app user can take | 
-|||| 
+| <*error-message*> | String | The message or text that describes the error and any actions the app user can take |
+||||
 
 *Example*
 
@@ -1883,11 +1883,11 @@ and returns the status, an error code, and an error message:
 
 <a name="wait-action"></a>
 
-### Wait action  
+### Wait action
 
 This action pauses workflow execution for the 
 specified interval or until the specified time, 
-but not both. 
+but not both.
 
 *Specified interval*
 
@@ -1920,12 +1920,12 @@ but not both.
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*number-of-units*> | Integer | For the **Delay** action, the number of units to wait | 
-| <*interval*> | String | For the **Delay** action, the interval to wait: "Second", "Minute", "Hour", "Day", "Week", "Month" | 
-| <*date-time-stamp*> | String | For the **Delay Until** action, the date and time to resume execution. This value must use the [UTC date time format](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*number-of-units*> | Integer | For the **Delay** action, the number of units to wait |
+| <*interval*> | String | For the **Delay** action, the interval to wait: "Second", "Minute", "Hour", "Day", "Week", "Month" |
+| <*date-time-stamp*> | String | For the **Delay Until** action, the date and time to resume execution. This value must use the [UTC date time format](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). |
+||||
 
 *Example 1*
 
@@ -1981,7 +1981,7 @@ such as a [Request](#request-trigger) or [HTTP](#http-trigger) trigger
 
 * To use the outputs from the nested logic app in your 
 parent logic app, the nested logic app must have a 
-[Response](#response-action) action 
+[Response](#response-action) action
 
 ```json
 "<nested-logic-app-name>": {
@@ -2002,10 +2002,10 @@ parent logic app, the nested logic app must have a
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*nested-logic-app-name*> | String | The name for the logic app you want to call | 
-| <*trigger-name*> | String | The name for the trigger in the nested logic app you want to call | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*nested-logic-app-name*> | String | The name for the logic app you want to call |
+| <*trigger-name*> | String | The name for the trigger in the nested logic app you want to call |
 | <*Azure-subscription-ID*> | String | The Azure subscription ID for the nested logic app |
 | <*Azure-resource-group*> | String | The Azure resource group name for the nested logic app |
 | <*nested-logic-app-name*> | String | The name for the logic app you want to call |
@@ -2013,10 +2013,10 @@ parent logic app, the nested logic app must have a
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------|  
-| <*header-content*> | JSON Object | Any headers to send with the call | 
-| <*body-content*> | JSON Object | Any message content to send with the call | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*header-content*> | JSON Object | Any headers to send with the call |
+| <*body-content*> | JSON Object | Any message content to send with the call |
 ||||
 
 *Outputs*
@@ -2028,7 +2028,7 @@ If the nested logic app doesn't include a Response action, the outputs are empty
 
 After the "Start_search" action finishes successfully, 
 this workflow action definition calls another logic app 
-named "Get_product_information", which passes in the specified inputs: 
+named "Get_product_information", which passes in the specified inputs:
 
 ```json
 "actions": {
@@ -2047,7 +2047,7 @@ named "Get_product_information", which passes in the specified inputs:
             "content-type": "application/json"
          }
       },
-      "runAfter": { 
+      "runAfter": {
          "Start_search": [ "Succeeded" ]
       }
    }
@@ -2070,7 +2070,7 @@ Learn [how to create "for each" loops](../logic-apps/logic-apps-control-flow-loo
 ```json
 "For_each": {
    "type": "Foreach",
-   "actions": { 
+   "actions": {
       "<action-1>": { "<action-definition-1>" },
       "<action-2>": { "<action-definition-2>" }
    },
@@ -2085,22 +2085,22 @@ Learn [how to create "for each" loops](../logic-apps/logic-apps-control-flow-loo
 }
 ```
 
-*Required* 
+*Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*action-1...n*> | String | The names of the actions that run on each array item | 
-| <*action-definition-1...n*> | JSON Object | The definitions of the actions that run | 
-| <*for-each-expression*> | String | The expression that references each item in the specified array | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*action-1...n*> | String | The names of the actions that run on each array item |
+| <*action-definition-1...n*> | JSON Object | The definitions of the actions that run |
+| <*for-each-expression*> | String | The expression that references each item in the specified array |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*count*> | Integer | By default, the "for each" loop iterations run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change "for each" loop concurrency](#change-for-each-concurrency). | 
-| <*operation-option*> | String | To run a "for each" loop sequentially, rather than in parallel, set either <*operation-option*> to `Sequential` or <*count*> to `1`, but not both. For more information, see [Run "for each" loops sequentially](#sequential-for-each). | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*count*> | Integer | By default, the "for each" loop iterations run at the same time, or in parallel up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). To change this limit by setting a new <*count*> value, see [Change "for each" loop concurrency](#change-for-each-concurrency). |
+| <*operation-option*> | String | To run a "for each" loop sequentially, rather than in parallel, set either <*operation-option*> to `Sequential` or <*count*> to `1`, but not both. For more information, see [Run "for each" loops sequentially](#sequential-for-each). |
+||||
 
 *Example*
 
@@ -2141,7 +2141,7 @@ To specify only an array that is passed as output from the trigger,
 this expression gets the <*array-name*> array from the trigger body. 
 To avoid a failure if the array doesn't exist, the expression uses the `?` operator:
 
-`@triggerBody()?['<array-name>']` 
+`@triggerBody()?['<array-name>']`
 
 <a name="if-action"></a>
 
@@ -2169,13 +2169,13 @@ Learn [how to create conditional statements](../logic-apps/logic-apps-control-fl
 }
 ```
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*condition*> | JSON Object | The condition, which can be an expression, to evaluate | 
-| <*action-1*> | JSON Object | The action to run when <*condition*> evaluates to true | 
-| <*action-definition*> | JSON Object | The definition for the action | 
-| <*action-2*> | JSON Object | The action to run when <*condition*> evaluates to false | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*condition*> | JSON Object | The condition, which can be an expression, to evaluate |
+| <*action-1*> | JSON Object | The action to run when <*condition*> evaluates to true |
+| <*action-definition*> | JSON Object | The definition for the action |
+| <*action-2*> | JSON Object | The action to run when <*condition*> evaluates to false |
+||||
 
 The actions in the `actions` or `else` objects get these statuses:
 
@@ -2193,10 +2193,10 @@ the workflow checks a website. If the variable is zero or less, the workflow che
    "type": "If",
    "expression": {
       "and": [ {
-         "greater": [ "@variables('myIntegerVariable')", 0 ] 
+         "greater": [ "@variables('myIntegerVariable')", 0 ]
       } ]
    },
-   "actions": { 
+   "actions": {
       "HTTP - Check this website": {
          "type": "Http",
          "inputs": {
@@ -2220,19 +2220,19 @@ the workflow checks a website. If the variable is zero or less, the workflow che
    },
    "runAfter": {}
 }
-```  
+```
 
 #### How conditions use expressions
 
 Here are some examples that show how you can use expressions in conditions:
-  
-| JSON | Result | 
-|------|--------| 
-| "expression": "@parameters('<*hasSpecialAction*>')" | For Boolean expressions only, the condition passes for any value that evaluates to true. <p>To convert other types to Boolean, use these functions: `empty()` or `equals()`. | 
-| "expression": "@greater(actions('<*action*>').output.value, parameters('<*threshold*>'))" | For comparison functions, the action runs only when the output from <*action*> is more than the <*threshold*> value. | 
-| "expression": "@or(greater(actions('<*action*>').output.value, parameters('<*threshold*>')), less(actions('<*same-action*>').output.value, 100))" | For logic functions and creating nested Boolean expressions, the action runs when the output from <*action*> is more than the <*threshold*> value or under 100. | 
-| "expression": "@equals(length(actions('<*action*>').outputs.errors), 0))" | You can use array functions for checking whether the array has any items. The action runs when the `errors` array is empty. | 
-||| 
+
+| JSON | Result |
+|------|--------|
+| "expression": "@parameters('<*hasSpecialAction*>')" | For Boolean expressions only, the condition passes for any value that evaluates to true. <p>To convert other types to Boolean, use these functions: `empty()` or `equals()`. |
+| "expression": "@greater(actions('<*action*>').output.value, parameters('<*threshold*>'))" | For comparison functions, the action runs only when the output from <*action*> is more than the <*threshold*> value. |
+| "expression": "@or(greater(actions('<*action*>').output.value, parameters('<*threshold*>')), less(actions('<*same-action*>').output.value, 100))" | For logic functions and creating nested Boolean expressions, the action runs when the output from <*action*> is more than the <*threshold*> value or under 100. |
+| "expression": "@equals(length(actions('<*action*>').outputs.errors), 0))" | You can use array functions for checking whether the array has any items. The action runs when the `errors` array is empty. |
+|||
 
 <a name="scope-action"></a>
 
@@ -2262,11 +2262,11 @@ status to determine whether other actions run. Learn [how to create scopes](../l
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------|  
+| Value | Type | Description |
+|-------|------|-------------|
 | <*inner-action-1...n*> | JSON Object | One or more actions that run inside the scope |
 | <*action-inputs*> | JSON Object | The inputs for each action |
-|||| 
+||||
 
 <a name="switch-action"></a>
 
@@ -2315,21 +2315,21 @@ runs the default actions. Learn
 
 *Required*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*expression-object-or-token*> | Varies | The expression, JSON object, or token to evaluate | 
-| <*action-name*> | String | The name of the action to run for the matching case | 
-| <*action-definition*> | JSON Object | The definition for the action to run for the matching case | 
-| <*matching-value*> | Varies | The value to compare with the evaluated result | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*expression-object-or-token*> | Varies | The expression, JSON object, or token to evaluate |
+| <*action-name*> | String | The name of the action to run for the matching case |
+| <*action-definition*> | JSON Object | The definition for the action to run for the matching case |
+| <*matching-value*> | Varies | The value to compare with the evaluated result |
+||||
 
 *Optional*
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*default-action-name*> | String | The name of the default action to run when no matching case exists | 
-| <*default-action-definition*> | JSON Object | The definition for the action to run when no matching case exists | 
-|||| 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*default-action-name*> | String | The name of the default action to run when no matching case exists |
+| <*default-action-definition*> | JSON Object | The definition for the action to run when no matching case exists |
+||||
 
 *Example*
 
@@ -2338,7 +2338,7 @@ to the approval request email selected the "Approve" option
 or the "Reject" option. Based on this choice, the **Switch** 
 action runs the actions for the matching case, which is 
 to send another email to the responder but with different 
-wording in each case. 
+wording in each case.
 
 ``` json
 "Switch": {
@@ -2347,11 +2347,11 @@ wording in each case.
    "cases": {
       "Case": {
          "actions": {
-            "Send_an_email": { 
+            "Send_an_email": {
                "type": "ApiConnection",
                "inputs": {
                   "Body": "Thank you for your approval.",
-                  "Subject": "Response received", 
+                  "Subject": "Response received",
                   "To": "Sophie.Owen@contoso.com"
                },
                "host": {
@@ -2368,11 +2368,11 @@ wording in each case.
       },
       "Case_2": {
          "actions": {
-            "Send_an_email_2": { 
+            "Send_an_email_2": {
                "type": "ApiConnection",
                "inputs": {
                   "Body": "Thank you for your response.",
-                  "Subject": "Response received", 
+                  "Subject": "Response received",
                   "To": "Sophie.Owen@contoso.com"
                },
                "host": {
@@ -2383,18 +2383,18 @@ wording in each case.
                "method": "post",
                "path": "/Mail"
             },
-            "runAfter": {}     
+            "runAfter": {}
          },
          "case": "Reject"
       }
    },
    "default": {
-      "actions": { 
-         "Send_an_email_3": { 
+      "actions": {
+         "Send_an_email_3": {
             "type": "ApiConnection",
             "inputs": {
                "Body": "Please respond with either 'Approve' or 'Reject'.",
-               "Subject": "Please respond", 
+               "Subject": "Please respond",
                "To": "Sophie.Owen@contoso.com"
             },
             "host": {
@@ -2405,11 +2405,11 @@ wording in each case.
             "method": "post",
             "path": "/Mail"
          },
-         "runAfter": {} 
+         "runAfter": {}
       }
    },
    "runAfter": {
-      "Send_approval_email": [ 
+      "Send_approval_email": [
          "Succeeded"
       ]
    }
@@ -2424,7 +2424,7 @@ This loop action contains actions that run until the specified condition is true
 The loop checks the condition as the last step after all other actions have run. 
 You can include more than one action in the `"actions"` object, 
 and the action must define at least one limit. Learn 
-[how to create "until" loops](../logic-apps/logic-apps-control-flow-loops.md#until-loop). 
+[how to create "until" loops](../logic-apps/logic-apps-control-flow-loops.md#until-loop).
 
 ```json
  "Until": {
@@ -2450,20 +2450,20 @@ and the action must define at least one limit. Learn
 }
 ```
 
-| Value | Type | Description | 
-|-------|------|-------------| 
-| <*action-name*> | String | The name for the action you want to run inside the loop | 
-| <*action-type*> | String | The action type you want to run | 
-| <*action-inputs*> | Various | The inputs for the action to run | 
-| <*condition*> | String | The condition or expression to evaluate after all the actions in the loop finish running | 
-| <*loop-count*> | Integer | The limit on the most number of loops that the action can run. The default `count` value is 60. | 
+| Value | Type | Description |
+|-------|------|-------------|
+| <*action-name*> | String | The name for the action you want to run inside the loop |
+| <*action-type*> | String | The action type you want to run |
+| <*action-inputs*> | Various | The inputs for the action to run |
+| <*condition*> | String | The condition or expression to evaluate after all the actions in the loop finish running |
+| <*loop-count*> | Integer | The limit on the most number of loops that the action can run. The default `count` value is 60. |
 | <*loop-timeout*> | String | The limit on the longest time that the loop can run. The default `timeout` value is `PT1H`, which is the required [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601). |
-|||| 
+||||
 
 *Example*
 
 This loop action definition sends an HTTP request to 
-the specified URL until one of these conditions is met: 
+the specified URL until one of these conditions is met:
 
 * The request gets a response with the "200 OK" status code.
 * The loop has run 60 times.
@@ -2503,14 +2503,14 @@ providing a *callback URL* where the endpoint can send responses.
 The `subscribe` call happens when the workflow changes in any way, 
 for example, when credentials are renewed, or when the input 
 parameters change for  a trigger or action. This call uses 
-the same parameters as standard HTTP actions. 
+the same parameters as standard HTTP actions.
 
 The `unsubscribe` call automatically happens when an operation 
 makes the trigger or action invalid, for example:
 
-* Deleting or disabling the trigger. 
-* Deleting or disabling the workflow. 
-* Deleting or disabling the subscription. 
+* Deleting or disabling the trigger.
+* Deleting or disabling the workflow.
+* Deleting or disabling the subscription.
 
 To support these calls, the `@listCallbackUrl()` expression returns a 
 unique "callback URL" for the trigger or action. This URL represents 
@@ -2525,7 +2525,7 @@ For both triggers and actions, you can limit the duration for the asynchronous
 pattern to a specific time interval by adding the `limit.timeout` property. 
 That way, if the action hasn't finished when the interval lapses, 
 the action's status is marked as `Cancelled` with the `ActionTimedOut` code. 
-The `timeout` property uses [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations). 
+The `timeout` property uses [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations).
 
 ``` json
 "<trigger-or-action-name>": {
@@ -2546,12 +2546,12 @@ You can change the default runtime behavior for
 triggers and actions with these `runtimeConfiguration` 
 properties in the trigger or action definition.
 
-| Property | Type | Description | Trigger or action | 
-|----------|------|-------------|-------------------| 
-| `runtimeConfiguration.concurrency.runs` | Integer | Change the [*default limit*](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits) on the number of logic app instances that can run at the same time, or in parallel. This value can help limit the number of requests that backend systems receive. <p>Setting the `runs` property to `1` works the same way as setting the `operationOptions` property to `SingleInstance`. You can set either property, but not both. <p>To change the default limit, see [Change trigger concurrency](#change-trigger-concurrency) or [Trigger instances sequentially](#sequential-trigger). | All triggers | 
-| `runtimeConfiguration.concurrency.maximumWaitingRuns` | Integer | Change the [*default limit*](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits) on the number of logic app instances that can wait to run when your logic app is already running the maximum concurrent instances. You can change the concurrency limit in the `concurrency.runs` property. <p>To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | All triggers | 
-| `runtimeConfiguration.concurrency.repetitions` | Integer | Change the [*default limit*](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits) on the number of "for each" loop iterations that can run at the same time, or in parallel. <p>Setting the `repetitions` property to `1` works the same way as setting the `operationOptions` property to `SingleInstance`. You can set either property, but not both. <p>To change the default limit, see [Change "for each" concurrency](#change-for-each-concurrency) or [Run "for each" loops sequentially](#sequential-for-each). | Action: <p>[Foreach](#foreach-action) | 
-||||| 
+| Property | Type | Description | Trigger or action |
+|----------|------|-------------|-------------------|
+| `runtimeConfiguration.concurrency.runs` | Integer | Change the [*default limit*](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits) on the number of logic app instances that can run at the same time, or in parallel. This value can help limit the number of requests that backend systems receive. <p>Setting the `runs` property to `1` works the same way as setting the `operationOptions` property to `SingleInstance`. You can set either property, but not both. <p>To change the default limit, see [Change trigger concurrency](#change-trigger-concurrency) or [Trigger instances sequentially](#sequential-trigger). | All triggers |
+| `runtimeConfiguration.concurrency.maximumWaitingRuns` | Integer | Change the [*default limit*](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits) on the number of logic app instances that can wait to run when your logic app is already running the maximum concurrent instances. You can change the concurrency limit in the `concurrency.runs` property. <p>To change the default limit, see [Change waiting runs limit](#change-waiting-runs). | All triggers |
+| `runtimeConfiguration.concurrency.repetitions` | Integer | Change the [*default limit*](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits) on the number of "for each" loop iterations that can run at the same time, or in parallel. <p>Setting the `repetitions` property to `1` works the same way as setting the `operationOptions` property to `SingleInstance`. You can set either property, but not both. <p>To change the default limit, see [Change "for each" concurrency](#change-for-each-concurrency) or [Run "for each" loops sequentially](#sequential-for-each). | Action: <p>[Foreach](#foreach-action) |
+|||||
 
 <a name="operation-options"></a>
 
@@ -2561,12 +2561,12 @@ You can change the default behavior for triggers
 and actions with the `operationOptions` property 
 in trigger or action definition.
 
-| Operation option | Type | Description | Trigger or action | 
-|------------------|------|-------------|-------------------| 
-| `DisableAsyncPattern` | String | Run HTTP-based actions synchronously, rather than asynchronously. <p><p>To set this option, see [Run actions synchronously](#asynchronous-patterns). | Actions: <p>[ApiConnection](#apiconnection-action), <br>[HTTP](#http-action), <br>[Response](#response-action) | 
-| `OptimizedForHighThroughput` | String | Change the [default limit](../logic-apps/logic-apps-limits-and-config.md#throughput-limits) on the number of action executions per 5 minutes to the [maximum limit](../logic-apps/logic-apps-limits-and-config.md#throughput-limits). <p><p>To set this option, see [Run in high throughput mode](#run-high-throughput-mode). | All actions | 
-| `Sequential` | String | Run "for each" loop iterations one at a time, rather than all at the same time in parallel. <p>This option works the same way as setting the `runtimeConfiguration.concurrency.repetitions` property to `1`. You can set either property, but not both. <p><p>To set this option, see [Run "for each" loops sequentially](#sequential-for-each).| Action: <p>[Foreach](#foreach-action) | 
-| `SingleInstance` | String | Run the trigger for each logic app instance sequentially and wait for the previously active run to finish before triggering the next logic app instance. <p><p>This option works the same way as setting the `runtimeConfiguration.concurrency.runs` property to `1`. You can set either property, but not both. <p>To set this option, see [Trigger instances sequentially](#sequential-trigger). | All triggers | 
+| Operation option | Type | Description | Trigger or action |
+|------------------|------|-------------|-------------------|
+| `DisableAsyncPattern` | String | Run HTTP-based actions synchronously, rather than asynchronously. <p><p>To set this option, see [Run actions synchronously](#asynchronous-patterns). | Actions: <p>[ApiConnection](#apiconnection-action), <br>[HTTP](#http-action), <br>[Response](#response-action) |
+| `OptimizedForHighThroughput` | String | Change the [default limit](../logic-apps/logic-apps-limits-and-config.md#throughput-limits) on the number of action executions per 5 minutes to the [maximum limit](../logic-apps/logic-apps-limits-and-config.md#throughput-limits). <p><p>To set this option, see [Run in high throughput mode](#run-high-throughput-mode). | All actions |
+| `Sequential` | String | Run "for each" loop iterations one at a time, rather than all at the same time in parallel. <p>This option works the same way as setting the `runtimeConfiguration.concurrency.repetitions` property to `1`. You can set either property, but not both. <p><p>To set this option, see [Run "for each" loops sequentially](#sequential-for-each).| Action: <p>[Foreach](#foreach-action) |
+| `SingleInstance` | String | Run the trigger for each logic app instance sequentially and wait for the previously active run to finish before triggering the next logic app instance. <p><p>This option works the same way as setting the `runtimeConfiguration.concurrency.runs` property to `1`. You can set either property, but not both. <p>To set this option, see [Trigger instances sequentially](#sequential-trigger). | All triggers |
 ||||
 
 <a name="change-trigger-concurrency"></a>
@@ -2576,12 +2576,12 @@ in trigger or action definition.
 By default, logic app instances run at the same time, concurrently, or in parallel up to the 
 [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits). 
 So, each trigger instance fires before the preceding logic app instance finishes running. 
-This limit helps control the number of requests that backend systems receive. 
+This limit helps control the number of requests that backend systems receive.
 
 To change the default limit, you can use either the code view editor or Logic Apps Designer 
 because changing the concurrency setting through the designer adds or updates the 
 `runtimeConfiguration.concurrency.runs` property in the underlying trigger definition 
-and vice versa. This property controls the maximum number of logic app instances that can run in parallel. 
+and vice versa. This property controls the maximum number of logic app instances that can run in parallel.
 
 > [!NOTE] 
 > If you set the trigger to run sequentially 
@@ -2591,7 +2591,7 @@ and vice versa. This property controls the maximum number of logic app instances
 > Otherwise, you get a validation error. 
 > For more information, see [Trigger instances sequentially](#sequential-trigger).
 
-#### Edit in code view 
+#### Edit in code view
 
 In the underlying trigger definition, add or update the 
 `runtimeConfiguration.concurrency.runs` property to a 
@@ -2619,7 +2619,7 @@ Here is an example that limits concurrent runs to 10 instances:
 1. In the trigger's upper-right corner, 
 choose the ellipses (...) button, and then choose **Settings**.
 
-2. Under **Concurrency Control**, set **Limit** to **On**. 
+2. Under **Concurrency Control**, set **Limit** to **On**.
 
 3. Drag the **Degree of Parallelism** slider to the value you want. 
 To run your logic app sequentially, drag the slider value to **1**.
@@ -2643,11 +2643,11 @@ action definition and vice versa. This property controls the maximum number of i
 > Otherwise, you get a validation error. 
 > For more information, see [Run "for each" loops sequentially](#sequential-for-each).
 
-#### Edit in code view 
+#### Edit in code view
 
 In the underlying "for each" definition, add or update the 
 `runtimeConfiguration.concurrency.repetitions` property to a 
-value between `1` and `50` inclusively. 
+value between `1` and `50` inclusively.
 
 Here is an example that limits concurrent runs to 10 iterations:
 
@@ -2670,7 +2670,7 @@ Here is an example that limits concurrent runs to 10 iterations:
 1. In the **For each** action, from the upper-right corner, 
 choose the ellipses (...) button, and then choose **Settings**.
 
-2. Under **Concurrency Control**, set **Concurrency Control** to **On**. 
+2. Under **Concurrency Control**, set **Concurrency Control** to **On**.
 
 3. Drag the **Degree of Parallelism** slider to the value you want. 
 To run your logic app sequentially, drag the slider value to **1**.
@@ -2684,7 +2684,7 @@ up to the [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-
 Each trigger instance fires before the previously active logic app instance finishes running. 
 Although you can [change this default limit](#change-trigger-concurrency), 
 when the number of logic app instances reaches the new concurrency limit, 
-any other new instances must wait to run. 
+any other new instances must wait to run.
 
 The number of runs that can wait also has a 
 [default limit](../logic-apps/logic-apps-limits-and-config.md#looping-debatching-limits), 
@@ -2719,18 +2719,18 @@ To run each logic app instance only after the previous instance finishes running
 set the trigger to run sequentially. You can use either the code view editor 
 or Logic Apps Designer because changing the concurrency setting through designer 
 also adds or updates the `runtimeConfiguration.concurrency.runs` 
-property in the underlying trigger definition and vice versa. 
+property in the underlying trigger definition and vice versa.
 
 > [!NOTE] 
 > When you set a trigger to run sequentially 
 > either by using the designer or the code view editor, 
 > don't set the trigger's `operationOptions` property 
 > to `Sequential` in the code view editor. 
-> Otherwise, you get a validation error. 
+> Otherwise, you get a validation error.
 
 #### Edit in code view
 
-In the trigger definition, set either of these properties, but not both. 
+In the trigger definition, set either of these properties, but not both.
 
 Set the `runtimeConfiguration.concurrency.runs` property to `1`:
 
@@ -2769,9 +2769,9 @@ Set the `operationOptions` property to `SingleInstance`:
 1. In the trigger's upper-right corner, 
 choose the ellipses (...) button, and then choose **Settings**.
 
-2. Under **Concurrency Control**, set **Limit** to **On**. 
+2. Under **Concurrency Control**, set **Limit** to **On**.
 
-3. Drag the **Degree of Parallelism** slider to the number `1`. 
+3. Drag the **Degree of Parallelism** slider to the number `1`.
 
 <a name="sequential-for-each"></a>
 
@@ -2781,7 +2781,7 @@ To run a "for each" loop iteration only after the previous iteration finishes ru
 set the "for each" action to run sequentially. You can use either the code view editor 
 or Logic Apps Designer because changing the action's concurrency through designer 
 also adds or updates the `runtimeConfiguration.concurrency.repetitions` 
-property in the underlying action definition and vice versa. 
+property in the underlying action definition and vice versa.
 
 > [!NOTE] 
 > When you set a "for each" action to run sequentially 
@@ -2792,7 +2792,7 @@ property in the underlying action definition and vice versa.
 
 #### Edit in code view
 
-In the action definition, set either of these properties, but not both. 
+In the action definition, set either of these properties, but not both.
 
 Set the `runtimeConfiguration.concurrency.repetitions` property to `1`:
 
@@ -2829,9 +2829,9 @@ Set the `operationOptions` property to `Sequential`:
 1. In the **For each** action's upper-right corner, 
 choose the ellipses (...) button, and then choose **Settings**.
 
-2. Under **Concurrency Control**, set **Concurrency Control** to **On**. 
+2. Under **Concurrency Control**, set **Concurrency Control** to **On**.
 
-3. Drag the **Degree of Parallelism** slider to the number `1`. 
+3. Drag the **Degree of Parallelism** slider to the number `1`.
 
 <a name="asynchronous-patterns"></a>
 
@@ -2850,7 +2850,7 @@ However, requests have a timeout limit, so for long-running actions,
 you can disable the asynchronous behavior by adding and setting 
 the `operationOptions` property to `DisableAsyncPattern` under 
 the action's inputs.
-  
+
 ```json
 "<some-long-running-action>": {
    "type": "Http",
@@ -2868,7 +2868,7 @@ For a single logic app run, the number of actions that execute every 5 minutes h
 [default limit](../logic-apps/logic-apps-limits-and-config.md#throughput-limits). 
 To raise this limit to the [maximum](../logic-apps/logic-apps-limits-and-config.md#throughput-limits) 
 possible, set the `operationOptions` property to `OptimizedForHighThroughput`. 
-This setting puts your logic app into "high throughput" mode. 
+This setting puts your logic app into "high throughput" mode.
 
 > [!NOTE]
 > High throughput mode is in preview. 
@@ -2908,17 +2908,17 @@ Here are the kinds of authentication you can set up:
 For this authentication type, your trigger or action definition can 
 include an `authentication` JSON object that has these properties:
 
-| Property | Required | Value | Description | 
-|----------|----------|-------|-------------| 
-| **type** | Yes | "Basic" | The authentication type to use, which is "Basic" here | 
+| Property | Required | Value | Description |
+|----------|----------|-------|-------------|
+| **type** | Yes | "Basic" | The authentication type to use, which is "Basic" here |
 | **username** | Yes | "@parameters('userNameParam')" | A parameter that passes the user name to authenticate for accessing the target service endpoint |
 | **password** | Yes | "@parameters('passwordParam')" | A parameter that passes the password to authenticate for accessing the target service endpoint |
-||||| 
+|||||
 
 For example, here's the format for the `authentication` 
 object in your trigger or action definition. 
 For more information about securing parameters, 
-see [Secure sensitive information](#secure-info). 
+see [Secure sensitive information](#secure-info).
 
 ```json
 "HTTP": {
@@ -2943,17 +2943,17 @@ see [Secure sensitive information](#secure-info).
 For this authentication type, your trigger or action definition can 
 include an `authentication` JSON object that has these properties:
 
-| Property | Required | Value | Description | 
-|----------|----------|-------|-------------| 
-| **type** | Yes | "ClientCertificate" | The authentication type to use for Secure Sockets Layer (SSL) client certificates | 
+| Property | Required | Value | Description |
+|----------|----------|-------|-------------|
+| **type** | Yes | "ClientCertificate" | The authentication type to use for Secure Sockets Layer (SSL) client certificates |
 | **pfx** | Yes | <*base64-encoded-pfx-file*> | The base64-encoded content from a Personal Information Exchange (PFX) file |
 | **password** | Yes | "@parameters('passwordParam')" | A parameter with the password for accessing the PFX file |
-||||| 
+|||||
 
 For example, here's the format for the `authentication` 
 object in your trigger or action definition. 
 For more information about securing parameters, 
-see [Secure sensitive information](#secure-info). 
+see [Secure sensitive information](#secure-info).
 
 ```json
 "authentication": {
@@ -2970,23 +2970,23 @@ see [Secure sensitive information](#secure-info).
 For this authentication type, your trigger or action definition can 
 include an `authentication` JSON object that has these properties:
 
-| Property | Required | Value | Description | 
-|----------|----------|-------|-------------| 
-| **type** | Yes | `ActiveDirectoryOAuth` | The authentication type to use, which is "ActiveDirectoryOAuth" for Azure AD OAuth | 
-| **authority** | No | <*URL-for-authority-token-issuer*> | The URL for the authority that provides the authentication token |  
-| **tenant** | Yes | <*tenant-ID*> | The tenant ID for the Azure AD tenant | 
-| **audience** | Yes | <*resource-to-authorize*> | The resource that you want authorization to use, for example, `https://management.core.windows.net/` | 
-| **clientId** | Yes | <*client-ID*> | The client ID for the app requesting authorization | 
-| **credentialType** | Yes | "Secret" or "Certificate" | The credential type the client uses for requesting authorization. This property and value don't appear in your underlying definition, but determines the required parameters for the credential type. | 
-| **password** | Yes, only for "Certificate" credential type | "@parameters('passwordParam')" | A parameter with the password for accessing the PFX file | 
+| Property | Required | Value | Description |
+|----------|----------|-------|-------------|
+| **type** | Yes | `ActiveDirectoryOAuth` | The authentication type to use, which is "ActiveDirectoryOAuth" for Azure AD OAuth |
+| **authority** | No | <*URL-for-authority-token-issuer*> | The URL for the authority that provides the authentication token | 
+| **tenant** | Yes | <*tenant-ID*> | The tenant ID for the Azure AD tenant |
+| **audience** | Yes | <*resource-to-authorize*> | The resource that you want authorization to use, for example, `https://management.core.windows.net/` |
+| **clientId** | Yes | <*client-ID*> | The client ID for the app requesting authorization |
+| **credentialType** | Yes | "Secret" or "Certificate" | The credential type the client uses for requesting authorization. This property and value don't appear in your underlying definition, but determines the required parameters for the credential type. |
+| **password** | Yes, only for "Certificate" credential type | "@parameters('passwordParam')" | A parameter with the password for accessing the PFX file |
 | **pfx** | Yes, only for "Certificate" credential type | <*base64-encoded-pfx-file*> | The base64-encoded content from a Personal Information Exchange (PFX) file |
 | **secret** | Yes, only for "Secret" credential type | <*secret-for-authentication*> | The base64-encoded secret that the client uses for requesting authorization |
-||||| 
+|||||
 
 For example, here's the format for the `authentication` object when 
 your trigger or action definition uses the "Secret" credential type:
 For more information about securing parameters, 
-see [Secure sensitive information](#secure-info). 
+see [Secure sensitive information](#secure-info).
 
 ```json
 "authentication": {
@@ -3005,7 +3005,7 @@ see [Secure sensitive information](#secure-info).
 To protect sensitive information that you use for authentication, 
 such as usernames and passwords, in your trigger and action definitions, 
 you can use parameters and the `@parameters()` expression so that this 
-information isn't visible after you save your logic app. 
+information isn't visible after you save your logic app.
 
 For example, suppose you're using "Basic" authentication 
 in your trigger or action definition. Here is an example 
@@ -3057,7 +3057,7 @@ define the parameters you used in your trigger or action definition:
 If you're creating or using an Azure Resource Manager deployment template, 
 you also have to include an outer `parameters` section for your template definition. 
 For more information about securing parameters, see 
-[Secure access to your logic apps](../logic-apps/logic-apps-securing-a-logic-app.md#secure-action-parameters). 
+[Secure access to your logic apps](../logic-apps/logic-apps-securing-a-logic-app.md#secure-action-parameters).
 
 ## Next steps
 

--- a/articles/logic-apps/logic-apps-workflow-actions-triggers.md
+++ b/articles/logic-apps/logic-apps-workflow-actions-triggers.md
@@ -2920,7 +2920,7 @@ object in your trigger or action definition.
 For more information about securing parameters, 
 see [Secure sensitive information](#secure-info). 
 
-```javascript
+```json
 "HTTP": {
    "type": "Http",
    "inputs": {
@@ -2955,7 +2955,7 @@ object in your trigger or action definition.
 For more information about securing parameters, 
 see [Secure sensitive information](#secure-info). 
 
-```javascript
+```json
 "authentication": {
    "password": "@parameters('passwordParam')",
    "pfx": "aGVsbG8g...d29ybGQ=",
@@ -2988,7 +2988,7 @@ your trigger or action definition uses the "Secret" credential type:
 For more information about securing parameters, 
 see [Secure sensitive information](#secure-info). 
 
-```javascript
+```json
 "authentication": {
    "audience": "https://management.core.windows.net/",
    "clientId": "34750e0b-72d1-4e4f-bbbe-664f6d04d411",
@@ -3011,7 +3011,7 @@ For example, suppose you're using "Basic" authentication
 in your trigger or action definition. Here is an example 
 `authentication` object that specifies a username and password:
 
-```javascript
+```json
 "HTTP": {
    "type": "Http",
    "inputs": {
@@ -3030,7 +3030,7 @@ in your trigger or action definition. Here is an example
 In the `parameters` section for your logic app definition, 
 define the parameters you used in your trigger or action definition:
 
-```javascript
+```json
 "definition": {
    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
    "actions": {


### PR DESCRIPTION
Typo: JSON code is displayed as Javascript.
Unnecessary spaces: When copying from the web page, unnecessary one-byte space is included behind the code.

