### PR TITLE
update kubectl run command

### DIFF
--- a/articles/aks/virtual-nodes-cli.md
+++ b/articles/aks/virtual-nodes-cli.md
@@ -267,7 +267,7 @@ The pod is assigned an internal IP address from the Azure virtual network subnet
 To test the pod running on the virtual node, browse to the demo application with a web client. As the pod is assigned an internal IP address, you can quickly test this connectivity from another pod on the AKS cluster. Create a test pod and attach a terminal session to it:
 
 ```console
-kubectl run -it --rm virtual-node-test --image=debian
+kubectl run --generator=run-pod/v1 -it --rm testvk --image=debian
 ```
 
 Install `curl` in the pod using `apt-get`:


### PR DESCRIPTION
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.