### PR TITLE
Change double quote to single to fix formatting

### DIFF
--- a/articles/azure-monitor/platform/alerts-metric-create-templates.md
+++ b/articles/azure-monitor/platform/alerts-metric-create-templates.md
@@ -2474,7 +2474,7 @@ Save the json below as list-of-vms-static.json for the purpose of this walk-thro
                 "PT5M",
                 "PT15M",
                 "PT30M",
-                "PT1H""
+                "PT1H"
             ],
             "metadata": {
                 "description": "how often the metric alert is evaluated represented in ISO 8601 duration format"


### PR DESCRIPTION
alerts-metric-create-templates.md contained a double quote at the end of a string in a json-file ("PT1H"" instead of "PT1H") which caused formatting of the json content to break. Simple typo fix.