### PR TITLE
Fix error in Storage File Sync Agent Update policy PowerShell code

### DIFF
--- a/includes/storage-sync-files-agent-update-policy.md
+++ b/includes/storage-sync-files-agent-update-policy.md
@@ -31,19 +31,23 @@ With agent version 6, the file sync team has introduced an agent auto-upgrade fe
 
 The following instructions describe how to change the settings after you've completed the installer, if you need to make changes.
 
-Open a shell and navigate to the directory where you installed the sync agent then import the server cmdlets, by default this would look something like this:
+Open a PowerShell console and navigate to the directory where you installed the sync agent then import the server cmdlets. By default this would look something like this:
 ```powershell
-cd C:\Program Files\Azure\StorageSyncAgent
-
-ipmo .\StorageSync.Management.ServerCmdlets.dll
+cd 'C:\Program Files\Azure\StorageSyncAgent'
+Import-Module -Name \StorageSync.Management.ServerCmdlets.dll
 ```
 
 You can run `Get-StorageSyncAgentAutoUpdatePolicy` to check the current policy setting and determine if you want to change it.
 
-To change the current policy setting to the delayed update track, you can use: `Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode UpdateBeforeExpiration`
+To change the current policy setting to the delayed update track, you can use: 
+```powershell
+Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode UpdateBeforeExpiration`
+```
 
 To change the current policy setting to the immediate update track, you can use:
-`Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode InstallLatest`
+```powershell
+Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode InstallLatest
+```
 
 #### Agent lifecycle and change management guarantees
 Azure File Sync is a cloud service, which continuously introduces new features and improvements. This means that a specific Azure File Sync agent version can only be supported for a limited time. To facilitate your deployment, the following rules guarantee you have enough time and notification to accommodate agent updates/upgrades in your change management process:

--- a/includes/storage-sync-files-agent-update-policy.md
+++ b/includes/storage-sync-files-agent-update-policy.md
@@ -39,7 +39,7 @@ Import-Module -Name \StorageSync.Management.ServerCmdlets.dll
 
 You can run `Get-StorageSyncAgentAutoUpdatePolicy` to check the current policy setting and determine if you want to change it.
 
-To change the current policy setting to the delayed update track, you can use: 
+To change the current policy setting to the delayed update track, you can use:
 ```powershell
 Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode UpdateBeforeExpiration`
 ```

--- a/includes/storage-sync-files-agent-update-policy.md
+++ b/includes/storage-sync-files-agent-update-policy.md
@@ -41,7 +41,7 @@ You can run `Get-StorageSyncAgentAutoUpdatePolicy` to check the current policy s
 
 To change the current policy setting to the delayed update track, you can use:
 ```powershell
-Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode UpdateBeforeExpiration`
+Set-StorageSyncAgentAutoUpdatePolicy -PolicyMode UpdateBeforeExpiration
 ```
 
 To change the current policy setting to the immediate update track, you can use:


### PR DESCRIPTION
The PowerShell example code on the `includes/storage-sync-files-agent-update-policy.md` would fail because of the space in the path. Also, using the `ipmo` alias makes the code less readable, so I also changed this to the full Import-Module name.

I've also included some other minor tweaks to the wording and put the other code examples in PowerShell code blocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoftdocs/azure-docs/40671)
<!-- Reviewable:end -->
