### PR TITLE
Switch $True to 1 for enabling the diagnostic logs

### DIFF
--- a/articles/automation/automation-manage-send-joblogs-log-analytics.md
+++ b/articles/automation/automation-manage-send-joblogs-log-analytics.md
@@ -58,7 +58,7 @@ If you need to find the *Name* of your Automation account, in the Azure portal s
    $workspaceId = "[resource id of the log analytics workspace]"
    $automationAccountId = "[resource id of your automation account]"
 
-   Set-AzureRmDiagnosticSetting -ResourceId $automationAccountId -WorkspaceId $workspaceId -Enabled $true
+   Set-AzureRmDiagnosticSetting -ResourceId $automationAccountId -WorkspaceId $workspaceId -Enabled 1
    ```
 
 After running this script, it may take an hour before you start to see records in Azure Monitor logs of new JobLogs or JobStreams being written.


### PR DESCRIPTION
This setting has been changed in the most recent cmdlets and is confusing customers.  Just need to update the content to reflect the latest parameter value required..