### PR TITLE
fix: articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md

### DIFF
--- a/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
+++ b/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
@@ -137,7 +137,7 @@ To download the application metadata or certificate from Azure AD, follow the st
 
 8. Go to **SAML Signing Certificate** section, then click **Download** column value. Depending on what the application requires configuring single sign-on, you see either the option to download the Metadata XML or the Certificate.
 
-Azure AD also provides a URL to get the metadata. Follow this pattern to get the metadata URL specific to the application: https://login.microsoftonline.com/<Directory ID>/federationmetadata/2007-06/federationmetadata.xml?appid=<Application ID>.
+Azure AD also provides a URL to get the metadata. Follow this pattern to get the metadata URL specific to the application: `https://login.microsoftonline.com/<Directory ID>/federationmetadata/2007-06/federationmetadata.xml?appid=<Application ID>`.
 
 ## Assign users to the application
 


### PR DESCRIPTION

Wrap backticks so <> elements aren't swallowed