### PR TITLE
Update PHP ORM that support SQL Server

### DIFF
--- a/articles/sql-database/sql-database-connect-query.md
+++ b/articles/sql-database/sql-database-connect-query.md
@@ -75,7 +75,7 @@ The following table lists examples of object-relational mapping (ORM) frameworks
 | :-- | :-- | :-- |
 | C# | Windows, Linux, macOS | [Entity Framework](https://docs.microsoft.com/ef)<br>[Entity Framework Core](https://docs.microsoft.com/ef/core/index) |
 | Java | Windows, Linux, macOS |[Hibernate ORM](https://hibernate.org/orm)|
-| PHP | Windows, Linux, macOS | [Laravel (Eloquent)](https://laravel.com/docs/5.0/eloquent) |
+| PHP | Windows, Linux, macOS | [Laravel (Eloquent)](https://laravel.com/docs/eloquent)<br>[Doctrine](https://www.doctrine-project.org/projects/orm.html) |
 | Node.js | Windows, Linux, macOS | [Sequelize ORM](https://docs.sequelizejs.com) |
 | Python | Windows, Linux, macOS |[Django](https://www.djangoproject.com/) |
 | Ruby | Windows, Linux, macOS | [Ruby on Rails](https://rubyonrails.org/) |


### PR DESCRIPTION
In Laravel Eloquent doc link, removing the version redirects to the most recent version for documentation.

Doctrine ORM also supports pdo_sqlsrv thanks to dbal (see https://www.doctrine-project.org/projects/doctrine-dbal/en/2.9/reference/configuration.html#driver).