### PR TITLE
Fix link markup to bing spell check

### DIFF
--- a/articles/cognitive-services/LUIS/luis-concept-utterance.md
+++ b/articles/cognitive-services/LUIS/luis-concept-utterance.md
@@ -33,7 +33,7 @@ When you first get started by [adding example utterances](luis-how-to-add-exampl
 
 ### Utterances aren't always well formed
 
-It may be a sentence, like "Book a ticket to Paris for me", or a fragment of a sentence, like "Booking" or "Paris flight."  Users often make spelling mistakes. When planning your app, consider whether or not you use [Bing Spell Check][(luis-tutorial-bing-spellcheck) to correct user input before passing it to LUIS. 
+It may be a sentence, like "Book a ticket to Paris for me", or a fragment of a sentence, like "Booking" or "Paris flight."  Users often make spelling mistakes. When planning your app, consider whether or not you use [Bing Spell Check](luis-tutorial-bing-spellcheck) to correct user input before passing it to LUIS. 
 
 If you do not spell check user utterances, you should train LUIS on utterances that include typos and misspellings.
 


### PR DESCRIPTION
There was a markup/down error that prevented the link to bing spell check to be parsed properly.