### PR TITLE
Added quotation marks for cmd on Windows

### DIFF
--- a/articles/azure-functions/functions-create-first-java-maven.md
+++ b/articles/azure-functions/functions-create-first-java-maven.md
@@ -55,8 +55,8 @@ mvn archetype:generate `
 
 ```cmd
 mvn archetype:generate ^
-	-DarchetypeGroupId=com.microsoft.azure ^
-	-DarchetypeArtifactId=azure-functions-archetype
+	"-DarchetypeGroupId=com.microsoft.azure" ^
+	"-DarchetypeArtifactId=azure-functions-archetype"
 ```
 
 Maven will ask you for values needed to finish generating the project. For _groupId_, _artifactId_, and _version_ values, see the [Maven naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html) reference. The _appName_ value must be unique across Azure, so Maven generates an app name based on the previously entered _artifactId_  as a default. The _packageName_ value determines the Java package for the generated function code.


### PR DESCRIPTION
On Windows you have to put the parameters of mvn archetype:generate command into quotation marks to get things working. If you fail to do so, you are getting the following error:

```
PS K:\Thrash\functions-java> mvn archetype:generate -DarchetypeGroupId=com.microsoft.azure -DarchetypeArtifactId=azure-functions-archetype
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.165 s
[INFO] Finished at: 2019-03-05T22:16:38+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] The goal you specified requires a project to execute but there is no POM in this directory (K:\Thrash\functions-java). Please verify you invoked Maven from the correct directory. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MissingProjectException
```