### PR TITLE
Change from Status to TrainingStatusType

### DIFF
--- a/articles/cognitive-services/Face/Face-API-How-to-Topics/HowtoIdentifyFacesinImage.md
+++ b/articles/cognitive-services/Face/Face-API-How-to-Topics/HowtoIdentifyFacesinImage.md
@@ -116,7 +116,7 @@ while(true)
 {
     trainingStatus = await faceClient.PersonGroup.GetTrainingStatusAsync(personGroupId);
  
-    if (trainingStatus.Status != Status.Running)
+    if (trainingStatus.Status != TrainingStatusType.Running)
     {
         break;
     }


### PR DESCRIPTION
Incorrect declaration showing Status.Running instead of TrainingStatusType.Running

```
while (true)
 {
        trainingStatus = await faceClient.PersonGroup.GetTrainingStatusAsync(personGroupId);

         if (trainingStatus.Status != TrainingStatusType.Running)
          {
               break;
          }

           await Task.Delay(1000);
}
```