### PR TITLE
Include Additional Scope Note For Troubleshooting

### DIFF
--- a/articles/active-directory/develop/v2-oauth2-auth-code-flow.md
+++ b/articles/active-directory/develop/v2-oauth2-auth-code-flow.md
@@ -55,6 +55,8 @@ client_id=6731de76-14a6-49ae-97bc-6eba6914391e
 &scope=openid%20offline_access%20https%3A%2F%2Fgraph.microsoft.com%2Fmail.read
 &state=12345
 ```
+> [!NOTE]
+> Scopes listed here are an URI encoded, space separated list. Your application may need to send an unencoded list to avoid receiving a consent error AADSTS65001. For example, scope="openid offline_access mail.read".
 
 > [!TIP]
 > Click the link below to execute this request! After signing in, your browser should be redirected to `https://localhost/myapp/` with a `code` in the address bar.


### PR DESCRIPTION
I spent a good amount of time troubleshoot this for a Go service I'm writing to hook into Azure AD. Finally was able to trace out requests in the MSAL app and see that the Python version actually just sends a non-encoded scope list to the authorize and token endpoints. This caused a good deal of grief so I thought it would be prudent to at least mention it in the docs. Not sure how great the copy is, so definitely would like some input on how I worded it. 

Thanks y'all and keep up the great work!