### PR TITLE
Fixed formatting

### DIFF
--- a/articles/synapse-analytics/how-to-analyze-complex-schema.md
+++ b/articles/synapse-analytics/how-to-analyze-complex-schema.md
@@ -160,7 +160,7 @@ First, depending how the data has been stored, users should use the following ta
 | BULK              | FORMAT |
 | -------------------- | --- |
 | 'https://ACCOUNTNAME.dfs.core.windows.net/FILESYSTEM/PATH/FINENAME.parquet' |'Parquet' (ADLSg2)|
-| N'endpoint=https://ACCOUNTNAME.documents-staging.windows-ppe.net:443/;account= ACCOUNTNAME;database=DATABASENAME;collection=COLLECTIONNAME;region=REGIONTOQUERY, SECRET='YOURSECRET' |'CosmosDB' (Synapse Link)|
+| N'endpoint=https://ACCOUNTNAME.documents-staging.windows-ppe.net:443/;account=ACCOUNTNAME;database=DATABASENAME;collection=COLLECTIONNAME;region=REGIONTOQUERY', SECRET='YOURSECRET' |'CosmosDB' (Synapse Link)|
 
 
 > [!NOTE]
@@ -174,8 +174,8 @@ Replace each field as follows:
 select *
 FROM
 openrowset(
-BULK 'YOUR BULK ABOVE',
-        	FORMAT='YOUR TYPE ABOVE'
+    BULK 'YOUR BULK ABOVE',
+    FORMAT='YOUR TYPE ABOVE'
 )
 with (id varchar(50),
         contextdataeventTime varchar(50) '$.context.data.eventTime',


### PR DESCRIPTION
The `BULK` example for Synapse Link was missing a single quote, which really threw me off for a while. It looked as though `SECRET` was part of the `BULK` value.