### PR TITLE
Fix Virtual Machines - Workloads TOC links

### DIFF
--- a/articles/virtual-machines/TOC.yml
+++ b/articles/virtual-machines/TOC.yml
@@ -9,15 +9,15 @@
 - name: Workloads
   items: 
   - name: Red Hat
-    href: /redhat/redhat-overview.md
+    href: https://docs.microsoft.com/azure/virtual-machines/workloads/redhat/overview
   - name: High performance computing
-    href: /hpc/overview.md
+    href: https://docs.microsoft.com/azure/virtual-machines/workloads/hpc/overview
   - name: SAP
-    href: /sap/get-started.md
+    href: https://docs.microsoft.com/azure/virtual-machines/workloads/sap/get-started.md
   - name: Oracle
-    href: /oracle/oracle-considerations.md
+    href: https://docs.microsoft.com/azure/virtual-machines/workloads/oracle/oracle-overview
   - name: Mainframe rehosting
-    href: /mainframe-rehosting/overview.md
+    href: https://docs.microsoft.com/azure/virtual-machines/workloads/mainframe-rehosting/overview
 - name: Classic deployments
   items:
   - name: Linux VMs using classic deployment

--- a/articles/virtual-machines/TOC.yml
+++ b/articles/virtual-machines/TOC.yml
@@ -13,7 +13,7 @@
   - name: High performance computing
     href: https://docs.microsoft.com/azure/virtual-machines/workloads/hpc/overview
   - name: SAP
-    href: https://docs.microsoft.com/azure/virtual-machines/workloads/sap/get-started.md
+    href: https://docs.microsoft.com/azure/virtual-machines/workloads/sap/get-started
   - name: Oracle
     href: https://docs.microsoft.com/azure/virtual-machines/workloads/oracle/oracle-overview
   - name: Mainframe rehosting


### PR DESCRIPTION
This PR is to fix the .md links under Workloads section, because current workloads links are not working at all (returning 404).

I also remove the .md so the link will point to the actual URL of the workloads links.