### PR TITLE
(AzureCXP) Update Missing Quotes

### DIFF
--- a/articles/governance/policy/concepts/definition-structure.md
+++ b/articles/governance/policy/concepts/definition-structure.md
@@ -447,7 +447,7 @@ This policy rule example uses **value** to check if the result of multiple neste
     "policyRule": {
         "if": {
             "value": "[less(length(field('tags')), 3)]",
-            "equals": true
+            "equals": "true"
         },
         "then": {
             "effect": "deny"


### PR DESCRIPTION
Based on customer feedback on this thread https://github.com/MicrosoftDocs/azure-docs/issues/51509, raised this PR. Understanding is that the policy rules is executed with a if condition and aligns with other rules in some of the other documentation https://docs.microsoft.com/en-us/azure/governance/policy/tutorials/create-custom-policy-definition#policy-rule.