### PR TITLE
Update azure-disks-dynamic-pv.md - Disk Caching for 4Ti

### DIFF
--- a/articles/aks/azure-disks-dynamic-pv.md
+++ b/articles/aks/azure-disks-dynamic-pv.md
@@ -36,9 +36,11 @@ Each AKS cluster includes two pre-created storage classes, both configured to wo
 * The *managed-premium* storage class provisions a premium Azure disk.
     * Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. If the AKS nodes in your cluster use premium storage, select the *managed-premium* class.
     
-These default storage classes don't allow you to update the volume size once created. To enable this ability, add the *allowVolumeExpansion: true* line to one of the default storage classes, or create you own custom storage class. You can edit an existing storage class using the `kubectl edit sc` command. 
-For example, if you want to use a disk of size 4Ti, you will have to create a storage class that defines "cachingmode: None" since [Disk Caching is not supported for disks 4 TiB and larger](https://docs.microsoft.com/azure/virtual-machines/windows/premium-storage-performance#disk-caching).
-For more information on storage classes and creating your own, see [Storage options for applications in AKS][storage-class-concepts].
+If you use one of the default storage classes, you can't update the volume size after the storage class is created. To be able to update the volume size after a storage class is created, add the line `allowVolumeExpansion: true` to one of the default storage classes, or you can create you own custom storage class. You can edit an existing storage class by using the `kubectl edit sc` command. 
+
+For example, if you want to use a disk of size 4 TiB, you must create a storage class that defines `cachingmode: None` because [disk caching isn't supported for disks 4 TiB and larger](../virtual-machines/windows/premium-storage-performance.md#disk-caching).
+
+For more information about storage classes and creating your own storage class, see [Storage options for applications in AKS][storage-class-concepts].
 
 Use the [kubectl get sc][kubectl-get] command to see the pre-created storage classes. The following example shows the pre-create storage classes available within an AKS cluster:
 

--- a/articles/aks/azure-disks-dynamic-pv.md
+++ b/articles/aks/azure-disks-dynamic-pv.md
@@ -36,7 +36,9 @@ Each AKS cluster includes two pre-created storage classes, both configured to wo
 * The *managed-premium* storage class provisions a premium Azure disk.
     * Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. If the AKS nodes in your cluster use premium storage, select the *managed-premium* class.
     
-These default storage classes don't allow you to update the volume size once created. To enable this ability, add the *allowVolumeExpansion: true* line to one of the default storage classes, or create you own custom storage class. You can edit an existing storage class using the `kubectl edit sc` command. For more information on storage classes and creating your own, see [Storage options for applications in AKS][storage-class-concepts].
+These default storage classes don't allow you to update the volume size once created. To enable this ability, add the *allowVolumeExpansion: true* line to one of the default storage classes, or create you own custom storage class. You can edit an existing storage class using the `kubectl edit sc` command. 
+For example, if you want to use a disk of size 4Ti, you will have to create a storage class that defines "cachingmode: None" since [Disk Caching is not supported for disks 4 TiB and larger](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#disk-caching).
+For more information on storage classes and creating your own, see [Storage options for applications in AKS][storage-class-concepts].
 
 Use the [kubectl get sc][kubectl-get] command to see the pre-created storage classes. The following example shows the pre-create storage classes available within an AKS cluster:
 

--- a/articles/aks/azure-disks-dynamic-pv.md
+++ b/articles/aks/azure-disks-dynamic-pv.md
@@ -37,7 +37,7 @@ Each AKS cluster includes two pre-created storage classes, both configured to wo
     * Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. If the AKS nodes in your cluster use premium storage, select the *managed-premium* class.
     
 These default storage classes don't allow you to update the volume size once created. To enable this ability, add the *allowVolumeExpansion: true* line to one of the default storage classes, or create you own custom storage class. You can edit an existing storage class using the `kubectl edit sc` command. 
-For example, if you want to use a disk of size 4Ti, you will have to create a storage class that defines "cachingmode: None" since [Disk Caching is not supported for disks 4 TiB and larger](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage-performance#disk-caching).
+For example, if you want to use a disk of size 4Ti, you will have to create a storage class that defines "cachingmode: None" since [Disk Caching is not supported for disks 4 TiB and larger](https://docs.microsoft.com/azure/virtual-machines/windows/premium-storage-performance#disk-caching).
 For more information on storage classes and creating your own, see [Storage options for applications in AKS][storage-class-concepts].
 
 Use the [kubectl get sc][kubectl-get] command to see the pre-created storage classes. The following example shows the pre-create storage classes available within an AKS cluster:


### PR DESCRIPTION
Adding a sentence to explain that Disk Caching is not supported for disk size 4Ti.

Using the default Storage Class would throw Message="Only Disk CachingType 'None' is supported for disk with size greater than 4095 GB."

Users can define their own storage class:

apiVersion: storage.k8s.io/v1
metadata:
  name: managed-premium-caching-none
provisioner: kubernetes.io/azure-disk
reclaimPolicy: Delete
parameters:
  storageaccounttype: Premium_LRS
  kind: Managed
  cachingmode: None