### PR TITLE
Typo: "becuase" changed to "because"

### DIFF
--- a/articles/app-service/configure-authentication-provider-microsoft.md
+++ b/articles/app-service/configure-authentication-provider-microsoft.md
@@ -41,7 +41,7 @@ This topic shows you how to configure Azure App Service or Azure Functions to us
 
    App Service provides authentication, but doesn't restrict authorized access to your site content and APIs. You must authorize users in your app code.
 
-1. (Optional) To restrict access to Microsoft account users, set **Action to take when request is not authenticated** to **Log in with Azure Active Directory**. When you set this functionality, your app requires all requests to be authenticated. It also redirects all unauthenticated requests to use AAD for authentication. Note that becuase you have configured your **Issuer Url** to use the Microsoft Account tenant, only personal acccounts will successfully authenticate.
+1. (Optional) To restrict access to Microsoft account users, set **Action to take when request is not authenticated** to **Log in with Azure Active Directory**. When you set this functionality, your app requires all requests to be authenticated. It also redirects all unauthenticated requests to use AAD for authentication. Note that because you have configured your **Issuer Url** to use the Microsoft Account tenant, only personal acccounts will successfully authenticate.
 
    > [!CAUTION]
    > Restricting access in this way applies to all calls to your app, which might not be desirable for apps that have a publicly available home page, as in many single-page applications. For such applications, **Allow anonymous requests (no action)** might be preferred so that the app manually starts authentication itself. For more information, see [Authentication flow](overview-authentication-authorization.md#authentication-flow).


### PR DESCRIPTION
Simple typo correction, "becuase" changed to "because".