### PR TITLE
Update proposal - container-service-limits.md

### DIFF
--- a/includes/container-service-limits.md
+++ b/includes/container-service-limits.md
@@ -16,7 +16,7 @@ ms.custom: include file
 | Maximum clusters per subscription | 100 |
 | Maximum nodes per cluster | 100 |
 | Maximum pods per node: [Basic networking][basic-networking] with Kubenet | 110 |
-| Maximum pods per node: [Advanced networking][advanced-networking] with Azure Container Networking Interface | Azure CLI deployment: 30<sup>1</sup><br />Azure Resource Manager template: 30<sup>1</sup><br />Portal deployment: 30 |
+| Maximum pods per node: [Advanced networking][advanced-networking] with Azure Container Networking Interface | Azure CLI deployment: 110<sup>1</sup><br />Azure Resource Manager template: 110<sup>1</sup><br />Portal deployment: 30 |
 
 <sup>1</sup>When you deploy an Azure Kubernetes Service (AKS) cluster with the Azure CLI or a Resource Manager template, this value is configurable up to 110 pods per node. You can't configure maximum pods per node after you've already deployed an AKS cluster, or if you deploy a cluster by using the Azure portal.<br />
 


### PR DESCRIPTION
According to troubleshoot document, Max default pods-per-node in AKS when the cluster is deployed in Azure CLI or ARM template is 110. 
https://docs.microsoft.com/en-us/azure/aks/troubleshooting#what-is-the-maximum-pods-per-node-setting-for-aks

>The maximum pods-per-node setting is 30 by default if you deploy an AKS cluster in the Azure portal. The maximum pods-per-node setting is 110 by default if you deploy an AKS cluster in the Azure CLI. (Make sure you're using the latest version of the Azure CLI).