### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/storage/files/storage-c-plus-plus-how-to-use-files.md
+++ b/articles/storage/files/storage-c-plus-plus-how-to-use-files.md
@@ -53,7 +53,7 @@ To use File storage, you need to connect to your Azure storage account. The firs
 
 ```cpp
 // Define the connection-string with your values.
-const utility::string_t 
+const utility::string_t
 storage_connection_string(U("DefaultEndpointsProtocol=https;AccountName=your_storage_account;AccountKey=your_storage_account_key"));
 ```
 
@@ -61,8 +61,8 @@ storage_connection_string(U("DefaultEndpointsProtocol=https;AccountName=your_sto
 You can use the **cloud_storage_account** class to represent your Storage Account information. To retrieve your storage account information from the storage connection string, you can use the **parse** method.
 
 ```cpp
-// Retrieve storage account from connection string.    
-azure::storage::cloud_storage_account storage_account = 
+// Retrieve storage account from connection string.
+azure::storage::cloud_storage_account storage_account =
   azure::storage::cloud_storage_account::parse(storage_connection_string);
 ```
 
@@ -71,7 +71,7 @@ All files and directories in an Azure file share reside in a container called a 
 
 ```cpp
 // Create the Azure Files client.
-azure::storage::cloud_file_client file_client = 
+azure::storage::cloud_file_client file_client =
   storage_account.create_cloud_file_client();
 ```
 
@@ -79,15 +79,15 @@ Using the Azure Files client, you can then obtain a reference to a share.
 
 ```cpp
 // Get a reference to the file share
-azure::storage::cloud_file_share share = 
+azure::storage::cloud_file_share share =
   file_client.get_share_reference(_XPLATSTR("my-sample-share"));
 ```
 
 To create the share, use the **create_if_not_exists** method of the **cloud_file_share** object.
 
 ```cpp
-if (share.create_if_not_exists()) {    
-    std::wcout << U("New share created") << std::endl;    
+if (share.create_if_not_exists()) {
+    std::wcout << U("New share created") << std::endl;
 }
 ```
 
@@ -98,7 +98,7 @@ Deleting a share is done by calling the **delete_if_exists** method on a cloud_f
 
 ```cpp
 // Get a reference to the share.
-azure::storage::cloud_file_share share = 
+azure::storage::cloud_file_share share =
   file_client.get_share_reference(_XPLATSTR("my-sample-share"));
 
 // delete the share if exists
@@ -116,7 +116,7 @@ azure::storage::cloud_file_directory directory = share.get_directory_reference(_
 directory.create_if_not_exists();
 
 // Create a subdirectory.
-azure::storage::cloud_file_directory subdirectory = 
+azure::storage::cloud_file_directory subdirectory =
   directory.get_subdirectory_reference(_XPLATSTR("my-sample-subdirectory"));
 subdirectory.create_if_not_exists();
 ```
@@ -126,11 +126,11 @@ Deleting a directory is a simple task, although it should be noted that you cann
 
 ```cpp
 // Get a reference to the share.
-azure::storage::cloud_file_share share = 
+azure::storage::cloud_file_share share =
   file_client.get_share_reference(_XPLATSTR("my-sample-share"));
 
 // Get a reference to the directory.
-azure::storage::cloud_file_directory directory = 
+azure::storage::cloud_file_directory directory =
   share.get_directory_reference(_XPLATSTR("my-sample-directory"));
 
 // Get a reference to the subdirectory you want to delete.
@@ -150,7 +150,7 @@ The following code demonstrates how to retrieve and output the URI of each item 
 
 ```cpp
 //Get a reference to the root directory for the share.
-azure::storage::cloud_file_directory root_dir = 
+azure::storage::cloud_file_directory root_dir =
   share.get_root_directory_reference();
 
 // Output URI of each item.
@@ -165,7 +165,7 @@ for (auto it = directory.list_files_and_directories(); it != end_of_results; ++i
     else if (it->is_file())
     {
         ucout << "File: " << it->as_file().uri().primary_uri().to_string() << std::endl;
-    }        
+    }
 }
 ```
 
@@ -183,22 +183,22 @@ Now that you have a reference to the root directory of the share, you can upload
 
 ```cpp
 // Upload a file from a stream.
-concurrency::streams::istream input_stream = 
+concurrency::streams::istream input_stream =
   concurrency::streams::file_stream<uint8_t>::open_istream(_XPLATSTR("DataFile.txt")).get();
 
-azure::storage::cloud_file file1 = 
+azure::storage::cloud_file file1 =
   root_dir.get_file_reference(_XPLATSTR("my-sample-file-1"));
 file1.upload_from_stream(input_stream);
 
 // Upload some files from text.
-azure::storage::cloud_file file2 = 
+azure::storage::cloud_file file2 =
   root_dir.get_file_reference(_XPLATSTR("my-sample-file-2"));
 file2.upload_text(_XPLATSTR("more text"));
 
 // Upload a file from a file.
-azure::storage::cloud_file file4 = 
+azure::storage::cloud_file file4 =
   root_dir.get_file_reference(_XPLATSTR("my-sample-file-3"));
-file4.upload_from_file(_XPLATSTR("DataFile.txt"));    
+file4.upload_from_file(_XPLATSTR("DataFile.txt"));
 ```
 
 ## Download a file
@@ -208,13 +208,13 @@ The following example uses the **download_to_stream** and **download_text** meth
 
 ```cpp
 // Download as text
-azure::storage::cloud_file text_file = 
+azure::storage::cloud_file text_file =
   root_dir.get_file_reference(_XPLATSTR("my-sample-file-2"));
 utility::string_t text = text_file.download_text();
 ucout << "File Text: " << text << std::endl;
 
 // Download as a stream.
-azure::storage::cloud_file stream_file = 
+azure::storage::cloud_file stream_file =
   root_dir.get_file_reference(_XPLATSTR("my-sample-file-3"));
 
 concurrency::streams::container_buffer<std::vector<uint8_t>> buffer;
@@ -230,14 +230,14 @@ outfile.close();
 Another common Azure Files operation is file deletion. The following code deletes a file named my-sample-file-3 stored under the root directory.
 
 ```cpp
-// Get a reference to the root directory for the share.    
-azure::storage::cloud_file_share share = 
+// Get a reference to the root directory for the share.
+azure::storage::cloud_file_share share =
   file_client.get_share_reference(_XPLATSTR("my-sample-share"));
 
-azure::storage::cloud_file_directory root_dir = 
+azure::storage::cloud_file_directory root_dir =
   share.get_root_directory_reference();
 
-azure::storage::cloud_file file = 
+azure::storage::cloud_file file =
   root_dir.get_file_reference(_XPLATSTR("my-sample-file-3"));
 
 file.delete_file_if_exists();
@@ -252,15 +252,15 @@ The example below shows how to check the current usage for a share and how to se
 
 ```cpp
 // Parse the connection string for the storage account.
-azure::storage::cloud_storage_account storage_account = 
+azure::storage::cloud_storage_account storage_account =
   azure::storage::cloud_storage_account::parse(storage_connection_string);
 
 // Create the file client.
-azure::storage::cloud_file_client file_client = 
+azure::storage::cloud_file_client file_client =
   storage_account.create_cloud_file_client();
 
 // Get a reference to the share.
-azure::storage::cloud_file_share share = 
+azure::storage::cloud_file_share share =
   file_client.get_share_reference(_XPLATSTR("my-sample-share"));
 if (share.exists())
 {
@@ -281,14 +281,14 @@ The following example creates a shared access policy on a share, and then uses t
 
 ```cpp
 // Parse the connection string for the storage account.
-azure::storage::cloud_storage_account storage_account = 
+azure::storage::cloud_storage_account storage_account =
   azure::storage::cloud_storage_account::parse(storage_connection_string);
 
 // Create the file client and get a reference to the share
-azure::storage::cloud_file_client file_client = 
+azure::storage::cloud_file_client file_client =
   storage_account.create_cloud_file_client();
 
-azure::storage::cloud_file_share share = 
+azure::storage::cloud_file_share share =
   file_client.get_share_reference(_XPLATSTR("my-sample-share"));
 
 if (share.exists())
@@ -296,18 +296,18 @@ if (share.exists())
     // Create and assign a policy
     utility::string_t policy_name = _XPLATSTR("sampleSharePolicy");
 
-    azure::storage::file_shared_access_policy sharedPolicy = 
+    azure::storage::file_shared_access_policy sharedPolicy =
       azure::storage::file_shared_access_policy();
 
     //set permissions to expire in 90 minutes
-    sharedPolicy.set_expiry(utility::datetime::utc_now() + 
+    sharedPolicy.set_expiry(utility::datetime::utc_now() +
        utility::datetime::from_minutes(90));
 
     //give read and write permissions
     sharedPolicy.set_permissions(azure::storage::file_shared_access_policy::permissions::write | azure::storage::file_shared_access_policy::permissions::read);
 
     //set permissions for the share
-    azure::storage::file_share_permissions permissions;    
+    azure::storage::file_share_permissions permissions;
 
     //retrieve the current list of shared access policies
     azure::storage::shared_access_policies<azure::storage::file_shared_access_policy> policies;
@@ -320,23 +320,23 @@ if (share.exists())
     share.upload_permissions(permissions);
 
     //Retrieve the root directory and file references
-    azure::storage::cloud_file_directory root_dir = 
+    azure::storage::cloud_file_directory root_dir =
         share.get_root_directory_reference();
-    azure::storage::cloud_file file = 
+    azure::storage::cloud_file file =
       root_dir.get_file_reference(_XPLATSTR("my-sample-file-1"));
 
-    // Generate a SAS for a file in the share 
-    //  and associate this access policy with it.        
+    // Generate a SAS for a file in the share
+    //  and associate this access policy with it.
     utility::string_t sas_token = file.get_shared_access_signature(sharedPolicy);
 
-    // Create a new CloudFile object from the SAS, and write some text to the file.        
+    // Create a new CloudFile object from the SAS, and write some text to the file.
     azure::storage::cloud_file file_with_sas(azure::storage::storage_credentials(sas_token).transform_uri(file.uri().primary_uri()));
-    utility::string_t text = _XPLATSTR("My sample content");        
-    file_with_sas.upload_text(text);        
+    utility::string_t text = _XPLATSTR("My sample content");
+    file_with_sas.upload_text(text);
 
     //Download and print URL with SAS.
-    utility::string_t downloaded_text = file_with_sas.download_text();        
-    ucout << downloaded_text << std::endl;        
+    utility::string_t downloaded_text = file_with_sas.download_text();
+    ucout << downloaded_text << std::endl;
     ucout << azure::storage::storage_credentials(sas_token).transform_uri(file.uri().primary_uri()).to_string() << std::endl;
 
 }


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.