### PR TITLE
Updated the parameters data type with the latest SDK.

### DIFF
--- a/articles/cognitive-services/Speech-Service/how-to-use-audio-input-streams.md
+++ b/articles/cognitive-services/Speech-Service/how-to-use-audio-input-streams.md
@@ -43,7 +43,7 @@ The following steps are required when using audio input streams:
           this.config = config;
       }
 
-      public size_t Read(byte *buffer, size_t size) {
+      public int Read(byte[] buffer, uint size) {
           // returns audio data to the caller.
           // e.g. return read(config.YYY, buffer, size);
       }


### PR DESCRIPTION
The latest API interface is returning an int value rather than size_t.

int Read(byte[] dataBuffer, uint size)