### PR TITLE
Adding East US 2 to list of management IPs

### DIFF
--- a/articles/hdinsight/hdinsight-management-ip-addresses.md
+++ b/articles/hdinsight/hdinsight-management-ip-addresses.md
@@ -68,7 +68,7 @@ Allow traffic from the IP addresses listed for the Azure HDInsight health and ma
 | United Kingdom | UK West | 51.141.13.110</br>51.141.7.20 | \*:443 | Inbound |
 | &nbsp; | UK South | 51.140.47.39</br>51.140.52.16 | \*:443 | Inbound |
 | United States | Central US | 13.89.171.122</br>13.89.171.124 | \*:443 | Inbound |
-| &nbsp; | East US | 13.82.225.233</br>40.71.175.99 | \*:443 | Inbound |
+| &nbsp; | East US and East US 2 | 13.82.225.233</br>40.71.175.99 | \*:443 | Inbound |
 | &nbsp; | North Central US | 157.56.8.38</br>157.55.213.99 | \*:443 | Inbound |
 | &nbsp; | West Central US | 52.161.23.15</br>52.161.10.167 | \*:443 | Inbound |
 | &nbsp; | West US | 13.64.254.98</br>23.101.196.19 | \*:443 | Inbound |


### PR DESCRIPTION
I was told that East US 2 has the same management IPs as East US. If this is the case, please accept this change. If not, can the correct one be added?

Thanks!