### PR TITLE
Update code example in manage-with-cli.md

### DIFF
--- a/articles/cosmos-db/manage-with-cli.md
+++ b/articles/cosmos-db/manage-with-cli.md
@@ -79,7 +79,7 @@ To get the keys for your Cosmos account, run the following command:
 
 ```azurecli-interactive
 # List account keys
-az cosmosdb list-keys \
+az cosmosdb keys list \
    --name  mycosmosdbaccount \
    --resource-group myResourceGroup
 ```


### PR DESCRIPTION
When running "az cosmosdb list-keys" the following warningmessage is presented: This command has been deprecated and will be removed in a future release. Use 'cosmosdb keys list' instead.

As of today both "az list-keys" and "az cosmosdb keys list" works. I have changed the code example accordingly - to match the new API.