### PR TITLE
Correct ACL evaluation algorithm for groups for ADLSGen2

### DIFF
--- a/articles/storage/blobs/data-lake-storage-access-control.md
+++ b/articles/storage/blobs/data-lake-storage-access-control.md
@@ -205,13 +205,12 @@ for entry in entries:
 member_count = 0
 perms = 0
 entries = get_acl_entries( path, NAMED_GROUP | OWNING_GROUP )
+mask = get_mask( path )
 for entry in entries:
 if (user_is_member_of_group(user, entry.identity)) :
-    member_count += 1
-    perms | =  entry.permissions
-if (member_count>0) :
-return ((desired_perms & perms & mask ) == desired_perms)
-
+    if ((desired_perms & entry.permissions & mask) == desired_perms)
+        return True 
+        
 # Handle other
 perms = get_perms_for_other(path)
 mask = get_mask( path )


### PR DESCRIPTION
In ADLS Gen2, for evaluating ACLs to a resource, we check if the user requesting access belongs to any group that gives them access to that resources. (We don't do an union of permissions from each group)