### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/api-management/api-management-application-templates.md
+++ b/articles/api-management/api-management-application-templates.md
@@ -76,9 +76,9 @@ Azure API Management provides you the ability to customize the content of develo
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|Paging|[Paging](api-management-template-data-model-reference.md#Paging) entity.|The paging information for the applications collection.|  
-|Applications|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications visible to the current user.|  
-|CategoryName|string|The category of application.|  
+|`Paging`|[Paging](api-management-template-data-model-reference.md#Paging) entity.|The paging information for the applications collection.|  
+|`Applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications visible to the current user.|  
+|`CategoryName`|string|The category of application.|  
   
 ### Sample template data  
   


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/api-management/api-management-application-templates.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏