### PR TITLE
fix: MD011/no-reversed-links

### DIFF
--- a/articles/azure-stack/azure-stack-storage-infrastructure-overview.md
+++ b/articles/azure-stack/azure-stack-storage-infrastructure-overview.md
@@ -87,13 +87,15 @@ Mirroring provides fault tolerance by keeping multiple copies of all data. How t
 
 ## Volume states
 
-To find out what state volumess are in, use the following PowerShell commands:
+To find out what state volumes are in, use the following PowerShell commands:
 
-\$scaleunit\_name = (Get-AzsScaleUnit)\[0\].name
+```powershell
+$scaleunit_name = (Get-AzsScaleUnit)[0].name
 
-\$subsystem\_name = (Get-AzsStorageSubSystem -ScaleUnit \$scaleunit\_name)\[0\].name
+$subsystem_name = (Get-AzsStorageSubSystem -ScaleUnit $scaleunit_name)[0].name
 
-Get-AzsVolume -ScaleUnit \$scaleunit\_name -StorageSubSystem \$subsystem\_name | Select-Object VolumeLabel, HealthStatus, OperationalStatus, RepairStatus, Description, Action, TotalCapacityGB, RemainingCapacityGB
+Get-AzsVolume -ScaleUnit $scaleunit_name -StorageSubSystem $subsystem_name | Select-Object VolumeLabel, HealthStatus, OperationalStatus, RepairStatus, Description, Action, TotalCapacityGB, RemainingCapacityGB
+```
 
 Here's an example of output showing a detached volume and a degraded/incomplete volume:
 
@@ -145,17 +147,15 @@ The volume can also be in the Unknown health state if the virtual disk has becom
 
 Use the following PowerShell commands to monitor the state of drives:
 
- 
+```powershell
+$scaleunit_name = (Get-AzsScaleUnit)[0].name
 
-\$scaleunit\_name = (Get-AzsScaleUnit)\[0\].name
-
-\$subsystem\_name = (Get-AzsStorageSubSystem -ScaleUnit \$scaleunit\_name)\[0\].name
+$subsystem_name = (Get-AzsStorageSubSystem -ScaleUnit $scaleunit_name)[0].name
 
 , SerialNumber
 
- 
-
-Get-AzsDrive -ScaleUnit \$scaleunit\_name -StorageSubSystem \$subsystem\_name | Select-Object StorageNode, PhysicalLocation, HealthStatus, OperationalStatus, Description, Action, Usage, CanPool, CannotPoolReason, SerialNumber, Model, MediaType, CapacityGB
+Get-AzsDrive -ScaleUnit $scaleunit_name -StorageSubSystem $subsystem_name | Select-Object StorageNode, PhysicalLocation, HealthStatus, OperationalStatus, Description, Action, Usage, CanPool, CannotPoolReason, SerialNumber, Model, MediaType, CapacityGB
+```
 
 The following sections describe the health states a drive can be in.
 

--- a/articles/machine-learning/team-data-science-process/data-blob.md
+++ b/articles/machine-learning/team-data-science-process/data-blob.md
@@ -69,12 +69,12 @@ Here are a few examples of ways to explore data using Pandas:
         print miss_num
 7. If you have missing values for a specific column in the data, you can drop them as follows:
    
-     dataframe_blobdata_noNA = dataframe_blobdata.dropna()
-     dataframe_blobdata_noNA.shape
+        dataframe_blobdata_noNA = dataframe_blobdata.dropna()
+        dataframe_blobdata_noNA.shape
    
    Another way to replace missing values is with the mode function:
    
-     dataframe_blobdata_mode = dataframe_blobdata.fillna({'<column_name>':dataframe_blobdata['<column_name>'].mode()[0]})        
+        dataframe_blobdata_mode = dataframe_blobdata.fillna({'<column_name>':dataframe_blobdata['<column_name>'].mode()[0]})        
 8. Create a histogram plot using variable number of bins to plot the distribution of a variable    
    
         dataframe_blobdata['<column_name>'].value_counts().plot(kind='bar')

--- a/articles/site-recovery/site-recovery-failover-to-azure-troubleshoot.md
+++ b/articles/site-recovery/site-recovery-failover-to-azure-troubleshoot.md
@@ -126,8 +126,10 @@ The Azure Site Recovery Master Target registration with the configuration server
  
 This error is indicated by the following strings in the installation log: 
 
+```
 RegisterHostStaticInfo encountered exception config/talwrapper.cpp(107)[post] CurlWrapper Post failed : server : 10.38.229.221, port : 443, phpUrl : request_handler.php, secure : true, ignoreCurlPartialError : false with error: [at curlwrapperlib/curlwrapper.cpp:processCurlResponse:231]   failed to post request: (35) - SSL connect error. 
- 
+```
+
 To resolve the issue:
  
 1. On the configuration server VM, open a command prompt and verify the proxy settings using the following commands:


### PR DESCRIPTION

Unwrapped code blocks with arrays get flagged as reversed links.
Some where escaped, but code fences do this better.