### PR TITLE
Non-Gallery apps now can use all Azure AD Editions

### DIFF
--- a/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
+++ b/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
@@ -19,8 +19,6 @@ ms.collection: M365-identity-device-management
 
 # How to configure federated single sign-on for a non-gallery application
 
-To configure single sign-on for a non-gallery application *without writing code*, you need to have a subscription or Azure AD Premium and the application must support SAML 2.0. For more information about Azure AD versions, visit [Azure AD pricing](https://azure.microsoft.com/pricing/details/active-directory/).
-
 ## Overview of steps required
 Below is a high-level overview of the steps required to configure federated single sign-on with SAML 2.0 for a non-gallery (e.g. custom) application.
 

--- a/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
+++ b/articles/active-directory/manage-apps/configure-federated-single-sign-on-non-gallery-applications.md
@@ -19,8 +19,7 @@ ms.collection: M365-identity-device-management
 
 # How to configure federated single sign-on for a non-gallery application
 
-## Overview of steps required
-Below is a high-level overview of the steps required to configure federated single sign-on with SAML 2.0 for a non-gallery (e.g. custom) application.
+This article provides a high-level overview of the steps required to configure federated single sign-on with SAML 2.0 for a non-gallery (e.g., custom) application.
 
 -   Configure the application’s metadata values in Azure AD (Sign on URL, Identifier, Reply URL)
 


### PR DESCRIPTION
Non-Gallery apps now can be used in all Azure AD Editions include Azure AD Free.

Source: https://techcommunity.microsoft.com/t5/azure-active-directory-identity/unlimited-sso-and-new-azure-ad-features-to-simplify-secure/ba-p/1257358

> As Brad Anderson also shared in his Microsoft 365 news blog this morning, we're extending the ability to use Azure AD single sign-on (SSO) for an unlimited number of cloud apps at no extra cost. **Whether you need gallery apps** or non-gallery apps, using OIDC, SAML or password SSO, we have removed the limit on the number of apps each user can be assigned for SSO access in Azure AD.