### PR TITLE
Change the limitation - long audio API

### DIFF
--- a/articles/cognitive-services/Speech-Service/long-audio-api.md
+++ b/articles/cognitive-services/Speech-Service/long-audio-api.md
@@ -39,22 +39,22 @@ When preparing your text file, make sure it:
 * Is either plain text (.txt) or SSML text (.txt)
 * Is encoded as [UTF-8 with Byte Order Mark (BOM)](https://www.w3.org/International/questions/qa-utf8-bom.en#bom)
 * Is a single file, not a zip
-* Contains more than 400 characters for plain text or 400 [billable characters](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech#pricing-note) for SSML text, and less than 10,000 paragraphs
+* Contains more than 400 characters for plain text or 400 [billable characters](https://docs.microsoft.com/azure/cognitive-services/speech-service/text-to-speech#pricing-note) for SSML text, and less than 10,000 paragraphs
   * For plain text, each paragraph is separated by hitting **Enter/Return** - View [plain text input example](https://github.com/Azure-Samples/Cognitive-Speech-TTS/blob/master/CustomVoice-API-Samples/Java/en-US.txt)
   * For SSML text, each SSML piece is considered a paragraph. SSML pieces shall be separated by different paragraphs - View [SSML text input example](https://github.com/Azure-Samples/Cognitive-Speech-TTS/blob/master/CustomVoice-API-Samples/Java/SSMLTextInputSample.txt)
 > [!NOTE]
-> For Chinese (Mainland), Chinese (Hong Kong), Chinese (Taiwan), Japanese and Korean, 1 word will be counted as 2 characters. 
+> For Chinese (Mainland), Chinese (Hong Kong), Chinese (Taiwan), Japanese, and Korean, one word will be counted as two characters. 
 
 ## Submit synthesis requests
 
-After preparing the input content, follow the [long-form audio synthesis quickstart](https://aka.ms/long-audio-python) to submit the request. If you have more than 1 input files, you will need to submit multiple requests. There are some limitations that needs to be aware. 
-* Client is allowed to submit up to 5 requests to server per second for each Azure subscription account. If it exceeds the limitation, client will get a 429 error code(too many requests). Please reduce the request amount per second
-* Server is allowed to run and queue up to 120 requests for each Azure subscription account. If it exceeds the limitation, server will return a 429 error code(too many requests). Please wait and avoid submitting new request until some requests are completed
+After preparing the input content, follow the [long-form audio synthesis quickstart](https://aka.ms/long-audio-python) to submit the request. If you have more than one input file, you will need to submit multiple requests. There are some limitations to be aware of: 
+* Client is allowed to submit up to 5 requests to server per second for each Azure subscription account. If it exceeds the limitation, client will get a 429 error code (too many requests). Please reduce the request amount per second
+* Server is allowed to run and queue up to 120 requests for each Azure subscription account. If it exceeds the limitation, server will return a 429 error code (too many requests). Please wait and avoid submitting new request until some requests are completed
 * Server will keep up to 20,000 requests for each Azure subscription account. If it exceeds the limitation, please delete some requests before submitting new ones
 
 ## Audio output formats
 
-We support flexible audio output formats. You can generate audio outputs per paragraph, or concatenate the audios into 1 output by setting 'concatenateResult' parameter. The following audio output formats are supported by the Long Audio API:
+We support flexible audio output formats. You can generate audio outputs per paragraph or concatenate the audios into one output by setting the 'concatenateResult' parameter. The following audio output formats are supported by the Long Audio API:
 
 > [!NOTE]
 > The default audio format is riff-16khz-16bit-mono-pcm.

--- a/articles/cognitive-services/Speech-Service/long-audio-api.md
+++ b/articles/cognitive-services/Speech-Service/long-audio-api.md
@@ -50,7 +50,7 @@ When preparing your text file, make sure it:
 After preparing the input content, follow the [long-form audio synthesis quickstart](https://aka.ms/long-audio-python) to submit the request. If you have more than 1 input files, you will need to submit multiple requests. There are some limitations that needs to be aware. 
 * Client is allowed to submit up to 5 requests to server per second for each Azure subscription account. If it exceeds the limitation, client will get a 429 error code(too many requests). Please reduce the request amount per second
 * Server is allowed to run and queue up to 120 requests for each Azure subscription account. If it exceeds the limitation, server will return a 429 error code(too many requests). Please wait and avoid submitting new request until some requests are completed
-* Server will keep up to 20,000 requests for each Azure subscription account. If it exceeds the limitation, please delete some requests before submiting new ones
+* Server will keep up to 20,000 requests for each Azure subscription account. If it exceeds the limitation, please delete some requests before submitting new ones
 
 ## Audio output formats
 

--- a/articles/cognitive-services/Speech-Service/long-audio-api.md
+++ b/articles/cognitive-services/Speech-Service/long-audio-api.md
@@ -37,15 +37,24 @@ This diagram provides a high-level overview of the workflow.
 When preparing your text file, make sure it:
 
 * Is either plain text (.txt) or SSML text (.txt)
-  * For plain text, each paragraph is separated by hitting **Enter/Return** - View [plain text input example](https://github.com/Azure-Samples/Cognitive-Speech-TTS/blob/master/CustomVoice-API-Samples/Java/en-US.txt)
-  * For SSML text, each SSML piece is considered a paragraph. SSML pieces shall be separated by different paragraphs - View [SSML text input example](https://github.com/Azure-Samples/Cognitive-Speech-TTS/blob/master/CustomVoice-API-Samples/Java/SSMLTextInputSample.txt). For language code, see [Speech Synthesis Markup Language (SSML)](speech-synthesis-markup.md)
 * Is encoded as [UTF-8 with Byte Order Mark (BOM)](https://www.w3.org/International/questions/qa-utf8-bom.en#bom)
-* Contains more than 10,000 characters or more than 50 paragraphs
 * Is a single file, not a zip
+* Contains more than 400 characters for plain text or 400 [billable characters](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/text-to-speech#pricing-note) for SSML text, and less than 10,000 paragraphs
+  * For plain text, each paragraph is separated by hitting **Enter/Return** - View [plain text input example](https://github.com/Azure-Samples/Cognitive-Speech-TTS/blob/master/CustomVoice-API-Samples/Java/en-US.txt)
+  * For SSML text, each SSML piece is considered a paragraph. SSML pieces shall be separated by different paragraphs - View [SSML text input example](https://github.com/Azure-Samples/Cognitive-Speech-TTS/blob/master/CustomVoice-API-Samples/Java/SSMLTextInputSample.txt)
+> [!NOTE]
+> For Chinese (Mainland), Chinese (Hong Kong), Chinese (Taiwan), Japanese and Korean, 1 word will be counted as 2 characters. 
+
+## Submit synthesis requests
+
+After preparing the input content, follow the [long-form audio synthesis quickstart](https://aka.ms/long-audio-python) to submit the request. If you have more than 1 input files, you will need to submit multiple requests. There are some limitations that needs to be aware. 
+* Client is allowed to submit up to 5 requests to server per second for each Azure subscription account. If it exceeds the limitation, client will get a 429 error code(too many requests). Please reduce the request amount per second
+* Server is allowed to run and queue up to 120 requests for each Azure subscription account. If it exceeds the limitation, server will return a 429 error code(too many requests). Please wait and avoid submitting new request until some requests are completed
+* Server will keep up to 20,000 requests for each Azure subscription account. If it exceeds the limitation, please delete some requests before submiting new ones
 
 ## Audio output formats
 
-The following audio output formats are supported by the Long Audio API:
+We support flexible audio output formats. You can generate audio outputs per paragraph, or concatenate the audios into 1 output by setting 'concatenateResult' parameter. The following audio output formats are supported by the Long Audio API:
 
 > [!NOTE]
 > The default audio format is riff-16khz-16bit-mono-pcm.


### PR DESCRIPTION
After receiving some feedback from users, we add more clear description of the limitation and notification when using the long audio API.