### PR TITLE
Update assign-user-or-group-access-portal.md

### DIFF
--- a/articles/active-directory/manage-apps/assign-user-or-group-access-portal.md
+++ b/articles/active-directory/manage-apps/assign-user-or-group-access-portal.md
@@ -33,7 +33,7 @@ With the following types of applications, you have the option of requiring users
 - Application Proxy applications that use Azure Active Directory Pre-Authentication
 - Applications built on the Azure AD application platform that use OAuth 2.0 / OpenID Connect Authentication after a user or admin has consented to that application.
 
-When user assignment is required, only those users you explicitly assign to the application (direct as user or based on a group membership) will be able to sign in. They can access the app on their My Apps page or by using a direct link. 
+When user assignment is required, only those users you explicitly assign to the application (either through direct user assignment or based on group membership) will be able to sign in. They can access the app on their My Apps page or by using a direct link. 
 
 When assignment is *not required*, either because you've set this option to **No** or because the application uses another SSO mode, any user will be able to access the application if they have a direct link to the application or the **User Access URL** in the application’s **Properties** page. 
 

--- a/articles/active-directory/manage-apps/assign-user-or-group-access-portal.md
+++ b/articles/active-directory/manage-apps/assign-user-or-group-access-portal.md
@@ -33,7 +33,7 @@ With the following types of applications, you have the option of requiring users
 - Application Proxy applications that use Azure Active Directory Pre-Authentication
 - Applications built on the Azure AD application platform that use OAuth 2.0 / OpenID Connect Authentication after a user or admin has consented to that application.
 
-When user assignment is required, only those users you explicitly assign to the application will be able to sign in. They can access the app on their My Apps page or by using a direct link. 
+When user assignment is required, only those users you explicitly assign to the application (direct as user or based on a group membership) will be able to sign in. They can access the app on their My Apps page or by using a direct link. 
 
 When assignment is *not required*, either because you've set this option to **No** or because the application uses another SSO mode, any user will be able to access the application if they have a direct link to the application or the **User Access URL** in the application’s **Properties** page. 
 
@@ -107,7 +107,9 @@ To require user assignment for an application:
 
 For more information about how to assign a user to an application role visit the documentation for [New-AzureADUserAppRoleAssignment](https://docs.microsoft.com/powershell/module/azuread/new-azureaduserapproleassignment?view=azureadps-2.0)
 
-To assign a group to an enterprise app, you need to replace `Get-AzureADUser` with `Get-AzureADGroup`.
+To assign a group to an enterprise app, you need to replace `Get-AzureADUser` with `Get-AzureADGroup` and replace `New-AzureADUserAppRoleAssignment` with `New-AzureADGroupAppRoleAssignment`.
+
+For more information about how to assign a group to an application role visit the documentation for [New-AzureADGroupAppRoleAssignment](https://docs.microsoft.com/powershell/module/azuread/new-azureadgroupapproleassignment?view=azureadps-2.0)
 
 ### Example
 

--- a/articles/active-directory/manage-apps/assign-user-or-group-access-portal.md
+++ b/articles/active-directory/manage-apps/assign-user-or-group-access-portal.md
@@ -105,11 +105,11 @@ To require user assignment for an application:
     New-AzureADUserAppRoleAssignment -ObjectId $user.ObjectId -PrincipalId $user.ObjectId -ResourceId $sp.ObjectId -Id $appRole.Id
     ```
 
-For more information about how to assign a user to an application role visit the documentation for [New-AzureADUserAppRoleAssignment](https://docs.microsoft.com/powershell/module/azuread/new-azureaduserapproleassignment?view=azureadps-2.0)
+For more information about how to assign a user to an application role, see the documentation for [New-AzureADUserAppRoleAssignment](https://docs.microsoft.com/powershell/module/azuread/new-azureaduserapproleassignment?view=azureadps-2.0).
 
-To assign a group to an enterprise app, you need to replace `Get-AzureADUser` with `Get-AzureADGroup` and replace `New-AzureADUserAppRoleAssignment` with `New-AzureADGroupAppRoleAssignment`.
+To assign a group to an enterprise app, you must replace `Get-AzureADUser` with `Get-AzureADGroup` and replace `New-AzureADUserAppRoleAssignment` with `New-AzureADGroupAppRoleAssignment`.
 
-For more information about how to assign a group to an application role visit the documentation for [New-AzureADGroupAppRoleAssignment](https://docs.microsoft.com/powershell/module/azuread/new-azureadgroupapproleassignment?view=azureadps-2.0)
+For more information about how to assign a group to an application role, see the documentation for [New-AzureADGroupAppRoleAssignment](https://docs.microsoft.com/powershell/module/azuread/new-azureadgroupapproleassignment?view=azureadps-2.0).
 
 ### Example
 


### PR DESCRIPTION
Pointed out differences when assigning a group instead  of a user object. Also added lines about the separate cmdlet needed.