### PR TITLE
updates guidance on deploying app certs to sf clusters

### DIFF
--- a/articles/service-fabric/scripts/service-fabric-powershell-add-application-certificate.md
+++ b/articles/service-fabric/scripts/service-fabric-powershell-add-application-certificate.md
@@ -19,15 +19,46 @@ ms.custom: mvc
 
 # Add an application certificate to a Service Fabric cluster
 
-This sample script creates a self-signed certificate in the specified Azure key vault and installs it to all nodes of the Service Fabric cluster. The certificate also downloads to a local folder. The name of the downloaded certificate is the same as the name of the certificate in the key vault. Customize the parameters as needed.
+This sample script walks through how to create a certificate in Key Vault and then deploy it to one of the VM scale sets your cluster runs on. This scenario does not use Service Fabric directly, but rather depends on Key Vault and on VMSS.
 
 [!INCLUDE [updated-for-az](../../../includes/updated-for-az.md)]
 
 If needed, install the Azure PowerShell using the instruction found in the [Azure PowerShell guide](/powershell/azure/overview) and then run `Connect-AzAccount` to create a connection with Azure. 
 
-## Sample script
+## Create a certificate in Key Vault
 
-[!code-powershell[main](../../../powershell_scripts/service-fabric/add-application-certificate/add-new-application-certificate.ps1 "Add an application certificate to a cluster")]
+```powershell
+$VaultName = ""
+$CertName = ""
+$SubjectName = "CN="
+
+$policy = New-AzKeyVaultCertificatePolicy -SubjectName $SubjectName -IssuerName Self -ValidityInMonths 12
+Add-AzKeyVaultCertificate -VaultName $VaultName -Name $CertName -CertificatePolicy $policy
+```
+
+## Update VMSS profile with certificate
+
+```powershell
+$ResourceGroupName = ""
+$VMSSName = ""
+$CertStore = "My" # Update this with the store you want your certificate placed in, this is LocalMachine\My
+
+$CertConfig = New-AzVmssVaultCertificateConfig -CertificateUrl (Get-AzKeyVaultCertificate -VaultName $VaultName -Name $CertName).SecretId -CertificateStore $CertStore
+$VMSS = Get-AzVmss -ResourceGroupName $ResourceGroupName -VMScaleSetName $VMSSName
+
+# If this KeyVault is already known by the VMSS, for example if the cluster certificate is deployed from this keyvault, use
+$VMSS.virtualmachineprofile.osProfile.secrets[0].vaultCertificates.Add($certConfig)
+
+# Otherwise use
+$VMSS = Add-AzVmssSecret -VirtualMachineScaleSet $VMSS -SourceVaultId (Get-AzKeyVault -VaultName $VaultName).ResourceId  -VaultCertificate $CertConfig
+```
+
+## Update the VMSS
+```powershell
+Update-AzVmss -ResourceGroupName $ResourceGroupName -VirtualMachineScaleSet $VMSS -VMScaleSetName $VMSSName
+```
+
+> If you would like the certificate placed on multiple node types in your cluster, the second and third parts of this script should be repeated for each node type that should have the certificate.
 
 ## Script explanation
 
@@ -35,7 +66,12 @@ This script uses the following commands: Each command in the table links to comm
 
 | Command | Notes |
 |---|---|
-| [Add-AzServiceFabricApplicationCertificate](/powershell/module/az.servicefabric/Add-azServiceFabricApplicationCertificate) | Add a new application certificate to the virtual machine scale set that make up the cluster.  |
+| [New-AzKeyVaultCertificatePolicy](/powershell/module/az.keyvault/New-AzKeyVaultCertificatePolicy) | Creates an in-memory policy representing the certificate |
+| [Add-AzKeyVaultCertificate](/powershell/module/az.keyvault/Add-AzKeyVaultCertificate)| Deploys the policy to Key Vault |
+| [New-AzVmssVaultCertificateConfig](/powershell/module/az.compute/New-AzVmssVaultCertificateConfig) | Creates an in-memory config representing the certificate in a VM |
+| [Get-AzVmss](/powershell/module/az.compute/Get-AzVmss) |  |
+| [Add-AzVmssSecret](/powershell/module/az.compute/Add-AzVmssSecret) | Adds the certificate to the in-memory definition of the VMSS |
+| [Update-AzVmss](/powershell/module/az.compute/Update-AzVmss) | Deploys the new definition of the VMSS |
 
 ## Next steps
 

--- a/articles/service-fabric/service-fabric-cluster-security-update-certs-azure.md
+++ b/articles/service-fabric/service-fabric-cluster-security-update-certs-azure.md
@@ -284,6 +284,10 @@ you can specify any number of client certificates. Each addition/deletion result
 
 To remove a secondary certificate from being used for cluster security, Navigate to the Security section and select the 'Delete' option from the context menu on the specific certificate.
 
+## Adding application certificates to a VMSS
+
+To deploy a certificate you use for your applications to your cluster, see [this sample Powershell script](\scripts\service-fabric-powershell-add-application-certificate.md).
+
 ## Next steps
 Read these articles for more information on cluster management:
 

--- a/articles/service-fabric/service-fabric-powershell-samples.md
+++ b/articles/service-fabric/service-fabric-powershell-samples.md
@@ -28,7 +28,7 @@ The following table includes links to PowerShell scripts samples that create and
 | **Create cluster** ||
 | [Create a cluster (Azure)](./scripts/service-fabric-powershell-create-secure-cluster-cert.md)| Creates an Azure Service Fabric cluster. |
 | **Manage cluster, nodes, and infrastructure** ||
-| [Add an application certificate](./scripts/service-fabric-powershell-add-application-certificate.md)| Adds an application X.509 certificate to all nodes in a cluster. |
+| [Add an application certificate](./scripts/service-fabric-powershell-add-application-certificate.md)| Creates an X509 certificate to Key Vault and deploys it to a VMSS in your cluster. |
 | [Update the RDP port range on cluster VMs](./scripts/service-fabric-powershell-change-rdp-port-range.md)|Changes the RDP port range on cluster node VMs in a deployed cluster.|
 | [Update the admin user and password for cluster node VMs](./scripts/service-fabric-powershell-change-rdp-user-and-pw.md) | Updates the admin username and password for cluster node VMs. |
 | [Open a port in the load balancer](./scripts/service-fabric-powershell-open-port-in-load-balancer.md) | Open an application port in the Azure load balancer to allow inbound traffic on a specific port. |


### PR DESCRIPTION
The old service fabric powershell command (Add-AzServiceFabricApplicationCertificate) is being deprecated, so this represents our new guidance on this scenario