### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/virtual-machines/windows/scheduled-events.md
+++ b/articles/virtual-machines/windows/scheduled-events.md
@@ -20,23 +20,23 @@ ms.author: ericrad
 ---
 # Azure Metadata Service: Scheduled Events for Windows VMs
 
-Scheduled Events is an Azure Metadata Service that gives your application time to prepare for virtual machine maintenance. It provides information about upcoming maintenance events (e.g. reboot) so your application can prepare for them and limit disruption. It is available for all Azure Virtual Machine types including PaaS and IaaS on both Windows and Linux. 
+Scheduled Events is an Azure Metadata Service that gives your application time to prepare for virtual machine maintenance. It provides information about upcoming maintenance events (e.g. reboot) so your application can prepare for them and limit disruption. It is available for all Azure Virtual Machine types including PaaS and IaaS on both Windows and Linux.
 
 For information about Scheduled Events on Linux, see [Scheduled Events for Linux VMs](../linux/scheduled-events.md).
 
-> [!Note] 
+> [!Note]
 > Scheduled Events is generally available in all Azure Regions. See [Version and Region Availability](#version-and-region-availability) for latest release information.
 
 ## Why Scheduled Events?
 
-Many applications can benefit from time to prepare for virtual machine maintenance. The time can be used to perform application specific tasks that improve availability, reliability, and serviceability including: 
+Many applications can benefit from time to prepare for virtual machine maintenance. The time can be used to perform application specific tasks that improve availability, reliability, and serviceability including:
 
 - Checkpoint and restore
 - Connection draining
-- Primary replica failover 
+- Primary replica failover
 - Removal from load balancer pool
 - Event logging
-- Graceful shutdown 
+- Graceful shutdown
 
 Using Scheduled Events your application can discover when maintenance will occur and trigger tasks to limit its impact. Enabling scheduled events gives your virtual machine a minimum amount of time before the maintenance activity is performed. See the Event Scheduling section below for details.
 
@@ -44,27 +44,27 @@ Scheduled Events provides events in the following use cases:
 - Platform initiated maintenance (e.g. Host OS Update)
 - User initiated maintenance (e.g. user restarts or redeploys a VM)
 
-## The Basics  
+## The Basics
 
 Azure Metadata service exposes information about running Virtual Machines using a REST Endpoint accessible from within the VM. The information is available via a non-routable IP so that it is not exposed outside the VM.
 
 ### Endpoint Discovery
-For VNET enabled VMs, the metadata service is available from a static non-routable IP, `169.254.169.254`. The full endpoint for the latest version of Scheduled Events is: 
+For VNET enabled VMs, the metadata service is available from a static non-routable IP, `169.254.169.254`. The full endpoint for the latest version of Scheduled Events is:
 
- > `http://169.254.169.254/metadata/scheduledevents?api-version=2017-08-01`
+> `http://169.254.169.254/metadata/scheduledevents?api-version=2017-08-01`
 
-If the Virtual Machine is not created within a Virtual Network, the default cases for cloud services and classic VMs, additional logic is required to discover the IP address to use. 
+If the Virtual Machine is not created within a Virtual Network, the default cases for cloud services and classic VMs, additional logic is required to discover the IP address to use.
 Refer to this sample to learn how to [discover the host endpoint](https://github.com/azure-samples/virtual-machines-python-scheduled-events-discover-endpoint-for-non-vnet-vm).
 
 ### Version and Region Availability
 The Scheduled Events Service is versioned. Versions are mandatory and the current version is `2017-08-01`.
 
-| Version | Release Type | Regions | Release Notes | 
+| Version | Release Type | Regions | Release Notes |
 | - | - | - | - |
-| 2017-08-01 | General Availability | All | <li> Removed prepended underscore from resource names for IaaS VMs<br><li>Metadata Header requirement enforced for all requests | 
+| 2017-08-01 | General Availability | All | <li> Removed prepended underscore from resource names for IaaS VMs<br><li>Metadata Header requirement enforced for all requests |
 | 2017-03-01 | Preview | All |<li>Initial release
 
-> [!NOTE] 
+> [!NOTE]
 > Previous preview releases of scheduled events supported {latest} as the api-version. This format is no longer supported and will be deprecated in the future.
 
 ### Enabling and Disabling Scheduled Events
@@ -91,7 +91,7 @@ curl http://169.254.169.254/metadata/scheduledevents?api-version=2017-08-01 -H @
 ```
 
 A response contains an array of scheduled events. An empty array means that there are currently no events scheduled.
-In the case where there are scheduled events, the response contains an array of events: 
+In the case where there are scheduled events, the response contains an array of events:
 ```
 {
     "DocumentIncarnation": {IncarnationID},
@@ -102,7 +102,7 @@ In the case where there are scheduled events, the response contains an array of 
             "ResourceType": "VirtualMachine",
             "Resources": [{resourceName}],
             "EventStatus": "Scheduled" | "Started",
-            "NotBefore": {timeInUTC},              
+            "NotBefore": {timeInUTC},
         }
     ]
 }
@@ -120,7 +120,7 @@ The DocumentIncarnation is an ETag and provides an easy way to inspect if the Ev
 | NotBefore| Time after which this event may start. <br><br> Example: <br><ul><li> Mon, 19 Sep 2016 18:29:47 GMT  |
 
 ### Event Scheduling
-Each event is scheduled a minimum amount of time in the future based on event type. This time is reflected in an event's `NotBefore` property. 
+Each event is scheduled a minimum amount of time in the future based on event type. This time is reflected in an event's `NotBefore` property.
 
 |EventType  | Minimum Notice |
 | - | - |
@@ -128,17 +128,17 @@ Each event is scheduled a minimum amount of time in the future based on event ty
 | Reboot | 15 minutes |
 | Redeploy | 10 minutes |
 
-### Event Scope		
-Scheduled events are delivered to:		  
- - All Virtual Machines in a Cloud Service		
- - All Virtual Machines in an Availability Set		
- - All Virtual Machines in a Scale Set Placement Group. 		
+### Event Scope
+Scheduled events are delivered to:
+- All Virtual Machines in a Cloud Service
+- All Virtual Machines in an Availability Set
+- All Virtual Machines in a Scale Set Placement Group.
 
-As a result, you should check the `Resources` field in the event to identify which VMs are going to be impacted. 
+As a result, you should check the `Resources` field in the event to identify which VMs are going to be impacted.
 
-### Starting an event 
+### Starting an event
 
-Once you have learned of an upcoming event and completed your logic for graceful shutdown, you can approve the outstanding event by making a `POST` call to the metadata service with the `EventId`. This indicates to Azure that it can shorten the minimum notification time (when possible). 
+Once you have learned of an upcoming event and completed your logic for graceful shutdown, you can approve the outstanding event by making a `POST` call to the metadata service with the `EventId`. This indicates to Azure that it can shorten the minimum notification time (when possible).
 
 The following is the json expected in the `POST` request body. The request should contain a list of `StartRequests`. Each `StartRequest` contains the `EventId` for the event you want to expedite:
 ```
@@ -156,16 +156,16 @@ The following is the json expected in the `POST` request body. The request shoul
 curl -H @{"Metadata"="true"} -Method POST -Body '{"StartRequests": [{"EventId": "f020ba2e-3bc0-4c40-a10b-86575a9eabd5"}]}' -Uri http://169.254.169.254/metadata/scheduledevents?api-version=2017-08-01
 ```
 
-> [!NOTE] 
+> [!NOTE]
 > Acknowledging an event allows the event to proceed for all `Resources` in the event, not just the virtual machine that acknowledges the event. You may therefore choose to elect a leader to coordinate the acknowledgement, which may be as simple as the first machine in the `Resources` field.
 
 
-## PowerShell sample 
+## PowerShell sample
 
 The following sample queries the metadata service for scheduled events and approves each outstanding event.
 
 ```PowerShell
-# How to get scheduled events 
+# How to get scheduled events
 function Get-ScheduledEvents($uri)
 {
     $scheduledEvents = Invoke-RestMethod -Headers @{"Metadata"="true"} -URI $uri -Method get
@@ -176,11 +176,11 @@ function Get-ScheduledEvents($uri)
 
 # How to approve a scheduled event
 function Approve-ScheduledEvent($eventId, $uri)
-{    
+{
     # Create the Scheduled Events Approval Document
     $startRequests = [array]@{"EventId" = $eventId}
-    $scheduledEventsApproval = @{"StartRequests" = $startRequests} 
-    
+    $scheduledEventsApproval = @{"StartRequests" = $startRequests}
+
     # Convert to JSON string
     $approvalString = ConvertTo-Json $scheduledEventsApproval
 
@@ -199,7 +199,7 @@ function Handle-ScheduledEvents($scheduledEvents)
 
 # Set up the scheduled events URI for a VNET-enabled VM
 $localHostIP = "169.254.169.254"
-$scheduledEventURI = 'http://{0}/metadata/scheduledevents?api-version=2017-08-01' -f $localHostIP 
+$scheduledEventURI = 'http://{0}/metadata/scheduledevents?api-version=2017-08-01' -f $localHostIP
 
 # Get events
 $scheduledEvents = Get-ScheduledEvents $scheduledEventURI
@@ -214,14 +214,14 @@ foreach($event in $scheduledEvents.Events)
     $entry = Read-Host "`nApprove event? Y/N"
     if($entry -eq "Y" -or $entry -eq "y")
     {
-        Approve-ScheduledEvent $event.EventId $scheduledEventURI 
+        Approve-ScheduledEvent $event.EventId $scheduledEventURI
     }
 }
-``` 
+```
 
-## Next steps 
+## Next steps
 
-- Watch a [Scheduled Events Demo](https://channel9.msdn.com/Shows/Azure-Friday/Using-Azure-Scheduled-Events-to-Prepare-for-VM-Maintenance) on Azure Friday. 
+- Watch a [Scheduled Events Demo](https://channel9.msdn.com/Shows/Azure-Friday/Using-Azure-Scheduled-Events-to-Prepare-for-VM-Maintenance) on Azure Friday.
 - Review the Scheduled Events code samples in the [Azure Instance Metadata Scheduled Events GitHub Repository](https://github.com/Azure-Samples/virtual-machines-scheduled-events-discover-endpoint-for-non-vnet-vm)
 - Read more about the APIs available in the [Instance Metadata service](instance-metadata-service.md).
 - Learn about [planned maintenance for Windows virtual machines in Azure](planned-maintenance.md).


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.