### PR TITLE
Include the warning that report-only mode is not applicable to "user …

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-report-only.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-report-only.md
@@ -27,7 +27,7 @@ Report-only mode is a new Conditional Access policy state that allows administra
 - Customers with an Azure Monitor subscription can monitor the impact of their Conditional Access policies using the Conditional Access insights workbook.
 
 > [!WARNING]
-> Policies in report-only mode that require compliant devices may prompt users on Mac, iOS, and Android to select a device certificate during policy evaluation, even though device compliance is not enforced. These prompts may repeat until the device is made compliant. To prevent end users from receiving prompts during sign-in, exclude device platforms Mac, iOS and Android from report-only policies that perform device compliance checks.
+> Policies in report-only mode that require compliant devices may prompt users on Mac, iOS, and Android to select a device certificate during policy evaluation, even though device compliance is not enforced. These prompts may repeat until the device is made compliant. To prevent end users from receiving prompts during sign-in, exclude device platforms Mac, iOS and Android from report-only policies that perform device compliance checks. Note that report-only mode is not applicable for CA policies with "User Actions" scope.
 
 ![Report-only tab in Azure AD sign-in log](./media/concept-conditional-access-report-only/report-only-detail-in-sign-in-log.png)
 


### PR DESCRIPTION
…action" CA policy

Include the warning that report-only mode is not applicable to "user action" CA policy as the changed document below:

https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/howto-conditional-access-policy-registration