### PR TITLE
Update ingress-tls.md

### DIFF
--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -121,7 +121,7 @@ helm repo update
 
 # Install the cert-manager Helm chart
 helm install \
-  --name cert-manager \
+  cert-manager \
   --namespace cert-manager \
   --version v0.8.0 \
   jetstack/cert-manager


### PR DESCRIPTION
Helm install did not needed --name parameter for mentioning the name. Just Helm install <name> works fine.
# Install the cert-manager Helm chart
helm install \
  --name cert-manager \
  --namespace cert-manager \
  --version v0.8.0 \
  jetstack/cert-manager