### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/virtual-machines/windows/hybrid-use-benefit-licensing.md
+++ b/articles/virtual-machines/windows/hybrid-use-benefit-licensing.md
@@ -49,7 +49,7 @@ All Windows Server OS based images are supported for Azure Hybrid Benefit for Wi
 ### Portal
 To create a VM with Azure Hybrid Benefit for Windows Server, use the toggle under the "Save money" section.
 
-### Powershell
+### PowerShell
 
 
 ```powershell
@@ -90,7 +90,7 @@ If you have an existing VM that you would like to convert to take advantage of A
 ### Portal
 From portal VM blade, you can update the VM to use Azure Hybrid Benefit by selecting "Configuration" option and toggle the "Azure hybrid benefit" option
 
-### Powershell
+### PowerShell
 - Convert existing Windows Server VMs to Azure Hybrid Benefit for Windows Server
 
     ```powershell
@@ -120,7 +120,7 @@ Once you have deployed your VM through either PowerShell, Resource Manager templ
 ### Portal
 From portal VM blade, you can view the toggle for Azure Hybrid Benefit for Windows Server by selecting "Configuration" tab.
 
-### Powershell
+### PowerShell
 The following example shows the license type for a single VM
 ```powershell
 Get-AzVM -ResourceGroup "myResourceGroup" -Name "myVM"
@@ -155,7 +155,7 @@ To see and count all virtual machines deployed with Azure Hybrid Benefit for Win
 ### Portal
 From the Virtual Machine or Virtual machine scale sets resource blade, you can view a list of all your VM(s) and licensing type by configuring the table column to include "Azure Hybrid Benefit". The VM setting can either be in "Enabled", "Not enabled" or "Not supported" state.
 
-### Powershell
+### PowerShell
 ```powershell
 $vms = Get-AzVM
 $vms | ?{$_.LicenseType -like "Windows_Server"} | select ResourceGroupName, Name, LicenseType
@@ -167,7 +167,7 @@ az vm list --query "[?licenseType=='Windows_Server']" -o table
 ```
 
 ## Deploy a Virtual Machine Scale Set with Azure Hybrid Benefit for Windows Server
-Within your virtual machine scale set Resource Manager templates, an additional parameter `licenseType` must be specified within your VirtualMachineProfile property. You can do this during create or update for your scale set through ARM template, Powershell, Azure CLI or REST.
+Within your virtual machine scale set Resource Manager templates, an additional parameter `licenseType` must be specified within your VirtualMachineProfile property. You can do this during create or update for your scale set through ARM template, PowerShell, Azure CLI or REST.
 
 The following example uses ARM template with a Windows Server 2016 Datacenter image:
 ```json

--- a/articles/virtual-machines/windows/hybrid-use-benefit-licensing.md
+++ b/articles/virtual-machines/windows/hybrid-use-benefit-licensing.md
@@ -74,10 +74,10 @@ az vm create \
 Within your Resource Manager templates, an additional parameter `licenseType` must be specified. You can read more about [authoring Azure Resource Manager templates](../../resource-group-authoring-templates.md)
 ```json
 "properties": {
-   "licenseType": "Windows_Server",
-   "hardwareProfile": {
+    "licenseType": "Windows_Server",
+    "hardwareProfile": {
         "vmSize": "[variables('vmSize')]"
-   }
+    }
 ```
 
 ## Convert an existing VM using Azure Hybrid Benefit for Windows Server
@@ -157,7 +157,7 @@ From the Virtual Machine or Virtual machine scale sets resource blade, you can v
 
 ### Powershell
 ```powershell
-$vms = Get-AzVM 
+$vms = Get-AzVM
 $vms | ?{$_.LicenseType -like "Windows_Server"} | select ResourceGroupName, Name, LicenseType
 ```
 

--- a/articles/virtual-machines/windows/hybrid-use-benefit-licensing.md
+++ b/articles/virtual-machines/windows/hybrid-use-benefit-licensing.md
@@ -73,7 +73,7 @@ az vm create \
 ### Template
 Within your Resource Manager templates, an additional parameter `licenseType` must be specified. You can read more about [authoring Azure Resource Manager templates](../../resource-group-authoring-templates.md)
 ```json
-"properties": {  
+"properties": {
    "licenseType": "Windows_Server",
    "hardwareProfile": {
         "vmSize": "[variables('vmSize')]"


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.