### PR TITLE
Removed references to preview of dedicated hosts

### DIFF
--- a/articles/virtual-machines/windows/dedicated-hosts-powershell.md
+++ b/articles/virtual-machines/windows/dedicated-hosts-powershell.md
@@ -25,7 +25,7 @@ Make sure that you have installed Azure PowerShell version 2.8.0 or later, and y
 ## Limitations
 
 - Virtual machine scale sets are not currently supported on dedicated hosts.
-- The following VM series are supported: DSv3, ESv3 and Fsv2. 
+- The following VM series are supported: DSv3, ESv3, and Fsv2. 
 
 ## Create a host group
 

--- a/articles/virtual-machines/windows/dedicated-hosts-powershell.md
+++ b/articles/virtual-machines/windows/dedicated-hosts-powershell.md
@@ -25,7 +25,7 @@ Make sure that you have installed Azure PowerShell version 2.8.0 or later, and y
 ## Limitations
 
 - Virtual machine scale sets are not currently supported on dedicated hosts.
-- The following VM series are supported: DSv3 and ESv3. 
+- The following VM series are supported: DSv3, ESv3 and Fsv2. 
 
 ## Create a host group
 
@@ -53,7 +53,7 @@ $hostGroup = New-AzHostGroup `
 
 ## Create a host
 
-Now let's create a dedicated host in the host group. In addition to a name for the host, you are required to provide the SKU for the host. Host SKU captures the supported VM series as well as the hardware generation for your dedicated host.  During the preview, we will support the following host SKU values: DSv3_Type1 and ESv3_Type1.
+Now let's create a dedicated host in the host group. In addition to a name for the host, you are required to provide the SKU for the host. Host SKU captures the supported VM series as well as the hardware generation for your dedicated host.
 
 
 For more information about the host SKUs and pricing, see [Azure Dedicated Host pricing](https://aka.ms/ADHPricing).

--- a/includes/virtual-machines-common-dedicated-hosts-portal.md
+++ b/includes/virtual-machines-common-dedicated-hosts-portal.md
@@ -13,7 +13,7 @@
 ## Limitations
 
 - Virtual machine scale sets are not currently supported on dedicated hosts.
-- The initial release supports the following VM series: DSv3 and ESv3. 
+- The initial release supports the following VM series: DSv3, ESv3 and Fsv2. 
 
 ## Create a host group
 

--- a/includes/virtual-machines-common-dedicated-hosts-portal.md
+++ b/includes/virtual-machines-common-dedicated-hosts-portal.md
@@ -49,7 +49,7 @@ It should only take a few moments to create the host group.
 
 ## Create a dedicated host
 
-Now create a dedicated host in the host group. In addition to a name for the host, you are required to provide the SKU for the host. Host SKU captures the supported VM series as well as the hardware generation for your dedicated host. The following host SKU values are supported: DSv3_Type1 and ESv3_Type1.
+Now create a dedicated host in the host group. In addition to a name for the host, you are required to provide the SKU for the host. Host SKU captures the supported VM series as well as the hardware generation for your dedicated host.
 
 For more information about the host SKUs and pricing, see [Azure Dedicated Host pricing](https://aka.ms/ADHPricing).
 


### PR DESCRIPTION
In Virtual Machine Windows session was removed references to preview of dedicated host.

Plus it was added the support to Fsv2 VM size.