### PR TITLE
Highlighted warnings

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-about-vpn-gateway-settings.md
+++ b/articles/vpn-gateway/vpn-gateway-about-vpn-gateway-settings.md
@@ -129,7 +129,9 @@ New-AzVirtualNetworkGateway -Name vnetgw1 -ResourceGroupName testrg `
 
 ## <a name="gwsub"></a>Gateway subnet
 
-Before you create a VPN gateway, you must create a gateway subnet. The gateway subnet contains the IP addresses that the virtual network gateway VMs and services use. When you create your virtual network gateway, gateway VMs are deployed to the gateway subnet and configured with the required VPN gateway settings. Never deploy anything else (for example, additional VMs) to the gateway subnet. The gateway subnet must be named 'GatewaySubnet' to work properly. Naming the gateway subnet 'GatewaySubnet' lets Azure know that this is the subnet to deploy the virtual network gateway VMs and services to.
+Before you create a VPN gateway, you must create a gateway subnet. The gateway subnet contains the IP addresses that the virtual network gateway VMs and services use. When you create your virtual network gateway, gateway VMs are deployed to the gateway subnet and configured with the required VPN gateway settings. **Never deploy anything else (for example, additional VMs) to the gateway subnet. Doing so will overexpose your deployed virtual machines.** 
+
+The gateway subnet **must** be named 'GatewaySubnet' to work properly. Naming the gateway subnet 'GatewaySubnet' lets Azure know that this is the subnet to deploy the virtual network gateway VMs and services to.
 
 >[!NOTE]
 >[!INCLUDE [vpn-gateway-gwudr-warning.md](../../includes/vpn-gateway-gwudr-warning.md)]


### PR DESCRIPTION
Added additional formatting to the VM Gateway warning to not place VMs in the Gateway subnet and provided a reason for doing so. Also highlighted the "must" for the naming convention used by the GatewaySubnet.