### PR TITLE
Updated note for Dynamics 365

### DIFF
--- a/articles/expressroute/expressroute-faqs.md
+++ b/articles/expressroute/expressroute-faqs.md
@@ -87,7 +87,8 @@ ExpressRoute supports [three routing domains](expressroute-circuit-peerings.md) 
 
 Dynamics 365 and Common Data Service (CDS) environments are hosted on Azure and therefore customers benefit from the underlying ExpressRoute support for Azure resources. You can connect to its service endpoints if your router filter includes the Azure regions your Dynamics 365/CDS environments are hosted in.
 
-Note: [ExpressRoute Premium](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-faqs#expressroute-premium) is **not** required for Dynamics 365 connectivity via Azure ExpressRoute.
+> [!NOTE]
+> [ExpressRoute Premium](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-faqs#expressroute-premium) is **not** required for Dynamics 365 connectivity via Azure ExpressRoute.
 
 ## Data and connections
 

--- a/articles/expressroute/expressroute-faqs.md
+++ b/articles/expressroute/expressroute-faqs.md
@@ -85,8 +85,7 @@ ExpressRoute supports [three routing domains](expressroute-circuit-peerings.md) 
 
 ### Is Dynamics 365 supported on ExpressRoute?
 
-Dynamics 365 and Common Data Service (CDS) environments are hosted on Azure and therefore customers benefit from the underlying ExpressRoute support for Azure resources. You can connect to its service endpoints if your router filter includes the Azure regions your Dynamics 365/CDS environments are hosted in.
-
+Dynamics 365 and Common Data Service (CDS) environments are hosted on Azure and therefore customers benefit from the underlying ExpressRoute support for Azure resources. You can connect to its service endpoints if your router filter includes the Azure regions your Dynamics 365/CDS environments are hosted in. The Dynamics route filter is referred to as CRM Online, 12076:5040, and does not require the Premium Add-On. 
 
 ## Data and connections
 

--- a/articles/expressroute/expressroute-faqs.md
+++ b/articles/expressroute/expressroute-faqs.md
@@ -85,7 +85,9 @@ ExpressRoute supports [three routing domains](expressroute-circuit-peerings.md) 
 
 ### Is Dynamics 365 supported on ExpressRoute?
 
-Dynamics 365 and Common Data Service (CDS) environments are hosted on Azure and therefore customers benefit from the underlying ExpressRoute support for Azure resources. You can connect to its service endpoints if your router filter includes the Azure regions your Dynamics 365/CDS environments are hosted in. The Dynamics route filter is referred to as CRM Online, 12076:5040, and does not require the Premium Add-On. 
+Dynamics 365 and Common Data Service (CDS) environments are hosted on Azure and therefore customers benefit from the underlying ExpressRoute support for Azure resources. You can connect to its service endpoints if your router filter includes the Azure regions your Dynamics 365/CDS environments are hosted in.
+
+Note: [ExpressRoute Premium](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-faqs#expressroute-premium) is **not** required for Dynamics 365 connectivity via Azure ExpressRoute.
 
 ## Data and connections
 


### PR DESCRIPTION
Clarifying that the Route Filter name for Dynamics 365 is called CRM Online, 12076:5040. This causes lots of confusion and cases.