### PR TITLE
Updated note section as below as it was not clear enough for customers

### DIFF
--- a/articles/active-directory/devices/hybrid-azuread-join-control.md
+++ b/articles/active-directory/devices/hybrid-azuread-join-control.md
@@ -79,7 +79,7 @@ Use the following example to create a Group Policy Object (GPO) to deploy a regi
 If you are using AD FS, you first need to configure client-side SCP using the instructions mentioned above but linking the GPO to your AD FS servers. The SCP object defines the source of authority for device objects. It can be on-premises or Azure AD. When this is configured for AD FS, the source for device objects is established as Azure AD.
 
 > [!NOTE]
-> If you failed to configure client-side SCP on your AD FS servers, the source for device identities would be considered as on-premises, and AD FS would start deleting device objects from on-premises directory after a stipulated period.
+> If you failed to configure client-side SCP on your AD FS servers, the source for device identities would be considered as on-premises, and if you have device writeback, AD FS would start deleting device objects from on-premises registered device container after a stipulated period.
 
 ## Controlled validation of hybrid Azure AD join on Windows down-level devices
 


### PR DESCRIPTION
 If you failed to configure client-side SCP on your AD FS servers, the source for device identities would be considered as on-premises, and if you have device writeback, AD FS would start deleting device objects from on-premises registered device container after a stipulated period.