### PR TITLE
Include Note about where to use Validation TPs

### DIFF
--- a/articles/active-directory-b2c/validation-technical-profile.md
+++ b/articles/active-directory-b2c/validation-technical-profile.md
@@ -35,6 +35,9 @@ A validation technical profile can be conditionally executed based on preconditi
 
 A self-asserted technical profile may define a validation technical profile to be used for validating some or all of its output claims. All of the input claims of the referenced technical profile must appear in the output claims of the referencing validation technical profile.
 
+> [!NOTE]
+> Only Self-Asserted Technical Profiles can use Validation Technical Profiles. If you need to validate the output claims from non-Self-Asserted Technical Profiles please consider using an additional Orchestration Step in your User Journey to accommodate the Technical Profile in charge of the validation.    
+
 ## ValidationTechnicalProfiles
 
 The **ValidationTechnicalProfiles** element contains the following elements:

--- a/articles/active-directory-b2c/validation-technical-profile.md
+++ b/articles/active-directory-b2c/validation-technical-profile.md
@@ -36,7 +36,7 @@ A validation technical profile can be conditionally executed based on preconditi
 A self-asserted technical profile may define a validation technical profile to be used for validating some or all of its output claims. All of the input claims of the referenced technical profile must appear in the output claims of the referencing validation technical profile.
 
 > [!NOTE]
-> Only Self-Asserted Technical Profiles can use Validation Technical Profiles. If you need to validate the output claims from non-Self-Asserted Technical Profiles please consider using an additional Orchestration Step in your User Journey to accommodate the Technical Profile in charge of the validation.    
+> Only self-asserted technical profiles can use validation technical profiles. If you need to validate the output claims from non-self-asserted technical profiles, consider using an additional orchestration step in your user journey to accommodate the technical profile in charge of the validation.    
 
 ## ValidationTechnicalProfiles
 


### PR DESCRIPTION
Please include the following note to make sure customers know that Validation Technical Profiles can only be used with Self-Asserted Technical Profiles:
"Only Self-Asserted Technical Profiles can use Validation Technical Profiles. If you need to validate the output claims from non-Self-Asserted Technical Profiles please consider using an additional Orchestration Step in your User Journey to accommodate the Technical Profile in charge of the validation"

Disclaimer: this is merely a docs issue, I've tested both public and confidential flows and the service works as expected.