### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/articles/azure-functions/functions-create-first-function-vs-code.md
+++ b/articles/azure-functions/functions-create-first-function-vs-code.md
@@ -36,7 +36,7 @@ Before you get started, make sure you have the following requirements in place:
 ::: zone-end  
 + [Visual Studio Code](https://code.visualstudio.com/) on one of the [supported platforms](https://code.visualstudio.com/docs/supporting/requirements#_platforms).  
 ::: zone pivot="programming-language-csharp"  
-+ The [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) for Visual Studio Code.  
++ The [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) for Visual Studio Code.  
 ::: zone-end  
 ::: zone pivot="programming-language-python"
 + The [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for Visual Studio Code.  

--- a/articles/azure-functions/functions-develop-vs-code.md
+++ b/articles/azure-functions/functions-develop-vs-code.md
@@ -295,7 +295,7 @@ To run your Functions project locally, you must meet these additional requiremen
 
     | Language | Requirement |
     | -------- | --------- |
-    | **C#** | [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)<br/>[.NET Core CLI tools](https://docs.microsoft.com/dotnet/core/tools/?tabs=netcore2x)   |
+    | **C#** | [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)<br/>[.NET Core CLI tools](https://docs.microsoft.com/dotnet/core/tools/?tabs=netcore2x)   |
     | **Java** | [Debugger for Java extension](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)<br/>[Java 8](https://aka.ms/azure-jdks)<br/>[Maven 3 or later](https://maven.apache.org/) |
     | **JavaScript** | [Node.js](https://nodejs.org/)<sup>*</sup> |  
     | **Python** | [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)<br/>[Python 3.6.8](https://www.python.org/downloads/) recommended|

--- a/articles/databox-online/data-box-edge-create-iot-edge-module.md
+++ b/articles/databox-online/data-box-edge-create-iot-edge-module.md
@@ -49,7 +49,7 @@ Before you begin, make sure you have:
 - The following development resources:
 
     - [Visual Studio Code](https://code.visualstudio.com/).
-    - [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+    - [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
     - [Azure IoT Edge extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-edge).
     - [.NET Core 2.1 SDK](https://www.microsoft.com/net/download).
     - [Docker CE](https://store.docker.com/editions/community/docker-ce-desktop-windows). You may have to create an account to download and install the software.

--- a/articles/dev-spaces/get-started-netcore.md
+++ b/articles/dev-spaces/get-started-netcore.md
@@ -75,7 +75,7 @@ Enter the following Azure CLI command, using the resource group that contains yo
 Rich features like Kubernetes debugging are available for .NET Core and Node.js developers using VS Code.
 
 1. If you don't have it, install [VS Code](https://code.visualstudio.com/Download).
-1. Download and install the [VS Azure Dev Spaces](https://marketplace.visualstudio.com/items?itemName=azuredevspaces.azds) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extensions. For each extension, click install on the extension's Marketplace page, and again in VS Code.
+1. Download and install the [VS Azure Dev Spaces](https://marketplace.visualstudio.com/items?itemName=azuredevspaces.azds) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extensions. For each extension, click install on the extension's Marketplace page, and again in VS Code.
 
 ## Create a web app running in a container
 

--- a/articles/dev-spaces/how-vs-code-works-with-dev-spaces.md
+++ b/articles/dev-spaces/how-vs-code-works-with-dev-spaces.md
@@ -49,7 +49,7 @@ You can see Visual Studio Code and the Azure Dev Spaces extension working with A
 
 [azds-extension]: https://marketplace.visualstudio.com/items?itemName=azuredevspaces.azds
 [azds-yaml]: how-dev-spaces-works.md#prepare-your-code
-[csharp-extension]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp
+[csharp-extension]: https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp
 [java-extension]: https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debugger-azds
 [maven]: https://maven.apache.org
 [quickstart-java]: quickstart-java.md

--- a/articles/dev-spaces/quickstart-netcore.md
+++ b/articles/dev-spaces/quickstart-netcore.md
@@ -24,7 +24,7 @@ Azure Dev Spaces also allows you to debug and iterate using:
 
 - An Azure subscription. If you don't have one, you can create a [free account](https://azure.microsoft.com/free).
 - [Visual Studio Code installed](https://code.visualstudio.com/download).
-- The [Azure Dev Spaces](https://marketplace.visualstudio.com/items?itemName=azuredevspaces.azds) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extensions for Visual Studio Code installed.
+- The [Azure Dev Spaces](https://marketplace.visualstudio.com/items?itemName=azuredevspaces.azds) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) extensions for Visual Studio Code installed.
 - [Azure CLI installed](/cli/azure/install-azure-cli?view=azure-cli-latest).
 
 ## Create an Azure Kubernetes Service cluster

--- a/articles/dev-spaces/troubleshooting.md
+++ b/articles/dev-spaces/troubleshooting.md
@@ -286,7 +286,7 @@ Try downloading and installing the latest version of the Azure Dev Spaces CLI:
 
 You may see this error when running the Visual Studio Code debugger. You might not have the VS Code extension for C# installed on your development machine. The C# extension includes debugging support for .NET Core (CoreCLR).
 
-To fix this issue, install the [VS Code extension for C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+To fix this issue, install the [VS Code extension for C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 ### Error "Configured debug type 'coreclr' is not supported"
 

--- a/articles/iot-accelerators/iot-accelerators-remote-monitoring-create-simulated-device.md
+++ b/articles/iot-accelerators/iot-accelerators-remote-monitoring-create-simulated-device.md
@@ -79,7 +79,7 @@ To follow this how-to guide, you need:
 
 * Visual Studio Code. You can [download Visual Studio Code for Mac, Linux, and Windows](https://code.visualstudio.com/download).
 * .NET Core. You can download [.NET Core for Mac, Linux, and Windows](https://www.microsoft.com/net/download).
-* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * Postman. You can download [Postman for Mac, Windows, or Linux](https://www.getpostman.com/apps).
 * An [IoT hub deployed to your Azure subscription](../../articles/iot-hub/iot-hub-create-through-portal.md). You need the IoT hub's connection string to complete the steps in this guide. You can get the connection string from the Azure portal.
 * A Cosmos DB database that uses the SQL API and that is configured for [strong consistency](../../articles/cosmos-db/how-to-manage-database-account.md). You need the Cosmos DB database's connection string to complete the steps in this guide. You can get the connection string from the Azure portal.

--- a/articles/iot-edge/how-to-vs-code-develop-module.md
+++ b/articles/iot-edge/how-to-vs-code-develop-module.md
@@ -34,7 +34,7 @@ Install [Visual Studio Code](https://code.visualstudio.com/) first and then add 
 - [Azure IoT Tools](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools)
 - [Docker extension](https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker)
 - Visual Studio extension(s) specific to the language you're developing in:
-  - C#, including Azure Functions: [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+  - C#, including Azure Functions: [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
   - Python: [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
   - Java: [Java Extension Pack for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack)
   - C: [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)

--- a/articles/iot-edge/tutorial-csharp-module.md
+++ b/articles/iot-edge/tutorial-csharp-module.md
@@ -56,7 +56,7 @@ Before beginning this tutorial, you should have gone through the previous tutori
 
 To complete these tutorials, prepare the following additional prerequisites on your development machine:
 
-* [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+* [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 * [.NET Core 2.1 SDK](https://www.microsoft.com/net/download).
 
 ## Create a module project

--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -47,7 +47,7 @@ Before beginning this tutorial, you should have gone through the previous tutori
 
 To develop an IoT Edge module in with Azure Functions, install the following additional prerequisites on your development machine:
 
-* [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+* [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 * [The .NET Core 2.1 SDK](https://www.microsoft.com/net/download).
 
 ## Create a function project

--- a/articles/iot-edge/tutorial-develop-for-linux.md
+++ b/articles/iot-edge/tutorial-develop-for-linux.md
@@ -60,7 +60,7 @@ A development machine:
   * Make sure that your development machine supports nested virtualization. This capability is necessary for running a container engine, which you install in the next section.
 * Most operating systems that can run a container engine can be used to develop IoT Edge modules for Linux devices. This tutorial uses a Windows computer, but points out known differences on MacOS or Linux.
 * Install [Git](https://git-scm.com/), to pull module template packages later in this tutorial.  
-* [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+* [C# for Visual Studio Code (powered by OmniSharp) extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 * [.NET Core 2.1 SDK](https://www.microsoft.com/net/download).
 
 An Azure IoT Edge device on Linux:

--- a/articles/iot-edge/tutorial-machine-learning-edge-02-prepare-environment.md
+++ b/articles/iot-edge/tutorial-machine-learning-edge-02-prepare-environment.md
@@ -36,7 +36,7 @@ The development VM will be set up with:
 * [VS Code Extensions](https://marketplace.visualstudio.com/search?target=VSCode)
   * [Azure IoT Tools](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools)
   * [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-  * [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+  * [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
   * [Docker](https://marketplace.visualstudio.com/items?itemName=PeterJausovec.vscode-docker)
   * [PowerShell](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
 

--- a/articles/iot-edge/tutorial-store-data-sql-server.md
+++ b/articles/iot-edge/tutorial-store-data-sql-server.md
@@ -44,7 +44,7 @@ Before beginning this tutorial, you should have gone through the previous tutori
 
 This tutorial uses an Azure Functions module to send data to the SQL Server. To develop an IoT Edge module with Azure Functions, install the following additional prerequisites on your development machine:
 
-* [C# for Visual Studio Code (powered by OmniSharp) extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+* [C# for Visual Studio Code (powered by OmniSharp) extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 * [.NET Core 2.1 SDK](https://www.microsoft.com/net/download).
 
 ## Create a function project

--- a/articles/service-fabric/service-fabric-get-started-vs-code.md
+++ b/articles/service-fabric/service-fabric-get-started-vs-code.md
@@ -44,7 +44,7 @@ The following prerequisites must be installed for Java development:
 The following prerequisites must be installed for .NET Core/C# development:
 
 * [.NET Core](https://www.microsoft.com/net/learn/get-started) (version 2.0.0 or later)
-* [C# for Visual Studio Code (powered by OmniSharp) VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) Needed to debug C# services. You can install either by clicking the Extensions icon in the **Activity Bar** in VS Code and searching for the extension, or from the VS Code Marketplace.
+* [C# for Visual Studio Code (powered by OmniSharp) VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) Needed to debug C# services. You can install either by clicking the Extensions icon in the **Activity Bar** in VS Code and searching for the extension, or from the VS Code Marketplace.
 
 ## Setup
 

--- a/articles/storage/common/storage-use-data-movement-library.md
+++ b/articles/storage/common/storage-use-data-movement-library.md
@@ -38,7 +38,7 @@ This document demonstrates how to create a .NET Core console application that ru
 1. Visit the [.NET Core Installation Guide](https://www.microsoft.com/net/core) to install .NET Core. When selecting your environment, choose the command-line option.
 2. From the command line, create a directory for your project. Navigate into this directory, then type `dotnet new console -o <sample-project-name>` to create a C# console project.
 3. Open this directory in Visual Studio Code. This step can be quickly done via the command line by typing `code .` in Windows.
-4. Install the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) from the Visual Studio Code Marketplace. Restart Visual Studio Code.
+4. Install the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) from the Visual Studio Code Marketplace. Restart Visual Studio Code.
 5. At this point, you should see two prompts. One is for adding "required assets to build and debug." Click "yes." Another prompt is for restoring unresolved dependencies. Click "restore."
 6. Modify `launch.json` under `.vscode` to use external terminal as a console. This setting should read as `"console": "externalTerminal"`
 7. Visual Studio Code allows you to debug .NET Core applications. Hit `F5` to run your application and verify that your setup is working. You should see "Hello World!" printed to the console.

--- a/articles/storage/queues/storage-quickstart-queues-dotnet-legacy.md
+++ b/articles/storage/queues/storage-quickstart-queues-dotnet-legacy.md
@@ -31,7 +31,7 @@ For information about choosing between .NET Core and the .NET Framework, see [Ch
 ### Linux
 
 - Install [.NET Core for Linux](https://www.microsoft.com/net/download/linux)
-- Optionally install [Visual Studio Code](https://www.visualstudio.com/) and the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp&dotnetid=963890049.1518206068)
+- Optionally install [Visual Studio Code](https://www.visualstudio.com/) and the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 
 ### macOS
 


### PR DESCRIPTION
[C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) has been renamed from `ms-vscode.csharp` to `ms-dotnettools.csharp`, this PR corrects to new correct uris.