### PR TITLE
Add requirements for Management VM

### DIFF
--- a/articles/active-directory-domain-services/password-policy.md
+++ b/articles/active-directory-domain-services/password-policy.md
@@ -76,7 +76,7 @@ You can configure a custom FGPP for the following reasons:
 * To configure a default password lifetime setting for the managed domain.
 
 To create a custom FGPP on your managed domain:
-1. Sign in to the Windows VM you use to administer your managed domain (Must be Minimum Server 2012 R2). If you don't have one, follow the instructions to [Manage an Azure AD Domain Services domain](manage-domain.md).
+1. Sign in to the Windows VM you use to administer your managed domain (must be a minimum of Windows Server 2012 R2). If you don't have one, follow the instructions to [Manage an Azure AD Domain Services domain](manage-domain.md).
 2. Launch the **Active Directory Administrative Center** on the VM.
 3. Click the domain name (for example, 'contoso100.com').
 4. Double-click **System** to open the System container.

--- a/articles/active-directory-domain-services/password-policy.md
+++ b/articles/active-directory-domain-services/password-policy.md
@@ -76,7 +76,7 @@ You can configure a custom FGPP for the following reasons:
 * To configure a default password lifetime setting for the managed domain.
 
 To create a custom FGPP on your managed domain:
-1. Sign in to the Windows VM you use to administer your managed domain. If you don't have one, follow the instructions to [Manage an Azure AD Domain Services domain](manage-domain.md).
+1. Sign in to the Windows VM you use to administer your managed domain (Must be Minimum Server 2012 R2). If you don't have one, follow the instructions to [Manage an Azure AD Domain Services domain](manage-domain.md).
 2. Launch the **Active Directory Administrative Center** on the VM.
 3. Click the domain name (for example, 'contoso100.com').
 4. Double-click **System** to open the System container.


### PR DESCRIPTION
From testing on a 2008 R2 server I was unable to create a new password settings object, I then tested with a 2012 R2 and 2016 server and was able to create the object.