### PR TITLE
Updated documentation on minimum subnet size based on customer feedback

### DIFF
--- a/articles/sql-database/sql-database-managed-instance-determine-size-vnet-subnet.md
+++ b/articles/sql-database/sql-database-managed-instance-determine-size-vnet-subnet.md
@@ -23,7 +23,7 @@ When you create a Managed Instance, Azure allocates a number of virtual machines
 By design, a Managed Instance needs a minimum of 16 IP addresses in a subnet and may use up to 256 IP addresses. As a result, you can use a subnet masks between /28 and /24 when defining your subnet IP ranges. A network mask bit of /28 (14 hosts per network) is a good size for a single general purpose or business-critical deployment. A mask bit of /27 (30 hosts per network) is ideal for a multiple Managed Instance deployments within the same VNet. Mask bit settings of /26 (62 hosts) and /24 (254 hosts) allows further scaling out of the VNet to support additional Managed Instances.
 
 > [!IMPORTANT]
-> A subnet size with 16 IP addresses is the bare minimum with limited potential for the further Managed Instance scale out. Choosing subnet with the prefix /27 or below is highly recommended.
+> A subnet size with 16 IP addresses is the bare minimum with limited potential for the further Managed Instance scale out. A subnet size with 16 IP addresses may not be sufficient even when scaling up an existing Managed Instance to a higher number of vCores. Choosing subnet with the prefix /27 or below is highly recommended.
 
 ## Determine subnet size
 


### PR DESCRIPTION
Customer faced a scenario which didn't allow them to scale up with the minimum subnet size as per our recommendation for single managed instance. Updating the highlighted note to prevent customers from facing this issue in future.