### PR TITLE
Added minor clarification on the reward score

### DIFF
--- a/articles/cognitive-services/personalizer/what-is-personalizer.md
+++ b/articles/cognitive-services/personalizer/what-is-personalizer.md
@@ -55,7 +55,7 @@ Personalizer used reinforcement learning to select the single best action, known
 
 Personalizer's **Rank** [API](https://go.microsoft.com/fwlink/?linkid=2092082) is called _every time_ you present content, in real-time. This is known as an **event**, noted with an _event ID_.
 
-Personalizer's **Reward** [API](https://westus2.dev.cognitive.microsoft.com/docs/services/personalizer-api/operations/Reward) can be called in real-time or delayed to better fit your infrastructure. You determine the reward score based on your business needs. That can be a single value such as 1 for good, and 0 for bad, or a number produced by an algorithm you create considering your business goals and metrics.
+Personalizer's **Reward** [API](https://westus2.dev.cognitive.microsoft.com/docs/services/personalizer-api/operations/Reward) can be called in real-time or delayed to better fit your infrastructure. You determine the reward score based on your business needs. The reward score is between 0 and 1. That can be a single value such as 1 for good, and 0 for bad, or a number produced by an algorithm you create considering your business goals and metrics.
 
 ## Personalizer content requirements
 


### PR DESCRIPTION
Added minor clarification that the reward score needs to be between 0 and 1. This wasn't obvious and was causing some initial confusion with customers.