### PR TITLE
Correcting typo in Form Recognizer index.yml

### DIFF
--- a/articles/cognitive-services/form-recognizer/index.yml
+++ b/articles/cognitive-services/form-recognizer/index.yml
@@ -82,8 +82,8 @@ landingContent:
             url: quickstarts/client-library.md?pivots=programming-language-java
           - text: Using the JavaScript SDK
             url: quickstarts/client-library.md?pivots=programming-language-javascript
-          - text: Using the REST API (cURL)
-            url: quickstarts/curl-train-extract.md
+          - text: Using the REST API (Python)
+            url: quickstarts/python-receipts.md
           - text: Using the REST API (cURL)
             url: quickstarts/curl-receipts.md
 


### PR DESCRIPTION
Typo in the Form Recognizer docs page. There were two cURL REST API quickstart links under receipt, and one linked to custom forms instead of Receipts. Correcting this to link to Python receipt quickstart instead.