### PR TITLE
Fixed query error in Azure CLI sample script

### DIFF
--- a/articles/azure-resource-manager/deployment-quota-exceeded.md
+++ b/articles/azure-resource-manager/deployment-quota-exceeded.md
@@ -31,7 +31,7 @@ To delete all deployments older than five days, use:
 
 ```azurecli-interactive
 startdate=$(date +%F -d "-5days")
-deployments=$(az group deployment list --resource-group exampleGroup --query "[?properties.timestamp>'$startdate'].name" --output tsv)
+deployments=$(az group deployment list --resource-group exampleGroup --query "[?properties.timestamp<'$startdate'].name" --output tsv)
 
 for deployment in $deployments
 do


### PR DESCRIPTION
The solution is about deleting deployments from the history older than 5 days but the query in the sample script filters deployments that are newer than 5 days old.