### PR TITLE
WTD #31442 updated data-lake-storage-access-control.md

### DIFF
--- a/articles/storage/blobs/data-lake-storage-access-control.md
+++ b/articles/storage/blobs/data-lake-storage-access-control.md
@@ -146,7 +146,7 @@ The user who created the item is automatically the owning user of the item. An o
 
 #### The owning group
 
-In the POSIX ACLs, every user is associated with a *primary group*. For example, user "Alice" might belong to the "finance" group. Alice might also belong to multiple groups, but one group is always designated as her primary group. In POSIX, when Alice creates a file, the owning group of that file is set to her primary group, which in this case is "finance." The owning group otherwise behaves similarly to assigned permissions for other users/groups.
+In the POSIX ACLs, every user is associated with a *primary group*. For example, user "Alice" might belong to the "finance" group. Alice might also belong to multiple groups, but one group is always designated as their primary group. In POSIX, when Alice creates a file, the owning group of that file is set to her primary group, which in this case is "finance." The owning group otherwise behaves similarly to assigned permissions for other users/groups.
 
 ##### Assigning the owning group for a new file or directory
 


### PR DESCRIPTION
Updated to remove gendered language. Still requires gender neutral names for example.