### PR TITLE
Update job login credential

### DIFF
--- a/articles/sql-database/replication-with-sql-database-managed-instance.md
+++ b/articles/sql-database/replication-with-sql-database-managed-instance.md
@@ -257,8 +257,8 @@ EXEC sp_addpushsubscription_agent
   @subscriber_security_mode = 0,
   @subscriber_login = N'$(target_username)',
   @subscriber_password = N'$(target_password)',
-  @job_login = N'$(target_username)',
-  @job_password = N'$(target_password)';
+  @job_login = N'$(username)',
+  @job_password = N'$(password)';
 
 -- Initialize the snapshot
 EXEC sp_startpublication_snapshot


### PR DESCRIPTION
Job is running against the MI side so it should use the distribution db credential which is the username and password instead of the target_user and target_password. It caused connection failure to the distribution db.