### PR TITLE
Updated manage-runas-account.md

### DIFF
--- a/articles/automation/manage-runas-account.md
+++ b/articles/automation/manage-runas-account.md
@@ -232,7 +232,7 @@ if (!(($AzureRmProfileVersion.Major -ge 3 -and $AzureRmProfileVersion.Minor -ge 
 
 
 Connect-AzAccount -Environment $EnvironmentName
-$Subscription = Get-AzSubscription -SubscriptionId $SubscriptionId
+$Subscription = Get-AzSubscription -SubscriptionId $SubscriptionId | Set-AzContext
 
 # Create a Run As account by using a service principal
 $CertifcateAssetName = "AzureRunAsCertificate"
@@ -294,7 +294,7 @@ if ($CreateClassicRunAsAccount) {
     CreateAutomationCertificateAsset $ResourceGroup $AutomationAccountName $ClassicRunAsAccountCertifcateAssetName $PfxCertPathForClassicRunAsAccount $PfxCertPlainPasswordForClassicRunAsAccount $false
 
     # Populate the ConnectionFieldValues
-    $SubscriptionName = $subscription.Subscription.Name
+    $SubscriptionName = $subscription.Name
     $ClassicRunAsAccountConnectionFieldValues = @{"SubscriptionName" = $SubscriptionName; "SubscriptionId" = $SubscriptionId; "CertificateAssetName" = $ClassicRunAsAccountCertifcateAssetName}
 
     # Create an Automation connection asset named AzureRunAsConnection in the Automation account. This connection uses the service principal.


### PR DESCRIPTION
Get-AzSubscription cmdlet returns the subscription ID, name and tenant for subscriptions that the account can access. The $SubscriptionName variable would end up being null with the actual code (line 169):

`$SubscriptionName = $subscription.Subscription.Name`

Also change the current context to use the specified subscription. it's better (and safer) to explicitly define the context before creating the Service Principal (as the default ​​for Role and Scope parameters are "Contributor" and the current subscription). 

See #55110 