### PR TITLE
Removed some steps not valid for vWAN and re-wrote some parts to fit vWAN rather that VPN Gateway article

### DIFF
--- a/articles/virtual-wan/openvpn-azure-ad-tenant.md
+++ b/articles/virtual-wan/openvpn-azure-ad-tenant.md
@@ -11,9 +11,9 @@ ms.date: 03/19/2020
 ms.author: alzam
 
 ---
-# Create an Azure Active Directory tenant for User VPN OpenVPN protocol connections
+# Prepare Azure Active Directory tenant for User VPN OpenVPN protocol connections
 
-When connecting to your VNet, you can use certificate-based authentication or RADIUS authentication. However, when you use the Open VPN protocol, you can also use Azure Active Directory authentication. This article helps you set up an Azure AD tenant for Virtual WAN User VPN (point-to-site) Open VPN authentication.
+When connecting to your Virtual Hub over the IKEv2 protocol, you can use certificate-based authentication or RADIUS authentication. However, when you use the OpenVPN protocol, you can also use Azure Active Directory authentication. This article helps you set up an Azure AD tenant for Virtual WAN User VPN (point-to-site) using OpenVPN authentication.
 
 > [!NOTE]
 > Azure AD authentication is supported only for OpenVPN&reg; protocol connections.
@@ -21,9 +21,9 @@ When connecting to your VNet, you can use certificate-based authentication or RA
 
 ## <a name="tenant"></a>1. Create the Azure AD tenant
 
-Create an Azure AD tenant using the steps in the [Create a new tenant](../active-directory/fundamentals/active-directory-access-create-new-tenant.md) article:
+Verify that you have an Azure AD tenant. If you don't have an Azure AD tenant, you can create one using the steps in the [Create a new tenant](../active-directory/fundamentals/active-directory-access-create-new-tenant.md) article:
 
-* Organizational name
+* Organization name
 * Initial domain name
 
 Example:
@@ -32,24 +32,15 @@ Example:
 
 ## <a name="users"></a>2. Create Azure AD tenant users
 
-Next, create two user accounts. Create one Global Admin account and one master user account. The master user account is used as your master embedding account (service account). When you create an Azure AD tenant user account, you adjust the Directory role for the type of user that you want to create.
+Next, create two user accounts in the newly created Azure AD tenant, one Global administrator account and one user account. The user account can be used to test OpenVPN authentication and the Global administrator account will be used to grant consent to the Azure VPN app registration. After you have created an Azure AD user account, you assign a **Directory Role** to the user in order to delegate administrative permissions.
 
-Use the steps in [this article](../active-directory/fundamentals/add-users-azure-active-directory.md) to create at least two users for your Azure AD tenant. Be sure to change the **Directory Role** to create the account types:
+Use the steps in [this article](../active-directory/fundamentals/add-users-azure-active-directory.md) to create the two users for your Azure AD tenant. Be sure to change the **Directory Role** on one of the created accounts to **Global administrator**.
 
-* Global Admin
-* User
+## <a name="enable-authentication"></a>3. Grant consent to the Azure VPN app registration
 
-## <a name="enable-authentication"></a>3. Enable Azure AD authentication on the VPN gateway
+1. Sign in to the Azure Portal as a user that is assigned the **Global administrator** role.
 
-1. Locate the Directory ID of the directory that you want to use for authentication. It is listed in the properties section of the Active Directory page.
-
-    ![Directory ID](./media/openvpn-create-azure-ad-tenant/directory-id.png)
-
-2. Copy the Directory ID.
-
-3. Sign in to the Azure portal as a user that is assigned the **Global administrator** role.
-
-4. Next, give admin consent. Copy and paste the URL that pertains to your deployment location in the address bar of your browser:
+2. Next, grant admin consent for your organization, this allows the Azure VPN application to sign in and read user profiles. Copy and paste the URL that pertains to your deployment location in the address bar of your browser:
 
     Public
 
@@ -75,20 +66,18 @@ Use the steps in [this article](../active-directory/fundamentals/add-users-azure
     https://https://login.chinacloudapi.cn/common/oauth2/authorize?client_id=49f817b6-84ae-4cc0-928c-73f27289b3aa&response_type=code&redirect_uri=https://portal.azure.cn&nonce=1234&prompt=admin_consent
     ```
 
-5. Select the **Global Admin** account if prompted.
+3. Select the **Global administrator** account if prompted.
 
     ![Directory ID](./media/openvpn-create-azure-ad-tenant/pick.png)
 
-6. Select **Accept** when prompted.
+4. Select **Accept** when prompted.
 
     ![Accept](./media/openvpn-create-azure-ad-tenant/accept.jpg)
 
-7. Under your Azure AD, in **Enterprise applications**, you see **Azure VPN** listed.
+5. Under your Azure AD, in **Enterprise applications**, you should now see **Azure VPN** listed.
 
     ![Azure VPN](./media/openvpn-create-azure-ad-tenant/azurevpn.png)
 
-8. Configure Azure AD authentication for User VPN and assign it to a Virtual Hub by following the steps in [Configure Azure AD authentication for Point-to-Site connection to Azure](virtual-wan-point-to-site-azure-ad.md)
-
 ## Next steps
 
-In order to connect to your virtual network, you must create and configure a VPN client profile and associate it to a Virtual Hub. See [Configure Azure AD authentication for Point-to-Site connection to Azure](virtual-wan-point-to-site-azure-ad.md).
+In order to connect to your virtual networks using Azure AD authentication, you must create a User VPN configuration and associate it to a Virtual Hub. See [Configure Azure AD authentication for Point-to-Site connection to Azure](virtual-wan-point-to-site-azure-ad.md).


### PR DESCRIPTION
Updated text in the introduction.
Updated part 1 "Create Azure AD Tenant" part to match the VPN Gateway article(https://docs.microsoft.com/en-us/azure/vpn-gateway/openvpn-azure-ad-tenant).
Updated part 2 "Create Azure AD Tenant users" with new text.
Renamed part 3  to "Grant consent to the Azure VPN app registration" and removed steps 1 and 2, the directory ID located and copied is never used in this article. 