### PR TITLE
Fix tenant URL for Cisco API

### DIFF
--- a/articles/active-directory/saas-apps/cisco-webex-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/cisco-webex-provisioning-tutorial.md
@@ -97,7 +97,7 @@ This section guides you through the steps to configure the Azure AD provisioning
 
     ![Cisco Webex Provisioning](./media/cisco-webex-provisioning-tutorial/secrettoken1.png)
 
-6.  In the **Tenant URL** field, enter a value in the form of `https://api.ciscoweb.com/v1/scim/[OrgId]`. To obtain `[OrgId]`, sign into your [Cisco Webex Control Hub](https://admin.webex.com/login). Click on your organization name on the bottom left and copy the value from **Organization ID**. 
+6.  In the **Tenant URL** field, enter a value in the form of `https://api.ciscospark.com/v1/scim/[OrgId]`. To obtain `[OrgId]`, sign into your [Cisco Webex Control Hub](https://admin.webex.com/login). Click on your organization name on the bottom left and copy the value from **Organization ID**. 
 
     * To obtain the value for **Secret Token**, navigate to this [URL](https://idbroker.webex.com/idb/saml2/jsp/doSSO.jsp?type=login&goto=https%3A%2F%2Fidbroker.webex.com%2Fidb%2Foauth2%2Fv1%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3DC4ca14fe00b0e51efb414ebd45aa88c1858c3bfb949b2405dba10b0ca4bc37402%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A3000%252Fauth%252Fcode%26scope%3Dspark%253Apeople_read%2520spark%253Apeople_write%2520Identity%253ASCIM%26state%3Dthis-should-be-a-random-string-for-security-purpose). From the webex sign in page that appears, sign in with the full Cisco Webex admin account for your organization. An error page appears saying that the site can't be reached, but this is normal.
 


### PR DESCRIPTION
The URL is incorrect per https://help.webex.com/en-us/aumpbz/Synchronize-Azure-Active-Directory-Users-into-Cisco-Webex-Control-Hub; it only works with the Cisco provided value.