### PR TITLE
Terraform K8 AKS application gateway documentation - resolve Terraform warnings

### DIFF
--- a/articles/terraform/terraform-create-k8s-cluster-with-aks-applicationgateway-ingress.md
+++ b/articles/terraform/terraform-create-k8s-cluster-with-aks-applicationgateway-ingress.md
@@ -219,7 +219,7 @@ Create the Terraform configuration file that lists all the variables required fo
     }
 
     variable "tags" {
-      type = "map"
+      type = map(string)
 
       default = {
         source = "terraform"
@@ -380,7 +380,7 @@ Create Terraform configuration file that creates all the resources.
 
       tags = var.tags
 
-      depends_on = ["azurerm_virtual_network.test", "azurerm_public_ip.test"]
+      depends_on = [azurerm_virtual_network.test, azurerm_public_ip.test]
     }
     ```
 
@@ -392,28 +392,28 @@ Create Terraform configuration file that creates all the resources.
       role_definition_name = "Network Contributor"
       principal_id         = var.aks_service_principal_object_id 
 
-      depends_on = ["azurerm_virtual_network.test"]
+      depends_on = [azurerm_virtual_network.test]
     }
 
     resource "azurerm_role_assignment" "ra2" {
       scope                = azurerm_user_assigned_identity.testIdentity.id
       role_definition_name = "Managed Identity Operator"
       principal_id         = var.aks_service_principal_object_id
-      depends_on           = ["azurerm_user_assigned_identity.testIdentity"]
+      depends_on           = [azurerm_user_assigned_identity.testIdentity]
     }
 
     resource "azurerm_role_assignment" "ra3" {
       scope                = azurerm_application_gateway.network.id
       role_definition_name = "Contributor"
       principal_id         = azurerm_user_assigned_identity.testIdentity.principal_id
-      depends_on           = ["azurerm_user_assigned_identity.testIdentity", "azurerm_application_gateway.network"]
+      depends_on           = [azurerm_user_assigned_identity.testIdentity, azurerm_application_gateway.network]
     }
 
     resource "azurerm_role_assignment" "ra4" {
       scope                = data.azurerm_resource_group.rg.id
       role_definition_name = "Reader"
       principal_id         = azurerm_user_assigned_identity.testIdentity.principal_id
-      depends_on           = ["azurerm_user_assigned_identity.testIdentity", "azurerm_application_gateway.network"]
+      depends_on           = [azurerm_user_assigned_identity.testIdentity, azurerm_application_gateway.network]
     }
     ```
 
@@ -461,7 +461,7 @@ Create Terraform configuration file that creates all the resources.
         service_cidr       = var.aks_service_cidr
       }
 
-      depends_on = ["azurerm_virtual_network.test", "azurerm_application_gateway.network"]
+      depends_on = [azurerm_virtual_network.test, azurerm_application_gateway.network]
       tags       = var.tags
     }
 


### PR DESCRIPTION
Quoted type constraints are deprecated
Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "map" and write
map(string) instead to explicitly indicate that the map elements are string

Quoted references are deprecated
In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning