### PR TITLE
Updates to example script

### DIFF
--- a/articles/synapse-analytics/sql/create-external-table-as-select.md
+++ b/articles/synapse-analytics/sql/create-external-table-as-select.md
@@ -38,7 +38,7 @@ WITH IDENTITY = 'SHARED ACCESS SIGNATURE',
 GO
 
 CREATE EXTERNAL DATA SOURCE [MyDataSource] WITH (
-    LOCATION = 'https://<storage account name>.blob.core.windows.net/csv', CREDENTIAL [SasTokenWrite]
+    LOCATION = 'https://<storage account name>.blob.core.windows.net/csv', CREDENTIAL = [SasTokenWrite]
 );
 GO
 
@@ -59,7 +59,7 @@ FROM
     OPENROWSET(
         BULK 'csv/population-unix/population.csv',
         DATA_SOURCE = 'sqlondemanddemo',
-        FORMAT = 'CSV', PARSER_VERSION = '2.0',
+        FORMAT = 'CSV', PARSER_VERSION = '2.0'
     ) WITH (
         CountryCode varchar(4),
         CountryName varchar(64),


### PR DESCRIPTION
Added a required "=" for the CREATE EXTERNAL DATA SOURCE command.

Removed an unnecessary comma breaking the CETAS command at the end of the example for "[dbo].[PopulationCETAS]".