### PR TITLE
Correct commands to use SUSE crm instead of RH pcs

### DIFF
--- a/articles/virtual-machines/workloads/sap/high-availability-guide-standard-load-balancer-outbound-connections.md
+++ b/articles/virtual-machines/workloads/sap/high-availability-guide-standard-load-balancer-outbound-connections.md
@@ -198,11 +198,11 @@ To allow pacemaker to communicate with the Azure management API, perform the fol
   - SUSE  
      ```
      # Place the cluster in maintenance mode
-     sudo pcs property set maintenance-mode=true
+     sudo crm configure property maintenance-mode=true
      #Restart on all nodes
      sudo systemctl restart pacemaker
      # Take the cluster out of maintenance mode
-     sudo pcs property set maintenance-mode=false
+     sudo crm configure property maintenance-mode=true
      ```
 
   - Red Hat  


### PR DESCRIPTION
Changed commands for "2. Restart the pacemaker service on all cluster nodes" for SUSE to use "crm" instead of the RH "pcs"