### PR TITLE
Linking to a complete sample for Web App calling Web API

### DIFF
--- a/articles/active-directory/develop/tutorial-v2-asp-webapp.md
+++ b/articles/active-directory/develop/tutorial-v2-asp-webapp.md
@@ -473,7 +473,7 @@ Learn about Web apps calling web APIs:.
 ### Learn the steps to create the application used in this quickstart
 
 > [!div class="nextstepaction"]
-> [Web apps calling Web APIs]( https://aka.ms/msal-net-authorization-code)
+> [Web apps calling Web APIs](https://docs.microsoft.com/en-us/graph/tutorials/aspnet)
 
 [!INCLUDE [Help and support](../../../includes/active-directory-develop-help-support-include.md)]
 


### PR DESCRIPTION
The existing link takes you to a page with a lot of good reference material, but it's a horrible tutorial (e.g. there is no start or end state and there is very little how-to involved). Instead, I'm proposing to change the link to the very well documented, complete, and working tutorial for Microsoft Graph ("Build ASP.NET MVC apps with Microsoft Graph"). This also helps users in the community start working with the Graph as their sample API.