### PR TITLE
Add instructions about how to paste from clipboard in nano

### DIFF
--- a/articles/iot-edge/how-to-install-iot-edge-linux.md
+++ b/articles/iot-edge/how-to-install-iot-edge-linux.md
@@ -188,6 +188,8 @@ Find the provisioning configurations of the file and uncomment the **Manual prov
    #     registration_id: "{registration_id}"
 ```
 
+To paste in nano editor press Shift + Insert.
+
 Save and close the file.
 
    `CTRL + X`, `Y`, `Enter`


### PR DESCRIPTION
Add instructions about how to paste from clipboard when editing in nano editor. 
Not everyone knows that Shift + Insert are the command, instead of Ctrl + V.