### PR TITLE
Twin Setting expects valid JSON or quoted String

### DIFF
--- a/articles/asc-for-iot/how-to-deploy-edge.md
+++ b/articles/asc-for-iot/how-to-deploy-edge.md
@@ -93,7 +93,7 @@ Complete each step to complete your IoT Edge deployment for Azure Security Cente
 1. On the **Module Twin Settings** tab, add the following configuration:
       
     ``` json
-      "ms_iotn:urn_azureiot_Security_SecurityAgentConfiguration":{}
+      "ms_iotn:urn_azureiot_Security_SecurityAgentConfiguration"
     ```
 
 1. Select **Update**.


### PR DESCRIPTION
Module twin content must be a string surrounded by quotation marks or valid JSON error message is displayed in the Azure Portal for this step.  
![image](https://user-images.githubusercontent.com/13575025/77491126-e6da0e80-6e0a-11ea-94c6-dc903de49341.png)

-------
cc: @mlottner