### PR TITLE
Brazil state name was wrong

### DIFF
--- a/articles/storage/files/storage-sync-files-planning.md
+++ b/articles/storage/files/storage-sync-files-planning.md
@@ -240,7 +240,7 @@ Azure File Sync is available only in the following regions:
 |--------|---------------------|
 | Australia East | New South Wales |
 | Australia Southeast | Victoria |
-| Brazil South | Sao Paolo State |
+| Brazil South | Sao Paulo State |
 | Canada Central | Toronto |
 | Canada East | Quebec City |
 | Central India | Pune |


### PR DESCRIPTION
The Brazilian region is located in the Sao Paulo State and the document stated Sao Paolo, which is incorrect. Thanks.