### PR TITLE
Preview the log in Event Hub

### DIFF
--- a/articles/api-management/api-management-howto-log-event-hubs.md
+++ b/articles/api-management/api-management-howto-log-event-hubs.md
@@ -30,9 +30,9 @@ Now that you have an Event Hub, the next step is to configure a [Logger](https:/
 
 API Management loggers are configured using the [API Management REST API](https://aka.ms/apimapi). For detailed request examples, see [how to create Loggers](https://docs.microsoft.com/rest/api/apimanagement/2019-12-01/logger/createorupdate).
 
-## Configure log-to-eventhubs policies
+## Configure log-to-eventhub policies
 
-Once your logger is configured in API Management, you can configure your log-to-eventhubs policies to log the desired events. The log-to-eventhubs policy can be used in either the inbound policy section or the outbound policy section.
+Once your logger is configured in API Management, you can configure your log-to-eventhub policy to log the desired events. The log-to-eventhub policy can be used in either the inbound policy section or the outbound policy section.
 
 1. Browse to your APIM instance.
 2. Select the API tab.
@@ -45,15 +45,32 @@ Once your logger is configured in API Management, you can configure your log-to-
 9. In the window on the right, select **Advanced policies** > **Log to EventHub**. This inserts the `log-to-eventhub` policy statement template.
 
 ```xml
-<log-to-eventhub logger-id ='logger-id'>
-  @( string.Join(",", DateTime.UtcNow, context.Deployment.ServiceName, context.RequestId, context.Request.IpAddress, context.Operation.Name))
+<log-to-eventhub logger-id="logger-id">
+    @{
+        return new JObject(
+            new JProperty("EventTime", DateTime.UtcNow.ToString()),
+            new JProperty("ServiceName", context.Deployment.ServiceName),
+            new JProperty("RequestId", context.RequestId),
+            new JProperty("RequestIp", context.Request.IpAddress),
+            new JProperty("OperationName", context.Operation.Name)
+        ).ToString();
+    }
 </log-to-eventhub>
 ```
-Replace `logger-id` with the value you used for `{new logger name}` in the URL to create the logger in the previous step.
+Replace `logger-id` with the value you used for `{loggerId}` in the request URL to create the logger in the previous step.
 
-You can use any expression that returns a string as the value for the `log-to-eventhub` element. In this example, a string containing the date and time, service name, request id, request ip address, and operation name is logged.
+You can use any expression that returns a string as the value for the `log-to-eventhub` element. In this example, a string in JSON format containing the date and time, service name, request id, request ip address, and operation name is logged.
 
 Click **Save** to save the updated policy configuration. As soon as it is saved the policy is active and events are logged to the designated Event Hub.
+
+## Preview the log in Event Hub using Azure Stream Analytics
+
+You can preview the log in Event Hub using [Azure Stream Analytics queries](https://docs.microsoft.com/azure/event-hubs/process-data-azure-stream-analytics). 
+
+1. In Azure Portal, browse to the Event Hub that the logger sends events to. 
+2. Select **Process data** tab under **Features**.
+3. Click **Explore** button on **Enable real time insights from events** card.
+4. You should be able to preview the log on **Input preview** tab. If the data shown isn't current, select **Refresh** to see the latest events.
 
 ## Next steps
 * Learn more about Azure Event Hubs

--- a/articles/api-management/api-management-howto-log-event-hubs.md
+++ b/articles/api-management/api-management-howto-log-event-hubs.md
@@ -63,14 +63,14 @@ You can use any expression that returns a string as the value for the `log-to-ev
 
 Click **Save** to save the updated policy configuration. As soon as it is saved the policy is active and events are logged to the designated Event Hub.
 
-## Preview the log in Event Hub using Azure Stream Analytics
+## Preview the log in Event Hubs by using Azure Stream Analytics
 
-You can preview the log in Event Hub using [Azure Stream Analytics queries](https://docs.microsoft.com/azure/event-hubs/process-data-azure-stream-analytics). 
+You can preview the log in Event Hubs by using [Azure Stream Analytics queries](https://docs.microsoft.com/azure/event-hubs/process-data-azure-stream-analytics). 
 
-1. In Azure Portal, browse to the Event Hub that the logger sends events to. 
-2. Select **Process data** tab under **Features**.
-3. Click **Explore** button on **Enable real time insights from events** card.
-4. You should be able to preview the log on **Input preview** tab. If the data shown isn't current, select **Refresh** to see the latest events.
+1. In the Azure portal, browse to the event hub that the logger sends events to. 
+2. Under **Features**, select the **Process data** tab.
+3. On the **Enable real time insights from events** card, select **Explore**.
+4. You should be able to preview the log on the **Input preview** tab. If the data shown isn't current, select **Refresh** to see the latest events.
 
 ## Next steps
 * Learn more about Azure Event Hubs


### PR DESCRIPTION
The original sample logged a string to Event Hub which could not be processed by using Stream Analytics. Readers would have to create a client to read the message from Event Hub even if they just wanted to preview the log data. 

To address this, I updated the sample to log JSON string and added a section for previewing the data in Event Hub. I think it would be more intuitive for readers to follow in this way. 

Other changes including: 
- removed the additional 's' from the policy name
- change the {new logger name} to {loggerId} to match the parameter name of the management API. 