### PR TITLE
delete wrong sentence

### DIFF
--- a/articles/security-center/security-center-alerts-data-services.md
+++ b/articles/security-center/security-center-alerts-data-services.md
@@ -22,7 +22,7 @@ ms.author: memildin
 
 ## SQL Database and SQL Data Warehouse <a name="data-sql"></a>
 
-SQL threat detection identifies anomalous activities indicating unusual and potentially harmful attempts to access or exploit databases. Security Center analyzes the SQL audit logs and runs natively in the SQL engine.
+SQL threat detection identifies anomalous activities indicating unusual and potentially harmful attempts to access or exploit databases. 
 
 |Alert|Description|
 |---|---|


### PR DESCRIPTION
delete: "Security Center analyzes the SQL audit logs and runs natively in the SQL engine." 
"runs natively in the SQL engine" is just wrong.
the "Security Center analyzes the SQL audit logs" is obvious and not needed without the second part of the sentence