### PR TITLE
Update connector-snowflake.md

### DIFF
--- a/articles/data-factory/connector-snowflake.md
+++ b/articles/data-factory/connector-snowflake.md
@@ -55,7 +55,11 @@ The following properties are supported for a Snowflake-linked service.
     "properties": {
         "type": "Snowflake",
         "typeProperties": {
-            "connectionString": "jdbc:snowflake://<accountname>.snowflakecomputing.com/?user=<username>&password=<password>&db=<database>&warehouse=<warehouse>&role=<myRole>"
+            "connectionString": "jdbc:snowflake://<accountname>.snowflakecomputing.com/?user=<username>&db=<database>&warehouse=<warehouse>&role=<myRole>",
+            "password": {
+                "type": "SecureString",
+				"value": "<password>"
+			}
         },
         "connectVia": {
             "referenceName": "<name of Integration Runtime>",


### PR DESCRIPTION
Example linked service JSON does not work. When used an index out of range error is produced. Modified to remove password from connection string and use password typeProperty.