### PR TITLE
Update application-gateway-autoscaling-zone-redundant.md

### DIFF
--- a/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
+++ b/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
@@ -40,7 +40,7 @@ With the v2 SKU, the pricing model is driven by consumption and is no longer att
 - **Fixed price** - This is hourly (or partial hour) price to provision a Standard_v2 or WAF_v2 Gateway. Please note that 0 additional minimum instances still ensures high availability of the service which is always included with fixed price.
 - **Capacity Unit price** - This is a consumption-based cost that is charged in addition to the fixed cost. Capacity unit charge is also computed hourly or partial hourly. There are three dimensions to capacity unit - compute unit, persistent connections, and throughput. Compute unit is a measure of processor capacity consumed. Factors affecting compute unit are TLS connections/sec, URL Rewrite computations, and WAF rule processing. Persistent connection is a measure of established TCP connections to the application gateway in a given billing interval. Throughput is average Megabits/sec processed by the system in a given billing interval.  The billing is done at a Capacity Unit level for anything above the reserved instance count.
 
-Each capacity unit is composed of at most: 1 compute unit, or 2500 persistent connections, or 2.22-Mbps throughput.
+Each capacity unit is composed of at most: 1 compute unit, 2500 persistent connections, and 2.22-Mbps throughput.
 
 Compute unit guidance:
 


### PR DESCRIPTION
@mscatyao just confirmed that "Each Capacity Unit is able to support 2500 persistent connections, 1 compute unit, and 2.22Mbps of throughput; they don’t affect each other (i.e. part of the capacity unit doesn’t go towards persistent connections vs compute unit vs throughput)."
I think the wording here should use "and" not "or" to make it clear that it is not a tradeoff.