### PR TITLE
Dazfuller/adf selfhosted ir java

### DIFF
--- a/articles/data-factory/create-self-hosted-integration-runtime.md
+++ b/articles/data-factory/create-self-hosted-integration-runtime.md
@@ -74,6 +74,9 @@ Here is a high-level data flow for the summary of steps for copying with a self-
 - If the host machine hibernates, the self-hosted integration runtime does not respond to data requests. Configure an appropriate power plan on the computer before you install the self-hosted integration runtime. If the machine is configured to hibernate, the self-hosted integration runtime installation prompts a message.
 - You must be an administrator on the machine to install and configure the self-hosted integration runtime successfully.
 - Copy activity runs happen on a specific frequency. Resource usage (CPU, memory) on the machine follows the same pattern with peak and idle times. Resource utilization also depends heavily on the amount of data being moved. When multiple copy jobs are in progress, you see resource usage go up during peak times.
+- Tasks may fail if extracting data in Parquet, ORC, or Avro formats. The file creation runs on the self-hosted integration machine and requires the following pre-requisites to work as expected.
+    - [Visual C++ 2010 Redistributable](https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe) package (x64)
+    - Java Runtime (JRE) version 8 from a JRE provider such as [Adopt OpenJDK](https://adoptopenjdk.net/), ensuring that the `JAVA_HOME` environment variable is set.
 
 ## Installation best practices
 You can install the self-hosted integration runtime by downloading an MSI setup package from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=39717). See [Move data between on-premises and cloud article](tutorial-hybrid-copy-powershell.md) for step-by-step instructions.

--- a/articles/data-factory/create-self-hosted-integration-runtime.md
+++ b/articles/data-factory/create-self-hosted-integration-runtime.md
@@ -74,7 +74,7 @@ Here is a high-level data flow for the summary of steps for copying with a self-
 - If the host machine hibernates, the self-hosted integration runtime does not respond to data requests. Configure an appropriate power plan on the computer before you install the self-hosted integration runtime. If the machine is configured to hibernate, the self-hosted integration runtime installation prompts a message.
 - You must be an administrator on the machine to install and configure the self-hosted integration runtime successfully.
 - Copy activity runs happen on a specific frequency. Resource usage (CPU, memory) on the machine follows the same pattern with peak and idle times. Resource utilization also depends heavily on the amount of data being moved. When multiple copy jobs are in progress, you see resource usage go up during peak times.
-- Tasks may fail if extracting data in Parquet, ORC, or Avro formats. The file creation runs on the self-hosted integration machine and requires the following pre-requisites to work as expected.
+- Tasks may fail if extracting data in Parquet, ORC, or Avro formats. The file creation runs on the self-hosted integration machine and requires the following pre-requisites to work as expected (see [Parquet format in Azure Data Factory](https://docs.microsoft.com/azure/data-factory/format-parquet#using-self-hosted-integration-runtime)).
     - [Visual C++ 2010 Redistributable](https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe) package (x64)
     - Java Runtime (JRE) version 8 from a JRE provider such as [Adopt OpenJDK](https://adoptopenjdk.net/), ensuring that the `JAVA_HOME` environment variable is set.
 


### PR DESCRIPTION
At the moment, if the documentation is followed then a self-hosted IR environment will not be able to generate files which require Java for generation (Parquet, ORC, Avro). To ensure that this works JRE8 is required along with the VC++ 2010 Redist package. I've validated this through the deployment of a number of self-hosted IR environments and others have encountered these [issues](https://stackoverflow.com/questions/53424666/unable-to-load-dll-jvm-dll-the-specified-module-could-not-be-found-azure-data-fa).