### PR TITLE
Added the 2 DHE for backward compatibility

### DIFF
--- a/articles/frontdoor/front-door-faq.md
+++ b/articles/frontdoor/front-door-faq.md
@@ -175,6 +175,8 @@ The following are the current cipher suites supported by Azure Front Door Servic
 - TLS_RSA_WITH_AES_128_CBC_SHA256
 - TLS_RSA_WITH_AES_256_CBC_SHA
 - TLS_RSA_WITH_AES_128_CBC_SHA
+- TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
 
 ### Does Azure Front Door Service also support re-encryption of traffic to the backend?
 


### PR DESCRIPTION
Added the 2 DHE for backward compatibility
The backwards-compatible DHE cipher suites are disabled by the “HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Cryptography\Configuration\SSL\00010002\Functions” registry value. To restore them at the lowest priority, add them to the end of the list: