### PR TITLE
Update sql-database-business-continuity.md

### DIFF
--- a/articles/sql-database/sql-database-business-continuity.md
+++ b/articles/sql-database/sql-database-business-continuity.md
@@ -59,7 +59,7 @@ If the maximum supported backup retention period for point-in-time restore (PITR
 |:---------------------------------------------| :-------------- | :----------------|
 | Automatic failover                           |     No          |      Yes         |
 | Fail over multiple databases simultaneously  |     No          |      Yes         |
-| Update connection string after failover      |     Yes         |      No          |
+| User must update connection string after failover      |     Yes         |      No          |
 | Managed instance supported                   |     No          |      Yes         |
 | Can be in same region as primary             |     Yes         |      No          |
 | Multiple replicas                            |     Yes         |      No          |


### PR DESCRIPTION
I thought I had proposed this change before. The current wording is unclear - it could be taken as "service updates connection string after failover" in which case the meaning becomes the opposite of what is intended.
Feel free to change the wording if it doesn't fit in the chart or the style guide, but it needs to be clearer. Particularly when localized, the meaning can be distorted.