### PR TITLE
Update effective-routes-virtual-hub.md

### DIFF
--- a/articles/virtual-wan/effective-routes-virtual-hub.md
+++ b/articles/virtual-wan/effective-routes-virtual-hub.md
@@ -55,7 +55,7 @@ Use the scroll bar at the bottom of the table to view the "AS Path".
 
 ### <a name="abouthubroute"></a>About the hub route table
 
-You can create a virtual hub route and apply the route to the virtual hub route table. You can apply multiple routes to the virtual hub route table. This lets you set a route for destination VNet via an IP address (typically the Network Virtual Appliance (NVA) in a spoke VNet). For more information about NVAs, see [Route traffic from a virtual hub to an NVA](virtual-wan-route-table-portal.md).
+You can create a virtual hub route and apply the route to the virtual hub route table. You can apply multiple routes to the virtual hub route table. This lets you set a route for destination VNet via an IP address (typically the Network Virtual Appliance (NVA) in a spoke VNet). For more information about NVAs, see [Route traffic from a virtual hub to an NVA](virtual-wan-route-table-portal.md). Please note that these routes will not show up in the effective route table. The effective route table contains only the prefixes for local and remote hubs plus connected Virtual Network address space and routes learned via BGP.
 
 ### <a name="aboutdefaultroute"></a>About default route (0.0.0.0/0)
 


### PR DESCRIPTION
Add additional caveat to about the hub route table to clarify that static routes to NVAs are not shown in effective route table by design. This came about from a support request.