### PR TITLE
Add "VM" by "host pool"

### DIFF
--- a/articles/virtual-desktop/fslogix-containers-azure-files.md
+++ b/articles/virtual-desktop/fslogix-containers-azure-files.md
@@ -85,7 +85,7 @@ To ensure your Windows Virtual Desktop environment follows best practices:
 
 - Azure Files storage account must be in the same region as the session host VMs.
 - Azure Files permissions should match permissions described in [Requirements - Profile Containers](/fslogix/fslogix-storage-config-ht).
-- Each host pool must be built of the same type and size VM based on the same master image.
+- Each host pool VM must be built of the same type and size VM based on the same master image.
 - Each host pool VM must be in the same resource group to aid management, scaling and updating.
 - For optimal performance, the storage solution and the FSLogix profile container should be in the same data center location.
 - The storage account containing the master image must be in the same region and subscription where the VMs are being provisioned.


### PR DESCRIPTION
"Each host pool" would mean that users couldn't deploy different types of host pools for different purposes.