### PR TITLE
Update get-started-unity-ios.md

### DIFF
--- a/articles/spatial-anchors/quickstarts/get-started-unity-ios.md
+++ b/articles/spatial-anchors/quickstarts/get-started-unity-ios.md
@@ -59,6 +59,9 @@ Save the scene by selecting **File** -> **Save**.
 
 Follow the instructions in the app to place and recall an anchor.
 
+> [!NOTE]
+> When running the app, if you don't see the camera as the background (for instance you instead see a blank, blue or other textures) then you need to re-import assets in Unity. Stop the app, then in Unity, from the top menu choose "Assets -> Re-import all". Then run the app again.
+
 In Xcode, stop the app by pressing **Stop**.
 
 [!INCLUDE [Clean-up section](../../../includes/clean-up-section-portal.md)]

--- a/articles/spatial-anchors/quickstarts/get-started-unity-ios.md
+++ b/articles/spatial-anchors/quickstarts/get-started-unity-ios.md
@@ -60,7 +60,7 @@ Save the scene by selecting **File** -> **Save**.
 Follow the instructions in the app to place and recall an anchor.
 
 > [!NOTE]
-> When running the app, if you don't see the camera as the background (for instance you instead see a blank, blue or other textures) then you need to re-import assets in Unity. Stop the app, then in Unity, from the top menu choose "Assets -> Re-import all". Then run the app again.
+> When running the app, if you don't see the camera as the background (for instance you instead see a blank, blue or other textures) then you likely need to re-import assets in Unity. Stop the app. From the top menu in Unity, choose **Assets -> Re-import all**. Then, run the app again.
 
 In Xcode, stop the app by pressing **Stop**.
 


### PR DESCRIPTION
Add note that Unity on iOS can sometimes get into a state where the camera feed is not shown in the app. To resolve in Unity Assets -> Re-import all". Two independent people have hit this on Reddit.