### PR TITLE
Fix typo in links to EventHub RBAC role definition

### DIFF
--- a/articles/event-hubs/authorize-access-azure-active-directory.md
+++ b/articles/event-hubs/authorize-access-azure-active-directory.md
@@ -29,8 +29,8 @@ When an RBAC role is assigned to an Azure AD security principal, Azure grants ac
 Azure provides the following built-in RBAC roles for authorizing access to Event Hubs data using Azure AD and OAuth:
 
 - [Azure Event Hubs Data owner](../role-based-access-control/built-in-roles.md#azure-event-hubs-data-owner): Use this role to give complete access to Event Hubs resources.
-- [Azure Event Hubs Data sender](../role-based-access-control/built-in-roles.md#azure-event-hubs-data-receiver): Use this role to give the send access to Event Hubs resources.
-- [Azure Event Hubs Data receiver](../role-based-access-control/built-in-roles.md#azure-event-hubs-data-sender): Use this role to give the consuming/receiving access to Event Hubs resources.
+- [Azure Event Hubs Data sender](../role-based-access-control/built-in-roles.md#azure-event-hubs-data-sender): Use this role to give the send access to Event Hubs resources.
+- [Azure Event Hubs Data receiver](../role-based-access-control/built-in-roles.md#azure-event-hubs-data-receiver): Use this role to give the consuming/receiving access to Event Hubs resources.
 
 ## Resource scope 
 Before you assign an RBAC role to a security principal, determine the scope of access that the security principal should have. Best practices dictate that it's always best to grant only the narrowest possible scope.


### PR DESCRIPTION
This pull request fixes a typo in the documentation for the EventHub RBAC role definitions, where the link for the "Azure Event Hubs Data sender" entry links to the receiver and the link for the "Azure Event Hubs Data receiver" entry links to the sender. This pull request makes the links consistent such the sender entry links to the sender and the receiver entry links to the receiver.