### PR TITLE
adding link to 4x CLI docs

### DIFF
--- a/articles/openshift/toc.yml
+++ b/articles/openshift/toc.yml
@@ -69,7 +69,9 @@
               href: cluster-administration-security-context-constraints.md
 - name: Reference
   items:
-    - name: Azure Red Hat OpenShift CLI
+    - name: Azure Red Hat OpenShift 4.3 CLI
+    - href: /cli/azure/aro
+    - name: Azure Red Hat OpenShift 3.11 CLI
       href: /cli/azure/openshift
     - name: Azure Red Hat OpenShift REST APIs
       href: /rest/api/openshift


### PR DESCRIPTION
@sakthi-vetrivel added a link for the 4.x CLI and updated the titles in the toc to reflect versions.