### PR TITLE
Fix Update-AzDisk to not be destructive

### DIFF
--- a/articles/virtual-machines/windows/convert-disk-storage.md
+++ b/articles/virtual-machines/windows/convert-disk-storage.md
@@ -58,9 +58,8 @@ foreach ($disk in $vmDisks)
 {
 	if ($disk.ManagedBy -eq $vm.Id)
 	{
-		$diskUpdateConfig = New-AzDiskUpdateConfig –AccountType $storageType
-		Update-AzDisk -DiskUpdate $diskUpdateConfig -ResourceGroupName $rgName `
-		-DiskName $disk.Name
+		$disk.Sku = [Microsoft.Azure.Management.Compute.Models.DiskSku]::new($storageType)
+		$disk | Update-AzDisk
 	}
 }
 
@@ -97,9 +96,8 @@ $vm.HardwareProfile.VmSize = $size
 Update-AzVM -VM $vm -ResourceGroupName $rgName
 
 # Update the storage type
-$diskUpdateConfig = New-AzDiskUpdateConfig -AccountType $storageType -DiskSizeGB $disk.DiskSizeGB
-Update-AzDisk -DiskUpdate $diskUpdateConfig -ResourceGroupName $rgName `
--DiskName $disk.Name
+$disk.Sku = [Microsoft.Azure.Management.Compute.Models.DiskSku]::new($storageType)
+$disk | Update-AzDisk
 
 Start-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name
 ```
@@ -142,9 +140,8 @@ Stop-AzVM -ResourceGroupName $vmResource.ResourceGroupName -Name $vmResource.Nam
 $vm = Get-AzVM -ResourceGroupName $vmResource.ResourceGroupName -Name $vmResource.Name 
 
 # Update the storage type
-$diskUpdateConfig = New-AzDiskUpdateConfig -AccountType $storageType -DiskSizeGB $disk.DiskSizeGB
-Update-AzDisk -DiskUpdate $diskUpdateConfig -ResourceGroupName $rgName `
--DiskName $disk.Name
+$disk.Sku = [Microsoft.Azure.Management.Compute.Models.DiskSku]::new($storageType)
+$disk | Update-AzDisk
 
 Start-AzVM -ResourceGroupName $vm.ResourceGroupName -Name $vm.Name
 ```


### PR DESCRIPTION
The current method of updating the disk:
$diskUpdateConfig = New-AzDiskUpdateConfig -AccountType $storageType -DiskSizeGB $disk.DiskSizeGB
Update-AzDisk -DiskUpdate $diskUpdateConfig -ResourceGroupName $rgName `
-DiskName $disk.Name

Will cause loss of properties on the disk (ie. tags).  Update-AzDisk does not get all of the original properties of the current disk, and it is a PUT operation, which means it is just doing a PUT of whatever is specified in the New-AzDiskUpdateConfig result, which means anything not specified in the request will be lost (ie. tags are removed).

This method will just update the properties that you are trying to change and preserve everything else:
$disk.Sku = [Microsoft.Azure.Management.Compute.Models.DiskSku]::new($storageType)
$disk | Update-AzDisk