### PR TITLE
Register PTA agent PowerShell example updated

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-pta-quick-start.md
+++ b/articles/active-directory/hybrid/how-to-connect-pta-quick-start.md
@@ -143,7 +143,7 @@ Second, you can create and run an unattended deployment script. This is useful w
         $cred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, $SecurePassword
 3. Go to **C:\Program Files\Microsoft Azure AD Connect Authentication Agent** and run the following script using the `$cred` object that you created:
 
-        RegisterConnector.ps1 -modulePath "C:\Program Files\Microsoft Azure AD Connect Authentication Agent\Modules\" -moduleName "AppProxyPSModule" -Authenticationmode Credentials -Usercredentials $cred -Feature PassthroughAuthentication
+        RegisterConnector.ps1 -modulePath "C:\Program Files\Microsoft Azure AD Connect Authentication Agent\Modules\" -moduleName "PassthroughAuthPSModule" -Authenticationmode Credentials -Usercredentials $cred -Feature PassthroughAuthentication
 
 >[!IMPORTANT]
 >If an Authentication Agent is installed on a Virtual Machine, you can't clone the Virtual Machine to setup another Authentication Agent. This method is **unsupported**.


### PR DESCRIPTION
The most current release of the PTA agent installer does not contain a module named "AppProxyPSModule". The correct module name is "PassthroughAuthPSModule". Updated the referenced module name in code line 146.