### PR TITLE
Update vpn-gateway-faq-p2s-all-include.md

### DIFF
--- a/includes/vpn-gateway-faq-p2s-all-include.md
+++ b/includes/vpn-gateway-faq-p2s-all-include.md
@@ -34,11 +34,11 @@ The following client operating systems are supported:
 
 Azure supports three types of Point-to-site VPN options:
 
-* Secure Socket Tunneling Protocol (SSTP). SSTP is a Microsoft proprietary SSL-based solution that can penetrate firewalls since most firewalls open the TCP port that 443 SSL uses.
+* Secure Socket Tunneling Protocol (SSTP). SSTP is a Microsoft proprietary SSL-based solution that can penetrate firewalls since most firewalls open the outbound TCP port that 443 SSL uses.
 
-* OpenVPN. OpenVPN is a SSL-based solution that can penetrate firewalls since most firewalls open the TCP port that 443 SSL uses.
+* OpenVPN. OpenVPN is a SSL-based solution that can penetrate firewalls since most firewalls open the outbound TCP port that 443 SSL uses.
 
-* IKEv2 VPN. IKEv2 VPN is a standards-based IPsec VPN solution that uses UDP port 500 and 4500 and IP protocol no. 50. Firewalls do not always open these ports, so there is a possibility of IKEv2 VPN not being able to traverse proxies and firewalls.
+* IKEv2 VPN. IKEv2 VPN is a standards-based IPsec VPN solution that uses outbound UDP ports 500 and 4500 and IP protocol no. 50. Firewalls do not always open these ports, so there is a possibility of IKEv2 VPN not being able to traverse proxies and firewalls.
 
 ### If I restart a client computer configured for Point-to-Site, will the VPN automatically reconnect?
 


### PR DESCRIPTION
Clarified ambiguous verbiage around firewall port 443 for IKEv2 and OpenVPN P2S connection. Updated to explain that port 443 outbound access is needed.