### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-monitor/log-query/unify-app-resource-data.md
+++ b/articles/azure-monitor/log-query/unify-app-resource-data.md
@@ -136,7 +136,7 @@ The following table shows the schema differences between Log Analytics and Appli
 | SessionId | session_Id | 
 | SourceSystem | operation_SyntheticSource |
 | TelemetryTYpe | type |
-| URL | _url |
+| URL | url |
 | UserAccountId | user_AccountId |
 
 ## Next steps


### PR DESCRIPTION
There is `_url` in the property name as Application Insights resource properties.
However, when I check the schema at the following site, it looks to me that `url` is correct.

https://dev.applicationinsights.io/apiexplorer/querySchema?appId=DEMO_APP&apiKey=DEMO_KEY