### PR TITLE
fix broken links

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website.md
+++ b/articles/storage/blobs/storage-blob-static-website.md
@@ -36,8 +36,8 @@ Files in the **$web** container are case-sensitive, served through anonymous acc
 You can use any of these tools to upload content to the **$web** container:
 
 > [!div class="checklist"]
-> * [Azure CLI](storage-blob-static-website-how-to.md#cli)
-> * [Azure PowerShell module](storage-blob-static-website-how-to.md#powershell)
+> * [Azure CLI](storage-blob-static-website-how-to.md?tabs=azure-cli)
+> * [Azure PowerShell module](storage-blob-static-website-how-to.md?tabs=azure-powershell)
 > * [AzCopy](../common/storage-use-azcopy-v10.md)
 > * [Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/)
 > * [Azure Pipelines](https://azure.microsoft.com/services/devops/pipelines/)


### PR DESCRIPTION
Currently links resolve to:

* https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website-how-to?tabs=azure-portal#cli
* https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website-how-to?tabs=azure-portal#powershell

Which don't automatically open to the correct tab

![image](https://user-images.githubusercontent.com/4307307/80512039-f1784e00-894a-11ea-96ac-0484824d7fcc.png)

Internal page links suggest the URLS should be 

* https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website-how-to?tabs=azure-cli
* https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website-how-to?tabs=azure-powershell

**Note** - I'm not sure if using a query param instead of a fragment url will work with the build engine, or if the how-to page should attempt to activate tabs when the hash id is found inside them.