### PR TITLE
Remove implication quota increases are possible

### DIFF
--- a/articles/notification-hubs/notification-hubs-push-notification-faq.md
+++ b/articles/notification-hubs/notification-hubs-push-notification-faq.md
@@ -81,7 +81,7 @@ If you have an existing mobile app backend and you want to add only the capabili
 
 Refer to the [Notification Hubs Pricing] page for details on the number of supported devices.
 
-If you need support for more than 10 million registered devices, it is recommended to partition your devices across multiple Notification Hubs.
+If you need support for more than 10 million registered devices, you must partition your devices across multiple hubs.
 
 ### How many push notifications can I send out?
 

--- a/articles/notification-hubs/notification-hubs-push-notification-faq.md
+++ b/articles/notification-hubs/notification-hubs-push-notification-faq.md
@@ -81,7 +81,7 @@ If you have an existing mobile app backend and you want to add only the capabili
 
 Refer to the [Notification Hubs Pricing] page for details on the number of supported devices.
 
-If you need support for more than 10 million registered devices, [contact us](https://azure.microsoft.com/overview/contact-us/) directly and we help you scale your solution.
+If you need support for more than 10 million registered devices, it is recommended to partition your devices across multiple Notification Hubs.
 
 ### How many push notifications can I send out?
 


### PR DESCRIPTION
Within Notification Hubs we cannot currently grant quota increase on device counts due to the strain it puts on the service and other regional customers. This commit removes from the FAQ the implication that we have the ability to increase quotas for customers.

Our recommendation for customers today is to partition their devices across multiple hubs.

I am a developer on the Notification Hubs team.