### PR TITLE
Fix typo

### DIFF
--- a/articles/automation/troubleshoot/update-agent-issues.md
+++ b/articles/automation/troubleshoot/update-agent-issues.md
@@ -114,7 +114,7 @@ CheckResultMessageArguments : {}
 
 RuleId                      : DotNetFrameworkInstalledCheck
 RuleGroupId                 : prerequisites
-RuleName                    : .Net Framework 4.5+
+RuleName                    : .NET Framework 4.5+
 RuleGroupName               : Prerequisite Checks
 RuleDescription             : .NET Framework version 4.5 or higher is required
 CheckResult                 : Passed

--- a/articles/azure-monitor/app/profiler-troubleshooting.md
+++ b/articles/azure-monitor/app/profiler-troubleshooting.md
@@ -84,7 +84,7 @@ When you configure Profiler, updates are made to the web app's settings. If your
 
 1. In the **Web App Control** pane, open **Settings**.
 
-1. Set **.Net Framework version** to **v4.6**.
+1. Set **.NET Framework version** to **v4.6**.
 
 1. Set **Always On** to **On**.
 

--- a/articles/azure-monitor/app/sampling.md
+++ b/articles/azure-monitor/app/sampling.md
@@ -23,8 +23,8 @@ Sampling reduces traffic and data costs, and helps you avoid throttling.
 
 ## In brief:
 * Sampling retains 1 in *n* records and discards the rest. For example, it might retain one in five events, a sampling rate of 20%. 
-* Adaptive Sampling is enabled by default in all the latest version of Asp.Net and Asp.Net Core Software Development Kits (SDKs).
-* You can also set sampling manually. This can be configured in the portal on the *Usage and estimated costs page*.  In the ASP.NET SDK in the ApplicationInsights.config file. In the Asp.Net Core SDK via code. Or in the Java SDK in the ApplicationInsights.xml file.
+* Adaptive Sampling is enabled by default in all the latest version of Asp.NET and Asp.NET Core Software Development Kits (SDKs).
+* You can also set sampling manually. This can be configured in the portal on the *Usage and estimated costs page*.  In the ASP.NET SDK in the ApplicationInsights.config file. In the Asp.NET Core SDK via code. Or in the Java SDK in the ApplicationInsights.xml file.
 * If you log custom events and need to ensure that a set of events is retained or discarded together, the events must have the same OperationId value.
 * The sampling divisor *n* is reported in each record in the property `itemCount`, which in Search appears under the friendly name "request count" or "event count". `itemCount==1`when sampling is not in operation.
 * If you write Analytics queries, you should [take account of sampling](../../azure-monitor/log-query/aggregations.md). In particular, instead of simply counting records, you should use `summarize sum(itemCount)`.

--- a/articles/azure-stack/azure-stack-app-service-release-notes-update-one.md
+++ b/articles/azure-stack/azure-stack-app-service-release-notes-update-one.md
@@ -54,7 +54,7 @@ Azure App Service on Azure Stack Update 1 includes the following improvements an
 - Updates to **App Service Tenant, Admin, Functions portals and Kudu tools**. Consistent with Azure Stack Portal SDK version.
 
 - **Updates to the following application frameworks and tools**:
-    - Added **.Net Core 2.0** support
+    - Added **.NET Core 2.0** support
     - Added **Node.JS** versions:
         - 6.11.2
         - 6.11.5

--- a/articles/backup/backup-sql-server-azure-vms.md
+++ b/articles/backup/backup-sql-server-azure-vms.md
@@ -61,7 +61,7 @@ Before you start, verify the following:
 **Supported geos** | Australia South East (ASE), East Australia (AE) <br> Brazil South (BRS)<br> Canada Central (CNC), Canada East (CE)<br> South East Asia (SEA), East Asia (EA) <br> East US (EUS), East US 2 (EUS2), West Central US (WCUS), West US (WUS); West US 2 (WUS 2) North Central US (NCUS) Central US (CUS) South Central US (SCUS) <br> India Central (INC), India South (INS) <br> Japan East (JPE), Japan West (JPW) <br> Korea Central (KRC), Korea South (KRS) <br> North Europe (NE), West Europe <br> South Africa North (SAN), South Africa West (SAW) <br> UAE Central (UAC), UAE North (UAN) <br> UK South (UKS), UK West (UKW)
 **Supported operating systems** | Windows Server 2016, Windows Server 2012 R2, Windows Server 2012<br/><br/> Linux isn't currently supported.
 **Supported SQL Server versions** | SQL Server 2017; SQL Server 2016, SQL Server 2014, SQL Server 2012.<br/><br/> Enterprise, Standard, Web, Developer, Express.
-**Supported .Net versions** | .NET Framework 4.5.2 and above installed on the VM
+**Supported .NET versions** | .NET Framework 4.5.2 and above installed on the VM
 
 
 

--- a/articles/cognitive-services/QnAMaker/Quickstarts/publish-kb-csharp.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/publish-kb-csharp.md
@@ -37,7 +37,7 @@ This quickstart calls QnA Maker APIs:
 ## Create knowledge base project
 
 1. Open Visual Studio 2017 Community edition.
-1. Create a new **Console App (.Net Core)** project and name the project `QnaMakerQuickstart`. Accept the defaults for the remaining settings.
+1. Create a new **Console App (.NET Core)** project and name the project `QnaMakerQuickstart`. Accept the defaults for the remaining settings.
 
 ## Add required dependencies
 

--- a/articles/cosmos-db/create-graph-dotnet.md
+++ b/articles/cosmos-db/create-graph-dotnet.md
@@ -155,7 +155,7 @@ Now go back to the Azure portal to get your connection string information and co
 
 1. From the [Azure portal](https://portal.azure.com/), navigate to your graph database account. In the **Overview** tab, you can see two endpoints- 
  
-   **.Net SDK URI** - This value is used when you connect to the graph account by using Microsoft.Azure.Graphs library. 
+   **.NET SDK URI** - This value is used when you connect to the graph account by using Microsoft.Azure.Graphs library. 
 
    **Gremlin Endpoint** - This value is used when you connect to the graph account by using Gremlin.Net library.
 

--- a/articles/cosmos-db/sql-api-dotnet-application-preview.md
+++ b/articles/cosmos-db/sql-api-dotnet-application-preview.md
@@ -72,7 +72,7 @@ In the next section, you create a new ASP.NET MVC application.
 
 3. In the **Name** box, type the name of the project. This tutorial uses the name "todo". If you choose to use something other than this, then wherever this tutorial talks about the todo namespace, adjust the provided code samples to use whatever you named your application. 
 
-4. Select **Browse** to navigate to the folder where you would like to create the project, and then choose **.Net framework 4.6.1** or higher. Select **OK**. 
+4. Select **Browse** to navigate to the folder where you would like to create the project, and then choose **.NET framework 4.6.1** or higher. Select **OK**. 
 
 5. The **New ASP.NET Web Application** dialog box appears. In the templates pane, select **MVC**.
 

--- a/articles/search/cognitive-search-create-custom-skill-example.md
+++ b/articles/search/cognitive-search-create-custom-skill-example.md
@@ -34,7 +34,7 @@ Although this example uses an Azure Function to host a web API, it is not requir
 
 1. In the New Project dialog, select **Installed**, expand **Visual C#** > **Cloud**, select **Azure Functions**, type a Name for your project, and select **OK**. The function app name must be valid as a C# namespace, so don't use underscores, hyphens, or any other nonalphanumeric characters.
 
-1. Select **Azure Functions v2 (.Net Core)**. You could also do it with version 1, but the code written below is based on the v2 template.
+1. Select **Azure Functions v2 (.NET Core)**. You could also do it with version 1, but the code written below is based on the v2 template.
 
 1. Select the type to be **HTTP Trigger**
 

--- a/articles/service-bus-messaging/service-bus-amqp-overview.md
+++ b/articles/service-bus-messaging/service-bus-amqp-overview.md
@@ -73,7 +73,7 @@ At this time the following client libraries are known to work with Service Bus:
 | C |Apache Qpid Proton-C |
 | PHP |Apache Qpid Proton-PHP |
 | Python |Apache Qpid Proton-Python |
-| C# |AMQP .Net Lite |
+| C# |AMQP .NET Lite |
 
 **Figure 2: Table of AMQP 1.0 client libraries**
 

--- a/articles/service-fabric/service-fabric-reliable-actors-get-started.md
+++ b/articles/service-fabric/service-fabric-reliable-actors-get-started.md
@@ -34,7 +34,7 @@ Launch Visual Studio 2015 or later as an administrator, and then create a new **
 
 ![Service Fabric tools for Visual Studio - new project][1]
 
-In the next dialog box, choose **Actor Service** under **.Net Core 2.0** and enter a name for the service.
+In the next dialog box, choose **Actor Service** under **.NET Core 2.0** and enter a name for the service.
 
 ![Service Fabric project templates][5]
 

--- a/articles/service-fabric/service-fabric-reliable-services-quick-start.md
+++ b/articles/service-fabric/service-fabric-reliable-services-quick-start.md
@@ -41,7 +41,7 @@ Launch Visual Studio 2015 or Visual Studio 2017 as an administrator, and create 
 
 ![Use the New Project dialog box to create a new Service Fabric application](media/service-fabric-reliable-services-quick-start/hello-stateless-NewProject.png)
 
-Then create a stateless service project using **.Net Core 2.0** named *HelloWorldStateless*:
+Then create a stateless service project using **.NET Core 2.0** named *HelloWorldStateless*:
 
 ![In the second dialog box, create a stateless service project](media/service-fabric-reliable-services-quick-start/hello-stateless-NewProject2.png)
 
@@ -123,7 +123,7 @@ In the same *HelloWorld* application, you can add a new service by right-clickin
 
 ![Add a service to your Service Fabric application](media/service-fabric-reliable-services-quick-start/hello-stateful-NewService.png)
 
-Select **.Net Core 2.0 -> Stateful Service** and name it *HelloWorldStateful*. Click **OK**.
+Select **.NET Core 2.0 -> Stateful Service** and name it *HelloWorldStateful*. Click **OK**.
 
 ![Use the New Project dialog box to create a new Service Fabric stateful service](media/service-fabric-reliable-services-quick-start/hello-stateful-NewProject.png)
 

--- a/articles/stream-analytics/TOC.yml
+++ b/articles/stream-analytics/TOC.yml
@@ -115,7 +115,7 @@
       href: stream-analytics-monitoring.md
     - name: Monitor jobs- PowerShell
       href: stream-analytics-monitor-and-manage-jobs-use-powershell.md
-    - name: Monitor jobs- Azure .Net SDK
+    - name: Monitor jobs- Azure .NET SDK
       href: stream-analytics-monitor-jobs.md
     - name: Monitor jobs- Visual Studio
       href: stream-analytics-monitor-jobs-use-vs.md

--- a/includes/cognitive-services-qnamaker-quickstart-csharp-create-project.md
+++ b/includes/cognitive-services-qnamaker-quickstart-csharp-create-project.md
@@ -13,6 +13,6 @@ ms.author: diberry
 ---
 
 1. Open Visual Studio 2017 Community edition.
-1. Create a new **Console App (.Net Core)** project and name the project `QnaMakerQuickstart`. Accept the defaults for the remaining settings.
+1. Create a new **Console App (.NET Core)** project and name the project `QnaMakerQuickstart`. Accept the defaults for the remaining settings.
 1. In the Solution Explorer, right-click on the project name, **QnaMakerQuickstart**, then select **Manage NuGet Packages...**.
 1. In the NuGet window, select **Browser**, then search for **Newtonsoft.JSON** and install the package. This package is used to parse the JSON returned from the QnaMaker HTTP response. 

--- a/includes/cognitive-services-speech-service-create-speech-project-vs-csharp.md
+++ b/includes/cognitive-services-speech-service-create-speech-project-vs-csharp.md
@@ -8,7 +8,7 @@ ms.author: wolfma
 
 1. Start Visual Studio 2017.
 
-1. From the menu bar in Visual Studio, select **Tools > Get Tools** and make sure that the **.Net desktop development** workload is available. If the workload hasn't been installed, mark the checkbox, then click **Modify** to start the installation. It may take a few minutes to download and install.
+1. From the menu bar in Visual Studio, select **Tools > Get Tools** and make sure that the **.NET desktop development** workload is available. If the workload hasn't been installed, mark the checkbox, then click **Modify** to start the installation. It may take a few minutes to download and install.
 
    If the checkbox next to **.NET desktop development** is selected, you can close the dialog box now.
 


### PR DESCRIPTION
Related to the [glossary](https://github.com/dotnet/docs/blob/master/docs/standard/glossary.md#net) - rename from `.Net` -> `.NET`

cc @ktoliver