### PR TITLE
Add a scenario the report contains masked info

### DIFF
--- a/articles/active-directory/manage-apps/tenant-restrictions.md
+++ b/articles/active-directory/manage-apps/tenant-restrictions.md
@@ -102,7 +102,7 @@ While configuration of tenant restrictions is done on the corporate proxy infras
 The admin for the tenant specified as the Restricted-Access-Context tenant can use this report to see sign-ins blocked because of the tenant restrictions policy, including the identity used and the target directory ID. Sign-ins are included if the tenant setting the restriction is either the user tenant or resource tenant for the sign-in.
 
 > [!NOTE]
-> The report may contain limited information such as target directory ID when users in tenant other than specified as the Restricted-Access-Context tenant sign in. In this case, user identity such as name and user principal name are masked to protect user data in other tenants.
+> The report may contain limited information, such as target directory ID, when a user who is in a tenant other than the Restricted-Access-Context tenant signs in. In this case, user identifiable information, such as name and user principal name, is masked to protect user data in other tenants.
 
 Like other reports in the Azure portal, you can use filters to specify the scope of your report. You can filter on a specific time interval, user, application, client, or status. If you select the **Columns** button, you can choose to display data with any combination of the following fields:
 

--- a/articles/active-directory/manage-apps/tenant-restrictions.md
+++ b/articles/active-directory/manage-apps/tenant-restrictions.md
@@ -101,6 +101,9 @@ While configuration of tenant restrictions is done on the corporate proxy infras
 
 The admin for the tenant specified as the Restricted-Access-Context tenant can use this report to see sign-ins blocked because of the tenant restrictions policy, including the identity used and the target directory ID. Sign-ins are included if the tenant setting the restriction is either the user tenant or resource tenant for the sign-in.
 
+> [!NOTE]
+> The report may contain limited information such as target directory ID when users in tenant other than specified as the Restricted-Access-Context tenant sign in. In this case, user identity such as name and user principal name are masked to protect user data in other tenants.
+
 Like other reports in the Azure portal, you can use filters to specify the scope of your report. You can filter on a specific time interval, user, application, client, or status. If you select the **Columns** button, you can choose to display data with any combination of the following fields:
 
 - **User**


### PR DESCRIPTION
When blocked users are in tenant other than specified as the Restricted-Access-Context tenant and they are not a guest user, tenant restrictions report shows user ID and object ID as 00000000-0000-0000-0000-000000000000. I got some customers reporting this behavior and would like to add this scenario to the document to reduce support requests.