### PR TITLE
Using single quotes works everywhere

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website-how-to.md
+++ b/articles/storage/blobs/storage-blob-static-website-how-to.md
@@ -148,13 +148,10 @@ These instructions show you how to upload files by using the version of Storage 
 
 Upload objects to the *$web* container from a source directory.
 
-> [!NOTE]
-> If you're using Azure Cloud Shell, make sure to add an `\` escape character when referring to the `$web` container (For example: `\$web`). If you're using a local installation of the Azure CLI, then you won't have to use the escape character.
-
 This example assumes that you're running commands from Azure Cloud Shell session.
 
 ```azurecli-interactive
-az storage blob upload-batch -s <source-path> -d \$web --account-name <storage-account-name>
+az storage blob upload-batch -s <source-path> -d '$web' --account-name <storage-account-name>
 ```
 
 > [!NOTE] 


### PR DESCRIPTION
Rather than having separate instructions for local shells and Cloud Shell (or other POSIX shells), using single quotes prevents variable expansion on all shells.