### PR TITLE
Add activity log alerts & Log alerts

### DIFF
--- a/includes/monitoring-limits.md
+++ b/includes/monitoring-limits.md
@@ -15,7 +15,7 @@ ms.custom: "include file"
 | Metric alerts (classic) |100 active alert rules per subscription. | Call support. |
 | Metric alerts |100 active alert rules per subscription. | Call support. |
 | Activity log alerts | 100 active alert rules per subscription. | Same as default. |
-| Log alerts | Unlimited | Unlimited |
+| Log alerts | 512 | Call support. |
 | Action groups |2,000 action groups per subscription. | Call support. |
 
 **Action group-specific limits**

--- a/includes/monitoring-limits.md
+++ b/includes/monitoring-limits.md
@@ -14,6 +14,8 @@ ms.custom: "include file"
 | Autoscale settings |100 per region per subscription. | Same as default. |
 | Metric alerts (classic) |100 active alert rules per subscription. | Call support. |
 | Metric alerts |100 active alert rules per subscription. | Call support. |
+| Activity log alerts | 100 active alert rules per subscription. | Same as default. |
+| Log alerts | Unlimited | Unlimited |
 | Action groups |2,000 action groups per subscription. | Call support. |
 
 **Action group-specific limits**


### PR DESCRIPTION
- Activity log alerts
The following document described the activity log alerts limit.

  - https://docs.microsoft.com/en-us/azure/azure-monitor/platform/activity-log-alerts
    > In a subscription up to 100 alert rules can be created for an activity of scope at either: a single resource, all resources in resource group (or) entire subscription level.

- Log alerts
It is not documented in publicly.
