### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/azure-monitor/platform/data-sources-collectd.md
+++ b/articles/azure-monitor/platform/data-sources-collectd.md
@@ -108,14 +108,14 @@ To maintain a familiar model between infrastructure metrics already collected by
 
 | CollectD Metric field | Azure Monitor field |
 |:--|:--|
-| host | Computer |
-| plugin | None |
-| plugin_instance | Instance Name<br>If **plugin_instance** is *null* then InstanceName="*_Total*" |
-| type | ObjectName |
-| type_instance | CounterName<br>If **type_instance** is *null* then CounterName=**blank** |
-| dsnames[] | CounterName |
-| dstypes | None |
-| values[] | CounterValue |
+| `host` | Computer |
+| `plugin` | None |
+| `plugin_instance` | Instance Name<br>If **plugin_instance** is *null* then InstanceName="*_Total*" |
+| `type` | ObjectName |
+| `type_instance` | CounterName<br>If **type_instance** is *null* then CounterName=**blank** |
+| `dsnames[]` | CounterName |
+| `dstypes` | None |
+| `values[]` | CounterValue |
 
 ## Next steps
 * Learn about [log queries](../log-query/log-query-overview.md) to analyze the data collected from data sources and solutions. 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/azure-monitor/platform/data-sources-collectd.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose property names by "\`") has no negative effect on the English version.
Please accept this change so that property names are not mistranslated in each language in each localized version.
🙏