### PR TITLE
Update resource-group-move-resources.md

### DIFF
--- a/articles/azure-resource-manager/resource-group-move-resources.md
+++ b/articles/azure-resource-manager/resource-group-move-resources.md
@@ -318,7 +318,7 @@ The operation may run for several minutes.
 
 ### Recovery Services limitations
 
- To move a Recovery Services vault, you must enroll in a [limited public preview](../backup/backup-azure-move-recovery-services-vault.md).
+ To move a Recovery Services vault, follow these steps: [Move resources to new resource group or subscription](../backup/backup-azure-move-recovery-services-vault.md).
 
 Currently, you can move one Recovery Services vault, per region, at a time. You can't move vaults that back up Azure Files, Azure File Sync, or SQL in IaaS virtual machines.
 


### PR DESCRIPTION
Removing wording about "limited Public Preview" since this feature is already GA.

Announcing Azure Backup support to move Recovery Services vaults across subscriptions and resource groups
https://azure.microsoft.com/en-us/updates/azure-backup-support-to-move-recovery-services-vaults/
Tuesday, April 16, 2019: GA support for move functionality for recovery services vaults where you can migrate a vault between subscriptions and resource groups