### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/includes/data-factory-azure-storage-linked-services.md
+++ b/includes/data-factory-azure-storage-linked-services.md
@@ -18,15 +18,15 @@ See the following section for steps to view/copy the account key for an Azure St
 **Example:**  
 
 ```json
-{  
-    "name": "StorageLinkedService",  
-    "properties": {  
-        "type": "AzureStorage",  
-        "typeProperties": {  
-            "connectionString": "DefaultEndpointsProtocol=https;AccountName=<accountname>;AccountKey=<accountkey>"  
-        }  
-    }  
-}  
+{
+    "name": "StorageLinkedService",
+    "properties": {
+        "type": "AzureStorage",
+        "typeProperties": {
+            "connectionString": "DefaultEndpointsProtocol=https;AccountName=<accountname>;AccountKey=<accountkey>"
+        }
+    }
+}
 ```
 
 ### Azure Storage Sas Linked Service
@@ -50,15 +50,15 @@ The Azure Storage SAS linked service allows you to link an Azure Storage Account
 **Example:**
 
 ```json
-{  
-    "name": "StorageSasLinkedService",  
-    "properties": {  
-        "type": "AzureStorageSas",  
-        "typeProperties": {  
-            "sasUri": "<Specify SAS URI of the Azure Storage resource>"   
-        }  
-    }  
-}  
+{
+    "name": "StorageSasLinkedService",
+    "properties": {
+        "type": "AzureStorageSas",
+        "typeProperties": {
+            "sasUri": "<Specify SAS URI of the Azure Storage resource>"
+        }
+    }
+}
 ```
 
 When creating an **SAS URI**, considering the following:  


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.