### PR TITLE
Add client_id parameter to sign-out request

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
@@ -271,7 +271,7 @@ GET https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{policy}/oauth2/v2.0/
 | {tenant} | Yes | Name of your Azure AD B2C tenant |
 | {policy} | Yes | The user flow that you want to use to sign the user out of your application. |
 | id_token_hint| No | A previously issued ID token to pass to the logout endpoint as a hint about the end user's current authenticated session with the client. The `id_token_hint` ensures that the `post_logout_redirect_uri` is a registered reply URL in your Azure AD B2C application settings. |
-| client_id | No* | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application.<br>\**This is required when using `Application` isolation SSO Configuration* |
+| client_id | No* | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application.<br>\**This is required when using `Application` isolation SSO configuration and _Require ID Token_ in logout request is set to `No`.* |
 | post_logout_redirect_uri | No | The URL that the user should be redirected to after successful sign out. If it isn't included, Azure AD B2C shows the user a generic message. Unless you provide an `id_token_hint`, you should not register this URL as a reply URL in your Azure AD B2C application settings. |
 | state | No | If a `state` parameter is included in the request, the same value should appear in the response. The application should verify that the `state` values in the request and response are identical. |
 

--- a/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
@@ -271,7 +271,7 @@ GET https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{policy}/oauth2/v2.0/
 | {tenant} | Yes | Name of your Azure AD B2C tenant |
 | {policy} | Yes | The user flow that you want to use to sign the user out of your application. |
 | id_token_hint| No | A previously issued ID token to pass to the logout endpoint as a hint about the end user's current authenticated session with the client. The `id_token_hint` ensures that the `post_logout_redirect_uri` is a registered reply URL in your Azure AD B2C application settings. |
-| client_id | No* | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application.<br>\**This is required when using `Application` isolation SSO configuration and _Require ID Token_ in logout request is set to `No`.* |
+| client_id | No* | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application.<br><br>\**This is required when using `Application` isolation SSO configuration and _Require ID Token_ in logout request is set to `No`.* |
 | post_logout_redirect_uri | No | The URL that the user should be redirected to after successful sign out. If it isn't included, Azure AD B2C shows the user a generic message. Unless you provide an `id_token_hint`, you should not register this URL as a reply URL in your Azure AD B2C application settings. |
 | state | No | If a `state` parameter is included in the request, the same value should appear in the response. The application should verify that the `state` values in the request and response are identical. |
 

--- a/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
+++ b/articles/active-directory-b2c/active-directory-b2c-reference-oidc.md
@@ -271,6 +271,7 @@ GET https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{policy}/oauth2/v2.0/
 | {tenant} | Yes | Name of your Azure AD B2C tenant |
 | {policy} | Yes | The user flow that you want to use to sign the user out of your application. |
 | id_token_hint| No | A previously issued ID token to pass to the logout endpoint as a hint about the end user's current authenticated session with the client. The `id_token_hint` ensures that the `post_logout_redirect_uri` is a registered reply URL in your Azure AD B2C application settings. |
+| client_id | No* | The application ID that the [Azure portal](https://portal.azure.com/) assigned to your application.<br>\**This is required when using `Application` isolation SSO Configuration* |
 | post_logout_redirect_uri | No | The URL that the user should be redirected to after successful sign out. If it isn't included, Azure AD B2C shows the user a generic message. Unless you provide an `id_token_hint`, you should not register this URL as a reply URL in your Azure AD B2C application settings. |
 | state | No | If a `state` parameter is included in the request, the same value should appear in the response. The application should verify that the `state` values in the request and response are identical. |
 


### PR DESCRIPTION
When using the `Application` isolation SSO configuration https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-token-session-sso#single-sign-on-sso-configuration, attempting to signout without specifying the client_id parameter results in a successful navigation to your `post_logout_redirect_uri`, but does not clear the cookie on the b2clogin site.  A subsequent login attempt will immediately succeed, without a credential re-prompt.