### PR TITLE
Update tutorial-enable-sspr-writeback.md

### DIFF
--- a/articles/active-directory/authentication/tutorial-enable-sspr-writeback.md
+++ b/articles/active-directory/authentication/tutorial-enable-sspr-writeback.md
@@ -50,7 +50,6 @@ Azure AD Connect lets you synchronize users, groups, and credential between an o
 To correctly work with SSPR writeback, the account specified in Azure AD Connect must have the appropriate permissions and options set. If you're not sure which account is currently in use, open Azure AD Connect and select the **View current configuration** option. The account that you need to add permissions to is listed under **Synchronized Directories**. The following permissions and options must be set on the account:
 
 * **Reset password**
-* **Change password**
 * **Write permissions** on `lockoutTime`
 * **Write permissions** on `pwdLastSet`
 * **Extended rights** on either:
@@ -68,7 +67,6 @@ To set up the appropriate permissions for password writeback to occur, complete 
 1. For **Principal**, select the account that permissions should be applied to (the account used by Azure AD Connect).
 1. In the **Applies to** drop-down list, select **Descendant User objects**.
 1. Under *Permissions*, select the boxes for the following options:
-    * **Change password**
     * **Reset password**
 1. Under *Properties*, select the boxes for the following options. You need to scroll through the list to find these options, which may already be set by default:
     * **Write lockoutTime**


### PR DESCRIPTION
"Change Password" permission is not required and in=fact it's not even granted to the MSOL account during the default wizard configuration/installation.
Change password  is in=fact inherited from SELF and Everyone
dsacls "CN=MSOL_6fad122ae1f5,CN=Users,DC=FABRIKAM,DC=COM"
Allow Everyone                        Change Password
Allow NT AUTHORITY\SELF               Change Password

Even the Set-ADSyncPasswordWritebackPermissions cmdlet (part of "C:\Program Files\Microsoft Azure Active Directory Connect\AdSyncConfig\AdSyncConfig.psm1") does not assign Password Change:
    # Define AD ACL
    $acls = "`"$ADConnectorIdentity" + ":CA;Reset Password;user`"" + " "
    $acls += "`"$ADConnectorIdentity" + ":WP;lockoutTime;user`"" + " "
    $acls += "`"$ADConnectorIdentity" + ":WP;pwdLastSet;user`""