### PR TITLE
Update recovery-using-backups.md

### DIFF
--- a/articles/azure-sql/database/recovery-using-backups.md
+++ b/articles/azure-sql/database/recovery-using-backups.md
@@ -89,7 +89,7 @@ To recover a managed instance database to a point in time by using the Azure por
   ![Screenshot of database restore options](./media/recovery-using-backups/pitr-backup-managed-instance-annotated.png)
 
 > [!TIP]
-> To programmatically restore a database from a backup, see [Programmatically performing recovery using automated backups](recovery-using-backups.md).
+> To programmatically restore a database from a backup, see [Programmatic recovery using automated backups](recovery-using-backups.md).
 
 ## Deleted database restore
 


### PR DESCRIPTION
The link on this Tip section "For a sample PowerShell script that shows how to perform a point-in-time restore of a database, see Restore a database by using PowerShell." was pointing to the top of the page, instead of to the correct section below.