### PR TITLE
Update how-to-connect-configure-ad-ds-connector-account.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-configure-ad-ds-connector-account.md
+++ b/articles/active-directory/hybrid/how-to-connect-configure-ad-ds-connector-account.md
@@ -30,12 +30,12 @@ The following table provides a summary of the permissions required on AD objects
 
 | Feature | Permissions |
 | --- | --- |
-| ms-DS-ConsistencyGuid feature |Write permissions to the ms-DS-ConsistencyGuid attribute documented in [Design Concepts - Using ms-DS-ConsistencyGuid as sourceAnchor](plan-connect-design-concepts.md#using-ms-ds-consistencyguid-as-sourceanchor). | 
+| ms-DS-ConsistencyGuid feature |Read and Write permissions to the ms-DS-ConsistencyGuid attribute documented in [Design Concepts - Using ms-DS-ConsistencyGuid as sourceAnchor](plan-connect-design-concepts.md#using-ms-ds-consistencyguid-as-sourceanchor). | 
 | Password hash sync |<li>Replicate Directory Changes</li>  <li>Replicate Directory Changes All |
-| Exchange hybrid deployment |Write permissions to the attributes documented in [Exchange hybrid writeback](reference-connect-sync-attributes-synchronized.md#exchange-hybrid-writeback) for users, groups, and contacts. |
+| Exchange hybrid deployment |Read and Write permissions to the attributes documented in [Exchange hybrid writeback](reference-connect-sync-attributes-synchronized.md#exchange-hybrid-writeback) for users, groups, and contacts. |
 | Exchange Mail Public Folder |Read permissions to the attributes documented in [Exchange Mail Public Folder](reference-connect-sync-attributes-synchronized.md#exchange-mail-public-folder) for public folders. | 
-| Password writeback |Write permissions to the attributes documented in [Getting started with password management](../authentication/howto-sspr-writeback.md) for users. |
-| Device writeback |Write permissions to device objects and containers documented in [device writeback](how-to-connect-device-writeback.md). |
+| Password writeback |Read and Write permissions to the attributes documented in [Getting started with password management](../authentication/howto-sspr-writeback.md) for users. |
+| Device writeback |Read and Write permissions to device objects and containers documented in [device writeback](how-to-connect-device-writeback.md). |
 | Group writeback |Read, Create, Update, and Delete group objects for synchronized **Office 365 groups**.  For more information see [Group Writeback](how-to-connect-preview.md#group-writeback).|
 
 ## Using the ADSyncConfig PowerShell Module 


### PR DESCRIPTION
Small update under the Permissions Summary table to state the obvious need to have read permissions as well. Customer/Support might only look at this table and decide to apply Write permissions only, which is not enough and will generate an error in AADConnect.