### PR TITLE
A limitation is confusing.

### DIFF
--- a/articles/expressroute/expressroute-howto-coexist-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-coexist-resource-manager.md
@@ -38,7 +38,7 @@ The steps to configure both scenarios are covered in this article. This article 
 * **Transit routing is not supported.** You cannot route (via Azure) between your local network connected via Site-to-Site VPN and your local network connected via ExpressRoute.
 * **Basic SKU gateway is not supported.** You must use a non-Basic SKU gateway for both the [ExpressRoute gateway](expressroute-about-virtual-network-gateways.md) and the [VPN gateway](../vpn-gateway/vpn-gateway-about-vpngateways.md).
 * **Only route-based VPN gateway is supported.** You must use a route-based [VPN Gateway](../vpn-gateway/vpn-gateway-about-vpngateways.md).
-* **Static route should be configured for your VPN gateway.** If your local network is connected to both ExpressRoute and a Site-to-Site VPN, you must have a static route configured in your local network to route the Site-to-Site VPN connection to the public Internet.
+* **Static route should be configured for your VPN gateway.** If your local network is connected to both ExpressRoute and a Site-to-Site VPN, you must have a static route configured in your local network to route the Site-to-Site VPN connection to the public Internet. This limitation is not routing protocol of Azure VPN Gateway but routing method for the public Internet of on-premise VPN device. 
 * **VPN Gateway defaults to ASN 65515 if not specified.** Azure VPN Gateway supports the BGP routing protocol. You can specify ASN (AS Number) for a virtual network by adding the -Asn switch. If you don't specify this parameter, the default AS number is 65515. You can use any ASN for the configuration, but if you select something other than 65515, you must reset the gateway for the setting to take effect.
 
 ## Configuration designs


### PR DESCRIPTION
The bellow sentence is confusing because this limitation seems routing protocol of Azure VPN Gateway. But actually it is other limitation which is routing method to access from on-premise VPN device to the public Internet.

"Static route should be configured for your VPN gateway."

I hope you will revise additional information in this limitation.