### PR TITLE
Update how-to-connect-syncservice-features.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-syncservice-features.md
+++ b/articles/active-directory/hybrid/how-to-connect-syncservice-features.md
@@ -91,7 +91,7 @@ Historically, updates to the UserPrincipalName attribute using the sync service 
 
 For more details, see [User names in Office 365, Azure, or Intune don't match the on-premises UPN or alternate login ID](https://support.microsoft.com/kb/2523192).
 
-Enabling this feature allows the sync engine to update the userPrincipalName when it is changed on-premises and you use password hash sync or pass-through authentication. If you use federation, this feature is not supported.
+Enabling this feature allows the sync engine to update the userPrincipalName when it is changed on-premises and you use password hash sync or pass-through authentication.
 
 This feature is on by default for newly created Azure AD directories. You can see if this feature is enabled for you by running:  
 


### PR DESCRIPTION
Removing outdated statement "If you use federation, this feature is not supported." under Synchronize userPrincipalName updates.  I think this statement might be related with OrgId legacy when Sync could not change the UPN for Federated users. That's not the case anymore so we should remove this statement.