### PR TITLE
Fix SSMS connection steps, password -> username

### DIFF
--- a/articles/private-link/create-private-endpoint-portal.md
+++ b/articles/private-link/create-private-endpoint-portal.md
@@ -222,9 +222,9 @@ After you've created **myVm*, connect to it from the internet as follows:
     | ------- | ----- |
     | Server type| Select **Database Engine**.|
     | Server name| Select *myserver.database.windows.net* |
-    | User name | Enter a password provided during the SQL server creation. |
-    |Password |Enter a password provided during the SQL server creation. |
-    |Remember password|Select **Yes**.|
+    | User name | Enter username provided during the SQL server creation. |
+    | Password |Enter a password provided during the SQL server creation. |
+    | Remember password |Select **Yes**.|
     |||
 1. Select **Connect**.
 2. Browse databases from left menu.


### PR DESCRIPTION
Previously had "password" in the User name instructions for connecting to SQL Server.  Updating to use "username" instead.