### PR TITLE
Fix variable syntax in the example script

### DIFF
--- a/articles/aks/use-network-policies.md
+++ b/articles/aks/use-network-policies.md
@@ -80,9 +80,9 @@ The following example script:
 Provide your own secure *SP_PASSWORD*. You can replace the *RESOURCE_GROUP_NAME* and *CLUSTER_NAME* variables:
 
 ```azurecli-interactive
-RESOURCE_GROUP_NAME=myResourceGroup-NP
-CLUSTER_NAME=myAKSCluster
-LOCATION=canadaeast
+$RESOURCE_GROUP_NAME="myResourceGroup-NP"
+$CLUSTER_NAME="myAKSCluster"
+$LOCATION="canadaeast"
 
 # Create a resource group
 az group create --name $RESOURCE_GROUP_NAME --location $LOCATION
@@ -96,22 +96,22 @@ az network vnet create \
     --subnet-prefix 10.240.0.0/16
 
 # Create a service principal and read in the application ID
-SP=$(az ad sp create-for-rbac --output json)
-SP_ID=$(echo $SP | jq -r .appId)
-SP_PASSWORD=$(echo $SP | jq -r .password)
+$SP=$(az ad sp create-for-rbac --output json)
+$SP_ID=$(echo $SP | jq -r .appId)
+$SP_PASSWORD=$(echo $SP | jq -r .password)
 
 # Wait 15 seconds to make sure that service principal has propagated
 echo "Waiting for service principal to propagate..."
 sleep 15
 
 # Get the virtual network resource ID
-VNET_ID=$(az network vnet show --resource-group $RESOURCE_GROUP_NAME --name myVnet --query id -o tsv)
+$VNET_ID=$(az network vnet show --resource-group $RESOURCE_GROUP_NAME --name myVnet --query id -o tsv)
 
 # Assign the service principal Contributor permissions to the virtual network resource
 az role assignment create --assignee $SP_ID --scope $VNET_ID --role Contributor
 
 # Get the virtual network subnet resource ID
-SUBNET_ID=$(az network vnet subnet show --resource-group $RESOURCE_GROUP_NAME --vnet-name myVnet --name myAKSSubnet --query id -o tsv)
+$SUBNET_ID=$(az network vnet subnet show --resource-group $RESOURCE_GROUP_NAME --vnet-name myVnet --name myAKSSubnet --query id -o tsv)
 
 # Create the AKS cluster and specify the virtual network and service principal information
 # Enable network policy by using the `--network-policy` parameter


### PR DESCRIPTION
Some of the PowerShell variables were missing the leading $; I also put double quotes around the strings provided for the first three values