### PR TITLE
Missing line continuation in azcli snippet

### DIFF
--- a/articles/load-balancer/quickstart-load-balancer-standard-public-cli.md
+++ b/articles/load-balancer/quickstart-load-balancer-standard-public-cli.md
@@ -230,9 +230,9 @@ for i in `seq 1 2`; do
     --nics myNic$i \
     --image UbuntuLTS \
     --generate-ssh-keys \
-    --custom-data cloud-init.txt
+    --custom-data cloud-init.txt \
     --no-wait
-    done
+done
 ```
 It may take a few minutes for the VMs to get deployed.
 


### PR DESCRIPTION
The "Create the virtual machines with az vm create." CLI snippet is missing a line continuation character on line 223 which causes an error if you run it. Also removed the indented spaces in front of the "done" command to line up with the "for" command.