### PR TITLE
New tips and tricks suggestion

### DIFF
--- a/articles/virtual-machines/extensions/custom-script-windows.md
+++ b/articles/virtual-machines/extensions/custom-script-windows.md
@@ -61,6 +61,7 @@ If your script is on a local server, then you may still need additional firewall
 * Custom Script extension does not natively support proxy servers, however you can use a file transfer tool that supports proxy servers within your script, such as *Curl*
 * Be aware of non-default directory locations that your scripts or commands may rely on, have logic to handle this situation.
 * Custom Script Extension will run under the LocalSystem Account
+* If you plan to use the *storageAccountName* and *storageAccountKey* properties, these must be collocated in *protectedSettings*.
 
 ## Extension schema
 

--- a/articles/virtual-machines/extensions/custom-script-windows.md
+++ b/articles/virtual-machines/extensions/custom-script-windows.md
@@ -61,7 +61,7 @@ If your script is on a local server, then you may still need additional firewall
 * Custom Script extension does not natively support proxy servers, however you can use a file transfer tool that supports proxy servers within your script, such as *Curl*
 * Be aware of non-default directory locations that your scripts or commands may rely on, have logic to handle this situation.
 * Custom Script Extension will run under the LocalSystem Account
-* If you plan to use the *storageAccountName* and *storageAccountKey* properties, these must be collocated in *protectedSettings*.
+* If you plan to use the *storageAccountName* and *storageAccountKey* properties, these properties must be collocated in *protectedSettings*.
 
 ## Extension schema
 


### PR DESCRIPTION
After extensive testing I have determined that when using storageAccountName and storageAccountKey these two properties must be collocated in protectedSettings.