### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/notification-hubs/notification-hubs-aspnet-backend-ios-apple-push-notification-service-apns-rich.md
+++ b/articles/notification-hubs/notification-hubs-aspnet-backend-ios-apple-push-notification-service-apns-rich.md
@@ -288,7 +288,7 @@ Now that you have modified your app backend to send just the *id* of a notificat
         NSString* richType = [self.userInfo objectForKey:@"richType"];
 
         // Retrieve image data
-        if ([richType isEqualToString:@"img"]) {  
+        if ([richType isEqualToString:@"img"]) {
             [self retrieveRichImageWithId:richId completion:^(NSError* error) {
                 if (!error){
                     // Send local notification


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.