### PR TITLE
Do not add project name to publish path

### DIFF
--- a/articles/azure-functions/functions-how-to-azure-devops.md
+++ b/articles/azure-functions/functions-how-to-azure-devops.md
@@ -42,7 +42,7 @@ steps:
     arguments: '--configuration Release --output publish_output'
     projects: '*.csproj'
     publishWebProjects: false
-    modifyOutputPath: true
+    modifyOutputPath: false
     zipAfterPublish: false
 - task: ArchiveFiles@2
   displayName: "Archive files"


### PR DESCRIPTION
Adds an extra `s` to the folder structure of the zip file. A full explanation can be found in the referenced issue.

closes #46782