### PR TITLE
Update maxient-conduct-manager-software-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/maxient-conduct-manager-software-tutorial.md
+++ b/articles/active-directory/saas-apps/maxient-conduct-manager-software-tutorial.md
@@ -24,9 +24,9 @@ ms.collection: M365-identity-device-management
 
 In this tutorial, you'll learn how to integrate Maxient Conduct Manager Software with Azure Active Directory (Azure AD). When you integrate Maxient Conduct Manager Software with Azure AD, you can:
 
-* Control in Azure AD who has access to Maxient Conduct Manager Software.
+* Utilize Azure AD to authenticate your users for the Maxient Conduct Manager Software
 * Enable your users to be automatically signed-in to Maxient Conduct Manager Software with their Azure AD accounts.
-* Manage your accounts in one central location - the Azure portal.
+
 
 To learn more about SaaS app integration with Azure AD, see [What is application access and single sign-on with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/active-directory-appssoaccess-whatis).
 
@@ -39,8 +39,7 @@ To get started, you need the following items:
 
 ## Scenario description
 
-In this tutorial, you configure and test Azure AD SSO in a test environment.
-
+In this tutorial, you will configure your Azure AD for use with Maxient Conduct Manager Software.
 
 
 * Maxient Conduct Manager Software supports **SP and IDP** initiated SSO
@@ -62,16 +61,13 @@ To configure the integration of Maxient Conduct Manager Software into Azure AD, 
 
 ## Configure and test Azure AD single sign-on for Maxient Conduct Manager Software
 
-Configure and test Azure AD SSO with Maxient Conduct Manager Software using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between an Azure AD user and the related user in Maxient Conduct Manager Software.
+Configure and test Azure AD SSO with Maxient Conduct Manager Software. For SSO to work, you need to establish a connection between Azure AD and the Maxient Conduct Manager Software.
 
 To configure and test Azure AD SSO with Maxient Conduct Manager Software, complete the following building blocks:
 
-1. **[Configure Azure AD SSO](#configure-azure-ad-sso)** - to enable your users to use this feature.
-    1. **[Create an Azure AD test user](#create-an-azure-ad-test-user)** - to test Azure AD single sign-on with B.Simon.
-    1. **[Assign the Azure AD test user](#assign-the-azure-ad-test-user)** - to enable B.Simon to use Azure AD single sign-on.
-1. **[Configure Maxient Conduct Manager Software SSO](#configure-maxient-conduct-manager-software-sso)** - to configure the single sign-on settings on application side.
-    1. **[Create Maxient Conduct Manager Software test user](#create-maxient-conduct-manager-software-test-user)** - to have a counterpart of B.Simon in Maxient Conduct Manager Software that is linked to the Azure AD representation of user.
-1. **[Test SSO](#test-sso)** - to verify whether the configuration works.
+1. **[Configure Azure AD SSO](#configure-azure-ad-sso)** - to enable your users to authenticate for use with the Maxient Conduct Manager Software
+    1. **[Assign all users to use Maxient](#assign-all-users-to-be-able-to-authenticate-for-the-Maxient-Conduct-Manager-Software)** - to allow everyone at your institution to be able to authenticate.
+1. **[Test Azure AD Setup With Maxient](#test-with-maxient)** - to verify whether the configuration works, and the correct attributes are being released
 
 ## Configure Azure AD SSO
 
@@ -91,27 +87,15 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
     `https://cm.maxient.com/<SCHOOLCODE>`
 
     > [!NOTE]
-	> The value is not real. Update the value with the actual Sign-on URL. Contact [Maxient Conduct Manager Software Client support team](mailto:support@maxient.com) to get the value. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+	> The value is not real. Update the value with the actual Sign-on URL. Work with your Maxient Implementation/Support representative to get the value.
 
-1. On the **Set up single sign-on with SAML** page, In the **SAML Signing Certificate** section, click copy button to copy **App Federation Metadata Url** and save it on your computer.
+1. On the **Set up single sign-on with SAML** page, In the **SAML Signing Certificate** section, click copy button to copy **App Federation Metadata Url** and save it on your computer.  You will need to provide your Maxient Implementation/Support representative with this URL.
 
 	![The Certificate download link](common/copy-metadataurl.png)
 
-### Create an Azure AD test user
+### Assign All Users to be Able to Authenticate for the Maxient Conduct Manager Software
 
-In this section, you'll create a test user in the Azure portal called B.Simon.
-
-1. From the left pane in the Azure portal, select **Azure Active Directory**, select **Users**, and then select **All users**.
-1. Select **New user** at the top of the screen.
-1. In the **User** properties, follow these steps:
-   1. In the **Name** field, enter `B.Simon`.  
-   1. In the **User name** field, enter the username@companydomain.extension. For example, `B.Simon@contoso.com`.
-   1. Select the **Show password** check box, and then write down the value that's displayed in the **Password** box.
-   1. Click **Create**.
-
-### Assign the Azure AD test user
-
-In this section, you'll enable B.Simon to use Azure single sign-on by granting access to Maxient Conduct Manager Software.
+In this section, you will grant access for all accounts to authenticate using the Azure system for the Maxient Conduct Manager Software.  It is important to note that this step is **REQUIRED** for Maxient to function properly.  Maxient leverages your Azure AD system to *authenticate* users. The *authorization* of users is performed within the Maxient system for the particular function they’re trying to perform. Maxient does not use attributes from your directory to make those decisions.
 
 1. In the Azure portal, select **Enterprise Applications**, and then select **All applications**.
 1. In the applications list, select **Maxient Conduct Manager Software**.
@@ -123,24 +107,12 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 	![The Add User link](common/add-assign-user.png)
 
-1. In the **Users and groups** dialog, select **B.Simon** from the Users list, then click the **Select** button at the bottom of the screen.
-1. If you're expecting any role value in the SAML assertion, in the **Select Role** dialog, select the appropriate role for the user from the list and then click the **Select** button at the bottom of the screen.
-1. In the **Add Assignment** dialog, click the **Assign** button.
+1. In the **Users and groups** dialog, select all users (or the appropriate groups) and **assign** them to be able to authenticate with Maxient.
 
-## Configure Maxient Conduct Manager Software SSO
+## Test with Maxient 
 
-To configure single sign-on on **Maxient Conduct Manager Software** side, you need to send the **App Federation Metadata Url** to [Maxient Conduct Manager Software support team](mailto:support@maxient.com). They set this setting to have the SAML SSO connection set properly on both sides.
-
-### Create Maxient Conduct Manager Software test user
-
-In this section, you create a user called Britta Simon in Maxient Conduct Manager Software. Work with [Maxient Conduct Manager Software support team](mailto:support@maxient.com) to add the users in the Maxient Conduct Manager Software platform. Users must be created and activated before you use single sign-on.
-
-## Test SSO 
-
-In this section, you test your Azure AD single sign-on configuration using the Access Panel.
-
-When you click the Maxient Conduct Manager Software tile in the Access Panel, you should be automatically signed in to the Maxient Conduct Manager Software for which you set up SSO. For more information about the Access Panel, see [Introduction to the Access Panel](https://docs.microsoft.com/azure/active-directory/active-directory-saas-access-panel-introduction).
-
+If a support ticket has not already been opened with a Maxient Implementation/Support representative, send an email to [support@maxient.com](mailto:support@maxient.com) with the subject "Campus Based Authentication/Azure Setup - <<School Name>>".  In the body of the email, provide the **App Federation Metadata Url**.  Maxient staff will respond with a test link to verify the proper attributes are being released.  
+	
 ## Additional resources
 
 - [ List of Tutorials on How to Integrate SaaS Apps with Azure Active Directory ](https://docs.microsoft.com/azure/active-directory/active-directory-saas-tutorial-list)

--- a/articles/active-directory/saas-apps/maxient-conduct-manager-software-tutorial.md
+++ b/articles/active-directory/saas-apps/maxient-conduct-manager-software-tutorial.md
@@ -87,7 +87,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
     `https://cm.maxient.com/<SCHOOLCODE>`
 
     > [!NOTE]
-	> The value is not real. Update the value with the actual Sign-on URL. Work with your Maxient Implementation/Support representative to get the value.
+    > The value is not real. Update the value with the actual Sign-on URL. Work with your Maxient Implementation/Support representative to get the value.
 
 1. On the **Set up single sign-on with SAML** page, In the **SAML Signing Certificate** section, click copy button to copy **App Federation Metadata Url** and save it on your computer.  You will need to provide your Maxient Implementation/Support representative with this URL.
 
@@ -111,7 +111,7 @@ In this section, you will grant access for all accounts to authenticate using th
 
 ## Test with Maxient 
 
-If a support ticket has not already been opened with a Maxient Implementation/Support representative, send an email to [support@maxient.com](mailto:support@maxient.com) with the subject "Campus Based Authentication/Azure Setup - <<School Name>>".  In the body of the email, provide the **App Federation Metadata Url**.  Maxient staff will respond with a test link to verify the proper attributes are being released.  
+If a support ticket has not already been opened with a Maxient Implementation/Support representative, send an email to [support@maxient.com](mailto:support@maxient.com) with the subject "Campus Based Authentication/Azure Setup - \<\<School Name\>\>". In the body of the email, provide the **App Federation Metadata Url**. Maxient staff will respond with a test link to verify the proper attributes are being released.  
 	
 ## Additional resources
 


### PR DESCRIPTION
This tutorial needed to be edited to match Maxient's operating procedures for setting up Campus Based Authentication.

Maxient clients, set up Azure AD for use with Maxient.  They must allow ALL USERS to authenticate (this does not grant access to the Maxient software) we ONLY use Azure to *authenticate* we take care of the *authorization* on our end.   Once things are set up, the client sends us their metadata URL and we reply with a test link.  This test link is an attribute reflector.  We need to make sure the proper attributes are being released.  Once that is done - the setup is complete.  We will turn on Authentication within Maxient when appropriate (immediately for current clients - just before training for clients in the process of implementation).   I believe the edits I made to this document reflect this, but it will need a little clean up (I am certain i messed up some tags and what not).  All references to a "test user" must be removed...that is not how our process works.

Any questions, please let me know.   Thanks!