### PR TITLE
Update troubleshoot to add reminder to check for soft-deleted users

### DIFF
--- a/articles/active-directory/governance/entitlement-management-troubleshoot.md
+++ b/articles/active-directory/governance/entitlement-management-troubleshoot.md
@@ -47,6 +47,10 @@ This article describes some items you should check to help you troubleshoot Azur
 
 * Ensure your directory is not configured for multi-geo. Entitlement management currently does not support multi-geo locations for SharePoint Online. SharePoint Online sites must be in the default geo-location to be governed with entitlement management. For more information, see [Multi-Geo Capabilities in OneDrive and SharePoint Online](https://docs.microsoft.com/Office365/Enterprise/multi-geo-capabilities-in-onedrive-and-sharepoint-online-in-office-365).
 
+## Access packages
+
+* If you are attempting to delete an access package or a policy and get an error that there are active assignments, but do not see any users with assignments, also check to see if any recently deleted users still have assignments.  During the 30-day window after a user has been deleted, the user account can be restored.   
+
 ## External users
 
 * When an external user wants to request access to an access package, make sure they are using the **My Access portal link** for the access package. For more information, see [Share link to request an access package](entitlement-management-access-package-settings.md). If an external user just visits **myaccess.microsoft.com** and does not use the full My Access portal link, then they will see the access packages available to them in their own organization and not in your organization.

--- a/articles/active-directory/governance/entitlement-management-troubleshoot.md
+++ b/articles/active-directory/governance/entitlement-management-troubleshoot.md
@@ -49,7 +49,7 @@ This article describes some items you should check to help you troubleshoot Azur
 
 ## Access packages
 
-* If you are attempting to delete an access package or a policy and get an error that there are active assignments, but do not see any users with assignments, also check to see if any recently deleted users still have assignments.  During the 30-day window after a user has been deleted, the user account can be restored.   
+* If you attempt to delete an access package or policy and see an error message that says there are active assignments, if you don't see any users with assignments, check to see whether any recently deleted users still have assignments. During the 30-day window after a user is deleted, the user account can be restored.   
 
 ## External users
 


### PR DESCRIPTION
If a user tries to delete an entitlement management object and gets an error indicating that the item cannot be deleted because there are active assignments, the user should check soft-deleted users.  (897895)