### PR TITLE
spell out what iKey is

### DIFF
--- a/articles/azure-monitor/app/troubleshoot-faq.md
+++ b/articles/azure-monitor/app/troubleshoot-faq.md
@@ -147,7 +147,7 @@ This is possible if your code sends such data. It can also happen if variables i
 
 **All** octets of the client web address are always set to 0 after the geo location attributes are looked up.
 
-## My iKey is visible in my web page source. 
+## My Instrumentation Key is visible in my web page source. 
 
 * This is common practice in monitoring solutions.
 * It can't be used to steal your data.
@@ -156,7 +156,7 @@ This is possible if your code sends such data. It can also happen if variables i
 
 You could:
 
-* Use two separate iKeys (separate Application Insights resources), for client and server data. Or
+* Use two separate Instrumentation Keys (separate Application Insights resources), for client and server data. Or
 * Write a proxy that runs in your server, and have the web client send data through that proxy.
 
 ## <a name="post"></a>How do I see POST data in Diagnostic search?


### PR DESCRIPTION
`iKey` is an abbreviation that is not justified in the document. 
`Instrumentation Key` is the term used everywhere.