### PR TITLE
Update - Allow third-party cookies requirement for Security info

### DIFF
--- a/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
@@ -33,6 +33,9 @@ Azure AD combined security information registration is not currently available t
 > [!IMPORTANT]
 > Users who are enabled for both the original preview and the enhanced combined registration experience will see the new behavior. Users who are enabled for both experiences will see only the new My Profile experience. The new My Profile aligns with the look and feel of combined registration and provides a seamless experience for users. Users can see My Profile by going to [https://myprofile.microsoft.com](https://myprofile.microsoft.com).
 
+> [!NOTE] 
+> If you encounter any error message while trying to access the Security info option (e.g. "Sorry, we can't sign you in"), please confirm that you do not have any configuration or group policy object that blocks third-party cookies on the web browser. 
+
 My Profile pages are localized based on the language settings of the computer accessing the page. Microsoft stores the most recent language used in the browser cache, so subsequent attempts to access the pages will continue to render in the last language used. If you clear the cache, the pages will re-render. If you want to force a specific language, you can add `?lng=<language>` to the end of the URL, where `<language>` is the code of the language you want to render.
 
 ![Set up SSPR or other security verification methods](media/howto-registration-mfa-sspr-combined/combined-security-info-my-profile.png)

--- a/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
@@ -34,7 +34,7 @@ Azure AD combined security information registration is not currently available t
 > Users who are enabled for both the original preview and the enhanced combined registration experience will see the new behavior. Users who are enabled for both experiences will see only the new My Profile experience. The new My Profile aligns with the look and feel of combined registration and provides a seamless experience for users. Users can see My Profile by going to [https://myprofile.microsoft.com](https://myprofile.microsoft.com).
 
 > [!NOTE] 
-> You might encounter any error messages while trying to access the Security info option. For example, "Sorry, we can't sign you in". In this case, confirm that you don't have any configuration or group policy object that blocks third-party cookies on the web browser. 
+> You might encounter an error message while trying to access the Security info option. For example, "Sorry, we can't sign you in". In this case, confirm that you don't have any configuration or group policy object that blocks third-party cookies on the web browser. 
 
 My Profile pages are localized based on the language settings of the computer accessing the page. Microsoft stores the most recent language used in the browser cache, so subsequent attempts to access the pages will continue to render in the last language used. If you clear the cache, the pages will re-render. If you want to force a specific language, you can add `?lng=<language>` to the end of the URL, where `<language>` is the code of the language you want to render.
 

--- a/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
@@ -34,7 +34,7 @@ Azure AD combined security information registration is not currently available t
 > Users who are enabled for both the original preview and the enhanced combined registration experience will see the new behavior. Users who are enabled for both experiences will see only the new My Profile experience. The new My Profile aligns with the look and feel of combined registration and provides a seamless experience for users. Users can see My Profile by going to [https://myprofile.microsoft.com](https://myprofile.microsoft.com).
 
 > [!NOTE] 
-> If you encounter any error message while trying to access the Security info option (e.g. "Sorry, we can't sign you in"), please confirm that you do not have any configuration or group policy object that blocks third-party cookies on the web browser. 
+> You might encounter any error messages while trying to access the Security info option. For example, "Sorry, we can't sign you in". In this case, confirm that you don't have any configuration or group policy object that blocks third-party cookies on the web browser. 
 
 My Profile pages are localized based on the language settings of the computer accessing the page. Microsoft stores the most recent language used in the browser cache, so subsequent attempts to access the pages will continue to render in the last language used. If you clear the cache, the pages will re-render. If you want to force a specific language, you can add `?lng=<language>` to the end of the URL, where `<language>` is the code of the language you want to render.
 


### PR DESCRIPTION
When accessing Security info option inside Mysignins, https://mysignins.microsoft.com/security-info, third-party cookies must be allowed on the web browsers configuration. If you block them, access will not be allowed.