### PR TITLE
Improve commands for Linux

### DIFF
--- a/includes/vpn-gateway-vwan-config-openvpn-clients.md
+++ b/includes/vpn-gateway-vwan-config-openvpn-clients.md
@@ -126,7 +126,7 @@
 5. Extract the private key and the base64 thumbprint from the .pfx. There are multiple ways to do this. Using OpenSSL on your computer is one way.
 
     ```
-    openssl.exe pkcs12 -in "filename.pfx" -nodes -out "profileinfo.txt"
+    openssl pkcs12 -in "filename.pfx" -nodes -out "profileinfo.txt"
     ```
    The *profileinfo.txt* file will contain the private key and the thumbprint for the CA, and the Client certificate. Be sure to use the thumbprint of the client certificate.
 
@@ -157,7 +157,7 @@
 11. To connect using the command line, type the following command:
   
     ```
-    sudo openvpn –-config <name and path of your VPN profile file>&
+    sudo openvpn --config <name and path of your VPN profile file>&
     ```
 12. To connect using the GUI, go to system settings.
 13. Click **+** to add a new VPN connection.


### PR DESCRIPTION
* The linux section improved
** 5. `openssl.exe pkcs12`  is not appropriate for Linux enviroment.
** 11. `sudo openvpn –-config` is  contained `\u2013` (dash)