### PR TITLE
speech-onprem chart version bump to 0.1.1

### DIFF
--- a/articles/cognitive-services/Speech-Service/speech-container-howto-on-premises.md
+++ b/articles/cognitive-services/Speech-Service/speech-container-howto-on-premises.md
@@ -145,7 +145,7 @@ To install the *helm chart* we'll need to execute the [`helm install`][helm-inst
 
 ```console
 helm install microsoft/cognitive-services-speech-onpremise \
-    --version 0.1.0 \
+    --version 0.1.1 \
     --values <config-values.yaml> \
     --name onprem-speech
 ```


### PR DESCRIPTION
`cognitive-services-speech-onprem` is now 0.1.1, which includes the change:
* support adding customer annotations on both `speech-to-text` and `text-to-speech` services.

This PR is coming with the other two:
https://github.com/MicrosoftDocs/azure-docs/pull/37565
https://github.com/MicrosoftDocs/azure-docs/pull/37566