### PR TITLE
change type of formPages variable

### DIFF
--- a/articles/cognitive-services/form-recognizer/includes/quickstarts/csharp-sdk.md
+++ b/articles/cognitive-services/form-recognizer/includes/quickstarts/csharp-sdk.md
@@ -166,7 +166,7 @@ To recognize the content of a file at a given URI, use the **StartRecognizeConte
 private static async Task<Guid> GetContent(
     FormRecognizerClient recognizerClient, string invoiceUri)
 {
-    Response<IReadOnlyList<FormPage>> formPages = await recognizerClient
+    Response<FormPageCollection> formPages = await recognizerClient
         .StartRecognizeContentFromUri(new Uri(invoiceUri))
         .WaitForCompletionAsync();
 ```


### PR DESCRIPTION
```csharp
await recognizerClient.StartRecognizeContentFromUri(new Uri(invoiceUri)).WaitForCompletionAsync();
```
does not return a response of type IReadOnlyList<FormPage>.  The return type is FormPAgeCollection. Variable changed to the corresponding type so it will compile.