### PR TITLE
Include Steps to Find Category ID

### DIFF
--- a/articles/cognitive-services/Translator/reference/v3-0-translate.md
+++ b/articles/cognitive-services/Translator/reference/v3-0-translate.md
@@ -50,7 +50,7 @@ Request parameters passed on the query string are:
   </tr>
   <tr>
     <td>category</td>
-    <td><em>Optional parameter</em>.<br/>A string specifying the category (domain) of the translation. This parameter is used to get translations from a customized system built with <a href="../customization.md">Custom Translator</a>. Add the Category ID from your Custom Translator project to this parameter to use your deployed customized system. Default value is: <code>general</code>.</td>
+    <td><em>Optional parameter</em>.<br/>A string specifying the category (domain) of the translation. This parameter is used to get translations from a customized system built with <a href="../customization.md">Custom Translator</a>. Add the Category ID from your Custom Translator project to this parameter to use your deployed customized system.  A CategoryID is created by concatenating the WorkspaceID, project label, and category code.  View your Cateogry ID by navigating to <a href="https://docs.microsoft.com/en-us/azure/cognitive-services/translator/custom-translator/how-to-create-project#view-project-details">project details</a> in the custom translation site.   Default value is: <code>general</code>.</td>
   </tr>
   <tr>
     <td>profanityAction</td>


### PR DESCRIPTION
The text makes it sound like you just plug in the name of the domain / category.  Instead, you need to find the category ID on the custom translation site or know how to construct it.