### PR TITLE
escape \ so that it doesn't interfere _ at end of the line.

### DIFF
--- a/articles/app-service/environment/create-ilb-ase.md
+++ b/articles/app-service/environment/create-ilb-ase.md
@@ -166,7 +166,7 @@ To upload your own certificates and test access:
 
 4. Set the DNS for your ASE domain. You can use a wildcard with your domain in your DNS. To do some simple tests, edit the hosts file on your VM to set the app name to the VIP IP address:
 
-	a. If your ASE has the domain name _.ilbase.com_ and you create the app named _mytestapp_, it's addressed at _mytestapp.ilbase.com_. You then set _mytestapp.ilbase.com_ to resolve to the ILB address. (On Windows, the hosts file is at _C:\Windows\System32\drivers\etc\_.)
+	a. If your ASE has the domain name _.ilbase.com_ and you create the app named _mytestapp_, it's addressed at _mytestapp.ilbase.com_. You then set _mytestapp.ilbase.com_ to resolve to the ILB address. (On Windows, the hosts file is at _C:\Windows\System32\drivers\etc\\_.)
 
 	b. To test web deployment publishing or access to the advanced console, create a record for _mytestapp.scm.ilbase.com_.
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34650736/55402200-cf689c80-558d-11e9-9e4c-b6f5c590f707.png)

The italic type didn't take effect because "\_" is treated as an escape character.