### PR TITLE
correct display name validation

### DIFF
--- a/articles/active-directory/develop/howto-add-app-roles-in-azure-ad-apps.md
+++ b/articles/active-directory/develop/howto-add-app-roles-in-azure-ad-apps.md
@@ -70,7 +70,7 @@ The following example shows the `appRoles` that you can assign to `users`.
 ```
 
 > [!NOTE]
->The `displayName` cannot contain spaces.
+>The `displayName` may contain spaces.
 
 You can define app roles to target `users`, `applications`, or both. When available to `applications`, app roles appear as application permissions under **Manage** section > **API permissions > Add a permission > My APIs > Choose an API > Application permissions**. The following example shows an app role targeted towards an `Application`.
 


### PR DESCRIPTION
I believe it's the case that the display name **may** contain spaces.  And if not, then the inverse change should be made to the App manifest documentation under the [`appRoles` attribute](https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest#approles-attribute) which includes a space for the `displayName` property