### PR TITLE
fix sql spark connector .sqlDB examples

### DIFF
--- a/articles/sql-database/sql-database-spark-connector.md
+++ b/articles/sql-database/sql-database-spark-connector.md
@@ -21,13 +21,13 @@ To get started, download the Spark to SQL DB connector from the [azure-sqldb-spa
 
 ## Official Supported Versions
 
-| Component	                           |Version                  |
-| :----------------------------------- | :---------------------- |
-| Apache Spark	                       |2.0.2 or later           |
-| Scala	                               |2.10 or later            |
-| Microsoft JDBC Driver for SQL Server |6.2 or later             |
-| Microsoft SQL Server	               |SQL Server 2008 or later |
-| Azure SQL Database	               |Supported                |
+| Component	                           | Version                  |
+| :----------------------------------- | :----------------------- |
+| Apache Spark	                       | 2.0.2 or later           |
+| Scala	                               | 2.10 or later            |
+| Microsoft JDBC Driver for SQL Server | 6.2 or later             |
+| Microsoft SQL Server	               | SQL Server 2008 or later |
+| Azure SQL Database	               | Supported                |
 
 The Spark connector for Azure SQL Database and SQL Server utilizes the Microsoft JDBC Driver for SQL Server to move data between Spark worker nodes and SQL databases:
  
@@ -83,7 +83,7 @@ val config = Config(Map(
 ))
 
 //Read all data in table dbo.Clients
-val collection = sqlContext.read.sqlDb(config)
+val collection = sqlContext.read.sqlDB(config)
 collection.show()
 ```
 
@@ -112,7 +112,7 @@ import com.microsoft.azure.sqldb.spark.config.Config
 import com.microsoft.azure.sqldb.spark.query._
 val query = """
               |UPDATE Customers
-              |SET ContactName = 'Alfred Schmidt', City= 'Frankfurt'
+              |SET ContactName = 'Alfred Schmidt', City = 'Frankfurt'
               |WHERE CustomerID = 1;
             """.stripMargin
 
@@ -140,13 +140,13 @@ import com.microsoft.azure.sqldb.spark.connect._
 val config = Config(Map(
   "url"            -> "mysqlserver.database.windows.net",
   "databaseName"   -> "MyDatabase",
-  "user"           -> "username ",
+  "user"           -> "username",
   "password"       -> "*********",
   "authentication" -> "ActiveDirectoryPassword",
   "encrypt"        -> "true"
 ))
 
-val collection = sqlContext.read.SqlDB(config)
+val collection = sqlContext.read.sqlDB(config)
 collection.show()
 ```
 
@@ -163,12 +163,12 @@ import com.microsoft.azure.sqldb.spark.connect._
 val config = Config(Map(
   "url"                   -> "mysqlserver.database.windows.net",
   "databaseName"          -> "MyDatabase",
-  "accessToken"           -> "access_token ",
+  "accessToken"           -> "access_token",
   "hostNameInCertificate" -> "*.database.windows.net",
   "encrypt"               -> "true"
 ))
 
-val collection = sqlContext.read.SqlDB(config)
+val collection = sqlContext.read.sqlDB(config)
 collection.show()
 ```
 
@@ -208,7 +208,7 @@ df.bulkCopyToSqlDB(bulkCopyConfig, bulkCopyMetadata)
 ## Next steps
 If you haven't already, download the Spark connector for Azure SQL Database and SQL Server from [azure-sqldb-spark GitHub repository](https://github.com/Azure/azure-sqldb-spark) and explore the additional resources in the repo:
 
--	[Sample Azure Databricks notebooks](https://github.com/Azure/azure-sqldb-spark/tree/master/samples/notebooks)
+- [Sample Azure Databricks notebooks](https://github.com/Azure/azure-sqldb-spark/tree/master/samples/notebooks)
 - [Sample scripts (Scala)](https://github.com/Azure/azure-sqldb-spark/tree/master/samples/scripts)
 
 You might also want to review the [Apache Spark SQL, DataFrames, and Datasets Guide](https://spark.apache.org/docs/latest/sql-programming-guide.html) and the [Azure Databricks documentation](https://docs.microsoft.com/azure/azure-databricks/).


### PR DESCRIPTION
character casing wasn't consistent across all instances of .sqlDB

- ensure all sql db references use: sqlDB
- remove trailing whitespace from parameter values to avoid confusion
- update requirements table formatting for consistency
- replace tab with single space in footnote for consistent markdown
list