### PR TITLE
remove $snapshotName from create image from managed disk

### DIFF
--- a/articles/virtual-machines/windows/capture-image-resource.md
+++ b/articles/virtual-machines/windows/capture-image-resource.md
@@ -139,7 +139,6 @@ If you want to create an image of only the OS disk, specify the managed disk ID 
 	$vmName = "myVM"
 	$rgName = "myResourceGroup"
 	$location = "EastUS"
-	$snapshotName = "mySnapshot"
 	$imageName = "myImage"
 	```
 


### PR DESCRIPTION
the variable $snapshotName is not used in this example of ## Create an image from a managed disk using PowerShell