### PR TITLE
Remove v2 Function requirement

### DIFF
--- a/articles/azure-monitor/platform/action-groups.md
+++ b/articles/azure-monitor/platform/action-groups.md
@@ -88,8 +88,6 @@ Send email to the members of the subscription's role.
 You may have a limited number of email actions in an Action Group. See the [rate limiting information](./../../azure-monitor/platform/alerts-rate-limiting.md) article.
 
 ### Function
-The function keys for Function Apps configured as actions are read through the Functions API, which currently requires v2 function apps to configure the app setting “AzureWebJobsSecretStorageType” to “files”. For more information, see [Changes to Key Management in Functions V2]( https://aka.ms/funcsecrets).
-
 You may have a limited number of Function actions in an Action Group.
 
 ### ITSM


### PR DESCRIPTION
This setting for v2 functions is no longer required as the portal was updated to use the new ARM APIs for function apps to retrieve keys.