### PR TITLE
Fixed .NET Framework version from 4.5 to 4.7.2

### DIFF
--- a/articles/data-lake-analytics/data-lake-analytics-u-sql-programmability-guide.md
+++ b/articles/data-lake-analytics/data-lake-analytics-u-sql-programmability-guide.md
@@ -123,7 +123,7 @@ Consult the [assembly registration instructions](https://blogs.msdn.microsoft.co
 
 
 ### Use assembly versioning
-Currently, U-SQL uses the .NET Framework version 4.5. So ensure that your own assemblies are compatible with that version of the runtime.
+Currently, U-SQL uses the .NET Framework version 4.7.2. So ensure that your own assemblies are compatible with that version of the runtime.
 
 As mentioned earlier, U-SQL runs code in a 64-bit (x64) format. So make sure that your code is compiled to run on x64. Otherwise you get the incorrect format error shown earlier.
 


### PR DESCRIPTION
We updated the .NET Framework version in ADLA/U-SQL back in Dec 2019.