### PR TITLE
Fix typo in webjobs-sdk-how-to.md

### DIFF
--- a/articles/app-service/webjobs-sdk-how-to.md
+++ b/articles/app-service/webjobs-sdk-how-to.md
@@ -39,7 +39,7 @@ When possible, examples are provides for both version 3.x and version 2.x.
 >
 > For more information, see [Compare the WebJobs SDK and Azure Functions](../azure-functions/functions-compare-logic-apps-ms-flow-webjobs.md#compare-functions-and-webjobs).
 
-## WebHobs host
+## WebJobs host
 
 The host is a runtime container for functions.  It listens for triggers and calls functions. In version 3.x, the host is an implementation of `IHost`, and in version 2.x you use the `JobHost` object. You create a host instance in your code and write code to customize its behavior.
 


### PR DESCRIPTION
Fix typo in "WebHobs" -> "WebJobs"