### PR TITLE
Azure Security Center for IoT is no longer in preview

### DIFF
--- a/articles/security-center/security-center-intro.md
+++ b/articles/security-center/security-center-intro.md
@@ -133,9 +133,9 @@ ranges or IP addresses, and for a limited amount of time.
 Security Center includes capabilities that help you perform automatic classification of your data in Azure SQL. You can also get assessments for potential vulnerabilities across Azure SQL and Storage services, and
 recommendations for how to mitigate them.
 
-### Protect IoT and hybrid cloud workloads (Preview)
+### Protect IoT and hybrid cloud workloads
 
-Azure Security Center for IoT (Internet of Things) simplifies hybrid workload protection by delivering unified visibility and control, adaptive threat prevention, and intelligent threat detection and response across workloads running on edge, on-premises, in Azure, and in other clouds. For more information, see [Azure Security Center for IoT (Preview)](https://docs.microsoft.com/azure/asc-for-iot/).
+Azure Security Center for IoT (Internet of Things) simplifies hybrid workload protection by delivering unified visibility and control, adaptive threat prevention, and intelligent threat detection and response across workloads running on edge, on-premises, in Azure, and in other clouds. For more information, see [Azure Security Center for IoT](https://docs.microsoft.com/azure/asc-for-iot/).
 
 ## Get secure faster
 


### PR DESCRIPTION
Azure Security Center for IoT has gone GA on July 29th, as can be found in https://azure.microsoft.com/en-us/blog/announcing-general-availability-for-the-azure-security-center-for-iot/.