### PR TITLE
Remove --enable-aad parameter on az aks update command

### DIFF
--- a/articles/aks/azure-ad-v2.md
+++ b/articles/aks/azure-ad-v2.md
@@ -94,7 +94,7 @@ The above command creates a three node AKS cluster, but the user, who created th
 Once you've created a group and added yourself (and others) as a member, you can update the cluster with the Azure AD group using the following command
 
 ```azurecli-interactive
-az aks update -g MyResourceGroup -n MyManagedCluster --enable-aad [--aad-admin-group-object-ids <id1,id2>] [--aad-tenant-id <id>]
+az aks update -g MyResourceGroup -n MyManagedCluster [--aad-admin-group-object-ids <id1,id2>] [--aad-tenant-id <id>]
 ```
 Alternatively, if you first create a group and add members, you can enable the Azure AD group at create time using the following command,
 


### PR DESCRIPTION
--enable-aad on az aks commands will fail because --enable-aad can only be used while creating the cluster. @mlearned can you verify?