### PR TITLE
Making folder explicit

### DIFF
--- a/articles/azure-functions/functions-create-first-java-maven.md
+++ b/articles/azure-functions/functions-create-first-java-maven.md
@@ -110,7 +110,7 @@ public class Function {
 
 ## Run the function locally
 
-Change directory to the newly created project folder and build and run the function with Maven:
+Change directory to the newly created project folder (the one containing your host.json and pom.xml files) and build and run the function with Maven:
 
 ```
 cd fabrikam-function


### PR DESCRIPTION
There was confusion about which folder you need to be in when building the function. I added a side-note to clarify it is in the "sub folder" created within the "empty folder" and not the "empty folder" itself. 

this is to fix #34355