### PR TITLE
Add quotes and index to bash command

### DIFF
--- a/articles/aks/configure-azure-cni.md
+++ b/articles/aks/configure-azure-cni.md
@@ -114,7 +114,7 @@ First, get the subnet resource ID for the existing subnet into which the AKS clu
 $ az network vnet subnet list \
     --resource-group myVnet \
     --vnet-name myVnet \
-    --query [].id --output tsv
+    --query "[0].id" --output tsv
 
 /subscriptions/<guid>/resourceGroups/myVnet/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/default
 ```


### PR DESCRIPTION
```
az network vnet subnet list \
    --resource-group myVnet \
    --vnet-name myVnet \
    --query "[0].id" --output tsv
```
returns `no matches found: [].id`

This command should use `--query "[0].id"` for the desired output.