### PR TITLE
Add 1902 ercs issue

### DIFF
--- a/articles/azure-stack/azure-stack-update-1902.md
+++ b/articles/azure-stack/azure-stack-update-1902.md
@@ -170,6 +170,18 @@ The following are post-installation known issues for this build version.
 
    To make sure the patch and update process results in the least amount of tenant downtime, make sure your Azure Stack stamp has more than 12 GB of available space in the **Capacity** blade. You can see this memory increase reflected in the **Capacity** blade after a successful installation of the update.
 
+- If you do not have a Hardware Lifecycle Host (HLH) - before 1902 you had to set Group Policy *Computer Configuration\Windows Settings\Security Settings\Local Policies\Security Options* to **Send LM & NTLM – use NTLMv2 session security if negotiated**; however, since 1902 you have to leave it as **Not Defined** or set it to **Send NTLMv2 response only** (which is a default value). Otherwise you will not be able to establish PowerShell Remote session and will receive an *Access is denied* error:
+   ```PowerShell
+   PS C:\Users\Administrator> $session = New-PSSession -ComputerName x.x.x.x -ConfigurationName PrivilegedEndpoint  -Credential $cred
+   New-PSSession : [x.x.x.x] Connecting to remote server x.x.x.x failed with the following error message : Access is denied. For more information, see the 
+   about_Remote_Troubleshooting Help topic.
+   At line:1 char:12
+   + $session = New-PSSession -ComputerName x.x.x.x -ConfigurationNa ...
+   +            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      + CategoryInfo          : OpenError: (System.Manageme....RemoteRunspace:RemoteRunspace) [New-PSSession], PSRemotingTransportException
+      + FullyQualifiedErrorId : AccessDenied,PSSessionOpenFailed
+   ```
+
 ### Networking  
 
 <!-- 3239127 - IS, ASDK -->

--- a/articles/azure-stack/azure-stack-update-1902.md
+++ b/articles/azure-stack/azure-stack-update-1902.md
@@ -170,7 +170,8 @@ The following are post-installation known issues for this build version.
 
    To make sure the patch and update process results in the least amount of tenant downtime, make sure your Azure Stack stamp has more than 12 GB of available space in the **Capacity** blade. You can see this memory increase reflected in the **Capacity** blade after a successful installation of the update.
 
-- If you do not have a Hardware Lifecycle Host (HLH) - before 1902 you had to set Group Policy *Computer Configuration\Windows Settings\Security Settings\Local Policies\Security Options* to **Send LM & NTLM – use NTLMv2 session security if negotiated**; however, since 1902 you have to leave it as **Not Defined** or set it to **Send NTLMv2 response only** (which is a default value). Otherwise you will not be able to establish PowerShell Remote session and will receive an *Access is denied* error:
+- If you do not have a Hardware Lifecycle Host (HLH): Before build 1902, you had to set Group Policy *Computer Configuration\Windows Settings\Security Settings\Local Policies\Security Options* to **Send LM & NTLM – use NTLMv2 session security if negotiated**. Since build 1902, you must leave it as **Not Defined** or set it to **Send NTLMv2 response only** (which is a default value). Otherwise, you won't be able to establish a PowerShell remote session and you'll receive an *Access is denied* error:
+
    ```PowerShell
    PS C:\Users\Administrator> $session = New-PSSession -ComputerName x.x.x.x -ConfigurationName PrivilegedEndpoint  -Credential $cred
    New-PSSession : [x.x.x.x] Connecting to remote server x.x.x.x failed with the following error message : Access is denied. For more information, see the 

--- a/articles/azure-stack/azure-stack-update-1902.md
+++ b/articles/azure-stack/azure-stack-update-1902.md
@@ -203,7 +203,7 @@ The following are post-installation known issues for this build version.
 - Network security groups (NSGs) do not work in Azure Stack in the same way as global Azure. In Azure, you can set multiple ports on one NSG rule (using the portal, PowerShell, and Resource Manager templates). In Azure Stack however, you cannot set multiple ports on one NSG rule via the portal. To work around this issue, use a Resource Manager template or PowerShell to set these additional rules.
 
 <!-- 3203799 - IS, ASDK -->
-- Azure Stack does not support attaching more than 4 Network Interfaces (NICs) to a VM instances today, regardless of the instance size.
+- Azure Stack does not support attaching more than 4 Network Interfaces (NICs) to a VM instance today, regardless of the instance size.
 
 - An issue has been identified in which packets over 1450 bytes to an Internal Load Balancer (ILB) are dropped. The issue is due to the MTU setting on the host being too low to accommodate VXLAN encapsulated packets that traverse the role, which as of 1901 has been moved to the host. There are at least two scenarios that you might encounter in which we have seen this issue manifest itself:
 


### PR DESCRIPTION
After 1902 upgrade you cannot connect to ERCS if you have not got the HLH.

This PR will warn others and free up MSFT support who will have to troubleshoot the issue otherwise.