### PR TITLE
Wrong max subscription per account

### DIFF
--- a/articles/azure-resource-manager/management/programmatically-create-subscription.md
+++ b/articles/azure-resource-manager/management/programmatically-create-subscription.md
@@ -200,7 +200,7 @@ To see a full list of all parameters, see [az account create](/cli/azure/ext/sub
 ### Limitations of Azure Enterprise subscription creation API
 
 - Only Azure Enterprise subscriptions can be created using this API.
-- There's a limit of 500 subscriptions per enrollment account. After that, more subscriptions for the account can only be created in the Azure portal. If you want to create more subscriptions through the API, create another enrollment account.
+- There's a limit of 200 subscriptions per enrollment account. After that, more subscriptions for the account can only be created in the Azure portal. If you want to create more subscriptions through the API, create another enrollment account.
 - Users who aren't Account Owners, but were added to an enrollment account via RBAC, can't create subscriptions in the Azure portal.
 - You can't select the tenant for the subscription to be created in. The subscription is always created in the home tenant of the Account Owner. To move the subscription to a different tenant, see [change subscription tenant](../../active-directory/fundamentals/active-directory-how-subscriptions-associated-directory.md).
 


### PR DESCRIPTION
Please revert back the limit to 200 in the docs - support/PG told me that the limit has not increased yet.