### PR TITLE
Fix typo

### DIFF
--- a/articles/data-factory/v1/data-factory-hive-activity.md
+++ b/articles/data-factory/v1/data-factory-hive-activity.md
@@ -80,7 +80,7 @@ The HDInsight Hive activity in a Data Factory [pipeline](data-factory-create-pip
 | outputs |Outputs produced by the Hive activity |Yes |
 | linkedServiceName |Reference to the HDInsight cluster registered as a linked service in Data Factory |Yes |
 | script |Specify the Hive script inline |No |
-| script path |Store the Hive script in an Azure blob storage and provide the path to the file. Use 'script' or 'scriptPath' property. Both cannot be used together. The file name is case-sensitive. |No |
+| scriptPath |Store the Hive script in an Azure blob storage and provide the path to the file. Use 'script' or 'scriptPath' property. Both cannot be used together. The file name is case-sensitive. |No |
 | defines |Specify parameters as key/value pairs for referencing within the Hive script using 'hiveconf' |No |
 
 ## Example


### PR DESCRIPTION
```
    "linkedServiceName": "MyHDInsightLinkedService",
    "typeProperties": {
      "script": "Hive script",
      "scriptPath": "<pathtotheHivescriptfileinAzureblobstorage>", ← scriptPath, Not script path
      "defines": {
        "param1": "param1Value"
      }
    },
```