### PR TITLE
Update title of catalog article

### DIFF
--- a/articles/active-directory/governance/entitlement-management-catalog-create.md
+++ b/articles/active-directory/governance/entitlement-management-catalog-create.md
@@ -1,5 +1,5 @@
 ---
-title: Create & manage resources in entitlement management - Azure AD
+title: Create & manage a catalog of resources in entitlement management - Azure AD
 description: Learn how to create a new container of resources and access packages in Azure Active Directory entitlement management.
 services: active-directory
 documentationCenter: ''


### PR DESCRIPTION
The title of the article was displaying as "Create and manage resources".  That was confusing because it was misread as creating the resources themselves, e.g., it was telling you how to create a group, app or site inside entitlement management.  Instead this article is about creating a catalog, and adding resources - apps groups and sites - that already exist to that catalog.