### PR TITLE
Add info about CocoaPods to Azure Notification Hubs SDK for iOS tutorial

### DIFF
--- a/articles/notification-hubs/notification-hubs-ios-apple-push-notification-apns-get-started.md
+++ b/articles/notification-hubs/notification-hubs-ios-apple-push-notification-apns-get-started.md
@@ -98,21 +98,21 @@ The Azure Notification Hubs SDK can be integrated into your app via [Cocoapods](
 
 - Integration via Cocoapods
 
-Add the following dependencies to your `podfile` to include Azure Notification Hubs SDK into your app.
+  Add the following dependencies to your `podfile` to include Azure Notification Hubs SDK into your app.
 
-```ruby
-pod 'AzureNotificationHubs-iOS'
-```
+  ```ruby
+  pod 'AzureNotificationHubs-iOS'
+  ```
 
-Run `pod install` to install your newly defined pod and open your `.xcworkspace`.
+  Run `pod install` to install your newly defined pod and open your `.xcworkspace`.
 
-> [!NOTE]
-> If you see an error like ```[!] Unable to find a specification for `AzureNotificationHubs-iOS` ```
->  while running `pod install`, please run `pod repo update` to get the latest pods from the Cocoapods repository and then run `pod install`.
+  > [!NOTE]
+  > If you see an error like ```[!] Unable to find a specification for `AzureNotificationHubs-iOS` ```
+  >  while running `pod install`, please run `pod repo update` to get the latest pods from the Cocoapods repository and then run `pod install`.
 
 - Integration by copying the binaries into your project
 
-Download the [Windows Azure Messaging Framework] and unzip the file. In Xcode, right-click your project and click the **Add Files to** option to add the **WindowsAzureMessaging.framework** folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
+  Download the [Windows Azure Messaging Framework] and unzip the file. In Xcode, right-click your project and click the **Add Files to** option to add the **WindowsAzureMessaging.framework** folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
 
     ![Unzip Azure SDK][10]
 

--- a/articles/notification-hubs/notification-hubs-ios-apple-push-notification-apns-get-started.md
+++ b/articles/notification-hubs/notification-hubs-ios-apple-push-notification-apns-get-started.md
@@ -92,29 +92,29 @@ You have now configured your notification hub with APNS, and you have the connec
 
     ![Xcode - push capabilities][12]
 
-5. Add the Azure Notification Hubs SDK modules
+5. Add the Azure Notification Hubs SDK modules.
 
-The Azure Notification Hubs SDK can be integrated into your app via [Cocoapods](https://cocoapods.org) or by manually adding the binaries to your project.
+   You can integrate the Azure Notification Hubs SDK in your app by using [Cocoapods](https://cocoapods.org) or by manually adding the binaries to your project.
 
-- Integration via Cocoapods
+   - Integration via Cocoapods
 
-  Add the following dependencies to your `podfile` to include Azure Notification Hubs SDK into your app.
+     Add the following dependencies to your `podfile` to include Azure Notification Hubs SDK into your app.
 
-  ```ruby
-  pod 'AzureNotificationHubs-iOS'
-  ```
+     ```ruby
+     pod 'AzureNotificationHubs-iOS'
+     ```
 
-  Run `pod install` to install your newly defined pod and open your `.xcworkspace`.
+     Run `pod install` to install your newly defined pod and open your `.xcworkspace`.
 
-  > [!NOTE]
-  > If you see an error like ```[!] Unable to find a specification for `AzureNotificationHubs-iOS` ```
-  >  while running `pod install`, please run `pod repo update` to get the latest pods from the Cocoapods repository and then run `pod install`.
+     > [!NOTE]
+     > If you see an error like ```[!] Unable to find a specification for `AzureNotificationHubs-iOS` ```
+     >  while running `pod install`, please run `pod repo update` to get the latest pods from the Cocoapods repository and then run `pod install`.
 
-- Integration by copying the binaries into your project
+   - Integration by copying the binaries into your project
 
-  Download the [Windows Azure Messaging Framework] and unzip the file. In Xcode, right-click your project and click the **Add Files to** option to add the **WindowsAzureMessaging.framework** folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
+     Download the [Windows Azure Messaging Framework] and unzip the file. In Xcode, right-click your project and click the **Add Files to** option to add the **WindowsAzureMessaging.framework** folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
 
-    ![Unzip Azure SDK][10]
+     ![Unzip Azure SDK][10]
 
 6. Add a new header file to your project named `HubInfo.h`. This file holds the constants for your notification hub. Add the following definitions and replace the string literal placeholders with your *hub name* and the *DefaultListenSharedAccessSignature* noted earlier.
 

--- a/articles/notification-hubs/notification-hubs-ios-apple-push-notification-apns-get-started.md
+++ b/articles/notification-hubs/notification-hubs-ios-apple-push-notification-apns-get-started.md
@@ -92,7 +92,27 @@ You have now configured your notification hub with APNS, and you have the connec
 
     ![Xcode - push capabilities][12]
 
-5. Download the [Windows Azure Messaging Framework] and unzip the file. In Xcode, right-click your project and click the **Add Files to** option to add the **WindowsAzureMessaging.framework** folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
+5. Add the Azure Notification Hubs SDK modules
+
+The Azure Notification Hubs SDK can be integrated into your app via [Cocoapods](https://cocoapods.org) or by manually adding the binaries to your project.
+
+- Integration via Cocoapods
+
+Add the following dependencies to your `podfile` to include Azure Notification Hubs SDK into your app.
+
+```ruby
+pod 'AzureNotificationHubs-iOS'
+```
+
+Run `pod install` to install your newly defined pod and open your `.xcworkspace`.
+
+> [!NOTE]
+> If you see an error like ```[!] Unable to find a specification for `AzureNotificationHubs-iOS` ```
+>  while running `pod install`, please run `pod repo update` to get the latest pods from the Cocoapods repository and then run `pod install`.
+
+- Integration by copying the binaries into your project
+
+Download the [Windows Azure Messaging Framework] and unzip the file. In Xcode, right-click your project and click the **Add Files to** option to add the **WindowsAzureMessaging.framework** folder to your Xcode project. Select **Options** and make sure **Copy items if needed** is selected, and then click **Add**.
 
     ![Unzip Azure SDK][10]
 


### PR DESCRIPTION
Azure Notification Hubs team have recently released the Azure Notification Hubs SDK for iOS to CocoaPods repository.

This PR updates the iOS tutorial to reflect that