### PR TITLE
Remove an extra space in resources key

### DIFF
--- a/articles/service-bus-messaging/service-bus-resource-manager-namespace-topic.md
+++ b/articles/service-bus-messaging/service-bus-resource-manager-namespace-topic.md
@@ -95,7 +95,7 @@ The Service Bus API version of the template.
 Creates a standard Service Bus namespace of type **Messaging**, with topic and subscription.
 
 ```json
-"resources ": [{
+"resources": [{
         "apiVersion": "[variables('sbVersion')]",
         "name": "[parameters('serviceBusNamespaceName')]",
         "type": "Microsoft.ServiceBus/Namespaces",


### PR DESCRIPTION
The resouces key has an extra space in it, that it should not. Proposing to take this out.