### PR TITLE
(AzureCXP) Adding context on Output format

### DIFF
--- a/articles/azure-resource-manager/templates/template-tutorial-add-outputs.md
+++ b/articles/azure-resource-manager/templates/template-tutorial-add-outputs.md
@@ -72,7 +72,7 @@ az deployment group create \
 
 ---
 
-In the output for the deployment command, you'll see an object similar to:
+In the output for the deployment command, you'll see an object similar to below only if the output is in JSON format:
 
 ```json
 {

--- a/articles/azure-resource-manager/templates/template-tutorial-add-outputs.md
+++ b/articles/azure-resource-manager/templates/template-tutorial-add-outputs.md
@@ -72,7 +72,7 @@ az deployment group create \
 
 ---
 
-In the output for the deployment command, you'll see an object similar to below only if the output is in JSON format:
+In the output for the deployment command, you'll see an object similar to the following example only if the output is in JSON format:
 
 ```json
 {


### PR DESCRIPTION
Based on customer feedback on below GitHub thread , added a context to call out that output of the deployment command is visible only if the out is in JSON format. Please review and let me know any re phrases are needed. Thank you

https://github.com/MicrosoftDocs/azure-docs/issues/51372