### PR TITLE
CNAME -> A

### DIFF
--- a/articles/dns/dns-custom-domain.md
+++ b/articles/dns/dns-custom-domain.md
@@ -49,7 +49,7 @@ On the **Add hostname** blade, enter the CNAME record in the **hostname** text f
 
 ## Public IP address
 
-To configure a custom domain for services that use a public IP address resource such as Application Gateway, Load Balancer, Cloud Service, Resource Manager VMs, and, Classic VMs, a CNAME record used.
+To configure a custom domain for services that use a public IP address resource such as Application Gateway, Load Balancer, Cloud Service, Resource Manager VMs, and, Classic VMs, an A record is used.
 
 Navigate to **Networking** > **Public IP address**, select the Public IP resource and click **Configuration**. Notate the IP address shown.
 


### PR DESCRIPTION
Logic error, example specified below uses an A record and an A record should be used as we refer to IP, not a DNS record.