### PR TITLE
adding a feature on Nginx IP whitelisting with AKS

### DIFF
--- a/articles/virtual-machines/linux/quick-create-cli.md
+++ b/articles/virtual-machines/linux/quick-create-cli.md
@@ -23,7 +23,7 @@ ms.custom: mvc
 
 The Azure CLI is used to create and manage Azure resources from the command line or in scripts. This quickstart shows you how to use the Azure CLI to deploy a Linux virtual machine (VM) in Azure. In this tutorial, we will be installing Ubuntu 16.04 LTS. To show the VM in action, you'll connect to it using SSH and install the NGINX web server.
 
-If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin.
+If you don't have an Azure subscriptions, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin.
 
 ## Launch Azure Cloud Shell
 


### PR DESCRIPTION
Azure AKS also support the IP whitelisting for Nginx-Ingress controller and the community driven helm chart has an option to provide values for the specific property ‘controller.service.loadBalancerSourceRanges’  
 
So to have the desired functionality the steps are:
Install helm chart for Ngnix-Ingress:
# helm install stable/nginx-ingress --name nginx-ingress --namespace ingress-basic -f nginx-ingress.yaml
 
Sample contents of ngnix-ingress.yaml value file for helm-chart :
`controller:
  autoscaling:
    enabled: true
  nodeSelector:
    beta.kubernetes.io/os: linux
  replicaCount: 2
  service:
    externalTrafficPolicy: Local
    loadBalancerSourceRanges:
    - a.b.c.d/32
    - w.x.y.z/32
defaultBackend:
  nodeSelector:
    beta.kubernetes.io/os: linux
`