### PR TITLE
Add note for Intune device enrollment scenario

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
@@ -47,7 +47,7 @@ The following steps will help create a Conditional Access policy to require devi
 1. Select **Create** to create to enable your policy.
 
 > [!NOTE]
-> You can enroll your new devices to Intune even if you select "Require device to be marked as compliant" for "All users" and "All cloud apps" using the steps above. "Require device to be marked as compliant" control does not block Intune enrollment. 
+> You can enroll your new devices to Intune even if you select **Require device to be marked as compliant** for **All users** and **All cloud apps** using the steps above. **Require device to be marked as compliant** control does not block Intune enrollment. 
 
 ### Known behavior
 

--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
@@ -46,6 +46,9 @@ The following steps will help create a Conditional Access policy to require devi
 1. Confirm your settings and set **Enable policy** to **On**.
 1. Select **Create** to create to enable your policy.
 
+> [!NOTE]
+> You can enroll your new devices to Intune even if you select "Require device to be marked as compliant" for "All users" and "All cloud apps" using the steps above. "Require device to be marked as compliant" control does not block Intune enrollment. 
+
 ### Known behavior
 
 On Windows 7, iOS, Android, macOS, and some third-party web browsers Azure AD identifies the device using a client certificate that is provisioned when the device is registered with Azure AD. When a user first signs in through the browser the user is prompted to select the certificate. The end user must select this certificate before they can continue to use the browser.


### PR DESCRIPTION
Now "Require device to be marked as compliant" control does not block Intune enrollment. Users do not need to exclude "Microsoft Intune" cloud apps or etc to allow Intune enrollment for new devices.