### PR TITLE
Update api-management-howto-deploy-self-hosted-gateway-to-docker.md

### DIFF
--- a/articles/api-management/api-management-howto-deploy-self-hosted-gateway-to-docker.md
+++ b/articles/api-management/api-management-howto-deploy-self-hosted-gateway-to-docker.md
@@ -30,7 +30,7 @@ This article provides the steps for deploying self-hosted Azure API Management g
 - [Provision a gateway resource in your API Management instance](api-management-howto-provision-self-hosted-gateway.md)
 
 > [!NOTE]
-> Self-hosted gateway is packaged as a Linux-based Docker container.
+> Self-hosted gateway is packaged as a x86-64 Linux-based Docker container.
 
 ## Deploy the self-hosted gateway to Docker
 


### PR DESCRIPTION
Tried APIM gateway on Ubuntu 19.10 running on Raspi-4 but container error out as "exec format error". Raspi-4 is based on ARM64 arch and not x86_64.