### PR TITLE
Update reference-connect-version-history.md

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-version-history.md
+++ b/articles/active-directory/hybrid/reference-connect-version-history.md
@@ -75,8 +75,8 @@ Under certain circumstances, servers that were auto upgraded to version 1.4.18.0
 - Added a deprecation warning for the sync service manager on the connector properties page. This warning notifies the user that changes should be made through the AADC wizard.
 - Added new error for issues with a user's password policy.
 - Prevent misconfiguration of  group filtering by domain and OU filters. Group filtering will show an error when the domain/OU of the entered group is already filtered out and keep the user from moving forward until the issue is resolved.
-- Users can no longer create a connector for Active Directory Domain Services or Windows Azure Active Directory in the old UI.
-- Fixed accessibility of custom UI controls in the Sync Service Manager
+- Users can no longer create a connector for Active Directory Domain Services or Windows Azure Active Directory in the Synchronization Service Manager UI.
+- Fixed accessibility of custom UI controls in the Synchronization Service Manager.
 - Enabled six federation management tasks for all sign-in methods in Azure AD Connect.  (Previously, only the “Update AD FS SSL certificate” task was available for all sign-ins.)
 - Added a warning when changing the sign-in method from federation to PHS or PTA that all Azure AD domains and users will be converted to managed authentication.
 - Removed token-signing certificates from the “Reset Azure AD and AD FS trust” task and added a separate sub-task to update these certificates.
@@ -128,7 +128,7 @@ Under certain circumstances, servers that were auto upgraded to version 1.4.18.0
 - Add support for Domain Refresh 
 - Exchange Mail Public Folders feature goes GA 
 - Improve wizard error handling for service failures 
-- Added warning link for old UI on connector properties page. 
+- Added warning link on Synchronization Service Manager UI in the connector properties page. 
 - The Unified Groups Writeback feature is now GA 
 - Improved SSPR error message when the DC is missing an LDAP control 
 - Added diagnostics for DCOM registry errors during install  
@@ -154,7 +154,7 @@ Under certain circumstances, servers that were auto upgraded to version 1.4.18.0
 - Fix VSS Errors with LocalDB  
 - Fix misleading error message when object type is not in scope 
 - Corrected an issue where installation of Azure AD PowerShell on a server could potentially cause an assembly conflict with Azure AD Connect. 
-- Fixed PHS bug on Staging Server when Connector Credentials are updated in the old UI. 
+- Fixed PHS bug on Staging Server when Connector Credentials are updated in the Synchronization Service Manager UI. 
 - Fixed some memory leaks 
 - Miscellaneous Autoupgrade fixes 
 - Miscellaneous fixes to Export and Unconfirmed Import Processing 


### PR DESCRIPTION
CSS and Customers might not know what's the "old UI". I believe we should avoid using internal slang in public documentation. Replacing all "OLD UI" references with "Synchronization Service Manager UI"