### PR TITLE
Azure CNI NAT implementation clarifying points

### DIFF
--- a/articles/aks/concepts-network.md
+++ b/articles/aks/concepts-network.md
@@ -69,6 +69,8 @@ For more information, see [Configure kubenet networking for an AKS cluster][aks-
 
 With Azure CNI, every pod gets an IP address from the subnet and can be accessed directly. These IP addresses must be unique across your network space, and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, as can otherwise lead to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.
 
+Unlike kubenet, traffic to endpoints within the same Vnet will not be NAT'd to the node's primary IP. The traffic will instead be seen with the Pod IP as the source address. Traffic external to the Vnet will still NAT to the node's primary IP.
+
 Nodes use the [Azure Container Networking Interface (CNI)][cni-networking] Kubernetes plugin.
 
 ![Diagram showing two nodes with bridges connecting each to a single Azure VNet][advanced-networking-diagram]

--- a/articles/aks/concepts-network.md
+++ b/articles/aks/concepts-network.md
@@ -69,7 +69,7 @@ For more information, see [Configure kubenet networking for an AKS cluster][aks-
 
 With Azure CNI, every pod gets an IP address from the subnet and can be accessed directly. These IP addresses must be unique across your network space, and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, as can otherwise lead to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.
 
-Unlike kubenet, traffic to endpoints within the same Vnet will not be NAT'd to the node's primary IP. The traffic will instead be seen with the Pod IP as the source address. Traffic external to the Vnet will still NAT to the node's primary IP.
+Unlike kubenet, traffic to endpoints in the same virtual network isn't NAT'd to the node's primary IP. The source address for traffic inside the virtual network is the pod IP. Traffic that's external to the virtual network still NATs to the node's primary IP.
 
 Nodes use the [Azure Container Networking Interface (CNI)][cni-networking] Kubernetes plugin.
 

--- a/articles/aks/configure-azure-cni.md
+++ b/articles/aks/configure-azure-cni.md
@@ -147,6 +147,10 @@ The following questions and answers apply to the **Azure CNI** networking config
 
   No. Deploying VMs in the subnet used by your Kubernetes cluster is not supported. VMs may be deployed in the same virtual network, but in a different subnet.
 
+* *What source IP will external systems see for traffic originating from an Azure CNI enabled Pod?*
+
+  Systems within the same Vnet as the AKS cluster will see the Pod IP as the source address for any traffic from the Pod. Systems outside of the AKS cluster Vnet will see the Node IP as the source address for any traffic from the Pod. 
+
 * *Can I configure per-pod network policies?*
 
   Yes, Kubernetes network policy is available in AKS. To get started, see [Secure traffic between pods by using network policies in AKS][network-policy].

--- a/articles/aks/configure-azure-cni.md
+++ b/articles/aks/configure-azure-cni.md
@@ -147,9 +147,9 @@ The following questions and answers apply to the **Azure CNI** networking config
 
   No. Deploying VMs in the subnet used by your Kubernetes cluster is not supported. VMs may be deployed in the same virtual network, but in a different subnet.
 
-* *What source IP will external systems see for traffic originating from an Azure CNI enabled Pod?*
+* *What source IP do external systems see for traffic that originates in an Azure CNI-enabled pod?*
 
-  Systems within the same Vnet as the AKS cluster will see the Pod IP as the source address for any traffic from the Pod. Systems outside of the AKS cluster Vnet will see the Node IP as the source address for any traffic from the Pod. 
+  Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod. 
 
 * *Can I configure per-pod network policies?*
 


### PR DESCRIPTION
Our docs are clear on how Kubenet traffic is NAT'd to the source node IP address on external calls, however it isnt clear how this is implemented for Azure CNI. Traffic within the same Vnet will maintain the Pod IP address, however traffic external to the Vnet will be NAT'd to the source node primary IP. 

This clarifying point is critical for people to understand when designing a network security plan around AKS.