### PR TITLE
Fix next step for IoT Edge support

### DIFF
--- a/articles/iot-central/preview/tutorial-define-edge-device-type.md
+++ b/articles/iot-central/preview/tutorial-define-edge-device-type.md
@@ -395,4 +395,4 @@ In this tutorial, you learned how to:
 Now that you've created a device template in your Azure IoT Central application, you can do this next:
 
 > [!div class="nextstepaction"]
-> [Connect device](./tutorial-connect-pnp-device.md)
+> [Connect edge device](./tutorial-add-edge-as-leaf-device.md)


### PR DESCRIPTION
This tutorial is about defining an IoT Edge device. So the next step should point to https://docs.microsoft.com/en-us/azure/iot-central/preview/tutorial-add-edge-as-leaf-device (instead of an original iot device).