### PR TITLE
Added filter query parameter to avoid paging graph results

### DIFF
--- a/articles/active-directory/cloud-provisioning/concept-attributes.md
+++ b/articles/active-directory/cloud-provisioning/concept-attributes.md
@@ -69,7 +69,7 @@ To view the schema and verify it, follow these steps.
 1.  Go to [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer).
 1.  Sign in with your global administrator account.
 1.  On the left, select **modify permissions** and ensure that **Directory.ReadWrite.All** is *Consented*.
-1.  Run the query https://graph.microsoft.com/beta/serviceprincipals/. This query returns a list of service principals.
+1.  Run the query https://graph.microsoft.com/beta/serviceprincipals/?$filter=startswith(Displayname,'Active'). This query returns a filtered list of service principals.
 1.  Locate `"appDisplayName": "Active Directory to Azure Active Directory Provisioning"` and note the value for `"id"`.
     ```
     "value": [


### PR DESCRIPTION
There are lots of service principals. Without the filter parameter, one has to page through the results using the @odata.nextLink in order to find the correct one.