### PR TITLE
Editorial fix: developer tools

### DIFF
--- a/articles/active-directory/manage-apps/customize-application-attributes.md
+++ b/articles/active-directory/manage-apps/customize-application-attributes.md
@@ -99,7 +99,7 @@ Applications and systems that support customization of the attribute list includ
 * Apps that support [SCIM 2.0](https://tools.ietf.org/html/rfc7643), where attributes defined in the [core schema](https://tools.ietf.org/html/rfc7643) need to be added
 
 >[!NOTE]
->Editing the list of supported attributes is only recommended for administrators who have customized the schema of their applications and systems, and have first-hand knowledge of how their custom attributes have been defined. This sometimes requires familiarity with the APIs and developers tools provided by an application or system. 
+>Editing the list of supported attributes is only recommended for administrators who have customized the schema of their applications and systems, and have first-hand knowledge of how their custom attributes have been defined. This sometimes requires familiarity with the APIs and developer tools provided by an application or system. 
 
 ![Editor](./media/customize-application-attributes/25.png) 
 


### PR DESCRIPTION
Use "developer tools" instead of "developers tools"