### PR TITLE
Fix path typo error

### DIFF
--- a/articles/machine-learning/service/tutorial-data-prep.md
+++ b/articles/machine-learning/service/tutorial-data-prep.md
@@ -98,8 +98,8 @@ Download two different NYC taxi data sets into dataflow objects. The datasets ha
 ```python
 from IPython.display import display
 
-green_path = "https://dprepdata.blob.core.windows.net/demo/green-small/*"])
-yellow_path = "https://dprepdata.blob.core.windows.net/demo/yellow-small/*"])
+green_path = "https://dprepdata.blob.core.windows.net/demo/green-small/*"
+yellow_path = "https://dprepdata.blob.core.windows.net/demo/yellow-small/*"
 
 # (optional) Download and view a subset of the data: https://dprepdata.blob.core.windows.net/demo/green-small/green_tripdata_2013-08.csv
 


### PR DESCRIPTION
[PR494](https://github.com/changeworld/azure-docs/pull/494) changed the structure of the `green_path` and `yellow_path` path names and left erroneous characters `])` at the end of the string when changing from a `join` to a URI.

The tutorial didn't run as is, so I am proposing changing the path string to correct.

As is code with incorrect syntax at end: 
```python
green_path = "https://dprepdata.blob.core.windows.net/demo/green-small/*"])
yellow_path = "https://dprepdata.blob.core.windows.net/demo/yellow-small/*"])
```

This PR changes them to:
```python
green_path = "https://dprepdata.blob.core.windows.net/demo/green-small/*"
yellow_path = "https://dprepdata.blob.core.windows.net/demo/yellow-small/*"
```