### PR TITLE
Update service-dependencies.md

### DIFF
--- a/articles/active-directory/conditional-access/service-dependencies.md
+++ b/articles/active-directory/conditional-access/service-dependencies.md
@@ -49,6 +49,7 @@ The below table lists additional service dependencies, where the client apps mus
 |                     | SharePoint                                  | Early-bound |
 | Microsoft Teams     | Exchange                                    | Early-bound |
 |                     | MS Planner                                  | Late-bound  |
+|                     | Microsoft Stream                            | Late-bound  |
 |                     | SharePoint                                  | Early-bound |
 |                     | Skype for Business Online                   | Early-bound |
 | Office Portal       | Exchange                                    | Late-bound  |


### PR DESCRIPTION
I added the dependency between Microsoft Teams and Microsoft Stream. Teams desktop app saves recordings to Stream if the user is assigned a Stream license and allowed to upload videos to Stream.  Therefore, recording on Teams will fail if accessing to Stream is blocked by CA.