### PR TITLE
Explicit runtime detection using --html flag

### DIFF
--- a/articles/app-service/app-service-web-get-started-html.md
+++ b/articles/app-service/app-service-web-get-started-html.md
@@ -47,7 +47,7 @@ cd html-docs-hello-world
 ```
 
 ```azurecli
-az webapp up --location westeurope --name <app_name> 
+az webapp up --location westeurope --name <app_name> --html
 ```
 
 The `az webapp up` command does the following actions:


### PR DESCRIPTION
The demo does not work without the --html flag. There are already 2 bugs closed with a similar issue [44124](https://github.com/MicrosoftDocs/azure-docs/issues/44124) which was fixed and closed, and [43633](https://github.com/MicrosoftDocs/azure-docs/issues/43633) which was **NOT** fixed and closed.  I had the same issue when using Cloud Shell. So, I decided to make a PR with a fix to make it easier for everyone. 
My reference for the fix : https://github.com/Azure/app-service-linux-docs/blob/master/AzWebAppUP/runtime_detection.md