### PR TITLE
Fix code that does not compile

### DIFF
--- a/articles/azure-monitor/app/worker-service.md
+++ b/articles/azure-monitor/app/worker-service.md
@@ -3,7 +3,7 @@ title: Application Insights for Worker Service apps (non-HTTP apps) | Microsoft 
 description: Monitoring .NET Core/.NET Framework non-HTTP apps with Application Insights.
 services: application-insights
 documentationcenter: .net
-author: cithomas
+author: cijothomas
 manager: carmonm
 ms.assetid: 3b722e47-38bd-4667-9ba4-65b7006c074c
 ms.service: application-insights

--- a/articles/azure-monitor/app/worker-service.md
+++ b/articles/azure-monitor/app/worker-service.md
@@ -93,9 +93,9 @@ Full example is shared [here](https://github.com/microsoft/ApplicationInsights-H
                 {
                     _logger.LogWarning("A sample warning message. By default, logs with severity Warning or higher is captured by Application Insights");
                     _logger.LogInformation("Calling bing.com");
-                    var res = await httpClient.GetAsync("https://bing.com");
+                    var res = await _httpClient.GetAsync("https://bing.com");
                     _logger.LogInformation("Calling bing completed with status:" + res.StatusCode);
-                    telemetryClient.TrackEvent("Bing call event completed");
+                    _telemetryClient.TrackEvent("Bing call event completed");
                 }
 
                 await Task.Delay(1000, stoppingToken);


### PR DESCRIPTION
telemetryClient and httpClient instances in ExecuteAsync method should be prefixed with _ in order to compile the example.