### PR TITLE
Fix nonunified

### DIFF
--- a/articles/marketplace/cloud-partner-portal/azure-applications/cpp-handling-review-feedback.md
+++ b/articles/marketplace/cloud-partner-portal/azure-applications/cpp-handling-review-feedback.md
@@ -13,14 +13,14 @@ ms.author: pabutler
 
 This article explains how to access the Azure DevOps environment used by the Microsoft Azure Marketplace review team.  If critical issues are found in your Azure application offer during the **Microsoft review** step, you can sign into this system to view detailed information about these issues (review feedback).  After you fix all these issues, you must resubmit your offer to continue to publish it on the Azure Marketplace.  The following diagram illustrates how this feedback process relates to the publishing process.
 
-![Publishing steps with VSTS feedback](./media/pub-flow-vsts-access.png)
+![Publishing steps with Azure DevOps feedback](./media/pub-flow-vsts-access.png)
 
 Typically, review issues are referenced as pull request (PR).  Each PR is linked to an online [Azure DevOps](https://azure.microsoft.com/services/devops/) (previously named Visual Studio Team Services (VSTS)) item, which contains details about the issue.  The following image displays an example of a review PR reference.  For complex situations, the review and support teams may also email you. 
 
 ![Status tab displaying review feedback](./media/status-tab-ms-review.png)
 
 
-## VSTS access
+## Azure DevOps access
 
 To view the PR items referenced in review feedback, publishers must first be granted proper authorization.  Otherwise, new publishers receive a `401 - Not Authorized` response page when trying to view PRs.  To request access to this Azure DevOps repository, perform the following steps:
 
@@ -35,7 +35,7 @@ To view the PR items referenced in review feedback, publishers must first be gra
     ![Support ticket category](./media/support-incident1.png)
 
 4. In **Step 1 of 2** page, supply your contact information and select **Continue**.
-5. In **Step 2 of 2** page, specify an incident title (for example `Request VSTS access`) and supply the information you collected in the first step (above).  Read and accept the agreement, then select **Submit**.
+5. In **Step 2 of 2** page, specify an incident title (for example `Request Azure DevOps access`) and supply the information you collected in the first step (above).  Read and accept the agreement, then select **Submit**.
 
 If the incident creation was successful, a confirmation page is displayed.  Save the confirmation information on this page for your reference.  The Microsoft Support Team should reply to your access request within a few business days.
 


### PR DESCRIPTION
The previous name (Visual Studio Team Services, VSTS) and the new name (Azure DevOps) are mixed in this file. So, I unified it into a new name.