### PR TITLE
Added Exchange ActiveSync to Legacy Auth Protocols

### DIFF
--- a/articles/active-directory/conditional-access/block-legacy-authentication.md
+++ b/articles/active-directory/conditional-access/block-legacy-authentication.md
@@ -62,6 +62,7 @@ The following options are considered legacy authentication protocols
 
 - Authenticated SMTP - Used by POP and IMAP client's to send email messages.
 - Autodiscover - Used by Outlook and EAS clients to find and connect to mailboxes in Exchange Online.
+- Exchange ActiveSync (EAS) - Used to connect to mailboxes in Exchange Online.
 - Exchange Online PowerShell - Used to connect to Exchange Online with remote PowerShell. If you block Basic authentication for Exchange Online PowerShell, you need to use the Exchange Online PowerShell Module to connect. For instructions, see [Connect to Exchange Online PowerShell using multi-factor authentication](/powershell/exchange/exchange-online/connect-to-exchange-online-powershell/mfa-connect-to-exchange-online-powershell).
 - Exchange Web Services (EWS) - A programming interface that's used by Outlook, Outlook for Mac, and third-party apps.
 - IMAP4 - Used by IMAP email clients.


### PR DESCRIPTION
Under the "Legacy authentication protocols" heading, there is no mention of Exchange ActiveSync, however further in the doc under "Block legacy authentication" the screenshot shows Exchange ActiveSync being blocked.

Exchange ActiveSync is listed as a legacy authentication protocol on the linked doc (Sign-in activity reports in the Azure Active Directory portal) - https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/concept-sign-ins#filter-sign-in-activities