### PR TITLE
Updating maximum size based on P5 release

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-clustering.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-clustering.md
@@ -117,7 +117,7 @@ For more information, see [Keys distribution model](https://redis.io/topics/clus
 For sample code on working with clustering and locating keys in the same shard with the StackExchange.Redis client, see the [clustering.cs](https://github.com/rustd/RedisSamples/blob/master/HelloWorld/Clustering.cs) portion of the [Hello World](https://github.com/rustd/RedisSamples/tree/master/HelloWorld) sample.
 
 ### What is the largest cache size I can create?
-The largest premium cache size is 53 GB. You can create up to 10 shards giving you a maximum size of 530 GB. If you need a larger size you can [request more](mailto:wapteams@microsoft.com?subject=Redis%20Cache%20quota%20increase). For more information, see [Azure Cache for Redis Pricing](https://azure.microsoft.com/pricing/details/cache/).
+The largest premium cache size is 120 GB. You can create up to 10 shards giving you a maximum size of 1.2TB GB. If you need a larger size you can [request more](mailto:wapteams@microsoft.com?subject=Redis%20Cache%20quota%20increase). For more information, see [Azure Cache for Redis Pricing](https://azure.microsoft.com/pricing/details/cache/).
 
 ### Do all Redis clients support clustering?
 At the present time not all clients support Redis clustering. StackExchange.Redis is one that does support for it. For more information on other clients, see the [Playing with the cluster](https://redis.io/topics/cluster-tutorial#playing-with-the-cluster) section of the [Redis cluster tutorial](https://redis.io/topics/cluster-tutorial). 

--- a/articles/azure-cache-for-redis/cache-migrate-to-redis.md
+++ b/articles/azure-cache-for-redis/cache-migrate-to-redis.md
@@ -58,7 +58,7 @@ Microsoft Azure Cache for Redis is available in the following tiers:
 
 * **Basic** – Single node. Multiple sizes up to 53 GB.
 * **Standard** – Two-node Primary/Replica. Multiple sizes up to 53 GB. 99.9% SLA.
-* **Premium** – Two-node Primary/Replica with up to 10 shards. Multiple sizes from 6 GB to 530 GB. All Standard tier features and more including support for [Redis cluster](cache-how-to-premium-clustering.md), [Redis persistence](cache-how-to-premium-persistence.md), and [Azure Virtual Network](cache-how-to-premium-vnet.md). 99.9% SLA.
+* **Premium** – Two-node Primary/Replica with up to 10 shards. Multiple sizes from 6 GB to 1.2 TB. All Standard tier features and more including support for [Redis cluster](cache-how-to-premium-clustering.md), [Redis persistence](cache-how-to-premium-persistence.md), and [Azure Virtual Network](cache-how-to-premium-vnet.md). 99.9% SLA.
 
 Each tier differs in terms of features and pricing. The features are covered later in this guide, and for more information on pricing, see [Cache Pricing Details](https://azure.microsoft.com/pricing/details/cache/).
 

--- a/includes/redis-cache-service-limits.md
+++ b/includes/redis-cache-service-limits.md
@@ -7,7 +7,7 @@ ms.author: wesmc
 ---
 | Resource | Limit |
 | --- | --- |
-| Cache size |530 GB |
+| Cache size |1.2 TB |
 | Databases |64 |
 | Maximum connected clients |40,000 |
 | Azure Cache for Redis replicas, for high availability |1 |


### PR DESCRIPTION
With the release of P5 a 120TB machine the maximum is now up to 1.2TB (10x120GB). Related to #39056 cc:@TimLovellSmith 