### PR TITLE
Bad code example - fix incorrect unicode dash

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-pta-quick-start.md
+++ b/articles/active-directory/hybrid/how-to-connect-pta-quick-start.md
@@ -140,7 +140,7 @@ Second, you can create and run an unattended deployment script. This is useful w
         $User = "<username>"
         $PlainPassword = '<password>'
         $SecurePassword = $PlainPassword | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object –TypeName System.Management.Automation.PSCredential –ArgumentList $User, $SecurePassword
+        $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, $SecurePassword
 3. Go to **C:\Program Files\Microsoft Azure AD Connect Authentication Agent** and run the following script using the `$cred` object that you created:
 
         RegisterConnector.ps1 -modulePath "C:\Program Files\Microsoft Azure AD Connect Authentication Agent\Modules\" -moduleName "AppProxyPSModule" -Authenticationmode Credentials -Usercredentials $cred -Feature PassthroughAuthentication


### PR DESCRIPTION
When running original it has a bad character, example output below:
```
Cannot find type [â€TypeName System.Management.Automation.PSCredential â€ArgumentList]: verify that the assembly
```