### PR TITLE
Modify dbo.vTableSizes for DW500c and lower

### DIFF
--- a/articles/sql-data-warehouse/sql-data-warehouse-tables-overview.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-tables-overview.md
@@ -196,6 +196,7 @@ INNER JOIN sys.pdw_nodes_tables nt
     ON tm.[physical_name] = nt.[name]
 INNER JOIN sys.dm_pdw_nodes pn
     ON  nt.[pdw_node_id] = pn.[pdw_node_id]
+    AND pn.type = 'COMPUTE'
 INNER JOIN sys.pdw_distributions di
     ON  nt.[distribution_id] = di.[distribution_id]
 INNER JOIN sys.dm_pdw_nodes_db_partition_stats nps


### PR DESCRIPTION
The dbo.vTableSizes view logically assumes that the pdw_node_id in sys.dm_pdw_nodes is unique for each record; however, this is not true for SLOs of DW500c and below as the compute and control node are on the same host and have the same pdw_node_id.  To correct this assumption, I put in a join filter of pn.type = 'COMPUTE' as all of the metrics pertain to compute node information only.  If the type is not used as part of the join (or could be a filter - I just chose the join), the join causes all metrics to double due to the control node sharing the same pdw_node_id.

Again, this issue is not seen for DW1000c and above as the control node is separated from compute in those configurations.  The change to this view is recommended to make it accurate for DW500c and lower SLOs.  I just completed a repro with a customer to provide this same mitigation.