### PR TITLE
Renaming Flow to Power Automate

### DIFF
--- a/articles/event-grid/overview.md
+++ b/articles/event-grid/overview.md
@@ -50,7 +50,7 @@ For full details on the capabilities of each handler as well as related articles
 * [Event Hubs](event-handlers.md#event-hubs)
 * [Hybrid Connections](event-handlers.md#hybrid-connections)
 * [Logic Apps](event-handlers.md#logic-apps)
-* [Microsoft Flow](https://preview.flow.microsoft.com/connectors/shared_azureeventgrid/azure-event-grid/)
+* [Power Automate (Formerly known as Microsoft Flow)](https://preview.flow.microsoft.com/connectors/shared_azureeventgrid/azure-event-grid/)
 * [Queue Storage](event-handlers.md#queue-storage)
 * [Service Bus](event-handlers.md#service-bus-queue)
 * [WebHooks](event-handlers.md#webhooks)


### PR DESCRIPTION
Microsoft Flow got renamed to Power Automate at Ignite