### PR TITLE
The Circuit Breaker resource is titled incorrectly

### DIFF
--- a/articles/azure-functions/functions-reliable-event-processing.md
+++ b/articles/azure-functions/functions-reliable-event-processing.md
@@ -118,7 +118,7 @@ Using this approach, no messages are lost, all messages are processed in order, 
 ## Resources
 
 - [Reliable event processing samples](https://github.com/jeffhollan/functions-csharp-eventhub-ordered-processing)
-- [Azure Durable Functions Circuit Breaker](https://github.com/jeffhollan/functions-durable-actor-circuitbreaker)
+- [Azure Durable Entity Circuit Breaker](https://github.com/jeffhollan/functions-durable-actor-circuitbreaker)
 
 ## Next steps
 


### PR DESCRIPTION
The circuit breaker takes advantage of a special flavor of stateful implementation based on the entity pattern. I am of the opinion that rather generally calling the same Durable *Functions*, it should explicitly point out that is an implementation of the Durable **entity** concept, which can even be used without using a Durable Functions orchestrator (which, otherwise, the current title implies).