### PR TITLE
Remove content-type from static website upload command

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website-how-to.md
+++ b/articles/storage/blobs/storage-blob-static-website-how-to.md
@@ -154,7 +154,7 @@ Upload objects to the *$web* container from a source directory.
 This example assumes that you're running commands from Azure Cloud Shell session.
 
 ```azurecli-interactive
-az storage blob upload-batch -s <source-path> -d \$web --account-name <storage-account-name> --content-type 'text/html; charset=utf-8'
+az storage blob upload-batch -s <source-path> -d \$web --account-name <storage-account-name>
 ```
 
 * Replace the `<storage-account-name>` placeholder value with the name of your storage account.
@@ -173,7 +173,6 @@ Upload objects to the *$web* container from a source directory.
 ```powershell
 # upload a file
 set-AzStorageblobcontent -File "<path-to-file>" `
--Properties @{ ContentType = "text/html; charset=utf-8";} `
 -Container `$web `
 -Blob "<blob-name>" `
 -Context $ctx


### PR DESCRIPTION
Running through this quickstart myself, I ran into issues where my Azure static website wasn't properly loading CSS content because my .css files were being served with MIME type `text/html` instead of `text/css`. Removing the explicit content-type flag from the az cli command caused the tool to properly set the content type for all of my files, letting my website work as expected.

It looks like this guide was specifying that to avoid situations where unrecognized filetypes were being given a content-type that meant they wouldn't be displayed in-browser as text. That's definitely a valid problem, but I'd imagine your average developer going through this tutorial is going to be primarily uploading HTML/CSS/JS/etc files that will be properly picked up by the content-type inference system. In that use case, not forcing `text/html` for every single file is going to be the path of least surprise.