### PR TITLE
Update resource-manager-governance-tags.md

### DIFF
--- a/includes/resource-manager-governance-tags.md
+++ b/includes/resource-manager-governance-tags.md
@@ -25,4 +25,6 @@ The following limitations apply to tags:
 * Tags applied to the resource group are not inherited by the resources in that resource group.
 * Tags can't be applied to classic resources such as Cloud Services.
 * Tag names can't contain these characters: `<`, `>`, `%`, `&`, `\`, `?`, `/`
-* Please note, currently Azure DNS zones and Traffic Manger services do not allow the use of spaces either in the tag. 
+
+   > [!NOTE]
+   > Currently Azure DNS zones and Traffic Manger services also don't allow the use of spaces in the tag. 

--- a/includes/resource-manager-governance-tags.md
+++ b/includes/resource-manager-governance-tags.md
@@ -25,3 +25,4 @@ The following limitations apply to tags:
 * Tags applied to the resource group are not inherited by the resources in that resource group.
 * Tags can't be applied to classic resources such as Cloud Services.
 * Tag names can't contain these characters: `<`, `>`, `%`, `&`, `\`, `?`, `/`
+* Please note, currently Azure DNS zones and Traffic Manger services do not allow the use of spaces either in the tag. 


### PR DESCRIPTION
Rohin Koul  PRINCIPAL PROGRAM MANAGER mentioned the following.  Customer has a space in the tag that s/he is trying to apply. There is a known issue in Azure DNS and Traffic Manager services and tags with spaces do not work. Please advice the customer to use “Cost_Center” or “CostCenter”  instead of “Cost Center”

Please add the line that I have proposed.

Thanks,