### PR TITLE
add note to third party app section of AAD Connect attribute list

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-sync-attributes-synchronized.md
+++ b/articles/active-directory/hybrid/reference-connect-sync-attributes-synchronized.md
@@ -12,7 +12,7 @@ ms.workload: identity
 ms.tgt_pltfrm: na
 ms.devlang: na
 ms.topic: reference
-ms.date: 04/24/2019
+ms.date: 04/15/2020
 ms.subservice: hybrid
 ms.author: billmath
 
@@ -370,7 +370,7 @@ This group is a set of attributes used as the minimal attributes needed for a ge
 * Yammer (only User is consumed)
 * [Hybrid Business-to-Business (B2B) cross-org collaboration scenarios offered by resources like SharePoint](https://go.microsoft.com/fwlink/?LinkId=747036)
 
-This group is a set of attributes that can be used if the Azure AD directory is not used to support Office 365, Dynamics, or Intune. It has a small set of core attributes.
+This group is a set of attributes that can be used if the Azure AD directory is not used to support Office 365, Dynamics, or Intune. It has a small set of core attributes.  Note that single sign on or provisioning to some third party applications will require configuring synchronization of additional attributes in addition to these attributes. The application requirements are described in the [SaaS app tutorial](/azure/active-directory/saas-apps/) for each application.
 
 | Attribute Name | User | Contact | Group | Comment |
 | --- |:---:|:---:|:---:| --- |

--- a/articles/active-directory/hybrid/reference-connect-sync-attributes-synchronized.md
+++ b/articles/active-directory/hybrid/reference-connect-sync-attributes-synchronized.md
@@ -370,7 +370,7 @@ This group is a set of attributes used as the minimal attributes needed for a ge
 * Yammer (only User is consumed)
 * [Hybrid Business-to-Business (B2B) cross-org collaboration scenarios offered by resources like SharePoint](https://go.microsoft.com/fwlink/?LinkId=747036)
 
-This group is a set of attributes that can be used if the Azure AD directory is not used to support Office 365, Dynamics, or Intune. It has a small set of core attributes.  Note that single sign on or provisioning to some third party applications will require configuring synchronization of additional attributes in addition to these attributes. The application requirements are described in the [SaaS app tutorial](/azure/active-directory/saas-apps/) for each application.
+This group is a set of attributes that can be used if the Azure AD directory is not used to support Office 365, Dynamics, or Intune. It has a small set of core attributes. Note that single sign-on or provisioning to some third-party applications requires configuring synchronization of attributes in addition to the attributes described here. Application requirements are described in the [SaaS app tutorial](../saas-apps/tutorial-list.md) for each application.
 
 | Attribute Name | User | Contact | Group | Comment |
 | --- |:---:|:---:|:---:| --- |


### PR DESCRIPTION
Add a link to the SaaS app tutorials, so that customers are aware that if they are synchronizing for in Azure AD Connect for use with 'third party application's they won't get all the attribute mappings they need for popular third party applications - they'll likely need to add more.