### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-monitor/platform/autoscale-webhook-email.md
+++ b/articles/azure-monitor/platform/autoscale-webhook-email.md
@@ -114,5 +114,5 @@ When the autoscale notification is generated, the following metadata is included
 | portalLink |Yes |Azure portal link to the summary page of the target resource |
 | oldCapacity |Yes |The current (old) instance count when Autoscale took a scale action |
 | newCapacity |Yes |The new instance count that Autoscale scaled the resource to |
-| Properties |No |Optional. Set of <Key, Value> pairs (for example,  Dictionary <String, String>). The properties field is optional. In a custom user interface  or Logic app based workflow, you can enter keys and values that can be passed using the payload. An alternate way to pass custom properties back to the outgoing webhook call is to use the webhook URI itself (as query parameters) |
+| properties |No |Optional. Set of <Key, Value> pairs (for example,  Dictionary <String, String>). The properties field is optional. In a custom user interface  or Logic app based workflow, you can enter keys and values that can be passed using the payload. An alternate way to pass custom properties back to the outgoing webhook call is to use the webhook URI itself (as query parameters) |
 


### PR DESCRIPTION
```
        },
        "properties": { ← properties, Not Properties
                "key1": "value1",
                "key2": "value2"
        }
```
