### PR TITLE
adding role information required

### DIFF
--- a/articles/active-directory/users-groups-roles/users-bulk-download.md
+++ b/articles/active-directory/users-groups-roles/users-bulk-download.md
@@ -22,7 +22,7 @@ Azure Active Directory (Azure AD) supports bulk user import (create) operations.
 
 ## Required permissions
 
-To download the list of users from the Azure AD admin center, you must be signed in with a user assigned to one or more organization-level administrator roles in Azure AD. Guest inviter and application developer are not considered administrator roles.
+To download the list of users from the Azure AD admin center, you must be signed in with a user assigned to one or more organization-level administrator roles in Azure AD (User Administrator is the minimum role required). Guest inviter and application developer are not considered administrator roles.
 
 ## To download a list of users
 


### PR DESCRIPTION
Team, it took me almost 2 hours to find out which role is required as a minimum requirement. I found user administrator is required to be able to view the results in case they do not want to give global admin roles.