### PR TITLE
Removing duplicate 'Office' app

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-grant.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-grant.md
@@ -80,7 +80,6 @@ This setting applies to the following iOS and Android apps:
 - Microsoft Kaizala
 - Microsoft Launcher
 - Microsoft Office
-- Microsoft Office Hub
 - Microsoft OneDrive
 - Microsoft OneNote
 - Microsoft Outlook


### PR DESCRIPTION
Office hub (the preview) to Office is still present in this list - should be removed now that Office has released to replace it