### PR TITLE
Pull Get header to match Insert and Delete

### DIFF
--- a/articles/cosmos-db/tutorial-develop-table-dotnet.md
+++ b/articles/cosmos-db/tutorial-develop-table-dotnet.md
@@ -249,7 +249,7 @@ Right click on your project **CosmosTableSamples**. Select **Add**, **New Item**
  }
 ```
 
-### Get an entity from a partition
+## Get an entity from a partition
 
 You can get entity from a partition by using the Retrieve method under the [TableOperation](https://docs.microsoft.com/dotnet/api/microsoft.azure.cosmos.table.tableoperation) class. The following code example gets the partition key row key, email and phone number of a customer entity. This example also prints out the request units consumed to query for the entity. To query for an entity, append the following code to **SamplesUtils.cs** file: 
 


### PR DESCRIPTION
This felt like a Markdown typo, making entity retrieval a sub-heading of the insert/merge section before jumping back up to H2 for the delete section. This change would align all those table operations on the same H2 level.