### PR TITLE
Incorrect reference to PS script at line 195, 198

### DIFF
--- a/articles/storage/blobs/storage-blob-storage-tiers.md
+++ b/articles/storage/blobs/storage-blob-storage-tiers.md
@@ -195,7 +195,7 @@ $storageAccount =Get-AzStorageAccount -ResourceGroupName $rgName -Name $accountN
 $ctx = $storageAccount.Context
 
 #Select the blob from a container
-$blobs = Get-AzStorageBlob -Container $containerName -Blob $blobName -Context $context
+$blob = Get-AzStorageBlob -Container $containerName -Blob $blobName -Context $context
 
 #Change the blob’s access tier to archive
 $blob.ICloudBlob.SetStandardBlobTier("Archive")


### PR DESCRIPTION
The name of the blob context is $ctx whereas it is referenced as $context at line number 198. The name of the variable should be $ctx at line 198.

Likewise, the name of the PS variable for blob is $blobs at lin number 198, whereas it is referenced as $blob at line 198 should be $blob.