### PR TITLE
Fix PackageSharingPolicy PackageRef

### DIFF
--- a/articles/service-fabric/service-fabric-manifest-example-reliable-services-app.md
+++ b/articles/service-fabric/service-fabric-manifest-example-reliable-services-app.md
@@ -65,7 +65,7 @@ See [Application manifest elements](#application-manifest-elements), [VotingWeb 
                                 MemorySwapInMB="[MemorySwapInMB]"/>
 
       <!-- Share the data package across multiple instances of the VotingData service-->
-      <PackageSharingPolicy PackageRef="VotingDataPkg.Data"/>
+      <PackageSharingPolicy PackageRef="Data"/>
 
       <!-- Give read rights on the "DataEndpoint" endpoint to the Customer2 account.-->
       <SecurityAccessPolicy GrantRights="Read" PrincipalRef="Customer2" ResourceRef="DataEndpoint" ResourceType="Endpoint"/>         


### PR DESCRIPTION
PackageSharingPolicy element PackageRef attribute takes the name of the package only; service manifest name should not be included. If one includes service manifest name as described here, Application manifest validation will fail with error:
_AggregateException: Aggregate exception has 1 exceptions. The PackageRef 'VotingDataPkg.Data' in PackageSharingPolicy is invalid. There is no matching Package in the corresponding ServiceManifest._

This doc describes PackageSharingPolicy element type: https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-service-model-schema-complex-types#packagesharingpolicytype-complextype