### PR TITLE
Key Vault references for App Service - Linux limitations & latest

### DIFF
--- a/articles/app-service/app-service-key-vault-references.md
+++ b/articles/app-service/app-service-key-vault-references.md
@@ -18,7 +18,7 @@ ms.custom: seodec18
 # Use Key Vault references for App Service and Azure Functions
 
 > [!NOTE] 
-> Key Vault references are not currently available in Linux consumption plans.
+> Key Vault references are not currently available in Linux consumption plans. ([See GitHub](https://github.com/Azure/Azure-Functions/issues/1354))
 
 This topic shows you how to work with secrets from Azure Key Vault in your App Service or Azure Functions application without requiring any code changes. [Azure Key Vault](../key-vault/key-vault-overview.md) is a service that provides centralized secrets management, with full control over access policies and audit history.
 
@@ -57,6 +57,11 @@ Alternatively:
 
 ```
 @Microsoft.KeyVault(VaultName=myvault;SecretName=mysecret;SecretVersion=ec96f02080254f109c51a1f14cdb1931)
+```
+
+You can also refer to the latest representation of a secret as following:
+```
+@Microsoft.KeyVault(SecretUri=https://myvault.vault.azure.net/secrets/mysecret/)
 ```
 
 


### PR DESCRIPTION
Key Vault references for App Service documentation improvement:
- Refer to GitHub issue for Linux Consumption limitation
- Document how to refer to latest version of a secret

Relates to https://github.com/MicrosoftDocs/azure-docs/issues/42878