### PR TITLE
Issue #53437  | Updated azure cli example for creating an iot hub resource. Changed a…

### DIFF
--- a/articles/iot-hub/virtual-network-support.md
+++ b/articles/iot-hub/virtual-network-support.md
@@ -195,7 +195,7 @@ A managed service identity can be assigned to your hub at resource provisioning 
 After substituting the values for your resource `name`, `location`, `SKU.name` and `SKU.tier`, you can use Azure CLI to deploy the resource in an existing resource group using:
 
 ```azurecli-interactive
-az group deployment create --name <deployment-name> --resource-group <resource-group-name> --template-file <template-file.json>
+az deployment group create --name <deployment-name> --resource-group <resource-group-name> --template-file <template-file.json>
 ```
 
 After the resource is created, you can retrieve the managed service identity assigned to your hub using Azure CLI:


### PR DESCRIPTION
Updated azure cli example for creating an iot hub resource. Changed az group deployment create --name <deployment-name> --resource-group <resource-group-name> --template-file <template-file.json> to az deployment group create --name <deployment-name> --resource-group <resource-group-name> --template-file <template-file.json>. Command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.