### PR TITLE
fix: Replace invalid characters in TOC

### DIFF
--- a/articles/active-directory/saas-apps/toc.yml
+++ b/articles/active-directory/saas-apps/toc.yml
@@ -181,7 +181,7 @@
         href: box-tutorial.md
       - name: Boxcryptor
         href: boxcryptor-tutorial.md
-      - name: Bpmâonline
+      - name: Bpm’online
         href: bpmonline-tutorial.md
       - name: Brandfolder
         href: brandfolder-tutorial.md
@@ -439,7 +439,7 @@
         href: floqast-tutorial.md
       - name: Fluxx Labs
         href: fluxxlabs-tutorial.md
-      - name: FM:Systems
+      - name: FM&#58Systems
         href: fm-systems-tutorial.md
       - name: Folloze
         href: folloze-tutorial.md
@@ -565,7 +565,7 @@
         href: infogix-tutorial.md
       - name: Infor CloudSuite
         href: infor-cloud-suite-tutorial.md
-      - name: Infor Retail â Information Management
+      - name: Infor Retail - Information Management
         href: inforretailinformationmanagement-tutorial.md
       - name: Inkling
         href: inkling-tutorial.md


### PR DESCRIPTION

- First was an appostrphe in the original title
- Colons can't be used even in quotes, so HTML encoded
- Third was a dash in original title