### PR TITLE
Update Sign-ins log retention period

### DIFF
--- a/articles/active-directory/reports-monitoring/reference-reports-data-retention.md
+++ b/articles/active-directory/reports-monitoring/reference-reports-data-retention.md
@@ -65,7 +65,7 @@ For security signals, the collection process starts when you opt-in to use the *
 | Report                 | Azure AD Free | Azure AD Basic | Azure AD Premium P1 | Azure AD Premium P2 |
 | :--                    | :--           | :--            | :--                 | :--                 |
 | Audit logs             | 7 days        |  7 days        | 30 days             | 30 days             |
-| Sign-ins               | N/A           |  N/A           | 30 days             | 30 days             |
+| Sign-ins               | 7 days        |  7 days        | 30 days             | 30 days             |
 | Azure MFA usage        | 30 days       |  30 days       | 30 days             | 30 days             |
 
 You can retain the audit and sign-in activity data for longer than the default retention period outlined above by routing it to an Azure storage account using Azure Monitor. For more information, see [Archive Azure AD logs to an Azure storage account](quickstart-azure-monitor-route-logs-to-storage-account.md).


### PR DESCRIPTION
As announced in blog below, AAD Free users can see sign-ins log for 7 days.

https://techcommunity.microsoft.com/t5/azure-active-directory-identity/new-tools-to-block-legacy-authentication-in-your-organization/ba-p/1225302