### PR TITLE
Clarifies at what level Principals should be

### DIFF
--- a/articles/service-fabric/how-to-deploy-service-fabric-application-system-assigned-managed-identity.md
+++ b/articles/service-fabric/how-to-deploy-service-fabric-application-system-assigned-managed-identity.md
@@ -58,7 +58,7 @@ This property declares (to Azure Resource Manager, and the Managed Identity and 
       </ManagedIdentities>
     </Principals>
     ```
-    This maps the identity assigned to the application as a resource to a friendly name, for further assignment to the services comprising the application. 
+    **Principals** should be a child of **ApplicationManifest** and lower in the manifest than **ServiceManifestImport**. This maps the identity assigned to the application as a resource to a friendly name, for further assignment to the services comprising the application. 
 
 2. In the **ServiceManifestImport** section corresponding to the service that is being assigned the managed identity, add an **IdentityBindingPolicy** element, as indicated below:
 


### PR DESCRIPTION
VSS is also picky about the order of the children and gives a warning if it is above ServiceManifestImport: "has invalid child element"