### PR TITLE
azure-files-volume.md: Don't use legacy subshell notation

### DIFF
--- a/articles/aks/azure-files-volume.md
+++ b/articles/aks/azure-files-volume.md
@@ -43,7 +43,7 @@ az group create --name $AKS_PERS_RESOURCE_GROUP --location $AKS_PERS_LOCATION
 az storage account create -n $AKS_PERS_STORAGE_ACCOUNT_NAME -g $AKS_PERS_RESOURCE_GROUP -l $AKS_PERS_LOCATION --sku Standard_LRS
 
 # Export the connection string as an environment variable, this is used when creating the Azure file share
-export AZURE_STORAGE_CONNECTION_STRING=`az storage account show-connection-string -n $AKS_PERS_STORAGE_ACCOUNT_NAME -g $AKS_PERS_RESOURCE_GROUP -o tsv`
+export AZURE_STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -n $AKS_PERS_STORAGE_ACCOUNT_NAME -g $AKS_PERS_RESOURCE_GROUP -o tsv)
 
 # Create the file share
 az storage share create -n $AKS_PERS_SHARE_NAME --connection-string $AZURE_STORAGE_CONNECTION_STRING


### PR DESCRIPTION
Using the legacy subshell notation `` ` `` in bash is usually discouraged. Mixing the legacy subshell notation and the newer one `$()` is very discouraged, and confusing at the very least. I had to re-read this shell script a few times until I realized what was going on.