### PR TITLE
Portal says "delete tenant" not "delete directory".  Say both in docs.

### DIFF
--- a/articles/active-directory/users-groups-roles/directory-delete-howto.md
+++ b/articles/active-directory/users-groups-roles/directory-delete-howto.md
@@ -41,7 +41,7 @@ You can't delete a directory in Azure AD until it passes several checks. These c
   
    ![Confirm organization before deleting](./media/directory-delete-howto/delete-directory-command.png)
 
-4. Select **Delete directory**.
+4. Select **Delete directory** or **Delete tenant**, depending on the portal UI experience.
   
    ![select the command to delete the organization](./media/directory-delete-howto/delete-directory-list.png)
 


### PR DESCRIPTION
On branch edburns-MSFT-aad-delete-nit Account for current portal UI using the term "delete tenant".

modified:   articles/active-directory/users-groups-roles/directory-delete-howto.md