### PR TITLE
Incorrect pre-reqs URI for installing Azure CLI docs

### DIFF
--- a/articles/key-vault/tutorial-net-create-vault-azure-web-app.md
+++ b/articles/key-vault/tutorial-net-create-vault-azure-web-app.md
@@ -39,7 +39,7 @@ If you don’t have an Azure subscription, create a [free account](https://azure
 * For Mac: [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/)
 * For Windows, Mac, and Linux:
   * [Git](https://git-scm.com/downloads)
-  * This tutorial requires that you run the Azure CLI locally. You must have the Azure CLI version 2.0.4 or later installed. Run `az --version` to find the version. If you need to install or upgrade the CLI, see [Install Azure CLI 2.0](https://review.docs.microsoft.com/cli/azure/install-azure-cli).
+  * This tutorial requires that you run the Azure CLI locally. You must have the Azure CLI version 2.0.4 or later installed. Run `az --version` to find the version. If you need to install or upgrade the CLI, see [Install Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli).
   * [.NET Core](https://www.microsoft.com/net/download/dotnet-core/2.1)
 
 ## About Managed Service Identity


### PR DESCRIPTION
Looks like the URI to the "review pending changes" was mistakenly checked in. I, and presumably the vast majority who aren't reviewers/approvers, are denied access to that page. Changed to the official docs.microsoft.com URI. as per https://github.com/MicrosoftDocs/azure-docs/issues/31550