### PR TITLE
correct syntax for az CLI

### DIFF
--- a/articles/healthcare-apis/fhir-paas-cli-quickstart.md
+++ b/articles/healthcare-apis/fhir-paas-cli-quickstart.md
@@ -55,7 +55,7 @@ az group create --name "myResourceGroup" --location westus2
 Use the template (`azuredeploy.json`) and the template parameter file (`azuredeploy.parameters.json`) to deploy the Azure API for FHIR:
 
 ```azurecli-interactive
-az group deployment create -g "myResourceGroup" --template-file azuredeploy.json --parameters @{azuredeploy.parameters.json}
+az group deployment create -g "myResourceGroup" --template-file azuredeploy.json --parameters @azuredeploy.parameters.json
 ```
 
 ## Fetch FHIR API capability statement


### PR DESCRIPTION
The parameters file should not be enclosed in {} for CLI commands. Without this change the deploy step will fail with the error "Unable to parse parameter: @{azuredeploy.parameters.json}"