### PR TITLE
Public Refresh token call does not pass a secret

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
@@ -206,7 +206,7 @@ POST {tenant}.onmicrosoft.com/{policy}/oauth2/v2.0/token HTTP/1.1
 Host: {tenant}.b2clogin.com
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=refresh_token&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=openid offline_access&refresh_token=AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrq...&redirect_uri=urn:ietf:wg:oauth:2.0:oob&client_secret=<your-application-secret>
+grant_type=refresh_token&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=openid offline_access&refresh_token=AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrq...&redirect_uri=urn:ietf:wg:oauth:2.0:oob
 ```
 
 | Parameter | Required | Description |


### PR DESCRIPTION
The point "Refresh the token" (https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oidc#refresh-the-token) uses a public redirect uri (urn:ietf:wg:oauth:2.0:oob). However in public refresh token flow, there are no client secrets passed since native apps do not have secrets. Please correct by either putting a confidential client redirect uri or removing the client secret from this call.

Disclaimer: this is merely a docs issue, I've tested both public and confidential flows and the service works as expected.