### PR TITLE
var client_ip and cookie_*name* are supported now

### DIFF
--- a/articles/application-gateway/rewrite-http-headers.md
+++ b/articles/application-gateway/rewrite-http-headers.md
@@ -91,10 +91,12 @@ This capability supports rewriting headers to the following server variables:
 | -------------------------- | :----------------------------------------------------------- |
 | ciphers_supported          | returns the list of ciphers supported by the client          |
 | ciphers_used               | returns the string of ciphers used for an established SSL connection |
+| client_ip                  | IP address of the client; particularly useful in scenarios where customers intend to rewrite the X-Forwarded-For header set by Application Gateway, so that the header contains only the IP address without the port information. |
 | client_port                | client port                                                  |
 | client_tcp_rtt             | information about the client TCP connection; available on systems that support the TCP_INFO socket option |
 | client_user                | when using HTTP authentication, the username supplied for authentication |
 | host                       | in this order of precedence: host name from the request line, or host name from the “Host” request header field, or the server name matching a request |
+| cookie_*name*              | the *name* cookie |
 | http_method                | the method used to make the URL request. For example GET, POST etc. |
 | http_status                | session status, eg: 200, 400, 403 etc.                       |
 | http_version               | request protocol, usually “HTTP/1.0”, “HTTP/1.1”, or “HTTP/2.0” |
@@ -115,10 +117,6 @@ This capability supports rewriting headers to the following server variables:
 - The HTTP header rewrite support is only supported on the new SKU [Standard_V2](https://docs.microsoft.com/azure/application-gateway/application-gateway-autoscaling-zone-redundant). The capability will not be supported on the old SKU.
 
 - Rewriting the Connect, Upgrade and Host headers is not supported yet.
-
-- Two important server variables, client_ip (the IP address of the client making the request) and cookie_*name* (the *name* cookie), are not supported yet. The client_ip server variable is particularly useful in scenarios where customers intend to rewrite the x-forwarded-for header set by Application Gateway, so that the header contains only the IP address of the client and not the port information.
-
-  Both these server variables will soon be supported.
 
 - The capability to conditionally rewrite the http headers will be available soon.
 


### PR DESCRIPTION
var client_ip and cookie_*name* are supported now. Removed them from the limitation and added to the supported server variables.