### PR TITLE
Simplify diskpart command in prepare-for-upload-vhd-image.md

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -100,13 +100,7 @@ On the VM that you plan to upload to Azure, run the following commands from an [
 3. Set the disk SAN policy to [`Onlineall`](https://technet.microsoft.com/library/gg252636.aspx):
    
     ```PowerShell
-    diskpart 
-    ```
-    In the open command prompt window, type the following commands:
-
-     ```DISKPART
-    san policy=onlineall
-    exit   
+    Set-StorageSetting -NewDiskPolicy OnlineAll
     ```
 
 4. Set Coordinated Universal Time (UTC) time for Windows. Also set the startup type of the Windows time service (`w32time`) to `Automatic`:


### PR DESCRIPTION
Instead of issuing two `diskpart` commands, use a single, easier-to-script PowerShell command.

(Docs are sparse, but it appears that `Set-StorageSetting` is available as far back as Windows Server 2012 (https://blogs.msdn.microsoft.com/san/2012/07/03/managing-storage-with-windows-powershell-on-windows-server-2012/))