### PR TITLE
Add Windows domain qualified name to NameID format

### DIFF
--- a/articles/active-directory/develop/active-directory-saml-claims-customization.md
+++ b/articles/active-directory/develop/active-directory-saml-claims-customization.md
@@ -60,6 +60,7 @@ From the **Choose name identifier format** dropdown, you can select one of the f
 | **Persistent** | Azure AD will use Persistent as the NameID format. |
 | **EmailAddress** | Azure AD will use EmailAddress as the NameID format. |
 | **Unspecified** | Azure AD will use Unspecified as the NameID format. |
+| **Windows domain qualified name** | Azure AD will use WindowsDomainQualifiedName as the NameID format. |
 
 Transient NameID is also supported, but is not available in the dropdown and cannot be configured on Azure's side. To learn more about the NameIDPolicy attribute, see [Single Sign-On SAML protocol](single-sign-on-saml-protocol.md).
 


### PR DESCRIPTION
[Choose name identifier format] dropdown contains 5 options. 
Current document lacks a reference to "Windows domain qualitifed name".