### PR TITLE
Update virtual-machines-common-classic-resource-manager-migration-ove…

### DIFF
--- a/includes/virtual-machines-common-classic-resource-manager-migration-overview.md
+++ b/includes/virtual-machines-common-classic-resource-manager-migration-overview.md
@@ -20,7 +20,7 @@ Resource Manager enables deploying complex applications through templates, confi
 Almost all the features from the classic deployment model are supported for compute, network, and storage under Azure Resource Manager. To benefit from the new capabilities in Azure Resource Manager, you can migrate existing deployments from the Classic deployment model.
 
 ## Supported resources for migration
-These classic IaaS resources are supported during migration
+Migration is supported for these classic IaaS resources.
 
 * Virtual Machines
 * Availability Sets
@@ -63,7 +63,7 @@ The following configurations are not currently supported. If support is added in
 >
 
 ### Migration of storage accounts
-To allow seamless migration, you can deploy Resource Manager VMs in a classic storage account. With this capability, compute and network resources can and should be migrated independently of storage accounts. Once you migrate over your Virtual Machines and Virtual Network, you need to migrate over your storage accounts to complete the migration process.
+To allow seamless migration, the VHD file representing your classic Virtual Machine's disk can remain in a classic storage account while that Virtual Machine is migrated to Resource Manager. With this capability, compute and network resources can and should be migrated independently of storage accounts. Once you migrate over your Virtual Machines and Virtual Network, you need to migrate over your storage accounts to complete the migration process.
 
 If your storage account does not have any associated disks or Virtual Machines data and only has blobs, files, tables, and queues then the migration to Azure Resource Manager can be done as a standalone migration without dependencies.
 
@@ -86,8 +86,6 @@ The following screenshots show how to upgrade a Classic storage account to an Az
 
 ### Migration of unattached resources
 Storage Accounts with no associated disks or Virtual Machines data may be migrated independently.
-
-Network Security Groups, Route Tables & Reserved IPs that are not attached to any Virtual Machines and Virtual Networks can also be migrated independently.
 
 <br>
 


### PR DESCRIPTION
We have a support request from a large customer (ending in 0180 for my reference) that expresses some confusion over this page. It's about the Japanese version, but the confusion stems from some unclear wording on the English page that I'm trying to address.

First, "supported during migration" is not very clear. That actually came up a year ago from another case from my team but it was never addressed in the doc, per #30798.

Next, the part about having ARM VMs in classic storage accounts is unclear. The current wording seems to suggest you could deploy a new ARM VM in a classic storage account. From the rest of the paragraph, it seems the point that is being made is that you should first migrate your classic VMs, and after that you will have ARM VMs in a classic storage account. Then you can migrate the storage account also. I made this clearer.

Finally, the section about unattached migration seems misleading and/or wrong when compared to the deep dive document.
It currently mentions NSGs, route tables, and Reserved IPs. Of those, the deep dive specifically says "Unassociated reserved IP migration is not currently supported," and for the other two it says it clones NSGs or UDRs (route tables) associated to a network when migrating the network. As far as I know, there is no independent migration of those two types.
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/migration-classic-resource-manager-deep-dive#translation-of-the-classic-deployment-model-to-resource-manager-resources

You can contact me at v-dibr if internal discussion is needed.