### PR TITLE
RDFE classic applications can't be moved

### DIFF
--- a/articles/azure-resource-manager/resource-group-move-resources.md
+++ b/articles/azure-resource-manager/resource-group-move-resources.md
@@ -130,6 +130,7 @@ The following list provides a general summary of Azure services that can't be mo
 * Azure Firewall
 * Azure Migrate
 * Certificates - App Service Certificates can be moved, but uploaded certificates have [limitations](#app-service-limitations).
+* Classic Applications
 * Container Instances
 * Container Service
 * Data Box


### PR DESCRIPTION
as per Cosmin in CRI 103426135 - RDFE classic applications can't be moved
"very old" plug-in resource model - ARM doesn't support it so can't be moved