### PR TITLE
Update web-sites-traffic-manager.md

### DIFF
--- a/articles/app-service/web-sites-traffic-manager.md
+++ b/articles/app-service/web-sites-traffic-manager.md
@@ -53,6 +53,4 @@ When using Azure Traffic Manager with Azure, keep in mind the following points:
 ## Next Steps
 For a conceptual and technical overview of Azure Traffic Manager, see [Traffic Manager Overview](../traffic-manager/traffic-manager-overview.md).
 
-For more information about using Traffic Manager with App Service, see the blog posts
-[Using Azure Traffic Manager with Azure Web Sites](https://blogs.msdn.com/b/waws/archive/2014/03/18/using-windows-azure-traffic-manager-with-waws.aspx) and [Azure Traffic Manager can now integrate with Azure Web Sites](https://azure.microsoft.com/blog/2014/03/27/azure-traffic-manager-can-now-integrate-with-azure-web-sites/).
 


### PR DESCRIPTION
The links to the Traffic Manager blogs in Azure App Service are broken because they are no longer existing.
I checked the new Azure App Service blog location and they were not migrated. Probably because they were from 2014. 
I suggest removing these paragraphs:
For more information about using Traffic Manager with App Service, see the blog posts
[Using Azure Traffic Manager with Azure Web Sites](https://blogs.msdn.com/b/waws/archive/2014/03/18/using-windows-azure-traffic-manager-with-waws.aspx) and [Azure Traffic Manager can now integrate with Azure Web Sites](https://azure.microsoft.com/blog/2014/03/27/azure-traffic-manager-can-now-integrate-with-azure-web-sites/).