### PR TITLE
add details about download pull secret

### DIFF
--- a/articles/openshift/tutorial-create-cluster.md
+++ b/articles/openshift/tutorial-create-cluster.md
@@ -75,9 +75,9 @@ A Red Hat pull secret enables your cluster to access Red Hat container registrie
 
    You will need to log in to your Red Hat account or create a new Red Hat account with your business email and accept the terms and conditions.
 
-2. Please go to the **[product page](https://developers.redhat.com/products/codeready-containers)** if it is the first time and after registration, it will take you to **[Red Hat OpenShift Cluster Manager page]** (https://cloud.redhat.com/openshift/) where you can Click **Download pull secret**.
+2. Go to the [**OpenShift product page**](https://developers.redhat.com/products/codeready-containers) if this is your first time creating a cluster. After registration, head to [**Red Hat OpenShift Cluster Manager page**](https://cloud.redhat.com/openshift/), where you can click **Download pull secret** and download a pull secret to be used with your ARO cluster.
 
-Keep the saved `pull-secret.txt` file somewhere safe - it will be used in each cluster creation if you need to create a cluster will include samples or operators from Red Hat or from certified partners
+Keep the saved `pull-secret.txt` file somewhere safe. The file will be used in each cluster creation if you need to create a cluster that includes samples or operators for Red Hat or certified partners.
 
 When running the `az aro create` command, you can reference your pull secret using the `--pull-secret @pull-secret.txt` parameter. Execute `az aro create` from the directory where you stored your `pull-secret.txt` file. Otherwise, replace `@pull-secret.txt` with `@<path-to-my-pull-secret-file>`.
 

--- a/articles/openshift/tutorial-create-cluster.md
+++ b/articles/openshift/tutorial-create-cluster.md
@@ -75,7 +75,7 @@ A Red Hat pull secret enables your cluster to access Red Hat container registrie
 
    You will need to log in to your Red Hat account or create a new Red Hat account with your business email and accept the terms and conditions.
 
-2. Please go to the **[product page](https://developers.redhat.com/products/codeready-containers)** and after registration, it will take you to Red Hat OpenShift Cluster Manager page where you can Click **Download pull secret**.
+2. Please go to the **[product page](https://developers.redhat.com/products/codeready-containers)** if it is the first time and after registration, it will take you to **[Red Hat OpenShift Cluster Manager page]** (https://cloud.redhat.com/openshift/) where you can Click **Download pull secret**.
 
 Keep the saved `pull-secret.txt` file somewhere safe - it will be used in each cluster creation if you need to create a cluster will include samples or operators from Red Hat or from certified partners
 

--- a/articles/openshift/tutorial-create-cluster.md
+++ b/articles/openshift/tutorial-create-cluster.md
@@ -75,9 +75,9 @@ A Red Hat pull secret enables your cluster to access Red Hat container registrie
 
    You will need to log in to your Red Hat account or create a new Red Hat account with your business email and accept the terms and conditions.
 
-2. **Click Download pull secret.**
+2. Please go to the **[product page](https://developers.redhat.com/products/codeready-containers)** and after registration, it will take you to Red Hat OpenShift Cluster Manager page where you can Click **Download pull secret**.
 
-Keep the saved `pull-secret.txt` file somewhere safe - it will be used in each cluster creation.
+Keep the saved `pull-secret.txt` file somewhere safe - it will be used in each cluster creation if you need to create a cluster will include samples or operators from Red Hat or from certified partners
 
 When running the `az aro create` command, you can reference your pull secret using the `--pull-secret @pull-secret.txt` parameter. Execute `az aro create` from the directory where you stored your `pull-secret.txt` file. Otherwise, replace `@pull-secret.txt` with `@<path-to-my-pull-secret-file>`.
 


### PR DESCRIPTION
I've gone through this article 3 times since yesterday ( create clusters 3 times ),  the reason that I'd create this PR is that I noticed there are some issues had been created on Github about ' No --pull-secret provided: cluster will not include samples or operators from Red Hat or from certified partners.' 

Honestly, I was confused in the beginning because I couldn't find 'Download pull secret'.  Hence the 1st time when creating the cluster I got the same warning message, but it did not affect any cluster creation activities.  Therefore when it comes to 2nd time, I went to create my RedHat account and it took me to the customer portal. Only until I got to the product page and fill in some more details about myself, then it took me to Red Hat OpenShift Cluster Manager page and I found 'Download pull secret' at 'Cluster' blade. I'll provide my screenshot in the comments. Please feel free to reach out to me if you have any concerns.  Thanks :)

![image](https://user-images.githubusercontent.com/4621560/83338099-b6a26680-a2b8-11ea-90e9-d351f11bbd7a.png)
