### PR TITLE
Fixed typo - removed ` from command

### DIFF
--- a/articles/healthcare-apis/fhir-oss-powershell-quickstart.md
+++ b/articles/healthcare-apis/fhir-oss-powershell-quickstart.md
@@ -31,7 +31,7 @@ $rg = New-AzureRmResourceGroup -Name $fhirServiceName -Location westus2
 The Microsoft FHIR Server for Azure [GitHub Repository](https://github.com/Microsoft/fhir-server) contains a template that will deploy all necessary resources. Deploy it with:
 
 ```azurepowershell-interactive
-New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/Microsoft/fhir-server/master/samples/templates/default-azuredeploy.json -ResourceGroupName $rg.ResourceGroupName -serviceName $fhirServiceName `
+New-AzureRmResourceGroupDeployment -TemplateUri https://raw.githubusercontent.com/Microsoft/fhir-server/master/samples/templates/default-azuredeploy.json -ResourceGroupName $rg.ResourceGroupName -serviceName $fhirServiceName
 ```
 
 ## Verify FHIR server is running


### PR DESCRIPTION
Removed an extra ` (backtick) that was causing the command to fail.