### PR TITLE
fix: Cleanup Dockerfile code fences

### DIFF
--- a/articles/aks/use-cosmosdb-osba-mongo-app.md
+++ b/articles/aks/use-cosmosdb-osba-mongo-app.md
@@ -205,7 +205,7 @@ This command generates several artifacts, including a *charts/* folder, which is
 
 Create a file at the root of your project named *Dockerfile* with this content:
 
-```dockerfile
+```Dockerfile
 FROM openjdk:8-jdk-alpine
 EXPOSE 8080
 WORKDIR /app

--- a/articles/app-service/containers/app-service-linux-ssh-support.md
+++ b/articles/app-service/containers/app-service-linux-ssh-support.md
@@ -56,7 +56,7 @@ These steps are shown in the Azure App Service repository as [an example](https:
     > be accessed via the Kudu / SCM Site, which is authenticated using the publishing
     > credentials.
 
-    ```docker
+    ```Dockerfile
     # ------------------------
     # SSH Server support
     # ------------------------
@@ -72,13 +72,13 @@ These steps are shown in the Azure App Service repository as [an example](https:
     > * `Ciphers` must include at least one of the following: `aes128-cbc,3des-cbc,aes256-cbc`.
     > * `MACs` must include at least one of the following: `hmac-sha1,hmac-sha1-96`.
 
-    ```docker
+    ```Dockerfile
     COPY sshd_config /etc/ssh/
     ```
 
 3. Include port 2222 in the [`EXPOSE` instruction](https://docs.docker.com/engine/reference/builder/#expose) for the Dockerfile. Although the root password is known, port 2222 cannot be accessed from the internet. It is an internal only port accessible only by containers within the bridge network of a private virtual network.
 
-    ```docker
+    ```Dockerfile
     EXPOSE 2222 80
     ```
 
@@ -91,7 +91,7 @@ These steps are shown in the Azure App Service repository as [an example](https:
 
 The Dockerfile uses the [`ENTRYPOINT` instruction](https://docs.docker.com/engine/reference/builder/#entrypoint) to run the script.
 
-    ```docker
+    ```Dockerfile
     COPY init_container.sh /opt/startup
     ...
     RUN chmod 755 /opt/startup/init_container.sh

--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -55,7 +55,7 @@ cd docker-django-webapp-linux
 
 In the Git repository, take a look at _Dockerfile_. This file describes the Python environment that is required to run your application. Additionally, the image sets up an [SSH](https://www.ssh.com/ssh/protocol/) server for secure communication between the container and the host.
 
-```docker
+```Dockerfile
 FROM python:3.4
 
 RUN mkdir /code
@@ -276,7 +276,7 @@ SSH enables secure communication between a container and a client. In order for 
 
 * A [RUN](https://docs.docker.com/engine/reference/builder/#run) instruction that calls `apt-get`, then sets the password for the root account to `"Docker!"`.
 
-    ```docker
+    ```Dockerfile
     ENV SSH_PASSWD "root:Docker!"
     RUN apt-get update \
             && apt-get install -y --no-install-recommends dialog \
@@ -290,7 +290,7 @@ SSH enables secure communication between a container and a client. In order for 
 
 * A [COPY](https://docs.docker.com/engine/reference/builder/#copy) instruction that instructs the Docker engine to copy the [sshd_config](https://man.openbsd.org/sshd_config) file to the */etc/ssh/* directory. Your configuration file should be based on [this sshd_config file](https://github.com/Azure-App-Service/node/blob/master/6.11.1/sshd_config).
 
-    ```docker
+    ```Dockerfile
     COPY sshd_config /etc/ssh/
     ```
 
@@ -301,7 +301,7 @@ SSH enables secure communication between a container and a client. In order for 
 
 * An [EXPOSE](https://docs.docker.com/engine/reference/builder/#expose) instruction that exposes port 2222 in the container. Although the root password is known, port 2222 cannot be accessed from the internet. It is an internal port accessible only by containers within the bridge network of a private virtual network. After that, commands copy SSH configuration details and start the `ssh` service.
 
-    ```docker
+    ```Dockerfile
     EXPOSE 8000 2222
     ```
 

--- a/articles/azure-functions/functions-create-function-linux-custom-image.md
+++ b/articles/azure-functions/functions-create-function-linux-custom-image.md
@@ -88,7 +88,7 @@ cd MyFunctionProj
 
 Take a look at the _Dockerfile_ in the root folder of the project. This file describes the environment that is required to run the function app on Linux. The following example is a Dockerfile that creates a container that runs a function app on the JavaScript (Node.js) worker runtime: 
 
-```docker
+```Dockerfile
 FROM mcr.microsoft.com/azure-functions/node:2.0
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot

--- a/articles/cognitive-services/Computer-vision/computer-vision-how-to-install-containers.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-how-to-install-containers.md
@@ -67,7 +67,7 @@ Use the [`docker pull`](https://docs.docker.com/engine/reference/commandline/pul
 
 ### Docker pull for the Recognize Text container
 
-```Docker
+```
 docker pull containerpreview.azurecr.io/microsoft/cognitive-services-rocognize-text:latest
 ```
 

--- a/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
@@ -107,7 +107,7 @@ The following Docker examples are for the recognize text container.
 
 ### Basic example 
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 \
   containerpreview.azurecr.io/microsoft/cognitive-services-recognize-text \
   Eula=accept \
@@ -117,7 +117,7 @@ The following Docker examples are for the recognize text container.
 
 ### Logging example with command-line arguments
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 \
   containerpreview.azurecr.io/microsoft/cognitive-services-recognize-text \
   Eula=accept \
@@ -128,7 +128,7 @@ The following Docker examples are for the recognize text container.
 
 ### Logging example with environment variable
 
-  ```Docker
+  ```
   SET Logging:Console:LogLevel=Information
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 \
   containerpreview.azurecr.io/microsoft/cognitive-services-recognize-text \

--- a/articles/cognitive-services/Face/face-how-to-install-containers.md
+++ b/articles/cognitive-services/Face/face-how-to-install-containers.md
@@ -63,7 +63,7 @@ Container images for Face API are available.
 
 ### Docker pull for the Face container
 
-```Docker
+```
 docker pull mcr.microsoft.com/azure-cognitive-services/face:latest
 ```
 

--- a/articles/cognitive-services/Face/face-resource-container-config.md
+++ b/articles/cognitive-services/Face/face-resource-container-config.md
@@ -107,7 +107,7 @@ The following Docker examples are for the face container.
 
 ### Basic example 
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 \
   containerpreview.azurecr.io/microsoft/cognitive-services-face \
   Eula=accept \
@@ -117,7 +117,7 @@ The following Docker examples are for the face container.
 
 ### Logging example with command-line arguments
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 containerpreview.azurecr.io/microsoft/cognitive-services-face \
   Eula=accept \
   Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} \
@@ -126,7 +126,7 @@ The following Docker examples are for the face container.
 
 ### Logging example with environment variable
 
-  ```Docker
+  ```
   SET Logging:Console:LogLevel=Information
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 containerpreview.azurecr.io/microsoft/cognitive-services-face \
   Eula=accept \

--- a/articles/cognitive-services/LUIS/luis-container-howto.md
+++ b/articles/cognitive-services/LUIS/luis-container-howto.md
@@ -55,7 +55,7 @@ The `--cpus` and `--memory` settings are used as part of the `docker run` comman
 
 Use the [`docker pull`](https://docs.docker.com/engine/reference/commandline/pull/) command to download a container image from the `mcr.microsoft.com/azure-cognitive-services/luis` repository:
 
-```Docker
+```
 docker pull mcr.microsoft.com/azure-cognitive-services/luis:latest
 ```
 

--- a/articles/cognitive-services/text-analytics/how-tos/text-analytics-how-to-install-containers.md
+++ b/articles/cognitive-services/text-analytics/how-tos/text-analytics-how-to-install-containers.md
@@ -72,19 +72,19 @@ Use the [`docker pull`](https://docs.docker.com/engine/reference/commandline/pul
 
 ### Docker pull for the Key phrase extraction container
 
-```Docker
+```
 docker pull mcr.microsoft.com/azure-cognitive-services/keyphrase:latest
 ```
 
 ### Docker pull for the language detection container
 
-```Docker
+```
 docker pull mcr.microsoft.com/azure-cognitive-services/language:latest
 ```
 
 ### Docker pull for the sentiment container
 
-```Docker
+```
 docker pull mcr.microsoft.com/azure-cognitive-services/sentiment:latest
 ```
 

--- a/articles/cognitive-services/text-analytics/text-analytics-resource-container-config.md
+++ b/articles/cognitive-services/text-analytics/text-analytics-resource-container-config.md
@@ -104,19 +104,19 @@ The following docker examples are for the keyphrase extraction container.
 
 ### Basic example 
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/keyphrase Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} 
   ```
 
 ### Logging example with command-line arguments
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/keyphrase Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} Logging:Console:LogLevel=Information
   ```
 
 ### Logging example with environment variable
 
-  ```Docker
+  ```
   SET Logging:Console:LogLevel=Information
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/keyphrase  Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY}
   ```
@@ -127,19 +127,19 @@ The following docker examples are for the language detection container.
 
 ### Basic example
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/language Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} Logging:Console:LogLevel=Information
   ```
 
 ### Logging example with command-line arguments
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/language Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} Logging:Console:LogLevel=Information
   ```
 
 ### Logging example with environment variable
 
-  ```Docker
+  ```
   SET Logging:Console:LogLevel=Information
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/language  Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY}
   ```
@@ -150,19 +150,19 @@ The following docker examples are for the sentiment analysis container.
 
 ### Basic example
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/sentiment Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} Logging:Console:LogLevel=Information
   ```
 
 ### Logging example with command-line arguments
 
-  ```Docker
+  ```
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/sentiment Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY} Logging:Console:LogLevel=Information
   ```
 
 ### Logging example with environment variable
 
-  ```Docker
+  ```
   SET Logging:Console:LogLevel=Information
   docker run --rm -it -p 5000:5000 --memory 4g --cpus 1 mcr.microsoft.com/azure-cognitive-services/sentiment Eula=accept Billing={BILLING_ENDPOINT_URI} ApiKey={BILLING_KEY}
   ```

--- a/articles/container-registry/container-registry-authentication-managed-identity.md
+++ b/articles/container-registry/container-registry-authentication-managed-identity.md
@@ -174,7 +174,7 @@ az acr login --name myContainerRegistry
 
 You should see a `Login succeeded` message. You can then run `docker` commands without providing credentials. For example, run [docker pull][docker-pull] to pull the `aci-helloworld:v1` image, specifying the login server name of your registry. The login server name consists of your container registry name (all lowercase) followed by `.azurecr.io` - for example, `mycontainerregistry.azurecr.io`.
 
-```docker
+```
 docker pull mycontainerregistry.azurecr.io/aci-helloworld:v1
 ```
 
@@ -226,7 +226,7 @@ az acr login --name myContainerRegistry
 
 You should see a `Login succeeded` message. You can then run `docker` commands without providing credentials. For example, run [docker pull][docker-pull] to pull the `aci-helloworld:v1` image, specifying the login server name of your registry. The login server name consists of your container registry name (all lowercase) followed by `.azurecr.io` - for example, `mycontainerregistry.azurecr.io`.
 
-```docker
+```
 docker pull mycontainerregistry.azurecr.io/aci-helloworld:v1
 ```
 

--- a/articles/container-registry/container-registry-authentication.md
+++ b/articles/container-registry/container-registry-authentication.md
@@ -56,7 +56,7 @@ Service principals enable headless connectivity to a registry in both pull and p
 
 You can also log in directly with a service principal. When you run the following command, interactively provide the service principal appID (username) and password when prompted. For best practices to manage login credentials, see the [docker login](https://docs.docker.com/engine/reference/commandline/login/) command reference:
 
-```Docker
+```
 docker login myregistry.azurecr.io
 ```
 
@@ -76,7 +76,7 @@ Each container registry includes an admin user account, which is disabled by def
 
 The admin account is provided with two passwords, both of which can be regenerated. Two passwords allow you to maintain connection to the registry by using one password while you regenerate the other. If the admin account is enabled, you can pass the username and either password to the `docker login` command when prompted for basic authentication to the registry. For example:
 
-```Docker
+```
 docker login myregistry.azurecr.io 
 ```
 

--- a/articles/container-registry/container-registry-get-started-docker-cli.md
+++ b/articles/container-registry/container-registry-get-started-docker-cli.md
@@ -33,7 +33,7 @@ az acr login --name myregistry
 
 You can also log in with [docker login](https://docs.docker.com/engine/reference/commandline/login/). For example, you might have [assigned a service principal](container-registry-authentication.md#service-principal) to your registry for an automation scenario. When you run the following command, interactively provide the service principal appID (username) and password when prompted. For best practices to manage login credentials, see the [docker login](https://docs.docker.com/engine/reference/commandline/login/) command reference:
 
-```Docker
+```
 docker login myregistry.azurecr.io
 ```
 
@@ -46,7 +46,7 @@ Both commands return `Login Succeeded` once completed.
 
 First, pull the public Nginx image to your local computer.
 
-```Docker
+```
 docker pull nginx
 ```
 
@@ -54,7 +54,7 @@ docker pull nginx
 
 Execute following [docker run](https://docs.docker.com/engine/reference/run/) command to start a local instance of the Nginx container interactively (`-it`) on port 8080. The `--rm` argument specifies that the container should be removed when you stop it.
 
-```Docker
+```
 docker run -it --rm -p 8080:80 nginx
 ```
 
@@ -70,7 +70,7 @@ To stop and remove the container, press `Control`+`C`.
 
 Use [docker tag](https://docs.docker.com/engine/reference/commandline/tag/) to create an alias of the image with the fully qualified path to your registry. This example specifies the `samples` namespace to avoid clutter in the root of the registry.
 
-```Docker
+```
 docker tag nginx myregistry.azurecr.io/samples/nginx
 ```
 
@@ -80,7 +80,7 @@ For more information about tagging with namespaces, see the [Repository namespac
 
 Now that you've tagged the image with the fully qualified path to your private registry, you can push it to the registry with [docker push](https://docs.docker.com/engine/reference/commandline/push/):
 
-```Docker
+```
 docker push myregistry.azurecr.io/samples/nginx
 ```
 
@@ -88,7 +88,7 @@ docker push myregistry.azurecr.io/samples/nginx
 
 Use the [docker pull](https://docs.docker.com/engine/reference/commandline/pull/) command to pull the image from your registry:
 
-```Docker
+```
 docker pull myregistry.azurecr.io/samples/nginx
 ```
 
@@ -96,7 +96,7 @@ docker pull myregistry.azurecr.io/samples/nginx
 
 Use the [docker run](https://docs.docker.com/engine/reference/run/) command to run the image you've pulled from your registry:
 
-```Docker
+```
 docker run -it --rm -p 8080:80 myregistry.azurecr.io/samples/nginx
 ```
 
@@ -108,7 +108,7 @@ To stop and remove the container, press `Control`+`C`.
 
 If you no longer need the Nginx image, you can delete it locally with the [docker rmi](https://docs.docker.com/engine/reference/commandline/rmi/) command.
 
-```Docker
+```
 docker rmi myregistry.azurecr.io/samples/nginx
 ```
 

--- a/articles/container-registry/container-registry-tutorial-prepare-registry.md
+++ b/articles/container-registry/container-registry-tutorial-prepare-registry.md
@@ -114,7 +114,7 @@ The Dockerfile included in the sample shows how the container is built. It start
 
 The [Dockerfile][dockerfile] is located at `./AcrHelloworld/Dockerfile` in the cloned source.
 
-```dockerfile
+```Dockerfile
 FROM microsoft/aspnetcore:2.0 AS base
 # Update <acrName> with the name of your registry
 # Example: uniqueregistryname.azurecr.io
@@ -158,7 +158,7 @@ uniqueregistryname.azurecr.io
 
 Next, update the `ENV DOCKER_REGISTRY` line with the FQDN of your registry's login server. This example reflects the example registry name, *uniqueregistryname*:
 
-```dockerfile
+```Dockerfile
 ENV DOCKER_REGISTRY uniqueregistryname.azurecr.io
 ```
 

--- a/articles/container-service/dcos-swarm/container-service-docker-swarm-mode-setup-ci-cd-acs-engine.md
+++ b/articles/container-service/dcos-swarm/container-service-docker-swarm-mode-setup-ci-cd-acs-engine.md
@@ -224,7 +224,9 @@ The release workflow is composed of two tasks that you add.
 
 2. Configure a second task to execute a bash command to run `docker` and `docker stack deploy` commands on the master node. See the following screen for details.
 
-    ```docker login -u $(docker.username) -p $(docker.password) $(docker.registry) && export DOCKER_HOST=:2375 && cd deploy && docker stack deploy --compose-file docker-compose-v3.yml myshop --with-registry-auth```
+    ```
+    docker login -u $(docker.username) -p $(docker.password) $(docker.registry) && export DOCKER_HOST=:2375 && cd deploy && docker stack deploy --compose-file docker-compose-v3.yml myshop --with-registry-auth
+    ```
 
     ![Azure DevOps - Release Bash](./media/container-service-docker-swarm-mode-setup-ci-cd-acs-engine/vsts-release-bash.png)
 

--- a/articles/iot-accelerators/iot-accelerators-microservices-example.md
+++ b/articles/iot-accelerators/iot-accelerators-microservices-example.md
@@ -120,13 +120,13 @@ You now need to update your local docker-compose.yml to pull your new docker ima
 2. Open docker-compose.yml in any text editor or IDE that you like.
 3. Locate the following code:
 
-    ```docker
+    ```yml
     image: azureiotpcs/iothub-manager-dotnet:testing
     ```
 
     and change it to look like the image below and save it.
 
-    ```cmd/sh
+    ```yml
     image: [docker ID]/iothub-manager-dotnet:testing
     ```
 

--- a/articles/service-fabric-mesh/service-fabric-mesh-faq.md
+++ b/articles/service-fabric-mesh/service-fabric-mesh-faq.md
@@ -96,7 +96,7 @@ Outgoing DNS queries from a container to the Service Fabric DNS service may fail
 - If the service name alone doesn't work, try the fully qualified name: ServiceName.ApplicationName.
 - In the Docker file for your service, add `EXPOSE <port>` where port is the port you are exposing your service on. For example:
 
-```DockerFile
+```Dockerfile
 EXPOSE 80
 ```
 

--- a/articles/service-fabric/service-fabric-get-started-mac.md
+++ b/articles/service-fabric/service-fabric-get-started-mac.md
@@ -61,7 +61,7 @@ To set up a local Docker container and have a Service Fabric cluster running on 
 
 2. In a new directory create a file called `Dockerfile` to build your Service Fabric Image:
 
-    ```dockerfile
+    ```Dockerfile
     FROM microsoft/service-fabric-onebox
     WORKDIR /home/ClusterDeployer
     RUN ./setup.sh

--- a/articles/service-fabric/service-fabric-local-linux-cluster-windows.md
+++ b/articles/service-fabric/service-fabric-local-linux-cluster-windows.md
@@ -48,7 +48,7 @@ To set up a local Docker container and have a service fabric cluster running on 
 
 2. In a new directory create a file called `Dockerfile` to build your Service Fabric Image:
 
-    ```dockerfile
+    ```Dockerfile
     FROM microsoft/service-fabric-onebox
     WORKDIR /home/ClusterDeployer
     RUN ./setup.sh

--- a/includes/cognitive-services-containers-docker-list-tip.md
+++ b/includes/cognitive-services-containers-docker-list-tip.md
@@ -10,7 +10,7 @@ ms.date: 01/24/2019
 > [!TIP]
 > You can use the [docker images](https://docs.docker.com/engine/reference/commandline/images/) command to list your downloaded container images. For example, the following command lists the ID, repository, and tag of each downloaded container image, formatted as a table:
 >
->  ```Docker
+>  ```
 >  docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}"
 >
 >  IMAGE ID            REPOSITORY                                                                TAG

--- a/includes/cognitive-services-containers-request-access.md
+++ b/includes/cognitive-services-containers-request-access.md
@@ -19,13 +19,13 @@ There are several ways to authenticate with the private container registry for C
 
 Use the [docker login](https://docs.docker.com/engine/reference/commandline/login/) command, as shown in the following example, to log into `containerpreview.azurecr.io`, the private container registry for Cognitive Services Containers. Replace *\<username\>* with the user name and *\<password\>* with the password provided in the credentials you received from the Azure Cognitive Services team.
 
-```docker
+```
 docker login containerpreview.azurecr.io -u <username> -p <password>
 ```
 
 If you have secured your credentials in a text file, you can concatenate the contents of that text file, using the `cat` command, to the `docker login` command as shown in the following example. Replace *\<passwordFile\>* with the path and name of the text file containing the password and *\<username\>* with the user name provided in your credentials.
 
-```docker
+```
 cat <passwordFile> | docker login containerpreview.azurecr.io -u <username> --password-stdin
 ```
 

--- a/includes/container-registry-quickstart-docker-pull.md
+++ b/includes/container-registry-quickstart-docker-pull.md
@@ -15,7 +15,7 @@ ms.custom: include file
 
 Now, you can pull and run the `hello-world:v1` container image from your container registry by using [docker run][docker-run]:
 
-```Docker
+```
 docker run <acrLoginServer>/hello-world:v1  
 ```
 

--- a/includes/container-registry-quickstart-docker-push.md
+++ b/includes/container-registry-quickstart-docker-push.md
@@ -14,7 +14,7 @@ ms.custom: include file
 
 To push an image to an Azure Container registry, you must first have an image. If you don't yet have any local container images, run the following [docker pull][docker-pull] command to pull an existing image from Docker Hub. For this example, pull the `hello-world` image.
 
-```Docker
+```
 docker pull hello-world
 ```
 
@@ -22,19 +22,19 @@ Before you can push an image to your registry, you must tag it with the fully qu
 
 Tag the image using the [docker tag][docker-tag] command. Replace `<acrLoginServer>` with the login server name of your ACR instance.
 
-```Docker
+```
 docker tag hello-world <acrLoginServer>/hello-world:v1
 ```
 
 Finally, use [docker push][docker-push] to push the image to the ACR instance. Replace `<acrLoginServer>` with the login server name of your ACR instance. This example creates the **hello-world** repository, containing the `hello-world:v1` image.
 
-```Docker
+```
 docker push <acrLoginServer>/hello-world:v1
 ```
 
 After pushing the image to your container registry, remove the `hello-world:v1` image from your local Docker environment. (Note that this [docker rmi][docker-rmi] command does not remove the image from the **hello-world** repository in your Azure container registry.)
 
-```Docker
+```
 docker rmi <acrLoginServer>/hello-world:v1
 ```
 


### PR DESCRIPTION

"Docker" isn't a valid language setting, and "Dockerfile" is only used
to represent actual Dockerfile syntax blocks