### PR TITLE
Clarify creating functions and fix minor issues

### DIFF
--- a/articles/azure-functions/functions-test-a-function.md
+++ b/articles/azure-functions/functions-test-a-function.md
@@ -37,8 +37,9 @@ The following example describes how to create a C# Function app in Visual Studio
 To set up your environment, create a Function and test app. The following steps help you create the apps and functions required to support the tests:
 
 1. [Create a new Functions app](./functions-create-first-azure-function.md) and name it *Functions*
-2. [Create an HTTP function from the template](./functions-create-first-azure-function.md) and name it *HttpTrigger*.
-3. [Create a timer function from the template](./functions-create-scheduled-function.md) and name it *TimerTrigger*.
+2. [Create an HTTP function from the template](./functions-create-your-first-function-visual-studio.md) and name it *HttpFunction*.
+3. Create a timer function from the template and name it *TimerTrigger*.
+4. Build the *Functions* app, if you haven't already.
 4. [Create an xUnit Test app](https://xunit.github.io/docs/getting-started-dotnet-core) in Visual Studio by clicking **File > New > Project > Visual C# > .NET Core > xUnit Test Project** and  name it *Functions.Test*. 
 5. Use Nuget to add a references from the test app [Microsoft.AspNetCore.Mvc](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc/)
 6. [Reference the *Functions* app](https://docs.microsoft.com/visualstudio/ide/managing-references-in-a-project?view=vs-2017) from *Functions.Test* app.
@@ -75,7 +76,7 @@ Next, **right-click** on the *Functions.Test* application and select **Add > Cla
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using Microsoft.Extensions.Logging.Abstractions.Internal;
 
 namespace Functions.Tests
 {

--- a/articles/azure-functions/functions-test-a-function.md
+++ b/articles/azure-functions/functions-test-a-function.md
@@ -40,9 +40,9 @@ To set up your environment, create a Function and test app. The following steps 
 2. [Create an HTTP function from the template](./functions-create-your-first-function-visual-studio.md) and name it *HttpFunction*.
 3. Create a timer function from the template and name it *TimerTrigger*.
 4. Build the *Functions* app, if you haven't already.
-4. [Create an xUnit Test app](https://xunit.github.io/docs/getting-started-dotnet-core) in Visual Studio by clicking **File > New > Project > Visual C# > .NET Core > xUnit Test Project** and  name it *Functions.Test*. 
-5. Use Nuget to add a references from the test app [Microsoft.AspNetCore.Mvc](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc/)
-6. [Reference the *Functions* app](https://docs.microsoft.com/visualstudio/ide/managing-references-in-a-project?view=vs-2017) from *Functions.Test* app.
+5. [Create an xUnit Test app](https://xunit.github.io/docs/getting-started-dotnet-core) in Visual Studio by clicking **File > New > Project > Visual C# > .NET Core > xUnit Test Project** and  name it *Functions.Test*. 
+6. Use Nuget to add a references from the test app [Microsoft.AspNetCore.Mvc](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc/)
+7. [Reference the *Functions* app](https://docs.microsoft.com/visualstudio/ide/managing-references-in-a-project?view=vs-2017) from *Functions.Test* app.
 
 ### Create test classes
 


### PR DESCRIPTION
 - Setup section specified that the HTTP trigger function should be called HttpTrigger, but the code for both FunctionsTests.cs and index.test.js reference a function called HttpFunction.
 - Linked examples for creating functions were for creating functions in the Portal, not using templates in VS as implied. Linked HTTP example to functions-create-your-first-function-visual-studio.md instead and removed Trigger example.
 - ListLogger class requires a reference to Microsoft.Extensions.Logging.Abstractions.Internal for the NullScope class, but doesn't require System.Text
In Setup it says to "Reference the Functions app from the Functions.Test app".  This only works if you have built the Functions app first, otherwise it won't recognize the reference. Added build step.