### PR TITLE
Update event schema with field requirement info

### DIFF
--- a/articles/event-grid/event-schema.md
+++ b/articles/event-grid/event-schema.md
@@ -81,14 +81,14 @@ All events have the same following top-level data:
 
 | Property | Type | Required | Description |
 | -------- | ---- | -------- | ----------- |
-| topic | string | No, but if included must match the Event Grid Topic ARM Id exactly. If not included, Event Grid will stamp onto the event. | Full resource path to the event source. This field isn't writeable. Event Grid provides this value. |
+| topic | string | No, but if included, must match the Event Grid topic Azure Resource Manager ID exactly. If not included, Event Grid will stamp onto the event. | Full resource path to the event source. This field isn't writeable. Event Grid provides this value. |
 | subject | string | Yes | Publisher-defined path to the event subject. |
 | eventType | string | Yes | One of the registered event types for this event source. |
 | eventTime | string | Yes | The time the event is generated based on the provider's UTC time. |
 | id | string | Yes | Unique identifier for the event. |
 | data | object | No | Event data specific to the resource provider. |
 | dataVersion | string | No, but will be stamped with an empty value. | The schema version of the data object. The publisher defines the schema version. |
-| metadataVersion | string | Not required, but if included, must match the Event Grid Schema `metadataVersion` exactly (currently only `1`). If not included, Event Grid will stamp onto the event. | The schema version of the event metadata. Event Grid defines the schema of the top-level properties. Event Grid provides this value. |
+| metadataVersion | string | Not required, but if included, must match the Event Grid Schema `metadataVersion` exactly (currently, only `1`). If not included, Event Grid will stamp onto the event. | The schema version of the event metadata. Event Grid defines the schema of the top-level properties. Event Grid provides this value. |
 
 To learn about the properties in the data object, see the event source:
 

--- a/articles/event-grid/event-schema.md
+++ b/articles/event-grid/event-schema.md
@@ -79,16 +79,16 @@ For example, the schema published for an Azure Blob storage event is:
 
 All events have the same following top-level data:
 
-| Property | Type | Description |
-| -------- | ---- | ----------- |
-| topic | string | Full resource path to the event source. This field isn't writeable. Event Grid provides this value. |
-| subject | string | Publisher-defined path to the event subject. |
-| eventType | string | One of the registered event types for this event source. |
-| eventTime | string | The time the event is generated based on the provider's UTC time. |
-| id | string | Unique identifier for the event. |
-| data | object | Event data specific to the resource provider. |
-| dataVersion | string | The schema version of the data object. The publisher defines the schema version. |
-| metadataVersion | string | The schema version of the event metadata. Event Grid defines the schema of the top-level properties. Event Grid provides this value. |
+| Property | Type | Required | Description |
+| -------- | ---- | -------- | ----------- |
+| topic | string | No, but if included must match the Event Grid Topic ARM Id exactly. If not included, Event Grid will stamp onto the event. | Full resource path to the event source. This field isn't writeable. Event Grid provides this value. |
+| subject | string | Yes | Publisher-defined path to the event subject. |
+| eventType | string | Yes | One of the registered event types for this event source. |
+| eventTime | string | Yes | The time the event is generated based on the provider's UTC time. |
+| id | string | Yes | Unique identifier for the event. |
+| data | object | No | Event data specific to the resource provider. |
+| dataVersion | string | No, but will be stamped with an empty value. | The schema version of the data object. The publisher defines the schema version. |
+| metadataVersion | string | Not required, but if included, must match the Event Grid Schema `metadataVersion` exactly (currently only `1`). If not included, Event Grid will stamp onto the event. | The schema version of the event metadata. Event Grid defines the schema of the top-level properties. Event Grid provides this value. |
 
 To learn about the properties in the data object, see the event source:
 


### PR DESCRIPTION
The documentation states that five fields are required, and never indicates which fields. [Issue #31259](https://github.com/MicrosoftDocs/azure-docs/issues/31259) asks for clarification on this, and the answer is provided there but has not been added into the docs.