### PR TITLE
Updated the portion about the availability sets

### DIFF
--- a/articles/virtual-machines/workloads/sap/sap-high-availability-architecture-scenarios.md
+++ b/articles/virtual-machines/workloads/sap/sap-high-availability-architecture-scenarios.md
@@ -353,12 +353,12 @@ _**Figure 1:** High-availability SAP application server_
 
 You must place all virtual machines that host SAP application server instances in the same Azure availability set. An Azure availability set ensures that:
 
-* All virtual machines are part of the same update domain.  
+* All virtual machines are not part of the same update domain.  
     An update domain ensures that the virtual machines aren't updated at the same time during planned maintenance downtime.
 
     The basic functionality, which builds on different update and fault domains within an Azure scale unit, was already introduced in the [update domains][planning-guide-3.2.2] section.
 
-* All virtual machines are part of the same fault domain.  
+* All virtual machines are not part of the same fault domain.  
     A fault domain ensures that virtual machines are deployed so that no single point of failure affects the availability of all virtual machines.
 
 The number of update and fault domains that can be used by an Azure availability set within an Azure scale unit is finite. If you keep adding VMs to a single availability set, two or more VMs will eventually end up in the same fault or update domain.


### PR DESCRIPTION
With an availability set, it prevents that all VMs in an availability sets are added to the same update or fault domain. I updated the following:
* All virtual machines are -> not <- part of the same update domain.
* All virtual machines are -> not <- part of the same fault domain.