### PR TITLE
Updates code snippet to use non-obsolete call to AddApplicationInsights

### DIFF
--- a/articles/app-service/webjobs-sdk-get-started.md
+++ b/articles/app-service/webjobs-sdk-get-started.md
@@ -386,7 +386,7 @@ To take advantage of [Application Insights](../azure-monitor/app/app-insights-ov
                     string instrumentationKey = context.Configuration["APPINSIGHTS_INSTRUMENTATIONKEY"];
                     if (!string.IsNullOrEmpty(instrumentationKey))
                     {
-                        b.AddApplicationInsights(o => o.InstrumentationKey = instrumentationKey);
+                        b.AddApplicationInsightsWebJobs(o => o.InstrumentationKey = instrumentationKey);
                     }
                 });
         var host = builder.Build();


### PR DESCRIPTION
The method `AddApplicationInsightsWebJobs` is marked obsolete so VS complains that it should be `AddApplicationInsightsWebJobs`