### PR TITLE
Added check marks for supported languages

### DIFF
--- a/articles/cognitive-services/text-analytics/language-support.md
+++ b/articles/cognitive-services/text-analytics/language-support.md
@@ -29,9 +29,9 @@ Language support is initially rolled out in preview, graduating to generally ava
 
 | Language    | Language code | Sentiment | Key phrases | Named Entity Recognition |   Notes  |
 |:----------- |:-------------:|:---------:|:-----------:|:-----------:|:-----------:
-| Arabic      | `ar`          |           |             | ✔ \*                     | |
+| Arabic      | `ar`          | ✔ \*     |             | ✔ \*                     | |
 | Czech       | `cs`          |           |             | ✔ \*                     | |
-| Chinese-Simplified | `zh-CN`|           |             | ✔ \*        |    |
+| Chinese-Simplified | `zh-CN`| ✔ \*     |             | ✔ \*        |    |
 | Danish      | `da`          | ✔ \*     | ✔           | ✔ \*            |     |
 | Dutch       | `nl`          | ✔ \*     | ✔          |  ✔ \*           |     |
 | English     | `en`          | ✔        | ✔           |  ✔ \*\*     |      |
@@ -41,7 +41,7 @@ Language support is initially rolled out in preview, graduating to generally ava
 | Greek       | `el`          | ✔ \*     |             |            |     |
 | Hungarian   | `hu`          |           |             |  ✔ \*          |     | 
 | Italian     | `it`          | ✔ \*     | ✔           |  ✔ \*           |     |
-| Japanese    | `ja`          |          | ✔           |  ✔ \*          |     |
+| Japanese    | `ja`          | ✔ \*     | ✔           |  ✔ \*          |     |
 | Korean      | `ko`          |          | ✔           |  ✔ \*          |     |
 | Norwegian  (Bokmål) | `no`  | ✔ \*     |  ✔          | ✔ \*            |     |
 | Polish      | `pl`          | ✔ \*     |  ✔          |  ✔ \*           |     |


### PR DESCRIPTION
Three languages currently supported for Sentiment are missing check marks in this language support table on this page - added check mark for Arabic, Chinese-Simplified and Japanese under Sentiment.