### PR TITLE
Correct spacing between "see" and "the"

### DIFF
--- a/includes/data-lake-storage-gen1-rename-note.md
+++ b/includes/data-lake-storage-gen1-rename-note.md
@@ -11,7 +11,7 @@
 ---
 
 > [!NOTE]
-> Azure Data Lake Storage Gen2 is now generally available. We recommend that you start using it today. For more information, see the [product page](https://aka.ms/adlsgen2-product).
+> Azure Data Lake Storage Gen2 is now generally available. We recommend that you start using it today. For more information, see the [product page](https://aka.ms/adlsgen2-product).
 > 
 
 


### PR DESCRIPTION
The spacing between the words "see" and "the" somehow caused the PDF output to show up as "seethe".  This PR corrects this issue.