### PR TITLE
fix technical profile name for JwtIssuer technical profile

### DIFF
--- a/articles/active-directory-b2c/session-behavior-custom-policy.md
+++ b/articles/active-directory-b2c/session-behavior-custom-policy.md
@@ -56,7 +56,7 @@ When you redirect the user to the Azure AD B2C sign-out endpoint (for both OAuth
 To support single sign-out, the token issuer technical profiles for both JWT and SAML must specify:
 
 - The protocol name, such as `<Protocol Name="OpenIdConnect" />`
-- The reference  to the session technical profile, such as `UseTechnicalProfileForSessionManagement ReferenceId="SM-jwt-issuer" />`.
+- The reference  to the session technical profile, such as `UseTechnicalProfileForSessionManagement ReferenceId="SM-OAuth-issuer" />`.
 
 The following example illustrates the JWT and SAML token issuers with single sign-out:
 
@@ -70,7 +70,7 @@ The following example illustrates the JWT and SAML token issuers with single sig
       <Protocol Name="OpenIdConnect" />
       <OutputTokenFormat>JWT</OutputTokenFormat>
       ...    
-      <UseTechnicalProfileForSessionManagement ReferenceId="SM-jwt-issuer" />
+      <UseTechnicalProfileForSessionManagement ReferenceId="SM-OAuth-issuer" />
     </TechnicalProfile>
 
     <!-- Session management technical profile for OIDC based tokens -->


### PR DESCRIPTION
The name of `OAuthSSOSessionProvider` used in `JwtIssuer` in technical profile is wrong in the current document. 