### PR TITLE
Add missing description

### DIFF
--- a/articles/azure-functions/functions-host-json.md
+++ b/articles/azure-functions/functions-host-json.md
@@ -189,6 +189,9 @@ Controls the logging behaviors of the function app, including Application Insigh
       "Function.MyFunction": "Information",
       "default": "None"
     },
+    "console": {
+        ...
+    },
     "applicationInsights": {
         ...
     }


### PR DESCRIPTION
The following explanatory part is not described in JSON format.
https://github.com/MicrosoftDocs/azure-docs/blame/master/articles/azure-functions/functions-host-json.md#L202
Therefore, I added the missing description in reference to applicationInsights.