### PR TITLE
Simple cat instead of edit => file => save

### DIFF
--- a/articles/container-registry/container-registry-helm-repos.md
+++ b/articles/container-registry/container-registry-helm-repos.md
@@ -77,13 +77,15 @@ rm -rf *
 
 In the `templates` folder, create a file called `configmap.yaml` with the following contents:
 
-```yml
+```console
+cat <<EOF > configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hello-world-configmap
 data:
   myvalue: "Hello World"
+EOF
 ```
 
 For more about creating and running this example, see [Getting Started](https://helm.sh/docs/chart_template_guide/getting_started/) in the Helm Docs.


### PR DESCRIPTION
For me something like this is straight more forward and easy to copy past. Would love to see this in the docs.