### PR TITLE
Fix broken link

### DIFF
--- a/articles/cognitive-services/Speech-Service/how-to-custom-speech-test-data.md
+++ b/articles/cognitive-services/Speech-Service/how-to-custom-speech-test-data.md
@@ -24,7 +24,7 @@ This table lists accepted data types, when each data type should be used, and th
 |-----------|-----------------|----------|-------------------|----------|
 | [Audio](#audio-data-for-testing) | Yes<br>Used for visual inspection | 5+ audio files | No | N/a |
 | [Audio + Human-labeled transcripts](#audio--human-labeled-transcript-data-for-testingtraining) | Yes<br>Used to evaluate accuracy | 0.5 - 5 hours of audio | Yes | 1 - 1,000 hours of audio |
-| [Related text](##related-text-data-for-training) | No | N/a | Yes | 1-200 MB of related text |
+| [Related text](#related-text-data-for-training) | No | N/a | Yes | 1-200 MB of related text |
 
 Files should be grouped by type into a dataset and uploaded as a zip file. Each dataset can only contain a single data type.
 


### PR DESCRIPTION
Removed the redundant `#` in link to the Related text section.