### PR TITLE
Remove reference to app proxy blog.

### DIFF
--- a/articles/active-directory/manage-apps/application-proxy-configure-single-sign-on-with-kcd.md
+++ b/articles/active-directory/manage-apps/application-proxy-configure-single-sign-on-with-kcd.md
@@ -154,5 +154,3 @@ But, in some cases, the request is successfully sent to the backend application 
 * [How to configure an Application Proxy application to use Kerberos Constrained Delegation](application-proxy-back-end-kerberos-constrained-delegation-how-to.md)
 * [Troubleshoot issues you're having with Application Proxy](application-proxy-troubleshoot.md)
 
-
-For the latest news and updates, check out the [Application Proxy blog](https://blogs.technet.com/b/applicationproxyblog/)


### PR DESCRIPTION
The blog is no longer available and there is no app proxy blog replacement.