### PR TITLE
Describe error The remote virtual network lacks a gateway

### DIFF
--- a/articles/virtual-network/virtual-network-troubleshoot-peering-issues.md
+++ b/articles/virtual-network/virtual-network-troubleshoot-peering-issues.md
@@ -231,6 +231,14 @@ To resolve this issue, delete the peering from both virtual networks, and then r
 
 To resolve this issue, configure the virtual network peering under **Azure Databricks**, and then specify the target virtual network by using **Resource ID**. For more information, see [Peer a Databricks virtual network to a remote virtual network](https://docs.azuredatabricks.net/administration-guide/cloud-configurations/azure/vnet-peering.html#id2).
 
+### The remote virtual network lacks a gateway
+
+This issue occurs when you peer vnets from different tenants and want to configure `Use Remote Gateways` afterwards. It is a limitation in Azure Portal that cannot validate presence of Vnet gateway in the other tenant's vnet.
+There are two ways to resolve the issue:
+
+ * Destroy the peerings and activate the `Use Remote Gateways` option during new peering creation
+ * Enable the `Use Remote Gateways` through PowerShell or CLI
+
 ## Next steps
 
 * [Troubleshooting connectivity problems between Azure VMs](https://docs.microsoft.com/azure/virtual-network/virtual-network-troubleshoot-connectivity-problem-between-vms)

--- a/articles/virtual-network/virtual-network-troubleshoot-peering-issues.md
+++ b/articles/virtual-network/virtual-network-troubleshoot-peering-issues.md
@@ -233,11 +233,12 @@ To resolve this issue, configure the virtual network peering under **Azure Datab
 
 ### The remote virtual network lacks a gateway
 
-This issue occurs when you peer vnets from different tenants and want to configure `Use Remote Gateways` afterwards. It is a limitation in Azure Portal that cannot validate presence of Vnet gateway in the other tenant's vnet.
+This issue occurs when you peer virtual networks from different tenants and later want to configure `Use Remote Gateways`. A limitation of the Azure portal is that it can't validate the presence of a virtual network gateway in another tenant's virtual network.
+
 There are two ways to resolve the issue:
 
- * Destroy the peerings and activate the `Use Remote Gateways` option during new peering creation
- * Enable the `Use Remote Gateways` through PowerShell or CLI
+ * Delete the peerings and activate the `Use Remote Gateways` option when you create a new peering.
+ * Use PowerShell or CLI, instead of the Azure portal, to enable `Use Remote Gateways`.
 
 ## Next steps
 


### PR DESCRIPTION
Through a support case we actually got confirmed this theory - we were told it's _Portal bug_ but I see it rather as a _Portal limitation_. Maybe we could get more precision on this one, but I find it important to have the error message listed anyway, as the solution indeed applies.

I was also thinking to link to Docs about how to enable (mention the `-useRemoteGateways` and `--use-remote-gateways` parameters), but I only see the list of parameters in [Manage vnet peering](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-manage-peering) but no PowerShell/CLI details, and I'm not sure if this level of detail is desired?