### PR TITLE
Use "Storage Service Encryption" more consistently

### DIFF
--- a/articles/virtual-machines/windows/disk-encryption.md
+++ b/articles/virtual-machines/windows/disk-encryption.md
@@ -1,5 +1,5 @@
 ---
-title: Server-side encryption of Azure Managed Disks - PowerShell
+title: Storage Service Encryption for Azure Managed Disks - PowerShell
 description: Azure Storage protects your data by encrypting it at rest before persisting it to Storage clusters. You can rely on Microsoft-managed keys for the encryption of your managed disks, or you can use customer-managed keys to manage encryption with your own keys.
 author: roygara
 ms.date: 04/21/2020
@@ -9,9 +9,9 @@ ms.service: virtual-machines-windows
 ms.subservice: disks
 ---
 
-# Server-side encryption of Azure managed disks
+# Azure Storage Service Encryption for managed disks
 
-Azure managed disks automatically encrypt your data by default when persisting it to the cloud. Server-side encryption (SSE) protects your data and helps you meet your organizational security and compliance commitments.
+Azure managed disks automatically encrypt your data by default when persisting it to the cloud. Storage Service Encryption (SSE) protects your data and helps you meet your organizational security and compliance commitments.
 
 Data in Azure managed disks is encrypted transparently using 256-bit [AES encryption](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard), one of the strongest block ciphers available, and is FIPS 140-2 compliant. For more information about the cryptographic modules underlying Azure managed disks, see [Cryptography API: Next Generation](https://docs.microsoft.com/windows/desktop/seccng/cng-portal)
 
@@ -32,7 +32,7 @@ By default, managed disks use platform-managed encryption keys. As of June 10, 2
 
 ## Customer-managed keys
 
-You can choose to manage encryption at the level of each managed disk, with your own keys. Server-side encryption for managed disks with customer-managed keys offers an integrated experience with Azure Key Vault. You can either import [your RSA keys](../../key-vault/keys/hsm-protected-keys.md) to your Key Vault or generate new RSA keys in Azure Key Vault. 
+You can choose to manage encryption at the level of each managed disk, with your own keys. Storage Service Encryption for managed disks with customer-managed keys offers an integrated experience with Azure Key Vault. You can either import [your RSA keys](../../key-vault/keys/hsm-protected-keys.md) to your Key Vault or generate new RSA keys in Azure Key Vault. 
 
 Azure managed disks handles the encryption and decryption in a fully transparent fashion using [envelope encryption](../../storage/common/storage-client-side-encryption.md#encryption-and-decryption-via-the-envelope-technique). It encrypts data using an [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) 256 based data encryption key (DEK), which is, in turn, protected using your keys. The Storage service generates data encryption keys and encrypts them with customer-managed keys using RSA encryption. The envelope encryption allows you to rotate (change) your keys periodically as per your compliance policies without impacting your VMs. When you rotate your keys, the Storage service re-encrypts the data encryption keys with the new customer-managed keys. 
 
@@ -54,7 +54,7 @@ The following list explains the diagram in more detail:
 1. That administrator creates an instance of Disk Encryption Set resource, specifying an Azure Key Vault ID and a key URL. Disk Encryption Set is a new resource introduced for simplifying the key management for managed disks. 
 1. When a disk encryption set is created, a [system-assigned managed identity](../../active-directory/managed-identities-azure-resources/overview.md) is created in Azure Active Directory (AD) and associated with the disk encryption set. 
 1. The Azure key vault administrator then grants the managed identity permission to perform operations in the key vault.
-1. A VM user creates disks by associating them with the disk encryption set. The VM user can also enable server-side encryption with customer-managed keys for existing resources by associating them with the disk encryption set. 
+1. A VM user creates disks by associating them with the disk encryption set. The VM user can also enable Storage Service Encryption with customer-managed keys for existing resources by associating them with the disk encryption set. 
 1. Managed disks use the managed identity to send requests to the Azure Key Vault.
 1. For reading or writing data, managed disks sends requests to Azure Key Vault to encrypt (wrap) and decrypt (unwrap) the data encryption key in order to perform encryption and decryption of the data. 
 
@@ -71,12 +71,12 @@ For now, customer-managed keys have the following restrictions:
 - If this feature is enabled for your disk, you cannot disable it.
     If you need to work around this, you must [copy all the data](disks-upload-vhd-to-managed-disk-powershell.md#copy-a-managed-disk) to an entirely different managed disk that isn't using customer-managed keys.
 - Only ["soft" and "hard" RSA keys](../../key-vault/keys/about-keys.md) of size 2080 are supported, no other keys or sizes.
-- Disks created from custom images that are encrypted using server-side encryption and customer-managed keys must be encrypted using the same customer-managed keys and must be in the same subscription.
-- Snapshots created from disks that are encrypted with server-side encryption and customer-managed keys must be encrypted with the same customer-managed keys.
+- Disks created from custom images that are encrypted using Storage Service Encryption and customer-managed keys must be encrypted using the same customer-managed keys and must be in the same subscription.
+- Snapshots created from disks that are encrypted with Storage Service Encryption and customer-managed keys must be encrypted with the same customer-managed keys.
 - All resources related to your customer-managed keys (Azure Key Vaults, disk encryption sets, VMs, disks, and snapshots) must be in the same subscription and region.
 - Disks, snapshots, and images encrypted with customer-managed keys cannot move to another subscription.
 - If you use the Azure portal to create your disk encryption set, you cannot use snapshots for now.
-- Managed disks encrypted using server-side encryption with customer-managed keys cannot also be encrypted with Azure Disk Encryption and vice versa
+- Managed disks encrypted using Storage Service Encryption with customer-managed keys cannot also be encrypted with Azure Disk Encryption and vice versa
 - For information about using customer-managed keys with shared image galleries, see [Preview: Use customer-managed keys for encrypting images](../image-version-encryption.md).
 
 ### PowerShell
@@ -157,7 +157,7 @@ $VirtualMachine = Add-AzVMDataDisk -VM $VirtualMachine -Name $($VMName +"DataDis
 New-AzVM -ResourceGroupName $ResourceGroupName -Location $LocationName -VM $VirtualMachine -Verbose
 ```
 
-#### Create an empty disk encrypted using server-side encryption with customer-managed keys and attach it to a VM
+#### Create an empty disk encrypted using Storage Service Encryption with customer-managed keys and attach it to a VM
 
 ```PowerShell
 $vmName = "yourVMName"
@@ -253,7 +253,7 @@ $keyVaultKey = Get-AzKeyVaultKey -VaultName $keyVaultName -Name $keyName
 Update-AzDiskEncryptionSet -Name $diskEncryptionSetName -ResourceGroupName $ResourceGroupName -SourceVaultId $keyVault.ResourceId -KeyUrl $keyVaultKey.Id
 ```
 
-#### Find the status of server-side encryption of a disk
+#### Find the status of Storage Service Encryption on a disk
 
 ```PowerShell
 $ResourceGroupName="yourResourceGroupName"
@@ -272,9 +272,9 @@ $disk.Encryption.Type
 > [!IMPORTANT]
 > Customer-managed keys rely on managed identities for Azure resources, a feature of Azure Active Directory (Azure AD). When you configure customer-managed keys, a managed identity is automatically assigned to your resources under the covers. If you subsequently move the subscription, resource group, or managed disk from one Azure AD directory to another, the managed identity associated with managed disks is not transferred to the new tenant, so customer-managed keys may no longer work. For more information, see [Transferring a subscription between Azure AD directories](../../active-directory/managed-identities-azure-resources/known-issues.md#transferring-a-subscription-between-azure-ad-directories).
 
-## Server-side encryption versus Azure disk encryption
+## Storage Service Encryption versus Azure Disk Encryption
 
-[Azure Disk Encryption](../../security/fundamentals/azure-disk-encryption-vms-vmss.md) leverages the [BitLocker](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-overview) feature of Windows to encrypt managed disks with customer-managed keys within the guest VM.  Server-side encryption with customer-managed keys improves on ADE by enabling you to use any OS types and images for your VMs by encrypting data in the Storage service.
+[Azure Disk Encryption](../../security/fundamentals/azure-disk-encryption-vms-vmss.md) leverages the [BitLocker](https://docs.microsoft.com/windows/security/information-protection/bitlocker/bitlocker-overview) feature of Windows to encrypt managed disks with customer-managed keys within the guest VM.  Storage Service Encryption with customer-managed keys improves on ADE by enabling you to use any OS types and images for your VMs by encrypting data in the Storage service.
 
 ## Next steps
 

--- a/includes/virtual-machines-managed-disks-overview.md
+++ b/includes/virtual-machines-managed-disks-overview.md
@@ -46,11 +46,11 @@ You can use [Azure role-based access control (RBAC)](../articles/role-based-acce
 
 ## Encryption
 
-Managed disks offer two different kinds of encryption. The first is Server Side Encryption (SSE), which is performed by the storage service. The second one is Azure Disk Encryption (ADE), which you can enable on the OS and data disks for your VMs.
+Managed disks offer two different kinds of encryption. The first is Storage Service Encryption (SSE), which is performed by the storage service. The second one is Azure Disk Encryption (ADE), which you can enable on the OS and data disks for your VMs.
 
-### Server-side encryption
+### Storage Service Encryption
 
-[Azure Server-side Encryption](../articles/virtual-machines/windows/disk-encryption.md) provides encryption-at-rest and safeguards your data to meet your organizational security and compliance commitments. Server-side encryption is enabled by default for all managed disks, snapshots, and images, in all the regions where managed disks are available. (Temporary disks, on the other hand, are not encrypted by Storage Service Encryption; see [Disk Roles: temporary disks](#temporary-disk)).
+[Azure Storage Service Encryption](../articles/virtual-machines/windows/disk-encryption.md) provides encryption-at-rest and safeguards your data to meet your organizational security and compliance commitments. Storage Service Encryption is enabled by default for all managed disks, snapshots, and images, in all the regions where managed disks are available. (Temporary disks, on the other hand, are not encrypted by Storage Service Encryption; see [Disk Roles: temporary disks](#temporary-disk)).
 
 You can either allow Azure to manage your keys for you, these are platform-managed keys, or you can manage the keys yourself, these are customer-managed keys. Visit the [Managed Disks FAQ page](../articles/virtual-machines/windows/faq-for-disks.md#managed-disks-and-storage-service-encryption) for more details.
 
@@ -79,7 +79,7 @@ This disk has a maximum capacity of 2,048 GiB.
 
 Every VM contains a temporary disk, which is not a managed disk. The temporary disk provides short-term storage for applications and processes and is intended to only store data such as page or swap files. Data on the temporary disk may be lost during a [maintenance event](../articles/virtual-machines/windows/manage-availability.md?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json#understand-vm-reboots---maintenance-vs-downtime) event or when you [redeploy a VM](../articles/virtual-machines/troubleshooting/redeploy-to-new-node-windows.md?toc=%2Fazure%2Fvirtual-machines%2Fwindows%2Ftoc.json). During a successful standard reboot of the VM, the data on the temporary disk will persist.  
 
-On Azure Linux VMs, the temporary disk is typically /dev/sdb and on Windows VMs the temporary disk is D: by default. The temporary disk is not encrypted by Server Side Encryption (see [Encryption](#encryption)).
+On Azure Linux VMs, the temporary disk is typically /dev/sdb and on Windows VMs the temporary disk is D: by default. The temporary disk is not encrypted by Storage Service Encryption (see [Encryption](#encryption)).
 
 ## Managed disk snapshots
 


### PR DESCRIPTION
Per #56994, I find the current differing uses of "SSE" as "Storage Service Encryption" versus "server-side encryption" throughout Azure documentation to be confusing.  [I think the difference between SSE and Azure Disk Encryption is already confusing enough](https://github.com/terraform-providers/terraform-provider-azurerm/issues/486#issuecomment-643099073), so if this PR is to your liking, consider this the first of at least one or two more PRs to use consistent terminology for SSE in Azure docs.

If "Storage Service Encryption" is not the canonical name for this feature, I'll be happy to update my PR and/or make a new PR to update the files that refer to it as "Storage Service Encryption" instead.  In that case I just need someone to tell me, definitively, *what does SSE stand for*.