### PR TITLE
Use camel case for template parameter

### DIFF
--- a/articles/azure-resource-manager/templates/linked-templates.md
+++ b/articles/azure-resource-manager/templates/linked-templates.md
@@ -355,7 +355,7 @@ To pass parameter values inline, use the **parameters** property.
       "contentVersion":"1.0.0.0"
      },
      "parameters": {
-      "StorageAccountName":{"value": "[parameters('StorageAccountName')]"}
+      "storageAccountName":{"value": "[parameters('storageAccountName')]"}
     }
    }
   }


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-best-practices#parameters, parameters should be named using camel case.