### PR TITLE
Removed "Next steps" link to GA docs

### DIFF
--- a/articles/time-series-insights/time-series-insights-update-how-to-shape-events.md
+++ b/articles/time-series-insights/time-series-insights-update-how-to-shape-events.md
@@ -152,4 +152,4 @@ In the example above, the flattened `data_flow` property would present a naming 
 
 ## Next steps
 
-- To put these guidelines into practice, read [Azure Time Series Insights Preview query syntax](./time-series-insights-query-data-csharp.md). You'll learn more about the query syntax for the Time Series Insights Preview REST API for data access.
+To put these guidelines into practice, read [Azure Time Series Insights Preview query syntax](./time-series-insights-query-data-csharp.md). You'll learn more about the query syntax for the Time Series Insights Preview REST API for data access.

--- a/articles/time-series-insights/time-series-insights-update-how-to-shape-events.md
+++ b/articles/time-series-insights/time-series-insights-update-how-to-shape-events.md
@@ -153,4 +153,3 @@ In the example above, the flattened `data_flow` property would present a naming 
 ## Next steps
 
 - To put these guidelines into practice, read [Azure Time Series Insights Preview query syntax](./time-series-insights-query-data-csharp.md). You'll learn more about the query syntax for the Time Series Insights Preview REST API for data access.
-- To learn about supported JSON shapes, read [Supported JSON shapes](./time-series-insights-send-events.md#supported-json-shapes).


### PR DESCRIPTION
Removed the final link in "Next Steps" list as it pointed to a page on shaping JSON for Time Series Insights GA which isn't relevant for TSI preview.