### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/tutorial-vm-windows-access-storage.md
+++ b/articles/active-directory/managed-identities-azure-resources/tutorial-vm-windows-access-storage.md
@@ -148,7 +148,7 @@ namespace StorageOAuthToken
                 string errorText = String.Format("{0} \n\n{1}", e.Message, e.InnerException != null ? e.InnerException.Message : "Acquire token failed");
                 return accessToken;
             }
-        }            
+        }
     }
 }
 ```

--- a/articles/active-directory/managed-identities-azure-resources/tutorial-vm-windows-access-storage.md
+++ b/articles/active-directory/managed-identities-azure-resources/tutorial-vm-windows-access-storage.md
@@ -26,8 +26,8 @@ This tutorial shows you how to use a system-assigned managed identity for a Wind
 
 > [!div class="checklist"]
 > * Create a blob container in a storage account
-> * Grant your Windows VM's system-assigned managed identity access to a storage account 
-> * Get an access and use it to call Azure Storage 
+> * Grant your Windows VM's system-assigned managed identity access to a storage account
+> * Get an access and use it to call Azure Storage
 
 > [!NOTE]
 > Azure Active Directory authentication for Azure Storage is in public preview.
@@ -36,14 +36,14 @@ This tutorial shows you how to use a system-assigned managed identity for a Wind
 
 [!INCLUDE [msi-tut-prereqs](../../../includes/active-directory-msi-tut-prereqs.md)]
 
-## Create a storage account 
+## Create a storage account
 
-In this section, you create a storage account. 
+In this section, you create a storage account.
 
 1. Click the **+ Create a resource** button found on the upper left-hand corner of the Azure portal.
 2. Click **Storage**, then **Storage account - blob, file, table, queue**.
-3. Under **Name**, enter a name for the storage account.  
-4. **Deployment model** and **Account kind** should be set to **Resource manager** and **Storage (general purpose v1)**. 
+3. Under **Name**, enter a name for the storage account.
+4. **Deployment model** and **Account kind** should be set to **Resource manager** and **Storage (general purpose v1)**.
 5. Ensure the **Subscription** and **Resource Group** match the ones you specified when you created your VM in the previous step.
 6. Click **Create**.
 
@@ -60,22 +60,22 @@ Files require blob storage so you need to create a blob container in which to st
 
     ![Create storage container](./media/msi-tutorial-linux-vm-access-storage/create-blob-container.png)
 
-5. Using an editor of your choice, create a file titled *hello world.txt* on your local machine.  Open the file and add the text (without the quotes) "Hello world! :)" and then save it. 
+5. Using an editor of your choice, create a file titled *hello world.txt* on your local machine. Open the file and add the text (without the quotes) "Hello world! :)" and then save it.
 6. Upload the file to the newly created container by clicking on the container name, then **Upload**
 7. In the **Upload blob** pane, under **Files**, click the folder icon and browse to the file **hello_world.txt** on your local machine, select the file, then click **Upload**.
     ![Upload text file](./media/msi-tutorial-linux-vm-access-storage/upload-text-file.png)
 
-## Grant your VM access to an Azure Storage container 
+## Grant your VM access to an Azure Storage container
 
-You can use the VM's system-assigned managed identity to retrieve the data in the Azure storage blob.   
+You can use the VM's system-assigned managed identity to retrieve the data in the Azure storage blob.
 
-1. Navigate back to your newly created storage account.  
-2. Click the **Access control (IAM)** link in the left panel.  
+1. Navigate back to your newly created storage account.
+2. Click the **Access control (IAM)** link in the left panel.
 3. Click **+ Add role assignment** on top of the page to add a new role assignment for your VM.
-4. Under **Role**, from the dropdown, select **Storage Blob Data Reader (Preview)**. 
-5. In the next dropdown, under **Assign access to**, choose **Virtual Machine**.  
-6. Next, ensure the proper subscription is listed in **Subscription** dropdown and then set **Resource Group** to **All resource groups**.  
-7. Under **Select**, choose your VM and then click **Save**. 
+4. Under **Role**, from the dropdown, select **Storage Blob Data Reader (Preview)**.
+5. In the next dropdown, under **Assign access to**, choose **Virtual Machine**.
+6. Next, ensure the proper subscription is listed in **Subscription** dropdown and then set **Resource Group** to **All resource groups**.
+7. Under **Select**, choose your VM and then click **Save**.
 
     ![Assign permissions](./media/tutorial-linux-vm-access-storage/access-storage-perms.png)
 
@@ -83,7 +83,7 @@ You can use the VM's system-assigned managed identity to retrieve the data in th
 
 Azure Storage natively supports Azure AD authentication, so it can directly accept access tokens obtained using a managed identity. This is part of Azure Storage's integration with Azure AD, and is different from supplying credentials on the connection string.
 
-Here's a .Net code example of opening a connection to Azure Storage using an access token and then reading the contents of the file you created earlier. This code must run on the VM to be able to access the VM's managed identity endpoint. .Net Framework 4.6 or higher is required to use the access token method. Replace the value of `<URI to blob file>` accordingly. You can obtain this value by navigating to file you created and uploaded to blob storage and copying the **URL** under **Properties** the **Overview** page.
+Here's a .Net code example of opening a connection to Azure Storage using an access token and then reading the contents of the file you created earlier. This code must run on the VM to be able to access the VM's managed identity endpoint. .NET Framework 4.6 or higher is required to use the access token method. Replace the value of `<URI to blob file>` accordingly. You can obtain this value by navigating to file you created and uploaded to blob storage and copying the **URL** under **Properties** the **Overview** page.
 
 ```csharp
 using System;
@@ -93,7 +93,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.IO;
 using System.Net;
-using System.Web.Script.Serialization; 
+using System.Web.Script.Serialization;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Blob;
 
@@ -105,7 +105,7 @@ namespace StorageOAuthToken
         {
             //get token
             string accessToken = GetMSIToken("https://storage.azure.com/");
-           
+
             //create token credential
             TokenCredential tokenCredential = new TokenCredential(accessToken);
 
@@ -116,7 +116,7 @@ namespace StorageOAuthToken
 
             //create block blob using storage credentials
             CloudBlockBlob blob = new CloudBlockBlob(blobAddress, storageCredentials);
-        
+
             //retrieve blob contents
             Console.WriteLine(blob.DownloadText());
             Console.ReadLine();
@@ -163,6 +163,3 @@ In this tutorial, you learned how enable a Windows VM's system-assigned identity
 
 > [!div class="nextstepaction"]
 > [Azure Storage](/azure/storage/common/storage-introduction)
-
-
-


### PR DESCRIPTION
* Typo: .Net Framework -> .NET Framework
* Remove unnecessary space behind the code: When copying the corresponding part from the web page, unnecessary space is included