### PR TITLE
Add on the boxes marked as "important" or "warning", an additional no…

### DIFF
--- a/articles/active-directory/manage-apps/grant-admin-consent.md
+++ b/articles/active-directory/manage-apps/grant-admin-consent.md
@@ -25,12 +25,17 @@ For more information on consenting to applications, see [Azure Active Directory 
 Granting tenant-wide admin consent requires you to sign in as [Global Administrator](../users-groups-roles/directory-assign-admin-roles.md#global-administrator--company-administrator), an [Application Administrator](../users-groups-roles/directory-assign-admin-roles.md#application-administrator), or a [Cloud Application Administrator](../users-groups-roles/directory-assign-admin-roles.md#cloud-application-administrator).
 
 > [!IMPORTANT]
-> When an application has been granted tenant-wide admin consent, all users will be able to sign in to the app unless it has been configured to require user assignment. To restrict which users can sign in to an application,  require user assignment and then assign users or groups to the application. For more information, see [Methods for assigning users and groups](methods-for-assigning-users-and-groups.md).
->For admin consent to Microsoft Graph API, it's required a Global Administrator role.
+> When an application has been granted tenant-wide admin consent, all users will be able to sign in to the app unless it has been configured to require user assignment. To restrict which users can sign in to an application, require user assignment and then assign users or groups to the application. For more information, see [Methods for assigning users and groups](methods-for-assigning-users-and-groups.md).
+>
+> The Global Administrator role is required in order to provide admin consent for the Microsoft Graph API.
+>
+
 
 > [!WARNING]
 > Granting tenant-wide admin consent to an application will grant the app and the app's publisher access to your organization's data. Carefully review the permissions the application is requesting before granting consent.
->For admin consent to Microsoft Graph API, it's required a Global Administrator role.
+>
+> The Global Administrator role is required in order to provide admin consent for the Microsoft Graph API.
+>
 
 ## Grant admin consent from the Azure portal
 

--- a/articles/active-directory/manage-apps/grant-admin-consent.md
+++ b/articles/active-directory/manage-apps/grant-admin-consent.md
@@ -26,9 +26,11 @@ Granting tenant-wide admin consent requires you to sign in as [Global Administra
 
 > [!IMPORTANT]
 > When an application has been granted tenant-wide admin consent, all users will be able to sign in to the app unless it has been configured to require user assignment. To restrict which users can sign in to an application,  require user assignment and then assign users or groups to the application. For more information, see [Methods for assigning users and groups](methods-for-assigning-users-and-groups.md).
+>For admin consent to Microsoft Graph API, it's required a Global Administrator role.
 
 > [!WARNING]
 > Granting tenant-wide admin consent to an application will grant the app and the app's publisher access to your organization's data. Carefully review the permissions the application is requesting before granting consent.
+>For admin consent to Microsoft Graph API, it's required a Global Administrator role.
 
 ## Grant admin consent from the Azure portal
 


### PR DESCRIPTION
…te that there are some restrictions with the Admin Consent.

Because it led to an unclear statement to customer, under the section https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent#prerequisites, we should add on the boxes marked as "important" or "warning", an additional note that there are some restrictions with the Admin Consent for the application Administrator and Cloud Application Administrator role, and each section role page should be consulted for details.
For admin consent to Microsoft Graph API, Customer requires a Global Administrator role.