### PR TITLE
(Azure CXP) fixes Updated Link for Security Intelligence Report

### DIFF
--- a/articles/security/azure-ad-secure-steps.md
+++ b/articles/security/azure-ad-secure-steps.md
@@ -14,7 +14,7 @@ ms.author: martincoetzer
 
 # Five steps to securing your identity infrastructure
 
-If you're reading this document, you're aware of the significance of security. You likely already carry the responsibility for securing your organization. If you need to convince others of the importance of security, send them to read the latest [Microsoft Security Intelligence report](https://www.microsoft.com/security/intelligence-report).
+If you're reading this document, you're aware of the significance of security. You likely already carry the responsibility for securing your organization. If you need to convince others of the importance of security, send them to read the latest [Microsoft Security Intelligence report](https://www.microsoft.com/en-us/security/operations/security-intelligence-report).
 
 This document will help you get a more secure posture using the capabilities of Azure Active Directory by using a five-step checklist to inoculate your organization against cyber-attacks.
 


### PR DESCRIPTION
Updated the Link for Security Intelligence Report from https://www.microsoft.com/security/intelligence-report to current https://www.microsoft.com/en-us/security/operations/security-intelligence-report . Because the link https://www.microsoft.com/security/intelligence-report ends up in Error. 

Closes #26063