### PR TITLE
Update convert-disk-storage.md

### DIFF
--- a/articles/virtual-machines/windows/convert-disk-storage.md
+++ b/articles/virtual-machines/windows/convert-disk-storage.md
@@ -117,7 +117,7 @@ Follow these steps:
 6. Change the **Account type** from **Standard HDD** to **Premium SSD**.
 7. Click **Save**, and close the disk pane.
 
-The disk type conversion is instantaneous. You can restart your VM after the conversion.
+The disk type conversion is instantaneous. You can start your VM after the conversion.
 
 ## Switch managed disks between Standard HDD and Standard SSD 
 


### PR DESCRIPTION
Since the VM must be deallocated at this point, it seems like "start" is a better choice than "restart". I get the idea, but it caused confusion in the Japanese translation on a support case since "Restart" is a specific operation that you can only perform when the VM is running.