### PR TITLE
Update site-recovery-limits.md

### DIFF
--- a/includes/site-recovery-limits.md
+++ b/includes/site-recovery-limits.md
@@ -21,9 +21,9 @@ The following limits apply to Azure Site Recovery.
 | Limit identifier | Limit |
 | --- | --- |
 | Number of vaults per subscription |500 |     
-| Number of servers per Azure vault |250 |
-| Number of protection groups per Azure vault |No limit |
-| Number of recovery plans per Azure vault |No limit |
+| Number of servers per Recovery Services vault |250 |
+| Number of protection groups per Recovery Services vault |No limit |
+| Number of recovery plans per Recovery Services vault |No limit |
 | Number of servers per protection group |No limit |
 | Number of servers per recovery plan |50 |
 

--- a/includes/site-recovery-limits.md
+++ b/includes/site-recovery-limits.md
@@ -25,5 +25,5 @@ The following limits apply to Azure Site Recovery.
 | Number of protection groups per Recovery Services vault |No limit |
 | Number of recovery plans per Recovery Services vault |No limit |
 | Number of servers per protection group |No limit |
-| Number of servers per recovery plan |50 |
+| Number of servers per recovery plan |100 |
 


### PR DESCRIPTION
Can we please use the full official term here? The Japanese translation for "Azure vault" has come through as something completely unrelated, which I imagine is due to false positives in translation memory. I'm hoping fixing the source will eventually trigger a retranslation into the correct term (Recovery Services コンテナー) in Japanese.