### PR TITLE
Update iot-hub-arduino-iot-devkit-az3166-get-started.md

### DIFF
--- a/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
+++ b/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
@@ -74,7 +74,8 @@ A device must be registered with your IoT hub before it can connect. In this qui
     ```azurecli-interactive
     az iot hub device-identity create --hub-name YourIoTHubName --device-id MyNodeDevice
     ```
-
+ > [!NOTE]
+    > If you get an error running 'device-identity', Install [Azure IOT Extension for Azure CLI](https://github.com/Azure/azure-iot-cli-extension/blob/dev/README.md) for more details.
 1. Run the following commands in Azure Cloud Shell to get the _device connection string_ for the device you just registered:
 
    **YourIoTHubName**: Replace this placeholder below with the name you choose for your IoT hub.

--- a/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
+++ b/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
@@ -74,8 +74,9 @@ A device must be registered with your IoT hub before it can connect. In this qui
     ```azurecli-interactive
     az iot hub device-identity create --hub-name YourIoTHubName --device-id MyNodeDevice
     ```
- > [!NOTE]
-    > If you get an error running 'device-identity', Install [Azure IOT Extension for Azure CLI](https://github.com/Azure/azure-iot-cli-extension/blob/dev/README.md) for more details.
+   > [!NOTE]
+   > If you get an error running `device-identity`, install the [Azure IOT Extension for Azure CLI](https://github.com/Azure/azure-iot-cli-extension/blob/dev/README.md) for more details.
+  
 1. Run the following commands in Azure Cloud Shell to get the _device connection string_ for the device you just registered:
 
    **YourIoTHubName**: Replace this placeholder below with the name you choose for your IoT hub.


### PR DESCRIPTION
Help note to fix error users get if they don't have the azure iot extension installed on their azure cli:
This error:
$ az iot hub device-identity create --hub-name anil-iot-hub --device-id MyNodeDevice
az iot hub: 'device-identity' is not in the 'az iot hub' command group. See 'az iot hub --help'.