### PR TITLE
Product Availability isn't driven by Status Page

### DIFF
--- a/articles/media-services/previous/scenarios-and-availability.md
+++ b/articles/media-services/previous/scenarios-and-availability.md
@@ -164,7 +164,7 @@ This section provides details about availability of Media Services features acro
 
 #### Availability
 
-Use [Azure Products by Region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=media-services&regions=all) to determine if Media Services is available in a given datacenter.
+Use [Azure Products by Region](https://azure.microsoft.com/global-infrastructure/services/?products=media-services&regions=all) to determine whether Media Services is available in a specific datacenter.
 
 ### Streaming endpoints 
 

--- a/articles/media-services/previous/scenarios-and-availability.md
+++ b/articles/media-services/previous/scenarios-and-availability.md
@@ -164,7 +164,7 @@ This section provides details about availability of Media Services features acro
 
 #### Availability
 
-To determine if Media Services is available in a datacenter, browse to https://azure.microsoft.com/status/ and scroll to the MEDIA table.
+Use [Azure Products by Region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=media-services&regions=all) to determine if Media Services is available in a given datacenter.
 
 ### Streaming endpoints 
 


### PR DESCRIPTION
[status.azure.com](https://status.azure.com) is primarily for outage notifications - it's not great for product availability as it doesn't announce when DCs are planning to launch a given service

## [Product Availability](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=media-services&regions=all)
![image](https://user-images.githubusercontent.com/26234626/77769331-ed31db80-7000-11ea-916e-854ce1d537bb.png)
