### PR TITLE
Add missing source line to 2 QuickStart samples

### DIFF
--- a/articles/cognitive-services/Computer-vision/QuickStarts/python-domain.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/python-domain.md
@@ -85,6 +85,7 @@ image = Image.open(BytesIO(requests.get(image_url).content))
 plt.imshow(image)
 plt.axis("off")
 _ = plt.title(landmark_name, size="x-large", y=-0.1)
+plt.show()
 ```
 
 ## Examine the response for the landmarks sample
@@ -162,6 +163,7 @@ image = Image.open(BytesIO(requests.get(image_url).content))
 plt.imshow(image)
 plt.axis("off")
 _ = plt.title(celebrity_name, size="x-large", y=-0.1)
+plt.show()
 ```
 
 ## Examine the response for the celebrities sample


### PR DESCRIPTION
In 1 of the Quickstarts for Cognitive Services > Computer Vision, the final line of code:
	plt.show()
appears to have been inadvertently omitted from both provided Python code samples.

The Quickstart is "Quickstart: Use a domain model using the REST API and Python in Computer Vision" at https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts/python-domain

This PR just adds this missing line of code to both code samples.