### PR TITLE
Removing extraneous period from command to enable logging

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-health-agent-install.md
+++ b/articles/active-directory/hybrid/how-to-connect-health-agent-install.md
@@ -136,7 +136,7 @@ In order for the Usage Analytics feature to gather and analyze data, the Azure A
 1. Open **Local Security Policy** by opening **Server Manager** on the Start screen, or Server Manager in the taskbar on the desktop, then click **Tools/Local Security Policy**.
 2. Navigate to the **Security Settings\Local Policies\User Rights Assignment** folder, and then double-click **Generate security audits**.
 3. On the **Local Security Setting** tab, verify that the AD FS service account is listed. If it is not present, click **Add User or Group** and add it to the list, and then click **OK**.
-4. To enable auditing, open a command prompt with elevated privileges and run the following command: ```auditpol.exe /set /subcategory:{0CCE9222-69AE-11D9-BED3-505054503030} /failure:enable /success:enable```.
+4. To enable auditing, open a command prompt with elevated privileges and run the following command: ```auditpol.exe /set /subcategory:{0CCE9222-69AE-11D9-BED3-505054503030} /failure:enable /success:enable```
 5. Close **Local Security Policy**.
 <br />   -- **The following steps are only required for primary AD FS servers.** -- <br />
 6. Open the **AD FS Management** snap-in (in Server Manager, click Tools, and then select AD FS Management).
@@ -149,7 +149,7 @@ In order for the Usage Analytics feature to gather and analyze data, the Azure A
 1. Open **Local Security Policy** by opening **Server Manager** on the Start screen, or Server Manager in the taskbar on the desktop, then click **Tools/Local Security Policy**.
 2. Navigate to the **Security Settings\Local Policies\User Rights Assignment** folder, and then double-click **Generate security audits**.
 3. On the **Local Security Setting** tab, verify that the AD FS service account is listed. If it is not present, click **Add User or Group** and add the AD FS service account to the list, and then click **OK**.
-4. To enable auditing, open a command prompt with elevated privileges and run the following command: <code>auditpol.exe /set /subcategory:{0CCE9222-69AE-11D9-BED3-505054503030} /failure:enable /success:enable.</code>
+4. To enable auditing, open a command prompt with elevated privileges and run the following command: <code>auditpol.exe /set /subcategory:{0CCE9222-69AE-11D9-BED3-505054503030} /failure:enable /success:enable</code>
 5. Close **Local Security Policy**.
 <br />   -- **The following steps are only required for primary AD FS servers.** -- <br />
 6. Open the **AD FS Management** snap-in (in Server Manager, click Tools, and then select AD FS Management).


### PR DESCRIPTION
Removed extra period from commandline example to enable verbose logging for 2012 R2 and 2016 to avoid confusion when copying from article