### PR TITLE
Clarify device registration requirements for per-device consent

### DIFF
--- a/articles/active-directory/conditional-access/terms-of-use.md
+++ b/articles/active-directory/conditional-access/terms-of-use.md
@@ -82,7 +82,7 @@ Once you have finalized your terms of use document, use the following procedure 
 1. For **Terms of use document**, browse to your finalized terms of use PDF and select it.
 1. Select the language for your terms of use document. The language option allows you to upload multiple terms of use, each with a different language. The version of the terms of use that an end user will see will be based on their browser preferences.
 1. To require end users to view the terms of use prior to accepting them, set **Require users to expand the terms of use** to **On**.
-1. To require end users to accept your terms of use on every device they are accessing from, set **Require users to consent on every device** to **On**. For more information, see [Per-device terms of use](#per-device-terms-of-use).
+1. To require end users to accept your terms of use on every device they are accessing from, set **Require users to consent on every device** to **On**. Users may be required to install additional applications if this option is enabled. For more information, see [Per-device terms of use](#per-device-terms-of-use).
 1. If you want to expire terms of use consents on a schedule, set **Expire consents** to **On**. When set to On, two additional schedule settings are displayed.
 
    ![Expire consents settings to set start date, frequency, and duration](./media/terms-of-use/expire-consents.png)
@@ -273,6 +273,10 @@ If a user is using Windows 10 and Microsoft Edge, they will receive a message si
 ![Windows 10 and Microsoft Edge - Message indicating your device must be registered](./media/terms-of-use/per-device-win10-edge.png)
 
 If they are using Chrome, they will be prompted to install the [Windows 10 Accounts extension](https://chrome.google.com/webstore/detail/windows-10-accounts/ppnbnpeolgkicgegkbkbjmhlideopiji).
+
+### Join an Android device
+
+If a user is using an Android device, they will be prompted to install the [Microsoft Authenticator app](https://play.google.com/store/apps/details?id=com.azure.authenticator).
 
 ### Browsers
 


### PR DESCRIPTION
Based on some feedback from a large customer I support, I am proposing the following edits:

In the **Add Terms of Use** section, add text to call out that additional apps may be required for per-device consent.

In the **Per-Device Terms Of Use** section, add sub-section titled **Join an Android Device** calling out that Authenticator app is required.  I don't appear to be able to add a screenshot to the commit directly, so I've attached a screenshot to this PR that could be used along with the text I added, similar to the content directly above related to Windows 10.

![per-device-android-authenticator](https://user-images.githubusercontent.com/52325421/74985225-e1446f80-53eb-11ea-9064-3ad005373ad4.png)
