### PR TITLE
Clarification of App ID meaning

### DIFF
--- a/articles/api-management/api-management-howto-protect-backend-with-aad.md
+++ b/articles/api-management/api-management-howto-protect-backend-with-aad.md
@@ -199,7 +199,7 @@ You can use the [Validate JWT](api-management-access-restriction-policies.md#Val
     <openid-config url="https://login.microsoftonline.com/{aad-tenant}/.well-known/openid-configuration" />
     <required-claims>
         <claim name="aud">
-            <value>{Application ID of backend-app}</value>
+            <value>{Application ID URI of backend-app}</value>
         </claim>
     </required-claims>
 </validate-jwt>


### PR DESCRIPTION
The documentation says to enter the Application ID, however the JWT contains `aud: api://**`. So it is the application ID URI that needs to be entered and not the application ID. This makes it clearer.