### PR TITLE
Simplified PowerShell invoking Azure Rest API's fixes #41114

### DIFF
--- a/articles/governance/policy/how-to/get-compliance-data.md
+++ b/articles/governance/policy/how-to/get-compliance-data.md
@@ -214,24 +214,14 @@ that can then be parsed.
 ```azurepowershell-interactive
 # Login first with Connect-AzAccount if not using Cloud Shell
 
-$azContext = Get-AzContext
-$azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
-$profileClient = New-Object -TypeName Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient -ArgumentList ($azProfile)
-$token = $profileClient.AcquireAccessToken($azContext.Subscription.TenantId)
-$authHeader = @{
-    'Content-Type'='application/json'
-    'Authorization'='Bearer ' + $token.AccessToken
-}
+# Invoke the REST API using the Invoke-AzResourceAction Cmdlet
+$response = Invoke-AzResourceAction -ResourceType Microsoft.PolicyInsights/policyStates -Action summarize -ResourceName latest -ApiVersion 2018-04-04 -Verbose -Force
 
-# Define the REST API to communicate with
-# Use double quotes for $restUri as some endpoints take strings passed in single quotes
-$restUri = "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04"
+# View the response object in a Table View 
+$response | Format-Table
 
-# Invoke the REST API
-$response = Invoke-RestMethod -Uri $restUri -Method POST -Headers $authHeader
-
-# View the response object (as JSON)
-$response
+# Optionally - View the response object as JSON
+$response | ConvertTo-Json
 ```
 
 ### Summarize results


### PR DESCRIPTION
Instead of needing to construct a messy amount of code to get Auth tokens you can run `Invoke-AzResourceAction` cmdlet

This fixes #41114