### PR TITLE
Update network-watcher-packet-capture-manage-cli.md

### DIFF
--- a/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
@@ -50,7 +50,7 @@ This article assumes you have the following resources:
 
 ### Step 1
 
-Run the `az vm extension set` cmdlet to install the packet capture agent on the guest virtual machine.
+Run the `az vm extension set` command to install the packet capture agent on the guest virtual machine.
 
 For Windows virtual machines:
 
@@ -66,10 +66,16 @@ az vm extension set --resource-group resourceGroupName --vm-name virtualMachineN
 
 ### Step 2
 
-To ensure that the agent is installed, run the `vm extension show` cmdlet and pass it the resource group and virtual machine name. Check the resulting list to ensure the agent is installed.
+To ensure that the agent is installed, run the `vm extension show` command and pass it the resource group and virtual machine name. Check the resulting list to ensure the agent is installed.
 
+For Windows virtual machines:
 ```azurecli
 az vm extension show --resource-group resourceGroupName --vm-name virtualMachineName --name NetworkWatcherAgentWindows
+```
+
+For Linux virtual machines:
+```azurecli
+az vm extension show --resource-group resourceGroupName --vm-name virtualMachineName --name AzureNetworkWatcherExtension
 ```
 
 The following sample is an example of the response from running `az vm extension show`
@@ -100,21 +106,13 @@ Once the preceding steps are complete, the packet capture agent is installed on 
 
 ### Step 1
 
-The next step is to retrieve the Network Watcher instance. TThe name of the Network Watcher is passed to the `az network watcher show` cmdlet in step 4.
-
-```azurecli
-az network watcher show --resource-group resourceGroup --name networkWatcherName
-```
-
-### Step 2
-
 Retrieve a storage account. This storage account is used to store the packet capture file.
 
 ```azurecli
-azure storage account list
+az storage account list
 ```
 
-### Step 3
+### Step 2
 
 Filters can be used to limit the data that is stored by the packet capture. The following example sets up a packet capture with several  filters.  The first three filters collect outgoing TCP traffic only from local IP 10.0.0.3 to destination ports 20, 80 and 443.  The last filter collects only UDP traffic.
 
@@ -122,7 +120,7 @@ Filters can be used to limit the data that is stored by the packet capture. The 
 az network watcher packet-capture create --resource-group {resourceGroupName} --vm {vmName} --name packetCaptureName --storage-account {storageAccountName} --filters "[{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"20\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"80\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"443\"},{\"protocol\":\"UDP\"}]"
 ```
 
-The following example is the expected output from running the `az network watcher packet-capture create` cmdlet.
+The following example is the expected output from running the `az network watcher packet-capture create` command.
 
 ```json
 {
@@ -177,13 +175,13 @@ roviders/microsoft.compute/virtualmachines/{vmName}/2017/05/25/packetcapture_16_
 
 ## Get a packet capture
 
-Running the `az network watcher packet-capture show-status` cmdlet, retrieves the status of a currently running, or completed packet capture.
+Running the `az network watcher packet-capture show-status` command, retrieves the status of a currently running, or completed packet capture.
 
 ```azurecli
 az network watcher packet-capture show-status --name packetCaptureName --location {networkWatcherLocation}
 ```
 
-The following example is the output from the `az network watcher packet-capture show-status` cmdlet. The following example is when the capture is Stopped, with a StopReason of TimeExceeded. 
+The following example is the output from the `az network watcher packet-capture show-status` command. The following example is when the capture is Stopped, with a StopReason of TimeExceeded. 
 
 ```
 {
@@ -202,14 +200,14 @@ cketCaptures/packetCaptureName",
 
 ## Stop a packet capture
 
-By running the `az network watcher packet-capture stop` cmdlet, if a capture session is in progress it is stopped.
+By running the `az network watcher packet-capture stop` command, if a capture session is in progress it is stopped.
 
 ```azurecli
 az network watcher packet-capture stop --name packetCaptureName --location westcentralus
 ```
 
 > [!NOTE]
-> The cmdlet returns no response when ran on a currently running capture session or an existing session that has already stopped.
+> The command returns no response when ran on a currently running capture session or an existing session that has already stopped.
 
 ## Delete a packet capture
 

--- a/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
@@ -61,7 +61,7 @@ az vm extension set --resource-group resourceGroupName --vm-name virtualMachineN
 For Linux virtual machines:
 
 ```azurecli
-az vm extension set --resource-group resourceGroupName --vm-name virtualMachineName --publisher Microsoft.Azure.NetworkWatcher --name NetworkWatcherAgentLinux--version 1.4
+az vm extension set --resource-group resourceGroupName --vm-name virtualMachineName --publisher Microsoft.Azure.NetworkWatcher --name NetworkWatcherAgentLinux --version 1.4
 ```
 
 ### Step 2
@@ -104,6 +104,7 @@ The following sample is an example of the response from running `az vm extension
 
 Once the preceding steps are complete, the packet capture agent is installed on the virtual machine.
 
+
 ### Step 1
 
 Retrieve a storage account. This storage account is used to store the packet capture file.
@@ -114,7 +115,7 @@ az storage account list
 
 ### Step 2
 
-Filters can be used to limit the data that is stored by the packet capture. The following example sets up a packet capture with several  filters.  The first three filters collect outgoing TCP traffic only from local IP 10.0.0.3 to destination ports 20, 80 and 443.  The last filter collects only UDP traffic.
+At this point, you are ready to create a packet capture.  First, let's examine the parameters you may want to configure. Filters are one such parameter that can be used to limit the data that is stored by the packet capture. The following example sets up a packet capture with several  filters.  The first three filters collect outgoing TCP traffic only from local IP 10.0.0.3 to destination ports 20, 80 and 443.  The last filter collects only UDP traffic.
 
 ```azurecli
 az network watcher packet-capture create --resource-group {resourceGroupName} --vm {vmName} --name packetCaptureName --storage-account {storageAccountName} --filters "[{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"20\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"80\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"443\"},{\"protocol\":\"UDP\"}]"

--- a/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
@@ -104,14 +104,8 @@ The following sample is an example of the response from running `az vm extension
 
 Once the preceding steps are complete, the packet capture agent is installed on the virtual machine.
 
+
 ### Step 1
-The next step is to retrieve the Network Watcher instance. TThe name of the Network Watcher is passed to the `az network watcher show` command in a subsequent step.
-
-```azurecli
-az network watcher show --resource-group resourceGroup --name networkWatcherName
-```
-
-### Step 2
 
 Retrieve a storage account. This storage account is used to store the packet capture file.
 
@@ -119,12 +113,12 @@ Retrieve a storage account. This storage account is used to store the packet cap
 az storage account list
 ```
 
-### Step 3
+### Step 2
 
 At this point, you are ready to create a packet capture.  First, let's examine the parameters you may want to configure. Filters are one such parameter that can be used to limit the data that is stored by the packet capture. The following example sets up a packet capture with several  filters.  The first three filters collect outgoing TCP traffic only from local IP 10.0.0.3 to destination ports 20, 80 and 443.  The last filter collects only UDP traffic.
 
 ```azurecli
-az network watcher packet-capture create --resource-group {resourceGroupName} --vm {vmName} --name packetCaptureName --storage-account {storageAccountName}  --location {location} --filters "[{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"20\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"80\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"443\"},{\"protocol\":\"UDP\"}]"
+az network watcher packet-capture create --resource-group {resourceGroupName} --vm {vmName} --name packetCaptureName --storage-account {storageAccountName} --filters "[{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"20\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"80\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"443\"},{\"protocol\":\"UDP\"}]"
 ```
 
 The following example is the expected output from running the `az network watcher packet-capture create` command.

--- a/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
+++ b/articles/network-watcher/network-watcher-packet-capture-manage-cli.md
@@ -104,8 +104,14 @@ The following sample is an example of the response from running `az vm extension
 
 Once the preceding steps are complete, the packet capture agent is installed on the virtual machine.
 
-
 ### Step 1
+The next step is to retrieve the Network Watcher instance. TThe name of the Network Watcher is passed to the `az network watcher show` command in a subsequent step.
+
+```azurecli
+az network watcher show --resource-group resourceGroup --name networkWatcherName
+```
+
+### Step 2
 
 Retrieve a storage account. This storage account is used to store the packet capture file.
 
@@ -113,12 +119,12 @@ Retrieve a storage account. This storage account is used to store the packet cap
 az storage account list
 ```
 
-### Step 2
+### Step 3
 
 At this point, you are ready to create a packet capture.  First, let's examine the parameters you may want to configure. Filters are one such parameter that can be used to limit the data that is stored by the packet capture. The following example sets up a packet capture with several  filters.  The first three filters collect outgoing TCP traffic only from local IP 10.0.0.3 to destination ports 20, 80 and 443.  The last filter collects only UDP traffic.
 
 ```azurecli
-az network watcher packet-capture create --resource-group {resourceGroupName} --vm {vmName} --name packetCaptureName --storage-account {storageAccountName} --filters "[{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"20\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"80\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"443\"},{\"protocol\":\"UDP\"}]"
+az network watcher packet-capture create --resource-group {resourceGroupName} --vm {vmName} --name packetCaptureName --storage-account {storageAccountName}  --location {location} --filters "[{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"20\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"80\"},{\"protocol\":\"TCP\", \"remoteIPAddress\":\"1.1.1.1-255.255.255\",\"localIPAddress\":\"10.0.0.3\", \"remotePort\":\"443\"},{\"protocol\":\"UDP\"}]"
 ```
 
 The following example is the expected output from running the `az network watcher packet-capture create` command.


### PR DESCRIPTION
I added a command for showing the Network Watcher extension for a Linux VM, as the difference in naming (e.g. AzureNetworkWatcherExtension for Linux) causes confusion when referencing the name of the extension on Windows.  Additionally, I may be mistaken, but I think the existing Step 1 under "Start a packet capture" is unnecessary.  "az network watcher show" is invalid.  Also, I changed "Start a packet capture" step 2 to retrieve the storage account with "az storage account list" instead of "azure storage account list".  Finally, I changed references to 'cmdlet' to 'command' to make it more consistent for the CLI portion of the documentation.