### PR TITLE
Update v2-app-types.md

### DIFF
--- a/articles/active-directory/develop/v2-app-types.md
+++ b/articles/active-directory/develop/v2-app-types.md
@@ -114,6 +114,8 @@ In this flow, the app receives an authorization code from the Microsoft identity
 
 ![Shows the native app authentication flow](./media/v2-app-types/convergence-scenarios-native.svg)
 
+*Note: If the application is using the default system webview, please check the information about "Confirm My Sign-In" functionality and error code AADSTS50199: https://docs.microsoft.com/pt-pt/azure/active-directory/develop/reference-aadsts-error-codes*
+
 ## Daemons and server-side apps
 
 Apps that have long-running processes or that operate without interaction with a user also need a way to access secured resources, such as web APIs. These apps can authenticate and get tokens by using the app's identity, rather than a user's delegated identity, with the OAuth 2.0 client credentials flow. You can prove the app's identity using a client secret or certificate. For more info, see [.NET Core daemon console application using Microsoft identity platform](https://github.com/Azure-Samples/active-directory-dotnetcore-daemon-v2).

--- a/articles/active-directory/develop/v2-app-types.md
+++ b/articles/active-directory/develop/v2-app-types.md
@@ -114,7 +114,8 @@ In this flow, the app receives an authorization code from the Microsoft identity
 
 ![Shows the native app authentication flow](./media/v2-app-types/convergence-scenarios-native.svg)
 
-*Note: If the application is using the default system webview, please check the information about "Confirm My Sign-In" functionality and error code AADSTS50199: https://docs.microsoft.com/pt-pt/azure/active-directory/develop/reference-aadsts-error-codes*
+> [!NOTE]
+> If the application uses the default system webview, check the information about "Confirm My Sign-In" functionality and error code AADSTS50199 in [Azure AD authentication and authorization error codes](reference-aadsts-error-codes.md).
 
 ## Daemons and server-side apps
 


### PR DESCRIPTION
Hello team, hope you're doing well.

In Mobile and native apps section it would be valuable to add a pointer to Azure AD Authentication error codes, especifically CMSI functionality, since further steps are required by the user to avoid this interruption, something like: 

Note: If the application is using the default system webview, please check the information about "Confirm My Sign-In" functionality and error code AADSTS50199: https://docs.microsoft.com/pt-pt/azure/active-directory/develop/reference-aadsts-error-codes

Thank you.
Pedro Ribeiro