### PR TITLE
Added exclude-path option for sync operation

### DIFF
--- a/articles/storage/common/storage-ref-azcopy-sync.md
+++ b/articles/storage/common/storage-ref-azcopy-sync.md
@@ -133,6 +133,8 @@ azcopy sync "https://[account].file.core.windows.net/[share]/[path/to/dir]?[SAS]
 
 **--exclude-attributes** string   (Windows only) Exclude files whose attributes match the attribute list. For example: A;S;R
 
+**--exclude-path** string Exclude these paths when copying. This option does not support wildcard characters (*). Checks relative path prefix(For example: myFolder;myFolder/subDirName/file.pdf). When used in combination with account traversal, paths do not include the container name.
+
 **--exclude-pattern** string      Exclude files where the name matches the pattern list. For example: *.jpg;*.pdf;exactName
 
 **-h, --help**                        help for sync

--- a/articles/storage/common/storage-ref-azcopy-sync.md
+++ b/articles/storage/common/storage-ref-azcopy-sync.md
@@ -101,6 +101,7 @@ Sync a single blob:
 
 ```azcopy
 azcopy sync "https://[account].blob.core.windows.net/[container]/[path/to/blob]?[SAS]" "https://[account].blob.core.windows.net/[container]/[path/to/blob]"
+```
 
 Sync a virtual directory:
 


### PR DESCRIPTION
AZCopy 10.3.3 now includes support for --exclude-path, which this document does not reference. I have copied the details from the "azcopy copy" doc page.