### PR TITLE
Update in setting the network host mode

### DIFF
--- a/articles/iot-accelerators/howto-opc-twin-deploy-modules.md
+++ b/articles/iot-accelerators/howto-opc-twin-deploy-modules.md
@@ -67,7 +67,7 @@ All modules are deployed using a deployment manifest.  An example manifest to de
               "restartPolicy": "always",
               "settings": {
                 "image": "mcr.microsoft.com/iotedge/opc-twin:latest",
-                "createOptions": "{\"NetworkingConfig\":{\"EndpointsConfig\":{\"host\":{}}},\"HostConfig\":{\"NetworkMode\":\"host\",\"CapAdd\":[\"NET_ADMIN\"]}}"
+                "createOptions": "{\"NetworkingConfig\": {\"EndpointsConfig\": {\"host\": {}}}, \"HostConfig\": {\"NetworkMode\": \"host\" }}"
               }
             },
             "opcpublisher": {
@@ -131,7 +131,7 @@ The easiest way to deploy the modules to an Azure IoT Edge gateway device is thr
    As *create options* use the following JSON:
 
    ```json
-   {"HostConfig":{"NetworkMode":"host","CapAdd":["NET_ADMIN"]}}
+   {"NetworkingConfig": {"EndpointsConfig": {"host": {}}}, "HostConfig": {"NetworkMode": "host" }}
    ```
 
    Fill out the optional fields if necessary. For more information about container create options, restart policy, and desired status see [EdgeAgent desired properties](https://docs.microsoft.com/azure/iot-edge/module-edgeagent-edgehub#edgeagent-desired-properties). For more information about the module twin see [Define or update desired properties](https://docs.microsoft.com/azure/iot-edge/module-composition#define-or-update-desired-properties).


### PR DESCRIPTION
We encountered issues when using OPC Twin module with createOptions as defined in your sample. The error message was this through edgeAgent logs: 

System.AggregateException: One or more errors occurred. (Error calling start module opctwin: Could not start module opctwin
        caused by: Could not start module opctwin
        caused by: failed to add interface veth15550b3 to sandbox: error setting interface "veth15550b3" IP to [My IP...]/16: cannot program address [My IP...]/16 in sandbox interface because it conflicts with existing route {Ifindex: 4 Dst: [my IP] Src: [my IP] Gw: <nil> Flags: [] Table: 254}) ---> Microsoft.Azure.Devices.Edge.Agent.Edgelet.EdgeletCommunicationException: Error calling start module opctwin: Could not start module opctwin
=====

Setting the host mode with the new createOptions in this update works on Ubuntu 16 LTS as well as ARM32 Raspbian. I have not tested on other platforms though. Not sure if that would negatively affect those.