### PR TITLE
Add missing hyphen

### DIFF
--- a/articles/aks/coredns-custom.md
+++ b/articles/aks/coredns-custom.md
@@ -16,7 +16,7 @@ ms.author: jenoller
 
 Azure Kubernetes Service (AKS) uses the [CoreDNS][coredns] project for cluster DNS management and resolution with all *1.12.x* and higher clusters. Previously, the kube-dns project was used. This kube-dns project is now deprecated. For more information about CoreDNS customization and Kubernetes, see the [official upstream documentation][corednsk8s].
 
-As AKS is a managed service, you cannot modify the main configuration for CoreDNS (a *CoreFile*). Instead, you use a Kubernetes *ConfigMap* to override the default settings. To see the default AKS CoreDNS ConfigMaps, use the `kubectl get configmaps -namespace=kube-system coredns -o yaml` command.
+As AKS is a managed service, you cannot modify the main configuration for CoreDNS (a *CoreFile*). Instead, you use a Kubernetes *ConfigMap* to override the default settings. To see the default AKS CoreDNS ConfigMaps, use the `kubectl get configmaps --namespace=kube-system coredns -o yaml` command.
 
 This article shows you how to use ConfigMaps for basic customization options of CoreDNS in AKS.
 


### PR DESCRIPTION
kubectl get configmap command generates an error as it is missing a hyphen