### PR TITLE
Updated the section on the firmware query output

### DIFF
--- a/articles/kinect-dk/update-device-firmware.md
+++ b/articles/kinect-dk/update-device-firmware.md
@@ -52,15 +52,15 @@ Azure Kinect DK doesn't update firmware automatically. You can use [Azure Kinect
 
     ```console
        >AzureKinectFirmwareTool.exe -q
-        == Azure Kinect DK Firmware Tool ==
-        Device Serial Number: 000036590812
-        Current Firmware Versions:
-        RGB camera firmware:      1.5.92
-        Depth camera firmware:    1.5.66
-        Depth config file:        6109.7
-        Audio firmware:           1.5.14
-        Build Config:             Production
-        Certificate Type:         Microsoft
+ == Azure Kinect DK Firmware Tool ==
+Device Serial Number: 000805192412
+Current Firmware Versions:
+  RGB camera firmware:      1.6.102
+  Depth camera firmware:    1.6.75
+  Depth config file:        6109.7
+  Audio firmware:           1.6.14
+  Build Config:             Production
+  Certificate Type:         Microsoft
     ```
 
 3. If you see the above output, your firmware is updated.


### PR DESCRIPTION
Old output suggested version 1.5, which means that the article considers the installation of SDK 1.2 only, rather than 1.3. This change should add professionalism for a single and consistent around "Getting started"