### PR TITLE
Fix capitalization in Azure SQL TOC

### DIFF
--- a/articles/sql-database/toc.yml
+++ b/articles/sql-database/toc.yml
@@ -51,7 +51,7 @@
       href: sql-database-connect-query-vscode.md
     - name: .NET with Visual Studio
       href: sql-database-connect-query-dotnet-visual-studio.md
-    - name: .NET core
+    - name: .NET Core
       href: sql-database-connect-query-dotnet-core.md
     - name: .NET with Active Directory MFA
       href: active-directory-interactive-connect-azure-sql-db.md


### PR DESCRIPTION
Just a quick fix to update ".NET core" to ".NET Core" in Quickstarts -> Query