### PR TITLE
Fix a typo in user.userprinicipalname

### DIFF
--- a/articles/active-directory/saas-apps/purecloud-by-genesys-tutorial.md
+++ b/articles/active-directory/saas-apps/purecloud-by-genesys-tutorial.md
@@ -122,7 +122,7 @@ To enable Azure AD SSO in the Azure portal, follow these steps:
 
 	| Name | Source attribute|
 	| ---------------| --------------- |
-	| Email | user.userprinicipalname |
+	| Email | user.userprincipalname |
 	| OrganizationName | `Your organization name` |
 
 1. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section,  find **Certificate (Base64)** and select **Download** to download the certificate and save it on your computer.


### PR DESCRIPTION
Email is incorrectly mapped to user.userprinicipalname (there is an unnecessary "i"). It should be "user.userprincipalname" so that UPN is properly given as Email in SAML assertion. A request to fix internal app metadata is already created to Microsoft internal incident management system.