### PR TITLE
Minor grammatical suggestions

### DIFF
--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -112,7 +112,7 @@ namespace MyNamespace
 
 ## Service lifetimes
 
-Azure Functions apps provide the same service lifetimes as [ASP.NET Dependency Injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection#service-lifetimes). For a Function app, the different service lifetimes behave as follows:
+Azure Functions apps provide the same service lifetimes as [ASP.NET Dependency Injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection#service-lifetimes). For a Functions app, the different service lifetimes behave as follows:
 
 - **Transient**: Transient services are created upon each request of the service.
 - **Scoped**: The scoped service lifetime matches a function execution lifetime. Scoped services are created once per execution. Later requests for that service during the execution reuse the existing service instance.

--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -12,7 +12,7 @@ ms.reviewer: jehollan
 
 Azure Functions supports the dependency injection (DI) software design pattern, which is a technique to achieve [Inversion of Control (IoC)](https://docs.microsoft.com/dotnet/standard/modern-web-apps-azure-architecture/architectural-principles#dependency-inversion) between classes and their dependencies.
 
-- Dependency injection in Azure Functions is built on the .NET Core Dependency Injection features. Familiarity with the [.NET Core dependency injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection) is recommended. There are differences, however, in how you override dependencies and how configuration values are read with Azure Functions on the Consumption plan.
+- Dependency injection in Azure Functions is built on the .NET Core Dependency Injection features. Familiarity with [.NET Core dependency injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection) is recommended. There are differences in how you override dependencies and how configuration values are read with Azure Functions on the Consumption plan.
 
 - Support for dependency injection begins with Azure Functions 2.x.
 
@@ -112,7 +112,7 @@ namespace MyNamespace
 
 ## Service lifetimes
 
-Azure Functions apps provide the same service lifetimes as [ASP.NET Dependency Injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection#service-lifetimes). For a Functions app, the different service lifetimes behave as follows:
+Azure Functions apps provide the same service lifetimes as [ASP.NET Dependency Injection](https://docs.microsoft.com/aspnet/core/fundamentals/dependency-injection#service-lifetimes). For a Function app, the different service lifetimes behave as follows:
 
 - **Transient**: Transient services are created upon each request of the service.
 - **Scoped**: The scoped service lifetime matches a function execution lifetime. Scoped services are created once per execution. Later requests for that service during the execution reuse the existing service instance.


### PR DESCRIPTION
- .NET Core dependency injection, while specific, is still somewhat abstract and probably shouldn't have a "the" preceding it.
- The "however" seems unnecessary in this sentence.
- Azure Functions is plural, but when talking about *a* function, I think singular Function rather than plural seems more correct.