### PR TITLE
Updating functions-bindings-timer.md

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -287,7 +287,7 @@ Expressed as a string, the `TimeSpan` format is `hh:mm:ss` when `hh` is less tha
 |---------|---------|
 |"01:00:00" | every hour        |
 |"00:01:00"|every minute         |
-|"24:00:00" | everyday        |
+|"1.00:00:00" | every day        |
 
 ## Scale-out
 


### PR DESCRIPTION
Due to how Timers are constructed, any value greater than 23 in the hours field will produce a shift and, so, "24:00:00" will actually be "dd:hh:mm", instead of "hh:mm:ss". 

More details on the maximum integer value for hour can be found here: https://referencesource.microsoft.com/#mscorlib/system/globalization/timespanparse.cs,a1b3bab8266c098b

Changing the documentation to reflect the proper notation for a single day, so that people don't use it as an example and waste time trying to troubleshoot it.