### PR TITLE
Update javascript qs to add sign-in audience to note in portal

### DIFF
--- a/articles/active-directory/develop/quickstart-v2-javascript.md
+++ b/articles/active-directory/develop/quickstart-v2-javascript.md
@@ -104,8 +104,8 @@ var msalConfig = {
 
 ```
 > [!div renderon="portal"]
-> [!NOTE]
-> This quickstart supports Enter_the_Supported_Account_Info_Here.
+> > [!NOTE]
+> > This quickstart supports Enter_the_Supported_Account_Info_Here.
 
 
 > [!div renderon="docs"]


### PR DESCRIPTION
Update javascript qs to move sign-in info audience from banner to a note within qs content.
Added one more '>' to be inside of portal div.