### PR TITLE
"Use the prediction API" guide has a wrong JSON example for endpoint response, Properties are not in PascalCase.

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/use-prediction-api.md
+++ b/articles/cognitive-services/Custom-Vision-Service/use-prediction-api.md
@@ -115,13 +115,13 @@ When you run the application, you are prompted to enter a path to an image file 
 
 ```json
 {
-    "Id":"7796df8e-acbc-45fc-90b4-1b0c81b73639",
-    "Project":"8622c779-471c-4b6e-842c-67a11deffd7b",
-    "Iteration":"59ec199d-f3fb-443a-b708-4bca79e1b7f7",
-    "Created":"2019-03-20T16:47:31.322Z",
-    "Predictions":[
-        {"TagId":"d9cb3fa5-1ff3-4e98-8d47-2ef42d7fb373","TagName":"cat", "Probability":1.0},
-        {"TagId":"9a8d63fb-b6ed-4462-bcff-77ff72084d99","TagName":"dog", "Probability":0.1087869}
+    "id":"7796df8e-acbc-45fc-90b4-1b0c81b73639",
+    "project":"8622c779-471c-4b6e-842c-67a11deffd7b",
+    "iteration":"59ec199d-f3fb-443a-b708-4bca79e1b7f7",
+    "created":"2019-03-20T16:47:31.322Z",
+    "predictions":[
+        {"tagId":"d9cb3fa5-1ff3-4e98-8d47-2ef42d7fb373","tagName":"cat", "probability":1.0},
+        {"tagId":"9a8d63fb-b6ed-4462-bcff-77ff72084d99","tagName":"dog", "probability":0.1087869}
     ]
 }
 ```


### PR DESCRIPTION
Currently, the endpoint returns the JSON properties without apply PascalCase