### PR TITLE
Explain why price included in the input

### DIFF
--- a/articles/machine-learning/service/ui-tutorial-automobile-price-deploy.md
+++ b/articles/machine-learning/service/ui-tutorial-automobile-price-deploy.md
@@ -103,7 +103,7 @@ You can test a web service in the web service tab in the visual interface.
 
     ![Screenshot showing the web service testing page](./media/ui-tutorial-automobile-price-deploy/web-service-test.png)
 
-1. Input testing data or use the autofilled sample data and select **Test** at the bottom. The test request is submitted to the web service and the results are shown on page.
+1. Input testing data or use the autofilled sample data and select **Test** at the bottom. The test request is submitted to the web service and the results are shown on page. A price value is generated for the input data, but it will not be used to generate the prediction.
 
 ## Manage the web service
 


### PR DESCRIPTION
User feedback showed concern about an input price value being used to predict an output price value. This clarifies that input price is not used.