### PR TITLE
Remove extra period from apt install command

### DIFF
--- a/articles/kinect-dk/sensor-sdk-download.md
+++ b/articles/kinect-dk/sensor-sdk-download.md
@@ -43,7 +43,7 @@ Now, you can install the necessary packages. The `k4a-tools` package includes th
 
  The basic tutorials require the `libk4a<major>.<minor>-dev` package. To install it, run
 
- `sudo apt install libk4a1.1-dev`.
+ `sudo apt install libk4a1.1-dev`
 
 If the command succeeds, the SDK is ready for use.
 


### PR DESCRIPTION
Some users may think

`sudo apt install libk4a1.1-dev`.

Includes the period in the command. Removing the period in order to make it clear that it's not part of the command.