### PR TITLE
Update security-center-provide-security-contact-details.md

### DIFF
--- a/articles/security-center/security-center-provide-security-contact-details.md
+++ b/articles/security-center/security-center-provide-security-contact-details.md
@@ -18,7 +18,7 @@ ms.author: memildin
 # Provide security contact details in Azure Security Center
 Azure Security Center will recommend that you provide security contact details for your Azure subscription if you haven’t already. This information will be used by Microsoft to contact you if the Microsoft Security Response Center (MSRC) discovers that your customer data has been accessed by an unlawful or unauthorized party. MSRC performs select security monitoring of the Azure network and infrastructure and receives threat intelligence and abuse complaints from third parties.
 
-An email notification is sent on the first daily occurrence of an alert and only for high severity alerts. Email preferences can only be configured for subscription policies. Resource groups within a subscription will inherit these settings. 
+An email notification is sent on the first daily occurrence of an alert and only for high severity alerts. Email preferences can only be configured for subscription policies. Resource groups within a subscription will inherit these settings. Alerts are available only in the Standard tier of Azure Security Center.
 
 Alert email notifications are sent:
 - Only for high severity alerts


### PR DESCRIPTION
See also #44944 
I'm assuming that the alerts this document says you can get by entering your email and turning alerts On are 100% the same as the alerts described in the two docs below.
https://docs.microsoft.com/en-us/azure/security-center/security-center-alerts-overview
https://docs.microsoft.com/en-us/azure/security-center/security-center-managing-and-responding-alerts
Importantly, those alerts are only available in Standard. We have a support request pushing for clarification of these documents and they want it to be clear that configuring this setting in Free tier does nothing. Please double-check with PG before approving the PR. Contact me internally at v-dibr if anything is unclear.