### PR TITLE
add ns creation command upfront

### DIFF
--- a/articles/aks/istio-install.md
+++ b/articles/aks/istio-install.md
@@ -175,6 +175,8 @@ Now move on to the next section to [Install the Istio CRDs on AKS](#install-the-
 Istio uses [Custom Resource Definitions (CRDs)][kubernetes-crd] to manage its runtime configuration. We need to install the Istio CRDs first, since the Istio components have a dependency on them. Use Helm and the `istio-init` chart to install the Istio CRDs into the `istio-system` namespace in your AKS cluster:
 
 ```azurecli
+kubectl create namespace istio-system
+
 helm install install/kubernetes/helm/istio-init --name istio-init --namespace istio-system
 ```
 


### PR DESCRIPTION
istio-system is not a namespace created upfront in AKS, you'll need to create by using kubectl utility before deploying istio to your AKS cluster. otherwise you'll get an error. I've already seen it happened to some users, for someone's not familiar with AKS or Service mesh, it is distracting. 