### PR TITLE
Update Keras to note support for CNTK backend

### DIFF
--- a/articles/machine-learning/data-science-virtual-machine/dsvm-ubuntu-intro.md
+++ b/articles/machine-learning/data-science-virtual-machine/dsvm-ubuntu-intro.md
@@ -174,7 +174,7 @@ Some example notebooks are available in JupyterHub.
 H2O is a fast, in-memory, distributed machine learning and predictive analytics platform. A Python package is installed in both the root and py35 Anaconda environments. An R package is also installed. To start H2O from the command-line, run `java -jar /dsvm/tools/h2o/current/h2o.jar`; there are various [command line options](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/starting-h2o.html#from-the-command-line) that you may like to configure. The Flow Web UI can be accessed by browsing to http://localhost:54321 to get started. Sample notebooks are also available in JupyterHub.
 
 #### Keras
-Keras is a high-level neural network API in Python that is capable of running on top of either TensorFlow or Theano. It is available in the root and py35 Python environments. 
+Keras is a high-level neural network API in Python that is capable of running on top of TensorFlow, Microsoft Cognitive Toolkit, or Theano. It is available in the root and py35 Python environments. 
 
 #### MXNet
 MXNet is a deep learning framework designed for both efficiency and flexibility. It has R and Python bindings included on the DSVM. Sample notebooks are included in JupyterHub, and sample code is available in /dsvm/samples/mxnet.

--- a/articles/machine-learning/data-science-virtual-machine/dsvm-ubuntu-intro.md
+++ b/articles/machine-learning/data-science-virtual-machine/dsvm-ubuntu-intro.md
@@ -28,7 +28,7 @@ The Data Science Virtual Machine for Linux is an Ubuntu-based virtual machine im
   * [Caffe2](https://github.com/caffe2/caffe2): A cross-platform version of Caffe
   * [Microsoft Cognitive Toolkit](https://github.com/Microsoft/CNTK): A deep learning software toolkit from Microsoft Research
   * [H2O](https://www.h2o.ai/): An open-source big data platform and graphical user interface
-  * [Keras](https://keras.io/): A high-level neural network API in Python for Theano and TensorFlow
+  * [Keras](https://keras.io/): A high-level neural network API in Python for TensorFlow, Microsoft Cognitive Toolkit, and Theano
   * [MXNet](http://mxnet.io/): A flexible, efficient deep learning library with many language bindings
   * [NVIDIA DIGITS](https://developer.nvidia.com/digits): A graphical system that simplifies common deep learning tasks
   * [PyTorch](http://pytorch.org/): A high-level Python library with support for dynamic networks


### PR DESCRIPTION
Keras supports Tensorflow, Theano AND Microsoft Cognitive Toolkit (formerly CNTK). It's noted correctly in other parts of this repo (see https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/machine-learning/data-science-virtual-machine/use-deep-learning-dsvm.md). See also the Keras docs (https://keras.io/backend/), which call out support for CNTK. 

As a side note, the Microsoft Cognitive Toolkit page (https://www.microsoft.com/en-us/cognitive-toolkit/) notes that CNTK is the former name, but CNTK remains in popular usage throughout much of the Azure Docs. Indeed, it is even referred to as CNTK in the Microsoft Cognitive Toolkit site. :-D  Is there guidance on fixing these other references? Can we continue to use the name CNTK in official documentation?