### PR TITLE
[Azure Red Hat OpenShift] Draw attention to distinction between AAD Graph and Microsoft Graph permissions

### DIFF
--- a/articles/openshift/howto-aad-app-configuration.md
+++ b/articles/openshift/howto-aad-app-configuration.md
@@ -89,8 +89,8 @@ For details on creating a new Azure AD application, see [Register an app with th
 ## Add API permissions
 
 1. In the **Manage** section click **API permissions**.
-2. Click **Add permission** and select **Azure Active Directory Graph** then **Delegated permissions**
-3. Expand **User** on the list below and make sure **User.Read** is enabled.
+2. Click **Add permission** and select **Azure Active Directory Graph** then **Delegated permissions**. 
+3. Expand **User** on the list below and enable the **User.Read** permission. If **User.Read** is enabled by default, ensure that it is the **Azure Active Directory Graph** permission **User.Read**, *not* the **Microsoft Graph** permission **User.Read**.
 4. Scroll up and select **Application permissions**.
 5. Expand **Directory** on the list below and enable **Directory.ReadAll**
 6. Click **Add permissions** to accept the changes.


### PR DESCRIPTION
Ran into this as a MSFT dev experimenting with ARO for the first time. Since SPs now create with MS Graph User.Read, I automatically went to Microsoft Graph perms rather than Azure Active Directory Graph perms.