### PR TITLE
For consistency - python sdk marked with

### DIFF
--- a/articles/iot-hub/iot-hub-reliability-features-in-sdks.md
+++ b/articles/iot-hub/iot-hub-reliability-features-in-sdks.md
@@ -125,7 +125,7 @@ For code samples in other languages, review the following implementation documen
 
 * [Node SDK](https://github.com/Azure/azure-iot-sdk-node/wiki/Connectivity-and-Retries#types-of-errors-and-how-to-detect-them)
 
-* [Python SDK](https://github.com/Azure/azure-iot-sdk-python)
+* [Python SDK](https://github.com/Azure/azure-iot-sdk-python) (Reliability not yet implemented)
 
 ## Next steps
 


### PR DESCRIPTION
Python sdk twice mentioned, but only once marked that it doesn't support policies (Reliability not yet implemented)
Fixed inconsistency.