### PR TITLE
Add "default" namespace to kubeadvisor command

### DIFF
--- a/articles/aks/kube-advisor-tool.md
+++ b/articles/aks/kube-advisor-tool.md
@@ -28,7 +28,7 @@ To run the tool on a cluster that is configured for [role-based access control (
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Azure/kube-advisor/master/sa.yaml
 
-kubectl run --rm -i -t kubeadvisor --image=mcr.microsoft.com/aks/kubeadvisor --restart=Never --overrides="{ \"apiVersion\": \"v1\", \"spec\": { \"serviceAccountName\": \"kube-advisor\" } }"
+kubectl run --rm -i -t kubeadvisor --image=mcr.microsoft.com/aks/kubeadvisor --restart=Never --overrides="{ \"apiVersion\": \"v1\", \"spec\": { \"serviceAccountName\": \"kube-advisor\" } }" --namespace default
 ```
 
 If you aren't using RBAC, you can run the command as follows:


### PR DESCRIPTION
The first command creates a resource in the "default" namespace, but the second command can fail because it assumes the default namespace is selected in the user's current context.

This change ensures the second command doesn't fail.