### PR TITLE
Need clarity on agenteless migration limits

### DIFF
--- a/articles/migrate/common-questions-server-migration.md
+++ b/articles/migrate/common-questions-server-migration.md
@@ -73,7 +73,7 @@ You must have at least vCenter Server 5.5 and vSphere ESXi host version 5.5.
 
 No. Azure Migrate supports migration only to managed disks (Standard HDD, Premium SSD).
 
-## How many VMs can I replicate at one time by using agentless migration?
+## How many VMs can I replicate at one time by using agentless migration? 
 
 Currently, you can migrate 100 VMs per instance of vCenter Server simultaneously. Migrate in batches of 10 VMs.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/migrate/migrate-support-matrix-vmware-migration
You can select up to 10 VMs at once for replication. If you want to migrate more machines, then replicate in groups of 10.
For VMware agentless migration, you can run up to 300 replications simultaneously.

https://docs.microsoft.com/en-us/azure/migrate/common-questions-server-migration
Currently, you can migrate 100 VMs per instance of vCenter Server simultaneously. Migrate in batches of 10 VMs.