### PR TITLE
Refresh Token call is passing a client secret

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-oauth-code.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oauth-code.md
@@ -168,7 +168,7 @@ POST {tenant}.onmicrosoft.com/{policy}/oauth2/v2.0/token HTTP/1.1
 Host: {tenant}.b2clogin.com
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=refresh_token&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&client_secret=JqQX2PNo9bpM0uEihUPzyrh&scope=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6 offline_access&refresh_token=AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrq...&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+grant_type=refresh_token&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6 offline_access&refresh_token=AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrq...&redirect_uri=urn:ietf:wg:oauth:2.0:oob
 ```
 
 | Parameter | Required? | Description |


### PR DESCRIPTION
Point 4 (https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oauth-code#4-refresh-the-token) captures the refresh_token call.

The latter call is used on the context of a public client as can be seen from the redirect_uri parameter (urn:ietf:wg:oauth:2.0:oob) and passes a client secret, which is not correct.

Can you please remove the client secret from this call or add a confidential client redirect_uri link instead?

Also it would be beneficial if you could write the distinction between public auth code flow and confidential auth code flow.

Disclaimer: this is merely a docs issue, I've tested both public and confidential flows and the service works as expected.