### PR TITLE
Fix typo in node type name reference

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-creation-create-template.md
+++ b/articles/service-fabric/service-fabric-cluster-creation-create-template.md
@@ -79,7 +79,7 @@ The cluster authentication certificate must be configured in both the Service Fa
       "extensionProfile": {
         "extensions": [
           {
-            "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType0Name')]",
+            "name": "[concat('ServiceFabricNodeVmExt_',variables('vmNodeType0Name'))]",
             "properties": {
               ...
               "settings": {


### PR DESCRIPTION
The node type name `vmNodeType0Name` is referenced as a string instead of a variable.
See also [this](https://github.com/Azure-Samples/service-fabric-cluster-templates/pull/23) corresponding PR.