### PR TITLE
Update sql-database-service-tier-hyperscale.md

### DIFF
--- a/articles/sql-database/sql-database-service-tier-hyperscale.md
+++ b/articles/sql-database/sql-database-service-tier-hyperscale.md
@@ -33,7 +33,7 @@ The Hyperscale service tier in Azure SQL Database provides the following additio
 
 - Support for up to 100 TB of database size
 - Nearly instantaneous database backups (based on file snapshots stored in Azure Blob storage) regardless of size with no IO impact on compute resources  
-- Fast database restores (based on file snapshots) in minutes rather than hours or days (not a size of data operation)
+- Fast database point-in-time restores (based on file snapshots) in minutes rather than hours or days (not a size of data operation)
 - Higher overall performance due to higher log throughput and faster transaction commit times regardless of data volumes
 - Rapid scale out - you can provision one or more read-only nodes for offloading your read workload and for use as hot-standbys
 - Rapid Scale up - you can, in constant time, scale up your compute resources to accommodate heavy workloads as and when needed, and then scale the compute resources back down when not needed.


### PR DESCRIPTION
Update hyperscale capabilities to explicitly say *point-in-time* restores are fast. This is needed because georestores are not fast and are a size-of-data operation.