### PR TITLE
fix typo in sample arm template of managed identity

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/qs-configure-template-windows-vmss.md
+++ b/articles/active-directory/managed-identities-azure-resources/qs-configure-template-windows-vmss.md
@@ -185,7 +185,7 @@ In this section, you assign a user-assigned managed identity to a virtual machin
        "identity": {
            "type": "userAssigned",
            "identityIds": [
-               "[resourceID('Micrososft.ManagedIdentity/userAssignedIdentities/',variables('<USERASSIGNEDIDENTITY>'))]"
+               "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/',variables('<USERASSIGNEDIDENTITY>'))]"
            ]
        }
 


### PR DESCRIPTION
If the wrong sample snippet is copied and used in arm template, it could cause some error in deployment like below:

Error: Code=InvalidIdentityId; Message=The identity ids '/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/rg-xxx/providers/Micrososft.ManagedIdentity/userAssignedIdentities/MSI_xxxx' are invalid. It must be of the following format: '/subscriptions/{
subscriptionId
}/resourceGroups/{
resourceGroupName
}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{
resourceName
}'.

It is tricky to spot such kind of bug.