### PR TITLE
Corrected typo in resource name

### DIFF
--- a/articles/container-instances/container-instances-managed-identity.md
+++ b/articles/container-instances/container-instances-managed-identity.md
@@ -150,7 +150,7 @@ az container exec --resource-group myResourceGroup --name mycontainer --exec-com
 Run the following commands in the bash shell in the container. To get an access token to use Azure Active Directory to authenticate to Key Vault, run the following command:
 
 ```bash
-curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net%2F' -H Metadata:true -s
+curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net' -H Metadata:true -s
 ```
 
 Output:


### PR DESCRIPTION
Resource name should not end with slash.
If the slash is present at the end of the resource, token will still be generated but all subsequent calls to vault API with this token will result in 401 HTTP Error