### PR TITLE
Change .UseFeatureFlags for 3.x code

### DIFF
--- a/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
@@ -142,8 +142,11 @@ Add the [Secret Manager tool](https://docs.microsoft.com/aspnet/core/security/ap
         webBuilder.ConfigureAppConfiguration((hostingContext, config) =>
         {
             var settings = config.Build();
-            config.AddAzureAppConfiguration(settings["ConnectionStrings:AppConfig"])
-                .UseFeatureFlags();
+            config.AddAzureAppConfiguration(options => {
+                    options.Connect(settings["ConnectionStrings:AppConfig"])
+                            .UseFeatureFlags();
+            });
+
         })
         .UseStartup<Startup>());
     ```


### PR DESCRIPTION
The current snippet for Update CreateHostBuilder for .NET Core 3.x wont compile. Should be changed as shown. 