### PR TITLE
misleading title

### DIFF
--- a/articles/active-directory/conditional-access/plan-conditional-access.md
+++ b/articles/active-directory/conditional-access/plan-conditional-access.md
@@ -204,9 +204,9 @@ If a user not in Group 1 attempts to access the app no “if’ condition is met
 
 The Conditional Access framework provides you with a great configuration flexibility. However, great flexibility also means you should carefully review each configuration policy before releasing it to avoid undesirable results.
 
-### Apply CA policies to every app
+### Apply CA policies to every app accessed by end users
 
-Access tokens are by default issued if a CA Policy condition does not trigger an access control. Ensure that every app has at least one conditional access policy applied
+Access tokens are by default issued if a CA Policy condition does not trigger an access control. Ensure that every app accessed by your users has at least one conditional access policy applied.
 
 > [!IMPORTANT]
 > Be very careful in using block and all apps in a single policy. This could lock admins out of the Azure Administration Portal, and exclusions cannot be configured for important end-points such as Microsoft Graph.


### PR DESCRIPTION
The title could be confused by admins to select "All cloud apps", which is a selection possible when configuring a CA policy.  Selecting "All cloud apps" also includes service dependencies that cannot be excluded and can cause unexpected CA results.

Title change better reflects that a CA admin should selectively choose the applications end-users utilize rather than a "catch-all" of using the "All cloud apps" selection.