### PR TITLE
Fix command line

### DIFF
--- a/articles/container-registry/container-registry-import-images.md
+++ b/articles/container-registry/container-registry-import-images.md
@@ -97,7 +97,7 @@ az acr import --name myregistry --source mysourceregistry.azurecr.io/aci-hellowo
 In the following example, *mysourceregistry* is in a different subscription from *myregistry* in the same Active Directory tenant. Supply the resource ID of the source registry with the `--registry` parameter. Notice that the `--source` parameter specifies only the source repository and image name, not the registry login server name.
  
 ```azurecli
-az acr import --name myregistry --source sourcerepo/aci-helloworld:latest --image aci-hello-world:latest --registry /subscriptions/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceResourceGroup/providers/Microsoft.ContainerRegistry/registries/mysourceregistry
+az acr import --name myregistry --source sourcerepo/aci-helloworld:latest --image aci-hello-world:latest --registry /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/sourceResourceGroup/providers/Microsoft.ContainerRegistry/registries/mysourceregistry
 ```
 
 ### Import from a registry using service principal credentials


### PR DESCRIPTION
Fix command line for section "Import from a registry in a different subscription". "/subscriptions" is repeated twice