### PR TITLE
Update storage-network-security.md

### DIFF
--- a/articles/storage/common/storage-network-security.md
+++ b/articles/storage/common/storage-network-security.md
@@ -248,7 +248,7 @@ IP network rules are only allowed for **public internet** IP addresses. IP addre
    > IP network rules have no effect on requests originating from the same Azure region as the storage account. Use [Virtual network rules](#grant-access-from-a-virtual-network) to allow same-region requests.
 
   > [!NOTE]
-  > Services deployed in the same region as the storage account use private Azure IP addresses for communication. Thus, you cannot restrict access to specific Azure services based on their public inbound IP address range.
+  > Services deployed in the same region as the storage account use private Azure IP addresses for communication. Thus, you cannot restrict access to specific Azure services based on their public outbound IP address range.
 
 Only IPV4 addresses are supported for configuration of storage firewall rules.
 


### PR DESCRIPTION
Normally the scenario here is that you want to add the **outbound** addresses of the other service (Web Apps being the most common) to the whitelist on the Storage account. I don't think the **inbound** address of the other service is very relevant, since traffic won't originate from Storage to that service.
Let me know if I'm somehow misunderstanding. We have to go over this issue on an almost weekly basis in support and it would be great to have clear documentation. There may be other wordings/examples to convey the issue more clearly here, just let me know if we want to try something different.