### PR TITLE
fixed small typo in backup-azure-delete-vault

### DIFF
--- a/articles/backup/backup-azure-delete-vault.md
+++ b/articles/backup/backup-azure-delete-vault.md
@@ -32,7 +32,7 @@ To properly delete a vault, you must follow the steps in this order:
 
 - **Step 1**: Disable the soft delete feature. [See here](https://docs.microsoft.com/azure/backup/backup-azure-security-feature-cloud#enabling-and-disabling-soft-delete) for the steps to disable soft delete.
 
-- **Step 2**: After disabling soft delete, check if there are any items previously remaining in thee soft deleted state. If there are items in soft deleted state, then you need to *undelete* and *delete* them again. [Follow these steps](https://docs.microsoft.com/azure/backup/backup-azure-security-feature-cloud#permanently-deleting-soft-deleted-backup-items) to find soft delete items and permanently delete them.
+- **Step 2**: After disabling soft delete, check if there are any items previously remaining in the soft deleted state. If there are items in soft deleted state, then you need to *undelete* and *delete* them again. [Follow these steps](https://docs.microsoft.com/azure/backup/backup-azure-security-feature-cloud#permanently-deleting-soft-deleted-backup-items) to find soft delete items and permanently delete them.
 
 - **Step 3**: You must check all of the following three places to verify if there are any protected items:
 


### PR DESCRIPTION
Just a very minor typo fix: "thee" should be "the"