### PR TITLE
Behavior of unhealthy threshold with v2 is different from v1.

### DIFF
--- a/articles/application-gateway/application-gateway-probe-overview.md
+++ b/articles/application-gateway/application-gateway-probe-overview.md
@@ -59,7 +59,7 @@ Once the match criteria is specified, it can be attached to probe configuration 
 | Probe URL |http://127.0.0.1:\<port\>/ |URL path |
 | Interval |30 |The amount of time in seconds to wait before the next health probe is sent.|
 | Time-out |30 |The amount of time in seconds the application gateway waits for a probe response before marking the probe as unhealthy. If a probe returns as healthy, the corresponding backend is immediately marked as healthy.|
-| Unhealthy threshold |3 |Governs how many probes to send in case there's a failure of the regular health probe. These additional health probes are sent in quick succession to determine the health of the backend quickly and don't wait for the probe interval. The back-end server is marked down after the consecutive probe failure count reaches the unhealthy threshold. |
+| Unhealthy threshold |3 |Governs how many probes to send in case there's a failure of the regular health probe. These additional health probes are sent in quick succession to determine the health of the backend quickly and don't wait for the probe interval. This behaivor is only v1 SKU. In the case of v2 SKU, the health probes wait the interval. The back-end server is marked down after the consecutive probe failure count reaches the unhealthy threshold. |
 
 > [!NOTE]
 > The port is the same port as the back-end HTTP settings.


### PR DESCRIPTION
I found that when health probe was failed in AppGW v2, next probe was sent after 30s interval. I think the following sentence in this document is only v1 SKU.  Could you revi

"These additional health probes are sent in quick succession to determine the health of the backend quickly and don't wait for the probe interval. "