### PR TITLE
Fixed typo in config instructions

### DIFF
--- a/articles/digital-twins/tutorial-facilities-analyze.md
+++ b/articles/digital-twins/tutorial-facilities-analyze.md
@@ -85,13 +85,13 @@ You can use the [Event Hubs](../event-hubs/event-hubs-about.md) service to creat
       - UdfCustom
       connectionString: Primary_connection_string_for_your_event_hub
       secondaryConnectionString: Secondary_connection_string_for_your_event_hub
-      path: Name_of_your_Event_Hubs_namespace
+      path: Name_of_your_Event_Hub
     - type: EventHub
       eventTypes:
       - DeviceMessage
       connectionString: Primary_connection_string_for_your_event_hub
       secondaryConnectionString: Secondary_connection_string_for_your_event_hub
-      path: Name_of_your_Event_Hubs_namespace
+      path: Name_of_your_Event_Hub
     ```
 
 1. Replace the placeholders `Primary_connection_string_for_your_event_hub` with the value of **Connection string--primary key** for the event hub. Make sure the format of this connection string is as follows:
@@ -106,7 +106,7 @@ You can use the [Event Hubs](../event-hubs/event-hubs-about.md) service to creat
    Endpoint=sb://nameOfYourEventHubNamespace.servicebus.windows.net/;SharedAccessKeyName=ManageSend;SharedAccessKey=yourShareAccessKey2GUID;EntityPath=nameOfYourEventHub
    ```
 
-1. Replace the placeholders `Name_of_your_Event_Hubs_namespace` with the name of your Event Hubs namespace.
+1. Replace the placeholders `Name_of_your_Event_Hub` with the name of your Event Hubs namespace.
 
     > [!IMPORTANT]
     > Enter all values without any quotes. Make sure there's at least one space character after the colons in the YAML file. You can also validate your YAML file contents by using any online YAML validator, such as [this tool](https://onlineyamltools.com/validate-yaml).


### PR DESCRIPTION
Azure Digital Twins' Tutorial on TSI Integration has a typo instructing users to fill out the ```actions\createEndpoints.yaml``` config that will result in both a 400 error for half and a failed endpoint for the other half. The path variable should be the name of the eventHub, not the name of the namespace the hub lives within.