### PR TITLE
Update curl-train-extract.md

### DIFF
--- a/articles/cognitive-services/form-recognizer/quickstarts/curl-train-extract.md
+++ b/articles/cognitive-services/form-recognizer/quickstarts/curl-train-extract.md
@@ -47,7 +47,7 @@ To train a Form Recognizer model with the documents in your Azure blob container
 1. Replace `<SAS URL>` with the Azure Blob storage container's shared access signature (SAS) URL. To retrieve the SAS URL, open the Microsoft Azure Storage Explorer, right-click your container, and select **Get shared access signature**. Make sure the **Read** and **List** permissions are checked, and click **Create**. Then copy the value in the **URL** section. It should have the form: `https://<storage account>.blob.core.windows.net/<container name>?<SAS value>`.
 
 ```bash
-curl -i -X POST "https://<Endpoint>/formrecognizer/v2.0-preview/custom/models" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: <subscription key>" --data-ascii "{ \"source\": \""<SAS URL>"\"}"
+curl -i -X POST "https://<Endpoint>/formrecognizer/v2.0-preview/custom/models" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key: <subscription key>" --data-ascii "{ \"source\": \"<SAS URL>"\"}""
 ```
 
 You'll receive a `201 (Success)` response with a **Location** header. The value of this header is the ID of the new model being trained. 


### PR DESCRIPTION
I made 2 edits to the cURL command for training as I found there was an extra " character in front of <SAS URL> that I had to remove and I added a " to the end of the cURL command.

This is what was in the document:
curl -i -X POST "https://<Endpoint>/formrecognizer/v2.0-preview/custom/models" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key:<subscription key>" --data-ascii "{ \"source\": \""<SAS URL>"\"}"

I had to use this format in order for this to work with the API:

curl -i -X POST "https://<Endpoint>/formrecognizer/v2.0-preview/custom/models" -H "Content-Type: application/json" -H "Ocp-Apim-Subscription-Key:<subscription key>" --data-ascii "{ \"source\": \"<SAS URL>"\"}""

Otherwise I was receiving this message: "Train request is either invalid or missing required parameters. Please reference the API reference and retry your request."