### PR TITLE
Fixed daemon.json folder reference

### DIFF
--- a/articles/iot-edge/troubleshoot.md
+++ b/articles/iot-edge/troubleshoot.md
@@ -378,7 +378,7 @@ Place `daemon.json` in the right location for your platform:
 | Platform | Location |
 | --------- | -------- |
 | Linux | `/etc/docker` |
-| Windows host with Windows containers | `C:\ProgramData\iotedge-moby-data\config` |
+| Windows host with Windows containers | `C:\ProgramData\iotedge-moby\config` |
 
 If the location already contains `daemon.json` file, add the **dns** key to it and save the file.
 


### PR DESCRIPTION
The folder reference is now on par with the pad mentioned (and which is actually checked) by 'iotedge check'.
Screendump op check:
![daemon json path to config](https://user-images.githubusercontent.com/694737/57693534-c3223580-7649-11e9-9b10-4051c2d31caf.png)
