### PR TITLE
Update how-to-configure-environment.md

### DIFF
--- a/articles/machine-learning/service/how-to-configure-environment.md
+++ b/articles/machine-learning/service/how-to-configure-environment.md
@@ -183,7 +183,7 @@ When you're using a local computer (which might also be a remote virtual machine
     This command installs the base Azure Machine Learning SDK with notebook and `automl` extras. The `automl` extra is a large install, and can be removed from the brackets if you don't intend to run automated machine learning experiments. The `automl` extra also includes the Azure Machine Learning Data Prep SDK by default as a dependency.
 
     ```shell
-    pip install azureml-sdk[notebooks, automl]
+    pip install azureml-sdk[notebooks,automl]
     ```
 
    > [!NOTE]


### PR DESCRIPTION
Took out extra space in "pip install azureml-sdk[notebooks, automl]", changed to "pip install azureml-sdk[notebooks,automl]".  The space inside the [] was causing an "ERROR: Invalid requirement: 'azureml-sdk[notebooks'" to be thrown.