### PR TITLE
Update create-ilb-ase.md

### DIFF
--- a/articles/app-service/environment/create-ilb-ase.md
+++ b/articles/app-service/environment/create-ilb-ase.md
@@ -105,7 +105,8 @@ To configure your DNS:
 
 - create a zone for *&lt;ASE name&gt;.appserviceenvironment.net*
 - create an A record in that zone that points * to the ILB IP address 
-- create a zone in *&lt;ASE name&gt;.scm.appserviceenvironment.net* named scm
+- create an empty A record (so that it's created as "same as parent folder") in that zone that points * to the ILB IP address
+- create a zone in *&lt;ASE name&gt;.appserviceenvironment.net* named scm
 - create an A record in the scm zone that points to the ILB IP address
 
 ## Publish with an ILB ASE
@@ -117,7 +118,7 @@ The SCM site name takes you to the Kudu console, called the **Advanced portal**,
 Internet-based CI systems, such as GitHub and Azure DevOps, will still work with an ILB ASE if the build agent is internet accessible and on the same network as ILB ASE. So in case of Azure DevOps, if the build agent is created on the same VNET as ILB ASE (different subnet is fine), it will be able to pull code from Azure DevOps git and deploy to ILB ASE. 
 If you don't want to create your own build agent, you need to use a CI system that uses a pull model, such as Dropbox.
 
-The publishing endpoints for apps in an ILB ASE use the domain that the ILB ASE was created with. This domain appears in the app's publishing profile and in the app's portal blade (**Overview** > **Essentials** and also **Properties**). If you have an ILB ASE with the domain suffix *&lt;ASE name&gt;.appserviceenvironment.net*, and an app named *mytest*, use *mytest.&lt;ASE name&gt;.appserviceenvironment.net* for FTP and *mytest.scm.contoso.net* for web deployment.
+The publishing endpoints for apps in an ILB ASE use the domain that the ILB ASE was created with. This domain appears in the app's publishing profile and in the app's portal blade (**Overview** > **Essentials** and also **Properties**). If you have an ILB ASE with the domain suffix *&lt;ASE name&gt;.appserviceenvironment.net*, and an app named *mytest*, use *mytest.&lt;ASE name&gt;.appserviceenvironment.net* for FTP and *mytest.scm.&lt;ASE name&gt;.appserviceenvironment.net* for web deployment.
 
 ## Configure an ILB ASE with a WAF device ##
 

--- a/articles/app-service/environment/create-ilb-ase.md
+++ b/articles/app-service/environment/create-ilb-ase.md
@@ -107,7 +107,7 @@ To configure your DNS:
 - Create an A record in that zone that points * to the ILB IP address 
 - Create an @ A record (so that it's created as "same as parent folder") in the *&lt;ASE name&gt;.appserviceenvironment.net* zone, that points to the ILB IP address
 - Create a zone in *&lt;ASE name&gt;.appserviceenvironment.net* named scm
-- Create an A record in the scm zone that points to the ILB IP address
+- Create an A record in the scm zone that points * to the ILB IP address
 
 ## Publish with an ILB ASE
 

--- a/articles/app-service/environment/create-ilb-ase.md
+++ b/articles/app-service/environment/create-ilb-ase.md
@@ -103,11 +103,11 @@ When you use an External VIP, the DNS is managed by Azure. Any app created in yo
 
 To configure your DNS:
 
-- create a zone for *&lt;ASE name&gt;.appserviceenvironment.net*
-- create an A record in that zone that points * to the ILB IP address 
-- create an empty A record (so that it's created as "same as parent folder") in that zone that points * to the ILB IP address
-- create a zone in *&lt;ASE name&gt;.appserviceenvironment.net* named scm
-- create an A record in the scm zone that points to the ILB IP address
+- Create a zone for *&lt;ASE name&gt;.appserviceenvironment.net*
+- Create an A record in that zone that points * to the ILB IP address 
+- Create an @ A record (so that it's created as "same as parent folder") in the *&lt;ASE name&gt;.appserviceenvironment.net* zone, that points to the ILB IP address
+- Create a zone in *&lt;ASE name&gt;.appserviceenvironment.net* named scm
+- Create an A record in the scm zone that points to the ILB IP address
 
 ## Publish with an ILB ASE
 


### PR DESCRIPTION
There has been some confusion among customers in regards to the DNS records they need to create due to a missing required record in the document and some typos:
Here's the full list of records required (with new record and typo fixed):
- Create a zone for *&lt;ASE name&gt;.appserviceenvironment.net*
- Create an A record in that zone that points * to the ILB IP address 
- Create an @ A record (so that it's created as "same as parent folder") in the *&lt;ASE name&gt;.appserviceenvironment.net* zone, that points to the ILB IP address
- Create a zone in *&lt;ASE name&gt;.appserviceenvironment.net* named scm
- Create an A record in the scm zone that points to the ILB IP address
There's also this typo (it said scm.contoso.net:
se *mytest.&lt;ASE name&gt;.appserviceenvironment.net* for FTP and *mytest.scm.&lt;ASE name&gt;.appserviceenvironment.net* for web deployment.