### PR TITLE
Update StorageClass - Az disk is deleted when PV is deleted

### DIFF
--- a/articles/aks/concepts-storage.md
+++ b/articles/aks/concepts-storage.md
@@ -56,8 +56,8 @@ To define different tiers of storage, such as Premium and Standard, you can crea
 
 In AKS, two initial StorageClasses are created:
 
-- *default* - Uses Azure Standard storage to create a Managed Disk. The reclaim policy indicates that the underlying Azure Disk is deleted when the pod that used it is deleted.
-- *managed-premium* - Uses Azure Premium storage to create Managed Disk. The reclaim policy again indicates that the underlying Azure Disk is deleted when the pod that used it is deleted.
+- *default* - Uses Azure Standard storage to create a Managed Disk. The reclaim policy indicates that the underlying Azure Disk is deleted when the persistent volume that used it is deleted.
+- *managed-premium* - Uses Azure Premium storage to create Managed Disk. The reclaim policy again indicates that the underlying Azure Disk is deleted when the persistent volume that used it is deleted.
 
 If no StorageClass is specified for a persistent volume, the default StorageClass is used. Take care when requesting persistent volumes so that they use the appropriate storage you need. You can create a StorageClass for additional needs using `kubectl`. The following example uses Premium Managed Disks and specifies that the underlying Azure Disk should be *retained* when the pod is deleted:
 


### PR DESCRIPTION
The managed storage class is deleted when the persistent volume is deleted, not pod.