### PR TITLE
Update apache-hadoop-connect-hive-jdbc-driver.md

### DIFF
--- a/articles/hdinsight/hadoop/apache-hadoop-connect-hive-jdbc-driver.md
+++ b/articles/hdinsight/hadoop/apache-hadoop-connect-hive-jdbc-driver.md
@@ -52,9 +52,9 @@ SQuirreL SQL is a JDBC client that can be used to remotely run Hive queries with
 2. In the following script, replace `sshuser` with the SSH user account name for the cluster.  Replace `CLUSTERNAME` with the HDInsight cluster name.  From a command line, change your work directory to the one created in the prior step, and then enter the following command to copy files from an HDInsight cluster:
 
     ```cmd
-    scp sshuser@CLUSTERNAME-ssh.azurehdinsight.net:/usr/hdp/current/hadoop-client/{hadoop-auth.jar,hadoop-common.jar,lib/log4j-*.jar,lib/slf4j-*.jar} .
+    scp sshuser@CLUSTERNAME-ssh.azurehdinsight.net:/usr/hdp/current/hadoop-client/{hadoop-auth.jar,hadoop-common.jar,lib/log4j-*.jar,lib/slf4j-*.jar,lib/curator-*.jar} .
 
-    scp sshuser@CLUSTERNAME-ssh.azurehdinsight.net:/usr/hdp/current/hive-client/lib/{commons-codec*.jar,commons-logging-*.jar,hive-*-1.2*.jar,httpclient-*.jar,httpcore-*.jar,libfb*.jar,libthrift-*.jar} .
+    scp sshuser@CLUSTERNAME-ssh.azurehdinsight.net:/usr/hdp/current/hive-client/lib/{commons-codec*.jar,commons-logging-*.jar,hive-*-*.jar,httpclient-*.jar,httpcore-*.jar,libfb*.jar,libthrift-*.jar} .
     ```
 
 3. Start the SQuirreL SQL application. From the left of the window, select **Drivers**.


### PR DESCRIPTION
scp script now copies curator jars to the client. The scp script also no longer looks for a specific version of the Hive JARs.