### PR TITLE
Fix 'Example configuration script', it is missing 'configurationArguments'

### DIFF
--- a/articles/virtual-machines/extensions/dsc-template.md
+++ b/articles/virtual-machines/extensions/dsc-template.md
@@ -249,8 +249,10 @@ to set LCM metadata.
 
 ```json
 "settings": {
-    "RegistrationUrl" : "[parameters('registrationUrl1')]",
-    "NodeConfigurationName" : "nodeConfigurationNameValue1"
+    "configurationArguments": {
+        "RegistrationUrl" : "[parameters('registrationUrl1')]",
+        "NodeConfigurationName" : "nodeConfigurationNameValue1"
+    }
 },
 "protectedSettings": {
     "configurationArguments": {


### PR DESCRIPTION
This was my reference. I tested it and it's working. Without the fix, the VM will not register as a Node in Azure Automation.
https://github.com/mgreenegit/azure-policy/blob/67d3e891fa888d0c3e5eb1b2502cfffd7a0806f3/samples/Automation/deploy-extension-register-virtual-machines-state-config/azurepolicy.rules.json#L226