### PR TITLE
Fastpath can be enabled on any kind of Expressroute

### DIFF
--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -173,7 +173,7 @@ Set-AzVirtualNetworkGatewayConnection -VirtualNetworkGatewayConnection $connecti
 The range of *RoutingWeight* is 0 to 32000. The default value is 0.
 
 ## Configure ExpressRoute FastPath 
-You can enable [ExpressRoute FastPath](expressroute-about-virtual-network-gateways.md) if your ExpressRoute circuit is on [ExpressRoute Direct](expressroute-erdirect-about.md) and your virtual network gateway is Ultra Performance or ErGw3AZ. FastPath improves data path performance such as packets per second and connections per second between your on-premises network and your virtual network. 
+You can enable [ExpressRoute FastPath](expressroute-about-virtual-network-gateways.md) if your virtual network gateway is Ultra Performance or ErGw3AZ. FastPath improves data path performance such as packets per second and connections per second between your on-premises network and your virtual network. 
 
 **Configure FastPath on a new connection**
 


### PR DESCRIPTION
Fastpath can be enabled on any kind of Expressroute. The indication that it requires a Expressroute Direct is wrong.