### PR TITLE
Updated docs to make TLS instructions clearer.

### DIFF
--- a/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
+++ b/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
@@ -16,8 +16,7 @@ There's an industry-wide push toward the exclusive use of Transport Layer Securi
 
 As a part of this effort, we'll be making the following changes to Azure Cache for Redis:
 
-* **Phase 1:** We'll configure the default minimum TLS version to be 1.2 for newly created cache instances
-(This used to be TLS 1.0). Existing cache instances won't be updated at this point.  You'll be allowed to [change the minimum TLS version](cache-configure.md#access-ports) back to 1.0 or 1.1 for backward compatibility, if needed.  This change can be done through the Azure portal or other management APIs.
+* **Phase 1:** We'll configure the default minimum TLS version to be 1.2 for newly created cache instances. (This used to be TLS 1.0). Existing cache instances won't be updated at this point. You'll be allowed to [change the minimum TLS version](cache-configure.md#access-ports) back to 1.0 or 1.1 for backward compatibility, if needed. This change can be done through the Azure portal or other management APIs.
 * **Phase 2:** We'll stop supporting TLS versions 1.0 and 1.1. After this change, your application will be required to use TLS 1.2 or later to communicate with your cache.
 
 Additionally, as a part of this change, we'll be removing support for older, insecure cypher suites.  Our supported cypher suites will be restricted to the following when the cache is configured with a minimum TLS version of 1.2.
@@ -84,27 +83,29 @@ In Java 8, TLS 1.2 is used by default and shouldn't require updates to your clie
 Node Redis and IORedis use TLS 1.2 by default.
 
 ### PHP
+
 #### Predis
- For versions less than PHP 7 Predis supports only TLS 1.0. These do not work with TLS 1.2, you need to upgrade.
  
- PHP 7.0 to PHP 7.2.1: Predis uses only TLS 1.0 or 1.1 by default. You can use the workaround below to use TLS 1.2.
- Specify TLS 1.2 when you create the client instance:
+* Versions earlier than PHP 7: Predis supports only TLS 1.0. These versions don't work with TLS 1.2; you must upgrade to use TLS 1.2.
+ 
+* PHP 7.0 to PHP 7.2.1: Predis uses only TLS 1.0 or 1.1 by default. You can use the following workaround to use TLS 1.2. Specify TLS 1.2 when you create the client instance:
 
-``` PHP
-$redis=newPredis\Client([
-    'scheme'=>'tls',
-    'host'=>'host',
-    'port'=>6380,
-    'password'=>'password',
-    'ssl'=>[
-        'crypto_type'=>STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-    ],
-]);
-```
+  ``` PHP
+  $redis=newPredis\Client([
+      'scheme'=>'tls',
+      'host'=>'host',
+      'port'=>6380,
+      'password'=>'password',
+      'ssl'=>[
+          'crypto_type'=>STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+      ],
+  ]);
+  ```
 
-On PHP 7.3 or above, Predis uses the latest TLS version.
+* PHP 7.3 and later versions: Predis uses the latest TLS version.
 
 #### PhpRedis
+
 PhpRedis doesn't support TLS on any PHP version.
 
 ### Python

--- a/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
+++ b/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
@@ -16,7 +16,8 @@ There's an industry-wide push toward the exclusive use of Transport Layer Securi
 
 As a part of this effort, we'll be making the following changes to Azure Cache for Redis:
 
-* **Phase 1:** We'll configure the default minimum TLS version to be 1.2 for newly created cache instances.  Existing cache instances won't be updated at this point.  You'll be allowed to [change the minimum TLS version](cache-configure.md#access-ports) back to 1.0 or 1.1 for backward compatibility, if needed.  This change can be done through the Azure portal or other management APIs.
+* **Phase 1:** We'll configure the default minimum TLS version to be 1.2 for newly created cache instances
+(This used to be TLS 1.0). Existing cache instances won't be updated at this point.  You'll be allowed to [change the minimum TLS version](cache-configure.md#access-ports) back to 1.0 or 1.1 for backward compatibility, if needed.  This change can be done through the Azure portal or other management APIs.
 * **Phase 2:** We'll stop supporting TLS versions 1.0 and 1.1. After this change, your application will be required to use TLS 1.2 or later to communicate with your cache.
 
 Additionally, as a part of this change, we'll be removing support for older, insecure cypher suites.  Our supported cypher suites will be restricted to the following when the cache is configured with a minimum TLS version of 1.2.
@@ -83,8 +84,11 @@ In Java 8, TLS 1.2 is used by default and shouldn't require updates to your clie
 Node Redis and IORedis use TLS 1.2 by default.
 
 ### PHP
-
-Predis on PHP 7 won't work because PHP 7 supports only TLS 1.0. On PHP 7.2.1 or earlier, Predis uses TLS 1.0 or 1.1 by default. You can specify TLS 1.2 when you create the client instance:
+#### Predis
+ < PHP 7 Predis supports only TLS 1.0. Does not work with TLS 1.2, you need to upgrade.
+ 
+ PHP 7.0 to PHP 7.2.1 -> Predis uses only TLS 1.0 or 1.1 by default. You can use the workaround below to use TLS 1.2.
+ Specify TLS 1.2 when you create the client instance:
 
 ``` PHP
 $redis=newPredis\Client([
@@ -100,6 +104,7 @@ $redis=newPredis\Client([
 
 On PHP 7.3 or above, Predis uses the latest TLS version.
 
+#### PhpRedis
 PhpRedis doesn't support TLS on any PHP version.
 
 ### Python

--- a/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
+++ b/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
@@ -85,9 +85,9 @@ Node Redis and IORedis use TLS 1.2 by default.
 
 ### PHP
 #### Predis
- < PHP 7 Predis supports only TLS 1.0. Does not work with TLS 1.2, you need to upgrade.
+ For versions less than PHP 7 Predis supports only TLS 1.0. These do not work with TLS 1.2, you need to upgrade.
  
- PHP 7.0 to PHP 7.2.1 -> Predis uses only TLS 1.0 or 1.1 by default. You can use the workaround below to use TLS 1.2.
+ PHP 7.0 to PHP 7.2.1: Predis uses only TLS 1.0 or 1.1 by default. You can use the workaround below to use TLS 1.2.
  Specify TLS 1.2 when you create the client instance:
 
 ``` PHP

--- a/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
+++ b/articles/azure-cache-for-redis/cache-remove-tls-10-11.md
@@ -16,7 +16,7 @@ There's an industry-wide push toward the exclusive use of Transport Layer Securi
 
 As a part of this effort, we'll be making the following changes to Azure Cache for Redis:
 
-* **Phase 1:** We'll configure the default minimum TLS version to be 1.2 for newly created cache instances. (This used to be TLS 1.0). Existing cache instances won't be updated at this point. You'll be allowed to [change the minimum TLS version](cache-configure.md#access-ports) back to 1.0 or 1.1 for backward compatibility, if needed. This change can be done through the Azure portal or other management APIs.
+* **Phase 1:** We'll configure the default minimum TLS version to be 1.2 for newly created cache instances. (This used to be TLS 1.0.) Existing cache instances won't be updated at this point. You'll be allowed to [change the minimum TLS version](cache-configure.md#access-ports) back to 1.0 or 1.1 for backward compatibility, if needed. This change can be done through the Azure portal or other management APIs.
 * **Phase 2:** We'll stop supporting TLS versions 1.0 and 1.1. After this change, your application will be required to use TLS 1.2 or later to communicate with your cache.
 
 Additionally, as a part of this change, we'll be removing support for older, insecure cypher suites.  Our supported cypher suites will be restricted to the following when the cache is configured with a minimum TLS version of 1.2.


### PR DESCRIPTION
Clearer instructions for Predis client on PHP. Also clarify the previous minimum version.