### PR TITLE
Fixed daemon.json path on Win10 IoT Enterprise

### DIFF
--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -210,7 +210,7 @@ Add (or append) this information to a file named `daemon.json` and place it the 
 | Platform | Location |
 | -------- | -------- |
 | Linux | `/etc/docker/` |
-| Windows | `C:\ProgramData\iotedge-moby-data\config\` |
+| Windows | `C:\ProgramData\iotedge-moby\config\` |
 
 The container engine must be restarted for the changes to take effect.
 


### PR DESCRIPTION
The correct path is 'C:\ProgramData\iotedge-moby\config\' as seen in the 'iotedge check' with verbose messages.

This issue is related to https://github.com/MicrosoftDocs/azure-docs/pull/31177 but on another docs page (31177 was related to articles/iot-edge/troubleshoot.md).