### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/virtual-machines/troubleshooting/troubleshoot-ssh-connection.md
+++ b/articles/virtual-machines/troubleshooting/troubleshoot-ssh-connection.md
@@ -108,7 +108,7 @@ The VM Access Extension for Linux reads in a json file that defines actions to c
 Create a file named `settings.json` with the following content:
 
 ```json
-{  
+{
     "reset_ssh":"True"
 }
 ```


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.