### PR TITLE
Update how-to-manage-ua-identity-cli.md

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli.md
+++ b/articles/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-cli.md
@@ -33,6 +33,9 @@ In this article, you learn how to create, list and delete a user-assigned manage
     - Use [Azure Cloud Shell](../../cloud-shell/overview.md) from the Azure portal (see next section).
     - Use the embedded Azure Cloud Shell via the "Try It" button, located in the top right corner of each code block.
     - [Install the latest version of the Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli) (2.0.13 or later) if you prefer to use a local CLI console. Sign in to Azure using `az login`, using an account that is associated with the Azure subscription under which you would like to deploy the user-assigned managed identity.
+    
+> [!NOTE]
+> In order to modify user permissions when using an app servivce principal using CLI you must provide the service principal additional permissions in Azure AD Graph API as portions of CLI perform GET requests against the Graph API. Otherwise, you may end up recieving a 'Insufficient privileges to complete the operation' message. To do this you will need to go into the App registration in Azure Active Directory, select your app, click on API permissions, scroll down and select Azure Active Directory Graph. From there select Application permissions, and then add the appropriate permissions. 
 
 [!INCLUDE [cloud-shell-try-it.md](../../../includes/cloud-shell-try-it.md)]
 


### PR DESCRIPTION
Our documentation lacks clarity regarding the needs for providing permissions to Graph API for corresponding service principals when managing users via CLI. I added a note in the prereq section however, if there is a better place for this information we should place it there. This is following direct customer feedback.