### PR TITLE
Fixed erroneous self-reference of fileHost

### DIFF
--- a/articles/storage/files/storage-how-to-use-files-linux.md
+++ b/articles/storage/files/storage-how-to-use-files-linux.md
@@ -75,7 +75,7 @@ uname -r
         --name $storageAccountName \
         --query "primaryEndpoints.file" | tr -d '"')
     smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))
-    fileHost=$(echo $fileHost | tr -d "/")
+    fileHost=$(echo $smbPath | tr -d "/")
 
     nc -zvw3 $fileHost 445
     ```


### PR DESCRIPTION
The line referred to itself, and instead should take in the $smbPath parameter.