### PR TITLE
In the section 'Abandon the existing encryption key'

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
@@ -79,7 +79,7 @@ Abandon the existing encryption key so that new encryption key can be created:
 
 2. Start a new PowerShell session.
 
-3. Navigate to folder: `$env:Program Files\Microsoft Azure AD Sync\bin\`
+3. Navigate to folder: `'$env:ProgramFiles\Microsoft Azure AD Sync\bin\'`
 
 4. Run the command: `./miiskmu.exe /a`
 


### PR DESCRIPTION
In the section 'Abandon the existing encryption key', Point 3 states that we need to Navigate to $env:Program Files\Microsoft Azure AD Sync\bin\. There is no space in Program Files and ideally, the revised command to be used is '$env:Program Files\Microsoft Azure AD Sync\bin\'