### PR TITLE
Remove unclosed #pragma from code sample for GetMetric

### DIFF
--- a/articles/azure-monitor/app/api-custom-events-metrics.md
+++ b/articles/azure-monitor/app/api-custom-events-metrics.md
@@ -158,8 +158,6 @@ If [sampling](../../azure-monitor/app/sampling.md) is in operation, the itemCoun
 *C#*
 
 ```csharp
-#pragma warning disable CA1716  // Namespace naming
-
 namespace User.Namespace.Example01
 {
     using System;


### PR DESCRIPTION
Remove `#pragma warning disable CA1716  // Namespace naming` from the opening line of the code sample for `GetMetric`