### PR TITLE
Add .NET example to 'Configure SSL connectivity'

### DIFF
--- a/articles/mariadb/howto-configure-ssl.md
+++ b/articles/mariadb/howto-configure-ssl.md
@@ -156,6 +156,23 @@ properties.setProperty("password", 'yourpassword');
 conn = DriverManager.getConnection(url, properties);
 ```
 
+### .NET (MySqlConnector)
+```csharp
+var builder = new MySqlConnectionStringBuilder
+{
+    Server = "mydemoserver.mysql.database.azure.com",
+    UserID = "myadmin@mydemoserver",
+    Password = "yourpassword",
+    Database = "quickstartdb",
+    SslMode = MySqlSslMode.VerifyCA,
+    CACertificateFile = "BaltimoreCyberTrustRoot.crt.pem",
+};
+using (var connection = new MySqlConnection(builder.ConnectionString))
+{
+    connection.Open();
+}
+```
+
 <!-- 
 ## Next steps
 Review various application connectivity options following [Connection libraries for Azure Database for MariaDB](concepts-connection-libraries.md)

--- a/articles/mysql/howto-configure-ssl.md
+++ b/articles/mysql/howto-configure-ssl.md
@@ -156,5 +156,22 @@ properties.setProperty("password", 'yourpassword');
 conn = DriverManager.getConnection(url, properties);
 ```
 
+### .NET (MySqlConnector)
+```csharp
+var builder = new MySqlConnectionStringBuilder
+{
+    Server = "mydemoserver.mysql.database.azure.com",
+    UserID = "myadmin@mydemoserver",
+    Password = "yourpassword",
+    Database = "quickstartdb",
+    SslMode = MySqlSslMode.VerifyCA,
+    CACertificateFile = "BaltimoreCyberTrustRoot.crt.pem",
+};
+using (var connection = new MySqlConnection(builder.ConnectionString))
+{
+    connection.Open();
+}
+```
+
 ## Next steps
 Review various application connectivity options following [Connection libraries for Azure Database for MySQL](concepts-connection-libraries.md)


### PR DESCRIPTION
This shows how to use MySqlConnector's `CACertificateFile` connection string option to supply the root certificate for Azure Database for MySQL and Azure Database for MariaDB.