### PR TITLE
Corrected link

### DIFF
--- a/articles/cognitive-services/Speaker-recognition/toc.yml
+++ b/articles/cognitive-services/Speaker-recognition/toc.yml
@@ -1,4 +1,5 @@
 - name: Speaker Recognition Documentation
+  href: Home.md
 - name: Overview
   items: 
   - name: Learn about Speaker Recognition


### PR DESCRIPTION
The Speaker Recognition Documentation page was not linked right, it should link to Home.md.