### PR TITLE
Fix the "Description" for "Operating system"

### DIFF
--- a/articles/hdinsight/hadoop/apache-hadoop-linux-create-cluster-get-started-portal.md
+++ b/articles/hdinsight/hadoop/apache-hadoop-linux-create-cluster-get-started-portal.md
@@ -60,7 +60,7 @@ In this section, you create a Hadoop cluster in HDInsight using the Azure portal
     |Property  |Description  |
     |---------|---------|
     |**Cluster type**     | Select **Hadoop** |
-    |**Operating system**     |  Select your Azure subscription. |
+    |**Operating system**     | Select **Linux** |
     |**Version**     | Select **Hadoop 2.7.3 (HDI 3.6)**|
 
     Click **Select** and then click **Next**.


### PR DESCRIPTION
This PR changes the `Description` for the `Operating system` from `Select your Azure subscription.` to `Select Linux`.