### PR TITLE
Update resource-provider-operations.md

### DIFF
--- a/articles/role-based-access-control/resource-provider-operations.md
+++ b/articles/role-based-access-control/resource-provider-operations.md
@@ -6666,8 +6666,6 @@ Azure service: [Virtual Network](../virtual-network/index.yml), [Load Balancer](
 > | Action | Microsoft.Network/privateEndpoints/read | Gets an private endpoint resource. |
 > | Action | Microsoft.Network/privateEndpoints/write | Creates a new private endpoint, or updates an existing private endpoint. |
 > | Action | Microsoft.Network/privateEndpoints/delete | Deletes an private endpoint resource. |
-> |  | **privateEndpoints/privateDnsZoneConfigs** |  |
-> | Action | Microsoft.Network/privateEndpoints/privateDnsZoneConfigs/write | Puts a Private DNS Zone Config |
 > |  | **privateLinkServices** |  |
 > | Action | Microsoft.Network/privateLinkServices/read | Gets an private link service resource. |
 > | Action | Microsoft.Network/privateLinkServices/write | Creates a new private link service, or updates an existing private link service. |


### PR DESCRIPTION
Per @avgupt@microsoft.com, Microsoft.Network/privateEndpoints/privateDnsZoneConfigs/write has been removed in favor of Microsoft.Network/privateEndpoints/privateDnsZoneGroups/write, so removing it from the documentation since it has already been removed from the provider via PowerShell and REST.