### PR TITLE
Update import-data with hint to valid connection string

### DIFF
--- a/articles/cosmos-db/import-data.md
+++ b/articles/cosmos-db/import-data.md
@@ -81,6 +81,19 @@ The JSON file source importer option allows you to import one or more single doc
 
 ![Screenshot of JSON file source options - Database migration tools](./media/import-data/jsonsource.png)
 
+The connection string is in the following format:
+
+`AccountEndpoint=<CosmosDB Endpoint>;AccountKey=<CosmosDB Key>;Database=<CosmosDB Database>`
+
+The `<CosmosDB Endpoint>` is the "Host" in [Azure Cosmos DB account] > [Connection Strings] with port number 443.  
+The `<AccountKey>` is the "Password" in [Azure Cosmos DB account] > [Connection Strings].  
+The `<CosmosDB Database>` is the CosmosDB database name. 
+  
+Example: 
+`AccountEndpoint=myCosmosDbName.documents.azure.com:443;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=ToDoList`
+  
+> [!NOTE] Use the Verify command to ensure that the MongoDB instance specified in the connection string field can be accessed.
+
 Here are some command-line samples to import JSON files:
 
 ```console

--- a/articles/cosmos-db/import-data.md
+++ b/articles/cosmos-db/import-data.md
@@ -85,12 +85,12 @@ The connection string is in the following format:
 
 `AccountEndpoint=<CosmosDB Endpoint>;AccountKey=<CosmosDB Key>;Database=<CosmosDB Database>`
 
-The `<CosmosDB Endpoint>` is the "Host" in [Azure Cosmos DB account] > [Connection Strings] with port number 443 and 'https://'.  
-The `<AccountKey>` is the "Password" in [Azure Cosmos DB account] > [Connection Strings].  
-The `<CosmosDB Database>` is the Cosmos DB database name. 
+* The `<CosmosDB Endpoint>` is the "Host" URI. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Connection Strings** or **Keys** pane, and copy the URI/Host field value.
+* The `<AccountKey>` is the "Password" or **PRIMARY KEY**. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Connection Strings** or **Keys** pane, and copy the "Password" or **PRIMARY KEY** value.
+* The `<CosmosDB Database>` is the Cosmos DB database name.
   
 Example: 
-`AccountEndpoint=https://myCosmosDbName.documents.azure.com:443;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=ToDoList`
+`AccountEndpoint=https://myCosmosDbName.documents.azure.com;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=myDBName`
   
 > [!NOTE] Use the Verify command to ensure that the Cosmos DB account specified in the connection string field can be accessed.
 

--- a/articles/cosmos-db/import-data.md
+++ b/articles/cosmos-db/import-data.md
@@ -85,14 +85,14 @@ The connection string is in the following format:
 
 `AccountEndpoint=<CosmosDB Endpoint>;AccountKey=<CosmosDB Key>;Database=<CosmosDB Database>`
 
-The `<CosmosDB Endpoint>` is the "Host" in [Azure Cosmos DB account] > [Connection Strings] with port number 443.  
+The `<CosmosDB Endpoint>` is the "Host" in [Azure Cosmos DB account] > [Connection Strings] with port number 443 and 'https://'.  
 The `<AccountKey>` is the "Password" in [Azure Cosmos DB account] > [Connection Strings].  
-The `<CosmosDB Database>` is the CosmosDB database name. 
+The `<CosmosDB Database>` is the Cosmos DB database name. 
   
 Example: 
-`AccountEndpoint=myCosmosDbName.documents.azure.com:443;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=ToDoList`
+`AccountEndpoint=https://myCosmosDbName.documents.azure.com:443;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=ToDoList`
   
-> [!NOTE] Use the Verify command to ensure that the MongoDB instance specified in the connection string field can be accessed.
+> [!NOTE] Use the Verify command to ensure that the Cosmos DB account specified in the connection string field can be accessed.
 
 Here are some command-line samples to import JSON files:
 

--- a/articles/cosmos-db/import-data.md
+++ b/articles/cosmos-db/import-data.md
@@ -85,14 +85,15 @@ The connection string is in the following format:
 
 `AccountEndpoint=<CosmosDB Endpoint>;AccountKey=<CosmosDB Key>;Database=<CosmosDB Database>`
 
-* The `<CosmosDB Endpoint>` is the endpoint URI. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Overview** pane and copy the **URI** value.
-* The `<AccountKey>` is the "Password" or **PRIMARY KEY**. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Connection Strings** or **Keys** pane, and copy the "Password" or **PRIMARY KEY** value.
-* The `<CosmosDB Database>` is the Cosmos DB database name.
+* The `<CosmosDB Endpoint>` is the endpoint URI. You can get this value from the Azure portal. Navigate to your Azure Cosmos account. Open the **Overview** pane and copy the **URI** value.
+* The `<AccountKey>` is the "Password" or **PRIMARY KEY**. You can get this value from the Azure portal. Navigate to your Azure Cosmos account. Open the **Connection Strings** or **Keys** pane, and copy the "Password" or **PRIMARY KEY** value.
+* The `<CosmosDB Database>` is the CosmosDB database name.
 
 Example: 
 `AccountEndpoint=https://myCosmosDBName.documents.azure.com:443/;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=myDatabaseName`
 
-> [!NOTE] Use the Verify command to ensure that the Cosmos DB account specified in the connection string field can be accessed.
+> [!NOTE]
+> Use the Verify command to ensure that the Cosmos DB account specified in the connection string field can be accessed.
 
 Here are some command-line samples to import JSON files:
 

--- a/articles/cosmos-db/import-data.md
+++ b/articles/cosmos-db/import-data.md
@@ -85,13 +85,13 @@ The connection string is in the following format:
 
 `AccountEndpoint=<CosmosDB Endpoint>;AccountKey=<CosmosDB Key>;Database=<CosmosDB Database>`
 
-* The `<CosmosDB Endpoint>` is the "Host" URI. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Connection Strings** or **Keys** pane, and copy the URI/Host field value.
+* The `<CosmosDB Endpoint>` is the endpoint URI. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Overview** pane and copy the **URI** value.
 * The `<AccountKey>` is the "Password" or **PRIMARY KEY**. You can get this value from the Azure Portal. Navigate to your Azure Cosmos account, and open the **Connection Strings** or **Keys** pane, and copy the "Password" or **PRIMARY KEY** value.
 * The `<CosmosDB Database>` is the Cosmos DB database name.
-  
+
 Example: 
-`AccountEndpoint=https://myCosmosDbName.documents.azure.com;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=myDBName`
-  
+`AccountEndpoint=https://myCosmosDBName.documents.azure.com:443/;AccountKey=wJmFRYna6ttQ79ATmrTMKql8vPri84QBiHTt6oinFkZRvoe7Vv81x9sn6zlVlBY10bEPMgGM982wfYXpWXWB9w==;Database=myDatabaseName`
+
 > [!NOTE] Use the Verify command to ensure that the Cosmos DB account specified in the connection string field can be accessed.
 
 Here are some command-line samples to import JSON files:


### PR DESCRIPTION
I think there was once a "Settings">"Keys" tab in Cosmos DB which is now gone. The "Connection String" tab does not show the needed Connection string for the JSON to CosmosDB migration. As a beginner I lost time finding out that port 443 is needed.

This is an attempt to show a example connection string.