### PR TITLE
Azure Files support premium storage

### DIFF
--- a/articles/aks/concepts-storage.md
+++ b/articles/aks/concepts-storage.md
@@ -30,7 +30,8 @@ Applications often need to be able to store and retrieve data. As Kubernetes typ
 Traditional volumes to store and retrieve data are created as Kubernetes resources backed by Azure Storage. You can manually create these data volumes to be assigned to pods directly, or have Kubernetes automatically create them. These data volumes can use Azure Disks or Azure Files:
 
 - *Azure Disks* can be used to create a Kubernetes *DataDisk* resource. Disks can use Azure Premium storage, backed by high-performance SSDs, or Azure Standard storage, backed by regular HDDs. For most production and development workloads, use Premium storage. Azure Disks are mounted as *ReadWriteOnce*, so are only available to a single node. For storage volumes that can be accessed by multiple nodes simultaneously, use Azure Files.
-- *Azure Files* can be used to mount an SMB 3.0 share backed by an Azure Storage account to pods. Files let you share data across multiple nodes and pods. Currently, Files can only use Azure Standard storage backed by regular HDDs.
+- *Azure Files* can be used to mount an SMB 3.0 share backed by an Azure Storage account to pods. Files let you share data across multiple nodes and pods. Files can use Azure Standard storage backed by regular HDDs, or Azure Premium storage, backed by high-performance SSDs.
+> [!NOTE] Azure Files support premium storage in AKS clusters that run Kubernetes 1.13 or higher.
 
 In Kubernetes, volumes can represent more than just a traditional disk where information can be stored and retrieved. Kubernetes volumes can also be used as a way to inject data into a pod for use by the containers. Common additional volume types in Kubernetes include:
 

--- a/articles/aks/concepts-storage.md
+++ b/articles/aks/concepts-storage.md
@@ -31,7 +31,8 @@ Traditional volumes to store and retrieve data are created as Kubernetes resourc
 
 - *Azure Disks* can be used to create a Kubernetes *DataDisk* resource. Disks can use Azure Premium storage, backed by high-performance SSDs, or Azure Standard storage, backed by regular HDDs. For most production and development workloads, use Premium storage. Azure Disks are mounted as *ReadWriteOnce*, so are only available to a single node. For storage volumes that can be accessed by multiple nodes simultaneously, use Azure Files.
 - *Azure Files* can be used to mount an SMB 3.0 share backed by an Azure Storage account to pods. Files let you share data across multiple nodes and pods. Files can use Azure Standard storage backed by regular HDDs, or Azure Premium storage, backed by high-performance SSDs.
-> [!NOTE] Azure Files support premium storage in AKS clusters that run Kubernetes 1.13 or higher.
+> [!NOTE] 
+> Azure Files support premium storage in AKS clusters that run Kubernetes 1.13 or higher.
 
 In Kubernetes, volumes can represent more than just a traditional disk where information can be stored and retrieved. Kubernetes volumes can also be used as a way to inject data into a pod for use by the containers. Common additional volume types in Kubernetes include:
 


### PR DESCRIPTION
As noted [here](https://docs.microsoft.com/en-us/azure/aks/azure-files-dynamic-pv), Azure Files support premium storage in AKS clusters that run Kubernetes 1.13 or higher.