### PR TITLE
NVA on the anther VNet.

### DIFF
--- a/articles/virtual-network/virtual-networks-udr-overview.md
+++ b/articles/virtual-network/virtual-networks-udr-overview.md
@@ -82,6 +82,9 @@ You can specify the following next hop types when creating a user-defined route:
 
       > [!NOTE]
       > Deploy a virtual appliance into a different subnet than the resources that route through the virtual appliance are deployed in. Deploying the virtual appliance to the same subnet, then applying a route table to the subnet that routes traffic through the virtual appliance, can result in routing loops, where traffic never leaves the subnet.
+      
+      > [!NOTE]
+      > If you need to connect to a virtual appliance which is on another virtual network, you can use only virtual network peering not VPN or ExpressRoute.
 
     - The private IP address of an Azure [internal load balancer](../load-balancer/load-balancer-get-started-ilb-arm-portal.md?toc=%2fazure%2fvirtual-network%2ftoc.json). A load balancer is often used as part of a [high availability strategy for network virtual appliances](/azure/architecture/reference-architectures/dmz/nva-ha?toc=%2fazure%2fvirtual-network%2ftoc.json).
 


### PR DESCRIPTION
If we setup a NVA on another network, we should use VNet peering to connect two VNet. We can not use VPN or ExpressRoute instead of VNet peering.
Example) Internet -- VNetA (NVA) <-VNet peering-> VNetB (Client)

I hope you will write this limitation in this documents.