### PR TITLE
Precision on parameters expression to be imported

### DIFF
--- a/articles/machine-learning/how-to-tune-hyperparameters.md
+++ b/articles/machine-learning/how-to-tune-hyperparameters.md
@@ -106,6 +106,7 @@ In random sampling, hyperparameter values are randomly selected from the defined
 
 ```Python
 from azureml.train.hyperdrive import RandomParameterSampling
+from azureml.train.hyperdrive import normal, uniform, choice
 param_sampling = RandomParameterSampling( {
         "learning_rate": normal(10, 3),
         "keep_probability": uniform(0.05, 0.1),
@@ -120,6 +121,7 @@ param_sampling = RandomParameterSampling( {
 
 ```Python
 from azureml.train.hyperdrive import GridParameterSampling
+from azureml.train.hyperdrive import choice
 param_sampling = GridParameterSampling( {
         "num_hidden_layers": choice(1, 2, 3),
         "batch_size": choice(16, 32)
@@ -137,6 +139,7 @@ Bayesian sampling only supports `choice`, `uniform`, and `quniform` distribution
 
 ```Python
 from azureml.train.hyperdrive import BayesianParameterSampling
+from azureml.train.hyperdrive import uniform, choice
 param_sampling = BayesianParameterSampling( {
         "learning_rate": uniform(0.05, 0.1),
         "batch_size": choice(16, 32, 64, 128)


### PR DESCRIPTION
To help customers to identify which parameters expression to import
from azureml.train.hyperdrive import choice, uniform was not mentioned.
Only reference is provided in the github MachineLearningNotebooks
https://github.com/Azure/MachineLearningNotebooks/blob/master/how-to-use-azureml/ml-frameworks/tensorflow/deployment/train-hyperparameter-tune-deploy-with-tensorflow/train-hyperparameter-tune-deploy-with-tensorflow.ipynb