### PR TITLE
Update control-flow-webhook-activity.md

### DIFF
--- a/articles/data-factory/control-flow-webhook-activity.md
+++ b/articles/data-factory/control-flow-webhook-activity.md
@@ -14,7 +14,7 @@ ms.date: 03/25/2019
 ---
 
 # Webhook activity in Azure Data Factory
-You can use a web hook activity to control the execution of pipelines through your custom code. Using the webhook activity, customers can call an endpoint and pass a callback URL. The pipeline run waits for the callback to be invoked before proceeding to the next activity.
+You can use a webhook activity to control the execution of pipelines through your custom code. Using the webhook activity, customers can call an endpoint and pass a callback URL. The pipeline run waits for the callback to be invoked before proceeding to the next activity.
 
 ## Syntax
 
@@ -55,7 +55,7 @@ type | Must be set to  **WebHook**. | String | Yes |
 method | Rest API method for the target endpoint. | String. Supported Types: 'POST' | Yes |
 url | Target endpoint and path | String (or expression with resultType of string). | Yes |
 headers | Headers that are sent to the request. For example, to set the language and type on a request: "headers" : { "Accept-Language": "en-us", "Content-Type": "application/json" }. | String (or expression with resultType of string) | Yes, Content-type header is required. "headers":{ "Content-Type":"application/json"} |
-body | Represents the payload that is sent to the endpoint. | Valid JSON (or expression with resultType of json). See the schema of the request payload in [Request payload schema](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fdata-factory%2Fcontrol-flow-web-activity%23request-payload-schema&amp;data=02%7C01%7Cshlo%40microsoft.com%7Cde517eae4e7f4f2c408d08d6b167f6b1%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636891457414397501&amp;sdata=ljUZv5csQQux2TT3JtTU9ZU8e1uViRzuX5DSNYkL0uE%3D&amp;reserved=0) section. | Yes |
+body | Represents the payload that is sent to the endpoint. | Valid JSON (or expression with resultType of JSON). See the schema of the request payload in [Request payload schema](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fdata-factory%2Fcontrol-flow-web-activity%23request-payload-schema&amp;data=02%7C01%7Cshlo%40microsoft.com%7Cde517eae4e7f4f2c408d08d6b167f6b1%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636891457414397501&amp;sdata=ljUZv5csQQux2TT3JtTU9ZU8e1uViRzuX5DSNYkL0uE%3D&amp;reserved=0) section. | Yes |
 authentication | Authentication method used for calling the endpoint. Supported Types are "Basic" or "ClientCertificate." For more information, see [Authentication](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fdata-factory%2Fcontrol-flow-web-activity%23authentication&amp;data=02%7C01%7Cshlo%40microsoft.com%7Cde517eae4e7f4f2c408d08d6b167f6b1%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636891457414397501&amp;sdata=GdA1%2Fh2pAD%2BSyWJHSW%2BSKucqoAXux%2F4L5Jgndd3YziM%3D&amp;reserved=0) section. If authentication is not required, exclude this property. | String (or expression with resultType of string) | No |
 timeout | How long the activity will wait for the &#39;callBackUri&#39; to be invoked. How long the activity will wait for the ‘callBackUri’ to be invoked. Default value is 10mins (“00:10:00”). Format is Timespan i.e. d.hh:mm:ss | String | No |
 Report status on callback | Allows the user the report the failed status of the webhook activity which will mark the activity as failed | Boolean | No |
@@ -64,11 +64,11 @@ Report status on callback | Allows the user the report the failed status of the 
 
 Azure Data Factory will pass an additional property “callBackUri” in the body to the url endpoint, and will expect this uri to be invoked before the timeout value specified. If the uri is not invoked, the activity will fail with status ‘TimedOut’.
 
-The web hook activity itself fails when the call to the custom endpoint fails. Any error message can be added into the body of the callback and used in a subsequent activity.
+The webhook activity itself fails when the call to the custom endpoint fails. Any error message can be added into the body of the callback and used in a subsequent activity.
 
-The body passed back to the call back URI should be valid JSON and you must set the Content-Type to `application/json`
+The body passed back to the callback URI should be valid JSON. You must set the Content-Type header to `application/json`.
 
-When using the "Report status on callback" option you have to add the following snippet to the body when making the callback:
+When you use the "Report status on callback" option, you must add the following snippet to the body when making the callback:
 
 ```
 {
@@ -88,6 +88,7 @@ When using the "Report status on callback" option you have to add the following 
 
 
 ## Next steps
+
 See other control flow activities supported by Data Factory:
 
 - [If Condition Activity](control-flow-if-condition-activity.md)

--- a/articles/data-factory/control-flow-webhook-activity.md
+++ b/articles/data-factory/control-flow-webhook-activity.md
@@ -55,15 +55,37 @@ type | Must be set to  **WebHook**. | String | Yes |
 method | Rest API method for the target endpoint. | String. Supported Types: 'POST' | Yes |
 url | Target endpoint and path | String (or expression with resultType of string). | Yes |
 headers | Headers that are sent to the request. For example, to set the language and type on a request: "headers" : { "Accept-Language": "en-us", "Content-Type": "application/json" }. | String (or expression with resultType of string) | Yes, Content-type header is required. "headers":{ "Content-Type":"application/json"} |
-body | Represents the payload that is sent to the endpoint. | The body passed back to the call back URI should be a valid JSON. See the schema of the request payload in [Request payload schema](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fdata-factory%2Fcontrol-flow-web-activity%23request-payload-schema&amp;data=02%7C01%7Cshlo%40microsoft.com%7Cde517eae4e7f4f2c408d08d6b167f6b1%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636891457414397501&amp;sdata=ljUZv5csQQux2TT3JtTU9ZU8e1uViRzuX5DSNYkL0uE%3D&amp;reserved=0) section. | Yes |
+body | Represents the payload that is sent to the endpoint. | Valid JSON (or expression with resultType of json). See the schema of the request payload in [Request payload schema](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fdata-factory%2Fcontrol-flow-web-activity%23request-payload-schema&amp;data=02%7C01%7Cshlo%40microsoft.com%7Cde517eae4e7f4f2c408d08d6b167f6b1%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636891457414397501&amp;sdata=ljUZv5csQQux2TT3JtTU9ZU8e1uViRzuX5DSNYkL0uE%3D&amp;reserved=0) section. | Yes |
 authentication | Authentication method used for calling the endpoint. Supported Types are "Basic" or "ClientCertificate." For more information, see [Authentication](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fdata-factory%2Fcontrol-flow-web-activity%23authentication&amp;data=02%7C01%7Cshlo%40microsoft.com%7Cde517eae4e7f4f2c408d08d6b167f6b1%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636891457414397501&amp;sdata=GdA1%2Fh2pAD%2BSyWJHSW%2BSKucqoAXux%2F4L5Jgndd3YziM%3D&amp;reserved=0) section. If authentication is not required, exclude this property. | String (or expression with resultType of string) | No |
 timeout | How long the activity will wait for the &#39;callBackUri&#39; to be invoked. How long the activity will wait for the ‘callBackUri’ to be invoked. Default value is 10mins (“00:10:00”). Format is Timespan i.e. d.hh:mm:ss | String | No |
+Report status on callback | Allows the user the report the failed status of the webhook activity which will mark the activity as failed | Boolean | No |
 
 ## Additional notes
 
 Azure Data Factory will pass an additional property “callBackUri” in the body to the url endpoint, and will expect this uri to be invoked before the timeout value specified. If the uri is not invoked, the activity will fail with status ‘TimedOut’.
 
-The web hook activity itself fails only when the call to the custom endpoint fails. Any error message can be added into the body of the callback and used in a subsequent activity.
+The web hook activity itself fails when the call to the custom endpoint fails. Any error message can be added into the body of the callback and used in a subsequent activity.
+
+The body passed back to the call back URI should be valid JSON and you must set the Content-Type to `application/json`
+
+When using the "Report status on callback" option you have to add the following snippet to the body when making the callback:
+
+```
+{
+    "Output": {
+        // output object will be used in activity output
+        "testProp": "testPropValue"
+    },
+    "Error": {
+        // Optional, set it when you want to fail the activity
+        "ErrorCode": "testErrorCode",
+        "Message": "error message to show in activity error"
+    },
+    "StatusCode": "403" // when status code is >=400, activity will be marked as failed
+}
+```
+
+
 
 ## Next steps
 See other control flow activities supported by Data Factory:


### PR DESCRIPTION
I have updated the page with information on how to use the Report status on callback feature with information provided by Monica F on the engineering team. I have also added a little tip about the content type as it is not clear when this fails what the reason is unless you go look at what http error 415 means. Even that only means invalid content type. Lastly I removed the piece about callback on the body of the request as that body refers to the body of any endpoint you are calling not the body of the callback