### PR TITLE
Improve formatting of numbered steps in final rendering of document

### DIFF
--- a/articles/api-management/api-management-howto-provision-self-hosted-gateway.md
+++ b/articles/api-management/api-management-howto-provision-self-hosted-gateway.md
@@ -36,6 +36,7 @@ Complete the following quickstart: [Create an Azure API Management instance](get
 3. Enter the **Name** and **Region** of the gateway.
 > [!TIP]
 > **Region** specifies intended location of the gateway nodes that will be associated with this gateway resource. It's semantically equivalent to a similar property associated with any Azure resource, but can be assigned an arbitrary string value.
+
 4. Optionally, enter a **Description** of the gateway resource.
 5. Optionally, select **+** under **APIs** to associate one or more APIs with this gateway resource.
 > [!TIP]
@@ -43,6 +44,7 @@ Complete the following quickstart: [Create an Azure API Management instance](get
 
 > [!IMPORTANT]
 > By default, none of the existing APIs will be associated with the new gateway resource. Therefore, attempts to invoke them via the new gateway will result in `404 Resource Not Found` responses.
+
 6. Click **Add**.
 
 Now the gateway resource has been provisioned in your API Management instance. You can proceed to deploy the gateway.


### PR DESCRIPTION
Added empty lines between the numbered lists and the tip and hint boxes, as the numbered steps is getting rendered inside the preceding tip boxes on the final docs website, even though it is not the case with the markdown preview.