### PR TITLE
Adding blob deletion script

### DIFF
--- a/articles/network-watcher/blob-deletion-script.md
+++ b/articles/network-watcher/blob-deletion-script.md
@@ -1,0 +1,122 @@
+# Blob Deletion script
+
+## Background
+Retention policies on Network Watcher - NSG Flow Logs were recently turned off. As a result, storage blobs created by NSG Flow logs will no longer be automatically deleted.
+
+## Workaround
+The customer is expected to manually delete the flow logs data from their storage accounts.
+
+Customers can use the below PowerShell script in lieu of the retention policy to delete blobs that are out of the retention period.
+
+Note: This change impacts only those customers who had configured a retention policy.
+A retention policy is defined as the number of days where storage blobs are retained on a storage account. A retention policy of zero days means that blobs are to be retained forever and none will be deleted.
+
+
+```
+#
+# This powershell script deletes all NSG flow log blobs that should not be retained anymore as per configured retention policy.
+# While configuring NSG flow logs on Azure portal, the user configures the retention period of NSG flow log blobs in
+# their storage account (in days).
+# This script reads all blobs and deletes blobs that are not to be retained (outside retention window)
+# if the retention days are zero; all blobs are retained forever and hence no blobs are deleted.
+#
+#
+
+param (
+        [string] [Parameter(Mandatory=$true)]  $SubscriptionId,
+        [string] [Parameter(Mandatory=$true)]  $Location,
+        [switch] [Parameter(Mandatory=$false)] $Confirm
+    )
+
+Login-AzAccount
+
+$SubId = Get-AzSubscription| Where-Object {$_.Id.contains($SubscriptionId.ToLower())}
+
+if ($SubId.Count -eq 0)
+{
+    Write-Error 'The SubscriptionId does not exist' -ErrorAction Stop
+}
+
+Set-AzContext -SubscriptionId $SubscriptionId
+
+$NsgList = Get-AzNetworkSecurityGroup | Where-Object {$_.Location -eq $Location}
+$NW = Get-AzNetworkWatcher | Where-Object {$_.Location -eq $Location}
+
+$FlowLogsList = @()
+foreach ($Nsg in $NsgList)
+{
+    # Query Flow Log Status which are enabled
+    $NsgFlowLog = Get-AzNetworkWatcherFlowLogStatus -NetworkWatcher $NW -TargetResourceId $Nsg.Id | Where-Object {$_.Enabled -eq "True"}
+    if ($NsgFlowLog.Count -gt 0)
+    {
+        $FlowLogsList +=  $NsgFlowLog
+        Write-Output ('Enabled NSG found: ' +  $NsgFlowLog.TargetResourceId)
+    }
+}
+
+foreach ($Psflowlog in $FlowLogsList)
+{
+    $RetentionDays = $Psflowlog.RetentionPolicy.Days
+    if ($RetentionDays -le 0)
+    {
+        continue
+    }
+
+    $Strings = $Psflowlog.StorageId -split '/'
+    $RGName = $Strings[4]
+    $StorageAccountName = $Strings[-1]
+
+    $Key = (Get-AzStorageAccountKey -ResourceGroupName $RGName -Name $StorageAccountName).Value[1]
+    $StorageAccount = New-AzStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $Key
+
+    $ContainerName = 'insights-logs-networksecuritygroupflowevent'  
+    $BLobsList = Get-AzStorageBlob -Container $ContainerName -Context $StorageAccount.Context
+
+    $TargetBLobsList = $BLobsList | Where-Object {$_.Name.contains($Psflowlog.TargetResourceId.ToUpper())}
+
+    $RetentionDate = Get-Date
+    $RetentionDate = $RetentionDate.AddDays(-1*$RetentionDays)
+    $RetentionDateInUTC = $RetentionDate.ToUniversalTime()
+
+    foreach ($Blob in $TargetBLobsList)
+    {
+        $BlobLastModifietedDTinUTC = [datetime]$Blob.LastModified.UtcDateTime
+
+        if ($BlobLastModifietedDTinUTC -ge  $RetentionDateInUTC)
+        {
+            Write-Output ($Blob.Name + '===>' + $BlobLastModifietedDTinUTC  + ' ===> RETAINED')
+            continue
+        }
+
+        if ($Confirm)
+        {
+            Write-Output (Blob to be deleted: $Blob.Name)
+            $Confirmation = Read-Host "Are you sure you want to remove this blob (Y/N)?"
+        }
+
+        if ((-not $Confirm) -or ($Confirmation -eq 'Y'))
+        {
+            Write-Output ($Blob.Name + '===>' + $BlobLastModifietedDTinUTC  + ' ===> DELETED')
+            Remove-AzStorageBlob -Container $container_name -Context $storage_account.Context -Blob $Blob.Name
+        }
+        else
+        {
+            Write-Output ($Blob.Name + '===>' + $BlobLastModifietedDTinUTC  + ' ===> RETAINED')
+        }
+    }
+}
+
+Write-Output ('Retention policy for all NSGs evaluated and completed successfully')
+
+```
+## Using the script
+Download the script to the current working directory or relevant path folders.
+The script accepts 3 parameters:
+  1. SubscriptionId [Mandatory]: The subscription ID from where you would like to delete NSG Flow Log blobs
+  2. Location [Mandatory]: The _location string_  of the region of the NSGs for which you would like to delete NSG Flow Log blobs.
+  3. Confirm [Optional]: Pass the confirm flag if you want to manually confirm the deletion of each storage blob.
+
+**Example:**
+We have saved the script as Delete-NsgFlowLogsBlobs.ps1 in this example.
+
+.\Delete-NsgFlowLogsBlobs.ps1 -SubscriptionId "99999999-9999-9999-9999-999999999999" -Location  "eastus2euap" -Confirm


### PR DESCRIPTION
Adding script that deletes blobs that are out of the retention period configured by the user.
This is needed to a recent incident requiring us to turn off retention policies for NSG Flow logs. 