### PR TITLE
Changing CreatePersonResult to Person

### DIFF
--- a/articles/cognitive-services/Face/Face-API-How-to-Topics/how-to-add-faces.md
+++ b/articles/cognitive-services/Face/Face-API-How-to-Topics/how-to-add-faces.md
@@ -83,7 +83,7 @@ await faceClient.LargePersonGroup.CreateAsync(personGroupId, personGroupName);
 Persons are created concurrently, and `await WaitCallLimitPerSecondAsync()` is also applied to avoid exceeding the call limit.
 
 ```csharp
-CreatePersonResult[] persons = new CreatePersonResult[PersonCount];
+Person[] persons = new Person[PersonCount];
 Parallel.For(0, PersonCount, async i =>
 {
     await WaitCallLimitPerSecondAsync();


### PR DESCRIPTION
The SDK is now returning a `Person` object on the `CreateAsync` operation instead of a `CreatePersonResult`