### PR TITLE
Fixes #54315

### DIFF
--- a/articles/aks/virtual-nodes-portal.md
+++ b/articles/aks/virtual-nodes-portal.md
@@ -150,8 +150,6 @@ spec:
       tolerations:
       - key: virtual-kubelet.io/provider
         operator: Exists
-      - key: azure.com/aci
-        effect: NoSchedule
 ```
 
 Run the application with the [kubectl apply][kubectl-apply] command.


### PR DESCRIPTION
The virtual node on ACI does not have the taint for azure.com/aci key. Removed the toleration for azure.com/aci.