### PR TITLE
Active connection metrics is provided at namespace level only

### DIFF
--- a/articles/event-hubs/event-hubs-metrics-azure-monitor.md
+++ b/articles/event-hubs/event-hubs-metrics-azure-monitor.md
@@ -85,7 +85,7 @@ Counts the number of data and management operations requests.
 
 | Metric Name | Description |
 | ------------------- | ----------------- |
-|ActiveConnections |The number of active connections on a namespace as well as on an entity.<br/><br/> Unit: Count <br/> Aggregation Type: Total <br/> Dimension: EntityName|
+|ActiveConnections |The number of active connections on a namespace.<br/><br/> Unit: Count <br/> Aggregation Type: Total <br/> Dimension: EntityName|
 |Connections Opened |The number of open connections.<br/><br/> Unit: Count <br/> Aggregation Type: Total <br/> Dimension: EntityName|
 |Connections Closed |The number of closed connections.<br/><br/> Unit: Count <br/> Aggregation Type: Total <br/> Dimension: EntityName|
 


### PR DESCRIPTION
Add filter by entity is disabled when ActiveConnections metric is selected.
![image](https://user-images.githubusercontent.com/1885824/77324500-9f159300-6cf5-11ea-9a40-70d5b94da61c.png)
