### PR TITLE
About V2 SKU.

### DIFF
--- a/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
+++ b/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
@@ -12,7 +12,7 @@ ms.custom: fasttrack-edit, references_regions
 
 # Autoscaling and Zone-redundant Application Gateway v2 
 
-Application Gateway is available under a Standard_v2. Web Application Firewall (WAF) is available under a WAF_v2 SKU. The v2 SKU offers performance enhancements and adds support for critical new features like autoscaling, zone redundancy, and support for static VIPs. Existing features under the Standard and WAF SKU continue to be supported in the new v2 SKU, with a few exceptions listed in [comparison](#differences-from-v1-sku) section.
+Application Gateway is available under a Standard_v2 SKU. Web Application Firewall (WAF) is available under a WAF_v2 SKU. The v2 SKU offers performance enhancements and adds support for critical new features like autoscaling, zone redundancy, and support for static VIPs. Existing features under the Standard and WAF SKU continue to be supported in the new v2 SKU, with a few exceptions listed in [comparison](#differences-from-v1-sku) section.
 
 The new v2 SKU includes the following enhancements:
 

--- a/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
+++ b/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
@@ -12,7 +12,7 @@ ms.custom: fasttrack-edit, references_regions
 
 # Autoscaling and Zone-redundant Application Gateway v2 
 
-Application Gateway and Web Application Firewall (WAF) are also available under a Standard_v2 and WAF_v2 SKU. The v2 SKU offers performance enhancements and adds support for critical new features like autoscaling, zone redundancy, and support for static VIPs. Existing features under the Standard and WAF SKU continue to be supported in the new v2 SKU, with a few exceptions listed in [comparison](#differences-from-v1-sku) section.
+Application Gateway is available under a Standard_v2. Web Application Firewall (WAF) is available under a WAF_v2 SKU. The v2 SKU offers performance enhancements and adds support for critical new features like autoscaling, zone redundancy, and support for static VIPs. Existing features under the Standard and WAF SKU continue to be supported in the new v2 SKU, with a few exceptions listed in [comparison](#differences-from-v1-sku) section.
 
 The new v2 SKU includes the following enhancements:
 


### PR DESCRIPTION
I read below sentence but it's confusing because I can not know whether WAF is supported by Standard V2 or not. I know WAF is supported by WAF v2 SKU so I want you to fix this sentence.

"Application Gateway and Web Application Firewall (WAF) are also available under a Standard_v2 and WAF_v2 SKU. "

E.G: Application Gateway is available under a Standard_v2. Web Application Firewall (WAF) is available under a WAF_v2 SKU.