### PR TITLE
Added version support note for Robo 3T

### DIFF
--- a/articles/cosmos-db/mongodb-mongochef.md
+++ b/articles/cosmos-db/mongodb-mongochef.md
@@ -17,6 +17,9 @@ To connect to a Cosmos account using Azure Cosmos DB's API for MongoDB, you must
 * Download and install [Studio 3T](https://studio3t.com/)
 * Have your Cosmos DB [connection string](connect-mongodb-account.md) information
 
+> [!NOTE]
+> Currently, Robo 3T v1.2 and lower are supported with Cosmos DB's API for MongoDB. 
+
 ## Create the connection in Studio 3T
 To add your Cosmos account to the Studio 3T connection manager, perform the following steps:
 


### PR DESCRIPTION
> [!NOTE]
> Currently, Robo 3T v1.2 and lower are supported with Cosmos DB's API for MongoDB.

@sivethe Please let me know if this needs to be re-worded at all. 