### PR TITLE
Fix syntax error in JavaScript code sample

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/how-to/text-to-speech-basics/text-to-speech-basics-javascript.md
+++ b/articles/cognitive-services/Speech-Service/includes/how-to/text-to-speech-basics/text-to-speech-basics-javascript.md
@@ -106,12 +106,11 @@ function synthesizeSpeech() {
                 console.log(JSON.stringify(result));
             }
             synthesizer.close();
-        }
-    },
-    error => {
-        console.log(error);
-        synthesizer.close();
-    });
+        },
+        error => {
+            console.log(error);
+            synthesizer.close();
+        });
 }
 ```
 


### PR DESCRIPTION
There was an extra brace `}` in the JS code sample. I noticed it when I tried to implement speech systhesis by following instructions in this article.