### PR TITLE
Update azure-to-azure-common-questions.md

### DIFF
--- a/articles/site-recovery/azure-to-azure-common-questions.md
+++ b/articles/site-recovery/azure-to-azure-common-questions.md
@@ -115,7 +115,7 @@ No, this is an unsupported scenario. However, if you accidentally move storage a
 A replication policy defines the settings for the retention history of recovery points. The policy also defines the frequency of app-consistent snapshots. By default, Azure Site Recovery creates a new replication policy with default settings of:
 
 - 24 hours for the retention history of recovery points.
-- 60 minutes for the frequency of app-consistent snapshots.
+- 4 hours for the frequency of app-consistent snapshots.
 
 [Learn more about replication settings](https://docs.microsoft.com/azure/site-recovery/azure-to-azure-tutorial-enable-replication#configure-replication-settings).
 


### PR DESCRIPTION
1 hr frequency of application-consistent snapshots seems to be outdated.
Per Portal verification and the doc below, the default is 4 hours.
https://docs.microsoft.com/en-us/azure/site-recovery/azure-to-azure-architecture#replication-policy