### PR TITLE
Update iOS info

### DIFF
--- a/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
@@ -3,7 +3,7 @@ title: Xamarin iOS considerations (MSAL.NET) | Azure
 titleSuffix: Microsoft identity platform
 description: Learn about specific considerations when using Xamarin iOS with the Microsoft Authentication Library for .NET (MSAL.NET).
 services: active-directory
-author: TylerMSFT
+author: jmprieur
 manager: CelesteDG
 
 ms.service: active-directory

--- a/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
@@ -27,13 +27,6 @@ On Xamarin iOS, there are several considerations that you must take into account
 - [Enable token cache sharing](#enable-token-cache-sharing-across-ios-applications)
 - [Enable Keychain access](#enable-keychain-access)
 
-## Known issues with iOS 12 and authentication
-Microsoft has released a [security advisory](https://github.com/aspnet/AspNetCore/issues/4647) to provide information about an incompatibility between iOS12 and some types of authentication. The incompatibility breaks social, WSFed, and OIDC logins. This advisory also provides guidance on what developers can do to remove current security restrictions added by ASP.NET to their applications to become compatible with iOS12.  
-
-When developing MSAL.NET applications on Xamarin iOS, you may see an infinite loop when trying to sign in to websites from iOS 12 (similar to this [ADAL issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1329). 
-
-You might also see a break in ASP.NET Core OIDC authentication with iOS 12 Safari as described in this [WebKit issue](https://bugs.webkit.org/show_bug.cgi?id=188165).
-
 ## Implement OpenUrl
 
 First you need to override the `OpenUrl` method of the `FormsApplicationDelegate` derived class and call `AuthenticationContinuationHelper.SetAuthenticationContinuationEventArgs`.
@@ -53,40 +46,28 @@ You'll also need to define a URL scheme, require permissions for your app to cal
 To enable keychain access, your application must have a keychain access group.
 You can set your keychain access group by using the `WithIosKeychainSecurityGroup()` api when creating your application as shown below:
 
-To enable single sign-on, you need to set the `PublicClientApplication.iOSKeychainSecurityGroup` property to the same value in all of the applications.
+To benefit from the cache and single sign-on, you need to set the keychain access group to the same value in all of your applications.
 
-An example of this using MSAL v3.x would be:
+An example of this using MSAL v4.x would be:
 ```csharp
 var builder = PublicClientApplicationBuilder
      .Create(ClientId)
-     .WithIosKeychainSecurityGroup("com.microsoft.msalrocks")
+     .WithIosKeychainSecurityGroup("com.microsoft.adalcache")
      .Build();
 ```
-
-The entitlements.plist should be updated to look like the following XML fragment:
 
 This change is *in addition* to enabling keychain access in the `Entitlements.plist` file, using either the below access group or your own:
 
 ```xml
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
 <dict>
   <key>keychain-access-groups</key>
   <array>
-    <string>$(AppIdentifierPrefix)com.microsoft.msalrocks</string>
+    <string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
   </array>
 </dict>
-</plist>
 ```
 
-An example of this using MSAL v4.x would be:
-
-```csharp
-PublicClientApplication.iOSKeychainSecurityGroup = "com.microsoft.msalrocks";
-```
-
-When using the `WithIosKeychainSecurityGroup()` api, MSAL will automatically append your security group to the end of the application's "team ID" (AppIdentifierPrefix) because when you build your application using xcode, it will do the same. [See iOS entitlements documentation for more details](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps). That's why you need to update the entitlements to include $(AppIdentifierPrefix) before the keychain access group in the entitlements.plist.
+When using the `WithIosKeychainSecurityGroup()` api, MSAL will automatically append your security group to the end of the application's "team ID" (AppIdentifierPrefix) because when you build your application using xcode, it will do the same. [See iOS entitlements documentation for more details](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps). That's why the entitlements need to include `$(AppIdentifierPrefix)` before the keychain access group in the `Entitlements.plist`.
 
 ### Enable token cache sharing across iOS applications
 
@@ -125,3 +106,10 @@ Sample | Platform | Description
 [https://github.com/Azure-Samples/active-directory-xamarin-native-v2](https://github.com/azure-samples/active-directory-xamarin-native-v2) | Xamarin iOS, Android, UWP | A simple Xamarin Forms app showcasing how to use MSAL to authenticate MSA and Azure AD via the Azure AD V2.0 endpoint, and access the Microsoft Graph with the resulting token.
 
 <!--- https://github.com/Azure-Samples/active-directory-xamarin-native-v2/blob/master/ReadmeFiles/Topology.png -->
+
+## Known issues with iOS 12 and authentication
+Microsoft has released a [security advisory](https://github.com/aspnet/AspNetCore/issues/4647) to provide information about an incompatibility between iOS12 and some types of authentication. The incompatibility breaks social, WSFed, and OIDC logins. This advisory also provides guidance on what developers can do to remove current security restrictions added by ASP.NET to their applications to become compatible with iOS12.  
+
+When developing MSAL.NET applications on Xamarin iOS, you may see an infinite loop when trying to sign in to websites from iOS 12 (similar to this [ADAL issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1329). 
+
+You might also see a break in ASP.NET Core OIDC authentication with iOS 12 Safari as described in this [WebKit issue](https://bugs.webkit.org/show_bug.cgi?id=188165).

--- a/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-ios-considerations.md
@@ -67,7 +67,7 @@ This change is *in addition* to enabling keychain access in the `Entitlements.pl
 </dict>
 ```
 
-When using the `WithIosKeychainSecurityGroup()` api, MSAL will automatically append your security group to the end of the application's "team ID" (AppIdentifierPrefix) because when you build your application using xcode, it will do the same. [See iOS entitlements documentation for more details](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps). That's why the entitlements need to include `$(AppIdentifierPrefix)` before the keychain access group in the `Entitlements.plist`.
+When you use the `WithIosKeychainSecurityGroup()` api, MSAL automatically appends your security group to the end of the application's *team ID* (AppIdentifierPrefix) because when you build your application using xcode, it will do the same. For more information, see [iOS entitlements documentation](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps). That's why the entitlements need to include `$(AppIdentifierPrefix)` before the keychain access group in the `Entitlements.plist`.
 
 ### Enable token cache sharing across iOS applications
 
@@ -110,6 +110,6 @@ Sample | Platform | Description
 ## Known issues with iOS 12 and authentication
 Microsoft has released a [security advisory](https://github.com/aspnet/AspNetCore/issues/4647) to provide information about an incompatibility between iOS12 and some types of authentication. The incompatibility breaks social, WSFed, and OIDC logins. This advisory also provides guidance on what developers can do to remove current security restrictions added by ASP.NET to their applications to become compatible with iOS12.  
 
-When developing MSAL.NET applications on Xamarin iOS, you may see an infinite loop when trying to sign in to websites from iOS 12 (similar to this [ADAL issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1329). 
+When developing MSAL.NET applications on Xamarin iOS, you might see an infinite loop when trying to sign in to websites from iOS 12 (similar to this [ADAL issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1329)). 
 
 You might also see a break in ASP.NET Core OIDC authentication with iOS 12 Safari as described in this [WebKit issue](https://bugs.webkit.org/show_bug.cgi?id=188165).


### PR DESCRIPTION
- update info for iOS, esp entitlements
- remove "com.microsoft.msalrocks" as this confuses customers. this is an example of a custom keychain group, but we want them to also use "com.microsoft.adalcache"
- clean up the entitlements xml code
- remove references to 3x 
- move iOS 12 security issue to the bottom as iOS 13.x has been released for a few months now