### PR TITLE
Add instructions if authorization server does not include a property …

### DIFF
--- a/articles/api-management/api-management-sample-send-request.md
+++ b/articles/api-management/api-management-sample-send-request.md
@@ -98,7 +98,7 @@ The `response-variable-name` attribute is used to give access the returned respo
 
 From the response object, you can retrieve the body and RFC 7622 tells API Management that the response must be a JSON object and must contain at least a property called `active` that is a boolean value. When `active` is true then the token is considered valid.
 
-Alternatively, if the authorization server does not include the "active" field to indicate that the token is valid or not, determine what properties are set in a valid token using a tool like Postman. For example, if a valid token response contains a property called "expires_in", check if this property name exists or not in the authorization server response in this way:
+Alternatively, if the authorization server doesn't include the "active" field to indicate whether the token is valid, use a tool like Postman to determine what properties are set in a valid token. For example, if a valid token response contains a property called "expires_in", check whether this property name exists in the authorization server response this way:
 
 <when condition="@(((IResponse)context.Variables["tokenstate"]).Body.As<JObject>().Property("expires_in") == null)">
 

--- a/articles/api-management/api-management-sample-send-request.md
+++ b/articles/api-management/api-management-sample-send-request.md
@@ -98,6 +98,10 @@ The `response-variable-name` attribute is used to give access the returned respo
 
 From the response object, you can retrieve the body and RFC 7622 tells API Management that the response must be a JSON object and must contain at least a property called `active` that is a boolean value. When `active` is true then the token is considered valid.
 
+Alternatively, if the authorization server does not include the "active" field to indicate that the token is valid or not, determine what properties are set in a valid token using a tool like Postman. For example, if a valid token response contains a property called "expires_in", check if this property name exists or not in the authorization server response in this way:
+
+<when condition="@(((IResponse)context.Variables["tokenstate"]).Body.As<JObject>().Property("expires_in") == null)">
+
 ### Reporting failure
 You can use a `<choose>` policy to detect if the token is invalid and if so, return a 401 response.
 


### PR DESCRIPTION
…called "active"

In case the authorization server does not include a property called "active", the API Management server returns "500 Internal Server Error". The instructions I've include provide a quick working alternative.