### PR TITLE
Condition fix in WAFlogQuery

### DIFF
--- a/articles/web-application-firewall/afds/waf-front-door-monitor.md
+++ b/articles/web-application-firewall/afds/waf-front-door-monitor.md
@@ -34,7 +34,7 @@ The following example query obtains WAF logs on blocked requests:
 ``` WAFlogQuery
 AzureDiagnostics
 | where ResourceType == "FRONTDOORS" and Category == "FrontdoorWebApplicationFirewallLog"
-| where action_name_s == "Block"
+| where action_s == "Block"
 
 ```
 


### PR DESCRIPTION
When trying to run original query you get an error 

`'where' operator: Failed to resolve column or scalar expression named 'action_name_s'`

Within AzureDiagnostics we have `action_s` not `action_name_s`.