### PR TITLE
add important requirement

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
@@ -46,6 +46,9 @@ The following Windows distributions are currently supported during the preview o
 - Windows Server 2019 Datacenter
 - Windows 10 1809 and later
 
+> [!IMPORTANT]
+> Remote connection to VMs joined to Azure AD is only allowed from Windows 10 PCs that are Azure AD joined or hybrid Azure AD joined to the **same** directory as the VM. 
+
 The following Azure regions are currently supported during the preview of this feature:
 
 - All Azure global regions


### PR DESCRIPTION
Added Important note to requirements section to make the customer aware that they must have an Azure AD Joined Machine to RDP to a windows VM with Azure AD Auth enabled.

The missing requirement caused myself and several other Azure engineers to fail to get this working several times. 
There is a similar not much farther down in the document, but putting all requirements in the requirements section makes it easier for customers to get this working.