### PR TITLE
Make title levels consistent and show in TOC

### DIFF
--- a/articles/cognitive-services/QnAMaker/How-To/set-up-qnamaker-service-azure.md
+++ b/articles/cognitive-services/QnAMaker/How-To/set-up-qnamaker-service-azure.md
@@ -83,7 +83,7 @@ Endpoint keys can be managed from the [QnA Maker portal](https://qnamaker.ai).
     >[!NOTE]
     >Refresh your keys if you think they've been compromised. This may require corresponding changes to your client application or bot code.
 
-### Upgrade QnA Maker SKU
+## Upgrade QnA Maker SKU
 
 When you want to have more questions and answers in your knowledge base, beyond your current tier, upgrade your QnA Maker service pricing tier.
 
@@ -97,7 +97,7 @@ To upgrade the QnA Maker management SKU:
 
     ![QnA Maker pricing](../media/qnamaker-how-to-upgrade-qnamaker/qnamaker-pricing-page.png)
 
-### Upgrade App Service
+## Upgrade App Service
 
  When your knowledge base needs to serve more requests from your client app, upgrade your App Service pricing tier.
 
@@ -107,7 +107,7 @@ Go to the App Service resource in the Azure portal, and select the **Scale up** 
 
 ![QnA Maker App Service scale](../media/qnamaker-how-to-upgrade-qnamaker/qnamaker-appservice-scale.png)
 
-### Upgrade the Azure Cognitive Search service
+## Upgrade the Azure Cognitive Search service
 
 If you plan to have many knowledge bases, upgrade your Azure Cognitive Search service pricing tier.
 


### PR DESCRIPTION
The three sections "Upgrade QnA Maker SKU", "Upgrade App Service", "Upgrade the Azure Cognitive Search service" are currently subheadings under "Find endpoint keys in the QnA Maker portal" which doesn't make sense. In addition, since they were 3rd level headers, they are not showing up in the TOC making them harder to discover.

This change makes all 3 sections level 2 headers.