### PR TITLE
Correct C# code blocks

### DIFF
--- a/articles/active-directory-b2c/b2clogin.md
+++ b/articles/active-directory-b2c/b2clogin.md
@@ -89,7 +89,7 @@ For migrating Azure API Management APIs protected by Azure AD B2C, see the [Migr
 
 If you're using [MSAL.NET][msal-dotnet] v2 or earlier, set the **ValidateAuthority** property to `false` on client instantiation to allow redirects to *b2clogin.com*. This setting is not required for MSAL.NET v3 and above.
 
-```CSharp
+```csharp
 ConfidentialClientApplication client = new ConfidentialClientApplication(...); // Can also be PublicClientApplication
 client.ValidateAuthority = false; // MSAL.NET v2 and earlier **ONLY**
 ```

--- a/articles/active-directory/develop/msal-net-client-assertions.md
+++ b/articles/active-directory/develop/msal-net-client-assertions.md
@@ -39,7 +39,7 @@ MSAL.NET has four methods to provide either credentials or assertions to the con
 
 A signed client assertion takes the form of a signed JWT with the payload containing the required authentication claims mandated by Azure AD, Base64 encoded. To use it:
 
-```CSharp
+```csharp
 string signedClientAssertion = ComputeAssertion();
 app = ConfidentialClientApplicationBuilder.Create(config.ClientId)
                                           .WithClientAssertion(signedClientAssertion)
@@ -59,7 +59,7 @@ sub | {ClientID} | The "sub" (subject) claim identifies the subject of the JWT. 
 
 Here is an example of how to craft these claims:
 
-```CSharp
+```csharp
 private static IDictionary<string, string> GetClaims()
 {
       //aud = https://login.microsoftonline.com/ + Tenant ID + /v2.0
@@ -85,7 +85,7 @@ private static IDictionary<string, string> GetClaims()
 
 Here is how to craft a signed client assertion:
 
-```CSharp
+```csharp
 string Encode(byte[] arg)
 {
     char Base64PadCharacter = '=';
@@ -135,7 +135,7 @@ string GetSignedClientAssertion()
 
 You also have the option of using [Microsoft.IdentityModel.JsonWebTokens](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens/) to create the assertion for you. The code will be a more elegant as shown in the example below:
 
-```CSharp
+```csharp
         string GetSignedClientAssertion()
         {
             var cert = new X509Certificate2("Certificate.pfx", "Password", X509KeyStorageFlags.EphemeralKeySet);
@@ -168,7 +168,7 @@ You also have the option of using [Microsoft.IdentityModel.JsonWebTokens](https:
 
 Once you have your signed client assertion, you can use it with the MSAL apis as shown below.
 
-```CSharp
+```csharp
             string signedClientAssertion = GetSignedClientAssertion();
 
             var confidentialApp = ConfidentialClientApplicationBuilder
@@ -181,7 +181,7 @@ Once you have your signed client assertion, you can use it with the MSAL apis as
 
 `WithClientClaims(X509Certificate2 certificate, IDictionary<string, string> claimsToSign, bool mergeWithDefaultClaims = true)` by default will produce a signed assertion containing the claims expected by Azure AD plus additional client claims that you want to send. Here is a code snippet on how to do that.
 
-```CSharp
+```csharp
 string ipAddress = "192.168.1.2";
 X509Certificate2 certificate = ReadCertificate(config.CertificateName);
 app = ConfidentialClientApplicationBuilder.Create(config.ClientId)

--- a/articles/active-directory/develop/msal-net-migration-ios-broker.md
+++ b/articles/active-directory/develop/msal-net-migration-ios-broker.md
@@ -49,7 +49,7 @@ In ADAL.NET, broker support was enabled on a per-authentication context basis. I
 
 `useBroker` flag to true in the `PlatformParameters` constructor to call the broker:
 
-```CSharp
+```csharp
 public PlatformParameters(
         UIViewController callerViewController, 
         bool useBroker)
@@ -57,7 +57,7 @@ public PlatformParameters(
 Also, in the platform-specific code, in this example, in the page renderer for iOS, set the 
 `useBroker` 
 flag to true:
-```CSharp
+```csharp
 page.BrokerParameters = new PlatformParameters(
           this, 
           true, 
@@ -65,7 +65,7 @@ page.BrokerParameters = new PlatformParameters(
 ```
 
 Then, include the parameters in the acquire token call:
-```CSharp
+```csharp
  AuthenticationResult result =
                     await
                         AuthContext.AcquireTokenAsync(
@@ -82,7 +82,7 @@ In MSAL.NET, broker support is enabled on a per-PublicClientApplication basis. I
 `WithBroker()` 
 parameter (set to true by default) in order to call the broker:
 
-```CSharp
+```csharp
 var app = PublicClientApplicationBuilder
                 .Create(ClientId)
                 .WithBroker()
@@ -90,7 +90,7 @@ var app = PublicClientApplicationBuilder
                 .Build();
 ```
 In the acquire token call:
-```CSharp
+```csharp
 result = await app.AcquireTokenInteractive(scopes)
              .WithParentActivityOrWindow(App.RootViewController)
              .ExecuteAsync();
@@ -106,7 +106,7 @@ A UIViewController is passed into
 
 `PlatformParameters` in the iOS-specific platform.
 
-```CSharp
+```csharp
 page.BrokerParameters = new PlatformParameters(
           this, 
           true, 
@@ -125,16 +125,16 @@ This assignment ensures that there's a UIViewController with the call to the bro
 **For example:**
 
 In `App.cs`:
-```CSharp
+```csharp
    public static object RootViewController { get; set; }
 ```
 In `AppDelegate.cs`:
-```CSharp
+```csharp
    LoadApplication(new App());
    App.RootViewController = new UIViewController();
 ```
 In the acquire token call:
-```CSharp
+```csharp
 result = await app.AcquireTokenInteractive(scopes)
              .WithParentActivityOrWindow(App.RootViewController)
              .ExecuteAsync();
@@ -168,7 +168,7 @@ as a prefix, followed by your
 For example:
 `$"msauth.(BundleId")`
 
-```CSharp
+```csharp
  <key>CFBundleURLTypes</key>
     <array>
       <dict>
@@ -201,7 +201,7 @@ Uses
 `msauth`
 
 
-```CSharp
+```csharp
 <key>LSApplicationQueriesSchemes</key>
 <array>
      <string>msauth</string>
@@ -213,7 +213,7 @@ Uses
 `msauthv2`
 
 
-```CSharp
+```csharp
 <key>LSApplicationQueriesSchemes</key>
 <array>
      <string>msauthv2</string>

--- a/articles/active-directory/develop/msal-net-migration.md
+++ b/articles/active-directory/develop/msal-net-migration.md
@@ -222,7 +222,7 @@ MSAL.NET does not expose refresh tokens, for security reasons: MSAL handles refr
 
 Fortunately, MSAL.NET now has an API that allows you to migrate your previous refresh tokens (acquired with ADAL) into the `IConfidentialClientApplication`:
 
-```CSharp
+```csharp
 /// <summary>
 /// Acquires an access token from an existing refresh token and stores it and the refresh token into 
 /// the application user token cache, where it will be available for further AcquireTokenSilent calls.

--- a/articles/active-directory/develop/msal-net-use-brokers-with-xamarin-apps.md
+++ b/articles/active-directory/develop/msal-net-use-brokers-with-xamarin-apps.md
@@ -34,7 +34,7 @@ Follow these steps to enable your Xamarin.iOS app to talk with the [Microsoft Au
 ### Step 1: Enable broker support
 Broker support is enabled on a per-PublicClientApplication basis. It's disabled by default. Use the `WithBroker()` parameter (set to true by default) when you create the PublicClientApplication through the PublicClientApplicationBuilder.
 
-```CSharp
+```csharp
 var app = PublicClientApplicationBuilder
                 .Create(ClientId)
                 .WithBroker()
@@ -45,7 +45,7 @@ var app = PublicClientApplicationBuilder
 ### Step 2: Update AppDelegate to handle the callback
 When the Microsoft Authentication Library for .NET (MSAL.NET) calls the broker, the broker in turn calls back to your application through the `OpenUrl` method of the `AppDelegate` class. Because MSAL waits for the response from the broker, your application needs to cooperate to call MSAL.NET back. To enable this cooperation, update the `AppDelegate.cs` file to override the following method.
 
-```CSharp
+```csharp
 public override bool OpenUrl(UIApplication app, NSUrl url, 
                              string sourceApplication,
                              NSObject annotation)
@@ -78,16 +78,16 @@ To do this, you do two things.
 **For example:**
 
 In `App.cs`:
-```CSharp
+```csharp
    public static object RootViewController { get; set; }
 ```
 In `AppDelegate.cs`:
-```CSharp
+```csharp
    LoadApplication(new App());
    App.RootViewController = new UIViewController();
 ```
 In the acquire token call:
-```CSharp
+```csharp
 result = await app.AcquireTokenInteractive(scopes)
              .WithParentActivityOrWindow(App.RootViewController)
              .ExecuteAsync();
@@ -137,11 +137,11 @@ Add `msauthv2` to the `LSApplicationQueriesSchemes` section of the `Info.plist` 
 
 ### Step 6: Register your redirect URI in the application portal
 Using the broker adds an extra requirement on your redirect URI. The redirect URI _must_ have the following format:
-```CSharp
+```csharp
 $"msauth.{BundleId}://auth"
 ```
 **For example:**
-```CSharp
+```csharp
 public static string redirectUriOnIos = "msauth.com.yourcompany.XForms://auth"; 
 ```
 Notice that the redirect URI matches the `CFBundleURLSchemes` name you included in the `Info.plist` file.

--- a/articles/active-directory/develop/msal-net-xamarin-android-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-android-considerations.md
@@ -32,7 +32,7 @@ var authResult = AcquireTokenInteractive(scopes)
 ```
 You can also set this at the PublicClientApplication level (in MSAL4.2+) via a callback.
 
-```CSharp
+```csharp
 // Requires MSAL.NET 4.2 or above
 var pca = PublicClientApplicationBuilder
   .Create("<your-client-id-here>")
@@ -42,7 +42,7 @@ var pca = PublicClientApplicationBuilder
 
 A recommendation is to use the CurrentActivityPlugin [here](https://github.com/jamesmontemagno/CurrentActivityPlugin).  Then your PublicClientApplication builder code would look like this:
 
-```CSharp
+```csharp
 // Requires MSAL.NET 4.2 or above
 var pca = PublicClientApplicationBuilder
   .Create("<your-client-id-here>")

--- a/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
@@ -38,7 +38,7 @@ You might also see a break in ASP.NET Core OIDC authentication with iOS 12 Safar
 
 First you need to override the `OpenUrl` method of the `FormsApplicationDelegate` derived class and call `AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs`.
 
-```CSharp
+```csharp
 public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
 {
     AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs(url);

--- a/articles/active-directory/develop/scenario-daemon-acquire-token.md
+++ b/articles/active-directory/develop/scenario-daemon-acquire-token.md
@@ -30,7 +30,7 @@ The scope to request for a client credential flow is the name of the resource fo
 
 # [.NET](#tab/dotnet)
 
-```CSharp
+```csharp
 ResourceId = "someAppIDURI";
 var scopes = new [] {  ResourceId+"/.default"};
 ```
@@ -67,7 +67,7 @@ To acquire a token for the app, you'll use `AcquireTokenForClient` or the equiva
 
 # [.NET](#tab/dotnet)
 
-```CSharp
+```csharp
 using Microsoft.Identity.Client;
 
 // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the

--- a/articles/active-directory/develop/scenario-daemon-app-configuration.md
+++ b/articles/active-directory/develop/scenario-daemon-app-configuration.md
@@ -133,7 +133,7 @@ Add the [Microsoft.IdentityClient](https://www.nuget.org/packages/Microsoft.Iden
 In MSAL.NET, the confidential client application is represented by the `IConfidentialClientApplication` interface.
 Use MSAL.NET namespace in the source code
 
-```CSharp
+```csharp
 using Microsoft.Identity.Client;
 IConfidentialClientApplication app;
 ```
@@ -161,7 +161,7 @@ Here is the code to instantiate the confidential client application with a clien
 
 # [.NET](#tab/dotnet)
 
-```CSharp
+```csharp
 app = ConfidentialClientApplicationBuilder.Create(config.ClientId)
            .WithClientSecret(config.ClientSecret)
            .WithAuthority(new Uri(config.Authority))
@@ -201,7 +201,7 @@ Here is the code to build an application with a certificate:
 
 # [.NET](#tab/dotnet)
 
-```CSharp
+```csharp
 X509Certificate2 certificate = ReadCertificate(config.CertificateName);
 app = ConfidentialClientApplicationBuilder.Create(config.ClientId)
     .WithCertificate(certificate)
@@ -268,7 +268,7 @@ MSAL.NET has two methods to provide signed assertions to the confidential client
 
 When you use `WithClientAssertion`, you need to provide a signed JWT. This advanced scenario is detailed in [Client assertions](msal-net-client-assertions.md)
 
-```CSharp
+```csharp
 string signedClientAssertion = ComputeAssertion();
 app = ConfidentialClientApplicationBuilder.Create(config.ClientId)
                                           .WithClientAssertion(signedClientAssertion)
@@ -278,7 +278,7 @@ app = ConfidentialClientApplicationBuilder.Create(config.ClientId)
 When you use `WithClientClaims`, MSAL.NET will compute itself a signed assertion containing the claims expected by Azure AD plus additional client claims that you want to send.
 Here is a code snippet on how to do that:
 
-```CSharp
+```csharp
 string ipAddress = "192.168.1.2";
 var claims = new Dictionary<string, string> { { "client_ip", ipAddress } };
 X509Certificate2 certificate = ReadCertificate(config.CertificateName);

--- a/articles/active-directory/develop/scenario-desktop-acquire-token.md
+++ b/articles/active-directory/develop/scenario-desktop-acquire-token.md
@@ -35,7 +35,7 @@ The web API is defined by its `scopes`. Whatever the experience you provide in y
 
 ### In MSAL.NET
 
-```CSharp
+```csharp
 AuthenticationResult result;
 var accounts = await app.GetAccountsAsync();
 IAccount account = ChooseAccount(accounts); // for instance accounts.FirstOrDefault
@@ -152,7 +152,7 @@ The following example shows minimal code to get a token interactively for readin
 # [.NET](#tab/dotnet)
 ### In MSAL.NET
 
-```CSharp
+```csharp
 string[] scopes = new string[] {"user.read"};
 var app = PublicClientApplicationBuilder.Create(clientId).Build();
 var accounts = await app.GetAccountsAsync();
@@ -181,7 +181,7 @@ On Android, you need to also specify the parent activity (using `.WithParentActi
 
 Being interactive, UI is important. `AcquireTokenInteractive` has one specific optional parameter enabling to specify, for platforms supporting it, the parent UI. When used in a desktop application, `.WithParentActivityOrWindow` has a different type depending on the platform:
 
-```CSharp
+```csharp
 // net45
 WithParentActivityOrWindow(IntPtr windowPtr)
 WithParentActivityOrWindow(IWin32Window window)
@@ -199,7 +199,7 @@ Remarks:
 - On Windows, you must call `AcquireTokenInteractive` from the UI thread so that the embedded browser gets the appropriate UI synchronization context.  Not calling from the UI thread may cause messages to not pump properly and/or deadlock scenarios with the UI. One way of calling MSAL from the UI thread if you aren't on the UI thread already is to use the `Dispatcher` on WPF.
 - If you're using WPF, to get a window from a WPF control, you can use  `WindowInteropHelper.Handle` class. The call is then, from a WPF control (`this`):
 
-  ```CSharp
+  ```csharp
   result = await app.AcquireTokenInteractive(scopes)
                     .WithParentActivityOrWindow(new WindowInteropHelper(this).Handle)
                     .ExecuteAsync();
@@ -223,7 +223,7 @@ The class defines the following constants:
 
 This modifier is used in an advanced scenario where you want the user to pre-consent to several resources upfront (and don't want to use the incremental consent, which is normally used with MSAL.NET / the Microsoft identity platform). For details see [How-to : have the user consent upfront for several resources](scenario-desktop-production.md#how-to-have--the-user-consent-upfront-for-several-resources).
 
-```CSharp
+```csharp
 var result = await app.AcquireTokenInteractive(scopesForCustomerApi)
                      .WithExtraScopeToConsent(scopesForVendorApi)
                      .ExecuteAsync();
@@ -251,7 +251,7 @@ The host of the `end Url` is always the `redirectUri`. To intercept the `end Url
 
 `WithCustomWebUi` is an extensibility point that allows you provide your own UI in public client applications, and to let the user go through the /Authorize endpoint of the identity provider and let them sign in and consent. MSAL.NET can, then, redeem the authentication code and get a token. It's for instance used in Visual Studio to have electrons applications (for instance VS Feedback) provide the web interaction, but leave it to MSAL.NET to do most of the work. You can also use it if you want to provide UI automation. In public client applications, MSAL.NET uses the PKCE standard ([RFC 7636 - Proof Key for Code Exchange by OAuth Public Clients](https://tools.ietf.org/html/rfc7636)) to ensure that security is respected: Only MSAL.NET can redeem the code.
 
-  ```CSharp
+  ```csharp
   using Microsoft.Identity.Client.Extensions;
   ```
 
@@ -262,7 +262,7 @@ In order to use `.WithCustomWebUI`, you need to:
   1. Implement the `ICustomWebUi`  interface (See [here](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/053a98d16596be7e9ca1ab916924e5736e341fe8/src/Microsoft.Identity.Client/Extensibility/ICustomWebUI.cs#L32-L70). You'll basically need to implement one method `AcquireAuthorizationCodeAsync` accepting the authorization code URL (computed by MSAL.NET), letting the user go through the interaction with the identity provider, and then returning back the URL by which the identity provider would have called your implementation back (including the authorization code). If you have issues, your implementation should throw a `MsalExtensionException` exception to nicely cooperate with MSAL.
   2. In your `AcquireTokenInteractive` call, you can use `.WithCustomUI()` modifier passing the instance of your custom web UI
 
-     ```CSharp
+     ```csharp
      result = await app.AcquireTokenInteractive(scopes)
                        .WithCustomWebUi(yourCustomWebUI)
                        .ExecuteAsync();
@@ -282,7 +282,7 @@ From MSAL.NET 4.1 [`SystemWebViewOptions`](https://docs.microsoft.com/dotnet/api
 
 To use this structure, you can write something like the following:
 
-```CSharp
+```csharp
 IPublicClientApplication app;
 ...
 
@@ -441,7 +441,7 @@ You normally need only one parameter (`scopes`). However depending on the way yo
 
 The following sample presents the most current case, with explanations of the kind of exceptions you can get, and their mitigations
 
-```CSharp
+```csharp
 static async Task GetATokenForGraph()
 {
  string authority = "https://login.microsoftonline.com/contoso.com";
@@ -588,7 +588,7 @@ The following constraints also apply:
 
 The following sample presents a simplified case
 
-```CSharp
+```csharp
 static async Task GetATokenForGraph()
 {
  string authority = "https://login.microsoftonline.com/contoso.com";
@@ -629,7 +629,7 @@ static async Task GetATokenForGraph()
 
 The following sample presents the most current case, with explanations of the kind of exceptions you can get, and their mitigations
 
-```CSharp
+```csharp
 static async Task GetATokenForGraph()
 {
  string authority = "https://login.microsoftonline.com/contoso.com";
@@ -892,7 +892,7 @@ Interactive authentication with Azure AD requires a web browser (for details see
 
 `IPublicClientApplication`contains a method named `AcquireTokenWithDeviceCode`
 
-```CSharp
+```csharp
  AcquireTokenWithDeviceCode(IEnumerable<string> scopes,
                             Func<DeviceCodeResult, Task> deviceCodeResultCallback)
 ```
@@ -906,7 +906,7 @@ This method takes as parameters:
 
 The following sample code presents the most current case, with explanations of the kind of exceptions you can get, and their mitigation.
 
-```CSharp
+```csharp
 private const string ClientId = "<client_guid>";
 private const string Authority = "https://login.microsoftonline.com/contoso.com";
 private readonly string[] Scopes = new string[] { "user.read" };
@@ -1117,7 +1117,7 @@ Below is an example of a naive implementation of custom serialization of a token
 
 After you build the application, you enable the serialization by calling ``TokenCacheHelper.EnableSerialization()`` passing the application `UserTokenCache`
 
-```CSharp
+```csharp
 app = PublicClientApplicationBuilder.Create(ClientId)
     .Build();
 TokenCacheHelper.EnableSerialization(app.UserTokenCache);
@@ -1125,7 +1125,7 @@ TokenCacheHelper.EnableSerialization(app.UserTokenCache);
 
 This helper class looks like the following code snippet:
 
-```CSharp
+```csharp
 static class TokenCacheHelper
  {
   public static void EnableSerialization(ITokenCache tokenCache)
@@ -1182,7 +1182,7 @@ A preview of a product quality token cache file-based serializer for public clie
 
 If you want to implement token cache serialization both with the Unified cache format (common to ADAL.NET 4.x and MSAL.NET 2.x, and with other MSALs of the same generation or older, on the same platform), you can get inspired by the following code:
 
-```CSharp
+```csharp
 string appLocation = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location;
 string cacheFolder = Path.GetFullPath(appLocation) + @"..\..\..\..");
 string adalV3cacheFileName = Path.Combine(cacheFolder, "cacheAdalV3.bin");
@@ -1199,7 +1199,7 @@ FilesBasedTokenCacheHelper.EnableSerialization(app.UserTokenCache,
 
 This time the helper class looks like the following code:
 
-```CSharp
+```csharp
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/articles/active-directory/develop/scenario-desktop-app-configuration.md
+++ b/articles/active-directory/develop/scenario-desktop-app-configuration.md
@@ -48,14 +48,14 @@ You'll need to build and manipulate MSAL.NET `IPublicClientApplication`.
 
 The following code instantiates a public client application, signing-in users in the Microsoft Azure public cloud, with a work and school account, or a personal Microsoft account.
 
-```CSharp
+```csharp
 IPublicClientApplication app = PublicClientApplicationBuilder.Create(clientId)
     .Build();
 ```
 
 If you intend to use interactive authentication or Device Code Flow, as seen above, you want to use the `.WithRedirectUri` modifier:
 
-```CSharp
+```csharp
 IPublicClientApplication app;
 app = PublicClientApplicationBuilder.Create(clientId)
         .WithDefaultRedirectUri()
@@ -66,7 +66,7 @@ app = PublicClientApplicationBuilder.Create(clientId)
 
 The following code instantiates a Public client application from a configuration object, which could be filled-in programmatically or read from a configuration file
 
-```CSharp
+```csharp
 PublicClientApplicationOptions options = GetOptions(); // your own method
 IPublicClientApplication app = PublicClientApplicationBuilder.CreateWithApplicationOptions(options)
         .WithDefaultRedirectUri()
@@ -77,7 +77,7 @@ IPublicClientApplication app = PublicClientApplicationBuilder.CreateWithApplicat
 
 You can elaborate the application building by adding a number of modifiers. For instance, if you want your application to be a multi-tenant application in a national cloud (here US Government), you could write:
 
-```CSharp
+```csharp
 IPublicClientApplication app;
 app = PublicClientApplicationBuilder.Create(clientId)
         .WithDefaultRedirectUri()
@@ -88,7 +88,7 @@ app = PublicClientApplicationBuilder.Create(clientId)
 
 MSAL.NET also contains a modifier for ADFS 2019:
 
-```CSharp
+```csharp
 IPublicClientApplication app;
 app = PublicClientApplicationBuilder.Create(clientId)
         .WithAdfsAuthority("https://consoso.com/adfs")
@@ -97,7 +97,7 @@ app = PublicClientApplicationBuilder.Create(clientId)
 
 Finally, if you want to acquire tokens for an Azure AD B2C tenant, can specify your tenant as shown in the following code snippet:
 
-```CSharp
+```csharp
 IPublicClientApplication app;
 app = PublicClientApplicationBuilder.Create(clientId)
         .WithB2CAuthority("https://fabrikamb2c.b2clogin.com/tfp/{tenant}/{PolicySignInSignUp}")
@@ -131,7 +131,7 @@ Imagine a .NET Core console application that has the following `appsettings.json
 
 You have little code to read this file using the .NET provided configuration framework;
 
-```CSharp
+```csharp
 public class SampleConfiguration
 {
  /// <summary>
@@ -174,7 +174,7 @@ public class SampleConfiguration
 
 Now, to create your application, you'll just need to write the following code:
 
-```CSharp
+```csharp
 SampleConfiguration config = SampleConfiguration.ReadFromJsonFile("appsettings.json");
 var app = PublicClientApplicationBuilder.CreateWithApplicationOptions(config.PublicClientApplicationOptions)
            .WithDefaultRedirectUri()

--- a/articles/active-directory/develop/scenario-desktop-call-api.md
+++ b/articles/active-directory/develop/scenario-desktop-call-api.md
@@ -97,7 +97,7 @@ task.resume()
 
 If you need to call several APIs for the same user, once you got a token for the first API, you can just call `AcquireTokenSilent`, and you'll get a token for the other APIs silently most of the time.
 
-```CSharp
+```csharp
 var result = await app.AcquireTokenXX("scopeApi1")
                       .ExecuteAsync();
 
@@ -110,7 +110,7 @@ The cases where interaction is required is when:
 - The user consented for the first API, but now needs to consent for more scopes (incremental consent)
 - The first API didn't require multiple-factor authentication, but the next one does.
 
-```CSharp
+```csharp
 var result = await app.AcquireTokenXX("scopeApi1")
                       .ExecuteAsync();
 

--- a/articles/active-directory/develop/scenario-desktop-production.md
+++ b/articles/active-directory/develop/scenario-desktop-production.md
@@ -47,7 +47,7 @@ For instance:
 
 ### In MSAL.NET
 
-```CSharp
+```csharp
 string[] scopesForCustomerApi = new string[]
 {
   "https://mytenant.onmicrosoft.com/customerapi/customer.read",
@@ -100,7 +100,7 @@ This call will get you an access token for the first web API.
 
 When you need to call the second web API, you can call `AcquireTokenSilent` API:
 
-```CSharp
+```csharp
 AcquireTokenSilent(scopesForVendorApi, accounts.FirstOrDefault()).ExecuteAsync();
 ```
 

--- a/articles/active-directory/develop/scenario-mobile-acquire-token.md
+++ b/articles/active-directory/develop/scenario-mobile-acquire-token.md
@@ -42,7 +42,7 @@ let scopes = ["https://graph.microsoft.com/.default"]
 ```
 
 #### Xamarin
-```CSharp 
+```csharp 
 var scopes = new [] {"https://graph.microsoft.com/.default"};
 ```
 
@@ -197,7 +197,7 @@ MSAL for iOS and macOS supports various modifiers when getting a token interacti
 
 The following example shows minimal code to get a token interactively for reading the user's profile with Microsoft Graph.
 
-```CSharp
+```csharp
 string[] scopes = new string[] {"user.read"};
 var app = PublicClientApplicationBuilder.Create(clientId).Build();
 var accounts = await app.GetAccountsAsync();
@@ -240,7 +240,7 @@ The class defines the following constants:
 
 This modifier is used in an advanced scenario where you want the user to pre-consent to several resources upfront (and don't want to use the incremental consent, which is normally used with MSAL.NET / the Microsoft identity platform v2.0). For details see [How-to : have the user consent upfront for several resources](scenario-desktop-production.md#how-to-have--the-user-consent-upfront-for-several-resources).
 
-```CSharp
+```csharp
 var result = await app.AcquireTokenInteractive(scopesForCustomerApi)
                      .WithExtraScopeToConsent(scopesForVendorApi)
                      .ExecuteAsync();

--- a/articles/active-directory/develop/scenario-mobile-app-configuration.md
+++ b/articles/active-directory/develop/scenario-mobile-app-configuration.md
@@ -74,7 +74,7 @@ The following paragraph explains how to instantiate the application for Xamarin.
 
 In Xamarin, or UWP, the simplest way to instantiate the application is as follows, where the `ClientId` is the Guid of your registered app.
 
-```CSharp
+```csharp
 var app = PublicClientApplicationBuilder.Create(clientId)
                                         .Build();
 ```
@@ -85,7 +85,7 @@ There are additional With*parameter* methods which set the UI parent, override t
 
 On Android, you need to pass the parent activity before you do the interactive authentication. On iOS, when using a broker, you need to pass-in the ViewController. In the same way on UWP, you might want to pass-in the parent window. This is possible when you acquire the token, but it's also possible to specify a callback at app creation time a delegate returning the UIParent.
 
-```CSharp
+```csharp
 IPublicClientApplication application = PublicClientApplicationBuilder.Create(clientId)
   .ParentActivityOrWindowFunc(() => parentUi)
   .Build();
@@ -93,7 +93,7 @@ IPublicClientApplication application = PublicClientApplicationBuilder.Create(cli
 
 On Android, we recommend you use the `CurrentActivityPlugin` [here](https://github.com/jamesmontemagno/CurrentActivityPlugin).  Then your `PublicClientApplication` builder code would look like this:
 
-```CSharp
+```csharp
 // Requires MSAL.NET 4.2 or above
 var pca = PublicClientApplicationBuilder
   .Create("<your-client-id-here>")
@@ -172,7 +172,7 @@ Follow the steps below to enable your Xamarin.iOS app to talk with the [Microsof
 
 Broker support is enabled on a per-`PublicClientApplication` basis. It's disabled by default. You must use the `WithBroker()` parameter (set to true by default) when creating the `PublicClientApplication` through the `PublicClientApplicationBuilder`.
 
-```CSharp
+```csharp
 var app = PublicClientApplicationBuilder
                 .Create(ClientId)
                 .WithBroker()
@@ -184,7 +184,7 @@ var app = PublicClientApplicationBuilder
 
 When MSAL.NET calls the broker, the broker will, in turn, call back to your application through the `AppDelegate.OpenUrl` method. Since MSAL will wait for the response from the broker, your application needs to cooperate to call MSAL.NET back. You do this by updating the `AppDelegate.cs` file to override the below method.
 
-```CSharp
+```csharp
 public override bool OpenUrl(UIApplication app, NSUrl url,
                              string sourceApplication,
                              NSObject annotation)
@@ -217,16 +217,16 @@ Do the following to set the object window:
 **For example:**
 
 In `App.cs`:
-```CSharp
+```csharp
    public static object RootViewController { get; set; }
 ```
 In `AppDelegate.cs`:
-```CSharp
+```csharp
    LoadApplication(new App());
    App.RootViewController = new UIViewController();
 ```
 In the Acquire Token call:
-```CSharp
+```csharp
 result = await app.AcquireTokenInteractive(scopes)
              .WithParentActivityOrWindow(App.RootViewController)
              .ExecuteAsync();

--- a/articles/active-directory/develop/scenario-mobile-call-api.md
+++ b/articles/active-directory/develop/scenario-mobile-call-api.md
@@ -131,7 +131,7 @@ If you need to call the same API several times, or if you need to call multiple 
 
 If you need to call several APIs for the same user, once you've acquired a token for a user, you can avoid repeatedly asking the user for credentials by subsequently calling `AcquireTokenSilent` to get a token.
 
-```CSharp
+```csharp
 var result = await app.AcquireTokenXX("scopeApi1")
                       .ExecuteAsync();
 
@@ -144,7 +144,7 @@ The cases where interaction is required is when:
 - The user consented for the first API, but now needs to consent for more scopes (incremental consent)
 - The first API didn't require multiple-factor authentication, but the next one does.
 
-```CSharp
+```csharp
 var result = await app.AcquireTokenXX("scopeApi1")
                       .ExecuteAsync();
 

--- a/articles/active-directory/develop/scenario-protected-web-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-protected-web-api-app-configuration.md
@@ -40,7 +40,7 @@ The information about the identity of the app, and about the user (unless the we
 
 Here's a C# code example that shows a client calling the API after it acquires a token with Microsoft Authentication Library for .NET (MSAL.NET):
 
-```CSharp
+```csharp
 var scopes = new[] {$"api://.../access_as_user}";
 var result = await app.AcquireToken(scopes)
                       .ExecuteAsync();
@@ -93,19 +93,19 @@ When an app is called on a controller action that holds an `[Authorize]` attribu
 
 In ASP.NET Core, this middleware is initialized in the Startup.cs file:
 
-```CSharp
+```csharp
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 ```
 
 The middleware is added to the web API by this instruction:
 
-```CSharp
+```csharp
  services.AddAzureAdBearer(options => Configuration.Bind("AzureAd", options));
 ```
 
  Currently, the ASP.NET Core templates create Azure Active Directory (Azure AD) web APIs that sign in users within your organization or any organization, not with personal accounts. But you can easily change them to use the Microsoft identity platform endpoint by adding this code to the Startup.cs file:
 
-```CSharp
+```csharp
 services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, options =>
 {
     // This is a Microsoft identity platform web API.

--- a/articles/active-directory/develop/scenario-protected-web-api-verification-scope-app-roles.md
+++ b/articles/active-directory/develop/scenario-protected-web-api-verification-scope-app-roles.md
@@ -39,7 +39,7 @@ To protect an ASP.NET/ASP.NET Core web API, you'll need to add the `[Authorize]`
 - The controller itself, if you want all the actions of the controller to be protected
 - The individual controller action for your API
 
-```CSharp
+```csharp
     [Authorize]
     public class TodoListController : Controller
     {
@@ -56,7 +56,7 @@ But this protection isn't enough. It guarantees only that ASP.NET/ASP.NET Core w
 
 If your API is called by a client app on behalf of a user, it needs to request a bearer token that has specific scopes for the API. (See [Code configuration | Bearer token](scenario-protected-web-api-app-configuration.md#bearer-token).)
 
-```CSharp
+```csharp
 [Authorize]
 public class TodoListController : Controller
 {
@@ -83,7 +83,7 @@ The `VerifyUserHasAnyAcceptedScope` method would do something like the following
 - Verify that there's a claim named `http://schemas.microsoft.com/identity/claims/scope` or `scp`.
 - Verify that the claim has a value that contains the scope expected by the API.
 
-```CSharp
+```csharp
     /// <summary>
     /// When applied to a <see cref="HttpContext"/>, verifies that the user authenticated in the 
     /// web API has any of the accepted scopes.
@@ -119,7 +119,7 @@ If your web API is called by a [daemon app](scenario-daemon-overview.md), that a
 You now need to have your APIs verify that the token it received contains the `roles` claim and
 that this claim has the value it expects. The code doing this verification is similar to the code that verifies delegated permissions, except that, instead of testing for `scopes`, your controller action will test for `roles`:
 
-```CSharp
+```csharp
 [Authorize]
 public class TodoListController : ApiController
 {
@@ -132,7 +132,7 @@ public class TodoListController : ApiController
 
 The `ValidateAppRole()` method can be something like this:
 
-```CSharp
+```csharp
 private void ValidateAppRole(string appRole)
 {
     //
@@ -159,7 +159,7 @@ The `roles` claim is also used for users in user assignment patterns. (See [How 
 
 If you want to allow only daemon apps to call your web API, add a condition, when you validate the app role, that the token is an app-only token:
 
-```CSharp
+```csharp
 string oid = ClaimsPrincipal.Current.FindFirst("oid")?.Value;
 string sub = ClaimsPrincipal.Current.FindFirst("sub")?.Value;
 bool isAppOnlyToken = oid == sub;

--- a/articles/active-directory/develop/scenario-web-api-call-api-acquire-token.md
+++ b/articles/active-directory/develop/scenario-web-api-call-api-acquire-token.md
@@ -28,7 +28,7 @@ Once you've built a client application object, use it to acquire a token that yo
 
 Here's an example of code that will be called in the actions of the API controllers, calling a downstream API (named todolist).
 
-```CSharp
+```csharp
 private async Task GetTodoList(bool isAppStarting)
 {
  ...
@@ -51,7 +51,7 @@ private async Task GetTodoList(bool isAppStarting)
 
 The `GetAccountIdentifier` method uses the claims associated with the identity of the user for which the web API received the JWT:
 
-```CSharp
+```csharp
 public static string GetMsalAccountId(this ClaimsPrincipal claimsPrincipal)
 {
  string userObjectId = GetObjectId(claimsPrincipal);

--- a/articles/active-directory/develop/scenario-web-api-call-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-api-call-api-app-configuration.md
@@ -30,7 +30,7 @@ The code to configure your web API so that it calls downstream web APIs builds o
 
 On top of the code configuration for any protected web APIs, you need to subscribe to the validation of the bearer token that's received when your API is called:
 
-```CSharp
+```csharp
 /// <summary>
 /// Protects the web API with Microsoft Identity Platform (a.k.k AAD v2.0)
 /// This supposes that the configuration files have a section named "AzureAD"
@@ -76,7 +76,7 @@ This flow is only available in the confidential client flow so the protected web
 
 ![image](https://user-images.githubusercontent.com/13203188/55967244-3d8e1d00-5c7a-11e9-8285-a54b05597ec9.png)
 
-```CSharp
+```csharp
 IConfidentialClientApplication app;
 
 #if !VariationWithCertificateCredentials
@@ -105,7 +105,7 @@ The `UserAssertion` is built from the bearer token received by the web API from 
 
 In practice, the OBO flow is often used to acquire a token for a downstream API and store it in the MSAL.NET user token cache so that other parts of the web API can later call on the [overrides](https://docs.microsoft.com/dotnet/api/microsoft.identity.client.clientapplicationbase.acquiretokensilent?view=azure-dotnet) of ``AcquireTokenOnSilent`` to call the downstream APIs. This call has the effect of refreshing the tokens, if needed.
 
-```CSharp
+```csharp
 private void AddAccountToCacheFromJwt(IEnumerable<string> scopes, JwtSecurityToken jwtToken, ClaimsPrincipal principal, HttpContext httpContext)
 {
     try

--- a/articles/active-directory/develop/scenario-web-api-call-api-call-api.md
+++ b/articles/active-directory/develop/scenario-web-api-call-api-call-api.md
@@ -29,7 +29,7 @@ Here's the continuation of the example code shown in [Protected web API calls we
 
 Once you acquired the token, use it as a bearer token to call the downstream API.
 
-```CSharp
+```csharp
 private async Task GetTodoList(bool isAppStarting)
 {
  ...

--- a/articles/active-directory/develop/scenario-web-app-call-api-acquire-token.md
+++ b/articles/active-directory/develop/scenario-web-app-call-api-acquire-token.md
@@ -30,7 +30,7 @@ Now that you have built you client application object, you'll use it to acquire 
 
 The controller methods are protected by an `[Authorize]` attribute that forces users being authenticated to use the Web App. Here is the code that calls Microsoft Graph.
 
-```CSharp
+```csharp
 [Authorize]
 public class HomeController : Controller
 {
@@ -51,7 +51,7 @@ The `ITokenAcquisition` service is injected by ASP.NET through dependency inject
 
 Here is a simplified code of the action of the HomeController, which gets a token to call the Microsoft Graph.
 
-```CSharp
+```csharp
 public async Task<IActionResult> Profile()
 {
  // Acquire the access token

--- a/articles/active-directory/develop/scenario-web-app-call-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-app-call-api-app-configuration.md
@@ -89,7 +89,7 @@ In practice the [ASP.NET Core Web app tutorial](https://github.com/Azure-Samples
 
 Here is the [Startup.cs#L40-L42](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/bc564d68179c36546770bf4d6264ce72009bc65a/2-WebApp-graph-user/2-1-Call-MSGraph/Startup.cs#L40-L42) code, featuring the call to the `AddMicrosoftIdentityPlatformAuthentication` method which adds authentication to the web app, and `AddMsal` which adds the capability of calling Web APIs. The call to `AddInMemoryTokenCaches` is about choosing a token cache implementation among the ones which are possible:
 
-```CSharp
+```csharp
 public class Startup
 {
   // Code not show here
@@ -109,7 +109,7 @@ public class Startup
 
 `Constants.ScopeUserRead` is defined in [Constants.cs#L5](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/bc564d68179c36546770bf4d6264ce72009bc65a/2-WebApp-graph-user/2-1-Call-MSGraph/Infrastructure/Constants.cs#L5)
 
-```CSharp
+```csharp
 public static class Constants
 {
     public const string ScopeUserRead = "User.Read";
@@ -122,7 +122,7 @@ You've already studied the content of `AddMicrosoftIdentityPlatformAuthenticatio
 
 The code for `AddMsal` is located in [Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs#L108-L159](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/bc564d68179c36546770bf4d6264ce72009bc65a/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs#L108-L159).
 
-```CSharp
+```csharp
 
 /// <summary>
 /// Extensions for IServiceCollection for startup initialization.
@@ -250,7 +250,7 @@ In ASP.NET Core, building the confidential client application uses information t
 
 The code for the `GetOrBuildConfidentialClientApplication()` method is in [Microsoft.Identity.Web/TokenAcquisition.cs#L290-L333](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/4b12ba02e73f62e3e3137f5f4b9ef43cec7c14fd/Microsoft.Identity.Web/TokenAcquisition.cs#L290-L333). It uses members that were injected by dependency injection (passed in the constructor of TokenAcquisition in [Microsoft.Identity.Web/TokenAcquisition.cs#L47-L59](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/4b12ba02e73f62e3e3137f5f4b9ef43cec7c14fd/Microsoft.Identity.Web/TokenAcquisition.cs#L47-L59))
 
-```CSharp
+```csharp
 public class TokenAcquisition : ITokenAcquisition
 {
   // Code omitted here for clarity
@@ -319,7 +319,7 @@ To sum-up, `AcquireTokenByAuthorizationCode` really redeems the authorization co
 
 The way ASP.NET handles things is similar to ASP.NET Core, except that the configuration of OpenIdConnect and the subscription to the `OnAuthorizationCodeReceived` event happens in the [App_Start\Startup.Auth.cs](https://github.com/Azure-Samples/ms-identity-aspnet-webapp-openidconnect/blob/a2da310539aa613b77da1f9e1c17585311ab22b7/WebApp/App_Start/Startup.Auth.cs) file. You'll find similar concepts as in ASP.NET Core, except that in ASP.NET you'll need to specify the RedirectUri in the [Web.config#L15](https://github.com/Azure-Samples/ms-identity-aspnet-webapp-openidconnect/blob/master/WebApp/Web.config#L15). This configuration is a bit less robust than what is done in ASP.NET Core, as you'll need to change it when you deploy your application.
 
-```CSharp
+```csharp
 public partial class Startup
 {
   public void ConfigureAuth(IAppBuilder app)

--- a/articles/active-directory/develop/scenario-web-app-call-api-call-api.md
+++ b/articles/active-directory/develop/scenario-web-app-call-api-call-api.md
@@ -38,7 +38,7 @@ Here is a simplified code of the action of the `HomeController`. This code gets 
 }
 ```
 
-```CSharp
+```csharp
 public async Task<IActionResult> Profile()
 {
  var application = BuildConfidentialClientApplication(HttpContext, HttpContext.User);

--- a/articles/active-directory/develop/scenario-web-app-call-api-sign-in.md
+++ b/articles/active-directory/develop/scenario-web-app-call-api-sign-in.md
@@ -35,7 +35,7 @@ This mechanism is illustrated in the `AddMsal()` method of [WebAppServiceCollect
 
 The **Logout Url** that you've registered for your application enables you to implement single sign-out. The Microsoft identity platform `logout` endpoint will call the **Logout URL** registered with your application. This call happens if the sign-out was initiated from your web app, or from another web app or the browser. For more information, see [Single sign-out](v2-protocols-oidc.md#single-sign-out).
 
-```CSharp
+```csharp
 public static class WebAppServiceCollectionExtensions
 {
  public static IServiceCollection AddMsal(this IServiceCollection services, IConfiguration configuration, IEnumerable<string> initialScopes, string configSectionName = "AzureAd")

--- a/articles/active-directory/develop/scenario-web-app-sign-user-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-app-sign-user-app-configuration.md
@@ -218,7 +218,7 @@ To add authentication with the Microsoft identity platform (formerly Azure AD v2
 
 The following code is available from [Startup.cs#L33-L34](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/faa94fd49c2da46b22d6694c4f5c5895795af26d/1-WebApp-OIDC/1-1-MyOrg/Startup.cs#L33-L34).
 
-```CSharp
+```csharp
 public class Startup
 {
  ...
@@ -253,7 +253,7 @@ In addition to the configuration, you can specify the name of the configuration 
 
 Tracing OpenId Connect middleware events can help you troubleshoot your web application if authentication doesn't work. Setting `subscribeToOpenIdConnectMiddlewareDiagnosticsEvents` to `true` will show you how information gets elaborated by the set of ASP.NET Core middleware as it progresses from the HTTP response to the identity of the user in `HttpContext.User`.
 
-```CSharp
+```csharp
 /// <summary>
 /// Add authentication with the Microsoft identity platform.
 /// This method expects the configuration file to have a section named "AzureAd" with the necessary settings to initialize authentication options.
@@ -318,7 +318,7 @@ The `AadIssuerValidator` class enables the issuer of the token to be validated i
 
 The code related to authentication in an ASP.NET web app and web APIs is located in the [App_Start/Startup.Auth.cs](https://github.com/Azure-Samples/ms-identity-aspnet-webapp-openidconnect/blob/a2da310539aa613b77da1f9e1c17585311ab22b7/WebApp/App_Start/Startup.Auth.cs#L17-L61) file.
 
-```CSharp
+```csharp
  public void ConfigureAuth(IAppBuilder app)
  {
   app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);

--- a/articles/active-directory/develop/scenario-web-app-sign-user-sign-in.md
+++ b/articles/active-directory/develop/scenario-web-app-sign-user-sign-in.md
@@ -116,7 +116,7 @@ in [AccountController.cs](https://github.com/aspnet/AspNetCore/blob/master/src/A
 
 In ASP.NET, signing out is triggered from the `SignOut()` method on a controller (for instance, [AccountController.cs#L16-L23](https://github.com/Azure-Samples/ms-identity-aspnet-webapp-openidconnect/blob/a2da310539aa613b77da1f9e1c17585311ab22b7/WebApp/Controllers/AccountController.cs#L16-L23)). This method isn't part of the ASP.NET framework (contrary to what happens in ASP.NET Core). It sends an OpenID sign-in challenge after proposing a redirect URI.
 
-```CSharp
+```csharp
 public void SignIn()
 {
     // Send an OpenID Connect sign-in request.
@@ -342,7 +342,7 @@ In ASP.NET, signing out is triggered from the `SignOut()` method on a controller
 - Clears the cache.
 - Redirects to the page that it wants.
 
-```CSharp
+```csharp
 /// <summary>
 /// Send an OpenID Connect sign-out request.
 /// </summary>
@@ -396,7 +396,7 @@ The post-logout URI enables applications to participate in the global sign-out.
 
 The ASP.NET Core OpenID Connect middleware enables your app to intercept the call to the Microsoft identity platform `logout` endpoint by providing an OpenID Connect event named `OnRedirectToIdentityProviderForSignOut`. For an example of how to subscribe to this event (to clear the token cache), see [Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs#L151-L156](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2/blob/faa94fd49c2da46b22d6694c4f5c5895795af26d/Microsoft.Identity.Web/WebAppServiceCollectionExtensions.cs#L151-L156).
 
-```CSharp
+```csharp
     // Handling the global sign-out
     options.Events.OnRedirectToIdentityProviderForSignOut = async context =>
     {
@@ -408,7 +408,7 @@ The ASP.NET Core OpenID Connect middleware enables your app to intercept the cal
 
 In ASP.NET, you delegate to the middleware to execute the sign-out, clearing the session cookie:
 
-```CSharp
+```csharp
 public class AccountController : Controller
 {
  ...

--- a/articles/cognitive-services/LUIS/luis-concept-data-alteration.md
+++ b/articles/cognitive-services/LUIS/luis-concept-data-alteration.md
@@ -116,7 +116,7 @@ Learn more about the [V3 prediction endpoint](luis-migration-api-v3.md).
 ## C# code determines correct value of timezoneOffset
 The following C# code uses the [TimeZoneInfo](https://docs.microsoft.com/dotnet/api/system.timezoneinfo) class's [FindSystemTimeZoneById](https://docs.microsoft.com/dotnet/api/system.timezoneinfo.findsystemtimezonebyid#examples) method to determine the correct `timezoneOffset` based on system time:
 
-```CSharp
+```csharp
 // Get CST zone id
 TimeZoneInfo targetZone = TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
 

--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/translate-sts/csharp/dotnet.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/translate-sts/csharp/dotnet.md
@@ -25,7 +25,7 @@ Before you get started, make sure to:
 
 1. Open **Program.cs**, and replace all the code in it with the following.
 
-   ```CSharp
+   ```csharp
    using System;
    using System.Threading.Tasks;
    using Microsoft.CognitiveServices.Speech;

--- a/articles/iot-hub/iot-hub-security-x509-get-started.md
+++ b/articles/iot-hub/iot-hub-security-x509-get-started.md
@@ -94,7 +94,7 @@ Next, we will show you how to create a C# application to simulate the X.509 devi
 
 1. Add the following `using` statements at the top of the **Program.cs** file:
 
-    ```CSharp
+    ```csharp
         using Microsoft.Azure.Devices.Client;
         using Microsoft.Azure.Devices.Shared;
         using System.Security.Cryptography.X509Certificates;
@@ -102,7 +102,7 @@ Next, we will show you how to create a C# application to simulate the X.509 devi
 
 1. Add the following fields to the **Program** class:
 
-    ```CSharp
+    ```csharp
         private static int MESSAGE_COUNT = 5;
         private const int TEMPERATURE_THRESHOLD = 30;
         private static String deviceId = "<your-device-id>";
@@ -115,7 +115,7 @@ Next, we will show you how to create a C# application to simulate the X.509 devi
 
 1. Add the following function to create random numbers for temperature and humidity and send these values to the hub:
 
-    ```CSharp
+    ```csharp
     static async Task SendEvent(DeviceClient deviceClient)
     {
         string dataBuffer;
@@ -137,7 +137,7 @@ Next, we will show you how to create a C# application to simulate the X.509 devi
 
 1. Finally, add the following lines of code to the **Main** function, replacing the placeholders _device-id_, _your-iot-hub-name_, and _absolute-path-to-your-device-pfx-file_ as required by your setup.
 
-    ```CSharp
+    ```csharp
     try
     {
         var cert = new X509Certificate2(@"<absolute-path-to-your-device-pfx-file>", "1234");

--- a/articles/logic-apps/logic-apps-scenario-function-sb-trigger.md
+++ b/articles/logic-apps/logic-apps-scenario-function-sb-trigger.md
@@ -120,7 +120,7 @@ Next, create the function that acts as the trigger and listens to the queue.
 
    This example uses the [`Task.Run` method](https://docs.microsoft.com/dotnet/api/system.threading.tasks.task.run) in [asynchronous](https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/async) mode. For more information, see [Asynchronous programming with async and await](https://docs.microsoft.com/dotnet/csharp/programming-guide/concepts/async/).
 
-   ```CSharp
+   ```csharp
    using System;
    using System.Threading.Tasks;
    using System.Net.Http;

--- a/articles/logic-apps/tutorial-process-email-attachments-workflow.md
+++ b/articles/logic-apps/tutorial-process-email-attachments-workflow.md
@@ -174,7 +174,7 @@ Now, use the code snippet provided by these steps to create an Azure function th
 
 1. After the editor opens, replace the template code with this sample code, which removes the HTML and returns results to the caller:
 
-   ```CSharp
+   ```csharp
    #r "Newtonsoft.Json"
 
    using System.Net;

--- a/articles/service-bus-messaging/service-bus-to-event-grid-integration-example.md
+++ b/articles/service-bus-messaging/service-bus-to-event-grid-integration-example.md
@@ -46,7 +46,7 @@ You can use any method to send a message to your Service Bus topic. The sample c
 3. Go to the **MessageSender** project, and then select **Program.cs**.
 4. Fill in your Service Bus topic name and the connection string you got from the previous step:
 
-    ```CSharp
+    ```csharp
     const string ServiceBusConnectionString = "YOUR CONNECTION STRING";
     const string TopicName = "YOUR TOPIC NAME";
     ```
@@ -65,7 +65,7 @@ Then, do the following steps:
 
 1. Expand **Functions** in the tree view, and select your function. Replace the code for the function with the following code: 
 
-    ```CSharp
+    ```csharp
     #r "Newtonsoft.Json"
     
     using System.Net;
@@ -127,7 +127,7 @@ Then, do the following steps:
     2. Select **~1** for **Runtime version**. 
 2. Expand **Functions** in the tree view, and select your function. Replace the code for the function with the following code: 
 
-    ```CSharp
+    ```csharp
     #r "Newtonsoft.Json"
     using System.Net;
     using Newtonsoft.Json;

--- a/articles/service-fabric/service-fabric-concepts-partitioning.md
+++ b/articles/service-fabric/service-fabric-concepts-partitioning.md
@@ -161,7 +161,7 @@ As we literally want to have one partition per letter, we can use 0 as the low k
    
     The extra GUID is there for an advanced case where secondary replicas also listen for read-only requests. When that's the case, you want to make sure that a new unique address is used when transitioning from primary to secondary to force clients to re-resolve the address. '+' is used as the address here so that the replica listens on all available hosts (IP, FQDN, localhost, etc.) The code below shows an example.
    
-    ```CSharp
+    ```csharp
     protected override IEnumerable<ServiceReplicaListener> CreateServiceReplicaListeners()
     {
          return new[] { new ServiceReplicaListener(context => this.CreateInternalListener(context))};
@@ -189,7 +189,7 @@ As we literally want to have one partition per letter, we can use 0 as the low k
     The listening URL is given to HttpListener. The published URL is the URL that is published to the Service Fabric Naming Service, which is used for service discovery. Clients will ask for this address through that discovery service. The address that clients get needs to have the actual IP or FQDN of the node in order to connect. So you need to replace '+' with the node's IP or FQDN as shown above.
 9. The last step is to add the processing logic to the service as shown below.
    
-    ```CSharp
+    ```csharp
     private async Task ProcessInternalRequest(HttpListenerContext context, CancellationToken cancelRequest)
     {
         string output = null;
@@ -245,7 +245,7 @@ As we literally want to have one partition per letter, we can use 0 as the low k
     ```
 13. You need to return a collection of ServiceInstanceListeners in the class Web. Again, you can choose to implement a simple HttpCommunicationListener.
     
-    ```CSharp
+    ```csharp
     protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
     {
         return new[] {new ServiceInstanceListener(context => this.CreateInputListener(context))};
@@ -261,7 +261,7 @@ As we literally want to have one partition per letter, we can use 0 as the low k
     ```
 14. Now you need to implement the processing logic. The HttpCommunicationListener calls `ProcessInputRequest` when a request comes in. So let's go ahead and add the code below.
     
-    ```CSharp
+    ```csharp
     private async Task ProcessInputRequest(HttpListenerContext context, CancellationToken cancelRequest)
     {
         String output = null;
@@ -307,7 +307,7 @@ As we literally want to have one partition per letter, we can use 0 as the low k
     
     Let's walk through it step by step. The code reads the first letter of the query string parameter `lastname` into a char. Then, it determines the partition key for this letter by subtracting the hexadecimal value of `A` from the hexadecimal value of the last names' first letter.
     
-    ```CSharp
+    ```csharp
     string lastname = context.Request.QueryString["lastname"];
     char firstLetterOfLastName = lastname.First();
     ServicePartitionKey partitionKey = new ServicePartitionKey(Char.ToUpper(firstLetterOfLastName) - 'A');
@@ -316,19 +316,19 @@ As we literally want to have one partition per letter, we can use 0 as the low k
     Remember, for this example, we are using 26 partitions with one partition key per partition.
     Next, we obtain the service partition `partition` for this key by using the `ResolveAsync` method on the `servicePartitionResolver` object. `servicePartitionResolver` is defined as
     
-    ```CSharp
+    ```csharp
     private readonly ServicePartitionResolver servicePartitionResolver = ServicePartitionResolver.GetDefault();
     ```
     
     The `ResolveAsync` method takes the service URI, the partition key, and a cancellation token as parameters. The service URI for the processing service is `fabric:/AlphabetPartitions/Processing`. Next, we get the endpoint of the partition.
     
-    ```CSharp
+    ```csharp
     ResolvedServiceEndpoint ep = partition.GetEndpoint()
     ```
     
     Finally, we build the endpoint URL plus the querystring and call the processing service.
     
-    ```CSharp
+    ```csharp
     JObject addresses = JObject.Parse(ep.Address);
     string primaryReplicaAddress = (string)addresses["Endpoints"].First();
     

--- a/includes/active-directory-develop-scenarios-call-apis-dotnet.md
+++ b/includes/active-directory-develop-scenarios-call-apis-dotnet.md
@@ -58,7 +58,7 @@ The `IAccount` interface represents information about a single account. The same
 
 Once the `AuthenticationResult` has been returned by MSAL (in `result`), you need to add it to the HTTP authorization header, before making the call to access the protected Web API.
 
-```CSharp
+```csharp
 httpClient = new HttpClient();
 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", result.AccessToken);
 


### PR DESCRIPTION
Changed several incorrect C# code blocks to the correct tag.

Incorrect
![incorrect](https://user-images.githubusercontent.com/5115577/70556848-f5fdbf00-1b81-11ea-9b88-82a7ea04d80d.PNG)

Correct
![correct](https://user-images.githubusercontent.com/5115577/70556869-feee9080-1b81-11ea-9e14-1821c9c9a908.PNG)

My apologies for tagging multiple authors in 1 PR, but since this was a trivial change with no actual content changed, I didn't want to send 35 PRs for each file.