### PR TITLE
Update Search Admin role

### DIFF
--- a/articles/active-directory/users-groups-roles/directory-assign-admin-roles.md
+++ b/articles/active-directory/users-groups-roles/directory-assign-admin-roles.md
@@ -383,7 +383,7 @@ Users with this role can view usage reporting data and the reports dashboard in 
 
 ### [Search Administrator](#search-administrator-permissions)
 
-Users in this role have full access to all Microsoft Search management features in the Microsoft 365 admin center. Search Administrators can delegate the Search Administrators and Search Editor roles to users, and create and manage content, like bookmarks, Q&As, and locations. Additionally, these users can view the message center, monitor service health, and create service requests.
+Users in this role have full access to all Microsoft Search management features in the Microsoft 365 admin center. Additionally, these users can view the message center, monitor service health, and create service requests.
 
 ### [Search Editor](#search-editor-permissions)
 


### PR DESCRIPTION
Removing incorrect information about the search admin being able to delegate the search editor role.