### PR TITLE
Update SQL Managed Instance outbound network security rules

### DIFF
--- a/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
+++ b/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
@@ -102,7 +102,7 @@ Deploy a managed instance in a dedicated subnet inside the virtual network. The 
 
 | Name       |Port          |Protocol|Source           |Destination|Action|
 |------------|--------------|--------|-----------------|-----------|------|
-|management  |80, 443, 12000|TCP     |Any              |All         |Allow |
+|management  |80, 443, 12000|TCP     |Any              |AzureCloud  |Allow |
 |mi_subnet   |Any           |Any     |Any              |MI SUBNET*  |Allow |
 
 > Make sure there is only one inbound rule for ports 9000, 9003, 1438, 1440, 1452 and one outbound rule for ports 80, 443, 12000. Managed Instance provisioning through ARM deployments may fail if inbound and output rules are configured separately for each ports. 

--- a/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
+++ b/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
@@ -102,7 +102,7 @@ Deploy a managed instance in a dedicated subnet inside the virtual network. The 
 
 | Name       |Port          |Protocol|Source           |Destination|Action|
 |------------|--------------|--------|-----------------|-----------|------|
-|management  |80, 443, 12000|TCP     |Any              |Internet   |Allow |
+|management  |80, 443, 12000|TCP     |Any              |All         |Allow |
 |mi_subnet   |Any           |Any     |Any              |MI SUBNET*  |Allow |
 
 > Make sure there is only one inbound rule for ports 9000, 9003, 1438, 1440, 1452 and one outbound rule for ports 80, 443, 12000. Managed Instance provisioning through ARM deployments may fail if inbound and output rules are configured separately for each ports. 


### PR DESCRIPTION
As per Srdan Bozovic <Srdjan.Bozovic@microsoft.com> the outbound network security rule for management traffic has changed from "Internet" to "AzureCloud".