### PR TITLE
Mention Timespan in FunctionTimeout

### DIFF
--- a/articles/azure-functions/functions-host-json.md
+++ b/articles/azure-functions/functions-host-json.md
@@ -142,7 +142,10 @@ A list of functions that the job host runs. An empty array means run all functio
 
 ## functionTimeout
 
-Indicates the timeout duration for all functions. It follows the timespan string format. In a serverless Consumption plan, the valid range is from 1 second to 10 minutes, and the default value is 5 minutes. In an App Service plan, there is no overall limit and the default depends on the runtime version. In version 2.x, the default value for an App Service plan is 30 minutes. In version 1.x, it's *null*, which indicates no timeout. It cannot be set as infinite . If we are not setting this value explicitly it will take the default 30 minutes value.
+Indicates the timeout duration for all functions. It follows the timespan string format. In a serverless Consumption plan, the valid range is from 1 second to 10 minutes, and the default value is 5 minutes.  
+In a Dedicated (App Service) plan, there is no overall limit, and the default depends on the runtime version: 
++ Version 1.x: the default is *null*, which indicates no timeout.   
++ Version 2.x: the default value is 30 minutes. A value of `-1` indicates unbounded execution.
 
 ```json
 {

--- a/articles/azure-functions/functions-host-json.md
+++ b/articles/azure-functions/functions-host-json.md
@@ -142,7 +142,7 @@ A list of functions that the job host runs. An empty array means run all functio
 
 ## functionTimeout
 
-Indicates the timeout duration for all functions. In a serverless Consumption plan, the valid range is from 1 second to 10 minutes, and the default value is 5 minutes. In an App Service plan, there is no overall limit and the default depends on the runtime version. In version 2.x, the default value for an App Service plan is 30 minutes. In version 1.x, it's *null*, which indicates no timeout. It cannot be set as infinite . If we are not setting this value explicitly it will take the default 30 minutes value.
+Indicates the timeout duration for all functions. It follows the timespan string format. In a serverless Consumption plan, the valid range is from 1 second to 10 minutes, and the default value is 5 minutes. In an App Service plan, there is no overall limit and the default depends on the runtime version. In version 2.x, the default value for an App Service plan is 30 minutes. In version 1.x, it's *null*, which indicates no timeout. It cannot be set as infinite . If we are not setting this value explicitly it will take the default 30 minutes value.
 
 ```json
 {


### PR DESCRIPTION
(AzureCXP) fixes MicrosoftDocs/azure-docs#35395