### PR TITLE
Minor Grammar Mistake Change

### DIFF
--- a/articles/active-directory/develop/howto-create-service-principal-portal.md
+++ b/articles/active-directory/develop/howto-create-service-principal-portal.md
@@ -174,7 +174,7 @@ If you choose not to use a certificate, you can create a new application secret.
    ![Copy the secret value because you can't retrieve this later](./media/howto-create-service-principal-portal/copy-secret.png)
 
 ## Configure access policies on resources
-Keep in mind, you might need to configure addition permissions on resources that your application needs to access. For example, you must also [update a key vault's access policies](/azure/key-vault/key-vault-secure-your-key-vault#data-plane-and-access-policies) to give your application access to keys, secrets, or certificates.  
+Keep in mind, you might need to configure additional permissions on resources that your application needs to access. For example, you must also [update a key vault's access policies](/azure/key-vault/key-vault-secure-your-key-vault#data-plane-and-access-policies) to give your application access to keys, secrets, or certificates.  
 
 1. In the [Azure portal](https://portal.azure.com), navigate to your key vault and select **Access policies**.  
 1. Select **Add access policy**, then select the key, secret, and certificate permissions you want to grant your application.  Select the service principal you created previously.


### PR DESCRIPTION
Under the "Configure access policies on resources" subheading, the wording was "...you might need to configure addition permissions on resources...". This was changed to "...you might need to configure additional permissions on resources..." since the word "addition" is not an adjective, which breaks grammar rules.