### PR TITLE
Corrected multipart/form-data request example JSON

### DIFF
--- a/articles/connectors/connectors-native-http.md
+++ b/articles/connectors/connectors-native-http.md
@@ -140,8 +140,8 @@ For example, suppose you have a logic app that sends an HTTP POST request for an
 Here is the same example that shows the HTTP action's JSON definition in the underlying workflow definition:
 
 ```json
-{
-   "HTTP_action": {
+"HTTP_action": {
+   "inputs": {
       "body": {
          "$content-type": "multipart/form-data",
          "$multipart": [


### PR DESCRIPTION
The properties runAfter & type should be inside the action object along with the input property, which was mislabeled as the action object itself.