### PR TITLE
Add note about license suspension on soft delete

### DIFF
--- a/articles/active-directory/fundamentals/license-users-groups.md
+++ b/articles/active-directory/fundamentals/license-users-groups.md
@@ -132,6 +132,9 @@ You can remove a license from a user's Azure AD user page, from the group overvi
 1. Select **Remove license**.
 
     ![Licensed groups page with Remove license option highlighted](media/license-users-groups/license-products-group-blade-with-remove-option-highlight.png)
+    
+    > [!NOTE]
+    > When an on-premises user account synced to Azure AD falls out of scope for the sync or when the sync is removed, the user is soft-deleted in Azure AD. When this occurs, licenses assigned to the user directly or via group-based licensing will be marked as **suspended** rather than **deleted**.
 
 ## Next steps
 


### PR DESCRIPTION
Added note to the **Remove a license** section, per email conversation with @SumitParikh (via Don Dominguez / donald). Note clarifies the behavior of assigned licenses when user is soft deleted because they are removed from AAD Sync scope.

