### PR TITLE
Various fixes

### DIFF
--- a/articles/azure-app-configuration/TOC.yml
+++ b/articles/azure-app-configuration/TOC.yml
@@ -67,7 +67,7 @@
           href: concept-disaster-recovery.md
 - name: How-to guides
   items:
-    - name: Integrate with Azure Managed Service Identity
+    - name: Integrate with Azure Managed Identity
       href: howto-integrate-azure-managed-service-identity.md
     - name: Import or export configuration data
       href: howto-import-export-data.md

--- a/articles/azure-app-configuration/cli-samples.md
+++ b/articles/azure-app-configuration/cli-samples.md
@@ -24,11 +24,11 @@ The following table includes links to bash scripts for Azure App Configuration b
 | | |
 |-|-|
 |**Create**||
-| [Create an app configuration store](./scripts/cli-create-service.md) | Creates a resource group and an app configuration store instance.  |
+| [Create an App Configuration store](./scripts/cli-create-service.md) | Creates a resource group and an App Configuration store instance.  |
 |**Use**||
 | [Work with key values](./scripts/cli-work-with-keys.md) | Creates, views, updates, and deletes key values. |
 | [Import key values](./scripts/cli-import.md) | Imports key values from other sources. |
 | [Export key values](./scripts/cli-export.md) | Exports key values to other targets. |
 |**Delete**||
-| [Delete an app configuration store](./scripts/cli-delete-service.md) | Deletes an app configuration store instance.  |
+| [Delete an App Configuration store](./scripts/cli-delete-service.md) | Deletes an App Configuration store instance.  |
 | | |

--- a/articles/azure-app-configuration/concept-app-configuration-event.md
+++ b/articles/azure-app-configuration/concept-app-configuration-event.md
@@ -17,7 +17,7 @@ Azure App Configuration events enable applications to react to changes in key-va
 
 Azure App Configuration events are sent to the Azure Event Grid which provides reliable delivery services to your applications through rich retry policies and dead-letter delivery. To learn more, see [Event Grid message delivery and retry](https://docs.microsoft.com/azure/event-grid/delivery-and-retry).
 
-Common app configuration event scenarios include refreshing application configuration, triggering deployments, or any configuration-oriented workflow. When changes are infrequent, but your scenario requires immediate responsiveness, event-based architecture can be especially efficient.
+Common App Configuration event scenarios include refreshing application configuration, triggering deployments, or any configuration-oriented workflow. When changes are infrequent, but your scenario requires immediate responsiveness, event-based architecture can be especially efficient.
 
 Take a look at [Route Azure App Configuration events to a custom web endpoint - CLI](./howto-app-configuration-event.md) for a quick example. 
 
@@ -32,11 +32,11 @@ Event grid uses [event subscriptions](../event-grid/concepts.md#event-subscripti
 > |`Microsoft.AppConfiguration.KeyValueDeleted`|Fired when a key-value is deleted|
 
 ## Event schema
-Azure App Configuration events contain all the information you need to respond to changes in your data. You can identify an app configuration event because the eventType property starts with "Microsoft.AppConfiguration". Additional information about the usage of Event Grid event properties is documented in [Event Grid event schema](../event-grid/event-schema.md).  
+Azure App Configuration events contain all the information you need to respond to changes in your data. You can identify an App Configuration event because the eventType property starts with "Microsoft.AppConfiguration". Additional information about the usage of Event Grid event properties is documented in [Event Grid event schema](../event-grid/event-schema.md).  
 
 > |Property|Type|Description|
 > |-------------------|------------------------|-----------------------------------------------------------------------|
-> |topic|string|Full Azure Resource Manager id of the app configuration that emits the event.|
+> |topic|string|Full Azure Resource Manager id of the App Configuration that emits the event.|
 > |subject|string|The URI of the key-value that is the subject of the event.|
 > |eventTime|string|The date/time that the event was generated, in ISO 8601 format.|
 > |eventType|string|"Microsoft.AppConfiguration.KeyValueModified" or "Microsoft.AppConfiguration.KeyValueDeleted".|
@@ -70,9 +70,9 @@ Here is an example of a KeyValueModified event:
 For more information, see [Azure App Configuration events schema](../event-grid/event-schema-app-configuration.md).
 
 ## Practices for consuming events
-Applications that handle app configuration events should follow a few recommended practices:
+Applications that handle App Configuration events should follow a few recommended practices:
 > [!div class="checklist"]
-> * As multiple subscriptions can be configured to route events to the same event handler, it is important not to assume events are from a particular source, but to check the topic of the message to ensure that it comes from the app configuration you are expecting.
+> * As multiple subscriptions can be configured to route events to the same event handler, it is important not to assume events are from a particular source, but to check the topic of the message to ensure that it comes from the App Configuration you are expecting.
 > * Similarly, check that the eventType is one you are prepared to process, and do not assume that all events you receive will be the types you expect.
 > * As messages can arrive out of order and after some delay, use the etag fields to understand if your information about objects is still up-to-date.  Also, use the sequencer fields to understand the order of events on any particular object.
 > * Use the subject field to access the key-value that was modified.

--- a/articles/azure-app-configuration/concept-disaster-recovery.md
+++ b/articles/azure-app-configuration/concept-disaster-recovery.md
@@ -21,7 +21,7 @@ Currently, Azure App Configuration is a regional service. Each configuration sto
 
 ## High-availability architecture
 
-To realize cross-region redundancy, you need to create multiple app configuration stores in different regions. With this setup, your application has at least one additional configuration store to fall back on if the primary store becomes inaccessible. The following diagram illustrates the topology between your application and its primary and secondary configuration stores:
+To realize cross-region redundancy, you need to create multiple App Configuration stores in different regions. With this setup, your application has at least one additional configuration store to fall back on if the primary store becomes inaccessible. The following diagram illustrates the topology between your application and its primary and secondary configuration stores:
 
 ![Geo-redundant stores](./media/geo-redundant-app-configuration-stores.png)
 

--- a/articles/azure-app-configuration/concept-key-value.md
+++ b/articles/azure-app-configuration/concept-key-value.md
@@ -25,7 +25,7 @@ Keys serve as the name for key-value pairs and are used to store and retrieve co
 
 The usage of configuration data within application frameworks might dictate specific naming schemes for key values. As an example, Java's Spring Cloud framework defines `Environment` resources that supply settings to a Spring application to be parameterized by variables that include *application name* and *profile*. Keys for Spring Cloud-related configuration data typically start with these two elements separated by a delimiter.
 
-Keys stored in App Configuration are case-sensitive, unicode-based strings. The keys *app1* and *App1* are distinct in an app configuration store. Keep this in mind when you use configuration settings within an application because some frameworks handle configuration keys case-insensitively. For example, the ASP.NET Core configuration system treats keys as case-insensitive strings. To avoid unpredictable behaviors when you query App Configuration within an ASP.NET Core application, don't use keys that differ only by casing.
+Keys stored in App Configuration are case-sensitive, unicode-based strings. The keys *app1* and *App1* are distinct in an App Configuration store. Keep this in mind when you use configuration settings within an application because some frameworks handle configuration keys case-insensitively. For example, the ASP.NET Core configuration system treats keys as case-insensitive strings. To avoid unpredictable behaviors when you query App Configuration within an ASP.NET Core application, don't use keys that differ only by casing.
 
 You can use any unicode character in key names entered into App Configuration except for `*`, `,`, and `\`. These characters are reserved. If you need to include a reserved character, you must escape it by using `\{Reserved Character}`. There's a combined size limit of 10,000 characters on a key-value pair. This limit includes all characters in the key, its value, and all associated optional attributes. Within this limit, you can have many hierarchical levels for keys.
 
@@ -53,7 +53,7 @@ Here are several examples of how you can structure your key names into a hierarc
 
 ### Label keys
 
-Key values in App Configuration can optionally have a label attribute. Labels are used to differentiate key values with the same key. A key *app1* with labels *A* and *B* forms two separate keys in an app configuration store. By default, the label for a key value is empty, or `null`.
+Key values in App Configuration can optionally have a label attribute. Labels are used to differentiate key values with the same key. A key *app1* with labels *A* and *B* forms two separate keys in an App Configuration store. By default, the label for a key value is empty, or `null`.
 
 Label provides a convenient way to create variants of a key. A common use of labels is to specify multiple environments for the same key:
 
@@ -69,7 +69,7 @@ You can use any unicode character in labels except for `*`, `,`, and `\`. These 
 
 ### Query key values
 
-Each key value is uniquely identified by its key plus a label that can be `null`. You query an app configuration store for key values by specifying a pattern. The app configuration store returns all key values that match the pattern and their corresponding values and attributes. Use the following key patterns in REST API calls to App Configuration:
+Each key value is uniquely identified by its key plus a label that can be `null`. You query an App Configuration store for key values by specifying a pattern. The App Configuration store returns all key values that match the pattern and their corresponding values and attributes. Use the following key patterns in REST API calls to App Configuration:
 
 | Key | |
 |---|---|
@@ -96,7 +96,7 @@ You also can include the following label patterns:
 
 Values assigned to keys are also unicode strings. You can use all unicode characters for values. There's an optional user-defined content type associated with each value. Use this attribute to store information, for example an encoding scheme, about a value that helps your application to process it properly.
 
-Configuration data stored in an app configuration store, which includes all keys and values, is encrypted at rest and in transit. App Configuration isn't a replacement solution for Azure Key Vault. Don't store application secrets in it.
+Configuration data stored in an App Configuration store, which includes all keys and values, is encrypted at rest and in transit. App Configuration isn't a replacement solution for Azure Key Vault. Don't store application secrets in it.
 
 ## Next steps
 

--- a/articles/azure-app-configuration/concept-point-time-snapshot.md
+++ b/articles/azure-app-configuration/concept-point-time-snapshot.md
@@ -17,7 +17,7 @@ ms.author: yegu
 
 # Point-in-time snapshot
 
-Azure App Configuration keeps records of the precise times when a new key-value pair is created and then modified. These records form a complete timeline in key-value changes. An app configuration store can reconstruct the history of any key value and replay its past value at any given moment, up to the present. With this feature, you can “time-travel” backward and retrieve an old key value. For example, you can get yesterday's configuration settings, just before the most recent deployment, in order to recover a previous configuration and roll back the application.
+Azure App Configuration keeps records of the precise times when a new key-value pair is created and then modified. These records form a complete timeline in key-value changes. An App Configuration store can reconstruct the history of any key value and replay its past value at any given moment, up to the present. With this feature, you can “time-travel” backward and retrieve an old key value. For example, you can get yesterday's configuration settings, just before the most recent deployment, in order to recover a previous configuration and roll back the application.
 
 ## Key-value retrieval
 

--- a/articles/azure-app-configuration/enable-dynamic-configuration-aspnet-core.md
+++ b/articles/azure-app-configuration/enable-dynamic-configuration-aspnet-core.md
@@ -215,7 +215,7 @@ Before you continue, finish [Create an ASP.NET Core app with App Configuration](
 
 ## Next steps
 
-In this tutorial, you added an Azure managed service identity to streamline access to App Configuration and improve credential management for your app. To learn more about how to use App Configuration, continue to the Azure CLI samples.
+In this tutorial, you enabled your ASP.NET Core web app to dynamically refresh configuration settings from App Configuration. To learn how to use an Azure managed identity to streamline access to App Configuration, continue to the next tutorial.
 
 > [!div class="nextstepaction"]
-> [CLI samples](./cli-samples.md)
+> [Managed identity integration](./howto-integrate-azure-managed-service-identity.md)

--- a/articles/azure-app-configuration/enable-dynamic-configuration-dotnet-core.md
+++ b/articles/azure-app-configuration/enable-dynamic-configuration-dotnet-core.md
@@ -137,7 +137,7 @@ The `ConfigureRefresh` method is used to specify the settings used to update the
 
 ## Next steps
 
-In this tutorial, you added an Azure managed service identity to streamline access to App Configuration and improve credential management for your app. To learn more about how to use App Configuration, continue to the Azure CLI samples.
+In this tutorial, you enabled your .NET Core app to dynamically refresh configuration settings from App Configuration. To learn how to use an Azure managed identity to streamline access to App Configuration, continue to the next tutorial.
 
 > [!div class="nextstepaction"]
-> [CLI samples](./cli-samples.md)
+> [Managed identity integration](./howto-integrate-azure-managed-service-identity.md)

--- a/articles/azure-app-configuration/enable-dynamic-configuration-dotnet.md
+++ b/articles/azure-app-configuration/enable-dynamic-configuration-dotnet.md
@@ -153,7 +153,7 @@ In this tutorial, you learn how to:
 
 ## Next steps
 
-In this tutorial, you added an Azure managed service identity to streamline access to App Configuration and improve credential management for your app. To learn how to add an Azure-managed service identity that streamlines access to App Configuration, continue to the next tutorial.
+In this tutorial, you enabled your .NET Framework app to dynamically refresh configuration settings from App Configuration. To learn how to use an Azure managed identity to streamline access to App Configuration, continue to the next tutorial.
 
 > [!div class="nextstepaction"]
 > [Managed identity integration](./howto-integrate-azure-managed-service-identity.md)

--- a/articles/azure-app-configuration/howto-app-configuration-event.md
+++ b/articles/azure-app-configuration/howto-app-configuration-event.md
@@ -46,7 +46,7 @@ az group create --name <resource_group_name> --location westus
 
 ## Create an App Configuration
 
-Replace `<appconfig_name>` with a unique name for your app configuration, and `<resource_group_name>` with the resource group you created earlier. The name must be unique because it is used as a DNS name.
+Replace `<appconfig_name>` with a unique name for your App Configuration, and `<resource_group_name>` with the resource group you created earlier. The name must be unique because it is used as a DNS name.
 
 ```azurecli-interactive
 az appconfig create \
@@ -78,7 +78,7 @@ You should see the site with no messages currently displayed.
 
 ## Subscribe to your App Configuration
 
-You subscribe to a topic to tell Event Grid which events you want to track and where to send those events. The following example subscribes to the app configuration you created, and passes the URL from your web app as the endpoint for event notification. Replace `<event_subscription_name>` with a name for your event subscription. For `<resource_group_name>` and `<appconfig_name>`, use the values you created earlier.
+You subscribe to a topic to tell Event Grid which events you want to track and where to send those events. The following example subscribes to the App Configuration you created, and passes the URL from your web app as the endpoint for event notification. Replace `<event_subscription_name>` with a name for your event subscription. For `<resource_group_name>` and `<appconfig_name>`, use the values you created earlier.
 
 The endpoint for your web app must include the suffix `/api/updates/`.
 
@@ -124,7 +124,7 @@ You've triggered the event, and Event Grid sent the message to the endpoint you 
 ```
 
 ## Clean up resources
-If you plan to continue working with this app configuration and event subscription, do not clean up the resources created in this article. If you do not plan to continue, use the following command to delete the resources you created in this article.
+If you plan to continue working with this App Configuration and event subscription, do not clean up the resources created in this article. If you do not plan to continue, use the following command to delete the resources you created in this article.
 
 Replace `<resource_group_name>` with the resource group you created above.
 

--- a/articles/azure-app-configuration/howto-import-export-data.md
+++ b/articles/azure-app-configuration/howto-import-export-data.md
@@ -17,17 +17,17 @@ ms.custom: mvc
 
 # Import or export configuration data
 
-Azure App Configuration supports data import and export operations. Use these operations to work with configuration data in bulk and exchange data between your app configuration store and code project. For example, you can set up one app configuration store for testing and another for production. You then can copy application settings between them via a file so that you don't have to enter data twice.
+Azure App Configuration supports data import and export operations. Use these operations to work with configuration data in bulk and exchange data between your App Configuration store and code project. For example, you can set up one App Configuration store for testing and another for production. You then can copy application settings between them via a file so that you don't have to enter data twice.
 
 This article provides a guide for importing and exporting data with App Configuration.
 
 ## Import data
 
-Import brings configuration data into an App Configuration store from an existing source, instead of manually entering it. Use the import function to migrate data into an app configuration store or aggregate data from multiple sources. App Configuration supports importing from a JSON, YAML, or properties file.
+Import brings configuration data into an App Configuration store from an existing source, instead of manually entering it. Use the import function to migrate data into an App Configuration store or aggregate data from multiple sources. App Configuration supports importing from a JSON, YAML, or properties file.
 
 Import data by using either the [Azure portal](https://portal.azure.com) or the [Azure CLI](./scripts/cli-import.md). From the Azure portal, follow these steps:
 
-1. Browse to your app configuration store, and select **Import/Export**.
+1. Browse to your App Configuration store, and select **Import/Export**.
 
 2. On the **Import** tab, select **Source service** > **Configuration File**.
 
@@ -47,11 +47,11 @@ Import data by using either the [Azure portal](https://portal.azure.com) or the 
 
 ## Export data
 
-Export writes configuration data stored in App Configuration to another destination. Use the export function, for example, to save data in an app configuration store to a file that's embedded with your application code during deployment.
+Export writes configuration data stored in App Configuration to another destination. Use the export function, for example, to save data in an App Configuration store to a file that's embedded with your application code during deployment.
 
 Export data by using either the [Azure portal](https://portal.azure.com) or the [Azure CLI](./scripts/cli-export.md). From the Azure portal, follow these steps:
 
-1. Browse to your app configuration store, and select **Import/Export**.
+1. Browse to your App Configuration store, and select **Import/Export**.
 
 2. On the **Export** tab, select **Target service** > **Configuration File**.
 

--- a/articles/azure-app-configuration/howto-integrate-azure-managed-service-identity.md
+++ b/articles/azure-app-configuration/howto-integrate-azure-managed-service-identity.md
@@ -16,15 +16,15 @@ ms.date: 02/24/2019
 ms.author: yegu
 
 ---
-# Integrate with Azure managed identities
+# Integrate with Azure Managed Identities
 
-Azure Active Directory [managed identities](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) help simplify secrets management for your cloud application. With a managed identity, you can set up your code to use the service principal that was created for the Azure compute service it runs on. You use a managed identity instead of a separate credential stored in Azure Key Vault or a local connection string. 
+Azure Active Directory [managed identities](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview) help simplify secrets management for your cloud application. With a managed identity, you can set up your code to use the service principal that was created for the Azure service it runs on. You use a managed identity instead of a separate credential stored in Azure Key Vault or a local connection string. 
 
-Azure App Configuration and its .NET Core, .NET, and Java Spring client libraries come with managed service identity (MSI) support built into them. Although you aren't required to use it, MSI eliminates the need for an access token that contains secrets. Your code can access the app configuration store using only the service endpoint. You can embed this URL in your code directly without the concern of exposing any secret.
+Azure App Configuration and its .NET Core, .NET Framework, and Java Spring client libraries come with the managed identity support built into them. Although you aren't required to use it, the managed identity eliminates the need for an access token that contains secrets. Your code can access the App Configuration store using only the service endpoint. You can embed this URL in your code directly without the concern of exposing any secret.
 
-This tutorial shows how you can take advantage of MSI to access App Configuration. It builds on the web app introduced in the quickstarts. Before you continue, finish [Create an ASP.NET Core app with App Configuration](./quickstart-aspnet-core-app.md) first.
+This tutorial shows how you can take advantage of the managed identity to access App Configuration. It builds on the web app introduced in the quickstarts. Before you continue, finish [Create an ASP.NET Core app with App Configuration](./quickstart-aspnet-core-app.md) first.
 
-In addition, this tutorial optionally shows how you can use MSI in conjunction with App Configuration's Key Vault references. This allows you to seamlessly access secrets stored in Key Vault as well as configuration values in App Configuration. If you wish to explore this capability, finish [Use Key Vault References with ASP.NET Core](./use-key-vault-references-dotnet-core.md) first.
+In addition, this tutorial optionally shows how you can use the managed identity in conjunction with App Configuration's Key Vault references. This allows you to seamlessly access secrets stored in Key Vault as well as configuration values in App Configuration. If you wish to explore this capability, finish [Use Key Vault References with ASP.NET Core](./use-key-vault-references-dotnet-core.md) first.
 
 You can use any code editor to do the steps in this tutorial. [Visual Studio Code](https://code.visualstudio.com/) is an excellent option available on the Windows, macOS, and Linux platforms.
 
@@ -60,7 +60,7 @@ To set up a managed identity in the portal, you first create an application as n
 
 ## Grant access to App Configuration
 
-1. In the [Azure portal](https://portal.azure.com), select **All resources** and select the app configuration store that you created in the quickstart.
+1. In the [Azure portal](https://portal.azure.com), select **All resources** and select the App Configuration store that you created in the quickstart.
 
 1. Select **Access control (IAM)**.
 
@@ -78,9 +78,9 @@ To set up a managed identity in the portal, you first create an application as n
 
 ## Use a managed identity
 
-1. Find the URL to your app configuration store by going into its configuration screen in the Azure portal, then clicking on the **Access Keys** tab.
+1. Find the URL to your App Configuration store by going into its configuration screen in the Azure portal, then clicking on the **Access Keys** tab.
 
-1. Open *appsettings.json*, and add the following script. Replace *\<service_endpoint>*, including the brackets, with the URL to your app configuration store. 
+1. Open *appsettings.json*, and add the following script. Replace *\<service_endpoint>*, including the brackets, with the URL to your App Configuration store. 
 
     ```json
     "AppConfig": {
@@ -199,7 +199,7 @@ http://<app_name>.azurewebsites.net
 
 ## Use managed identity in other languages
 
-App Configuration providers for .NET Framework and Java Spring also have built-in support for managed identity. In these cases, use your app configuration store's URL endpoint instead of its full connection string when you configure a provider. For example, for the .NET Framework console app created in the quickstart, specify the following settings in the *App.config* file:
+App Configuration providers for .NET Framework and Java Spring also have built-in support for managed identity. In these cases, use your App Configuration store's URL endpoint instead of its full connection string when you configure a provider. For example, for the .NET Framework console app created in the quickstart, specify the following settings in the *App.config* file:
 
 ```xml
     <configSections>
@@ -224,6 +224,7 @@ App Configuration providers for .NET Framework and Java Spring also have built-i
 [!INCLUDE [azure-app-configuration-cleanup](../../includes/azure-app-configuration-cleanup.md)]
 
 ## Next steps
+In this tutorial, you added an Azure managed identity to streamline access to App Configuration and improve credential management for your app. To learn more about how to use App Configuration, continue to the Azure CLI samples.
 
 > [!div class="nextstepaction"]
 > [CLI samples](./cli-samples.md)

--- a/articles/azure-app-configuration/integrate-ci-cd-pipeline.md
+++ b/articles/azure-app-configuration/integrate-ci-cd-pipeline.md
@@ -26,7 +26,7 @@ If you have an Azure DevOps Pipeline, you can fetch key-values from App Configur
 
 ## Deploy App Configuration data with your application
 
-Your application may fail to run if it depends on Azure App Configuration and cannot reach it. You can enhance the resiliency of your application to deal with such an event, however unlikely it is to happen. To do so, package the current configuration data into a file that's deployed with the application and loaded locally during its startup. This approach guarantees that your application has default setting values at least. These values are overwritten by any newer changes in an app configuration store when it's available.
+Your application may fail to run if it depends on Azure App Configuration and cannot reach it. You can enhance the resiliency of your application to deal with such an event, however unlikely it is to happen. To do so, package the current configuration data into a file that's deployed with the application and loaded locally during its startup. This approach guarantees that your application has default setting values at least. These values are overwritten by any newer changes in an App Configuration store when it's available.
 
 Using the [Export](./howto-import-export-data.md#export-data) function of Azure App Configuration, you can automate the process of retrieving current configuration data as a single file. Then embed this file in a build or deployment step in your continuous integration and continuous deployment (CI/CD) pipeline.
 
@@ -40,7 +40,7 @@ If you build locally, download and install the [Azure CLI](https://docs.microsof
 
 To do a cloud build, with Azure DevOps for example, make sure the [Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) is installed in your build system.
 
-### Export an app configuration store
+### Export an App Configuration store
 
 1. Open your *.csproj* file, and add the following script:
 
@@ -51,7 +51,7 @@ To do a cloud build, with Azure DevOps for example, make sure the [Azure CLI](ht
     </Target>
     ```
 
-    Add the *ConnectionString* associated with your app configuration store as an environment variable.
+    Add the *ConnectionString* associated with your App Configuration store as an environment variable.
 
 2. Open *Program.cs*, and update the `CreateWebHostBuilder` method to use the exported JSON file by calling the `config.AddJsonFile()` method.
 
@@ -71,7 +71,7 @@ To do a cloud build, with Azure DevOps for example, make sure the [Azure CLI](ht
 
 ### Build and run the app locally
 
-1. Set an environment variable named **ConnectionString**, and set it to the access key to your app configuration store. If you use the Windows command prompt, run the following command and restart the command prompt to allow the change to take effect:
+1. Set an environment variable named **ConnectionString**, and set it to the access key to your App Configuration store. If you use the Windows command prompt, run the following command and restart the command prompt to allow the change to take effect:
 
         setx ConnectionString "connection-string-of-your-app-configuration-store"
 

--- a/articles/azure-app-configuration/overview.md
+++ b/articles/azure-app-configuration/overview.md
@@ -54,7 +54,7 @@ App Configuration complements [Azure Key Vault](https://azure.microsoft.com/serv
 
 ## Use App Configuration
 
-The easiest way to add an app configuration store to your application is through a client library that Microsoft provides. Based on the programming language and framework, the following best methods are available to you.
+The easiest way to add an App Configuration store to your application is through a client library that Microsoft provides. Based on the programming language and framework, the following best methods are available to you.
 
 | Programming language and framework | How to connect |
 |---|---|

--- a/articles/azure-app-configuration/quickstart-aspnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-aspnet-core-app.md
@@ -27,7 +27,7 @@ In this quickstart, you incorporate Azure App Configuration into an ASP.NET Core
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 - [.NET Core SDK](https://dotnet.microsoft.com/download)
 
-## Create an app configuration store
+## Create an App Configuration store
 
 [!INCLUDE [azure-app-configuration-create](../../includes/azure-app-configuration-create.md)]
 
@@ -78,7 +78,7 @@ To use Secret Manager, add a `UserSecretsId` element to your *.csproj* file.
 
 The Secret Manager tool stores sensitive data for development work outside of your project tree. This approach helps prevent the accidental sharing of app secrets within source code. For more information on Secret Manager, please see [Safe storage of app secrets in development in ASP.NET Core](https://docs.microsoft.com/aspnet/core/security/app-secrets)
 
-## Connect to an app configuration store
+## Connect to an App Configuration store
 
 1. Add a reference to the `Microsoft.Azure.AppConfiguration.AspNetCore` NuGet package by running the following command:
 
@@ -92,7 +92,7 @@ The Secret Manager tool stores sensitive data for development work outside of yo
     ```
 3. Add a secret named *ConnectionStrings:AppConfig* to Secret Manager.
 
-    This secret contains the connection string to access your app configuration store. Replace the value in the following command with the connection string for your app configuration store.
+    This secret contains the connection string to access your App Configuration store. Replace the value in the following command with the connection string for your App Configuration store.
 
     This command must be executed in the same directory as the *.csproj* file.
 
@@ -213,7 +213,7 @@ The Secret Manager tool stores sensitive data for development work outside of yo
 
 ## Next steps
 
-In this quickstart, you created a new app configuration store and used it with an ASP.NET Core web app via the [App Configuration provider](https://go.microsoft.com/fwlink/?linkid=2074664). To learn more about how to use App Configuration, continue to the next tutorial that demonstrates how to configure your web app to dynamically refresh configuration settings.
+In this quickstart, you created a new App Configuration store and used it with an ASP.NET Core web app via the [App Configuration provider](https://go.microsoft.com/fwlink/?linkid=2074664). To learn more about how to use App Configuration, continue to the next tutorial that demonstrates how to configure your web app to dynamically refresh configuration settings.
 
 > [!div class="nextstepaction"]
 > [Use dynamic configuration in an ASP.NET Core app](./enable-dynamic-configuration-aspnet-core.md)

--- a/articles/azure-app-configuration/quickstart-dotnet-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-app.md
@@ -28,7 +28,7 @@ In this quickstart, you incorporate Azure App Configuration into a .NET Framewor
 - [Visual Studio 2019](https://visualstudio.microsoft.com/vs)
 - [.NET Framework 4.7.2](https://dotnet.microsoft.com/download)
 
-## Create an app configuration store
+## Create an App Configuration store
 
 [!INCLUDE [azure-app-configuration-create](../../includes/azure-app-configuration-create.md)]
 
@@ -48,7 +48,7 @@ In this quickstart, you incorporate Azure App Configuration into a .NET Framewor
 
 1. In **Configure your new project**, enter a project name. Under **Framework**, select **.NET Framework 4.7.1** or higher. Click **Create**.
 
-## Connect to an app configuration store
+## Connect to an App Configuration store
 
 1. Right-click your project, and select **Manage NuGet Packages**. On the **Browse** tab, search and add the following NuGet packages to your project. If you can't find them, select the **Include prerelease** check box.
 
@@ -78,7 +78,7 @@ In this quickstart, you incorporate Azure App Configuration into a .NET Framewor
     </appSettings>
     ```
 
-   The connection string of your app configuration store is read from the environment variable `ConnectionString`. Add the `Environment` configuration builder before the `MyConfigStore` in the `configBuilders` property of the `appSettings` section.
+   The connection string of your App Configuration store is read from the environment variable `ConnectionString`. Add the `Environment` configuration builder before the `MyConfigStore` in the `configBuilders` property of the `appSettings` section.
 
 1. Open *Program.cs*, and update the `Main` method to use App Configuration by calling `ConfigurationManager`.
 
@@ -93,7 +93,7 @@ In this quickstart, you incorporate Azure App Configuration into a .NET Framewor
 
 ## Build and run the app locally
 
-1. Set an environment variable named **ConnectionString** to the connection string of your app configuration store. If you use the Windows command prompt, run the following command:
+1. Set an environment variable named **ConnectionString** to the connection string of your App Configuration store. If you use the Windows command prompt, run the following command:
 
         setx ConnectionString "connection-string-of-your-app-configuration-store"
 
@@ -109,7 +109,7 @@ In this quickstart, you incorporate Azure App Configuration into a .NET Framewor
 
 ## Next steps
 
-In this quickstart, you created a new app configuration store and used it with a .NET Framework console app. To learn more about how to use App Configuration, continue to the next tutorial that demonstrates authentication.
+In this quickstart, you created a new App Configuration store and used it with a .NET Framework console app. To learn more about how to use App Configuration, continue to the next tutorial that demonstrates authentication.
 
 > [!div class="nextstepaction"]
 > [Managed identity integration](./howto-integrate-azure-managed-service-identity.md)

--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -27,7 +27,7 @@ In this quickstart, you incorporate Azure App Configuration into a .NET Core con
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 - [.NET Core SDK](https://dotnet.microsoft.com/download)
 
-## Create an app configuration store
+## Create an App Configuration store
 
 [!INCLUDE [azure-app-configuration-create](../../includes/azure-app-configuration-create.md)]
 
@@ -49,7 +49,7 @@ You use the [.NET Core command-line interface (CLI)](https://docs.microsoft.com/
 
         dotnet new console
 
-## Connect to an app configuration store
+## Connect to an App Configuration store
 
 1. Add a reference to the `Microsoft.Extensions.Configuration.AzureAppConfiguration` NuGet package by running the following command:
 
@@ -81,7 +81,7 @@ You use the [.NET Core command-line interface (CLI)](https://docs.microsoft.com/
 
 ## Build and run the app locally
 
-1. Set an environment variable named **ConnectionString**, and set it to the access key to your app configuration store. If you use the Windows command prompt, run the following command and restart the command prompt to allow the change to take effect:
+1. Set an environment variable named **ConnectionString**, and set it to the access key to your App Configuration store. If you use the Windows command prompt, run the following command and restart the command prompt to allow the change to take effect:
 
         setx ConnectionString "connection-string-of-your-app-configuration-store"
 
@@ -107,7 +107,7 @@ You use the [.NET Core command-line interface (CLI)](https://docs.microsoft.com/
 
 ## Next steps
 
-In this quickstart, you created a new app configuration store and used it with a .NET Core console app via the [App Configuration provider](https://go.microsoft.com/fwlink/?linkid=2074664). To learn more about how to use App Configuration, continue to the next tutorial that demonstrates authentication.
+In this quickstart, you created a new App Configuration store and used it with a .NET Core console app via the [App Configuration provider](https://go.microsoft.com/fwlink/?linkid=2074664). To learn more about how to use App Configuration, continue to the next tutorial that demonstrates authentication.
 
 > [!div class="nextstepaction"]
 > [Managed identity integration](./howto-integrate-azure-managed-service-identity.md)

--- a/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
@@ -30,7 +30,7 @@ The .NET Core Feature Management libraries extend the framework with comprehensi
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
 - [.NET Core SDK](https://dotnet.microsoft.com/download).
 
-## Create an app configuration store
+## Create an App Configuration store
 
 [!INCLUDE [azure-app-configuration-create](../../includes/azure-app-configuration-create.md)]
 
@@ -77,7 +77,7 @@ Add the [Secret Manager tool](https://docs.microsoft.com/aspnet/core/security/ap
 
 1. Save the file.
 
-## Connect to an app configuration store
+## Connect to an App Configuration store
 
 1. Add reference to the `Microsoft.Azure.AppConfiguration.AspNetCore` and the `Microsoft.FeatureManagement.AspNetCore` NuGet packages by running the following commands:
 

--- a/articles/azure-app-configuration/quickstart-feature-flag-dotnet.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-dotnet.md
@@ -30,7 +30,7 @@ The .NET Feature Management libraries extend the framework with comprehensive fe
 - [Visual Studio 2019](https://visualstudio.microsoft.com/vs)
 - [.NET Framework 4.7.2](https://dotnet.microsoft.com/download)
 
-## Create an app configuration store
+## Create an App Configuration store
 
 [!INCLUDE [azure-app-configuration-create](../../includes/azure-app-configuration-create.md)]
 
@@ -42,7 +42,7 @@ The .NET Feature Management libraries extend the framework with comprehensive fe
 
 1. In **Configure your new project**, enter a project name. Under **Framework**, select **.NET Framework 4.7.1** or higher. Click **Create**.
 
-## Connect to an app configuration store
+## Connect to an App Configuration store
 
 1. Right-click your project, and select **Manage NuGet Packages**. On the **Browse** tab, search and add the following NuGet packages to your project. If you can't find them, select the **Include prerelease** check box.
 
@@ -88,7 +88,7 @@ The .NET Feature Management libraries extend the framework with comprehensive fe
 
 ## Build and run the app locally
 
-1. Set an environment variable named **ConnectionString** to the connection string of your app configuration store. If you use the Windows command prompt, run the following command:
+1. Set an environment variable named **ConnectionString** to the connection string of your App Configuration store. If you use the Windows command prompt, run the following command:
 
         setx ConnectionString "connection-string-of-your-app-configuration-store"
 

--- a/articles/azure-app-configuration/quickstart-feature-flag-spring-boot.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-spring-boot.md
@@ -84,7 +84,7 @@ You use the [Spring Initializr](https://start.spring.io/) to create a new Spring
 
 ## Connect to an App Configuration store
 
-1. Open `bootstrap.properties` which is under the resources directory of your app, and add the following lines to the file. Add the app configuration information.
+1. Open `bootstrap.properties` which is under the resources directory of your app, and add the following lines to the file. Add the App Configuration information.
 
     ```properties
     spring.cloud.azure.appconfiguration.stores[0].name= ${APP_CONFIGURATION_CONNECTION_STRING}

--- a/articles/azure-app-configuration/quickstart-java-spring-app.md
+++ b/articles/azure-app-configuration/quickstart-java-spring-app.md
@@ -28,7 +28,7 @@ In this quickstart, you incorporate Azure App Configuration into a Java Spring a
 - A supported [Java Development Kit (JDK)](https://docs.microsoft.com/java/azure/jdk) with version 8.
 - [Apache Maven](https://maven.apache.org/download.cgi) version 3.0 or above.
 
-## Create an app configuration store
+## Create an App Configuration store
 
 [!INCLUDE [azure-app-configuration-create](../../includes/azure-app-configuration-create.md)]
 
@@ -55,7 +55,7 @@ You use the [Spring Initializr](https://start.spring.io/) to create a new Spring
 
 3. After you specify the previous options, select **Generate Project**. When prompted, download the project to a path on your local computer.
 
-## Connect to an app configuration store
+## Connect to an App Configuration store
 
 1. After you extract the files on your local system, your simple Spring Boot application is ready for editing. Locate the *pom.xml* file in the root directory of your app.
 
@@ -65,7 +65,7 @@ You use the [Spring Initializr](https://start.spring.io/) to create a new Spring
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>spring-cloud-starter-azure-appconfiguration-config</artifactId>
-        <version>1.1.0.M4</version>
+        <version>1.1.0.M5</version>
     </dependency>
     ```
 
@@ -135,7 +135,7 @@ You use the [Spring Initializr](https://start.spring.io/) to create a new Spring
       ```shell
       curl -X GET http://localhost:8080/
       ```
-    You see the message that you entered in the app configuration store.
+    You see the message that you entered in the App Configuration store.
 
 ## Clean up resources
 
@@ -143,9 +143,7 @@ You use the [Spring Initializr](https://start.spring.io/) to create a new Spring
 
 ## Next steps
 
-In this quickstart, you created a new app configuration store and used it with a Java Spring app. For more information, see [Spring on Azure](https://docs.microsoft.com/java/azure/spring-framework/).
-
-To learn more about how to use App Configuration, continue to the next tutorial that demonstrates authentication.
+In this quickstart, you created a new App Configuration store and used it with a Java Spring app. For more information, see [Spring on Azure](https://docs.microsoft.com/java/azure/spring-framework/). To learn how to use an Azure managed identity to streamline access to App Configuration, continue to the next tutorial.
 
 > [!div class="nextstepaction"]
 > [Managed identity integration](./howto-integrate-azure-managed-service-identity.md)


### PR DESCRIPTION
- Use "managed identity" instead of "managed *service* identity"
- Use capital "App Configuration" instead of "app configuration"
- Update the next step section of a few tutorial docs, which had incorrect text.