### PR TITLE
Delete task cannot archive files

### DIFF
--- a/articles/data-factory/delete-activity.md
+++ b/articles/data-factory/delete-activity.md
@@ -20,7 +20,7 @@ ms.date: 08/20/2019
 You can use the Delete Activity in Azure Data Factory to delete files or folders from on-premises storage stores or cloud storage stores. Use this activity to clean up or archive files when they are no longer needed.
 
 > [!WARNING]
-> Deleted files or folders cannot be restored. Be cautious when using the Delete activity to delete files or folders.
+> Deleted files or folders cannot be restored (this is only possible is the storage account has soft delete disabled, if enabled, the file can be undeleted and restored back). Be cautious when using the Delete activity to delete files or folders.
 
 ## Best practices
 

--- a/articles/data-factory/delete-activity.md
+++ b/articles/data-factory/delete-activity.md
@@ -17,7 +17,7 @@ ms.date: 08/20/2019
 
 # Delete Activity in Azure Data Factory
 
-You can use the Delete Activity in Azure Data Factory to delete files or folders from on-premises storage stores or cloud storage stores. Use this activity to clean up or archive files when they are no longer needed.
+You can use the Delete Activity in Azure Data Factory to delete files or folders from on-premises storage stores or cloud storage stores. Use this activity to delete the file or folder from the blob store or the data lake itself.
 
 > [!WARNING]
 > Deleted files or folders cannot be restored (this is only possible is the storage account has soft delete disabled, if enabled, the file can be undeleted and restored back). Be cautious when using the Delete activity to delete files or folders.


### PR DESCRIPTION
In the introductory paragraph, we say that this activity can be used to archive files, in addition, to delete files themselves. This is factually incorrect and this task is not used to move data to archive tier. Moving to an archive tier or changing blob storage class is not an activity that this task can do.