### PR TITLE
Clarification of NotActions and multiple roles

### DIFF
--- a/articles/role-based-access-control/role-definitions.md
+++ b/articles/role-based-access-control/role-definitions.md
@@ -205,7 +205,7 @@ The `DataActions` permission specifies the data operations that the role allows 
 The `NotDataActions` permission specifies the data operations that are excluded from the allowed `DataActions`. The access granted by a role (effective permissions) is computed by subtracting the `NotDataActions` operations from the `DataActions` operations. Each resource provider provides its respective set of APIs to fulfill data operations.
 
 > [!NOTE]
-> If a user is assigned a role that excludes a data operation in `NotDataActions`, and is assigned a second role that grants access to the same data operation, the user is allowed to perform that data operation. `NotDataActions` is not a deny rule – it is simply a convenient way to create a set of allowed data operations when specific data operations need to be excluded.
+> If a user is assigned a role that excludes a data operation in `NotDataActions`, and is assigned a second role that grants explicit (not wildcarded) access to the same data operation, the user is allowed to perform that data operation. `NotDataActions` is not a deny rule – it is simply a convenient way to create a set of allowed data operations when specific data operations need to be excluded.
 >
 
 ## AssignableScopes


### PR DESCRIPTION
I'd like to see the not cleaned up in the NotActions section to be a little more clear about what happens when multiple roles are assigned.

The way that I read this is if one roles has NotActions but a second role has Actions that the Actions allowed on the second role would override the NotActions specified on the first role. This appears to be the case only if the Actions are specified in the second role, not wildcarded.

For an example, take Contributor and Owner. They both have <"actions": ["*"],> but the Contributor role has specific NotActions defined. Those specified NotActions appear to override the wildcard allowed actions on the Owner role.

I've simply changed language here to say that a second role that grants explicit access to the same operations (not wildcarded) will allow the user to perform that operation.