### PR TITLE
Bitlocker encryption must be disabled before sysprep

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -535,6 +535,9 @@ images. Before you use this procedure, make sure Sysprep supports the role of th
 information, see
 [Sysprep support for server roles](/windows-hardware/manufacture/desktop/sysprep-support-for-server-roles).
 
+In particular, Sysprep requires the drives to be fully decrypted before execution. If you have enabled Encryption on your VM, please disable it before running sysprep.
+
+
 ### Generalize a VHD
 
 >[!NOTE]

--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -535,7 +535,7 @@ images. Before you use this procedure, make sure Sysprep supports the role of th
 information, see
 [Sysprep support for server roles](/windows-hardware/manufacture/desktop/sysprep-support-for-server-roles).
 
-In particular, Sysprep requires the drives to be fully decrypted before execution. If you have enabled Encryption on your VM, please disable it before running sysprep.
+In particular, Sysprep requires the drives to be fully decrypted before execution. If you have enabled encryption on your VM, disable it before running Sysprep.
 
 
 ### Generalize a VHD


### PR DESCRIPTION
CRI 194235863 - sysprep needs bitlocker to but turned off before it can proceed to generalize the OS.

for hex 0x80310039 / decimal -2144272327
FVE_E_NOT_DECRYPTED winerror.h

The drive must be fully decrypted to complete this operation.
Sysprep has explicitly wrote a method in bdesysprep.dll to precheck if bitlocker is turned on and halt the sysprep if encryption is enabled.