### PR TITLE
Update scenario-protected-web-api-app-registration.md

### DIFF
--- a/articles/active-directory/develop/scenario-protected-web-api-app-registration.md
+++ b/articles/active-directory/develop/scenario-protected-web-api-app-registration.md
@@ -34,7 +34,7 @@ The accepted token version depends on the **Supported account types** value you 
 After you create the application, you can determine or change the accepted token version by following these steps:
 
 1. In the Azure portal, select your app and then select **Manifest**.
-1. Find the property **accessTokenAcceptedVersion** in the manifest. The property's default value is 2.
+1. Find the property **accessTokenAcceptedVersion** in the manifest.
 1. The value specifies to Azure Active Directory (Azure AD) which token version the web API accepts.
     - If the value is 2, the web API accepts v2.0 tokens.
     - If the value is **null**, the web API accepts v1.0 tokens.


### PR DESCRIPTION
" The property's default value is 2." 
This is the default value for the old portal. 
Now the value depends on the Supported account type. So this explanation is not necessary.