### PR TITLE
Updated CircuitRouteStat cmd, fixed a copy/paste error

### DIFF
--- a/articles/expressroute/expressroute-troubleshooting-expressroute-overview.md
+++ b/articles/expressroute/expressroute-troubleshooting-expressroute-overview.md
@@ -272,7 +272,7 @@ The following example shows the response of the command for a peering that does 
 ## Confirm the traffic flow
 To get the combined primary and secondary path traffic statistics--bytes in and out--of a peering context, use the following command:
 
-	Get-AzureDedicatedCircuitStats -ServiceKey 97f85950-01dd-4d30-a73c-bf683b3a6e5c -AccessType Private
+	Get-AzExpressRouteCircuitStat -ExpressRouteCircuitName ********** -ResourceGroupName ***** -PeeringType AzurePrivatePeering
 
 A sample output of the command is:
 
@@ -282,7 +282,7 @@ A sample output of the command is:
 
 A sample output of the command for a non-existent peering is:
 
-	Get-AzExpressRouteCircuitRouteTable : The BGP Peering AzurePublicPeering with Service Key ********************* is not found.
+	Get-AzExpressRouteCircuitRouteStat : The BGP Peering AzurePublicPeering with Service Key ********************* is not found.
 	StatusCode: 400
 
 ## Next Steps


### PR DESCRIPTION
Updated reference to the Get-AzureDedicatedCircuitStats command to the current version, Get-AzExpressRouteCircuitStat. Corrected output for Get-AzExpressRouteCircuitStat error (which had been copied and pasted from the previous section).