### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/azure-monitor/platform/computer-groups.md
+++ b/articles/azure-monitor/platform/computer-groups.md
@@ -122,15 +122,15 @@ A record is created in the Log Analytics workspace for each computer group membe
 
 | Property | Description |
 |:--- |:--- |
-| Type |*ComputerGroup* |
-| SourceSystem |*SourceSystem* |
-| Computer |Name of the member computer. |
-| Group |Name of the group. |
-| GroupFullName |Full path to the group including the source and source name. |
-| GroupSource |Source that group was collected from. <br><br>ActiveDirectory<br>WSUS<br>WSUSClientTargeting |
-| GroupSourceName |Name of the source that the group was collected from.  For Active Directory, this is the domain name. |
-| ManagementGroupName |Name of the management group for SCOM agents.  For other agents, this is AOI-\<workspace ID\> |
-| TimeGenerated |Date and time the computer group was created or updated. |
+| `Type` |*ComputerGroup* |
+| `SourceSystem` |*SourceSystem* |
+| `Computer` |Name of the member computer. |
+| `Group` |Name of the group. |
+| `GroupFullName` |Full path to the group including the source and source name. |
+| `GroupSource` |Source that group was collected from. <br><br>ActiveDirectory<br>WSUS<br>WSUSClientTargeting |
+| `GroupSourceName` |Name of the source that the group was collected from.  For Active Directory, this is the domain name. |
+| `ManagementGroupName` |Name of the management group for SCOM agents.  For other agents, this is AOI-\<workspace ID\> |
+| `TimeGenerated` |Date and time the computer group was created or updated. |
 
 ## Next steps
 * Learn about [log queries](../log-query/log-query-overview.md) to analyze the data collected from data sources and solutions.  


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/platform/computer-groups.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏