### PR TITLE
update virtual-machines-common-infrastructure-automation.md

### DIFF
--- a/includes/virtual-machines-common-infrastructure-automation.md
+++ b/includes/virtual-machines-common-infrastructure-automation.md
@@ -2,7 +2,7 @@
 author: cynthn
 ms.service: virtual-machines
 ms.topic: include
-ms.date: 10/26/2018
+ms.date: 04/11/2019
 ms.author: cynthn
 ---
 # Use infrastructure automation tools with virtual machines in Azure
@@ -51,16 +51,7 @@ Learn how to:
 
 Cloud-init also works across distributions. For example, you don't use **apt-get install** or **yum install** to install a package. Instead you can define a list of packages to install. Cloud-init automatically uses the native package management tool for the distro you select.
 
- We are actively working with our endorsed Linux distro partners in order to have cloud-init enabled images available in the Azure marketplace. These images make your cloud-init deployments and configurations work seamlessly with VMs and virtual machine scale sets. The following table outlines the current cloud-init enabled images availability on the Azure platform:
-
-| Publisher | Offer | SKU | Version | cloud-init ready
-|:--- |:--- |:--- |:--- |:--- 
-|Canonical |UbuntuServer |16.04-LTS |latest |yes | 
-|Canonical |UbuntuServer |14.04.5-LTS |latest |yes |
-|CoreOS |CoreOS |Stable |latest |yes |
-|OpenLogic |CentOS |7-CI |latest |preview |
-|RedHat |RHEL |7-RAW-CI |latest |preview |
-
+We are actively working with our endorsed Linux distro partners in order to have cloud-init enabled images available in the Azure marketplace. These images make your cloud-init deployments and configurations work seamlessly with VMs and virtual machine scale sets. 
 Learn more details about cloud-init on Azure:
 
 - [Cloud-init support for Linux virtual machines in Azure](../articles/virtual-machines/linux/using-cloud-init.md)


### PR DESCRIPTION
Updated virtual-machines-common-infrastructure-automation.md to removed outdated table of linux distributions with cloud-init support.  The linked-to article, ../articles/virtual-machines/linux/using-cloud-init.md, has the up-to-date list of images that support cloud-init.  No need to have this list in two places.