### PR TITLE
Add instruction on service annotations.

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/text-to-speech-chart-config.md
+++ b/articles/cognitive-services/Speech-Service/includes/text-to-speech-chart-config.md
@@ -32,5 +32,6 @@ To override the "umbrella" chart, add the prefix `textToSpeech.` on any paramete
 | `image.args.apikey` (required) | Used to track billing information. ||
 | `service.type` | The Kubernetes service type of the **text-to-speech** service. See the [Kubernetes service types instructions](https://kubernetes.io/docs/concepts/services-networking/service/) for more details and verify cloud provider support. | `LoadBalancer` |
 | `service.port`|  The port of the **text-to-speech** service. | `80` |
+|`service.annotations`| The annotations user can add to **text-to-speech** service metadata. For instance:<br/> **annotations:**<br/>`   ` **some/annotation1: value1**<br/>`  ` **some/annotation2: value2** | annotations, one per each line| |
 | `service.autoScaler.enabled` | Whether the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) is enabled. If `true`, the `text-to-speech-autoscaler` will be deployed in the Kubernetes cluster. | `true` |
 | `service.podDisruption.enabled` | Whether the [Pod Disruption Budget](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) is enabled. If `true`, the `text-to-speech-poddisruptionbudget` will be deployed in the Kubernetes cluster. | `true` |


### PR DESCRIPTION
Now `text-to-speech` chart supports adding custom annotations to service meta in version 0.1.1
With this change, user can apply azure internal load balancer annotation on service.

If the format is not pretty, please feel free to edit it :)