### PR TITLE
Remove indented code block

### DIFF
--- a/articles/machine-learning/how-to-configure-auto-train.md
+++ b/articles/machine-learning/how-to-configure-auto-train.md
@@ -77,6 +77,7 @@ Requirements for training data:
 The following code examples demonstrate how to store the data in these formats.
 
 * TabularDataset
+
   ```python
   from azureml.core.dataset import Dataset
   from azureml.opendatasets import Diabetes
@@ -88,14 +89,14 @@ The following code examples demonstrate how to store the data in these formats.
 
 * Pandas dataframe
 
-    ```python
-    import pandas as pd
-    from sklearn.model_selection import train_test_split
+  ```python
+  import pandas as pd
+  from sklearn.model_selection import train_test_split
 
-    df = pd.read_csv("your-local-file.csv")
-    train_data, test_data = train_test_split(df, test_size=0.1, random_state=42)
-    label = "label-col-name"
-    ```
+  df = pd.read_csv("your-local-file.csv")
+  train_data, test_data = train_test_split(df, test_size=0.1, random_state=42)
+  label = "label-col-name"
+  ```
 
 ## Fetch data for running experiment on remote compute
 
@@ -142,30 +143,30 @@ There are several options that you can use to configure your automated machine l
 
 Some examples include:
 
-1.    Classification experiment using AUC weighted as the primary metric with experiment timeout minutes set to 30 minutes and 2 cross-validation folds.
+1. Classification experiment using AUC weighted as the primary metric with experiment timeout minutes set to 30 minutes and 2 cross-validation folds.
 
-```python
-    automl_classifier=AutoMLConfig(
-    task='classification',
-    primary_metric='AUC_weighted',
-    experiment_timeout_minutes=30,
-    blacklist_models=['XGBoostClassifier'],
-    training_data=train_data,
-    label_column_name=label,
-    n_cross_validations=2)
-```
-2.    Below is an example of a regression experiment set to end after 60 minutes with five validation cross folds.
+   ```python
+       automl_classifier=AutoMLConfig(
+       task='classification',
+       primary_metric='AUC_weighted',
+       experiment_timeout_minutes=30,
+       blacklist_models=['XGBoostClassifier'],
+       training_data=train_data,
+       label_column_name=label,
+       n_cross_validations=2)
+   ```
+2. Below is an example of a regression experiment set to end after 60 minutes with five validation cross folds.
 
-```python
-    automl_regressor = AutoMLConfig(
-    task='regression',
-    experiment_timeout_minutes=60,
-    whitelist_models=['kNN regressor'],
-    primary_metric='r2_score',
-    training_data=train_data,
-    label_column_name=label,
-    n_cross_validations=5)
-```
+   ```python
+      automl_regressor = AutoMLConfig(
+      task='regression',
+      experiment_timeout_minutes=60,
+      whitelist_models=['kNN regressor'],
+      primary_metric='r2_score',
+      training_data=train_data,
+      label_column_name=label,
+      n_cross_validations=5)
+   ```
 
 The three different `task` parameter values (the third task-type is `forecasting`, and uses a similar algorithm pool as `regression` tasks) determine the list of models to apply. Use the `whitelist` or `blacklist` parameters to further modify iterations with the available models to include or exclude. The list of supported models can be found on [SupportedModels Class](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels) for ([Classification](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels.classification), [Forecasting](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels.forecasting), and [Regression](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels.regression)).
 

--- a/articles/machine-learning/how-to-configure-auto-train.md
+++ b/articles/machine-learning/how-to-configure-auto-train.md
@@ -144,28 +144,28 @@ Some examples include:
 
 1.    Classification experiment using AUC weighted as the primary metric with experiment timeout minutes set to 30 minutes and 2 cross-validation folds.
 
-    ```python
+```python
     automl_classifier=AutoMLConfig(
-        task='classification',
-        primary_metric='AUC_weighted',
-        experiment_timeout_minutes=30,
-        blacklist_models=['XGBoostClassifier'],
-        training_data=train_data,
-        label_column_name=label,
-        n_cross_validations=2)
-    ```
+    task='classification',
+    primary_metric='AUC_weighted',
+    experiment_timeout_minutes=30,
+    blacklist_models=['XGBoostClassifier'],
+    training_data=train_data,
+    label_column_name=label,
+    n_cross_validations=2)
+```
 2.    Below is an example of a regression experiment set to end after 60 minutes with five validation cross folds.
 
-    ```python
+```python
     automl_regressor = AutoMLConfig(
-        task='regression',
-        experiment_timeout_minutes=60,
-        whitelist_models=['kNN regressor'],
-        primary_metric='r2_score',
-        training_data=train_data,
-        label_column_name=label,
-        n_cross_validations=5)
-    ```
+    task='regression',
+    experiment_timeout_minutes=60,
+    whitelist_models=['kNN regressor'],
+    primary_metric='r2_score',
+    training_data=train_data,
+    label_column_name=label,
+    n_cross_validations=5)
+```
 
 The three different `task` parameter values (the third task-type is `forecasting`, and uses a similar algorithm pool as `regression` tasks) determine the list of models to apply. Use the `whitelist` or `blacklist` parameters to further modify iterations with the available models to include or exclude. The list of supported models can be found on [SupportedModels Class](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels) for ([Classification](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels.classification), [Forecasting](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels.forecasting), and [Regression](https://docs.microsoft.com/python/api/azureml-train-automl-client/azureml.train.automl.constants.supportedmodels.regression)).
 

--- a/articles/machine-learning/how-to-configure-auto-train.md
+++ b/articles/machine-learning/how-to-configure-auto-train.md
@@ -126,14 +126,14 @@ Use custom validation dataset if random split is not acceptable, usually time se
 ## Compute to run experiment
 
 Next determine where the model will be trained. An automated machine learning training experiment can run on the following compute options:
-*    Your local machine such as a local desktop or laptop – Generally when you have small dataset and you are still in the exploration stage.
-*    A remote machine in the cloud – [Azure Machine Learning Managed Compute](concept-compute-target.md#amlcompute) is a managed service that enables the ability to train machine learning models on clusters of Azure virtual machines.
+* Your local machine such as a local desktop or laptop – Generally when you have small dataset and you are still in the exploration stage.
+* A remote machine in the cloud – [Azure Machine Learning Managed Compute](concept-compute-target.md#amlcompute) is a managed service that enables the ability to train machine learning models on clusters of Azure virtual machines.
 
-    See this [GitHub site](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/automated-machine-learning) for examples of notebooks with local and remote compute targets.
+  See this [GitHub site](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/automated-machine-learning) for examples of notebooks with local and remote compute targets.
 
-*   An Azure Databricks cluster in your Azure subscription. You can find more details here - [Setup Azure Databricks cluster for Automated ML](how-to-configure-environment.md#azure-databricks)
+* An Azure Databricks cluster in your Azure subscription. You can find more details here - [Setup Azure Databricks cluster for Automated ML](how-to-configure-environment.md#azure-databricks)
 
-    See this [GitHub site](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/azure-databricks/automl) for examples of notebooks with Azure Databricks.
+  See this [GitHub site](https://github.com/Azure/MachineLearningNotebooks/tree/master/how-to-use-azureml/azure-databricks/automl) for examples of notebooks with Azure Databricks.
 
 <a name='configure-experiment'></a>
 


### PR DESCRIPTION
The indented code block looked strange because the markdown could be seen.

By removing the indentation the code block renders normally.