### PR TITLE
Fixing a type in a comment

### DIFF
--- a/articles/virtual-desktop/app-attach.md
+++ b/articles/virtual-desktop/app-attach.md
@@ -303,8 +303,7 @@ Before you update the PowerShell scripts, make sure you have the volume GUID of 
 
     $packageManager = [Windows.Management.Deployment.PackageManager]::new()
 
-    $path = $msixJunction + $parentFolder + $packageName # needed if we do the
-    pbisigned.vhd
+    $path = $msixJunction + $parentFolder + $packageName # needed if we do the pbisigned.vhd
 
     $path = ([System.Uri]$path).AbsoluteUri
 


### PR DESCRIPTION
A comment was split in two lines. The second line became a command as it was missing the comment tag.