### PR TITLE
ignore warning Tip added

### DIFF
--- a/articles/cosmos-db/create-graph-gremlin-console.md
+++ b/articles/cosmos-db/create-graph-gremlin-console.md
@@ -81,7 +81,7 @@ make sure to wrap the value of hosts parameter within brackets [].
 1. In your terminal, run `:remote connect tinkerpop.server conf/remote-secure.yaml` to connect to your app service.
 
     > [!TIP]
-    > If you receive the error `No appenders could be found for logger` ensure that you updated the serializer value in the remote-secure.yaml file as described in step 2. 
+    > If you receive the error `No appenders could be found for logger` ensure that you updated the serializer value in the remote-secure.yaml file as described in step 2. If your configuration is correct, then this warning can be safely ignored as it should not impact the use of the console. 
 
 1. Next run `:remote console` to redirect all console commands to the remote server.
 


### PR DESCRIPTION
added further info to the existing Tip block to indicate that users can safely ignore the warning given, once they have confirmed that their configuration is correct.