### PR TITLE
Undo the broken formatting

### DIFF
--- a/articles/event-hubs/event-hubs-create.md
+++ b/articles/event-hubs/event-hubs-create.md
@@ -23,49 +23,52 @@ To complete this quickstart, make sure that you have:
 A resource group is a logical collection of Azure resources. All resources are deployed and managed in a resource group. To create a resource group:
 
 1. Sign in to the [Azure portal](https://portal.azure.com).
-2. In the left navigation, click **Resource groups**. Then click **Add**.
+1. In the left navigation, click **Resource groups**. Then click **Add**.
 
    ![Resource groups - Add button](./media/event-hubs-quickstart-portal/resource-groups1.png)
 
-2. For **Subscription**, select the name of the Azure subscription in which you want to create the resource group.
-3. Type a unique **name for the resource group**. The system immediately checks to see if the name is available in the currently selected Azure subscription.
-4. Select a **region** for the resource group.
-5. Select **Review + Create**.
+1. For **Subscription**, select the name of the Azure subscription in which you want to create the resource group.
+1. Type a unique **name for the resource group**. The system immediately checks to see if the name is available in the currently selected Azure subscription.
+1. Select a **region** for the resource group.
+1. Select **Review + Create**.
 
    ![Resource group - create](./media/event-hubs-quickstart-portal/resource-groups2.png)
-6. On the **Review + Create** page, select **Create**. 
+1. On the **Review + Create** page, select **Create**. 
 
 ## Create an Event Hubs namespace
 
 An Event Hubs namespace provides a unique scoping container, referenced by its fully qualified domain name, in which you create one or more event hubs. To create a namespace in your resource group using the portal, do the following actions:
 
 1. In the Azure portal, and click **Create a resource** at the top left of the screen.
-2. Select **All services** in the left menu, and select **star (`*`)** next to **Event Hubs** in the **Analytics** category. Confirm that **Event Hubs** is added to **FAVORITES** in the left navigational menu. 
+1. Select **All services** in the left menu, and select **star (`*`)** next to **Event Hubs** in the **Analytics** category. Confirm that **Event Hubs** is added to **FAVORITES** in the left navigational menu. 
     
    ![Search for Event Hubs](./media/event-hubs-quickstart-portal/select-event-hubs-menu.png)
-3. Select **Event Hubs** under **FAVORITES** in the left navigational menu, and select **Add** on the toolbar.
+1. Select **Event Hubs** under **FAVORITES** in the left navigational menu, and select **Add** on the toolbar.
 
    ![Add button](./media/event-hubs-quickstart-portal/event-hubs-add-toolbar.png)
-4. On the **Create namespace** page, take the following steps:  
-    a. Select the **subscription** in which you want to create the namespace.  
-    b. Select the **resource group** you created in the previous step.   
-    c. Enter a **name** for the namespace. The system immediately checks to see if the name is available.  
-    d. Select a **location** for the namespace.      
-    e. Choose the **pricing tier** (Basic or Standard).    
-    f. Leave the **throughput units** settings as it is. To learn about throughput units, see [Event Hubs scalability](event-hubs-scalability.md#throughput-units)  
-    g. Select **Review + Create** at the bottom of the page.
-       ![Create an event hub namespace](./media/event-hubs-quickstart-portal/create-event-hub1.png)
-       
-    h. On the **Review + Create** page, review the settings, and select **Create**. Wait for the deployment to complete. 
-       ![Review + create page](./media/event-hubs-quickstart-portal/review-create.png)
+1. On the **Create namespace** page, take the following steps:  
+   1. Select the **subscription** in which you want to create the namespace.  
+   1. Select the **resource group** you created in the previous step.   
+   1. Enter a **name** for the namespace. The system immediately checks to see if the name is available.  
+   1. Select a **location** for the namespace.      
+   1. Choose the **pricing tier** (Basic or Standard).    
+   1. Leave the **throughput units** settings as it is. To learn about throughput units, see [Event Hubs scalability](event-hubs-scalability.md#throughput-units).  
+   1. Select **Review + Create** at the bottom of the page.
       
-    i. On the **Deployment** page, select **Go to resource** to navigate to the page for your namespace. 
+      ![Create an event hub namespace](./media/event-hubs-quickstart-portal/create-event-hub1.png)
+   1. On the **Review + Create** page, review the settings, and select **Create**. Wait for the deployment to complete. 
+      
+      ![Review + create page](./media/event-hubs-quickstart-portal/review-create.png)
+      
+   1. On the **Deployment** page, select **Go to resource** to navigate to the page for your namespace. 
+      
       ![Deployment complete - go to resource](./media/event-hubs-quickstart-portal/deployment-complete.png)  
-    j. Confirm that you see the **Event Hubs Namespace** page similar to the following example:   
+   1. Confirm that you see the **Event Hubs Namespace** page similar to the following example:   
+      
       ![Home page for the namespace](./media/event-hubs-quickstart-portal/namespace-home-page.png)       
 
-       > [!NOTE]
-       > Azure Event Hubs provides you with a Kafka endpoint. This endpoint enables your Event Hubs namespace to natively understand [Apache Kafka](https://kafka.apache.org/intro) message protocol and APIs. With this capability, you can communicate with your event hubs as you would with Kafka topics without changing your protocol clients or running your own clusters. Event Hubs supports [Apache Kafka versions 1.0](https://kafka.apache.org/10/documentation.html) and later. For more information, see [Use Event Hubs from Apache Kafka applications](event-hubs-for-kafka-ecosystem-overview.md).
+      > [!NOTE]
+      > Azure Event Hubs provides you with a Kafka endpoint. This endpoint enables your Event Hubs namespace to natively understand [Apache Kafka](https://kafka.apache.org/intro) message protocol and APIs. With this capability, you can communicate with your event hubs as you would with Kafka topics without changing your protocol clients or running your own clusters. Event Hubs supports [Apache Kafka versions 1.0](https://kafka.apache.org/10/documentation.html) and later. For more information, see [Use Event Hubs from Apache Kafka applications](event-hubs-for-kafka-ecosystem-overview.md).
     
 ## Create an event hub
 
@@ -78,7 +81,7 @@ To create an event hub within the namespace, do the following actions:
 1. Type a name for your event hub, then click **Create**.
    
     ![Create event hub](./media/event-hubs-quickstart-portal/create-event-hub5.png)
-4. You can check the status of the event hub creation in alerts. After the event hub is created, you see it in the list of event hubs as shown in the following image:
+1. You can check the status of the event hub creation in alerts. After the event hub is created, you see it in the list of event hubs as shown in the following image:
 
     ![Event hub created](./media/event-hubs-quickstart-portal/event-hub-created.png)
 

--- a/articles/event-hubs/event-hubs-create.md
+++ b/articles/event-hubs/event-hubs-create.md
@@ -46,25 +46,24 @@ An Event Hubs namespace provides a unique scoping container, referenced by its f
 3. Select **Event Hubs** under **FAVORITES** in the left navigational menu, and select **Add** on the toolbar.
 
    ![Add button](./media/event-hubs-quickstart-portal/event-hubs-add-toolbar.png)
-4. On the **Create namespace** page, take the following steps:
-    1. Select the **subscription** in which you want to create the namespace.
-    2. Select the **resource group** you created in the previous step. 
-    3. Enter a **name** for the namespace. The system immediately checks to see if the name is available.
-    4. Select a **location** for the namespace.    
-    5. Choose the **pricing tier** (Basic or Standard).  
-    6. Leave the **throughput units** settings as it is. To learn about throughput units, see [Event Hubs scalability](event-hubs-scalability.md#throughput-units)  
-    5. Select **Review + Create** at the bottom of the page.
+4. On the **Create namespace** page, take the following steps:  
+    a. Select the **subscription** in which you want to create the namespace.  
+    b. Select the **resource group** you created in the previous step.   
+    c. Enter a **name** for the namespace. The system immediately checks to see if the name is available.  
+    d. Select a **location** for the namespace.      
+    e. Choose the **pricing tier** (Basic or Standard).    
+    f. Leave the **throughput units** settings as it is. To learn about throughput units, see [Event Hubs scalability](event-hubs-scalability.md#throughput-units)  
+    g. Select **Review + Create** at the bottom of the page.
 
        ![Create an event hub namespace](./media/event-hubs-quickstart-portal/create-event-hub1.png)
-   6. On the **Review + Create** page, review the settings, and select **Create**. Wait for the deployment to complete. 
+   h. On the **Review + Create** page, review the settings, and select **Create**. Wait for the deployment to complete. 
 
        ![Review + create page](./media/event-hubs-quickstart-portal/review-create.png)
-   7. On the **Deployment** page, select **Go to resource** to navigate to the page for your namespace. 
+   i. On the **Deployment** page, select **Go to resource** to navigate to the page for your namespace. 
 
-      ![Deployment complete - go to resource](./media/event-hubs-quickstart-portal/deployment-complete.png)
-   8. Confirm that you see the **Event Hubs Namespace** page similar to the following example: 
-
-       ![Home page for the namespace](./media/event-hubs-quickstart-portal/namespace-home-page.png)       
+      ![Deployment complete - go to resource](./media/event-hubs-quickstart-portal/deployment-complete.png)  
+   j. Confirm that you see the **Event Hubs Namespace** page similar to the following example:   
+      ![Home page for the namespace](./media/event-hubs-quickstart-portal/namespace-home-page.png)       
 
        > [!NOTE]
        > Azure Event Hubs provides you with a Kafka endpoint. This endpoint enables your Event Hubs namespace to natively understand [Apache Kafka](https://kafka.apache.org/intro) message protocol and APIs. With this capability, you can communicate with your event hubs as you would with Kafka topics without changing your protocol clients or running your own clusters. Event Hubs supports [Apache Kafka versions 1.0](https://kafka.apache.org/10/documentation.html) and later. For more information, see [Use Event Hubs from Apache Kafka applications](event-hubs-for-kafka-ecosystem-overview.md).

--- a/articles/event-hubs/event-hubs-create.md
+++ b/articles/event-hubs/event-hubs-create.md
@@ -54,15 +54,14 @@ An Event Hubs namespace provides a unique scoping container, referenced by its f
     e. Choose the **pricing tier** (Basic or Standard).    
     f. Leave the **throughput units** settings as it is. To learn about throughput units, see [Event Hubs scalability](event-hubs-scalability.md#throughput-units)  
     g. Select **Review + Create** at the bottom of the page.
-
        ![Create an event hub namespace](./media/event-hubs-quickstart-portal/create-event-hub1.png)
-   h. On the **Review + Create** page, review the settings, and select **Create**. Wait for the deployment to complete. 
-
+       
+    h. On the **Review + Create** page, review the settings, and select **Create**. Wait for the deployment to complete. 
        ![Review + create page](./media/event-hubs-quickstart-portal/review-create.png)
-   i. On the **Deployment** page, select **Go to resource** to navigate to the page for your namespace. 
-
+      
+    i. On the **Deployment** page, select **Go to resource** to navigate to the page for your namespace. 
       ![Deployment complete - go to resource](./media/event-hubs-quickstart-portal/deployment-complete.png)  
-   j. Confirm that you see the **Event Hubs Namespace** page similar to the following example:   
+    j. Confirm that you see the **Event Hubs Namespace** page similar to the following example:   
       ![Home page for the namespace](./media/event-hubs-quickstart-portal/namespace-home-page.png)       
 
        > [!NOTE]


### PR DESCRIPTION
I mistakenly broke formatting in '4. On the Create namespace page, take the following steps:'.

Viewing the original document, (https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create)
I undo the broken formatting as the original document.