### PR TITLE
Fix SoX audio conversion commands

### DIFF
--- a/articles/cognitive-services/Speech-Service/how-to-custom-speech-test-data.md
+++ b/articles/cognitive-services/Speech-Service/how-to-custom-speech-test-data.md
@@ -61,8 +61,8 @@ If your audio doesn’t satisfy these properties or you want to check if it does
 
 | Activity | Description | Sox command |
 |----------|-------------|-------------|
-| Check audio format | Use this command to check the audio file format. | `soxi <filename>.wav` |
-| Convert audio format | Use this command to convert the audio file to single channel, 16-bit, 48 KHz. | `sox <filename>.wav -b 16 -3 signed-integer -c l -r 48k -t wav <filename>.wav` |
+| Check audio format | Use this command to check the audio file format. | `sox --i <filename>.wav` |
+| Convert audio format | Use this command to convert the audio file to single channel, 16-bit, 48 KHz. | `sox <filename>.wav -b 16 -e signed-integer -c l -r 16k -t wav <filename>.wav` |
 
 ## Audio + human-labeled transcript data for testing/training
 


### PR DESCRIPTION
Hello. This PR includes some fixes to the `sox` commands used for testing and converting audio data:

1. `soxi` is not a binary that normally ships with SoX, but `sox --i <file>` accomplishes the same thing and works with the default installation
2. The option `-3` is a typo from the encoding option `-e` (and will thus cause an error)
3. **Most importantly**, the `-r` option for sampling rate has been reduced to 16k to match with Azure requirements and prevent the dreaded "Failed to upload data" when the sampling rate is greater (such as at the 48k in the example command)

I spent more time than I would like to admit trying to figure out why my seemingly valid audio and transcription files were failing to validate on Azure until I realized that the SoX commands had a few errors in them. Hopefully this can prevent someone else's future frustrations.