### PR TITLE
Incorrect EventType for RunStatusChanged

### DIFF
--- a/articles/event-grid/event-schema-machine-learning.md
+++ b/articles/event-grid/event-schema-machine-learning.md
@@ -146,7 +146,7 @@ This section contains an example of what that data would look like for each even
 [{
   "topic": "/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/Microsoft.MachineLearningServices/workspaces/{workspace-name}",
   "subject": "experiments/0fa9dfaa-cba3-4fa7-b590-23e48548f5c1/runs/AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5",
-  "eventType": "Microsoft.MachineLearningServices.RunCompleted",
+  "eventType": "Microsoft.MachineLearningServices.RunStatusChanged",
   "eventTime": "2017-06-26T18:41:00.9584103Z",
   "id": "831e1650-001e-001b-66ab-eeb76e069631",
   "data": {


### PR DESCRIPTION
The event `Microsoft.MachineLearningServices.RunStatusChanged` will send a json with key `eventType` and value `Microsoft.MachineLearningServices.RunStatusChanged` and not with the value `Microsoft.MachineLearningServices.RunCompleted`

Thanks!