### PR TITLE
fix for partition key in sample code

### DIFF
--- a/articles/cosmos-db/sql-api-nodejs-application.md
+++ b/articles/cosmos-db/sql-api-nodejs-application.md
@@ -111,7 +111,7 @@ Now that you have completed the initial setup and configuration, next you will w
     const debug = require('debug')('todo:taskDao')
 
     // For simplicity we'll set a constant partition key
-    const partitionKey = '0'
+    const partitionKey = undefined
     class TaskDao {
       /**
        * Manages reading, adding, and updating Tasks in Cosmos DB


### PR DESCRIPTION
By default CosmosDB utilizes an empty partition key, so getitem() fails if the partition key is set to '0' instead of undefined

https://www.drewsk.tech/2019/12/04/25-days-of-serverless-day-4/