### PR TITLE
Adds EastUS as a supported region

### DIFF
--- a/articles/azure-arc/servers/onboard-portal.md
+++ b/articles/azure-arc/servers/onboard-portal.md
@@ -35,6 +35,7 @@ The script to automate the download and installation, and to establish the conne
 
     >[!NOTE]
     >Azure Arc for servers (preview) supports only the following regions:
+    >- EastUS
     >- WestUS2
     >- WestEurope
     >- SoutheastAsia


### PR DESCRIPTION
As per https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-arc/servers/overview.md#supported-regions - EastUS is a supported region for storing machine metadata.