### PR TITLE
Fixed formatting in hyper-v-vmm-performance-results.md

### DIFF
--- a/articles/site-recovery/hyper-v-vmm-performance-results.md
+++ b/articles/site-recovery/hyper-v-vmm-performance-results.md
@@ -103,7 +103,7 @@ The results clearly show that Site Recovery, coupled with Hyper-V Replica, scale
 
 | Server | RAM | Model | Processor | Number of processors | NIC | Software |
 | --- | --- | --- | --- | --- | --- | --- |
-| Hyper-V servers in cluster: <br />ESTLAB-HOST11<br />ESTLAB-HOST12<br />ESTLAB-HOST13<br />ESTLAB-HOST14<br />ESTLAB-HOST25 |128ESTLAB-HOST25 has 256 |Dell ™ PowerEdge ™ R820 |Intel(R) Xeon(R) CPU E5-4620 0 \@ 2.20GHz |4 |I Gbps x 4 |Windows Server Datacenter 2012 R2 (x64) + Hyper-V role |
+| Hyper-V servers in cluster: <br />ESTLAB-HOST11<br />ESTLAB-HOST12<br />ESTLAB-HOST13<br />ESTLAB-HOST14<br />ESTLAB-HOST25 |128<br />ESTLAB-HOST25 has 256 |Dell ™ PowerEdge ™ R820 |Intel(R) Xeon(R) CPU E5-4620 0 \@ 2.20GHz |4 |I Gbps x 4 |Windows Server Datacenter 2012 R2 (x64) + Hyper-V role |
 | VMM Server |2 | | |2 |1 Gbps |Windows Server Database 2012 R2 (x64) + VMM 2012 R2 |
 
 ### Secondary site
@@ -128,11 +128,11 @@ The results clearly show that Site Recovery, coupled with Hyper-V Replica, scale
 
 | Workload | I/O size (KB) | % Access | %Read | Outstanding I/Os | I/O pattern |
 | --- | --- | --- | --- | --- | --- |
-| File Server |48163264 |60%20%5%5%10% |80%80%80%80%80% |88888 |All 100% random |
-| SQL Server (volume 1)SQL Server (volume 2) |864 |100%100% |70%0% |88 |100% random100% sequential |
+| File Server |4<br />8<br />16<br />32<br />64 |60%<br />20%<br />5%<br />5%<br />10% |80%<br />80%<br />80%<br />80%<br />80% |8<br />8<br />8<br />8<br />8 |All 100% random |
+| SQL Server (volume 1)<br />SQL Server (volume 2) |8<br />64 |100%<br />100% |70%<br />0% |8<br />8 |100% random<br />100% sequential |
 | Exchange |32 |100% |67% |8 |100% random |
-| Workstation/VDI |464 |66%34% |70%95% |11 |Both 100% random |
-| Web File Server |4864 |33%34%33% |95%95%95% |888 |All 75% random |
+| Workstation/VDI |4<br />64 |66%<br />34% |70%<br />95% |1<br />1 |Both 100% random |
+| Web File Server |4<br />8<br />64 |33%<br />34%<br />33% |95%<br />95%<br />95% |8<br />8<br />8 |All 75% random |
 
 ### VM configuration
 


### PR DESCRIPTION
Primary site and Server Workload tables has formatting issues that made the tables difficult to read.
I've updated the the table formatting to make it more readable.