### PR TITLE
Incorrect property names/keys - Run events

### DIFF
--- a/articles/event-grid/event-schema-machine-learning.md
+++ b/articles/event-grid/event-schema-machine-learning.md
@@ -90,12 +90,12 @@ This section contains an example of what that data would look like for each even
   "eventTime": "2017-06-26T18:41:00.9584103Z",
   "id": "831e1650-001e-001b-66ab-eeb76e069631",
   "data": {
-    "ExperimentId": "0fa9dfaa-cba3-4fa7-b590-23e48548f5c1",
-    "ExperimentName": "automl-local-regression",
-    "RunId": "AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5",
-    "RunType": null,
-    "RunTags": {},
-    "RunProperties": {
+    "experimentId": "0fa9dfaa-cba3-4fa7-b590-23e48548f5c1",
+    "experimentName": "automl-local-regression",
+    "runId": "AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5",
+    "runType": null,
+    "runTags": {},
+    "runProperties": {
         "runTemplate": "automl_child",
         "pipeline_id": "5adc0a4fe02504a586f09a4fcbb241f9a4012062",
         "pipeline_spec": "{\"objects\": [{\"class_name\": \"StandardScaler\", \"module\": \"sklearn.preprocessing\", \"param_args\": [], \"param_kwargs\": {\"with_mean\": true, \"with_std\": false}, \"prepared_kwargs\": {}, \"spec_class\": \"preproc\"}, {\"class_name\": \"LassoLars\", \"module\": \"sklearn.linear_model\", \"param_args\": [], \"param_kwargs\": {\"alpha\": 0.001, \"normalize\": true}, \"prepared_kwargs\": {}, \"spec_class\": \"sklearn\"}], \"pipeline_id\": \"5adc0a4fe02504a586f09a4fcbb241f9a4012062\"}",
@@ -150,12 +150,12 @@ This section contains an example of what that data would look like for each even
   "eventTime": "2017-06-26T18:41:00.9584103Z",
   "id": "831e1650-001e-001b-66ab-eeb76e069631",
   "data": {
-    "ExperimentId": "0fa9dfaa-cba3-4fa7-b590-23e48548f5c1",
-    "ExperimentName": "automl-local-regression",
-    "RunId": "AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5",
-    "RunType": null,
-    "RunTags": {},
-    "RunProperties": {
+    "experimentId": "0fa9dfaa-cba3-4fa7-b590-23e48548f5c1",
+    "experimentName": "automl-local-regression",
+    "runId": "AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5",
+    "runType": null,
+    "runTags": {},
+    "runProperties": {
         "runTemplate": "automl_child",
         "pipeline_id": "5adc0a4fe02504a586f09a4fcbb241f9a4012062",
         "pipeline_spec": "{\"objects\": [{\"class_name\": \"StandardScaler\", \"module\": \"sklearn.preprocessing\", \"param_args\": [], \"param_kwargs\": {\"with_mean\": true, \"with_std\": false}, \"prepared_kwargs\": {}, \"spec_class\": \"preproc\"}, {\"class_name\": \"LassoLars\", \"module\": \"sklearn.linear_model\", \"param_args\": [], \"param_kwargs\": {\"alpha\": 0.001, \"normalize\": true}, \"prepared_kwargs\": {}, \"spec_class\": \"sklearn\"}], \"pipeline_id\": \"5adc0a4fe02504a586f09a4fcbb241f9a4012062\"}",
@@ -170,7 +170,7 @@ This section contains an example of what that data would look like for each even
         "scoring_data_location": "aml://artifact/ExperimentRun/dcid.AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5/outputs/scoring_file_v_1_0_0.py",
         "model_data_location": "aml://artifact/ExperimentRun/dcid.AutoML_ad912b2d-6467-4f32-a616-dbe4af6dd8fc_5/outputs/model.pkl"
     },
-   "RunStatus": "failed"
+   "runStatus": "failed"
    },
   "dataVersion": "",
   "metadataVersion": "1"
@@ -217,12 +217,12 @@ The data object has the following properties for each event type:
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| ExperimentId | string | The ID of the experiment that the run belongs to. |
-| ExperimentName | string | The name of the experiment that the run belongs to. |
-| RunId | string | The ID of the Run that was completed. |
-| RunType | string | The Run Type of the completed Run. |
-| RunTags | object | The tags of the completed Run. |
-| RunProperties | object | The properties of the completed Run. |
+| experimentId | string | The ID of the experiment that the run belongs to. |
+| experimentName | string | The name of the experiment that the run belongs to. |
+| runId | string | The ID of the Run that was completed. |
+| runType | string | The Run Type of the completed Run. |
+| runTags | object | The tags of the completed Run. |
+| runProperties | object | The properties of the completed Run. |
 
 ### Microsoft.MachineLearningServices.DatasetDriftDetected
 
@@ -241,13 +241,13 @@ The data object has the following properties for each event type:
 
 | Property | Type | Description |
 | -------- | ---- | ----------- |
-| ExperimentId | string | The ID of the experiment that the run belongs to. |
-| ExperimentName | string | The name of the experiment that the run belongs to. |
-| RunId | string | The ID of the Run that was completed. |
-| RunType | string | The Run Type of the completed Run. |
-| RunTags | object | The tags of the completed Run. |
-| RunProperties | object | The properties of the completed Run. |
-| RunStatus | string | The status of the Run. |
+| experimentId | string | The ID of the experiment that the run belongs to. |
+| experimentName | string | The name of the experiment that the run belongs to. |
+| runId | string | The ID of the Run that was completed. |
+| runType | string | The Run Type of the completed Run. |
+| runTags | object | The tags of the completed Run. |
+| runProperties | object | The properties of the completed Run. |
+| runStatus | string | The status of the Run. |
 
 ## Tutorials and how-tos
 | Title | Description |


### PR DESCRIPTION
The property names/keys emitted by the  event type `Microsoft.MachineLearningServices.RunCompleted` and `Microsoft.MachineLearningServices.RunStatusChanged` are different from what is documented. 
This will cause an issue during Serialization process.

Example of JSON data emitted by **Logic Apps** and **Web Hook** - for the property `data` in the events.

1. Status=`NotStarted`
`{"runStatus":"NotStarted","experimentId":"acbeb929-1dc7-4e76-916f-9f0f5f840710","experimentName":"ml-pipeline-X-dev","runId":"adf1f8e9-f61d-45e2-a14c-2a771f2622e9","runType":"azureml.PipelineRun","runTags":{"azureml.pipelineid":"1606206d-9b5a-4da8-b3d0-2991054d82ca","azureml.pipelineComponent":"pipelinerun"},"runProperties":{"azureml.runsource":"azureml.PipelineRun","runSource":"SDK","runType":"HTTP","azureml.parameters":"{\"client_id\":\"c1\"}","azureml.pipelineid":"1606206d-9b5a-4da8-b3d0-2991054d82ca"}}`

2. Status=`Running`
`{"runStatus":"Running","experimentId":"acbeb929-1dc7-4e76-916f-9f0f5f840710","experimentName":"ml-pipeline-X-dev","runId":"adf1f8e9-f61d-45e2-a14c-2a771f2622e9","runType":"azureml.PipelineRun","runTags":{"azureml.pipelineid":"1606206d-9b5a-4da8-b3d0-2991054d82ca","azureml.pipelineComponent":"pipelinerun"},"runProperties":{"azureml.runsource":"azureml.PipelineRun","runSource":"SDK","runType":"HTTP","azureml.parameters":"{\"client_id\":\"c1\"}","azureml.pipelineid":"1606206d-9b5a-4da8-b3d0-2991054d82ca"}}`

3. Status=`Failed`
`{"runStatus":"Failed","experimentId":"acbeb929-1dc7-4e76-916f-9f0f5f840710","experimentName":"ml-pipeline-X-dev","runId":"adf1f8e9-f61d-45e2-a14c-2a771f2622e9","runType":"azureml.PipelineRun","runTags":{"azureml.pipelineid":"1606206d-9b5a-4da8-b3d0-2991054d82ca","azureml.pipelineComponent":"pipelinerun"},"runProperties":{"azureml.runsource":"azureml.PipelineRun","runSource":"SDK","runType":"HTTP","azureml.parameters":"{\"client_id\":\"c1\"}","azureml.pipelineid":"1606206d-9b5a-4da8-b3d0-2991054d82ca"}}`

This needs to be fixed. 
Thanks!