### PR TITLE
Changed "synchronous" to "asynchronous" when stating out parameters n…

### DIFF
--- a/articles/azure-functions/functions-bindings-twilio.md
+++ b/articles/azure-functions/functions-bindings-twilio.md
@@ -118,7 +118,7 @@ public static void Run(string myQueueItem, out SMSMessage message,  TraceWriter 
 }
 ```
 
-You can't use out parameters in synchronous code. Here's an asynchronous C# script code example:
+You can't use out parameters in asynchronous code. Here's an asynchronous C# script code example:
 
 ```cs
 #r "Newtonsoft.Json"
@@ -294,7 +294,7 @@ public static void Run(string myQueueItem, out CreateMessageOptions message,  IL
 }
 ```
 
-You can't use out parameters in synchronous code. Here's an asynchronous C# script code example:
+You can't use out parameters in asynchronous code. Here's an asynchronous C# script code example:
 
 ```cs
 #r "Newtonsoft.Json"


### PR DESCRIPTION
…ot supported

Fixed reference to not being able to use out parameters with <i>synchronous code</i> to instead state they cannot be used with <i>asynchronous</i> code.