### PR TITLE
Update cdn-front-door-allowed-ca.md

### DIFF
--- a/includes/cdn-front-door-allowed-ca.md
+++ b/includes/cdn-front-door-allowed-ca.md
@@ -49,6 +49,10 @@ The following CAs are allowed when you create your own certificate:
 - Go Daddy Secure Certificate Authority - G2
 - QuoVadis Root CA2 G3
 - RapidSSL RSA CA 2018
+- SSL.com EV Root Certification Authority ECC
+- SSL.com EV Root Certification Authority RSA R2
+- SSL.com Root Certification Authority ECC
+- SSL.com Root Certification Authority RSA
 - Symantec Class 3 EV SSL CA - G3
 - Symantec Class 3 Secure Server CA - G4
 - Symantec Enterprise Mobile Root for Microsoft


### PR DESCRIPTION
updating the CA list to reflect SSL.com (included in Windows since 2017 see https://gallery.technet.microsoft.com/Trusted-Root-Certificate-2696b664/file/180283/1/Trusted%20Root%20Program%20Participants%20As%20of%20Sept%2026%202017.xlsx) per January 2019 email from Max Gattuso:

"Hi Leo,

I apologize for the delay. We will be adding support for all CA’s listed in the Microsoft Root CA program including SSL.com and it will be available to customers in early February.

Thanks,
Max"