### PR TITLE
Noted 5 seconds minimum

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-direct-methods.md
+++ b/articles/iot-hub/iot-hub-devguide-direct-methods.md
@@ -31,7 +31,7 @@ Direct methods are implemented on the device and may require zero or more inputs
 > When you invoke a direct method on a device, property names and values can only contain US-ASCII printable alphanumeric, except any in the following set: ``{'$', '(', ')', '<', '>', '@', ',', ';', ':', '\', '"', '/', '[', ']', '?', '=', '{', '}', SP, HT}``
 > 
 
-Direct methods are synchronous and either succeed or fail after the timeout period (default: 30 seconds, settable up to 300 seconds). Direct methods are useful in interactive scenarios where you want a device to act if and only if the device is online and receiving commands. For example, turning on a light from a phone. In these scenarios, you want to see an immediate success or failure so the cloud service can act on the result as soon as possible. The device may return some message body as a result of the method, but it isn't required for the method to do so. There is no guarantee on ordering or any concurrency semantics on method calls.
+Direct methods are synchronous and either succeed or fail after the timeout period (default: 30 seconds, settable between 5 and 300 seconds). Direct methods are useful in interactive scenarios where you want a device to act if and only if the device is online and receiving commands. For example, turning on a light from a phone. In these scenarios, you want to see an immediate success or failure so the cloud service can act on the result as soon as possible. The device may return some message body as a result of the method, but it isn't required for the method to do so. There is no guarantee on ordering or any concurrency semantics on method calls.
 
 Direct methods are HTTPS-only from the cloud side, and MQTT or AMQP from the device side.
 


### PR DESCRIPTION
Current service SDK throws an ArgumentError if timeout period is below 5 seconds. This should be noted