### PR TITLE
Update document to make step 6 clearer

### DIFF
--- a/articles/cosmos-db/sql-api-dotnetcore-get-started.md
+++ b/articles/cosmos-db/sql-api-dotnetcore-get-started.md
@@ -71,7 +71,7 @@ Use the following steps to create an Azure Cosmos account:
 
    ![Screenshot of the right-click menu for the project](./media/sql-api-dotnetcore-get-started/nosql-tutorial-manage-nuget-pacakges.png)
 
-6. On the **NuGet** tab, select **Browse** at the top of the window, and type **azure documentdb** in the search box.
+6. On the **NuGet** tab, select **Browse** at the top of the window, and type **azure documentdb** in the search box. Ensure that the **include prerelease** checkbox is checked.
 
 7. In the results, find **Microsoft.Azure.DocumentDB.Core** and select **Install**.
 


### PR DESCRIPTION
Minor addition, but in step 6, "In the NuGet tab, click Browse, and type Microsoft.Azure.Cosmos in the search box.", it should also mention that the 'include prerelease" checkbox should be checked - mostly because by default it's not. This makes the documentation slightly easier to follow.