### PR TITLE
Remove tracing configuration adjustment

### DIFF
--- a/articles/service-fabric/service-fabric-networking-modes.md
+++ b/articles/service-fabric/service-fabric-networking-modes.md
@@ -54,15 +54,6 @@ When a container service restarts or moves to another node in the cluster, the I
                     ]
                 },
                 {
-                    "name":  "Trace/Etw", 
-                    "parameters": [
-                    {
-                            "name": "Level",
-                            "value": "5"
-                    }
-                    ]
-                },
-                {
                     "name": "Setup",
                     "parameters": [
                     {


### PR DESCRIPTION
Setting the tracing level to 5 is equivalent to Verbose and shouldn't be used outside of debug scenarios.