### PR TITLE
Clarification on 'ER Premium add-on'

### DIFF
--- a/articles/expressroute/expressroute-introduction.md
+++ b/articles/expressroute/expressroute-introduction.md
@@ -100,9 +100,10 @@ You can pick a billing model that works best for you. Choose between the billing
 * **Unlimited data**. Billing is based on a monthly fee; all inbound and outbound data transfer is included free of charge.
 * **Metered data**. Billing is based on a monthly fee; all inbound data transfer is free of charge. Outbound data transfer is charged per GB of data transfer. Data transfer rates vary by region.
 * **ExpressRoute premium add-on**. ExpressRoute premium is an add-on to the ExpressRoute circuit. The ExpressRoute premium add-on provides the following capabilities: 
-  * Increased route limits for Azure public and Azure private peering from 4,000 routes to 10,000 routes.
+  * Increased route limits for Azure public (within Microsoft Peering) and Azure private peering from 4,000 routes to 10,000 routes.
   * Global connectivity for services. An ExpressRoute circuit created in any region (excluding national clouds) will have access to resources across any other region in the world. For example, a virtual network created in West Europe can be accessed through an ExpressRoute circuit provisioned in Silicon Valley.
   * Increased number of VNet links per ExpressRoute circuit from 10 to a larger limit, depending on the bandwidth of the circuit.
+  * Allows connectivity to Office 365 through Microsoft Peering
 
 ## FAQ
 For frequently asked questions about ExpressRoute, see [ExpressRoute FAQ](expressroute-faqs.md).


### PR DESCRIPTION
1. Per FAQ "Can I use Office365 (including Exchange and Skype for Business) on ExpressRoute?" https://azure.microsoft.com/en-us/pricing/details/expressroute/ - Premium is needed to enable ER connectivity to Office 365
2. Azure Public peering no longer exists and was collapsed into Microsoft Peering