### PR TITLE
Clarify logging filter rules example

### DIFF
--- a/articles/azure-monitor/app/ilogger.md
+++ b/articles/azure-monitor/app/ilogger.md
@@ -326,22 +326,20 @@ The following examples apply filter rules to ApplicationInsightsLoggerProvider.
 
 ### Create filter rules in configuration with appsettings.json
 
-For ApplicationInsightsLoggerProvider, the provider alias is `ApplicationInsights`. The following section of *appsettings.json* configures logs for *Warning* and above from all categories and *Error* and above from categories that start with "Microsoft" to be sent to `ApplicationInsightsLoggerProvider`.
+For ApplicationInsightsLoggerProvider, the provider alias is `ApplicationInsights`. The following section of *appsettings.json* instructs logging providers generally to log at level *Warning* and above. It then overrides the `ApplicationInsightsLoggerProvider` to log categories that start with "Microsoft" at level *Error* and above.
 
 ```json
 {
   "Logging": {
-    "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Warning",
-        "Microsoft": "Error"
-      }
-    },
     "LogLevel": {
       "Default": "Warning"
+    },
+    "ApplicationInsights": {
+      "LogLevel": {
+        "Microsoft": "Error"
+      }
     }
-  },
-  "AllowedHosts": "*"
+  }
 }
 ```
 


### PR DESCRIPTION
Fixes #48062.
* Reorders to put ApplicationInsights override after the general setting.
* Removes duplicate default setting in ApplicationInsights.
* Removes `AllowedHosts` setting unrelated to logging, making the example more specifically a "section of" the config as described above the example.