### PR TITLE
Update virtual-machine-scale-sets-automatic-upgrade.md

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade.md
@@ -108,14 +108,14 @@ PUT or PATCH on `/subscriptions/subscription_id/resourceGroups/myResourceGroup/p
 ```
 
 ### Azure PowerShell
-Use the [Update-AzVmss](/powershell/module/az.compute/update-azvmss) cmdlet to check OS upgrade history for your scale set. The following example configures automatic upgrades for the scale set named *myScaleSet* in the resource group named *myResourceGroup*:
+Use the [Update-AzVmss](/powershell/module/az.compute/update-azvmss) cmdlet to configure automatic OS image upgrades for your scale set. The following example configures automatic upgrades for the scale set named *myScaleSet* in the resource group named *myResourceGroup*:
 
 ```azurepowershell-interactive
 Update-AzVmss -ResourceGroupName "myResourceGroup" -VMScaleSetName "myScaleSet" -AutomaticOSUpgrade $true
 ```
 
 ### Azure CLI 2.0
-Use [az vmss update](/cli/azure/vmss#az-vmss-update) to check the OS upgrade history for your scale set. Use Azure CLI 2.0.47 or above. The following example configures automatic upgrades for the scale set named *myScaleSet* in the resource group named *myResourceGroup*:
+Use [az vmss update](/cli/azure/vmss#az-vmss-update) to configure automatic OS image upgrades for your scale set. Use Azure CLI 2.0.47 or above. The following example configures automatic upgrades for the scale set named *myScaleSet* in the resource group named *myResourceGroup*:
 
 ```azurecli-interactive
 az vmss update --name myScaleSet --resource-group myResourceGroup --set UpgradePolicy.AutomaticOSUpgradePolicy.EnableAutomaticOSUpgrade=true


### PR DESCRIPTION
lines 111 and 118 claimed that Update-AzVmss and "az vmss update" were used to get the update history of a scaleset, which is not true. i assume that line was wrongly copied and pasted from line 215 or 222 where in turn correctly Get-AzVmss and "az vm image list" are explained.
my changes were in lines 111 and 118 to say "to configure automatic OS image upgrades for your scale set" instead of "to check OS upgrade history of your scale set"