### PR TITLE
change processed_data1 to output_data1

### DIFF
--- a/articles/machine-learning/service/how-to-create-your-first-pipeline.md
+++ b/articles/machine-learning/service/how-to-create-your-first-pipeline.md
@@ -266,9 +266,9 @@ from azureml.pipeline.steps import PythonScriptStep
 
 trainStep = PythonScriptStep(
     script_name="train.py",
-    arguments=["--input", blob_input_data, "--output", processed_data1],
+    arguments=["--input", blob_input_data, "--output", output_data1],
     inputs=[blob_input_data],
-    outputs=[processed_data1],
+    outputs=[output_data1],
     compute_target=compute_target,
     source_directory=project_folder
 )


### PR DESCRIPTION
change "processed_data1" under the #steps section to "output_data1" to match up with the earlier example from the #configure-data-reference section.  This helps avoid notebook syntax errors when trying to follow along.