### PR TITLE
Update event-hubs-limits.md

### DIFF
--- a/includes/event-hubs-limits.md
+++ b/includes/event-hubs-limits.md
@@ -2,7 +2,7 @@
 title: include file
 description: include file
 services: event-hubs
-author: sethmanheim
+author: spelluru
 ms.service: event-hubs
 ms.topic: include
 ms.date: 05/22/2019

--- a/includes/event-hubs-limits.md
+++ b/includes/event-hubs-limits.md
@@ -13,7 +13,7 @@ ms.custom: "include file"
 
 The following tables provide quotas and limits specific to [Azure Event Hubs](https://azure.microsoft.com/services/event-hubs/). For information about Event Hubs pricing, see [Event Hubs pricing](https://azure.microsoft.com/pricing/details/event-hubs/).
 
-The following limits are common across basic, standard, and dedicated tiers. 
+The following limits are common across basic and standard tiers. 
 
 | Limit | Scope | Notes | Value |
 | --- | --- | --- | --- |


### PR DESCRIPTION
the first set of limits do not apply to Dedicated Tier, for example the limit of 10 Event Hubs per Namespace. The table below says for Dedicated you can have 1000 EHs per namespace. Also the other values in that first table to not seem to apply to dedicated (please correct me if I'm wrong).