### PR TITLE
update local-deploy script section

### DIFF
--- a/articles/machine-learning/service/how-to-troubleshoot-deployment.md
+++ b/articles/machine-learning/service/how-to-troubleshoot-deployment.md
@@ -160,12 +160,12 @@ If you encounter problems deploying a model to ACI or AKS, try deploying it as a
 To deploy locally, modify your code to use `LocalWebservice.deploy_configuration()` to create a deployment configuration. Then use `Model.deploy()` to deploy the service. The following example deploys a model (contained in the `model` variable) as a local web service:
 
 ```python
-from azureml.core.model import InferenceConfig
+from azureml.core.model import InferenceConfig,Model
 from azureml.core.webservice import LocalWebservice
 
 # Create inference configuration. This creates a docker image that contains the model.
 inference_config = InferenceConfig(runtime= "python", 
-                                   execution_script="score.py",
+                                   entry_script="score.py",
                                    conda_file="myenv.yml")
 
 # Create a local deployment, using port 8890 for the web service endpoint


### PR DESCRIPTION
Minor PR that updates local deploy script with latest SDK
     InferenceConfig constructor, execution_script has been rename to entry_script

Import Model missing, from azureml.core.model import InferenceConfig,Model for sample to be self contained