### PR TITLE
(Azure CXP) fixes MicrosoftDocs/azure-docs#29263

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-health-agent-install.md
+++ b/articles/active-directory/hybrid/how-to-connect-health-agent-install.md
@@ -259,7 +259,7 @@ $secpasswd = ConvertTo-SecureString "PASSWORD" -AsPlainText -Force
 $myCreds = New-Object System.Management.Automation.PSCredential ($userName, $secpasswd)
 import-module "C:\Program Files\Azure Ad Connect Health Adds Agent\PowerShell\AdHealthAdds"
  
-Register-AzureADConnectHealthADDSAgent -UserPrincipalName $USERNAME -Credential $password
+Register-AzureADConnectHealthADDSAgent -UserPrincipalName $USERNAME -Credential $myCreds
 
 ```
 


### PR DESCRIPTION
Changed the following in the section [Quick agent installation in multiple servers
](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-health-agent-install#quick-agent-installation-in-multiple-servers)

```powershell
Register-AzureADConnectHealthADDSAgent -UserPrincipalName $USERNAME -Credential $password
```
to 
```powershell
Register-AzureADConnectHealthADDSAgent -UserPrincipalName $USERNAME -Credential $myCreds
```