### PR TITLE
Added a side note for the required AAD roles

### DIFF
--- a/articles/aks/aad-integration.md
+++ b/articles/aks/aad-integration.md
@@ -199,6 +199,8 @@ Apply the binding using the [kubectl apply][kubectl-apply] command as shown in t
 kubectl apply -f rbac-aad-group.yaml
 ```
 
+Note: The designated AAD user or group must have the roles '_Azure Kubernetes Service Cluster Admin Role_' and '_Azure Kubernetes Service Cluster User Role_' set on the cluster resource. 
+
 For more information on securing a Kubernetes cluster with RBAC, see [Using RBAC Authorization][rbac-authorization].
 
 ## Access cluster with Azure AD


### PR DESCRIPTION
Following this tutorial for one of our customers I ran into the issue of a failing authorization. Turned out the user was missing roles and I was not aware of this pre-condition. That said, I'd propose to add the below hint for others to take not of.
=> The user must have both roles 'Azure Kubernetes Service Cluster Admin Role' and 'Azure Kubernetes Service Cluster User Role' to use the cluster. The RBAC binding by itself will not suffice to connect to the cluster.