### PR TITLE
Fix typo in batch-transcription.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/batch-transcription.md
+++ b/articles/cognitive-services/Speech-Service/batch-transcription.md
@@ -60,7 +60,7 @@ Configuration parameters are provided as JSON:
 {
   "recordingsUrl": "<URL to the Azure blob to transcribe>",
   "models": [{"Id":"<optional acoustic model ID>"},{"Id":"<optional language model ID>"}],
-  "locale": "<locale to us, for example en-US>",
+  "locale": "<locale to use, for example en-US>",
   "name": "<user defined name of the transcription batch>",
   "description": "<optional description of the transcription>",
   "properties": {


### PR DESCRIPTION
"locale to us" should be "locale to us**e**"