### PR TITLE
Fix NOT IN -> NIN

### DIFF
--- a/articles/digital-twins/concepts-query-language.md
+++ b/articles/digital-twins/concepts-query-language.md
@@ -31,10 +31,10 @@ Here are the operations available in Azure Digital Twins Query Store language:
 * Get twins by relationship properties.
 * Get twins over multiple relationship types (`JOIN` queries). There are limitations on the number of `JOIN`s allowed (one level for public preview).
 * Use custom function `IS_OF_MODEL(twinCollection, twinTypeName)`, which allows filtering based on the twin's [model](concepts-models.md). It supports inheritance.
-* Use any combination (`AND`, `OR`, `NOT` operator) of the above.
 * Use scalar functions: `IS_BOOL`, `IS_DEFINED`, `IS_NULL`, `IS_NUMBER`, `IS_OBJECT`, `IS_PRIMITIVE`, `IS_STRING`, `STARTS_WITH`, `ENDS_WITH`.
-* Use query comparison operators: `AND`/`OR`/`NOT`,  `IN`/`NOT IN`, `STARTSWITH`/`ENDSWITH`, `=`, `!=`, `<`, `>`, `<=`, `>=`.
-* Use continuation: The query object is instantiated with a page size (up to 100). You can retrieve the digital twins one page at a time, by repeating calls to the `nextAsTwin` method.
+* Use query comparison operators: `IN`/`NIN`, `=`, `!=`, `<`, `>`, `<=`, `>=`.
+* Use any combination (`AND`, `OR`, `NOT` operator) of the above.
+* Use continuation: The query object is instantiated with a page size (up to 100). You can retrieve the digital twins one page at a time by providing the continuation token in subsequent calls to the API.
 
 ## Next steps
 


### PR DESCRIPTION
The Azure Digital Twins Query Language uses NIN rather than NOT IN.
Also removed reference STARTSWITH and ENDSWITH in query comparison operators, which were never a thing. 
Removed confusing reference to `nextAsTwin` which is not a thing.