### PR TITLE
remove unsued  "errors"

### DIFF
--- a/articles/sql-database/sql-database-connect-query-go.md
+++ b/articles/sql-database/sql-database-connect-query-go.md
@@ -115,7 +115,6 @@ Get the connection information you need to connect to the Azure SQL database. Yo
        "context"
        "log"
        "fmt"
-       "errors"
    )
 
    var db *sql.DB


### PR DESCRIPTION
when i run 'go run sample.go',  (version: go1.11)
it returns  ' imported and not used: "errors" '