### PR TITLE
Removed caching-mode attrigute from APIM cache-store policy sample

### DIFF
--- a/articles/api-management/api-management-howto-cache.md
+++ b/articles/api-management/api-management-howto-cache.md
@@ -67,7 +67,7 @@ With caching policies shown in this example, the first request to the **GetSpeak
 
 9. In the **outbound** element, add the following policy:
 
-        <cache-store caching-mode="cache-on" duration="20" />
+        <cache-store duration="20" />
 
     **Duration** specifies the expiration interval of the cached responses. In this example, the interval is **20** seconds.
 


### PR DESCRIPTION
The attribute has been long removed from policy.