### PR TITLE
fix: articles/active-directory/hybrid/how-to-connect-syncservice-duplicate-attribute-resiliency.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-syncservice-duplicate-attribute-resiliency.md
+++ b/articles/active-directory/hybrid/how-to-connect-syncservice-duplicate-attribute-resiliency.md
@@ -36,7 +36,7 @@ If there is an attempt to provision a new object with a UPN or ProxyAddress valu
 
 ## Behavior with Duplicate Attribute Resiliency
 Instead of completely failing to provision or update an object with a duplicate attribute, Azure Active Directory “quarantines” the duplicate attribute which would violate the uniqueness constraint. If this attribute is required for provisioning, like UserPrincipalName, the service assigns a placeholder value. The format of these temporary values is  
-“***<OriginalPrefix>+<4DigitNumber>\@<InitialTenantDomain>.onmicrosoft.com***”.  
+“***\<OriginalPrefix>+\<4DigitNumber>\@\<InitialTenantDomain>.onmicrosoft.com***”.  
 If the attribute is not required, like a  **ProxyAddress**, Azure Active Directory simply quarantines the conflict attribute and proceeds with the object creation or update.
 
 Upon quarantining the attribute, information about the conflict is sent in the same error report email used in the old behavior. However, this info only appears in the error report one time, when the quarantine happens, it does not continue to be logged in future emails. Also, since the export for this object has succeeded, the sync client does not log an error and does not retry the create / update operation upon subsequent sync cycles.
@@ -110,7 +110,7 @@ To do a broad string search use the **-SearchString** flag. This can be used ind
 `Get-MsolDirSyncProvisioningError -ErrorCategory PropertyConflict -SearchString User`
 
 #### In a limited quantity or all
-1. **MaxResults <Int>** can be used to limit the query to a specific number of values.
+1. **MaxResults \<Int>** can be used to limit the query to a specific number of values.
 2. **All** can be used to ensure all results are retrieved in the case that a large number of errors exists.
 
 `Get-MsolDirSyncProvisioningError -ErrorCategory PropertyConflict -MaxResults 5`


### PR DESCRIPTION

Escape elements