### PR TITLE
Update signalr-quickstart-rest-api.md for error code

### DIFF
--- a/articles/azure-signalr/signalr-quickstart-rest-api.md
+++ b/articles/azure-signalr/signalr-quickstart-rest-api.md
@@ -236,7 +236,7 @@ API Version | API HTTP Method | Request URL
 Response Status Code | Description
 ---|---
 `200` | Service Good
-`503` | Service Unavailable
+`5xx` | Service Error
 
 [!INCLUDE [Cleanup](includes/signalr-quickstart-cleanup.md)]
 


### PR DESCRIPTION
Not restricted to 503, but all 5xx code indicates service error.