### PR TITLE
(AzureCXP) Adding log size info

### DIFF
--- a/articles/active-directory/reports-monitoring/concept-activity-logs-azure-monitor.md
+++ b/articles/active-directory/reports-monitoring/concept-activity-logs-azure-monitor.md
@@ -67,7 +67,7 @@ If you already have an Azure AD license, you need an Azure subscription to set u
 
 ### Storage size for activity logs
 
-Every audit log event uses about 2 KB of data storage. For a tenant with 100,000 users, which would incur about 1.5 million events per day, you would need about 3 GB of data storage per day. Because writes occur in approximately five-minute batches, you can anticipate approximately 9,000 write operations per month. 
+Every audit log event uses about 2 KB of data storage. Sign in event logs are about 4 KB of data storage. For a tenant with 100,000 users, which would incur about 1.5 million events per day, you would need about 3 GB of data storage per day. Because writes occur in approximately five-minute batches, you can anticipate approximately 9,000 write operations per month. 
 
 
 The following table contains a cost estimate of, depending on the size of the tenant, a general-purpose v2 storage account in West US for at least one year of retention. To create a more accurate estimate for the data volume that you anticipate for your application, use the [Azure storage pricing calculator](https://azure.microsoft.com/pricing/details/storage/blobs/).


### PR DESCRIPTION
The sign-in events should be about 4kb of data storage per sign-in event. per git issue : 