### PR TITLE
Minor tweak to initial description

### DIFF
--- a/articles/app-service/overview.md
+++ b/articles/app-service/overview.md
@@ -21,7 +21,7 @@ ms.custom: seodec18
 ---
 # App Service overview
 
-*Azure App Service* is a service for hosting web applications, REST APIs, and mobile back ends. You can develop in your favorite language, be it .NET, .NET Core, Java, Ruby, Node.js, PHP, or Python. Applications run and scale with ease on both Windows and Linux-based environments. For Linux-based environments, see [App Service on Linux](containers/app-service-linux-intro.md). 
+*Azure App Service* is an HTTP-based service for hosting web applications, REST APIs, and mobile back ends. You can develop in your favorite language, be it .NET, .NET Core, Java, Ruby, Node.js, PHP, or Python. Applications run and scale with ease on both Windows and Linux-based environments. For Linux-based environments, see [App Service on Linux](containers/app-service-linux-intro.md). 
 
 App Service not only adds the power of Microsoft Azure to your application, such as security, load balancing, autoscaling, and automated management. You can also take advantage of its DevOps capabilities, such as continuous deployment from Azure DevOps, GitHub, Docker Hub, and other sources, package management, staging environments, custom domain, and SSL certificates. 
 


### PR DESCRIPTION
Added verbiage indicating the service is an HTTP-based service since customer questions arise from time to time about whether App Service handles TCP/IP based traffic (which it doesn't).