### PR TITLE
troubleshoot-domain-ssl-certificates.md#an-app-service-certificate-wa…

### DIFF
--- a/articles/app-service/troubleshoot-domain-ssl-certificates.md
+++ b/articles/app-service/troubleshoot-domain-ssl-certificates.md
@@ -187,8 +187,7 @@ If the current certificate that uses the wrong domain is in the “Issued” sta
 The App Service certificate was renewed, but the app that uses the App Service certificate is still using the old certificate. Also, you received a warning that the HTTPS protocol is required.
 
 #### Cause 
-App Service automatically syncs your certificate within 48 hours. When you rotate or update a certificate, sometimes the application is still retrieving the old certificate and not the newly updated certificate. The reason is that the job to sync the certificate resource hasn't run yet. 
-click Sync. The sync operation automatically updates the hostname bindings for the certificate in App Service without causing any downtime to your apps.
+App Service automatically syncs your certificate within 48 hours. When you rotate or update a certificate, sometimes the application is still retrieving the old certificate and not the newly updated certificate. The reason is that the job to sync the certificate resource hasn't run yet. Click Sync. The sync operation automatically updates the hostname bindings for the certificate in App Service without causing any downtime to your apps.
  
 #### Solution
 

--- a/articles/app-service/troubleshoot-domain-ssl-certificates.md
+++ b/articles/app-service/troubleshoot-domain-ssl-certificates.md
@@ -187,7 +187,8 @@ If the current certificate that uses the wrong domain is in the “Issued” sta
 The App Service certificate was renewed, but the app that uses the App Service certificate is still using the old certificate. Also, you received a warning that the HTTPS protocol is required.
 
 #### Cause 
-Azure App Service runs a background job every eight hours and syncs the certificate resource if there are any changes. When you rotate or update a certificate, sometimes the application is still retrieving the old certificate and not the newly updated certificate. The reason is that the job to sync the certificate resource hasn't run yet. 
+App Service automatically syncs your certificate within 48 hours. When you rotate or update a certificate, sometimes the application is still retrieving the old certificate and not the newly updated certificate. The reason is that the job to sync the certificate resource hasn't run yet. 
+click Sync. The sync operation automatically updates the hostname bindings for the certificate in App Service without causing any downtime to your apps.
  
 #### Solution
 


### PR DESCRIPTION
…s-renewed-but-the-app-shows-the-old-certificate

This is outdated "Azure App Service runs a background job every eight hours and syncs the certificate resource if there are any changes"
The sync currently takes 48 hours check below documentation 
https://docs.microsoft.com/en-us/azure/app-service/web-sites-purchase-ssl-web-site#renew-certificate

proposed change:
App Service automatically syncs your certificate within 48 hours. When you rotate or update a certificate, sometimes the application is still retrieving the old certificate and not the newly updated certificate. The reason is that the job to sync the certificate resource hasn't run yet. 
click Sync. The sync operation automatically updates the hostname bindings for the certificate in App Service without causing any downtime to your apps.