### PR TITLE
In "Shrink the Database" Section

### DIFF
--- a/articles/active-directory/hybrid/tshoot-connect-recover-from-localdb-10gb-limit.md
+++ b/articles/active-directory/hybrid/tshoot-connect-recover-from-localdb-10gb-limit.md
@@ -69,7 +69,7 @@ The name of the database created for Azure AD Connect is **ADSync**. To perform 
 
 3. Navigate to folder `%ProgramFiles%\Microsoft SQL Server\110\Tools\Binn`.
 
-4. Start **sqlcmd** utility by running the command `./SQLCMD.EXE -S "(localdb)\.\ADSync" -U <Username> -P <Password>`, using the credential of a sysadmin or the database DBO.
+4. Start **sqlcmd** utility by running the command `SQLCMD using ./SQLCMD.EXE -S "(localdb)\.\ADSync"`.
 
 5. To shrink the database, at the sqlcmd prompt (1>), enter `DBCC Shrinkdatabase(ADSync,1);`, followed by `GO` in the next line.
 


### PR DESCRIPTION
In "Shrink the Database" Section when we attempt to launch SQLCMD using ./SQLCMD.EXE -S "(localdb)\.\ADSync" -U <Username> -P <Password>, the execution fails stating "Password: Sqlcmd: Error: Microsoft SQL Server Native Client 11.0 : Login failed
for user" and this is the case with the account used during installation or a user who is a member of the local administrators or Sync Service account or a user who is member of local group ADSyncAdmins
	
If we do not specify -U and -P switch then execution completes successfully. So ideally SQLCMD should be executed as SQLCMD using ./SQLCMD.EXE -S "(localdb)\.\ADSync".
	
As per the article for SQLCMD https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility?view=sql-server-ver15. "If neither the -U option or the -P option is specified,  sqlcmd tries to connect by using Microsoft Windows Authentication mode. Authentication is based on the Windows account of the user who is running sqlcmd"