### PR TITLE
Change naively to natively

### DIFF
--- a/articles/iot-hub/iot-hub-event-grid-routing-comparison.md
+++ b/articles/iot-hub/iot-hub-event-grid-routing-comparison.md
@@ -59,7 +59,7 @@ IoT Hub message routing and the IoT Hub integration with Event Grid perform diff
 
    IoT Hub message routing supports limited number of unique endpoints and endpoint types, but you can build connectors to reroute the data and events to additional endpoints. For a complete list of supported endpoints, see the table in the previous section. 
 
-   The IoT Hub integration with Event Grid supports 500 endpoints per IoT Hub and a larger variety of endpoint types. It naively integrates with Azure Functions, Logic Apps, Storage and Service Bus queues, and also works with webhooks to extend sending data outside of the Azure service ecosystem and into third-party business applications.
+   The IoT Hub integration with Event Grid supports 500 endpoints per IoT Hub and a larger variety of endpoint types. It natively integrates with Azure Functions, Logic Apps, Storage and Service Bus queues, and also works with webhooks to extend sending data outside of the Azure service ecosystem and into third-party business applications.
 
 * **Does it matter if your data arrives in order?**
 


### PR DESCRIPTION
The term "naively" has implications in English that I don't think are intended here, hinting at potentially a sub-standard integration. Use "natively" instead to indicate a smooth and feature-full integration.