### PR TITLE
Delete unnecessary spaces

### DIFF
--- a/articles/event-grid/event-schema-resource-groups.md
+++ b/articles/event-grid/event-schema-resource-groups.md
@@ -173,7 +173,7 @@ The following example shows the schema for a **ResourceDeleteSuccess** event. Th
 The following example shows the schema for a **ResourceActionSuccess** event. The same schema is used for **ResourceActionFailure** and **ResourceActionCancel** events with different values for `eventType`.
 
 ```json
-[{   
+[{
   "subject": "/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventHub/namespaces/{namespace}/AuthorizationRules/RootManageSharedAccessKey",
   "eventType": "Microsoft.Resources.ResourceActionSuccess",
   "eventTime": "2018-10-08T22:46:22.6022559Z",
@@ -189,7 +189,7 @@ The following example shows the schema for a **ResourceActionSuccess** event. Th
         "roleDefinitionId": "{ID}",
         "principalId": "{ID}",
         "principalType": "ServicePrincipal"
-      }     
+      }
     },
     "claims": {
       "aud": "{audience-claim}",
@@ -202,7 +202,8 @@ The following example shows the schema for a **ResourceActionSuccess** event. Th
       "appidacr": "2",
       "http://schemas.microsoft.com/identity/claims/identityprovider": "{URL}",
       "http://schemas.microsoft.com/identity/claims/objectidentifier": "{ID}",
-      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "{ID}",       "http://schemas.microsoft.com/identity/claims/tenantid": "{ID}",
+      "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier": "{ID}",
+      "http://schemas.microsoft.com/identity/claims/tenantid": "{ID}",
       "uti": "{ID}",
       "ver": "1.0"
     },
@@ -222,7 +223,7 @@ The following example shows the schema for a **ResourceActionSuccess** event. Th
   },
   "dataVersion": "2",
   "metadataVersion": "1",
-  "topic": "/subscriptions/{subscription-id}/resourceGroups/{resource-group}" 
+  "topic": "/subscriptions/{subscription-id}/resourceGroups/{resource-group}"
 }]
 ```
 


### PR DESCRIPTION
When copying from the web page, there is an unnecessary space after the code.