### PR TITLE
update for framework note and diagnostic tip

### DIFF
--- a/articles/azure-monitor/app/monitor-performance-live-website-now.md
+++ b/articles/azure-monitor/app/monitor-performance-live-website-now.md
@@ -143,6 +143,8 @@ We are tracking this issue [here](https://github.com/Microsoft/ApplicationInsigh
 * To output verbose logs, modify the config file: `C:\Program Files\Microsoft Application Insights\Status Monitor\Microsoft.Diagnostics.Agent.StatusMonitor.exe.config` and add `<add key="TraceLevel" value="All" />` to the `appsettings`.
 Then restart status monitor.
 
+* As Status Monitor is a .net application you can also enable [.net tracing by adding the appropriate diagnostics to the config file](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/trace-debug/system-diagnostics-element). For example, in some scenarios it can be useful to see what's happening at the network level by [configuring network tracing](https://docs.microsoft.com/en-us/dotnet/framework/network-programming/how-to-configure-network-tracing)
+
 ### Insufficient permissions
   
 * On the server, if you see a message about "insufficient permissions", try the following:
@@ -178,7 +180,7 @@ OS support for Application Insights Status Monitor on Server:
 * Windows server 2012 R2
 * Windows Server 2016
 
-with latest SP and .NET Framework 4.5
+with latest SP and .NET Framework 4.5 (Status Monitor is built on this version of the framework)
 
 On the client side: Windows 7, 8, 8.1 and 10, again with .NET Framework 4.5
 
@@ -271,7 +273,9 @@ When you select a web app for Status Monitor to instrument:
 
 ### What version of Application Insights SDK does Status Monitor install?
 
-As of now, Status Monitor can only install Application Insights SDK versions 2.3 or 2.4.
+As of now, Status Monitor can only install Application Insights SDK versions 2.3 or 2.4. 
+
+The Application Insights SDK Version 2.4 is the [last version to support .net 4.0](https://github.com/microsoft/ApplicationInsights-dotnet/releases/tag/v2.5.0-beta1) which was [EOL January 2016](https://devblogs.microsoft.com/dotnet/support-ending-for-the-net-framework-4-4-5-and-4-5-1/). Therefore, as of now Status Monitor can be used to instrument a .net 4.0 application. 
 
 ### Do I need to run Status Monitor whenever I update the app?
 

--- a/articles/azure-monitor/app/monitor-performance-live-website-now.md
+++ b/articles/azure-monitor/app/monitor-performance-live-website-now.md
@@ -143,7 +143,7 @@ We are tracking this issue [here](https://github.com/Microsoft/ApplicationInsigh
 * To output verbose logs, modify the config file: `C:\Program Files\Microsoft Application Insights\Status Monitor\Microsoft.Diagnostics.Agent.StatusMonitor.exe.config` and add `<add key="TraceLevel" value="All" />` to the `appsettings`.
 Then restart status monitor.
 
-* As Status Monitor is a .net application you can also enable [.net tracing by adding the appropriate diagnostics to the config file](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/trace-debug/system-diagnostics-element). For example, in some scenarios it can be useful to see what's happening at the network level by [configuring network tracing](https://docs.microsoft.com/en-us/dotnet/framework/network-programming/how-to-configure-network-tracing)
+* As Status Monitor is a .NET application you can also enable [.net tracing by adding the appropriate diagnostics to the config file](https://docs.microsoft.com/dotnet/framework/configure-apps/file-schema/trace-debug/system-diagnostics-element). For example, in some scenarios it can be useful to see what's happening at the network level by [configuring network tracing](https://docs.microsoft.com/dotnet/framework/network-programming/how-to-configure-network-tracing)
 
 ### Insufficient permissions
   
@@ -275,7 +275,7 @@ When you select a web app for Status Monitor to instrument:
 
 As of now, Status Monitor can only install Application Insights SDK versions 2.3 or 2.4. 
 
-The Application Insights SDK Version 2.4 is the [last version to support .net 4.0](https://github.com/microsoft/ApplicationInsights-dotnet/releases/tag/v2.5.0-beta1) which was [EOL January 2016](https://devblogs.microsoft.com/dotnet/support-ending-for-the-net-framework-4-4-5-and-4-5-1/). Therefore, as of now Status Monitor can be used to instrument a .net 4.0 application. 
+The Application Insights SDK Version 2.4 is the [last version to support .NET 4.0](https://github.com/microsoft/ApplicationInsights-dotnet/releases/tag/v2.5.0-beta1) which was [EOL January 2016](https://devblogs.microsoft.com/dotnet/support-ending-for-the-net-framework-4-4-5-and-4-5-1/). Therefore, as of now Status Monitor can be used to instrument a .NET 4.0 application. 
 
 ### Do I need to run Status Monitor whenever I update the app?
 


### PR DESCRIPTION
Clearer the difference between the framework built on and the app to be monitored .net version ... plus tip to add .net diagnostics if the built in logging proves to be insufficient