### PR TITLE
Fix typo

### DIFF
--- a/articles/service-bus-messaging/service-bus-migrate-standard-premium.md
+++ b/articles/service-bus-messaging/service-bus-migrate-standard-premium.md
@@ -28,7 +28,7 @@ Some of the points to note:
 - The **premium** namespace should have **no entities** in it for the migration to succeed. 
 - All **entities** in the standard namespace are **copied** to the premium namespace during the migration process. 
 - Migration supports **1,000 entities per messaging unit** on the premium tier. To identify how many messaging units you need, start with the number of entities that you have on your current standard namespace. 
-- You can't directly migrate from **basic tier** to **premier tier**, but you can do so indirectly by migrating from basic to standard first and then from the standard to premium in the next step.
+- You can't directly migrate from **basic tier** to **premium tier**, but you can do so indirectly by migrating from basic to standard first and then from the standard to premium in the next step.
 
 ## Migration steps
 Some conditions are associated with the migration process. Familiarize yourself with the following steps to reduce the possibility of errors. These steps outline the migration process, and the step-by-step details are listed in the sections that follow.


### PR DESCRIPTION
Amend "premier" to read "premium" in line with all other references to premium service tier