### PR TITLE
Update resource-group-move-resources.md

### DIFF
--- a/articles/azure-resource-manager/resource-group-move-resources.md
+++ b/articles/azure-resource-manager/resource-group-move-resources.md
@@ -163,6 +163,7 @@ The following scenarios aren't yet supported:
 * Virtual Machines with certificate stored in Key Vault can be moved to a new resource group in the same subscription, but not across subscriptions.
 * Virtual Machine Scale Sets with Standard SKU Load Balancer or Standard SKU Public IP can't be moved.
 * Virtual machines created from Marketplace resources with plans attached can't be moved across resource groups or subscriptions. Deprovision the virtual machine in the current subscription, and deploy again in the new subscription.
+* Virtual machines in an existing Virtual Network where the user does not intend to move all resources in the Virtual Network.
 
 To move virtual machines configured with Azure Backup, use the following workaround:
 


### PR DESCRIPTION
You can't move a virtual machine using the Portal if that VM is in a virtual network with other resources (and you are not moving all resource including the virtual network). Attempting to do so results in validation errors.