### PR TITLE
Removed Microsoft.Network/secureGateways

### DIFF
--- a/articles/azure-monitor/platform/diagnostic-logs-schema.md
+++ b/articles/azure-monitor/platform/diagnostic-logs-schema.md
@@ -218,8 +218,6 @@ The schema for resource diagnostic logs varies depending on the resource and log
 |Microsoft.Network/applicationGateways|ApplicationGatewayAccessLog|Application Gateway Access Log|
 |Microsoft.Network/applicationGateways|ApplicationGatewayPerformanceLog|Application Gateway Performance Log|
 |Microsoft.Network/applicationGateways|ApplicationGatewayFirewallLog|Application Gateway Firewall Log|
-|Microsoft.Network/securegateways|AzureFirewallApplicationRule|Azure Firewall Application Rule|
-|Microsoft.Network/securegateways|AzureFirewallNetworkRule|Azure Firewall Network Rule|
 |Microsoft.Network/azurefirewalls|AzureFirewallApplicationRule|Azure Firewall Application Rule|
 |Microsoft.Network/azurefirewalls|AzureFirewallNetworkRule|Azure Firewall Network Rule|
 |Microsoft.Network/virtualNetworkGateways|GatewayDiagnosticLog|Gateway Diagnostic Logs|

--- a/articles/azure-resource-manager/complete-mode-deletion.md
+++ b/articles/azure-resource-manager/complete-mode-deletion.md
@@ -1443,7 +1443,6 @@ Jump to a resource provider namespace:
 > | publicIPPrefixes | Yes |
 > | routeFilters | Yes |
 > | routeTables | Yes |
-> | secureGateways | Yes |
 > | serviceEndpointPolicies | Yes |
 > | trafficManagerGeographicHierarchies | No |
 > | trafficmanagerprofiles | Yes |

--- a/articles/azure-resource-manager/move-support-resources.md
+++ b/articles/azure-resource-manager/move-support-resources.md
@@ -936,7 +936,6 @@ Jump to a resource provider namespace:
 > | publicipprefixes | Yes | Yes |
 > | routefilters | No | No |
 > | routetables | Yes | Yes |
-> | securegateways | Yes | Yes |
 > | serviceendpointpolicies | Yes | Yes |
 > | trafficmanagerprofiles | Yes | Yes |
 > | virtualhubs | No | No |

--- a/articles/azure-resource-manager/tag-support.md
+++ b/articles/azure-resource-manager/tag-support.md
@@ -1440,7 +1440,6 @@ Jump to a resource provider namespace:
 > | publicIPPrefixes | Yes | Yes |
 > | routeFilters | Yes | Yes |
 > | routeTables | Yes | Yes |
-> | secureGateways | Yes | Yes |
 > | serviceEndpointPolicies | Yes | Yes |
 > | trafficManagerGeographicHierarchies | No | No |
 > | trafficmanagerprofiles | Yes | Yes |


### PR DESCRIPTION
As Microsoft.Network/secureGateways has been deprecated in favor of Microsoft.Network/azureFirewalls, removed reference to it.