### PR TITLE
Updated storage blob event source flag

### DIFF
--- a/articles/storage/blobs/storage-blob-event-quickstart.md
+++ b/articles/storage/blobs/storage-blob-event-quickstart.md
@@ -88,7 +88,7 @@ storageid=$(az storage account show --name <storage_account_name> --resource-gro
 endpoint=https://$sitename.azurewebsites.net/api/updates
 
 az eventgrid event-subscription create \
-  --resource-id $storageid \
+  --source-resource-id $storageid \
   --name <event_subscription_name> \
   --endpoint $endpoint
 ```


### PR DESCRIPTION
Fixes "Argument 'resource_id' has been deprecated and will be removed in version '3.0.0'. Use '--source-resource-id' instead" warning when running command in CLI