### PR TITLE
(AzureCXP) Updating deprecated command

### DIFF
--- a/articles/azure-monitor/insights/container-insights-hybrid-setup.md
+++ b/articles/azure-monitor/insights/container-insights-hybrid-setup.md
@@ -223,7 +223,7 @@ To first identify the full resource ID of your Log Analytics workspace required 
        az login
        az account set --subscription "Subscription Name"
        # execute deployment command to add container insights solution to the specified Log Analytics workspace
-       az group deployment create --resource-group <resource group of log analytics workspace> --template-file ./containerSolution.json --parameters @./containerSolutionParams.json
+       az deployment group create --resource-group <resource group of log analytics workspace> --name <deployment name> --template-file  ./containerSolution.json --parameters @./containerSolutionParams.json
        ```
 
        The configuration change can take a few minutes to complete. When it's completed, a message is displayed that's similar to the following and includes the result:


### PR DESCRIPTION
az group deployment is throwing below error 

This command is implicitly deprecated because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.

So changed the command to reflect it with 'deployment group' command