### PR TITLE
Fixed a typo

### DIFF
--- a/articles/security/azure-security-disk-encryption-windows.md
+++ b/articles/security/azure-security-disk-encryption-windows.md
@@ -148,7 +148,7 @@ The following table lists the Resource Manager template parameters for existing 
 
 ### Encrypt virtual machine scale sets with Azure PowerShell
 
-Use the [Set-AzVmssDiskEncryptionExtension](/powershell/module/az.compute/set-azvmssdiskencryptionextension) cmdlet to enable encryption on a Windows virtual machine scale set. The resource group, VM, and key vault should have already been created as prerequisites.
+Use the [Set-AzVmssDiskEncryptionExtension](/powershell/module/az.compute/set-azvmssdiskencryptionextension) cmdlet to enable encryption on a Windows virtual machine scale set. The resource group, virtual machine scale set, and key vault should have already been created as prerequisites.
 
 -  **Encrypt a running virtual machine scale set**:
     ```azurepowershell


### PR DESCRIPTION
Under the encrypt a virtual machine scale set one of the prerequisites stated a vm rather than a virtual machine scale set.