### PR TITLE
Corrected missing end-tick to Creating VM

### DIFF
--- a/articles/application-gateway/redirect-http-to-https-powershell.md
+++ b/articles/application-gateway/redirect-http-to-https-powershell.md
@@ -278,7 +278,7 @@ Set-AzVmssStorageProfile $vmssConfig `
   -ImageReferencePublisher MicrosoftWindowsServer `
   -ImageReferenceOffer WindowsServer `
   -ImageReferenceSku 2016-Datacenter `
-  -ImageReferenceVersion latest
+  -ImageReferenceVersion latest `
   -OsDiskCreateOption FromImage
 Set-AzVmssOsProfile $vmssConfig `
   -AdminUsername azureuser `


### PR DESCRIPTION
On line 282 of the markdown, the end tick was missing causing an error when running the script as is.