### PR TITLE
Fix inconsistent max length of metadata value

### DIFF
--- a/articles/cognitive-services/QnAMaker/limits.md
+++ b/articles/cognitive-services/QnAMaker/limits.md
@@ -74,7 +74,8 @@ The length and acceptable characters for metadata name and value are listed in t
 Overall limits on the content in the knowledge base:
 * Length of answer text: 25,000
 * Length of question text: 1,000
-* Length of metadata key/value text: 100
+* Length of metadata key text: 100
+* Length of metadata value text: 500
 * Supported characters for metadata name: Alphabets, digits and `_`
 * Supported characters for metadata value: All except `:` and `|`
 * Length of file name: 200


### PR DESCRIPTION
Maximum length of metadata value is inconsistent in this doc (100 and 500). 500 should be correct.