### PR TITLE
Correct outbound ports documentation for Virtual Machines

### DIFF
--- a/includes/batch-virtual-network-ports.md
+++ b/includes/batch-virtual-network-ports.md
@@ -69,7 +69,7 @@ You do not need to specify NSGs at the subnet level because Batch configures its
 
 | Source | Source ports | Destination | Destination service tag | Destination ports | Protocol | Action |
 | --- | --- | --- | --- | --- | --- | --- |
-| Any | * | [Service tag](../articles/virtual-network/security-overview.md#service-tags) | `Storage` (in the same region as your Batch account and VNet) | 443 | Any | Allow |
+| Any | * | [Service tag](../articles/virtual-network/security-overview.md#service-tags) | `Storage` (in the same region as your Batch account and VNet) | 443 | TCP | Allow |
 
 ### Pools in the Cloud Services configuration
 

--- a/includes/batch-virtual-network-ports.md
+++ b/includes/batch-virtual-network-ports.md
@@ -67,9 +67,9 @@ You do not need to specify NSGs at the subnet level because Batch configures its
 
 **Outbound security rules**
 
-| Source | Source ports | Destination | Destination service tag | Protocol | Action |
-| --- | --- | --- | --- | --- | --- |
-| Any | 443 | [Service tag](../articles/virtual-network/security-overview.md#service-tags) | `Storage` (in the same region as your Batch account and VNet)  | Any | Allow |
+| Source | Source ports | Destination | Destination service tag | Destination ports | Protocol | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| Any | * | [Service tag](../articles/virtual-network/security-overview.md#service-tags) | `Storage` (in the same region as your Batch account and VNet) | 443 | Any | Allow |
 
 ### Pools in the Cloud Services configuration
 


### PR DESCRIPTION
The existing documentation states that the source ports must be set to 443. This should be  the destination ports.