### PR TITLE
Bug in "lesser" function.

### DIFF
--- a/articles/data-factory/data-flow-expression-functions.md
+++ b/articles/data-factory/data-flow-expression-functions.md
@@ -442,7 +442,7 @@ ___
 ### <code>lesser</code>
 <code><b>lesser(<i>&lt;value1&gt;</i> : any, <i>&lt;value2&gt;</i> : any) => boolean</b></code><br/><br/>
 Comparison less operator. Same as < operator
-* ``lesser(12 < 24) -> true``
+* ``lesser(12, 24) -> true``
 * ``'abcd' < 'abc' -> false``
 ___
 ### <code>lesserOrEqual</code>


### PR DESCRIPTION
In the documentation appears like 
lesser(12 < 24)
But in fact lesser function needs two arguments, like: 
lesser(12, 24)