### PR TITLE
Fix error in example code

### DIFF
--- a/articles/cognitive-services/Bing-Image-Search/image-search-sdk-node-quickstart.md
+++ b/articles/cognitive-services/Bing-Image-Search/image-search-sdk-node-quickstart.md
@@ -35,7 +35,7 @@ Get a [Cognitive Services access key](https://azure.microsoft.com/try/cognitive-
 
     ```javascript
     'use strict';
-    const Search = require('azure-cognitiveservices-imagesearch');
+    const ImageSearchAPIClient = require('azure-cognitiveservices-imagesearch');
     const CognitiveServicesCredentials = require('ms-rest-azure').CognitiveServicesCredentials;
     ```
 
@@ -50,7 +50,7 @@ Get a [Cognitive Services access key](https://azure.microsoft.com/try/cognitive-
 
     //instantiate the image search client 
     let credentials = new CognitiveServicesCredentials(serviceKey);
-    let imageSearchApiClient = new Search.ImageSearchAPIClient(credentials);
+    let imageSearchApiClient = new ImageSearchAPIClient(credentials);
 
     ```
 


### PR DESCRIPTION
There seems to be an error in the example code in the Bing Image Search SDK for Node.js quickstart guide.  A method with the name “ImageSearchAPIClient” is called on the object imported from node module “azure-cognitiveservices-imagesearch”, but calling this method results in a runtime error, and a console.log of the imported object shows that this method does not exist.  According to npm documentation, the function imported from that module should be called directly, rather than calling a method on it.  When I make that adjustment the example code runs correctly.

To make code more readable, I renamed the function imported from the node module.  This also reflects the variable name used for that function in the npm documentation.