### PR TITLE
Updates for Speech Services GA

### DIFF
--- a/articles/azure-government/documentation-government-services-aiandcognitiveservices.md
+++ b/articles/azure-government/documentation-government-services-aiandcognitiveservices.md
@@ -82,7 +82,7 @@ Variations in Azure Government:
   Locales for the following languages are supported. 
   - English (United States) - en-us
 
-See details of supported locales by features in [Language and region support for the Speech Services](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). 
+See details of supported locales by features in [Language and region support for the Speech Services](https://docs.microsoft.com/azure/cognitive-services/speech-service/language-support). 
 
 ## Language
  

--- a/articles/azure-government/documentation-government-services-aiandcognitiveservices.md
+++ b/articles/azure-government/documentation-government-services-aiandcognitiveservices.md
@@ -61,6 +61,29 @@ Variations in Azure Government:
  
 For more information, see the [global Azure documentation](../cognitive-services/content-moderator/overview.md) and [Content Moderator API documentation](https://westus.dev.cognitive.microsoft.com/docs/services/57cf753a3f9b070c105bd2c1/operations/57cf753a3f9b070868a1f66c).
 
+## Speech
+
+### Speech Services
+
+Variations in Azure Government:
+
+- Endpoint:  https://virginia.stt.speech.azure.us
+- Auth Token Service: https://virginia.api.cognitive.microsoft.us/sts/v1.0/issueToken 
+- Available SKUs: S1
+- Supported features:
+  - Speech-to-Text 
+  - Custom Speech (Acoustic/language adaptation)
+  - Text-to-Speech 
+  - Speech Translator
+- Unsupported features
+  - Custom Voice
+  - Neural voices for Text-to-speech
+- Supported locales: 
+  Locales for the following languages are supported. 
+  - English (United States) - en-us
+
+See details of supported locales by features in [Language and region support for the Speech Services](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support). 
+
 ## Language
  
 ### Translator Text (Text Translation): 


### PR DESCRIPTION
Now, Speech Services is available in FairFax. Added a new section of "Speech" and "Speech Services" under it. For now, en-US is supported, but we'll add more locales by June 28. Once more locales are available, we'll update the locale list (we'll send another PR).