### PR TITLE
fix: articles/time-series-insights/time-series-insights-parameterized-urls.md

### DIFF
--- a/articles/time-series-insights/time-series-insights-parameterized-urls.md
+++ b/articles/time-series-insights/time-series-insights-parameterized-urls.md
@@ -76,13 +76,13 @@ The 'multiChartStack=<true/false>' parameter enables stacking in the chart and t
 - 'multiChartStack=false&multiChartSameScale=true' 
   - Stacking must be enabled to use the same Y-axis scale across terms.  It is 'false' by default, so passing 'true' enables this functionality.  
   
-The 'timeBucketUnit=<Unit>&timeBucketSize=<integer>' enables you to adjust the interval slider to provide a more granular or smoother, more aggregated view of the chart.  
-- 'timeBucketUnit=<Unit>&timeBucketSize=<integer>'
+The `timeBucketUnit=<Unit>&timeBucketSize=<integer>` enables you to adjust the interval slider to provide a more granular or smoother, more aggregated view of the chart.  
+- `timeBucketUnit=<Unit>&timeBucketSize=<integer>`
   - Units = days, hours, minutes, seconds, milliseconds.  Always capitalize the unit.
   - Define the number of units by passing the desired integer for timeBucketSize.  Note, you smooth up to 7 days.  
   
-The 'timezoneOffset=<integer>' parameter enables you to set the timezone for the chart to be viewed in as an offset to UTC.  
-  - 'timezoneOffset=-<integer>'
+The `timezoneOffset=<integer>` parameter enables you to set the timezone for the chart to be viewed in as an offset to UTC.  
+  - `timezoneOffset=-<integer>`
     - The integer is always in milliseconds.  
     - Note, this functionality is slightly different than what we enable in the TSI explorer, where we enable you to choose local (browser time) or UTC.  
  


### PR DESCRIPTION

Use backticks so element isn't swallowed