### PR TITLE
Correct backtick escaping

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-messages-construct.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-construct.md
@@ -26,7 +26,7 @@ An IoT Hub message consists of:
 
 * An opaque binary body.
 
-Property names and values can only contain ASCII alphanumeric characters, plus `{'!', '#', '$', '%, '&', ''', '*', '+', '-', '.', '^', '_', '`', '|', '~'}` when you send device-to-cloud messages using the HTTPS protocol or send cloud-to-device messages.
+Property names and values can only contain ASCII alphanumeric characters, plus ``{'!', '#', '$', '%, '&', ''', '*', '+', '-', '.', '^', '_', '`', '|', '~'}`` when you send device-to-cloud messages using the HTTPS protocol or send cloud-to-device messages.
 
 Device-to-cloud messaging with IoT Hub has the following characteristics:
 


### PR DESCRIPTION
Previously, the `<code>` block was being ended early by the backtick that should have been escaped. The proper way to escape backticks is to use more backticks: https://github.com/github/markup/issues/363