### PR TITLE
Update troubleshoot-activation-problems.md

### DIFF
--- a/articles/virtual-machines/troubleshooting/troubleshoot-activation-problems.md
+++ b/articles/virtual-machines/troubleshooting/troubleshoot-activation-problems.md
@@ -42,9 +42,9 @@ Generally, Azure VM activation issues occur if the Windows VM is not configured 
 ## Solution
 
 >[!NOTE]
->If you are using a site-to-site VPN and forced tunneling, see [Use Azure custom routes to enable KMS activation with forced tunneling](https://blogs.msdn.com/b/mast/archive/2015/05/20/use-azure-custom-routes-to-enable-kms-activation-with-forced-tunneling.aspx). 
+>If you are using a site-to-site VPN and forced tunneling, see [Use Azure custom routes to enable KMS activation with forced tunneling](https://docs.microsoft.com/azure/vpn-gateway/vpn-gateway-about-forced-tunneling). 
 >
->If you are using ExpressRoute and you have a default route published, see [Azure VM may fail to activate over ExpressRoute](https://blogs.msdn.com/b/mast/archive/2015/12/01/azure-vm-may-fail-to-activate-over-expressroute.aspx).
+>If you are using ExpressRoute and you have a default route published, see [Can I block Internet connectivity to virtual networks connected to ExpressRoute circuits?](https://docs.microsoft.com/azure/expressroute/expressroute-faqs).
 
 ### Step 1 Configure the appropriate KMS client setup key
 
@@ -98,7 +98,9 @@ For the VM that is created from a custom image, you must configure the appropria
   
     Also make sure that the outbound network traffic to KMS endpoint with 1688 port is not blocked by the firewall in the VM.
 
-5. After you verify successful connectivity to kms.core.windows.net, run the following command at that elevated Windows PowerShell prompt. This command tries activation multiple times.
+5. Verify using [Network Watcher Next Hop](https://docs.microsoft.com/azure/network-watcher/network-watcher-next-hop-overview) that the next hop type from the VM in question to the destination IP 23.102.135.246 (for kms.core.windows.net) or the IP of the appropriate KMS endpoint that applies to your region is **Internet**.  If the result is VirtualAppliance or VirtualNetworkGateway, it is likely that a default route exists.  Contact your network adminstrator and work with them to determine the correct course of action.  This may be a [custom route](https://docs.microsoft.com/azure/virtual-machines/troubleshooting/custom-routes-enable-kms-activation) if that solution is consistent with your organization's policies.
+
+6. After you verify successful connectivity to kms.core.windows.net, run the following command at that elevated Windows PowerShell prompt. This command tries activation multiple times.
 
     ```powershell
     1..12 | ForEach-Object { Invoke-Expression "$env:windir\system32\cscript.exe $env:windir\system32\slmgr.vbs /ato" ; start-sleep 5 }


### PR DESCRIPTION
1. Corrected the notice at the top of the article to reference the relevant pages on docs.microsoft.com instead of missing blog posts.
2. Added a step to "Step 2 Verify the connectivity between the VM and Azure KMS service" to use Azure Network Watcher Next Hop Verify to ensure the customer ruled out the issues at the top of the article (the VM administrator troubleshooting KMS activation issues may not know the network issues involved and the added step will enable them to rule it in/out as a potential issue with minimal networking knowledge).