### PR TITLE
Trimming white space on the syntax

### DIFF
--- a/articles/active-directory/develop/active-directory-configurable-token-lifetimes.md
+++ b/articles/active-directory/develop/active-directory-configurable-token-lifetimes.md
@@ -258,6 +258,14 @@ In this example, you create a policy that lets your users' sign in less frequent
 
     ```powershell
     Set-AzureADPolicy -Id $policy.Id -DisplayName $policy.DisplayName -Definition @('{"TokenLifetimePolicy":{"Version":1,"MaxAgeSingleFactor":"2.00:00:00"}}')
+
+> [!NOTE]
+
+if the syntax has any leading white space. it wont throw error currently and to trim the error. Please replace below command.
+
+Get-AzureADPolicy -id <TLP-ID> | set-azureadpolicy -Definition @($((Get-AzureADPolicy -id <TLP-ID>).Replace(" ","")))
+
+TLP-ID --> is the policy id 
     ```
 
 ### Example: Create a policy for web sign-in

--- a/articles/active-directory/develop/active-directory-configurable-token-lifetimes.md
+++ b/articles/active-directory/develop/active-directory-configurable-token-lifetimes.md
@@ -261,7 +261,7 @@ In this example, you create a policy that lets your users' sign in less frequent
 
 > [!NOTE]
 
-if the syntax has any leading white space. it wont throw error currently and to trim the error. Please replace below command.
+if the syntax has any leading white space. it wont throw error currently and to trim the space. Please replace below command.
 
 Get-AzureADPolicy -id <TLP-ID> | set-azureadpolicy -Definition @($((Get-AzureADPolicy -id <TLP-ID>).Replace(" ","")))
 


### PR DESCRIPTION
> [!NOTE]

if the syntax has any leading white space. it wont throw error currently and to trim the space. Please replace below command.

Get-AzureADPolicy -id <TLP-ID> | set-azureadpolicy -Definition @($((Get-AzureADPolicy -id <TLP-ID>).Replace(" ","")))

TLP-ID --> is the policy id