### PR TITLE
Adding aka.ms links to ASP.NET Core Web API tuto

### DIFF
--- a/articles/active-directory/develop/sample-v2-code.md
+++ b/articles/active-directory/develop/sample-v2-code.md
@@ -97,7 +97,7 @@ Desktop (Console)   | ![.NET/C# (Desktop)](media/sample-v2-code/logo_NETcore.png
 
 ## Web APIs
 
-The following sample shows how to protect a web API with the Azure AD v2.0 endpoint. This API is exercised by a WPF application, but it can be called by any application. The web API also calls Microsoft Graph
+The following sample shows how to protect a web API with the Azure AD v2.0 endpoint. This API is exercised by a WPF application, but it can be called by any application. The web API also calls Microsoft Graph.
 
 Platform | Sample
  -------- | -------------------

--- a/articles/active-directory/develop/sample-v2-code.md
+++ b/articles/active-directory/develop/sample-v2-code.md
@@ -70,7 +70,7 @@ The following samples show public client applications (desktop/mobile applicatio
 
 Client application | Platform | Flow/Grant | Calls Microsoft Graph | Calls an ASP.NET Core 2.0 Web API
 ------------------ | -------- |  ----------| ---------- | -------------------------
-Desktop (WPF)      | ![.NET/C#](media/sample-v2-code/logo_NET.png) | interactive | [dotnet-desktop-msgraph-v2](https://github.com/azure-samples/active-directory-dotnet-desktop-msgraph-v2) | [dotnet-native-aspnetcore-v2](https://github.com/azure-samples/active-directory-dotnet-native-aspnetcore-v2)
+Desktop (WPF)      | ![.NET/C#](media/sample-v2-code/logo_NET.png) | interactive | [dotnet-desktop-msgraph-v2](https://github.com/azure-samples/active-directory-dotnet-desktop-msgraph-v2) | [dotnet-native-aspnetcore-v2](https://aka.ms/msidentity-aspnetcore-webapi)
 Desktop (Console)   | ![.NET/C# (Desktop)](media/sample-v2-code/logo_NET.png) | Integrated Windows Authentication |[dotnet-iwa-v2](https://github.com/azure-samples/active-directory-dotnet-iwa-v2)
 Desktop (Console)   | ![.NET/C# (Desktop)](media/sample-v2-code/logo_NETcore.png) | Username/Password |[dotnetcore-up-v2](https://github.com/azure-samples/active-directory-dotnetcore-console-up-v2)
 Mobile (UWP)   | ![.NET/C# (UWP)](media/sample-v2-code/logo_windows.png) | interactive |[dotnet-native-uwp-v2](https://github.com/azure-samples/active-directory-dotnet-native-uwp-v2) |
@@ -97,11 +97,11 @@ Desktop (Console)   | ![.NET/C# (Desktop)](media/sample-v2-code/logo_NETcore.png
 
 ## Web APIs
 
-The following sample shows how to protect a web API with the Azure AD v2.0 endpoint. This API is exercised by a WPF application, but it can be called by any application.
+The following sample shows how to protect a web API with the Azure AD v2.0 endpoint. This API is exercised by a WPF application, but it can be called by any application. The web API also calls Microsoft Graph
 
 Platform | Sample
  -------- | -------------------
-![.NET/C#](media/sample-v2-code/logo_NET.png) | WebAPI (service) of [dotnet-native-aspnetcore-v2](https://github.com/azure-samples/active-directory-dotnet-native-aspnetcore-v2)
+![.NET/C#](media/sample-v2-code/logo_NET.png) | WebAPI (service) of [dotnet-native-aspnetcore-v2](https://aka.ms/msidentity-aspnetcore-webapi-calls-msgraph)
 
 ## Other Microsoft Graph samples
 


### PR DESCRIPTION
Adding aka.ms links to the ASP.NET Core Web API tutorial so that we can do some folder renamings, and even a repo rebranding.

@CelesteDG : I used the quick edit for this one as I need to recreate and resync my fork.