### PR TITLE
Removed the -containerSasToken $token

### DIFF
--- a/articles/azure-resource-manager/resource-group-linked-templates.md
+++ b/articles/azure-resource-manager/resource-group-linked-templates.md
@@ -518,7 +518,7 @@ In PowerShell, you get a token for the container and deploy the templates with t
 Set-AzCurrentStorageAccount -ResourceGroupName ManageGroup -Name storagecontosotemplates
 $token = New-AzStorageContainerSASToken -Name templates -Permission r -ExpiryTime (Get-Date).AddMinutes(30.0)
 $url = (Get-AzStorageBlob -Container templates -Blob parent.json).ICloudBlob.uri.AbsoluteUri
-New-AzResourceGroupDeployment -ResourceGroupName ExampleGroup -TemplateUri ($url + $token) -containerSasToken $token
+New-AzResourceGroupDeployment -ResourceGroupName ExampleGroup -TemplateUri ($url + $token)
 ```
 
 For Azure CLI in a Bash shell, you get a token for the container and deploy the templates with the following code:


### PR DESCRIPTION
When I run the script it throws an error. When I run the script without it works!

Error below:
New-AzResourceGroupDeployment : A parameter cannot be found that matches parameter name 'containerSasToken'.
At line:1 char:92
+ ... e ExampleGroup -TemplateUri ($url + $token) -containerSasToken $token
    + CategoryInfo          : InvalidArgument: (:) [New-AzResourceGroupDeployment], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.NewAzureResourceGroupDeploymentCmdlet