### PR TITLE
Fix Windows Defender urls

### DIFF
--- a/articles/azure-stack/azure-stack-integrate-endpoints.md
+++ b/articles/azure-stack/azure-stack-integrate-endpoints.md
@@ -73,7 +73,7 @@ Azure Stack supports only transparent proxy servers. In a deployment where a tra
 |Patch & Update|https://&#42;.azureedge.net|HTTPS|443|Public VIP - /27|
 |Registration|https:\//management.azure.com|HTTPS|443|Public VIP - /27|
 |Usage|https://&#42;.microsoftazurestack.com<br>https://*.trafficmanager.net |HTTPS|443|Public VIP - /27|
-|Windows Defender|.wdcp.microsoft.com<br>.wdcpalt.microsoft.com<br>*.updates.microsoft.com<br>*.download.microsoft.com<br>https:\//msdl.microsoft.com/download/symbols<br>https:\//www.microsoft.com/pkiops/crl<br>https:\//www.microsoft.com/pkiops/certs<br>https:\//crl.microsoft.com/pki/crl/products<br>https:\//www.microsoft.com/pki/certs<br>https:\//secure.aadcdn.microsoftonline-p.com<br>|HTTPS|80<br>443|Public VIP - /27<br>Public infrastructure Network|
+|Windows Defender|\*.wdcp.microsoft.com<br>\*.wdcpalt.microsoft.com<br>\*.wd.microsoft.com<br>\*.update.microsoft.com<br>\*.download.microsoft.com<br>http:\//msdl.microsoft.com/download/symbols<br>http:\//www.microsoft.com/pkiops/crl<br>http:\//www.microsoft.com/pkiops/certs<br>http:\//crl.microsoft.com/pki/crl/products<br>http:\//www.microsoft.com/pki/certs<br>https:\//secure.aadcdn.microsoftonline-p.com<br>|HTTPS|80<br>443|Public VIP - /27<br>Public infrastructure Network|
 |NTP|(IP of NTP server provided for deployment)|UDP|123|Public VIP - /27|
 |DNS|(IP of DNS server provided for deployment)|TCP<br>UDP|53|Public VIP - /27|
 |CRL|(URL under CRL Distribution Points on your certificate)|HTTP|80|Public VIP - /27|


### PR DESCRIPTION
According to Windows Defender doc below, Windows Defender endpoint information of Azure Stack doc are incorrect.  Please review it.
https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-antivirus/configure-network-connections-windows-defender-antivirus