### PR TITLE
Fixing link to Visual C++ packages

### DIFF
--- a/articles/cognitive-services/Speech-Service/ship-application.md
+++ b/articles/cognitive-services/Speech-Service/ship-application.md
@@ -25,8 +25,8 @@ The Cognitive Services Speech SDK is tested on Windows 10 and on Windows Server 
 
 The Cognitive Services Speech SDK requires the [Microsoft Visual C++ Redistributable for Visual Studio 2019](https://support.microsoft.com/help/2977003/the-latest-supported-visual-c-downloads) on the system. You can download installers for the latest version of the `Microsoft Visual C++ Redistributable for Visual Studio 2019` here:
 
-- [Win32](https://aka.ms/vs/15/release/vc_redist.x86.exe)
-- [x64](https://aka.ms/vs/15/release/vc_redist.x64.exe)
+- [Win32](https://aka.ms/vs/16/release/vc_redist.x86.exe)
+- [x64](https://aka.ms/vs/16/release/vc_redist.x64.exe)
 
 If your application uses managed code, the `.NET Framework 4.6.1` or later is required on the target machine.
 


### PR DESCRIPTION
Links were not pointing in the right version of the packages