### PR TITLE
Updating Link Text + Destination

### DIFF
--- a/articles/storage/blobs/TOC.yml
+++ b/articles/storage/blobs/TOC.yml
@@ -449,7 +449,7 @@
       - name: Storage Resource Provider
         href: /java/api/overview/azure/storage/management
     - name: JavaScript (version 12.x)
-      href: /javascript/api/@azure/storage-blob/?view=azure-node-preview
+      href: /javascript/api/@azure/storage-blob/
     - name: Python (version 12.x)
       href: /python/api/azure-storage-blob/
     - name: REST

--- a/articles/storage/queues/TOC.yml
+++ b/articles/storage/queues/TOC.yml
@@ -214,9 +214,9 @@
       href: /java/api/com.microsoft.azure.storage.queue
     - name: Storage Resource Provider
       href: /java/api/overview/azure/storage/management
-  - name: JavaScript (version 10.x)
+  - name: JavaScript (version 12.x)
     href: /javascript/api/@azure/storage-queue
-  - name: Python (version 2.x)
+  - name: Python (version 12.x)
     href: /python/api/azure-storage-queue/?view=azure-python
   - name: REST
     items:


### PR DESCRIPTION
Context:

Version `12.0.0` of storage queues AND blobs released last week. This is for both `JS` and `Python`. 

This updates the ToC to reflect such a thing. Not only this, but the storage-blob for js is no longer preview.

