### PR TITLE
Fix missing space

### DIFF
--- a/articles/cosmos-db/consistency-levels-across-apis.md
+++ b/articles/cosmos-db/consistency-levels-across-apis.md
@@ -20,7 +20,7 @@ When using Cassandra API or Azure Cosmos DB’s API for MongoDB, applications ge
 
 ## <a id="cassandra-mapping"></a>Mapping between Apache Cassandra and Azure Cosmos DB consistency levels
 
-Unlike AzureCosmos DB, Apache Cassandra does not natively provide precisely defined consistency guarantees.  Instead, Apache Cassandra provides a write consistency level and a read consistency level, to enable the high availability, consistency, and latency tradeoffs. When using Azure Cosmos DB’s Cassandra API: 
+Unlike Azure Cosmos DB, Apache Cassandra does not natively provide precisely defined consistency guarantees.  Instead, Apache Cassandra provides a write consistency level and a read consistency level, to enable the high availability, consistency, and latency tradeoffs. When using Azure Cosmos DB’s Cassandra API: 
 
 * The write consistency level of Apache Cassandra is mapped to the default consistency level configured on your Azure Cosmos account. 
 


### PR DESCRIPTION
Add a space between "Azure" and "CosmosDB"