### PR TITLE
Fix broken TOC indent of application insights articles

### DIFF
--- a/articles/azure-monitor/toc.yml
+++ b/articles/azure-monitor/toc.yml
@@ -472,7 +472,7 @@
               href: app/export-stream-analytics.md
         - name: Export data model
           href: app/export-data-model.md
-        - name: Troubleshoot
+      - name: Troubleshoot
         items:
         - name: No data for .NET
           href: app/asp-net-troubleshoot-no-data.md


### PR DESCRIPTION
This PR fixes TOC indentation which determines TOC tree structure. It enables app insights data export related topics and provides a right header for trouble shooting related articles.
