### PR TITLE
Updated endpoint from ASM to ARM

### DIFF
--- a/articles/service-bus-messaging/service-bus-management-libraries.md
+++ b/articles/service-bus-messaging/service-bus-management-libraries.md
@@ -47,7 +47,7 @@ The pattern to manipulate any Service Bus resource follows a common protocol:
    ```csharp
    var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
 
-   var result = await context.AcquireTokenAsync("https://management.core.windows.net/", new ClientCredential(clientId, clientSecret));
+   var result = await context.AcquireTokenAsync("https://management.azure.com/", new ClientCredential(clientId, clientSecret));
    ```
 2. Create the `ServiceBusManagementClient` object:
 
@@ -136,7 +136,7 @@ namespace SBusADApp
                 var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
 
                 var result = await context.AcquireTokenAsync(
-                    "https://management.core.windows.net/",
+                    "https://management.azure.com/",
                     new ClientCredential(clientId, clientSecret)
                 );
 


### PR DESCRIPTION
ASM API will be deprecated in Nov/2019 so we have to change endpoint to ARM.
https://blogs.msdn.microsoft.com/servicebus/2018/11/01/deprecating-service-management-support-for-azure-service-bus-relay-and-event-hubs/
https://docs.microsoft.com/en-us/rest/api/servicebus/ (check Important note)

ARM API: https://docs.microsoft.com/en-us/rest/api/servicebus/queues/createorupdate
old ASM(classic RDFE) API: https://docs.microsoft.com/en-us/rest/api/servicebus/create-queue