### PR TITLE
Fix client/browser-side trackTrace documentation

### DIFF
--- a/articles/azure-monitor/app/api-custom-events-metrics.md
+++ b/articles/azure-monitor/app/api-custom-events-metrics.md
@@ -563,7 +563,11 @@ telemetry.trackTrace({
 *Client/Browser-side JavaScript*
 
 ```javascript
-trackTrace(message: string, properties?: {[string]:string}, severityLevel?: SeverityLevel)
+trackTrace({
+    message: string, 
+    properties?: {[string]:string}, 
+    severityLevel?: SeverityLevel
+})
 ```
 
 Log a diagnostic event such as entering or leaving a method.


### PR DESCRIPTION
trackTrace does not - at least in the browser - take 3 separate parameters. It takes a single parameter, an object, with properties `message` and `properties`. I left the documentation in for `severityLevel` but I am unconvinced that the existing documentation on providing it is accurate, as I was unable to use it in my testing.