### PR TITLE
(AzureCXP) Updating typo

### DIFF
--- a/articles/migrate/tutorial-migrate-vmware.md
+++ b/articles/migrate/tutorial-migrate-vmware.md
@@ -241,9 +241,9 @@ After you've verified that the test migration works as expected, you can migrate
 4. A migration job starts for the VM. Track the job in Azure notifications.
 5. After the job finishes, you can view and manage the VM from the **Virtual Machines** page.
 
-## Complete the migration
+## Complete the Migration
 
-1. After the migration is done, right-click the VM > **Stop migration**. This stops replication for the on-premises machine, and cleans up replication state information for the VM.
+1. After the migration is done, right-click the VM > **Stop Replication**. This stops replication for the on-premises machine, and cleans up replication state information for the VM.
 2. Install the Azure VM [Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/agent-windows) or [Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/agent-linux) agent on the migrated machines.
 3. Perform any post-migration app tweaks, such as updating database connection strings, and web server configurations.
 4. Perform final application and migration acceptance testing on the migrated application now running in Azure.

--- a/articles/migrate/tutorial-migrate-vmware.md
+++ b/articles/migrate/tutorial-migrate-vmware.md
@@ -241,7 +241,7 @@ After you've verified that the test migration works as expected, you can migrate
 4. A migration job starts for the VM. Track the job in Azure notifications.
 5. After the job finishes, you can view and manage the VM from the **Virtual Machines** page.
 
-## Complete the Migration
+## Complete the migration
 
 1. After the migration is done, right-click the VM > **Stop Replication**. This stops replication for the on-premises machine, and cleans up replication state information for the VM.
 2. Install the Azure VM [Windows](https://docs.microsoft.com/azure/virtual-machines/extensions/agent-windows) or [Linux](https://docs.microsoft.com/azure/virtual-machines/extensions/agent-linux) agent on the migrated machines.


### PR DESCRIPTION
Based on customer feedback of this github thread https://github.com/MicrosoftDocs/azure-docs/issues/48885.
Updating the typo for Migration and also Stop Replication instead of Stop Migration.