### PR TITLE
(Azure CXP fixes) Doc enhancement

### DIFF
--- a/includes/active-directory-ds-prerequisites.md
+++ b/includes/active-directory-ds-prerequisites.md
@@ -24,6 +24,6 @@ ms.author: maheshu
 >
 > Follow the instructions below, depending on the type of users in your Azure
 > AD directory. Complete both sets of instructions if you have a mix of cloud-only
-> and synced user accounts in your Azure AD directory.
+> and synced user accounts in your Azure AD directory. You may not be able to carry out the following operations in case you are trying to  use a B2B Guest account (example , your gmail or MSA from a different Identity provider which we allow) becasue we do not have the password for these users synced to managed domain as these are guest accounts in the directory. The complete information about these accounts including their passwords would be outside of Azure AD and as this information is not in Azure AD hence it does not even get synced to the managed domain. 
 > - [Instructions for cloud-only user accounts](../articles/active-directory-domain-services/active-directory-ds-getting-started-password-sync.md)
 > - [Instructions for user accounts synchronized from an on-premises directory](../articles/active-directory-domain-services/active-directory-ds-getting-started-password-sync-synced-tenant.md)


### PR DESCRIPTION
This is an update as per the MSDN  customer thread https://social.msdn.microsoft.com/Forums/en-US/54c98f9b-b79b-4c9a-a936-9f4fdcccedab/binding-to-aad-via-ldaps-ends-up-with-49-invalid-credentials?forum=WindowsAzureAD#8f840214-68b4-4663-886e-e1713890aaa4 

The customer was trying to logon to secure Ldap on a managed domain using his B2B guest account which is gmail ID and it failed with an error "Binding to AAD via LDAPS ends up with "(49) Invalid Credentials""