### PR TITLE
Remove python as Windows-only from app-service-deploy-prepare-repo.md

### DIFF
--- a/includes/app-service-deploy-prepare-repo.md
+++ b/includes/app-service-deploy-prepare-repo.md
@@ -21,7 +21,7 @@ To get automatic builds from the Azure App Service Kudu build server, make sure 
 | PHP | _index.php_ |
 | Ruby (Linux only) | _Gemfile_ |
 | Node.js | _server.js_, _app.js_, or _package.json_ with a start script |
-| Python (Windows only) | _\*.py_, _requirements.txt_, or _runtime.txt_ |
+| Python | _\*.py_, _requirements.txt_, or _runtime.txt_ |
 | HTML | _default.htm_, _default.html_, _default.asp_, _index.htm_, _index.html_, or _iisstart.htm_ |
 | WebJobs | _\<job_name>/run.\<extension>_ under _App\_Data/jobs/continuous_ (for continuous WebJobs) or _App\_Data/jobs/triggered_ (for triggered WebJobs). For more information, see [Kudu WebJobs documentation](https://github.com/projectkudu/kudu/wiki/WebJobs). |
 | Functions | See [Continuous deployment for Azure Functions](../articles/azure-functions/functions-continuous-deployment.md#requirements-for-continuous-deployment). |


### PR DESCRIPTION
Python is supported on App service Linux as well, with the same configuration files.