### PR TITLE
service-to-service-authentication.md: Add `--resource` argument to `az account get-access-key` 

### DIFF
--- a/articles/key-vault/service-to-service-authentication.md
+++ b/articles/key-vault/service-to-service-authentication.md
@@ -84,7 +84,7 @@ To use Azure CLI:
 
 1. Sign in to the Azure portal: *az login* to sign in to Azure.
 
-1. Verify access by entering *az account get-access-token*. If you receive an error, check that the right version of Azure CLI is correctly installed.
+1. Verify access by entering *az account get-access-token --resource https://vault.azure.net*. If you receive an error, check that the right version of Azure CLI is correctly installed.
 
    If Azure CLI isn't installed to the default directory, you may receive an error reporting that `AzureServiceTokenProvider` can't find the path for Azure CLI. Use the **AzureCLIPath** environment variable to define the Azure CLI installation folder. `AzureServiceTokenProvider` adds the directory specified in the **AzureCLIPath** environment variable to the **Path** environment variable when necessary.
 


### PR DESCRIPTION
Add `--resource https://vault.azure.net` argument to `az account get-access-key` - without it, the generated access key doesn't work with Key Vault (invalid audience error).