### PR TITLE
Semi-Colon is not required by Hive 2.0 View

### DIFF
--- a/articles/hdinsight/hadoop/apache-hadoop-linux-create-cluster-get-started-portal.md
+++ b/articles/hdinsight/hadoop/apache-hadoop-linux-create-cluster-get-started-portal.md
@@ -114,11 +114,7 @@ In this section, you create a Hadoop cluster in HDInsight using the Azure portal
    
         SHOW TABLES;
 
-    ![HDInsight Hive views](./media/apache-hadoop-linux-tutorial-get-started/hiveview-1.png "HDInsight Hive View Query Editor")
-   
-   > [!NOTE]  
-   > Semi-colon is required by Hive.       
-
+    ![HDInsight Hive views](./media/apache-hadoop-linux-tutorial-get-started/hiveview-1.png "HDInsight Hive View Query Editor")     
 
 5. Select **Execute**. A **RESULTS** tab appears beneath the **QUERY** tab and displays information about the job. 
    


### PR DESCRIPTION
Semi-Colon is not required by Hive 2.0 View.  It is required in beeline, but that's not being used here.  I have tested an confirmed this.