### PR TITLE
M41584: Adding missing word "save"

### DIFF
--- a/articles/storage/blobs/data-lake-storage-migrate-on-premises-HDFS-cluster.md
+++ b/articles/storage/blobs/data-lake-storage-migrate-on-premises-HDFS-cluster.md
@@ -206,7 +206,7 @@ To create a service principal, see [How to: Use the portal to create an Azure AD
 
 * When performing the steps in the [Assign the application to a role](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#assign-the-application-to-a-role) section of the article, make sure to assign the **Storage Blob Data Contributor** role to the service principal.
 
-* When performing the steps in the [Get values for signing in](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#get-values-for-signing-in) section of the article, application ID, and client secret values into a text file. You'll need those soon.
+* When performing the steps in the [Get values for signing in](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#get-values-for-signing-in) section of the article, save application ID, and client secret values into a text file. You'll need those soon.
 
 ### Generate a list of copied files with their permissions
 


### PR DESCRIPTION
Translator has reported possible source content issue. 
Description: "save" word is missing before "application ID"