### PR TITLE
Update GitHub product requirements for SAML single sign-on

### DIFF
--- a/articles/active-directory/saas-apps/github-tutorial.md
+++ b/articles/active-directory/saas-apps/github-tutorial.md
@@ -34,7 +34,7 @@ If you don't have an Azure subscription, [create a free account](https://azure.m
 To configure Azure AD integration with GitHub, you need the following items:
 
 * An Azure AD subscription. If you don't have an Azure AD environment, you can get one-month trial [here](https://azure.microsoft.com/pricing/free-trial/)
-* GitHub single sign-on enabled subscription
+* A GitHub organization created in [GitHub Enterprise Cloud](https://help.github.com/articles/github-s-products/#github-enterprise), which requires the [GitHub Enterprise billing plan](https://help.github.com/articles/github-s-billing-plans/#billing-plans-for-organizations)
 
 ## Scenario description
 


### PR DESCRIPTION
This pull request updates the [_Tutorial: Azure Active Directory integration with GitHub_ guide](https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/github-tutorial) to reflect recent GitHub product name changes ([1](https://help.github.com/articles/github-s-products/), [2](https://help.github.com/articles/github-s-billing-plans/), [3](https://github.blog/2019-01-07-new-year-new-github/)) and attempts to clarify what's required on the GitHub side for SAML single sign-on via Azure AD.

Closes #24684.