### PR TITLE
fix(img-class): add endPoint, image path info

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/node-tutorial.md
+++ b/articles/cognitive-services/Custom-Vision-Service/node-tutorial.md
@@ -41,7 +41,7 @@ Create a new file called *sample.js* in your preferred project directory.
 
 ### Create the Custom Vision service project
 
-Add the following code to your script to create a new Custom Vision service project. Insert your subscription keys in the appropriate definitions.
+Add the following code to your script to create a new Custom Vision service project. Insert your subscription keys in the appropriate definitions and set the sampleDataRoot path value to your image folder path. Make sure the endPoint value matches the training and prediction endpoints you have created at [Customvision.ai](https://www.customvision.ai/).
 
 ```javascript
 const util = require('util');


### PR DESCRIPTION
Related [PR](https://github.com/MicrosoftDocs/azure-docs/pull/36360/files)
When you create a new account at customvision.io, API endpoint is set automatically to user's region.
If the reader doesn't pay attention to matching the endPoint variable, they might get Resource not found error.