### PR TITLE
Missing backtick on line 52

### DIFF
--- a/articles/firewall/deploy-availability-zone-powershell.md
+++ b/articles/firewall/deploy-availability-zone-powershell.md
@@ -49,7 +49,7 @@ New-AzFirewall `
   -ResourceGroupName $rgName `
   -Location centralus `
   -VirtualNetwork $vnet `
-  -PublicIpAddress @($pip1)
+  -PublicIpAddress @($pip1) `
   -Zone 1,2,3
 ```
 


### PR DESCRIPTION
Added backtick ` character after  -PublicIpAddress @($pip1)
Without that causes Azure Firewall to be created without being Availability Zone aware.