### PR TITLE
Added additiona information on only prompting on interactive logins

### DIFF
--- a/articles/active-directory/identity-protection/howto-mfa-policy.md
+++ b/articles/active-directory/identity-protection/howto-mfa-policy.md
@@ -17,7 +17,9 @@ ms.collection: M365-identity-device-management
 ---
 # How To: Configure the Azure Multi-Factor Authentication registration policy
 
-Azure AD Identity Protection helps you manage the roll-out of multi-factor authentication (MFA) registration by configuring a Conditional Access policy to require MFA registration no matter what app you are signing in to. This article explains what the policy can be used for and how to configure it.
+Azure AD Identity Protection helps you manage the roll-out of multi-factor authentication (MFA) registration by configuring a Conditional Access policy to require MFA registration no matter what modern authentication app you are signing in to. This article explains what the policy can be used for and how to configure it.
+
+
 
 ## What is the Azure Multi-Factor Authentication registration policy?
 
@@ -55,6 +57,8 @@ When you configure the MFA registration policy, you need to make the following c
 - **Save** your policy
 
 ## User experience
+
+Azure Active Directory Identity Protection will prompt your users to register the next time they sign in interactively.
 
 For an overview of the related user experience, see:
 


### PR DESCRIPTION
Per (https://docs.microsoft.com/en-us/azure/active-directory/authentication/howto-mfa-getstarted#registration-with-identity-protection), the MFA registration will only occur during an interactive login (so WIA logins on corpnet or other non-interactive logins) will not prompt the user to register for MFA.