### PR TITLE
Fixed broken table markdown

### DIFF
--- a/articles/azure-functions/functions-compare-logic-apps-ms-flow-webjobs.md
+++ b/articles/azure-functions/functions-compare-logic-apps-ms-flow-webjobs.md
@@ -44,7 +44,8 @@ Functions and Logic Apps are Azure services that enable serverless workloads. Az
 
 For Azure Functions, you develop orchestrations by writing code and using the [Durable Functions extension](durable/durable-functions-overview.md). For Logic Apps, you create orchestrations by using a GUI or editing configuration files.
 
-You can mix and match services when you build an orchestration, calling functions from logic apps and calling logic apps from functions. Choose how to build each orchestration based on the services' capabilities or your personal preference. The following table lists some of the key differences between these  
+You can mix and match services when you build an orchestration, calling functions from logic apps and calling logic apps from functions. Choose how to build each orchestration based on the services' capabilities or your personal preference. The following table lists some of the key differences between these:
+
 |  | Durable Functions | Logic Apps |
 | --- | --- | --- |
 | Development | Code-first (imperative) | Designer-first (declarative) |


### PR DESCRIPTION
Now the actual table is shown instead of the markup code for the table comparing Durable Functions with Logic Apps