### PR TITLE
add ARM template example for existing AKS

### DIFF
--- a/articles/machine-learning/how-to-deploy-azure-kubernetes-service.md
+++ b/articles/machine-learning/how-to-deploy-azure-kubernetes-service.md
@@ -132,6 +132,7 @@ For more information on creating an AKS cluster using the Azure CLI or portal, s
 
 * [Create an AKS cluster (CLI)](https://docs.microsoft.com/cli/azure/aks?toc=%2Fazure%2Faks%2FTOC.json&bc=%2Fazure%2Fbread%2Ftoc.json&view=azure-cli-latest#az-aks-create)
 * [Create an AKS cluster (portal)](https://docs.microsoft.com/azure/aks/kubernetes-walkthrough-portal?view=azure-cli-latest)
+* [Create an AKS cluster (ARM Template on Azure Quickstart templates)](https://github.com/cloudmelon/azure-quickstart-templates/tree/master/101-aks-azml-targetcompute)
 
 The following examples demonstrate how to attach an existing AKS cluster to your workspace:
 


### PR DESCRIPTION
Based on our previous discussion, I created this PR for a new ARM template on Azure quickstart templates ( https://github.com/Azure/azure-quickstart-templates/pull/7667 ). I'll update the PR with the publication of the URL of official Azure quickstart template website.  @sauryadas please have a look, thanks :)

The template allows us to deploy an AKS cluster that can be easily integrated with entreprise-grade devops process and fulfill the condition to be attached with Azure ML as compute target resources. AKS cluster in this template is not MSI ( Managed Service Identity ) enabled and also has at least one system pool ( latest definition at Azure documentation )