### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/azure-monitor/platform/data-sources-alerts-nagios-zabbix.md
+++ b/articles/azure-monitor/platform/data-sources-alerts-nagios-zabbix.md
@@ -87,15 +87,15 @@ Alert records collected by Nagios have a **Type** of **Alert** and a **SourceSys
 
 | Property | Description |
 |:--- |:--- |
-| Type |*Alert* |
-| SourceSystem |*Nagios* |
-| AlertName |Name of the alert. |
-| AlertDescription | Description of the alert. |
-| AlertState | Status of the service or host.<br><br>OK<br>WARNING<br>UP<br>DOWN |
-| HostName | Name of the host that created the alert. |
-| PriorityNumber | Priority level of the alert. |
-| StateType | The type of state of the alert.<br><br>SOFT - Issue that has not been rechecked.<br>HARD - Issue that has been rechecked a specified number of times.  |
-| TimeGenerated |Date and time the alert was created. |
+| `Type` |*Alert* |
+| `SourceSystem` |*Nagios* |
+| `AlertName` |Name of the alert. |
+| `AlertDescription` | Description of the alert. |
+| `AlertState` | Status of the service or host.<br><br>OK<br>WARNING<br>UP<br>DOWN |
+| `HostName` | Name of the host that created the alert. |
+| `PriorityNumber` | Priority level of the alert. |
+| `StateType` | The type of state of the alert.<br><br>SOFT - Issue that has not been rechecked.<br>HARD - Issue that has been rechecked a specified number of times.  |
+| `TimeGenerated` |Date and time the alert was created. |
 
 
 ### Zabbix alert records
@@ -103,17 +103,17 @@ Alert records collected by Zabbix have a **Type** of **Alert** and a **SourceSys
 
 | Property | Description |
 |:--- |:--- |
-| Type |*Alert* |
-| SourceSystem |*Zabbix* |
-| AlertName | Name of the alert. |
-| AlertPriority | Severity of the alert.<br><br>not classified<br>information<br>warning<br>average<br>high<br>disaster  |
-| AlertState | State of the alert.<br><br>0 - State is up-to-date.<br>1 - State is unknown.  |
-| AlertTypeNumber | Specifies whether alert can generate multiple problem events.<br><br>0 - State is up-to-date.<br>1 - State is unknown.    |
-| Comments | Additional comments for alert. |
-| HostName | Name of the host that created the alert. |
-| PriorityNumber | Value indicating severity of the alert.<br><br>0 - not classified<br>1 - information<br>2 - warning<br>3 - average<br>4 - high<br>5 - disaster |
-| TimeGenerated |Date and time the alert was created. |
-| TimeLastModified |Date and time the state of the alert was last changed. |
+| `Type` |*Alert* |
+| `SourceSystem` |*Zabbix* |
+| `AlertName` | Name of the alert. |
+| `AlertPriority` | Severity of the alert.<br><br>not classified<br>information<br>warning<br>average<br>high<br>disaster  |
+| `AlertState` | State of the alert.<br><br>0 - State is up-to-date.<br>1 - State is unknown.  |
+| `AlertTypeNumber` | Specifies whether alert can generate multiple problem events.<br><br>0 - State is up-to-date.<br>1 - State is unknown.    |
+| `Comments` | Additional comments for alert. |
+| `HostName` | Name of the host that created the alert. |
+| `PriorityNumber` | Value indicating severity of the alert.<br><br>0 - not classified<br>1 - information<br>2 - warning<br>3 - average<br>4 - high<br>5 - disaster |
+| `TimeGenerated` |Date and time the alert was created. |
+| `TimeLastModified` |Date and time the state of the alert was last changed. |
 
 
 ## Next steps


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/platform/data-sources-alerts-nagios-zabbix.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏