### PR TITLE
Edit variables.tf

### DIFF
--- a/articles/terraform/terraform-create-vm-scaleset-network-disks-hcl.md
+++ b/articles/terraform/terraform-create-vm-scaleset-network-disks-hcl.md
@@ -75,7 +75,7 @@ Within the Azure Cloud Shell, do the following steps:
 
    variable "tags" {
     description = "A map of the tags to use for the resources that are deployed"
-    type        = "map"
+    type        = map
 
     default = {
       environment = "codelab"


### PR DESCRIPTION
Got this error when applying Terraform config:  "Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "map" and write
map(string) instead to explicitly indicate that the map elements are strings."

Fixed by removing quotes around map string.