### PR TITLE
Make this document easier to understand

### DIFF
--- a/articles/azure-resource-manager/managed-applications/key-vault-access.md
+++ b/articles/azure-resource-manager/managed-applications/key-vault-access.md
@@ -47,33 +47,114 @@ This article describes how to configure the Key Vault to work with Managed Appli
 
 ## Reference Key Vault secret
 
-To pass a secret from a Key Vault to a template in your Managed Application, you must use a [linked template](../templates/linked-templates.md) and reference the Key Vault in the parameters for the linked template. Provide the resource ID of the Key Vault and the name of the secret.
+To pass a secret from a Key Vault to a template in your Managed Application, you must use a [linked or nested template](../templates/linked-templates.md) and reference the Key Vault in the parameters for the linked or nested template. Provide the resource ID of the Key Vault and the name of the secret.
 
 ```json
-"resources": [{
-  "apiVersion": "2015-01-01",
-  "name": "linkedTemplate",
-  "type": "Microsoft.Resources/deployments",
-  "properties": {
-    "mode": "incremental",
-    "templateLink": {
-      "uri": "https://raw.githubusercontent.com/Azure/azure-docs-json-samples/master/azure-resource-manager/keyvaultparameter/sqlserver.json",
-      "contentVersion": "1.0.0.0"
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "The location where the resources will be deployed."
+      }
     },
-    "parameters": {
-      "adminPassword": {
-        "reference": {
-          "keyVault": {
-            "id": "/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.KeyVault/vaults/<key-vault-name>"
-          },
-          "secretName": "<secret-name>"
-        }
-      },
-      "adminLogin": { "value": "[parameters('adminLogin')]" },
-      "sqlServerName": {"value": "[parameters('sqlServerName')]"}
+    "vaultName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the keyvault that contains the secret."
+      }
+    },
+    "secretName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the secret."
+      }
+    },
+    "vaultResourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the resource group that contains the keyvault."
+      }
+    },
+    "vaultSubscription": {
+      "type": "string",
+      "defaultValue": "[subscription().subscriptionId]",
+      "metadata": {
+        "description": "The name of the subscription that contains the keyvault."
+      }
     }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2018-05-01",
+      "name": "dynamicSecret",
+      "properties": {
+        "mode": "Incremental",
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "adminLogin": {
+              "type": "string"
+            },
+            "adminPassword": {
+              "type": "securestring"
+            },
+            "location": {
+              "type": "string"
+            }
+          },
+          "variables": {
+            "sqlServerName": "[concat('sql-', uniqueString(resourceGroup().id, 'sql'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Sql/servers",
+              "apiVersion": "2018-06-01-preview",
+              "name": "[variables('sqlServerName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "administratorLogin": "[parameters('adminLogin')]",
+                "administratorLoginPassword": "[parameters('adminPassword')]"
+              }
+            }
+          ],
+          "outputs": {
+            "sqlFQDN": {
+              "type": "string",
+              "value": "[reference(variables('sqlServerName')).fullyQualifiedDomainName]"
+            }
+          }
+        },
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "adminLogin": {
+            "value": "ghuser"
+          },
+          "adminPassword": {
+            "reference": {
+              "keyVault": {
+                "id": "[resourceId(parameters('vaultSubscription'), parameters('vaultResourceGroupName'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]"
+              },
+              "secretName": "[parameters('secretName')]"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
   }
-}],
+}
 ```
 
 ## Next steps


### PR DESCRIPTION
Having just done this, I struggled for 2 days trying to figure out how the parameters worked. The concept of referencing the Key Vault is very straight forward. It's how everything fits together that is difficult to understand. Especially since the majority of the other documentation calls for using a parameters file.

Originally it says you must use **linked** templates which is not true, you can also use nested. And I think understanding nested templates makes linked templates simple. Also, by providing a complete template instead of just a resource block it shows how the key vault parameters are not defined in the top parameters block but they are defined in the resources.deployment.parameters block.