### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/logic-apps/logic-apps-track-integration-account-custom-tracking-schema.md
+++ b/articles/logic-apps/logic-apps-track-integration-account-custom-tracking-schema.md
@@ -44,7 +44,7 @@ This article provides custom code that you can use in the layers outside of your
          "eventLevel": "",
          "eventTime": "",
          "recordType": "",
-         "record": {                
+         "record": {
          }
       }
    ]


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.