### PR TITLE
Syntax error?

### DIFF
--- a/articles/active-directory/develop/scenario-protected-web-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-protected-web-api-app-configuration.md
@@ -106,7 +106,7 @@ The middleware is added to the web API by this instruction:
 
 ```csharp
  services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
-         .AddAzureAdBearer(options => Configuration.Bind("AzureAd", options));
+         .AddAzureADBearer(options => Configuration.Bind("AzureAd", options));
 ```
 
  Currently, the ASP.NET Core templates create Azure Active Directory (Azure AD) web APIs that sign in users within your organization or any organization. They don't sign in users with personal accounts. But you can change the templates to use the Microsoft identity platform endpoint by adding this code to Startup.cs:


### PR DESCRIPTION
Looks like it should be AddAzureADBearer instead of AddAzureAdBearer:
---
 services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
             .AddAzureADBearer(options => Configuration.Bind("AzureAd", options));
---
at least if the extension method of Microsoft.AspNetCore.Authentication.AzureADAuthenticationBuilderExtensions should be used