### PR TITLE
Fix typo `resolvconf` path on Ubuntu

### DIFF
--- a/articles/virtual-machines/linux/azure-dns.md
+++ b/articles/virtual-machines/linux/azure-dns.md
@@ -101,7 +101,7 @@ To check the current settings on a Linux virtual machine, 'cat /etc/resolv.conf'
 The resolv.conf file is auto-generated and should not be edited. The specific steps that add the 'options' line vary by distribution:
 
 **Ubuntu** (uses resolvconf)
-1. Add the options line to '/etc/resolveconf/resolv.conf.d/head'.
+1. Add the options line to '/etc/resolvconf/resolv.conf.d/head'.
 2. Run 'resolvconf -u' to update.
 
 **SUSE** (uses netconf)


### PR DESCRIPTION
I checked files on Ubuntu.

```
$ ls -l /etc/resolvconf/resolv.conf.d/
total 4
-rw-r--r-- 1 root root   0 Jun  4  2015 base
-rw-r--r-- 1 root root 181 Apr  6 11:57 head
```