### PR TITLE
Update text-to-speech.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/text-to-speech.md
+++ b/articles/cognitive-services/Speech-Service/text-to-speech.md
@@ -48,10 +48,7 @@ This table lists the core features for text-to-speech:
 | Create and manage voice font tests. | No | Yes\* |
 | Manage subscriptions. | No | Yes\* |
 
-\* *These services are available using the cris.ai endpoint. See [Swagger reference](https://westus.cris.ai/swagger/ui/index).*
-
-> [!NOTE]
-> The custom voice endpoints implement throttling that limits requests to 25 per 5 seconds. When throttling occurs, you'll be notified via message headers.
+\* *These services are available using the cris.ai endpoint. See [Swagger reference](https://westus.cris.ai/swagger/ui/index). These custom voice training and management APIs implement throttling that limits requests to 25 per 5 seconds, while the speech synthesis API itself implements throttling that allows 200 requests per second as the highest. When throttling occurs, you'll be notified via message headers.*
 
 ## Get started with text to speech
 


### PR DESCRIPTION
the current note is not accurate. What limits 25 requests per 5 seconds is the custom voice training and managing APIs not the custom voice endpoint API itself. also we should say the speech synthesis API allows a TPS of 200 so people don't get confused.