### PR TITLE
Update iot-hub-arduino-iot-devkit-az3166-get-started.md

### DIFF
--- a/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
+++ b/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
@@ -170,9 +170,7 @@ Follow these steps to prepare the development environment for the DevKit:
 
     ![Install Azure IoT Tools](media/iot-hub-arduino-devkit-az3166-get-started/getting-started/install-azure-iot-tools.png)
 
-    Or use this direct link:
-    > [!div class="nextstepaction"]
-    > [Install Azure IoT Tools extension pack](vscode:extension/vsciot-vscode.azure-iot-tools)
+    Or use this direct URL: `vscode:extension/vsciot-vscode.azure-iot-tools`
 
     > [!NOTE]
     > The Azure IoT Tools extension pack contains the [Azure IoT Device Workbench](https://aka.ms/iot-workbench) which is used to develop and debug on various IoT devkit devices. The [Azure IoT Hub extension](https://aka.ms/iot-toolkit), also included with the Azure IoT Tools extension pack, is used to manage and interact with Azure IoT Hubs.


### PR DESCRIPTION
Because this link 404s under certain conditions, it's not supported as direct link. It should be styled as inline code that users can copy and paste if they have VS Code installed:

`vscode:extension/vsciot-vscode.azure-iot-tools`