### PR TITLE
Eliminate double reference to NetworkWatcher

### DIFF
--- a/articles/network-watcher/network-watcher-packet-capture-manage-powershell.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-powershell.md
@@ -126,8 +126,7 @@ Once the preceding steps are complete, the packet capture agent is installed on 
 The next step is to retrieve the Network Watcher instance. This variable is passed to the `New-AzNetworkWatcherPacketCapture` cmdlet in step 4.
 
 ```powershell
-$nw = Get-AzResource | Where {$_.ResourceType -eq "Microsoft.Network/networkWatchers" -and $_.Location -eq "WestCentralUS" }
-$networkWatcher = Get-AzNetworkWatcher -Name $nw.Name -ResourceGroupName $nw.ResourceGroupName  
+$networkWatcher = Get-AzResource | Where {$_.ResourceType -eq "Microsoft.Network/networkWatchers" -and $_.Location -eq "WestCentralUS" }
 ```
 
 ### Step 2


### PR DESCRIPTION
No need to make two separate calls to get a pointer to the appropriate NetworkWatcher. Collapsing into one.