### PR TITLE
docs: rename load() to config()

### DIFF
--- a/articles/storage/blobs/storage-quickstart-blobs-nodejs-v10.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-nodejs-v10.md
@@ -95,7 +95,7 @@ Credentials are read from environment variables based on the appropriate context
 
 ```javascript
 if (process.env.NODE_ENV !== 'production') {
-    require('dotenv').load();
+    require('dotenv').config();
 }
 ```
 


### PR DESCRIPTION
the dotenv package recommends using `require('dotenv').config()`.
The `load()` method is undefined.