### PR TITLE
Make it clear that event hub scalability is limited by MIN(Partitions, ThroughputUnits)

### DIFF
--- a/articles/event-hubs/event-hubs-features.md
+++ b/articles/event-hubs/event-hubs-features.md
@@ -155,6 +155,8 @@ There are two factors which influence scaling with Event Hubs.
 *	Throughput units
 *	Partitions
 
+Partition can only use a maximum of one throughput unit each. This means for an event hub instance, the maximum amount of throuhput units that can be consumed by that event hub is limited by the number of partitions chosen.
+
 ### Throughput units
 
 The throughput capacity of Event Hubs is controlled by *throughput units*. Throughput units are pre-purchased units of capacity. A single throughput lets you:


### PR DESCRIPTION
It is not immediately clear how important the partition count is when considering scalability of event hubs, because the documentation does not clearly note that a partition can use at most one throughput unit.