### PR TITLE
Azure Static Web Apps - Replace external links with links to Azure Docs

### DIFF
--- a/articles/static-web-apps/overview.md
+++ b/articles/static-web-apps/overview.md
@@ -40,7 +40,7 @@ With Static Web Apps, static assets are separated from a traditional web server 
 
 ## What you can do with Static Web Apps
 
-- **Build modern JavaScript applications** with frameworks and libraries like [Angular](getting-started.md#tab/angular), [React](getting-started.md#tab/react), [Svelte](https://docs.microsoft.com/en-us/learn/modules/publish-app-service-static-web-app-api/), [Vue](getting-started.md#tab/vue) with an [Azure Functions](apis.md) back-end.
+- **Build modern JavaScript applications** with frameworks and libraries like [Angular](getting-started.md#tabs=angular), [React](getting-started.md#tabs=react), [Svelte](https://docs.microsoft.com/learn/modules/publish-app-service-static-web-app-api/), [Vue](getting-started.md#tabs=vue) with an [Azure Functions](apis.md) back-end.
 - **Publish static sites** with frameworks like [Gatsby](publish-gatsby.md), [Hugo](publish-hugo.md), [VuePress](publish-vuepress.md).
 - **Deploy web applications** with frameworks like [Next.js](deploy-nextjs.md) and [Nuxt.js](deploy-nuxtjs.md).
 

--- a/articles/static-web-apps/overview.md
+++ b/articles/static-web-apps/overview.md
@@ -40,7 +40,7 @@ With Static Web Apps, static assets are separated from a traditional web server 
 
 ## What you can do with Static Web Apps
 
-- **Build modern JavaScript applications** with frameworks and libraries like [Angular](https://angular.io/), [React](https://reactjs.org/), [Svelte](https://svelte.dev/), [Vue](https://vuejs.org/) with an [Azure Functions](https://azure.microsoft.com/services/functions/) back-end.
+- **Build modern JavaScript applications** with frameworks and libraries like [Angular](getting-started.md#tab/angular), [React](getting-started.md#tab/react), [Svelte](https://docs.microsoft.com/en-us/learn/modules/publish-app-service-static-web-app-api/), [Vue](getting-started.md#tab/vue) with an [Azure Functions](apis.md) back-end.
 - **Publish static sites** with frameworks like [Gatsby](publish-gatsby.md), [Hugo](publish-hugo.md), [VuePress](publish-vuepress.md).
 - **Deploy web applications** with frameworks like [Next.js](deploy-nextjs.md) and [Nuxt.js](deploy-nuxtjs.md).
 


### PR DESCRIPTION
- As we're using the Azure Docs links for "Publish static sites" and "Deploy web applications" sections, maybe it would be good to use the same criteria for "Build modern JavaScript applications" links and redirect to the Azure Static Web Apps tutorials.
- As there's no Svelte tutorial, I used Microsoft Learn link.
- For Azure Functions, and replaced the link with the Azure Static Web Apps documentation page for Azure Functions instead of its service page.