### PR TITLE
Fixed a typo 'doman' -> 'domain' on line 35 of articles/frontdoor/index.yml

### DIFF
--- a/articles/frontdoor/index.yml
+++ b/articles/frontdoor/index.yml
@@ -32,7 +32,7 @@ sections:
     style: unordered
     items:
     - html: <a href="front-door-custom-domain.md">Add a custom domain to your Front Door</a>
-    - html: <a href="front-door-custom-domain-https.md">Enable HTTPS for a custom doman</a>
+    - html: <a href="front-door-custom-domain-https.md">Enable HTTPS for a custom domain</a>
 - title: Reference
   items:
   - type: list


### PR DESCRIPTION
Fixed a typo.