### PR TITLE
Included links to the CLI and PS cmdlets

### DIFF
--- a/articles/virtual-network/manage-public-ip-address-prefix.md
+++ b/articles/virtual-network/manage-public-ip-address-prefix.md
@@ -69,6 +69,13 @@ Once you create a prefix, you must create static IP addresses from the prefix. I
    |Idle timeout (minutes)|No|How many minutes to keep a TCP or HTTP connection open without relying on clients to send keep-alive messages. |
    |DNS name label|No|Must be unique within the Azure region you create the name in (across all subscriptions and all customers). Azure automatically registers the name and IP address in its DNS so you can connect to a resource with the name. Azure appends a default subnet such as *location.cloudapp.azure.com* (where location is the location you select) to the name you provide, to create the fully qualified DNS name.For more information, see [Use Azure DNS with an Azure public IP address](../dns/dns-custom-domain.md?toc=%2fazure%2fvirtual-network%2ftoc.json#public-ip-address).|
 
+Alternatively you may use the CLI and PS commands below with the --public-ip-prefix (CLI) and -PublicIpPrefix (PS) parameters, to create a Public IP address resource. 
+
+|Tool|Command|
+|---|---|
+|CLI|[az network public-ip create](/cli/azure/network/public-ip?view=azure-cli-latest#az-network-public-ip-create)|
+|PowerShell|[New-AzPublicIpAddress](/powershell/module/az.network/new-azpublicipaddress?view=azps-2.0.0)|
+
 ## View or delete a prefix
 
 1. In the box that contains the text *Search resources* at the top of the Azure portal, type *public ip address prefix*. When **Public IP address prefixes** appear in the search results, select it.


### PR DESCRIPTION
Included links to the CLI and PS cmdlets that allow you to programmatically consume the ip addresses in the prefix you've just created.  This helps the end user by not having to search for the appropriate commands.  This also follows the same guidelines as the paragraph above that shows you the cli and ps for programmatically creating a Public IP prefix.