### PR TITLE
Fix "hotels" index creation URL

### DIFF
--- a/articles/search/search-fiddler.md
+++ b/articles/search/search-fiddler.md
@@ -68,13 +68,13 @@ In Postman, formulate a request that looks like the following screenshot. Choose
 
 In Azure Search, you usually create the index before loading it with data. The [Create Index REST API](https://docs.microsoft.com/rest/api/searchservice/create-index) is used for this task. 
 
-The URL is extended to include the `hotel` index name.
+The URL is extended to include the `hotels` index name.
 
 To do this in Postman:
 
 1. Change the verb to **PUT**.
 
-2. Copy in this URL `https://<YOUR-SEARCH-SERVICE-NAME>.search.windows.net/indexes/hotel?api-version=2019-05-06`.
+2. Copy in this URL `https://<YOUR-SEARCH-SERVICE-NAME>.search.windows.net/indexes/hotels?api-version=2019-05-06`.
 
 3. Provide the index definition (shown below) in the body of the request.
 
@@ -252,7 +252,7 @@ For the target, copy in a modified version of this URL: `https://<YOUR-SEARCH-SE
 
 ### 1 - Create an index
 
-Change the verb to **PUT**. Copy in a modified version of this URL: `https://<YOUR-SEARCH-SERVICE-NAME>.search.windows.net/indexes/hotel?api-version=2019-05-06`. Copy the index definition provided above to the request body. Your page should look similar to the following screenshot. Click **Execute** on the top right to send the completed request.
+Change the verb to **PUT**. Copy in a modified version of this URL: `https://<YOUR-SEARCH-SERVICE-NAME>.search.windows.net/indexes/hotels?api-version=2019-05-06`. Copy the index definition provided above to the request body. Your page should look similar to the following screenshot. Click **Execute** on the top right to send the completed request.
 
 ![Fiddler request body][7]
 


### PR DESCRIPTION
In the body the name is "hotels" but in the request URL "hotel". 
This cases the request to fail with 400 BadRequest: "The index name 'hotel' in the request payload does not match the name 'hotels' in the request URL."

Changed it to be "hotels" everywhere.