### PR TITLE
fixed character bug in pg_restore command

### DIFF
--- a/articles/postgresql/howto-migrate-using-dump-and-restore.md
+++ b/articles/postgresql/howto-migrate-using-dump-and-restore.md
@@ -31,7 +31,7 @@ pg_dump -Fc -v --host=localhost --username=masterlogin --dbname=testdb > testdb.
 ## Restore the data into the target Azure Database for PostrgeSQL using pg_restore
 After you've created the target database, you can use the pg_restore command and the -d, --dbname parameter to restore the data into the target database from the dump file.
 ```bash
-pg_restore -v --no-owner –-host=<server name> --port=<port> --username=<user@servername> --dbname=<target database name> <database>.dump
+pg_restore -v --no-owner --host=<server name> --port=<port> --username=<user@servername> --dbname=<target database name> <database>.dump
 ```
 Including the --no-owner parameter causes all objects created during the restore to be owned by the user specified with --username. For more information, see the official PostgreSQL documentation on [pg_restore](https://www.postgresql.org/docs/9.6/static/app-pgrestore.html).
 


### PR DESCRIPTION
pr fixes a bug where a hyphen-looking character was used instead of a real hyphen, leading to errors if the documented command was executed.