### PR TITLE
Fix typo

### DIFF
--- a/articles/media-services/latest/media-services-event-schemas.md
+++ b/articles/media-services/latest/media-services-event-schemas.md
@@ -196,7 +196,7 @@ The data object has the following properties:
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| Outputs | Array | Gets the Job outputs.|
+| outputs | Array | Gets the Job outputs.|
 
 ### JobOutputStateChange
 


### PR DESCRIPTION
```
    "outputs": [ ← outputs, Not Outputs
      {
        "@odata.type": "#Microsoft.Media.JobOutputAsset",
        "assetName": "output-7640689F",
        "error": null,
        "label": "VideoAnalyzerPreset_0",
        "progress": 100,
        "state": "Finished"
      }
    ],
```