### PR TITLE
Update instance-pools-configure.md

### DIFF
--- a/articles/azure-sql/managed-instance/instance-pools-configure.md
+++ b/articles/azure-sql/managed-instance/instance-pools-configure.md
@@ -94,7 +94,7 @@ $instancePool = New-AzSqlInstancePool `
   -Name "mi-pool-name" `
   -SubnetId $subnet.Id `
   -LicenseType "LicenseIncluded" `
-  -VCore 80 `
+  -VCore 8 `
   -Edition "GeneralPurpose" `
   -ComputeGeneration "Gen5" `
   -Location "westeurope"
@@ -110,13 +110,13 @@ After the successful deployment of the instance pool, it's time to create a mana
 To create a managed instance, execute the following command:
 
 ```powershell
-$instanceOne = $instancePool | New-AzSqlInstance -Name "mi-pool-name" -VCore 2 -StorageSizeInGB 256
+$instanceOne = $instancePool | New-AzSqlInstance -Name "mi-one-name" -VCore 2 -StorageSizeInGB 256
 ```
 
 Deploying an instance inside a pool takes a couple of minutes. After the first instance has been created, additional instances can be created:
 
 ```powershell
-$instanceTwo = $instancePool | New-AzSqlInstance -Name "mi-pool-name" -VCore 4 -StorageSizeInGB 512
+$instanceTwo = $instancePool | New-AzSqlInstance -Name "mi-two-name" -VCore 4 -StorageSizeInGB 512
 ```
 
 ## Create a database 


### PR DESCRIPTION
- update managed instance pool creation command to use 8 cores instead of 80 cores, to avoid new user accidentally copy/paste, and create an unneeded maximum size pool 
- correct script to add managed instance into instance pool, the -Name parameter refers to the name of the instance being added, but not the instance pool name