### PR TITLE
Clarification on IKEv1 usage in Basic SKUs

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-about-compliance-crypto.md
+++ b/articles/vpn-gateway/vpn-gateway-about-compliance-crypto.md
@@ -16,7 +16,7 @@ This article discusses how you can configure Azure VPN gateways to satisfy your 
 
 ## About IKEv1 and IKEv2 for Azure VPN connections
 
-Traditionally we allowed IKEv1 connections for Basic SKUs only and allowed IKEv2 connections for all VPN gateway SKUs other than Basic SKUs. The Basic SKUs allow only 1 connection and along with other limitations such as performance, customers using legacy devices that support only IKEv1 protocols were having limited experience. In order to enhance the experience of customers using IKEv1 protocols, we are now allowing IKEv1 connections for all of the VPN gateway SKUs, except Basic SKU. For more information, see [VPN Gateway SKUs](https://docs.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku).
+Traditionally we allowed IKEv1 connections for Basic SKUs only and allowed IKEv2 connections for all VPN gateway SKUs other than Basic SKUs. The Basic SKUs allow only 1 connection and along with other limitations such as performance, customers using legacy devices that support only IKEv1 protocols were having limited experience. In order to enhance the experience of customers using IKEv1 protocols, we are now allowing IKEv1 connections for all of the VPN gateway SKUs, except Route-Based gateways of Basic SKU. For more information, see [VPN Gateway SKUs](https://docs.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpn-gateway-settings#gwsku).
 
 ![Azure VPN Gateway IKEv1 and IKEv2 connections](./media/vpn-gateway-about-compliance-crypto/ikev1-ikev2-connections.png)
 


### PR DESCRIPTION
I know for a fact that IKEv1 was in the pass only supported by Basic Policy-Based VPN GWs, and now it is supported also in Route-Based VPN GWs in all SKUs, except Basic.

Saying this way, you don't get any confusion, but as it is written in the document:

"In order to enhance the experience of customers using IKEv1 protocols, we are now allowing IKEv1 connections for all of the VPN gateway SKUs, except Basic SKU", it looks like IKEv1 is allowed in all VPNGW SKUs, but not in Basic SKU either Policy ou Route-Based.

I believe it just lacks the VPN type on the end of the sentence to clarify it.