### PR TITLE
Fix images in Verify data transform and transfer

### DIFF
--- a/articles/databox-online/azure-stack-edge-deploy-configure-compute.md
+++ b/articles/databox-online/azure-stack-edge-deploy-configure-compute.md
@@ -132,11 +132,11 @@ To verify that the module is running, do the following:
 
     ![Verify data transform](./media/azure-stack-edge-deploy-configure-compute/verify-data-1.png)
  
-1.    In File Explorer, connect to both the Edge local and Edge shares you created previously.
+1. In File Explorer, connect to both the Edge local and Edge shares you created previously.
 
     ![Verify data transform](./media/azure-stack-edge-deploy-configure-compute/verify-data-2.png) 
  
-1.    Add data to the local share.
+1. Add data to the local share.
 
     ![Verify data transform](./media/azure-stack-edge-deploy-configure-compute/verify-data-3.png) 
  


### PR DESCRIPTION
According to [the spec](https://github.github.com/gfm/#list-items), the spaces before each list item determines the leading indent of the whole list item.
In order to make the image link NOT a code block, it must share the same spaces as the list item text.

Closes #54491