### PR TITLE
Fix wrong url for trigger sync

### DIFF
--- a/articles/azure-functions/functions-deployment-technologies.md
+++ b/articles/azure-functions/functions-deployment-technologies.md
@@ -47,7 +47,7 @@ Before continuing, it's important to learn some key concepts that will be critic
 When you change any of your triggers, the Functions infrastructure needs to be aware of these changes. This synchronization happens automatically for many deployment technologies. However, in some cases you must manually synchronize your triggers. When you deploy your updates using an external package URL, local Git, cloud sync, or FTP, you must be sure to manually synchronize your triggers. You can synchronize triggers in one of three ways:
 
 * Restart your function app in the Azure portal
-* Send an HTTP POST request to `https://www.{functionappname}.azurewebsites.net/admin/host/synctriggers?code=<API_KEY>` using the [master key](functions-bindings-http-webhook.md#authorization-keys).
+* Send an HTTP POST request to `https://{functionappname}.azurewebsites.net/admin/host/synctriggers?code=<API_KEY>` using the [master key](functions-bindings-http-webhook.md#authorization-keys).
 * Send an HTTP POST request to `https://management.azure.com/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>/providers/Microsoft.Web/sites/<FUNCTION_APP_NAME>/syncfunctiontriggers?api-version=2016-08-01`. Replace the placeholders with your subscription ID, resource group name, and the name of your function app.
 
 ## Deployment technology details  


### PR DESCRIPTION
The trigger sync url should not contain the "www." before {functionappname}.