### PR TITLE
Remove jq in FHIR object id lookup instructions

### DIFF
--- a/articles/healthcare-apis/find-identity-object-ids.md
+++ b/articles/healthcare-apis/find-identity-object-ids.md
@@ -25,7 +25,7 @@ $(Get-AzureADUser -Filter "UserPrincipalName eq 'myuser@consoso.com'").ObjectId
 or you can use the Azure CLI:
 
 ```azurecli-interactive
-az ad user show --upn-or-object-id myuser@consoso.com --query objectId --out tsv
+az ad user show --id myuser@consoso.com --query objectId --out tsv
 ```
 
 ## Find service principal object ID

--- a/articles/healthcare-apis/find-identity-object-ids.md
+++ b/articles/healthcare-apis/find-identity-object-ids.md
@@ -25,7 +25,7 @@ $(Get-AzureADUser -Filter "UserPrincipalName eq 'myuser@consoso.com'").ObjectId
 or you can use the Azure CLI:
 
 ```azurecli-interactive
-az ad user show --upn-or-object-id myuser@consoso.com | jq -r .objectId
+az ad user show --upn-or-object-id myuser@consoso.com --query objectId --out tsv
 ```
 
 ## Find service principal object ID
@@ -45,7 +45,7 @@ $(Get-AzureADServicePrincipal -Filter "DisplayName eq 'testapp'").ObjectId
 If you are using the Azure CLI, you can use:
 
 ```azurecli-interactive
-az ad sp show --id XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX | jq -r .objectId
+az ad sp show --id XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX --query objectId --out tsv
 ```
 
 ## Find a security group object ID
@@ -60,7 +60,7 @@ Where `mygroup` is the name of the group you are interested in.
 If you are using the Azure CLI, you can use:
 
 ```azurecli-interactive
-az ad group show --group "mygroup" | jq -r .objectId
+az ad group show --group "mygroup" --query objectId --out tsv
 ```
 
 ## Next steps


### PR DESCRIPTION
Currently the FHIR documentation on how to look up Azure Active Directory object IDs using the Azure CLI depends on the external tool `jq` to extract specific items from JSON payloads returned by the CLI.

However, the Azure CLI supports querying the JSON responses natively via [--query](https://docs.microsoft.com/en-us/cli/azure/query-azure-cli). As such, this change updates the documentation to use `--query` instead of `jq` which removes an external tool dependency and also makes the Azure CLI snippets work on Windows.