### PR TITLE
Incorrect path mounted in docker run command (issue 21047)

### DIFF
--- a/articles/cosmos-db/local-emulator.md
+++ b/articles/cosmos-db/local-emulator.md
@@ -263,13 +263,13 @@ To start the image, run the following commands.
 From the command-line:
 ```cmd
 md %LOCALAPPDATA%\CosmosDBEmulatorCert 2>null
-docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:C:\CosmosDB.Emulator\CosmosDBEmulatorCert -P -t -i -m 2GB microsoft/azure-cosmosdb-emulator
+docker run -v %LOCALAPPDATA%\CosmosDBEmulatorCert:C:\CosmosDB.Emulator\bind-mount -P -t -i -m 2GB microsoft/azure-cosmosdb-emulator
 ```
 
 From PowerShell:
 ```powershell
 md $env:LOCALAPPDATA\CosmosDBEmulatorCert 2>null
-docker run -v $env:LOCALAPPDATA\CosmosDBEmulatorCert:C:\CosmosDB.Emulator\CosmosDBEmulatorCert -P -t -i -m 2GB microsoft/azure-cosmosdb-emulator
+docker run -v $env:LOCALAPPDATA\CosmosDBEmulatorCert:C:\CosmosDB.Emulator\bind-mount -P -t -i -m 2GB microsoft/azure-cosmosdb-emulator
 ```
 
 The response looks similar to the following:


### PR DESCRIPTION
According to issue #21047  the path mounted in docker run command is incorrect
Container image does not have `CosmosDBEmulatorCert` directory, and instead `bind-mount` directory should be used, as described in comments, and verified.
For details, see the image description of CosmosDB emulator https://hub.docker.com/r/microsoft/azure-cosmosdb-emulator/