### PR TITLE
Fix actions related to SF Dictionary added event

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-notifications.md
+++ b/articles/service-fabric/service-fabric-reliable-services-notifications.md
@@ -174,7 +174,7 @@ Use the action property in **NotifyDictionaryChangedEventArgs** to cast **Notify
 
 * **NotifyDictionaryChangedAction.Rebuild**: **NotifyDictionaryRebuildEventArgs**
 * **NotifyDictionaryChangedAction.Clear**: **NotifyDictionaryClearEventArgs**
-* **NotifyDictionaryChangedAction.Add** and **NotifyDictionaryChangedAction.Remove**: **NotifyDictionaryItemAddedEventArgs**
+* **NotifyDictionaryChangedAction.Add**: **NotifyDictionaryItemAddedEventArgs**
 * **NotifyDictionaryChangedAction.Update**: **NotifyDictionaryItemUpdatedEventArgs**
 * **NotifyDictionaryChangedAction.Remove**: **NotifyDictionaryItemRemovedEventArgs**
 


### PR DESCRIPTION
NotifyDictionaryItemAddedEventArgs is not generated when the action property is NotifyDictionaryChangedAction.Remove