### PR TITLE
Clarify AllowCloudPasswordValidation use

### DIFF
--- a/articles/active-directory/manage-apps/configure-authentication-for-federated-users-portal.md
+++ b/articles/active-directory/manage-apps/configure-authentication-for-federated-users-portal.md
@@ -76,8 +76,8 @@ For more information about auto-acceleration using the domain hints that are sup
 ### Home Realm Discovery policy for auto-acceleration
 Some applications do not provide a way to configure the authentication request they emit. In these cases, it’s not possible to use domain hints to control auto-acceleration. Auto-acceleration can be configured via policy to achieve the same behavior.  
 
-## Enable direct authentication for legacy applications
-Best practice is for applications to use AAD libraries and interactive sign-in to authenticate users. The libraries take care of the federated user flows.  Sometimes legacy applications aren't written to understand federation. They don't perform home realm discovery and do not interact with the correct federated endpoint to authenticate a user. If you choose to, you can use HRD Policy to enable specific legacy applications that submit username/password credentials to authenticate directly with Azure Active Directory. Password Hash Sync must be enabled. 
+## Enable direct ROPC authentication of federated users for legacy applications
+Best practice is for applications to use AAD libraries and interactive sign-in to authenticate users. The libraries take care of the federated user flows.  Sometimes legacy applications, especially those that use ROPC grants, submit username and password directly to Azure AD, and aren't written to understand federation. They don't perform home realm discovery and do not interact with the correct federated endpoint to authenticate a user. If you choose to, you can use HRD Policy to enable specific legacy applications that submit username/password credentials using the ROPC grant to authenticate directly with Azure Active Directory. Password Hash Sync must be enabled. 
 
 > [!IMPORTANT]
 > Only enable direct authentication if you have Password Hash Sync turned on and you know it's okay to authenticate this application without any policies implemented by your on-premises IdP. If you turn off Password Hash Sync, or turn off Directory Synchronization with AD Connect for any reason, you should remove this policy to prevent the possibility of direct authentication using a stale password hash.
@@ -105,7 +105,7 @@ Following is an example HRD policy definition:
     {  
     "AccelerateToFederatedDomain":true,
     "PreferredDomain":"federated.example.edu",
-    "AllowCloudPasswordValidation":true
+    "AllowCloudPasswordValidation":false
     }
    }
 ```


### PR DESCRIPTION
Clarify that AllowCloudPasswordValidation only affects usage of ROPC username/password auth with Azure AD for a federated user.
Change default setting in example to false to reduce chances of accidently switching it on