### PR TITLE
Update groups-dynamic-membership.md

### DIFF
--- a/articles/active-directory/users-groups-roles/groups-dynamic-membership.md
+++ b/articles/active-directory/users-groups-roles/groups-dynamic-membership.md
@@ -376,8 +376,10 @@ The following device attributes can be used.
  enrollmentProfileName | Apple Device Enrollment Profile, Device enrollment - Corporate device identifiers (Android - Kiosk), or Windows Autopilot profile name | (device.enrollmentProfileName -eq "DEP iPhones")
  isRooted | true false | (device.isRooted -eq true)
  managementType | MDM (for mobile devices)<br>PC (for computers managed by the Intune PC agent) | (device.managementType -eq "MDM")
+ organizationalUnit | a valid on-premises organizational unit (OU) | (device.organizationalUnit -contains "laptop")
  deviceId | a valid Azure AD device ID | (device.deviceId -eq "d4fe7726-5966-431c-b3b8-cddc8fdb717d")
  objectId | a valid Azure AD object ID |  (device.objectId -eq 76ad43c9-32c5-45e8-a272-7b58b58f596d")
+ devicePhysicalIds | any string value used by Autopilot, such as all Autopilot devices, OrderID, or PurchaseOrderID  | (device.devicePhysicalIDs -any _ -contains "[ZTDId]") (device.devicePhysicalIds -any _ -eq "[OrderID]:179887111881") (device.devicePhysicalIds -any _ -eq "[PurchaseOrderId]:76222342342")
  systemLabels | any string matching the Intune device property for tagging Modern Workplace devices | (device.systemLabels -contains "M365Managed")
 
 > [!Note]  


### PR DESCRIPTION
Added Organizational Unit, which does appear in the AAD dynamic membership rules as a property.

Also added devicePhysicalIds based on details at https://docs.microsoft.com/en-us/intune/enrollment/enrollment-autopilot#create-an-autopilot-device-group