### PR TITLE
Fix bcdedit commands for PowerShell in prepare-for-upload-vhd-image.md

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -269,23 +269,19 @@ Make sure the VM is healthy, secure, and RDP accessible:
     > Use an elevated PowerShell window to run these commands.
    
    ```powershell
-    cmd
-
-    bcdedit /set {bootmgr} integrityservices enable
-    bcdedit /set {default} device partition=C:
-    bcdedit /set {default} integrityservices enable
-    bcdedit /set {default} recoveryenabled Off
-    bcdedit /set {default} osdevice partition=C:
-    bcdedit /set {default} bootstatuspolicy IgnoreAllFailures
+    bcdedit /set "{bootmgr}" integrityservices enable
+    bcdedit /set "{default}" device partition=C:
+    bcdedit /set "{default}" integrityservices enable
+    bcdedit /set "{default}" recoveryenabled Off
+    bcdedit /set "{default}" osdevice partition=C:
+    bcdedit /set "{default}" bootstatuspolicy IgnoreAllFailures
 
     #Enable Serial Console Feature
-    bcdedit /set {bootmgr} displaybootmenu yes
-    bcdedit /set {bootmgr} timeout 5
-    bcdedit /set {bootmgr} bootems yes
-    bcdedit /ems {current} ON
+    bcdedit /set "{bootmgr}" displaybootmenu yes
+    bcdedit /set "{bootmgr}" timeout 5
+    bcdedit /set "{bootmgr}" bootems yes
+    bcdedit /ems "{current}" ON
     bcdedit /emssettings EMSPORT:1 EMSBAUDRATE:115200
-
-    exit
    ```
 3. The dump log can be helpful in troubleshooting Windows crash issues. Enable the dump log collection:
 


### PR DESCRIPTION
The `bcdedit` commands in `prepare-for-upload-vhd-image.md` don't work in PowerShell due to the special characters ('{', '}').

The docs said to run in a PowerShell window, then open cmd, then run the commands. Instead, simply quote the commands (per the documentation https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcdedit--set) and run directly in PowerShell.