### PR TITLE
Fixed Blob Storage quickstart for CLI

### DIFF
--- a/articles/storage/blobs/storage-quickstart-blobs-cli.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-cli.md
@@ -57,7 +57,7 @@ If you used the previously described method to create a file in your Azure Cloud
 ```azurecli-interactive
 az storage blob upload \
     --container-name mystoragecontainer \
-    --name helloworld
+    --name helloworld \
     --file helloworld
 ```
 

--- a/includes/storage-quickstart-tutorial-intro-include-cli.md
+++ b/includes/storage-quickstart-tutorial-intro-include-cli.md
@@ -30,7 +30,7 @@ az storage account create \
 
 ## Specify storage account credentials
 
-The Azure CLI needs your storage account credentials for most of the commands in this tutorial. While there are several options for doing so, one of the easiest ways to provide them is to set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCESS_KEY` environment variables.
+The Azure CLI needs your storage account credentials for most of the commands in this tutorial. While there are several options for doing so, one of the easiest ways to provide them is to set `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables.
 
 First, display your storage account keys by using the [az storage account keys list](/cli/azure/storage/account/keys) command:
 
@@ -41,9 +41,9 @@ az storage account keys list \
     --output table
 ```
 
-Now, set the `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCESS_KEY` environment variables. You can do this in the Bash shell by using the `export` command:
+Now, set the `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_KEY` environment variables. You can do this in the Bash shell by using the `export` command:
 
 ```bash
 export AZURE_STORAGE_ACCOUNT="mystorageaccountname"
-export AZURE_STORAGE_ACCESS_KEY="myStorageAccountKey"
+export AZURE_STORAGE_KEY="myStorageAccountKey"
 ```


### PR DESCRIPTION
I found what I believe to be two errors in the quickstart:

1. The environmental variable should be `AZURE_STORAGE_KEY`, not `AZURE_STORAGE_ACCESS_KEY` (this is also what the CLI shows in the help messages)
2. There was a missing escape character in a command, before a newline character