### PR TITLE
Adding note to include registry FQDN in docker-custom-image-name

### DIFF
--- a/articles/app-service/containers/tutorial-custom-docker-image.md
+++ b/articles/app-service/containers/tutorial-custom-docker-image.md
@@ -522,6 +522,9 @@ az webapp config container set --name <app_name> --resource-group myResourceGrou
 > [!NOTE]
 > `https://` is required in *\<docker-registry-server-url>*.
 >
+> [!NOTE]
+> When using registry other than dockerhub, `docker-custom-image-name` must include fully-qualified domain name (FQDN) of your registry.  
+> For Azure Container Registry, this will look like `<azure-container-registry>.azurecr.io/mydockerimage`.
 
 The command reveals output similar to the following JSON string, showing that the configuration change succeeded:
 


### PR DESCRIPTION
Adding note to include registry FQDN in docker-custom-image-name.
Even though this is already mentioned in the text above the "az webapp config container set" command, its not visible enough.
I feel this is a critical piece and needs to be highlighted more.