### PR TITLE
WTD #31434 updated cloud-services-dotnet-get-started.md

### DIFF
--- a/articles/cloud-services/cloud-services-dotnet-get-started.md
+++ b/articles/cloud-services/cloud-services-dotnet-get-started.md
@@ -697,7 +697,7 @@ public override void Run()
 }
 ```
 
-After each iteration of the loop, if no queue message was found, the program sleeps for a second. This prevents the worker role from incurring excessive CPU time and storage transaction costs. The Microsoft Customer Advisory Team tells a story about a  developer who forgot to include this, deployed to production, and left for vacation. When he got back, his oversight cost more than the vacation.
+After each iteration of the loop, if no queue message was found, the program sleeps for a second. This prevents the worker role from incurring excessive CPU time and storage transaction costs. The Microsoft Customer Advisory Team tells a story about a  developer who forgot to include this, deployed to production, and left for vacation. When they got back, their oversight cost more than the vacation.
 
 Sometimes the content of a queue message causes an error in processing. This is called a *poison message*, and if you just logged an error and restarted the loop, you could endlessly try to process that message.  Therefore the catch block includes an if statement that checks to see how many times the app has tried to process the current message, and if it has been more than 5 times, the message is deleted from the queue.
 


### PR DESCRIPTION
updated to remove gendered language.  I would also recommend improving the example, as joking about someone losing their job due to a mistake isn't kind, and reads a bit tone-deaf.