### PR TITLE
Update how-to-routefilter-powershell.md

### DIFF
--- a/articles/expressroute/how-to-routefilter-powershell.md
+++ b/articles/expressroute/how-to-routefilter-powershell.md
@@ -127,7 +127,7 @@ New-AzRouteFilter -Name "MyRouteFilter" -ResourceGroupName "MyResourceGroup" -Lo
 You can specify a set of BGP communities as a comma-separated list, as shown in the example. Run the following command to create a new rule:
  
 ```azurepowershell-interactive
-$rule = New-AzRouteFilterRuleConfig -Name "Allow-EXO-D365" -Access Allow -RouteFilterRuleType Community -CommunityList "12076:5010,12076:5040"
+$rule = New-AzRouteFilterRuleConfig -Name "Allow-EXO-D365" -Access Allow -RouteFilterRuleType Community -CommunityList 12076:5010,12076:5040
 ```
 
 ### 3. Add the rule to the route filter


### PR DESCRIPTION
With the quotes around the community values in New-AzRouteFilterRuleConfig, Set-AzRouteFilter throws the following:
set-azroutefilter : Community name 12076:51004,12076:51006 of route filter rule
/subscriptions/b0b5c8ed-2baa-4c8a-86fe-82f035a7b3fd/resourceGroups/web/providers/Microsoft.Network/routeFilters/test-rf/routeFilterRules/Allow-EastWest is invalid. The name must contain
colon (:).
StatusCode: 400
ReasonPhrase: Bad Request
OperationID : 'd9de59b4-df96-47d2-8c95-5df0cabb6345'