### PR TITLE
update capacity unit metrics

### DIFF
--- a/articles/application-gateway/application-gateway-metrics.md
+++ b/articles/application-gateway/application-gateway-metrics.md
@@ -82,7 +82,7 @@ For Application Gateway, the following metrics are available:
 
 - **Current capacity units**
 
-   Count of capacity units consumed to load balance the traffic. There are three determinants to capacity unit - compute unit, persistent connections and throughput. Each capacity unit is composed of at most: 1 compute unit, or 2500 persistent connections, or 2.22-Mbps throughput.
+   Count of capacity units consumed to load balance the traffic. There are three determinants to capacity unit - compute unit, persistent connections and throughput. Each capacity unit is composed of at most: 1 compute unit, or 2500 persistent connections, or 2.22-MBps throughput.
 
 - **Current compute units**
 


### PR DESCRIPTION
change the capacity units throughput metric to read MB(megabyte) instead of Mb(megabit) to reflect how the metric is displayed for that resource in Azure Metrics, discussed this with support.