### PR TITLE
2 service clients don't need await

### DIFF
--- a/articles/storage/blobs/storage-quickstart-blobs-nodejs.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-nodejs.md
@@ -162,7 +162,7 @@ Add this code to the end of the `main` function:
 
 ```javascript
 // Create the BlobServiceClient object which will be used to create a container client
-const blobServiceClient = await BlobServiceClient.fromConnectionString(AZURE_STORAGE_CONNECTION_STRING);
+const blobServiceClient = BlobServiceClient.fromConnectionString(AZURE_STORAGE_CONNECTION_STRING);
 
 // Create a unique name for the container
 const containerName = 'quickstart' + uuidv1();
@@ -171,7 +171,7 @@ console.log('\nCreating container...');
 console.log('\t', containerName);
 
 // Get a reference to a container
-const containerClient = await blobServiceClient.getContainerClient(containerName);
+const containerClient = blobServiceClient.getContainerClient(containerName);
 
 // Create the container
 const createContainerResponse = await containerClient.create();


### PR DESCRIPTION
BlobServiceClient.fromConnectionString returns a BlobServiceClient as per 
https://docs.microsoft.com/en-us/javascript/api/@azure/storage-blob/blobserviceclient?view=azure-node-latest#fromconnectionstring-string--storagepipelineoptions-
It doesn't need to use the await.

Same for blobServiceClient.getContainerClient
https://docs.microsoft.com/en-us/javascript/api/@azure/storage-blob/blobserviceclient?view=azure-node-latest#getcontainerclient-string-
It doesn't need the await.