### PR TITLE
Adding Switzerland's PDL value of CHE to the table.

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sync-feature-preferreddatalocation.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-feature-preferreddatalocation.md
@@ -46,6 +46,7 @@ The geos in Office 365 available for Multi-Geo are:
 | Japan | JPN |
 | Korea | KOR |
 | South Africa | ZAF |
+| Switzerland | CHE |
 | United Arab Emirates | ARE |
 | United Kingdom | GBR |
 | United States | NAM |


### PR DESCRIPTION
The Office 365 Multi-Geo team has enabled Switzerland as of March 18th 2020 to be used by all Multi-Geo customers. Adding the PreferredDataLocation value of CHE to the table. Please contact PM 'brianday' with any questions. Thank you.