### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/api-management/api-management-issue-templates.md
+++ b/articles/api-management/api-management-issue-templates.md
@@ -94,11 +94,11 @@ Azure API Management provides you the ability to customize the content of develo
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|Issues|Collection of [Issue](api-management-template-data-model-reference.md#Issue) entities.|The issues visible to the current user.|  
-|Paging|[Paging](api-management-template-data-model-reference.md#Paging) entity.|The paging information for the applications collection.|  
-|IsAuthenticated|boolean|Whether the current user is signed-in to the developer portal.|  
-|CanReportIssues|boolean|Whether the current user has permissions to file an issue.|  
-|Search|string|This property is deprecated and should not be used.|  
+|`Issues`|Collection of [Issue](api-management-template-data-model-reference.md#Issue) entities.|The issues visible to the current user.|  
+|`Paging`|[Paging](api-management-template-data-model-reference.md#Paging) entity.|The paging information for the applications collection.|  
+|`IsAuthenticated`|boolean|Whether the current user is signed-in to the developer portal.|  
+|`CanReportIssues`|boolean|Whether the current user has permissions to file an issue.|  
+|`Search`|string|This property is deprecated and should not be used.|  
   
 ### Sample template data  
   


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/microsoftdocs/azure-docs.ja-jp/blob/live/articles/api-management/api-management-issue-templates.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏