### PR TITLE
removed references to intr/nointr (deprecated)

### DIFF
--- a/articles/hpc-cache/hpc-cache-mount.md
+++ b/articles/hpc-cache/hpc-cache-mount.md
@@ -32,7 +32,7 @@ Example:
 
 ```
 root@test-client:/tmp# mkdir hpccache
-root@test-client:/tmp# sudo mount 10.0.0.28:/blob-demo-0722 ./hpccache/ -orw,tcp,mountproto=tcp,vers3,hard,intr
+root@test-client:/tmp# sudo mount 10.0.0.28:/blob-demo-0722 ./hpccache/ -orw,tcp,mountproto=tcp,vers3,hard
 root@test-client:/tmp# 
 ```
 
@@ -45,7 +45,7 @@ After this command succeeds, the contents of the storage export should be visibl
 
 For a robust client mount, pass these settings and arguments in your mount command: 
 
-``mount -o hard,nointr,proto=tcp,mountproto=tcp,retry=30 ${CACHE_IP_ADDRESS}:/${NAMESPACE_PATH} ${LOCAL_FILESYSTEM_MOUNT_POINT}``
+``mount -o hard,proto=tcp,mountproto=tcp,retry=30 ${CACHE_IP_ADDRESS}:/${NAMESPACE_PATH} ${LOCAL_FILESYSTEM_MOUNT_POINT}``
 
 | Recommended mount command settings | |
 --- | --- 


### PR DESCRIPTION
Both an example and a recommendation included 'intr' text. Both references have been removed.