### PR TITLE
Databricks Runtime Version 5.2 no longer available

### DIFF
--- a/articles/azure-databricks/quickstart-create-databricks-workspace-portal.md
+++ b/articles/azure-databricks/quickstart-create-databricks-workspace-portal.md
@@ -74,7 +74,7 @@ In this section, you create an Azure Databricks workspace using the Azure portal
     Accept all other default values other than the following:
 
    * Enter a name for the cluster.
-   * For this article, create a cluster with **5.2** runtime.
+   * For this article, create a cluster with **5.3** runtime.
    * Make sure you select the **Terminate after \_\_ minutes of inactivity** checkbox. Provide a duration (in minutes) to terminate the cluster, if the cluster is not being used.
     
      Select **Create cluster**. Once the cluster is running, you can attach notebooks to the cluster and run Spark jobs.


### PR DESCRIPTION
Runtime version 5.2 is no longer available for selection in the selectionlist when creating a new cluster. 5.3 is the current oldest 5.X version you can select. There are 4 different 5.3 runtimes available, 5.3 with or without GPU and 5.3 ML with or without GPU. Please specify which one to choose in the context of the article and perhaps a link to documentation explaining the differences.