### PR TITLE
Correcting sample for App Configuration

### DIFF
--- a/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
@@ -184,7 +184,7 @@ The Secret Manager tool stores sensitive data for development work outside of yo
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddControllersWithViews();
-        services.AddFeatureManagement();
+        services.AddSingleton(Configuration).AddFeatureManagement();
     }
 
     ---


### PR DESCRIPTION
Sample code for configuring Startup.cs in Azure App Configuration has a bug for dotnet code 3.x

