### PR TITLE
Changing an to a in title - Licence assignment problems page

### DIFF
--- a/articles/active-directory/users-groups-roles/licensing-groups-resolve-problems.md
+++ b/articles/active-directory/users-groups-roles/licensing-groups-resolve-problems.md
@@ -1,6 +1,6 @@
 ---
 
-title: Resolve license assignment problems for an group - Azure Active Directory | Microsoft Docs
+title: Resolve license assignment problems for a group - Azure Active Directory | Microsoft Docs
 description: How to identify and resolve license assignment problems when you're using Azure Active Directory group-based licensing
 services: active-directory
 keywords: Azure AD licensing


### PR DESCRIPTION
The title has "Resolve license assignment problems for **an** group - Azure Active Directory | Microsoft Docs" instead of "Resolve license assignment problems for **a** group - Azure Active Directory | Microsoft Docs".