### PR TITLE
Update ADLA Java SDK documentation to latest version

### DIFF
--- a/articles/data-lake-analytics/data-lake-analytics-manage-use-java-sdk.md
+++ b/articles/data-lake-analytics/data-lake-analytics-manage-use-java-sdk.md
@@ -9,7 +9,7 @@ ms.author: saveenr
 ms.reviewer: jasonwhowell
 ms.assetid: 07830b36-2fe3-4809-a846-129cf67b6a9e
 ms.topic: conceptual
-ms.date: 06/18/2017
+ms.date: 08/20/2019
 ---
 # Manage Azure Data Lake Analytics using a Java app
 [!INCLUDE [manage-selector](../../includes/data-lake-analytics-selector-manage.md)]
@@ -31,74 +31,65 @@ The code following snippet provides code for **non-interactive** authentication,
 3. Open the newly created **"pom.xml"** file and add the following snippet of text between the **\</version>** tag and the **\</project>** tag:
 
 ```
-<repositories>
-    <repository>
-        <id>adx-snapshots</id>
-        <name>Azure ADX Snapshots</name>
-        <url>http://adxsnapshots.azurewebsites.net/</url>
-        <layout>default</layout>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository>
-    <repository>
-        <id>oss-snapshots</id>
-        <name>Open Source Snapshots</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <layout>default</layout>
-        <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>always</updatePolicy>
-        </snapshots>
-    </repository>
-</repositories>
 <dependencies>
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-client-authentication</artifactId>
-        <version>1.0.0-20160513.000802-24</version>
+        <version>1.6.12</version>
     </dependency>
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-client-runtime</artifactId>
-        <version>1.0.0-20160513.000812-28</version>
+        <version>1.6.12</version>
     </dependency>
     <dependency>
         <groupId>com.microsoft.rest</groupId>
         <artifactId>client-runtime</artifactId>
-        <version>1.0.0-20160513.000825-29</version>
+        <version>1.6.12</version>
     </dependency>
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-mgmt-datalake-store</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.22.0</version>
     </dependency>
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-mgmt-datalake-analytics</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.22.0</version>
+    </dependency>
+    <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-data-lake-store-sdk</artifactId>
+        <version>2.3.6</version>
+        <exclusions>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
 </dependencies>
 ```
 
 Go to **File > Settings > Build > Execution > Deployment**. Select **Build Tools > Maven > Importing**. Then check **Import Maven projects automatically**.
 
-Open `Main.java` and replace the existing code block with the following code snippet:
+Open `Main.java` and replace the existing code block with the following code:
 
-```
-package com.company;
-
+```java
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
+import com.microsoft.azure.datalake.store.*;
+import com.microsoft.azure.datalake.store.oauth2.*;
+import com.microsoft.azure.management.datalake.analytics.implementation.*;
 import com.microsoft.azure.management.datalake.store.*;
+import com.microsoft.azure.management.datalake.store.implementation.*;
 import com.microsoft.azure.management.datalake.store.models.*;
 import com.microsoft.azure.management.datalake.analytics.*;
 import com.microsoft.azure.management.datalake.analytics.models.*;
 import com.microsoft.rest.credentials.ServiceClientCredentials;
+
 import java.io.*;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.UUID;
 import java.util.List;
@@ -110,31 +101,29 @@ public class Main {
     private static String _location;
 
     private static String _tenantId;
-    private static String _subId;
+    private static String _subscriptionId;
     private static String _clientId;
     private static String _clientSecret;
 
     private static DataLakeStoreAccountManagementClient _adlsClient;
-    private static DataLakeStoreFileSystemManagementClient _adlsFileSystemClient;
+    private static ADLStoreClient _adlsStoreClient;
     private static DataLakeAnalyticsAccountManagementClient _adlaClient;
     private static DataLakeAnalyticsJobManagementClient _adlaJobClient;
-    private static DataLakeAnalyticsCatalogManagementClient _adlaCatalogClient;
 
     public static void main(String[] args) throws Exception {
-
         _adlsAccountName = "<DATA-LAKE-STORE-NAME>";
         _adlaAccountName = "<DATA-LAKE-ANALYTICS-NAME>";
         _resourceGroupName = "<RESOURCE-GROUP-NAME>";
         _location = "East US 2";
 
         _tenantId = "<TENANT-ID>";
-        _subId =  "<SUBSCRIPTION-ID>";
+        _subscriptionId =  "<SUBSCRIPTION-ID>";
         _clientId = "<CLIENT-ID>";
 
-        _clientSecret = "<CLIENT-SECRET>"; 
-        
-        String localFolderPath = "C:\\local_path\\"; 
-        
+        _clientSecret = "<CLIENT-SECRET>";
+
+        String localFolderPath = "C:\\local_path\\";
+
         // ----------------------------------------
         // Authenticate
         // ----------------------------------------
@@ -144,34 +133,30 @@ public class Main {
         // ----------------------------------------
         // List Data Lake Store and Analytics accounts that this app can access
         // ----------------------------------------
-        System.out.println(String.format("All ADL Store accounts that this app can access in subscription %s:", _subId));
-        List<DataLakeStoreAccount> adlsListResult = _adlsClient.getAccountOperations().list().getBody();
-        for (DataLakeStoreAccount acct : adlsListResult) {
-            System.out.println(acct.getName());
+        System.out.println(String.format("All ADL Store accounts that this app can access in subscription %s:", _subscriptionId));
+        List<DataLakeStoreAccountBasic> adlsListResult = _adlsClient.accounts().list();
+        for (DataLakeStoreAccountBasic acct : adlsListResult) {
+            System.out.println(acct.name());
         }
-        
-        System.out.println(String.format("All ADL Analytics accounts that this app can access in subscription %s:", _subId));
-        List<DataLakeAnalyticsAccount> adlaListResult = _adlaClient.getAccountOperations().list().getBody();
-        for (DataLakeAnalyticsAccount acct : adlaListResult) {
-            System.out.println(acct.getName());
+
+        System.out.println(String.format("All ADL Analytics accounts that this app can access in subscription %s:", _subscriptionId));
+        List<DataLakeAnalyticsAccountBasic> adlaListResult = _adlaClient.accounts().list();
+        for (DataLakeAnalyticsAccountBasic acct : adlaListResult) {
+            System.out.println(acct.name());
         }
         WaitForNewline("Accounts displayed.", "Creating files.");
 
         // ----------------------------------------
         // Create a file in Data Lake Store: input1.csv
         // ----------------------------------------
-
-        byte[] bytesContents = "123,abc".getBytes();
-        _adlsFileSystemClient.getFileSystemOperations().create(_adlsAccountName, "/input1.csv", bytesContents, true);
-
+        CreateFile("/input1.csv", "123,abc", true);
         WaitForNewline("File created.", "Submitting a job.");
 
         // ----------------------------------------
         // Submit a job to Data Lake Analytics
         // ----------------------------------------
-
-string script = "@input =  EXTRACT Data string FROM \"/input1.csv\" USING Extractors.Csv(); OUTPUT @input TO @\"/output1.csv\" USING Outputters.Csv();", "testJob";
-        UUID jobId = SubmitJobByScript(script);
+        String script = "@input = EXTRACT Row1 string, Row2 string FROM \"/input1.csv\" USING Extractors.Csv(); OUTPUT @input TO @\"/output1.csv\" USING Outputters.Csv();";
+        UUID jobId = SubmitJobByScript(script, "testJob");
         WaitForNewline("Job submitted.", "Getting job status.");
 
         // ----------------------------------------
@@ -189,6 +174,130 @@ string script = "@input =  EXTRACT Data string FROM \"/input1.csv\" USING Extrac
         DownloadFile("/output1.csv", localFolderPath + "output1.csv");
         WaitForNewline("Job output downloaded.", "Deleting file.");
 
+        DeleteFile("/output1.csv");
+        WaitForNewline("File deleted.", "Done.");
+    }
+
+    public static void SetupClients(ServiceClientCredentials creds) {
+        _adlsClient = new DataLakeStoreAccountManagementClientImpl(creds);
+        _adlaClient = new DataLakeAnalyticsAccountManagementClientImpl(creds);
+        _adlaJobClient = new DataLakeAnalyticsJobManagementClientImpl(creds);
+        _adlsClient.withSubscriptionId(_subscriptionId);
+        _adlaClient.withSubscriptionId(_subscriptionId);
+
+        String authEndpoint = "https://login.microsoftonline.com/" + _tenantId + "/oauth2/token";
+        AccessTokenProvider provider = new ClientCredsTokenProvider(authEndpoint, _clientId, _clientSecret);
+        _adlsStoreClient = ADLStoreClient.createClient(_adlsAccountName + ".azuredatalakestore.net", provider);
+    }
+
+    public static void WaitForNewline(String reason, String nextAction) {
+        if (nextAction == null)
+            nextAction = "";
+
+        System.out.println(reason + "\r\nPress ENTER to continue...");
+        try {
+            System.in.read();
+        } catch (Exception e) {
+        }
+
+        if (!nextAction.isEmpty()) {
+            System.out.println(nextAction);
+        }
+    }
+
+    // Create accounts
+    public static void CreateAccounts() throws InterruptedException, CloudException, IOException {
+        // Create ADLS account
+        CreateDataLakeStoreAccountParameters adlsParameters = new CreateDataLakeStoreAccountParameters();
+        adlsParameters.withLocation(_location);
+
+        _adlsClient.accounts().create(_resourceGroupName, _adlsAccountName, adlsParameters);
+
+        // Create ADLA account
+        AddDataLakeStoreWithAccountParameters adlsInfo = new AddDataLakeStoreWithAccountParameters();
+        adlsInfo.withName(_adlsAccountName);
+
+        List<AddDataLakeStoreWithAccountParameters> adlsInfoList = new ArrayList<>();
+        adlsInfoList.add(adlsInfo);
+
+        CreateDataLakeAnalyticsAccountParameters adlaParameters = new CreateDataLakeAnalyticsAccountParameters();
+        adlaParameters.withLocation(_location);
+        adlaParameters.withDefaultDataLakeStoreAccount(_adlsAccountName);
+        adlaParameters.withDataLakeStoreAccounts(adlsInfoList);
+
+        _adlaClient.accounts().create(_resourceGroupName, _adlaAccountName, adlaParameters);
+    }
+
+    // Create a file
+    public static void CreateFile(String path, String contents, boolean force) throws IOException, CloudException {
+        byte[] bytesContents = contents.getBytes();
+
+        ADLFileOutputStream stream = _adlsStoreClient.createFile(path, IfExists.OVERWRITE, "777", force);
+        stream.write(bytesContents);
+        stream.close();
+    }
+
+    // Delete a file
+    public static void DeleteFile(String filePath) throws IOException, CloudException {
+        _adlsStoreClient.delete(filePath);
+    }
+
+    // Download a file
+    private static void DownloadFile(String srcPath, String destPath) throws IOException, CloudException {
+        ADLFileInputStream stream = _adlsStoreClient.getReadStream(srcPath);
+
+        PrintWriter pWriter = new PrintWriter(destPath, Charset.defaultCharset().name());
+
+        String fileContents = "";
+        if (stream != null) {
+            Writer writer = new StringWriter();
+
+            char[] buffer = new char[1024];
+            try {
+                Reader reader = new BufferedReader(
+                        new InputStreamReader(stream, "UTF-8"));
+                int n;
+                while ((n = reader.read(buffer)) != -1) {
+                    writer.write(buffer, 0, n);
+                }
+            } finally {
+                stream.close();
+            }
+            fileContents = writer.toString();
+        }
+
+        pWriter.println(fileContents);
+        pWriter.close();
+    }
+
+    // Submit a U-SQL job
+    private static UUID SubmitJobByScript(String script, String jobName) throws IOException, CloudException {
+        UUID jobId = java.util.UUID.randomUUID();
+        CreateJobProperties properties = new CreateUSqlJobProperties();
+        properties.withScript(script);
+        CreateJobParameters parameters = new CreateJobParameters();
+        parameters.withName(jobName);
+        parameters.withType(JobType.USQL);
+        parameters.withProperties(properties);
+
+        JobInformation jobInfo = _adlaJobClient.jobs().create(_adlaAccountName, jobId, parameters);
+
+        return jobInfo.jobId();
+    }
+
+    // Wait for job completion
+    private static JobResult WaitForJob(UUID jobId) throws IOException, CloudException {
+        JobInformation jobInfo = _adlaJobClient.jobs().get(_adlaAccountName, jobId);
+        while (jobInfo.state() != JobState.ENDED) {
+            jobInfo = _adlaJobClient.jobs().get(_adlaAccountName, jobId);
+        }
+        return jobInfo.result();
+    }
+
+    // Retrieve job status
+    private static String GetJobStatus(UUID jobId) throws IOException, CloudException {
+        JobInformation jobInfo = _adlaJobClient.jobs().get(_adlaAccountName, jobId);
+        return jobInfo.state().toString();
     }
 }
 ```
@@ -198,176 +307,10 @@ Provide the values for parameters called out in the code snippet:
 * `_adlaAccountName`
 * `_adlsAccountName`
 * `_resourceGroupName`
-
-Replace the placeholders for:
-* `CLIENT-ID`,
-* `CLIENT-SECRET`,
-* `TENANT-ID`
-* `SUBSCRIPTION-ID`
-
-## Helper functions
-
-### Setup clients
-
-```
-public static void SetupClients(ServiceClientCredentials creds)
-{
-    _adlsClient = new DataLakeStoreAccountManagementClientImpl(creds);
-    _adlsFileSystemClient = new DataLakeStoreFileSystemManagementClientImpl(creds);
-    _adlaClient = new DataLakeAnalyticsAccountManagementClientImpl(creds);
-    _adlaJobClient = new DataLakeAnalyticsJobManagementClientImpl(creds);
-    _adlaCatalogClient = new DataLakeAnalyticsCatalogManagementClientImpl(creds);
-    _adlsClient.setSubscriptionId(_subId);
-    _adlaClient.setSubscriptionId(_subId);
-}
-```
-
-
-### Wait for input
-
-```
-public static void WaitForNewline(String reason, String nextAction)
-{
-    if (nextAction == null)
-        nextAction = "";
-
-    System.out.println(reason + "\r\nPress ENTER to continue...");
-    try{System.in.read();}
-    catch(Exception e){}
-
-    if (!nextAction.isEmpty())
-    {
-        System.out.println(nextAction);
-    }
-}
-```
-
-### Create accounts
-
-```
-public static void CreateAccounts() throws InterruptedException, CloudException, IOException 
-{
-    // Create ADLS account
-    DataLakeStoreAccount adlsParameters = new DataLakeStoreAccount();
-    adlsParameters.setLocation(_location);
-
-    _adlsClient.getAccountOperations().create(_resourceGroupName, _adlsAccountName, adlsParameters);
-
-    // Create ADLA account
-    DataLakeStoreAccountInfo adlsInfo = new DataLakeStoreAccountInfo();
-    adlsInfo.setName(_adlsAccountName);
-
-    DataLakeStoreAccountInfoProperties adlsInfoProperties = new DataLakeStoreAccountInfoProperties();
-    adlsInfo.setProperties(adlsInfoProperties);
-
-    List<DataLakeStoreAccountInfo> adlsInfoList = new ArrayList<DataLakeStoreAccountInfo>();
-    adlsInfoList.add(adlsInfo);
-
-    DataLakeAnalyticsAccountProperties adlaProperties = new DataLakeAnalyticsAccountProperties();
-    adlaProperties.setDataLakeStoreAccounts(adlsInfoList);
-    adlaProperties.setDefaultDataLakeStoreAccount(_adlsAccountName);
-
-    DataLakeAnalyticsAccount adlaParameters = new DataLakeAnalyticsAccount();
-    adlaParameters.setLocation(_location);
-    adlaParameters.setName(_adlaAccountName);
-    adlaParameters.setProperties(adlaProperties);
-
-    _adlaClient.getAccountOperations().create(_resourceGroupName, _adlaAccountName, adlaParameters);
-}
-```
-
-### Create a file
-
-```
-public static void CreateFile(String path, String contents, boolean force) throws IOException, CloudException 
-{
-    byte[] bytesContents = contents.getBytes();
-
-    _adlsFileSystemClient.getFileSystemOperations().create(_adlsAccountName, path, bytesContents, force);
-}
-```
-
-### Delete a file
-
-```
-public static void DeleteFile(String filePath) throws IOException, CloudException 
-{
-    _adlsFileSystemClient.getFileSystemOperations().delete(filePath, _adlsAccountName);
-}
-```
-
-### Download a file
-
-```
-public static void DownloadFile(String srcPath, String destPath) throws IOException, CloudException 
-{
-    InputStream stream = _adlsFileSystemClient.getFileSystemOperations().open(srcPath, _adlsAccountName).getBody();
-
-    PrintWriter pWriter = new PrintWriter(destPath, Charset.defaultCharset().name());
-
-    String fileContents = "";
-    if (stream != null) {
-        Writer writer = new StringWriter();
-
-        char[] buffer = new char[1024];
-        try {
-            Reader reader = new BufferedReader(
-                    new InputStreamReader(stream, "UTF-8"));
-            int n;
-            while ((n = reader.read(buffer)) != -1) {
-                writer.write(buffer, 0, n);
-            }
-        } finally {
-            stream.close();
-        }
-        fileContents =  writer.toString();
-    }
-
-    pWriter.println(fileContents);
-    pWriter.close();
-}
-```
-
-### Submit a U-SQL job
-
-```
-public static UUID SubmitJobByScript(String script, String jobName) throws IOException, CloudException 
-{
-    UUID jobId = java.util.UUID.randomUUID();
-    USqlJobProperties properties = new USqlJobProperties();
-    properties.setScript(script);
-    JobInformation parameters = new JobInformation();
-    parameters.setName(jobName);
-    parameters.setJobId(jobId);
-    parameters.setType(JobType.USQL);
-    parameters.setProperties(properties);
-
-    JobInformation jobInfo = _adlaJobClient.getJobOperations().create(_adlaAccountName, jobId, parameters).getBody();
-
-    return jobId;
-}
-
-// Wait for job completion
-public static JobResult WaitForJob(UUID jobId) throws IOException, CloudException 
-{
-    JobInformation jobInfo = _adlaJobClient.getJobOperations().get(_adlaAccountName, jobId).getBody();
-    while (jobInfo.getState() != JobState.ENDED)
-    {
-        jobInfo = _adlaJobClient.getJobOperations().get(_adlaAccountName,jobId).getBody();
-    }
-    return jobInfo.getResult();
-}
-```
-
-### Retrieve job status
-
-```
-public static String GetJobStatus(UUID jobId) throws IOException, CloudException 
-{
-    JobInformation jobInfo = _adlaJobClient.getJobOperations().get(_adlaAccountName, jobId).getBody();
-    return jobInfo.getState().toValue();
-}
-```
+* `_tenantId`
+* `_subId`
+* `_clientId`
+* `_clientSecret`
 
 ## Next steps
 


### PR DESCRIPTION
The docs for the ADLA Java SDK are two years out of date, have syntax errors, and use deprecated API calls. This change adds a working example that can be run out of the box after the credentials are supplied.