### PR TITLE
fix typo in doc reference

### DIFF
--- a/articles/virtual-machines/linux/disk-encryption-key-vault.md
+++ b/articles/virtual-machines/linux/disk-encryption-key-vault.md
@@ -26,7 +26,7 @@ Creating and configuring a key vault for use with Azure Disk Encryption involves
 These steps are illustrated in the following quickstarts:
 
 - [Create and encrypt a Linux VM with Azure CLI](disk-encryption-cli-quickstart.md)
-- [Create and encrypt a Linux VM with Azure PowerShell](disk-encryption-cli-quickstart.md)
+- [Create and encrypt a Linux VM with Azure PowerShell](disk-encryption-powershell-quickstart.md)
 
 You may also, if you wish, generate or import a key encryption key (KEK).
 


### PR DESCRIPTION
The powershell link accidently pointed to the az cli documentation, instead of the powershell version.