### PR TITLE
The sentence explains the RU distribution is still misleading

### DIFF
--- a/articles/cosmos-db/set-throughput.md
+++ b/articles/cosmos-db/set-throughput.md
@@ -23,7 +23,7 @@ The throughput provisioned on an Azure Cosmos container is exclusively reserved 
 
 Setting provisioned throughput on a container is the most frequently used option. You can elastically scale throughput for a container by provisioning any amount of throughput by using [Request Units (RUs)](request-units.md). 
 
-Assuming a good partition key that distributes the logical partitions evenly among the physical partitions, the throughput is also distributed evenly across all the logical partitions of the container. You cannot selectively specify the throughput for logical partitions. Because one or more logical partitions of a container are hosted by a physical partition, the physical partitions belong exclusively to the container and support the throughput provisioned on the container. 
+The throughput provisioned for a container is evenly distributed among its physical partitions, and assuming a good partition key that distributes the logical partitions evenly among the physical partitions, the throughput is also distributed evenly across all the logical partitions of the container. You cannot selectively specify the throughput for logical partitions. Because one or more logical partitions of a container are hosted by a physical partition, the physical partitions belong exclusively to the container and support the throughput provisioned on the container. 
 
 If the workload running on a logical partition consumes more than the throughput that was allocated to that logical partition, your operations get rate-limited. When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. For more information on partitioning, see [Logical partitions](partition-data.md).
 


### PR DESCRIPTION
The sentence explains the RU distribution is still misleading unless you know "The throughput provisioned for a container is evenly distributed among its physical partitions.." part, so I added it at the beginning of that sentence.