### PR TITLE
Fix broken link for QueueAttribute

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-queue.md
+++ b/articles/azure-functions/functions-bindings-storage-queue.md
@@ -637,7 +637,7 @@ In the [Java functions runtime library](/java/api/overview/azure/functions/runti
 
 # [C#](#tab/csharp)
 
-In [C# class libraries](functions-dotnet-class-library.md), use the [QueueAttribute](https://github.com/Azure/azure-webjobs-sdk/blob/master/src/Microsoft.Azure.WebJobs/QueueAttribute.cs).
+In [C# class libraries](functions-dotnet-class-library.md), use the [QueueAttribute](https://github.com/Azure/azure-webjobs-sdk/blob/master/src/Microsoft.Azure.WebJobs.Extensions.Storage/Queues/QueueAttribute.cs).
 
 The attribute applies to an `out` parameter or the return value of the function. The attribute's constructor takes the name of the queue, as shown in the following example:
 


### PR DESCRIPTION
Replaces old link targeting QueueAttribute.cs file.
QueueAttribute.cs moved from folder "Microsoft.Azure.WebJobs" into "Microsoft.Azure.WebJobs.Extensions.Storage".
While namespace name being the same "Microsoft.Azure.WebJobs".