### PR TITLE
Update Chef examples to use latest stable version

### DIFF
--- a/articles/virtual-machines/extensions/chef.md
+++ b/articles/virtual-machines/extensions/chef.md
@@ -46,7 +46,7 @@ The following JSON shows the schema for the Chef VM Extension. The extension req
   "properties": {
     "publisher": "Chef.Bootstrap.WindowsAzure",
     "type": "[parameters('chef_vm_extension_type')]",
-    "typeHandlerVersion": "1210.12",
+    "typeHandlerVersion": "1210.13",
     "settings": {
       "bootstrap_options": {
         "chef_server_url": "[parameters('chef_server_url')]",
@@ -68,7 +68,7 @@ The following JSON shows the schema for the Chef VM Extension. The extension req
 | apiVersion | `2017-12-01` | string (date) |
 | publisher | `Chef.Bootstrap.WindowsAzure` | string |
 | type | `LinuxChefClient` (Linux), `ChefClient` (Windows) | string |
-| typeHandlerVersion | `1210.12` | string (double) |
+| typeHandlerVersion | `1210.13` | string (double) |
 
 ### Settings
 
@@ -114,7 +114,7 @@ az vm extension set \
   --vm-name myExistingVM \
   --name LinuxChefClient \
   --publisher Chef.Bootstrap.WindowsAzure \
-  --version 1210.12 --protected-settings '{"validation_key": "<validation_key>"}' \
+  --version 1210.13 --protected-settings '{"validation_key": "<validation_key>"}' \
   --settings '{ "bootstrap_options": { "chef_server_url": "<chef_server_url>", "validation_client_name": "<validation_client_name>" }, "runlist": "<run_list>" }'
 ```
 


### PR DESCRIPTION
The latest stable version of the extension is available under TypeVersion `1210.13`. This PR updates the examples in the documentation.