### PR TITLE
replace "smart quotes" around "Standard"

### DIFF
--- a/articles/storage/blobs/storage-blob-rehydration.md
+++ b/articles/storage/blobs/storage-blob-rehydration.md
@@ -93,7 +93,7 @@ $ctx = $storageAccount.Context
 $blobs = Get-AzStorageBlob -Container $containerName -Blob $blobName -Context $context
 
 #Change the blob’s access tier to Hot using Standard priority rehydrate
-$blob.ICloudBlob.SetStandardBlobTier("Hot", “Standard”)
+$blob.ICloudBlob.SetStandardBlobTier("Hot", "Standard")
 ```
 ---
 


### PR DESCRIPTION
the smart quotes on line 96 was causing errors, replaced them with standard quotes