### PR TITLE
Updating with PowerShell commands on removing a P2S

### DIFF
--- a/articles/vpn-gateway/point-to-site-about.md
+++ b/articles/vpn-gateway/point-to-site-about.md
@@ -167,10 +167,15 @@ A P2S configuration requires quite a few specific steps. The following articles 
 
 ## How do I remove the configuration of a P2S connection?
 
-A P2S configuration can be removed using az cli and the following command : 
+A P2S configuration can be removed using Azure CLI and PowerShell using the following commands : 
 
+### Azure CLI
 `az network vnet-gateway update --name <gateway-name> --resource-group <resource-group name> --remove "vpnClientConfiguration"`
- 
+### PowerShell
+`$gw=Get-AzVirtualNetworkGateway -name <gateway-name>`  
+`$gw.VPNClientConfiguration = $null`  
+`Set-AzVirtualNetworkGateway -VirtualNetworkGateway $gw`
+
 ## <a name="faqcert"></a>FAQ for native Azure certificate authentication
 
 [!INCLUDE [vpn-gateway-point-to-site-faq-include](../../includes/vpn-gateway-faq-p2s-azurecert-include.md)]


### PR DESCRIPTION
I updated the section "How do I remove the configuration of a P2S connection?" to reflect the PowerShell commands used for removal.

Having these commands on public documentation is necessary since this is a common issue. I am internal to CXP, so please reach out to me if you need to discuss these changes further (brcunnin).