### PR TITLE
docs(cognitive-services): change custom vision library path

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/node-tutorial-object-detection.md
+++ b/articles/cognitive-services/Custom-Vision-Service/node-tutorial-object-detection.md
@@ -47,8 +47,8 @@ Add the following code to your script to create a new Custom Vision service proj
 
 ```javascript
 const util = require('util');
-const TrainingApi = require("azure-cognitiveservices-customvision-training");
-const PredictionApi = require("azure-cognitiveservices-customvision-prediction");
+const TrainingApi = require("@azure/cognitiveservices-customvision-training");
+const PredictionApi = require("@azure/cognitiveservices-customvision-prediction");
 
 const setTimeoutPromise = util.promisify(setTimeout);
 


### PR DESCRIPTION
Although, quick-start step installs @azure/cognitiveservices-customvision-..., code sample was requiring azure-cognitiveservices-customvision-... 
Fixes to the correct path.