### PR TITLE
Updated description of RBAC in AAD integration

### DIFF
--- a/articles/storage/common/storage-auth.md
+++ b/articles/storage/common/storage-auth.md
@@ -29,7 +29,7 @@ The following table describes the options that Azure Storage offers for authoriz
 
 Each authorization option is briefly described below:
 
-- **Azure Active Directory (Azure AD) integration** for blobs, and queues. Azure AD provides role-based access control (RBAC) for fine-grained control over a client's access to resources in a storage account. For more information regarding Azure AD integration for blobs and queues, see [Authorize access to Azure blobs and queues using Azure Active Directory](storage-auth-aad.md).
+- **Azure Active Directory (Azure AD) integration** for blobs, and queues. Azure AD provides role-based access control (RBAC) for control over a client's access to resources in a storage account. For more information regarding Azure AD integration for blobs and queues, see [Authorize access to Azure blobs and queues using Azure Active Directory](storage-auth-aad.md).
 
 - **Azure Active Directory Domain Services (Azure AD DS) authentication** for Azure Files. Azure Files supports identity-based authorization over Server Message Block (SMB) through Azure AD DS. You can use RBAC for fine-grained control over a client's access to Azure Files resources in a storage account. For more information regarding Azure Files authentication using domain services, refer to our [overview](../files/storage-files-active-directory-overview.md).
 


### PR DESCRIPTION
It is confusing to read here that RBAC (under the menu of ADLS) offers fine-grained control albeit over resources in the storage account rather than data and then in another section read that "RBAC role assignments is a powerful mechanism to control access permissions, it is a very coarsely grained mechanism relative to ACLs"
https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-access-control
To avoid confusion I would recommend removing the term fine-grained unless it is specified that the most granular scope of the resource is at the container level.