### PR TITLE
Correct link to Windows 2019 LTSC doc link

### DIFF
--- a/articles/app-service/app-service-web-get-started-windows-container.md
+++ b/articles/app-service/app-service-web-get-started-windows-container.md
@@ -175,7 +175,7 @@ To tell App Service to pull in the new image from Docker Hub, restart the app. B
 
 You are free to use a different custom Docker image to run your app. However, you must choose the right [parent image](https://docs.docker.com/develop/develop-images/baseimages/) for the framework you want: 
 
-- To deploy .NET Framework apps, use a parent image based on the Windows Server Core 2019 [Long-Term Servicing Channel (LTSC)](https://docs.microsoft.com/windows-server/get-started/semi-annual-channel-overview#long-term-servicing-channel-ltsc) release. 
+- To deploy .NET Framework apps, use a parent image based on the Windows Server Core 2019 [Long-Term Servicing Channel (LTSC)](https://docs.microsoft.com/windows-server/get-started-19/servicing-channels-19#long-term-servicing-channel-ltsc) release. 
 - To deploy .NET Core apps, use a parent image based on the Windows Server Nano 1809 [Semi-Annual Servicing Channel (SAC)](https://docs.microsoft.com/windows-server/get-started-19/servicing-channels-19#semi-annual-channel) release. 
 
 It takes some time to download a parent image during app start-up. However, you can reduce start-up time by using one of the following parent images that are already cached in Azure App Service:


### PR DESCRIPTION
Correct link to Windows 2019 LTSC doc link. 

A further correction on previous issue of #29244 of minor doc app service on windows container.