### PR TITLE
Added Azure AD to Role name

### DIFF
--- a/articles/automation/automation-solution-vm-management.md
+++ b/articles/automation/automation-solution-vm-management.md
@@ -74,7 +74,7 @@ To deploy the Start/Stop VMs during off hours solution to an Automation Account 
 To deploy the Start/Stop VMs during off hours solution to a new Automation Account and Log Analytics workspace the user deploying the solution needs the permissions defined in the preceding section as well as the following permissions:
 
 - Co-administrator on subscription - This is needed to create the Classic Run As Account
-- Be part of the **Application Developer** role. For more details on configuring Run As Accounts, see [Permissions to configure Run As accounts](manage-runas-account.md#permissions).
+- Be part of the Azure Active Directory **Application Developer** role. For more details on configuring Run As Accounts, see [Permissions to configure Run As accounts](manage-runas-account.md#permissions).
 
 | Permission |Scope|
 | --- | --- |


### PR DESCRIPTION
When reading this document it is confusing when it starts talking about the "Applicaiton Developer" role, after spending the last section talking about RBAC permissions. There is no indicator that this is an Azure AD role, seperate to RBAC, and I have seen users be confused by this. I have added clarification.