### PR TITLE
Update quick-create-cli.md

### DIFF
--- a/articles/virtual-machines/windows/quick-create-cli.md
+++ b/articles/virtual-machines/windows/quick-create-cli.md
@@ -51,8 +51,7 @@ az vm create \
     --resource-group myResourceGroup \
     --name myVM \
     --image win2016datacenter \
-    --admin-username azureuser \
-    --admin-password myPassword
+    --admin-username azureuser
 ```
 
 It takes a few minutes to create the VM and supporting resources. The following example output shows the VM create operation was successful.


### PR DESCRIPTION
VMs require a password length between 12 and 123 characters, causing the existing code snippet to fail. I've removed it as the content owners have stated they want users to enter a password. (See #48490).