### PR TITLE
update topics note

### DIFF
--- a/articles/event-hubs/event-hubs-kafka-connect-tutorial.md
+++ b/articles/event-hubs/event-hubs-kafka-connect-tutorial.md
@@ -103,7 +103,9 @@ In this step, a Kafka Connect worker is started locally in distributed mode, usi
 4. Run `./bin/connect-distributed.sh /PATH/TO/connect-distributed.properties`.  The Connect worker REST API is ready for interaction when you see `'INFO Finished starting connectors and tasks'`. 
 
 > [!NOTE]
-> Event Hubs supports Kafka clients creating topics automatically. A quick check of the namespace in the Azure portal reveals that the Connect worker's internal topics have been created automatically.
+> Kafka Connect uses the Kafka AdminClient API to automatically create topics with recommended configurations, including compaction. A quick check of the namespace in the Azure portal reveals that the Connect worker's internal topics have been created automatically.
+>
+>Kafka Connect internal topics **must use compaction**.  The Event Hubs team is not responsible for fixing improper configurations if internal Connect topics are incorrectly configured.
 
 ### Create connectors
 This section walks you through spinning up FileStreamSource and FileStreamSink connectors. 


### PR DESCRIPTION
Previous note was misleading.  Kafka Connect does not use topic auto-creation, it uses the AdminClient API.

Also adding note on compaction as a warning to those who create topics themselves.