### PR TITLE
Change label: "diagnostic logs" to "diagnostic settings"

### DIFF
--- a/articles/firewall/tutorial-diagnostics.md
+++ b/articles/firewall/tutorial-diagnostics.md
@@ -36,7 +36,7 @@ Before starting this tutorial, you should read [Azure Firewall logs and metrics]
 It can take a few minutes for the data to appear in your logs after you complete this procedure to turn on diagnostic logging. If you don't see anything at first, check again in  a few more minutes.
 
 1. In the Azure portal, open your firewall resource group and click the firewall.
-2. Under **Monitoring**, click **Diagnostic logs**.
+2. Under **Monitoring**, click **Diagnostic settings**.
 
    For Azure Firewall, two service-specific logs are available:
 


### PR DESCRIPTION
Just a quick label fix that I noticed when setting up a firewall. The docs say "Diagnostic logs" but the label is "Diagnostic settings".

![image](https://user-images.githubusercontent.com/5757382/55161196-fc9ef000-5132-11e9-94b2-f70e4a39459f.png)
