### PR TITLE
Backend target steps not matching the image

### DIFF
--- a/articles/application-gateway/create-ssl-portal.md
+++ b/articles/application-gateway/create-ssl-portal.md
@@ -152,7 +152,7 @@ On the **Configuration** tab, you'll connect the frontend and backend pool you c
 
 4. On the **Backend targets** tab, select **myBackendPool** for the **Backend target**.
 
-5. For the **HTTP setting**, select **Create new** to create a new HTTP setting. The HTTP setting will determine the behavior of the routing rule. In the **Add an HTTP setting** window that opens, enter *myHTTPSetting* for the **HTTP setting name**. Accept the default values for the other settings in the **Add an HTTP setting** window, then select **Add** to return to the **Add a routing rule** window. 
+5. For the **HTTP setting**, select **Create new** to create a new HTTP setting. The HTTP setting will determine the behavior of the routing rule. In the **Add an HTTP setting** window that opens, enter *myHTTPSetting* for the **HTTP setting name**. Accept the default values for the other settings in the **Add an HTTP setting** window, then select **Add** to return to the **Add a routing rule** window. (The default values do not match the below screenshot which is confusing)
 
    ![Create new application gateway: HTTP setting](./media/create-ssl-portal/application-gateway-create-httpsetting.png)
 


### PR DESCRIPTION
Step 5 regarding the "Backend targets" the image is not matching the default configuration that you are being asked to accept. The screenshot shows HTTPS however the default value is HTTP. Please review this part. Thank You.