### PR TITLE
Incorrect link in "Migrate to AFS" section

### DIFF
--- a/articles/storsimple/storsimple-8000-migration-options.md
+++ b/articles/storsimple/storsimple-8000-migration-options.md
@@ -39,7 +39,7 @@ For more information on how to migrate data using a StorSimple 8000 series, go t
 
 This brand new migration option enables customers to store their organization’s file shares in the Azure Files. These files shares are then centralized for on-premises access using Azure File Sync (AFS). AFS can be deployed on a Windows Server host. The actual data migration is then performed as a host copy or using the migration tool.
 
-For more information on how to migrate data to Azure File Sync, go to [Migrate data from StorSimple 5000-7000 series to Azure File Sync](https://aka.ms/StorSimpleMigrationAFS).
+For more information on how to migrate data to Azure File Sync, go to [Migrate data from StorSimple 5000-7000 series to Azure File Sync](storsimple-5000-7000-afs-migration.md).
 
 ### Third-party options
 


### PR DESCRIPTION
The link led back to this page, not to the AFS page - corrected to match the link at the bottom of the page.