### PR TITLE
Fix Post-Trigger RequestOptions for .NET

### DIFF
--- a/articles/cosmos-db/how-to-use-stored-procedures-triggers-udfs.md
+++ b/articles/cosmos-db/how-to-use-stored-procedures-triggers-udfs.md
@@ -320,7 +320,7 @@ var newItem = {
     albums: ["Hellujah", "Rotators", "Spinning Top"]
 };
 
-var options = { postTriggerInclude: "trgPostUpdateMetadata" };
+RequestOptions options = new RequestOptions { PostTriggerInclude = new List<string> { "trgPostUpdateMetadata" } };
 Uri containerUri = UriFactory.CreateDocumentCollectionUri("myDatabase", "myContainer");
 await client.createDocumentAsync(containerUri, newItem, options);
 ```


### PR DESCRIPTION
Syntax for setting the request options in the Post-Trigger for is incorrect.