### PR TITLE
Update azure-disks-dynamic-pv.md

### DIFF
--- a/articles/aks/azure-disks-dynamic-pv.md
+++ b/articles/aks/azure-disks-dynamic-pv.md
@@ -36,7 +36,7 @@ Each AKS cluster includes two pre-created storage classes, both configured to wo
 * The *managed-premium* storage class provisions a premium Azure disk.
     * Premium disks are backed by SSD-based high-performance, low-latency disk. Perfect for VMs running production workload. If the AKS nodes in your cluster use premium storage, select the *managed-premium* class.
     
-If you use one of the default storage classes, you can't update the volume size after the storage class is created. To be able to update the volume size after a storage class is created, add the line `allowVolumeExpansion: true` to one of the default storage classes, or you can create you own custom storage class. You can edit an existing storage class by using the `kubectl edit sc` command. 
+If you use one of the default storage classes, you can't update the volume size after the storage class is created. To be able to update the volume size after a storage class is created, add the line `allowVolumeExpansion: true` to one of the default storage classes, or you can create you own custom storage class. Note that it's not supported to reduce the size of a PVC (to prevent data loss). You can edit an existing storage class by using the `kubectl edit sc` command. 
 
 For example, if you want to use a disk of size 4 TiB, you must create a storage class that defines `cachingmode: None` because [disk caching isn't supported for disks 4 TiB and larger](../virtual-machines/windows/premium-storage-performance.md#disk-caching).
 


### PR DESCRIPTION
CRI 183406250 where a customer attempted to reduce the size of a PVC - causing error:

The disk/snapshot resource with id /subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/kubernetes-dynamic-pvc-... cannot be resized down. Reducing disk/snapshot size is not supported in Azure to prevent data loss. If you do need to reduce the size of the disk, please create new snapshot/disks with the appropriate size. More information is available at https://aka.ms/AzureDisksFAQ