### PR TITLE
Update link to kured yaml

### DIFF
--- a/articles/aks/node-updates-kured.md
+++ b/articles/aks/node-updates-kured.md
@@ -53,8 +53,7 @@ You can't remain on the same Kubernetes version during an upgrade event. You mus
 To deploy the `kured` DaemonSet, apply the following sample YAML manifest from their GitHub project page. This manifest creates a role and cluster role, bindings, and a service account, then deploys the DaemonSet using `kured` version 1.1.0 that supports AKS clusters 1.9 or later.
 
 ```console
-kubectl apply -f https://github.com/weaveworks/kured/releases/download/1.1.0/kured-1.1.0.yaml
-```
+kubectl apply -f https://github.com/weaveworks/kured/releases/download/1.2.0/kured-1.2.0-dockerhub.yaml
 
 You can also configure additional parameters for `kured`, such as integration with Prometheus or Slack. For more information about additional configuration parameters, see the [kured installation docs][kured-install].
 


### PR DESCRIPTION
Kured has moved to docker hub now and updated the location of the yaml file. Changed the link so it goes to the updated version