### PR TITLE
Updated json boolean value to remove quotes

### DIFF
--- a/articles/virtual-machines/troubleshooting/troubleshoot-ssh-connection.md
+++ b/articles/virtual-machines/troubleshooting/troubleshoot-ssh-connection.md
@@ -133,7 +133,7 @@ Create a file named `settings.json` with the following content:
 
 ```json
 {
-    "reset_ssh":"True"
+    "reset_ssh":True
 }
 ```
 


### PR DESCRIPTION
References like:

```
"check_disk": "false"
"reset_ssh": "false"
```
Should not have double quotes since they are boolean values.
On JSON boolean values a non empty string is considered true so "False" of being considered as false is considered as true
This leads to, as an example, "check_disk" : "false" actually triggering a fsck causing the extension deployment to fail with "Check Failed" because fsck command fails due to the data disks being mounted and "reset_ssh" : "False" will in fact reset the ssh daemon configuration to be reset.