### PR TITLE
Updating Red Hat OpenShift docs link in TOC

### DIFF
--- a/articles/openshift/toc.yml
+++ b/articles/openshift/toc.yml
@@ -45,6 +45,6 @@
   - name: Regional availability
     href: https://azure.microsoft.com/regions/services/
   - name: Red Hat OpenShift documentation
-    href: https://docs.openshift.org/latest/welcome/index.html
+    href: https://docs.openshift.com/aro/welcome/index.html
   - name: Azure Roadmap
     href: https://azure.microsoft.com/roadmap/


### PR DESCRIPTION
Pointing to the ARO specific docs, vs generic OKD docs.