### PR TITLE
AccelNet updated constraints updated

### DIFF
--- a/articles/virtual-network/virtual-network-network-interface-vm.md
+++ b/articles/virtual-network/virtual-network-network-interface-vm.md
@@ -146,7 +146,7 @@ To learn about network interface settings and how to change them, see [Manage ne
 
 - Deleting a VM doesn't delete the network interfaces that are attached to it. When you delete a VM, the network interfaces are detached from the VM. You can add those network interfaces to different VMs or delete them.
 
-- Acheiving the optimal performance documented requires Accelerated Networking. In some cases, it needs to be explicitly enabled for [Windows](create-vm-accelerated-networking-powershell.md) or [Linux](create-vm-accelerated-networking-cli.md) virtual machines.
+- Achieving the optimal performance documented requires Accelerated Networking. In some cases, you must explicitly enable Accelerated Networking for [Windows](create-vm-accelerated-networking-powershell.md) or [Linux](create-vm-accelerated-networking-cli.md) virtual machines.
 
 ## Next steps
 

--- a/articles/virtual-network/virtual-network-network-interface-vm.md
+++ b/articles/virtual-network/virtual-network-network-interface-vm.md
@@ -146,7 +146,7 @@ To learn about network interface settings and how to change them, see [Manage ne
 
 - Deleting a VM doesn't delete the network interfaces that are attached to it. When you delete a VM, the network interfaces are detached from the VM. You can add those network interfaces to different VMs or delete them.
 
-- As with IPv6, you can't attach a network interface with accelerated networking enabled to a VM after you create it. Further, to take advantage of accelerated networking, you must also complete steps within the VM operating system. Learn more about accelerated networking, and other constraints when using it, for [Windows](create-vm-accelerated-networking-powershell.md) or [Linux](create-vm-accelerated-networking-cli.md) virtual machines.
+- Acheiving the optimal performance documented requires Accelerated Networking. In some cases, it needs to be explicitly enabled for [Windows](create-vm-accelerated-networking-powershell.md) or [Linux](create-vm-accelerated-networking-cli.md) virtual machines.
 
 ## Next steps
 


### PR DESCRIPTION
Getting top performance requires AccelNet which may need to be turned on when it is not the default.