### PR TITLE
Change busybox to hello-world to match quickstart

### DIFF
--- a/articles/container-registry/container-registry-get-started-azure-cli.md
+++ b/articles/container-registry/container-registry-get-started-azure-cli.md
@@ -90,13 +90,13 @@ Output:
 ```
 Result
 ----------------
-busybox
+hello-world
 ```
 
-The following example lists the tags on the **busybox** repository.
+The following example lists the tags on the **hello-world** repository.
 
 ```azurecli
-az acr repository show-tags --name <acrName> --repository busybox --output table
+az acr repository show-tags --name <acrName> --repository hello-world --output table
 ```
 
 Output:


### PR DESCRIPTION
If you follow this quickstart from top to bottom the 'az acr repository list' command would show "hello-world", not "busybox".  I just updated the quick start to reflect the actual repository created.