### PR TITLE
Adding Verizon CDN rules engine regex information

### DIFF
--- a/articles/cdn/cdn-verizon-premium-rules-engine-reference.md
+++ b/articles/cdn/cdn-verizon-premium-rules-engine-reference.md
@@ -67,6 +67,8 @@ Special Character | Description
 Space | A space character is typically treated as a literal character.
 'value' | Single quotes are treated as literal characters. A set of single quotes does not have special meaning.
 
+Match conditions and features that support regular expressions accept patterns defined by Perl Compatible Regular Expressions (PCRE).
+
 ## Next steps
 
 - [Rules engine match conditions](cdn-verizon-premium-rules-engine-reference-match-conditions.md)


### PR DESCRIPTION
Adding information about which regex patterns are used in the Verizon CDN rules engine.

Futher information: https://docs.vdms.com/cdn/index.html#Quick_References/HRE_QR.htm?Highlight=rules%20engine

Based on an e-mail with @mdgattuso and Verizon.