### PR TITLE
Update allowed-locations.md

### DIFF
--- a/articles/governance/policy/samples/allowed-locations.md
+++ b/articles/governance/policy/samples/allowed-locations.md
@@ -96,7 +96,7 @@ $scope = Get-AzResourceGroup -Name 'YourResourceGroup'
 $policyparam = '{ "listOfAllowedLocations": { "value": [ "eastus2", "westus" ] } }'
 
 # Create the Policy Assignment
-$assignment = New-AzPolicyAssignment -Name 'allowed-locations-assignment' -DisplayName 'Allowed locations Assignment' -Scope $scope.ResourceId -PolicyDefinition $definition -PolicyParameter $policyparam
+$assignment = New-AzPolicyAssignment -Name "allowed-locations-assign" -DisplayName "Allowed locations Assignment" -Scope $scope.ResourceId -PolicyDefinition $definition -PolicyParameter $policyparam
 ```
 
 ### Remove with Azure PowerShell


### PR DESCRIPTION
New-AzPolicyAssignment fails if the Name is longer than 24.
"New-AzPolicyAssignment : InvalidPolicyAssignmentName : The policy assignment name 'allowed-locations-assignment' is invalid. The policy assignment name length must not exceed '24' characters."

The Portal allows the Name to be 128 long. I have created an iszsue for this:
https://github.com/Azure/azure-powershell/issues/9464