### PR TITLE
correcting terminology to reflect physical workflow

### DIFF
--- a/articles/migrate/tutorial-prepare-physical.md
+++ b/articles/migrate/tutorial-prepare-physical.md
@@ -39,7 +39,7 @@ You need set up permissions for Azure Migrate deployment.
 **Task** | **Details** 
 --- | --- 
 **Create an Azure Migrate project** | Your Azure account needs Contributer or Owner permissions to create a project. | 
-**Register resource providers** | Azure Migrate uses a lightweight Azure Migrate appliance to discover and assess Hyper-V VMs with Azure Migrate Server Assessment.<br/><br/> During appliance registration, resource providers are registered with the subscription chosen in the appliance. [Learn more](migrate-appliance-architecture.md#appliance-registration).<br/><br/> To register the resource providers, you need a Contributor or Owner role on the subscription.
+**Register resource providers** | Azure Migrate uses a lightweight Azure Migrate appliance to discover and assess physical machines with Azure Migrate Server Assessment.<br/><br/> During appliance registration, resource providers are registered with the subscription chosen in the appliance. [Learn more](migrate-appliance-architecture.md#appliance-registration).<br/><br/> To register the resource providers, you need a Contributor or Owner role on the subscription.
 **Create Azure AD app** | When registering the appliance, Azure Migrate creates an Azure Active Directory (Azure AD) app that's used for communication  between the agents running on the appliance with their respective services running on Azure. [Learn more](migrate-appliance-architecture.md#appliance-registration).<br/><br/> You need permissions to create Azure AD apps (available in the Application Developer) role.
 
 


### PR DESCRIPTION
Replacing "hyper-V Vms" with "physical machines" as this article is about the physical not hyper V workflow