### PR TITLE
[Windows support] Replaced self-link with link to kubernetes.io

### DIFF
--- a/articles/aks/windows-node-limitations.md
+++ b/articles/aks/windows-node-limitations.md
@@ -26,7 +26,7 @@ This article outlines some of the limitations and OS concepts for Windows Server
 
 ## Limitations for Windows Server in Kubernetes
 
-Windows Server containers must run on a Windows-based container host. To run Windows Server containers in AKS, you can [create a node pool that runs Windows Server][windows-node-cli] as the guest OS. Window Server node pool support includes some limitations that are part of the upstream Windows Server in Kubernetes project. These limitations are not specific to AKS. For more information on this upstream support for Windows Server in Kubernetes, see [Windows Server containers in Kubernetes limitations](https://docs.microsoft.com/azure/aks/windows-node-limitations).
+Windows Server containers must run on a Windows-based container host. To run Windows Server containers in AKS, you can [create a node pool that runs Windows Server][windows-node-cli] as the guest OS. Window Server node pool support includes some limitations that are part of the upstream Windows Server in Kubernetes project. These limitations are not specific to AKS. For more information on this upstream support for Windows Server in Kubernetes, see [Windows Server containers in Kubernetes limitations](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#supported-functionality-and-limitations).
 
 The following upstream limitations for Windows Server containers in Kubernetes are relevant to AKS:
 


### PR DESCRIPTION
https://docs.microsoft.com/azure/aks/windows-node-limitations had a link to itself, which seems like a mistake. From the context, I am guessing that the author meant to link to something on the Kubernetes website. I am picking a link that seems to best match the surrounding text.

CC @richbg