### PR TITLE
Update app-service-authentication-how-to.md

### DIFF
--- a/articles/app-service/app-service-authentication-how-to.md
+++ b/articles/app-service/app-service-authentication-how-to.md
@@ -408,7 +408,8 @@ The following exhausts possible configuration options within the file:
                 },
                 "login": {
                     "nameClaimType": "<name of claim containing name>",
-                    "loginScopes": [
+                    "scope": [
+                        "openid",
                         "profile",
                         "email"
                     ],


### PR DESCRIPTION
- Changed `loginScopes` to `scope` property
  - Did not work properly with `loginScopes`
- Added `openid` scope
  - Since `openid` scope is required in OpenID Connect