### PR TITLE
Added prefix to beta key to make the example work

### DIFF
--- a/articles/azure-app-configuration/quickstart-feature-flag-spring-boot.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-spring-boot.md
@@ -175,7 +175,7 @@ Use the [Spring Initializr](https://start.spring.io/) to create a new Spring Boo
 
         @GetMapping("/welcome")
         public String mainWithParam(Model model) {
-            model.addAttribute("Beta", featureManager.isEnabledAsync("Beta").block());
+            model.addAttribute("Beta", featureManager.isEnabledAsync("featureManagement.Beta").block());
             return "welcome";
         }
     }


### PR DESCRIPTION
This example doesn't work without prefixing keys with `featureManager.`. All keys get prefixed in the init phase where they are put into a HashMap.