### PR TITLE
Fix error in JWT validation policy

### DIFF
--- a/articles/api-management/api-management-howto-protect-backend-with-aad.md
+++ b/articles/api-management/api-management-howto-protect-backend-with-aad.md
@@ -198,7 +198,7 @@ You can use the [Validate JWT](api-management-access-restriction-policies.md#Val
     <openid-config url="https://login.microsoftonline.com/{aad-tenant}/.well-known/openid-configuration" />
     <required-claims>
         <claim name="aud">
-            <value>{Application ID URI of backend-app}</value>
+            <value>{Application ID of backend-app}</value>
         </claim>
     </required-claims>
 </validate-jwt>


### PR DESCRIPTION
The 'value' is noted as the 'App ID URK of backend-app' however the App ID URI would be api://<App ID> which will fail validation. the aud claim just has the App ID