### PR TITLE
Corrected a copy/paste typo

### DIFF
--- a/articles/logic-apps/logic-apps-track-b2b-messages-omsportal.md
+++ b/articles/logic-apps/logic-apps-track-b2b-messages-omsportal.md
@@ -256,7 +256,7 @@ Here are the property descriptions for each EDIFACT message.
 | Receiver | The host partner specified in **Receive Settings**, or the guest partner specified in **Send Settings** for an EDIFACT agreement |
 | Logic App | The logic app where the EDIFACT actions are set up |
 | Status | The EDIFACT message status <br>Success = Received or sent a valid EDIFACT message. No functional ack is set up. <br>Success = Received or sent a valid EDIFACT message. Functional ack is set up and received, or a functional ack is sent. <br>Failed = Received or sent an invalid EDIFACT message <br>Pending = Received or sent a valid EDIFACT message. Functional ack is set up, and a functional ack is expected. |
-| Ack | Functional Ack (997) status <br>Accepted = Received or sent a positive functional ack. <br>Rejected = Received or sent a negative functional ack. <br>Pending = Expecting a functional ack but not received. <br>Pending = Generated a functional ack but can't send to partner. <br>Not Required = Functional Ack is not set up. |
+| Ack | Functional Ack (CONTRL) status <br>Accepted = Received or sent a positive functional ack. <br>Rejected = Received or sent a negative functional ack. <br>Pending = Expecting a functional ack but not received. <br>Pending = Generated a functional ack but can't send to partner. <br>Not Required = Functional Ack is not set up. |
 | Direction | The EDIFACT message direction |
 | Correlation ID | The ID that correlates all the triggers and actions in a logic app |
 | Msg type | The EDIFACT message type |


### PR DESCRIPTION
I found what looked to be a copy/paste typo from the X12 documentation section. The functional ACK name in EDIFACT was given incorrectly as a 997 which is for X12. I entered the correct name for the functional ACK in EDIFACT. 

Thanks, Ben