### PR TITLE
Tell users to wait 5 to 10 minutes after the script action is complete

### DIFF
--- a/articles/hdinsight/interactive-query/apache-hive-migrate-workloads.md
+++ b/articles/hdinsight/interactive-query/apache-hive-migrate-workloads.md
@@ -94,11 +94,7 @@ In HDInsight 3.6, the GUI client for interacting with Hive server is the Ambari 
 
 Launch a script action against your cluster, with "Head nodes" as the node type for execution. Paste the following URI into the textbox marked "Bash Script URI": https://hdiconfigactions.blob.core.windows.net/dasinstaller/LaunchDASInstaller.sh
 
-Wait for 5 to 10 minutes before you access the below URL.
-
-Data Analytics Studio can be launched with URL : https://\<clustername>.azurehdinsight.net/das/
-
-
+Wait 5 to 10 minutes, then launch Data Analytics Studio by using this URL: https://\<clustername>.azurehdinsight.net/das/
 
 Once DAS is installed, if you don't see the queries you’ve run in the queries viewer, do the following steps:
 

--- a/articles/hdinsight/interactive-query/apache-hive-migrate-workloads.md
+++ b/articles/hdinsight/interactive-query/apache-hive-migrate-workloads.md
@@ -94,6 +94,8 @@ In HDInsight 3.6, the GUI client for interacting with Hive server is the Ambari 
 
 Launch a script action against your cluster, with "Head nodes" as the node type for execution. Paste the following URI into the textbox marked "Bash Script URI": https://hdiconfigactions.blob.core.windows.net/dasinstaller/LaunchDASInstaller.sh
 
+Wait for 5 to 10 minutes before you access the below URL.
+
 Data Analytics Studio can be launched with URL : https://\<clustername>.azurehdinsight.net/das/
 
 


### PR DESCRIPTION
After the script action is shown as "Succeeded" in the Azure portal. We need to wait 5 - 10 minutes before the user access the DAS URL. One has to wait because after the script action takes place, Ambari has to install and start the component.