### PR TITLE
Update schema-cscfg-networkconfiguration.md

### DIFF
--- a/articles/cloud-services/schema-cscfg-networkconfiguration.md
+++ b/articles/cloud-services/schema-cscfg-networkconfiguration.md
@@ -44,7 +44,7 @@ The following example shows the `NetworkConfiguration` element and its child ele
         <DnsServer name="<server-name>" IPAddress="<server-address>" />
       </DnsServers>
     </Dns>
-    <VirtualNetworkSite name="<site-name>"/>
+    <VirtualNetworkSite name="Group <RG-VNet> <VNet-name>"/>
     <AddressAssignments>
       <InstanceAddress roleName="<role-name>">
         <Subnets>


### PR DESCRIPTION
VirtualNetworkSite element is written as : <VirtualNetworkSite name="<site-name>"/>

whereas it is supposed to be like : <VirtualNetworkSite name="Group <RG-Name-VNet> <VNET-Name>"/>