### PR TITLE
Linking to the current docs for ABFS driver

### DIFF
--- a/articles/storage/blobs/data-lake-storage-abfs-driver.md
+++ b/articles/storage/blobs/data-lake-storage-abfs-driver.md
@@ -53,7 +53,7 @@ Details of all supported configuration entries are specified in the [Official Ha
 
 ### Hadoop documentation
 
-The ABFS driver is fully documented in the [Official Hadoop documentation](https://hadoop.apache.org/docs/current/hadoop-azure/index.html)
+The ABFS driver is fully documented in the [Official Hadoop documentation](https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md)
 
 ## Next steps
 


### PR DESCRIPTION
The older link was to the Hadoop WASB docs which have not been updated for a while, hence linking to https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/site/markdown/abfs.md as per the advice of the ADLS Gen 2 PM team.