### PR TITLE
update the kube-reserved formula

### DIFF
--- a/articles/aks/concepts-clusters-workloads.md
+++ b/articles/aks/concepts-clusters-workloads.md
@@ -101,9 +101,9 @@ To maintain node performance and functionality, resources are reserved on each n
 
 The above rules for memory and CPU allocation are used to keep agent nodes healthy, including some hosting system pods that are critical to cluster health. These allocation rules also cause the node to report less allocatable memory and CPU than it would if it were not part of a Kubernetes cluster. The above resource reservations can't be changed.
 
-For example, if a node offers 7 GB, it will report 34% of memory not allocatable on top of the 750Mi hard eviction threshold.
+For example, if a node offers 7 GB, it will report 34% of memory not allocatable including the 750Mi hard eviction threshold.
 
-`(0.25*4) + (0.20*3) = + 1 GB + 0.6GB = 1.6GB / 7GB = 22.86% reserved`
+`0.75 + (0.25*4) + (0.20*3) = 0.75GB + 1GB + 0.6GB = 2.35GB / 7GB = 33.57% reserved`
 
 In addition to reservations for Kubernetes itself, the underlying node OS also reserves an amount of CPU and memory resources to maintain OS functions.
 


### PR DESCRIPTION
The original description was a bit misleading. It mentioned 34% but the result of the formula was 22.86%. Also 34% should be the result of both `eviction-hard` and `kube-reserved`. The "on top of" in the original description sounds like it was only `kube-reserved`. 

Related issue #51212