### PR TITLE
correct url endpoint to the correct version

### DIFF
--- a/articles/active-directory/develop/v2-oauth2-device-code.md
+++ b/articles/active-directory/develop/v2-oauth2-device-code.md
@@ -53,7 +53,7 @@ The client must first check with the authentication server for a device and user
 ```
 // Line breaks are for legibility only.
 
-POST https://login.microsoftonline.com/{tenant}/devicecode
+POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/devicecode
 Content-Type: application/x-www-form-urlencoded
 
 client_id=6731de76-14a6-49ae-97bc-6eba6914391e


### PR DESCRIPTION
"The URL for the device authorisation request returns a 404. Where https://login.microsoftonline.com/{tenant}/devicecode is shown, I believe it was meant to be https://login.microsoftonline.com/{tenant}/oauth2/v2.0/devicecode, which does return the expected results."

Also see #30881 