### PR TITLE
Update limitation

### DIFF
--- a/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
+++ b/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
@@ -40,7 +40,7 @@ During preview, there is no charge. You are billed for resources other than appl
 |Issue|Details|
 |--|--|
 |Authentication certificate|Not supported.<br>For more information, see [Overview of end to end SSL with Application Gateway](ssl-overview.md#end-to-end-ssl-with-the-v2-sku).|
-|Mixing Standard_v2 and Standard Application Gateway on the same subnet|Not supported.<br>Additionally, if autoscaling is enabled, one subnet can have only one application gateway.|
+|Mixing Standard_v2 and Standard Application Gateway on the same subnet|Not supported|
 |User Defined Route (UDR) on Application Gateway subnet|Not supported|
 |NSG for Inbound port range| - 65200 to 65535 for Standard_v2 SKU<br>- 65503 to 65534 for Standard SKU.<br>For more information, see the [FAQ](application-gateway-faq.md#are-network-security-groups-supported-on-the-application-gateway-subnet).|
 |Performance logs in Azure diagnostics|Not supported.<br>Azure metrics should be used.|


### PR DESCRIPTION
After NRP 116 rollout the limitation of having only one autoscale AppGW in a subnet has been removed