### PR TITLE
Fix nonunified

### DIFF
--- a/articles/lab-services/add-artifact-repository.md
+++ b/articles/lab-services/add-artifact-repository.md
@@ -17,7 +17,7 @@ ms.author: spelluru
 
 ---
 # Add an artifact repository to your lab in DevTest Labs
-DevTest Labs allows you to specify an artifact to be added to a VM at the time of creating the VM or after the VM is created. This artifact could be a tool or an application that you want to install on the VM. Artifacts are defined in a JSON file loaded from a GitHub or VSTS Git repository. 
+DevTest Labs allows you to specify an artifact to be added to a VM at the time of creating the VM or after the VM is created. This artifact could be a tool or an application that you want to install on the VM. Artifacts are defined in a JSON file loaded from a GitHub or Azure DevOps Git repository. 
 
 The [public artifact repository](https://github.com/Azure/azure-devtestlab/tree/master/Artifacts), maintained by DevTest Labs, provides many common tools for both Windows and Linux. A link to this repository is automatically added to your lab. You can create your own artifact repository with specific tools that aren't available in the public artifact repository. To learn about creating custom artifacts, see [Create custom artifacts](devtest-lab-artifact-author.md).
 


### PR DESCRIPTION
The previous name (Visual Studio Team Services, VSTS) and the new name (Azure DevOps) are mixed in this file. So, I unified it into a new name.