### PR TITLE
remove link to self

### DIFF
--- a/articles/virtual-machines/windows/dedicated-hosts.md
+++ b/articles/virtual-machines/windows/dedicated-hosts.md
@@ -24,6 +24,4 @@ ms.author: cynthn
 
 - You can deploy a dedicated host using [Azure PowerShell](dedicated-hosts-powershell.md), the [portal](dedicated-hosts-portal.md), and [Azure CLI](../linux/dedicated-hosts-cli.md).
 
-- For more information, see the [Dedicated hosts](dedicated-hosts.md) overview.
-
 - There is sample template, found [here](https://github.com/Azure/azure-quickstart-templates/blob/master/201-vm-dedicated-hosts/README.md), that uses both zones and fault domains for maximum resiliency in a region.


### PR DESCRIPTION
The bottom list for "Next steps" includes a link to this page.  In other words, the page links to itself.  That feels counterproductive.