### PR TITLE
Update storage-ref-azcopy-sync.md

### DIFF
--- a/articles/storage/common/storage-ref-azcopy-sync.md
+++ b/articles/storage/common/storage-ref-azcopy-sync.md
@@ -61,6 +61,9 @@ Sync a single file:
 azcopy sync "/path/to/file.txt" "https://[account].blob.core.windows.net/[container]/[path/to/blob]"
 ```
 
+[!NOTE] The destination blob MUST exist. Use ```azcopy copy``` to copy a single file which does not yet exist in the destination.
+Otherwise, the error *Cannot perform sync due to error: sync must happen between source and destination of the same type, e.g. either file <-> file, or directory/container <-> directory/container* occurs.
+
 Same as above, but this time, also compute MD5 hash of the file content and save it as the blob's Content-MD5 property:
 
 ```azcopy

--- a/articles/storage/common/storage-ref-azcopy-sync.md
+++ b/articles/storage/common/storage-ref-azcopy-sync.md
@@ -61,8 +61,8 @@ Sync a single file:
 azcopy sync "/path/to/file.txt" "https://[account].blob.core.windows.net/[container]/[path/to/blob]"
 ```
 
-[!NOTE] The destination blob MUST exist. Use ```azcopy copy``` to copy a single file which does not yet exist in the destination.
-Otherwise, the error *Cannot perform sync due to error: sync must happen between source and destination of the same type, e.g. either file <-> file, or directory/container <-> directory/container* occurs.
+> [!NOTE]
+> The destination blob *must* exist. Use `azcopy copy` to copy a single file that does not yet exist in the destination. Otherwise, the following error occurs: `Cannot perform sync due to error: sync must happen between source and destination of the same type, e.g. either file <-> file, or directory/container <-> directory/container`.
 
 Same as above, but this time, also compute MD5 hash of the file content and save it as the blob's Content-MD5 property:
 


### PR DESCRIPTION
It turns out that when using **azcopy sync**, for a single file, the destination blob MUST exist. Otherwise, it will fail with a less-than-user-friendly error, leaving people wondering why the provided example does not work.
 
See: https://github.com/Azure/azure-storage-azcopy/issues/328