### PR TITLE
Fix with Server not found in Kerberos database

### DIFF
--- a/articles/active-directory-domain-services/join-ubuntu-linux-vm.md
+++ b/articles/active-directory-domain-services/join-ubuntu-linux-vm.md
@@ -151,6 +151,12 @@ Successfully enrolled machine in realm
 
 If your VM can't successfully complete the domain-join process, make sure that the VM's network security group allows outbound Kerberos traffic on TCP + UDP port 464 to the virtual network subnet for your Azure AD DS managed domain.
 
+If you received the error *Unspecified GSS failure.  Minor code may provide more information (Server not found in Kerberos database)*, open the file */etc/krb5.conf* and add the following code in `[libdefaults]` section and try again:
+
+```console
+rdns=false
+```
+
 ## Update the SSSD configuration
 
 One of the packages installed in a previous step was for System Security Services Daemon (SSSD). When a user tries to sign in to a VM using domain credentials, SSSD relays the request to an authentication provider. In this scenario, SSSD uses Azure AD DS to authenticate the request.


### PR DESCRIPTION
Hello, minutes ago I tried add Ubuntu server on Azure AD Managed domain and received the error Unspecified GSS failure.  Minor code may provide more information (Server not found in Kerberos database).
I found the following documentation of RHEL but works on Ubuntu server. https://access.redhat.com/discussions/3370851

This could help to others to reduce time on adding machines and use more Azure ADDS