### PR TITLE
Revert FQDN name changes to match service

### DIFF
--- a/articles/vmware-cloudsimple/disaster-recovery-site-recovery-manager.md
+++ b/articles/vmware-cloudsimple/disaster-recovery-site-recovery-manager.md
@@ -96,7 +96,7 @@ You can add an external identity provider as described in [Use Azure AD as an id
 
 To provide IP address lookup, IP address management, and name resolution services for your workloads in the AVS Private Cloud, set up a DHCP and DNS server as described in [Set up DNS and DHCP applications and workloads in your AVS Private Cloud](dns-dhcp-setup.md).
 
-The *.avs.io domain is used by management VMs and hosts in your AVS Private Cloud. To resolve requests to this domain, configure DNS forwarding on the DNS server as described in [Create a Conditional Forwarder](on-premises-dns-setup.md#create-a-conditional-forwarder).
+The *.cloudsimple.io domain is used by management VMs and hosts in your AVS Private Cloud. To resolve requests to this domain, configure DNS forwarding on the DNS server as described in [Create a Conditional Forwarder](on-premises-dns-setup.md#create-a-conditional-forwarder).
 
 ### Install vSphere Replication Appliance in your on-premises environment
 

--- a/articles/vmware-cloudsimple/disaster-recovery-zerto.md
+++ b/articles/vmware-cloudsimple/disaster-recovery-zerto.md
@@ -46,7 +46,7 @@ The following sections describe how to deploy a DR solution using Zerto Virtual 
 To enable Zerto Virtual Replication from your on-premises environment to your AVS Private Cloud, complete the following prerequisites.
 
 1. [Set up a Site-to-Site VPN connection between your on-premises network and your AVS Private Cloud](set-up-vpn.md).
-2. [Set up DNS lookup so that your AVS Private Cloud management components are forwarded to AVS Private Cloud DNS servers](on-premises-dns-setup.md). To enable forwarding of DNS lookup, create a forwarding zone entry in your on-premises DNS server for `*.AVS.io` to AVS DNS servers.
+2. [Set up DNS lookup so that your AVS Private Cloud management components are forwarded to AVS Private Cloud DNS servers](on-premises-dns-setup.md). To enable forwarding of DNS lookup, create a forwarding zone entry in your on-premises DNS server for `*.cloudsimple.io` to AVS DNS servers.
 3. Set up DNS lookup so that on-premises vCenter components are forwarded to on-premises DNS servers. The DNS servers must be reachable from your AVS Private Cloud over Site-to-Site VPN. For assistance, submit a [support request](https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/newsupportrequest), providing the following information. 
 
     * On-premises DNS domain name

--- a/articles/vmware-cloudsimple/migration-layer-2-vpn.md
+++ b/articles/vmware-cloudsimple/migration-layer-2-vpn.md
@@ -43,7 +43,7 @@ Verify that the following are in place before deploying and configuring the solu
 * The version of the standalone NSX-T Edge appliance is compatible with the NSX-T Manager version (NSX-T 2.3.0) used in your AVS Private Cloud environment.
 * A trunk port group has been created in the on-premises vCenter with forged transmits enabled.
 * A public IP address has been reserved to use for the NSX-T standalone client uplink IP  address, and 1:1 NAT is in place for translation between the two addresses.
-* DNS forwarding is set on the on-premises DNS servers for the az.AVS.io domain to point to the AVS Private Cloud DNS servers.
+* DNS forwarding is set on the on-premises DNS servers for the az.cloudsimple.io domain to point to the AVS Private Cloud DNS servers.
 * RTT latency is less than or equal to 150 ms, as required for vMotion to work across the two sites.
 
 ## Limitations and considerations

--- a/articles/vmware-cloudsimple/on-premises-dns-setup.md
+++ b/articles/vmware-cloudsimple/on-premises-dns-setup.md
@@ -26,10 +26,10 @@ To access the vCenter server on an AVS Private Cloud from on-premises workstatio
 
 Use either of these options for the DNS configuration.
 
-* [Create a zone on the DNS server for *.AVS.io](#create-a-zone-on-a-microsoft-windows-dns-server)
-* [Create a conditional forwarder on your on-premises DNS server to resolve *.AVS.io](#create-a-conditional-forwarder)
+* [Create a zone on the DNS server for *.cloudsimple.io](#create-a-zone-on-a-microsoft-windows-dns-server)
+* [Create a conditional forwarder on your on-premises DNS server to resolve *.cloudsimple.io](#create-a-conditional-forwarder)
 
-## Create a zone on the DNS server for *.AVS.io
+## Create a zone on the DNS server for *.cloudsimple.io
 
 You can set up a zone up as a stub zone and point to the DNS servers on the Private
 Cloud for name resolution. This section provides information on using a BIND DNS server or a Microsoft Windows DNS server.
@@ -76,7 +76,7 @@ from the AVS portal.
 
 ## Create a conditional forwarder
 
-A conditional forwarder forwards all DNS name resolution requests to the designated server. With this setup, any request to *.AVS.io is forwarded to the DNS servers located on the AVS Private Cloud. The following examples show how to set up
+A conditional forwarder forwards all DNS name resolution requests to the designated server. With this setup, any request to *.cloudsimple.io is forwarded to the DNS servers located on the AVS Private Cloud. The following examples show how to set up
 forwarders on different types of DNS servers.
 
 ### Create a conditional forwarder on a BIND DNS server

--- a/articles/vmware-cloudsimple/on-premises-firewall-configuration.md
+++ b/articles/vmware-cloudsimple/on-premises-firewall-configuration.md
@@ -22,7 +22,7 @@ To access your AVS Private Cloud vCenter and NSX-T manager, ports defined in the
 
 | Port       | Source                           | Destination                      | Purpose                                                                                                                |
 |------------|----------------------------------|----------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| 53 (UDP)   | On-premises DNS servers          | AVS Private Cloud DNS servers        | Required for forwarding DNS lookup of *az.AVS.io* to AVS Private Cloud DNS servers from on-premises network.     |
+| 53 (UDP)   | On-premises DNS servers          | AVS Private Cloud DNS servers        | Required for forwarding DNS lookup of *az.cloudsimple.io* to AVS Private Cloud DNS servers from on-premises network.     |
 | 53 (UDP)   | AVS Private Cloud DNS servers        | On-premises DNS servers          | Required for forwarding DNS look up of on-premises domain names from AVS Private Cloud vCenter to on-premises DNS servers. |
 | 80 (TCP)   | On-premises network              | AVS Private Cloud management network | Required for redirecting vCenter URL from *http* to *https*.                                                         |
 | 443 (TCP)  | On-premises network              | AVS Private Cloud management network | Required for accessing vCenter and NSX-T manager from on-premises network.                                           |

--- a/articles/vmware-cloudsimple/set-up-vpn.md
+++ b/articles/vmware-cloudsimple/set-up-vpn.md
@@ -92,7 +92,7 @@ A Point-to-Site VPN connection resolves the DNS names of the first AVS Private C
 
     ![Edit VPN Connection](media/viscosity-edit-connection.png)
 
-7. Click the **Networking** tab and enter the AVS Private Cloud DNS server IP addresses separated by a comma or space and the domain as ```cloudsimple.io```. Select **Ignore DNS settings sent by VPN server**.
+7. Click the **Networking** tab and enter the AVS Private Cloud DNS server IP addresses separated by a comma or space and the domain as ```az.cloudsimple.io```. Select **Ignore DNS settings sent by VPN server**.
 
     ![VPN Networking](media/viscosity-edit-connection-networking.png)
 

--- a/articles/vmware-cloudsimple/set-up-vpn.md
+++ b/articles/vmware-cloudsimple/set-up-vpn.md
@@ -92,7 +92,7 @@ A Point-to-Site VPN connection resolves the DNS names of the first AVS Private C
 
     ![Edit VPN Connection](media/viscosity-edit-connection.png)
 
-7. Click the **Networking** tab and enter the AVS Private Cloud DNS server IP addresses separated by a comma or space and the domain as ```AVS.io```. Select **Ignore DNS settings sent by VPN server**.
+7. Click the **Networking** tab and enter the AVS Private Cloud DNS server IP addresses separated by a comma or space and the domain as ```cloudsimple.io```. Select **Ignore DNS settings sent by VPN server**.
 
     ![VPN Networking](media/viscosity-edit-connection-networking.png)
 
@@ -112,4 +112,4 @@ To set up your on-premises VPN gateway in high-availability mode, see [Configure
 
 > [!IMPORTANT]
 >    1. Set TCP MSS Clamping at 1200 on your VPN device. Or if your VPN devices do not support MSS clamping, you can alternatively set the MTU on the tunnel interface to 1240 bytes instead.
-> 2. After Site-to-Site VPN is set up, forward the DNS requests for *.AVS.io to the AVS Private Cloud DNS servers. Follow the instructions in [On-Premises DNS Setup](on-premises-dns-setup.md).
+> 2. After Site-to-Site VPN is set up, forward the DNS requests for *.cloudsimple.io to the AVS Private Cloud DNS servers. Follow the instructions in [On-Premises DNS Setup](on-premises-dns-setup.md).


### PR DESCRIPTION
Updating all changes to AVS.io (A domain we don't own) to point back to cloudsimple.io.