### PR TITLE
Update faqs.md

### DIFF
--- a/articles/active-directory-domain-services/faqs.md
+++ b/articles/active-directory-domain-services/faqs.md
@@ -10,7 +10,7 @@ ms.service: active-directory
 ms.subservice: domain-services
 ms.workload: identity
 ms.topic: how-to
-ms.date: 03/09/2020
+ms.date: 06/05/2020
 ms.author: iainfou
 
 ---
@@ -53,6 +53,7 @@ Yes. For more information, see [how to enable Azure AD Domain Services in Azure 
 
 ### Can I enable Azure AD Domain Services in a federated Azure AD directory? I do not synchronize password hashes to Azure AD. Can I enable Azure AD Domain Services for this directory?
 No. To authenticate users via NTLM or Kerberos, Azure AD Domain Services needs access to the password hashes of user accounts. In a federated directory, password hashes aren't stored in the Azure AD directory. Therefore, Azure AD Domain Services doesn't work with such Azure AD directories.
+However, if you are using Azure AD Connect for password hash synchronization, you can use Azure AD Domain Services because the password hash values on Azure AD.
 
 ### Can I make Azure AD Domain Services available in multiple virtual networks within my subscription?
 The service itself doesn't directly support this scenario. Your managed domain is available in only one virtual network at a time. However, you can configure connectivity between multiple virtual networks to expose Azure AD Domain Services to other virtual networks. For more information, see [how to connect virtual networks in Azure using VPN gateways](../vpn-gateway/virtual-networks-configure-vnet-to-vnet-connection.md) or [virtual network peering](../virtual-network/virtual-network-peering-overview.md).

--- a/articles/active-directory-domain-services/faqs.md
+++ b/articles/active-directory-domain-services/faqs.md
@@ -53,7 +53,8 @@ Yes. For more information, see [how to enable Azure AD Domain Services in Azure 
 
 ### Can I enable Azure AD Domain Services in a federated Azure AD directory? I do not synchronize password hashes to Azure AD. Can I enable Azure AD Domain Services for this directory?
 No. To authenticate users via NTLM or Kerberos, Azure AD Domain Services needs access to the password hashes of user accounts. In a federated directory, password hashes aren't stored in the Azure AD directory. Therefore, Azure AD Domain Services doesn't work with such Azure AD directories.
-However, if you are using Azure AD Connect for password hash synchronization, you can use Azure AD Domain Services because the password hash values on Azure AD.
+
+However, if you're using Azure AD Connect for password hash synchronization, you can use Azure AD Domain Services because the password hash values are stored in Azure AD.
 
 ### Can I make Azure AD Domain Services available in multiple virtual networks within my subscription?
 The service itself doesn't directly support this scenario. Your managed domain is available in only one virtual network at a time. However, you can configure connectivity between multiple virtual networks to expose Azure AD Domain Services to other virtual networks. For more information, see [how to connect virtual networks in Azure using VPN gateways](../vpn-gateway/virtual-networks-configure-vnet-to-vnet-connection.md) or [virtual network peering](../virtual-network/virtual-network-peering-overview.md).


### PR DESCRIPTION
The following sentence has been added.
Even in a federation environment, Azure AD DS can be used in any environment where the password hash value is synchronized with Azure AD.

---
However, if you are using Azure AD Connect for password hash synchronization, you can use Azure AD Domain Services because the password hash values on Azure AD.