### PR TITLE
Update azure-automation-service-limits.md

### DIFF
--- a/includes/azure-automation-service-limits.md
+++ b/includes/azure-automation-service-limits.md
@@ -28,9 +28,9 @@ ms.custom: "include file"
 | Maximum number of Automation accounts in a subscription |No limit ||
 | Maximum number of Hybrid Worker Groups per Automation Account|4,000||
 |Maximum number of concurrent jobs that can be run on a single Hybrid Runbook Worker|50 ||
-| Maximum runbook job parameter size   | 512 kilobits||
+| Maximum runbook job parameter size   | 512 kibibits||
 | Maximum runbook parameters   | 50|If you reach the 50-parameter limit, you can pass a JSON or XML string to a parameter and parse it with the runbook.|
-| Maximum webhook payload size |  512 kilobits|
+| Maximum webhook payload size |  512 kibibits|
 | Maximum days that job data is retained|30 days|
 | Maximum PowerShell workflow state size |5 MB| Applies to PowerShell workflow runbooks when checkpointing workflow.|
 


### PR DESCRIPTION
I have a support case reporting this message when trying to send a 1 mb parameter in a Runbook:

`  'message': '{\\'Message\\':\\'The request is invalid.\\',\\'ModelState\\':{\\'job.properties.parameters\\':[\\'Job parameter values too long. Max allowed length:524288. Parameter names: myString\\']}}'`

This suggests to me that the maximum is not 512 kilobits (512000 bits), but 512 kibibits (524288 bits). I don't have any evidence on the webhook payload but I'm just assuming it's the same.
Can you check on these values? For that matter, I now notice that the memory/disk space limits are all MB and GB. Are we sure those are not MiB and GiB?