### PR TITLE
ubuntu 17.10 no longer available. changed to 18.10

### DIFF
--- a/articles/network-watcher/connection-monitor.md
+++ b/articles/network-watcher/connection-monitor.md
@@ -69,7 +69,7 @@ Complete the steps in [Create the first VM](#create-the-first-vm) again, with th
 
 |Step|Setting|Value|
 |---|---|---|
-| 1 | Select **Ubuntu Server 17.10 VM** |                                                                         |
+| 1 | Select **Ubuntu Server 18.10 VM** |                                                                         |
 | 3 | Name                              | myVm2                                                                   |
 | 3 | Authentication type               | Paste your SSH public key or select **Password**, and enter a password. |
 | 3 | Resource group                    | Select **Use existing** and select **myResourceGroup**.                 |


### PR DESCRIPTION
This image no longer available. Change to 18.10 will not affect the guide, but will not frustrate users who can't create a vm from an image mentioned here.

test script
az vm image list-skus --location "north europe" --publisher "Canonical" --offer "UbuntuServer" --query "[].name"