### PR TITLE
ubuntu 17.10 no longer available. changed to 18.10

### DIFF
--- a/articles/network-watcher/diagnose-vm-network-traffic-filtering-problem.md
+++ b/articles/network-watcher/diagnose-vm-network-traffic-filtering-problem.md
@@ -34,7 +34,7 @@ Log in to the Azure portal at https://portal.azure.com.
 ## Create a VM
 
 1. Select **+ Create a resource** found on the upper, left corner of the Azure portal.
-2. Select **Compute**, and then select **Windows Server 2016 Datacenter** or **Ubuntu Server 17.10 VM**.
+2. Select **Compute**, and then select **Windows Server 2016 Datacenter** or **Ubuntu Server 18.10 VM**.
 3. Enter, or select, the following information, accept the defaults for the remaining settings, and then select **OK**:
 
     |Setting|Value|


### PR DESCRIPTION
This image no longer available. Change to 18.10 will not affect the guide, but will not frustrate users who can't create a vm from an image mentioned here.

test script
az vm image list-skus --location "north europe" --publisher "Canonical" --offer "UbuntuServer" --query "[].name"