### PR TITLE
Update overview-patch-os-runtime.md

### DIFF
--- a/articles/app-service/overview-patch-os-runtime.md
+++ b/articles/app-service/overview-patch-os-runtime.md
@@ -74,7 +74,7 @@ The following table shows how to the versions of Windows and of the language run
 | Information | Where to find it | 
 |-|-|
 | Windows version | See `https://<appname>.scm.azurewebsites.net/Env.cshtml` (under System info) |
-| .NET version | At `https://<appname>.scm.azurewebsites.net/DebugConsole`, run the following command in the command prompt: <br>`powershell -command "gci 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Net Framework Setup\NDP\CDF'"` |
+| .NET version | At `https://<appname>.scm.azurewebsites.net/DebugConsole`, run the following command in the command prompt: <br>`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full"` |
 | .NET Core version | At `https://<appname>.scm.azurewebsites.net/DebugConsole`, run the following command in the command prompt: <br> `dotnet --version` |
 | PHP version | At `https://<appname>.scm.azurewebsites.net/DebugConsole`, run the following command in the command prompt: <br> `php --version` |
 | Default Node.js version | In the [Cloud Shell](../cloud-shell/overview.md), run the following command: <br> `az webapp config appsettings list --resource-group <groupname> --name <appname> --query "[?name=='WEBSITE_NODE_DEFAULT_VERSION']"` |


### PR DESCRIPTION
The registry key to check for the .NET version installed is pointing to NDP\v4\CDF which is for Common Data Forms. The correct path per https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#detect-net-framework-45-and-later-versions should be HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full.
This caused for one customer to open a support case because it was showing they were using .NET Framework 4.0 when they were really using 4.7 as NDP\v4\Full showed.
Also running 'powershell -command "gci 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Net Framework Setup\NDP\v4\Full'"' doesn't show the value inside Full, only the values underneath but "reg query" does work, so changing the full command.