### PR TITLE
Update regional availability link

### DIFF
--- a/articles/aks/faq.md
+++ b/articles/aks/faq.md
@@ -189,7 +189,6 @@ No AKS is a managed service, and manipulation of the IaaS resources is not suppo
 
 <!-- LINKS - internal -->
 
-[aks-regions]: ./quotas-skus-regions.md#region-availability
 [aks-upgrade]: ./upgrade-cluster.md
 [aks-cluster-autoscale]: ./autoscaler.md
 [aks-advanced-networking]: ./configure-azure-cni.md
@@ -208,7 +207,7 @@ No AKS is a managed service, and manipulation of the IaaS resources is not suppo
 [availability-zones]: ./availability-zones.md
 
 <!-- LINKS - external -->
-
+[aks-regions]: https://azure.microsoft.com/global-infrastructure/services/?products=kubernetes-service
 [auto-scaler]: https://github.com/kubernetes/autoscaler
 [cordon-drain]: https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/
 [hexadite]: https://github.com/Hexadite/acs-keyvault-agent


### PR DESCRIPTION
The FAQ doc links to another doc which then links to the regional availability page on Azure.microsoft.com. Updating the FAQ link to go directly to the regional availability page.