### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/api-management/api-management-user-profile-templates.md
+++ b/articles/api-management/api-management-user-profile-templates.md
@@ -101,17 +101,17 @@ Azure API Management provides you the ability to customize the content of develo
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|firstName|string|First name of the current user.|  
-|lastName|string|Last name of the current user.|  
-|companyName|string|The company name of the current user.|  
-|addresserEmail|string|Email address of the current user.|  
-|developersUsageStatisticsLinkk|string|Relative URL to view analytics for the current user.|  
-|subscriptions|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
-|applications|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
-|changePasswordUrl|string|The relative URL to change the current user's password.|  
-|changeNameOrEmailUrl|string|The relative URL to change the name and email for the current user.|  
-|canChangePassword|boolean|Whether the current user can change their password.|  
-|isSystemUser|boolean|Whether the current user is a member of one of the built-in [groups](api-management-key-concepts.md#groups).|  
+|`firstName`|string|First name of the current user.|  
+|`lastName`|string|Last name of the current user.|  
+|`companyName`|string|The company name of the current user.|  
+|`addresserEmail`|string|Email address of the current user.|  
+|`developersUsageStatisticsLinkk`|string|Relative URL to view analytics for the current user.|  
+|`subscriptions`|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
+|`applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
+|`changePasswordUrl`|string|The relative URL to change the current user's password.|  
+|`changeNameOrEmailUrl`|string|The relative URL to change the name and email for the current user.|  
+|`canChangePassword`|boolean|Whether the current user can change their password.|  
+|`isSystemUser`|boolean|Whether the current user is a member of one of the built-in [groups](api-management-key-concepts.md#groups).|  
   
 ### Sample template data  
   
@@ -322,17 +322,17 @@ Azure API Management provides you the ability to customize the content of develo
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|firstName|string|First name of the current user.|  
-|lastName|string|Last name of the current user.|  
-|companyName|string|The company name of the current user.|  
-|addresserEmail|string|Email address of the current user.|  
-|developersUsageStatisticsLinkk|string|Relative URL to view analytics for the current user.|  
-|subscriptions|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
-|applications|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
-|changePasswordUrl|string|The relative URL to change the current user's password.|  
-|changeNameOrEmailUrl|string|The relative URL to change the name and email for the current user.|  
-|canChangePassword|boolean|Whether the current user can change their password.|  
-|isSystemUser|boolean|Whether the current user is a member of one of the built-in [groups](api-management-key-concepts.md#groups).|  
+|`firstName`|string|First name of the current user.|  
+|`lastName`|string|Last name of the current user.|  
+|`companyName`|string|The company name of the current user.|  
+|`addresserEmail`|string|Email address of the current user.|  
+|`developersUsageStatisticsLinkk`|string|Relative URL to view analytics for the current user.|  
+|`subscriptions`|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
+|`applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
+|`changePasswordUrl`|string|The relative URL to change the current user's password.|  
+|`changeNameOrEmailUrl`|string|The relative URL to change the name and email for the current user.|  
+|`canChangePassword`|boolean|Whether the current user can change their password.|  
+|`isSystemUser`|boolean|Whether the current user is a member of one of the built-in [groups](api-management-key-concepts.md#groups).|  
   
 ### Sample template data  
   
@@ -485,17 +485,17 @@ Azure API Management provides you the ability to customize the content of develo
   
 |Property|Type|Description|  
 |--------------|----------|-----------------|  
-|firstName|string|First name of the current user.|  
-|lastName|string|Last name of the current user.|  
-|companyName|string|The company name of the current user.|  
-|addresserEmail|string|Email address of the current user.|  
-|developersUsageStatisticsLinkk|string|Relative URL to view analytics for the current user.|  
-|subscriptions|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
-|applications|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
-|changePasswordUrl|string|The relative URL to change the current user's password.|  
-|changeNameOrEmailUrl|string|The relative URL to change the name and email for the current user.|  
-|canChangePassword|boolean|Whether the current user can change their password.|  
-|isSystemUser|boolean|Whether the current user is a member of one of the built-in [groups](api-management-key-concepts.md#groups).|  
+|`firstName`|string|First name of the current user.|  
+|`lastName`|string|Last name of the current user.|  
+|`companyName`|string|The company name of the current user.|  
+|`addresserEmail`|string|Email address of the current user.|  
+|`developersUsageStatisticsLinkk`|string|Relative URL to view analytics for the current user.|  
+|`subscriptions`|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
+|`applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
+|`changePasswordUrl`|string|The relative URL to change the current user's password.|  
+|`changeNameOrEmailUrl`|string|The relative URL to change the name and email for the current user.|  
+|`canChangePassword`|boolean|Whether the current user can change their password.|  
+|`isSystemUser`|boolean|Whether the current user is a member of one of the built-in [groups](api-management-key-concepts.md#groups).|  
   
 ### Sample template data  
   

--- a/articles/api-management/api-management-user-profile-templates.md
+++ b/articles/api-management/api-management-user-profile-templates.md
@@ -105,7 +105,7 @@ Azure API Management provides you the ability to customize the content of develo
 |`lastName`|string|Last name of the current user.|  
 |`companyName`|string|The company name of the current user.|  
 |`addresserEmail`|string|Email address of the current user.|  
-|`developersUsageStatisticsLinkk`|string|Relative URL to view analytics for the current user.|  
+|`developersUsageStatisticsLink`|string|Relative URL to view analytics for the current user.|  
 |`subscriptions`|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
 |`applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
 |`changePasswordUrl`|string|The relative URL to change the current user's password.|  
@@ -326,7 +326,7 @@ Azure API Management provides you the ability to customize the content of develo
 |`lastName`|string|Last name of the current user.|  
 |`companyName`|string|The company name of the current user.|  
 |`addresserEmail`|string|Email address of the current user.|  
-|`developersUsageStatisticsLinkk`|string|Relative URL to view analytics for the current user.|  
+|`developersUsageStatisticsLink`|string|Relative URL to view analytics for the current user.|  
 |`subscriptions`|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
 |`applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
 |`changePasswordUrl`|string|The relative URL to change the current user's password.|  
@@ -489,7 +489,7 @@ Azure API Management provides you the ability to customize the content of develo
 |`lastName`|string|Last name of the current user.|  
 |`companyName`|string|The company name of the current user.|  
 |`addresserEmail`|string|Email address of the current user.|  
-|`developersUsageStatisticsLinkk`|string|Relative URL to view analytics for the current user.|  
+|`developersUsageStatisticsLink`|string|Relative URL to view analytics for the current user.|  
 |`subscriptions`|Collection of [Subscription](api-management-template-data-model-reference.md#Subscription) entities.|The subscriptions for the current user.|  
 |`applications`|Collection of [Application](api-management-template-data-model-reference.md#Application) entities.|The applications of the current user.|  
 |`changePasswordUrl`|string|The relative URL to change the current user's password.|  


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/api-management/api-management-user-profile-templates.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏