### PR TITLE
Adding location to "microsoft.alertsmanagement/smartdetectoralertrules"

### DIFF
--- a/articles/azure-monitor/app/proactive-arm-config.md
+++ b/articles/azure-monitor/app/proactive-arm-config.md
@@ -146,6 +146,7 @@ This Azure Resource Manager template demonstrates configuring a Failure Anomalie
             "type": "microsoft.alertsmanagement/smartdetectoralertrules",
             "apiVersion": "2019-03-01",
             "name": "Failure Anomalies - my-app",
+            "location": "global"
             "properties": {
                   "description": "Detects a spike in the failure rate of requests or dependencies",
                   "state": "Enabled",


### PR DESCRIPTION
As of this morning (8/28/19) our deployments that were successful yesterday started failing due with:
{
  "error": {
    "code": "LocationRequired",
    "message": "The location property is required for this definition."
  }
}

After some experimentation we were able to get this to deploy by adding:
"location": "global"

I don't know for certain if this is the 100% accurate value to use or not.  **Please Confirm**

I can also be reached at kipph@microsoft.com.