### PR TITLE
Per-User MFA warning and migration reference

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
@@ -353,7 +353,10 @@ If you see the following error message when you initiate a remote desktop connec
 
 If you have configured a Conditional Access policy that requires multi-factor authentication (MFA) before you can access the resource, then you need to ensure that the Windows 10 PC initiating the remote desktop connection to your VM signs in using a strong authentication method such as Windows Hello. If you do not use a strong authentication method for your remote desktop connection, you will see the previous error.
 
-If you have not deployed Windows Hello for Business and if that is not an option for now, you can exclude MFA requirement by configuring Conditional Access policy that excludes "Azure Windows VM Sign-In" app from the list of cloud apps that require MFA. To learn more about Windows Hello for Business, see [Windows Hello for Business Overview](/windows/security/identity-protection/hello-for-business/hello-identity-verification).
+If you have not deployed Windows Hello for Business and if that is not an option for now, you can exclude MFA requirement by configuring Conditional Access policy that excludes "Azure Windows VM Sign-In" app from the list of cloud apps that require MFA. To learn more about Windows Hello for Business, see [Windows Hello for Business Overview](/windows/security/identity-protection/hello-for-business/hello-identity-verification). 
+
+> [!NOTE]
+> If you are still using per-user MFA you must first convert to Conditional Access based MFA if you intend to try and exclude "Azure Windows VM Sign-In". See [Convert users from per-user MFA to Conditional Access based MFA](/azure/active-directory/authentication/howto-mfa-userstates#convert-users-from-per-user-mfa-to-conditional-access-based-mfa).
 
 > [!NOTE]
 > Windows Hello for Business PIN authentication with RDP has been supported by Windows 10 for several versions, however support for Biometric authentication with RDP was added in Windows 10 version 1809. Using Windows Hello for Business auth during RDP is only available for deployments that use cert trust model and currently not available for key trust model.


### PR DESCRIPTION
The legacy per-user MFA functionality must first be turned off and MFA be enforced through Conditional Access before you are able to exclude the "Azure Windows VM Sign-In" for organisations that can't perform Windows Hello for Business yet.

#53814 