### PR TITLE
One rule for multiple ports

### DIFF
--- a/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
+++ b/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
@@ -105,6 +105,8 @@ Deploy a managed instance in a dedicated subnet inside the virtual network. The 
 |management  |80, 443, 12000|TCP     |Any              |Internet   |Allow |
 |mi_subnet   |Any           |Any     |Any              |MI SUBNET*  |Allow |
 
+> Make sure there is only one inbound rule for ports 9000, 9003, 1438, 1440, 1452 and one outbound rule for ports 80, 443, 12000. Managed Instance provisioning through ARM deployments may fail if inbound and output rules are configured separately for each ports. 
+
 \* MI SUBNET refers to the IP address range for the subnet in the form 10.x.x.x/y. You can find this information in the Azure portal, in subnet properties.
 
 > [!IMPORTANT]


### PR DESCRIPTION
In case the inbound and outbound security rules list ports individually, the Managed Instance provisioning through ARM may fail with ConflictWithNetworkIntentPolicy exception and message "Found conflicts with NetworkIntentPolicy. Details: Subnet or Virtual Network cannot have resources or properties which conflict with network intent policy.". In order to avoid such issues, ensure one inbound and one outbound rule for ports that need to remain open.