### PR TITLE
Add documentation on AutoML known issue

### DIFF
--- a/articles/machine-learning/resource-known-issues.md
+++ b/articles/machine-learning/resource-known-issues.md
@@ -91,6 +91,22 @@ Sometimes it can be helpful if you can provide diagnostic information when askin
     ```bash
     automl_setup
     ```
+    
+* **KeyError: 'brand' when running AutoML on local compute or Azure Databricks cluster**
+
+    If a new environment was created after 10 June 2020 using SDK 1.7.0 or lower, training may fail with the above error due to an update in the py-cpuinfo package. (Environments created on or before 10 June 2020 are unaffected, as well as experiments run on remote compute as cached training images are used.) To work around this issue, either of the two following steps can be taken:
+    
+    1. Update the SDK version to 1.8.0 or higher (this will also downgrade py-cpuinfo to 5.0.0):
+    
+    ```Python
+    pip install --upgrade azureml-sdk[automl]
+    ```
+    
+    2. Downgrade the installed version of py-cpuinfo to 5.0.0:
+    
+    ```Python
+    pip install py-cpuinfo==5.0.0
+    ```
   
 * **Error message: Cannot uninstall 'PyYAML'**
 

--- a/articles/machine-learning/resource-known-issues.md
+++ b/articles/machine-learning/resource-known-issues.md
@@ -98,13 +98,13 @@ Sometimes it can be helpful if you can provide diagnostic information when askin
     
     1. Update the SDK version to 1.8.0 or higher (this will also downgrade py-cpuinfo to 5.0.0):
     
-    ```Python
+    ```bash
     pip install --upgrade azureml-sdk[automl]
     ```
     
     2. Downgrade the installed version of py-cpuinfo to 5.0.0:
     
-    ```Python
+    ```bash
     pip install py-cpuinfo==5.0.0
     ```
   

--- a/articles/machine-learning/resource-known-issues.md
+++ b/articles/machine-learning/resource-known-issues.md
@@ -94,19 +94,19 @@ Sometimes it can be helpful if you can provide diagnostic information when askin
     
 * **KeyError: 'brand' when running AutoML on local compute or Azure Databricks cluster**
 
-    If a new environment was created after 10 June 2020 using SDK 1.7.0 or lower, training may fail with the above error due to an update in the py-cpuinfo package. (Environments created on or before 10 June 2020 are unaffected, as well as experiments run on remote compute as cached training images are used.) To work around this issue, either of the two following steps can be taken:
+    If a new environment was created after June 10, 2020, by using SDK 1.7.0 or earlier, training might fail with this error due to an update in the py-cpuinfo package. (Environments created on or before June 10, 2020, are unaffected, as are experiments run on remote compute because cached training images are used.) To work around this issue, take either of the following two steps:
     
-    1. Update the SDK version to 1.8.0 or higher (this will also downgrade py-cpuinfo to 5.0.0):
+    * Update the SDK version to 1.8.0 or later (this also downgrades py-cpuinfo to 5.0.0):
     
-    ```bash
-    pip install --upgrade azureml-sdk[automl]
-    ```
+      ```bash
+      pip install --upgrade azureml-sdk[automl]
+      ```
     
-    2. Downgrade the installed version of py-cpuinfo to 5.0.0:
+    * Downgrade the installed version of py-cpuinfo to 5.0.0:
     
-    ```bash
-    pip install py-cpuinfo==5.0.0
-    ```
+      ```bash
+      pip install py-cpuinfo==5.0.0
+      ```
   
 * **Error message: Cannot uninstall 'PyYAML'**
 


### PR DESCRIPTION
There is a known issue in AutoML affecting SDK versions prior to 1.8.0 that will cause training to fail. This PR contains workaround steps for the issue for customers who run into it.