### PR TITLE
Update permissions required in subscription

### DIFF
--- a/articles/sentinel/connect-azure-activity.md
+++ b/articles/sentinel/connect-azure-activity.md
@@ -27,7 +27,8 @@ You can stream logs from [Azure Activity log](../azure-monitor/platform/platform
 
 ## Prerequisites
 
-- User with contributor permissions to Log Analytics workspace 
+- User with Contributor permissions to Log Analytics workspace 
+- User with Reader permissions to the Subscription being connected to perform the Read action on /subscriptions/_subscription_being_monitored_/providers/microsoft.insights/eventtypes/management
 
 
 ## Connect to Azure Activity log


### PR DESCRIPTION
Missing required permissions at subscription level. This is specially important when the workspace is in a subscription (owned by security team) and the monitored subscription is different (owned by a department team).
If the permission is missing, this error is produced:
Failed to connect 'Dev subscription' to Activity logs. Please verify you have access to this subscription. Error: The client 'cloud2@contoso.onmicrosoft.com' with object id 'aabf66b7-6638-485b-817c-ff30809a4243' has permission to perform action 'Microsoft.OperationalInsights/workspaces/datasources/write' on scope '/subscriptions/a65f6a6c-a0a7-49c3-91a9-960b74a442c1/resourceGroups/myRG/providers/Microsoft.OperationalInsights/workspaces/myLA/datasources/a65f6a6ca0a749c391a9960b74a442c1'; however, it does not have permission to perform action 'read' on the linked scope(s) '/subscriptions/e35f6a6c-a0a7-49c3-91a9-960b74a442c1/providers/microsoft.insights/eventtypes/management' or the linked scope(s) are invalid.