### PR TITLE
(AzureCXP) Doc update

### DIFF
--- a/articles/active-directory/authentication/tutorial-enable-sspr-writeback.md
+++ b/articles/active-directory/authentication/tutorial-enable-sspr-writeback.md
@@ -33,7 +33,7 @@ In this tutorial, you learn how to:
 
 To complete this tutorial, you need the following resources and privileges:
 
-* A working Azure AD tenant with at least an Azure AD Premium P2 trial license enabled.
+* A working Azure AD tenant with at least an Azure AD Premium P1 or P2 trial license enabled.
     * If needed, [create one for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
     * For more information, see [Licensing requirements for Azure AD SSPR](concept-sspr-licensing.md).
 * An account with *global administrator* privileges.


### PR DESCRIPTION
(Updated line 36 )

Before : 
* A working Azure AD tenant with at least an Azure AD Premium P2 trial license enabled. 
After
* A working Azure AD tenant with at least an Azure AD Premium P1 or P2 trial license enabled.

Closes MicrosoftDocs/azure-docs#57333