### PR TITLE
Adding 2019 to list of support client OS.

### DIFF
--- a/includes/vpn-gateway-faq-p2s-all-include.md
+++ b/includes/vpn-gateway-faq-p2s-all-include.md
@@ -23,6 +23,7 @@ The following client operating systems are supported:
 * Windows Server 2012 (64-bit only)
 * Windows Server 2012 R2 (64-bit only)
 * Windows Server 2016 (64-bit only)
+* Windows Server 2019 (64-bit only)
 * Windows 10
 * Mac OS X version 10.11 or above
 * Linux (StrongSwan)


### PR DESCRIPTION
Confirmed with more recent document written: https://docs.microsoft.com/en-us/azure/vpn-gateway/work-remotely-support#p2s

I also tested this in my lab with the a Windows Server 2019 VM and was able to successfully connect via P2S using certificate.