### PR TITLE
Fix PoSH script to unregister serverendpoint

### DIFF
--- a/articles/storage/files/storage-sync-files-server-registration.md
+++ b/articles/storage/files/storage-sync-files-server-registration.md
@@ -132,16 +132,17 @@ This can also be accomplished with a simple PowerShell script:
 
 ```powershell
 Import-Module "C:\Program Files\Azure\StorageSyncAgent\StorageSync.Management.PowerShell.Cmdlets.dll"
+$resourceGroupName = "<your-resource-group>"
 
 $accountInfo = Connect-AzAccount
-Login-AzStorageSync -SubscriptionId $accountInfo.Context.Subscription.Id -TenantId $accountInfo.Context.Tenant.Id -ResourceGroupName "<your-resource-group>"
+Login-AzStorageSync -SubscriptionId $accountInfo.Context.Subscription.Id -TenantId $accountInfo.Context.Tenant.Id -ResourceGroupName $resourceGroupName
 
 $StorageSyncService = "<your-storage-sync-service>"
 
-Get-AzStorageSyncGroup -StorageSyncServiceName $StorageSyncService | ForEach-Object { 
+Get-AzStorageSyncGroup -StorageSyncServiceName $StorageSyncService -ResourceGroupName $resourceGroupName | ForEach-Object { 
     $SyncGroup = $_; 
-    Get-AzStorageSyncServerEndpoint -StorageSyncServiceName $StorageSyncService -SyncGroupName $SyncGroup.Name | Where-Object { $_.DisplayName -eq $env:ComputerName } | ForEach-Object { 
-        Remove-AzStorageSyncServerEndpoint -StorageSyncServiceName $StorageSyncService -SyncGroupName $SyncGroup.Name -ServerEndpointName $_.Name 
+    Get-AzStorageSyncServerEndpoint -StorageSyncServiceName $StorageSyncService -ResourceGroupName $resourceGroupName -SyncGroupName $SyncGroup.SyncGroupName | Where-Object { $_.FriendlyName -eq $env:ComputerName } | ForEach-Object { 
+        Remove-AzStorageSyncServerEndpoint -StorageSyncServiceName $StorageSyncService -SyncGroupName $SyncGroup.SyncGroupName -ServerEndpointName $_.Name 
     } 
 }
 ```


### PR DESCRIPTION
Current PoSH is incorrect in 3 places:
a) We need the -ResourceGroupName parameter in both the Get-AzStorageSyncGroup and Get-AzStorageSyncServerEndpoint cmdlets (they are missing)
b) $SyncGroup.Name Name is not a valid property of object type AzStorageSyncGroup $SyncGroup.SyncGroupName
c) $_.DisplayName is not a valid object property for AzStorageSyncServerEndpoint changed to $_.FriendlyName