### PR TITLE
Removed URI from the explanation of the resource attribute

### DIFF
--- a/articles/api-management/api-management-authentication-policies.md
+++ b/articles/api-management/api-management-authentication-policies.md
@@ -150,7 +150,7 @@ In this example client certificate is identified by resource name.
   
 |Name|Description|Required|Default|  
 |----------|-----------------|--------------|-------------|  
-|resource|String. The App ID URI of the target web API (secured resource) in Azure Active Directory.|Yes|N/A|  
+|resource|String. The App ID of the target web API (secured resource) in Azure Active Directory.|Yes|N/A|  
 |output-token-variable-name|String. Name of the context variable that will receive token value as an object type `string`. |No|N/A|  
 |ignore-error|Boolean. If set to `true`, the policy pipeline will continue to execute even if an access token is not obtained.|No|false|  
   


### PR DESCRIPTION
Rather than passing the App ID URI (which is of the format api://_guid_), one should pass in the App ID (_guid_ only) in order to retrieve the access token generated for a managed identity.