### PR TITLE
Fix Typo - GiB to TiB

### DIFF
--- a/includes/virtual-machines-common-premium-storage-performance.md
+++ b/includes/virtual-machines-common-premium-storage-performance.md
@@ -230,7 +230,7 @@ Azure Premium Storage offers eight GA disk sizes and three disk sizes that are i
 
 | Premium Disks Type  | P4    | P6    | P10   | P15 | P20   | P30   | P40   | P50   | P60   | P70   | P80   |
 |---------------------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
-| Disk size           | 32 GiB | 64 GiB | 128 GiB| 256 GiB| 512 GB            | 1,024 GiB (1 TiB)    | 2,048 GiB (2 TiB)    | 4,095 GiB (4 TiB)    | 8,192 GiB (8 TiB)    | 16,384 GiB (16 TiB)    | 32,767 GiB (32 GiB)    |
+| Disk size           | 32 GiB | 64 GiB | 128 GiB| 256 GiB| 512 GB            | 1,024 GiB (1 TiB)    | 2,048 GiB (2 TiB)    | 4,095 GiB (4 TiB)    | 8,192 GiB (8 TiB)    | 16,384 GiB (16 TiB)    | 32,767 GiB (32 TiB)    |
 | IOPS per disk       | 120   | 240   | 500   | 1100 | 2300              | 5000              | 7500              | 7500              | 12,500              | 15,000              | 20,000              |
 | Throughput per disk | 25 MiB per second  | 50 MiB per second  | 100 MiB per second |125 MiB per second | 150 MiB per second | 200 MiB per second | 250 MiB per second | 250 MiB per second | 480 MiB per second | 750 MiB per second | 750 MiB per second |
 


### PR DESCRIPTION
In response to issue #27436 Change GiB to TiB in Premium Storage Disk Sizes

Article URL:
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#premium-storage-disk-sizes

Screenshot:
https://i.imgur.com/4LsRExp.png

Premium Disk Type P80 currently says: **32,767 GiB (32 GiB)**
32,767 is 32 Terabytes not Gigabytes.
It should say: **32,767 GiB (32 TiB)**