### PR TITLE
[AKS] Reverting changes on YAML formatting

### DIFF
--- a/articles/aks/use-network-policies.md
+++ b/articles/aks/use-network-policies.md
@@ -232,7 +232,7 @@ spec:
   ingress:
   - from:
     - namespaceSelector: {}
-    - podSelector:
+      podSelector:
         matchLabels:
           app: webapp
           role: frontend
@@ -353,7 +353,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           purpose: development
-    - podSelector:
+      podSelector:
         matchLabels:
           app: webapp
           role: frontend


### PR DESCRIPTION
Reverting from https://github.com/MicrosoftDocs/azure-docs-pr/pull/66534

Appears to have been an issue in Kubernetes used.