### PR TITLE
Update quickstart-load-balancer-standard-public-portal.md

### DIFF
--- a/articles/load-balancer/quickstart-load-balancer-standard-public-portal.md
+++ b/articles/load-balancer/quickstart-load-balancer-standard-public-portal.md
@@ -270,7 +270,7 @@ For more information on outbound connections, see [Outbound connections in Azure
 
 5. In **Virtual machines**, select **+ Add**.
 
-6. Check the boxes next to **myVM1**, **myVM2**, and **myVM3**. 
+6. Check the boxes next to **myVM1**, **myVM2**, and **myVM3**. --> These 3 VMs are already added to "myBackendPool" adding them again to "myBackendPoolOutbound" will raise an error regarding a conflict with the NicUpdate
 
 7. Select **Add**.
 


### PR DESCRIPTION
The VMs have already been added to the first backend pool created for the load balancer "myBackendPool", adding the same VMs to "myBackendPoolOutbound" fails while updating the NIC of these VM. Can you please review the instructions of this lab? Thank You.