### PR TITLE
Intune Managed Browser is depricated

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-grant.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-grant.md
@@ -78,7 +78,6 @@ This setting applies to the following iOS and Android apps:
 - Microsoft Edge
 - Microsoft Excel
 - Microsoft Flow
-- Microsoft Intune Managed Browser
 - Microsoft Invoicing
 - Microsoft Kaizala
 - Microsoft Launcher


### PR DESCRIPTION
Intune has deprecated the Intune Managed Browser app:
https://techcommunity.microsoft.com/t5/intune-customer-success/use-microsoft-edge-for-your-protected-intune-browser-experience/ba-p/1004269