### PR TITLE
Fix to Cosmos DB Quickstart templates url

### DIFF
--- a/articles/cosmos-db/manage-sql-with-resource-manager.md
+++ b/articles/cosmos-db/manage-sql-with-resource-manager.md
@@ -200,5 +200,5 @@ Here are some additional resources:
 
 * [Azure Resource Manager documentation](/azure/azure-resource-manager/)
 * [Azure Cosmos DB resource provider schema](/azure/templates/microsoft.documentdb/allversions)
-* [Azure Cosmos DB Quickstart templates](https://azure.microsoft.com/resources/templates/?resourceType=Microsoft.DocumentDB&pageNumber=1&sort=Popular)
+* [Azure Cosmos DB Quickstart templates](https://azure.microsoft.com/resources/templates/?resourceType=Microsoft.Documentdb&pageNumber=1&sort=Popular)
 * [Troubleshoot common Azure Resource Manager deployment errors](../azure-resource-manager/resource-manager-common-deployment-errors.md)


### PR DESCRIPTION
When clicking clickstart link it would go to the quickstart page but not find Cosmos DB resources. Have updated the url and variables to the correct naming/ casing and left in the pagenumber and sorting options that was previously there.