### PR TITLE
update the doc to reflect the support of CentOS8

### DIFF
--- a/articles/azure-monitor/platform/log-analytics-agent.md
+++ b/articles/azure-monitor/platform/log-analytics-agent.md
@@ -129,7 +129,7 @@ alternatives --set python /usr/sbin/python2
 The following versions of the Linux operating system are officially supported for the Linux agent:
 
 * Amazon Linux 2017.09 (x64)
-* CentOS Linux 6 (x64) and 7 (x64)  
+* CentOS Linux 6 (x64) and 7 (x64) and 8 (x64)
 * Oracle Linux 6 and 7 (x64) 
 * Red Hat Enterprise Linux Server 6 (x64), 7 (x64), and 8 (x64)
 * Debian GNU/Linux 8 and 9 (x64)


### PR DESCRIPTION
It should be clear that CentOS 8 is now also supported (as RHEL 8 is now supported as well)