### PR TITLE
Update tag-support.md

### DIFF
--- a/articles/azure-resource-manager/management/tag-support.md
+++ b/articles/azure-resource-manager/management/tag-support.md
@@ -12,7 +12,7 @@ To get the same data as a file of comma-separated values, download [tag-support.
 
 Jump to a resource provider namespace:
 > [!div class="op_single_selector"]
-> - [Microsoft.AAD](#microsoftaad)
+> - [Microsoft.AAD](#microsoftaad)**
 > - [Microsoft.Addons](#microsoftaddons)
 > - [Microsoft.ADHybridHealthService](#microsoftadhybridhealthservice)
 > - [Microsoft.Advisor](#microsoftadvisor)


### PR DESCRIPTION
need either clarification or correction. Does it refer to Azure AD or Azure AD Domain Services? If AADDS, tags are not supported, hence the need to clarify to which component it refers to or to correct innacurate information.

** marks the intended section