### PR TITLE
docs: complete npm based setup example

### DIFF
--- a/articles/azure-monitor/app/javascript.md
+++ b/articles/azure-monitor/app/javascript.md
@@ -37,6 +37,7 @@ const appInsights = new ApplicationInsights({ config: {
   /* ...Other Configuration Options... */
 } });
 appInsights.loadAppInsights();
+appInsights.trackPageView();
 ```
 
 ### Snippet based setup


### PR DESCRIPTION
When using the npm based setup, in order for App Insights to start tracking a call to `trackPageView` is required after `loadAppInsights`. This has been added to the example.