### PR TITLE
WAF log query for blocked requests is invalid

### DIFF
--- a/articles/web-application-firewall/afds/waf-front-door-monitor.md
+++ b/articles/web-application-firewall/afds/waf-front-door-monitor.md
@@ -34,7 +34,7 @@ The following example query obtains WAF logs on blocked requests:
 ``` WAFlogQuery
 AzureDiagnostics
 | where ResourceType == "FRONTDOORS" and Category == "FrontdoorWebApplicationFirewallLog"
-| where action_s == "Block"
+| where action_name_s == "Block"
 
 ```
 


### PR DESCRIPTION
'action_s' should be 'action_name_s'