### PR TITLE
Update runtime ruby version to `RUBY|2.6.2'

### DIFF
--- a/includes/app-service-web-create-web-app-ruby-linux-no-h.md
+++ b/includes/app-service-web-create-web-app-ruby-linux-no-h.md
@@ -12,7 +12,7 @@ ms.custom: "include file"
 
 Create a [web app](../articles/app-service/containers/app-service-linux-intro.md) in the `myAppServicePlan` App Service plan. 
 
-In the Cloud Shell, you can use the [`az webapp create`](/cli/azure/webapp?view=azure-cli-latest) command. In the following example, replace `<app-name>` with a globally unique app name (valid characters are `a-z`, `0-9`, and `-`). The runtime is set to `RUBY|2.3`. To see all supported runtimes, run [`az webapp list-runtimes --linux`](/cli/azure/webapp?view=azure-cli-latest). 
+In the Cloud Shell, you can use the [`az webapp create`](/cli/azure/webapp?view=azure-cli-latest) command. In the following example, replace `<app-name>` with a globally unique app name (valid characters are `a-z`, `0-9`, and `-`). The runtime is set to `RUBY|2.6.2`. To see all supported runtimes, run [`az webapp list-runtimes --linux`](/cli/azure/webapp?view=azure-cli-latest). 
 
 ```azurecli-interactive
 # Bash


### PR DESCRIPTION
`'RUBY|2.3'` is no longer a supported runtime. When you run `az webapp list-runtimes --linux` the only supported ruby runtimes are `'RUBY|2.5.5'` and `'RUBY|2.6.2'`.