### PR TITLE
OMS Workspace resource Sku Parameter update

### DIFF
--- a/articles/automation/automation-update-management-deploy-template.md
+++ b/articles/automation/automation-update-management-deploy-template.md
@@ -165,8 +165,7 @@ The following parameters in the template are set with a default value for the Lo
             "location": "[parameters('location')]",
             "properties": {
                 "sku": { 
-                    "name": "CapacityReservation",
-                    "capacityReservationLevel": 100
+                    "name": "[parameters('pricingTier')]"
                 },
                 "retentionInDays": "[parameters('dataRetention')]",
                 "features": {


### PR DESCRIPTION
pricingTier parameter was not used. OMS Workspace resource had a hardcoded value for 100GB/day Capacity Reservation tier which would result in ~£5,500 commitment.