### PR TITLE
Health extension docs edited for Linux example.

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension.md
@@ -145,16 +145,25 @@ Update-AzVmss -ResourceGroupName $vmScaleSetResourceGroup `
 
 Use [az vmss extension set](/cli/azure/vmss/extension#az-vmss-extension-set) to add the Application Health extension to the scale set model definition.
 
-The following example adds the Application Health extension to the scale set model of a Windows-based scale set.
+The following example adds the Application Health extension to the scale set model of a Linux-based scale set.
 
 ```azurecli-interactive
 az vmss extension set \
-  --name ApplicationHealthWindows \
+  --name ApplicationHealthLinux \
   --publisher Microsoft.ManagedServices \
   --version 1.0 \
   --resource-group <myVMScaleSetResourceGroup> \
   --vmss-name <myVMScaleSet> \
   --settings ./extension.json
+```
+The extension.json file content.
+
+```json
+{
+  "protocol": "<protocol>",
+  "port": "<port>",
+  "requestPath": "</requestPath>"
+}
 ```
 
 


### PR DESCRIPTION
This section was not including Linux extension example and there was a lack of extension.json file contenat - which is far different from REST request body JSON. I have changed the example for Linux Extension and added an extension.json file content.