### PR TITLE
Adding that A-records aren't supported for free certificates

### DIFF
--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -56,6 +56,7 @@ The free App Service Managed Certificate is a turn-key solution for securing you
 - Does not support wildcard certificates.
 - Does not support naked domains.
 - Is not exportable.
+- Does not support DNS A-records.
 
 > [!NOTE]
 > The free certificate is issued by DigiCert. For some top-level domains, you must explicitly allow DigiCert as a certificate issuer by creating a [CAA domain record](https://wikipedia.org/wiki/DNS_Certification_Authority_Authorization) with the value: `0 issue digicert.com`.


### PR DESCRIPTION
I was using A records for DNS for my free app service certificate. It wasn't abundantly clear from the documentation that a CNAME is required (although it is mentioned in the docs), so I added a line in the section that explains HOW to create it that A records aren't supported.