### PR TITLE
fix request unit sample for cassandra

### DIFF
--- a/articles/cosmos-db/find-request-unit-charge.md
+++ b/articles/cosmos-db/find-request-unit-charge.md
@@ -1,11 +1,11 @@
 ---
-title: Fixing request unit (RU) sample for cassandra
-description: Cassandra has a different endianness on the request unit byte buffer so you need to invert it before
-author: bitcloud
+title: Find the request unit (RU) charge in Azure Cosmos DB
+description: Learn how to find the request unit (RU) charge for any operation executed against an Azure Cosmos container.
+author: ThomasWeiss
 ms.service: cosmos-db
 ms.topic: sample
-ms.date: 05/30/2019
-ms.author: ThomasWeiss
+ms.date: 05/23/2019
+ms.author: thweiss
 ---
 # Find the request unit charge in Azure Cosmos DB
 

--- a/articles/cosmos-db/find-request-unit-charge.md
+++ b/articles/cosmos-db/find-request-unit-charge.md
@@ -1,19 +1,11 @@
 ---
-title: Find the request unit (RU) charge in Azure Cosmos DB
-description: Learn how to find the request unit (RU) charge for any operation executed against an Azure Cosmos container.
-author: ThomasWeiss
-ms.service: cosmos-db
-ms.topic: sample
-ms.date: 05/23/2019
-ms.author: thweiss
----
 title: Fixing request unit (RU) sample for cassandra
 description: Cassandra has a different endianness on the request unit byte buffer so you need to invert it before
 author: bitcloud
 ms.service: cosmos-db
 ms.topic: sample
 ms.date: 05/30/2019
-ms.author: bitcloud
+ms.author: ThomasWeiss
 ---
 # Find the request unit charge in Azure Cosmos DB
 

--- a/articles/cosmos-db/find-request-unit-charge.md
+++ b/articles/cosmos-db/find-request-unit-charge.md
@@ -7,7 +7,14 @@ ms.topic: sample
 ms.date: 05/23/2019
 ms.author: thweiss
 ---
-
+title: Fixing request unit (RU) sample for cassandra
+description: Cassandra has a different endianness on the request unit byte buffer so you need to invert it before
+author: bitcloud
+ms.service: cosmos-db
+ms.topic: sample
+ms.date: 05/30/2019
+ms.author: bitcloud
+---
 # Find the request unit charge in Azure Cosmos DB
 
 This article presents the different ways you can find the [request unit](request-units.md) (RU) consumption for any operation executed against a container in Azure Cosmos DB. Currently, you can measure this consumption only by using the Azure portal or by inspecting the response sent back from Azure Cosmos DB through one of the SDKs.
@@ -226,7 +233,7 @@ When you use the [.NET SDK](https://www.nuget.org/packages/CassandraCSharpDriver
 
 ```csharp
 RowSet rowSet = session.Execute("SELECT table_name FROM system_schema.tables;");
-double requestCharge = BitConverter.ToDouble(rowSet.Info.IncomingPayload["RequestCharge"], 0);
+double requestCharge = BitConverter.ToDouble(rowSet.Info.IncomingPayload["RequestCharge"].Reverse().ToArray(), 0);
 ```
 
 For more information, see [Quickstart: Build a Cassandra app by using the .NET SDK and Azure Cosmos DB](create-cassandra-dotnet.md).


### PR DESCRIPTION
Cassandra has a different endianness on the request unit byte buffer so you need to invert it before.

I don't know if there is an easy way to propagate those changes to the other translations, but I guess you probably have some tooling for that ;-)