### PR TITLE
VM Agent supports Server 2008 R2 and greater

### DIFF
--- a/articles/virtual-machines/extensions/agent-windows.md
+++ b/articles/virtual-machines/extensions/agent-windows.md
@@ -56,7 +56,7 @@ To boot a VM you must have the PA installed on the VM, however the WinGA does no
 If you do not have the Agents installed, you cannot use some Azure services, such as Azure Backup or Azure Security. These services require an extension to be installed. If you have deployed a VM without the WinGA, you can install the latest version of the agent later.
 
 ### Manual installation
-The Windows VM agent can be manually installed with a Windows installer package. Manual installation may be necessary when you create a custom VM image that is deployed to Azure. To manually install the Windows VM Agent, [download the VM Agent installer](https://go.microsoft.com/fwlink/?LinkID=394789).
+The Windows VM agent can be manually installed with a Windows installer package. Manual installation may be necessary when you create a custom VM image that is deployed to Azure. To manually install the Windows VM Agent, [download the VM Agent installer](https://go.microsoft.com/fwlink/?LinkID=394789).  The VM Agent is supported on Windows Server 2008 R2 and greater.
 
 The VM Agent can be installed by double-clicking the Windows installer file. For an automated or unattended installation of the VM agent, run the following command:
 


### PR DESCRIPTION
The Azure VM Agent only supports Windows Server 2008 R2 and greater for installation.  You cannot install the VM Agent on a Windows Server 2000/2003/2008 machine.