### PR TITLE
Clarify that approved apps require v2 CA policies

### DIFF
--- a/articles/active-directory/conditional-access/technical-reference.md
+++ b/articles/active-directory/conditional-access/technical-reference.md
@@ -198,7 +198,7 @@ In your Conditional Access policy, you can require that an access attempt to the
 
 ![Control access for approved client apps](./media/technical-reference/21.png)
 
-This setting applies to the following client apps:
+This setting applies to the following client apps in v2 policies:
 
 - Microsoft Azure Information Protection
 - Microsoft Bookings


### PR DESCRIPTION
Approved apps do not work with classic policies and only work with v2 policies.  Added clarification that the list of approved apps are for v2 policies.