### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-communication.md
+++ b/articles/service-fabric/service-fabric-reliable-services-communication.md
@@ -370,7 +370,7 @@ class MyExceptionHandler : IExceptionHandler
 public class MyExceptionHandler implements ExceptionHandler {
 
     @Override
-    public ExceptionHandlingResult handleException(ExceptionInformation exceptionInformation, OperationRetrySettings retrySettings) {        
+    public ExceptionHandlingResult handleException(ExceptionInformation exceptionInformation, OperationRetrySettings retrySettings) {
 
         /* if exceptionInformation.getException() is known and is transient (can be retried without re-resolving)
          */


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.