### PR TITLE
Most policy operators only support strings

### DIFF
--- a/articles/governance/policy/concepts/definition-structure.md
+++ b/articles/governance/policy/concepts/definition-structure.md
@@ -267,18 +267,18 @@ within an **allOf** operation.
 A condition evaluates whether a **field** or the **value** accessor meets certain criteria. The
 supported conditions are:
 
-- `"equals": "value"`
-- `"notEquals": "value"`
-- `"like": "value"`
-- `"notLike": "value"`
-- `"match": "value"`
-- `"matchInsensitively": "value"`
-- `"notMatch": "value"`
-- `"notMatchInsensitively": "value"`
-- `"contains": "value"`
-- `"notContains": "value"`
-- `"in": ["value1","value2"]`
-- `"notIn": ["value1","value2"]`
+- `"equals": "stringValue"`
+- `"notEquals": "stringValue"`
+- `"like": "stringValue"`
+- `"notLike": "stringValue"`
+- `"match": "stringValue"`
+- `"matchInsensitively": "stringValue"`
+- `"notMatch": "stringValue"`
+- `"notMatchInsensitively": "stringValue"`
+- `"contains": "stringValue"`
+- `"notContains": "stringValue"`
+- `"in": ["stringValue1","stringValue2"]`
+- `"notIn": ["stringValue1","stringValue2"]`
 - `"containsKey": "keyName"`
 - `"notContainsKey": "keyName"`
 - `"less": "value"`


### PR DESCRIPTION
Try to make it more clear that most policy operators only support strings.
Feel free to show this in a different way.

Rationale: I've seen a couple of cases recently where customers were trying to compare objects with "equals". This is not supported: the underlying function is a string comparison, and it only converts value types (e.g. bools and ints) to strings on the fly. Policy definition validation error messages could be better here, but hoping to stop a few people from trying to author such policies in the first place.