### PR TITLE
Update container-instances-limits.md

### DIFF
--- a/includes/container-instances-limits.md
+++ b/includes/container-instances-limits.md
@@ -7,7 +7,7 @@ ms.author: danlep
 ---
 | Resource | Default limit |
 | --- | :--- |
-| Container groups per [subscription](../articles/billing-buy-sign-up-azure-subscription.md) | 100<sup>1</sup> |
+| Container groups per region per [subscription](../articles/billing-buy-sign-up-azure-subscription.md) | 100<sup>1</sup> |
 | Number of containers per container group | 60 |
 | Number of volumes per container group | 20 |
 | Ports per IP | 5 |


### PR DESCRIPTION
Customer found an inaccuracy in this table. Turns out we limit container groups per region per subscription (i.e. using the same subscription, a customer can deploy 100 container groups in West US and then another 100 container groups in East US)