### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/marketplace/cloud-partner-portal-orig/cloud-partner-portal-api-retrieve-offers.md
+++ b/articles/marketplace/cloud-partner-portal-orig/cloud-partner-portal-api-retrieve-offers.md
@@ -51,10 +51,10 @@ Body example
 
 ### Response
 
-``` json
-  200 OK 
-  [ 
-      {  
+```json
+  200 OK
+  [
+      {
           "offerTypeId": "microsoft-azure-virtualmachines",
           "publisherId": "contoso",
           "status": "published",


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.