### PR TITLE
Link to Routing Preference overview

### DIFF
--- a/articles/virtual-network/routing-preference-portal.md
+++ b/articles/virtual-network/routing-preference-portal.md
@@ -16,7 +16,7 @@ ms.author: mnayak
 ---
 # Configure routing preference for a public IP address using the Azure portal
 
-This article shows you how to configure routing preference via ISP network (**Internet** option) for a public IP address. After creating the public IP address, you can associate it with the following Azure resources for inbound and outbound traffic to the internet:
+This article shows you how to configure [routing preference](https://docs.microsoft.com/en-us/azure/virtual-network/routing-preference-overview) via ISP network (**Internet** option) for a public IP address. After creating the public IP address, you can associate it with the following Azure resources for inbound and outbound traffic to the internet:
 
 * Virtual machine
 * Virtual machine scale set

--- a/articles/virtual-network/routing-preference-portal.md
+++ b/articles/virtual-network/routing-preference-portal.md
@@ -16,7 +16,7 @@ ms.author: mnayak
 ---
 # Configure routing preference for a public IP address using the Azure portal
 
-This article shows you how to configure [routing preference](https://docs.microsoft.com/en-us/azure/virtual-network/routing-preference-overview) via ISP network (**Internet** option) for a public IP address. After creating the public IP address, you can associate it with the following Azure resources for inbound and outbound traffic to the internet:
+This article shows you how to configure [routing preference](https://docs.microsoft.com/azure/virtual-network/routing-preference-overview) via ISP network (**Internet** option) for a public IP address. After creating the public IP address, you can associate it with the following Azure resources for inbound and outbound traffic to the internet:
 
 * Virtual machine
 * Virtual machine scale set


### PR DESCRIPTION
A link to a page describing Routing Preference should be at the beginning of this document, rather than just a related link at the end.