### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/azure-monitor/insights/solution-agenthealth.md
+++ b/articles/azure-monitor/insights/solution-agenthealth.md
@@ -70,21 +70,21 @@ A record with a type of **Heartbeat** is created.  These records have the proper
 
 | Property | Description |
 | --- | --- |
-| Type | *Heartbeat*|
-| Category | Value is *Direct Agent*, *SCOM Agent*, or *SCOM Management Server*.|
-| Computer | Computer name.|
-| OSType | Windows or Linux operating system.|
-| OSMajorVersion | Operating system major version.|
-| OSMinorVersion | Operating system minor version.|
-| Version | Log Analytics Agent or Operations Manager Agent version.|
-| SCAgentChannel | Value is *Direct* and/or *SCManagementServer*.|
-| IsGatewayInstalled | If Log Analytics gateway is installed, value is *true*, otherwise value is *false*.|
-| ComputerIP | IP address of the computer.|
-| RemoteIPCountry | Geographic location where computer is deployed.|
-| ManagementGroupName | Name of Operations Manager management group.|
-| SourceComputerId | Unique ID of computer.|
-| RemoteIPLongitude | Longitude of computer's geographic location.|
-| RemoteIPLatitude | Latitude of computer's geographic location.|
+| `Type` | *Heartbeat*|
+| `Category` | Value is *Direct Agent*, *SCOM Agent*, or *SCOM Management Server*.|
+| `Computer` | Computer name.|
+| `OSType` | Windows or Linux operating system.|
+| `OSMajorVersion` | Operating system major version.|
+| `OSMinorVersion` | Operating system minor version.|
+| `Version` | Log Analytics Agent or Operations Manager Agent version.|
+| `SCAgentChannel` | Value is *Direct* and/or *SCManagementServer*.|
+| `IsGatewayInstalled` | If Log Analytics gateway is installed, value is *true*, otherwise value is *false*.|
+| `ComputerIP` | IP address of the computer.|
+| `RemoteIPCountry` | Geographic location where computer is deployed.|
+| `ManagementGroupName` | Name of Operations Manager management group.|
+| `SourceComputerId` | Unique ID of computer.|
+| `RemoteIPLongitude` | Longitude of computer's geographic location.|
+| `RemoteIPLatitude` | Latitude of computer's geographic location.|
 
 Each agent reporting to an Operations Manager management server will send two heartbeats, and SCAgentChannel property's value will include both **Direct** and **SCManagementServer** depending on what data sources and monitoring solutions you have enabled in your subscription. If you recall, data from solutions are either sent directly from an Operations Manager management server to Azure Monitor, or because of the volume of data collected on the agent, are sent directly from the agent to Azure Monitor. For heartbeat events which have the value **SCManagementServer**, the ComputerIP value is the IP address of the management server since the data is actually uploaded by it.  For heartbeats where SCAgentChannel is set to **Direct**, it is the public IP address of the agent.  
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/insights/solution-agenthealth.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏