### PR TITLE
Adding filters and selectors

### DIFF
--- a/articles/search/search-more-like-this.md
+++ b/articles/search/search-more-like-this.md
@@ -26,7 +26,7 @@ You cannot use `MoreLikeThis` on searchable sub-fields in a [complex type](searc
 
 ## Examples
 
-All examples below use [hotels sample from Quickstart](search-get-started-portal.md).
+All examples below use the [hotels sample from Quickstart](search-get-started-portal.md).
 
 ### Simple Query
 

--- a/articles/search/search-more-like-this.md
+++ b/articles/search/search-more-like-this.md
@@ -26,9 +26,9 @@ You cannot use `MoreLikeThis` on searchable sub-fields in a [complex type](searc
 
 ## Examples
 
-All examples below use the [hotels sample from Quickstart](search-get-started-portal.md).
+All following examples use the hotels sample from [Quickstart: Create a search index in the Azure portal](search-get-started-portal.md).
 
-### Simple Query
+### Simple query
 
 The following query finds documents whose description fields are most similar to the field of the source document as specified by the `moreLikeThis` parameter:
 
@@ -47,7 +47,7 @@ POST /indexes/hotels-sample-index/docs/search?api-version=2019-05-06-Preview
     }
 ```
 
-### Applying Filters
+### Apply filters
 
 `MoreLikeThis` can be combined with other common query parameters like `$filter`. For instance, the query can be restricted to only hotels whose category is 'Budget' and where the rating is higher than 3.5:
 
@@ -55,9 +55,9 @@ POST /indexes/hotels-sample-index/docs/search?api-version=2019-05-06-Preview
 GET /indexes/hotels-sample-index/docs?moreLikeThis=20&searchFields=Description&$filter=(Category eq 'Budget' and Rating gt 3.5)&api-version=2019-05-06-Preview
 ```
 
-### Selecting Fields and Limiting Results
+### Select fields and limit results
 
-The `$top` selector can be used to limit how many results should be returned in a `MoreLikeThis` query. Also, fields can be selected with `$select`. Here the top 3 hotels are selected along with their Id, Name and Rating: 
+The `$top` selector can be used to limit how many results should be returned in a `MoreLikeThis` query. Also, fields can be selected with `$select`. Here the top three hotels are selected along with their ID, Name, and Rating: 
 
 ```
 GET /indexes/hotels-sample-index/docs?moreLikeThis=20&searchFields=Description&$filter=(Category eq 'Budget' and Rating gt 3.5)&$top=3&$select=HotelId,HotelName,Rating&api-version=2019-05-06-Preview

--- a/articles/search/search-more-like-this.md
+++ b/articles/search/search-more-like-this.md
@@ -24,22 +24,44 @@ By default, the contents of all top-level searchable fields are considered. If y
 
 You cannot use moreLikeThis on searchable sub-fields in a [complex type](search-howto-complex-data-types.md).
 
-## Examples 
+## Examples
 
-Below is an example of a moreLikeThis query. The query finds documents whose description fields are most similar to the field of the source document as specified by the `moreLikeThis` parameter.
+All examples below uses [hotels sample from Quickstart](search-get-started-portal.md).
+
+### Simple query
+
+The following query finds documents whose description fields are most similar to the field of the source document as specified by the `moreLikeThis` parameter:
 
 ```
-Get /indexes/hotels/docs?moreLikeThis=1002&searchFields=description&api-version=2019-05-06-Preview
+GET /indexes/hotels-sample-index/docs?moreLikeThis=29&searchFields=Description&api-version=2019-05-06-Preview
 ```
 
+In this example, it was searched similar hotels to `HotelId=29`.
+Besides doing a HTTP GET, it also can always be sent as a HTTP POST:
+
 ```
-POST /indexes/hotels/docs/search?api-version=2019-05-06-Preview
+POST /indexes/hotels-sample-index/docs/search?api-version=2019-05-06-Preview
     {
-      "moreLikeThis": "1002",
-      "searchFields": "description"
+      "moreLikeThis": "29",
+      "searchFields": "Description"
     }
 ```
 
+### Applying Filters
+
+moreLikeThis can be combined with other common query parameters like `$filter`. For instance, the query can be restricted to only hotels which category is Budget and the rating is higher than 3.5:
+
+```
+GET /indexes/hotels-sample-index/docs?moreLikeThis=20&searchFields=Description&$filter=(Category eq 'Budget' and Rating gt 3.5)&api-version=2019-05-06-Preview
+```
+
+### Selecting fields and Limiting Results
+
+The `$top` selector can be used to limit how many results should be returned in a moreLikeThis query. Also, fields can be selected with `$select`. Here the top 3 hotels are selected along with their Id, Name and Rating: 
+
+```
+GET /indexes/hotels-sample-index/docs?moreLikeThis=20&searchFields=Description&$filter=(Category eq 'Budget' and Rating gt 3.5)&$top=3&$select=HotelId,HotelName,Rating&api-version=2019-05-06-Preview
+```
 
 ## Next steps
 

--- a/articles/search/search-more-like-this.md
+++ b/articles/search/search-more-like-this.md
@@ -22,13 +22,13 @@ ms.date: 11/04/2019
 
 By default, the contents of all top-level searchable fields are considered. If you want to specify particular fields instead, you can use the `searchFields` parameter. 
 
-You cannot use moreLikeThis on searchable sub-fields in a [complex type](search-howto-complex-data-types.md).
+You cannot use `MoreLikeThis` on searchable sub-fields in a [complex type](search-howto-complex-data-types.md).
 
 ## Examples
 
-All examples below uses [hotels sample from Quickstart](search-get-started-portal.md).
+All examples below use [hotels sample from Quickstart](search-get-started-portal.md).
 
-### Simple query
+### Simple Query
 
 The following query finds documents whose description fields are most similar to the field of the source document as specified by the `moreLikeThis` parameter:
 
@@ -36,8 +36,8 @@ The following query finds documents whose description fields are most similar to
 GET /indexes/hotels-sample-index/docs?moreLikeThis=29&searchFields=Description&api-version=2019-05-06-Preview
 ```
 
-In this example, it was searched similar hotels to `HotelId=29`.
-Besides doing a HTTP GET, it also can always be sent as a HTTP POST:
+In this example, the request searches for hotels similar to the one with `HotelId` 29.
+Rather than using HTTP GET, you can also invoke `MoreLikeThis` using HTTP POST:
 
 ```
 POST /indexes/hotels-sample-index/docs/search?api-version=2019-05-06-Preview
@@ -49,15 +49,15 @@ POST /indexes/hotels-sample-index/docs/search?api-version=2019-05-06-Preview
 
 ### Applying Filters
 
-moreLikeThis can be combined with other common query parameters like `$filter`. For instance, the query can be restricted to only hotels which category is Budget and the rating is higher than 3.5:
+`MoreLikeThis` can be combined with other common query parameters like `$filter`. For instance, the query can be restricted to only hotels whose category is 'Budget' and where the rating is higher than 3.5:
 
 ```
 GET /indexes/hotels-sample-index/docs?moreLikeThis=20&searchFields=Description&$filter=(Category eq 'Budget' and Rating gt 3.5)&api-version=2019-05-06-Preview
 ```
 
-### Selecting fields and Limiting Results
+### Selecting Fields and Limiting Results
 
-The `$top` selector can be used to limit how many results should be returned in a moreLikeThis query. Also, fields can be selected with `$select`. Here the top 3 hotels are selected along with their Id, Name and Rating: 
+The `$top` selector can be used to limit how many results should be returned in a `MoreLikeThis` query. Also, fields can be selected with `$select`. Here the top 3 hotels are selected along with their Id, Name and Rating: 
 
 ```
 GET /indexes/hotels-sample-index/docs?moreLikeThis=20&searchFields=Description&$filter=(Category eq 'Budget' and Rating gt 3.5)&$top=3&$select=HotelId,HotelName,Rating&api-version=2019-05-06-Preview


### PR DESCRIPTION
fix #43906

Also, it changes:
* `description` field to `Description` - which is the current Hotels sample schema.
* `hotels` indexer name to `hotels-sample-index`, which is also the default value to Hotels sample when deployed from Azure portal.
* Id `1002` to `20`, since `1002` is not a valid id in the sample