### PR TITLE
Fix Typing Error: Source should be replace as Sink

### DIFF
--- a/articles/data-factory/connector-azure-cosmos-db.md
+++ b/articles/data-factory/connector-azure-cosmos-db.md
@@ -199,7 +199,7 @@ When copy data from Cosmos DB, unless you want to [export JSON documents as-is](
 
 To copy data to Azure Cosmos DB (SQL API), set the **sink** type in Copy Activity to **DocumentDbCollectionSink**. 
 
-The following properties are supported in the Copy Activity **source** section:
+The following properties are supported in the Copy Activity **sink** section:
 
 | Property | Description | Required |
 |:--- |:--- |:--- |


### PR DESCRIPTION
The section is for properties that are present for Azure Cosmos DB as Sink. Seems like to be a small typo