### PR TITLE
Fix default value from web.config to iisnode.yml

### DIFF
--- a/articles/app-service/app-service-web-nodejs-best-practices-and-troubleshoot-guide.md
+++ b/articles/app-service/app-service-web-nodejs-best-practices-and-troubleshoot-guide.md
@@ -85,7 +85,7 @@ In addition to this, for streaming applications, you must also set responseBuffe
 
 ### watchedFiles
 
-A semi-colon separated list of files that are watched for changes. Any change to a file causes the application to recycle. Each entry consists of an optional directory name as well as a required file name, which are relative to the directory where the main application entry point is located. Wild cards are allowed in the file name portion only. The default value is `*.js;web.config`
+A semi-colon separated list of files that are watched for changes. Any change to a file causes the application to recycle. Each entry consists of an optional directory name as well as a required file name, which are relative to the directory where the main application entry point is located. Wild cards are allowed in the file name portion only. The default value is `*.js;iisnode.yml`
 
 ### recycleSignalEnabled
 


### PR DESCRIPTION
iisnode watchedFiles is mentioned as the below.

```<attribute name="watchedFiles" type="string" expanded="true" defaultValue="*.js;iisnode.yml"/>```
https://github.com/Azure/iisnode/blob/master/src/config/iisnode_schema_x64.xml#L57

However, the docs said that "The default value is *.js;__web.config__".
https://docs.microsoft.com/en-us/azure/app-service/app-service-web-nodejs-best-practices-and-troubleshoot-guide#watchedfiles

So, I fixed correct value, __"iisnode.yml"__.