### PR TITLE
Machines can be referenced in multiple recovery plans

### DIFF
--- a/articles/site-recovery/recovery-plan-overview.md
+++ b/articles/site-recovery/recovery-plan-overview.md
@@ -14,8 +14,7 @@ ms.author: raynew
 
 This article describes recovery plans in [Azure Site Recovery](site-recovery-overview.md).
 
-A recovery plan gathers machines into recovery groups. You can customize a plan by adding order, instructions, and tasks to it. After a plan is defined, you can run a failover on it.
-
+A recovery plan gathers machines into recovery groups. You can customize a plan by adding order, instructions, and tasks to it. After a plan is defined, you can run a failover on it.  Machines can be referenced in multiple Recovery Plans, in which subsequent plans will skip the deployment/startup of the machine if it was previously deployed via another recovery plan.
 
 
 ## Why use a recovery plan?


### PR DESCRIPTION
Adding verbiage that machines can be referenced in multiple recovery plans.  If a machine was previously deployed via another recovery plan, the item will be skipped in the second plan.