### PR TITLE
Added note for gateway name and port

### DIFF
--- a/articles/iot-edge/how-to-connect-downstream-device.md
+++ b/articles/iot-edge/how-to-connect-downstream-device.md
@@ -35,7 +35,10 @@ Before following the steps in this article, you should have two devices ready to
 2. A downstream device that has a device identity from IoT Hub. 
     You cannot use an IoT Edge device as the downstream device. Instead, use a device registered as a regular IoT device in IoT Hub. In the portal, you can register a new device in the **IoT devices** section. Or you can use the Azure CLI to [register a device](../iot-hub/quickstart-send-telemetry-c.md#register-a-device). Copy the connection string and have it available to use in later sections. 
 
-    Currently, only downstream devices with symmetric key authentication can connect through IoT Edge gateways. X.509 certificate authorities and X.509 self-signed certificates are not currently supported. 
+    Currently, only downstream devices with symmetric key authentication can connect through IoT Edge gateways. X.509 certificate authorities and X.509 self-signed certificates are not currently supported.
+    
+    >[!NOTE]
+>The "<gateway name>" used  to create the certificates in this instruction, needs to be the same name as used as hostname in your IoT Edge config.yaml file and as GatewayHostName in the connection string of the downstream device. The "<gateway name>" needs to be resolvable to an IP Address, either using DNS or a host file entry. Communication based on the protocol used (MQTTS:8883/AMQPS:5671/HTTPS:433) must be possible between downstream device and the transparant IoT Edge. If a firewall is in between, the respective port needs to be open.
 
 ## Prepare a downstream device
 

--- a/articles/iot-edge/how-to-connect-downstream-device.md
+++ b/articles/iot-edge/how-to-connect-downstream-device.md
@@ -38,7 +38,7 @@ Before following the steps in this article, you should have two devices ready to
     Currently, only downstream devices with symmetric key authentication can connect through IoT Edge gateways. X.509 certificate authorities and X.509 self-signed certificates are not currently supported.
     
     >[!NOTE]
->The "<gateway name>" used  to create the certificates in this instruction, needs to be the same name as used as hostname in your IoT Edge config.yaml file and as GatewayHostName in the connection string of the downstream device. The "<gateway name>" needs to be resolvable to an IP Address, either using DNS or a host file entry. Communication based on the protocol used (MQTTS:8883/AMQPS:5671/HTTPS:433) must be possible between downstream device and the transparant IoT Edge. If a firewall is in between, the respective port needs to be open.
+>The "gateway name" used  to create the certificates in this instruction, needs to be the same name as used as hostname in your IoT Edge config.yaml file and as GatewayHostName in the connection string of the downstream device. The "gateway name" needs to be resolvable to an IP Address, either using DNS or a host file entry. Communication based on the protocol used (MQTTS:8883/AMQPS:5671/HTTPS:433) must be possible between downstream device and the transparant IoT Edge. If a firewall is in between, the respective port needs to be open.
 
 ## Prepare a downstream device
 

--- a/articles/iot-edge/how-to-connect-downstream-device.md
+++ b/articles/iot-edge/how-to-connect-downstream-device.md
@@ -37,8 +37,8 @@ Before following the steps in this article, you should have two devices ready to
 
     Currently, only downstream devices with symmetric key authentication can connect through IoT Edge gateways. X.509 certificate authorities and X.509 self-signed certificates are not currently supported.
     
-    >[!NOTE]
->The "gateway name" used  to create the certificates in this instruction, needs to be the same name as used as hostname in your IoT Edge config.yaml file and as GatewayHostName in the connection string of the downstream device. The "gateway name" needs to be resolvable to an IP Address, either using DNS or a host file entry. Communication based on the protocol used (MQTTS:8883/AMQPS:5671/HTTPS:433) must be possible between downstream device and the transparant IoT Edge. If a firewall is in between, the respective port needs to be open.
+> [!NOTE]
+> The "gateway name" used  to create the certificates in this instruction, needs to be the same name as used as hostname in your IoT Edge config.yaml file and as GatewayHostName in the connection string of the downstream device. The "gateway name" needs to be resolvable to an IP Address, either using DNS or a host file entry. Communication based on the protocol used (MQTTS:8883/AMQPS:5671/HTTPS:433) must be possible between downstream device and the transparant IoT Edge. If a firewall is in between, the respective port needs to be open.
 
 ## Prepare a downstream device
 


### PR DESCRIPTION
As added in the part of creatig the transparant gateway. It needs to be clear that the gateway name needs to be the same all around and that it needs to be resolvable to an IP Address. And also it needs to be clear that when there is a firewall between the downstream device and the transparant gateway, the respective port needs to be open.