### PR TITLE
Correct powershell script output for AAD webhook delivery

### DIFF
--- a/articles/event-grid/secure-webhook-delivery.md
+++ b/articles/event-grid/secure-webhook-delivery.md
@@ -99,10 +99,10 @@ else
     
 New-AzureADServiceAppRoleAssignment -Id $myApp.AppRoles[0].Id -ResourceId $myServicePrincipal.ObjectId -ObjectId $eventGridSP.ObjectId -PrincipalId $eventGridSP.ObjectId
     
-Write-Host "My Azure AD Tenant Id" + $myTenantId
-Write-Host "My Azure AD Application Id" + $myAzureADApplicationObjectId
-Write-Host "My Azure AD Application ($myApp.ObjectId): " + $myApp.ObjectId
-Write-Host "My Azure AD Application's Roles"
+Write-Host "My Azure AD Tenant Id: $myTenantId"
+Write-Host "My Azure AD Application Id: $($myApp.AppId)"
+Write-Host "My Azure AD Application ObjectId: $($myApp.ObjectId)"
+Write-Host "My Azure AD Application's Roles: "
 Write-Host $myApp.AppRoles
 ```
     


### PR DESCRIPTION
This patch corrects the included powershell script so that the correct ID (Application Id rather than Object Id) is returned at the bottom of the script so that the instructions provided can be completed successfully.