### PR TITLE
Update api-management-using-with-vnet.md

### DIFF
--- a/articles/api-management/api-management-using-with-vnet.md
+++ b/articles/api-management/api-management-using-with-vnet.md
@@ -21,7 +21,7 @@ Azure Virtual Networks (VNETs) allow you to place any of your Azure resources in
 Azure API Management can be deployed inside the virtual network (VNET), so it can access backend services within the network. The developer portal and API gateway, can be configured to be accessible either from the Internet or only within the virtual network.
 
 > [!NOTE]
-> Azure API Management supports both classic and Azure Resource Manager VNets.
+> Api import document url must be hosted on a publicly accessible internet address.
 
 [!INCLUDE [updated-for-az](../../includes/updated-for-az.md)]
 

--- a/articles/api-management/api-management-using-with-vnet.md
+++ b/articles/api-management/api-management-using-with-vnet.md
@@ -21,7 +21,7 @@ Azure Virtual Networks (VNETs) allow you to place any of your Azure resources in
 Azure API Management can be deployed inside the virtual network (VNET), so it can access backend services within the network. The developer portal and API gateway, can be configured to be accessible either from the Internet or only within the virtual network.
 
 > [!NOTE]
-> Api import document url must be hosted on a publicly accessible internet address.
+> The API import document URL must be hosted on a publicly accessible internet address.
 
 [!INCLUDE [updated-for-az](../../includes/updated-for-az.md)]
 


### PR DESCRIPTION
The open API specification link (API definition) we use to import API's should be publicly available as per my understanding.
But the document does not mention it any where at least evidently.
Often when customers put Api management in VNET, unaware of the about fact they often raise this as a concern.

So i request please feel free to modify as you seem fit the sentence and update the document.

Note it is mentioned here : https://docs.microsoft.com/en-us/rest/api/apimanagement/2019-01-01/apis/createorupdate#contentformat