### PR TITLE
Changed reference to point to correct PowerShell module.

### DIFF
--- a/articles/iot-accelerators/howto-opc-twin-deploy-existing.md
+++ b/articles/iot-accelerators/howto-opc-twin-deploy-existing.md
@@ -25,7 +25,7 @@ The core of the module is the Supervisor identity. The supervisor manages endpoi
 
 ## Prerequisites
 
-Make sure you have PowerShell and [Azure PowerShell](https://docs.microsoft.com/powershell/azure/install-az-ps) extensions installed. If you've not already done so, clone this GitHub repository. Run the following commands in PowerShell:
+Make sure you have PowerShell and [AzureRM PowerShell module](https://docs.microsoft.com/powershell/azure/azurerm/install-azurerm-ps) extensions installed. If you've not already done so, clone this GitHub repository. Run the following commands in PowerShell:
 
 ```powershell
 git clone --recursive https://github.com/Azure/azure-iiot-components.git


### PR DESCRIPTION
Changed reference of `Az` PowerShell module to `AzureRM` PowerShell module since that one is used by deployment script in `azure-iiot-components` repo.