### PR TITLE
added note about secrets manifest files

### DIFF
--- a/articles/aks/concepts-security.md
+++ b/articles/aks/concepts-security.md
@@ -69,7 +69,7 @@ To filter the flow of traffic in virtual networks, Azure uses network security g
 
 A Kubernetes *Secret* is used to inject sensitive data into pods, such as access credentials or keys. You first create a Secret using the Kubernetes API. When you define your pod or deployment, a specific Secret can be requested. Secrets are only provided to nodes that have a scheduled pod that requires it, and the Secret is stored in *tmpfs*, not written to disk. When the last pod on a node that requires a Secret is deleted, the Secret is deleted from the node's tmpfs. Secrets are stored within a given namespace and can only be accessed by pods within the same namespace.
 
-The use of Secrets reduces the sensitive information that is defined in the pod or service YAML manifest. Instead, you request the Secret stored in Kubernetes API Server as part of your YAML manifest. This approach only provides the specific pod access to the Secret.
+The use of Secrets reduces the sensitive information that is defined in the pod or service YAML manifest. Instead, you request the Secret stored in Kubernetes API Server as part of your YAML manifest. This approach only provides the specific pod access to the Secret. Please note: the raw secret manifest files contains the secret data in base64 format (see the [official documentation][secret-risks] for more details). Therefore, this file should be treated as sensitive information, and never committed to source control.
 
 ## Next steps
 
@@ -88,6 +88,7 @@ For additional information on core Kubernetes and AKS concepts, see the followin
 <!-- LINKS - External -->
 [kured]: https://github.com/weaveworks/kured
 [kubernetes-network-policies]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+[secret-risks]: https://kubernetes.io/docs/concepts/configuration/secret/#risks
 
 <!-- LINKS - Internal -->
 [aks-daemonsets]: concepts-clusters-workloads.md#daemonsets


### PR DESCRIPTION
Added a few lines clarifying that secrets manifests files should be treated as sensitive files - warning users to never commit them.
Do you see value in mentioning OSS projects for encrypting manifest files? Like Seald Secrets/Helm Secrets/Kamus?