### PR TITLE
Fixed prerequisites relating to required permissions 

### DIFF
--- a/articles/sentinel/connect-azure-security-center.md
+++ b/articles/sentinel/connect-azure-security-center.md
@@ -28,7 +28,7 @@ Azure Sentinel enables you to connect alerts from [Azure Security Center](../sec
 
 ## Prerequisites
 
-- If you want to export alerts from Azure Security Center, you must be an owner of the subscription whose logs you stream.
+- To export alerts from Azure Security Center, you must have the Security Reader role in the subscription of the logs you stream.
 
 - You must have the [Azure Security Center Standard tier](../security-center/security-center-pricing.md) running on the subscription. If not, [upgrade your subscription to standard](https://azure.microsoft.com/pricing/details/security-center/).
 

--- a/articles/sentinel/connect-azure-security-center.md
+++ b/articles/sentinel/connect-azure-security-center.md
@@ -28,11 +28,10 @@ Azure Sentinel enables you to connect alerts from [Azure Security Center](../sec
 
 ## Prerequisites
 
-- If you want to export alerts from Azure Security Center, you must be a contributor on the subscription whose logs you stream.
+- If you want to export alerts from Azure Security Center, you must be an owner of the subscription whose logs you stream.
 
 - You must have the [Azure Security Center Standard tier](../security-center/security-center-pricing.md) running on the subscription. If not, [upgrade your subscription to standard](https://azure.microsoft.com/pricing/details/security-center/).
 
-- You must log in with a user that has global administrator or security administrator permissions on each subscription you want to connect.
 
 
 ## Connect to Azure Security Center


### PR DESCRIPTION
It is not required to be an azure active directory global administrator to get Azure Security Centre log information. Also it is required to be an Owner of the subscription for this connector to work and it is not accurate to state that this connector needs Azure AD Global administrator permissions. I have updated the document with correct permissions needed for this connector to work.