### PR TITLE
Azure AD Basic was replaced by Office 365 Apps

### DIFF
--- a/includes/active-directory-p2-license.md
+++ b/includes/active-directory-p2-license.md
@@ -6,4 +6,4 @@ ms.date: 04/30/2019
 ms.author: daveba
 ---
 
-Using this feature requires an Azure AD Premium P2 license. To find the right license for your requirements, see [Comparing generally available features of the Free, Basic, and Premium editions](https://azure.microsoft.com/pricing/details/active-directory/).
+Using this feature requires an Azure AD Premium P2 license. To find the right license for your requirements, see [Comparing generally available features of the Free, Office 365 Apps, and Premium editions](https://azure.microsoft.com/pricing/details/active-directory/).


### PR DESCRIPTION
Azure AD Basic was replaced by Office 365 Apps - if you follow the link it's not listed.