### PR TITLE
Update Custom Vision Image Classification node.js Quickstart

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/node-tutorial.md
+++ b/articles/cognitive-services/Custom-Vision-Service/node-tutorial.md
@@ -47,8 +47,8 @@ Add the following code to your script to create a new Custom Vision service proj
 ```javascript
 const util = require('util');
 const fs = require('fs');
-const TrainingApiClient = require("@azure/cognitiveservices-customvision-training");
-const PredictionApiClient = require("@azure/cognitiveservices-customvision-prediction");
+const TrainingApi = require("@azure/cognitiveservices-customvision-training");
+const PredictionApi = require("@azure/cognitiveservices-customvision-prediction");
 
 const setTimeoutPromise = util.promisify(setTimeout);
 
@@ -61,7 +61,7 @@ const endPoint = "https://<my-resource-name>.cognitiveservices.azure.com/"
 
 const publishIterationName = "classifyModel";
 
-const trainer = new TrainingApiClient(trainingKey, endPoint);
+const trainer = new TrainingApi.TrainingAPIClient(trainingKey, endPoint);
 
 (async () => {
     console.log("Creating project...");
@@ -129,7 +129,7 @@ await trainer.publishIteration(sampleProject.id, trainingIteration.id, publishIt
 To send an image to the prediction endpoint and retrieve the prediction, add the following code to the end of the file:
 
 ```javascript
-    const predictor = new PredictionApiClient(predictionKey, endPoint);
+    const predictor = new PredictionApi.PredictionAPIClient(predictionKey, endPoint);
     const testFile = fs.readFileSync(`${sampleDataRoot}/Test/test_image.jpg`);
 
     const results = await predictor.classifyImage(sampleProject.id, publishIterationName, testFile);


### PR DESCRIPTION
Should be a quick one!

The way we were requiring our library and instantiating API clients for https://docs.microsoft.com/en-us/azure/cognitive-services/custom-vision-service/node-tutorial  wasn't actually functioning code.

I updated the sample to be working JS, using the same naming patterns for the two `require` objects as we're using in the corresponding Object Detection quickstart (https://docs.microsoft.com/en-us/azure/cognitive-services/custom-vision-service/node-tutorial-object-detection), which doesn't have these issues.

Thanks!