### PR TITLE
docs update on adding svelte app starter on Azure Static Web App

### DIFF
--- a/articles/static-web-apps/getting-started.md
+++ b/articles/static-web-apps/getting-started.md
@@ -42,6 +42,12 @@ This article uses GitHub template repositories to make it easy for you to create
   - https://github.com/staticwebdev/vue-basic/generate
 - Name your repository **my-first-static-web-app**
 
+# [Svelte](#tab/svelte)
+
+- Make sure you are logged in to GitHub and, navigate to the following location to create a new repository
+  - https://github.com/sumitkharche/svelte-swa-starter/generate
+- Name your repository **my-first-static-web-app**
+
 # [No Framework](#tab/vanilla-javascript)
 
 - Make sure you are logged in to GitHub and, navigate to the following location to create a new repository
@@ -113,6 +119,12 @@ Next, add configuration details specific to your preferred front-end framework.
 - Enter **/** in the _App location_ box
 - Clear the default value from the _Api location_ box
 - Enter **dist** in the _App artifact location_ box
+
+# [Svelte](#tab/svelte)
+
+- Enter **/** in the _App location_ box
+- Clear the default value from the _Api location_ box
+- Enter **public** in the _App artifact location_ box
 
 # [No Framework](#tab/vanilla-javascript)
 

--- a/articles/static-web-apps/index.yml
+++ b/articles/static-web-apps/index.yml
@@ -33,6 +33,8 @@ landingContent:
             url: /azure/static-web-apps/getting-started?tabs=react
           - text: Create your first Vue app
             url: /azure/static-web-apps/getting-started?tabs=vue
+          - text: Create your first Svelte app
+            url: /azure/static-web-apps/getting-started?tabs=svelte
           - text: Create your first app (no framework)
             url: /azure/static-web-apps/getting-started?tabs=vanilla-javascript
       - linkListType: learn


### PR DESCRIPTION
- [x]  Added new tab for svelte app in `getting-started.md`.
- [x]  Updated `index.yml` to show the create svelte app link.
