### PR TITLE
NETSH WINHTTP update

### DIFF
--- a/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
+++ b/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
@@ -151,7 +151,7 @@ To enable this, please follow the next steps:
 These settings make the connector use the same forward proxy for the communication to Azure and to the backend application. If the connector to Azure communication requires no forward proxy or a different forward proxy, you can set this up with modifying the file ApplicationProxyConnectorService.exe.config as described in the sections Bypass outbound proxies or Use the outbound proxy server.
 
 > [!NOTE]
-> There are different ways to configure the Internet proxy in the operating system. Proxy settings configured via NETSH WINHHTP (run NETSH WINHTTP SHOW PROXY to verify it) ovveride the proxy settings you configured in Step 2. 
+> There are different ways to configure the Internet proxy in the operating system. Proxy settings configured via NETSH WINHHTP (run NETSH WINHTTP SHOW PROXY to verify it) override the proxy settings you configured in Step 2. 
 
 The connector updater service will use the machine proxy as well. This behavior can be changed by modifying the file ApplicationProxyConnectorUpdaterService.exe.config.
 

--- a/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
+++ b/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
@@ -150,6 +150,9 @@ To enable this, please follow the next steps:
 
 These settings make the connector use the same forward proxy for the communication to Azure and to the backend application. If the connector to Azure communication requires no forward proxy or a different forward proxy, you can set this up with modifying the file ApplicationProxyConnectorService.exe.config as described in the sections Bypass outbound proxies or Use the outbound proxy server.
 
+> [!NOTE]
+> There are different ways to configure the Internet proxy in the operating system. Proxy settings configured via NETSH WINHHTP (run NETSH WINHTTP SHOW PROXY to verify it) ovveride the proxy settings you configured in Step 2. 
+
 The connector updater service will use the machine proxy as well. This behavior can be changed by modifying the file ApplicationProxyConnectorUpdaterService.exe.config.
 
 ## Troubleshoot connector proxy problems and service connectivity issues

--- a/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
+++ b/articles/active-directory/manage-apps/application-proxy-configure-connectors-with-proxy-servers.md
@@ -151,7 +151,7 @@ To enable this, please follow the next steps:
 These settings make the connector use the same forward proxy for the communication to Azure and to the backend application. If the connector to Azure communication requires no forward proxy or a different forward proxy, you can set this up with modifying the file ApplicationProxyConnectorService.exe.config as described in the sections Bypass outbound proxies or Use the outbound proxy server.
 
 > [!NOTE]
-> There are different ways to configure the Internet proxy in the operating system. Proxy settings configured via NETSH WINHHTP (run NETSH WINHTTP SHOW PROXY to verify it) override the proxy settings you configured in Step 2. 
+> There are various ways to configure the internet proxy in the operating system. Proxy settings configured via NETSH WINHHTP (run `NETSH WINHTTP SHOW PROXY` to verify) override the proxy settings you configured in Step 2. 
 
 The connector updater service will use the machine proxy as well. This behavior can be changed by modifying the file ApplicationProxyConnectorUpdaterService.exe.config.
 


### PR DESCRIPTION
"> [!NOTE]
> There are different ways to configure the Internet proxy in the operating system. Proxy settings configured via NETSH WINHHTP (run NETSH WINHTTP SHOW PROXY to verify it) ovveride the proxy settings you configured in Step 2. " - Based on latest support experience we must add this information.