### PR TITLE
Improve wording/formatting of key-vault-limits.md.

### DIFF
--- a/includes/key-vault-limits.md
+++ b/includes/key-vault-limits.md
@@ -5,7 +5,8 @@ ms.topic: include
 ms.date: 11/09/2018	
 ms.author: jroth
 ---
-Key transactions (Max transactions allowed in 10 seconds, per vault per region<sup>1</sup>):
+
+## Key transactions (Max transactions allowed in 10 seconds, per vault per region<sup>1</sup>):
 
 |Key type|HSM-key<br>CREATE Key|HSM-key<br>All other transactions|Software-key<br>CREATE Key|Software-key<br>All other transactions|
 |:---|---:|---:|---:|---:|
@@ -16,31 +17,20 @@ Key transactions (Max transactions allowed in 10 seconds, per vault per region<s
 |ECC P-384|5|1000|10|2000|
 |ECC P-521|5|1000|10|2000|
 |ECC SECP256K1|5|1000|10|2000|
-|
 
 > [!NOTE]
-> The thresholds above are weighted and enforcement is on their sum. You can do 125 RSA-HSM-4k operations and 0 RSA-HSM-2k, or 124 RSA-HSM-4k and 16 RSA-HSM-2k. Afterward, in the same 10-second interval, any other operation will cause an AKV client exception.
+> In the table above, we see that for RSA 2048-bit software-keys, we allow 2000 GET transactions per 10 seconds, and that for RSA 2048-bit HSM-keys, we allow 1000 GET transactions per 10 seconds.
+>
+> Note that the throttling thresholds are weighted, and enforcement is on their sum. For example, in the table above, we can see that when performing GET operations on RSA HSM-keys, it is 8 times more expensive to use 4096-bit keys compared to 2048-bit keys (since 1000/125 = 8). Thus, in a given 10-second interval, an AKV client could do exactly one of the following before encountering a `429` throttling HTTP status code:
+> - 2000 RSA 2048-bit software-key GET transactions, **or**
+> - 1000 RSA 2048-bit HSM-key GET transactions, **or**
+> - 125 RSA 4096-bit HSM-key GET transactions, **or**
+> - 124 RSA 4096-bit HSM-key GET transactions and 8 RSA 2048-bit HSM-key GET transactions.
 
-> [!NOTE]
-> If you look at the table below, you see that for software-backed keys we allow 2000 transactions per 10 seconds, and for HSM backed keys we allow 1000 transactions      per 10 seconds. 
-  The ratio of software-backed transactions for 3072 keys to 2048 keys is 500/2000 or 0.4. This means that if a customer does 500 3072 key transactions in 10 seconds, they reach their max limit and can't do any other key operations. 
-   
-|Key type  | Software key |HSM-key  |
-|---------|---------|---------|
-|RSA 2048-bit     |    2000     |   1000    |
-|RSA 3072-bit     |     500    |    250     |
-|RSA 4096-bit     |    125     |    250     |
-|ECC P-256     |    2000     |  1000     |
-|ECC P-384     |    2000     |  1000     |
-|ECC P-521     |    2000     |  1000     |
-|ECC SECP256K1     |    2000     |  1000     |
-
-
-Secrets, Managed Storage Account Keys, and vault transactions:
+## Secrets, Managed Storage Account Keys, and vault transactions:
 | Transactions type | Max transactions allowed in 10 seconds, per vault per region<sup>1</sup> |
 | --- | --- |
 | All transactions |2000 |
-|
 
 See [Azure Key Vault throttling guidance](../articles/key-vault/key-vault-ovw-throttling.md) for information on how to handle throttling when these limits are exceeded.
 


### PR DESCRIPTION
This commit improves the wording/formatting for AKV's throttling limits by:
- Removing a redundant table (all the information in the 2nd table is already contained in the 1st table).
- Merging together and simplifying the two "notes".
- Fixing some incorrect math in the note (16 should have been 8 instead).
- Adding headers for each of the two tables.