### PR TITLE
(Azure CXP) fixes Updated the tutorial to include tenantId parameter

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-azure-ad-graph.md
+++ b/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-azure-ad-graph.md
@@ -39,10 +39,14 @@ This tutorial shows you how to use a system-assigned managed identity for a Wind
 
 ## Connect to Azure AD
 
-You need to connect to Azure AD to assign the VM to a group as well as grant the VM permission to retrieve its group memberships.
+You need to connect to Azure AD to assign the VM to a group as well as grant the VM permission to retrieve its group memberships. You can use Connect-AzureAD cmdlet directly or with TenantId paramter in case you have multiple tenants.
 
 ```powershell
 Connect-AzureAD
+```
+OR
+```powershell
+Connect-AzureAD -TenantId "Object Id of the tenant"
 ```
 
 ## Add your VM identity to a group in Azure AD
@@ -75,7 +79,13 @@ You will need Azure AD PowerShell to use this option. If you don't have it insta
    ```powershell
    Connect-AzureAD
    ```
+   To connect to a specific Azure Active Directory, use the _TenantId_ parameter, as follows:
 
+   ```PowerShell
+   Connect-AzureAD -TenantId "Object Id of the tenant"
+   ```
+
+   
 2. Run the following PowerShell commands to assign the ``Directory.Read.All`` application permission to the service principal that represents your VM's identity.
 
    ```powershell


### PR DESCRIPTION
Added TenantId parameter options for Connect-AzureAD cmdlet as per [customer suggestion](https://github.com/MicrosoftDocs/azure-docs/issues/24913) for scenarios where they may have different tenant for test/Devops .