### PR TITLE
[Azure search] Note about storage account firewall

### DIFF
--- a/articles/search/search-indexer-troubleshooting.md
+++ b/articles/search/search-indexer-troubleshooting.md
@@ -30,14 +30,11 @@ Azure Storage provides a configurable firewall. By default, the firewall is disa
 
 There's no specific error message when the firewall is enabled. Typically, firewall errors look like `The remote server returned an error: (403) Forbidden`.
 
-You can verify that the firewall is enabled in the [portal](https://docs.microsoft.com/azure/storage/common/storage-network-security#azure-portal). If the firewall is enabled, you have two options for getting around this issue:
+You can verify that the firewall is enabled in the [portal](https://docs.microsoft.com/azure/storage/common/storage-network-security#azure-portal). The only supported workaround is to disable the firewall by choosing to allow access from ['All networks'](https://docs.microsoft.com/azure/storage/common/storage-network-security#azure-portal).
 
-1. Disable the firewall by choosing to allow access from ['All networks'](https://docs.microsoft.com/azure/storage/common/storage-network-security#azure-portal)
-1. [Add an exception](https://docs.microsoft.com/azure/storage/common/storage-network-security#managing-ip-network-rules) for the IP address of your search service. To find this IP address, use the following command:
+If your indexer does not have an attached skillset, you _may_ attempt to [add an exception](https://docs.microsoft.com/azure/storage/common/storage-network-security#managing-ip-network-rules) for the IP addresses of your search service. However, this scenario is not supported and is not guaranteed to work.
 
-`nslookup <service name>.search.windows.net`
-
-Exceptions don't work for [cognitive search](cognitive-search-concept-intro.md). The only workaround is to disable the firewall.
+You can find out the IP address of your search service by pinging its FQDN (`<your-search-service-name>.search.windows.net`).
 
 ### Cosmos DB
 


### PR DESCRIPTION
1. Correct the proposed troubleshooting steps when an indexer run fails due to storage account firewall
    * Only disabling the firewall is the actual supported/recommended step
2. Add a disclaimer about possibly adding exceptions to the search service IP addresses.
    * We've seen this work on some occasions but not others - therefore, warning customers that though this is a possible route, their mileage might vary