### PR TITLE
Update sap-hana-scale-out-standby-netapp-files-rhel.md

### DIFF
--- a/articles/virtual-machines/workloads/sap/sap-hana-scale-out-standby-netapp-files-rhel.md
+++ b/articles/virtual-machines/workloads/sap/sap-hana-scale-out-standby-netapp-files-rhel.md
@@ -347,7 +347,9 @@ Configure and prepare your OS by doing the following steps:
     net.core.optmem_max = 16777216
     net.ipv4.tcp_rmem = 65536 16777216 16777216
     net.ipv4.tcp_wmem = 65536 16777216 16777216
-    net.core.netdev_max_backlog = 300000 net.ipv4.tcp_slow_start_after_idle=0 net.ipv4.tcp_no_metrics_save = 1
+    net.core.netdev_max_backlog = 300000 
+    net.ipv4.tcp_slow_start_after_idle=0 
+    net.ipv4.tcp_no_metrics_save = 1
     net.ipv4.tcp_moderate_rcvbuf = 1
     net.ipv4.tcp_window_scaling = 1
     net.ipv4.tcp_timestamps = 1


### PR DESCRIPTION
In section Operating system configuration and preparation step 3 newlines were missing in the example netapp-hana.conf sysctl file.