### PR TITLE
Move HTTP2 service Information to the top

### DIFF
--- a/articles/frontdoor/front-door-http2.md
+++ b/articles/frontdoor/front-door-http2.md
@@ -14,6 +14,9 @@ ms.author: sharadag
 ---
 
 # HTTP/2 support in Azure Front Door Service
+
+Currently, HTTP/2 support is active for all Front Door configurations. No further action is required from customers.
+
 HTTP/2 is a major revision to HTTP/1.1. It provides faster web performance, reduced response time, and improved user experience, while maintaining the familiar HTTP methods, status codes, and semantics. Though HTTP/2 is designed to work with HTTP and HTTPS, many client web browsers only support HTTP/2 over Transport Layer Security (TLS).
 
 ### HTTP/2 benefits
@@ -44,10 +47,6 @@ All of the major browsers have implemented HTTP/2 support in their current versi
 |Mozilla Firefox| 38|
 |Opera| 32|
 |Safari| 9|
-
-## Enabling HTTP/2 support in Azure Front Door Service
-
-Currently, HTTP/2 support is active for all Front Door configurations. No further action is required from customers.
 
 ## Next Steps
 


### PR DESCRIPTION
I was looking for this exact information today and surprised to see that the most important info is the last paragraph. I think the doc should lead with the service information about HTTP2 that matches the title