### PR TITLE
Fix link redirects to wrong site

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-queue.md
+++ b/articles/azure-functions/functions-bindings-storage-queue.md
@@ -45,4 +45,4 @@ Functions 1.x apps automatically have a reference the [Microsoft.Azure.WebJobs](
 ## Next steps
 
 - [Run a function as queue storage data changes (Trigger)](./functions-bindings-storage-queue-trigger.md)
-- [Write queue storage messages (Output binding)](./functions-bindings-storage-blob-output.md)
+- [Write queue storage messages (Output binding)](./functions-bindings-storage-queue-output.md)


### PR DESCRIPTION
The "Write queue storage messages (Output binding)" was redirecting to blobstorage example site instead of queue storage example.

Opened feedback #48717
