### PR TITLE
Fixed CIDRE Ranges

### DIFF
--- a/articles/load-balancer/tutorial-load-balancer-standard-manage-portal.md
+++ b/articles/load-balancer/tutorial-load-balancer-standard-manage-portal.md
@@ -120,9 +120,9 @@ In this section you'll need to replace the following parameters in the steps wit
 | **\<resource-group-name>**  | myResourceGroupSLB (Select existing resource group) |
 | **\<virtual-network-name>** | myVNet          |
 | **\<region-name>**          | West Europe      |
-| **\<IPv4-address-space>**   | 10.1.0.0\16          |
+| **\<IPv4-address-space>**   | 10.1.0.0/16          |
 | **\<subnet-name>**          | mySubnet        |
-| **\<subnet-address-range>** | 10.1.0.0\24          |
+| **\<subnet-address-range>** | 10.1.0.0/24          |
 
 [!INCLUDE [virtual-networks-create-new](../../includes/virtual-networks-create-new.md)]
 


### PR DESCRIPTION
CIDRE ranges use '/' and documentation uses '\'. This will not work if the user copies and pastes this info into the Azure portal.