### PR TITLE
Update automation-runbook-execution.md

### DIFF
--- a/articles/automation/automation-runbook-execution.md
+++ b/articles/automation/automation-runbook-execution.md
@@ -281,9 +281,10 @@ Other details such as the person or account that started the runbook can be retr
 $SubID = "00000000-0000-0000-0000-000000000000"
 $rg = "ResourceGroup01"
 $AutomationAccount = "MyAutomationAccount"
-$JobResourceID = "/subscriptions/$subid/resourcegroups/$rg/providers/Microsoft.Automation/automationAccounts/$AutomationAccount/jobs"
+$RunbookName = "Test-Runbook"
+$ResourceID = "/subscriptions/$subid/resourcegroups/$rg/providers/Microsoft.Automation/automationAccounts/$AutomationAccount/runbooks/$RunbookName"
 
-Get-AzureRmLog -ResourceId $JobResourceID -MaxRecord 1 | Select Caller
+Get-AzureRmLog -ResourceId $ResourceID -MaxRecord 1 | Select Caller
 ```
 
 ## Fair share


### PR DESCRIPTION
Since the description says "last user to run the runbook", I believe the ResourceID should point to a runbook rather than jobs? There can be some other runbook generating activity in jobs and the query would return caller from that other runbook.