### PR TITLE
remove remarks

### DIFF
--- a/articles/azure-resource-manager/resource-group-template-functions-resource.md
+++ b/articles/azure-resource-manager/resource-group-template-functions-resource.md
@@ -665,8 +665,6 @@ The **managedBy** property is returned only for resource groups that contain res
 
 ### Remarks
 
-The `resourceGroup()` function can't be used in a template that is [deployed at the subscription level](deploy-to-subscription.md). It can only be used in templates that are deployed to a resource group.
-
 A common use of the resourceGroup function is to create resources in the same location as the resource group. The following example uses the resource group location for a default parameter value.
 
 ```json


### PR DESCRIPTION
'The resourceGroup() function can't be used in a template that is deployed at the subscription level. It can only be used in templates that are deployed to a resource group.'

This is not correct. I can deploy on a subscription level an append policy using the function ResourceGroup() and it works flawlessly.
Example : {
  "mode": "Indexed",
  "policyRule": {
    "if": {
      "field": "tags['owner']",
      "notEquals": "[resourceGroup().tags['owner']]"
    },
    "then": {
      "effect": "append",
      "details": [
        {
          "field": "tags['owner']",
          "value": "[resourceGroup().tags['owner']]"
        }
      ]
    }
  },
  "parameters": {}
}