### PR TITLE
Add initializer sample which reads data from HttpContext

### DIFF
--- a/articles/azure-monitor/app/api-filtering-sampling.md
+++ b/articles/azure-monitor/app/api-filtering-sampling.md
@@ -494,7 +494,7 @@ public void Initialize(ITelemetry telemetry)
 
 #### Add information from HttpContext
 
-The following sample initializer reads data from the [`HttpContext`](https://docs.microsoft.com/aspnet/core/fundamentals/http-context?view=aspnetcore-3.1) and appends it to a `RequestTelemetry` instance.
+The following sample initializer reads data from the [`HttpContext`](https://docs.microsoft.com/aspnet/core/fundamentals/http-context?view=aspnetcore-3.1) and appends it to a `RequestTelemetry` instance. The `IHttpContextAccessor` is automatically provided through constructor dependency injection.
 
 ```csharp
 public class HttpContextRequestTelemetryInitializer : ITelemetryInitializer

--- a/articles/azure-monitor/app/api-filtering-sampling.md
+++ b/articles/azure-monitor/app/api-filtering-sampling.md
@@ -494,7 +494,7 @@ public void Initialize(ITelemetry telemetry)
 
 #### Add information from HttpContext
 
-The following sample initializer reads data from the [`HttpContext`](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-context?view=aspnetcore-3.1) and appends it to a `RequestTelemetry` instance.
+The following sample initializer reads data from the [`HttpContext`](https://docs.microsoft.com/aspnet/core/fundamentals/http-context?view=aspnetcore-3.1) and appends it to a `RequestTelemetry` instance.
 
 ```csharp
 public class HttpContextRequestTelemetryInitializer : ITelemetryInitializer


### PR DESCRIPTION
This useful functionality is hidden away in some StackOverflow posts and some official telemetry initializers, for example [here](https://github.com/microsoft/ApplicationInsights-aspnetcore/blob/a135f1f7d9da7beb11f9bcf20a30f7e779b739f2/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/TelemetryInitializerBase.cs).