### PR TITLE
fix typo (extra space) in pip command

### DIFF
--- a/articles/machine-learning/service/how-to-configure-environment.md
+++ b/articles/machine-learning/service/how-to-configure-environment.md
@@ -183,7 +183,7 @@ When you're using a local computer (which might also be a remote virtual machine
     This command installs the base Azure Machine Learning SDK with notebook and `automl` extras. The `automl` extra is a large install, and can be removed from the brackets if you don't intend to run automated machine learning experiments. The `automl` extra also includes the Azure Machine Learning Data Prep SDK by default as a dependency.
 
     ```shell
-    pip install azureml-sdk[notebooks, automl]
+    pip install azureml-sdk[notebooks,automl]
     ```
 
    > [!NOTE]


### PR DESCRIPTION
local env step 4, pip cmd pip install azureml-sdk[notebooks, automl]
failed w/ ERROR: Invalid requirement: 'azureml-sdk[notebooks,'
until I removed the extra space:
pip install azureml-sdk[notebooks,automl]