### PR TITLE
Deprecated public_ip_address_allocation replaced

### DIFF
--- a/articles/virtual-machines/linux/terraform-create-complete-vm.md
+++ b/articles/virtual-machines/linux/terraform-create-complete-vm.md
@@ -92,7 +92,7 @@ resource "azurerm_public_ip" "myterraformpublicip" {
     name                         = "myPublicIP"
     location                     = "eastus"
     resource_group_name          = "${azurerm_resource_group.myterraformgroup.name}"
-    public_ip_address_allocation = "dynamic"
+    allocation_method = "Dynamic"
 
     tags {
         environment = "Terraform Demo"
@@ -284,7 +284,7 @@ resource "azurerm_public_ip" "myterraformpublicip" {
     name                         = "myPublicIP"
     location                     = "eastus"
     resource_group_name          = "${azurerm_resource_group.myterraformgroup.name}"
-    public_ip_address_allocation = "dynamic"
+    address_allocation = "Dynamic"
 
     tags {
         environment = "Terraform Demo"


### PR DESCRIPTION
The example gives you a warning that public_ip_address_allocation is deprecated in the latest azure provider 1.21:
Warning: azurerm_public_ip.azuredevopspublicip: "public_ip_address_allocation": [DEPRECATED] this property has been deprecated in favor of `allocation_method` to better match the api