### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/search/cognitive-search-skill-textmerger.md
+++ b/articles/search/cognitive-search-skill-textmerger.md
@@ -63,7 +63,7 @@ This example shows the output of the previous input, assuming that the *insertPr
         "recordId": "1",
         "data":
            {
-             "mergedText": "The quick brown fox jumps over the lazy dog" 
+             "mergedText": "The quick brown fox jumps over the lazy dog"
            }
       }
     ]
@@ -128,10 +128,10 @@ The following example skillset uses the OCR skill to extract text from images em
 The example above assumes that a normalized-images field exists. To get normalized-images field, set the *imageAction* configuration in your indexer definition to *generateNormalizedImages* as shown below:
 
 ```json
-{  
-   //...rest of your indexer definition goes here ... 
-  "parameters":{  
-      "configuration":{  
+{
+   //...rest of your indexer definition goes here ...
+  "parameters":{
+      "configuration":{
          "dataToExtract":"contentAndMetadata",
          "imageAction":"generateNormalizedImages"
       }

--- a/articles/search/cognitive-search-skill-textmerger.md
+++ b/articles/search/cognitive-search-skill-textmerger.md
@@ -39,17 +39,17 @@ A JSON document providing usable input for this skill could be:
 
 ```json
 {
-    "values": [
+  "values": [
+    {
+      "recordId": "1",
+      "data":
       {
-        "recordId": "1",
-        "data":
-           {
-             "text": "The brown fox jumps over the dog" ,
-             "itemsToInsert": ["quick", "lazy"],
-             "offsets": [3, 28],
-           }
+        "text": "The brown fox jumps over the dog",
+        "itemsToInsert": ["quick", "lazy"],
+        "offsets": [3, 28],
       }
-    ]
+    }
+  ]
 }
 ```
 
@@ -58,15 +58,15 @@ This example shows the output of the previous input, assuming that the *insertPr
 
 ```json
 {
-    "values": [
+  "values": [
+    {
+      "recordId": "1",
+      "data":
       {
-        "recordId": "1",
-        "data":
-           {
-             "mergedText": "The quick brown fox jumps over the lazy dog"
-           }
+        "mergedText": "The quick brown fox jumps over the lazy dog"
       }
-    ]
+    }
+  ]
 }
 ```
 
@@ -82,22 +82,22 @@ The following example skillset uses the OCR skill to extract text from images em
   "skills":
   [
     {
-        "description": "Extract text (plain and structured) from image.",
-        "@odata.type": "#Microsoft.Skills.Vision.OcrSkill",
-        "context": "/document/normalized_images/*",
-        "defaultLanguageCode": "en",
-        "detectOrientation": true,
-        "inputs": [
-          {
-            "name": "image",
-            "source": "/document/normalized_images/*"
-          }
-        ],
-        "outputs": [
-          {
-            "name": "text"
-          }
-        ]
+      "description": "Extract text (plain and structured) from image.",
+      "@odata.type": "#Microsoft.Skills.Vision.OcrSkill",
+      "context": "/document/normalized_images/*",
+      "defaultLanguageCode": "en",
+      "detectOrientation": true,
+      "inputs": [
+        {
+          "name": "image",
+          "source": "/document/normalized_images/*"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "text"
+        }
+      ]
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.MergeSkill",
@@ -129,13 +129,13 @@ The example above assumes that a normalized-images field exists. To get normaliz
 
 ```json
 {
-   //...rest of your indexer definition goes here ...
+  //...rest of your indexer definition goes here ...
   "parameters":{
-      "configuration":{
-         "dataToExtract":"contentAndMetadata",
-         "imageAction":"generateNormalizedImages"
-      }
-   }
+    "configuration":{
+        "dataToExtract":"contentAndMetadata",
+        "imageAction":"generateNormalizedImages"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
* Delete unnecessary spaces: When copying from the web page, there is an unnecessary space after the code.
* Fix indent: Indentation is misaligned. The indents are mixed in 2 and 4. We standardized to 4.