### PR TITLE
Remove hard-coded image size from the tutorial

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/export-model-python.md
+++ b/articles/cognitive-services/Custom-Vision-Service/export-model-python.md
@@ -107,8 +107,10 @@ augmented_image = resize_to_256_square(max_square_image)
 ### Crop the center for the specific input size for the model
 
 ```Python
-# The compact models have a network size of 227x227, the model requires this size.
-network_input_size = 227
+# Get the input size of the model
+with tf.Session() as sess:
+    input_tensor_shape = sess.graph.get_tensor_by_name('Placeholder:0').shape.as_list()
+network_input_size = input_tensor_shape[1]
 
 # Crop the center for the specified network_input_Size
 augmented_image = crop_center(augmented_image, network_input_size, network_input_size)


### PR DESCRIPTION
As we changed the input size of the model, this code will throw an exception. We need to get the size from the model, instead of hard-coding it.