### PR TITLE
Add note about OATH token secret key

### DIFF
--- a/articles/active-directory/authentication/concept-authentication-methods.md
+++ b/articles/active-directory/authentication/concept-authentication-methods.md
@@ -153,7 +153,7 @@ Users may have a combination of up to five OATH hardware tokens or authenticator
 
 ## OATH hardware tokens (public preview)
 
-OATH is an open standard that specifies how one-time password (OTP) codes are generated. Azure AD will support the use of OATH-TOTP SHA-1 tokens of the 30-second or 60-second variety. Customers can procure these tokens from the vendor of their choice. Secret keys are limited to 128 characters, which may not be compatible with all tokens.
+OATH is an open standard that specifies how one-time password (OTP) codes are generated. Azure AD will support the use of OATH-TOTP SHA-1 tokens of the 30-second or 60-second variety. Customers can procure these tokens from the vendor of their choice. Secret keys are limited to 128 characters, which may not be compatible with all tokens. The secret keys need to be encoded in Base32.
 
 ![Uploading OATH tokens to the MFA Server OATH tokens blade](media/concept-authentication-methods/oath-tokens-azure-ad.png)
 


### PR DESCRIPTION
Added sentence that the OATH token secret keys need to be encoded in base 32.  A MS client tried using a 40 character hex code and was getting a generic error that "something went wrong".  The announcement that this feature is available mentions that the secret key needs to be base 32 - here is the link to the announcement.  https://techcommunity.microsoft.com/t5/Azure-Active-Directory-Identity/Hardware-OATH-tokens-in-Azure-MFA-in-the-cloud-are-now-available/ba-p/276466