### PR TITLE
Update Microsoft.Azure.WebJobs.Extensions.Storage package for C# bindings to current version to fix #58193

### DIFF
--- a/articles/azure-functions/functions-add-output-binding-storage-queue-vs-code.md
+++ b/articles/azure-functions/functions-add-output-binding-storage-queue-vs-code.md
@@ -64,7 +64,7 @@ Extension bundles usage is enabled in the host.json file at the root of the proj
 With the exception of HTTP and timer triggers, bindings are implemented as extension packages. Run the following [dotnet add package](/dotnet/core/tools/dotnet-add-package) command in the Terminal window to add the Storage extension package to your project.
 
 ```bash
-dotnet add package Microsoft.Azure.WebJobs.Extensions.Storage --version 3.0.4
+dotnet add package Microsoft.Azure.WebJobs.Extensions.Storage --version 4.0.2
 ```
 
 ::: zone-end


### PR DESCRIPTION
Update Microsoft.Azure.WebJobs.Extensions.Storage package to current version.