### PR TITLE
Update languages: Portuguese (Brazil) key

### DIFF
--- a/articles/cognitive-services/Translator/language-support.md
+++ b/articles/cognitive-services/Translator/language-support.md
@@ -243,7 +243,7 @@ View reference documentation for the [Dictionary Lookup](reference/v3-0-dictiona
 | Norwegian      | `nb`          |
 | Persian      | `fa`          |
 | Polish      | `pl`          |
-| Portuguese (Brazil)     | `pt-br`          |
+| Portuguese (Brazil)     | `pt`          |
 | Romanian      | `ro`          |
 | Russian      | `ru`          |
 | Serbian (Latin)      | `sr-Latn`          |


### PR DESCRIPTION
I saw supported languages response as below, the key changed to "pt"
```json
        "pt": {
            "name": "Portuguese (Brazil)",
            "nativeName": "Português (Brasil)",
            "dir": "ltr"
        }
```