### PR TITLE
Fix Terraform example to create k8s cluster on AKS - tags element

### DIFF
--- a/articles/terraform/terraform-create-k8s-cluster-with-tf-and-aks.md
+++ b/articles/terraform/terraform-create-k8s-cluster-with-tf-and-aks.md
@@ -160,7 +160,7 @@ Create the Terraform configuration file that declares the resources for the Kube
             }
         }
 
-        tags {
+        tags = {
             Environment = "Development"
         }
     }


### PR DESCRIPTION
Fixes #33032

The issue contains sufficient information to understand the simple fix for a syntax error but basically when trying to use the example using `terraform plan` or `terraform apply` one receives the following error without the fix in this PR
```
> terraform plan

Error: Unsupported block type

  on k8s.tf line 60, in resource "azurerm_kubernetes_cluster" "k8s":
  60:     tags {

Blocks of type "tags" are not expected here. Did you mean to define argument
"tags"? If so, use the equals sign to assign it a value.
```

The terraform documentation [here](https://www.terraform.io/docs/extend/best-practices/naming.html#attribute-names) backs the syntax correction of the `tags` element.