### PR TITLE
Replace Text Ruby Script to "Go Application"

### DIFF
--- a/articles/cognitive-services/Face/QuickStarts/go.md
+++ b/articles/cognitive-services/Face/QuickStarts/go.md
@@ -306,7 +306,7 @@ You should see a JSON string of detected face data printed to the console. The f
 
 ## Next steps
 
-In this quickstart, you wrote a Ruby script that calls the Azure Face API to detect faces in an image and return their attributes. Next, explore the Face API reference documentation to learn more.
+In this quickstart, you wrote a Go Console Application that calls the Azure Face API to detect faces in an image and return their attributes. Next, explore the Face API reference documentation to learn more.
 
 > [!div class="nextstepaction"]
 > [Face API](https://westus.dev.cognitive.microsoft.com/docs/services/563879b61984550e40cbbe8d/operations/563879b61984550f30395236)


### PR DESCRIPTION
This Quickstart  is a Go Application, not a Ruby Script