### PR TITLE
Centralizing functions timeout information

### DIFF
--- a/articles/azure-functions/functions-scale.md
+++ b/articles/azure-functions/functions-scale.md
@@ -41,7 +41,7 @@ On an App Service plan, you can scale between tiers to allocate different amount
 When you're using a Consumption plan, instances of the Azure Functions host are dynamically added and removed based on the number of incoming events. This serverless plan scales automatically, and you're charged for compute resources only when your functions are running. On a Consumption plan, a function execution times out after a configurable period of time.
 
 > [!NOTE]
-> The default timeout for functions on a Consumption plan is 5 minutes. The value can be increased for the Function App up to a maximum of 10 minutes by changing the property `functionTimeout` in the [host.json](functions-host-json.md#functiontimeout) project file.
+> The default and maximum timeout for functions in consumption is described in the [Functions Versions](functions-versions.md) article.
 
 Billing is based on number of executions, execution time, and memory used. Billing is aggregated across all functions within a function app. For more information, see the [Azure Functions pricing page].
 
@@ -59,9 +59,12 @@ Consider an App Service plan in the following cases:
 * You have existing, underutilized VMs that are already running other App Service instances.
 * Your function apps run continuously, or nearly continuously. In this case, an App Service Plan can be more cost-effective.
 * You need more CPU or memory options than what is provided on the Consumption plan.
-* Your code needs to run longer than the maximum execution time allowed on the Consumption plan, which is up to 10 minutes.
+* Your code needs to run longer than the maximum execution time allowed on the Consumption plan. 
 * You require features that are only available on an App Service plan, such as support for App Service Environment, VNET/VPN connectivity, and larger VM sizes.
 * You want to run your function app on Linux, or you want to provide a custom image on which to run your functions.
+
+> [!NOTE]
+> The default and maximum timeout for functions in an App Service plan is described in the [Functions Versions](functions-versions.md) article.
 
 A VM decouples cost from number of executions, execution time, and memory used. As a result, you won't pay more than the cost of the VM instance that you allocate. For details about how the App Service plan works, see the [Azure App Service plans in-depth overview](../app-service/overview-hosting-plans.md). 
 

--- a/articles/azure-functions/functions-scale.md
+++ b/articles/azure-functions/functions-scale.md
@@ -41,7 +41,7 @@ On an App Service plan, you can scale between tiers to allocate different amount
 When you're using a Consumption plan, instances of the Azure Functions host are dynamically added and removed based on the number of incoming events. This serverless plan scales automatically, and you're charged for compute resources only when your functions are running. On a Consumption plan, a function execution times out after a configurable period of time.
 
 > [!NOTE]
-> The default and maximum timeout for functions in consumption is described in the [Functions Versions](functions-versions.md) article.
+> The default and maximum timeout for functions in consumption is described in the [Azure Functions runtime versions overview](functions-versions.md#timeout) article.
 
 Billing is based on number of executions, execution time, and memory used. Billing is aggregated across all functions within a function app. For more information, see the [Azure Functions pricing page].
 
@@ -64,7 +64,7 @@ Consider an App Service plan in the following cases:
 * You want to run your function app on Linux, or you want to provide a custom image on which to run your functions.
 
 > [!NOTE]
-> The default and maximum timeout for functions in an App Service plan is described in the [Functions Versions](functions-versions.md) article.
+> The default and maximum timeout for functions in an App Service plan is described in the [Azure Functions runtime versions overview](functions-versions.md#timeout) article.
 
 A VM decouples cost from number of executions, execution time, and memory used. As a result, you won't pay more than the cost of the VM instance that you allocate. For details about how the App Service plan works, see the [Azure App Service plans in-depth overview](../app-service/overview-hosting-plans.md). 
 

--- a/articles/azure-functions/functions-versions.md
+++ b/articles/azure-functions/functions-versions.md
@@ -123,6 +123,17 @@ The following table shows which bindings are supported in each runtime version.
 
 [!INCLUDE [Full bindings table](../../includes/functions-bindings.md)]
 
+## Default and Maximum Timeout Duration 
+
+Azure Functions in the Consumption plan have a default timeout of 5 minutes, and a maximum configurable timeout of 10 minutes for both 1.x and 2.x runtime versions.
+
+Azure Functions on an App Service Plan have an unlimited default and unlimited maximum timeout for the 1.x runtime; and a 30 minutes default and unlimited maximum timeout for the 2.x runtime.
+
+[!INCLUDE [Timeout Duration table](../../includes/functions-timeout-duration.md)]
+
+The timeout value can be changed for the Function App by changing the property functionTimeout in the [host.json](functions-host-json.md#functiontimeout) project file for both runtime versions.
+
+
 ## Next steps
 
 For more information, see the following resources:

--- a/articles/azure-functions/functions-versions.md
+++ b/articles/azure-functions/functions-versions.md
@@ -133,7 +133,6 @@ Azure Functions on an App Service Plan have an unlimited default and unlimited m
 
 The timeout value can be changed for the Function App by changing the property functionTimeout in the [host.json](functions-host-json.md#functiontimeout) project file for both runtime versions.
 
-
 ## Next steps
 
 For more information, see the following resources:

--- a/articles/azure-functions/functions-versions.md
+++ b/articles/azure-functions/functions-versions.md
@@ -123,7 +123,7 @@ The following table shows which bindings are supported in each runtime version.
 
 [!INCLUDE [Full bindings table](../../includes/functions-bindings.md)]
 
-## Default and Maximum Timeout Duration 
+## <a name="timeout"></a>Default and Maximum Timeout Duration 
 
 Azure Functions in the Consumption plan have a default timeout of 5 minutes, and a maximum configurable timeout of 10 minutes for both 1.x and 2.x runtime versions.
 

--- a/includes/functions-timeout-duration.md
+++ b/includes/functions-timeout-duration.md
@@ -1,0 +1,18 @@
+---
+title: include file
+description: include file
+services: functions
+author: nzthiago
+ms.service: azure-functions
+ms.topic: include
+ms.date: 02/21/2018
+ms.author: nzthiago
+ms.custom: include file
+---
+
+| Plan | Runtime Version | Default | Maximum |
+|------|---------|---------|---------|
+| Consumption | 1.x | 5 | 10 |
+| Consumption | 2.x | 5 | 10 |
+| App Service | 1.x | Unlimited | Unlimited |
+| App Service | 2.x | 30 | Unlimited |


### PR DESCRIPTION
Centralizing Functions timeout information in one article with a table between runtimes v1 and v2. The Functions Host article (functions-host-json.md) also includes similar information but I haven't changed it.
This change comes as feedback in Azure Advisors that the information should be update covered in one article only.  