### PR TITLE
Update service-fabric-tutorial-dotnet-app-enable-https-endpoint.md

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-dotnet-app-enable-https-endpoint.md
+++ b/articles/service-fabric/service-fabric-tutorial-dotnet-app-enable-https-endpoint.md
@@ -135,7 +135,7 @@ serviceContext =>
                     int port = serviceContext.CodePackageActivationContext.GetEndpoint("EndpointHttps").Port;
                     opt.Listen(IPAddress.IPv6Any, port, listenOptions =>
                     {
-                        listenOptions.UseHttps(GetCertificateFromStore());
+                        listenOptions.UseHttps(GetHttpsCertificateFromStore());
                         listenOptions.NoDelay = true;
                     });
                 })
@@ -160,21 +160,23 @@ serviceContext =>
 Also add the following method so that Kestrel can find the certificate in the `Cert:\LocalMachine\My` store using the subject.  
 
 Replace "&lt;your_CN_value&gt;" with "mytestcert" if you created a self-signed certificate with the previous PowerShell command, or use the CN of your certificate.
+Be aware that in the case of local deployment to `localhost` server endpoint it's preferable to use the sunject "CN=localhost" (`Issued to` property of the certificate should contatin the url of the server endpoint) for avoiding authentication exceptions.
 
 ```csharp
-private X509Certificate2 GetCertificateFromStore()
+private X509Certificate2 GetHttpsCertificateFromStore()
 {
-	var store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
-	try
+	using (var store = new X509Store(StoreName.My, StoreLocation.LocalMachine))
 	{
 		store.Open(OpenFlags.ReadOnly);
 		var certCollection = store.Certificates;
 		var currentCerts = certCollection.Find(X509FindType.FindBySubjectDistinguishedName, "CN=<your_CN_value>", false);
-		return currentCerts.Count == 0 ? null : currentCerts[0];
-	}
-	finally
-	{
-		store.Close();
+		
+		if (currentCerts.Count == 0)
+                {
+                    throw new Exception("Https certificate is not found.");
+                }
+		
+		return currentCerts[0];
 	}
 }
 ```


### PR DESCRIPTION
Some improvements regarding using self-signed development certificate:
1. Use `using` for creating a new store instead of manual closing it (as it's net core and we have a dispose method).
2. More accurate name for the method.
3. Throw an exception in case of missing the certificate. It will make the debugging easier.
4. Some note regarding the subject of a certificate for local deployment.