### PR TITLE
Changed dependency from spring-cloud-azure-appconfiguration-config to…

### DIFF
--- a/articles/azure-app-configuration/quickstart-feature-flag-spring-boot.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-spring-boot.md
@@ -59,7 +59,7 @@ Use the [Spring Initializr](https://start.spring.io/) to create a new Spring Boo
     ```xml
     <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>spring-cloud-azure-appconfiguration-config</artifactId>
+        <artifactId>spring-cloud-azure-appconfiguration-config-web</artifactId>
         <version>1.1.2</version>
     </dependency>
     <dependency>
@@ -78,7 +78,7 @@ Use the [Spring Initializr](https://start.spring.io/) to create a new Spring Boo
     ```xml
     <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>spring-cloud-azure-appconfiguration-config</artifactId>
+        <artifactId>spring-cloud-azure-appconfiguration-config-web</artifactId>
         <version>1.2.2</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
… spring-cloud-azure-appconfiguration-config-web

The feature flag `beta` doesn't change after 30s and more without changing the dependency from `spring-cloud-azure-appconfiguration-config` to `spring-cloud-azure-appconfiguration-config-web` in the pom file.