### PR TITLE
Version 2.x IsDevelopment set in a local file

### DIFF
--- a/articles/app-service/webjobs-sdk-how-to.md
+++ b/articles/app-service/webjobs-sdk-how-to.md
@@ -99,7 +99,25 @@ static async Task Main()
 
 #### Version 2.*x*
 
-The `JobHostConfiguration` class has a `UseDevelopmentSettings` method that enables development mode.  The following example shows how to use development settings. To make `config.IsDevelopment` return `true` when it runs locally, set a local environment variable named `AzureWebJobsEnv` with the value `Development`.
+The `JobHostConfiguration` class has a `UseDevelopmentSettings` method that enables development mode.  The following example shows how to use development settings. To make `config.IsDevelopment` return `true` when it runs locally, set a local environment variable named `AzureWebJobsEnv` with the value `Development` in a local configuration file only.
+
+Local app.config file:
+```
+  <appSettings>
+	   <add key="AzureWebJobsEnv" value="Development" />
+  </appSettings>
+```
+
+This will not work, where appsettings.config is a shared solution level application config file referenced locally via the file attribute:
+```
+app.config:
+  <appSettings file="..\appsettings.config"></appSettings>
+
+appsettings.config:
+  <appSettings>
+	   <add key="AzureWebJobsEnv" value="Development" />
+  </appSettings>
+```
 
 ```cs
 static void Main()


### PR DESCRIPTION
Version 2.x app.config IsDevelopment setting only effective if set in a local app.config file, not in an application configuration file referenced locally via the file attribute
see Issue #55627