### PR TITLE
Added note about FQDN support in TM when using DNS A record

### DIFF
--- a/articles/dns/dns-alias.md
+++ b/articles/dns/dns-alias.md
@@ -20,7 +20,7 @@ An alias record set is supported for the following record types in an Azure DNS 
 - CNAME
 
 > [!NOTE]
-> If you intend to use an alias record for the A or AAAA record types to point to an [Azure Traffic Manager profile](../traffic-manager/quickstart-create-traffic-manager-profile.md) you must make sure that the Traffic Manager profile has only [external endpoints](../traffic-manager/traffic-manager-endpoint-types.md#external-endpoints). You must provide the IPv4 or IPv6 address for external endpoints in Traffic Manager. Ideally, use static IP addresses.
+> If you intend to use an alias record for the A or AAAA record types to point to an [Azure Traffic Manager profile](../traffic-manager/quickstart-create-traffic-manager-profile.md) you must make sure that the Traffic Manager profile has only [external endpoints](../traffic-manager/traffic-manager-endpoint-types.md#external-endpoints). You must provide the IPv4 or IPv6 address for external endpoints in Traffic Manager - you may not use fully-qualified domain names (FQDNs) in endpoints. Ideally, use static IP addresses.
 
 ## Capabilities
 


### PR DESCRIPTION
You cannot use FQDNs in Traffic Manager endpoints when using Azure DNS A records to point to the Traffic Manager profile. Added a note here explicitly saying this.