### PR TITLE
Corrected existing AKS integration

### DIFF
--- a/articles/aks/cluster-container-registry-integration.md
+++ b/articles/aks/cluster-container-registry-integration.md
@@ -51,7 +51,7 @@ This step may take several minutes to complete.
 
 ## Create ACR integration for existing AKS clusters
 
-Integrate ACR with existing ACR clusters by supplying valid values for **acr-name** and **acr-resource-id** below.
+Integrate an existing ACR with existing AKS clusters by supplying valid values for **acr-name** or **acr-resource-id** as below.
 
 ```azurecli
 az aks update -n myAKSCluster -g myResourceGroup --enable-acr --acr <acrName>


### PR DESCRIPTION
It only works for existing ACR, not new ACR and s/ACR/AKS/. Also the ACR name OR the ID needs to be provided, not both.