### PR TITLE
Signout URL not matching the one suggested

### DIFF
--- a/articles/active-directory/develop/scenario-web-app-sign-user-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-app-sign-user-app-configuration.md
@@ -26,7 +26,7 @@ The libraries that are used to protect a web app (and a web API) are:
 
 | Platform | Library | Description |
 |----------|---------|-------------|
-| ![.NET](media/sample-v2-code/logo_net.png) | [Identity Model Extensions for .NET](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki) | Used directly by ASP.NET and ASP.NET Core, Microsoft Identity Model Extensions for .NET proposes a set of DLLs running on both .NET Framework and .NET Core. From an ASP.NET or ASP.NET Core web app, you can control token validation by using the **TokenValidationParameters** class (in particular, in some partner scenarios). |
+| ![.NET](media/sample-v2-code/logo_NET.png) | [Identity Model Extensions for .NET](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki) | Used directly by ASP.NET and ASP.NET Core, Microsoft Identity Model Extensions for .NET proposes a set of DLLs running on both .NET Framework and .NET Core. From an ASP.NET or ASP.NET Core web app, you can control token validation by using the **TokenValidationParameters** class (in particular, in some partner scenarios). |
 | ![Java](media/sample-v2-code/small_logo_java.png) | [MSAL Java](https://github.com/AzureAD/microsoft-authentication-library-for-java/wiki) | Support for Java web applications |
 | ![Python](media/sample-v2-code/small_logo_python.png) | [MSAL Python](https://github.com/AzureAD/microsoft-authentication-library-for-python/wiki) | Support for Python web applications |
 
@@ -92,7 +92,7 @@ In ASP.NET Core, these settings are located in the [appsettings.json](https://gi
     // Client ID (application ID) obtained from the Azure portal
     "ClientId": "[Enter the Client Id]",
     "CallbackPath": "/signin-oidc",
-    "SignedOutCallbackPath ": "/signout-callback-oidc"
+    "SignedOutCallbackPath ": "/signout-oidc"
   }
 }
 ```
@@ -131,7 +131,7 @@ In ASP.NET Core, another file ([properties\launchSettings.json](https://github.c
 
 In the Azure portal, the reply URIs that you need to register on the **Authentication** page for your application need to match these URLs. For the two preceding configuration files, they would be `https://localhost:44321/signin-oidc`. The reason is that `applicationUrl` is `http://localhost:3110`, but `sslPort` is specified (44321). `CallbackPath` is `/signin-oidc`, as defined in `appsettings.json`.
 
-In the same way, the sign-out URI would be set to `https://localhost:44321/signout-callback-oidc`.
+In the same way, the sign-out URI would be set to `https://localhost:44321/signout-oidc`.
 
 # [ASP.NET](#tab/aspnet)
 


### PR DESCRIPTION
Hi!

Was going through the tutorial, thank you a lot for your great work.

Noticed the logout URL does not match the one suggested on the registration page: https://docs.microsoft.com/en-gb/azure/active-directory/develop/scenario-web-app-sign-user-app-registration?tabs=aspnetcore

Also, tweaked the image name from logo_net.png to logo_NET.png as I noticed the preview in GitHub "Preview Changes" wasn't fetching it.

Hope it helps, thank you.

Alberto