### PR TITLE
Link to Cosmos DB index policy JSON format desc.

### DIFF
--- a/articles/cosmos-db/how-to-manage-indexing-policy.md
+++ b/articles/cosmos-db/how-to-manage-indexing-policy.md
@@ -14,7 +14,7 @@ In Azure Cosmos DB, data is indexed following [indexing policies](index-policy.m
 
 ## Indexing policy examples
 
-Here are some examples of indexing policies shown in their JSON format, which is how they are exposed on the Azure portal. The same parameters can be set through the Azure CLI or any SDK.
+Here are some examples of indexing policies shown in [their JSON format](index-policy.md#include-exclude-paths), which is how they are exposed on the Azure portal. The same parameters can be set through the Azure CLI or any SDK.
 
 ### Opt-out policy to selectively exclude some property paths
 
@@ -148,7 +148,7 @@ This indexing policy is equivalent to the one below which manually sets ```kind`
     ],
     "excludedPaths": [
         {
-            "path": "/\"_etag\"/?"
+            "path": "/_etag/?"
         }
     ],
     "spatialIndexes": [

--- a/articles/cosmos-db/index-policy.md
+++ b/articles/cosmos-db/index-policy.md
@@ -29,7 +29,7 @@ Azure Cosmos DB supports two indexing modes:
 
 By default, indexing policy is set to `automatic`. It's achieved by setting the `automatic` property in the indexing policy to `true`. Setting this property to `true` allows Azure CosmosDB to automatically index documents as they are written.
 
-## Including and excluding property paths
+## <a id="include-exclude-paths"></a> Including and excluding property paths
 
 A custom indexing policy can specify property paths that are explicitly included or excluded from indexing. By optimizing the number of paths that are indexed, you can lower the amount of storage used by your container and improve the latency of write operations. These paths are defined following [the method described in the indexing overview section](index-overview.md#from-trees-to-property-paths) with the following additions:
 
@@ -70,7 +70,7 @@ Any indexing policy has to include the root path `/*` as either an included or a
 
 - For paths with regular characters that include: alphanumeric characters and _ (underscore), you don’t have to escape the path string around double quotes (for example, "/path/?"). For paths with other special characters, you need to escape the path string around double quotes (for example, "/\"path-abc\"/?"). If you expect special characters in your path, you can escape every path for safety. Functionally it doesn’t make any difference if you escape every path Vs just the ones that have special characters.
 
-- The system property "etag" is excluded from indexing by default, unless the etag is added to the included path for indexing.
+- The system property "_etag" is excluded from indexing by default, unless the etag is added to the included path for indexing.
 
 When including and excluding paths, you may encounter the following attributes:
 


### PR DESCRIPTION
* Adds a link to a description of the Cosmos DB indexing policy JSON
  format.
* Adds stable anchor for said link.
* Removed unneeded quotes around "_etag" in the example indexing
  policies.
* Refers to the system property with its leading underscore, "_etag".

Fixes https://github.com/MicrosoftDocs/azure-docs/issues/49417