### PR TITLE
Fix Grammar

### DIFF
--- a/articles/active-directory/devices/assign-local-admin.md
+++ b/articles/active-directory/devices/assign-local-admin.md
@@ -75,7 +75,7 @@ Windows Autopilot provides you with an option to prevent primary user performing
 
 In addition to using the Azure AD join process, you can also manually elevate a regular user to become a local administrator on one specific device. This step requires you to already be a member of the local administrators group. 
 
-Starting with the **Windows 10 1709** release, you can do perform this task from **Settings -> Accounts -> Other users**. Select **Add a work or school user**, enter the user's UPN under **User account** and select *Administrator* under **Account type**  
+Starting with the **Windows 10 1709** release, you can perform this task from **Settings -> Accounts -> Other users**. Select **Add a work or school user**, enter the user's UPN under **User account** and select *Administrator* under **Account type**  
  
 Additionally, you can also add users using the command prompt:
 


### PR DESCRIPTION
Manually elevate a user on a device 

Removed "do" from "you can perform this task from **Settings -> Accounts -> Other users**."