### PR TITLE
Add 'activate your environment' for Python 3.x

### DIFF
--- a/articles/cognitive-services/Bing-Web-Search/web-sdk-python-quickstart.md
+++ b/articles/cognitive-services/Bing-Web-Search/web-sdk-python-quickstart.md
@@ -60,6 +60,12 @@ Create a virtual environment with `venv` for Python 3.x:
 python -m venv mytestenv
 ```
 
+Activate your environment:
+
+```console
+mytestenv\Scripts\activate.bat
+```
+
 Install Bing Web Search SDK dependencies:
 
 ```console


### PR DESCRIPTION
Missing a step for how to activate venv for Python 3.x. There was only a step provided for Python 2.x but not Python 3.x