### PR TITLE
Update title of document

### DIFF
--- a/articles/virtual-machines/index.yml
+++ b/articles/virtual-machines/index.yml
@@ -3,7 +3,7 @@ documentType: LandingData
 title: Virtual Machines Documentation
 metadata:
   document_id: na
-  title: Azure Linux Virtual Machine Documentation - Tutorials, API Reference | Microsoft Docs
+  title: Azure Virtual Machine Documentation - Tutorials, API Reference | Microsoft Docs
   meta.description: Learn how to create, deploy, and manage Windows or Linux virtual machines. Tutorials, API references, and other documentation.
   services: virtual-machines
   author: czeumault


### PR DESCRIPTION
Shows Azure Linux Virtual Machine, when it should really just be Azure Virtual Machine documentation.  As a landing page, it has both windows and linux information on it.