### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/api-management/api-management-api-templates.md
+++ b/articles/api-management/api-management-api-templates.md
@@ -86,7 +86,7 @@ The templates in this section allow you to customize the content of the API page
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|apis|Collection of [API summary](api-management-template-data-model-reference.md#APISummary) entities.|The APIs visible to the current user.|  
+|`apis`|Collection of [API summary](api-management-template-data-model-reference.md#APISummary) entities.|The APIs visible to the current user.|  
   
 ### Sample template data  
   
@@ -341,15 +341,15 @@ The templates in this section allow you to customize the content of the API page
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|apiId|string|The id of the current API.|  
-|apiName|string|The name of the API.|  
-|apiDescription|string|A description of the API.|  
-|api|[API summary](api-management-template-data-model-reference.md#APISummary) entity.|The current API.|  
-|operation|[Operation](api-management-template-data-model-reference.md#Operation)|The currently displayed operation.|  
-|sampleUrl|string|The URL for the current operation.|  
-|operationMenu|[Operation menu](api-management-template-data-model-reference.md#Menu)|A menu of operations for this API.|  
-|consoleUrl|URI|The URI for the **Try it** button.|  
-|samples|Collection of [Code sample](api-management-template-data-model-reference.md#Sample) entities.|The code samples for the current operation..|  
+|`apiId`|string|The id of the current API.|  
+|`apiName`|string|The name of the API.|  
+|`apiDescription`|string|A description of the API.|  
+|`api`|[API summary](api-management-template-data-model-reference.md#APISummary) entity.|The current API.|  
+|`operation`|[Operation](api-management-template-data-model-reference.md#Operation)|The currently displayed operation.|  
+|`sampleUrl`|string|The URL for the current operation.|  
+|`operationMenu`|[Operation menu](api-management-template-data-model-reference.md#Menu)|A menu of operations for this API.|  
+|`consoleUrl`|URI|The URI for the **Try it** button.|  
+|`samples`|Collection of [Code sample](api-management-template-data-model-reference.md#Sample) entities.|The code samples for the current operation..|  
   
 ### Sample template data  
   


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/insights/service-map.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏