### PR TITLE
Update create-validation-host-pool.md

### DIFF
--- a/articles/virtual-desktop/create-validation-host-pool.md
+++ b/articles/virtual-desktop/create-validation-host-pool.md
@@ -41,7 +41,7 @@ Set-RdsHostPool -TenantName $myTenantName -Name "contosoHostPool" -ValidationEnv
 Run the following PowerShell cmdlet to confirm that the validation property has been set. Replace the values in quotes by the values relevant to your session.
 
 ```powershell
-Get-RdsHostPool -TenantName $myTenantName -Name "contosoHostPool" -ValidationEnv $true
+Get-RdsHostPool -TenantName $myTenantName -Name "contosoHostPool"
 ```
 
 The results from the cmdlet should look similar to this output:


### PR DESCRIPTION
In the Confirm step at the end the Get-Rdshostpool command does not accept -validationenv and is not required to view the hostpool info that shows : ValidationEnv = True