### PR TITLE
Corrected link to "use the cluster autoscaler..."

### DIFF
--- a/articles/aks/cluster-autoscaler.md
+++ b/articles/aks/cluster-autoscaler.md
@@ -100,7 +100,7 @@ It takes a few minutes to create the cluster and configure the cluster autoscale
 ## Change the cluster autoscaler settings
 
 > [!IMPORTANT]
-> If you have the *multiple agent pools* feature enabled on your subscription, skip to the [autoscale with multiple agent pools section](##use-the-cluster-autoscaler-with-multiple-node-pools-enabled). Clusters with multiple agent pools enabled require use of the `az aks nodepool` command set to change node pool specific properties instead of `az aks`. The below instructions assume you have not enabled multiple node pools. To check if you have it enabled, run `az feature  list -o table` and look for `Microsoft.ContainerService/multiagentpoolpreview`.
+> If you have the *multiple agent pools* feature enabled on your subscription, skip to the [autoscale with multiple agent pools section](#use-the-cluster-autoscaler-with-multiple-node-pools-enabled). Clusters with multiple agent pools enabled require use of the `az aks nodepool` command set to change node pool specific properties instead of `az aks`. The below instructions assume you have not enabled multiple node pools. To check if you have it enabled, run `az feature  list -o table` and look for `Microsoft.ContainerService/multiagentpoolpreview`.
 
 In the previous step to create an AKS cluster or update an existing node pool, the cluster autoscaler minimum node count was set to *1*, and the maximum node count was set to *3*. As your application demands change, you may need to adjust the cluster autoscaler node count.
 


### PR DESCRIPTION
There were too many `#` symbols in the link