### PR TITLE
Document idempotency requirements

### DIFF
--- a/articles/role-based-access-control/role-assignments-template.md
+++ b/articles/role-based-access-control/role-assignments-template.md
@@ -154,6 +154,8 @@ New-AzDeployment -Location centralus -TemplateFile rbac-test.json -principalId $
 az deployment create --location centralus --template-file rbac-test.json --parameters principalId=$userid builtInRoleType=Reader
 ```
 
+Note this template is not idempotent unless the same roleNameGuid value is provided as a parameter for each deployment of the template. If no roleNameGuid is provided, by default a new GUID is generated on each deployment and subsequent deployments will fail with a Conflict: RoleAssignmentExists error.
+
 ## Create a role assignment at a resource scope
 
 If you need to create a role assignment at the level of a resource, the format of the role assignment is different. You provide the resource provider namespace and resource type of the resource to assign the role to. You also include the name of the resource in the name of the role assignment.
@@ -175,8 +177,6 @@ To use the template, you must specify the following inputs:
 
 - The unique identifier of a user, group, or application to assign the role to
 - The role to assign
-- A unique identifier that will be used for the role assignment, or you can use the default identifier
-
 
 ```json
 {
@@ -198,13 +198,6 @@ To use the template, you must specify the following inputs:
             ],
             "metadata": {
                 "description": "Built-in role to assign"
-            }
-        },
-        "roleNameGuid": {
-            "type": "string",
-            "defaultValue": "[newGuid()]",
-            "metadata": {
-                "description": "A new GUID used to identify the role assignment"
             }
         },
         "location": {
@@ -233,7 +226,7 @@ To use the template, you must specify the following inputs:
         {
             "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
             "apiVersion": "2018-09-01-preview",
-            "name": "[concat(variables('storageName'), '/Microsoft.Authorization/', parameters('roleNameGuid'))]",
+            "name": "[concat(variables('storageName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('storageName'))))]",
             "dependsOn": [
                 "[variables('storageName')]"
             ],

--- a/articles/role-based-access-control/role-assignments-template.md
+++ b/articles/role-based-access-control/role-assignments-template.md
@@ -154,7 +154,8 @@ New-AzDeployment -Location centralus -TemplateFile rbac-test.json -principalId $
 az deployment create --location centralus --template-file rbac-test.json --parameters principalId=$userid builtInRoleType=Reader
 ```
 
-Note this template is not idempotent unless the same roleNameGuid value is provided as a parameter for each deployment of the template. If no roleNameGuid is provided, by default a new GUID is generated on each deployment and subsequent deployments will fail with a Conflict: RoleAssignmentExists error.
+> [!NOTE]
+> This template is not idempotent unless the same `roleNameGuid` value is provided as a parameter for each deployment of the template. If no `roleNameGuid` is provided, by default a new GUID is generated on each deployment and subsequent deployments will fail with a `Conflict: RoleAssignmentExists` error.
 
 ## Create a role assignment at a resource scope
 


### PR DESCRIPTION
Change resource-specific role assignment to be idempotent by default. This explains & avoids a very common pitfall.