### PR TITLE
Update Deadline docs to reference Azure Render Hub

### DIFF
--- a/articles/batch/batch-rendering-render-managers.md
+++ b/articles/batch/batch-rendering-render-managers.md
@@ -21,6 +21,10 @@ The following render managers are supported:
 * [Royal Render](https://www.royalrender.de/)
 * [Thinkbox Deadline](https://deadline.thinkboxsoftware.com/)
 
+## Azure Render Hub
+
+Azure Render Hub simplifies the creation and management of Azure render farms.  Render Hub has native support for PipelineFx Qube and Deadline 10.  For more information and detailed instructions see [the GitHub repository](https://github.com/Azure/azure-render-hub).
+
 ## Using Azure with PipelineFX Qube
 
 Azure Render Hub supports popular render managers including Deadline.  For instructions on deploying and using Render Hub see [the GitHub repository](https://github.com/Azure/azure-render-hub).

--- a/articles/batch/batch-rendering-render-managers.md
+++ b/articles/batch/batch-rendering-render-managers.md
@@ -23,7 +23,9 @@ The following render managers are supported:
 
 ## Using Azure with PipelineFX Qube
 
-Scripts and instructions to enable Azure Batch pool VMs to be used as Qube workers are in [the GitHub repository](https://github.com/Azure/azure-qube).
+Azure Render Hub supports popular render managers including Deadline.  For instructions on deploying and using Render Hub see [the GitHub repository](https://github.com/Azure/azure-render-hub).
+
+Scripts and instructions to enable Azure Batch pool VMs to be used as Qube workers are also available in [the GitHub repository](https://github.com/Azure/azure-qube).
 
 ## Using Azure with Royal Render
 
@@ -33,7 +35,7 @@ For an example of a Royal Render customer using the Azure integration, see the [
 
 ## Using Azure with Thinkbox Deadline
 
-Scripts and instructions to enable Azure Batch pool VMs to be used as Deadline slaves are in [the GitHub repository](https://github.com/Azure/azure-deadline).
+Azure Render Hub supports popular render managers including Deadline.  For instructions on deploying and using Render Hub see [the GitHub repository](https://github.com/Azure/azure-render-hub).
 
 ## Next steps
 


### PR DESCRIPTION
Remove the old azure-deadline GitHub link and reference Azure Render Hub.