### PR TITLE
Wrong element in Limit call rate by key

### DIFF
--- a/articles/api-management/api-management-access-restriction-policies.md
+++ b/articles/api-management/api-management-access-restriction-policies.md
@@ -181,9 +181,9 @@ In the following example, the rate limit is keyed by the caller IP address.
 
 ### Elements
 
-| Name      | Description   | Required |
-| --------- | ------------- | -------- |
-| set-limit | Root element. | Yes      |
+| Name              | Description   | Required |
+| ----------------- | ------------- | -------- |
+| rate-limit-by-key | Root element. | Yes      |
 
 ### Attributes
 


### PR DESCRIPTION
The root element in Limit call rate by key is rate-limit-by-key, not set-limit