### PR TITLE
CRI 142287225 - disks must be of same size

### DIFF
--- a/articles/virtual-machines/windows/os-disk-swap.md
+++ b/articles/virtual-machines/windows/os-disk-swap.md
@@ -26,7 +26,7 @@ If you have an existing VM, but you want to swap the disk for a backup disk or a
 
 The VM does need to be stopped\deallocated, then the resource ID of the managed disk can be replaced with the resource ID of a different managed disk.
 
-Make sure that the VM size and storage type are compatible with the disk you want to attach. For example, if the disk you want to use is in Premium Storage, then the VM needs to be capable of Premium Storage (like a DS-series size). Also the 2 disks must have the same size.
+Make sure that the VM size and storage type are compatible with the disk you want to attach. For example, if the disk you want to use is in Premium Storage, then the VM needs to be capable of Premium Storage (like a DS-series size). Also the two disks must have the same size.
 
 Get a list of disks in a resource group using [Get-AzDisk](https://docs.microsoft.com/powershell/module/az.compute/get-azdisk)
 

--- a/articles/virtual-machines/windows/os-disk-swap.md
+++ b/articles/virtual-machines/windows/os-disk-swap.md
@@ -26,7 +26,7 @@ If you have an existing VM, but you want to swap the disk for a backup disk or a
 
 The VM does need to be stopped\deallocated, then the resource ID of the managed disk can be replaced with the resource ID of a different managed disk.
 
-Make sure that the VM size and storage type are compatible with the disk you want to attach. For example, if the disk you want to use is in Premium Storage, then the VM needs to be capable of Premium Storage (like a DS-series size). 
+Make sure that the VM size and storage type are compatible with the disk you want to attach. For example, if the disk you want to use is in Premium Storage, then the VM needs to be capable of Premium Storage (like a DS-series size). Also the 2 disks must have the same size.
 
 Get a list of disks in a resource group using [Get-AzDisk](https://docs.microsoft.com/powershell/module/az.compute/get-azdisk)
 


### PR DESCRIPTION
RDBug 16801448:ResizeDiskError while swapping Disks of different sizes 

currently OS Disk Swap only supports swapping 2 disks with the same size. This needs to be called out in the doc