### PR TITLE
Correct the referenced package

### DIFF
--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -51,9 +51,9 @@ You use the [.NET Core command-line interface (CLI)](https://docs.microsoft.com/
 
 ## Connect to an app configuration store
 
-1. Add a reference to the `Microsoft.Azure.AppConfiguration.AspNetCore` NuGet package by running the following command:
+1. Add a reference to the `Microsoft.Extensions.Configuration.AzureAppConfiguration` NuGet package by running the following command:
 
-        dotnet add package Microsoft.Azure.AppConfiguration.AspNetCore --version 2.0.0-preview-009200001-7
+        dotnet add package Microsoft.Extensions.Configuration.AzureAppConfiguration --version 2.0.0-preview-009470001-1371
 
 2. Run the following command to restore packages for your project:
 


### PR DESCRIPTION
The .NET Core app should reference `Microsoft.Extensions.Configuration.AzureAppConfiguration` instead of `Microsoft.Azure.AppConfiguration.AspNetCore`. The latter is for ASP.NET Core app.