### PR TITLE
Update to New-RdsRegistrationInfo cmdlet usage

### DIFF
--- a/articles/virtual-desktop/create-host-pools-powershell.md
+++ b/articles/virtual-desktop/create-host-pools-powershell.md
@@ -32,7 +32,7 @@ New-RdsHostPool -TenantName <tenantname> -Name <hostpoolname>
 Run the next cmdlet to create a registration token to authorize a session host to join the host pool and save it to a new file on your local computer. You can specify how long the registration token is valid by using the -ExpirationHours parameter.
 
 ```powershell
-New-RdsRegistrationInfo -TenantName <tenantname> -HostPoolName <hostpoolname> -ExpirationHours <number of hours> | Select-Object -ExpandProperty Token > <PathToRegFile>
+New-RdsRegistrationInfo -TenantName <tenantname> -HostPoolName <hostpoolname> -ExpirationHours <number of hours> | Select-Object -ExpandProperty Token | Out-File -FilePath <PathToRegFile>
 ```
 
 After that, run this cmdlet to add Azure Active Directory users to the default desktop app group for the host pool.


### PR DESCRIPTION
Update to New-RdsRegistrationInfo cmdlet usage: 
use **Out-File** instead of ">" to make it more clear to users