### PR TITLE
Update To explicit use TLS 1.2 when downloading

### DIFF
--- a/articles/aks/istio-install.md
+++ b/articles/aks/istio-install.md
@@ -79,6 +79,8 @@ In PowerShell, use `Invoke-WebRequest` to download the latest Istio release and 
 $ISTIO_VERSION="1.1.3"
 
 # Windows
+# Use TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = "tls12"
 $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -URI "https://github.com/istio/istio/releases/download/$ISTIO_VERSION/istio-$ISTIO_VERSION-win.zip" -OutFile "istio-$ISTIO_VERSION.zip"
 Expand-Archive -Path "istio-$ISTIO_VERSION.zip" -DestinationPath .
 ```


### PR DESCRIPTION
Github use TLS 1.2 only. This fix would allow the script to execute without error, as described in #34168.
@paulbouwer