### PR TITLE
Updated step 2 of Steps to enable a backup

### DIFF
--- a/includes/virtual-machines-common-backup-and-disaster-recovery-for-azure-iaas-disks.md
+++ b/includes/virtual-machines-common-backup-and-disaster-recovery-for-azure-iaas-disks.md
@@ -143,7 +143,7 @@ Use the following steps to enable backups of your VMs by using the [Azure portal
 
     b. On the **Recovery Services vaults** menu, click **Add** and follow the steps to create a new vault in the same region as the VM. For example, if your VM is in the West US region, pick West US for the vault.
 
-1.	Verify the storage replication for the newly created vault. Access the vault under **Recovery Services vaults** and go to **Settings** > **Backup Configuration**. Ensure the **geo-redundant storage** option is selected by default. This option ensures that your vault is automatically replicated to a secondary datacenter. For example, your vault in West US is automatically replicated to East US.
+1.	Verify the storage replication for the newly created vault. Access the vault under **Recovery Services vaults** and go to **Properties** > **Backup Configuration** > **Update**. Ensure the **geo-redundant storage** option is selected by default. This option ensures that your vault is automatically replicated to a secondary datacenter. For example, your vault in West US is automatically replicated to East US.
 
 1.	Configure the backup policy and select the VM from the same UI.
 


### PR DESCRIPTION
Under the section "Steps to enable a backup", Step 2 showing how to verify the storage replication of a recovery services vault was not consistent with Azure portal. Step 2 is now updated to reflect the correct menu location for storage replication  in Azure portal.