### PR TITLE
Update formatting for CLI example

### DIFF
--- a/articles/container-instances/container-instances-restart-policy.md
+++ b/articles/container-instances/container-instances-restart-policy.md
@@ -52,7 +52,10 @@ az container create \
 Azure Container Instances starts the container, and then stops it when its application (or script, in this case) exits. When Azure Container Instances stops a container whose restart policy is `Never` or `OnFailure`, the container's status is set to **Terminated**. You can check a container's status with the [az container show][az-container-show] command:
 
 ```azurecli-interactive
-az container show --resource-group myResourceGroup --name mycontainer --query containers[0].instanceView.currentState.state
+az container show \
+    --resource-group myResourceGroup \
+    --name mycontainer \
+    --query containers[0].instanceView.currentState.state
 ```
 
 Example output:


### PR DESCRIPTION
What: Split 2nd cli example into multiple lines
Why: The example is too long to fit on a single causing it to scroll horizontally

closes #50561