### PR TITLE
Update quick starts for Event Hubs and Event Processor Host

### DIFF
--- a/articles/event-hubs/event-hubs-node-get-started-send.md
+++ b/articles/event-hubs/event-hubs-node-get-started-send.md
@@ -34,182 +34,147 @@ To complete this tutorial, you need the following prerequisites:
 - Clone the [sample GitHub repository](https://github.com/Azure/azure-event-hubs-node) on your machine. 
 
 
-## Send events
-This section shows you how to create a Node.js application that sends events to an event hub. 
-
-### Install Node.js package
-Install Node.js package for Azure Event Hubs on your machine. 
+### Install npm package
+To install the npm package for Event Hubs, open a command prompt that has `npm` in its path, change the directory
+to the folder where you want to have your samples and then run this command
 
 ```shell
 npm install @azure/event-hubs
 ```
 
-If you haven't cloned the Git repository as mentioned in the prerequisite, download the [sample](https://github.com/Azure/azure-event-hubs-node/tree/master/client/examples) from GitHub. 
-
-The SDK you have cloned contains multiple samples that show you how to send events to an event hub using node.js. In this quickstart, you use the **simpleSender.js** example. To observe events being received, open another terminal, and receive events using the [receive sample](event-hubs-node-get-started-receive.md).
-
-1. Open the project on Visual Studio Code. 
-2. Create a file named **.env** under the **client** folder. Copy and paste sample environmental variables from the **sample.env** in the root folder.
-3. Configure your event hub connection string, event hub name, and storage endpoint. For instructions on getting a connection string for an event hub, [Get connection string](event-hubs-create.md#create-an-event-hubs-namespace).
-4. On your Azure CLI, navigate to the **client** folder path. Install node packages and build the project by running the following commands:
-
-    ```shell
-    npm i
-    npm run build
-    ```
-5. Start sending events by running the following command: 
-
-    ```shell
-    node dist/examples/simpleSender.js
-    ```
-
-
-### Review the sample code 
-Review the sample code in the simpleSender.js file to send events to an event hub.
-
-```javascript
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const lib_1 = require("../lib");
-const dotenv = require("dotenv");
-dotenv.config();
-const connectionString = "EVENTHUB_CONNECTION_STRING";
-const entityPath = "EVENTHUB_NAME";
-const str = process.env[connectionString] || "";
-const path = process.env[entityPath] || "";
-
-async function main() {
-    const client = lib_1.EventHubClient.createFromConnectionString(str, path);
-    const data = {
-        body: "Hello World!!"
-    };
-    const delivery = await client.send(data);
-    console.log(">>> Sent the message successfully: ", delivery.tag.toString());
-    console.log(delivery);
-    console.log("Calling rhea-promise sender close directly. This should result in sender getting reconnected.");
-    await Object.values(client._context.senders)[0]._sender.close();
-    // await client.close();
-}
-
-main().catch((err) => {
-    console.log("error: ", err);
-});
-
-```
-
-Remember to set your environment variables before running the script. You can either configure them in the command line as shown in the following example, or use the [dotenv package](https://www.npmjs.com/package/dotenv#dotenv). 
-
-```shell
-// For windows
-set EVENTHUB_CONNECTION_STRING="<your-connection-string>"
-set EVENTHUB_NAME="<your-event-hub-name>"
-
-// For linux or macos
-export EVENTHUB_CONNECTION_STRING="<your-connection-string>"
-export EVENTHUB_NAME="<your-event-hub-name>"
-```
-
-## Receive events
-This tutorial shows how to receive events from an event hub by using Azure [EventProcessorHost](event-hubs-event-processor-host.md) in a Node.js application. The EventProcessorHost (EPH) helps you efficiently receive events from an event hub by creating receivers across all partitions in the consumer group of an event hub. It checkpoints metadata on received messages at regular intervals in an Azure Storage Blob. This approach makes it easy to continue receiving messages from where you left off at a later time.
-
-The code for this quickstart is available on [GitHub](https://github.com/Azure/azure-event-hubs-node/tree/master/processor).
-
-### Clone the Git repository
-Download or clone the [sample](https://github.com/Azure/azure-event-hubs-node/tree/master/processor/examples/) from GitHub. 
-
-### Install the EventProcessorHost
-Install the EventProcessorHost for Event Hubs module. 
+To install the npm package for Event Processor Host, run the below command instead
 
 ```shell
 npm install @azure/event-processor-host
 ```
 
-### Receive events using EventProcessorHost
-The SDK you have cloned contains multiple samples that show you how to receive events from an event hub using Node.js. In this quickstart, you use the **singleEPH.js** example. To observe events being received, open another terminal, and send events using the [send sample](event-hubs-node-get-started-send.md).
+## Send events
 
-1. Open the project on Visual Studio Code. 
-2. Create a file named **.env** under the **processor** folder. Copy and paste sample environmental variables from the **sample.env** in the root folder.
-3. Configure your event hub connection string, event hub name, and storage endpoint. You can copy connection string for your event hub from **Connection string-primary** key under **RootManageSharedAccessKey** on the Event Hub page in the Azure portal. For detailed steps, see [Get connection string](event-hubs-create.md#create-an-event-hubs-namespace).
-4. On your Azure CLI, navigate to the **processor** folder path. Install node packages and build the project by running the following commands:
+This section shows you how to create a Node.js application that sends events to an event hub. 
 
-    ```shell
-    npm i
-    npm run build
-    ```
-5. Receive events with your event processor host by running the following command:
+1. Open your favorite editor, such as [Visual Studio Code](https://code.visualstudio.com). 
+2. Create a file called `send.js` and paste the below code into it. This will send 100 events to your Event Hub
+```javascript
+const { EventHubClient } = require("@azure/event-hubs");
 
-    ```shell
-    node dist/examples/singleEph.js
-    ```
+// Define connection string and the name of the Event Hub
+const connectionString = "";
+const eventHubsName = "";
 
-### Review the sample code 
-Here is the sample code to receive events from an event hub using node.js. You can manually create a sampleEph.js file, and run it to receive events to an event hub. 
-
-  ```javascript
-  const { EventProcessorHost, delay } = require("@azure/event-processor-host");
-
-  const path = process.env.EVENTHUB_NAME;
-  const storageCS = process.env.STORAGE_CONNECTION_STRING;
-  const ehCS = process.env.EVENTHUB_CONNECTION_STRING;
-  const storageContainerName = "test-container";
+async function main() {
+  const client = EventHubClient.createFromConnectionString(connectionString, eventHubsName);
   
-  async function main() {
-    // Create the Event Processor Host
-    const eph = EventProcessorHost.createFromConnectionString(
-      EventProcessorHost.createHostName("my-host"),
-      storageCS,
-      storageContainerName,
-      ehCS,
-      {
-        eventHubPath: path,
-        onEphError: (error) => {
-          console.log("This handler will notify you of any internal errors that happen " +
-          "during partition and lease management: %O", error);
-        }
-      }
-    );
-    let count = 0;
-    // Message event handler
-    const onMessage = async (context/*PartitionContext*/, data /*EventData*/) => {
-      console.log(">>>>> Rx message from '%s': '%s'", context.partitionId, data.body);
-      count++;
-      // let us checkpoint every 100th message that is received across all the partitions.
-      if (count % 100 === 0) {
-        return await context.checkpoint();
-      }
-    };
-    // Error event handler
-    const onError = (error) => {
-      console.log(">>>>> Received Error: %O", error);
-    };
-    // start the EPH
-    await eph.start(onMessage, onError);
-    // After some time let' say 2 minutes
-    await delay(120000);
-    // This will stop the EPH.
-    await eph.stop();
+  for (let i = 0; i < 100; i++) {
+    const eventData = {body: `Event ${i}`};
+    console.log(`Sending message: ${eventData.body}`);
+    await client.send(eventData);
   }
-  
-  main().catch((err) => {
-    console.log(err);
-  });
-      
-  ```
 
-Remember to set your environment variables before running the script. You can either configure this in the command line as shown in the following example, or use the [dotenv package](https://www.npmjs.com/package/dotenv#dotenv). 
+  await client.close();
+}
 
-```shell
-// For windows
-set EVENTHUB_CONNECTION_STRING="<your-connection-string>"
-set EVENTHUB_NAME="<your-event-hub-name>"
-
-// For linux or macos
-export EVENTHUB_CONNECTION_STRING="<your-connection-string>"
-export EVENTHUB_NAME="<your-event-hub-name>"
+main().catch(err => {
+  console.log("Error occurred: ", err);
+});
 ```
+3. Enter the connection string and the name of your Event Hub in the above code
+4. Then run the command `node send.js` in a command prompt to execute this file.
 
-You can find more samples [here](https://github.com/Azure/azure-event-hubs-node/tree/master/processor/examples).
+Congratulations! You have now sent messages to an event hub.
 
+
+## Receive events
+
+This section shows you how to create a Node.js application that receives events from a single partition
+of a consumer group in an event hub. 
+
+1. Open your favorite editor, such as [Visual Studio Code](https://code.visualstudio.com). 
+2. Create a file called `receive.js` and paste the below code into it. This will receive events from one of the partitions
+in your Event Hub
+```javascript
+const { EventHubClient, delay } = require("@azure/event-hubs");
+
+// Define connection string and related Event Hubs entity name here
+const connectionString = "";
+const eventHubsName = "";
+
+async function main() {
+  const client = EventHubClient.createFromConnectionString(connectionString, eventHubsName);
+  const allPartitionIds = await client.getPartitionIds();
+  const firstPartitionId = allPartitionIds[0];
+
+  const receiveHandler = client.receive(firstPartitionId, eventData => {
+    console.log(`Received message: ${eventData.body} from partition ${firstPartitionId}`);
+  }, error => {
+    console.log('Error when receiving message: ', error)
+  });
+  
+  // Sleep for a while before stopping the receive operation.
+  await delay(15000);
+  await receiveHandler.stop();
+
+  await client.close();
+}
+
+main().catch(err => {
+  console.log("Error occurred: ", err);
+});
+```
+3. Enter the connection string and the name of your Event Hub in the above code
+4. Then run the command `node receive.js` in a command prompt to execute this file.
+
+Congratulations! You have now received messages from event hub.
+
+## Receive events using Event Processor Host
+
+This tutorial shows how to receive events from an event hub by using Azure [EventProcessorHost](event-hubs-event-processor-host.md) in a Node.js application. The EventProcessorHost (EPH) helps you efficiently receive events from an event hub by creating receivers across all partitions in the consumer group of an event hub. It checkpoints metadata on received messages at regular intervals in an Azure Storage Blob. This approach makes it easy to continue receiving messages from where you left off at a later time.
+
+1. Open your favorite editor, such as [Visual Studio Code](https://code.visualstudio.com). 
+2. Create a file called `receiveAll.js` and paste the below code into it. This will receive events from all the partitions
+in your Event Hub
+```javascript
+const { EventProcessorHost, delay } = require("@azure/event-processor-host");
+
+// Define connection string and related Event Hubs entity name here
+const eventhubsConnectionString = "";
+const eventHubsName = "";
+const storageConnectionString = "";
+
+async function main() {
+  const eph = EventProcessorHost.createFromConnectionString(
+    "my-eph",
+    storageConnectionString,
+    "my-storage-container-name",
+    eventhubsConnectionString,
+    {
+      eventHubPath: eventHubsName,
+      onEphError: (error) => {
+        console.log("[%s] Error: %O", ephName, error);
+      }
+    }
+  );
+
+
+  eph.start((context, eventData) => {
+    console.log(`Received message: ${eventData.body} from partition ${context.partitionId}`);
+  }, error => {
+    console.log('Error when receiving message: ', error)
+  });
+  
+  // Sleep for a while before stopping the receive operation.
+  await delay(15000);
+  await eph.stop();
+}
+
+main().catch(err => {
+  console.log("Error occurred: ", err);
+});
+
+```
+3. Enter the connection string and the name of your Event Hub in the above code along with connection string for an Azure Blob Storage
+4. Then run the command `node receiveAll.js` in a command prompt to execute this file.
+
+Congratulations! You have now received messages from event hub using Event Processor Host.
 
 ## Next steps
 Read the following articles:
@@ -217,4 +182,4 @@ Read the following articles:
 - [EventProcessorHost](event-hubs-event-processor-host.md)
 - [Features and terminology in Azure Event Hubs](event-hubs-features.md)
 - [Event Hubs FAQ](event-hubs-faq.md)
-- Check out other Node.js samples for Event Hubs on [GitHub](https://github.com/Azure/azure-event-hubs-node/tree/master/client/examples/).
+- Check out other Node.js samples for [Event Hubs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples) and [Event Processor Host](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-processor-host/samples) on GitHub


### PR DESCRIPTION
The existing quick starts for Event Hubs and Event Processor Host require the user to clone the repository, build the source code and set environment variables. This change removes the need to do this and simplifies the process