### PR TITLE
Adding the FeatureName parameter in example

### DIFF
--- a/includes/bastion-preview-register-include.md
+++ b/includes/bastion-preview-register-include.md
@@ -23,7 +23,7 @@
 3. Use the following command to verify that the *AllowBastionHost* feature is registered with your subscription:
 
     ```azurepowershell-interactive
-    Get-AzProviderFeature -ProviderNamespace Microsoft.Network
+    Get-AzProviderFeature -ProviderNamespace Microsoft.Network -FeatureName AllowBastionHost
     ````
 
     It may take a few minutes for registration to complete.


### PR DESCRIPTION
Using the FeatureName parameter will prevent that the user needs to search for the feature in a big list of ProviderFeatures.