### PR TITLE
Add --resource-group to aks-engine deploy

### DIFF
--- a/articles/cosmos-db/bootstrap-kubernetes-cluster.md
+++ b/articles/cosmos-db/bootstrap-kubernetes-cluster.md
@@ -127,6 +127,7 @@ To learn more about etcd API in Azure Cosmos DB, see the [overview](etcd-api-int
      --client-secret <Service_ principal_password> \
      --dns-prefix <Region_unique_dns_name > \
      --location centralus \
+     --resource-group <Resource_Group_Name> \
      --api-model <Fully_qualified_path_to_the_template_file>  \
      --force-overwrite
    ```


### PR DESCRIPTION
The AKS-ENGINE didn't like as the doc currently shows complaining that --resource-group was not specified. Using the DNS prefix from the apimodel as the resource group name. However, the app id generated doesn't have rights to create RGs, only to operate on the RG that was created (fired back a 403). Specifying --resource-group fixes.