### PR TITLE
Improve language around persistence

### DIFF
--- a/articles/cloud-shell/overview.md
+++ b/articles/cloud-shell/overview.md
@@ -66,11 +66,9 @@ Cloud Shell is a flexible tool that can be used from:
 * [Visual Studio Code Azure Account extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account)
 
 ### Connect your Microsoft Azure Files storage
-Cloud Shell machines are temporary and require a new or existing Azure Files share to be mounted as `clouddrive` to persist your files.
+Cloud Shell machines are temporary, but your files are persisted in two ways: through a disk image, and through a mounted file share named `clouddrive`.  On first launch, Cloud Shell prompts to create a resource group, storage account, and Azure Files share on your behalf. This is a one-time step and will be automatically attached for all sessions. A single file share can be mapped and will be used by both Bash and PowerShell in Cloud Shell.
 
-On first launch Cloud Shell prompts to create a resource group, storage account, and Azure Files share on your behalf. This is a one-time step and will be automatically attached for all sessions. A single file share can be mapped and will be used by both Bash and PowerShell in Cloud Shell.
-
-Read more to learn how to mount a [new or existing storage account](persisting-shell-storage.md).
+Read more to learn how to mount a [new or existing storage account](persisting-shell-storage.md) or to learn about the [persistence mechanisms used in Cloud Shell](persisting-shell-storage.md#how-cloud-shell-storage-works).
 
 ## Concepts
 * Cloud Shell runs on a temporary host provided on a per-session, per-user basis


### PR DESCRIPTION
The previous version implies that the only place data is persisted is the clouddrive file share, but https://docs.microsoft.com/en-us/azure/cloud-shell/persisting-shell-storage states the situation more correctly and clearly. This edit attempts to remove the incorrect implication without going into depth that is already on the linked-to page.