### PR TITLE
Fix VMSS command line parameter

### DIFF
--- a/articles/aks/windows-container-cli.md
+++ b/articles/aks/windows-container-cli.md
@@ -139,7 +139,7 @@ az aks create \
     --generate-ssh-keys \
     --windows-admin-password $PASSWORD_WIN \
     --windows-admin-username azureuser \
-    --vm-set-type VirtualMachineScaleSets \
+    --enable-vmss \
     --network-plugin azure
 ```
 


### PR DESCRIPTION
The VMSS command line parameter changed from `--vm-set-type VirtualMachineScaleSets` to `--enable-vmss`