### PR TITLE
Change to not translate unique names

### DIFF
--- a/articles/cognitive-services/KES/SchemaFormat.md
+++ b/articles/cognitive-services/KES/SchemaFormat.md
@@ -39,14 +39,14 @@ Below is a list of supported attribute data types:
 
 | Type | Description | Operations | Example |
 |------|-------------|------------|---------|
-| String | String (1-1024 characters) | equals, starts_with | "hello world" |
-| Int32 | Signed 32-bit integer | equals, starts_with, is_between | 2016 |
-| Int64 | Signed 64-bit integer | equals, starts_with, is_between | 9876543210 |
-| Double | Double-precision floating-point value | equals, starts_with, is_between | 1.602e-19 |
-| Date | Date (1400-01-01 to 9999-12-31) | equals, is_between | '2016-03-14' |
-| Guid | Globally unique identifier | equals | "602DD052-CC47-4B23-A16A-26B52D30C05B" |
-| Blob | Internally compressed non-indexed data | *None* | "Empower every person and every organization on the planet to achieve more" |
-| Composite | Composition of multiple sub-attributes| *N/A* | { "Name":"harry shum", "Affiliation":"microsoft" } |
+| `String` | String (1-1024 characters) | equals, starts_with | "hello world" |
+| `Int32` | Signed 32-bit integer | equals, starts_with, is_between | 2016 |
+| `Int64` | Signed 64-bit integer | equals, starts_with, is_between | 9876543210 |
+| `Double` | Double-precision floating-point value | equals, starts_with, is_between | 1.602e-19 |
+| `Date` | Date (1400-01-01 to 9999-12-31) | equals, is_between | '2016-03-14' |
+| `Guid` | Globally unique identifier | equals | "602DD052-CC47-4B23-A16A-26B52D30C05B" |
+| `Blob` | Internally compressed non-indexed data | *None* | "Empower every person and every organization on the planet to achieve more" |
+| `Composite` | Composition of multiple sub-attributes| *N/A* | { "Name":"harry shum", "Affiliation":"microsoft" } |
 
 String attributes are used to represent string values that may appear as part of the user query.  They support the exact-match *equals* operation, as well as the *starts_with* operation for query completion scenarios, such as matching "micros" with "microsoft".  Case-insensitive and fuzzy matching to handle spelling errors will be supported in a future release.
 


### PR DESCRIPTION
Same as #23964
An incorrect translation has been made in the localized version by machine translation.
※ Machine translation translates property name
Evidence: https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/live/articles/cognitive-services/KES/SchemaFormat.md
In the following files, it was made not to make mistranslation by putting proper names in "\`".
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/role-based-access-control/custom-roles.md
This change(enclose type names by "\`") has no negative effect on the English version.
Please accept this change so that type names are not mistranslated in each language in each localized version.
🙏