### PR TITLE
Adds note Search-AzGraph defaults to Subscriptions

### DIFF
--- a/articles/governance/resource-graph/first-query-powershell.md
+++ b/articles/governance/resource-graph/first-query-powershell.md
@@ -98,12 +98,12 @@ the results returned will be consistent and as expected -- ordered by the **Name
 still limited to the top five results.
 
 > [!NOTE]
-   > If the query does not return results from a subscription you already have access to, then note that
-   > `Search-AzGraph` cmdlet defaults to subscriptions in the default context. To see the list of subscription ids
-   > which are part of the default context run this `(Get-AzContext).Account.ExtendedProperties.Subscriptions`
-   > If you wish to search across all the subscriptions you have access to, one can set the PSDefaultParameterValues for
-   > `Search-AzGraph' cmdlet by running 
-   > `$PSDefaultParameterValues=@{"Search-AzGraph:Subscription"= $(Get-AzSubscription).ID }`
+> If the query does not return results from a subscription you already have access to, then note that
+> `Search-AzGraph` cmdlet defaults to subscriptions in the default context. To see the list of subscription ids
+> which are part of the default context run this `(Get-AzContext).Account.ExtendedProperties.Subscriptions`
+> If you wish to search across all the subscriptions you have access to, one can set the PSDefaultParameterValues for
+> `Search-AzGraph' cmdlet by running 
+> `$PSDefaultParameterValues=@{"Search-AzGraph:Subscription"= $(Get-AzSubscription).ID }`
    
 ## Clean up resources
 

--- a/articles/governance/resource-graph/first-query-powershell.md
+++ b/articles/governance/resource-graph/first-query-powershell.md
@@ -97,6 +97,14 @@ When the final query is run several times, assuming that nothing in your environ
 the results returned will be consistent and as expected -- ordered by the **Name** property, but
 still limited to the top five results.
 
+> [!NOTE]
+   > If the query does not return results from a subscription you already have access to, then note that
+   > `Search-AzGraph` cmdlet defaults to subscriptions in the default context. To see the list of subscription ids
+   > which are part of the default context run this `(Get-AzContext).Account.ExtendedProperties.Subscriptions`
+   > If you wish to search across all the subscriptions you have access to, one can set the PSDefaultParameterValues for
+   > `Search-AzGraph' cmdlet by running 
+   > `$PSDefaultParameterValues=@{"Search-AzGraph:Subscription"= $(Get-AzSubscription).ID }`
+   
 ## Clean up resources
 
 If you wish to remove the Resource Graph module from your Azure PowerShell environment, you can do


### PR DESCRIPTION
Added a note about how Search-AzGraph defaults to Subscriptions in the default context.
Also, added a one-liner to make it search across all the subscriptions using PSDefaultParameterValues.