### PR TITLE
Fixed the indentation for the F#

### DIFF
--- a/articles/notebooks/install-packages-jupyter-notebook.md
+++ b/articles/notebooks/install-packages-jupyter-notebook.md
@@ -62,9 +62,19 @@ Then install packages:
 
 ```fsharp
 Paket.Package
-[ "MathNet.Numerics"
-"MathNet.Numerics.FSharp"
-]
+  [ "MathNet.Numerics"
+    "MathNet.Numerics.FSharp"
+  ]
+```
+
+Then load the paket generator:
+```fsharp
+#load "Paket.Generated.Refs.fsx"
+```
+
+Open the libray:
+```fsharp
+open MathNet.Numerics
 ```
 
 ## Next steps


### PR DESCRIPTION
Fixed the indentation for the Paket.Package that was throwing error:  ```This value is not a function and cannot be applied. Did you forget to terminate a declaration?``` when copied and pasted directly into the F# notebook.
Added 2 extra steps to make it clearer on how to get the libraries functioning in the notebook.