### PR TITLE
Added a Windows OS (Non-server) section

### DIFF
--- a/articles/security-center/security-center-os-coverage.md
+++ b/articles/security-center/security-center-os-coverage.md
@@ -44,6 +44,10 @@ The following sections list the supported server operating systems on which the 
 
 To learn more about the supported features for the Windows operating systems, listed above, see [Virtual machine / server supported features](security-center-services.md##vm-server-features).
 
+### Windows operating systems <a name="os-windows (non-server)"></a>
+
+Azure Security Center integrates with Azure services to monitor and protect your Windows-based virtual machines.
+
 ### Linux operating systems <a name="os-linux"></a>
 
 64-bit


### PR DESCRIPTION
Filing on behalf of Japanese Internal Customer:
Context: ASC installed the MMAgent on a Win 10 VM on a end customer's subscription which they applied ASC Standard Tier to. The end customer did not see any mention of Win 10 being a supported platform and so did not think to opt-out this VM.  I made a suggested edit in this doc by including information from the “Windows” sub heading here:
https://docs.microsoft.com/en-us/azure/security-center/security-center-alerts-iaas#windows-

under a new sub heading:  ### Windows operating systems <a name="os-windows (non-server)"></a> under # Supported platforms 

But I believe much can be done to improve on this.  Any expert assistance to incorporate this above info in a way so that "customers aren't surprised to see new unexpected costs generated because ASC also installs the MMAgent on all the Non-Server Windows based VMs if auto provisioning is enabled", is greatly appreciated.