### PR TITLE
Remove jq in FHIR access token lookup

### DIFF
--- a/articles/healthcare-apis/get-healthcare-apis-access-token-cli.md
+++ b/articles/healthcare-apis/get-healthcare-apis-access-token-cli.md
@@ -29,7 +29,7 @@ az login
 The Azure API for FHIR uses a `resource`  or `Audience` with URI equal to the URI of the FHIR server `https://<FHIR ACCOUNT NAME>.azurehealthcareapis.com`. You can obtain a token and store it in a variable (named `$token`) with the following command:
 
 ```azurecli-interactive
-token=$(az account get-access-token --resource=https://<FHIR ACCOUNT NAME>.azurehealthcareapis.com | jq -r .accessToken)
+token=$(az account get-access-token --resource=https://<FHIR ACCOUNT NAME>.azurehealthcareapis.com --query accessToken --output tsv)
 ```
 
 ## Use with Azure API for FHIR


### PR DESCRIPTION
Currently the FHIR documentation on how to look up an access token for the FHIR Server using the Azure CLI depends on the external tool `jq` to extract specific items from JSON payloads returned by the CLI.

However, the Azure CLI supports querying the JSON responses natively via [--query](https://docs.microsoft.com/en-us/cli/azure/query-azure-cli). As such, this change updates the documentation to use `--query` instead of `jq` which removes an external tool dependency and also makes the Azure CLI snippets work on Windows.