### PR TITLE
public_ip_address_allocation deprecated

### DIFF
--- a/articles/terraform/terraform-create-vm-cluster-with-infrastructure.md
+++ b/articles/terraform/terraform-create-vm-cluster-with-infrastructure.md
@@ -98,7 +98,7 @@ In this section, you create a file that contains resource definitions for your i
     name                         = "publicIPForLB"
     location                     = "${azurerm_resource_group.test.location}"
     resource_group_name          = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+    allocation_method            = "Static"
    }
 
    resource "azurerm_lb" "test" {


### PR DESCRIPTION
Same change than
https://github.com/MicrosoftDocs/azure-docs/pull/25243/commits/c8e1678f6d385bfb3844d3bcb6c97983ece8df87