### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/automation/automation-source-control-integration-legacy.md
+++ b/articles/automation/automation-source-control-integration-legacy.md
@@ -59,17 +59,17 @@ If you already have a GitHub account and a repository that you want to link to A
      
      | **Parameter** | **Value** |
      |:--- |:--- |
-     | Name |Microsoft.Azure.Automation.SourceControl.Connection |
-     | Type |String |
-     | Value |{"Branch":\<*Your branch name*>,"RunbookFolderPath":\<*Runbook folder path*>,"ProviderType":\<*has a value 1 for GitHub*>,"Repository":\<*Name of your repository*>,"Username":\<*Your GitHub user name*>} |
+     | `Name`  |Microsoft.Azure.Automation.SourceControl.Connection |
+     | `Type`  |String |
+     | `Value` |{"Branch":\<*Your branch name*>,"RunbookFolderPath":\<*Runbook folder path*>,"ProviderType":\<*has a value 1 for GitHub*>,"Repository":\<*Name of your repository*>,"Username":\<*Your GitHub user name*>} |
 
      * The variable **Microsoft.Azure.Automation.SourceControl.OAuthToken**, contains the secure encrypted value of your OAuthToken.  
 
      |**Parameter**            |**Value** |
      |:---|:---|
-     | Name  | Microsoft.Azure.Automation.SourceControl.OAuthToken |
-     | Type | Unknown(Encrypted) |
-     | Value | <*Encrypted OAuthToken*> |  
+     | `Name`  | Microsoft.Azure.Automation.SourceControl.OAuthToken |
+     | `Type`  | Unknown(Encrypted) |
+     | `Value` | <*Encrypted OAuthToken*> |  
 
      ![Variables](media/automation-source-control-integration-legacy/automation_04_Variables.png)  
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates parameter name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/automation/automation-source-control-integration-legacy.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose parameter names by "\`") has no negative effect on the English version.
Please accept this change so that parameter names are not mistranslated in each language in each localized version.
🙏