### PR TITLE
#51027 Update sampling telemetry note for excludedTypes

### DIFF
--- a/articles/azure-functions/functions-host-json.md
+++ b/articles/azure-functions/functions-host-json.md
@@ -136,7 +136,7 @@ Controls options for Application Insights, including [sampling options](./functi
 For the complete JSON structure, see the earlier [example host.json file](#sample-hostjson-file).
 
 > [!NOTE]
-> Log sampling may cause some executions to not show up in the Application Insights monitor blade. To avoid log sampling, add `samplingExcludedTypes: "Request"` to the `applicationInsights` value.
+> Log sampling may cause some executions to not show up in the Application Insights monitor blade. To avoid log sampling, add `excludedTypes: "Request"` to the `samplingSettings` value.
 
 | Property | Default | Description |
 | --------- | --------- | --------- | 


### PR DESCRIPTION
Closes #51027 

The note incorrectly states "Log sampling may cause some executions to not show up in the Application Insights monitor blade. To avoid log sampling, add samplingExcludedTypes: "Request" to the applicationInsights value.".

The property table below shows "excludedTypes" under the "samplingSettings" value, not "samplingExcludedTypes" under the "applicationInsights" value.

The note should read "Log sampling may cause some executions to not show up in the Application Insights monitor blade. To avoid log sampling, add excludedTypes: "Request" to the samplingSettings value.".