### PR TITLE
Use consistent names for environment variables

### DIFF
--- a/articles/cognitive-services/QnAMaker/includes/quickstart-sdk-python.md
+++ b/articles/cognitive-services/QnAMaker/includes/quickstart-sdk-python.md
@@ -60,7 +60,7 @@ Create variables for your resource's Azure endpoint and key. If you created the 
 
 |Environment variable|variable|Example|
 |--|--|--|
-|`QNAMAKER_SUBSCRIPTION_KEY`|`subscription_key`|The key is a 32 character string and is available in the Azure portal, on the QnA Maker resource, on the Quickstart page. This is not the same as the prediction endpoint key.|
+|`QNAMAKER_KEY`|`subscription_key`|The key is a 32 character string and is available in the Azure portal, on the QnA Maker resource, on the Quickstart page. This is not the same as the prediction endpoint key.|
 |`QNAMAKER_HOST`|`host`| Your authoring endpoint, in the format of `https://YOUR-RESOURCE-NAME.cognitiveservices.azure.com`, includes your **resource name**. This is not the same URL used to query the prediction endpoint.|
 
 [!code-python[Azure resource variables](~/samples-qnamaker-python/documentation-samples/quickstarts/knowledgebase_quickstart/knowledgebase_quickstart.py?name=resourcekeys)]


### PR DESCRIPTION
Earlier in the article, we're asked to create a `QNAMAKER_KEY` variable. However, unless I'm mistaken, this variable is later referred to as `QNAMAKER_SUBSCRIPTION_KEY`, which could cause confusion for folks who are trying to follow the instructions step by step.