### PR TITLE
Change parameter name

### DIFF
--- a/articles/firewall/tutorial-hybrid-ps.md
+++ b/articles/firewall/tutorial-hybrid-ps.md
@@ -47,7 +47,7 @@ This article requires that you run PowerShell locally. You must have the Azure P
 
 There are three key requirements for this scenario to work correctly:
 
-- A User Defined Route (UDR) on the spoke subnet that points to the Azure Firewall IP address as the default gateway. BGP route propagation must be **Disabled** on this route table.
+- A User Defined Route (UDR) on the spoke subnet that points to the Azure Firewall IP address as the default gateway. Virtual network gateway route propagation must be **Disabled** on this route table.
 - A UDR on the hub gateway subnet must point to the firewall IP address as the next hop to the spoke networks.
 
    No UDR is required on the Azure Firewall subnet, as it learns routes from BGP.
@@ -350,7 +350,7 @@ Set-AzVirtualNetwork
 
 #Now create the default route
 
-#Create a table, with BGP route propagation disabled
+#Create a table, with BGP route propagation disabled. The property is now called "Virtual network gateway route propagation," but the API still refers to the parameter as "DisableBgpRoutePropagation."
 $routeTableSpokeDG = New-AzRouteTable `
   -Name 'UDR-DG' `
   -ResourceGroupName $RG1 `


### PR DESCRIPTION
Need to update from "BGP route propagation" to "Virtual network gateway route propagation."
Also, since the API still uses "BGP" in the parameter name, need to indicate so. 