### PR TITLE
Update to reflect updated functionality

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-syncservice-features.md
+++ b/articles/active-directory/hybrid/how-to-connect-syncservice-features.md
@@ -84,12 +84,14 @@ Set-MsolDirSyncFeature -Feature EnableSoftMatchOnUpn -Enable $true
 
 ## Synchronize userPrincipalName updates
 
-Historically, updates to the UserPrincipalName attribute using the sync service from on-premises has been blocked, unless both of these conditions are true:
+Historically, updates to the UserPrincipalName attribute using the sync service from on-premises has been blocked, unless both of these conditions were true:
 
 * The user is managed (non-federated).
 * The user has not been assigned a license.
 
-For more details, see [User names in Office 365, Azure, or Intune don't match the on-premises UPN or alternate login ID](https://support.microsoft.com/kb/2523192).
+> [!NOTE]
+> From March 2019, synchronizing UPN changes for federated user accounts is allowed.
+> 
 
 Enabling this feature allows the sync engine to update the userPrincipalName when it is changed on-premises and you use password hash sync or pass-through authentication.
 


### PR DESCRIPTION
Doc update to illustrate UPN updated to federated accounts is now allowed.
Also, removing the broken link to a support doc which is no longer available.