### PR TITLE
try to add clarity for management access

### DIFF
--- a/articles/role-based-access-control/role-definitions.md
+++ b/articles/role-based-access-control/role-definitions.md
@@ -83,7 +83,7 @@ Role-based access control for management operations is specified in the `Actions
 - Create, update, or delete a blob container
 - Delete a resource group and all of its resources
 
-Management access is not inherited to your data provided the container authentication method is set to "Azure AD User Account" and not "Access Key". This separation prevents roles with wildcards (`*`) from having unrestricted access to your data. For example, if a user has a [Reader](built-in-roles.md#reader) role on a subscription, then they can view the storage account, but by default they can't view the underlying data.
+Management access is not inherited to your data provided that the container authentication method is set to "Azure AD User Account" and not "Access Key". This separation prevents roles with wildcards (`*`) from having unrestricted access to your data. For example, if a user has a [Reader](built-in-roles.md#reader) role on a subscription, then they can view the storage account, but by default they can't view the underlying data.
 
 Previously, role-based access control was not used for data operations. Authorization for data operations varied across resource providers. The same role-based access control authorization model used for management operations has been extended to data operations.
 

--- a/articles/role-based-access-control/role-definitions.md
+++ b/articles/role-based-access-control/role-definitions.md
@@ -83,7 +83,7 @@ Role-based access control for management operations is specified in the `Actions
 - Create, update, or delete a blob container
 - Delete a resource group and all of its resources
 
-Management access is not inherited to your data. This separation prevents roles with wildcards (`*`) from having unrestricted access to your data. For example, if a user has a [Reader](built-in-roles.md#reader) role on a subscription, then they can view the storage account, but by default they can't view the underlying data.
+Management access is not inherited to your data provided the container authentication method is set to "Azure AD User Account" and not "Access Key". This separation prevents roles with wildcards (`*`) from having unrestricted access to your data. For example, if a user has a [Reader](built-in-roles.md#reader) role on a subscription, then they can view the storage account, but by default they can't view the underlying data.
 
 Previously, role-based access control was not used for data operations. Authorization for data operations varied across resource providers. The same role-based access control authorization model used for management operations has been extended to data operations.
 


### PR DESCRIPTION
Currently, this doc does not specify that the management plane access effects described only occur when the authentication method is set to Azure AD User Account. If the storage container has the default authentication method (access key), roles will have access to the blobs. I am open to consideration on the language, but I think we should include something specifying how to separate that access.