### PR TITLE
Update Ruby Supported Versions

### DIFF
--- a/articles/app-service/containers/app-service-linux-intro.md
+++ b/articles/app-service/containers/app-service-linux-intro.md
@@ -35,7 +35,7 @@ App Service on Linux supports a number of Built-in images in order to increase d
 | PHP | 5.6, 7.0, 7.2 |
 | Python | 2.7, 3.6, 3.7 |
 | .NET Core | 1.0, 1.1, 2.0, 2.1, 2.2 |
-| Ruby | 2.3.8, 2.4.5, 2.5.5, 2.6.2 |
+| Ruby | 2.3, 2.4, 2.5, 2.6 |
 
 ## Deployments
 

--- a/articles/app-service/containers/app-service-linux-intro.md
+++ b/articles/app-service/containers/app-service-linux-intro.md
@@ -35,7 +35,7 @@ App Service on Linux supports a number of Built-in images in order to increase d
 | PHP | 5.6, 7.0, 7.2 |
 | Python | 2.7, 3.6, 3.7 |
 | .NET Core | 1.0, 1.1, 2.0, 2.1, 2.2 |
-| Ruby | 2.3, 2.4 |
+| Ruby | 2.3.8, 2.4.5, 2.5.5, 2.6.2 |
 
 ## Deployments
 


### PR DESCRIPTION
the Ruby versions available for a web app for linux are  | Ruby | 2.3.8, 2.4.5, 2.5.5, 2.6.2 |  based on running the command az webapp list-runtimes --linux on Azure CLI