### PR TITLE
For update the limit for number of sites on WAF.

### DIFF
--- a/articles/application-gateway/waf-overview.md
+++ b/articles/application-gateway/waf-overview.md
@@ -33,7 +33,7 @@ This section describes the core benefits that Application Gateway and its WAF pr
 
 * Protect your web applications from web vulnerabilities and attacks without modification to back-end code.
 
-* Protect multiple web applications at the same time. An instance of Application Gateway can host of up to 20 websites that are protected by a web application firewall.
+* Protect multiple web applications at the same time. An instance of Application Gateway can host of up to 100 websites that are protected by a web application firewall.
 
 ### Monitoring
 


### PR DESCRIPTION
Application Gateway has the limit for number of sites.
The limit is 100 as the following document show even though using WAF SKU. But this document shows the limit is 20 on WAF.

Application Gateway limits
https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#application-gateway-limits

-----------
The following table applies to v1, v2, Standard, and WAF SKUs unless otherwise stated.
Number of sites	100
-----------

Could you change the description?