### PR TITLE
Updated plural use of Azure Blueprints and brand

### DIFF
--- a/articles/governance/blueprints/overview.md
+++ b/articles/governance/blueprints/overview.md
@@ -4,7 +4,7 @@ description: Understand how the Azure Blueprints service enables you to create, 
 ms.date: 11/21/2019
 ms.topic: overview
 ---
-# What is Azure Blueprints?
+# What are Azure Blueprints?
 
 Just as a blueprint allows an engineer or an architect to sketch a project's design parameters,
 Azure Blueprints enables cloud architects and central information technology groups to define a
@@ -13,7 +13,7 @@ patterns, and requirements. Azure Blueprints makes it possible for development t
 build and stand up new environments with trust they're building within organizational compliance
 with a set of built-in components -- such as networking -- to speed up development and delivery.
 
-Blueprints are a declarative way to orchestrate the deployment of various resource templates and
+Azure Blueprints are a declarative way to orchestrate the deployment of various resource templates and
 other artifacts such as:
 
 - Role Assignments
@@ -34,20 +34,20 @@ is a package to bring each of these _artifact_ types together and allow you to c
 that package -- including through a CI/CD pipeline. Ultimately, each is assigned to a subscription
 in a single operation that can be audited and tracked.
 
-Nearly everything that you want to include for deployment in Blueprints can be accomplished with a
+Nearly everything that you want to include for deployment in Azure Blueprints can be accomplished with a
 Resource Manager template. However, a Resource Manager template is a document that doesn't exist
 natively in Azure – each is stored either locally or in source control. The template gets used for
 deployments of one or more Azure resources, but once those resources deploy there's no active
 connection or relationship to the template.
 
-With Blueprints, the relationship between the blueprint definition (what _should be_ deployed) and
+With Azure Blueprints, the relationship between the blueprint definition (what _should be_ deployed) and
 the blueprint assignment (what _was_ deployed) is preserved. This connection supports improved
-tracking and auditing of deployments. Blueprints can also upgrade several subscriptions at once that
+tracking and auditing of deployments. Azure Blueprints can also upgrade several subscriptions at once that
 are governed by the same blueprint.
 
 There's no need to choose between a Resource Manager template and a blueprint. Each blueprint can
 consist of zero or more Resource Manager template _artifacts_. This support means that previous
-efforts to develop and maintain a library of Resource Manager templates are reusable in Blueprints.
+efforts to develop and maintain a library of Resource Manager templates are reusable in Azure Blueprints.
 
 ## How it's different from Azure Policy
 
@@ -68,7 +68,7 @@ support using parameters with policies and initiatives.
 
 ## Blueprint definition
 
-A blueprint is made up of _artifacts_. Blueprints currently support the following resources
+A blueprint is made up of _artifacts_. Azure Blueprints currently support the following resources
 as artifacts:
 
 |Resource  | Hierarchy options| Description  |
@@ -80,14 +80,14 @@ as artifacts:
 
 ### Blueprint definition locations
 
-When creating a blueprint definition, you'll define where the blueprint is saved. Blueprints can be
+When creating a blueprint definition, you'll define where the blueprint is saved. Azure Blueprints can be
 saved to a [management group](../management-groups/overview.md) or subscription that you have
 **Contributor** access to. If the location is a management group, the blueprint is available to
 assign to any child subscription of that management group.
 
 ### Blueprint parameters
 
-Blueprints can pass parameters to either a policy/initiative or an Azure Resource Manager template.
+Azure Blueprints can pass parameters to either a policy/initiative or an Azure Resource Manager template.
 When adding either _artifact_ to a blueprint, the author decides to provide a defined value for each
 blueprint assignment or to allow each blueprint assignment to provide a value at assignment time.
 This flexibility provides the option to define a pre-determined value for all uses of the blueprint


### PR DESCRIPTION
- Corrected "is" to "are"
- Placed Azure back into product name