### PR TITLE
fixing the built-in apps path

### DIFF
--- a/articles/virtual-desktop/publish-apps.md
+++ b/articles/virtual-desktop/publish-apps.md
@@ -33,7 +33,7 @@ To publish a built-in app:
    ```
 
 >[!NOTE]
-> Windows Virtual Desktop only supports publishing apps with install locations that begin with `C:\Program Files\Windows Apps`.
+> Windows Virtual Desktop only supports publishing apps with install locations that begin with `C:\Program Files\WindowsApps`.
 
 ## Update app icons
 


### PR DESCRIPTION
there is no space between "Windows" and "Apps", in the C:\Program Files\WindowsApps path