### PR TITLE
Improve Advice on Avoiding OS Version Changes

### DIFF
--- a/articles/automation/automation-update-management.md
+++ b/articles/automation/automation-update-management.md
@@ -252,13 +252,11 @@ The following sections explain potential issues with patching Linux distros.
 
 ### Unexpected OS-level upgrades
 
-On some Linux variants, such as Red Hat Enterprise Linux, OS-level upgrades might occur through packages. This might lead to Update Management runs where the OS version number changes. Because Update Management uses the same methods to update packages that an administrator would use locally on the Linux computer, this behavior is intentional.
+Linux upgrades the OS minor version as part of normal patching and most applications that support Linux also support this approach.
 
-To avoid updating the OS version through Update Management runs, use the **Exclusion** feature.
+RedHat Linux offers an alternative. In the rare case that minor version changes absolutely must be avoided, use [RedHat Extended Update Support](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/update-infrastructure-redhat#rhel-eus-and-version-locking-rhel-vms) to accomplish this goal.
 
-In Red Hat Enterprise Linux, the package name to exclude is redhat-release-server.x86_64.
-
-![Packages to exclude for Linux](./media/automation-update-management/linuxpatches.png)
+Not all Linux vendors include version locking as an option.
 
 ### Critical/security patches aren't applied
 


### PR DESCRIPTION
Excluding the release files doesn't actually stop the OS from upgrading-- it just makes it report an incorrect version. The kernel and all supporting programs that make a functionally different OS version are still installed. Only the /etc/redhat-release file and other informational files are skipped.

Here is the contents of that RPM:

```text
[root@rhel7 tmp]# rpm -q -l redhat-release-server
/etc/issue
/etc/issue.net
/etc/os-release
/etc/pki/product-default
/etc/pki/product-default/69.pem
/etc/pki/rpm-gpg
/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-legacy-former
/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-legacy-release
/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-legacy-rhx
/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
/etc/redhat-release
/etc/rpm/macros.dist
/etc/system-release
/etc/system-release-cpe
/usr/lib/systemd/system-preset/85-display-manager.preset
/usr/lib/systemd/system-preset/90-default.preset
/usr/share/doc/redhat-release/GPL
```
RedHat EUS is a better option for version-locking RedHat since this actually avoids upgrading to the new software.