### PR TITLE
Public auth code flow does not use a client secret

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
@@ -137,7 +137,7 @@ POST {tenant}.onmicrosoft.com/{policy}/oauth2/v2.0/token HTTP/1.1
 Host: {tenant}.b2clogin.com
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=authorization_code&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6 offline_access&code=AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrq...&redirect_uri=urn:ietf:wg:oauth:2.0:oob&client_secret=<your-application-secret>
+grant_type=authorization_code&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6 offline_access&code=AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrq...&redirect_uri=urn:ietf:wg:oauth:2.0:oob
 ```
 
 | Parameter | Required | Description |


### PR DESCRIPTION
The point "Get a token" (https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oidc#get-a-token) uses a public redirect uri (urn:ietf:wg:oauth:2.0:oob) to redeem the code for a token. However in public auth code flow there are no client secrets passed since native apps do not have secrets. Please correct by either putting a confidential client redirect uri or removing the client secret from this call.

Disclaimer: this is merely a docs issue, I've tested both public and confidential flows and the service works as expected.