### PR TITLE
New-Volume create a Volume1 path

### DIFF
--- a/articles/virtual-machines/workloads/sap/sap-high-availability-installation-wsfc-file-share.md
+++ b/articles/virtual-machines/workloads/sap/sap-high-availability-installation-wsfc-file-share.md
@@ -243,6 +243,12 @@ To create a CSV volume with mirror resiliency, execute the following PowerShell 
 ```powershell
 New-Volume -StoragePoolFriendlyName S2D* -FriendlyName SAPPR1 -FileSystem CSVFS_ReFS -Size 5GB -ResiliencySettingName Mirror
 ```
+
+To help volume identification, rename it to match its usage
+```powershell
+Rename-Item "C:\ClusterStorage\Volume1" "C:\ClusterStorage\SAP$SAPSID"
+```
+
 To create SAPMNT and set folder and share security, execute the following PowerShell script on one of the SOFS cluster nodes:
 
 ```powershell


### PR DESCRIPTION
The New-Volume cmdlet will mount the volume as c:\clusterstorage\volume1. In the script following it is assumed instead that the volume is mounted as C:\ClusterStorage\SAP$SAPSID . It is necessary before to rename the mount point.