### PR TITLE
Port 5671 can also be used along with 5672 for logging to Event hub P…

### DIFF
--- a/articles/api-management/api-management-using-with-vnet.md
+++ b/articles/api-management/api-management-using-with-vnet.md
@@ -110,7 +110,7 @@ When an API Management service instance is hosted in a VNET, the ports in the fo
 | * / 80, 443                  | Outbound           | TCP                | VIRTUAL_NETWORK / Storage             | **Dependency on Azure Storage**                             | External & Internal  |
 | * / 80, 443                  | Outbound           | TCP                | VIRTUAL_NETWORK / AzureActiveDirectory | Azure Active Directory (where applicable)                   | External & Internal  |
 | * / 1433                     | Outbound           | TCP                | VIRTUAL_NETWORK / SQL                 | **Access to Azure SQL endpoints**                           | External & Internal  |
-| * / 5672                     | Outbound           | TCP                | VIRTUAL_NETWORK / EventHub            | Dependency for Log to Event Hub policy and monitoring agent | External & Internal  |
+| * / 5671 - 5672                     | Outbound           | TCP                | VIRTUAL_NETWORK / EventHub            | Dependency for Log to Event Hub policy and monitoring agent | External & Internal  |
 | * / 445                      | Outbound           | TCP                | VIRTUAL_NETWORK / Storage             | Dependency on Azure File Share for GIT                      | External & Internal  |
 | * / 1886                     | Outbound           | TCP                | VIRTUAL_NETWORK / INTERNET            | Needed to publish Health status to Resource Health          | External & Internal  |
 | * / 443                     | Outbound           | TCP                | VIRTUAL_NETWORK / AzureMonitor         | Publish Diagnostics Logs and Metrics                        | External & Internal  |


### PR DESCRIPTION
…olicy and Monitoring Agent.

Port 5671 can also be used along with 5672 for logging to Event hub Policy and Monitoring Agent.

Service bus needs either outbound port 5671 to be open, or both 5672 and 443 to be open based on the AMQP protocol documentation. APIM's documentation states that only 5672 needs to be open , so we are trying to update the documentation. Tried at my end and found VNET has outbound 5672 open but both 5671 and 443 are blocked, which is preventing EventHub client from communicating with Service Bus. Recommended Solution:
1. Open outbound port 5671 and try saving policy again. 

2. If policy saving fails with same error after opening port 5671, open outbound port 443 and try saving the policy again.

3. If the above two steps don't resolve the problem, have the customer create a UDR with Management endpoint I.P. addresses and next hop to the internet using documented guidance. Afterwards, attempt another save of the policy.

Please feel free to contact me in case of any doubts or queries.