### PR TITLE
Update relay-hybrid-connections-protocol.md

### DIFF
--- a/articles/service-bus-relay/relay-hybrid-connections-protocol.md
+++ b/articles/service-bus-relay/relay-hybrid-connections-protocol.md
@@ -82,7 +82,7 @@ namespace, and a security token that confers the "Listen" right on that name.
 When the WebSocket is accepted by the service, the registration is complete and
 the established WebSocket is kept alive as the "control channel" for
 enabling all subsequent interactions. The service allows up to 25 concurrent
-listeners one Hybrid Connection. The quota for AppHooks is to be determined.
+listeners for one Hybrid Connection. The quota for AppHooks is to be determined.
 
 For Hybrid Connections, if there are two or more active listeners, incoming
 connections are balanced across them in random order; fair distribution is


### PR DESCRIPTION
just added the word "for" changing "The service allows up to 25 concurrent listeners one Hybrid Connection" to "The service allows up to 25 concurrent listeners for one Hybrid Connection". Other options could include "per" or "on".