### PR TITLE
Update quick-create-cli.md

### DIFF
--- a/articles/virtual-machines/windows/quick-create-cli.md
+++ b/articles/virtual-machines/windows/quick-create-cli.md
@@ -52,7 +52,7 @@ az vm create \
     --name myVM \
     --image win2016datacenter \
     --admin-username azureuser \
-    --admin-password myPassword
+    --admin-password myPassword123
 ```
 
 It takes a few minutes to create the VM and supporting resources. The following example output shows the VM create operation was successful.


### PR DESCRIPTION
VMs require a password length between 12 and 123 characters, causing the existing code snippet fail. I've appended `123` to the end of the password to extend the length.