### PR TITLE
Add viewport meta tag into the sample HTML

### DIFF
--- a/articles/active-directory-b2c/customize-ui-overview.md
+++ b/articles/active-directory-b2c/customize-ui-overview.md
@@ -104,6 +104,7 @@ Get started using your own HTML and CSS in your user experience pages by followi
     <html>
       <head>
         <title>!Add your title here!</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="https://mystore1.blob.core.windows.net/b2c/style.css">
       </head>
       <body>


### PR DESCRIPTION
The proposed change here will allow the page to zoom on mobile devices and allow CSS media queries to work.

Its good practice to add this tag into HTML5 pages to support accessible zooming and media queries in CSS.

I took the example on this page as a basis to try and create a custom user flow page, and then used it to add more and more styling. Took me quite a while to figure out why CSS media queries weren't working as I just assumed this was there.