### PR TITLE
Updated to doc to reflect the note removed.

### DIFF
--- a/articles/spring-cloud/spring-cloud-quickstart-launch-app-cli.md
+++ b/articles/spring-cloud/spring-cloud-quickstart-launch-app-cli.md
@@ -122,9 +122,6 @@ az spring-cloud app create --name auth-service
 az spring-cloud app create --name account-service
 ```
 
->[!NOTE]
-> The application names must match the names of the JARS exactly for the provided configuration server to work properly.
-
 ## Deploy applications and set environment variables
 
 We need to actually deploy our applications to Azure. Use the following commands to deploy all three applications:


### PR DESCRIPTION
Deleted the Note - The application names must match the names of the JARS exactly for the provided configuration server to work properly. as per customer's request.