### PR TITLE
Remove incorrect note about pseudo username/password

### DIFF
--- a/articles/azure-monitor/platform/log-analytics-agent.md
+++ b/articles/azure-monitor/platform/log-analytics-agent.md
@@ -176,9 +176,6 @@ For the Linux agent, the proxy server is specified during installation or [after
 
 `[protocol://][user:password@]proxyhost[:port]`
 
-> [!NOTE]
-> If your proxy server does not require you to authenticate, the Linux agent still requires providing a pseudo user/password. This can be any username or password.
-
 |Property| Description |
 |--------|-------------|
 |Protocol | https |


### PR DESCRIPTION
Remove incorrect note about a pseudo username/password being required. The Linux Agent proxy config file does not require that a pseudo username/password be included in the proxy.conf when using anonymous authentication.