### PR TITLE
prerequisites section

### DIFF
--- a/articles/sentinel/connect-azure-activity.md
+++ b/articles/sentinel/connect-azure-activity.md
@@ -27,7 +27,7 @@ You can stream logs from [Azure Activity log](../azure-monitor/platform/activity
 
 ## Prerequisites
 
-- User with global administrator or security administrator permissions
+- User with contributor permissions to Log Analytics workspace 
 
 
 ## Connect to Azure Activity log


### PR DESCRIPTION
listed permissions are in correct. Global administrator is an Azure AD role and it's not an Azure role. For this activity, you only need write access to the subscription that is hosting the log analytics workspace.