### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/media-services/latest/widevine-license-template-overview.md
+++ b/articles/media-services/latest/widevine-license-template-overview.md
@@ -25,21 +25,21 @@ A Widevine license request is formatted as a JSON message.
 >[!NOTE]
 > You can create an empty message with no values, just "{}." Then a license template is created with defaults. The default works for most cases. Microsoft-based license-delivery scenarios should always use the defaults. If you need to set the "provider" and "content_id" values, a provider must match Widevine credentials.
 
-    {  
+    {
        "payload":"<license challenge>",
        "content_id": "<content id>"
        "provider": "<provider>"
        "allowed_track_types":"<types>",
-       "content_key_specs":[  
-          {  
+       "content_key_specs":[
+          {
              "track_type":"<track type 1>"
           },
-          {  
+          {
              "track_type":"<track type 2>"
           },
           …
        ],
-       "policy_overrides":{  
+       "policy_overrides":{
           "can_play":<can play>,
           "can persist":<can persist>,
           "can_renew":<can renew>,


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.