### PR TITLE
reference using directive (not a using statement)

### DIFF
--- a/articles/cloud-services/cloud-services-dotnet-diagnostics-trace-flow.md
+++ b/articles/cloud-services/cloud-services-dotnet-diagnostics-trace-flow.md
@@ -60,7 +60,7 @@ After you complete the steps to add the listener, you can add trace statements t
 
 ### To add trace statement to your code
 1. Open a source file for your application. For example, the \<RoleName>.cs file for the worker role or web role.
-2. Add the following using statement if it has not already been added:
+2. Add the following using directive if it has not already been added:
     ```
         using System.Diagnostics;
     ```


### PR DESCRIPTION
Address incorrect use of ["using statement"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement) to refer to a ["using directive"](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-directive).