### PR TITLE
Fix "converged reference" mention

### DIFF
--- a/articles/active-directory/authentication/howto-sspr-reporting.md
+++ b/articles/active-directory/authentication/howto-sspr-reporting.md
@@ -50,7 +50,7 @@ In the Azure portal experience, we have improved the way that you can view passw
 
 ### Combined registration
 
-If you have enabled [combined registration](https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-registration-mfa-sspr-combined), information regarding user activity in the audit logs will be found under **Security** > **Authentication Methods**.
+If you have enabled [combined registration](https://docs.microsoft.com/azure/active-directory/authentication/concept-registration-mfa-sspr-combined), information regarding user activity in the audit logs will be found under **Security** > **Authentication Methods**.
 
 ## Description of the report columns in the Azure portal
 

--- a/articles/active-directory/authentication/howto-sspr-reporting.md
+++ b/articles/active-directory/authentication/howto-sspr-reporting.md
@@ -48,9 +48,9 @@ In the Azure portal experience, we have improved the way that you can view passw
 6. From the **Filter** menu at the top of the pane, select the **Service** drop-down list, and change it to the **Self-service Password Management** service type.
 7. Optionally, further filter the list by choosing the specific **Activity** you're interested in.
 
-### Converged registration (preview)
+### Combined registration
 
-If you are participating in the public preview of converged registration, information regarding user activity in the audit logs will be found under **Security** > **Authentication Methods**.
+If you have enabled [combined registration](https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-registration-mfa-sspr-combined), information regarding user activity in the audit logs will be found under **Security** > **Authentication Methods**.
 
 ## Description of the report columns in the Azure portal
 


### PR DESCRIPTION
I can't validate the accuracy of the reporting information location in the case of combined registration, but I can validate that "converged registration (preview)" should be "combined registration" which went GA in April.