### PR TITLE
Allows up to 20GB per partition

### DIFF
--- a/articles/cosmos-db/cassandra-faq.md
+++ b/articles/cosmos-db/cassandra-faq.md
@@ -11,7 +11,7 @@ ms.author: thvankra
 
 ## What are some key differences between Apache Cassandra and the Cassandra API?
 
-- Apache Cassandra recommends a 100-MB limit on the size of a partition key. The Cassandra API for Azure Cosmos DB allows up to 10 GB per partition.
+- Apache Cassandra recommends a 100-MB limit on the size of a partition key. The Cassandra API for Azure Cosmos DB allows up to 20 GB per partition.
 - Apache Cassandra allows you to disable durable commits. You can skip writing to the commit log and go directly to the memtables. This can lead to data loss if the node goes down before memtables are flushed to SSTables on disk. Azure Cosmos DB always does durable commits to help prevent data loss.
 - Apache Cassandra can see diminished performance if the workload involves many replacements or deletions. The reason is tombstones that the read workload needs to skip over to fetch the latest data. The Cassandra API won't see diminished read performance when the workload has many replacements or deletions.
 - During scenarios of high replacement workloads, compaction needs to run to merge SSTables on disk. (A merge is needed because Apache Cassandra's writes are append only. Multiple updates are stored as individual SSTable entries that need to be periodically merged). This situation can also lead to lowered read performance during compaction. This performance impact doesn't happen in the Cassandra API because the API doesn't implement compaction.


### PR DESCRIPTION
The documentation says that Cosmos DB allows up to 10 Gb but this is not updated. However, Cosmos DB now allows up to 20 GB per partition. A single logical partition has an upper limit of 20 GB of storage.

Please check:
- https://azure.microsoft.com/en-us/updates/cosmos-db-partition-size-20gb/
- https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview#choose-partitionkey