### PR TITLE
Added more instructions and details

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website-custom-domain.md
+++ b/articles/storage/blobs/storage-blob-static-website-custom-domain.md
@@ -40,8 +40,10 @@ Sign in to the [Azure portal](https://portal.azure.com/) to get started.
 1. In the **New Endpoint** section, fill out the fields to create a new CDN endpoint.
 1. Enter an endpoint name, such as *mystaticwebsiteCDN*.
 1. Enter your website domain as the hostname for your CDN endpoint.
-1. For the origin hostname, enter your the static website endpoint. To find your static website endpoint, navigate to the **Static website** section for your storage account and copy the endpoint. 
+1. For the origin hostname, enter your the static website endpoint. To find your static website endpoint, navigate to the **Static website** section for your storage account and copy the endpoint (remove the preceding https:// )
 1. Test your CDN endpoint by navigating to *mywebsitecdn.azureedge.net* in your browser.
+1. Additionaly verify by navigating to the **New Endpoint** under settings, origin to see if the Origin type is set  to *Custom Origin*
+and *Origin hostname* displays the Static webiste endpoint name.
 
 ## Enable custom domain and SSL
 


### PR DESCRIPTION
Step 7 - Origin name when copied as such from the static website endpoint name gives an error, after little bit of digging it appears that the preceding https:// needs to be removed.
Step 9- This is a additional verification for someone who would like to dig more when creating of CDN didnot work