### PR TITLE
Mention vCenter v6.7 support

### DIFF
--- a/articles/migrate/tutorial-assessment-vmware.md
+++ b/articles/migrate/tutorial-assessment-vmware.md
@@ -25,7 +25,7 @@ If you don't have an Azure subscription, create a [free account](https://azure.m
 
 ## Prerequisites
 
-- **VMware**: The VMs that you plan to migrate must be managed by vCenter Server running version 5.5, 6.0, or 6.5. Additionally, you need one ESXi host running version 5.5 or higher to deploy the collector VM.
+- **VMware**: The VMs that you plan to migrate must be managed by vCenter Server running version 5.5, 6.0, 6.5, or 6.7. Additionally, you need one ESXi host running version 5.5 or higher to deploy the collector VM.
 - **vCenter Server account**: You need a read-only account to access the vCenter Server. Azure Migrate uses this account to discover the on-premises VMs.
 - **Permissions**: On the vCenter Server, you need permissions to create a VM by importing a file in .OVA format.
 


### PR DESCRIPTION
The [about](https://docs.microsoft.com/en-us/azure/migrate/migrate-overview#current-limitations) document mentions 6.7 as a supported version of vCenter Server, adding that version number here for consistency.