### PR TITLE
(Azure CXP) fixes MicrosoftDOcs/azure-docs#35990

### DIFF
--- a/articles/active-directory/develop/msal-logging.md
+++ b/articles/active-directory/develop/msal-logging.md
@@ -66,7 +66,7 @@ class Program
                       .Build();
 
     AuthenticationResult result = application.AcquireTokenInteractive(scopes)
-                                             .ExecuteAsnc();
+                                             .ExecuteAsync().Result;
   }
  }
  ```


### PR DESCRIPTION
Corrected a typo and added missing ".result"