### PR TITLE
Updated code example to get the most recently created node

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-scale-up-down.md
+++ b/articles/service-fabric/service-fabric-cluster-scale-up-down.md
@@ -108,7 +108,7 @@ The steps for manually removing node state apply only to node types with a *Bron
 To keep the nodes of the cluster evenly distributed across upgrade and fault domains, and hence enable their even utilization, the most recently created node should be removed first. In other words, the nodes should be removed in the reverse order of their creation. The most recently created node is the one with the greatest `virtual machine scale set InstanceId` property value. The code examples below return the most recently created node.
 
 ```powershell
-Get-ServiceFabricNode | Sort-Object { $_.NodeName.Substring($_.NodeName.LastIndexOf('_') + 1) } -Descending | Select-Object -First 1
+Get-ServiceFabricNode | Sort NodeInstanceId -Descending | Select -First 1
 ```
 
 ```azurecli

--- a/articles/service-fabric/service-fabric-cluster-scale-up-down.md
+++ b/articles/service-fabric/service-fabric-cluster-scale-up-down.md
@@ -108,7 +108,7 @@ The steps for manually removing node state apply only to node types with a *Bron
 To keep the nodes of the cluster evenly distributed across upgrade and fault domains, and hence enable their even utilization, the most recently created node should be removed first. In other words, the nodes should be removed in the reverse order of their creation. The most recently created node is the one with the greatest `virtual machine scale set InstanceId` property value. The code examples below return the most recently created node.
 
 ```powershell
-Get-ServiceFabricNode | Sort NodeInstanceId -Descending | Select -First 1
+Get-ServiceFabricNode | Sort-Object NodeInstanceId -Descending | Select-Object -First 1
 ```
 
 ```azurecli


### PR DESCRIPTION
Per the text above this example, the most recently created node is the one with the greatest `NodeInstanceId` property, so you can get it by just sort descending on this property and grabbing the first one.

The code that was provided split the name of the node to find the node with the highest number in its name, but this didn't work if you had more than 10 nodes because _node1_10 (for example) was treated as if it was numbered 1.