### PR TITLE
Remove SOUTH CENTRAL US from WebApps

### DIFF
--- a/articles/private-link/private-link-overview.md
+++ b/articles/private-link/private-link-overview.md
@@ -58,7 +58,7 @@ Azure Private Link provides the following benefits:
 |  |Azure Service Bus | All public regions      |   Preview   |
 |  |Azure Relay | All public regions      |   Preview   |
 |  |Azure Event Grid| All public regions      |   Preview   <br/> [Learn more](https://docs.microsoft.com/azure/event-grid/network-security)   |
-|  |Azure Web Apps | EAST US, WEST US2, SOUTH CENTRAL US      |   Preview   <br/> [Learn more](https://docs.microsoft.com/azure/app-service/networking/private-endpoint)   |
+|  |Azure Web Apps | EAST US, WEST US2, |   Preview   <br/> [Learn more](https://docs.microsoft.com/azure/app-service/networking/private-endpoint)   |
 
 For the most up-to-date notifications, check the [Azure Virtual Network updates page](https://azure.microsoft.com/updates/?product=virtual-network).
 


### PR DESCRIPTION
The documentation for privatelink for WebApps states only EASTUS and WEST US2 are supported for this privatelink preview.  https://docs.microsoft.com/en-us/azure/private-link/create-private-endpoint-webapp-portal 

Either that's wrong or this is wrong.  I'm betting this is, and adjusting.