### PR TITLE
Terratest unit test fix: FormatArgs expecting an Options reference type

### DIFF
--- a/articles/terraform/terratest-in-terraform-modules.md
+++ b/articles/terraform/terratest-in-terraform-modules.md
@@ -222,7 +222,7 @@ func TestUT_StorageAccountName(t *testing.T) {
 		// Terraform init and plan only
 		tfPlanOutput := "terraform.tfplan"
 		terraform.Init(t, tfOptions)
-		terraform.RunTerraformCommand(t, tfOptions, terraform.FormatArgs(tfOptions.Vars, "plan", "-out="+tfPlanOutput)...)
+		terraform.RunTerraformCommand(t, tfOptions, terraform.FormatArgs(tfOptions, "plan", "-out="+tfPlanOutput)...)
 
 		// Read and parse the plan output
 		f, err := os.Open(path.Join(tfOptions.TerraformDir, tfPlanOutput))


### PR DESCRIPTION
As discussed in #26747, `FormatArgs` expects an `Options` reference type instead of a `map[string]interface{}`.