### PR TITLE
[Azure Red Hat OpenShift] Clarify that customer admin group cannot currently be specified in the Azure Portal

### DIFF
--- a/articles/openshift/cluster-administration-cluster-admin-role.md
+++ b/articles/openshift/cluster-administration-cluster-admin-role.md
@@ -31,7 +31,7 @@ For example, having the `list` verb means that you can display a list of all obj
 
 ## Configure the customer administrator role
 
-You can configure the customer-admin-cluster cluster role only during cluster creation by providing the flag `--customer-admin-group-id`. This field is not currently configurable in the Azure Portal. To learn how to configure Azure Active Directory and the Administrators group, see [Azure Active Directory integration for Azure Red Hat OpenShift](howto-aad-app-configuration.md).
+You can configure the customer-admin-cluster cluster role only during cluster creation by providing the flag `--customer-admin-group-id`. This field is not currently configurable in the Azure portal. To learn how to configure Azure Active Directory and the Administrators group, see [Azure Active Directory integration for Azure Red Hat OpenShift](howto-aad-app-configuration.md).
 
 ## Next steps
 

--- a/articles/openshift/cluster-administration-cluster-admin-role.md
+++ b/articles/openshift/cluster-administration-cluster-admin-role.md
@@ -31,7 +31,7 @@ For example, having the `list` verb means that you can display a list of all obj
 
 ## Configure the customer administrator role
 
-You can configure the customer-admin-cluster cluster role only during cluster creation by providing the flag `--customer-admin-group-id`. To learn how to configure Azure Active Directory and the Administrators group, see [Azure Active Directory integration for Azure Red Hat OpenShift](howto-aad-app-configuration.md).
+You can configure the customer-admin-cluster cluster role only during cluster creation by providing the flag `--customer-admin-group-id`. This field is not currently configurable in the Azure Portal. To learn how to configure Azure Active Directory and the Administrators group, see [Azure Active Directory integration for Azure Red Hat OpenShift](howto-aad-app-configuration.md).
 
 ## Next steps
 

--- a/articles/openshift/howto-aad-app-configuration.md
+++ b/articles/openshift/howto-aad-app-configuration.md
@@ -56,7 +56,7 @@ To grant cluster admin access, the memberships in an Azure AD security group are
 10. On the page that appears, copy down the **Object ID**. We will refer to this value as `GROUPID` in the [Create an Azure Red Hat OpenShift cluster](tutorial-create-cluster.md) tutorial.
 
 > [!IMPORTANT]
-> In order to sync this group with the "osa-customer-admins" OpenShift group, create the cluster via the Azure CLI. The Azure Portal currently lacks a field to set this group.
+> To sync this group with the osa-customer-admins OpenShift group, create the cluster by using the Azure CLI. The Azure portal currently lacks a field to set this group.
 
 ## Create an Azure AD app registration
 

--- a/articles/openshift/howto-aad-app-configuration.md
+++ b/articles/openshift/howto-aad-app-configuration.md
@@ -55,6 +55,9 @@ To grant cluster admin access, the memberships in an Azure AD security group are
 9. When the group is created, you will see it in the list of all groups. Click on the new group.
 10. On the page that appears, copy down the **Object ID**. We will refer to this value as `GROUPID` in the [Create an Azure Red Hat OpenShift cluster](tutorial-create-cluster.md) tutorial.
 
+> [!IMPORTANT]
+> In order to sync this group with the "osa-customer-admins" OpenShift group, create the cluster via the Azure CLI. The Azure Portal currently lacks a field to set this group.
+
 ## Create an Azure AD app registration
 
 You can automatically create an Azure Active Directory (Azure AD) app registration client as part of creating the cluster by omitting the `--aad-client-app-id` flag to the `az openshift create` command. This tutorial shows you how to create the Azure AD app registration for completeness.


### PR DESCRIPTION
Worth noting in the docs that currently, creation of an ARO cluster in the Azure Portal does not allow this group to be set.