### PR TITLE
Update documentation so that older SDKs don't run into run.parent bug

### DIFF
--- a/articles/machine-learning/how-to-track-experiments.md
+++ b/articles/machine-learning/how-to-track-experiments.md
@@ -124,6 +124,8 @@ Use the __Execute Python Script__ module to add logging logic to your designer e
         run.log(name='Mean_Absolute_Error', value=dataframe1['Mean_Absolute_Error'])
 
         # Log the mean absolute error to the parent run to see the metric in the run details page.
+        # Note: `run.parent.log()` should not be called multiple times because of performance issues.
+        # If repeated calls are necessary, cache `run.parent` as a local variable and call `log()` on that variable.
         run.parent.log(name='Mean_Absolute_Error', value=dataframe1['Mean_Absolute_Error'])
     
         return dataframe1,

--- a/articles/machine-learning/how-to-track-experiments.md
+++ b/articles/machine-learning/how-to-track-experiments.md
@@ -124,8 +124,8 @@ Use the __Execute Python Script__ module to add logging logic to your designer e
         run.log(name='Mean_Absolute_Error', value=dataframe1['Mean_Absolute_Error'])
 
         # Log the mean absolute error to the parent run to see the metric in the run details page.
-        # Note: `run.parent.log()` should not be called multiple times because of performance issues.
-        # If repeated calls are necessary, cache `run.parent` as a local variable and call `log()` on that variable.
+        # Note: 'run.parent.log()' should not be called multiple times because of performance issues.
+        # If repeated calls are necessary, cache 'run.parent' as a local variable and call 'log()' on that variable.
         run.parent.log(name='Mean_Absolute_Error', value=dataframe1['Mean_Absolute_Error'])
     
         return dataframe1,


### PR DESCRIPTION
A performance bug was found which makes the `run.parent` call very expensive and prone to hanging. This is a short-term IcM repair item.