### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/azure-monitor/insights/solutions-resources-searches-alerts.md
+++ b/articles/azure-monitor/insights/solutions-resources-searches-alerts.md
@@ -171,10 +171,10 @@ The properties for Alert action resources are described in the following tables.
 
 | Element name | Required | Description |
 |:--|:--|:--|
-| Type | Yes | Type of the action.  This is **Alert** for alert actions. |
-| Name | Yes | Display name for the alert.  This is the name that's displayed in the console for the alert rule. |
-| Description | No | Optional description of the alert. |
-| Severity | Yes | Severity of the alert record from the following values:<br><br> **critical**<br>**warning**<br>**informational**
+| `Type` | Yes | Type of the action.  This is **Alert** for alert actions. |
+| `Name` | Yes | Display name for the alert.  This is the name that's displayed in the console for the alert rule. |
+| `Description` | No | Optional description of the alert. |
+| `Severity` | Yes | Severity of the alert record from the following values:<br><br> **critical**<br>**warning**<br>**informational**
 
 
 #### Threshold
@@ -182,8 +182,8 @@ This section is required. It defines the properties for the alert threshold.
 
 | Element name | Required | Description |
 |:--|:--|:--|
-| Operator | Yes | Operator for the comparison from the following values:<br><br>**gt = greater than<br>lt = less than** |
-| Value | Yes | The value to compare the results. |
+| `Operator` | Yes | Operator for the comparison from the following values:<br><br>**gt = greater than<br>lt = less than** |
+| `Value` | Yes | The value to compare the results. |
 
 ##### MetricsTrigger
 This section is optional. Include it for a metric measurement alert.
@@ -193,9 +193,9 @@ This section is optional. Include it for a metric measurement alert.
 
 | Element name | Required | Description |
 |:--|:--|:--|
-| TriggerCondition | Yes | Specifies whether the threshold is for total number of breaches or consecutive breaches from the following values:<br><br>**Total<br>Consecutive** |
-| Operator | Yes | Operator for the comparison from the following values:<br><br>**gt = greater than<br>lt = less than** |
-| Value | Yes | Number of the times the criteria must be met to trigger the alert. |
+| `TriggerCondition` | Yes | Specifies whether the threshold is for total number of breaches or consecutive breaches from the following values:<br><br>**Total<br>Consecutive** |
+| `Operator` | Yes | Operator for the comparison from the following values:<br><br>**gt = greater than<br>lt = less than** |
+| `Value` | Yes | Number of the times the criteria must be met to trigger the alert. |
 
 
 #### Throttling


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates element name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/insights/solutions-resources-searches-alerts.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose element names by "\`") has no negative effect on the English version.
Please accept this change so that element names are not mistranslated in each language in each localized version.
🙏