### PR TITLE
Mention target architecture for Linux binaries

### DIFF
--- a/articles/storage/common/storage-use-azcopy-v10.md
+++ b/articles/storage/common/storage-use-azcopy-v10.md
@@ -26,7 +26,7 @@ First, download the AzCopy V10 executable file to any directory on your computer
 
 - [Windows 64-bit](https://aka.ms/downloadazcopy-v10-windows) (zip)
 - [Windows 32-bit](https://aka.ms/downloadazcopy-v10-windows-32bit) (zip)
-- [Linux](https://aka.ms/downloadazcopy-v10-linux) (tar)
+- [Linux x86-64](https://aka.ms/downloadazcopy-v10-linux) (tar)
 - [MacOS](https://aka.ms/downloadazcopy-v10-mac) (zip)
 
 These files are compressed as a zip file (Windows and Mac) or a tar file (Linux). To download and decompress the tar file on Linux, see the documentation for your Linux distribution.


### PR DESCRIPTION
I was disappointed when I downloaded the Linux binaries and discovered that they aren't compiled for ARM. Updating the docs to mention the target architecture.