### PR TITLE
Adding semi annually to access review frequency

### DIFF
--- a/articles/active-directory/governance/create-access-review.md
+++ b/articles/active-directory/governance/create-access-review.md
@@ -48,7 +48,7 @@ For more information, see [License requirements](access-reviews-overview.md#lice
 
     ![Create an access review - Start and end dates](./media/create-access-review/start-end-dates.png)
 
-1. To make the access review recurring, change the **Frequency** setting from **One time** to **Weekly**, **Monthly**, **Quarterly** or **Annually**. Use the **Duration** slider or text box to define how many days each review of the recurring series will be open for input from reviewers. For example, the maximum duration that you can set for a monthly review is 27 days, to avoid overlapping reviews.
+1. To make the access review recurring, change the **Frequency** setting from **One time** to **Weekly**, **Monthly**, **Quarterly**, **Semi-annually** or **Annually**. Use the **Duration** slider or text box to define how many days each review of the recurring series will be open for input from reviewers. For example, the maximum duration that you can set for a monthly review is 27 days, to avoid overlapping reviews.
 
 1. Use the **End** setting to specify how to end the recurring access review series. The series can end in three ways: it runs continuously to start reviews indefinitely, until a specific date, or after a defined number of occurrences has been completed. You, another User administrator, or another Global administrator can stop the series after creation by changing the date in **Settings**, so that it ends on that date.
 

--- a/articles/active-directory/governance/create-access-review.md
+++ b/articles/active-directory/governance/create-access-review.md
@@ -48,7 +48,7 @@ For more information, see [License requirements](access-reviews-overview.md#lice
 
     ![Create an access review - Start and end dates](./media/create-access-review/start-end-dates.png)
 
-1. To make the access review recurring, change the **Frequency** setting from **One time** to **Weekly**, **Monthly**, **Quarterly**, **Semi-annually** or **Annually**. Use the **Duration** slider or text box to define how many days each review of the recurring series will be open for input from reviewers. For example, the maximum duration that you can set for a monthly review is 27 days, to avoid overlapping reviews.
+1. To make the access review recurring, change the **Frequency** setting from **One time** to **Weekly**, **Monthly**, **Quarterly**, **Semi-annually**, or **Annually**. Use the **Duration** slider or text box to define how many days each review of the recurring series will be open for input from reviewers. For example, the maximum duration that you can set for a monthly review is 27 days, to avoid overlapping reviews.
 
 1. Use the **End** setting to specify how to end the recurring access review series. The series can end in three ways: it runs continuously to start reviews indefinitely, until a specific date, or after a defined number of occurrences has been completed. You, another User administrator, or another Global administrator can stop the series after creation by changing the date in **Settings**, so that it ends on that date.
 


### PR DESCRIPTION
Semi-annually as an access review frequency was missing in the documentation but is a valid option in the access review functionality in Azure, added it.