### PR TITLE
Fix typos in Cognitive Speech SDK intent recognition quickstarts

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/cpp/windows.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/cpp/windows.md
@@ -18,6 +18,7 @@ zone_pivot_groups: programming-languages-set-two
 Before you get started, make sure to:
 
 > [!div class="checklist"]
+>
 > * [Create an Azure Speech Resource](../../../../get-started.md)
 > * [Create a LUIS application and get an endpoint key](../../../../quickstarts/create-luis.md)
 > * [Setup your development environment](../../../../quickstarts/setup-platform.md?tabs=windows)
@@ -37,16 +38,16 @@ Let's add some code that works as a skeleton for our project. Make note that you
 
 ## Create a Speech configuration
 
-Before you can initialize a `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoing key and region. Insert this code in the `recognizeIntent()` method.
+Before you can initialize an `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoint key and region. Insert this code in the `recognizeIntent()` method.
 
 This sample uses the `FromSubscription()` method to build the `SpeechConfig`. For a full list of available methods, see [SpeechConfig Class](https://docs.microsoft.com/cpp/cognitive-services/speech/speechconfig).
 
 > [!NOTE]
-> It is important to use the LUIS Endpoint key and not the Starter or Authroing keys as only the Endpoint key is valid for speech to intent recognition. See [Create a LUIS application and get an endpoint key](~/articles/cognitive-services/Speech-Service/quickstarts/create-luis.md) for instructions on how to get the correct key.
+> It is important to use the LUIS Endpoint key and not the Starter or Authoring keys as only the Endpoint key is valid for speech to intent recognition. See [Create a LUIS application and get an endpoint key](~/articles/cognitive-services/Speech-Service/quickstarts/create-luis.md) for instructions on how to get the correct key.
 
 [!code-cpp[](~/samples-cognitive-services-speech-sdk/quickstart/cpp/windows/intent-recognition/helloworld/helloworld.cpp?range=25)]
 
-## Initialize a IntentRecognizer
+## Initialize an IntentRecognizer
 
 Now, let's create an `IntentRecognizer`. Insert this code in the `recognizeIntent()` method, right below your Speech configuration.
 [!code-cpp[](~/samples-cognitive-services-speech-sdk/quickstart/cpp/windows/intent-recognition/helloworld/helloworld.cpp?range=28)]
@@ -58,8 +59,8 @@ You now need to associate a `LanguageUnderstandingModel` with the intent recogni
 
 ## Recognize an intent
 
-From the `IntentRecognizer` object, you're going to call the `RecognizeOnceAsync()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop reconizing speech.
-For similicity we'll wait on the future returned to complete.
+From the `IntentRecognizer` object, you're going to call the `RecognizeOnceAsync()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop recognizing speech.
+For simplicity we'll wait on the future returned to complete.
 
 Inside the using statement, add this code:
 [!code-cpp[](~/samples-cognitive-services-speech-sdk/quickstart/cpp/windows/intent-recognition/helloworld/helloworld.cpp?range=44)]
@@ -73,7 +74,7 @@ Inside the using statement, below `RecognizeOnceAsync()`, add this code:
 
 ## Check your code
 
-At this point, your code should look like this: 
+At this point, your code should look like this:  
 (We've added some comments to this version)
 [!code-cpp[](~/samples-cognitive-services-speech-sdk/quickstart/cpp/windows/intent-recognition/helloworld/helloworld.cpp?range=6-81)]
 
@@ -81,7 +82,7 @@ At this point, your code should look like this:
 
 Now you're ready to build your app and test our speech recognition using the Speech service.
 
-1. **Compile the code** - From the menu bar of Visual Stuio, choose **Build** > **Build Solution**.
+1. **Compile the code** - From the menu bar of Visual Studio, choose **Build** > **Build Solution**.
 2. **Start your app** - From the menu bar, choose **Debug** > **Start Debugging** or press **F5**.
 3. **Start recognition** - It'll prompt you to speak a phrase in English. Your speech is sent to the Speech service, transcribed as text, and rendered in the console.
 

--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/csharp/dotnet.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/csharp/dotnet.md
@@ -18,6 +18,7 @@ zone_pivot_groups: programming-languages-set-two
 Before you get started, make sure to:
 
 > [!div class="checklist"]
+>
 > * [Create an Azure Speech Resource](../../../../get-started.md)
 > * [Create a LUIS application and get an endpoint key](../../../../quickstarts/create-luis.md)
 > * [Setup your development environment](../../../../quickstarts/setup-platform.md?tabs=dotnet)
@@ -37,18 +38,18 @@ Let's add some code that works as a skeleton for our project. Make note that you
 
 ## Create a Speech configuration
 
-Before you can initialize a `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoing key and region. Insert this code in the `RecognizeIntentAsync()` method.
+Before you can initialize an `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoint key and region. Insert this code in the `RecognizeIntentAsync()` method.
 
 This sample uses the `FromSubscription()` method to build the `SpeechConfig`. For a full list of available methods, see [SpeechConfig Class](https://docs.microsoft.com/dotnet/api/microsoft.cognitiveservices.speech.speechconfig?view=azure-dotnet).
 
 > [!NOTE]
-> It is important to use the LUIS Endpoint key and not the Starter or Authroing keys as only the Endpoint key is valid for speech to intent recognition. See [Create a LUIS application and get an endpoint key](~/articles/cognitive-services/Speech-Service/quickstarts/create-luis.md) for instructions on how to get the correct key.
+> It is important to use the LUIS Endpoint key and not the Starter or Authoring keys as only the Endpoint key is valid for speech to intent recognition. See [Create a LUIS application and get an endpoint key](~/articles/cognitive-services/Speech-Service/quickstarts/create-luis.md) for instructions on how to get the correct key.
 
 [!code-csharp[](~/samples-cognitive-services-speech-sdk/quickstart/csharp/dotnet/intent-recognition/helloworld/Program.cs?range=26)]
 
-## Initialize a IntentRecognizer
+## Initialize an IntentRecognizer
 
-Now, let's create a `IntentRecognizer`. This object is created inside of a using statement to ensure the proper release of unmanaged resources. Insert this code in the `RecognizeIntentAsync()` method, right below your Speech configuration.
+Now, let's create an `IntentRecognizer`. This object is created inside of a using statement to ensure the proper release of unmanaged resources. Insert this code in the `RecognizeIntentAsync()` method, right below your Speech configuration.
 [!code-csharp[](~/samples-cognitive-services-speech-sdk/quickstart/csharp/dotnet/intent-recognition/helloworld/Program.cs?range=28-30,76)]
 
 ## Add a LanguageUnderstandingModel and Intents
@@ -58,7 +59,7 @@ You now need to associate a `LanguageUnderstandingModel` with the intent recogni
 
 ## Recognize an intent
 
-From the `IntentRecognizer` object, you're going to call the `RecognizeOnceAsync()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop reconizing speech.
+From the `IntentRecognizer` object, you're going to call the `RecognizeOnceAsync()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop recognizing speech.
 
 Inside the using statement, add this code:
 [!code-csharp[](~/samples-cognitive-services-speech-sdk/quickstart/csharp/dotnet/intent-recognition/helloworld/Program.cs?range=46)]
@@ -72,7 +73,7 @@ Inside the using statement, below `RecognizeOnceAsync()`, add this code:
 
 ## Check your code
 
-At this point, your code should look like this: 
+At this point, your code should look like this:  
 (We've added some comments to this version)
 [!code-csharp[](~/samples-cognitive-services-speech-sdk/quickstart/csharp/dotnet/intent-recognition/helloworld/Program.cs?range=5-86)]
 

--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/header.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/header.md
@@ -15,7 +15,8 @@ zone_pivot_groups: programming-languages-set-two
 
 In this quickstart you will use the [Speech SDK](~/articles/cognitive-services/speech-service/speech-sdk.md) to interactively recognize speech from audio data captured from a microphone. After satisfying a few prerequisites, recognizing speech from a microphone only takes four steps:
 > [!div class="checklist"]
+>
 > * Create a ````SpeechConfig```` object from your subscription key and region.
-> * Create a ````IntentRecognizer```` object using the ````SpeechConfig```` object from above.
+> * Create an ````IntentRecognizer```` object using the ````SpeechConfig```` object from above.
 > * Using the ````IntentRecognizer```` object, start the recognition process for a single utterance.
 > * Inspect the ````IntentRecognitionResult```` returned.

--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/java/jre.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/java/jre.md
@@ -18,6 +18,7 @@ zone_pivot_groups: programming-languages-set-two
 Before you get started, make sure to:
 
 > [!div class="checklist"]
+>
 > * [Create an Azure Speech Resource](../../../../get-started.md)
 > * [Create a LUIS application and get an endpoint key](../../../../quickstarts/create-luis.md)
 > * [Setup your development environment](../../../../quickstarts/setup-platform.md?tabs=jre)
@@ -34,18 +35,18 @@ Let's add some code that works as a skeleton for our project.
 
 ## Create a Speech configuration
 
-Before you can initialize a `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoing key and region. Insert this code in the try / catch block in main
+Before you can initialize an `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoint key and region. Insert this code in the try / catch block in main
 
 This sample uses the `FromSubscription()` method to build the `SpeechConfig`. For a full list of available methods, see [SpeechConfig Class](https://docs.microsoft.com/dotnet/api/microsoft.cognitiveservices.speech.speechconfig?view=azure-dotnet).
 
 > [!NOTE]
-> It is important to use the LUIS Endpoint key and not the Starter or Authroing keys as only the Endpoint key is valid for speech to intent recognition. See [Create a LUIS application and get an endpoint key](~/articles/cognitive-services/Speech-Service/quickstarts/create-luis.md) for instructions on how to get the correct key.
+> It is important to use the LUIS Endpoint key and not the Starter or Authoring keys as only the Endpoint key is valid for speech to intent recognition. See [Create a LUIS application and get an endpoint key](~/articles/cognitive-services/Speech-Service/quickstarts/create-luis.md) for instructions on how to get the correct key.
 
 [!code-java[](~/samples-cognitive-services-speech-sdk/quickstart/java/jre/intent-recognition/src/speechsdk/quickstart/Main.java?range=27)]
 
-## Initialize a IntentRecognizer
+## Initialize an IntentRecognizer
 
-Now, let's create a `IntentRecognizer`. Insert this code right below your Speech configuration.
+Now, let's create an `IntentRecognizer`. Insert this code right below your Speech configuration.
 [!code-java[](~/samples-cognitive-services-speech-sdk/quickstart/java/jre/intent-recognition/src/speechsdk/quickstart/Main.java?range=30)]
 
 ## Add a LanguageUnderstandingModel and Intents
@@ -55,7 +56,7 @@ You now need to associate a `LanguageUnderstandingModel` with the intent recogni
 
 ## Recognize an intent
 
-From the `IntentRecognizer` object, you're going to call the `recognizeOnceAsync()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop reconizing speech.
+From the `IntentRecognizer` object, you're going to call the `recognizeOnceAsync()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop recognizing speech.
 
 [!code-java[](~/samples-cognitive-services-speech-sdk/quickstart/java/jre/intent-recognition/src/speechsdk/quickstart/Main.java?range=41)]
 
@@ -73,7 +74,7 @@ It's important to release the speech resources when you're done using them. Inse
 
 ## Check your code
 
-At this point, your code should look like this:
+At this point, your code should look like this:  
 (We've added some comments to this version)
 [!code-java[](~/samples-cognitive-services-speech-sdk/quickstart/java/jre/intent-recognition/src/speechsdk/quickstart/Main.java?range=6-76)]
 

--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/python/python.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/intent-recognition/python/python.md
@@ -18,6 +18,7 @@ zone_pivot_groups: programming-languages-set-two
 Before you get started, make sure to:
 
 > [!div class="checklist"]
+>
 > * [Create an Azure Speech Resource](../../../../get-started.md)
 > * [Create a LUIS application and get an endpoint key](../../../../quickstarts/create-luis.md)
 > * [Setup your development environment](../../../../quickstarts/setup-platform.md)
@@ -34,7 +35,7 @@ Let's add some code that works as a skeleton for our project.
 
 ## Create a Speech configuration
 
-Before you can initialize a `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoing key and region. Insert this code next.
+Before you can initialize an `IntentRecognizer` object, you need to create a configuration that uses your LUIS Endpoint key and region. Insert this code next.
 
 This sample constructs the `SpeechConfig` object using LUIS key and region. For a full list of available methods, see [SpeechConfig Class](https://docs.microsoft.com/python/api/azure-cognitiveservices-speech/azure.cognitiveservices.speech.speechconfig).
 
@@ -43,9 +44,9 @@ This sample constructs the `SpeechConfig` object using LUIS key and region. For 
 
 [!code-python[](~/samples-cognitive-services-speech-sdk/quickstart/python/intent-recognition/quickstart.py?range=12)]
 
-## Initialize a IntentRecognizer
+## Initialize an IntentRecognizer
 
-Now, let's create a `IntentRecognizer`. Insert this code right below your Speech configuration.
+Now, let's create an `IntentRecognizer`. Insert this code right below your Speech configuration.
 [!code-python[](~/samples-cognitive-services-speech-sdk/quickstart/python/intent-recognition/quickstart.py?range=15)]
 
 ## Add a LanguageUnderstandingModel and Intents
@@ -55,7 +56,7 @@ You now need to associate a `LanguageUnderstandingModel` with the intent recogni
 
 ## Recognize an intent
 
-From the `IntentRecognizer` object, you're going to call the `recognize_once()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop reconizing speech.
+From the `IntentRecognizer` object, you're going to call the `recognize_once()` method. This method lets the Speech service know that you're sending a single phrase for recognition, and that once the phrase is identified to stop recognizing speech.
 [!code-python[](~/samples-cognitive-services-speech-sdk/quickstart/python/intent-recognition/quickstart.py?range=35)]
 
 ## Display the recognition results (or errors)
@@ -67,7 +68,7 @@ Inside the using statement, below your call to `recognize_once()`, add this code
 
 ## Check your code
 
-At this point, your code should look like this:
+At this point, your code should look like this:  
 (We've added some comments to this version)
 [!code-python[](~/samples-cognitive-services-speech-sdk/quickstart/python/intent-recognition/quickstart.py?range=5-47)]
 


### PR DESCRIPTION
In addition to some typo fixes and Markdown formatting fixes, I had thought the following line was intended to be two lines because of the line break in the Markdown, so I used a double-space to have it render on two lines:

> At this point, your code should look like this: (We've added some comments to this version)