### PR TITLE
Adding instruction to use absolute paths in startup script

### DIFF
--- a/articles/app-service/containers/configure-language-java.md
+++ b/articles/app-service/containers/configure-language-java.md
@@ -135,7 +135,7 @@ Developers running a single application with one deployment slot in their App Se
 
 When tuning application heap settings, review your App Service plan details and take into account multiple applications and deployment slot needs to find the optimal allocation of memory.
 
-If you are deploying a JAR application, it should be named *app.jar* so that the built-in image can correctly identify your app. (The Maven plugin does this renaming automatically.) If you do not wish to rename your JAR to *app.jar*, you can upload a shell script with the command to run your JAR. Then paste the full path to this script in the [Startup File](app-service-linux-faq.md#built-in-images) textbox in the Configuration section of the portal.
+If you are deploying a JAR application, it should be named *app.jar* so that the built-in image can correctly identify your app. (The Maven plugin does this renaming automatically.) If you do not wish to rename your JAR to *app.jar*, you can upload a shell script with the command to run your JAR. Then paste the full path to this script in the [Startup File](app-service-linux-faq.md#built-in-images) textbox in the Configuration section of the portal. **Note:** The startup script does not run from the directory into which it is placed. Therefore, always use absolute paths to reference files in your startup script (e.g. `java -jar /home/myapp/myapp.jar`).
 
 ### Turn on web sockets
 

--- a/articles/app-service/containers/configure-language-java.md
+++ b/articles/app-service/containers/configure-language-java.md
@@ -135,7 +135,7 @@ Developers running a single application with one deployment slot in their App Se
 
 When tuning application heap settings, review your App Service plan details and take into account multiple applications and deployment slot needs to find the optimal allocation of memory.
 
-If you are deploying a JAR application, it should be named *app.jar* so that the built-in image can correctly identify your app. (The Maven plugin does this renaming automatically.) If you do not wish to rename your JAR to *app.jar*, you can upload a shell script with the command to run your JAR. Then paste the full path to this script in the [Startup File](app-service-linux-faq.md#built-in-images) textbox in the Configuration section of the portal. **Note:** The startup script does not run from the directory into which it is placed. Therefore, always use absolute paths to reference files in your startup script (e.g. `java -jar /home/myapp/myapp.jar`).
+If you are deploying a JAR application, it should be named *app.jar* so that the built-in image can correctly identify your app. (The Maven plugin does this renaming automatically.) If you do not wish to rename your JAR to *app.jar*, you can upload a shell script with the command to run your JAR. Then paste the full path to this script in the [Startup File](app-service-linux-faq.md#built-in-images) textbox in the Configuration section of the portal. The startup script does not run from the directory into which it is placed. Therefore, always use absolute paths to reference files in your startup script (for example: `java -jar /home/myapp/myapp.jar`).
 
 ### Turn on web sockets
 


### PR DESCRIPTION
In working with a customer to migrate an application to app servers, we have encountered a failure if the startup script attempts to reference a jar file via a relative path. The issue is that startup scripts are copied to `/tmp` and run from there. Therefore, only absolute paths in startup scripts will work.