### PR TITLE
Fixed pip package name

### DIFF
--- a/articles/storage/queues/storage-python-how-to-use-queue-storage.md
+++ b/articles/storage/queues/storage-python-how-to-use-queue-storage.md
@@ -38,7 +38,7 @@ The [Azure Storage SDK for Python](https://github.com/azure/azure-storage-python
 To install via the Python Package Index (PyPI), type:
 
 ```bash
-pip install azure-storage-blob==2.1.0
+pip install azure-storage-queue==2.1.0
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The original command installs the `azure-storage-blob` package, which if you run the example will end up with an `ImportError: No module named queue`.

I believe the intent was to include the `azure-storage-queue` package, with which the code runs fine.