### PR TITLE
Specifying the statement about adding space

### DIFF
--- a/articles/virtual-network/manage-virtual-network.md
+++ b/articles/virtual-network/manage-virtual-network.md
@@ -42,7 +42,7 @@ Complete the following tasks before completing steps in any section of this arti
      - 169.254.0.0/16 (Link-local)
      - 168.63.129.16/32 (Internal DNS, DHCP, and Azure Load Balancer [health probe](../load-balancer/load-balancer-custom-probe-overview.md#probesource))
 
-     Although you can define only one address range when you create the virtual network, you can add more address ranges to the address space after the virtual network is created. To learn how to add an address range to an existing virtual network, see [Add or remove an address range](#add-or-remove-an-address-range).
+     Although you can define only one address range when you create the virtual network in the portal, you can add more address ranges to the address space after the virtual network is created. To learn how to add an address range to an existing virtual network, see [Add or remove an address range](#add-or-remove-an-address-range).
 
      >[!WARNING]
      >If a virtual network has address ranges that overlap with another virtual network or on-premises network, the two networks cannot be connected. Before you define an address range, consider whether you might want to connect the virtual network to other virtual networks or on-premises networks in the future.


### PR DESCRIPTION
The statement is portal specific. You can create multiple address spaces in one vnet in an arm template.

ex. below
      "apiVersion": "2018-10-01",
      "type": "Microsoft.Network/virtualNetworks",
      "name": "[parameters('vnetName')]",
      "location": "[parameters('location')]",
      "properties": {
        "addressSpace": {
          "addressPrefixes": [
            "[parameters('vnetAddressPrefix')]", "10.2.0.0/16"
          ]
        }
      },