### PR TITLE
Remove obsolete limitations

### DIFF
--- a/articles/cloud-shell/troubleshooting.md
+++ b/articles/cloud-shell/troubleshooting.md
@@ -106,10 +106,6 @@ Cloud Shell supports the latest versions of following browsers:
 
 [!INCLUDE [copy-paste](../../includes/cloud-shell-copy-paste.md)]
 
-### For a given user, only one shell can be active
-
-Users can only launch one type of shell at a time, either **Bash** or **PowerShell**. However, you may have multiple instances of Bash or PowerShell running at one time. Swapping between Bash or PowerShell causes Cloud Shell to restart, which terminates existing sessions.
-
 ### Usage limits
 
 Cloud Shell is intended for interactive use cases. As a result, any long-running non-interactive sessions are ended without warning.
@@ -137,10 +133,6 @@ The `SqlServer` module included in Cloud Shell has only prerelease support for P
 ### Default file location when created from Azure drive
 
 Using PowerShell cmdlets, users cannot create files under the Azure drive. When users create new files using other tools, such as vim or nano, the files are saved to the `$HOME` by default.
-
-### Commands that create GUI pop-ups are not supported
-
-If the user runs a command that would create a Windows dialog box, such as `Connect-AzureAD`, `Connect-AzureRmAccount`, or `Connect-AzAccount`, one sees an error message such as: `Unable to load DLL 'IEFRAME.dll': The specified module could not be found. (Exception from HRESULT: 0x8007007E)`.
 
 ### Tab completion can throw PSReadline exception
 


### PR DESCRIPTION
It's not true anymore that one user can run just one shell at the time. It's possible now to run Bash and PowerShell at the same time in different tabs.
Connect-AzAccount (its alias Connect-AzureRmAccount) and Connect-AzureAD work now without a problem. Authentication changed to the devicelogin-based.