### PR TITLE
Update image-version-managed-image-powershell.md

### DIFF
--- a/articles/virtual-machines/image-version-managed-image-powershell.md
+++ b/articles/virtual-machines/image-version-managed-image-powershell.md
@@ -94,8 +94,8 @@ $job = $imageVersion = New-AzGalleryImageVersion `
    -GalleryImageDefinitionName $imageDefinition.Name `
    -GalleryImageVersionName '1.0.0' `
    -GalleryName $gallery.Name `
-   -ResourceGroupName $resourceGroup.ResourceGroupName `
-   -Location $resourceGroup.Location `
+   -ResourceGroupName $imageDefinition.ResourceGroupName `
+   -Location $imageDefinition.Location `
    -TargetRegion $targetRegions  `
    -Source $managedImage.Id.ToString() `
    -PublishingProfileEndOfLifeDate '2020-12-31' `


### PR DESCRIPTION
The execution of New-AzGalleryImageVersion fails because the -ResourceGroupName and -Location are referencing a variable that does not exist in any of the steps ($resourceGroup). It has to use $imageDefinition instead :)