### PR TITLE
Added a defined instance id to JS subOrchestration

### DIFF
--- a/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
@@ -21,7 +21,7 @@ An orchestrator function can call another orchestrator function by calling the [
 Sub-orchestrator functions behave just like activity functions from the caller's perspective. They can return a value, throw an exception, and can be awaited by the parent orchestrator function. 
 
 > [!NOTE]
-> At the moment, it is necessary to provide an instanceId argument value to the subOrchestration API in JavaScript.
+> Currently, it's necessary to provide an `instanceId` argument value to the subOrchestration API in JavaScript.
 
 ## Example
 

--- a/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
@@ -18,7 +18,10 @@ In addition to calling activity functions, orchestrator functions can call other
 
 An orchestrator function can call another orchestrator function by calling the [CallSubOrchestratorAsync](https://azure.github.io/azure-functions-durable-extension/api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html#Microsoft_Azure_WebJobs_DurableOrchestrationContext_CallSubOrchestratorAsync_) or the [CallSubOrchestratorWithRetryAsync](https://azure.github.io/azure-functions-durable-extension/api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html#Microsoft_Azure_WebJobs_DurableOrchestrationContext_CallSubOrchestratorWithRetryAsync_) methods in .NET, or the `callSubOrchestrator` or `callSubOrchestratorWithRetry` methods in JavaScript. The [Error Handling & Compensation](durable-functions-error-handling.md#automatic-retry-on-failure) article has more information on automatic retry.
 
-Sub-orchestrator functions behave just like activity functions from the caller's perspective. They can return a value, throw an exception, and can be awaited by the parent orchestrator function. At the moment, it is necessary to provide an instanceId to properly call the subOrchestration in Javascript.
+Sub-orchestrator functions behave just like activity functions from the caller's perspective. They can return a value, throw an exception, and can be awaited by the parent orchestrator function. 
+
+> [!NOTE]
+> At the moment, it is necessary to provide an instanceId argument value to the subOrchestration API in JavaScript.
 
 ## Example
 

--- a/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
@@ -14,11 +14,11 @@ ms.author: azfuncdf
 
 # Sub-orchestrations in Durable Functions (Azure Functions)
 
-In addition to calling activity functions, orchestrator functions can  call other orchestrator functions. For example, you can build a larger orchestration out of a library of orchestrator functions. Or you can run multiple instances of an orchestrator function in parallel.
+In addition to calling activity functions, orchestrator functions can call other orchestrator functions. For example, you can build a larger orchestration out of a library of orchestrator functions. Or you can run multiple instances of an orchestrator function in parallel.
 
 An orchestrator function can call another orchestrator function by calling the [CallSubOrchestratorAsync](https://azure.github.io/azure-functions-durable-extension/api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html#Microsoft_Azure_WebJobs_DurableOrchestrationContext_CallSubOrchestratorAsync_) or the [CallSubOrchestratorWithRetryAsync](https://azure.github.io/azure-functions-durable-extension/api/Microsoft.Azure.WebJobs.DurableOrchestrationContext.html#Microsoft_Azure_WebJobs_DurableOrchestrationContext_CallSubOrchestratorWithRetryAsync_) methods in .NET, or the `callSubOrchestrator` or `callSubOrchestratorWithRetry` methods in JavaScript. The [Error Handling & Compensation](durable-functions-error-handling.md#automatic-retry-on-failure) article has more information on automatic retry.
 
-Sub-orchestrator functions behave just like activity functions from the caller's perspective. They can return a value, throw an exception, and can be awaited by the parent orchestrator function.
+Sub-orchestrator functions behave just like activity functions from the caller's perspective. They can return a value, throw an exception, and can be awaited by the parent orchestrator function. At the moment, it is necessary to provide an instanceId to properly call the subOrchestration in Javascript.
 
 ## Example
 
@@ -103,9 +103,12 @@ module.exports = df.orchestrator(function*(context) {
 
     // Run multiple device provisioning flows in parallel
     const provisioningTasks = [];
+    var id = 0;
     for (const deviceId of deviceIds) {
-        const provisionTask = context.df.callSubOrchestrator("DeviceProvisioningOrchestration", deviceId);
+        const child_id = context.df.instanceId+`:${id}`;
+        const provisionTask = context.df.callSubOrchestrator("DeviceProvisioningOrchestration", deviceId, child_id);
         provisioningTasks.push(provisionTask);
+        id++;
     }
 
     yield context.df.Task.all(provisioningTasks);


### PR DESCRIPTION
Currently subOrchestrations fail in Javascript if an instance id is not specified. This bug has been unsolved for months now and the workaround needs to be properly documented, otherwise we (the azure users) end up wasting valuable time trying to figure out why our subOrchestration is not working.