### PR TITLE
Federated users UPN suffix changes

### DIFF
--- a/articles/active-directory/hybrid/tshoot-connect-objectsync.md
+++ b/articles/active-directory/hybrid/tshoot-connect-objectsync.md
@@ -58,11 +58,6 @@ When UserPrincipalName (UPN)/Alternate Login ID suffix is not verified with the 
 
 ![Azure AD replaces UPN](media/tshoot-connect-objectsync/objsynch2.png)
 
-### Changing UPN Suffix from one federated domain to another federated domain
-Azure Active Directory does not allow the synchronization of UserPrincipalName (UPN)/Alternate Login ID suffix change from one federated domain to another federated domain. This applies to domains, that are verified with the Azure AD Tenant and have the Authentication Type as Federated.
-
-![No UPN synch from one federated domain to another](media/tshoot-connect-objectsync/objsynch3.png) 
-
 ### Azure AD Tenant DirSync Feature ‘SynchronizeUpnForManagedUsers’ is disabled
 When the Azure AD Tenant DirSync Feature ‘SynchronizeUpnForManagedUsers’ is disabled, Azure Active Directory does not allow synchronization updates to UserPrincipalName/Alternate Login ID for licensed user accounts with managed authentication.
 


### PR DESCRIPTION
Since, around March 2019, user UPN suffix changes from one federated domain to another federated domain are allowed and can be synchronized directly by AADConnect's sync engine.
So this information is now outdated and misleading.