### PR TITLE
Adding Node.js SDK reference for Custom Vision

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/toc.yml
+++ b/articles/cognitive-services/Custom-Vision-Service/toc.yml
@@ -77,9 +77,9 @@
     - name: Java
       href: https://docs.microsoft.com/java/api/overview/azure/cognitiveservices/client/customvision?view=azure-java-stable
     - name: Node.js - Training
-      href: https://docs.microsoft.com/en-gb/javascript/api/overview/azure/cognitiveservices/customvisiontraining?view=azure-node-latest
+      href: https://docs.microsoft.com/javascript/api/overview/azure/cognitiveservices/customvisiontraining?view=azure-node-latest
     - name: Node.js - Prediction
-      href: https://docs.microsoft.com/en-gb/javascript/api/overview/azure/cognitiveservices/customvisionprediction?view=azure-node-latest
+      href: https://docs.microsoft.com/javascript/api/overview/azure/cognitiveservices/customvisionprediction?view=azure-node-latest
     - name: Python
       href: https://docs.microsoft.com/python/api/overview/azure/cognitiveservices/customvision?view=azure-python
     - name: Go - Training

--- a/articles/cognitive-services/Custom-Vision-Service/toc.yml
+++ b/articles/cognitive-services/Custom-Vision-Service/toc.yml
@@ -76,6 +76,10 @@
       href: https://docs.microsoft.com/dotnet/api/overview/azure/cognitiveservices/client/customvision?view=azure-dotnet
     - name: Java
       href: https://docs.microsoft.com/java/api/overview/azure/cognitiveservices/client/customvision?view=azure-java-stable
+    - name: Node.js - Training
+      href: https://docs.microsoft.com/en-gb/javascript/api/overview/azure/cognitiveservices/customvisiontraining?view=azure-node-latest
+    - name: Node.js - Prediction
+      href: https://docs.microsoft.com/en-gb/javascript/api/overview/azure/cognitiveservices/customvisionprediction?view=azure-node-latest
     - name: Python
       href: https://docs.microsoft.com/python/api/overview/azure/cognitiveservices/customvision?view=azure-python
     - name: Go - Training


### PR DESCRIPTION
SDK reference was missing in Reference section (but samples for Node.js are available in Quickstart)