### PR TITLE
Tensorflow 2.0 compatibility

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/export-model-python.md
+++ b/articles/cognitive-services/Custom-Vision-Service/export-model-python.md
@@ -44,7 +44,7 @@ The downloaded zip file contains a model.pb and a labels.txt. These files repres
 import tensorflow as tf
 import os
 
-graph_def = tf.GraphDef()
+graph_def = tf.compat.v1.GraphDef()
 labels = []
 
 # These are set to the default names from exported models, update as needed.
@@ -52,7 +52,7 @@ filename = "model.pb"
 labels_filename = "labels.txt"
 
 # Import the TF graph
-with tf.gfile.GFile(filename, 'rb') as f:
+with tf.io.gfile.GFile(filename, 'rb') as f:
     graph_def.ParseFromString(f.read())
     tf.import_graph_def(graph_def, name='')
 
@@ -112,7 +112,7 @@ augmented_image = resize_to_256_square(max_square_image)
 
 ```Python
 # Get the input size of the model
-with tf.Session() as sess:
+with tf.compat.v1.Session() as sess:
     input_tensor_shape = sess.graph.get_tensor_by_name('Placeholder:0').shape.as_list()
 network_input_size = input_tensor_shape[1]
 
@@ -176,7 +176,7 @@ Once the image is prepared as a tensor, we can send it through the model for a p
 output_layer = 'loss:0'
 input_node = 'Placeholder:0'
 
-with tf.Session() as sess:
+with tf.compat.v1.Session() as sess:
     try:
         prob_tensor = sess.graph.get_tensor_by_name(output_layer)
         predictions, = sess.run(prob_tensor, {input_node: [augmented_image] })


### PR DESCRIPTION
The instructions were correct for tensorflow 1, but the latest 1.14 would already produce some deprecation warnings.
Using the latest tensorflow 2, the deprecated accesses were removed, rendering the sample code not working.

These changes make the sample code compatible with tensorflow 1.14 and 2.0