### PR TITLE
Correct the PowerShell link for deployment manager powershell module

### DIFF
--- a/articles/azure-resource-manager/templates/toc.yml
+++ b/articles/azure-resource-manager/templates/toc.yml
@@ -253,7 +253,7 @@
   - name: REST
     href: /rest/api/resources/
   - name: Azure PowerShell
-    href: /powershell/module/az.resources
+    href: /powershell/module/az.deploymentmanager
   - name: Azure CLI
     href: /cli/azure/resource
   - name: .NET


### PR DESCRIPTION
Current link is pointing to the wrong PowerShell module.

Should point to:
https://docs.microsoft.com/en-us/powershell/module/az.deploymentmanager/?view=azps-3.5.0#deployment_manager