### PR TITLE
 Fix ResourceProvider to be with UpperCamelCase

### DIFF
--- a/articles/cosmos-db/monitor-cosmos-db.md
+++ b/articles/cosmos-db/monitor-cosmos-db.md
@@ -104,7 +104,7 @@ Following are queries that you can use to help you monitor your Azure Cosmos dat
 
     ```Kusto
     AzureDiagnostics 
-    | where ResourceProvider=="MICROSOFT.DOCUMENTDB" and Category=="DataPlaneRequests"
+    | where ResourceProvider=="Microsoft.DocumentDb" and Category=="DataPlaneRequests"
 
     ```
 

--- a/articles/cosmos-db/monitor-cosmos-db.md
+++ b/articles/cosmos-db/monitor-cosmos-db.md
@@ -112,7 +112,7 @@ Following are queries that you can use to help you monitor your Azure Cosmos dat
 
     ```Kusto
     AzureActivity 
-    | where ResourceProvider=="MICROSOFT.DOCUMENTDB" and Category=="DataPlaneRequests" 
+    | where ResourceProvider=="Microsoft.DocumentDb" and Category=="DataPlaneRequests" 
     | summarize count() by Resource
 
     ```
@@ -121,7 +121,7 @@ Following are queries that you can use to help you monitor your Azure Cosmos dat
 
     ```Kusto
     AzureActivity 
-    | where Caller == "test@company.com" and ResourceProvider=="MICROSOFT.DOCUMENTDB" and Category=="DataPlaneRequests" 
+    | where Caller == "test@company.com" and ResourceProvider=="Microsoft.DocumentDb" and Category=="DataPlaneRequests" 
     | summarize count() by Resource
     ```
 


### PR DESCRIPTION
In AzureActivity table: The ResourceProvider of CosmosDB is Microsoft.DocumentDb (UpperCamelCase), and not MICROSOFT.DOCUMENTDB (as it is in AzureDiagnostics table)