### PR TITLE
Fix spelling of 'Group Administrator' to be correct: 'Groups Administrator'

### DIFF
--- a/articles/active-directory/users-groups-roles/directory-assign-admin-roles.md
+++ b/articles/active-directory/users-groups-roles/directory-assign-admin-roles.md
@@ -242,7 +242,7 @@ Users in this role can read settings and administrative information across Micro
 > These features are currently in development.
 >
 
-### [Group Administrator](#group-administrator-permissions)
+### [Groups Administrator](#groups-administrator-permissions)
 
 Users in this role can create/manage groups and its settings like naming and expiration policies. It is important to understand that assigning a user to this role gives them the ability to manage all groups in the tenant across various workloads like Teams, SharePoint, Yammer in addition to Outlook. Also the user will be able to manage the various groups settings across various admin portals like Microsoft Admin Center, Azure portal, as well as workload specific ones like Teams and SharePoint Admin Centers.
 
@@ -1077,7 +1077,7 @@ Can read everything that a Global Administrator can, but not edit anything.
 | microsoft.office365.usageReports/allEntities/read	| Read Office 365 usage reports. |
 | microsoft.office365.webPortal/allEntities/standard/read	| Read standard properties on all resources in microsoft.office365.webPortal. |
 
-### Group Administrator permissions
+### Groups Administrator permissions
 Can manage all aspects of groups and group settings like naming and expiration policies.
 
 | **Actions** | **Description** |
@@ -1714,7 +1714,7 @@ Directory Writers | Directory writers | 9360feb5-f418-4baa-8175-e2a00bac4301
 Exchange Service Administrator | Exchange administrator | 29232cdf-9323-42fd-ade2-1d097af3e4de
 External Identity Provider Administrator | External Identity Provider Administrator | be2f45a1-457d-42af-a067-6ec1fa63bc45
 Global Reader | Global reader | f2ef992c-3afb-46b9-b7cf-a126ee74c451
-Group Administrator | Group administrator | fdd7a751-b60b-444a-984c-02652fe8fa1c 
+Groups Administrator | Groups administrator | fdd7a751-b60b-444a-984c-02652fe8fa1c 
 Guest Inviter | Guest inviter | 95e79109-95c0-4d8e-aee3-d01accf2d47b
 Helpdesk Administrator | Helpdesk administrator | 729827e3-9c14-49f7-bb1b-9608f156bbb8
 Intune Service Administrator | Intune administrator | 3a2c62db-5318-420d-8d74-23affee5d9d5


### PR DESCRIPTION
This is what I see in Azure, which indicates a missing plural `s`:
![image](https://user-images.githubusercontent.com/9250262/74547943-d2217580-4f44-11ea-95a8-fad0056ce357.png)
