### PR TITLE
Clarifying backup charges

### DIFF
--- a/articles/sql-database/sql-database-automated-backups.md
+++ b/articles/sql-database/sql-database-automated-backups.md
@@ -76,11 +76,11 @@ Like PITR, the LTR backups are geo-redundant and protected by [Azure Storage cro
 For more information, see [Long-term backup retention](sql-database-long-term-retention.md).
 
 ## Storage costs
-For databases and elastic pools using the DTU model there is no additional charge for backup storage.
+For databases and elastic pools that use the DTU model, there is no additional charge for backup storage.
 
 For single databases and managed instances, a minimum backup storage amount equal to 100% of database size is provided at no extra charge. For elastic pools, a minimum backup storage amount equal to 100% of the allocated data storage for the pool is provided at no extra charge. Additional consumption of backup storage will be charged in GB/month. This additional consumption will depend on the workload and size of the individual databases.
 
-Since all the log backups and differential backups are retained for the full retention period, databases which are heavilly modified will have higher backup charges.   
+Because all the log backups and differential backups are retained for the full retention period, databases that are heavily modified will have higher backup charges.   
 
 For more information about storage prices, see the [pricing](https://azure.microsoft.com/pricing/details/sql-database/single/) page. 
 

--- a/articles/sql-database/sql-database-automated-backups.md
+++ b/articles/sql-database/sql-database-automated-backups.md
@@ -76,7 +76,11 @@ Like PITR, the LTR backups are geo-redundant and protected by [Azure Storage cro
 For more information, see [Long-term backup retention](sql-database-long-term-retention.md).
 
 ## Storage costs
+For databases and elastic pools using the DTU model there is no additional charge for backup storage.
+
 For single databases and managed instances, a minimum backup storage amount equal to 100% of database size is provided at no extra charge. For elastic pools, a minimum backup storage amount equal to 100% of the allocated data storage for the pool is provided at no extra charge. Additional consumption of backup storage will be charged in GB/month. This additional consumption will depend on the workload and size of the individual databases.
+
+Since all the log backups and differential backups are retained for the full retention period, databases which are heavilly modified will have higher backup charges.   
 
 For more information about storage prices, see the [pricing](https://azure.microsoft.com/pricing/details/sql-database/single/) page. 
 


### PR DESCRIPTION
clarifying that the backup charges only apply to the vCore model, and that differentials are retained for the retention period.