### PR TITLE
Update operator-best-practices-scheduler.md

### DIFF
--- a/articles/aks/operator-best-practices-scheduler.md
+++ b/articles/aks/operator-best-practices-scheduler.md
@@ -121,7 +121,7 @@ The [kube-advisor][kube-advisor] tool is an associated AKS open source project t
 
 The kube-advisor tool can report on resource request and limits missing in PodSpecs for Windows applications as well as Linux applications, but the kube-advisor tool itself must be scheduled on a Linux pod. You can schedule a pod to run on a node pool with a specific OS using a [node selector][k8s-node-selector] in the pod's configuration.
 
-In an AKS cluster that hosts multiple development teams and applications, it can be hard to track pods without these resource requests and limits set. As a best practice, regularly run `kube-advisor` on your AKS clusters, especially if you don't assign resource quotas to namespaces.
+In an AKS cluster that hosts multiple development teams and applications, it can be hard to track pods without these resource requests and limits set. As a best practice, regularly run `kube-advisor` on your AKS clusters, especially if you assign resource quotas to namespaces.
 
 ## Next steps
 


### PR DESCRIPTION
As per my understanding, Running kube-advisor, to look for the pods without Resource Requests and Limits defined, would make sense when Resource Quotas are defined in a cluster. 