### PR TITLE
Cast results of time delta too double

### DIFF
--- a/articles/azure-monitor/app/api-custom-events-metrics.md
+++ b/articles/azure-monitor/app/api-custom-events-metrics.md
@@ -948,7 +948,7 @@ long startTime = System.currentTimeMillis();
 
 long endTime = System.currentTimeMillis();
 Map<String, Double> metrics = new HashMap<>();
-metrics.put("ProcessingTime", endTime-startTime);
+metrics.put("ProcessingTime", (double)endTime-startTime);
 
 // Setup some properties
 Map<String, String> properties = new HashMap<>();


### PR DESCRIPTION
I think you need to convert this to a double to appease the Java Compiler. The map is supposed to be double for App Insights.