### PR TITLE
Replaced synchronous method Run() with its async counterpart RunAsync() for v.3.*

### DIFF
--- a/articles/app-service/webjobs-sdk-how-to.md
+++ b/articles/app-service/webjobs-sdk-how-to.md
@@ -88,7 +88,7 @@ The process for enabling development mode depends on the SDK version.
 Version 3.*x* uses the standard ASP.NET Core APIs. Call the [`UseEnvironment`](/dotnet/api/microsoft.extensions.hosting.hostinghostbuilderextensions.useenvironment) method on the [`HostBuilder`](/dotnet/api/microsoft.extensions.hosting.hostbuilder) instance. Pass a string named `development`, as in this example:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.UseEnvironment("development");
@@ -99,7 +99,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -240,7 +240,7 @@ The process for installing and managing binding types depends on whether you're 
 In version 3.*x*, the storage bindings are included in the `Microsoft.Azure.WebJobs.Extensions.Storage` package. Call the `AddAzureStorage` extension method in the `ConfigureWebJobs` method, as shown here:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -251,7 +251,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -259,7 +259,7 @@ static void Main()
 To use other trigger and binding types, install the NuGet package that contains them and call the `Add<binding>` extension method implemented in the extension. For example, if you want to use an Azure Cosmos DB binding, install `Microsoft.Azure.WebJobs.Extensions.CosmosDB` and call `AddCosmosDB`, like this:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -270,7 +270,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -322,7 +322,7 @@ The process for binding to the [`ExecutionContext`] depends on your SDK version.
 Call the `AddExecutionContextBinding` extension method in the `ConfigureWebJobs` method, as shown here:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -333,7 +333,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -377,7 +377,7 @@ You can configure the following bindings:
 This example shows how to configure the Azure Cosmos DB trigger:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -394,8 +394,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -407,7 +406,7 @@ For more details, see the [Azure CosmosDB binding](../azure-functions/functions-
 This example shows how to configure the Event Hubs trigger:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -423,8 +422,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -438,7 +436,7 @@ These examples show how to configure the Queue storage trigger:
 #### Version 3.*x*
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -454,8 +452,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -484,7 +481,7 @@ For more details, see the [host.json v1.x reference](../azure-functions/function
 This example shows how to configure the SendGrid output binding:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -499,8 +496,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -512,7 +508,7 @@ For more details, see the [SendGrid binding](../azure-functions/functions-bindin
 This example shows how to configure the Service Bus trigger:
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -527,8 +523,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -542,7 +537,7 @@ Some trigger and binding types define their own custom configuration types. For 
 #### Version 3.*x*
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -553,8 +548,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```
@@ -928,7 +922,7 @@ internal class CustomTelemetryInitializer : ITelemetryInitializer
 Call [`ConfigureServices`] in the builder to add your custom [`ITelemetryInitializer`] to the pipeline.
 
 ```cs
-static void Main()
+static async Task Main()
 {
     var builder = new HostBuilder();
     builder.ConfigureWebJobs(b =>
@@ -955,8 +949,7 @@ static void Main()
     var host = builder.Build();
     using (host)
     {
-
-        host.Run();
+        await host.RunAsync();
     }
 }
 ```


### PR DESCRIPTION
Most of the code snippets will be copied straight to the editor. Hence, we should highlight using the asynchronous version of the `Run` method `RunAsync` rather than the synchronous method.