### PR TITLE
Fix typo correct the application

### DIFF
--- a/articles/active-directory/manage-apps/application-proxy-security.md
+++ b/articles/active-directory/manage-apps/application-proxy-security.md
@@ -143,7 +143,7 @@ If you configured the app to preauthenticate with Azure AD, users are redirected
 
 2. After all checks have passed, the Azure AD STS issues a signed token for the application and redirects the user back to the Application Proxy service.
 
-3. Application Proxy verifies that the token was issued to correct the application. It performs other checks also, such as ensuring that the token was signed by Azure AD, and that it is still within the valid window.
+3. Application Proxy verifies that the token was issued to the correct application. It performs other checks also, such as ensuring that the token was signed by Azure AD, and that it is still within the valid window.
 
 4. Application Proxy sets an encrypted authentication cookie to indicate that authentication to the application has occurred. The cookie includes an expiration timestamp that's based on the token from Azure AD and other data, such as the user name that the authentication is based on. The cookie is encrypted with a private key known only to the Application Proxy service.
 


### PR DESCRIPTION
Should "was issued to correct the application" be "was issued to the correct application"?