### PR TITLE
Remove misleading statement for Public IP

### DIFF
--- a/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
+++ b/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
@@ -12,6 +12,7 @@ ms.tgt_pltfrm: na
 ms.workload: infrastructure-services
 ms.date: 3/2/2020
 ms.author: rohink
+ms.custom: fasttrack-edit
 ---
 
 # Name resolution for resources in Azure virtual networks
@@ -181,8 +182,7 @@ If forwarding queries to Azure doesn't suit your needs, you should provide your 
 * Be secured against access from the internet, to mitigate threats posed by external agents.
 
 > [!NOTE]
-> For best performance, when you are using Azure VMs as DNS servers, IPv6 should be disabled. A [public IP address](virtual-network-public-ip-address.md) should be assigned to each DNS server VM. 
-> 
+> For best performance, when you are using Azure VMs as DNS servers, IPv6 should be disabled.
 
 ### Web apps
 Suppose you need to perform name resolution from your web app built by using App Service, linked to a virtual network, to VMs in the same virtual network. In addition to setting up a custom DNS server that has a DNS forwarder that forwards queries to Azure (virtual IP 168.63.129.16), perform the following steps:


### PR DESCRIPTION
Public IP address is not required for internet FQDN name resolution. If keep this statement in public, please clarify the benefit and scenario.