### PR TITLE
Changed "using Microsoft.Azure"

### DIFF
--- a/articles/visual-studio/vs-storage-aspnet-getting-started-blobs.md
+++ b/articles/visual-studio/vs-storage-aspnet-getting-started-blobs.md
@@ -51,7 +51,7 @@ include creating a blob container, and uploading, listing, downloading, and dele
 1. Add the following `using` directives to the `BlobsController.cs` file:
 
     ```csharp
-	using Microsoft.Azure;
+    using Microsoft.WindowsAzure;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
 	```


### PR DESCRIPTION
Changed "using Microsoft.Azure" (with incorrect spacing) to "using Microsoft.WindowsAzure" (with correct spacing).