### PR TITLE
Correct the target connection info for SQL MI in DMS document

### DIFF
--- a/articles/dms/howto-sql-server-to-azure-sql-mi-powershell.md
+++ b/articles/dms/howto-sql-server-to-azure-sql-mi-powershell.md
@@ -116,13 +116,11 @@ $sourceConnInfo = New-AzDmsConnInfo -ServerType SQL `
   -TrustServerCertificate:$true
 ```
 
-The next example shows creation of Connection Info for a Azure SQL Managed Instance named ‘targetmanagedinstance.database.windows.net’ using sql authentication:
+The next example shows creation of Connection Info for a Azure SQL Managed Instance named ‘targetmanagedinstance’:
 
 ```powershell
-$targetConnInfo = New-AzDmsConnInfo -ServerType SQL `
-  -DataSource "targetmanagedinstance.database.windows.net" `
-  -AuthType SqlAuthentication `
-  -TrustServerCertificate:$false
+$targetResourceId = (Get-AzSqlInstance -Name "targetmanagedinstance").Id
+$targetConnInfo = New-AzDmsConnInfo -ServerType SQLMI -MiResourceId $targetResourceId
 ```
 
 ### Provide databases for the migration project


### PR DESCRIPTION
If the target is SQL MI, the target connection info should use type SQLMI instead.