### PR TITLE
Updated two PowerShell sections

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-via-arm.md
@@ -173,7 +173,7 @@ Deploy the cluster using PowerShell:
 
 ```powershell
 $resourceGroupLocation="westus"
-$resourceGroupName="mylinux"
+$resourceGroupName="mycluster"
 $vaultName="myvault"
 $vaultResourceGroupName="myvaultrg"
 $certPassword="Password!1" | ConvertTo-SecureString -AsPlainText -Force 
@@ -225,7 +225,7 @@ Deploy the cluster using PowerShell:
 
 ```powershell
 $resourceGroupLocation="westus"
-$resourceGroupName="mylinux"
+$resourceGroupName="mycluster"
 $vaultName="myvault"
 $vaultResourceGroupName="myvaultrg"
 $certPassword="Password!1" | ConvertTo-SecureString -AsPlainText -Force 


### PR DESCRIPTION
Two PowerShell scripts were deploying Windows-based clusters. The resource groups were called mylinux. I have changed to mycluster to match the rest of the document and to take confusion away between windows and Linux clusters.