### PR TITLE
Updating "Getting started" with additional step needed to install git lfs

### DIFF
--- a/articles/spatial-anchors/quickstarts/get-started-ios.md
+++ b/articles/spatial-anchors/quickstarts/get-started-ios.md
@@ -28,7 +28,10 @@ You'll learn how to:
 To complete this quickstart, make sure you have:
 
 - A developer enabled macOS machine with the latest version of <a href="https://geo.itunes.apple.com/us/app/xcode/id497799835?mt=12" target="_blank">Xcode</a> and <a href="https://cocoapods.org" target="_blank">CocoaPods</a> installed.
-- Git installed via HomeBrew. Enter the following command into a single line of the Terminal: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`. Then, run `brew install git` and `brew install git-lfs`.
+- Git installed via HomeBrew:
+  - Enter the following command into a single line of the Terminal: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`. 
+  - Then, run `brew install git` and `brew install git-lfs`.
+  - Lastly, update your git config with `git lfs install` (for the current user) or `git lfs install --system` (for the entire system)
 - A developer enabled <a href="https://developer.apple.com/documentation/arkit/verifying_device_support_and_user_permission" target="_blank">ARKit compatible</a> iOS device.
 
 [!INCLUDE [Create Spatial Anchors resource](../../../includes/spatial-anchors-get-started-create-resource.md)]

--- a/articles/spatial-anchors/quickstarts/get-started-ios.md
+++ b/articles/spatial-anchors/quickstarts/get-started-ios.md
@@ -29,9 +29,9 @@ To complete this quickstart, make sure you have:
 
 - A developer enabled macOS machine with the latest version of <a href="https://geo.itunes.apple.com/us/app/xcode/id497799835?mt=12" target="_blank">Xcode</a> and <a href="https://cocoapods.org" target="_blank">CocoaPods</a> installed.
 - Git installed via HomeBrew:
-  - Enter the following command into a single line of the Terminal: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`. 
-  - Then, run `brew install git` and `brew install git-lfs`.
-  - Lastly, update your git config with `git lfs install` (for the current user) or `git lfs install --system` (for the entire system)
+  1. Enter the following command as a single line in the terminal: `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`. 
+  1. Run `brew install git` and `brew install git-lfs`.
+  1. Update your git config with `git lfs install` (for the current user) or `git lfs install --system` (for the entire system).
 - A developer enabled <a href="https://developer.apple.com/documentation/arkit/verifying_device_support_and_user_permission" target="_blank">ARKit compatible</a> iOS device.
 
 [!INCLUDE [Create Spatial Anchors resource](../../../includes/spatial-anchors-get-started-create-resource.md)]


### PR DESCRIPTION
Previously the last instruction on installing Git just said 'brew install git-lfs', but an additional step is needed to finish installation (running 'git lfs install' or 'git lfs install --system). This is a really easy step to miss (the instruction to do it is hidden in the output of 'brew install git-lfs'), and results in all sorts of unexpected errors popping up later (i.e. AppIcon images not working properly).