### PR TITLE
TimeSpan is not supported for ElasticPremium

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -164,7 +164,9 @@ public void keepAlive(
 
 In [C# class libraries](functions-dotnet-class-library.md), use the [TimerTriggerAttribute](https://github.com/Azure/azure-webjobs-sdk-extensions/blob/master/src/WebJobs.Extensions/Extensions/Timers/TimerTriggerAttribute.cs).
 
-The attribute's constructor takes a CRON expression or a `TimeSpan`. You can use `TimeSpan`  only if the function app is running on an App Service plan. The following example shows a CRON expression:
+The attribute's constructor takes a CRON expression or a `TimeSpan`. You can use `TimeSpan` only if the function app is running on an App Service plan. `TimeSpan` is not supported for Consumption or Elastic Premium Functions.
+
+The following example shows a CRON expression:
 
 ```csharp
 [FunctionName("TimerTriggerCSharp")]


### PR DESCRIPTION
Explicitly update description to indicate ElasticPremium (and Consumption) customers should use CRON