### PR TITLE
Update sql-database-managed-instance-connectivity-architecture.md

### DIFF
--- a/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
+++ b/articles/sql-database/sql-database-managed-instance-connectivity-architecture.md
@@ -105,7 +105,8 @@ Deploy a managed instance in a dedicated subnet inside the virtual network. The 
 |management  |80, 443, 12000|TCP     |Any              |AzureCloud  |Allow |
 |mi_subnet   |Any           |Any     |Any              |MI SUBNET*  |Allow |
 
-> Make sure there is only one inbound rule for ports 9000, 9003, 1438, 1440, 1452 and one outbound rule for ports 80, 443, 12000. Managed Instance provisioning through ARM deployments may fail if inbound and output rules are configured separately for each ports. 
+> [!IMPORTANT]
+> Ensure there is only one inbound rule for ports 9000, 9003, 1438, 1440, 1452 and one outbound rule for ports 80, 443, 12000. Managed Instance provisioning through ARM deployments will fail if inbound and output rules are configured separately for each port. If these ports are in separate rules, the deployment will fail with error code `VnetSubnetConflictWithIntendedPolicy`
 
 \* MI SUBNET refers to the IP address range for the subnet in the form 10.x.x.x/y. You can find this information in the Azure portal, in subnet properties.
 


### PR DESCRIPTION
Adding an Important box around the NSG notes about keeping inbound/outbound rules in a single inbound or outbound rule.  This was both missed and misunderstood by a customer today and needs more clarity and emphasis.