### PR TITLE
Moved Deployment section from Scenarios tab

### DIFF
--- a/articles/cognitive-services/Speech-Service/index.md
+++ b/articles/cognitive-services/Speech-Service/index.md
@@ -596,6 +596,49 @@ description: Get started with the Speech service. Recognize speech, synthesize s
                         </ul>
                     </li>
                     <li>
+                        <a href="#deploy-architecture">Concepts</a>
+                        <ul id="deploy-architecture" class="cardsC">
+                            <li>
+                                <a href="speech-container-howto.md?tabs=stt">
+                                    <div class="cardSize">
+                                        <div class="cardPadding">
+                                            <div class="card">
+                                                <div class="cardImageOuter">
+                                                    <div class="cardImage bgdAccent1">
+                                                        <img src="media/hub/speech-containers.png" alt="" />
+                                                    </div>
+                                                </div>
+                                                <div class="cardText">
+                                                    <h3>Deploy Speech service to containers</h3>
+                                                    <p>Use Docker to deploy the Speech service to a container instance.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="regions.md">
+                                    <div class="cardSize">
+                                        <div class="cardPadding">
+                                            <div class="card">
+                                                <div class="cardImageOuter">
+                                                    <div class="cardImage bgdAccent1">
+                                                        <img src="media/hub/speech-regions.png" alt="" />
+                                                    </div>
+                                                </div>
+                                                <div class="cardText">
+                                                    <h3>Supported regions</h3>
+                                                    <p>Learn where the Speech service is supported.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>                                    
+                        </ul>
+                    </li>                    
+                    <li>
                         <a href="#support">Support</a>
                         <ul id="support" class="cardsC">
                             <li>
@@ -913,50 +956,7 @@ description: Get started with the Speech service. Recognize speech, synthesize s
                                 </a>
                             </li>
                         </ul>
-                    </li>
-                    <li>
-                        <a href="#deploy-architecture">Deployment</a>
-                        <ul id="deploy-architecture" class="cardsC">
-                            <li>
-                                <a href="speech-container-howto.md?tabs=stt">
-                                    <div class="cardSize">
-                                        <div class="cardPadding">
-                                            <div class="card">
-                                                <div class="cardImageOuter">
-                                                    <div class="cardImage bgdAccent1">
-                                                        <img src="media/hub/speech-containers.png" alt="" />
-                                                    </div>
-                                                </div>
-                                                <div class="cardText">
-                                                    <h3>Deploy Speech service to containers</h3>
-                                                    <p>Use Docker to deploy the Speech service to a container instance.</p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li>
-                                <a href="regions.md">
-                                    <div class="cardSize">
-                                        <div class="cardPadding">
-                                            <div class="card">
-                                                <div class="cardImageOuter">
-                                                    <div class="cardImage bgdAccent1">
-                                                        <img src="media/hub/speech-regions.png" alt="" />
-                                                    </div>
-                                                </div>
-                                                <div class="cardText">
-                                                    <h3>Supported regions</h3>
-                                                    <p>Learn where the Speech service is supported.</p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>                                    
-                        </ul>
-                    </li>                    
+                    </li>                   
                 </ul>
             </li>
         </ul>


### PR DESCRIPTION
Moved Deployment section from the Scenarios tab to the Get Started tab above Support and renamed it to Concepts. This was after a discussion with @chrisbasoglu and @robch. Talked to @erhopf about the change as well. @dapine as FYI.