### PR TITLE
Adding CICI to the index

### DIFF
--- a/articles/data-factory/index.yml
+++ b/articles/data-factory/index.yml
@@ -75,6 +75,7 @@ sections:
     - html: Transform data in virtual network - <a href="/azure/data-factory/tutorial-transform-data-hive-virtual-network-portal">Data Factory UI</a> | <a href="/azure/data-factory/tutorial-transform-data-hive-virtual-network">Azure PowerShell</a>
     - html: Add branching and chaining - <a href="/azure/data-factory/tutorial-control-flow-portal">Data Factory UI</a> | <a href="/azure/data-factory/tutorial-control-flow">.NET</a> 
     - html: Run SSIS packages in Azure - <a href="/azure/data-factory/tutorial-create-azure-ssis-runtime-portal">Data Factory UI</a> | <a href="/azure/data-factory/tutorial-deploy-ssis-packages-azure">Azure PowerShell</a>
+    - html: Continuous integration and delivery (CI/CD) in Azure Data Factory - <a href="/azure/data-factory/continuous-integration-deployment">Data Factory UI</a>
 - title: Samples
   items:
   - type: paragraph


### PR DESCRIPTION
We're running a Data DevOps hack @ Microsoft and one of the most recurrent feedbacks were in regards to finding this document on the Data Factory documentation.

People said that it was difficult to find it down 2 levels on the tree index. The feedback was that it makes sense to be on the home index, under the Step-by-Step tutorials.