### PR TITLE
Highlight the need to end Issue with a slash

### DIFF
--- a/articles/vpn-gateway/openvpn-azure-ad-tenant.md
+++ b/articles/vpn-gateway/openvpn-azure-ad-tenant.md
@@ -100,7 +100,7 @@ Use the steps in [this article](../active-directory/fundamentals/add-users-azure
     ```
 
    > [!NOTE]
-   > Ensure that you don't miss the trailing slash at the end of the Issuer.
+   > Make sure you include a trailing slash at the end of the `AadIssuerUri` value. Otherwise, the command will fail.
 
 10. Create and download the profile by running the following commands. Change the -ResourceGroupName and -Name values to match your own.
 

--- a/articles/vpn-gateway/openvpn-azure-ad-tenant.md
+++ b/articles/vpn-gateway/openvpn-azure-ad-tenant.md
@@ -99,6 +99,9 @@ Use the steps in [this article](../active-directory/fundamentals/add-users-azure
     Set-AzVirtualNetworkGateway -VirtualNetworkGateway $gw -AadTenantUri "https://login.microsoftonline.com/<your Directory ID>" -AadAudienceId "41b23e61-6c1e-4545-b367-cd054e0ed4b4" -AadIssuerUri "https://sts.windows.net/<your Directory ID>/" -VpnClientAddressPool 192.168.0.0/24 -VpnClientProtocol OpenVPN
     ```
 
+   > [!NOTE]
+   > Ensure that you don't miss the trailing slash at the end of the Issuer.
+
 10. Create and download the profile by running the following commands. Change the -ResourceGroupName and -Name values to match your own.
 
     ```azurepowershell-interactive


### PR DESCRIPTION
If you don't place the ending slash on the Issue the VPN connection will fail with a an error that doesn't help the clients identify the problem. Suggestion is to highlight this requirement to avoid configuration problems.