### PR TITLE
Update functions-test-a-function.md

### DIFF
--- a/articles/azure-functions/functions-test-a-function.md
+++ b/articles/azure-functions/functions-test-a-function.md
@@ -69,7 +69,7 @@ Next, **right-click** on the *Functions.Test* application and select **Add > Cla
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using System.Text;
+using Microsoft.Extensions.Logging.Abstractions.Internal;
 
 namespace Functions.Tests
 {


### PR DESCRIPTION
System.Text is not used as a reference and using Microsoft.Extensions.Logging.Abstractions.Internal is needed for compiling the code