### PR TITLE
Make it clear you shouldn't override MachineConfig objects

### DIFF
--- a/articles/openshift/support-policies-v4.md
+++ b/articles/openshift/support-policies-v4.md
@@ -23,6 +23,7 @@ Certain configurations for Azure Red Hat OpenShift 4 clusters can affect your cl
 * Don't modify the OpenShift cluster version.
 * Don't remove or modify Azure Red Hat OpenShift service logging (mdsd pods).
 * Don't remove or modify the 'arosvc.azurecr.io' cluster pull secret.
+* Don't override the cluster machine configuration (e.g. kubelet configuration) in any way.
 * All cluster virtual machines must have outbound internet access, at least to the Azure Resource Manager (ARM) and service logging (Geneva) endpoints.
 * The Azure Red Hat OpenShift service accesses your cluster via Private Link Service.  Don't remove or modify service access.
 * Non-RHCOS compute nodes aren't supported. For example, you can't use a RHEL compute node.

--- a/articles/openshift/support-policies-v4.md
+++ b/articles/openshift/support-policies-v4.md
@@ -23,7 +23,7 @@ Certain configurations for Azure Red Hat OpenShift 4 clusters can affect your cl
 * Don't modify the OpenShift cluster version.
 * Don't remove or modify Azure Red Hat OpenShift service logging (mdsd pods).
 * Don't remove or modify the 'arosvc.azurecr.io' cluster pull secret.
-* Don't override the cluster machine configuration (e.g. kubelet configuration) in any way.
+* Don't override any of the cluster's MachineConfig objects (e.g. kubelet configuration) in any way.
 * All cluster virtual machines must have outbound internet access, at least to the Azure Resource Manager (ARM) and service logging (Geneva) endpoints.
 * The Azure Red Hat OpenShift service accesses your cluster via Private Link Service.  Don't remove or modify service access.
 * Non-RHCOS compute nodes aren't supported. For example, you can't use a RHEL compute node.

--- a/articles/openshift/support-policies-v4.md
+++ b/articles/openshift/support-policies-v4.md
@@ -23,7 +23,7 @@ Certain configurations for Azure Red Hat OpenShift 4 clusters can affect your cl
 * Don't modify the OpenShift cluster version.
 * Don't remove or modify Azure Red Hat OpenShift service logging (mdsd pods).
 * Don't remove or modify the 'arosvc.azurecr.io' cluster pull secret.
-* Don't override any of the cluster's MachineConfig objects (e.g. kubelet configuration) in any way.
+* Don't override any of the cluster's MachineConfig objects (for example, the kubelet configuration) in any way.
 * All cluster virtual machines must have outbound internet access, at least to the Azure Resource Manager (ARM) and service logging (Geneva) endpoints.
 * The Azure Red Hat OpenShift service accesses your cluster via Private Link Service.  Don't remove or modify service access.
 * Non-RHCOS compute nodes aren't supported. For example, you can't use a RHEL compute node.


### PR DESCRIPTION
This could lead to cluster configurations that keep important pieces (e.g. the kubelet) from starting up, which would break the entire cluster.