### PR TITLE
Remove powershell example for retrieving roleDefinitionIds

### DIFF
--- a/articles/governance/policy/how-to/remediate-resources.md
+++ b/articles/governance/policy/how-to/remediate-resources.md
@@ -60,10 +60,6 @@ the role. To get the ID for the 'Contributor' role in your environment, use the 
 az role definition list --name 'Contributor'
 ```
 
-```azurepowershell-interactive
-Get-AzRoleDefinition -Name 'Contributor'
-```
-
 ## Manually configure the managed identity
 
 When creating an assignment using the portal, Azure Policy both generates the managed identity and


### PR DESCRIPTION
The powershell command `Get-AzRoleDefinition` does not show the full resource identifier.