### PR TITLE
Update a sentence for clarification

### DIFF
--- a/articles/event-hubs/get-started-dotnet-standard-send-v2.md
+++ b/articles/event-hubs/get-started-dotnet-standard-send-v2.md
@@ -100,7 +100,7 @@ This section shows you how to create a .NET Core console application to send eve
     > For the complete source code with more informational comments, see [this file on the GitHub](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEventBatch.cs)
 
 ## Receive events
-This section shows how to write a .NET Core console application that receives messages from an event hub using an event processor. The event processor simplifies receiving events from event hubs by managing persistent checkpoints and parallel receives from those event hubs. An event processor is associated with a specific event Hub and a consumer group. It receives events from multiple partitions in the event hub, passing them to a handler delegate for processing using code that you provide. 
+This section shows how to write a .NET Core console application that receives messages from an event hub using an event processor. The event processor simplifies receiving events from event hubs by managing persistent checkpoints and parallel receptions from those event hubs. An event processor is associated with a specific event Hub and a consumer group. It receives events from multiple partitions in the event hub, passing them to a handler delegate for processing using code that you provide. 
 
 
 > [!NOTE]


### PR DESCRIPTION
before : parallel receives
after : parallel receptions

It seems like 
The event processor simplifies receiving events from event hubs by
1) managing persistent checkpoints
2) managing parallel receptions
from those event hubs.
If it is correct, the sentence should be modified as 'parallel receptions'.