### PR TITLE
Revert "Correcting sample for App Configuration"

### DIFF
--- a/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
@@ -184,7 +184,7 @@ The Secret Manager tool stores sensitive data for development work outside of yo
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddControllersWithViews();
-        services.AddSingleton(Configuration).AddFeatureManagement();
+        services.AddFeatureManagement();
     }
 
     ---


### PR DESCRIPTION
Discussed further with @zhenlan - singleton should already be added, no need to call `AddSingleton` explicitly. I ran through the quickstart and validated that it works as written against .NET Core 3.1, so this change is unnecessary.