### PR TITLE
Include note on when converged registration CA policy will apply

### DIFF
--- a/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
@@ -46,6 +46,9 @@ If you have configured the Site to Zone Assignment List in Internet Explorer, th
 
 Securing when and how users register for Azure Multi-Factor Authentication and self-service password reset is now possible with user actions in Conditional Access policy. This feature is available to organizations who have enabled the [combined registration feature](../authentication/concept-registration-mfa-sspr-combined.md). This functionality may be enabled in organizations where they want users to register for Azure Multi-Factor Authentication and SSPR from a central location such as a trusted network location during HR onboarding.
 
+> [!NOTE]
+> This policy will only apply when a user navigates to a combined registration page.  This policy will not enforce MFA enrollment when accessing other applications.  You can create an MFA registration policy utilizing Azure Identity Protection [Azure Identity Protection - Configure MFA Policy](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/howto-identity-protection-configure-mfa-policy)
+
 For more information about creating trusted locations in Conditional Access, see the article [What is the location condition in Azure Active Directory Conditional Access?](../conditional-access/location-condition.md#named-locations)
 
 ### Create a policy to require registration from a trusted location

--- a/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
@@ -47,7 +47,7 @@ If you have configured the Site to Zone Assignment List in Internet Explorer, th
 Securing when and how users register for Azure Multi-Factor Authentication and self-service password reset is now possible with user actions in Conditional Access policy. This feature is available to organizations who have enabled the [combined registration feature](../authentication/concept-registration-mfa-sspr-combined.md). This functionality may be enabled in organizations where they want users to register for Azure Multi-Factor Authentication and SSPR from a central location such as a trusted network location during HR onboarding.
 
 > [!NOTE]
-> This policy only applies when a user navigates to a combined registration page.  This policy doesn't enforce MFA enrollment when accessing other applications.  You can create an MFA registration policy utilizing Azure Identity Protection [Azure Identity Protection - Configure MFA Policy](../identity-protection/howto-identity-protection-configure-mfa-policy.md)
+> This policy applies only when a user accesses a combined registration page. This policy doesn't enforce MFA enrollment when a user accesses other applications. You can create an MFA registration policy by using [Azure Identity Protection - Configure MFA Policy](../identity-protection/howto-identity-protection-configure-mfa-policy.md).
 
 For more information about creating trusted locations in Conditional Access, see the article [What is the location condition in Azure Active Directory Conditional Access?](../conditional-access/location-condition.md#named-locations)
 

--- a/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
@@ -47,7 +47,7 @@ If you have configured the Site to Zone Assignment List in Internet Explorer, th
 Securing when and how users register for Azure Multi-Factor Authentication and self-service password reset is now possible with user actions in Conditional Access policy. This feature is available to organizations who have enabled the [combined registration feature](../authentication/concept-registration-mfa-sspr-combined.md). This functionality may be enabled in organizations where they want users to register for Azure Multi-Factor Authentication and SSPR from a central location such as a trusted network location during HR onboarding.
 
 > [!NOTE]
-> This policy will only apply when a user navigates to a combined registration page.  This policy will not enforce MFA enrollment when accessing other applications.  You can create an MFA registration policy utilizing Azure Identity Protection [Azure Identity Protection - Configure MFA Policy](https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/howto-identity-protection-configure-mfa-policy)
+> This policy only applies when a user navigates to a combined registration page.  This policy doesn't enforce MFA enrollment when accessing other applications.  You can create an MFA registration policy utilizing Azure Identity Protection [Azure Identity Protection - Configure MFA Policy](../identity-protection/howto-identity-protection-configure-mfa-policy.md)
 
 For more information about creating trusted locations in Conditional Access, see the article [What is the location condition in Azure Active Directory Conditional Access?](../conditional-access/location-condition.md#named-locations)
 


### PR DESCRIPTION
Added note that identifies when the CA policy will be executed.  There has been some customer confusion where customers are expecting MFA registration to be required on scoped users when accessing any application.  This policy only applies to when a user is accessing an MFA registration page like aka.ms/mysecurityinfo.  Added link to ID Protection page link on how to create an MFA registration requirement policy