### PR TITLE
Removed misplaced tag <a>

### DIFF
--- a/articles/event-grid/event-schema-blob-storage.md
+++ b/articles/event-grid/event-schema-blob-storage.md
@@ -48,6 +48,7 @@ These events are triggered if you enable a hierarchical namespace on the storage
 > [!NOTE]
 > If you want to ensure that the **Microsoft.Storage.BlobCreated** event is triggered only when a Block Blob is completely committed, filter the event for the `FlushWithClose` REST API call. This API call triggers the **Microsoft.Storage.BlobCreated** event only after data is fully committed to a Block Blob. To learn how to create a filter, see [Filter events for Event Grid](https://docs.microsoft.com/azure/event-grid/how-to-filter-events).
 
+<a name="example-event"></a>
 ### The contents of an event response
 
 When an event is triggered, the Event Grid service sends data about that event to subscribing endpoint.

--- a/articles/event-grid/event-schema-blob-storage.md
+++ b/articles/event-grid/event-schema-blob-storage.md
@@ -48,8 +48,6 @@ These events are triggered if you enable a hierarchical namespace on the storage
 > [!NOTE]
 > If you want to ensure that the **Microsoft.Storage.BlobCreated** event is triggered only when a Block Blob is completely committed, filter the event for the `FlushWithClose` REST API call. This API call triggers the **Microsoft.Storage.BlobCreated** event only after data is fully committed to a Block Blob. To learn how to create a filter, see [Filter events for Event Grid](https://docs.microsoft.com/azure/event-grid/how-to-filter-events).
 
-<a id="example-event" />
-
 ### The contents of an event response
 
 When an event is triggered, the Event Grid service sends data about that event to subscribing endpoint.


### PR DESCRIPTION
The tag apparently forced the rest of the document to act as a link
https://docs.microsoft.com/en-us/azure/event-grid/event-schema-blob-storage?toc=/azure/storage/blobs/toc.json#the-contents-of-an-event-response
(checked in Firefox and Edge)