### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/api-management/api-management-howto-properties.md
+++ b/articles/api-management/api-management-howto-properties.md
@@ -23,10 +23,10 @@ Each API Management service instance has a properties collection of key/value pa
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| Display name |string |Alphanumeric string used for referencing the property in the policies. |
-| Value |string |The value of the property. It may not be empty or consist only of whitespace. |
-|Secret|boolean|Determines whether the value is a secret and should be encrypted or not.|
-| Tags |array of string |Optional tags that when provided can be used to filter the property list. |
+| `Display name` |string |Alphanumeric string used for referencing the property in the policies. |
+| `Value`        |string |The value of the property. It may not be empty or consist only of whitespace. |
+| `Secret`       |boolean|Determines whether the value is a secret and should be encrypted or not.|
+| `Tags`         |array of string |Optional tags that when provided can be used to filter the property list. |
 
 ![Named values](./media/api-management-howto-properties/named-values.png)
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates attribute name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/api-management/api-management-howto-properties.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose attribute names by "\`") has no negative effect on the English version.
Please accept this change so that attribute names are not mistranslated in each language in each localized version.
🙏

