### PR TITLE
Update TelemetryConfiguration.Active usage

### DIFF
--- a/articles/azure-monitor/app/api-filtering-sampling.md
+++ b/articles/azure-monitor/app/api-filtering-sampling.md
@@ -92,7 +92,11 @@ public class SuccessfulDependencyFilter : ITelemetryProcessor
 	}
 }
 ```
-3. Insert this in ApplicationInsights.config:
+
+3. Add your processor
+
+**ASP.NET apps**
+Insert this in ApplicationInsights.config:
 
 ```xml
 <TelemetryProcessors>
@@ -125,6 +129,26 @@ builder.Build();
 ```
 
 TelemetryClients created after this point will use your processors.
+
+**ASP.NET Core apps**
+
+> [!NOTE]
+> Adding initializer using `ApplicationInsights.config` or using `TelemetryConfiguration.Active` is not valid for ASP.NET Core applications. 
+
+
+For [ASP.NET Core](asp-net-core.md#adding-telemetry-telemetry-processors) applications, adding a new `TelemetryInitializer` is done by adding it to the Dependency Injection container, as shown below. This is done in `ConfigureServices` method of your `Startup.cs` class.
+
+```csharp
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // ...
+        services.AddApplicationInsightsTelemetry();
+        services.AddApplicationInsightsTelemetryProcessor<SuccessfulDependencyFilter>();
+
+        // If you have more processors:
+        services.AddApplicationInsightsTelemetryProcessor<AnotherProcessor>();
+    }
+```
 
 ### Example filters
 #### Synthetic requests
@@ -233,7 +257,7 @@ namespace MvcWebRole.Telemetry
 }
 ```
 
-**Load your initializer**
+**ASP.NET apps: Load your initializer**
 
 In ApplicationInsights.config:
 
@@ -252,16 +276,28 @@ In ApplicationInsights.config:
 ```csharp
 protected void Application_Start()
 {
-	// ...
-	TelemetryConfiguration.Active.TelemetryInitializers
-	.Add(new MyTelemetryInitializer());
+    // ...
+    TelemetryConfiguration.Active.TelemetryInitializers.Add(new MyTelemetryInitializer());
 }
 ```
 
-
 [See more of this sample.](https://github.com/Microsoft/ApplicationInsights-Home/tree/master/Samples/AzureEmailService/MvcWebRole)
 
-<a name="js-initializer"></a>
+**ASP.NET Core apps: Load your initializer**
+
+> [!NOTE]
+> Adding initializer using `ApplicationInsights.config` or using `TelemetryConfiguration.Active` is not valid for ASP.NET Core applications. 
+
+For [ASP.NET Core](asp-net-core.md#adding-telemetryinitializers) applications, adding a new `TelemetryInitializer` is done by adding it to the Dependency Injection container, as shown below. This is done in `ConfigureServices` method of your `Startup.cs` class.
+
+```csharp
+ using Microsoft.ApplicationInsights.Extensibility;
+ using CustomInitializer.Telemetry;
+ public void ConfigureServices(IServiceCollection services)
+{
+    services.AddSingleton<ITelemetryInitializer, MyTelemetryInitializer>();
+}
+```
 
 ### Java telemetry initializers
 

--- a/articles/azure-monitor/app/app-map.md
+++ b/articles/azure-monitor/app/app-map.md
@@ -115,7 +115,7 @@ namespace CustomInitializer.Telemetry
 }
 ```
 
-**Load initializer to the active TelemetryConfiguration**
+**ASP.NET apps: Load initializer to the active TelemetryConfiguration**
 
 In ApplicationInsights.config :
 
@@ -128,9 +128,6 @@ In ApplicationInsights.config :
       </TelemetryInitializers>
     </ApplicationInsights>
 ```
-
-> [!NOTE]
-> Adding initializer using `ApplicationInsights.config` is not valid for ASP.NET Core applications.
 
 An alternate method for ASP.NET Web apps is to instantiate the initializer in code, for example in Global.aspx.cs:
 
@@ -145,15 +142,20 @@ An alternate method for ASP.NET Web apps is to instantiate the initializer in co
     }
 ```
 
+> [!NOTE]
+> Adding initializer using `ApplicationInsights.config` or using `TelemetryConfiguration.Active` is not valid for ASP.NET Core applications. 
+
+**ASP.NET Core apps: Load initializer to the TelemetryConfiguration**
+
 For [ASP.NET Core](asp-net-core.md#adding-telemetryinitializers) applications, adding a new `TelemetryInitializer` is done by adding it to the Dependency Injection container, as shown below. This is done in `ConfigureServices` method of your `Startup.cs` class.
 
 ```csharp
  using Microsoft.ApplicationInsights.Extensibility;
  using CustomInitializer.Telemetry;
  public void ConfigureServices(IServiceCollection services)
-    {
-        services.AddSingleton<ITelemetryInitializer, MyCustomTelemetryInitializer>();
-    }
+{
+    services.AddSingleton<ITelemetryInitializer, MyTelemetryInitializer>();
+}
 ```
 
 ### Node.js

--- a/articles/azure-monitor/app/asp-net-core.md
+++ b/articles/azure-monitor/app/asp-net-core.md
@@ -172,7 +172,7 @@ If your project doesn't include `_Layout.cshtml`, you can still add [client-side
 You can customize the Application Insights SDK for ASP.NET Core to change the default configuration. Users of the Application Insights ASP.NET SDK might be familiar with changing configuration by using `ApplicationInsights.config` or by modifying `TelemetryConfiguration.Active`. You change configuration differently for ASP.NET Core. Add the ASP.NET Core SDK to the application and configure it by using ASP.NET Core built-in [dependency injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection). Make almost all configuration changes in the `ConfigureServices()` method of your `Startup.cs` class, unless you're directed otherwise. The following sections offer more information.
 
 > [!NOTE]
-> In ASP.NET Core applications, changing configuration by modifying `TelemetryConfiguration.Active` isn't recommended.
+> In ASP.NET Core applications, changing configuration by modifying `TelemetryConfiguration.Active` isn't supported.
 
 ### Using ApplicationInsightsServiceOptions
 
@@ -309,6 +309,23 @@ using Microsoft.ApplicationInsights.Channel;
     }
 ```
 
+### Disable telemetry dynamically
+
+If you want to disable telemetry conditionally and dynamically, you may resolve `TelemetryConfiguration` instance with ASP.NET Core dependency injection container anywhere in your code and set `DisableTelemetry` flag on it.
+
+```csharp
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddApplicationInsightsTelemetry();
+    }
+
+    public void Configure(IApplicationBuilder app, IHostingEnvironment env, TelemetryConfiguration configuration)
+    {
+        configuration.DisableTelemetry = true;
+        ...
+    }
+```
+
 ## Frequently asked questions
 
 ### How can I track telemetry that's not automatically collected?
@@ -403,3 +420,4 @@ using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 * [Configure a snapshot collection](https://docs.microsoft.com/azure/application-insights/app-insights-snapshot-debugger) to see the state of source code and variables at the moment an exception is thrown.
 * [Use the API](../../azure-monitor/app/api-custom-events-metrics.md) to send your own events and metrics for a detailed view of your app's performance and usage.
 * Use [availability tests](../../azure-monitor/app/monitor-web-app-availability.md) to check your app constantly from around the world.
+* [Dependency Injection in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/fundamentals/dependency-injection)

--- a/articles/azure-monitor/app/custom-operations-tracking.md
+++ b/articles/azure-monitor/app/custom-operations-tracking.md
@@ -46,7 +46,10 @@ In this example, trace context is propagated according to the [HTTP Protocol for
 ```csharp
 public class ApplicationInsightsMiddleware : OwinMiddleware
 {
-    private readonly TelemetryClient telemetryClient = new TelemetryClient(TelemetryConfiguration.Active);
+    // you may create a new TelemetryConfiguration instance, reuse one you already have
+    // or fetch the instance created by Application Insights SDK.
+    private readonly TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.CreateDefault();
+    private readonly TelemetryClient telemetryClient = new TelemetryClient(telemetryConfiguration);
     
     public ApplicationInsightsMiddleware(OwinMiddleware next) : base(next) {}
 
@@ -203,20 +206,7 @@ public async Task Process(BrokeredMessage message)
 The following example shows how to track the [Azure Storage queue](../../storage/queues/storage-dotnet-how-to-use-queues.md) operations and correlate telemetry between the producer, the consumer, and Azure Storage. 
 
 The Storage queue has an HTTP API. All calls to the queue are tracked by the Application Insights Dependency Collector for HTTP requests.
-Make sure you have `Microsoft.ApplicationInsights.DependencyCollector.HttpDependenciesParsingTelemetryInitializer` in `applicationInsights.config`. If you don't have it, add it programmatically as described in [Filtering and Preprocessing in the Azure Application Insights SDK](../../azure-monitor/app/api-filtering-sampling.md).
-
-If you configure Application Insights manually, make sure you create and initialize `Microsoft.ApplicationInsights.DependencyCollector.DependencyTrackingTelemetryModule` similarly to:
- 
-```csharp
-DependencyTrackingTelemetryModule module = new DependencyTrackingTelemetryModule();
-
-// You can prevent correlation header injection to some domains by adding it to the excluded list.
-// Make sure you add a Storage endpoint. Otherwise, you might experience request signature validation issues on the Storage service side.
-module.ExcludeComponentCorrelationHttpHeadersOnDomains.Add("core.windows.net");
-module.Initialize(TelemetryConfiguration.Active);
-
-// Do not forget to dispose of the module during application shutdown.
-```
+It is configured by default on ASP.NET and ASP.NET Core applications, with other kinds of applicaiton, you can refer to [console applications documentation](../../azure-monitor/app/console.md)
 
 You also might want to correlate the Application Insights operation ID with the Storage request ID. For information on how to set and get a Storage request client and a server request ID, see [Monitor, diagnose, and troubleshoot Azure Storage](../../storage/common/storage-monitoring-diagnosing-troubleshooting.md#end-to-end-tracing).
 

--- a/articles/azure-monitor/app/how-do-i.md
+++ b/articles/azure-monitor/app/how-do-i.md
@@ -131,16 +131,25 @@ Learn more about [pricing and quotas](../../azure-monitor/app/pricing.md).
 ## Disable telemetry
 To **dynamically stop and start** the collection and transmission of telemetry from the server:
 
-```
+### ASP.NET Classic applications
 
+```csharp
     using  Microsoft.ApplicationInsights.Extensibility;
 
     TelemetryConfiguration.Active.DisableTelemetry = true;
 ```
 
+### Other applications
+It is not recommended to use `TelemetryConfiguration.Active` singleton on console or ASP.NET Core applications.
+if you created `TelemetryConfiguration` instance yourself - set `DisableTelemetry` to `true`.
 
+For ASP.NET Core applications you may access `TelemetryConfiguration` instance using [ASP.NET Core dependency injection](https://docs.microsoft.com/en-us/aspnet/fundamentals/dependency-injection)
 
-To **disable selected standard collectors** - for example, performance counters, HTTP requests, or dependencies - delete or comment out the relevant lines in [ApplicationInsights.config](../../azure-monitor/app/api-custom-events-metrics.md). You could do this, for example, if you want to send your own TrackRequest data.
+## Disable selected standard collectors
+You can disable standard collectors (for example, performance counters, HTTP requests, or dependencies)
+
+* **ASP.NET applications** - Delete or comment out the relevant lines in [ApplicationInsights.config](../../azure-monitor/app/configuration-with-applicationinsights-config)
+* **ASP.NET Core applicaitons** - Follow configuration options in [ApplicationInsights ASP.NET Core](../../azure-monitor/app/asp-net-core.md)
 
 ## View system performance counters
 Among the metrics you can show in metrics explorer are a set of system performance counters. There's a predefined blade titled **Servers** that displays several of them.

--- a/articles/azure-monitor/app/how-do-i.md
+++ b/articles/azure-monitor/app/how-do-i.md
@@ -143,13 +143,13 @@ To **dynamically stop and start** the collection and transmission of telemetry f
 It is not recommended to use `TelemetryConfiguration.Active` singleton on console or ASP.NET Core applications.
 if you created `TelemetryConfiguration` instance yourself - set `DisableTelemetry` to `true`.
 
-For ASP.NET Core applications you may access `TelemetryConfiguration` instance using [ASP.NET Core dependency injection](https://docs.microsoft.com/en-us/aspnet/fundamentals/dependency-injection)
+For ASP.NET Core applications you may access `TelemetryConfiguration` instance using [ASP.NET Core dependency injection](https://docs.microsoft.com/en-us/aspnet/fundamentals/dependency-injection). Please find more details in [ApplicationInsights for ASP.NET Core applications](../../azure-monitor/app/asp-net-core) article.
 
 ## Disable selected standard collectors
 You can disable standard collectors (for example, performance counters, HTTP requests, or dependencies)
 
 * **ASP.NET applications** - Delete or comment out the relevant lines in [ApplicationInsights.config](../../azure-monitor/app/configuration-with-applicationinsights-config)
-* **ASP.NET Core applicaitons** - Follow configuration options in [ApplicationInsights ASP.NET Core](../../azure-monitor/app/asp-net-core.md)
+* **ASP.NET Core applicaitons** - Follow telemetry modules configuration options in [ApplicationInsights ASP.NET Core](../../azure-monitor/app/asp-net-core.md#configuring-or-removing-default-telemetrymodules)
 
 ## View system performance counters
 Among the metrics you can show in metrics explorer are a set of system performance counters. There's a predefined blade titled **Servers** that displays several of them.

--- a/articles/azure-monitor/app/usage-overview.md
+++ b/articles/azure-monitor/app/usage-overview.md
@@ -127,11 +127,11 @@ For this technique, you attach distinct property values to all the telemetry tha
 
 In the Application Insights portal, filter and split your data on the property values, so as to compare the different versions.
 
-To do this, [set up a telemetry initializer](../../azure-monitor/app/api-filtering-sampling.md##add-properties-itelemetryinitializer):
+To do this, [set up a telemetry initializer](../../azure-monitor/app/api-filtering-sampling.md#add-properties-itelemetryinitializer):
+
+**ASP.NET apps**
 
 ```csharp
-
-
     // Telemetry initializer class
     public class MyTelemetryInitializer : ITelemetryInitializer
     {
@@ -150,8 +150,24 @@ In the web app initializer such as Global.asax.cs:
     {
         // ...
         TelemetryConfiguration.Active.TelemetryInitializers
-        .Add(new MyTelemetryInitializer());
+         .Add(new MyTelemetryInitializer());
     }
+```
+
+**ASP.NET Core apps**
+
+> [!NOTE]
+> Adding initializer using `ApplicationInsights.config` or using `TelemetryConfiguration.Active` is not valid for ASP.NET Core applications. 
+
+For [ASP.NET Core](asp-net-core.md#adding-telemetryinitializers) applications, adding a new `TelemetryInitializer` is done by adding it to the Dependency Injection container, as shown below. This is done in `ConfigureServices` method of your `Startup.cs` class.
+
+```csharp
+ using Microsoft.ApplicationInsights.Extensibility;
+ using CustomInitializer.Telemetry;
+ public void ConfigureServices(IServiceCollection services)
+{
+    services.AddSingleton<ITelemetryInitializer, MyTelemetryInitializer>();
+}
 ```
 
 All new TelemetryClients automatically add the property value you specify. Individual telemetry events can override the default values.


### PR DESCRIPTION
`TelemetryConfiguration.Active` is deprecated on .NET Core (https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152)

This change updates documentation (that I found) regarding `Active` usage to provide better options on .NET Core.
