### PR TITLE
Missing a step to come to authentication method

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-enable.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-enable.md
@@ -106,7 +106,7 @@ Registration features for FIDO2 security keys rely on the combined registration 
 ### Enable new passwordless authentication methods
 
 1. Sign in to the [Azure portal](https://portal.azure.com)
-1. Browse to **Azure Active Directory** > **Authentication methods** > **Authentication method policy (Preview)**
+1. Browse to **Azure Active Directory** > **Security** > **Authentication methods** > **Authentication method policy (Preview)**
 1. Under each **Method**, choose the following options
    1. **Enable** - Yes or No
    1. **Target** - All users or Select users


### PR DESCRIPTION
Here a screenshot when you go to active directory and the is no option Authentication method, you have to select Security.

![Azure-Password-Less-001](https://user-images.githubusercontent.com/22030609/61807507-f814ea80-ae39-11e9-8b93-209cfce0b179.png)

And now you can select Authentication Method.

![Azure-Password-Less-002](https://user-images.githubusercontent.com/22030609/61807523-fcd99e80-ae39-11e9-959f-743bc7b4c15f.png)
