### PR TITLE
Clear description about timeout values

### DIFF
--- a/articles/application-gateway/application-gateway-faq.md
+++ b/articles/application-gateway/application-gateway-faq.md
@@ -67,7 +67,7 @@ For the v2 SKU, open the public IP resource and select **Configuration**. The **
 
 *Keep-Alive timeout* governs how long the Application Gateway will wait for a client to send another HTTP request on a persistent connection before reusing it or closing it. *TCP idle timeout* governs how long a TCP connection is kept open in case of no activity. 
 
-The *Keep-Alive timeout* in the Application Gateway v1 SKU is 120 seconds and in the v2 SKU it's 75 seconds. The *TCP idle timeout* is a 4-minute default on the frontend virtual IP (VIP) of both v1 and v2 SKU of Application Gateway. 
+The *Keep-Alive timeout* in the Application Gateway v1 SKU is 120 seconds and in the v2 SKU it's 75 seconds. The *TCP idle timeout* is a 4-minute default on the frontend virtual IP (VIP) of both v1 and v2 SKU of Application Gateway. These values are fixed, customer can't change them.
 
 ### Does the IP or DNS name change over the lifetime of the application gateway?
 

--- a/articles/application-gateway/application-gateway-faq.md
+++ b/articles/application-gateway/application-gateway-faq.md
@@ -67,7 +67,7 @@ For the v2 SKU, open the public IP resource and select **Configuration**. The **
 
 *Keep-Alive timeout* governs how long the Application Gateway will wait for a client to send another HTTP request on a persistent connection before reusing it or closing it. *TCP idle timeout* governs how long a TCP connection is kept open in case of no activity. 
 
-The *Keep-Alive timeout* in the Application Gateway v1 SKU is 120 seconds and in the v2 SKU it's 75 seconds. The *TCP idle timeout* is a 4-minute default on the frontend virtual IP (VIP) of both v1 and v2 SKU of Application Gateway. These values are fixed, customer can't change them.
+The *Keep-Alive timeout* in the Application Gateway v1 SKU is 120 seconds and in the v2 SKU it's 75 seconds. The *TCP idle timeout* is a 4-minute default on the frontend virtual IP (VIP) of both v1 and v2 SKU of Application Gateway. You can't change these values.
 
 ### Does the IP or DNS name change over the lifetime of the application gateway?
 


### PR DESCRIPTION
Users cannot understand whether the timeout values are configurable or not.
They need clear description that the values are fixed.