### PR TITLE
remove wrong instruction about TCP port range 11000-11999

### DIFF
--- a/articles/sql-database/sql-database-gateway-migration.md
+++ b/articles/sql-database/sql-database-gateway-migration.md
@@ -46,7 +46,7 @@ You will not be impacted if you have :
 
 ## What to do you do if you're affected
 
-We recommend that you allow outbound traffic to IP addresses for all the [Azure SQL Database gateway IP addresses](sql-database-connectivity-architecture.md#azure-sql-database-gateway-ip-addresses) in the region on TCP port 1433, and port range 11000-11999 in your firewall device. For more information on port ranges, see [Connection policy](sql-database-connectivity-architecture.md#connection-policy).
+We recommend that you allow outbound traffic to IP addresses for all the [Azure SQL Database gateway IP addresses](sql-database-connectivity-architecture.md#azure-sql-database-gateway-ip-addresses) in the region on TCP port 1433 in your firewall device. For more information on port ranges, see [Connection policy](sql-database-connectivity-architecture.md#connection-policy).
 
 Connections made from applications using Microsoft JDBC Driver below version 4.0 might fail certificate validation. Lower versions of Microsoft JDBC rely on Common Name (CN) in the Subject field of the certificate. The mitigation is to ensure that the hostNameInCertificate property is set to *.database.windows.net. For more information on how to set the hostNameInCertificate property, see [Connecting with SSL Encryption](/sql/connect/jdbc/connecting-with-ssl-encryption).
 


### PR DESCRIPTION
the document ask customer to open port range 11000-11999 for all the gateway IPs which is not needed as this is only used when connection is redirected to the actual node and not the gateway node.