### PR TITLE
Wrong assertion

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
+++ b/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
@@ -21,7 +21,7 @@ ms.collection: M365-identity-device-management
 This article provides information that you need to synchronize your user passwords from an on-premises Active Directory instance to a cloud-based Azure Active Directory (Azure AD) instance.
 
 ## How password hash synchronization works
-The Active Directory domain service stores passwords in the form of a hash value representation, of the actual user password. A hash value is a result of a one-way mathematical function (the *hashing algorithm*). There is no method to revert the result of a one-way function to the plain text version of a password. You cannot use a password hash to sign in to your on-premises network.
+The Active Directory domain service stores passwords in the form of a hash value representation, of the actual user password. A hash value is a result of a one-way mathematical function (the *hashing algorithm*). There is no method to revert the result of a one-way function to the plain text version of a password. 
 
 To synchronize your password, Azure AD Connect sync extracts your password hash from the on-premises Active Directory instance. Extra security processing is applied to the password hash before it is synchronized to the Azure Active Directory authentication service. Passwords are synchronized on a per-user basis and in chronological order.
 


### PR DESCRIPTION
The assertion "You cannot use a password hash to sign in to your on-premises network." is wrong. Retrieving hashes is the whole idea behind Pass-the-Hash attacks. I suggest to just remove the phrase from the document.