### PR TITLE
Remove spaces in Azure CLI install example

### DIFF
--- a/articles/virtual-machines/extensions/oms-linux.md
+++ b/articles/virtual-machines/extensions/oms-linux.md
@@ -188,8 +188,8 @@ az vm extension set \
   --vm-name myVM \
   --name OmsAgentForLinux \
   --publisher Microsoft.EnterpriseCloud.Monitoring \
-  --version 1.7 --protected-settings '{"workspaceKey": "omskey"}' \
-  --settings '{"workspaceId": "omsid"}'
+  --version 1.10.1 --protected-settings '{"workspaceKey":"omskey"}' \
+  --settings '{"workspaceId":"omsid"}'
 ```
 
 ## Troubleshoot and support


### PR DESCRIPTION
When running the command from a CMD prompt in Windows, there need to be no spaces in the JSON values for --settings and --protected-settings or the command will fail. Remove the spaces from the example in the documentation. See [this issue](https://github.com/MicrosoftDocs/azure-docs/issues/20073) for more info.

Also, update the example version to latest OMS release.