### PR TITLE
Remove reference to a Hybrid join scenario

### DIFF
--- a/articles/active-directory/devices/azureadjoin-plan.md
+++ b/articles/active-directory/devices/azureadjoin-plan.md
@@ -37,7 +37,7 @@ This article assumes that you are familiar with the [Introduction to device mana
 
 ## Plan your implementation
 
-To plan your hybrid Azure AD implementation, you should familiarize yourself with:
+To plan your Azure AD join implementation, you should familiarize yourself with:
 
 |   |   |
 |---|---|


### PR DESCRIPTION
This article describes AADJ, not DJ++. Remove "Hybrid" reference to avoid confusion.