### PR TITLE
use TrackDependency instead of Track

### DIFF
--- a/articles/azure-monitor/app/custom-operations-tracking.md
+++ b/articles/azure-monitor/app/custom-operations-tracking.md
@@ -314,7 +314,7 @@ public async Task<MessagePayload> Dequeue(CloudQueue queue)
     {
         // Update status code and success as appropriate.
         telemetry.Stop();
-        telemetryClient.Track(telemetry);
+        telemetryClient.TrackDependency(telemetry);
     }
 
     return null;


### PR DESCRIPTION
`TelemetryClient.Track` usage is not recommended and results in a warning: `This method is an internal part of Application Insights infrastructure. Do not call.`