### PR TITLE
change typo 'function' to 'attribute' for context

### DIFF
--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -327,7 +327,7 @@ def main(req: azure.functions.HttpRequest,
     return f'{context.invocation_id}'
 ```
 
-The [**Context**](/python/api/azure-functions/azure.functions.context?view=azure-python) class has the following methods:
+The [**Context**](/python/api/azure-functions/azure.functions.context?view=azure-python) class has the following string attributes:
 
 `function_directory`  
 The directory in which the function is running.


### PR DESCRIPTION
azure.functions.context.function_directory and other fields is not callable: they are simply string attributes, not functions