### PR TITLE
Adding Python EventGrid output binding example.

### DIFF
--- a/articles/azure-functions/functions-bindings-event-grid-output.md
+++ b/articles/azure-functions/functions-bindings-event-grid-output.md
@@ -158,7 +158,51 @@ module.exports = function(context) {
 
 # [Python](#tab/python)
 
-The Event Grid output binding is not available for Python.
+The following example shows a trigger binding in a *function.json* file and a [Python function](functions-reference-python.md) that uses the binding. It then sends in an event to the custom event grid topic, as specified by the `topicEndpointUri`.
+
+Here's the binding data in the *function.json* file:
+```json
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "type": "eventGridTrigger",
+      "name": "eventGridEvent",
+      "direction": "in"
+    },
+    {
+      "type": "eventGrid",
+      "name": "outputEvent",
+      "topicEndpointUri": "MyEventGridTopicUriSetting",
+      "topicKeySetting": "MyEventGridTopicKeySetting",
+      "direction": "out"
+    }
+  ],
+  "disabled": false
+}
+```
+
+Here's the python sample to send a event to a custom Event Grid topic by setting the `EventGridOutputEvent`.
+```python
+import logging
+import azure.functions as func
+import datetime
+
+
+def main(eventGridEvent: func.EventGridEvent, 
+         outputEvent: func.Out[func.EventGridOutputEvent]) -> None:
+
+    logging.log("eventGridEvent: ", eventGridEvent)
+
+    outputEvent.set(
+        func.EventGridOutputEvent(
+            id="test-id",
+            data={"tag1": "value1", "tag2": "value2"},
+            subject="test-subject",
+            event_type="test-event-1",
+            event_time=datetime.datetime.utcnow(),
+            data_version="1.0"))
+```
 
 # [Java](#tab/java)
 

--- a/articles/azure-functions/functions-bindings-event-grid-output.md
+++ b/articles/azure-functions/functions-bindings-event-grid-output.md
@@ -158,9 +158,10 @@ module.exports = function(context) {
 
 # [Python](#tab/python)
 
-The following example shows a trigger binding in a *function.json* file and a [Python function](functions-reference-python.md) that uses the binding. It then sends in an event to the custom event grid topic, as specified by the `topicEndpointUri`.
+The following example shows a trigger binding in a *function.json* file and a [Python function](functions-reference-python.md) that uses the binding. It then sends in an event to the custom Event Grid topic, as specified by the `topicEndpointUri`.
 
 Here's the binding data in the *function.json* file:
+
 ```json
 {
   "scriptFile": "__init__.py",
@@ -182,7 +183,8 @@ Here's the binding data in the *function.json* file:
 }
 ```
 
-Here's the python sample to send a event to a custom Event Grid topic by setting the `EventGridOutputEvent`.
+Here's the Python sample to send a event to a custom Event Grid topic by setting the `EventGridOutputEvent`:
+
 ```python
 import logging
 import azure.functions as func


### PR DESCRIPTION
The new python event grid output binding was added in https://github.com/Azure/azure-functions-python-library/pull/56 and is now supported in [azure-functions-python-1.2.1](https://pypi.org/project/azure-functions) module.