### PR TITLE
Use AzCopy in a script -> linux script single line syntax error

### DIFF
--- a/articles/storage/common/storage-use-azcopy-v10.md
+++ b/articles/storage/common/storage-use-azcopy-v10.md
@@ -282,7 +282,7 @@ The URL appears in the output of this command. Your script can then download AzC
 
 | Operating system  | Command |
 |--------|-----------|
-| **Linux** | `wget -O azcopyv10.tar https://azcopyvnext.azureedge.net/release20190301/azcopy_linux_amd64_10.0.8.tar.gz tar -xf azcopyv10.tar --strip-components=1 ./azcopy` |
+| **Linux** | `wget -O azcopy_v10.tar.gz https://aka.ms/downloadazcopy-v10-linux && tar -xf azcopy_v10.tar.gz --strip-components=1` |
 | **Windows** | `Invoke-WebRequest https://azcopyvnext.azureedge.net/release20190517/azcopy_windows_amd64_10.1.2.zip -OutFile azcopyv10.zip <<Unzip here>>` |
 
 ### Escape special characters in SAS tokens


### PR DESCRIPTION
Could not execute as it was formatted as a one-line script, but has to be broken up into 2commands. Also updated the URI