### PR TITLE
Add viewport meta tag into the sample HTML

### DIFF
--- a/includes/active-directory-b2c-html-how-to.md
+++ b/includes/active-directory-b2c-html-how-to.md
@@ -27,6 +27,7 @@ Your custom page content can contain any HTML elements, including CSS and JavaSc
 <html>
 <head>
     <title>My Product Brand Name</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
     <div id="api"></div>
@@ -90,6 +91,7 @@ Create a custom page content with your product's brand name in the title.
    <html>
    <head>
        <title>My Product Brand Name</title>
+       <meta name="viewport" content="width=device-width, initial-scale=1">
    </head>
    <body>
        <div id="api"></div>


### PR DESCRIPTION
Similar to the earlier PR, https://github.com/MicrosoftDocs/azure-docs/pull/59960, I found another place where it could be useful to put the viewport meta tag into the sample HTML to help ensure people copy paste a responsive-enabled template to start with.