### PR TITLE
Add East Asia to AKS regions

### DIFF
--- a/articles/aks/container-service-quotas.md
+++ b/articles/aks/container-service-quotas.md
@@ -30,6 +30,7 @@ Azure Kubernetes Service (AKS) is available in the following regions:
 - Canada Central
 - Canada East
 - Central US
+- East Asia
 - East US
 - East US2
 - Japan East


### PR DESCRIPTION
Azure Kubernetes Service (AKS) was announced GA in East Asia on 11 Dec 2018.
https://azure.microsoft.com/en-us/updates/general-availability-azure-kubernetes-service-in-east-asia/