### PR TITLE
Added new grant_type metadata item to ROPC TechnicalProfile

### DIFF
--- a/articles/active-directory-b2c/custom-policy-password-change.md
+++ b/articles/active-directory-b2c/custom-policy-password-change.md
@@ -61,6 +61,7 @@ Complete the steps in [Get started with custom policies in Active Directory B2C]
               <Item Key="response_types">id_token</Item>
               <Item Key="response_mode">query</Item>
               <Item Key="scope">email openid</Item>
+              <Item Key="grant_type">password</Item>
               <Item Key="UsePolicyInRedirectUri">false</Item>
               <Item Key="HttpBinding">POST</Item>
               <Item Key="client_id">ProxyIdentityExperienceFrameworkAppId</Item>

--- a/articles/active-directory-b2c/ropc-custom.md
+++ b/articles/active-directory-b2c/ropc-custom.md
@@ -99,6 +99,7 @@ Complete the steps in [Get started with custom policies in Azure Active Director
         <Item Key="response_types">id_token</Item>
         <Item Key="response_mode">query</Item>
         <Item Key="scope">email openid</Item>
+        <Item Key="grant_type">password</Item>
       </Metadata>
       <InputClaims>
         <InputClaim ClaimTypeReferenceId="logonIdentifier" PartnerClaimType="username" Required="true" DefaultValue="{OIDC:Username}"/>


### PR DESCRIPTION
This is an update to the docs for B2C custom policies adding a `grant_type` metadata item to ROPC-based technical profiles.  Adding this metadata item enables Just-in-time migration via ROPC and REST.  See [here](https://github.com/Azure-Samples/active-directory-b2c-custom-policy-starterpack/pull/65) for further details.