### PR TITLE
Update domains-admin-takeover.md

### DIFF
--- a/articles/active-directory/users-groups-roles/domains-admin-takeover.md
+++ b/articles/active-directory/users-groups-roles/domains-admin-takeover.md
@@ -125,40 +125,40 @@ cmdlet | Usage
 
 1. Connect to Azure AD using the credentials that were used to respond to the self-service offering:
    ```powershell
-    Install-Module -Name MSOnline
-    $msolcred = get-credential
+   Install-Module -Name MSOnline
+   $msolcred = get-credential
     
-    connect-msolservice -credential $msolcred
+   connect-msolservice -credential $msolcred
    ```
 2. Get a list of domains:
   
    ```powershell
-    Get-MsolDomain
+   Get-MsolDomain
    ```
 3. Run the Get-MsolDomainVerificationDns cmdlet to create a challenge:
    ```powershell
-    Get-MsolDomainVerificationDns –DomainName *your_domain_name* –Mode DnsTxtRecord
-  
+   Get-MsolDomainVerificationDns –DomainName *your_domain_name* –Mode DnsTxtRecord
+   ```
     For example:
-  
-    Get-MsolDomainVerificationDns –DomainName contoso.com –Mode DnsTxtRecord
+   ```
+   Get-MsolDomainVerificationDns –DomainName contoso.com –Mode DnsTxtRecord
    ```
 
 4. Copy the value (the challenge) that is returned from this command. For example:
    ```powershell
-    MS=32DD01B82C05D27151EA9AE93C5890787F0E65D9
+   MS=32DD01B82C05D27151EA9AE93C5890787F0E65D9
    ```
 5. In your public DNS namespace, create a DNS txt record that contains the value that you copied in the previous step. The name for this record is the name of the parent domain, so if you create this resource record by using the DNS role from Windows Server, leave the Record name blank and just paste the value into the Text box.
 6. Run the Confirm-MsolDomain cmdlet to verify the challenge:
   
    ```powershell
-    Confirm-MsolEmailVerifiedDomain -DomainName *your_domain_name*
+   Confirm-MsolDomain –DomainName *your_domain_name* –ForceTakeover Force
    ```
   
    For example:
   
    ```powershell
-    Confirm-MsolEmailVerifiedDomain -DomainName contoso.com
+   Confirm-MsolDomain –DomainName contoso.com –ForceTakeover Force
    ```
 
 A successful challenge returns you to the prompt without an error.


### PR DESCRIPTION
There is a wrong cmdlet on the step 6 of "external admin takeover". The step instructs to run the Confirm-MsolDomain cmdlet, but the cmdlet in the example is another one (Confirm-MsolEmailVerifiedDomain). The cmdlet Confirm-MsolEmailVerifiedDomain might be used on the "internal admin takeover" procedure, and for now it's under "external admin takeover". 
I also fixed the quoting code of the step 3 that has the "For example" within the code block and space in the beginning of each cmdlet.