### PR TITLE
(AzureCXP) fixes (#30155)

### DIFF
--- a/articles/machine-learning/service/how-to-build-deploy-onnx.md
+++ b/articles/machine-learning/service/how-to-build-deploy-onnx.md
@@ -115,7 +115,7 @@ Here is an example for deploying an ONNX model:
 
    model = Model.register(model_path = "model.onnx",
                           model_name = "MyONNXmodel",
-                          tags = ["onnx"],
+                          tags = {"type": "onnx"},
                           description = "test",
                           workspace = ws)
    ```
@@ -129,7 +129,7 @@ Here is an example for deploying an ONNX model:
                                                      runtime = "python",
                                                      conda_file = "myenv.yml",
                                                      description = "test",
-                                                     tags = ["onnx"]
+                                                     tags = {"type": "onnx"}
                                                     )
 
    image = ContainerImage.create(name = "myonnxmodelimage",


### PR DESCRIPTION
According to the doc:  https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.core.image.containerimage?view=azure-ml-py
Tag should be dict[str or str] Dictionary of key value tags to give this image.