### PR TITLE
DCsv2 changes for GA

### DIFF
--- a/articles/virtual-machines/dcv2-series.md
+++ b/articles/virtual-machines/dcv2-series.md
@@ -9,12 +9,12 @@
  ms.author: lahugh
 ---
 
-# Preview: DCsv2-series
+# DCsv2-series
 
 
 The DCsv2-series can help protect the confidentiality and integrity of your data and code while it’s processed in the public cloud. These machines are backed by the latest generation of Intel XEON E-2288G Processor with SGX technology. With the Intel Turbo Boost Technology these machines can go up to 5.0GHz. DCsv2 series instances enable customers to build secure enclave-based applications to protect their code and data while it’s in use.
 
-Example use cases include confidential multiparty data sharing, fraud detection, anti-money laundering, blockchain, confidential usage analytics, intelligence analysis and confidential machine learning.
+Example use cases include: confidential multiparty data sharing, fraud detection, anti-money laundering, blockchain, confidential usage analytics, intelligence analysis and confidential machine learning.
 
 Premium Storage: Supported*
 
@@ -36,9 +36,9 @@ Memory Preserving Updates: Not Supported
 | Standard_DC8_v2  | 8   | 32          | 400                    | 8              | 16000/128 (172)                                                         | 12800/192                                 | 2                                            |
 
 - DCsv2-series VMs are [generation 2 VMs](./linux/generation-2.md#creating-a-generation-2-vm) and only support `Gen2` images.
-- Currently available in UK South and Canada Central only.
-- Previous generation of Confidential Compute VMs: [DC Series](sizes-previous-gen.md)
-- Create DCsv2 VMs using Azure Portal [Create VM - Portal](./linux/quick-create-portal.md)
+- Currently available in UK South, Canada Central, and US East only.
+- Previous generation of Confidential Compute VMs: [DC Series](sizes-previous-gen#preview-dc-series)
+- Create DCsv2 VMs using [Azure Portal](./linux/quick-create-portal.md) or the [Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/microsoft-azure-compute.acc-virtual-machine-v2?tab=overview)
 
 
 

--- a/articles/virtual-machines/dcv2-series.md
+++ b/articles/virtual-machines/dcv2-series.md
@@ -37,8 +37,8 @@ Memory Preserving Updates: Not Supported
 
 - DCsv2-series VMs are [generation 2 VMs](./linux/generation-2.md#creating-a-generation-2-vm) and only support `Gen2` images.
 - Currently available in UK South, Canada Central, and US East only.
-- Previous generation of Confidential Compute VMs: [DC Series](sizes-previous-gen#preview-dc-series)
-- Create DCsv2 VMs using [Azure Portal](./linux/quick-create-portal.md) or the [Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/microsoft-azure-compute.acc-virtual-machine-v2?tab=overview)
+- Previous generation of Confidential Compute VMs: [DC series](sizes-previous-gen.md#preview--dc--series)
+- Create DCsv2 VMs using the [Azure portal](./linux/quick-create-portal.md) or [Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/microsoft-azure-compute.acc-virtual-machine-v2?tab=overview)
 
 
 

--- a/articles/virtual-machines/dcv2-series.md
+++ b/articles/virtual-machines/dcv2-series.md
@@ -37,7 +37,7 @@ Memory Preserving Updates: Not Supported
 
 - DCsv2-series VMs are [generation 2 VMs](./linux/generation-2.md#creating-a-generation-2-vm) and only support `Gen2` images.
 - Currently available in UK South, Canada Central, and US East only.
-- Previous generation of Confidential Compute VMs: [DC series](sizes-previous-gen.md#preview--dc--series)
+- Previous generation of Confidential Compute VMs: [DC series](sizes-previous-gen.md#preview-dc-series)
 - Create DCsv2 VMs using the [Azure portal](./linux/quick-create-portal.md) or [Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/microsoft-azure-compute.acc-virtual-machine-v2?tab=overview)
 
 

--- a/articles/virtual-machines/linux/generation-2.md
+++ b/articles/virtual-machines/linux/generation-2.md
@@ -22,7 +22,7 @@ Generation 2 VMs use the new UEFI-based boot architecture rather than the BIOS-b
 Generation 1 VMs are supported by all VM sizes in Azure (except for Mv2-series VMs). Azure now offers generation 2 support for the following selected VM series:
 
 * [B-series](https://docs.microsoft.com/azure/virtual-machines/linux/b-series-burstable)
-* [DC-series](../dcv2-series.md)
+* [DCsv2-series](../dcv2-series.md)
 * [DSv2-series](../dv2-dsv2-series.md) and [Dsv3-series](../dv3-dsv3-series.md)
 * [Esv3-series](../ev3-esv3-series.md)
 * [Fsv2-series](../fsv2-series.md)

--- a/articles/virtual-machines/sizes-previous-gen.md
+++ b/articles/virtual-machines/sizes-previous-gen.md
@@ -215,6 +215,8 @@ Premium Storage caching:  Not Supported
 
 ## Preview: DC-series
 
+**Newer size recommendation**: [DCsv2-series](dcv2-series.md)
+
 Premium Storage: Supported
 
 Premium Storage caching: Supported

--- a/articles/virtual-machines/windows/generation-2.md
+++ b/articles/virtual-machines/windows/generation-2.md
@@ -23,7 +23,7 @@ Generation 2 VMs use the new UEFI-based boot architecture rather than the BIOS-b
 Generation 1 VMs are supported by all VM sizes in Azure (except for Mv2-series VMs). Azure now offers generation 2 support for the following selected VM series:
 
 * [B-series](https://docs.microsoft.com/azure/virtual-machines/windows/b-series-burstable)
-* [DC-series](../dcv2-series.md)
+* [DCsv2-series](../dcv2-series.md)
 * [DSv2-series](../dv2-dsv2-series.md) and [Dsv3-series](../dv3-dsv3-series.md)
 * [Dasv4-series](https://docs.microsoft.com/azure/virtual-machines/dav4-dasv4-series)
 * [Esv3-series](../ev3-esv3-series.md)


### PR DESCRIPTION
@ju-shim - submitted are the changes for DCsv2-Series and related content. This is meant to go live on 4/27.
DC-Series are staying in preview and are considered a "previous" size.
DCsv2-Series are becoming GA 