### PR TITLE
Update automate-custom-reports.md

### DIFF
--- a/articles/azure-monitor/app/automate-custom-reports.md
+++ b/articles/azure-monitor/app/automate-custom-reports.md
@@ -89,6 +89,9 @@ availabilityResults
 
 5. Select the **_Application Insights scheduled digest template_**.
 
+     > [!NOTE]
+     > By default function apps are created with runtime version 2.x, so you need to [target Azure function runtime version](https://docs.microsoft.com/en-us/azure/azure-functions/set-runtime-version) to 1.x to use "Application Insights scheduled digest" template listed below.
+
    ![New Function Application Insights Template screenshot](./media/automate-custom-reports/function-app-04.png)
 
 6. Enter an appropriate recipient e-mail address for your report and select **Create**.

--- a/articles/azure-monitor/app/automate-custom-reports.md
+++ b/articles/azure-monitor/app/automate-custom-reports.md
@@ -90,7 +90,7 @@ availabilityResults
 5. Select the **_Application Insights scheduled digest template_**.
 
      > [!NOTE]
-     > By default function apps are created with runtime version 2.x, so you need to [target Azure function runtime version](https://docs.microsoft.com/azure/azure-functions/set-runtime-version) to 1.x to use "Application Insights scheduled digest" template listed below.
+     > By default, function apps are created with runtime version 2.x. You must [target Azure Functions runtime version](https://docs.microsoft.com/azure/azure-functions/set-runtime-version) 1.x to use the Application Insights scheduled digest template.
 
    ![New Function Application Insights Template screenshot](./media/automate-custom-reports/function-app-04.png)
 

--- a/articles/azure-monitor/app/automate-custom-reports.md
+++ b/articles/azure-monitor/app/automate-custom-reports.md
@@ -90,7 +90,7 @@ availabilityResults
 5. Select the **_Application Insights scheduled digest template_**.
 
      > [!NOTE]
-     > By default function apps are created with runtime version 2.x, so you need to [target Azure function runtime version](https://docs.microsoft.com/en-us/azure/azure-functions/set-runtime-version) to 1.x to use "Application Insights scheduled digest" template listed below.
+     > By default function apps are created with runtime version 2.x, so you need to [target Azure function runtime version](https://docs.microsoft.com/azure/azure-functions/set-runtime-version) to 1.x to use "Application Insights scheduled digest" template listed below.
 
    ![New Function Application Insights Template screenshot](./media/automate-custom-reports/function-app-04.png)
 


### PR DESCRIPTION
As by default function apps are created with runtime version 2.x, so you need to [target Azure function runtime version](https://docs.microsoft.com/en-us/azure/azure-functions/set-runtime-version) to 1.x to use "Application Insights scheduled digest" template. So added the step, so that readers will not get confused.