### PR TITLE
IPv6 examples: replace ace:cab:deca with fd00:cab:deca

### DIFF
--- a/articles/virtual-network/ipv6-add-to-existing-vnet-cli.md
+++ b/articles/virtual-network/ipv6-add-to-existing-vnet-cli.md
@@ -113,13 +113,13 @@ Add IPv6 address ranges to the virtual network and subnet hosting the load balan
 az network vnet update \
 --name myVnet  `
 --resource-group MyResourceGroupSLB \
---address-prefixes  "10.0.0.0/16"  "ace:cab:deca::/48"
+--address-prefixes  "10.0.0.0/16"  "fd00:cab:deca::/48"
 
 az network vnet subnet update \
 --vnet-name myVnet \
 --name mySubnet \
 --resource-group MyResourceGroupSLB \
---address-prefixes  "10.0.0.0/24"  "ace:cab:deca:deed::/64"  
+--address-prefixes  "10.0.0.0/24"  "fd00:cab:deca:deed::/64"  
 ```
 
 ## Add IPv6 configuration to NICs

--- a/articles/virtual-network/ipv6-add-to-existing-vnet-powershell.md
+++ b/articles/virtual-network/ipv6-add-to-existing-vnet-powershell.md
@@ -131,14 +131,14 @@ Add IPv6 address ranges to the virtual network and subnet hosting the VMs as fol
 #Retreive the VNET object
 $vnet = Get-AzVirtualNetwork  -ResourceGroupName $rg.ResourceGroupName -Name "myVnet" 
 #Add IPv6 prefix to the VNET
-$vnet.addressspace.addressprefixes.add("ace:cab:deca::/48")
+$vnet.addressspace.addressprefixes.add("fd00:cab:deca::/48")
 #Update the running VNET
 $vnet |  Set-AzVirtualNetwork
 
 #Retrieve the subnet object from the local copy of the VNET
 $subnet= $vnet.subnets[0]
 #Add IPv6 prefix to the Subnet (subnet of the VNET prefix, of course)
-$subnet.addressprefix.add("ace:cab:deca::/64")
+$subnet.addressprefix.add("fd00:cab:deca::/64")
 #Update the running VNET with the new subnet configuration
 $vnet |  Set-AzVirtualNetwork
 

--- a/articles/virtual-network/ipv6-configure-standard-load-balancer-template-json.md
+++ b/articles/virtual-network/ipv6-configure-standard-load-balancer-template-json.md
@@ -73,7 +73,7 @@ Template section to add:
               "protocol": "Tcp",
               "sourcePortRange": "33819-33829",
               "destinationPortRange": "5000-6000",
-              "sourceAddressPrefix": "ace:cab:deca:deed::/64",
+              "sourceAddressPrefix": "fd00:cab:deca:deed::/64",
               "destinationAddressPrefix": "cab:ace:deca:deed::/64",
               "access": "Allow",
               "priority": 1003,
@@ -96,7 +96,7 @@ If you're using a network virtual appliance, add IPv6 routes in the Route Table.
           {
             "name": "v6route",
             "properties": {
-              "addressPrefix": "ace:cab:deca:deed::/64",
+              "addressPrefix": "fd00:cab:deca:deed::/64",
               "nextHopType": "VirtualAppliance",
               "nextHopIpAddress": "deca:cab:ace:f00d::1"
             }

--- a/articles/virtual-network/ipv6-configure-template-json.md
+++ b/articles/virtual-network/ipv6-configure-template-json.md
@@ -75,7 +75,7 @@ Template section to add:
               "protocol": "Tcp",
               "sourcePortRange": "33819-33829",
               "destinationPortRange": "5000-6000",
-              "sourceAddressPrefix": "ace:cab:deca:deed::/64",
+              "sourceAddressPrefix": "fd00:cab:deca:deed::/64",
               "destinationAddressPrefix": "cab:ace:deca:deed::/64",
               "access": "Allow",
               "priority": 1003,
@@ -98,7 +98,7 @@ If you're using a network virtual appliance, add IPv6 routes in the Route Table.
           {
             "name": "v6route",
             "properties": {
-              "addressPrefix": "ace:cab:deca:deed::/64",
+              "addressPrefix": "fd00:cab:deca:deed::/64",
               "nextHopType": "VirtualAppliance",
               "nextHopIpAddress": "deca:cab:ace:f00d::1"
             }

--- a/articles/virtual-network/ipv6-dual-stack-standard-internal-load-balancer-powershell.md
+++ b/articles/virtual-network/ipv6-dual-stack-standard-internal-load-balancer-powershell.md
@@ -27,7 +27,7 @@ The procedure to create an IPv6-capable Internal Load Balancer is nearly identic
 ```azurepowershell
  $frontendIPv6 = New-AzLoadBalancerFrontendIpConfig `
  -Name "dsLbFrontEnd_v6" `
- -PrivateIpAddress "ace:cab:deca:deed::100" `
+ -PrivateIpAddress "fd00:cab:deca:deed::100" `
  -PrivateIpAddressVersion "IPv6" `
  -Subnet $DsSubnet
 ```
@@ -99,14 +99,14 @@ Create a virtual network using [New-AzVirtualNetwork](/powershell/module/az.netw
 # Create dual stack subnet config
 $DsSubnet = New-AzVirtualNetworkSubnetConfig `
   -Name "dsSubnet" `
-  -AddressPrefix "10.0.0.0/24","ace:cab:deca:deed::/64"
+  -AddressPrefix "10.0.0.0/24","fd00:cab:deca:deed::/64"
 
 # Create the virtual network
 $vnet = New-AzVirtualNetwork `
   -ResourceGroupName $rg.ResourceGroupName `
   -Location $rg.Location  `
   -Name "dsVnet" `
-  -AddressPrefix "10.0.0.0/16","ace:cab:deca::/48"  `
+  -AddressPrefix "10.0.0.0/16","fd00:cab:deca::/48"  `
   -Subnet $DsSubnet
 
 #Refresh the fully populated subnet for use in load balancer frontend configuration
@@ -129,7 +129,7 @@ $frontendIPv4 = New-AzLoadBalancerFrontendIpConfig `
 
 $frontendIPv6 = New-AzLoadBalancerFrontendIpConfig `
   -Name "dsLbFrontEnd_v6" `
-  -PrivateIpAddress "ace:cab:deca:deed::100"  `
+  -PrivateIpAddress "fd00:cab:deca:deed::100"  `
   -PrivateIpAddressVersion "IPv6"   `
   -Subnet $DsSubnet
 

--- a/articles/virtual-network/scripts/virtual-network-cli-sample-ipv6-dual-stack-standard-load-balancer.md
+++ b/articles/virtual-network/scripts/virtual-network-cli-sample-ipv6-dual-stack-standard-load-balancer.md
@@ -198,7 +198,7 @@ az network vnet create \
 --name dsVNET \
 --resource-group DsResourceGroup01 \
 --location eastus  \
---address-prefixes "10.0.0.0/16" "ace:cab:deca::/48"
+--address-prefixes "10.0.0.0/16" "fd00:cab:deca::/48"
 
 # Create a single dual stack subnet
 
@@ -206,7 +206,7 @@ az network vnet subnet create \
 --name dsSubNET \
 --resource-group DsResourceGroup01 \
 --vnet-name dsVNET \
---address-prefixes "10.0.0.0/24" "ace:cab:deca:deed::/64" \
+--address-prefixes "10.0.0.0/24" "fd00:cab:deca:deed::/64" \
 --network-security-group dsNSG1
 
 # Create NICs

--- a/articles/virtual-network/scripts/virtual-network-cli-sample-ipv6-dual-stack.md
+++ b/articles/virtual-network/scripts/virtual-network-cli-sample-ipv6-dual-stack.md
@@ -181,7 +181,7 @@ az network vnet create \
 --name dsVNET \
 --resource-group DsResourceGroup01 \
 --location eastus  \
---address-prefixes "10.0.0.0/16" "ace:cab:deca::/48"
+--address-prefixes "10.0.0.0/16" "fd00:cab:deca::/48"
 
 # Create a single dual stack subnet
 
@@ -190,7 +190,7 @@ az network vnet subnet create \
 --resource-group DsResourceGroup01 \
 --vnet-name dsVNET \
 --address-prefix 10.0.0.0/24 \
---address-prefix "ace:cab:deca:deed::/64" \
+--address-prefix "fd00:cab:deca:deed::/64" \
 --network-security-group dsNSG1
 
 # Create NICs

--- a/articles/virtual-network/scripts/virtual-network-powershell-sample-ipv6-dual-stack-standard-load-balancer.md
+++ b/articles/virtual-network/scripts/virtual-network-powershell-sample-ipv6-dual-stack-standard-load-balancer.md
@@ -171,14 +171,14 @@ $nsg = New-AzNetworkSecurityGroup `
 # Create dual stack subnet
 $subnet = New-AzVirtualNetworkSubnetConfig `
 -Name "dsSubnet" `
--AddressPrefix "10.0.0.0/24","ace:cab:deca:deed::/64"
+-AddressPrefix "10.0.0.0/24","fd00:cab:deca:deed::/64"
 
 # Create the virtual network
 $vnet = New-AzVirtualNetwork `
 -ResourceGroupName $rg.ResourceGroupName `
 -Location $rg.Location  `
 -Name "dsVnet" `
--AddressPrefix "10.0.0.0/16","ace:cab:deca::/48"  `
+-AddressPrefix "10.0.0.0/16","fd00:cab:deca::/48"  `
 -Subnet $subnet
   
 #Create network interfaces (NICs)

--- a/articles/virtual-network/scripts/virtual-network-powershell-sample-ipv6-dual-stack.md
+++ b/articles/virtual-network/scripts/virtual-network-powershell-sample-ipv6-dual-stack.md
@@ -168,14 +168,14 @@ $nsg = New-AzNetworkSecurityGroup `
 # Create dual stack subnet config
 $subnet = New-AzVirtualNetworkSubnetConfig `
 -Name "dsSubnet" `
--AddressPrefix "10.0.0.0/24","ace:cab:deca:deed::/64"
+-AddressPrefix "10.0.0.0/24","fd00:cab:deca:deed::/64"
 
 # Create the virtual network
 $vnet = New-AzVirtualNetwork `
   -ResourceGroupName $rg.ResourceGroupName `
   -Location $rg.Location  `
   -Name "dsVnet" `
-  -AddressPrefix "10.0.0.0/16","ace:cab:deca::/48"  `
+  -AddressPrefix "10.0.0.0/16","fd00:cab:deca::/48"  `
   -Subnet $subnet
   
   #Create network interfaces (NICs)

--- a/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-cli.md
+++ b/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-cli.md
@@ -280,7 +280,7 @@ az network vnet create \
 --name dsVNET \
 --resource-group DsResourceGroup01 \
 --location eastus  \
---address-prefixes "10.0.0.0/16" "ace:cab:deca::/48"
+--address-prefixes "10.0.0.0/16" "fd00:cab:deca::/48"
 
 # Create a single dual stack subnet
 
@@ -288,7 +288,7 @@ az network vnet subnet create \
 --name dsSubNET \
 --resource-group DsResourceGroup01 \
 --vnet-name dsVNET \
---address-prefixes "10.0.0.0/24" "ace:cab:deca:deed::/64" \
+--address-prefixes "10.0.0.0/24" "fd00:cab:deca:deed::/64" \
 --network-security-group dsNSG1
 ```
 

--- a/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-powershell.md
+++ b/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-powershell.md
@@ -246,14 +246,14 @@ Create a virtual network with [New-AzVirtualNetwork](/powershell/module/az.netwo
 # Create dual stack subnet
 $subnet = New-AzVirtualNetworkSubnetConfig `
 -Name "dsSubnet" `
--AddressPrefix "10.0.0.0/24","ace:cab:deca:deed::/64"
+-AddressPrefix "10.0.0.0/24","fd00:cab:deca:deed::/64"
 
 # Create the virtual network
 $vnet = New-AzVirtualNetwork `
   -ResourceGroupName $rg.ResourceGroupName `
   -Location $rg.Location  `
   -Name "dsVnet" `
-  -AddressPrefix "10.0.0.0/16","ace:cab:deca::/48"  `
+  -AddressPrefix "10.0.0.0/16","fd00:cab:deca::/48"  `
   -Subnet $subnet
 ```
 

--- a/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-standard-load-balancer-cli.md
+++ b/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-standard-load-balancer-cli.md
@@ -279,7 +279,7 @@ az network vnet create \
 --name dsVNET \
 --resource-group DsResourceGroup01 \
 --location eastus  \
---address-prefixes "10.0.0.0/16" "ace:cab:deca::/48"
+--address-prefixes "10.0.0.0/16" "fd00:cab:deca::/48"
 
 # Create a single dual stack subnet
 
@@ -287,7 +287,7 @@ az network vnet subnet create \
 --name dsSubNET \
 --resource-group DsResourceGroup01 \
 --vnet-name dsVNET \
---address-prefixes "10.0.0.0/24" "ace:cab:deca:deed::/64" \
+--address-prefixes "10.0.0.0/24" "fd00:cab:deca:deed::/64" \
 --network-security-group dsNSG1
 ```
 

--- a/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-standard-load-balancer-powershell.md
+++ b/articles/virtual-network/virtual-network-ipv4-ipv6-dual-stack-standard-load-balancer-powershell.md
@@ -247,14 +247,14 @@ Create a virtual network with [New-AzVirtualNetwork](/powershell/module/az.netwo
 # Create dual stack subnet
 $subnet = New-AzVirtualNetworkSubnetConfig `
 -Name "dsSubnet" `
--AddressPrefix "10.0.0.0/24","ace:cab:deca:deed::/64"
+-AddressPrefix "10.0.0.0/24","fd00:cab:deca:deed::/64"
 
 # Create the virtual network
 $vnet = New-AzVirtualNetwork `
   -ResourceGroupName $rg.ResourceGroupName `
   -Location $rg.Location  `
   -Name "dsVnet" `
-  -AddressPrefix "10.0.0.0/16","ace:cab:deca::/48"  `
+  -AddressPrefix "10.0.0.0/16","fd00:cab:deca::/48"  `
   -Subnet $subnet
 ```
 


### PR DESCRIPTION
Currently, the IPv6 documentation examples use the range ace:cab:deca::/48. My understanding is that IPv6 ranges in Virtual Networks should use a private, and not globally routable address space. The a::/3 address range is currently unallocated/reserved, but may eventually become globally routable.

Unique Local Addresses in IPv6 are similar to IPv4 private address ranges, and use the fc00::/7 address range.

Updating the documentation makes it clear to users that a Unique Local Address range is required for Virtual Networks.
