### PR TITLE
Replace no-break space in disks-upload-vhd-to-managed-disk-powershell.md

### DIFF
--- a/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
+++ b/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
@@ -72,7 +72,7 @@ Use AzCopy v10 to upload your local VHD file to a managed disk by specifying the
 This upload has the same throughput as the equivalent [standard HDD](disks-types.md#standard-hdd). For example, if you have a size that equates to S4, you will have a throughput of up to 60 MiB/s. But, if you have a size that equates to S70, you will have a throughput of up to 500 MiB/s.
 
 ```
-AzCopy.exe copy "c:\somewhere\mydisk.vhd" $diskSas.AccessSAS --blob-type PageBlob
+AzCopy.exe copy "c:\somewhere\mydisk.vhd" $diskSas.AccessSAS --blob-type PageBlob
 ```
 
 After the upload is complete, and you no longer need to write any more data to the disk, revoke the SAS. Revoking the SAS will change the state of the managed disk and allow you to attach the disk to a VM.


### PR DESCRIPTION
There is a Unicode character 'NARROW NO-BREAK SPACE' (U+202F) in the sample usage of AzCopy.exe.
AzCopy.exe prints a strange error in some environment (I saw the error in PowerShell 5.1 on Windows 10 build 19603, but it works in PowerShell 7.0). Changing the space to a regular space can fix this issue.