### PR TITLE
Fix Json formatting in autoscale doc

### DIFF
--- a/articles/hdinsight/hdinsight-autoscale-clusters.md
+++ b/articles/hdinsight/hdinsight-autoscale-clusters.md
@@ -177,12 +177,12 @@ You can create an HDInsight cluster with schedule-based Autoscaling an Azure Res
             "minInstanceCount": 10,
             "maxInstanceCount": 10
           }
-        },
+        }
       ]
     }
   },
   "name": "workernode",
-  "targetInstanceCount": 4,
+  "targetInstanceCount": 4
 }
 ```
 
@@ -205,7 +205,7 @@ https://management.azure.com/subscriptions/{subscription Id}/resourceGroups/{res
 Use the appropriate parameters in the request payload. The json payload below could be used to enable Autoscale. Use the payload `{autoscale: null}` to disable Autoscale.
 
 ```json
-{ autoscale: { capacity: { minInstanceCount: 3, maxInstanceCount: 2 } } }
+{ "autoscale": { "capacity": { "minInstanceCount": 3, "maxInstanceCount": 2 } } }
 ```
 
 See the previous section on [enabling load-based autoscale](#load-based-autoscaling) for a full description of all payload parameters.


### PR DESCRIPTION
Issue:
The JSON payload for enabling autoscale results in HTTP Bad Request as it is malformed.

Fix:
Fix the autoscale REST payload to adhere to valid JSON format.