### PR TITLE
Adding Microsoft Bookings

### DIFF
--- a/articles/active-directory/conditional-access/technical-reference.md
+++ b/articles/active-directory/conditional-access/technical-reference.md
@@ -201,6 +201,7 @@ In your conditional access policy, you can require that an access attempt to the
 This setting applies to the following client apps:
 
 - Microsoft Azure Information Protection
+- Microsoft Bookings
 - Microsoft Edge
 - Microsoft Excel
 - Microsoft Flow


### PR DESCRIPTION
We had a customer bring to our attention that Microsoft Bookings is not listed on this page as an approved client app: https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/technical-reference#approved-client-app-requirement 

The Microsoft Bookings app has done the integration work with the Intune SDK (that my team owns) and becoming CA enabled back last year (see email below). 

Please see if you can make the update to the docs page referenced above, as that is not owned by the Intune team.
