### PR TITLE
Escape angle brackets

### DIFF
--- a/articles/active-directory/manage-apps/use-scim-to-provision-users-and-groups.md
+++ b/articles/active-directory/manage-apps/use-scim-to-provision-users-and-groups.md
@@ -152,7 +152,7 @@ The easiest way to implement a SCIM endpoint that can accept provisioning reques
    ![][2]
    *Figure 4: Configuring provisioning in the Azure portal*
     
-6. In the **Tenant URL** field, enter the internet-exposed URL and port of your SCIM endpoint. The entry is something like http://testmachine.contoso.com:9000 or http://<ip-address>:9000/, where <ip-address> is the internet exposed IP address.  
+6. In the **Tenant URL** field, enter the internet-exposed URL and port of your SCIM endpoint. The entry is something like http://testmachine.contoso.com:9000 or http://\<ip-address>:9000/, where \<ip-address> is the internet exposed IP address.  
 7. If the SCIM endpoint requires an OAuth bearer token from an issuer other than Azure AD, then copy the required OAuth bearer token into the optional **Secret Token** field. If this field is left blank, then Azure AD will include an OAuth bearer token issued from Azure AD with each request. Apps that use Azure AD as an identity provider can validate this Azure AD -issued token.
 8. Click the **Test Connection** button to have Azure Active Directory attempt to connect to the SCIM endpoint. If the attempts fail, error information is displayed.  
 


### PR DESCRIPTION
Fix Markdown missing text in "http://:9000/, where is the internet" by escaping <ip-address>