### PR TITLE
Updated code snippet to use `IAsyncCollector`

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus.md
+++ b/articles/azure-functions/functions-bindings-service-bus.md
@@ -471,12 +471,12 @@ public static void Run(TimerInfo myTimer, ILogger log, out string outputSbQueue)
 Here's C# script code that creates multiple messages:
 
 ```cs
-public static void Run(TimerInfo myTimer, ILogger log, ICollector<string> outputSbQueue)
+public static async Task Run(TimerInfo myTimer, ILogger log, IAsyncCollector<string> outputSbQueue)
 {
     string message = $"Service Bus queue messages created at: {DateTime.Now}";
     log.LogInformation(message); 
-    outputSbQueue.Add("1 " + message);
-    outputSbQueue.Add("2 " + message);
+    await outputSbQueue.AddAsync("1 " + message);
+    await outputSbQueue.AddAsync("2 " + message);
 }
 ```
 


### PR DESCRIPTION
As part of this PR, I have replaced `ICollector` has been with `IAsyncCollector`

**Why I feel this change is important**

Whether we like it or not, most of the developers (like me) copy the code snippet directly and then modify it as per scenario. Hence, I feel it is important for docs to reflect the best possible in option in the code sample. 
I'm of the opinion that providing an `async` option over synchronous should be preferred in the snippet. While there is a mention of `IAsyncCollector` in the documentation, no written docs can take can replace the code snippet. This has motivated me to propose this change.