### PR TITLE
Show required arguments in azcopy login example

### DIFF
--- a/articles/storage/common/storage-ref-azcopy-login.md
+++ b/articles/storage/common/storage-ref-azcopy-login.md
@@ -79,7 +79,7 @@ azcopy login --identity --identity-resource-id "/subscriptions/<subscriptionId>/
 Log in as a service principal using a client secret. Set the environment variable AZCOPY_SPA_CLIENT_SECRET to the client secret for secret based service principal auth.
 
 ```azcopy
-azcopy login --service-principal --application-id "YOUR_APP_ID" --tenant_id "YOUR_TENANT_ID"
+azcopy login --service-principal --application-id "YOUR_APP_ID" --tenant-id "YOUR_TENANT_ID"
 ```
 
 Log in as a service principal using a certificate and password. Set the environment variable AZCOPY_SPA_CERT_PASSWORD to the certificate's password for cert-based service principal authorization.

--- a/articles/storage/common/storage-ref-azcopy-login.md
+++ b/articles/storage/common/storage-ref-azcopy-login.md
@@ -79,7 +79,7 @@ azcopy login --identity --identity-resource-id "/subscriptions/<subscriptionId>/
 Log in as a service principal using a client secret. Set the environment variable AZCOPY_SPA_CLIENT_SECRET to the client secret for secret based service principal auth.
 
 ```azcopy
-azcopy login --service-principal
+azcopy login --service-principal --application-id "YOUR_APP_ID" --tenant_id "YOUR_TENANT_ID"
 ```
 
 Log in as a service principal using a certificate and password. Set the environment variable AZCOPY_SPA_CERT_PASSWORD to the certificate's password for cert-based service principal authorization.


### PR DESCRIPTION
Hello,

I spent today failing to login to azcopy due to an issue originally identified [here](https://github.com/Azure/azure-storage-azcopy/issues/819#issuecomment-571856163).

The docs show application-id and tenant-id for service principal auth under "options", as opposed to in the example commands. As they are not optional and people like me will assume the example commands are complete, I think they should be included.

Hope this helps others get up and running faster.