### PR TITLE
Fixed threshold parameters in examples.

### DIFF
--- a/articles/azure-monitor/platform/alerts-metric-create-templates.md
+++ b/articles/azure-monitor/platform/alerts-metric-create-templates.md
@@ -100,7 +100,7 @@ Save the json below as simplestaticmetricalert.json for the purpose of this walk
             }
         },
         "threshold": {
-            "type": "int",
+            "type": "double",
             "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
@@ -1141,7 +1141,7 @@ Save the json below as all-vms-in-resource-group-static.json for the purpose of 
             }
         },
         "threshold": {
-            "type": "int",
+            "type": "double",
             "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
@@ -1788,7 +1788,7 @@ Save the json below as all-vms-in-subscription-static.json for the purpose of th
             }
         },
         "threshold": {
-            "type": "int",
+            "type": "double",
             "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
@@ -2429,7 +2429,7 @@ Save the json below as list-of-vms-static.json for the purpose of this walk-thro
             }
         },
         "threshold": {
-            "type": "int",
+            "type": "double",
             "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."

--- a/articles/azure-monitor/platform/alerts-metric-create-templates.md
+++ b/articles/azure-monitor/platform/alerts-metric-create-templates.md
@@ -100,8 +100,8 @@ Save the json below as simplestaticmetricalert.json for the purpose of this walk
             }
         },
         "threshold": {
-            "type": "string",
-            "defaultValue": "0",
+            "type": "int",
+            "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
             }
@@ -1141,8 +1141,8 @@ Save the json below as all-vms-in-resource-group-static.json for the purpose of 
             }
         },
         "threshold": {
-            "type": "string",
-            "defaultValue": "0",
+            "type": "int",
+            "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
             }
@@ -1788,8 +1788,8 @@ Save the json below as all-vms-in-subscription-static.json for the purpose of th
             }
         },
         "threshold": {
-            "type": "string",
-            "defaultValue": "0",
+            "type": "int",
+            "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
             }
@@ -2429,8 +2429,8 @@ Save the json below as list-of-vms-static.json for the purpose of this walk-thro
             }
         },
         "threshold": {
-            "type": "string",
-            "defaultValue": "0",
+            "type": "int",
+            "defaultValue": 0,
             "metadata": {
                 "description": "The threshold value at which the alert is activated."
             }


### PR DESCRIPTION
This proposed change correlates to issue #40121 that I opened up. I was only able to test with "Template for a simple static threshold metric alert" and was unable to test the other templates. I assume the same changes apply to those as well.