### PR TITLE
Fix command to set public access off

### DIFF
--- a/articles/storage/blobs/storage-secure-access-application.md
+++ b/articles/storage/blobs/storage-secure-access-application.md
@@ -40,8 +40,9 @@ blobStorageAccount=<blob_storage_account>
 blobStorageAccountKey=$(az storage account keys list -g myResourceGroup \
 -n $blobStorageAccount --query [0].value --output tsv) 
 
-az storage container set-permission \ --account-name $blobStorageAccount \ --account-key $blobStorageAccountKey \ --name thumbnails  \
---public-access off
+az storage container set-permission \ 
+--account-name $blobStorageAccount --account-key $blobStorageAccountKey \ 
+--name thumbnails --public-access off
 ``` 
 
 ## Configure SAS tokens for thumbnails


### PR DESCRIPTION
Fix issue that you need to start a newline after a backslash in a sh command.
Fixed closing off public access command.