### PR TITLE
Update GitHub product requirements for provisioning

### DIFF
--- a/articles/active-directory/saas-apps/github-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/github-provisioning-tutorial.md
@@ -29,11 +29,11 @@ The objective of this tutorial is to show you the steps you need to perform in G
 The scenario outlined in this tutorial assumes that you already have the following items:
 
 *   An Azure Active directory tenant
-*   A GitHub tenant with the [Business Cloud plan](https://help.github.com/articles/organization-billing-plans/#github-business-cloud) or better enabled 
-*   A user account in GitHub with Admin permissions 
+*   A GitHub organization created in [GitHub Enterprise Cloud](https://help.github.com/articles/github-s-products/#github-enterprise), which requires the [GitHub Enterprise billing plan](https://help.github.com/articles/github-s-billing-plans/#billing-plans-for-organizations)
+*   A user account in GitHub with Admin permissions to the organization
 
 > [!NOTE]
-> The Azure AD provisioning integration relies on the [GitHub SCIM API](https://developer.github.com/v3/scim/), which is available to GitHub teams on the Business plan or better.
+> The Azure AD provisioning integration relies on the [GitHub SCIM API](https://developer.github.com/v3/scim/), which is available to [GitHub Enterprise Cloud](https://help.github.com/articles/github-s-products/#github-enterprise) customers on the [GitHub Enterprise billing plan](https://help.github.com/articles/github-s-billing-plans/#billing-plans-for-organizations).
 
 ## Assigning users to GitHub
 


### PR DESCRIPTION
This pull request updates the [_Tutorial: Configure GitHub for automatic user provisioning_ guide](https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/github-provisioning-tutorial) to reflect recent GitHub product name changes ([1](https://help.github.com/articles/github-s-products/), [2](https://help.github.com/articles/github-s-billing-plans/), [3](https://github.blog/2019-01-07-new-year-new-github/)) and attempts to clarify what's required on the GitHub side for access provisioning when using single sign-on via Azure AD.

The _Note_ callout about the SCIM API seems redundant to me after updating the bullet point about the GitHub requirements in the _Prerequisites_ section, but maybe it's okay 🤔

Closes #24685.