### PR TITLE
added 90 day retention period

### DIFF
--- a/articles/application-gateway/configure-keyvault-ps.md
+++ b/articles/application-gateway/configure-keyvault-ps.md
@@ -66,7 +66,7 @@ $certificate = Get-AzKeyVaultCertificate -VaultName $kv -Name "cert1"
 $secretId = $certificate.SecretId.Replace($certificate.Version, "")
 ```
 > [!NOTE]
-> The -EnableSoftDelete flag must be used for SSL termination to function properly.
+> The -EnableSoftDelete flag must be used for SSL termination to function properly. If you're configuring [Key Vault soft-delete through Portal](https://docs.microsoft.com/azure/key-vault/key-vault-ovw-soft-delete#soft-delete-behavior), the retention period must be kept at 90 days, the default value. Application Gateway doesn't support a different retention period yet. 
 
 ### Create a virtual network
 


### PR DESCRIPTION
Added 90 day retention period requirement to the note; KeyVault won't work with AppGW right now if the retention period is set to a different value. This only applies if they're trying to configure the Key Vault through Portal (retention period shows up on the Portal UI).