### PR TITLE
Include information on encoding messages

### DIFF
--- a/articles/iot-hub/quickstart-send-telemetry-dotnet.md
+++ b/articles/iot-hub/quickstart-send-telemetry-dotnet.md
@@ -116,6 +116,7 @@ The simulated device application connects to a device-specific endpoint on your 
     The following screenshot shows the output as the simulated device application sends telemetry to your IoT hub:
 
     ![Run the simulated device](media/quickstart-send-telemetry-dotnet/SimulatedDevice.png)
+**Message Encoding**
 
 ## Read the telemetry from your hub
 


### PR DESCRIPTION
Should information on encoding messages to support IoT Hub Routing Queries be added?  Per IoT Hub documentation below, messages must be encoded in UTF-8, UTF-16, or UTF-32 to support message routing on the body:
https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-routing-query-syntax#message-routing-query-based-on-message-body
I also filed the following Github issue to add this to the sample code.
https://github.com/Azure-Samples/azure-iot-samples-csharp/issues/68