### PR TITLE
Update azure-portal-safelist-urls.md

### DIFF
--- a/articles/azure-portal/azure-portal-safelist-urls.md
+++ b/articles/azure-portal/azure-portal-safelist-urls.md
@@ -30,7 +30,7 @@ The URL endpoints to safelist for the Azure portal are specific to the Azure clo
 *.applicationinsights.io
 *.azure.com
 *.azure.net
-*.azureafd.net
+*.azurefd.net
 *.azure-api.net
 *.azuredatalakestore.net
 *.azureedge.net


### PR DESCRIPTION
One of address in public cloud “*.azureafd.net" needs to be or added “*.azurefd.net” (no “a” between 'azure' and 'fd')

When we access Azure Portal - [App Service] - [Diagnose and solve problems], we need to go through “.azurefd.net”. However, this is not included the safelist and users unable to access the the page if they using the list for proxy.

Therefore, we need to update the doc to include “*.azurefd.net”.

![image](https://user-images.githubusercontent.com/34254938/80057560-d3cd7200-8561-11ea-9f66-d73619e86c80.png)
