### PR TITLE
Specified the needed permissions

### DIFF
--- a/articles/key-vault/service-to-service-authentication.md
+++ b/articles/key-vault/service-to-service-authentication.md
@@ -148,7 +148,7 @@ This applies only to local development. When your solution is deployed to Azure,
 
 ## Running the application using managed identity or user-assigned identity 
 
-When you run your code on an Azure App Service or an Azure VM with a managed identity enabled, the library automatically uses the managed identity. No code changes are required. 
+When you run your code on an Azure App Service or an Azure VM with a managed identity enabled, the library automatically uses the managed identity. No code changes are required, but be aware that this will only work if the managed identity has both *get* and *list* permissions for the key vault. You can set this up under the key vaults *Access Policies*.
 
 Alternatively, you may authenticate with a user-assigned identity. For more information on user-assigned identities, see [About Managed Identities for Azure resources](../active-directory/managed-identities-azure-resources/overview.md#how-does-the-managed-identities-for-azure-resources-work). The connection string is specified in the [Connection String Support](#connection-string-support) section below.
 


### PR DESCRIPTION
It was not specified anywhere in this document or anywhere else the permissions needed for the managed identity to get this to work.  I propose this doc. change because I spent a long time trying to access the key vault with a Managed Identity having only the GET permission. After adding the LIST permission too, it worked.