### PR TITLE
Update fairplay-license-overview.md

### DIFF
--- a/articles/media-services/latest/fairplay-license-overview.md
+++ b/articles/media-services/latest/fairplay-license-overview.md
@@ -60,7 +60,7 @@ The following are required when using Media Services to encrypt your HLS content
   * password for the .pfx
   
 > [!NOTE]
-> Azure Media Services does not check the certificate expiration date during packaging or key delivery. It will continue to work after certificate expiration.
+> Azure Media Services doesn't check the certificate expiration date during packaging or key delivery. It will continue to work after the certificate expires.
 
 ## FairPlay and player apps
 

--- a/articles/media-services/latest/fairplay-license-overview.md
+++ b/articles/media-services/latest/fairplay-license-overview.md
@@ -58,6 +58,9 @@ The following are required when using Media Services to encrypt your HLS content
   * .der file
   * .pfx file
   * password for the .pfx
+  
+> [!NOTE]
+> Azure Media Services does not check the certificate expiration date during packaging or key delivery. It will continue to work after certificate expiration.
 
 ## FairPlay and player apps
 


### PR DESCRIPTION
Added note that AMS does not validate certificate expiration date during packaging or key delivery (as per Apple guidance, but cannot state this explicitly).