### PR TITLE
Correct paragraph about rate-limiting

### DIFF
--- a/articles/cosmos-db/set-throughput.md
+++ b/articles/cosmos-db/set-throughput.md
@@ -27,7 +27,7 @@ Setting provisioned throughput on a container is the most frequently used option
 
 The throughput provisioned for a container is evenly distributed among its physical partitions, and assuming a good partition key that distributes the logical partitions evenly among the physical partitions, the throughput is also distributed evenly across all the logical partitions of the container. You cannot selectively specify the throughput for logical partitions. Because one or more logical partitions of a container are hosted by a physical partition, the physical partitions belong exclusively to the container and support the throughput provisioned on the container. 
 
-If the workload running on a logical partition consumes more than the throughput that was allocated to that logical partition, your operations get rate-limited. When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. For more information on partitioning, see [Logical partitions](partition-data.md).
+If the workload running on a physical partition consumes more than the throughput that was allocated to that physical partition, your operations get rate-limited. When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. For more information on partitioning, see [Partitioning and horizontal scaling in Azure Cosmos DB](partition-data.md).
 
 We recommend that you configure throughput at the container granularity when you want guaranteed performance for the container.
 

--- a/articles/cosmos-db/set-throughput.md
+++ b/articles/cosmos-db/set-throughput.md
@@ -27,8 +27,9 @@ Setting provisioned throughput on a container is the most frequently used option
 
 The throughput provisioned for a container is evenly distributed among its physical partitions, and assuming a good partition key that distributes the logical partitions evenly among the physical partitions, the throughput is also distributed evenly across all the logical partitions of the container. You cannot selectively specify the throughput for logical partitions. Because one or more logical partitions of a container are hosted by a physical partition, the physical partitions belong exclusively to the container and support the throughput provisioned on the container. 
 
-If the workload running on a logical partition consumes more than the throughput that was allocated to the underlying physical partition, it is possible your operations get rate-limited. When one logical partition has disproportionately more requests compared to other partition key values, this is known as a "hot partition."
-When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. You should also ensure you have chosen a partition key that evenly distributes storage and request volume. For more information on partitioning, see [Partitioning and horizontal scaling in Azure Cosmos DB](partition-data.md).
+If the workload running on a logical partition consumes more than the throughput that was allocated to the underlying physical partition, it's possible that your operations will be rate-limited. What is known as a _hot partition_ occurs when one logical partition has disproportionately more requests than other partition key values.
+
+When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. You also should ensure that you choose a partition key that evenly distributes storage and request volume. For more information about partitioning, see [Partitioning and horizontal scaling in Azure Cosmos DB](partition-data.md).
 
 We recommend that you configure throughput at the container granularity when you want guaranteed performance for the container.
 

--- a/articles/cosmos-db/set-throughput.md
+++ b/articles/cosmos-db/set-throughput.md
@@ -27,7 +27,8 @@ Setting provisioned throughput on a container is the most frequently used option
 
 The throughput provisioned for a container is evenly distributed among its physical partitions, and assuming a good partition key that distributes the logical partitions evenly among the physical partitions, the throughput is also distributed evenly across all the logical partitions of the container. You cannot selectively specify the throughput for logical partitions. Because one or more logical partitions of a container are hosted by a physical partition, the physical partitions belong exclusively to the container and support the throughput provisioned on the container. 
 
-If the workload running on a physical partition consumes more than the throughput that was allocated to that physical partition, your operations get rate-limited. When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. For more information on partitioning, see [Partitioning and horizontal scaling in Azure Cosmos DB](partition-data.md).
+If the workload running on a logical partition consumes more than the throughput that was allocated to the underlying physical partition, it is possible your operations get rate-limited. When one logical partition has disproportionately more requests compared to other partition key values, this is known as a "hot partition."
+When rate-limiting occurs, you can either increase the provisioned throughput for the entire container or retry the operations. You should also ensure you have chosen a partition key that evenly distributes storage and request volume. For more information on partitioning, see [Partitioning and horizontal scaling in Azure Cosmos DB](partition-data.md).
 
 We recommend that you configure throughput at the container granularity when you want guaranteed performance for the container.
 


### PR DESCRIPTION
As the referenced article at the end of the paragraph states:
"Throughput provisioned for a container is divided evenly among physical partitions. A partition key design that doesn't distribute the throughput requests evenly might create "hot" partitions. Hot partitions might result in rate-limiting and in inefficient use of the provisioned throughput, and higher costs."