### PR TITLE
Update apache-hadoop-use-hive-beeline.md

### DIFF
--- a/articles/hdinsight/hadoop/apache-hadoop-use-hive-beeline.md
+++ b/articles/hdinsight/hadoop/apache-hadoop-use-hive-beeline.md
@@ -41,7 +41,7 @@ Replace `<headnode-FQDN>` with the fully qualified domain name of a cluster head
 
 ### To HDInsight Enterprise Security Package (ESP) cluster
 
-When connecting from a client to an Enterprise Security Package (ESP) cluster joined to Azure Active Directory (AAD), you must also specify the domain name `<AAD-Domain>` and the name of a domain user account with permissions to access the cluster `<username>`:
+When connecting from a client to an Enterprise Security Package (ESP) cluster joined to Azure Active Directory (AAD) on a machine in same realm of the cluster, you must also specify the domain name `<AAD-Domain>` and the name of a domain user account with permissions to access the cluster `<username>`:
 
 ```bash
 kinit <username>
@@ -54,7 +54,7 @@ Replace `<username>` with the name of an account on the domain with permissions 
 
 ### Over public internet
 
-When connecting over the public internet, you must provide the cluster login account name (default `admin`) and password. For example, using Beeline from a client system to connect to the `<clustername>.azurehdinsight.net` address. This connection is made over port `443`, and is encrypted using SSL:
+When connecting to a non-ESP or Azure Active Directory (AAD) joined ESP cluster over the public internet, you must provide the cluster login account name (default `admin`) and password. For example, using Beeline from a client system to connect to the `<clustername>.azurehdinsight.net` address. This connection is made over port `443`, and is encrypted using SSL:
 
 ```bash
 beeline -u 'jdbc:hive2://clustername.azurehdinsight.net:443/;ssl=true;transportMode=http;httpPath=/hive2' -n admin -p password


### PR DESCRIPTION
A customer wanted to connect to an AAD joined cluster using beeline on a client machine that is in different realm than the cluster. He found the original doc was confusing in two sections: 1) section "To HDInsight Enterprise Security Package (ESP) cluster" does not specify the case that "client machine and the HDI cluster are not on the same realm" will not work with the connection string; 2) section "Over public internet" does not clarify if the connection string can work with ESP clusters or not.