### PR TITLE
Broken code samples link

### DIFF
--- a/articles/media-services/video-indexer/video-indexer-embed-widgets.md
+++ b/articles/media-services/video-indexer/video-indexer-embed-widgets.md
@@ -260,7 +260,7 @@ By default, the player will start playing the video. you can choose not to by pa
 
 ## Code samples
 
-See the [code samples](https://github.com/Azure-Samples/media-services-video-indexer/tree/master/Widgets) repo that contains samples for Video Indexer API and Widgets:
+See the [code samples](https://github.com/Azure-Samples/media-services-video-indexer/tree/master/Embedding%20widgets) repo that contains samples for Video Indexer API and Widgets:
 
 | File/folder                       | Description                                |
 |-----------------------------------|--------------------------------------------|


### PR DESCRIPTION
Fixes link as folder renamed from Widgets to Embedded Widgets in this commit: https://github.com/Azure-Samples/media-services-video-indexer/commit/6f85498b1ab00904bae97661ce6b6ef37981e732.