### PR TITLE
Update service-fabric-patterns-networking.md

### DIFF
--- a/articles/service-fabric/service-fabric-patterns-networking.md
+++ b/articles/service-fabric/service-fabric-patterns-networking.md
@@ -94,7 +94,8 @@ In the examples in this article, we use the Service Fabric template.json. You ca
                 "defaultValue": "10.0.0.0/24"
             },*/
     ```
-   We can also comment out the parameter with name "virtualNetworkName" so that it won't prompt you to enter the Virtual network name twice in the cluster deployment blade in Azure Portal.
+
+   You also can comment out the parameter with the name "virtualNetworkName" so that it won't prompt you to enter the virtual network name twice in the cluster deployment blade in the Azure portal.
 
 2. Comment out `nicPrefixOverride` attribute of `Microsoft.Compute/virtualMachineScaleSets`, because you are using existing subnet and you have disabled this variable in step 1.
 

--- a/articles/service-fabric/service-fabric-patterns-networking.md
+++ b/articles/service-fabric/service-fabric-patterns-networking.md
@@ -94,6 +94,7 @@ In the examples in this article, we use the Service Fabric template.json. You ca
                 "defaultValue": "10.0.0.0/24"
             },*/
     ```
+   We can also comment out the parameter with name "virtualNetworkName" so that it won't prompt you to enter the Virtual network name twice in the cluster deployment blade in Azure Portal.
 
 2. Comment out `nicPrefixOverride` attribute of `Microsoft.Compute/virtualMachineScaleSets`, because you are using existing subnet and you have disabled this variable in step 1.
 


### PR DESCRIPTION
Removed the duplicate parameter "virtualNetworkName" so that it won't prompt to enter the VNET name again in cluster deployment blade in Azure Portal.
This parameter is not being used by the template as we have added another parameter for existing VNET Name. This additional VNET parameter needs to be removed.