### PR TITLE
ContinuouslyAvailable parameter is wrong

### DIFF
--- a/articles/virtual-machines/workloads/sap/sap-high-availability-installation-wsfc-file-share.md
+++ b/articles/virtual-machines/workloads/sap/sap-high-availability-installation-wsfc-file-share.md
@@ -266,7 +266,7 @@ New-Item -Path $SAPGlobalFOlder -ItemType Directory
 $UsrSAPFolder = "C:\ClusterStorage\SAP$SAPSID\usr\sap\"
 
 # Create a SAPMNT file share and set share security
-New-SmbShare -Name sapmnt -Path $UsrSAPFolder -FullAccess "BUILTIN\Administrators", $ASCSClusterObjectNode1, $ASCSClusterObjectNode2 -ContinuouslyAvailable $false -CachingMode None -Verbose
+New-SmbShare -Name sapmnt -Path $UsrSAPFolder -FullAccess "BUILTIN\Administrators", $ASCSClusterObjectNode1, $ASCSClusterObjectNode2 -ContinuouslyAvailable $true -CachingMode None -Verbose
 
 # Get SAPMNT file share security settings
 Get-SmbShareAccess sapmnt


### PR DESCRIPTION
The -ContinuouslyAvailable parameter value to New-SmbShare should be $true, as it is the whole purpose of setting up a Scale-Out file server, having a fileshare continuosly available