### PR TITLE
Fix the connection string configuration command

### DIFF
--- a/articles/app-service/app-service-web-tutorial-dotnetcore-sqldb.md
+++ b/articles/app-service/app-service-web-tutorial-dotnetcore-sqldb.md
@@ -174,7 +174,7 @@ In this step, you deploy your SQL Database-connected .NET Core application to Ap
 To set connection strings for your Azure app, use the [`az webapp config appsettings set`](/cli/azure/webapp/config/appsettings?view=azure-cli-latest#az-webapp-config-appsettings-set) command in the Cloud Shell. In the following command, replace *\<app name>*, as well as the *\<connection_string>* parameter with the connection string you created earlier.
 
 ```azurecli-interactive
-az webapp config connection-string set --resource-group myResourceGroup --name <app name> --settings MyDbConnection='<connection_string>' --connection-string-type SQLServer
+az webapp config connection-string set --resource-group myResourceGroup --name <app name> --settings MyDbConnection="<connection_string>" --connection-string-type SQLServer
 ```
 
 In ASP.NET Core, you can use this named connection string (`MyDbConnection`) using the standard pattern, like any connection string specified in *appsettings.json*. In this case, `MyDbConnection` is also defined in your *appsettings.json*. When running in App Service, the connection string defined in App Service takes precedence over the connection string defined in your *appsettings.json*. The code uses the *appsettings.json* value during local development, and the same code uses the App Service value when deployed.


### PR DESCRIPTION
The connection string delimiter character as apostrophe (') works on Cloud Shell but does not in Azure CLI (Win10 command prompt). The quotation mark (") works on both.