### PR TITLE
cdn standard rules: fix broken table

### DIFF
--- a/articles/cdn/cdn-standard-rules-engine-match-conditions.md
+++ b/articles/cdn/cdn-standard-rules-engine-match-conditions.md
@@ -121,6 +121,7 @@ Operator | Request Body | Case Transform
 ### Request Header
 
 **Required fields**
+
 Header Name | Operator | Header Value | Case Transform
 ------------|----------|--------------|---------------
 String | [Standard operator list](#standard-operator-list) | String, Int | No transform, to uppercase, to lowercase


### PR DESCRIPTION
adding a nl after the header makes this render as an actual table