### PR TITLE
Update Clients calling without SNI header

### DIFF
--- a/includes/api-management-custom-domain.md
+++ b/includes/api-management-custom-domain.md
@@ -14,7 +14,7 @@ If the customer has one or multiple custom domains configured for Proxy, APIM ca
 If the customer is using a client, which does not send the [SNI](https://tools.ietf.org/html/rfc6066#section-3) header, APIM creates responses based on the following logic:
 
 * If the service has just one custom domain configured for Proxy, the Default Certificate is the certificate that was issued to the Proxy custom domain.
-* If the service has configured multiple custom domains for Proxy (only supported in the **Premium** tier), the customer can designate which certificate should be the default certificate. To set the default certificate, the [defaultSslBinding](https://docs.microsoft.com/rest/api/apimanagement/2019-01-01/apimanagementservice/createorupdate#hostnameconfiguration) property should be set to true ("defaultSslBinding":"true"). If the customer does not set the property, the default certificate is the certificate issued to default Proxy domain hosted at *.azure-api.net.
+* If the service has configured multiple custom domains for Proxy (supported in the **Developer** and **Premium** tier), the customer can designate which certificate should be the default certificate. To set the default certificate, the [defaultSslBinding](https://docs.microsoft.com/rest/api/apimanagement/2019-01-01/apimanagementservice/createorupdate#hostnameconfiguration) property should be set to true ("defaultSslBinding":"true"). If the customer does not set the property, the default certificate is the certificate issued to default Proxy domain hosted at *.azure-api.net.
 
 ## Support for PUT/POST request with large payload
 


### PR DESCRIPTION
The message is to be updated in the second point of 'Clients calling without SNI header'
(supported in the **Developer** and **Premium** tier)

The APIM has been updated and the service has started supporting the operation in the developer tier too.