### PR TITLE
added default regex and message

### DIFF
--- a/articles/managed-applications/microsoft-common-passwordbox.md
+++ b/articles/managed-applications/microsoft-common-passwordbox.md
@@ -34,8 +34,8 @@ A control that can be used to provide and confirm a password.
   "toolTip": "",
   "constraints": {
     "required": true,
-    "regex": "",
-    "validationMessage": ""
+    "regex": "^[a-zA-Z0-9]{8,}$",
+    "validationMessage": "Password must be at least 8 characters long, contain only numbers and letters"
   },
   "options": {
     "hideConfirmation": false


### PR DESCRIPTION
Publishers have been copy+pasting this control and it's been making it to the review step in this empty state. We want them to at least have password validations by the time they reach publisher review