### PR TITLE
Path to installation script is updated

### DIFF
--- a/articles/asc-for-iot/how-to-deploy-linux-c.md
+++ b/articles/asc-for-iot/how-to-deploy-linux-c.md
@@ -49,7 +49,7 @@ To install and deploy the security agent, do the following:
 
 1. Download the most recent version to your machine from [Github](https://aka.ms/iot-security-github-c).
 
-1. Extract the contents of the package and navigate to the _/Install_ folder.
+1. Extract the contents of the package and navigate to the _/src/installation_ folder.
 
 1. Add running permissions to the **InstallSecurityAgent script** by running the following:
     


### PR DESCRIPTION
The folder of InstallSecurityAgent.sh is now https://github.com/Azure/Azure-IoT-Security-Agent-C/tree/master/src/installation