### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/active-directory-b2c/validation-technical-profile.md
+++ b/articles/active-directory-b2c/validation-technical-profile.md
@@ -61,8 +61,8 @@ The **Precondition** element contains the following attribute:
 
 | Attribute | Required | Description |
 | --------- | -------- | ----------- |
-| Type | Yes | The type of check or query to perform for the precondition. Either `ClaimsExist` is specified to ensure that actions should be performed if the specified claims exist in the user's current claim set, or `ClaimEquals` is specified that the actions should be performed if the specified claim exists and its value is equal to the specified value. |
-| ExecuteActionsIf | Yes | Indicates whether the actions in the precondition should be performed if the test is true or false. |
+| `Type` | Yes | The type of check or query to perform for the precondition. Either `ClaimsExist` is specified to ensure that actions should be performed if the specified claims exist in the user's current claim set, or `ClaimEquals` is specified that the actions should be performed if the specified claim exists and its value is equal to the specified value. |
+| `ExecuteActionsIf` | Yes | Indicates whether the actions in the precondition should be performed if the test is true or false. |
 
 The **Precondition** element contains following elements:
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates parameter name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/active-directory-b2c/validation-technical-profile.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose attribute names by "\`") has no negative effect on the English version.
Please accept this change so that attribute names are not mistranslated in each language in each localized version.
🙏