### PR TITLE
Included the range of prefix under constraints

### DIFF
--- a/articles/virtual-network/public-ip-address-prefix.md
+++ b/articles/virtual-network/public-ip-address-prefix.md
@@ -53,6 +53,7 @@ You can associate the following resources to a static public IP address from a p
 
 - You can't specify the IP addresses for the prefix. Azure allocates the IP addresses for the prefix, based on the size that you specify.
 - The default size of a prefix is /28 or 16 public IP addresses.
+- The minimum size of a prefix is /31 or 2 public IP addresses, and the maximum is /28 or 16 public IP addresses.
 - You can't change the range, once you've created the prefix.
 - The range is for IPv4 addresses only. The range does not contain IPv6 addresses.
 - Only static public IP addresses created with the Standard SKU can be assigned from the prefix's range. To learn more about public IP address SKUs, see [public IP address](virtual-network-ip-addresses-overview-arm.md#public-ip-addresses).


### PR DESCRIPTION
There's a disconnect between the sample shown on the pricing calculator and what you can actually create as an Azure Public IP Prefix.  I attempted to create a /24 and was greeted with an error that the minimum is /28 and the maximum is /31.  This is inside the Az cloud shell within the portal.  

I added the line here so that customers know what they can and can't deploy without trial and error.