### PR TITLE
Clearer distinction but public/confidential flow

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
@@ -145,7 +145,7 @@ grant_type=authorization_code&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&sco
 | {tenant} | Yes | Name of your Azure AD B2C tenant |
 | {policy} | Yes | The user flow that was used to acquire the authorization code. You can't use a different user flow in this request. Add this parameter to the query string, not to the POST body. |
 | client_id | Yes | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application. |
-| client_secret | Yes | The application secret that was generated in the [Azure portal](https://portal.azure.com/). This application secret is an important security artifact. You should store it securely on your server. Change this client secret on a periodic basis. |
+| client_secret | Yes, in Web Apps | The application secret that was generated in the [Azure portal](https://portal.azure.com/). Client secrets are used in this flow for Web App scenarios, where the client can securely store a client secret. For Native App (public client) scenarios, client secrets cannot be securely stored, threfore not used on this flow. If using a client secret, please change it on a periodic basis. |
 | code | Yes | The authorization code that you acquired in the beginning of the user flow. |
 | grant_type | Yes | The type of grant, which must be `authorization_code` for the authorization code flow. |
 | redirect_uri | Yes | The `redirect_uri` parameter of the application where you received the authorization code. |
@@ -214,7 +214,7 @@ grant_type=refresh_token&client_id=90c0fe63-bcf2-44d5-8fb7-b8bbc0b29dc6&scope=op
 | {tenant} | Yes | Name of your Azure AD B2C tenant |
 | {policy} | Yes | The user flow that was used to acquire the original refresh token. You can't use a different user flow in this request. Add this parameter to the query string, not to the POST body. |
 | client_id | Yes | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application. |
-| client_secret | Yes | The application secret that was generated in the [Azure portal](https://portal.azure.com/). This application secret is an important security artifact. You should store it securely on your server. Change this client secret on a periodic basis. |
+| client_secret | Yes, in Web Apps | The application secret that was generated in the [Azure portal](https://portal.azure.com/). Client secrets are used in this flow for Web App scenarios, where the client can securely store a client secret. For Native App (public client) scenarios, client secrets cannot be securely stored, threfore not used on this call. If using a client secret, please change it on a periodic basis. |
 | grant_type | Yes | The type of grant, which must be a refresh token for this part of the authorization code flow. |
 | refresh_token | Yes | The original refresh token that was acquired in the second part of the flow. The `offline_access` scope must be used in both the authorization and token requests in order to receive a refresh token. |
 | redirect_uri | No | The `redirect_uri` parameter of the application where you received the authorization code. |


### PR DESCRIPTION
Redeeming the auth code for a token and refreshing an access token differ when you are on a confidential or public client scenario. This update tries to make difference clearer in the use of the client secret on those calls.

Disclaimer: this is merely a docs issue, I've tested both public and confidential flows and the service works as expected.