### PR TITLE
Update app-service-move-limitations.md

### DIFF
--- a/articles/azure-resource-manager/move-limitations/app-service-move-limitations.md
+++ b/articles/azure-resource-manager/move-limitations/app-service-move-limitations.md
@@ -18,7 +18,7 @@ When moving a Web App across subscriptions, the following guidance applies:
     - App Service plans
     - Uploaded or imported SSL certificates
     - App Service Environments
-- All App Service resources in the resource group must be moved together.
+- All App Service resources in the resource group must be moved together. Note that App Service Environments cannot be moved to a new Resource Group nor to a new Subscription.
 - You can move a certificate bound to a web without deleting the SSL bindings, as long as the certificate is moved with all other resources in the resource group.
 - App Service resources can only be moved from the resource group in which they were originally created. If an App Service resource is no longer in its original resource group, move it back to its original resource group. Then, move the resource across subscriptions.
 


### PR DESCRIPTION
Customers are getting confused by the fact that we mention App Service Environments on the list of App Services resources and immediately after we say that all App Service resources need to be moved. Since App Service Environments cannot be moved, I suggest adding a note like this:
- All App Service resources in the resource group must be moved together. Note that App Service Environments cannot be moved to a new Resource Group nor to a new Subscription.