### PR TITLE
Change language around ordering of identity

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-identity.md
+++ b/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-identity.md
@@ -45,7 +45,7 @@ This remainder of this section highlights the nuances of the implementation to h
 
 ### Allocation of values
 
-The IDENTITY property doesn't guarantee the order in which the surrogate values are allocated, which reflects the behavior of SQL Server and Azure SQL Database. However, in Synapse SQL pool, the absence of a guarantee is more pronounced.
+The IDENTITY property doesn't guarantee the order in which the surrogate values are allocated, which is in contrast to the behavior of SQL Server and Azure SQL Database. In Synapse SQL pool, the absence of a guarantee is more pronounced.
 
 The following example is an illustration:
 


### PR DESCRIPTION
The previous language is unclear as it references SQL Server and Azure SQL which do guarantee the ordering of identity creation. Language change to make it clearer that Synapse SQL pool is in contrast to SQL Server and Azure SQL.