### PR TITLE
Updated section on Cosmos DB emulator

### DIFF
--- a/articles/cosmos-db/sql-api-nodejs-get-started.md
+++ b/articles/cosmos-db/sql-api-nodejs-get-started.md
@@ -125,8 +125,9 @@ Now that your app exists, you need to make sure it can talk to Azure Cosmos DB. 
 > [!Note]
 > If connecting to the **Cosmos DB Emulator**, disable SSL verification by creating a custom connection Policy.
 >   ```
->   const connectionPolicy = new cosmos.ConnectionPolicy ()
->   connectionPolicy.DisableSSLVerification = true
+>   const ConnectionPolicy = require('@azure/cosmos').ConnectionPolicy;
+>   const connectionPolicy = new ConnectionPolicy();
+>   connectionPolicy.DisableSSLVerification = true;
 >
 >   const client = new CosmosClient({ endpoint: endpoint, auth: { masterKey: masterKey }, connectionPolicy });
 >   ```


### PR DESCRIPTION
Corrected the error:
```
const connectionPolicy = new cosmos.ConnectionPolicy ()
                         ^

ReferenceError: cosmos is not defined
```

while using the nodejs code with Cosmos DB emulator.
Using:
-node v10.15.1
-npm v6.4.1 