### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/active-directory-b2c/claimsschema.md
+++ b/articles/active-directory-b2c/claimsschema.md
@@ -102,8 +102,8 @@ The **Mask** element contains the following attributes:
 
 | Attribute | Required | Description |
 | --------- | -------- | ----------- |
-| Type | Yes | The type of the claim mask. Possible values: `Simple` or `Regex`. The `Simple` value indicates that a simple text mask is applied to the leading portion of a string claim. The `Regex` value indicates that a regular expression is applied to the string claim as whole.  If the `Regex` value is specified, an optional attribute must also be defined with the regular expression to use. |
-| Regex | No | If **Type** is set to `Regex`, specify the regular expression to use.
+| `Type` | Yes | The type of the claim mask. Possible values: `Simple` or `Regex`. The `Simple` value indicates that a simple text mask is applied to the leading portion of a string claim. The `Regex` value indicates that a regular expression is applied to the string claim as whole.  If the `Regex` value is specified, an optional attribute must also be defined with the regular expression to use. |
+| `Regex` | No | If **`Type`** is set to `Regex`, specify the regular expression to use.
 
 The following example configures a **PhoneNumber** claim with the `Simple` mask:
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates parameter name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/active-directory-b2c/claimsschema.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose attribute names by "\`") has no negative effect on the English version.
Please accept this change so that attribute names are not mistranslated in each language in each localized version.
🙏