### PR TITLE
Mising namespace in hello-world-ingress.yaml file

### DIFF
--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -165,7 +165,8 @@ Create a file named `hello-world-ingress.yaml` and copy in the following example
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: hello-world-ingress  
+  name: hello-world-ingress
+  namespace: ingress-basic
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"


### PR DESCRIPTION
running the sample as described in the page, will not work. When accessing/browsing to the EXTERNALIP (and EXETERNALIP/hello-world-two), a 503 error will show up (503 Service Temporarily Unavailable
nginx/1.17.10). 
To get it working, add the " namespace: ingress-basic" to line 5 of hello-world-ingress.yaml file.