### PR TITLE
removed concat from sample code

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-functions-resource.md
+++ b/articles/azure-resource-manager/resource-group-template-functions-resource.md
@@ -723,8 +723,7 @@ Often, you need to use this function when using a storage account or virtual net
       }
   },
   "variables": {
-      "vnetID": "[resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-      "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', parameters('subnet1Name'))]"
+      "subnet1Ref": "[resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet1Name'))]"
   },
   "resources": [
   {


### PR DESCRIPTION
remove unnecessary code and used a multi-part resourceId for the sample.