### PR TITLE
Update luis-boundaries.md

### DIFF
--- a/articles/cognitive-services/LUIS/luis-boundaries.md
+++ b/articles/cognitive-services/LUIS/luis-boundaries.md
@@ -34,7 +34,7 @@ If your app exceeds the LUIS model limits and boundaries, consider using a [LUIS
 | [Preview - Dynamic list entities](https://aka.ms/luis-api-v3-doc#dynamic-lists-passed-in-at-prediction-time)|2 lists of ~1k per query prediction endpoint request|
 | [Patterns](luis-concept-patterns.md)|500 patterns per application.<br>Maximum length of pattern is 400 characters.<br>3 Pattern.any entities per pattern<br>Maximum of 2 nested optional texts in pattern|
 | [Pattern.any](./luis-concept-entity-types.md)|100 per application, 3 pattern.any entities per pattern |
-| [Phrase list][phrase-list]|500 phrase lists. Non-interchangeable phraselist has max of 5,000 phrases. Interchangeable Phraselist has max of 50,000 phrases. Maximum number of total phrases per application  of 500,000 phrases.|
+| [Phrase list][phrase-list]|500 phrase lists. 10 global phrase lists due to the model as a feature limit. Non-interchangeable phraselist has max of 5,000 phrases. Interchangeable Phraselist has max of 50,000 phrases. Maximum number of total phrases per application  of 500,000 phrases.|
 | [Prebuilt entities](./luis-prebuilt-entities.md) | no limit|
 | [Regular expression entities](./luis-concept-entity-types.md)|20 entities<br>500 character max. per regular expression entity pattern|
 | [Roles](luis-concept-roles.md)|300 roles per application. 10 roles per entity|


### PR DESCRIPTION
You can't have more than 10 global phrase lists because that means each model would have 10 phrase lists as descriptors, and the model as a feature limit states that you can only have 10 phrase lists as a descriptor to each model, but it's not obvious to people that this is what's happening when they try to create more than 10 global phrase lists.