### PR TITLE
Replaced hostName with endpoint in query

### DIFF
--- a/articles/azure-app-configuration/scripts/cli-create-service.md
+++ b/articles/azure-app-configuration/scripts/cli-create-service.md
@@ -39,7 +39,7 @@ appConfigHostname=$(az appconfig create \
   --name $myAppConfigStoreName \
   --location eastus \
   --resource-group $myResourceGroupName \
-  --query hostName \
+  --query endpoint \
   --sku free \
   -o tsv
   )


### PR DESCRIPTION
There is no `hostName` in the response, just an `endpoint`.

```json
sven@Azure:~$ az appconfig show --name spaceship-appc -g svenmalvik-rg
{
  "creationDate": "2020-05-08T10:00:52+00:00",
  "encryption": {
    "keyVaultProperties": null
  },
  "endpoint": "https://spaceship-appc.azconfig.io",
  "id": "/subscriptions/xxxx/resourceGroups/svenmalvik-rg/providers/Microsoft.AppConfiguration/configurationStores/spaceship-appc",
  "identity": null,
  "location": "westeurope",
  "name": "spaceship-appc",
  "provisioningState": "Succeeded",
  "resourceGroup": "svenmalvik-rg",
  "sku": {
    "name": "free"
  },
  "tags": {},
  "type": "Microsoft.AppConfiguration/configurationStores"
}
```