### PR TITLE
Correct permissions for requesting JIT access

### DIFF
--- a/articles/security-center/security-center-just-in-time.md
+++ b/articles/security-center/security-center-just-in-time.md
@@ -46,7 +46,7 @@ When a user requests access to a VM, Security Center checks that the user has [R
 | --- | --- |
 | Configure or edit a JIT policy for a VM | *Assign these actions to the role:*  <ul><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/> ```Microsoft.Security/locations/jitNetworkAccessPolicies/write``` </li><li> On the scope of a subscription or Resource Group or VM: <br/>```Microsoft.Compute/virtualMachines/write```</li></ul> | 
 | ||
-|Request JIT access to a VM | *Assign these actions to the user:*  <ul><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/>  ```Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action``` </li><li>  On the scope of a Subscription or Resource Group or VM:<br/> ```Microsoft.Compute/virtualMachines/read``` </li></ul>|
+|Request JIT access to a VM | *Assign these actions to the user:*  <ul><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/>  ```Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action``` </li><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/>  ```Microsoft.Security/locations/jitNetworkAccessPolicies/*/read``` </li><li>  On the scope of a Subscription or Resource Group or VM:<br/> ```Microsoft.Compute/virtualMachines/read``` </li><li>  On the scope of a Subscription or Resource Group or VM:<br/> ```Microsoft.Network/networkInterfaces/*/read``` </li></ul>|
 
 
 ## Configure JIT on a VM

--- a/articles/security-center/security-center-just-in-time.md
+++ b/articles/security-center/security-center-just-in-time.md
@@ -44,9 +44,8 @@ When a user requests access to a VM, Security Center checks that the user has [R
 
 | To enable a user to: | Permissions to set|
 | --- | --- |
-| Configure or edit a JIT policy for a VM | *Assign these actions to the role:*  <ul><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/> ```Microsoft.Security/locations/jitNetworkAccessPolicies/write``` </li><li> On the scope of a subscription or Resource Group or VM: <br/>```Microsoft.Compute/virtualMachines/write```</li></ul> | 
-| ||
-|Request JIT access to a VM | *Assign these actions to the user:*  <ul><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/>  ```Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action``` </li><li>On the scope of a subscription or Resource Group that is associated with the VM:<br/>  ```Microsoft.Security/locations/jitNetworkAccessPolicies/*/read``` </li><li>  On the scope of a Subscription or Resource Group or VM:<br/> ```Microsoft.Compute/virtualMachines/read``` </li><li>  On the scope of a Subscription or Resource Group or VM:<br/> ```Microsoft.Network/networkInterfaces/*/read``` </li></ul>|
+| Configure or edit a JIT policy for a VM | *Assign these actions to the role:*  <ul><li>On the scope of a subscription or resource group that is associated with the VM:<br/> `Microsoft.Security/locations/jitNetworkAccessPolicies/write` </li><li> On the scope of a subscription or resource group or VM: <br/>`Microsoft.Compute/virtualMachines/write`</li></ul> | 
+|Request JIT access to a VM | *Assign these actions to the user:*  <ul><li>On the scope of a subscription or resource group that is associated with the VM:<br/>  `Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action` </li><li>On the scope of a subscription or resource group that is associated with the VM:<br/>  `Microsoft.Security/locations/jitNetworkAccessPolicies/*/read` </li><li>  On the scope of a subscription or resource group or VM:<br/> `Microsoft.Compute/virtualMachines/read` </li><li>  On the scope of a subscription or resource group or VM:<br/> `Microsoft.Network/networkInterfaces/*/read` </li></ul>|
 
 
 ## Configure JIT on a VM


### PR DESCRIPTION
The current set of permissions listed in the documentation for 'Request JIT access to a VM' are insufficient to allow a user with just those rights to see the request access button for JIT on the virtual machine blade or initiate the JIT request action.

I created a custom role definition with just these 4 permissions and verified that they do allow you to successfully request JIT access.