### PR TITLE
Update azure-disks-dynamic-pv.md

### DIFF
--- a/articles/aks/azure-disks-dynamic-pv.md
+++ b/articles/aks/azure-disks-dynamic-pv.md
@@ -37,6 +37,7 @@ Each AKS cluster includes two pre-created storage classes, both configured to wo
     * Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. If the AKS nodes in your cluster use premium storage, select the *managed-premium* class.
     
 These default storage classes don't allow you to update the volume size once created. To enable this ability, add the *allowVolumeExpansion: true* line to one of the default storage classes, or create you own custom storage class. You can edit an existing storage class using the `kubectl edit sc` command. For more information on storage classes and creating your own, see [Storage options for applications in AKS][storage-class-concepts].
+Note that it's not supported to reduce the size of a PVC (to prevent data loss).
 
 Use the [kubectl get sc][kubectl-get] command to see the pre-created storage classes. The following example shows the pre-create storage classes available within an AKS cluster:
 


### PR DESCRIPTION
CRI 183406250 where a customer attempted to reduce the size of a PVC - causing error:

The disk/snapshot resource with id /subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-... cannot be resized down. Reducing disk/snapshot size is not supported in Azure to prevent data loss. If you do need to reduce the size of the disk, please create new snapshot/disks with the appropriate size. More information is available at https://aka.ms/AzureDisksFAQ