### PR TITLE
Updated to mention 'project-rename'

### DIFF
--- a/articles/azure-monitor/log-query/splunk-cheatsheet.md
+++ b/articles/azure-monitor/log-query/splunk-cheatsheet.md
@@ -120,12 +120,12 @@ Splunk also has an `eval` function, which is not to be comparable with the `eval
 
 
 ### Rename 
-Azure Monitor uses the same operator to rename and to create a new field. Splunk has two separate operators, `eval` and `rename`.
+Azure Monitor uses the `project-rename` operator to rename a field. `project-rename` allows the query to take advantage of any indexes pre-built for a field. Splunk has a `rename` operator to do the same.
 
 | |  | |
 |:---|:---|:---|
 | Splunk | **rename** |  <code>Event.Rule=330009.2<br>&#124; rename Date.Exception as execption</code> |
-| Azure Monitor | **extend** | <code>Office_Hub_OHubBGTaskError<br>&#124; extend exception = Date_Exception</code> |
+| Azure Monitor | **project-rename** | <code>Office_Hub_OHubBGTaskError<br>&#124; project-rename exception = Date_Exception</code> |
 | | |
 
 


### PR DESCRIPTION
project-rename is the complement to Splunk's rename operator. Both allow the query to take advantage of pre-built indexes, whereas 'project' and 'eval' do not.