### PR TITLE
Explicitly state the maximum MFA Bypass Trusted IP range count

### DIFF
--- a/articles/active-directory/authentication/howto-mfa-mfasettings.md
+++ b/articles/active-directory/authentication/howto-mfa-mfasettings.md
@@ -293,7 +293,7 @@ If your organization deploys the NPS extension to provide MFA to on-premises app
 
 | Azure AD tenant type | Trusted IPs feature options |
 |:--- |:--- |
-| Managed |**Specific range of IP addresses**: Administrators specify a range of IP addresses that can bypass two-step verification for users who sign in from the company intranet.|
+| Managed |**Specific range of IP addresses**: Administrators specify a range of IP addresses that can bypass two-step verification for users who sign in from the company intranet. A maximum of 50 Trusted IP ranges can be configured.|
 | Federated |**All Federated Users**: All federated users who sign in from inside of the organization can bypass two-step verification. The users bypass verification by using a claim that is issued by Active Directory Federation Services (AD FS).<br/>**Specific range of IP addresses**: Administrators specify a range of IP addresses that can bypass two-step verification for users who sign in from the company intranet. |
 
 The Trusted IPs bypass works only from inside of the company intranet. If you select the **All Federated Users** option and a user signs in from outside the company intranet, the user has to authenticate by using two-step verification. The process is the same even if the user presents an AD FS claim. 


### PR DESCRIPTION
In trying to find information regarding a maximum number of Trusted IP ranges that can be configured for AAD MFA Bypass, this document was where I ended up finding the following:
In the steps to enable Trusted IPs using Conditional Access, one of the steps listed is "Enter up to 50 IP address ranges".
While this implies a maximum of 50 Trusted IPs when configuring IP ranges (rather than All Federated Users bypass), I think that the maximum should be explicitly stated - and should be stated earlier in the comparison table rather than later in the "how-to" steps.