### PR TITLE
dbo.vTableSizes view not accurate for small SLO

### DIFF
--- a/articles/sql-data-warehouse/sql-data-warehouse-tables-overview.md
+++ b/articles/sql-data-warehouse/sql-data-warehouse-tables-overview.md
@@ -208,6 +208,7 @@ LEFT OUTER JOIN (select * from sys.pdw_column_distribution_properties where dist
 LEFT OUTER JOIN sys.columns c
     ON cdp.[object_id] = c.[object_id]
     AND cdp.[column_id] = c.[column_id]
+WHERE pn.[type] = 'COMPUTE'
 )
 , size
 AS


### PR DESCRIPTION
The view definition for dbo.vTableSizes doubles the sizes of the tables when the DW size (SLO) is DW500c or below.  This is happening because the query assumes that the control node is separate from the compute nodes; however, on lower SLOs, it is not.  As such, a filter needs to be added to ensure the counts are accurate.