### PR TITLE
Updated SelectUniqueValue Note

### DIFF
--- a/articles/active-directory/manage-apps/functions-for-customizing-application-data.md
+++ b/articles/active-directory/manage-apps/functions-for-customizing-application-data.md
@@ -175,7 +175,8 @@ Requires a minimum of two arguments, which are unique value generation rules def
 
 > [!NOTE]
 >1. This is a top-level function, it cannot be nested.
->2. This function is only meant to be used for entry creations. When using it with an attribute, set the **Apply Mapping** property to **Only during object creation**.
+>2. This function cannot be applied to attributes that have a matching precedence. 	
+>3. This function is only meant to be used for entry creations. When using it with an attribute, set the **Apply Mapping** property to **Only during object creation**.
 
 
 **Parameters:**<br> 


### PR DESCRIPTION
Updated SelectUniqueValue to specifically call out that this function cannot be applied to an attribute with a matching precedence (joining attribute)