### PR TITLE
Added steps to check feature registration state

### DIFF
--- a/articles/governance/policy/concepts/rego-for-aks.md
+++ b/articles/governance/policy/concepts/rego-for-aks.md
@@ -67,9 +67,22 @@ preview, follow these steps in either the Azure portal or with Azure CLI:
 
   # Feature register: enables installing the add-on
   az feature register --namespace Microsoft.ContainerService --name AKS-AzurePolicyAutoApprove
-
+  
+  # Use the following to confirm the feature has registered
+  az feature list -o table --query "[?contains(name, 'Microsoft.ContainerService/AKS-AzurePolicyAutoApprove')].{Name:name,State:properties.state}"
+  
+  # Once the above shows 'Registered' run the following to propagate the update
+  az provider register -n Microsoft.ContainerService
+  
   # Feature register: enables the add-on to call the Azure Policy resource provider
   az feature register --namespace Microsoft.PolicyInsights --name AKS-DataplaneAutoApprove
+  
+  # Use the following to confirm the feature has registered
+  az feature list -o table --query "[?contains(name, 'Microsoft.PolicyInsights/AKS-DataPlaneAutoApprove')].{Name:name,State:properties.state}"
+  
+  # Once the above shows 'Registered' run the following to propagate the update
+  az provider register -n Microsoft.PolicyInsights
+  
   ```
 
 ## Azure Policy Add-on


### PR DESCRIPTION
Minor update to the CLI steps to provide the reader the steps needed to check the status of the feature registration and then execute the register command to propagate the change for both the Microsoft.ContainerService/AKS-DataplaneAutoApprove and Microsoft.PolicyInsights/AKS-DataPlaneAutoApprove features.