### PR TITLE
Remove CSP exception note

### DIFF
--- a/articles/marketplace/private-offers.md
+++ b/articles/marketplace/private-offers.md
@@ -45,9 +45,6 @@ Private offers are only discoverable via the [Azure portal](https://azure.micros
 
 Private offers will also appear in search results. Just look out for the “Private” badge.
 
-> [!Note]
-> Private offers are not supported with subscriptions established through a reseller of the Cloud Solution Provider program (CSP).
-
 ## Next steps
 
 If you would like to take advantage of these new capabilities, you can get started selling on the [Azure Marketplace](https://azuremarketplace.microsoft.com/sell).


### PR DESCRIPTION
The note here about private offers not being available to subscriptions created by CSPs is incorrect.  It causes confusion with ISVs and should be removed.