### PR TITLE
Delete unexpected else

### DIFF
--- a/articles/container-registry/container-registry-delete.md
+++ b/articles/container-registry/container-registry-delete.md
@@ -223,7 +223,6 @@ then
     az acr repository show-manifests --name $REGISTRY --repository $REPOSITORY  --query "[?tags[0]==null].digest" -o tsv \
     | xargs -I% az acr repository delete --name $REGISTRY --image $REPOSITORY@% --yes
 else
-    else
     echo "No data deleted."
     echo "Set ENABLE_DELETE=true to enable image deletion of these images in $REPOSITORY:"
     az acr repository show-manifests --name $REGISTRY --repository $REPOSITORY --query "[?tags[0]==null]" -o tsv


### PR DESCRIPTION
The delete sample script had too many elses and would fail to execute. Fixing the script by removing the extra else.