### PR TITLE
Add note about PuTTy changing pub key format

### DIFF
--- a/articles/virtual-machines/linux/ssh-from-windows.md
+++ b/articles/virtual-machines/linux/ssh-from-windows.md
@@ -60,13 +60,13 @@ To create an SSH RSA key pair with PuTTYgen:
 
 4. Move the mouse around in the blank area to provide randomness for the key.
 
-5. After the public key is generated, optionally enter and confirm a passphrase. You will be prompted for the passphrase when you authenticate to the VM with your private SSH key. Without a passphrase, if someone obtains your private key, they can sign in to any VM or service that uses that key. We recommend you create a passphrase. However, if you forget the passphrase, there is no way to recover it.
+4. After the public key is generated, optionally enter and confirm a passphrase. You will be prompted for the passphrase when you authenticate to the VM with your private SSH key. Without a passphrase, if someone obtains your private key, they can sign in to any VM or service that uses that key. We recommend you create a passphrase. However, if you forget the passphrase, there is no way to recover it.
 
-6. The public key is displayed at the top of the window. You can copy this entire public key and then paste it into the Azure portal or an Azure Resource Manager template when you create a Linux VM. You can also select **Save public key** to save a copy to your computer. Note that when saving to a file PuTTy converts the public key to a different format [RFC4716](https://tools.ietf.org/html/rfc4716), which may not be compatible with all APIs, so for use in Azure portal, it's preferable to copy the one displayed in the PuTTy window.
+5. The public key is displayed at the top of the window. You can copy this entire public key and then paste it into the Azure portal or into an Azure Resource Manager template when you create a Linux VM. You can also select **Save public key** to save a copy to your computer. Note that when saving to a file, PuTTY converts the public key to a different format, [RFC4716](https://tools.ietf.org/html/rfc4716). The RFC4716 format might not be compatible with all APIs. So, to use in the Azure portal, we recommend that you copy the public key that's displayed in the PuTTY window.
 
     ![Save PuTTY public key file](./media/ssh-from-windows/save-public-key.png)
 
-7. Optionally, to save the private key in PuTTy private key format (.ppk file), select **Save private key**. You will need the .ppk file later to use PuTTY to make an SSH connection to the VM.
+6. Optionally, to save the private key in PuTTy private key format (.ppk file), select **Save private key**. You will need the .ppk file later to use PuTTY to make an SSH connection to the VM.
 
     ![Save PuTTY private key file](./media/ssh-from-windows/save-ppk-file.png)
 

--- a/articles/virtual-machines/linux/ssh-from-windows.md
+++ b/articles/virtual-machines/linux/ssh-from-windows.md
@@ -62,7 +62,7 @@ To create an SSH RSA key pair with PuTTYgen:
 
 5. After the public key is generated, optionally enter and confirm a passphrase. You will be prompted for the passphrase when you authenticate to the VM with your private SSH key. Without a passphrase, if someone obtains your private key, they can sign in to any VM or service that uses that key. We recommend you create a passphrase. However, if you forget the passphrase, there is no way to recover it.
 
-6. The public key is displayed at the top of the window. You can copy this entire public key and then paste it into the Azure portal or an Azure Resource Manager template when you create a Linux VM. You can also select **Save public key** to save a copy to your computer:
+6. The public key is displayed at the top of the window. You can copy this entire public key and then paste it into the Azure portal or an Azure Resource Manager template when you create a Linux VM. You can also select **Save public key** to save a copy to your computer. Note that when saving to a file PuTTy converts the public key to a different format [RFC4716](https://tools.ietf.org/html/rfc4716), which may not be compatible with all APIs, so for use in Azure portal, it's preferable to copy the one displayed in the PuTTy window.
 
     ![Save PuTTY public key file](./media/ssh-from-windows/save-public-key.png)
 

--- a/articles/virtual-machines/linux/ssh-from-windows.md
+++ b/articles/virtual-machines/linux/ssh-from-windows.md
@@ -58,7 +58,7 @@ To create an SSH RSA key pair with PuTTYgen:
 
 2. Click **Generate**. By default PuTTYgen generates a 2048-bit SSH-2 RSA key.
 
-4. Move the mouse around in the blank area to provide randomness for the key.
+3. Move the mouse around in the blank area to provide randomness for the key.
 
 4. After the public key is generated, optionally enter and confirm a passphrase. You will be prompted for the passphrase when you authenticate to the VM with your private SSH key. Without a passphrase, if someone obtains your private key, they can sign in to any VM or service that uses that key. We recommend you create a passphrase. However, if you forget the passphrase, there is no way to recover it.
 


### PR DESCRIPTION
When saving to file, PuTTy changes the format of the public key. AML UI for creating new computes does not recognize this format but the old DSVM UI did. This has created pain for customers. This note intends to warn users in an effort to avoid this issue.