### PR TITLE
Adding a video to Event Hubs about page

### DIFF
--- a/articles/event-hubs/event-hubs-about.md
+++ b/articles/event-hubs/event-hubs-about.md
@@ -29,7 +29,7 @@ The following scenarios are some of the scenarios where you can use Event Hubs:
 - User telemetry processing
 - Device telemetry streaming
 
-[!VIDEO https://www.youtube.com/watch?v=45wgY-VSk9I]
+[!VIDEO https://www.youtube.com/embed/45wgY-VSk9I]
 
 ## Why use Event Hubs?
 


### PR DESCRIPTION
The [previous PR](https://github.com/MicrosoftDocs/azure-docs-pr/pull/82484) had a youtube watch link (not the embed link). This could be the reason why the video wasn't showing up on [the page](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-about) properly.

Changing the youtube link to the embed link. /cc @ShubhaVijayasarathy 

@JasonWHowell is this the correct syntax?