### PR TITLE
Update tutorial-ingress-controller-add-on-existing.md

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
@@ -37,7 +37,7 @@ az feature register --name AKS-IngressApplicationGatewayAddon --namespace micros
 
 It might take a few minutes for the status to show Registered. You can check on the registration status using the [az feature list](https://docs.microsoft.com/cli/azure/feature#az-feature-register) command:
 ```azurecli-interactive
-az feature list -o table --query "[?contains(name, 'Microsoft.ContainerService/AKS-IngressApplicationGatewayAddon')].{Name:name,State:properties.state}"
+az feature list -o table --query "[?contains(name, 'microsoft.containerservice/AKS-IngressApplicationGatewayAddon')].{Name:name,State:properties.state}"
 ```
 
 When ready, refresh the registration of the Microsoft.ContainerService resource provider using the [az provider register](https://docs.microsoft.com/cli/azure/provider#az-provider-register) command:


### PR DESCRIPTION
It apparently seems like creating a registration with name "microsoft.containerservice" irrespective of making it "Microsoft.ContainerService".  No clue why this is.  But then the document should reflect the lower case of the namespace "microsoft.containerservice" while querying for the status for the registration or else you don't get any status result.  

Can this be made better?  Why is the name space "microsoft.containerservice" in lowercase while all others are in pascal casing?