### PR TITLE
Hybrid Azure AD join is not supported on Windows down-level devices w…

### DIFF
--- a/articles/active-directory/devices/hybrid-azuread-join-plan.md
+++ b/articles/active-directory/devices/hybrid-azuread-join-plan.md
@@ -78,7 +78,7 @@ Hybrid Azure AD join is supported for FIPS-compliant TPM 2.0 and not supported f
 
 Hybrid Azure AD join is not supported for Windows Server running the Domain Controller (DC) role.
 
-Hybrid Azure AD join is not supported on Windows down-level devices when using credential roaming or user profile roaming.
+Hybrid Azure AD join is not supported on Windows down-level devices when using credential roaming or user profile roaming or mandatory profile.
 
 If you are relying on the System Preparation Tool (Sysprep) and if you are using a **pre-Windows 10 1809** image for installation, make sure that image is not from a device that is already registered with Azure AD as Hybrid Azure AD join.
 


### PR DESCRIPTION
when using HAADJ with lower end devices

included mandatory profile - which kind of profile customization and customer reports this is not working when we use mandatory profiles and which is not included in this article as not supported. which cause confusion for customers. hence updated here