### PR TITLE
Typo included, remove space

### DIFF
--- a/articles/active-directory/manage-apps/use-scim-to-provision-users-and-groups.md
+++ b/articles/active-directory/manage-apps/use-scim-to-provision-users-and-groups.md
@@ -73,7 +73,7 @@ Applications that support the SCIM profile described in this article can be conn
    *Figure 3: Configuring provisioning in the Azure portal*
     
 6. In the **Tenant URL** field, enter the URL of the application's SCIM endpoint. Example: https://api.contoso.com/scim/v2/
-7. If the SCIM endpoint requires an OAuth bearer token from an issuer other than Azure AD, then copy the required OAuth bearer token into the optional **Secret Token** field. If this field is left blank, then Azure AD included an OAuth bearer token issued from Azure AD with each request. Apps that use Azure AD as an identity provider can validate this Azure AD -issued token.
+7. If the SCIM endpoint requires an OAuth bearer token from an issuer other than Azure AD, then copy the required OAuth bearer token into the optional **Secret Token** field. If this field is left blank, then Azure AD includes an OAuth bearer token issued from Azure AD with each request. Apps that use Azure AD as an identity provider can validate this Azure AD-issued token.
 8. Click the **Test Connection** button to have Azure Active Directory attempt to connect to the SCIM endpoint. If the attempts fail, error information is displayed.  
 
     >[!NOTE]


### PR DESCRIPTION
"Azure AD included an OAuth bearer" should be "Azure AD includes an OAuth bearer"
"Azure AD -issued token" should be "Azure AD-issued token"