### PR TITLE
Added: Azure Bastion incompatible with AADLoginForWindows

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
@@ -201,7 +201,7 @@ require multi-factor authentication as a grant access control.
 ## Log in using Azure AD credentials to a Windows VM
 
 > [!IMPORTANT]
-> Remote connection to VMs joined to Azure AD is only allowed from Windows 10 PCs that are Azure AD joined or hybrid Azure AD joined to the **same** directory as the VM. Additionally, to RDP using Azure AD credentials, the user must belong to one of the two RBAC roles, Virtual Machine Administrator Login or Virtual Machine User Login.
+> Remote connection to VMs joined to Azure AD is only allowed from Windows 10 PCs that are Azure AD joined or hybrid Azure AD joined to the **same** directory as the VM. Additionally, to RDP using Azure AD credentials, the user must belong to one of the two RBAC roles, Virtual Machine Administrator Login or Virtual Machine User Login. At this time, Azure Bastion cannot be used to login using Azure Active Directory authentication with the AADLoginForWindows extension. Only direct RDP is supported.
 
 To login in to your Windows Server 2019 virtual machine using Azure AD: 
 


### PR DESCRIPTION
Azure Bastion is not yet compatible with the AADLoginForWindows extension. This is somewhat implied in the text "Remote connection to VMs joined to Azure AD is **only** allowed from Windows 10 PCs that are Azure AD joined or hybrid Azure AD joined to the same directory as the VM."  This change is to explicitly state that one cannot use AAD login through Azure Bastion to avoid any confusion that could otherwise arise.

**Note to Developers:** Please add support for AADLoginForWindows through Azure Bastion.
