### PR TITLE
Update access to container log

### DIFF
--- a/articles/app-service/containers/app-service-linux-intro.md
+++ b/articles/app-service/containers/app-service-linux-intro.md
@@ -64,7 +64,7 @@ Based on a current limitation, for the same resource group you cannot mix Window
 
 ## Troubleshooting
 
-When your application fails to start or you want to check the logging from your app, check the Docker logs in the LogFiles directory. You can access this directory either through your SCM site or via FTP. To log the `stdout` and `stderr` from your container, you need to enable **Docker Container logging** under **App Service Logs**. The setting takes effect immediately. App Service detects the change and restarts the container automatically.
+When your application fails to start or you want to check the logging from your app, check the Docker logs in the LogFiles directory. You can access this directory either through your SCM site or via FTP. To log the `stdout` and `stderr` from your container, you need to enable **Application logging** under **App Service Logs**. The setting takes effect immediately. App Service detects the change and restarts the container automatically. Once enabled, access to your container logs is available under **Log stream**.
 
 You can access the SCM site from **Advanced Tools** in the **Development Tools** menu.
 


### PR DESCRIPTION
The option to enable container logging does not seem to be accurate. It seems that what needs to be enabled is application logging.