### PR TITLE
Fix #31150 (Update Azure SDK for Python's Service Bus link)

### DIFF
--- a/articles/service-bus-messaging/service-bus-samples.md
+++ b/articles/service-bus-messaging/service-bus-samples.md
@@ -24,7 +24,7 @@ The Service Bus messaging samples demonstrate key features in [Service Bus messa
 | -------------------- | ----------------------- |
 | .NET, Java, and Management | https://github.com/Azure/azure-service-bus/ |
 | Node.js | https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples |
-| Python | https://github.com/Azure/azure-sdk-for-python/tree/master/azure-servicebus |
+| Python | https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/servicebus/azure-servicebus |
 
 ## Service Bus Explorer
 


### PR DESCRIPTION
Fix #31150 

Update Azure SDK for Python's Service Bus link, because Azure SDK for Python repo has updated the folder location of Azure Service Bus folder.