### PR TITLE
Fix typo in 'preAuthorizedApplications' property

### DIFF
--- a/articles/active-directory/develop/supported-accounts-validation.md
+++ b/articles/active-directory/develop/supported-accounts-validation.md
@@ -37,7 +37,7 @@ See the following table for the validation differences of various properties for
 | Redirect URIs (`replyURLs`) | See [Redirect URI/reply URL restrictions and limitations](reply-url.md) for more info. | | | 
 | API permissions (`requiredResourceAccess`) | No limit* | No limit* | Maximum of 50 resources per application and 30 permissions per resource (e.g. Microsoft Graph). Total limit of 200 per application (resources x permissions). | 
 | Scopes defined by this API (`oauth2Permissions`) | Maximum scope name length of 120 characters <br><br> No limit* on the number of scopes defined | Maximum scope name length of 120 characters <br><br> No limit* on the number of scopes defined |  Maximum scope name length of 40 characters <br><br> Maximum of 100 scopes defined | 
-| Authorized client applications (`preautorizedApplications`) | No limit* | No limit* | Total maximum of 500 <br><br> Maximum of 100 client apps defined <br><br> Maximum of 30 scopes defined per client | 
+| Authorized client applications (`preAuthorizedApplications`) | No limit* | No limit* | Total maximum of 500 <br><br> Maximum of 100 client apps defined <br><br> Maximum of 30 scopes defined per client | 
 | appRoles | Supported <br> No limit* | Supported <br> No limit* | Not supported | 
 | Logout URL | http://localhost is allowed <br><br> Maximum length of 255 characters | http://localhost is allowed <br><br> Maximum length of 255 characters | <br><br> https://localhost is allowed, http://localhost fails for MSA <br><br> Maximum length of 255 characters <br><br> HTTP scheme is not allowed <br><br> Wildcards are not supported | 
 


### PR DESCRIPTION
The property should be `preAuthorizedApplications` as demonstrated in the screenshot below:

![image](https://user-images.githubusercontent.com/2101647/88660602-66118300-d11a-11ea-86b1-968e2d5bed75.png)

