### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#40251

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell.md
+++ b/articles/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell.md
@@ -105,7 +105,7 @@ The following table lists the corresponding Diffie-Hellman Groups supported by t
 | 2                         | DHGroup2                 | PFS2         | 1024-bit MODP  |
 | 14                        | DHGroup14<br>DHGroup2048 | PFS2048      | 2048-bit MODP  |
 | 19                        | ECP256                   | ECP256       | 256-bit ECP    |
-| 20                        | ECP384                   | ECP284       | 384-bit ECP    |
+| 20                        | ECP384                   | ECP384       | 384-bit ECP    |
 | 24                        | DHGroup24                | PFS24        | 2048-bit MODP  |
 
 Refer to [RFC3526](https://tools.ietf.org/html/rfc3526) and [RFC5114](https://tools.ietf.org/html/rfc5114) for more details.


### PR DESCRIPTION
typo in 108 link -->  ECP384