### PR TITLE
Cleaning up auth methods for AAD Database users and Logins

### DIFF
--- a/articles/sql-database/sql-database-aad-authentication.md
+++ b/articles/sql-database/sql-database-aad-authentication.md
@@ -112,8 +112,9 @@ To create a contained database user in Azure SQL Database, Managed Instance, or 
 
 Azure Active Directory authentication supports the following methods of connecting to a database using Azure AD identities:
 
-- Using integrated Windows authentication
-- Using an Azure AD principal name and a password
+- Azure Active Directory Password
+- Azure Active Directory Integrated
+- Azure Active Directory Universal with MFA
 - Using Application token authentication
 
 The following authentication methods are supported for Azure AD server principals (logins) (**public preview**):
@@ -121,7 +122,6 @@ The following authentication methods are supported for Azure AD server principal
 - Azure Active Directory Password
 - Azure Active Directory Integrated
 - Azure Active Directory Universal with MFA
-- Azure Active Directory Interactive
 
 
 ### Additional considerations


### PR DESCRIPTION
"Azure Active Directory Integrated" was listed twice for aad logins.  "Using an Azure AD principal name and a password" should be changed to "Azure Active Directory Password" , and "Using integrated Windows authentication" changed to "Azure Active Directory Integrated".  And is it really the case that token auth is not supported for AAD Logins?