### PR TITLE
Updated api-management-howto-developer-portal.md

### DIFF
--- a/articles/api-management/api-management-howto-developer-portal.md
+++ b/articles/api-management/api-management-howto-developer-portal.md
@@ -45,6 +45,9 @@ Follow the steps below to access the managed version of the portal.
 1. Go to your API Management service instance in the Azure portal.
 1. Click on the **New developer portal (preview)** button in the top navigation bar. A new browser tab with an administrative version of the portal will open. If you're accessing the portal for the first time, the default content will be automatically provisioned.
 
+> [!NOTE]
+> New developer portal needs to be published explicitly, if the API Management Service is in Internal VNET.
+
 ## <a name="managed-tutorial"></a> Edit and customize the managed version of the portal
 
 In the video below we demonstrate how to edit the content of the portal, customize the website's look, and publish the changes.


### PR DESCRIPTION
Added comments to make it clear that when API Management is in VNET Internal we should explicitly publish the new developer portal for it to be available even internally.