### PR TITLE
Confusing table for GRID drivers

### DIFF
--- a/includes/virtual-machines-n-series-windows-support.md
+++ b/includes/virtual-machines-n-series-windows-support.md
@@ -33,5 +33,5 @@ Please note that the Nvidia extension will always install the latst driver. We p
 
 | OS | Driver |
 | -------- |------------- |
-| Windows Server 2019<br/><br/>Windows Server 2016<br/><br/>Windows 10 | [GRID 9.1 (431.79)](https://go.microsoft.com/fwlink/?linkid=874181) (.exe) <br/><br/> [GRID 9.0 (431.02)](https://download.microsoft.com/download/8/C/C/8CC88D54-EB07-44D3-8FA9-B797B173ED04/431.02_grid_win10_server2016_server2019_64bit_international.exe) (.exe)  |
+| Windows Server 2019<br/><br/>Windows Server 2016<br/><br/>Windows 10 | [GRID 9.1 (431.79)](https://go.microsoft.com/fwlink/?linkid=874181) (.exe) <br/><br/> [GRID 9.0 (431.02)](https://download.microsoft.com/download/8/C/C/8CC88D54-EB07-44D3-8FA9-B797B173ED04/431.02_grid_win10_server2016_server2019_64bit_international.exe) (.exe) <br/><br/> [GRID 9.1 (431.79)](https://go.microsoft.com/fwlink/?linkid=874181) (.exe) |
 | Windows Server 2012 R2<br/><br/>Windows Server 2008 R2<br/><br/>Windows 8<br/><br/>Windows 7 | [GRID 9.1 (431.79)](https://go.microsoft.com/fwlink/?linkid=874184) (.exe)<br/><br/> [GRID 9.0 (431.02)](https://download.microsoft.com/download/B/D/6/BD6D1C34-E41F-4654-B5AB-F4DA9C08AA64/431.02_grid_win7_win8_server2008R2_server2012R2_64bit_international.exe) (.exe)  |


### PR DESCRIPTION
It's difficult to see that GRID drivers should be used for Windows 10 as well. Two drivers versions appears next to Windows server 2016 and Windows server 2019, but nothing next to Windows 10. Perhaps make the drivers centered in the right column so it appears to apply to all operating systems and not just 2016/2019 server.