### PR TITLE
Remove "AzureGateway-*GUID*.cloudapp.net"

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-troubleshoot-vpn-point-to-site-connection-problems.md
+++ b/articles/vpn-gateway/vpn-gateway-troubleshoot-vpn-point-to-site-connection-problems.md
@@ -43,8 +43,7 @@ To resolve this problem, follow these steps:
     | Certificate | Location |
     | ------------- | ------------- |
     | AzureClient.pfx  | Current User\Personal\Certificates |
-    | Azuregateway-*GUID*.cloudapp.net  | Current User\Trusted Root Certification Authorities|
-    | AzureGateway-*GUID*.cloudapp.net, AzureRoot.cer    | Local Computer\Trusted Root Certification Authorities|
+    | AzureRoot.cer    | Local Computer\Trusted Root Certification Authorities|
 
 3. Go to C:\Users\<UserName>\AppData\Roaming\Microsoft\Network\Connections\Cm\<GUID>, manually install the certificate (*.cer file) on the user and computer's store.
 


### PR DESCRIPTION
Self-signed certificate (AzureGateway-*GUID*.cloudapp.net) is not using now.
https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-point-to-site-gateway-public-ca