### PR TITLE
Add links nugets in Azure Cosmos Db Table tutorial

### DIFF
--- a/articles/cosmos-db/tutorial-develop-table-dotnet.md
+++ b/articles/cosmos-db/tutorial-develop-table-dotnet.md
@@ -53,7 +53,7 @@ To obtain the NuGet package, follow these steps:
 
 1. Right-click your project in **Solution Explorer** and choose **Manage NuGet Packages**.
 
-1. Search online for `Microsoft.Azure.Cosmos.Table`, `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Configuration.Json`, `Microsoft.Extensions.Configuration.Binder` and select **Install** to install the Microsoft Azure Cosmos DB Table Library.
+1. Search online for [`Microsoft.Azure.Cosmos.Table`](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Table), [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration), [`Microsoft.Extensions.Configuration.Json`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json), [`Microsoft.Extensions.Configuration.Binder`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Binder) and select **Install** to install the Microsoft Azure Cosmos DB Table Library.
 
 ## Configure your storage connection string
 


### PR DESCRIPTION
Add links to concrete nugets in Azure Cosmos Db Table tutorial, so user can i.e. open links and copy/paste packagereference. Or just be sure that he installed correct nugets