### PR TITLE
Typo fix for CSP blurb from Cosmos DB to Blob Storage

### DIFF
--- a/articles/storage/blobs/storage-blob-reserved-capacity.md
+++ b/articles/storage/blobs/storage-blob-reserved-capacity.md
@@ -50,7 +50,7 @@ To purchase reserved capacity:
 
 - You must be in the **Owner** role for at least one Enterprise or individual subscription with pay-as-you-go rates.
 - For Enterprise subscriptions, **Add Reserved Instances** must be enabled in the EA portal. Or, if that setting is disabled, you must be an EA Admin on the subscription.
-- For the Cloud Solution Provider (CSP) program, only admin agents or sales agents can buy Azure Cosmos DB reserved capacity.
+- For the Cloud Solution Provider (CSP) program, only admin agents or sales agents can buy Azure Blob Storage reserved capacity.
 
 ## Determine required capacity before purchase
 


### PR DESCRIPTION
Was refrencing Cosmos DB & should of been Blob Storage.