### PR TITLE
Add assignedroles for User

### DIFF
--- a/articles/active-directory/develop/active-directory-claims-mapping.md
+++ b/articles/active-directory/develop/active-directory-claims-mapping.md
@@ -320,6 +320,7 @@ The ID element identifies which property on the source provides the value for th
 | User | jobtitle | Job Title |
 | User | employeeid | Employee ID |
 | User | facsimiletelephonenumber | Facsimile Telephone Number |
+| User | assignedroles | list of App roles assigned to user|
 | application, resource, audience | displayname | Display Name |
 | application, resource, audience | objected | ObjectID |
 | application, resource, audience | tags | Service Principal Tag |


### PR DESCRIPTION
User supports `assignedroles` using AD Claims mapping policies. This update will add reference to it in the docs