### PR TITLE
Including language around UDR support for V2 SKU

### DIFF
--- a/articles/application-gateway/configuration-overview.md
+++ b/articles/application-gateway/configuration-overview.md
@@ -70,7 +70,7 @@ For the v1 SKU, user-defined routes (UDRs) are supported on the Application Gate
 For the v2 SKU, UDRs are not supported on the Application Gateway subnet. For more information, see [Azure Application Gateway v2 SKU](application-gateway-autoscaling-zone-redundant.md#differences-with-v1-sku).
 
 > [!NOTE]
-> UDRs will not be supported for the v2 SKU at General Availability.  If you require UDRs you should continue to deploy v1 SKU.
+> UDRs will not be supported for the v2 SKU.  If you require UDRs you should continue to deploy v1 SKU.
 
 > [!NOTE]
 > Using UDRs on the Application Gateway subnet causes the health status in the [back-end health view](https://docs.microsoft.com/azure/application-gateway/application-gateway-diagnostics#back-end-health) to appear as "Unknown." It also causes generation of Application Gateway logs and metrics to fail. We recommend that you don't use UDRs on the Application Gateway subnet so that you can view the back-end health, logs, and metrics.

--- a/articles/application-gateway/configuration-overview.md
+++ b/articles/application-gateway/configuration-overview.md
@@ -70,7 +70,7 @@ For the v1 SKU, user-defined routes (UDRs) are supported on the Application Gate
 For the v2 SKU, UDRs are not supported on the Application Gateway subnet. For more information, see [Azure Application Gateway v2 SKU](application-gateway-autoscaling-zone-redundant.md#differences-with-v1-sku).
 
 > [!NOTE]
-> UDRs will not be supported for the v2 SKU.  If you require UDRs you should continue to deploy v1 SKU.
+> UDRs are not supported for the v2 SKU.  If you require UDRs you should continue to deploy v1 SKU.
 
 > [!NOTE]
 > Using UDRs on the Application Gateway subnet causes the health status in the [back-end health view](https://docs.microsoft.com/azure/application-gateway/application-gateway-diagnostics#back-end-health) to appear as "Unknown." It also causes generation of Application Gateway logs and metrics to fail. We recommend that you don't use UDRs on the Application Gateway subnet so that you can view the back-end health, logs, and metrics.

--- a/articles/application-gateway/configuration-overview.md
+++ b/articles/application-gateway/configuration-overview.md
@@ -67,7 +67,10 @@ For this scenario, use NSGs on the Application Gateway subnet. Put the following
 
 For the v1 SKU, user-defined routes (UDRs) are supported on the Application Gateway subnet, as long as they don't alter end-to-end request/response communication. For example, you can set up a UDR in the Application Gateway subnet to point to a firewall appliance for packet inspection. But you must make sure that the packet can reach its intended destination after inspection. Failure to do so might result in incorrect health-probe or traffic-routing behavior. This includes learned routes or default 0.0.0.0/0 routes that are propagated by Azure ExpressRoute or VPN gateways in the virtual network.
 
-For the v2 SKU, UDRs aren't supported on the Application Gateway subnet. For more information, see [Azure Application Gateway v2 SKU](application-gateway-autoscaling-zone-redundant.md#differences-with-v1-sku).
+For the v2 SKU, UDRs are not supported on the Application Gateway subnet. For more information, see [Azure Application Gateway v2 SKU](application-gateway-autoscaling-zone-redundant.md#differences-with-v1-sku).
+
+> [!NOTE]
+> UDRs will not be supported for the v2 SKU at General Availability.  If you require UDRs you should continue to deploy v1 SKU.
 
 > [!NOTE]
 > Using UDRs on the Application Gateway subnet causes the health status in the [back-end health view](https://docs.microsoft.com/azure/application-gateway/application-gateway-diagnostics#back-end-health) to appear as "Unknown." It also causes generation of Application Gateway logs and metrics to fail. We recommend that you don't use UDRs on the Application Gateway subnet so that you can view the back-end health, logs, and metrics.


### PR DESCRIPTION
The question around "why doesn't V2 sku support UDR" has been asked more than one time at the partner level, in discussions with Microsoft.  Each time someone references this document, and someone from PM states it's on a backlog.  We can't really depend on that statement here.  The effort is to clarify for folks that UDRs are not supported at General Availability, which hopefully leads one to believe that it is possible the support will show up post-GA, and instead ask the question of when.  Rather than reading the statement as finite, that it is not supported and no one is working on bringing it to v2 SKU.  The note below it states why using UDRs is not a good practice if you want back-end health, logs, and metrics, but people will do what the system allows, at their level of risk acceptance. 

This also makes the statement that if you require UDR you shouldn't move to v2 (with the expectation that support will show up any time soon).  That you should continue with v1.  This would be the correct "practice" for customers until public committments of support are made by Microsoft.