### PR TITLE
Remove brackets

### DIFF
--- a/articles/azure-sql/managed-instance/auditing-configure.md
+++ b/articles/azure-sql/managed-instance/auditing-configure.md
@@ -108,7 +108,7 @@ The following section describes the configuration of auditing on your managed in
 
         ```SQL
         CREATE SERVER AUDIT [<your_audit_name>]
-        TO URL ( PATH ='<container_url>' [, RETENTION_DAYS =  integer ])
+        TO URL ( PATH ='<container_url>' , RETENTION_DAYS =  integer )
         GO
         ```
 


### PR DESCRIPTION
The brackets around RETENTION_DAYS make it look like required syntax. Unlike the line above where it will work with or without them; the statement fails if they are included around the RETENTION_DAYS value.