### PR TITLE
Added 'Azure Data Explorer' to table

### DIFF
--- a/articles/security/fundamentals/encryption-atrest.md
+++ b/articles/security/fundamentals/encryption-atrest.md
@@ -266,6 +266,7 @@ Client-side encryption of Azure SQL Database data is supported through the [Alwa
 | Azure Analysis Services          | Yes                | -                  | -                  |
 | Azure Data Catalog               | Yes                | -                  | -                  |
 | Apache Kafka on Azure HDInsight  | Yes                | All RSA Lengths.   | -                  |
+| Azure Data Explorer              | Yes                | -                  | -                  |
 | Azure Data Factory               | Yes                | -                  | -                  |
 | Azure Data Lake Store            | Yes                | Yes, RSA 2048-bit  | -                  |
 | **Containers**                   |                    |                    |                    |


### PR DESCRIPTION
Per this feedback item (https://feedback.azure.com/forums/357324-azure-monitor-application-insights/suggestions/17141321-application-insights-encryption-at-rest) and this announcements blog post (https://azure.microsoft.com/en-us/blog/azure-monitor-january-2019-updates/), Azure Data Explorer data is being encrypted at rest.

Adding this line to the table to reflect that reality. Azure Monitor & Azure Log Analytics are similarly affected (being built on ADE), but I'm not sure whether they warrant their owns lines/entries in the table.