### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/media-services/previous/media-services-analytics-overview.md
+++ b/articles/media-services/previous/media-services-analytics-overview.md
@@ -107,10 +107,10 @@ Response:
 
     . . .
 
-    {  
+    {
        "odata.metadata":"https://media.windows.net/api/$metadata#MediaProcessors",
-       "value":[  
-          {  
+       "value":[
+          {
              "Id":"nb:mpid:UUID:074c3899-d9fb-448f-9ae1-4ebcbe633056",
              "Description":"Azure Media OCR",
              "Name":"Azure Media OCR",


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.