### PR TITLE
Cleaning up UDP protocol referenced in the table

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-ports.md
+++ b/articles/active-directory/hybrid/reference-connect-ports.md
@@ -30,21 +30,21 @@ This table describes the ports and protocols that are required for communication
 | --- | --- | --- |
 | DNS |53 (TCP/UDP) |DNS lookups on the destination forest. |
 | Kerberos |88 (TCP/UDP) |Kerberos authentication to the AD forest. |
-| MS-RPC |135 (TCP/UDP) |Used during the initial configuration of the Azure AD Connect wizard when it binds to the AD forest, and also during Password synchronization. |
-| LDAP |389 (TCP/UDP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
-| SMB | 445 (TCP/UDP) |Used by Seamless SSO to create a computer account in the AD forest. |
-| LDAP/SSL |636 (TCP/UDP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using SSL. |
-| RPC |49152- 65535 (Random high RPC Port)(TCP/UDP) |Used during the initial configuration of Azure AD Connect when it binds to the AD forests, and during Password synchronization. See [KB929851](https://support.microsoft.com/kb/929851), [KB832017](https://support.microsoft.com/kb/832017), and [KB224196](https://support.microsoft.com/kb/224196) for more information. |
-|WinRM  | 5985 (TCP/UDP) |Only used if you are installing AD FS with gMSA by Azure AD Connect Wizard|
-|AD DS Web Services | 9389 (TCP/UDP) |Only used if you are installing AD FS with gMSA by Azure AD Connect Wizard |
+| MS-RPC |135 (TCP) |Used during the initial configuration of the Azure AD Connect wizard when it binds to the AD forest, and also during Password synchronization. |
+| LDAP |389 (TCP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
+| SMB | 445 (TCP) |Used by Seamless SSO to create a computer account in the AD forest. |
+| LDAP/SSL |636 (TCP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using SSL. |
+| RPC |49152- 65535 (Random high RPC Port)(TCP) |Used during the initial configuration of Azure AD Connect when it binds to the AD forests, and during Password synchronization. See [KB929851](https://support.microsoft.com/kb/929851), [KB832017](https://support.microsoft.com/kb/832017), and [KB224196](https://support.microsoft.com/kb/224196) for more information. |
+|WinRM  | 5985 (TCP) |Only used if you are installing AD FS with gMSA by Azure AD Connect Wizard|
+|AD DS Web Services | 9389 (TCP) |Only used if you are installing AD FS with gMSA by Azure AD Connect Wizard |
 
 ## Table 2 - Azure AD Connect and Azure AD
 This table describes the ports and protocols that are required for communication between the Azure AD Connect server and Azure AD.
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTP |80 (TCP/UDP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
-| HTTPS |443(TCP/UDP) |Used to synchronize with Azure AD. |
+| HTTP |80 (TCP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
+| HTTPS |443(TCP) |Used to synchronize with Azure AD. |
 
 For a list of URLs and IP addresses you need to open in your firewall, see [Office 365 URLs and IP address ranges](https://support.office.com/article/Office-365-URLs-and-IP-address-ranges-8548a211-3fe7-47cb-abb1-355ea5aa88a2).
 
@@ -53,8 +53,8 @@ This table describes the ports and protocols that are required for communication
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTP |80 (TCP/UDP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
-| HTTPS |443(TCP/UDP) |Used to synchronize with Azure AD. |
+| HTTP |80 (TCP) |Used to download CRLs (Certificate Revocation Lists) to verify SSL certificates. |
+| HTTPS |443(TCP) |Used to synchronize with Azure AD. |
 | WinRM |5985 |WinRM Listener |
 
 ## Table 4 - WAP and Federation Servers
@@ -62,14 +62,14 @@ This table describes the ports and protocols that are required for communication
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTPS |443(TCP/UDP) |Used for authentication. |
+| HTTPS |443(TCP) |Used for authentication. |
 
 ## Table 5 - WAP and Users
 This table describes the ports and protocols that are required for communication between users and the WAP servers.
 
 | Protocol | Ports | Description |
 | --- | --- | --- |
-| HTTPS |443(TCP/UDP) |Used for device authentication. |
+| HTTPS |443(TCP) |Used for device authentication. |
 | TCP |49443 (TCP) |Used for certificate authentication. |
 
 ## Table 6a & 6b - Pass-through Authentication with Single Sign On (SSO) and Password Hash Sync with Single Sign On (SSO)

--- a/articles/active-directory/hybrid/reference-connect-ports.md
+++ b/articles/active-directory/hybrid/reference-connect-ports.md
@@ -31,9 +31,9 @@ This table describes the ports and protocols that are required for communication
 | DNS |53 (TCP/UDP) |DNS lookups on the destination forest. |
 | Kerberos |88 (TCP/UDP) |Kerberos authentication to the AD forest. |
 | MS-RPC |135 (TCP) |Used during the initial configuration of the Azure AD Connect wizard when it binds to the AD forest, and also during Password synchronization. |
-| LDAP |389 (TCP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
+| LDAP |389 (TCP/UDP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
 | SMB | 445 (TCP) |Used by Seamless SSO to create a computer account in the AD forest. |
-| LDAP/SSL |636 (TCP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using SSL. |
+| LDAP/SSL |636 (TCP/UDP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using SSL. |
 | RPC |49152- 65535 (Random high RPC Port)(TCP) |Used during the initial configuration of Azure AD Connect when it binds to the AD forests, and during Password synchronization. See [KB929851](https://support.microsoft.com/kb/929851), [KB832017](https://support.microsoft.com/kb/832017), and [KB224196](https://support.microsoft.com/kb/224196) for more information. |
 |WinRM  | 5985 (TCP) |Only used if you are installing AD FS with gMSA by Azure AD Connect Wizard|
 |AD DS Web Services | 9389 (TCP) |Only used if you are installing AD FS with gMSA by Azure AD Connect Wizard |


### PR DESCRIPTION
for most ports the protocol should only be TCP, for example RPC, SMB, HTTP, except for DNS/Kerberos where UDP maybe used.