### PR TITLE
Fix command parameter

### DIFF
--- a/articles/iot-hub/quickstart-send-telemetry-node.md
+++ b/articles/iot-hub/quickstart-send-telemetry-node.md
@@ -77,7 +77,7 @@ A device must be registered with your IoT hub before it can connect. In this qui
    **YourIoTHubName**: Replace this placeholder below with the name you choose for your IoT hub.
 
     ```azurecli-interactive
-    az iot hub show-connection-string --hub-name YourIoTHubName --output table
+    az iot hub show-connection-string --name YourIoTHubName --output table
     ```
 
     Make a note of the service connection string, which looks like:


### PR DESCRIPTION
Changing parameter 'hub-name' to 'name' on command 'az iot hub show-connection-string'