### PR TITLE
Remove Minute Metrics note from Storage Analytics Metrics

### DIFF
--- a/articles/storage/common/storage-analytics-metrics.md
+++ b/articles/storage/common/storage-analytics-metrics.md
@@ -68,9 +68,6 @@ Follow these steps to enable metrics in the [Azure portal](https://portal.azure.
 
 The [Azure portal](https://portal.azure.com) does not currently enable you to configure minute metrics in your storage account; you must enable minute metrics using PowerShell or programmatically.
 
-> [!NOTE]
->  Note that the Azure portal does not currently enable you to configure minute metrics in your storage account. You must enable minute metrics using PowerShell or programmatically.
-
 ## Enable Storage metrics using PowerShell  
 You can use PowerShell on your local machine to configure Storage Metrics in your storage account by using the Azure PowerShell cmdlet **Get-AzureStorageServiceMetricsProperty** to retrieve the current settings, and the cmdlet **Set-AzureStorageServiceMetricsProperty** to change the current settings.  
 

--- a/articles/storage/common/storage-analytics-metrics.md
+++ b/articles/storage/common/storage-analytics-metrics.md
@@ -69,7 +69,7 @@ Follow these steps to enable metrics in the [Azure portal](https://portal.azure.
 The [Azure portal](https://portal.azure.com) does not currently enable you to configure minute metrics in your storage account; you must enable minute metrics using PowerShell or programmatically.
 
 ## Enable Storage metrics using PowerShell  
-You can use PowerShell on your local machine to configure Storage Metrics in your storage account by using the Azure PowerShell cmdlet **Get-AzureStorageServiceMetricsProperty** to retrieve the current settings, and the cmdlet **Set-AzureStorageServiceMetricsProperty** to change the current settings.  
+You can use PowerShell on your local machine to configure Storage Metrics in your storage account by using the Azure PowerShell cmdlet **Get-AzStorageServiceMetricsProperty** to retrieve the current settings, and the cmdlet **Set-AzStorageServiceMetricsProperty** to change the current settings.  
 
 The cmdlets that control Storage Metrics use the following parameters:  
 
@@ -85,22 +85,22 @@ For example, the following command switches on minute metrics for the blob servi
 > [!NOTE]
 > This command assumes that you've signed into your Azure subscription by using the `Connect-AzAccount` command.
 
-```  
+```powershell
 $storageAccount = Get-AzStorageAccount -ResourceGroupName "<resource-group-name>" -AccountName "<storage-account-name>"
 
-Set-AzureStorageServiceMetricsProperty -MetricsType Minute -ServiceType Blob -MetricsLevel ServiceAndApi  -RetentionDays 5 -Context $storageAccount.Context
+Set-AzStorageServiceMetricsProperty -MetricsType Minute -ServiceType Blob -MetricsLevel ServiceAndApi  -RetentionDays 5 -Context $storageAccount.Context
 ```  
 
 * Replace the `<resource-group-name>` placeholder value with the name of your resource group.
-
+        
 * Replace the `<storage-account-name>` placeholder value with the name of your storage account.
 
 
 
 The following command retrieves the current hourly metrics level and retention days for the blob service in your default storage account:  
 
-```  
-Get-AzureStorageServiceMetricsProperty -MetricsType Hour -ServiceType Blob -Context $storagecontext.Context
+```powershell
+Get-AzStorageServiceMetricsProperty -MetricsType Hour -ServiceType Blob -Context $storagecontext.Context
 ```  
 
 For information about how to configure the Azure PowerShell cmdlets to work with your Azure subscription and how to select the default storage account to use, see: [How to install and configure Azure PowerShell](https://azure.microsoft.com/documentation/articles/install-configure-powershell/).  


### PR DESCRIPTION
This PR removes the Note from the Storage Analytic Metrics page claiming that these Minute metrics cans can not be configured via the Portal (only via PowerShell). This no longer appears to be correct:
![image](https://user-images.githubusercontent.com/7589164/66812349-3a5c4c80-ef8f-11e9-8b50-2f5672846810.png)

I have also corrected the PowerShell examples to use only the Az cmdlets. The examples previously mixed Azure classic cmdlets and Az cmdlets which can result in authentication problems. I also set the PowerShell markdown blocks to be PowerShell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoftdocs/azure-docs/40756)
<!-- Reviewable:end -->
