### PR TITLE
Suggest to fix TimeSpan parsing

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -288,7 +288,7 @@ Expressed as a string, the `TimeSpan` format is `hh:mm:ss` when `hh` is less tha
 |"01:00:00" | every hour        |
 |"00:01:00"|every minute         |
 |"24:00:00" | every 24 days        |
-|"1:00:00:00:00" | everyday |
+|"1.00:00:00" | every day        |
 |"1" | everyday |
 
 ## Scale-out

--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -289,7 +289,6 @@ Expressed as a string, the `TimeSpan` format is `hh:mm:ss` when `hh` is less tha
 |"00:01:00"|every minute         |
 |"24:00:00" | every 24 days        |
 |"1.00:00:00" | every day        |
-|"1" | everyday |
 
 ## Scale-out
 

--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -287,7 +287,9 @@ Expressed as a string, the `TimeSpan` format is `hh:mm:ss` when `hh` is less tha
 |---------|---------|
 |"01:00:00" | every hour        |
 |"00:01:00"|every minute         |
-|"24:00:00" | everyday        |
+|"24:00:00" | every 24 days        |
+|"1:00:00:00:00" | everyday |
+|"1" | everyday |
 
 ## Scale-out
 


### PR DESCRIPTION
I'm sorry for that I have not try it on REAL Azure.
If it implemented by [.NET TimeSpan.Parse](https://docs.microsoft.com/en-us/dotnet/api/system.timespan.parse), `24:00:00` seems to be _24_ days.