### PR TITLE
Added link to plans for supported web app plans

### DIFF
--- a/articles/traffic-manager/traffic-manager-endpoint-types.md
+++ b/articles/traffic-manager/traffic-manager-endpoint-types.md
@@ -58,7 +58,7 @@ Nested endpoints combine multiple Traffic Manager profiles to create flexible tr
 
 Some additional considerations apply when configuring Web Apps as endpoints in Traffic Manager:
 
-1. Only Web Apps at the 'Standard' SKU or above are eligible for use with Traffic Manager. Attempts to add a Web App of a lower SKU fail. Downgrading the SKU of an existing Web App results in Traffic Manager no longer sending traffic to that Web App.
+1. Only Web Apps at the 'Standard' SKU or above are eligible for use with Traffic Manager. Attempts to add a Web App of a lower SKU fail. Downgrading the SKU of an existing Web App results in Traffic Manager no longer sending traffic to that Web App. For more information on supported plans see the [App Service Plans](https://azure.microsoft.com/en-us/pricing/details/app-service/plans/)
 2. When an endpoint receives an HTTP request, it uses the 'host' header in the request to determine which Web App should service the request. The host header contains the DNS name used to initiate the request, for example 'contosoapp.azurewebsites.net'. To use a different DNS name with your Web App, the DNS name must be registered as a custom domain name for the App. When adding a Web App endpoint as an Azure endpoint, the Traffic Manager profile DNS name is automatically registered for the App. This registration is automatically removed when the endpoint is deleted.
 3. Each Traffic Manager profile can have at most one Web App endpoint from each Azure region. To work around for this constraint, you can configure a Web App as an External endpoint. For more information, see the [FAQ](traffic-manager-faqs.md#traffic-manager-endpoints).
 


### PR DESCRIPTION
Primarily added this change due to trying to find out if consumption plans with Azure Functions are supported by Traffic Manager (but seems like the link would be useful for other plan types).