### PR TITLE
Fix link to article on how to copy the AI instrumentation key

### DIFF
--- a/articles/app-service/webjobs-sdk-get-started.md
+++ b/articles/app-service/webjobs-sdk-get-started.md
@@ -428,7 +428,7 @@ In this section, you do the following tasks to set up Application Insights loggi
 
 1. If you don't already have an Application Insights resource that you can use, [create one](../azure-monitor/app/create-new-resource.md ). Set **Application type** to **General**, and skip the sections that follow **Copy the instrumentation key**.
 
-1. If you already have an Application Insights resource that you want to use, [copy the instrumentation key](../azure-monitor/app/create-new-resource.md #copy-the-instrumentation-key).
+1. If you already have an Application Insights resource that you want to use, [copy the instrumentation key](../azure-monitor/app/create-new-resource.md#copy-the-instrumentation-key).
 
 ### Configure app settings 
 


### PR DESCRIPTION
Link was not being displayed correctly due to a misplaced space.