### PR TITLE
Update load-balancer-custom-probe-overview.md

### DIFF
--- a/articles/load-balancer/load-balancer-custom-probe-overview.md
+++ b/articles/load-balancer/load-balancer-custom-probe-overview.md
@@ -114,6 +114,9 @@ The following illustrates how you could express this kind of probe configuration
 
 HTTP and HTTPS probes build on the TCP probe and issue an HTTP GET with the specified path. Both of these probes support relative paths for the HTTP GET. HTTPS probes are the same as HTTP probes with the addition of a Transport Layer Security (TLS, formerly known as SSL) wrapper. The health probe is marked up when the instance responds with an HTTP status 200 within the timeout period.  The health probe attempts to check the configured health probe port every 15 seconds by default. The minimum probe interval is 5 seconds. The total duration of all intervals cannot exceed 120 seconds.
 
+> [!NOTE]
+> The HTTPs Probe requires the use of certificates based that have a minimum signature hash of SHA256 in the entire chain.
+
 HTTP / HTTPS probes can also be useful to implement your own logic to remove instances from load balancer rotation if the probe port is also the listener for the service itself. For example, you might decide to remove an instance if it's above 90% CPU and return a non-200 HTTP status. 
 
 If you use Cloud Services and have web roles that use w3wp.exe, you also achieve automatic monitoring of your website. Failures in your website code return a non-200 status to the load balancer probe.


### PR DESCRIPTION
Updating requirements for HTTP probe. SHA-1 is no longer supported.