### PR TITLE
Chaging the parameter name from --hub-name

### DIFF
--- a/articles/iot-hub/quickstart-control-device-dotnet.md
+++ b/articles/iot-hub/quickstart-control-device-dotnet.md
@@ -89,7 +89,7 @@ A device must be registered with your IoT hub before it can connect. In this qui
 You also need your IoT hub _service connection string_ to enable the back-end application to connect to the hub and retrieve the messages. The following command retrieves the service connection string for your IoT hub:
 
 ```azurecli-interactive
-az iot hub show-connection-string --hub-name YourIoTHubName --output table
+az iot hub show-connection-string --name YourIoTHubName --output table
 ```
 
 Make a note of the service connection string, which looks like:


### PR DESCRIPTION
See https://github.com/microsoftdocs/azure-docs/issues/25777  This sample command line contains the incorrect parameter name "--hub-name" the actual parameter name is "--name".