### PR TITLE
Add limitation to the list

### DIFF
--- a/articles/sql-database/sql-database-sync-data.md
+++ b/articles/sql-database/sql-database-sync-data.md
@@ -123,6 +123,7 @@ Provisioning and deprovisioning during sync group creation, update, and deletion
 - The names of objects (databases, tables, and columns) cannot contain the printable characters period (.), left square bracket ([), or right square bracket (]).
 - Azure Active Directory authentication is not supported.
 - Tables with same name but different schema (for example, dbo.customers and sales.customers) are not supported.
+- Columns with User Defined Data Types are not supported
 
 #### Unsupported data types
 


### PR DESCRIPTION
Adding the limitation: Columns with User Defined Data Types are not supported
There is open feedback about this topic:
https://feedback.azure.com/forums/908035-sql-server/suggestions/32900872-allow-columns-with-user-defined-data-types-to-be-i
At this time Microsoft team review this option. In the mean time people ask about this in the MSDN forums and since it was not yet documented they present it as a bug.