### PR TITLE
doc: container-registry: add missing apt update

### DIFF
--- a/articles/container-registry/container-registry-authentication-managed-identity.md
+++ b/articles/container-registry/container-registry-authentication-managed-identity.md
@@ -74,6 +74,7 @@ ssh azureuser@publicIpAddress
 Run the following command to install Docker on the VM:
 
 ```bash
+sudo apt update
 sudo apt install docker.io -y
 ```
 


### PR DESCRIPTION
On a fresh VM Without an ```apt update``` before installing the docker.io package, apt will not be able to find the docker.io package.

```shell
azureuser@myDockerVM:~$ sudo apt install docker.io -y
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package docker.io
E: Couldn't find any package by glob 'docker.io'
E: Couldn't find any package by regex 'docker.io'
```