### PR TITLE
jitin/fix-policy-sample-documentation

### DIFF
--- a/articles/api-management/api-management-howto-mutual-certificates-for-clients.md
+++ b/articles/api-management/api-management-howto-mutual-certificates-for-clients.md
@@ -44,7 +44,7 @@ Below policies can be configured to check the issuer and subject of a client cer
 
 ```xml
 <choose>
-    <when condition="@(context.Request.Certificate == null || context.Request.Certificate.Issuer != 'trusted-issuer' || context.Request.Certificate.SubjectName != 'expected-subject-name')" >
+    <when condition="@(context.Request.Certificate == null || context.Request.Certificate.Issuer != "trusted-issuer" || context.Request.Certificate.SubjectName.Name != "expected-subject-name")" >
         <return-response>
             <set-status code="403" reason="Invalid client certificate" />
         </return-response>
@@ -58,7 +58,7 @@ Below policies can be configured to check the thumbprint of a client certificate
 
 ```xml
 <choose>
-    <when condition="@(context.Request.Certificate == null || context.Request.Certificate.Thumbprint != 'desired-thumbprint')" >
+    <when condition="@(context.Request.Certificate == null || context.Request.Certificate.Thumbprint != "desired-thumbprint")" >
         <return-response>
             <set-status code="403" reason="Invalid client certificate" />
         </return-response>


### PR DESCRIPTION
- Policy uses single quotes vs double quotes
- context.Request.Certificate.SubjectName is an object and needs to name property for string comparison