### PR TITLE
Updated to username/password issue

### DIFF
--- a/articles/active-directory/hybrid/tshoot-connect-pass-through-authentication.md
+++ b/articles/active-directory/hybrid/tshoot-connect-pass-through-authentication.md
@@ -69,11 +69,8 @@ To confirm that this is the issue, first test that the Pass-through Authenticati
 
 If you get the same username/password error, this means that the Pass-through Authentication agent is working correctly and the issue may be that the on-premises UPN is non-routable. To learn more, see [Configuring Alternate Login ID]( https://docs.microsoft.com/windows-server/identity/ad-fs/operations/configuring-alternate-login-id#:~:text=%20Configuring%20Alternate%20Login%20ID,See%20Also.%20%20More).
 
-[!IMPORTANT]
->If the Azure AD Connect Server is not domain joined, which is a requirement mentioned in [Azure AD Connect: Prerequisites](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-install-prerequisites#installation-prerequisites), then the invalid username/password issue will occur also.
-
-
-
+> [!IMPORTANT]
+> If the Azure AD Connect server isn't domain joined, a requirement mentioned in [Azure AD Connect: Prerequisites](https://docs.microsoft.com/azure/active-directory/hybrid/how-to-connect-install-prerequisites#installation-prerequisites), the invalid username/password issue occurs.
 
 ### Sign-in failure reasons on the Azure Active Directory admin center (needs Premium license)
 

--- a/articles/active-directory/hybrid/tshoot-connect-pass-through-authentication.md
+++ b/articles/active-directory/hybrid/tshoot-connect-pass-through-authentication.md
@@ -69,7 +69,8 @@ To confirm that this is the issue, first test that the Pass-through Authenticati
 
 If you get the same username/password error, this means that the Pass-through Authentication agent is working correctly and the issue may be that the on-premises UPN is non-routable. To learn more, see [Configuring Alternate Login ID]( https://docs.microsoft.com/windows-server/identity/ad-fs/operations/configuring-alternate-login-id#:~:text=%20Configuring%20Alternate%20Login%20ID,See%20Also.%20%20More).
 
-
+[!IMPORTANT]
+>If the Azure AD Connect Server is not domain joined, which is a requirement mentioned in [Azure AD Connect: Prerequisites](https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-install-prerequisites#installation-prerequisites), then the invalid username/password issue will occur also.
 
 
 


### PR DESCRIPTION
Added an important section reminding customers that Azure AD Connect needs to be joined to the domain.  Reason for adding, worked an SR with a customer where customer and I saw article and still were not able to figure out issue.  This will prevent SRs for customer's who do not read the prerequisites for Azure AD Connect.