### PR TITLE
Labeled Create application, avoid click, helps

### DIFF
--- a/articles/active-directory/manage-apps/adding-gallery-app-common-problems.md
+++ b/articles/active-directory/manage-apps/adding-gallery-app-common-problems.md
@@ -24,13 +24,13 @@ This article helps you understand the common problems people face when adding Az
 
 ## I clicked the “add” button and my application took a long time to appear
 
-Under some circumstances, it can take 1-2 minutes (and sometimes longer) for an application to appear after adding it to your directory. While this is not the normal expected performance, you can see the application addition is in progress by clicking on the **Notifications** icon (the bell) in the upper right of the [Azure portal](https://portal.azure.com/) and looking for an **In Progress** or **Completed** notification labeled **Create application.**
+Under some circumstances, it can take 1-2 minutes (and sometimes longer) for an application to appear after adding it to your directory. While this is not the normal expected performance, you can see the application addition is in progress by clicking on the **Notifications** icon (the bell) in the upper right of the [Azure portal](https://portal.azure.com/) and looking for an **In Progress** or **Completed** notification labeled **Adding application.**
 
 If your application is never added, or you encounter an error when clicking the **Add** button, you’ll see a **Notification** in an **Error** state. If you want more details about the error to learn more to or share with a support engineer, you can see more information about the error by following the steps in the [How to see the details of a portal notification](#how-to-see-the-details-of-a-portal-notification) section.
 
 ## I clicked the “add” button and my application didn’t appear
 
-Sometimes, due to transient issues, networking problems, or a bug, adding an application fail. You can tell this happens when you click the **Notifications** icon (the bell) in the upper right of the Azure portal and you see a red (!) icon next to your **Create application** notification. This indicates there was an error when creating the application.
+Sometimes, due to transient issues, networking problems, or a bug, adding an application fails. You can tell this happens when you click the **Notifications** icon (the bell) in the upper right of the Azure portal and you see a red (!) icon next to your **Adding application** notification. This indicates there was an error when creating the application.
 
 If you encounter an error when clicking the **Add** button, you’ll see a **Notification** in an **Error** state. If you want more details about the error to learn more to or share with a support engineer, you can see more information about the error by following the steps in the [How to see the details of a portal notification](#how-to-see-the-details-of-a-portal-notification) section.
 
@@ -38,13 +38,13 @@ If you encounter an error when clicking the **Add** button, you’ll see a **Not
 
 If you need help learning about applications, the [List of Tutorials on How to Integrate SaaS Apps with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/active-directory-saas-tutorial-list) article is a good place to start.
 
-In addition to this, the [Azure AD Applications Document Library](https://docs.microsoft.com/azure/active-directory/active-directory-apps-index) help you to learn more about single sign-on with Azure AD and how it works.
+In addition to this, the [Azure AD Applications Document Library](https://docs.microsoft.com/azure/active-directory/active-directory-apps-index) helps you to learn more about single sign-on with Azure AD and how it works.
 
 ## How to see the details of a portal notification
 
 You can see the details of any portal notification by following the steps below:
 
-1.  click the **Notifications** icon (the bell) in the upper right of the Azure Portal
+1.  Select the **Notifications** icon (the bell) in the upper right of the Azure Portal
 
 2.  Select any notification in an **Error** state (those with a red (!) next to them).
 
@@ -57,7 +57,7 @@ You can see the details of any portal notification by following the steps below:
 
 5.  If you still need help, you can also share this information with a support engineer or the product group to get help with your problem.
 
-6.  Click the **copy** **icon** to the right of the **Copy error** textbox to copy all the notification details to share with a support or product group engineer
+6.  Click the **copy** **icon** to the right of the **Copy error** textbox to copy all the notification details to share with a support or product group engineer.
 
 ## How to get help by sending notification details to a support engineer
 


### PR DESCRIPTION
When adding an AD Gallery Application the label of the notification is "Adding application", not "Create application"
Click is specific for mouse actions, it should be avoided, instead use Select.
