### PR TITLE
Grammar, typos, and general formatting

### DIFF
--- a/articles/site-recovery/azure-to-azure-how-to-reprotect.md
+++ b/articles/site-recovery/azure-to-azure-how-to-reprotect.md
@@ -13,8 +13,7 @@ ms.author: rajanaki
 ---
 # Reprotect failed over Azure VMs to the primary region
 
-
-When you [fail over](site-recovery-failover.md) Azure VMs from one region to another using [Azure Site Recovery](site-recovery-overview.md), the VMs boot up in the secondary region, in an unprotected state. If fail back the VMs to the primary region, you need to do the following:
+When you [fail over](site-recovery-failover.md) Azure VMs from one region to another using [Azure Site Recovery](site-recovery-overview.md), the VMs boot up in the secondary region, in an **unprotected** state. If you want to fail back the VMs to the primary region, you need to do the following:
 
 - Reprotect the VMs in the secondary region, so that they start to replicate to the primary region.
 - After reprotection completes and the VMs are replicating, you can fail them over from the secondary to primary region.
@@ -36,7 +35,7 @@ When you [fail over](site-recovery-failover.md) Azure VMs from one region to ano
 
 ### Customize reprotect settings
 
-You can customize the following properties of the target VMe during reprotection.
+You can customize the following properties of the target VM during reprotection.
 
 ![Customize](./media/site-recovery-how-to-reprotect-azure-to-azure/customizeblade.png)
 
@@ -49,7 +48,6 @@ You can customize the following properties of the target VMe during reprotection
 |Cache Storage     | You can specify a cache storage account to be used during replication. By default, a new cache storage account is be created, if it doesn't exist.         |
 |Availability Set     |If the VM in the secondary region is part of an availability set, you can choose an availability set for the target VM in the primary region. By default, Site Recovery tries to find the existing availability set in the primary region, and use it. During customization, you can specify a new availability set.         |
 
-
 ### What happens during reprotection?
 
 By default the following occurs:
@@ -61,34 +59,31 @@ By default the following occurs:
 
 When you trigger a reprotect job, and the target VM exists, the following occurs:
 
-1. The target side VM is turned off if it's running.
+1. The target side VM is turned off if it is running.
 2. If the VM is using managed disks, a copy of original disks are created with '-ASRReplica' suffix. The original disks are deleted. The '-ASRReplica' copies are used for replication.
 3. If the VM is using unmanaged disks, the target VM's data disks are detached and used for replication. A copy of the OS disk is created and attached on the VM. The original OS disk is detached and used for replication.
-4. Only changes between the source disk and the target disk are synchronized. The differentials are computed by comparing both the disks and then transferred. To find the estimated time check below.
-5. After the synchronization completes, the delta replication begins, and creates a recovery point in line with the replication policy.
+4. Only changes between the source disk and the target disk are synchronized. The differentials are computed by comparing both the disks and then transferred. Check below to find the estimated time to complete the reprotection.
+5. After the synchronization completes, the delta replication begins and a recovery point is created in line with the replication policy.
 
 When you trigger a reprotect job, and the target VM and disks do not exist, the following occurs:
 1. If the VM is using managed disks, replica disks are created with '-ASRReplica' suffix. The '-ASRReplica' copies are used for replication.
 2. If the VM is using unmanaged disks, replica disks are created in the target storage account.
 3. The entire disks are copied from the failed over region to the new target region.
-4. After the synchronization completes, the delta replication begins, and creates a recovery point in line with the replication policy.
+4. After the synchronization completes, the delta replication begins and a recovery point is created in line with the replication policy.
 
-#### Estimated time  to do the reprotection 
+#### Estimated time to do the reprotection 
 
-In most cases, Azure Site Recovery doesn’t replicates the complete data to the source region. 
-Below are the conditions that determines how much data would be replicated :
+In most cases, Azure Site Recovery doesn’t replicate the complete data to the source region. 
+Below are the conditions that determines how much data would be replicated:
 
-1.	If the source VM data is deleted, corrupted or inaccessible due to some reason like resource group change/delete then during reprotection complete IR will happen as there is no data available on the source region to use.
-2.	If the source VM data is accessible then only  differentials are computed by comparing both the disks and then transferred. Check the below table to get the estimated time 
+1.	If the source VM data is deleted, corrupted, or inaccessible due to some reason, like a resource group change/delete, then during reprotection a complete Site Recovery will happen as there is no data available on the source region to use.
+2.	If the source VM data is accessible then only differentials are computed by comparing both the disks and then transferred. Check the table below to get the estimated time.
 
-|**Example situation ** | **Time taken to Reprotect  ** |
-|--- | --- |
-|Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used and rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- No data change after failover| Approximate time 45 minutes – 1.5 hours<br/> - During reprotection Site Recovery will populate the checksum of whole data  which will take 127 GB/ 45 MBs ~45 minutes<br/>- Some overhead  time is required for Site Recovery to do auto scale that  is 20-30 minutes<br/>- No Egress charges |
-|Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used and rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- 45 GB data changes after failover| Approximate time 1 hours – 2 hours<br/>- During reprotection Site Recovery will populate the checksum of whole data  which will take 127 GB/ 45 MBs ~45 minutes<br/>- Transfer time to apply changes of 45 GB that is 45 GB/ 45 MBps ~ 17 minutes<br/>- Egress charges would be only for 45 GB data not for the checksum|
+|Example situation | Time taken to Reprotect |
+|---|---|
+|Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used and the rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- No data change after failover| Approximate time: 45 minutes – 1.5 hours<br/> - During reprotection, Site Recovery will populate the checksum of all data which will take 127 GB/ 45 MBs ~45 minutes<br/>- Some overhead time is required for Site Recovery to auto scale: approx. 20-30 minutes<br/>- No Egress charges |
+|Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used and rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- 45 GB data changes after failover| Approximate time: 1 hours – 2 hours<br/>- During reprotection, Site Recovery will populate the checksum of all data which will take 127 GB/ 45 MBs ~45 minutes<br/>- Transfer time to apply changes of 45 GB that is 45 GB/ 45 MBps ~ 17 minutes<br/>- Egress charges would be for 45 GB data changes, not for the checksum |
  
-
-
-
 ## Next steps
 
-After the VM is protected, you can initiate a failover. The failover shuts down the VM in the secondary region, and creates and boots VM in the primary region, with some small downtime. We recommend you choose a time accordingly, and that you run a test failover before initiating a full failover to the primary site. [Learn more](site-recovery-failover.md) about failover.
+After the VM is protected, you can initiate a failover. The failover shuts down the VM in the secondary region and creates and boots the VM in the primary region, with some small downtime during this process. We recommend you choose an appropriate time for this process, and that you run a test failover before initiating a full failover to the primary site. [Learn more](site-recovery-failover.md) about Azure Site Recovery failover.

--- a/articles/site-recovery/azure-to-azure-how-to-reprotect.md
+++ b/articles/site-recovery/azure-to-azure-how-to-reprotect.md
@@ -77,11 +77,11 @@ In most cases, Azure Site Recovery doesn’t replicate the complete data to the 
 Below are the conditions that determines how much data would be replicated:
 
 1.	If the source VM data is deleted, corrupted, or inaccessible due to some reason, like a resource group change/delete, then during reprotection a complete Site Recovery will happen as there is no data available on the source region to use.
-2.	If the source VM data is accessible then only differentials are computed by comparing both the disks and then transferred. Check the table below to get the estimated time.
+2.	If the source VM data is accessible, then only differentials are computed by comparing both the disks and then transferred. Check the table below to get the estimated time.
 
 |Example situation | Time taken to Reprotect |
 |---|---|
-|Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used and the rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- No data change after failover| Approximate time: 45 minutes – 1.5 hours<br/> - During reprotection, Site Recovery will populate the checksum of all data which will take 127 GB/ 45 MBs ~45 minutes<br/>- Some overhead time is required for Site Recovery to auto scale: approx. 20-30 minutes<br/>- No Egress charges |
+|Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used, and the rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- No data change after failover| Approximate time: 45 minutes – 1.5 hours<br/> - During reprotection, Site Recovery will populate the checksum of all data which will take 127 GB/ 45 MBs ~45 minutes<br/>- Some overhead time is required for Site Recovery to auto scale: approx. 20-30 minutes<br/>- No Egress charges |
 |Source region has 1 VM with 1 TB standard Disk<br/>- Only 127 GB data is used and rest of the disk is empty<br/>- Disk type is standard with 60 MiB/S throughput<br/>- 45 GB data changes after failover| Approximate time: 1 hours – 2 hours<br/>- During reprotection, Site Recovery will populate the checksum of all data which will take 127 GB/ 45 MBs ~45 minutes<br/>- Transfer time to apply changes of 45 GB that is 45 GB/ 45 MBps ~ 17 minutes<br/>- Egress charges would be for 45 GB data changes, not for the checksum |
  
 ## Next steps

--- a/articles/site-recovery/azure-to-azure-how-to-reprotect.md
+++ b/articles/site-recovery/azure-to-azure-how-to-reprotect.md
@@ -59,17 +59,17 @@ By default the following occurs:
 
 When you trigger a reprotect job, and the target VM exists, the following occurs:
 
-1. The target side VM is turned off if it is running.
+1. The target side VM is turned off if it's running.
 2. If the VM is using managed disks, a copy of original disks are created with '-ASRReplica' suffix. The original disks are deleted. The '-ASRReplica' copies are used for replication.
 3. If the VM is using unmanaged disks, the target VM's data disks are detached and used for replication. A copy of the OS disk is created and attached on the VM. The original OS disk is detached and used for replication.
 4. Only changes between the source disk and the target disk are synchronized. The differentials are computed by comparing both the disks and then transferred. Check below to find the estimated time to complete the reprotection.
-5. After the synchronization completes, the delta replication begins and a recovery point is created in line with the replication policy.
+5. After the synchronization completes, the delta replication begins, and a recovery point is created in line with the replication policy.
 
 When you trigger a reprotect job, and the target VM and disks do not exist, the following occurs:
 1. If the VM is using managed disks, replica disks are created with '-ASRReplica' suffix. The '-ASRReplica' copies are used for replication.
 2. If the VM is using unmanaged disks, replica disks are created in the target storage account.
 3. The entire disks are copied from the failed over region to the new target region.
-4. After the synchronization completes, the delta replication begins and a recovery point is created in line with the replication policy.
+4. After the synchronization completes, the delta replication begins, and a recovery point is created in line with the replication policy.
 
 #### Estimated time to do the reprotection 
 
@@ -86,4 +86,4 @@ Below are the conditions that determines how much data would be replicated:
  
 ## Next steps
 
-After the VM is protected, you can initiate a failover. The failover shuts down the VM in the secondary region and creates and boots the VM in the primary region, with some small downtime during this process. We recommend you choose an appropriate time for this process, and that you run a test failover before initiating a full failover to the primary site. [Learn more](site-recovery-failover.md) about Azure Site Recovery failover.
+After the VM is protected, you can initiate a failover. The failover shuts down the VM in the secondary region and creates and boots the VM in the primary region, with some small downtime during this process. We recommend you choose an appropriate time for this process and that you run a test failover before initiating a full failover to the primary site. [Learn more](site-recovery-failover.md) about Azure Site Recovery failover.


### PR DESCRIPTION
I corrected some grammar as well as some typos and/or missing context words. Also made the formatting consistent for the tables. Added bold around the word "unprotected" in the first paragraph because that is key information for the reader to know about the status of a failed over VM.