### PR TITLE
Update CLI export command for MS Build

### DIFF
--- a/articles/azure-app-configuration/integrate-ci-cd-pipeline.md
+++ b/articles/azure-app-configuration/integrate-ci-cd-pipeline.md
@@ -47,7 +47,7 @@ To do a cloud build, with Azure DevOps for example, make sure the [Azure CLI](ht
     ```xml
     <Target Name="Export file" AfterTargets="Build">
         <Message Text="Export the configurations to a temp file. " />
-        <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Condition="$(ConnectionString) != ''" Command="az appconfig kv export -f $(OutDir)\azureappconfig.json --format json --separator : --connection-string $(ConnectionString)" />
+        <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Condition="$(ConnectionString) != ''" Command="az appconfig kv export -d file --path $(OutDir)\azureappconfig.json --format json --separator : --connection-string $(ConnectionString)" />
     </Target>
     ```
 


### PR DESCRIPTION
As we shipped a new version of CLI extension. There is a breaking change for "az appconfig kv export" command. Previously to export configurations from App Configuration to a file, the command is
 "az appconfig kv export -f $(OutDir)\azureappconfig.json --format json --separator : --connection-string $(ConnectionString)"
In the new version, it should be 
 "az appconfig kv export -d file --path $(OutDir)\azureappconfig.json --format json --separator : --connection-string $(ConnectionString)"