### PR TITLE
Update manage-virtual-network.md

### DIFF
--- a/articles/virtual-network/manage-virtual-network.md
+++ b/articles/virtual-network/manage-virtual-network.md
@@ -44,9 +44,8 @@ Complete the following tasks before completing steps in any section of this arti
 
      Although you can define only one address range when you create the virtual network in the portal, you can add more address ranges to the address space after the virtual network is created. To learn how to add an address range to an existing virtual network, see [Add or remove an address range](#add-or-remove-an-address-range).
 
-     >[!WARNING]
-     >If a virtual network has address ranges that overlap with another virtual network or on-premises network, the two networks cannot be connected. Before you define an address range, consider whether you might want to connect the virtual network to other virtual networks or on-premises networks in the future. Microsoft recommends configuring virtual network address ranges with private address space or public address space owned by your organization.  Some Azure features may break as a result of specifying public address space owned by Microsoft.
-     >
+     > [!WARNING]
+     > If a virtual network has address ranges that overlap with another virtual network or on-premises network, the two networks can't be connected. Before you define an address range, consider whether you might want to connect the virtual network to other virtual networks or on-premises networks in the future. Microsoft recommends configuring virtual network address ranges with private address space or public address space owned by your organization.
      >
 
      - **Subnet name**: The subnet name must be unique within the virtual network. You cannot change the subnet name after the subnet is created. The portal requires that you define one subnet when you create a virtual network, even though a virtual network isn't required to have any subnets. In the portal, you can define only one subnet when you create a virtual network. You can add more subnets to the virtual network later, after the virtual network is created. To add a subnet to a virtual network, see [Manage subnets](virtual-network-manage-subnet.md). You can create a virtual network that has multiple subnets by using Azure CLI or PowerShell.

--- a/articles/virtual-network/manage-virtual-network.md
+++ b/articles/virtual-network/manage-virtual-network.md
@@ -45,7 +45,7 @@ Complete the following tasks before completing steps in any section of this arti
      Although you can define only one address range when you create the virtual network in the portal, you can add more address ranges to the address space after the virtual network is created. To learn how to add an address range to an existing virtual network, see [Add or remove an address range](#add-or-remove-an-address-range).
 
      >[!WARNING]
-     >If a virtual network has address ranges that overlap with another virtual network or on-premises network, the two networks cannot be connected. Before you define an address range, consider whether you might want to connect the virtual network to other virtual networks or on-premises networks in the future.
+     >If a virtual network has address ranges that overlap with another virtual network or on-premises network, the two networks cannot be connected. Before you define an address range, consider whether you might want to connect the virtual network to other virtual networks or on-premises networks in the future. Microsoft recommends configuring virtual network address ranges with private address space or public address space owned by your organization.  Some Azure features may break as a result of specifying public address space owned by Microsoft.
      >
      >
 


### PR DESCRIPTION
Add a warning that Microsoft recommends virtual networks be configured with private address space or public address space owned by the customers organization.  This will prevent problems generally for the customer.  If the customer uses public space owned by Microsoft, some Azure services/products may not function.  This change proposal is a result of a support escalation.