### PR TITLE
Required to install Azure Private DNS Module

### DIFF
--- a/articles/dns/private-dns-getstarted-powershell.md
+++ b/articles/dns/private-dns-getstarted-powershell.md
@@ -49,6 +49,8 @@ A DNS zone is created by using the `New-AzPrivateDnsZone` cmdlet.
 The following example creates a virtual network named **myAzureVNet**. Then it creates a DNS zone named **private.contoso.com** in the **MyAzureResourceGroup** resource group, links the DNS zone to the **MyAzureVnet** virtual network, and enables automatic registration.
 
 ```azurepowershell
+Install-Module -Name Az.PrivateDns -force
+
 $backendSubnet = New-AzVirtualNetworkSubnetConfig -Name backendSubnet -AddressPrefix "10.2.0.0/24"
 $vnet = New-AzVirtualNetwork `
   -ResourceGroupName MyAzureResourceGroup `


### PR DESCRIPTION
It is required to use Azure Private DNS Module before using New-AzPrivateDnsZone Command. This is currently not working in Azure Cloudshell without manually installing the module using Install-Module -Name Az.PrivateDns.