### PR TITLE
Normalize Terraform code fences

### DIFF
--- a/articles/terraform/terraform-backend.md
+++ b/articles/terraform/terraform-backend.md
@@ -76,7 +76,7 @@ To configure Terraform to use the backend, include a *backend* configuration wit
 
 The following example configures a Terraform backend and creates an Azure resource group. Replace the values with values from your environment.
 
-```json
+```terraform
 terraform {
   backend "azurerm" {
     storage_account_name  = "tstate09762"

--- a/articles/terraform/terraform-cloud-shell.md
+++ b/articles/terraform/terraform-cloud-shell.md
@@ -28,7 +28,7 @@ Terraform is installed and immediately available in Cloud Shell. Terraform scrip
 
 Azure Terraform modules require credentials to access and make changes to the resources in your Azure subscription. When working in the Cloud Shell, add the following code to your scripts to use Azure Terraform modules in the Cloud Shell:
 
-```tf
+```terraform
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
 }

--- a/articles/terraform/terraform-create-k8s-cluster-with-aks-applicationgateway-ingress.md
+++ b/articles/terraform/terraform-create-k8s-cluster-with-aks-applicationgateway-ingress.md
@@ -77,7 +77,7 @@ Create the Terraform configuration file that declares the Azure provider.
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     provider "azurerm" {
         version = "~>1.18"
     }
@@ -104,7 +104,7 @@ Create the Terraform configuration file that declares the Azure provider.
 
 2. Paste the following code into the editor:
     
-    ```JSON
+    ```terraform
     variable "resource_group_name" {
       description = "Name of the resource group already created."
     }
@@ -251,7 +251,7 @@ Create Terraform configuration file that creates all the resources.
 
     a. Create a locals block for computed variables to reuse
 
-    ```JSON
+    ```terraform
     # # Locals block for hardcoded names. 
     locals {
         backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
@@ -264,7 +264,7 @@ Create Terraform configuration file that creates all the resources.
     }
     ```
     b. Create a data source for Resource group, new User identity
-    ```JSON
+    ```terraform
     data "azurerm_resource_group" "rg" {
       name = "${var.resource_group_name}"
     }
@@ -280,7 +280,7 @@ Create Terraform configuration file that creates all the resources.
     }
     ```
     c. Create base networking resources
-   ```JSON
+   ```terraform
     resource "azurerm_virtual_network" "test" {
       name                = "${var.virtual_network_name}"
       location            = "${data.azurerm_resource_group.rg.location}"
@@ -324,7 +324,7 @@ Create Terraform configuration file that creates all the resources.
     }
     ```
     d. Create Application Gateway resource
-    ```JSON
+    ```terraform
     resource "azurerm_application_gateway" "network" {
       name                = "${var.app_gateway_name}"
       resource_group_name = "${data.azurerm_resource_group.rg.name}"
@@ -389,7 +389,7 @@ Create Terraform configuration file that creates all the resources.
     }
     ```
     e. Create role assignments
-    ```JSON
+    ```terraform
     resource "azurerm_role_assignment" "ra1" {
       scope                = "${data.azurerm_subnet.kubesubnet.id}"
       role_definition_name = "Network Contributor"
@@ -420,7 +420,7 @@ Create Terraform configuration file that creates all the resources.
     }
     ```
     f. Create the Kubernetes cluster
-    ```JSON
+    ```terraform
     resource "azurerm_kubernetes_cluster" "k8s" {
       name       = "${var.aks_name}"
       location   = "${data.azurerm_resource_group.rg.location}"
@@ -497,7 +497,7 @@ Create Terraform configuration file that creates all the resources.
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     output "client_key" {
         value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_key}"
     }
@@ -582,7 +582,7 @@ In this section, you see how to use the `terraform init` command to create the r
 
 1. Paste the following variables created earlier into the editor:
 
-    ```JSON
+    ```terraform
       resource_group_name = <Name of the Resource Group already created>
 
       location = <Location of the Resource Group>

--- a/articles/terraform/terraform-create-k8s-cluster-with-tf-and-aks.md
+++ b/articles/terraform/terraform-create-k8s-cluster-with-tf-and-aks.md
@@ -69,7 +69,7 @@ Create the Terraform configuration file that declares the Azure provider.
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     provider "azurerm" {
         version = "~>1.5"
     }
@@ -100,7 +100,7 @@ Create the Terraform configuration file that declares the resources for the Kube
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     resource "azurerm_resource_group" "k8s" {
         name     = "${var.resource_group_name}"
         location = "${var.location}"
@@ -197,7 +197,7 @@ Create the Terraform configuration file that declares the resources for the Kube
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     variable "client_id" {}
     variable "client_secret" {}
 
@@ -261,7 +261,7 @@ Create the Terraform configuration file that declares the resources for the Kube
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     output "client_key" {
         value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_key}"
     }

--- a/articles/terraform/terraform-create-vm-cluster-module.md
+++ b/articles/terraform/terraform-create-vm-cluster-module.md
@@ -30,7 +30,7 @@ For more information on Terraform, see the [Terraform documentation](https://www
 
  Review [Install Terraform and configure access to Azure](/azure/virtual-machines/linux/terraform-install-configure) to create an Azure service principal. Use this service principal to populate a new file `azureProviderAndCreds.tf` in an empty directory with the following code:
 
-```tf
+```terraform
 variable subscription_id {}
 variable tenant_id {}
 variable client_id {}
@@ -48,7 +48,7 @@ provider "azurerm" {
 
 Create a new Terraform template named `main.tf` with the following code:
 
-```tf
+```terraform
 module mycompute {
     source = "Azure/compute/azurerm"
     resource_group_name = "myResourceGroup"

--- a/articles/terraform/terraform-create-vm-cluster-with-infrastructure.md
+++ b/articles/terraform/terraform-create-vm-cluster-with-infrastructure.md
@@ -41,7 +41,7 @@ In this section, you generate an Azure service principal, and two Terraform conf
 
 5. Copy the following code into your variable declaration file:
 
-   ```tf
+   ```terraform
    variable subscription_id {}
    variable tenant_id {}
    variable client_id {}
@@ -59,7 +59,7 @@ In this section, you generate an Azure service principal, and two Terraform conf
 
 7. Copy the following code into your variables file. Make sure to replace the placeholders as follows: For `subscription_id`, use the Azure subscription ID you specified when running `az account set`. For `tenant_id`, use the `tenant` value returned from `az ad sp create-for-rbac`. For `client_id`, use the `appId` value returned from `az ad sp create-for-rbac`. For `client_secret`, use the `password` value returned from `az ad sp create-for-rbac`.
 
-   ```tf
+   ```terraform
    subscription_id = "<azure-subscription-id>"
    tenant_id = "<tenant-returned-from-creating-a-service-principal>"
    client_id = "<appId-returned-from-creating-a-service-principal>"
@@ -74,7 +74,7 @@ In this section, you create a file that contains resource definitions for your i
 
 2. Copy following sample resource definitions into the newly created `main.tf` file: 
 
-   ```tf
+   ```terraform
    resource "azurerm_resource_group" "test" {
     name     = "acctestrg"
     location = "West US 2"

--- a/articles/terraform/terraform-create-vm-scaleset-network-disks-hcl.md
+++ b/articles/terraform/terraform-create-vm-scaleset-network-disks-hcl.md
@@ -75,7 +75,7 @@ Within the Azure Cloud Shell, perform the following steps:
 
 1. Paste the following code into the editor:
 
-   ```JSON
+   ```terraform
    variable "location" {
     description = "The location where resources will be created"
    }
@@ -119,7 +119,7 @@ Within the Azure Cloud Shell, perform the following steps:
 1. Paste the following code into the editor to expose the fully qualified domain name (FQDN) for the virtual machines.
    :
 
-   ```JSON
+   ```terraform
     output "vmss_public_ip" {
         value = "${azurerm_public_ip.vmss.fqdn}"
     }
@@ -152,7 +152,7 @@ Within the Azure Cloud Shell, perform the following steps:
 
 1. Paste the following code to the end of the file to expose the fully qualified domain name (FQDN) for the virtual machines.
 
-   ```JSON
+   ```terraform
    resource "azurerm_resource_group" "vmss" {
     name     = "${var.resource_group_name}"
     location = "${var.location}"
@@ -247,7 +247,7 @@ In Cloud Shell, perform the following steps:
 
 1. Paste the following code to the end of the file:
 
-   ```JSON
+   ```terraform
    resource "azurerm_lb" "vmss" {
     name                = "vmss-lb"
     location            = "${var.location}"
@@ -364,7 +364,7 @@ In Cloud Shell, perform the following steps:
 
 1. Paste the following code into the editor:
 
-   ```JSON
+   ```yml
    #cloud-config
    packages:
     - nginx
@@ -388,7 +388,7 @@ In Cloud Shell, perform the following steps:
 
 1. Customize the deployment by pasting the following code to the end of the file:
 
-    ```JSON
+    ```terraform
     variable "application_port" {
        description = "The port that you want to expose to the external load balancer"
        default     = 80
@@ -453,7 +453,7 @@ An SSH *jumpbox* is a single server that you "jump" through in order to access o
 
 1. Paste the following code to the end of the file:
 
-   ```JSON
+   ```terraform
    resource "azurerm_public_ip" "jumpbox" {
     name                         = "jumpbox-public-ip"
     location                     = "${var.location}"
@@ -523,7 +523,7 @@ An SSH *jumpbox* is a single server that you "jump" through in order to access o
 
 1. Paste the following code to the end of the file to display the hostname of the jumpbox when the deployment is complete:
 
-   ```
+   ```terraform
    output "jumpbox_public_ip" {
       value = "${azurerm_public_ip.jumpbox.fqdn}"
    }

--- a/articles/terraform/terraform-create-vm-scaleset-network-disks-using-packer-hcl.md
+++ b/articles/terraform/terraform-create-vm-scaleset-network-disks-using-packer-hcl.md
@@ -50,7 +50,7 @@ In this step, you define variables that customize the resources created by Terra
 
 Edit the `variables.tf` file, copy the following code, then save the changes.
 
-```tf 
+```terraform 
 variable "location" {
   description = "The location where resources are created"
   default     = "East US"
@@ -72,7 +72,7 @@ When you deploy your Terraform template, you want to get the fully qualified dom
 
 Edit the `output.tf` file, and copy the following code to expose the fully qualified domain name for the virtual machines. 
 
-```hcl 
+```terraform 
 output "vmss_public_ip" {
     value = "${azurerm_public_ip.vmss.fqdn}"
 }
@@ -89,7 +89,7 @@ You also need a resource group where all the resources are created.
 
 Edit and copy the following code in the ```vmss.tf``` file: 
 
-```tf 
+```terraform 
 
 resource "azurerm_resource_group" "vmss" {
   name     = "${var.resource_group_name}"
@@ -183,7 +183,7 @@ In this step, you create the following resources on the network that was previou
 
 Add the following code to the end of the `vmss.tf` file.
 
-```tf
+```terraform
 
 
 resource "azurerm_lb" "vmss" {
@@ -301,7 +301,7 @@ resource "azurerm_virtual_machine_scale_set" "vmss" {
 
 Customize the deployment by adding the following code to `variables.tf`:
 
-```tf 
+```terraform 
 variable "application_port" {
     description = "The port that you want to expose to the external load balancer"
     default     = 80
@@ -349,7 +349,7 @@ Add the following resources to your existing deployment:
 
 Add the following code to the end of the `vmss.tf` file:
 
-```hcl 
+```terraform 
 resource "azurerm_public_ip" "jumpbox" {
   name                         = "jumpbox-public-ip"
   location                     = "${var.location}"
@@ -423,7 +423,7 @@ resource "azurerm_virtual_machine" "jumpbox" {
 
 Edit `outputs.tf` to add the following code that displays the hostname of the jumpbox when the deployment completes:
 
-```
+```terraform
 output "jumpbox_public_ip" {
     value = "${azurerm_public_ip.jumpbox.fqdn}"
 }

--- a/articles/terraform/terraform-hub-spoke-hub-network.md
+++ b/articles/terraform/terraform-hub-spoke-hub-network.md
@@ -68,7 +68,7 @@ Create the Terraform configuration file that declares Hub virtual network.
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     locals {
       prefix-hub         = "hub"
       hub-location       = "CentralUS"

--- a/articles/terraform/terraform-hub-spoke-hub-nva.md
+++ b/articles/terraform/terraform-hub-spoke-hub-nva.md
@@ -63,7 +63,7 @@ Create the Terraform configuration file that declares On-Premises Virtual networ
 
 1. Paste the following code into the editor:
     
-    ```JSON
+    ```terraform
     locals {
       prefix-hub-nva         = "hub-nva"
       hub-nva-location       = "CentralUS"

--- a/articles/terraform/terraform-hub-spoke-introduction.md
+++ b/articles/terraform/terraform-hub-spoke-introduction.md
@@ -113,7 +113,7 @@ Create the Terraform configuration file that declares the Azure provider.
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     provider "azurerm" {
         version = "~>1.22"
     }
@@ -133,7 +133,7 @@ Create the Terraform configuration file for common variables that are used acros
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     variable "location" {
       description = "Location of the network"
       default     = "centralus"

--- a/articles/terraform/terraform-hub-spoke-on-prem.md
+++ b/articles/terraform/terraform-hub-spoke-on-prem.md
@@ -61,7 +61,7 @@ Create the Terraform configuration file that declares an on-premises VNet.
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     locals {
       onprem-location       = "SouthCentralUS"
       onprem-resource-group = "onprem-vnet-rg"

--- a/articles/terraform/terraform-hub-spoke-spoke-network.md
+++ b/articles/terraform/terraform-hub-spoke-spoke-network.md
@@ -61,7 +61,7 @@ Two spoke scripts are created in this section. Each script defines a spoke virtu
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     locals {
       spoke1-location       = "CentralUS"
       spoke1-resource-group = "spoke1-vnet-rg"
@@ -183,7 +183,7 @@ Two spoke scripts are created in this section. Each script defines a spoke virtu
     
 1. Paste the following code into the editor:
     
-    ```JSON
+    ```terraform
     locals {
       spoke2-location       = "CentralUS"
       spoke2-resource-group = "spoke2-vnet-rg"

--- a/articles/terraform/terraform-slot-walkthru.md
+++ b/articles/terraform/terraform-slot-walkthru.md
@@ -69,7 +69,7 @@ This article illustrates an example use of deployment slots by walking you throu
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     # Configure the Azure provider
     provider "azurerm" { }
 
@@ -261,7 +261,7 @@ To test swapping the two deployment slots, perform the following steps:
 
 1. Paste the following code into the editor:
 
-    ```JSON
+    ```terraform
     # Configure the Azure provider
     provider "azurerm" { }
 

--- a/articles/terraform/terratest-in-terraform-modules.md
+++ b/articles/terraform/terratest-in-terraform-modules.md
@@ -68,7 +68,7 @@ First, create a new folder named `staticwebpage` under your GoPath `src` folder.
 
 The static webpage module accepts three inputs. The inputs are declared in `./variables.tf`:
 
-```hcl
+```terraform
 variable "location" {
   description = "The Azure region in which to create all resources."
 }
@@ -85,7 +85,7 @@ variable "html_path" {
 
 As we mentioned earlier in the article, this module also outputs a URL that's declared in `./outputs.tf`:
 
-```hcl
+```terraform
 output "homepage_url" {
   value = "${azurerm_storage_blob.homepage.url}"
 }
@@ -99,7 +99,7 @@ The main logic of the module provisions four resources:
 
 The static webpage module logic is implemented in `./main.tf`:
 
-```hcl
+```terraform
 resource "azurerm_resource_group" "main" {
   name     = "${var.website_name}-staging-rg"
   location = "${var.location}"
@@ -161,7 +161,7 @@ First, we use an empty HTML file named `./test/fixtures/storage-account-name/emp
 
 The file  `./test/fixtures/storage-account-name/main.tf` is the test case frame. It accepts one input, `website_name`, which is also the input of the unit tests. The logic is shown here:
 
-```hcl
+```terraform
 variable "website_name" {
   description = "The name of your static website."
 }
@@ -304,7 +304,7 @@ Let's start with the samples. A new sample folder named `hello-world/` is create
 
 The Terraform sample `./examples/hello-world/main.tf` is similar to the one shown in the unit test. There's one significant difference: the sample also prints out the URL of the uploaded HTML as a webpage named `homepage`.
 
-```hcl
+```terraform
 variable "website_name" {
   description = "The name of your static website."
   default     = "Hello-World"


### PR DESCRIPTION
For Learn content, we added colorization support for Terraform. We noticed that in Docs, we use the JSON colorizer, which, although it produces reasonable output, isn't exactly correct (plus, it shows a misleading label on the code block.) We saw other examples that use "tf", which displays "tf" as the label.

This change applies that colorization to a sampling of examples we found. It normalizes "tf", "hcl", and "JSON" to use "terraform", which colorizes HCL code correctly and applies the "Terraform" label to the code block.

(I assumed this PR would kick off a build that we can verify before merging this change, like we have on Learn. Apologies for not understanding the process here. We should verify that this colorizer is available across Docs before merging.)

Thanks for considering :) 