### PR TITLE
TM - Added note about endpoints changing SubID

### DIFF
--- a/articles/traffic-manager/traffic-manager-FAQs.md
+++ b/articles/traffic-manager/traffic-manager-FAQs.md
@@ -319,9 +319,9 @@ Traffic Manager responds with the DNS name or IP address of the endpoint. To sup
 
 Typically, Traffic Manager is used to direct traffic to applications deployed in different regions. However, it can also be used where an application has more than one deployment in the same region. The Traffic Manager Azure endpoints do not permit more than one Web App endpoint from the same Azure region to be added to the same Traffic Manager profile.
 
-### How do I move my Traffic Manager profile’s Azure endpoints to a different resource group?
+### How do I move my Traffic Manager profile’s Azure endpoints to a different resource group or subscription?
 
-Azure endpoints that are associated with a Traffic Manager profile are tracked using their resource IDs. When an Azure resource that is being used as an endpoint (for example,  Public IP, Classic Cloud Service, WebApp, or another Traffic Manager profile used in a nested manner) is moved to a different resource group, its resource ID changes. In this scenario, currently, you must update the Traffic Manager profile by first deleting and then adding back the endpoints to the profile.
+Azure endpoints that are associated with a Traffic Manager profile are tracked using their resource IDs. When an Azure resource that is being used as an endpoint (for example,  Public IP, Classic Cloud Service, WebApp, or another Traffic Manager profile used in a nested manner) is moved to a different resource group or subscription, its resource ID changes. In this scenario, currently, you must update the Traffic Manager profile by first deleting and then adding back the endpoints to the profile.
 
 ## Traffic Manager endpoint monitoring
 


### PR DESCRIPTION
While moving RGs, you need to remove and re-add the endpoint to get a fresh Resource ID. You need to do the same for SubID if your endpoint moves subscriptions. Added to the FAQ to account for this.