### PR TITLE
Update MySqlConnector code to use new property name.

### DIFF
--- a/articles/mysql/howto-configure-ssl.md
+++ b/articles/mysql/howto-configure-ssl.md
@@ -208,7 +208,7 @@ var builder = new MySqlConnectionStringBuilder
     Password = "yourpassword",
     Database = "quickstartdb",
     SslMode = MySqlSslMode.VerifyCA,
-    CACertificateFile = "BaltimoreCyberTrustRoot.crt.pem",
+    SslCa = "BaltimoreCyberTrustRoot.crt.pem",
 };
 using (var connection = new MySqlConnection(builder.ConnectionString))
 {


### PR DESCRIPTION
The CACertificateFile property has been obsoleted and replaced with SslCa.