### PR TITLE
Adding note about verification via TXT records

### DIFF
--- a/articles/dns/dns-web-sites-custom-domain.md
+++ b/articles/dns/dns-web-sites-custom-domain.md
@@ -78,6 +78,9 @@ New-AzDnsRecordSet -Name "@" -RecordType "A" -ZoneName "contoso.com" `
 
 App Services uses this record only at configuration time to verify that you own the custom domain. You can delete this TXT record after your custom domain is validated and configured in App Service.
 
+> [!NOTE]
+> If you want to verify the domain name, but not route production traffic to the web app, you only need to specify the TXT record for the verification step.  Verification does not require an A or CNAME record in addition to the TXT record.
+
 ```powershell
 New-AzDnsRecordSet -ZoneName contoso.com -ResourceGroupName MyAzureResourceGroup `
  -Name "@" -RecordType "txt" -Ttl 600 `


### PR DESCRIPTION
The TXT record can solely be used for verification, which can help customers validate the web app will work the way it work before doing a large cutover from another service to an Azure Web App.