### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-backup-restore.md
+++ b/articles/service-fabric/service-fabric-reliable-services-backup-restore.md
@@ -186,7 +186,7 @@ class MyCustomActorService : ActorService
 {
      public MyCustomActorService(StatefulServiceContext context, ActorTypeInformation actorTypeInfo)
             : base(context, actorTypeInfo)
-     {                  
+     {
      }
     
     //
@@ -209,7 +209,7 @@ class MyCustomActorService : ActorService
 {
      public MyCustomActorService(StatefulServiceContext context, ActorTypeInformation actorTypeInfo)
             : base(context, actorTypeInfo, null, null, new KvsActorStateProvider(true)) // Enable incremental backup
-     {                  
+     {
      }
     
     //

--- a/articles/service-fabric/service-fabric-reliable-services-backup-restore.md
+++ b/articles/service-fabric/service-fabric-reliable-services-backup-restore.md
@@ -184,13 +184,13 @@ Reliable Actors Framework is built on top of Reliable Services. The ActorService
 ```csharp
 class MyCustomActorService : ActorService
 {
-     public MyCustomActorService(StatefulServiceContext context, ActorTypeInformation actorTypeInfo)
-            : base(context, actorTypeInfo)
-     {
-     }
+    public MyCustomActorService(StatefulServiceContext context, ActorTypeInformation actorTypeInfo)
+          : base(context, actorTypeInfo)
+    {
+    }
     
     //
-   // Method overrides and other code.
+    // Method overrides and other code.
     //
 }
 ```
@@ -199,7 +199,7 @@ When you create a custom actor service class, you need to register that as well 
 
 ```csharp
 ActorRuntime.RegisterActorAsync<MyActor>(
-   (context, typeInfo) => new MyCustomActorService(context, typeInfo)).GetAwaiter().GetResult();
+    (context, typeInfo) => new MyCustomActorService(context, typeInfo)).GetAwaiter().GetResult();
 ```
 
 The default state provider for Reliable Actors is `KvsActorStateProvider`. Incremental backup is not enabled by default for `KvsActorStateProvider`. You can enable incremental backup by creating `KvsActorStateProvider` with the appropriate setting in its constructor and then passing it to ActorService constructor as shown in following code snippet:
@@ -207,13 +207,13 @@ The default state provider for Reliable Actors is `KvsActorStateProvider`. Incre
 ```csharp
 class MyCustomActorService : ActorService
 {
-     public MyCustomActorService(StatefulServiceContext context, ActorTypeInformation actorTypeInfo)
-            : base(context, actorTypeInfo, null, null, new KvsActorStateProvider(true)) // Enable incremental backup
-     {
-     }
+    public MyCustomActorService(StatefulServiceContext context, ActorTypeInformation actorTypeInfo)
+          : base(context, actorTypeInfo, null, null, new KvsActorStateProvider(true)) // Enable incremental backup
+    {
+    }
     
     //
-   // Method overrides and other code.
+    // Method overrides and other code.
     //
 }
 ```


### PR DESCRIPTION
* Delete unnecessary spaces: When copying from the web page, there is an unnecessary space after the code.
* Fix indent: Indentation is misaligned.