### PR TITLE
"your" to "a/an" in Spring Cloud toc

### DIFF
--- a/articles/spring-cloud/toc.yml
+++ b/articles/spring-cloud/toc.yml
@@ -8,29 +8,29 @@
 - name: Quickstarts
   expanded: true 
   items:
-    - name: Launch your Spring Cloud app using the portal
+    - name: Launch a Spring Cloud app using the portal
       href: spring-cloud-quickstart-launch-app-portal.md
-    - name: Launch your Spring Cloud app using the Azure CLI
+    - name: Launch a Spring Cloud app using the Azure CLI
       href: spring-cloud-quickstart-launch-app-cli.md 
-    - name: Launch your Spring Cloud app from source
+    - name: Launch a Spring Cloud app from source
       href: spring-cloud-launch-from-source.md
-    - name: Launch your Spring Cloud app using Maven
+    - name: Launch a Spring Cloud app using Maven
       href: spring-cloud-quickstart-launch-app-maven.md
 - name: Tutorials
   items:
-    - name: Set up your Config Server
+    - name: Set up a Config Server
       href: spring-cloud-tutorial-config-server.md
-    - name: Manually scale your application
+    - name: Manually scale an application
       href: spring-cloud-tutorial-scale-manual.md
-    - name: Monitor your application using distributed tracing and App Insights
+    - name: Monitor an application using distributed tracing and App Insights
       href: spring-cloud-tutorial-distributed-tracing.md
     - name: Monitor Spring Cloud resources using alerts and action groups
       href: spring-cloud-tutorial-alerts-action-groups.md
-    - name: Bind your application to Azure CosmosDB
+    - name: Bind an application to Azure CosmosDB
       href: spring-cloud-tutorial-bind-cosmos.md
-    - name: Bind your application with Azure Cache for Redis
+    - name: Bind an application with Azure Cache for Redis
       href: spring-cloud-tutorial-bind-redis.md
-    - name: Bind your application to Azure MySQL
+    - name: Bind an application to Azure MySQL
       href: spring-cloud-tutorial-bind-mysql.md
 - name: Concepts
   items: 


### PR DESCRIPTION
Make TOC names follow the pattern in the corresponding doc titles.  A quickstart, for example, is not about launching "your" app but a sample we provide.