### PR TITLE
Add host caching description about "None"

### DIFF
--- a/includes/virtual-machines-common-premium-storage-performance.md
+++ b/includes/virtual-machines-common-premium-storage-performance.md
@@ -287,7 +287,7 @@ By configuring ReadOnly caching on Premium Storage data disks, you can achieve l
 By default, the OS disks have ReadWrite caching enabled. We have recently added support for ReadWrite caching on data disks as well. If you are using ReadWrite caching, you must have a proper way to write the data from cache to persistent disks. For example, SQL Server handles writing cached data to the persistent storage disks on its own. Using ReadWrite cache with an application that does not handle persisting the required data can lead to data loss, if the VM crashes.
 
 *None*  
-Currently, **None** is only supported on data disks. It is not supported on OS disks, if you set **None** on an OS disk it will override this internally and set it to **ReadOnly**.
+Currently, **None** is only supported on data disks. It is not supported on OS disks. If you set **None** on an OS disk it will override this internally and set it to **ReadOnly**.
 
 As an example, you can apply these guidelines to SQL Server running on Premium Storage by doing the following,
 

--- a/includes/virtual-machines-common-premium-storage-performance.md
+++ b/includes/virtual-machines-common-premium-storage-performance.md
@@ -287,7 +287,7 @@ By configuring ReadOnly caching on Premium Storage data disks, you can achieve l
 By default, the OS disks have ReadWrite caching enabled. We have recently added support for ReadWrite caching on data disks as well. If you are using ReadWrite caching, you must have a proper way to write the data from cache to persistent disks. For example, SQL Server handles writing cached data to the persistent storage disks on its own. Using ReadWrite cache with an application that does not handle persisting the required data can lead to data loss, if the VM crashes.
 
 *None*  
-In currently, None is only supported on the data disks. It is not supported on the OS disks. Also, the caching setting is overridden internally to ReadOnly if set None on the OS disks.
+Currently, **None** is only supported on data disks. It is not supported on OS disks, if you set **None** on an OS disk it will override this internally and set it to **ReadOnly**.
 
 As an example, you can apply these guidelines to SQL Server running on Premium Storage by doing the following,
 

--- a/includes/virtual-machines-common-premium-storage-performance.md
+++ b/includes/virtual-machines-common-premium-storage-performance.md
@@ -286,6 +286,9 @@ By configuring ReadOnly caching on Premium Storage data disks, you can achieve l
 *ReadWrite*  
 By default, the OS disks have ReadWrite caching enabled. We have recently added support for ReadWrite caching on data disks as well. If you are using ReadWrite caching, you must have a proper way to write the data from cache to persistent disks. For example, SQL Server handles writing cached data to the persistent storage disks on its own. Using ReadWrite cache with an application that does not handle persisting the required data can lead to data loss, if the VM crashes.
 
+*None*  
+In currently, None is only supported on the data disks. It is not supported on the OS disks. Also, the caching setting is overridden internally to ReadOnly if set None on the OS disks.
+
 As an example, you can apply these guidelines to SQL Server running on Premium Storage by doing the following,
 
 1. Configure "ReadOnly" cache on premium storage disks hosting data files.  


### PR DESCRIPTION
In currently, None is only supported on the data disks. It is not supported on the OS disks. Also, the caching setting is overridden internally to ReadOnly if set None on the OS disks.