### PR TITLE
I think there is a syntax error here

### DIFF
--- a/articles/governance/blueprints/create-blueprint-rest-api.md
+++ b/articles/governance/blueprints/create-blueprint-rest-api.md
@@ -301,7 +301,7 @@ artifact.
                      "tags": {
                         "[parameters('tagNameFromBP')]": "[parameters('tagValueFromBP')]"
                      },
-                     "location": "[resourceGroups('storageRG').location]",
+                     "location": "[resourceGroup().location]",
                      "sku": {
                          "name": "[parameters('storageAccountTypeFromBP')]"
                      },


### PR DESCRIPTION
According to below document, 
https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-template-functions-resource#resourcegroup
The syntax of resourceGroup() is : 
"location": "[resourceGroup().location]",
"resources": [
   {
      "apiVersion": "2016-08-01",
      "type": "Microsoft.Web/sites",
      "name": "[parameters('siteName')]",
      "location": "[resourceGroup().location]",
      ...
   }
]

A common use of the resourceGroup function is to create resources in the same location as the resource group. The following example uses the resource group location to assign the location for a web site.



The specified template to create the blueprint fails due to this issue.