### PR TITLE
Update webjobs-sdk-get-started.md

### DIFF
--- a/articles/app-service/webjobs-sdk-get-started.md
+++ b/articles/app-service/webjobs-sdk-get-started.md
@@ -334,6 +334,7 @@ The WebJobs SDK looks for the storage connection string in the Application Setti
     ```
 
 1. Replace *{storage connection string}* with the connection string that you copied earlier.
+1. Select the *appsettings.json* file in Solution Explorer and in the **Properties** window, set the setting **Copy to Output Directory** to **Copy if newer**.
 
 ### App.config (SDK version 2.x)
 


### PR DESCRIPTION
The guide tells you to create a .NET Framework console application, and this project template doesn't include an *appsettings.json* file, so you have to add it manually. However, you'll run into an issue when you get to the section **Test locally**, which is an **InvalidOperationException** telling you that the storage account "Storage" has not been configured. It turns out that the *appsettings.json file* needs to be copied to the output directory (Which of course makes sense), but the guide doesn't say anything about this step.

So this change is simply adding this step to help others avoid spending time Googling and debugging.