### PR TITLE
Modified bullets under Cluster name based on CSS case

### DIFF
--- a/articles/hdinsight/hdinsight-hadoop-provision-linux-clusters.md
+++ b/articles/hdinsight/hdinsight-hadoop-provision-linux-clusters.md
@@ -78,7 +78,7 @@ HDInsight cluster names have the following restrictions:
 - Allowed characters: a-z, 0-9, A-Z 
 - Max length: 59
 - Reserved names: apps
-- Must be unique
+- The cluster naming scope is for all Azure, across all subscriptions. So the cluster name must be unique worldwide.
 - First 6 characters must be unique within a VNET
 
 ## Cluster login and SSH username


### PR DESCRIPTION
One of the customers had the following question - What is the scope within which the HDI cluster name needs to be unique? 
The answer provided by CSS : The cluster naming scope is for all Azure, across all subscriptions. So you cluster name must be unique worldwide. - so updated this doc to reflect this so that we can deflect the same questions in future.