### PR TITLE
Add clarity to certificate setup

### DIFF
--- a/articles/logic-apps/logic-apps-enterprise-integration-certificates.md
+++ b/articles/logic-apps/logic-apps-enterprise-integration-certificates.md
@@ -119,7 +119,7 @@ provide these details for your certificate. When you're done, choose **OK**.
    |----------|-------|-------------|
    | **Name** | <*certificate-name*> | Your certificate's name, which is "privateCert" in this example | 
    | **Certificate Type** | Private | Your certificate's type |
-   | **Certificate** | <*certificate-file-name*> | To find and select the certificate file you want to upload, choose the folder icon next to the **Certificate** box. | 
+   | **Certificate** | <*certificate-file-name*> | To find and select the certificate file you want to upload, choose the folder icon next to the **Certificate** box. When using a key vault for the private key, the uploaded file will be the public certificate. | 
    | **Resource Group** | <*integration-account-resource-group*> | Your integration account's resource group, which is "MyResourceGroup" in this example | 
    | **Key Vault** | <*key-vault-name*> | Your Azure key vault's name |
    | **Key name** | <*key-name*> | Your key's name |


### PR DESCRIPTION
I just setup AS2 certificates for a customer using logic apps and found a little extra information about the private key setup would really help. The screenshot showed the public certificate set for the upload but the comments table could have been more explicit to help. My extra line helps add clarity for the private key setup.