### PR TITLE
SKU name DCsv2 was missing an 's' everywhere

### DIFF
--- a/articles/virtual-machines/dcv2-series.md
+++ b/articles/virtual-machines/dcv2-series.md
@@ -9,10 +9,10 @@
  ms.author: lahugh
 ---
 
-# Preview: DCv2-series
+# Preview: DCsv2-series
 
 
-The DCv2-series can help protect the confidentiality and integrity of your data and code while it’s processed in the public cloud. These machines are backed by the latest generation of Intel XEON E-2288G Processor with SGX technology. With the Intel Turbo Boost Technology these machines can go up to 5.0GHz. DCv2 series instances enable customers to build secure enclave-based applications to protect their code and data while it’s in use.
+The DCsv2-series can help protect the confidentiality and integrity of your data and code while it’s processed in the public cloud. These machines are backed by the latest generation of Intel XEON E-2288G Processor with SGX technology. With the Intel Turbo Boost Technology these machines can go up to 5.0GHz. DCsv2 series instances enable customers to build secure enclave-based applications to protect their code and data while it’s in use.
 
 Example use cases include confidential multiparty data sharing, fraud detection, anti-money laundering, blockchain, confidential usage analytics, intelligence analysis and confidential machine learning.
 
@@ -35,10 +35,10 @@ Memory Preserving Updates: Not Supported
 | Standard_DC4s_v2 | 4    | 16          | 200                    | 4              | 8000/64 (86)                                                            | 6400/96                                   | 2                                            |
 | Standard_DC8_v2  | 8   | 32          | 400                    | 8              | 16000/128 (172)                                                         | 12800/192                                 | 2                                            |
 
-- DCv2-series VMs are [generation 2 VMs](./linux/generation-2.md#creating-a-generation-2-vm) and only support `Gen2` images.
+- DCsv2-series VMs are [generation 2 VMs](./linux/generation-2.md#creating-a-generation-2-vm) and only support `Gen2` images.
 - Currently available in UK South only.
 - Previous generation of Confidential Compute VMs: [DC Series](sizes-previous-gen.md)
-- Create DCv2 VMs using Azure Portal [Create VM - Portal](./linux/quick-create-portal.md)
+- Create DCsv2 VMs using Azure Portal [Create VM - Portal](./linux/quick-create-portal.md)
 
 
 


### PR DESCRIPTION
The SKU family name is DCsv2. It was DCv2 in the docs, corrected it to DCsv2