### PR TITLE
Replace double quotes with single quotes in bash script snippet

### DIFF
--- a/articles/service-fabric/service-fabric-quickstart-containers-linux.md
+++ b/articles/service-fabric/service-fabric-quickstart-containers-linux.md
@@ -48,14 +48,14 @@ To deploy the application to Azure, you need a Service Fabric cluster to run the
 #!/bin/bash
 
 # Variables
-ResourceGroupName="containertestcluster" 
-ClusterName="containertestcluster" 
-Location="eastus" 
-Password="q6D7nN%6ck@6" 
-Subject="containertestcluster.eastus.cloudapp.azure.com" 
-VaultName="containertestvault" 
-VmPassword="Mypa$$word!321"
-VmUserName="sfadminuser"
+ResourceGroupName='containertestcluster' 
+ClusterName='containertestcluster' 
+Location='eastus' 
+Password='q6D7nN%6ck@6' 
+Subject='containertestcluster.eastus.cloudapp.azure.com' 
+VaultName='containertestvault' 
+VmPassword='Mypa$$word!321'
+VmUserName='sfadminuser'
 
 # Login to Azure and set the subscription
 az login


### PR DESCRIPTION
Having a `$` symbol within double quotes can bring unexpected result because it attempts to interpret that it's an environment variable