### PR TITLE
Application Insights Java SDK 2.5-beta doc

### DIFF
--- a/articles/azure-monitor/app/java-agent-25-beta.md
+++ b/articles/azure-monitor/app/java-agent-25-beta.md
@@ -1,0 +1,164 @@
+---
+title: Performance monitoring for Java web apps in Azure Application Insights | Microsoft Docs
+description: Extended performance and usage monitoring of your Java website with Application Insights.
+services: application-insights
+documentationcenter: java
+author: mrbullwinkle
+manager: carmonm
+ms.assetid: 84017a48-1cb3-40c8-aab1-ff68d65e2128
+ms.service: application-insights
+ms.workload: tbd
+ms.tgt_pltfrm: ibiza
+ms.topic: conceptual
+ms.date: 01/10/2019
+ms.author: mbullwin
+---
+# Monitor dependencies, caught exceptions and method execution times in Java web apps
+
+
+If you have [instrumented your Java web app with Application Insights][java], you can use the Java Agent to get deeper insights, without any code changes:
+
+* **Dependencies:** Data about calls that your application makes to other components, including:
+  * **REST calls** made via HttpClient, OkHttp, and RestTemplate (Spring) are captured.
+  * **Redis** calls made via the Jedis client are captured.
+  * **[JDBC calls](https://docs.oracle.com/javase/7/docs/technotes/guides/jdbc/)** - MySQL, SQL Server and Oracle DB commands are automatically captured. For MySQL, if the call takes longer than 10s, the agent reports the query plan.
+* **Caught exceptions:** Information about exceptions that are handled by your code.
+* **Method execution time:** Information about the time it takes to execute specific methods.
+
+To use the Java agent, you install it on your server. Your web apps must be instrumented with the [Application Insights Java SDK][java]. 
+
+## Install the Application Insights agent for Java
+1. On the machine running your Java server, [download the agent](https://github.com/Microsoft/ApplicationInsights-Java/releases/latest). Please ensure to download the same version of Java Agent as Application Insights Java SDK core and web packages.
+2. Edit the application server startup script, and add the following JVM:
+   
+    `javaagent:`*full path to the agent JAR file*
+   
+    For example, in Tomcat on a Linux machine:
+   
+    `export JAVA_OPTS="$JAVA_OPTS -javaagent:<full path to agent JAR file>"`
+3. Restart your application server.
+
+## Configure the agent
+Create a file named `AI-Agent.xml` and place it in the same folder as the agent JAR file.
+
+Set the content of the xml file. Edit the following example to include or omit the features you want.
+
+```XML
+
+    <?xml version="1.0" encoding="utf-8"?>
+    <ApplicationInsightsAgent>
+      <Instrumentation>
+
+        <!-- Collect remote dependency data -->
+        <BuiltIn enabled="true">
+           <!-- Disable Redis or alter threshold call duration above which arguments are sent.
+               Defaults: enabled, 10000 ms -->
+           <Jedis enabled="true" thresholdInMS="1000"/>
+
+           <!-- Set SQL query duration above which query plan is reported (MySQL, PostgreSQL). Default is 10000 ms. -->
+           <MaxStatementQueryLimitInMS>1000</MaxStatementQueryLimitInMS>
+        </BuiltIn>
+
+        <!-- Collect data about caught exceptions
+             and method execution times -->
+
+        <Class name="com.myCompany.MyClass">
+           <Method name="methodOne"
+               reportCaughtExceptions="true"
+               reportExecutionTime="true"
+               />
+           <!-- Report on the particular signature
+                void methodTwo(String, int) -->
+           <Method name="methodTwo"
+              reportExecutionTime="true"
+              signature="(Ljava/lang/String;I)V" />
+        </Class>
+
+      </Instrumentation>
+    </ApplicationInsightsAgent>
+
+```
+
+You have to enable reports exception and method timing for individual methods.
+
+By default, `reportExecutionTime` is true and `reportCaughtExceptions` is false.
+
+## Additional config (Spring Boot)
+
+`java -javaagent:/path/to/agent.jar -jar path/to/TestApp.jar`
+
+For Azure App Services do the following:
+
+* Select Settings > Application Settings
+* Under App Settings, add a new key value pair:
+
+Key: `JAVA_OPTS`
+Value: `-javaagent:D:/home/site/wwwroot/applicationinsights-agent-2.3.1-SNAPSHOT.jar`
+
+For the latest version of the Java agent check the releases [here](https://github.com/Microsoft/ApplicationInsights-Java/releases
+). 
+
+The agent must be packaged as a resource in your project such that it ends up in the D:/home/site/wwwroot/ directory. You can confirm that your agent is in the correct App Service directory by going to **Development Tools** > **Advanced Tools** > **Debug Console** and examining the contents of the site directory.    
+
+* Save the settings and Restart your app. (These steps only apply to App Services running on Windows.)
+
+> [!NOTE]
+> AI-Agent.xml and the agent jar file should be in the same folder. They are often placed together in the `/resources` folder of the project.  
+
+### Spring Rest Template
+
+In order for Application Insights to successfully instrument HTTP calls made with Spring's Rest Template, use of the Apache HTTP Client is required. By default Spring's Rest Template is not configured to use the Apache HTTP Client. By specifying [HttpComponentsClientHttpRequestfactory](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.html) in the constructor of a Spring Rest Template, it will use Apache HTTP.
+
+Here's an example of how to do this with Spring Beans. This is a very simple example which uses the default settings of the factory class.
+
+```java
+@bean
+public ClientHttpRequestFactory httpRequestFactory() {
+return new HttpComponentsClientHttpRequestFactory()
+}
+@Bean(name = 'myRestTemplate')
+public RestTemplate dcrAccessRestTemplate() {
+    return new RestTemplate(httpRequestFactory())
+}
+```
+
+#### Enable W3C distributed tracing
+
+Add the following to AI-Agent.xml:
+
+```xml
+<Instrumentation>
+        <BuiltIn enabled="true">
+            <HTTP enabled="true" W3C="true" enableW3CBackCompat="true"/>
+        </BuiltIn>
+    </Instrumentation>
+```
+
+> [!NOTE]
+> Backward compatibility mode is enabled by default and the enableW3CBackCompat parameter is optional and should be used only when you want to turn it off. 
+
+Ideally this would be the case when all your services have been updated to newer version of SDKs supporting W3C protocol. It is highly recommended to move to newer version of SDKs with W3C support as soon as possible.
+
+Make sure that **both [incoming](correlation.md#w3c-distributed-tracing) and outgoing (agent) configurations** are exactly same.
+
+## View the data
+In the Application Insights resource, aggregated remote dependency and method execution times appears [under the Performance tile][metrics].
+
+To search for individual instances of dependency, exception, and method reports, open [Search][diagnostic].
+
+[Diagnosing dependency issues - learn more](../../azure-monitor/app/asp-net-dependencies.md#diagnosis).
+
+## Questions? Problems?
+* No data? [Set firewall exceptions](../../azure-monitor/app/ip-addresses.md)
+* [Troubleshooting Java](java-troubleshoot.md)
+
+<!--Link references-->
+
+[api]: ../../azure-monitor/app/api-custom-events-metrics.md
+[apiexceptions]: ../../azure-monitor/app/api-custom-events-metrics.md#track-exception
+[availability]: ../../azure-monitor/app/monitor-web-app-availability.md
+[diagnostic]: ../../azure-monitor/app/diagnostic-search.md
+[eclipse]: app-insights-java-eclipse.md
+[java]: java-get-started.md
+[javalogs]: java-trace-logs.md
+[metrics]: ../../azure-monitor/app/metrics-explorer.md

--- a/articles/azure-monitor/app/java-agent-25-beta.md
+++ b/articles/azure-monitor/app/java-agent-25-beta.md
@@ -1,6 +1,6 @@
 ---
-title: Performance monitoring for Java web apps in Azure Application Insights | Microsoft Docs
-description: Extended performance and usage monitoring of your Java website with Application Insights.
+title: Performance monitoring for Java web apps in Azure Application Insights (2.5-beta) | Microsoft Docs
+description: Extended performance and usage monitoring of your Java website with Application Insights (2.5-beta).
 services: application-insights
 documentationcenter: java
 author: mrbullwinkle
@@ -19,11 +19,18 @@ ms.author: mbullwin
 If you have [instrumented your Java web app with Application Insights][java], you can use the Java Agent to get deeper insights, without any code changes:
 
 * **Dependencies:** Data about calls that your application makes to other components, including:
-  * **REST calls** made via HttpClient, OkHttp, and RestTemplate (Spring) are captured.
-  * **Redis** calls made via the Jedis client are captured.
-  * **[JDBC calls](https://docs.oracle.com/javase/7/docs/technotes/guides/jdbc/)** - MySQL, SQL Server and Oracle DB commands are automatically captured. For MySQL, if the call takes longer than 10s, the agent reports the query plan.
-* **Caught exceptions:** Information about exceptions that are handled by your code.
-* **Method execution time:** Information about the time it takes to execute specific methods.
+  * **Outgoing HTTP calls** made via Apache HttpClient, OkHttp, and `java.net.HttpURLConnection` are captured.
+  * **Redis calls** made via the Jedis client are captured.
+  * **JDBC queries** - For MySQL and PostgreSQL, if the call takes longer than 10s, the agent reports the query plan.
+
+* **Application logging:** Capture and correlate your application logs with HTTP requests and other telemetry
+  * **Log4j 1.2**
+  * **Log4j2**
+  * **Logback**
+
+* **Better operation naming:** (used for aggregation of requests in the portal)
+  * **Spring** - based on `@RequestMapping`.
+  * **JAX-RS** - based on `@Path`. 
 
 To use the Java agent, you install it on your server. Your web apps must be instrumented with the [Application Insights Java SDK][java]. 
 
@@ -44,44 +51,31 @@ Create a file named `AI-Agent.xml` and place it in the same folder as the agent 
 Set the content of the xml file. Edit the following example to include or omit the features you want.
 
 ```XML
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInsightsAgent>
+   <Instrumentation>
+      <BuiltIn enabled="true">
 
-    <?xml version="1.0" encoding="utf-8"?>
-    <ApplicationInsightsAgent>
-      <Instrumentation>
+         <!-- disable capturing logging performed through Log4j 1.2, Log4j2 and Logback, default is true -->
+         <Logging enabled="true" />
 
-        <!-- Collect remote dependency data -->
-        <BuiltIn enabled="true">
-           <!-- Disable Redis or alter threshold call duration above which arguments are sent.
-               Defaults: enabled, 10000 ms -->
-           <Jedis enabled="true" thresholdInMS="1000"/>
+         <!-- disable capturing outgoing HTTP calls performed through Apache HttpClient,
+              OkHttp and java.net.HttpURLConnection, default is true -->
+         <HTTP enabled="true" />
 
-           <!-- Set SQL query duration above which query plan is reported (MySQL, PostgreSQL). Default is 10000 ms. -->
-           <MaxStatementQueryLimitInMS>1000</MaxStatementQueryLimitInMS>
-        </BuiltIn>
+         <!-- disable capturing JDBC queries, default is true -->
+         <JDBC enabled="true" />
 
-        <!-- Collect data about caught exceptions
-             and method execution times -->
+         <!-- disable capturing Redis calls, default is true -->
+         <Jedis enabled="true" />
 
-        <Class name="com.myCompany.MyClass">
-           <Method name="methodOne"
-               reportCaughtExceptions="true"
-               reportExecutionTime="true"
-               />
-           <!-- Report on the particular signature
-                void methodTwo(String, int) -->
-           <Method name="methodTwo"
-              reportExecutionTime="true"
-              signature="(Ljava/lang/String;I)V" />
-        </Class>
+         <!-- Set SQL query duration above which query plan is reported (MySQL, PostgreSQL). Default is 10000 ms. -->
+         <MaxStatementQueryLimitInMS>1000</MaxStatementQueryLimitInMS>
 
-      </Instrumentation>
-    </ApplicationInsightsAgent>
-
+      </BuiltIn>
+   </Instrumentation>
+</ApplicationInsightsAgent>
 ```
-
-You have to enable reports exception and method timing for individual methods.
-
-By default, `reportExecutionTime` is true and `reportCaughtExceptions` is false.
 
 ## Additional config (Spring Boot)
 
@@ -93,7 +87,7 @@ For Azure App Services do the following:
 * Under App Settings, add a new key value pair:
 
 Key: `JAVA_OPTS`
-Value: `-javaagent:D:/home/site/wwwroot/applicationinsights-agent-2.3.1-SNAPSHOT.jar`
+Value: `-javaagent:D:/home/site/wwwroot/applicationinsights-agent-2.5.0-BETA.jar`
 
 For the latest version of the Java agent check the releases [here](https://github.com/Microsoft/ApplicationInsights-Java/releases
 ). 
@@ -105,33 +99,16 @@ The agent must be packaged as a resource in your project such that it ends up in
 > [!NOTE]
 > AI-Agent.xml and the agent jar file should be in the same folder. They are often placed together in the `/resources` folder of the project.  
 
-### Spring Rest Template
-
-In order for Application Insights to successfully instrument HTTP calls made with Spring's Rest Template, use of the Apache HTTP Client is required. By default Spring's Rest Template is not configured to use the Apache HTTP Client. By specifying [HttpComponentsClientHttpRequestfactory](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.html) in the constructor of a Spring Rest Template, it will use Apache HTTP.
-
-Here's an example of how to do this with Spring Beans. This is a very simple example which uses the default settings of the factory class.
-
-```java
-@bean
-public ClientHttpRequestFactory httpRequestFactory() {
-return new HttpComponentsClientHttpRequestFactory()
-}
-@Bean(name = 'myRestTemplate')
-public RestTemplate dcrAccessRestTemplate() {
-    return new RestTemplate(httpRequestFactory())
-}
-```
-
 #### Enable W3C distributed tracing
 
 Add the following to AI-Agent.xml:
 
 ```xml
 <Instrumentation>
-        <BuiltIn enabled="true">
-            <HTTP enabled="true" W3C="true" enableW3CBackCompat="true"/>
-        </BuiltIn>
-    </Instrumentation>
+   <BuiltIn enabled="true">
+      <HTTP enabled="true" W3C="true" enableW3CBackCompat="true"/>
+   </BuiltIn>
+</Instrumentation>
 ```
 
 > [!NOTE]

--- a/articles/azure-monitor/app/java-get-started-25-beta.md
+++ b/articles/azure-monitor/app/java-get-started-25-beta.md
@@ -1,0 +1,495 @@
+---
+title: Java web app analytics with Azure Application Insights | Microsoft Docs
+description: 'Application Performance Monitoring for Java web apps with Application Insights. '
+services: application-insights
+documentationcenter: java
+author: lgayhardt
+manager: carmonm
+ms.assetid: 051d4285-f38a-45d8-ad8a-45c3be828d91
+ms.service: application-insights
+ms.workload: tbd
+ms.tgt_pltfrm: ibiza
+ms.topic: conceptual
+ms.date: 05/24/2019
+ms.author: lagayhar
+---
+# Get started with Application Insights in a Java web project
+
+[Application Insights](https://azure.microsoft.com/services/application-insights/) is an extensible analytics service for web developers that helps you understand the performance and usage of your live application. Use it to [automatically instrument request, track dependencies, and collect performance counters](auto-collect-dependencies.md#java), diagnose performance issues and exceptions, and [write code][api] to track what users do with your app. 
+
+![Screenshot of overview sample data](./media/java-get-started/overview-graphs.png)
+
+Application Insights supports Java apps running on Linux, Unix, or Windows.
+
+You need:
+
+* JRE version 1.7 or 1.8
+* A subscription to [Microsoft Azure](https://azure.microsoft.com/).
+
+If you prefer the Spring framework try the [configure a Spring Boot initializer app to use Application Insights guide](https://docs.microsoft.com/java/azure/spring-framework/configure-spring-boot-java-applicationinsights)
+
+## 1. Get an Application Insights instrumentation key
+1. Sign in to the [Microsoft Azure portal](https://portal.azure.com).
+2. Create an Application Insights resource. Set the application type to Java web application.
+
+3. Find the instrumentation key of the new resource. You'll need to paste this key into your code project shortly.
+
+    ![In the new resource overview, click Properties and copy the Instrumentation Key](./media/java-get-started/instrumentation-key-001.png)
+
+## 2. Add the Application Insights SDK for Java to your project
+*Choose the appropriate way for your project.*
+
+#### If you're using Maven... <a name="maven-setup" />
+If your project is already set up to use Maven for build, merge the following code to your pom.xml file.
+
+Then, refresh the project dependencies to get the binaries downloaded.
+
+```XML
+
+    <repositories>
+       <repository>
+          <id>central</id>
+          <name>Central</name>
+          <url>http://repo1.maven.org/maven2</url>
+       </repository>
+    </repositories>
+
+    <dependencies>
+      <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>applicationinsights-web</artifactId>
+        <!-- or applicationinsights-core for bare API -->
+        <version>[2.0,)</version>
+      </dependency>
+    </dependencies>
+```
+
+* *Build or checksum validation errors?* Try using a specific version, such as: `<version>2.0.n</version>`. You'll find the latest version in the [SDK release notes](https://github.com/Microsoft/ApplicationInsights-Java#release-notes) or in the [Maven artifacts](https://search.maven.org/#search%7Cga%7C1%7Capplicationinsights).
+* *Need to update to a new SDK?* Refresh your project's dependencies.
+
+#### If you're using Gradle... <a name="gradle-setup" />
+If your project is already set up to use Gradle for build, merge the following code to your build.gradle file.
+
+Then refresh the project dependencies to get the binaries downloaded.
+
+```gradle
+
+    repositories {
+      mavenCentral()
+    }
+
+    dependencies {
+      compile group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '2.+'
+      // or applicationinsights-core for bare API
+    }
+```
+
+#### If you're using Eclipse to create a Dynamic Web project ...
+Use the [Application Insights SDK for Java plug-in][eclipse]. Note: even though using this plugin will get you up and running with Application Insights quicker (assuming you're not using Maven/Gradle), it is not a dependency management system. As such, updating the plugin will not automatically update the Application Insights libraries in your project.
+
+* *Build or checksum validation errors?* Try using a specific version, such as: `version:'2.0.n'`. You'll find the latest version in the [SDK release notes](https://github.com/Microsoft/ApplicationInsights-Java#release-notes) or in the [Maven artifacts](https://search.maven.org/#search%7Cga%7C1%7Capplicationinsights).
+* *To update to a new SDK* Refresh your project's dependencies.
+
+#### Otherwise, if you are manually managing dependencies ...
+Download the [latest version](https://github.com/Microsoft/ApplicationInsights-Java/releases/latest) and copy the necessary files into your project, replacing any previous versions.
+
+### Questions...
+* *What's the relationship between the `-core` and `-web` components?*
+  * `applicationinsights-core` gives you the bare API. You always need this component.
+  * `applicationinsights-web` gives you metrics that track HTTP request counts and response times. You can omit this component if you don't want this telemetry automatically collected. For example, if you want to write your own.
+  
+* *How should I update the SDK to the latest version?*
+  * If you are using Gradle or Maven...
+    * Update your build file to specify the latest version or use Gradle/Maven's wildcard syntax to include the latest version automatically. Then, refresh your project's dependencies. The wildcard syntax can be seen in the examples above for [Gradle](#gradle-setup) or [Maven](#maven-setup).
+  * If you are manually managing dependencies...
+    * Download the latest [Application Insights SDK for Java](https://github.com/Microsoft/ApplicationInsights-Java/releases/latest) and replace the old ones. Changes are described in the [SDK release notes](https://github.com/Microsoft/ApplicationInsights-Java#release-notes).
+
+## 3. Add an ApplicationInsights.xml file
+Add ApplicationInsights.xml to the resources folder in your project, or make sure it is added to your project’s deployment class path. Copy the following XML into it.
+
+Substitute the instrumentation key that you got from the Azure portal.
+
+```XML
+
+    <?xml version="1.0" encoding="utf-8"?>
+    <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+
+
+      <!-- The key from the portal: -->
+      <InstrumentationKey>** Your instrumentation key **</InstrumentationKey>
+
+
+      <!-- HTTP request component (not required for bare API) -->
+      <TelemetryModules>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule"/>
+      </TelemetryModules>
+
+      <!-- Events correlation (not required for bare API) -->
+      <!-- These initializers add context data to each event -->
+
+      <TelemetryInitializers>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationNameTelemetryInitializer"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebSessionTelemetryInitializer"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserTelemetryInitializer"/>
+        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserAgentTelemetryInitializer"/>
+
+      </TelemetryInitializers>
+    </ApplicationInsights>
+```
+
+Optionally, the configuration file can reside in any location accessible to your application.  The system property `-Dapplicationinsights.configurationDirectory` specifies the directory that contains ApplicationInsights.xml. For example, a configuration file located at `E:\myconfigs\appinsights\ApplicationInsights.xml` would be configured with the property `-Dapplicationinsights.configurationDirectory="E:\myconfigs\appinsights"`.
+
+* The instrumentation key is sent along with every item of telemetry and tells Application Insights to display it in your resource.
+* The HTTP Request component is optional. It automatically sends telemetry about requests and response times to the portal.
+* Event correlation is an addition to the HTTP request component. It assigns an identifier to each request received by the server, and adds this identifier as a property to every item of telemetry as the property 'Operation.Id'. It allows you to correlate the telemetry associated with each request by setting a filter in [diagnostic search][diagnostic].
+
+### Alternative ways to set the instrumentation key
+Application Insights SDK looks for the key in this order:
+
+1. System property: -DAPPLICATION_INSIGHTS_IKEY=your_ikey
+2. Environment variable: APPLICATION_INSIGHTS_IKEY
+3. Configuration file: ApplicationInsights.xml
+
+You can also [set it in code](../../azure-monitor/app/api-custom-events-metrics.md#ikey):
+
+```java
+    String instrumentationKey = "00000000-0000-0000-0000-000000000000";
+
+    if (instrumentationKey != null)
+    {
+        TelemetryConfiguration.getActive().setInstrumentationKey(instrumentationKey);
+    }
+```
+
+## 4. Add an HTTP filter
+The last configuration step allows the HTTP request component to log each web request. (Not required if you just want the bare API.)
+
+### Spring Boot Applications
+Register the Application Insights `WebRequestTrackingFilter` in your Configuration class:
+
+```Java
+package <yourpackagename>.configurations;
+
+import javax.servlet.Filter;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
+
+@Configuration
+public class AppInsightsConfig {
+
+    @Bean
+    public String telemetryConfig() {
+        String telemetryKey = System.getenv("<instrumentation key>");
+        if (telemetryKey != null) {
+            TelemetryConfiguration.getActive().setInstrumentationKey(telemetryKey);
+        }
+        return telemetryKey;
+    }
+
+    /**
+     * Programmatically registers a FilterRegistrationBean to register WebRequestTrackingFilter
+     * @param webRequestTrackingFilter
+     * @return Bean of type {@link FilterRegistrationBean}
+     */
+    @Bean
+    public FilterRegistrationBean webRequestTrackingFilterRegistrationBean(WebRequestTrackingFilter webRequestTrackingFilter) {
+        FilterRegistrationBean registration = new FilterRegistrationBean();
+        registration.setFilter(webRequestTrackingFilter);
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 10);
+        return registration;
+    }
+
+
+    /**
+     * Creates bean of type WebRequestTrackingFilter for request tracking
+     * @param applicationName Name of the application to bind filter to
+     * @return {@link Bean} of type {@link WebRequestTrackingFilter}
+     */
+    @Bean
+    @ConditionalOnMissingBean
+
+    public WebRequestTrackingFilter webRequestTrackingFilter(@Value("${spring.application.name:application}") String applicationName) {
+        return new WebRequestTrackingFilter(applicationName);
+    }
+
+
+}
+```
+
+> [!NOTE]
+> If you're using Spring Boot 1.3.8 or older replace the FilterRegistrationBean with the line below
+
+```Java
+    import org.springframework.boot.context.embedded.FilterRegistrationBean;
+```
+
+This class will configure the `WebRequestTrackingFilter` to be the first filter on the http filter chain. It will also pull the instrumentation key from the operating system environment variable if it is available.
+
+> We are using the web http filter configuration rather than the Spring MVC configuration because this is a Spring Boot application, and it has its own Spring MVC configuration. See the sections below for Spring MVC specific configuration.
+
+### Applications Using Web.xml
+Locate and open the web.xml file in your project, and merge the following code under the web-app node, where your application filters are configured.
+
+To get the most accurate results, the filter should be mapped before all other filters.
+
+```XML
+
+    <filter>
+      <filter-name>ApplicationInsightsWebFilter</filter-name>
+      <filter-class>
+        com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter
+      </filter-class>
+    </filter>
+    <filter-mapping>
+       <filter-name>ApplicationInsightsWebFilter</filter-name>
+       <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+   <!-- This listener handles shutting down the TelemetryClient when an application/servlet is undeployed. -->
+    <listener>
+      <listener-class>com.microsoft.applicationinsights.web.internal.ApplicationInsightsServletContextListener</listener-class>
+    </listener>
+```
+
+#### If you're using Spring Web MVC 3.1 or later
+Edit these elements in *-servlet.xml to include the Application Insights package:
+
+```XML
+
+    <context:component-scan base-package=" com.springapp.mvc, com.microsoft.applicationinsights.web.spring"/>
+
+    <mvc:interceptors>
+        <mvc:interceptor>
+            <mvc:mapping path="/**"/>
+            <bean class="com.microsoft.applicationinsights.web.spring.RequestNameHandlerInterceptorAdapter" />
+        </mvc:interceptor>
+    </mvc:interceptors>
+```
+
+#### If you're using Struts 2
+Add this item to the Struts configuration file (usually named struts.xml or struts-default.xml):
+
+```XML
+
+     <interceptors>
+       <interceptor name="ApplicationInsightsRequestNameInterceptor" class="com.microsoft.applicationinsights.web.struts.RequestNameInterceptor" />
+     </interceptors>
+     <default-interceptor-ref name="ApplicationInsightsRequestNameInterceptor" />
+```
+
+If you have interceptors defined in a default stack, the interceptor can be added to that stack.
+
+## 5. Run your application
+Either run it in debug mode on your development machine, or publish to your server.
+
+## 6. View your telemetry in Application Insights
+Return to your Application Insights resource in [Microsoft Azure portal](https://portal.azure.com).
+
+HTTP requests data appears on the overview blade. (If it isn't there, wait a few seconds and then click Refresh.)
+
+![Screenshot of overview sample data](./media/java-get-started/overview-graphs.png)
+
+[Learn more about metrics.][metrics]
+
+Click through any chart to see more detailed aggregated metrics.
+
+![Application Insights failures pane with charts](./media/java-get-started/006-barcharts.png)
+
+> Application Insights assumes the format of HTTP requests for MVC applications is: `VERB controller/action`. For example, `GET Home/Product/f9anuh81`, `GET Home/Product/2dffwrf5` and `GET Home/Product/sdf96vws` are grouped into `GET Home/Product`. This grouping enables meaningful aggregations of requests, such as number of requests and average execution time for requests.
+>
+>
+
+### Instance data
+Click through a specific request type to see individual instances.
+
+![Drill into a specific sample view](./media/java-get-started/007-instance.png)
+
+### Analytics: Powerful query language
+As you accumulate more data, you can run queries both to aggregate data and to find individual instances.  [Analytics](../../azure-monitor/app/analytics.md) is a powerful tool for both for understanding performance and usage, and for diagnostic purposes.
+
+![Example of Analytics](./media/java-get-started/0025.png)
+
+## 7. Install your app on the server
+Now publish your app to the server, let people use it, and watch the telemetry show up on the portal.
+
+* Make sure your firewall allows your application to send telemetry to these ports:
+
+  * dc.services.visualstudio.com:443
+  * f5.services.visualstudio.com:443
+
+* If outgoing traffic must be routed through a firewall, define system properties `http.proxyHost` and `http.proxyPort`.
+
+* On Windows servers, install:
+
+  * [Microsoft Visual C++ Redistributable](https://www.microsoft.com/download/details.aspx?id=40784)
+
+    (This component enables performance counters.)
+
+## Azure App Service config (Spring Boot)
+
+Spring Boot apps running on Windows require additional configuration to run on Azure App Services. Modify **web.config** and add the following:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <system.webServer>
+        <handlers>
+            <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified"/>
+        </handlers>
+        <httpPlatform processPath="%JAVA_HOME%\bin\java.exe" arguments="-Djava.net.preferIPv4Stack=true -Dserver.port=%HTTP_PLATFORM_PORT% -jar &quot;%HOME%\site\wwwroot\AzureWebAppExample-0.0.1-SNAPSHOT.jar&quot;">
+        </httpPlatform>
+    </system.webServer>
+</configuration>
+```
+
+## Exceptions and request failures
+Unhandled exceptions are automatically collected.
+
+To collect data on other exceptions, you have two options:
+
+* [Insert calls to trackException() in your code][apiexceptions].
+* [Install the Java Agent on your server](java-agent.md). You specify the methods you want to watch.
+
+## Monitor method calls and external dependencies
+[Install the Java Agent](java-agent.md) to log specified internal methods and calls made through JDBC, with timing data.
+
+## W3C distributed tracing
+
+The Application Insights Java SDK now supports [W3C distributed tracing](https://w3c.github.io/trace-context/).
+
+The incoming SDK configuration is explained further in our article on [correlation](correlation.md#w3c-distributed-tracing).
+
+Outgoing SDK configuration is defined in the [AI-Agent.xml](java-agent.md) file.
+
+## Performance counters
+Open **Investigate**, **Metrics**, to see a range of performance counters.
+
+![Screenshot of metrics pane with process private bytes selected](./media/java-get-started/011-perf-counters.png)
+
+### Customize performance counter collection
+To disable collection of the standard set of performance counters, add the following code under the root node of the ApplicationInsights.xml file:
+
+```XML
+    <PerformanceCounters>
+       <UseBuiltIn>False</UseBuiltIn>
+    </PerformanceCounters>
+```
+
+### Collect additional performance counters
+You can specify additional performance counters to be collected.
+
+#### JMX counters (exposed by the Java Virtual Machine)
+
+```XML
+    <PerformanceCounters>
+      <Jmx>
+        <Add objectName="java.lang:type=ClassLoading" attribute="TotalLoadedClassCount" displayName="Loaded Class Count"/>
+        <Add objectName="java.lang:type=Memory" attribute="HeapMemoryUsage.used" displayName="Heap Memory Usage-used" type="composite"/>
+      </Jmx>
+    </PerformanceCounters>
+```
+
+* `displayName` – The name displayed in the Application Insights portal.
+* `objectName` – The JMX object name.
+* `attribute` – The attribute of the JMX object name to fetch
+* `type` (optional) - The type of JMX object’s attribute:
+  * Default: a simple type such as int or long.
+  * `composite`: the perf counter data is in the format of 'Attribute.Data'
+  * `tabular`: the perf counter data is in the format of a table row
+
+#### Windows performance counters
+Each [Windows performance counter](https://msdn.microsoft.com/library/windows/desktop/aa373083.aspx) is a member of a category (in the same way that a field is a member of a class). Categories can either be global, or can have numbered or named instances.
+
+```XML
+    <PerformanceCounters>
+      <Windows>
+        <Add displayName="Process User Time" categoryName="Process" counterName="%User Time" instanceName="__SELF__" />
+        <Add displayName="Bytes Printed per Second" categoryName="Print Queue" counterName="Bytes Printed/sec" instanceName="Fax" />
+      </Windows>
+    </PerformanceCounters>
+```
+
+* displayName – The name displayed in the Application Insights portal.
+* categoryName – The performance counter category (performance object) with which this performance counter is associated.
+* counterName – The name of the performance counter.
+* instanceName – The name of the performance counter category instance, or an empty string (""), if the category contains a single instance. If the categoryName is Process, and the performance counter you'd like to collect is from the current JVM process on which your app is running, specify `"__SELF__"`.
+
+### Unix performance counters
+* [Install collectd with the Application Insights plugin](java-collectd.md) to get a wide variety of system and network data.
+
+## Local forwarder
+
+[Local forwarder](https://docs.microsoft.com/azure/application-insights/local-forwarder) is an agent that collects Application Insights or [OpenCensus](https://opencensus.io/) telemetry from a variety of SDKs and frameworks and routes it to Application Insights. It's capable of running under Windows and Linux.
+
+```xml
+<Channel type="com.microsoft.applicationinsights.channel.concrete.localforwarder.LocalForwarderTelemetryChannel">
+<DeveloperMode>false</DeveloperMode>
+<EndpointAddress><!-- put the hostname:port of your LocalForwarder instance here --></EndpointAddress>
+<!-- The properties below are optional. The values shown are the defaults for each property -->
+<FlushIntervalInSeconds>5</FlushIntervalInSeconds><!-- must be between [1, 500]. values outside the bound will be rounded to nearest bound -->
+<MaxTelemetryBufferCapacity>500</MaxTelemetryBufferCapacity><!-- units=number of telemetry items; must be between [1, 1000] -->
+</Channel>
+```
+
+If you are using SpringBoot starter, add the following to your configuration file (application.properties):
+
+```yml
+azure.application-insights.channel.local-forwarder.endpoint-address=<!--put the hostname:port of your LocalForwarder instance here-->
+azure.application-insights.channel.local-forwarder.flush-interval-in-seconds=<!--optional-->
+azure.application-insights.channel.local-forwarder.max-telemetry-buffer-capacity=<!--optional-->
+```
+
+Default values are the same for SpringBoot application.properties and applicationinsights.xml configuration.
+
+## Get user and session data
+OK, you're sending telemetry from your web server. Now to get the full 360-degree view of your application, you can add more monitoring:
+
+* [Add telemetry to your web pages][usage] to monitor page views and user metrics.
+* [Set up web tests][availability] to make sure your application stays live and responsive.
+
+## Capture log traces
+You can use Application Insights to slice and dice logs from Log4J, Logback, or other logging frameworks. You can correlate the logs with HTTP requests and other telemetry. [Learn how][javalogs].
+
+## Send your own telemetry
+Now that you've installed the SDK, you can use the API to send your own telemetry.
+
+* [Track custom events and metrics][api] to learn what users are doing with your application.
+* [Search events and logs][diagnostic] to help diagnose problems.
+
+## Availability web tests
+Application Insights can test your website at regular intervals to check that it's up and responding well.
+
+[Learn more about how to setup availability web tests.][availability]
+
+## Questions? Problems?
+[Troubleshooting Java](java-troubleshoot.md)
+
+## Next steps
+* [Monitor dependency calls](java-agent.md)
+* [Monitor Unix performance counters](java-collectd.md)
+* Add [monitoring to your web pages](javascript.md) to monitor page load times, AJAX calls, browser exceptions.
+* Write [custom telemetry](../../azure-monitor/app/api-custom-events-metrics.md) to track usage in the browser or at the server.
+* Use  [Analytics](../../azure-monitor/app/analytics.md) for powerful queries over telemetry from your app
+* For more information, visit [Azure for Java developers](/java/azure).
+
+<!--Link references-->
+
+[api]: ../../azure-monitor/app/api-custom-events-metrics.md
+[apiexceptions]: ../../azure-monitor/app/api-custom-events-metrics.md#trackexception
+[availability]: ../../azure-monitor/app/monitor-web-app-availability.md
+[diagnostic]: ../../azure-monitor/app/diagnostic-search.md
+[eclipse]: ../../azure-monitor/learn/java-quick-start.md
+[javalogs]: java-trace-logs.md
+[metrics]: ../../azure-monitor/app/metrics-explorer.md
+[usage]: javascript.md

--- a/articles/azure-monitor/app/java-get-started-25-beta.md
+++ b/articles/azure-monitor/app/java-get-started-25-beta.md
@@ -1,6 +1,6 @@
 ---
-title: Java web app analytics with Azure Application Insights | Microsoft Docs
-description: 'Application Performance Monitoring for Java web apps with Application Insights. '
+title: Java web app analytics with Azure Application Insights (2.5-beta) | Microsoft Docs
+description: 'Application Performance Monitoring for Java web apps with Application Insights (2.5-beta). '
 services: application-insights
 documentationcenter: java
 author: lgayhardt
@@ -13,7 +13,7 @@ ms.topic: conceptual
 ms.date: 05/24/2019
 ms.author: lagayhar
 ---
-# Get started with Application Insights in a Java web project
+# Get started with Application Insights in a Java web project (2.5-beta)
 
 [Application Insights](https://azure.microsoft.com/services/application-insights/) is an extensible analytics service for web developers that helps you understand the performance and usage of your live application. Use it to [automatically instrument request, track dependencies, and collect performance counters](auto-collect-dependencies.md#java), diagnose performance issues and exceptions, and [write code][api] to track what users do with your app. 
 
@@ -23,10 +23,8 @@ Application Insights supports Java apps running on Linux, Unix, or Windows.
 
 You need:
 
-* JRE version 1.7 or 1.8
+* Java 7 or later
 * A subscription to [Microsoft Azure](https://azure.microsoft.com/).
-
-If you prefer the Spring framework try the [configure a Spring Boot initializer app to use Application Insights guide](https://docs.microsoft.com/java/azure/spring-framework/configure-spring-boot-java-applicationinsights)
 
 ## 1. Get an Application Insights instrumentation key
 1. Sign in to the [Microsoft Azure portal](https://portal.azure.com).
@@ -45,27 +43,16 @@ If your project is already set up to use Maven for build, merge the following co
 Then, refresh the project dependencies to get the binaries downloaded.
 
 ```XML
-
-    <repositories>
-       <repository>
-          <id>central</id>
-          <name>Central</name>
-          <url>http://repo1.maven.org/maven2</url>
-       </repository>
-    </repositories>
-
     <dependencies>
       <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>applicationinsights-web</artifactId>
+        <artifactId>applicationinsights-web-auto</artifactId>
+        <!-- or applicationinsights-web for manual web filter registration -->
         <!-- or applicationinsights-core for bare API -->
-        <version>[2.0,)</version>
+        <version>2.5-beta</version>
       </dependency>
     </dependencies>
 ```
-
-* *Build or checksum validation errors?* Try using a specific version, such as: `<version>2.0.n</version>`. You'll find the latest version in the [SDK release notes](https://github.com/Microsoft/ApplicationInsights-Java#release-notes) or in the [Maven artifacts](https://search.maven.org/#search%7Cga%7C1%7Capplicationinsights).
-* *Need to update to a new SDK?* Refresh your project's dependencies.
 
 #### If you're using Gradle... <a name="gradle-setup" />
 If your project is already set up to use Gradle for build, merge the following code to your build.gradle file.
@@ -73,34 +60,27 @@ If your project is already set up to use Gradle for build, merge the following c
 Then refresh the project dependencies to get the binaries downloaded.
 
 ```gradle
-
-    repositories {
-      mavenCentral()
-    }
-
     dependencies {
-      compile group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '2.+'
+      compile group: 'com.microsoft.azure', name: 'applicationinsights-web-auto', version: '2.5-beta'
+      // or applicationinsights-web for manual web filter registration
       // or applicationinsights-core for bare API
     }
 ```
-
-#### If you're using Eclipse to create a Dynamic Web project ...
-Use the [Application Insights SDK for Java plug-in][eclipse]. Note: even though using this plugin will get you up and running with Application Insights quicker (assuming you're not using Maven/Gradle), it is not a dependency management system. As such, updating the plugin will not automatically update the Application Insights libraries in your project.
-
-* *Build or checksum validation errors?* Try using a specific version, such as: `version:'2.0.n'`. You'll find the latest version in the [SDK release notes](https://github.com/Microsoft/ApplicationInsights-Java#release-notes) or in the [Maven artifacts](https://search.maven.org/#search%7Cga%7C1%7Capplicationinsights).
-* *To update to a new SDK* Refresh your project's dependencies.
 
 #### Otherwise, if you are manually managing dependencies ...
 Download the [latest version](https://github.com/Microsoft/ApplicationInsights-Java/releases/latest) and copy the necessary files into your project, replacing any previous versions.
 
 ### Questions...
-* *What's the relationship between the `-core` and `-web` components?*
-  * `applicationinsights-core` gives you the bare API. You always need this component.
-  * `applicationinsights-web` gives you metrics that track HTTP request counts and response times. You can omit this component if you don't want this telemetry automatically collected. For example, if you want to write your own.
+* *What's the relationship between the `-web-auto`, `-web` and `-core` components?*
+  * `applicationinsights-web-auto` gives you metrics that track HTTP servlet request counts and response times,
+    by automatically registering the Application Insights servlet filter at runtime.
+  * `applicationinsights-web` also gives you metrics that track HTTP servlet request counts and response times,
+    but requires manual registration of the Application Insights servlet filter in your application.
+  * `applicationinsights-core` gives you just the bare API, for example, if your application is not servlet-based.
   
 * *How should I update the SDK to the latest version?*
   * If you are using Gradle or Maven...
-    * Update your build file to specify the latest version or use Gradle/Maven's wildcard syntax to include the latest version automatically. Then, refresh your project's dependencies. The wildcard syntax can be seen in the examples above for [Gradle](#gradle-setup) or [Maven](#maven-setup).
+    * Update your build file to specify the latest version.
   * If you are manually managing dependencies...
     * Download the latest [Application Insights SDK for Java](https://github.com/Microsoft/ApplicationInsights-Java/releases/latest) and replace the old ones. Changes are described in the [SDK release notes](https://github.com/Microsoft/ApplicationInsights-Java#release-notes).
 
@@ -110,34 +90,30 @@ Add ApplicationInsights.xml to the resources folder in your project, or make sur
 Substitute the instrumentation key that you got from the Azure portal.
 
 ```XML
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
 
-    <?xml version="1.0" encoding="utf-8"?>
-    <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+   <!-- The key from the portal: -->
+   <InstrumentationKey>** Your instrumentation key **</InstrumentationKey>
 
+   <!-- HTTP request component (not required for bare API) -->
+   <TelemetryModules>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"/>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule"/>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule"/>
+   </TelemetryModules>
 
-      <!-- The key from the portal: -->
-      <InstrumentationKey>** Your instrumentation key **</InstrumentationKey>
+   <!-- Events correlation (not required for bare API) -->
+   <!-- These initializers add context data to each event -->
+   <TelemetryInitializers>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer"/>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationNameTelemetryInitializer"/>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebSessionTelemetryInitializer"/>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserTelemetryInitializer"/>
+      <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserAgentTelemetryInitializer"/>
+   </TelemetryInitializers>
 
-
-      <!-- HTTP request component (not required for bare API) -->
-      <TelemetryModules>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule"/>
-      </TelemetryModules>
-
-      <!-- Events correlation (not required for bare API) -->
-      <!-- These initializers add context data to each event -->
-
-      <TelemetryInitializers>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationNameTelemetryInitializer"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebSessionTelemetryInitializer"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserTelemetryInitializer"/>
-        <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserAgentTelemetryInitializer"/>
-
-      </TelemetryInitializers>
-    </ApplicationInsights>
+</ApplicationInsights>
 ```
 
 Optionally, the configuration file can reside in any location accessible to your application.  The system property `-Dapplicationinsights.configurationDirectory` specifies the directory that contains ApplicationInsights.xml. For example, a configuration file located at `E:\myconfigs\appinsights\ApplicationInsights.xml` would be configured with the property `-Dapplicationinsights.configurationDirectory="E:\myconfigs\appinsights"`.
@@ -149,8 +125,8 @@ Optionally, the configuration file can reside in any location accessible to your
 ### Alternative ways to set the instrumentation key
 Application Insights SDK looks for the key in this order:
 
-1. System property: -DAPPLICATION_INSIGHTS_IKEY=your_ikey
-2. Environment variable: APPLICATION_INSIGHTS_IKEY
+1. System property: -DAPPINSIGHTS_INSTRUMENTATIONKEY=your_ikey
+2. Environment variable: APPINSIGHTS_INSTRUMENTATIONKEY
 3. Configuration file: ApplicationInsights.xml
 
 You can also [set it in code](../../azure-monitor/app/api-custom-events-metrics.md#ikey):
@@ -164,131 +140,10 @@ You can also [set it in code](../../azure-monitor/app/api-custom-events-metrics.
     }
 ```
 
-## 4. Add an HTTP filter
-The last configuration step allows the HTTP request component to log each web request. (Not required if you just want the bare API.)
+## 4. Add agent
 
-### Spring Boot Applications
-Register the Application Insights `WebRequestTrackingFilter` in your Configuration class:
-
-```Java
-package <yourpackagename>.configurations;
-
-import javax.servlet.Filter;
-
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.Ordered;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
-import com.microsoft.applicationinsights.TelemetryConfiguration;
-import com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter;
-
-@Configuration
-public class AppInsightsConfig {
-
-    @Bean
-    public String telemetryConfig() {
-        String telemetryKey = System.getenv("<instrumentation key>");
-        if (telemetryKey != null) {
-            TelemetryConfiguration.getActive().setInstrumentationKey(telemetryKey);
-        }
-        return telemetryKey;
-    }
-
-    /**
-     * Programmatically registers a FilterRegistrationBean to register WebRequestTrackingFilter
-     * @param webRequestTrackingFilter
-     * @return Bean of type {@link FilterRegistrationBean}
-     */
-    @Bean
-    public FilterRegistrationBean webRequestTrackingFilterRegistrationBean(WebRequestTrackingFilter webRequestTrackingFilter) {
-        FilterRegistrationBean registration = new FilterRegistrationBean();
-        registration.setFilter(webRequestTrackingFilter);
-        registration.addUrlPatterns("/*");
-        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 10);
-        return registration;
-    }
-
-
-    /**
-     * Creates bean of type WebRequestTrackingFilter for request tracking
-     * @param applicationName Name of the application to bind filter to
-     * @return {@link Bean} of type {@link WebRequestTrackingFilter}
-     */
-    @Bean
-    @ConditionalOnMissingBean
-
-    public WebRequestTrackingFilter webRequestTrackingFilter(@Value("${spring.application.name:application}") String applicationName) {
-        return new WebRequestTrackingFilter(applicationName);
-    }
-
-
-}
-```
-
-> [!NOTE]
-> If you're using Spring Boot 1.3.8 or older replace the FilterRegistrationBean with the line below
-
-```Java
-    import org.springframework.boot.context.embedded.FilterRegistrationBean;
-```
-
-This class will configure the `WebRequestTrackingFilter` to be the first filter on the http filter chain. It will also pull the instrumentation key from the operating system environment variable if it is available.
-
-> We are using the web http filter configuration rather than the Spring MVC configuration because this is a Spring Boot application, and it has its own Spring MVC configuration. See the sections below for Spring MVC specific configuration.
-
-### Applications Using Web.xml
-Locate and open the web.xml file in your project, and merge the following code under the web-app node, where your application filters are configured.
-
-To get the most accurate results, the filter should be mapped before all other filters.
-
-```XML
-
-    <filter>
-      <filter-name>ApplicationInsightsWebFilter</filter-name>
-      <filter-class>
-        com.microsoft.applicationinsights.web.internal.WebRequestTrackingFilter
-      </filter-class>
-    </filter>
-    <filter-mapping>
-       <filter-name>ApplicationInsightsWebFilter</filter-name>
-       <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
-   <!-- This listener handles shutting down the TelemetryClient when an application/servlet is undeployed. -->
-    <listener>
-      <listener-class>com.microsoft.applicationinsights.web.internal.ApplicationInsightsServletContextListener</listener-class>
-    </listener>
-```
-
-#### If you're using Spring Web MVC 3.1 or later
-Edit these elements in *-servlet.xml to include the Application Insights package:
-
-```XML
-
-    <context:component-scan base-package=" com.springapp.mvc, com.microsoft.applicationinsights.web.spring"/>
-
-    <mvc:interceptors>
-        <mvc:interceptor>
-            <mvc:mapping path="/**"/>
-            <bean class="com.microsoft.applicationinsights.web.spring.RequestNameHandlerInterceptorAdapter" />
-        </mvc:interceptor>
-    </mvc:interceptors>
-```
-
-#### If you're using Struts 2
-Add this item to the Struts configuration file (usually named struts.xml or struts-default.xml):
-
-```XML
-
-     <interceptors>
-       <interceptor name="ApplicationInsightsRequestNameInterceptor" class="com.microsoft.applicationinsights.web.struts.RequestNameInterceptor" />
-     </interceptors>
-     <default-interceptor-ref name="ApplicationInsightsRequestNameInterceptor" />
-```
-
-If you have interceptors defined in a default stack, the interceptor can be added to that stack.
+[Install the Java Agent](java-agent-25-beta.md) to capture outgoing HTTP calls, JDBC queries, application logging
+and better operation naming.
 
 ## 5. Run your application
 Either run it in debug mode on your development machine, or publish to your server.
@@ -306,9 +161,8 @@ Click through any chart to see more detailed aggregated metrics.
 
 ![Application Insights failures pane with charts](./media/java-get-started/006-barcharts.png)
 
-> Application Insights assumes the format of HTTP requests for MVC applications is: `VERB controller/action`. For example, `GET Home/Product/f9anuh81`, `GET Home/Product/2dffwrf5` and `GET Home/Product/sdf96vws` are grouped into `GET Home/Product`. This grouping enables meaningful aggregations of requests, such as number of requests and average execution time for requests.
->
->
+[TODO update image with 2.5-beta operation naming provided by agent]
+
 
 ### Instance data
 Click through a specific request type to see individual instances.
@@ -354,15 +208,14 @@ Spring Boot apps running on Windows require additional configuration to run on A
 ```
 
 ## Exceptions and request failures
-Unhandled exceptions are automatically collected.
+Unhandled exceptions and request failures are automatically collected by the Application Insights web filter.
 
-To collect data on other exceptions, you have two options:
-
-* [Insert calls to trackException() in your code][apiexceptions].
-* [Install the Java Agent on your server](java-agent.md). You specify the methods you want to watch.
+To collect data on other exceptions, you can [insert calls to trackException() in your code][apiexceptions].
 
 ## Monitor method calls and external dependencies
 [Install the Java Agent](java-agent.md) to log specified internal methods and calls made through JDBC, with timing data.
+
+And for automatic operation naming.
 
 ## W3C distributed tracing
 
@@ -458,9 +311,6 @@ OK, you're sending telemetry from your web server. Now to get the full 360-degre
 * [Add telemetry to your web pages][usage] to monitor page views and user metrics.
 * [Set up web tests][availability] to make sure your application stays live and responsive.
 
-## Capture log traces
-You can use Application Insights to slice and dice logs from Log4J, Logback, or other logging frameworks. You can correlate the logs with HTTP requests and other telemetry. [Learn how][javalogs].
-
 ## Send your own telemetry
 Now that you've installed the SDK, you can use the API to send your own telemetry.
 
@@ -490,6 +340,6 @@ Application Insights can test your website at regular intervals to check that it
 [availability]: ../../azure-monitor/app/monitor-web-app-availability.md
 [diagnostic]: ../../azure-monitor/app/diagnostic-search.md
 [eclipse]: ../../azure-monitor/learn/java-quick-start.md
-[javalogs]: java-trace-logs.md
+[javalogs]: java-trace-logs-25-beta.md
 [metrics]: ../../azure-monitor/app/metrics-explorer.md
 [usage]: javascript.md

--- a/articles/azure-monitor/app/java-trace-logs-25-beta.md
+++ b/articles/azure-monitor/app/java-trace-logs-25-beta.md
@@ -1,0 +1,167 @@
+---
+title: Explore Java trace logs in Azure Application Insights | Microsoft Docs
+description: Search Log4J or Logback traces in Application Insights
+services: application-insights
+documentationcenter: java
+author: mrbullwinkle
+manager: carmonm
+ms.assetid: fc0a9e2f-3beb-4f47-a9fe-3f86cd29d97a
+ms.service: application-insights
+ms.workload: tbd
+ms.tgt_pltfrm: ibiza
+ms.topic: conceptual
+ms.date: 05/18/2019
+ms.author: mbullwin
+---
+# Explore Java trace logs in Application Insights
+If you're using Logback or Log4J (v1.2 or v2.0) for tracing, you can have your trace logs sent automatically to Application Insights where you can explore and search on them.
+
+## Install the Java SDK
+
+Follow the instructions to install [Application Insights SDK for Java][java], if you haven't already done that.
+
+## Add logging libraries to your project
+*Choose the appropriate way for your project.*
+
+#### If you're using Maven...
+If your project is already set up to use Maven for build, merge one of the following snippets of code into your pom.xml file.
+
+Then refresh the project dependencies, to get the binaries downloaded.
+
+*Logback*
+
+```XML
+
+    <dependencies>
+       <dependency>
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>applicationinsights-logging-logback</artifactId>
+          <version>[2.0,)</version>
+       </dependency>
+    </dependencies>
+```
+
+*Log4J v2.0*
+
+```XML
+
+    <dependencies>
+       <dependency>
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>applicationinsights-logging-log4j2</artifactId>
+          <version>[2.0,)</version>
+       </dependency>
+    </dependencies>
+```
+
+*Log4J v1.2*
+
+```XML
+
+    <dependencies>
+       <dependency>
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>applicationinsights-logging-log4j1_2</artifactId>
+          <version>[2.0,)</version>
+       </dependency>
+    </dependencies>
+```
+
+#### If you're using Gradle...
+If your project is already set up to use Gradle for build, add one of the following lines to the `dependencies` group in your build.gradle file:
+
+Then refresh the project dependencies, to get the binaries downloaded.
+
+**Logback**
+
+```
+
+    compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-logback', version: '2.0.+'
+```
+
+**Log4J v2.0**
+
+```
+    compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j2', version: '2.0.+'
+```
+
+**Log4J v1.2**
+
+```
+    compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j1_2', version: '2.0.+'
+```
+
+#### Otherwise ...
+Follow the guidelines to manually install Application Insights Java SDK, download the jar (After arriving at Maven Central Page click on 'jar' link in download section) for appropriate appender and add the downloaded appender jar to the project.
+
+| Logger | Download | Library |
+| --- | --- | --- |
+| Logback |[Logback appender Jar](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22applicationinsights-logging-logback%22) |applicationinsights-logging-logback |
+| Log4J v2.0 |[Log4J v2 appender Jar](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22applicationinsights-logging-log4j2%22) |applicationinsights-logging-log4j2 |
+| Log4j v1.2 |[Log4J v1.2 appender Jar](https://search.maven.org/#search%7Cga%7C1%7Ca%3A%22applicationinsights-logging-log4j1_2%22) |applicationinsights-logging-log4j1_2 |
+
+
+## Add the appender to your logging framework
+To start getting traces, merge the relevant snippet of code to the Log4J or Logback configuration file: 
+
+*Logback*
+
+```XML
+
+    <appender name="aiAppender" 
+      class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender">
+        <instrumentationKey>[APPLICATION_INSIGHTS_KEY]</instrumentationKey>
+    </appender>
+    <root level="trace">
+      <appender-ref ref="aiAppender" />
+    </root>
+```
+
+*Log4J v2.0*
+
+```XML
+
+    <Configuration packages="com.microsoft.applicationinsights.log4j.v2">
+      <Appenders>
+        <ApplicationInsightsAppender name="aiAppender" instrumentationKey="[APPLICATION_INSIGHTS_KEY]" />
+      </Appenders>
+      <Loggers>
+        <Root level="trace">
+          <AppenderRef ref="aiAppender"/>
+        </Root>
+      </Loggers>
+    </Configuration>
+```
+
+*Log4J v1.2*
+
+```XML
+
+    <appender name="aiAppender" 
+         class="com.microsoft.applicationinsights.log4j.v1_2.ApplicationInsightsAppender">
+        <param name="instrumentationKey" value="[APPLICATION_INSIGHTS_KEY]" />
+    </appender>
+    <root>
+      <priority value ="trace" />
+      <appender-ref ref="aiAppender" />
+    </root>
+```
+
+The Application Insights appenders can be referenced by any configured logger, and not necessarily by the root logger (as shown in the code samples above).
+
+## Explore your traces in the Application Insights portal
+Now that you've configured your project to send traces to Application Insights, you can view and search these traces in the Application Insights portal, in the [Search][diagnostic] blade.
+
+Exceptions submitted via loggers will be displayed on the portal as Exception Telemetry.
+
+![In the Application Insights portal, open Search](./media/java-trace-logs/01-diagnostics.png)
+
+## Next steps
+[Diagnostic search][diagnostic]
+
+<!--Link references-->
+
+[diagnostic]: ../../azure-monitor/app/diagnostic-search.md
+[java]: java-get-started.md
+
+

--- a/articles/azure-monitor/app/java-trace-logs-25-beta.md
+++ b/articles/azure-monitor/app/java-trace-logs-25-beta.md
@@ -1,6 +1,6 @@
 ---
-title: Explore Java trace logs in Azure Application Insights | Microsoft Docs
-description: Search Log4J or Logback traces in Application Insights
+title: Explore Java trace logs in Azure Application Insights (2.5-beta) | Microsoft Docs
+description: Search Log4J or Logback traces in Application Insights (2.5-beta)
 services: application-insights
 documentationcenter: java
 author: mrbullwinkle
@@ -13,8 +13,29 @@ ms.topic: conceptual
 ms.date: 05/18/2019
 ms.author: mbullwin
 ---
-# Explore Java trace logs in Application Insights
+
+
+# Explore Java trace logs in Application Insights (2.5-beta)
 If you're using Logback or Log4J (v1.2 or v2.0) for tracing, you can have your trace logs sent automatically to Application Insights where you can explore and search on them.
+
+## Note: if you are using the Application Insights Java agent
+
+You can configure the Application Insights Java agent to automatically capture your logs,
+by enabling the feature in the `AI-Agent.xml` file:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<ApplicationInsightsAgent>
+   <Instrumentation>
+      <BuiltIn enabled="true">
+         <Logging enabled="true" />
+      </BuiltIn>
+   </Instrumentation>
+   <AgentLogger />
+</ApplicationInsightsAgent>
+```
+
+Otherwise...
 
 ## Install the Java SDK
 

--- a/articles/azure-monitor/app/micrometer-java-25-beta.md
+++ b/articles/azure-monitor/app/micrometer-java-25-beta.md
@@ -1,0 +1,250 @@
+---
+title: How to use Micrometer with Azure Application Insights Java SDK | Microsoft Docs
+description: 'A step by step guide on using Micrometer with your Application Insights Spring Boot and non-Spring Boot applications. '
+services: application-insights
+documentationcenter: java
+author: lgayhardt
+manager: carmonm
+ms.assetid: 051d4285-f38a-45d8-ad8a-45c3be828d91
+ms.service: application-insights
+ms.workload: tbd
+ms.tgt_pltfrm: ibiza
+ms.topic: conceptual
+ms.date: 11/01/2018
+ms.author: lagayhar
+---
+# How to use Micrometer with Azure Application Insights Java SDK
+Micrometer application monitoring measures metrics for JVM-based application code and lets you export the data to your favorite monitoring systems. This article will teach you how to use Micrometer with Application Insights for both Spring Boot and non-Spring Boot applications.
+
+## Using Spring Boot 1.5x
+Add the following dependencies to your pom.xml or build.gradle file: 
+* [Application Insights spring-boot-starter](https://github.com/Microsoft/ApplicationInsights-Java/tree/master/azure-application-insights-spring-boot-starter)1.1.0-BETA or above
+* Micrometer Azure Registry 1.1.0 or above
+* [Micrometer Spring Legacy](https://micrometer.io/docs/ref/spring/1.5) 1.1.0 or above (this backports the autoconfig code in the Spring framework).
+* [ApplicationInsights Resource](../../azure-monitor/app/create-new-resource.md )
+
+Steps
+
+1. Update the pom.xml file of your Spring Boot application and add the following dependencies in it:
+
+    ```XML
+    <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>applicationinsights-spring-boot-starter</artifactId>
+        <version>1.1.0-BETA</version>
+    </dependency>
+
+    <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-spring-legacy</artifactId>
+        <version>1.1.0</version>
+    </dependency>
+
+    <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-azure-monitor</artifactId>
+        <version>1.1.0</version>
+    </dependency>
+
+    ```
+2. Update the application.properties or yml file with the Application Insights Instrumentation key using the following property:
+
+     `azure.application-insights.instrumentation-key=<your-instrumentation-key-here>`
+1. Build your application and run
+2. The above should get you up and running with pre-aggregated metrics auto collected to Azure Monitor. For details on how to fine-tune Application Insights Spring Boot starter refer to the [readme on GitHub](https://github.com/Microsoft/ApplicationInsights-Java/blob/master/azure-application-insights-spring-boot-starter/README.md).
+
+## Using Spring 2.x
+
+Add the following dependencies to your pom.xml or build.gradle file:
+
+* Application Insights Spring-boot-starter 2.1.2 or above
+* Azure-spring-boot-metrics-starters 2.0.7 or above  
+* [Application Insights Resource](../../azure-monitor/app/create-new-resource.md )
+
+Steps:
+
+1. Update the pom.xml file of your Spring Boot application and add the following dependency in it:
+
+    ```XML
+    <dependency> 
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>azure-spring-boot-metrics-starter</artifactId>
+          <version>2.0.7</version>
+    </dependency>
+    ```
+1. Update the application.properties or yml file with the Application Insights Instrumentation key using the following property:
+
+     `azure.application-insights.instrumentation-key=<your-instrumentation-key-here>`
+3. Build your application and run
+4. The above should get you running with pre-aggregated metrics auto collected to Azure Monitor. For details on how to fine-tune Application Insights Spring Boot starter refer to the [readme on GitHub](https://github.com/Microsoft/azure-spring-boot/releases/latest).
+
+Default Metrics:
+
+*    Automatically configured metrics for Tomcat, JVM, Logback Metrics, Log4J metrics, Uptime Metrics, Processor Metrics, FileDescriptorMetrics.
+*    For example, if the netflix hystrix is present on class path we get those metrics as well. 
+*    The following metrics can be available by adding respective beans. 
+        - CacheMetrics (CaffeineCache, EhCache2, GuavaCache, HazelcaseCache, Jcache)     
+        - DataBaseTableMetrics 
+        - HibernateMetrics 
+        - JettyMetrics 
+        - OkHttp3 metrics 
+        - Kafka Metrics 
+
+ 
+
+How to turn off automatic metrics collection: 
+ 
+- JVM Metrics: 
+    - management.metrics.binders.jvm.enabled=false 
+- Logback Metrics: 
+    - management.metrics.binders.logback.enabled=false
+- Uptime Metrics: 
+    - management.metrics.binders.uptime.enabled=false 
+- Processor Metrics:
+    -  management.metrics.binders.processor.enabled=false 
+- FileDescriptorMetrics:
+    - management.metrics.binders.files.enabled=false 
+- Hystrix Metrics if library on classpath: 
+    - management.metrics.binders.hystrix.enabled=false 
+- AspectJ Metrics if library on classpath: 
+    - spring.aop.enabled=false 
+
+> [!NOTE]
+> Specify the properties above in the application.properties or application.yml file of your Spring Boot application
+
+## Use Micrometer with non-Spring Boot web applications
+
+Add the following dependencies to your pom.xml or build.gradle file:
+ 
+* [Application Insight Core 2.2.0](https://www.nuget.org/packages/Microsoft.ApplicationInsights/2.2.0) or above
+* [Application Insights Web 2.2.0](https://www.nuget.org/packages/Microsoft.ApplicationInsights.Web/2.2.0) or above
+* [Register Web Filter](https://docs.microsoft.com/azure/application-insights/app-insights-java-get-started)
+* Micrometer Azure Registry 1.1.0 or above
+* [Application Insights Resource](../../azure-monitor/app/create-new-resource.md )
+
+Steps:
+
+1. Add the following dependencies in your pom.xml or build.gradle file:
+
+    ```XML
+        <dependency>
+        	<groupId>io.micrometer</groupId>
+        	<artifactId>micrometer-registry-azure-monitor</artifactId>
+        	<version>1.1.0</version>
+        </dependency>
+        
+        <dependency>
+        	<groupId>com.microsoft.azure</groupId>
+        	<artifactId>applicationinsights-web</artifactId>
+        	<version>2.2.0</version>
+        </dependency
+     ```
+
+2. Put Application Insights.xml in the resources folder
+
+    Sample Servlet class (emits a timer metric):
+
+    ```Java
+        @WebServlet("/hello")
+        public class TimedDemo extends HttpServlet {
+    
+          private static final long serialVersionUID = -4751096228274971485L;
+    
+          @Override
+          @Timed(value = "hello.world")
+          protected void doGet(HttpServletRequest request, HttpServletResponse response)
+              throws ServletException, IOException {
+    
+            response.getWriter().println("Hello World!");
+            MeterRegistry registry = (MeterRegistry) getServletContext().getAttribute("AzureMonitorMeterRegistry");
+    
+        //create new Timer metric
+            Timer sampleTimer = registry.timer("timer");
+            Stream<Integer> infiniteStream = Stream.iterate(0, i -> i+1);
+            infiniteStream.limit(10).forEach(integer -> {
+              try {
+                Thread.sleep(1000);
+                sampleTimer.record(integer, TimeUnit.MILLISECONDS);
+              } catch (Exception e) {}
+               });
+          }
+          @Override
+          public void init() throws ServletException {
+            System.out.println("Servlet " + this.getServletName() + " has started");
+          }
+          @Override
+          public void destroy() {
+            System.out.println("Servlet " + this.getServletName() + " has stopped");
+          }
+    
+        }
+    
+    ```
+
+      Sample configuration class:
+
+    ```Java
+         @WebListener
+         public class MeterRegistryConfiguration implements ServletContextListener {
+     
+           @Override
+           public void contextInitialized(ServletContextEvent servletContextEvent) {
+     
+         // Create AzureMonitorMeterRegistry
+           private final AzureMonitorConfig config = new AzureMonitorConfig() {
+             @Override
+             public String get(String key) {
+                 return null;
+             }
+            @Override
+               public Duration step() {
+                 return Duration.ofSeconds(60);}
+     
+             @Override
+             public boolean enabled() {
+                 return false;
+             }
+         };
+     
+      MeterRegistry azureMeterRegistry = AzureMonitorMeterRegistry.builder(config);
+     
+             //set the config to be used elsewhere
+             servletContextEvent.getServletContext().setAttribute("AzureMonitorMeterRegistry", azureMeterRegistry);
+     
+           }
+     
+           @Override
+           public void contextDestroyed(ServletContextEvent servletContextEvent) {
+     
+           }
+         }
+    ```
+
+To learn more about metrics, refer to the [Micrometer documentation](https://micrometer.io/docs/).
+
+Other sample code on how to create different types of metrics can be found in[the official Micrometer GitHub repo](https://github.com/micrometer-metrics/micrometer/tree/master/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples).
+
+## How to bind additional metrics collection
+
+### SpringBoot/Spring
+
+Create a bean of the respective metric category. For example, say we need Guava cache Metrics:
+
+```Java
+	@Bean
+	GuavaCacheMetrics guavaCacheMetrics() {
+		Return new GuavaCacheMetrics();
+	}
+```
+There are several metrics that are not enabled by default but can be bound in the above fashion. For a complete list, refer to [the official Micrometer GitHub repo](https://github.com/micrometer-metrics/micrometer/tree/master/micrometer-core/src/main/java/io/micrometer/core/instrument/binder ).
+
+### Non-Spring apps
+Add the following binding code to the configuration  file:
+```Java 
+	New GuavaCacheMetrics().bind(registry);
+```
+
+## Next steps
+
+* To learn more about Micrometer refer to the official [Micrometer documentation](https://micrometer.io/docs).
+* To learn about Spring on Azure refer to the official [Spring on Azure documentation](https://docs.microsoft.com/java/azure/spring-framework/?view=azure-java-stable).

--- a/articles/azure-monitor/app/micrometer-java-25-beta.md
+++ b/articles/azure-monitor/app/micrometer-java-25-beta.md
@@ -115,10 +115,8 @@ How to turn off automatic metrics collection:
 ## Use Micrometer with non-Spring Boot web applications
 
 Add the following dependencies to your pom.xml or build.gradle file:
- 
-* [Application Insight Core 2.2.0](https://www.nuget.org/packages/Microsoft.ApplicationInsights/2.2.0) or above
-* [Application Insights Web 2.2.0](https://www.nuget.org/packages/Microsoft.ApplicationInsights.Web/2.2.0) or above
-* [Register Web Filter](https://docs.microsoft.com/azure/application-insights/app-insights-java-get-started)
+
+* Application Insights Web Auto 2.5.0-BETA or above
 * Micrometer Azure Registry 1.1.0 or above
 * [Application Insights Resource](../../azure-monitor/app/create-new-resource.md )
 
@@ -135,14 +133,41 @@ Steps:
         
         <dependency>
         	<groupId>com.microsoft.azure</groupId>
-        	<artifactId>applicationinsights-web</artifactId>
-        	<version>2.2.0</version>
-        </dependency
+        	<artifactId>applicationinsights-web-auto</artifactId>
+        	<version>2.5.0-BETA</version>
+        </dependency>
      ```
 
-2. Put Application Insights.xml in the resources folder
+2. Put `ApplicationInsights.xml` file in the resources folder
 
-    Sample Servlet class (emits a timer metric):
+    ```XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings" schemaVersion="2014-05-30">
+    
+       <!-- The key from the portal: -->
+       <InstrumentationKey>** Your instrumentation key **</InstrumentationKey>
+    
+       <!-- HTTP request component (not required for bare API) -->
+       <TelemetryModules>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebRequestTrackingTelemetryModule"/>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebSessionTrackingTelemetryModule"/>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.modules.WebUserTrackingTelemetryModule"/>
+       </TelemetryModules>
+    
+       <!-- Events correlation (not required for bare API) -->
+       <!-- These initializers add context data to each event -->
+       <TelemetryInitializers>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationIdTelemetryInitializer"/>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebOperationNameTelemetryInitializer"/>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebSessionTelemetryInitializer"/>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserTelemetryInitializer"/>
+          <Add type="com.microsoft.applicationinsights.web.extensibility.initializers.WebUserAgentTelemetryInitializer"/>
+       </TelemetryInitializers>
+    
+    </ApplicationInsights>
+    ```
+
+3. Sample Servlet class (emits a timer metric):
 
     ```Java
         @WebServlet("/hello")
@@ -181,7 +206,7 @@ Steps:
     
     ```
 
-      Sample configuration class:
+4. Sample configuration class:
 
     ```Java
          @WebListener

--- a/articles/azure-monitor/toc.yml
+++ b/articles/azure-monitor/toc.yml
@@ -384,18 +384,26 @@
         items:
         - name: Web apps
           href: app/java-get-started.md        
+        - name: Web apps (2.5-beta)
+          href: app/java-get-started-25-beta.md
         - name: Docker apps
           href: app/docker.md
         - name: Log traces
           href: app/java-trace-logs.md
+        - name: Log traces (2.5-beta)
+          href: app/java-trace-logs-25-beta.md
         - name: Unix metrics
           href: app/java-collectd.md
         - name: Dependencies
           href: app/java-agent.md
+        - name: Dependencies (2.5-beta)
+          href: app/java-agent-25-beta.md
         - name: Filter telemetry
           href: app/java-filter-telemetry.md
         - name: Micrometer Metrics
           href: app/micrometer-java.md
+        - name: Micrometer Metrics (2.5-beta)
+          href: app/micrometer-java-25-beta.md
         - name: Configure a Spring Boot Initializer app
           href: /java/azure/spring-framework/configure-spring-boot-java-applicationinsights
       - name: Node.js apps


### PR DESCRIPTION
There have been simplifications in the 2.5-beta that impact/reduce/change doc.

Until it is GA, it seems worth duplicating the impacted pages and having 2.5-beta specific doc pages sitting side-by-side with existing doc.

Open to any and all suggestions!

cc: @MS-jgol @AlexKlimovMS @littleaj