### PR TITLE
Update starter.md changed "limit" to "top"

### DIFF
--- a/articles/governance/resource-graph/samples/starter.md
+++ b/articles/governance/resource-graph/samples/starter.md
@@ -103,7 +103,7 @@ Search-AzGraph -Query "project name, location, type| where type =~ 'Microsoft.Co
 
 ## <a name="show-sorted"/>Show first five virtual machines by name and their OS type
 
-This query will use `limit` to only retrieve five matching records that are ordered by name. The type
+This query will use `top` to only retrieve five matching records that are ordered by name. The type
 of the Azure resource is `Microsoft.Compute/virtualMachines`. `project` tells Azure Resource Graph
 which properties to include.
 


### PR DESCRIPTION
This query will use `limit` to only retrieve five matching records that are ordered by name. The type
of the Azure resource is `Microsoft.Compute/virtualMachines`. `project` tells Azure Resource Graph
which properties to include.

Limit just limits the output, top allows for sorting as provided in the example as well. Changed "limit" to "top" in the introductory paragraph as this is used in the examples as well.