### PR TITLE
Updated field name to temp from temperature

### DIFF
--- a/articles/iot-central/tutorial-add-device.md
+++ b/articles/iot-central/tutorial-add-device.md
@@ -164,7 +164,7 @@ In the previous section, you created a skeleton Node.js project for an applicati
     // Send device telemetry.
     function sendTelemetry() {
       var temperature = targetTemperature + (Math.random() * 15);
-      var data = JSON.stringify({ temperature: temperature });
+      var data = JSON.stringify({ temp: temperature });
       var message = new Message(data);
       client.sendEvent(message, (err, res) => console.log(`Sent message: ${message.getData()}` +
         (err ? `; error: ${err.toString()}` : '') +


### PR DESCRIPTION
The default field name for temperature in IoT Central is temp, not temperature. IoT Central will not recognise receiving the temperature if the field name is not temp
![image](https://user-images.githubusercontent.com/16961689/57732906-14581680-7696-11e9-92f8-0e1b076ec2ee.png)
