### PR TITLE
Fixing typo in the example Azure URL

### DIFF
--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -250,7 +250,7 @@ az webapp config appsettings set --resource-group myResourceGroup --name <app_na
 
 ### Test the web app
 
-Verify that the web app works by browsing to it (`http://<app_name>azurewebsites.net`). 
+Verify that the web app works by browsing to it (`http://<app_name>.azurewebsites.net`). 
 
 ![Test web app port configuration](./media/app-service-linux-using-custom-docker-image/app-service-linux-browse-azure.png)
 


### PR DESCRIPTION
Fixing typo in the example Azure URL in the Test the web app section. It was missing the period between the app_name and  azurewebsites.