### PR TITLE
Update add-sharepoint-datasources.md

### DIFF
--- a/articles/cognitive-services/QnAMaker/How-To/add-sharepoint-datasources.md
+++ b/articles/cognitive-services/QnAMaker/How-To/add-sharepoint-datasources.md
@@ -1,7 +1,7 @@
 ---
-title: Sharepoint files - QnA Maker
+title: SharePoint files - QnA Maker
 titleSuffix: Azure Cognitive Services
-description: Add secured Sharepoint data sources to your knowledge base to enrich the knowledge base with questions and answers that may be secured with Active Directory.
+description: Add secured SharePoint data sources to your knowledge base to enrich the knowledge base with questions and answers that may be secured with Active Directory.
 services: cognitive-services
 author: diberry
 manager: nitinme
@@ -12,26 +12,26 @@ ms.date: 06/24/2019
 ms.author: diberry
 ---
 
-# Add a secured Sharepoint data source to your knowledge base
+# Add a secured SharePoint data source to your knowledge base
 
-Add secured Sharepoint data sources to your knowledge base to enrich the knowledge base with questions and answers that may be secured with Active Directory. 
+Add secured SharePoint data sources to your knowledge base to enrich the knowledge base with questions and answers that may be secured with Active Directory. 
 
-When you add a secured Sharepoint document to your knowledge base, as the QnA Maker manager, you must request Active Directory permission for QnA Maker. Once this permission is given from the Active Directory manager to QnA Maker for access to Sharepoint, it doesn't have to be given again. Each subsequent document addition to the knowledge base will not need authorization if it is in the same Sharepoint resource. 
+When you add a secured SharePoint document to your knowledge base, as the QnA Maker manager, you must request Active Directory permission for QnA Maker. Once this permission is given from the Active Directory manager to QnA Maker for access to SharePoint, it doesn't have to be given again. Each subsequent document addition to the knowledge base will not need authorization if it is in the same SharePoint resource. 
 
 If the QnA Maker knowledge base manager is not the Active Directory manager, you will need to communicate with the Active Directory manager to finish this process.
 
 ## Add supported file types to knowledge base
 
-You can add all QnA Maker-supported [file types](../Concepts/data-sources-supported.md) from a Sharepoint server to your knowledge base. You may have to grant [permissions](#permissions) if the file resource is secured.
+You can add all QnA Maker-supported [file types](../Concepts/data-sources-supported.md) from a SharePoint site to your knowledge base. You may have to grant [permissions](#permissions) if the file resource is secured.
 
-1. From the Sharepoint server, select the file's ellipsis menu, `...`.
+1. From the library with the SharePoint site, select the file's ellipsis menu, `...`.
 1. Copy the file's URL.
 
-    ![Get the Sharepoint file URL by selecting the file's ellipsis menu then copying the URL.](../media/add-sharepoint-datasources/get-sharepoint-file-url.png)
+    ![Get the SharePoint file URL by selecting the file's ellipsis menu then copying the URL.](../media/add-sharepoint-datasources/get-sharepoint-file-url.png)
 
 1. In the QnA Maker portal, on the **Settings** page, [add the URL](edit-knowledge-base.md#add-datasource) to the knowledge base. 
 
-### Images with Sharepoint files
+### Images with SharePoint files
 
 If files include images, those are not extracted. You can add the image, from the QnA Maker portal, after the file is extracted into QnA pairs.
 
@@ -47,26 +47,26 @@ When you test the QnA pair in the interactive test panel, in the QnA Maker porta
 
 ## Permissions
 
-Granting permissions happens when a secured file from a Sharepoint server is added to a knowledge base. Depending on how the Sharepoint is set up and the permissions of the person adding the file, this could require:
+Granting permissions happens when a secured file from a SharePoint site is added to a knowledge base. Depending on how the SharePoint is set up and the permissions of the person adding the file, this could require:
 
 * no additional steps - the person adding the file has all the permissions needed.
 * steps by both [knowledge base manager](#knowledge-base-manager-add-sharepoint-data-source-in-qna-maker-portal) and [Active Directory manager](#active-directory-manager-grant-file-read-access-to-qna-maker).
 
 See the steps listed below. 
 
-### Knowledge base manager: add Sharepoint data source in QnA Maker portal
+### Knowledge base manager: add SharePoint data source in QnA Maker portal
 
-When the **QnA Maker manager** adds a secured Sharepoint document to a knowledge base, the knowledge base manager initiates a request for permission that the Active Directory manager needs to complete.
+When the **QnA Maker manager** adds a secured SharePoint document to a knowledge base, the knowledge base manager initiates a request for permission that the Active Directory manager needs to complete.
 
 The request begins with a pop-up to authenticate to an Active Directory account. 
 
 ![Authenticate User Account](../media/add-sharepoint-datasources/authenticate-user-account.png)
 
-Once the QnA Maker manager selects the account, the Active Directory administrator will receive a notice that they need to allow the QnA Maker app (not the QnA Maker manager) access to the Sharepoint resource. The Active Directory manager will need to do this for every Sharepoint resource, but not every document in that resource. 
+Once the QnA Maker manager selects the account, the Azure Active Directory administrator will receive a notice that they need to allow the QnA Maker app (not the QnA Maker manager) access to the SharePoint resource. The Azure Active Directory manager will need to do this for every SharePoint resource, but not every document in that resource. 
 
 ### Active directory manager: grant file read access to QnA Maker
 
-The Active Directory manager (not the QnA Maker manager) needs to grant access to QnA Maker to access the Sharepoint resource by selecting [this link](https://login.microsoftonline.com/common/oauth2/v2.0/authorize?response_type=id_token&scope=Files.Read%20Files.Read.All%20Sites.Read.All%20User.Read%20User.ReadBasic.All%20profile%20openid%20email&client_id=c2c11949-e9bb-4035-bda8-59542eb907a6&redirect_uri=https%3A%2F%2Fwww.qnamaker.ai%3A%2FCreate&state=68) to authorize the QnA Maker Portal Sharepoint enterprise app to have file read permissions. 
+The Active Directory manager (not the QnA Maker manager) needs to grant access to QnA Maker to access the SharePoint resource by selecting [this link](https://login.microsoftonline.com/common/oauth2/v2.0/authorize?response_type=id_token&scope=Files.Read%20Files.Read.All%20Sites.Read.All%20User.Read%20User.ReadBasic.All%20profile%20openid%20email&client_id=c2c11949-e9bb-4035-bda8-59542eb907a6&redirect_uri=https%3A%2F%2Fwww.qnamaker.ai%3A%2FCreate&state=68) to authorize the QnA Maker Portal SharePoint enterprise app to have file read permissions. 
 
 ![Azure Active Directory manager grants permission interactively](../media/add-sharepoint-datasources/aad-manager-grants-permission-interactively.png)
 
@@ -124,13 +124,13 @@ The Active Directory manager will get a pop-up window requesting permissions to 
   
 <!--
 
-## Add Sharepoint data source with APIs
+## Add SharePoint data source with APIs
 
-You need to get the Sharepoint file's URI before adding it to QnA Maker. 
+You need to get the SharePoint file's URI before adding it to QnA Maker. 
 
-## Get Sharepoint File URI
+## Get SharePoint File URI
 
-Use the following steps to transform the Sharepoint URL into a sharing token.
+Use the following steps to transform the SharePoint URL into a sharing token.
 
 1. Encode the URL using [base64](https://en.wikipedia.org/wiki/Base64). 
 
@@ -149,7 +149,7 @@ Use the following steps to transform the Sharepoint URL into a sharing token.
 
     Get the **@microsoft.graph.downloadUrl** and use this as `fileuri` in the QnA Maker APIs.
 
-### Add or update a Sharepoint File URI to your knowledge base
+### Add or update a SharePoint File URI to your knowledge base
 
 Use the **@microsoft.graph.downloadUrl** from the previous section as the `fileuri` in the QnA Maker API for [adding a knowledge base](https://go.microsoft.com/fwlink/?linkid=2092179) or [updating a knowledge base](https://docs.microsoft.com/rest/api/cognitiveservices/qnamaker/knowledgebase/update). The following fields are mandatory: name, fileuri, filename, source.
 
@@ -172,10 +172,10 @@ Use the **@microsoft.graph.downloadUrl** from the previous section as the `fileu
 
 
 
-## Remove QnA Maker app from Sharepoint authorization
+## Remove QnA Maker app from SharePoint authorization
 
 1. Use the steps in the previous section to find the Qna Maker app in the Active Directory admin center. 
-1. When you select the **QnAMakerPortalSharepoint**, select **Overview**. 
+1. When you select the **QnAMakerPortalSharePoint**, select **Overview**. 
 1. Select **Delete** to remove permissions. 
 
 -->


### PR DESCRIPTION
SharePoint should be written with a capital P to match the product , have changed this in most places apart from where it matches the lowercase name used in screenshots for AD permissions.
Also had some questions when I used this with a customer around how to get server url and AD administrator, have updated to try and clarify is Azure AD/ SharePoint site nothing to do with physical machines.  Lots of different ways that could be worded that might work better than what I have proposed though.