### PR TITLE
Fix Redis usage sample code

### DIFF
--- a/articles/azure-cache-for-redis/cache-dotnet-how-to-use-azure-redis-cache.md
+++ b/articles/azure-cache-for-redis/cache-dotnet-how-to-use-azure-redis-cache.md
@@ -124,7 +124,7 @@ Add the following code for the `Main` procedure of the `Program` class for your 
         {
             // Connection refers to a property that returns a ConnectionMultiplexer
             // as shown in the previous example.
-            IDatabase cache = lazyConnection.Value.GetDatabase();
+            IDatabase cache = Connection.GetDatabase();
 
             // Perform cache operations using the cache object...
 


### PR DESCRIPTION
This sample code was using the wrong variable to refer to the ConnectionMultiplexer object that is used for communicating with Redis. It is clear from the comments in the sample as well as the code snippet above this sample that the original intention was to use the "Connection" property instead of the private "lazyConnection" field.