### PR TITLE
Service Fabric AAD: Add solution for AADSTS50011 error when using Powershell

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-setup-aad.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-setup-aad.md
@@ -110,6 +110,16 @@ Select "App registrations" in AAD page, select your cluster application, and the
 
 ![Web application reply url][web-application-reply-url]
 
+### Connecting to the cluster using Azure AD authentication via Powershell gives an error when you sign in: "AADSTS50011":
+#### Problem
+When you try to connect to a Service Fabric cluster using Azure AD via Powershell, the login page returns a failure: "AADSTS50011: The reply url specified in the request does not match the reply urls configured for the application: &lt;guid&gt;."
+
+#### Reason
+Similar to above, Powershell attempts to authenticate against Azure AD, which provides a redirect URL which is not listed in the Azure AD application **Reply URLs** list.  
+
+#### Solution
+Same process as above, but the URL must be set to "urn:ietf:wg:oauth:2.0:oob", which is a special redirect for command line authentication.
+
 ### Connect the cluster by using Azure AD authentication via PowerShell
 To connect the Service Fabric cluster, use the following PowerShell command example:
 

--- a/articles/service-fabric/service-fabric-cluster-creation-setup-aad.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-setup-aad.md
@@ -106,19 +106,19 @@ When you try to sign in to Azure AD in Service Fabric Explorer, the page returns
 The cluster (web) application that represents Service Fabric Explorer attempts to authenticate against Azure AD, and as part of the request it provides the redirect return URL. But the URL is not listed in the Azure AD application **REPLY URL** list.
 
 #### Solution
-Select "App registrations" in AAD page, select your cluster application, and then select the **Reply URLs** button. On "Reply URLs" page, add the URL of Service Fabric Explorer to the list or replace one of the items in the list. When you have finished, save your change.
+On the Azure AD page, select **App registrations**, select your cluster application, and then select **Reply URLs**. In the **Reply URLs** pane, add the Service Fabric Explorer URL to the list, or replace one of the items in the list. Save your change.
 
-![Web application reply url][web-application-reply-url]
+![Web application reply URL][web-application-reply-url]
 
-### Connecting to the cluster using Azure AD authentication via Powershell gives an error when you sign in: "AADSTS50011":
+### Connecting to the cluster using Azure AD authentication via PowerShell gives an error when you sign in: "AADSTS50011"
 #### Problem
-When you try to connect to a Service Fabric cluster using Azure AD via Powershell, the login page returns a failure: "AADSTS50011: The reply url specified in the request does not match the reply urls configured for the application: &lt;guid&gt;."
+When you try to connect to a Service Fabric cluster using Azure AD via PowerShell, the sign-in page returns a failure: "AADSTS50011: The reply url specified in the request does not match the reply urls configured for the application: &lt;guid&gt;."
 
 #### Reason
-Similar to above, Powershell attempts to authenticate against Azure AD, which provides a redirect URL which is not listed in the Azure AD application **Reply URLs** list.  
+Similar to the preceding issue, PowerShell attempts to authenticate against Azure AD, which provides a redirect URL that isn't listed in the Azure AD application **Reply URLs** list.  
 
 #### Solution
-Same process as above, but the URL must be set to "urn:ietf:wg:oauth:2.0:oob", which is a special redirect for command line authentication.
+Use the same process as in the preceding issue, but the URL must be set to `urn:ietf:wg:oauth:2.0:oob`, a special redirect for command-line authentication.
 
 ### Connect the cluster by using Azure AD authentication via PowerShell
 To connect the Service Fabric cluster, use the following PowerShell command example:


### PR DESCRIPTION
Documenting a case I came across today where attempting to connect to a Service Fabric cluster using Azure AD resulted in an invalid redirect URI error. Unlike the error you get when logging into the explorer like in the screenshot in the same document, it does not show you what URI you are being redirected to, making this pretty awkward to work out unless you know what to look for. 
![image](https://user-images.githubusercontent.com/9156622/67966514-e642a080-fbfb-11e9-90fd-d05a8a66b736.png)

To find out what was going on I had to spin up Wireshark to sniff the packets and see where the response was redirecting 😄 