### PR TITLE
Update OMS Endpoints

### DIFF
--- a/articles/azure-monitor/platform/agent-linux-troubleshoot.md
+++ b/articles/azure-monitor/platform/agent-linux-troubleshoot.md
@@ -154,7 +154,7 @@ Below the output plugin, uncomment the following section by removing the `#` in 
 
 2. Review the section [Update proxy settings](agent-manage.md#update-proxy-settings) to verify you have properly configured the agent to communicate through a proxy server.    
 
-3. Double check that the endpoints outlined in the Azure Monitor [network firewall requirements](log-analytics-agent.md#network-firewall-requirements) list are properly whitelisted. If you utilize Azure Automation, the necessary network configuration steps are linked above as well.
+3. Double check that the endpoints outlined in the Azure Monitor [network firewall requirements](log-analytics-agent.md#firewall-requirements) list are properly whitelisted. If you utilize Azure Automation, the necessary network configuration steps are linked above as well.
 
 ## Issue: You receive a 403 error when trying to onboard
 

--- a/articles/azure-monitor/platform/agent-linux-troubleshoot.md
+++ b/articles/azure-monitor/platform/agent-linux-troubleshoot.md
@@ -153,15 +153,8 @@ Below the output plugin, uncomment the following section by removing the `#` in 
 `/opt/microsoft/omsagent/bin/omsadmin.sh -w <Workspace ID> -s <Workspace Key> -p <Proxy Conf> -v`
 
 2. Review the section [Update proxy settings](agent-manage.md#update-proxy-settings) to verify you have properly configured the agent to communicate through a proxy server.    
-* Double check that the following Azure Monitor endpoints are whitelisted:
 
-    |Agent Resource| Ports | Direction |
-    |------|---------|----------|  
-    |*.ods.opinsights.azure.com | Port 443| Inbound and outbound |  
-    |*.oms.opinsights.azure.com | Port 443| Inbound and outbound |  
-    |*.blob.core.windows.net | Port 443| Inbound and outbound |  
-
-    If you plan to use the Azure Automation Hybrid Runbook Worker to connect to and register with the Automation service to use runbooks or management solutions in your environment, it must have access to the port number and the URLs described in [Configure your network for the Hybrid Runbook Worker](../../automation/automation-hybrid-runbook-worker.md#network-planning). 
+3. Double check that the endpoints outlined in the Azure Monitor [network firewall requirements](log-analytics-agent.md#network-firewall-requirements) list are properly whitelisted. If you utilize Azure Automation, the necessary network configuration steps are linked above as well.
 
 ## Issue: You receive a 403 error when trying to onboard
 

--- a/articles/azure-monitor/platform/agent-linux-troubleshoot.md
+++ b/articles/azure-monitor/platform/agent-linux-troubleshoot.md
@@ -154,7 +154,7 @@ Below the output plugin, uncomment the following section by removing the `#` in 
 
 2. Review the section [Update proxy settings](agent-manage.md#update-proxy-settings) to verify you have properly configured the agent to communicate through a proxy server.    
 
-3. Double check that the endpoints outlined in the Azure Monitor [network firewall requirements](log-analytics-agent.md#firewall-requirements) list are properly whitelisted. If you utilize Azure Automation, the necessary network configuration steps are linked above as well.
+3. Double-check that the endpoints outlined in the Azure Monitor [network firewall requirements](log-analytics-agent.md#firewall-requirements) list are added to an allow list correctly. If you use Azure Automation, the necessary network configuration steps are linked above as well.
 
 ## Issue: You receive a 403 error when trying to onboard
 

--- a/articles/azure-monitor/platform/log-analytics-agent.md
+++ b/articles/azure-monitor/platform/log-analytics-agent.md
@@ -156,19 +156,23 @@ The agent for Linux and Windows communicates outbound to the Azure Monitor servi
 
 ![Log Analytics agent communication diagram](./media/log-analytics-agent/log-analytics-agent-01.png)
 
+The information below list the proxy and firewall configuration information required for the Linux and Windows agent to communicate with Azure Monitor logs.
 
-## Network firewall requirements
-The information below list the proxy and firewall configuration information required for the Linux and Windows agent to communicate with Azure Monitor logs.  
+### Firewall requirements
 
 |Agent Resource|Ports |Direction |Bypass HTTPS inspection|
 |------|---------|--------|--------|   
-|*.ods.opinsights.azure.com |Port 443 |Outbound|Yes |  
-|*.oms.opinsights.azure.com |Port 443 |Outbound|Yes |  
-|*.blob.core.windows.net |Port 443 |Outbound|Yes |  
+|*.ods.opinsights.azure.com |Port 443 |Inbound and Outbound|Yes |  
+|*.oms.opinsights.azure.com |Port 443 |Inbound and Outbound|Yes |  
+|*.blob.core.windows.net |Port 443 |Inbound and Outbound|Yes |
+|*.azure-automation.net |Port 443 |Inbound and Outbound|Yes |
+|*.azure.com |Port 443|Inbound and Outbound|Yes |
 
 For firewall information required for Azure Government, see [Azure Government management](../../azure-government/documentation-government-services-monitoringandmanagement.md#azure-monitor-logs). 
 
 If you plan to use the Azure Automation Hybrid Runbook Worker to connect to and register with the Automation service to use runbooks or management solutions in your environment, it must have access to the port number and the URLs described in [Configure your network for the Hybrid Runbook Worker](../../automation/automation-hybrid-runbook-worker.md#network-planning). 
+
+### Proxy configuration
 
 The Windows and Linux agent supports communicating either through a proxy server or Log Analytics gateway to Azure Monitor using the HTTPS protocol.  Both anonymous and basic authentication (username/password) are supported.  For the Windows agent connected directly to the service, the proxy configuration is specified during installation or [after deployment](agent-manage.md#update-proxy-settings) from Control Panel or with PowerShell.  
 

--- a/articles/azure-monitor/platform/log-analytics-agent.md
+++ b/articles/azure-monitor/platform/log-analytics-agent.md
@@ -156,7 +156,7 @@ The agent for Linux and Windows communicates outbound to the Azure Monitor servi
 
 ![Log Analytics agent communication diagram](./media/log-analytics-agent/log-analytics-agent-01.png)
 
-The information below list the proxy and firewall configuration information required for the Linux and Windows agent to communicate with Azure Monitor logs.
+The following table lists the proxy and firewall configuration information that's required for the Linux and Windows agents to communicate with Azure Monitor logs.
 
 ### Firewall requirements
 


### PR DESCRIPTION
ADO 6458300
- Add `*.azure-automation.net` and `*.azure.com`. The latter is necessary because OMS homing service is communicating with a cert from the domain `OMS-SSL[Timestamp][Region].azure.com`. HDI team experienced issues in past that were alleviated by whitelisting that domain.  
To my knowledge `*.azure.com` will only match domains one level lower (e.g. `foo.azure.com` and not `foo.bar.azure.com`, meaning you still must specify rules for the two opinsights domains.
- Clean up duplicate info in troubleshooting and link back to source of truth.