### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/azure-monitor/platform/api-alerts.md
+++ b/articles/azure-monitor/platform/api-alerts.md
@@ -89,9 +89,9 @@ All actions have the properties in the following table.  Different types of aler
 
 | Property | Description |
 |:--- |:--- |
-| Type |Type of the action.  Currently the possible values are Alert and Webhook. |
-| Name |Display name for the alert. |
-| Version |The API version being used.  Currently, this should always be set to 1. |
+| `Type` |Type of the action.  Currently the possible values are Alert and Webhook. |
+| `Name` |Display name for the alert. |
+| `Version` |The API version being used.  Currently, this should always be set to 1. |
 
 ### Retrieving actions
 
@@ -149,8 +149,8 @@ Thresholds have the properties in the following table.
 
 | Property | Description |
 |:--- |:--- |
-| Operator |Operator for the threshold comparison. <br> gt = Greater Than <br> lt = Less Than |
-| Value |Value for the threshold. |
+| `Operator` |Operator for the threshold comparison. <br> gt = Greater Than <br> lt = Less Than |
+| `Value` |Value for the threshold. |
 
 For example, consider an event query with an Interval of 15 minutes, a Timespan of 30 minutes, and a Threshold of greater than 10. In this case, the query would be run every 15 minutes, and an alert would be triggered if it returned 10 events that were created over a 30-minute span.
 
@@ -182,9 +182,9 @@ Log Analytics allows you to classify your alerts into categories, to allow easie
 
 |Log Analytics Severity Level  |Azure Alerts Severity Level  |
 |---------|---------|
-|critical |Sev 0|
-|warning |Sev 1|
-|informational | Sev 2|
+|`critical` |Sev 0|
+|`warning` |Sev 1|
+|`informational` | Sev 2|
 
 Following is a sample response for an action with only a threshold and severity. 
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/platform/api-alerts.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏