### PR TITLE
Get service principal ID for AAD App

### DIFF
--- a/articles/lighthouse/how-to/onboard-customer.md
+++ b/articles/lighthouse/how-to/onboard-customer.md
@@ -81,7 +81,7 @@ In order to define authorizations, you'll need to know the ID values for each us
 (Get-AzADUser -UserPrincipalName '<yourUPN>').id
 
 # To retrieve the objectId for an SPN
-(Get-AzADApplication -DisplayName '<appDisplayName>').objectId
+(Get-AzADApplication -DisplayName '<appDisplayName>' | Get-AzADServicePrincipal).Id
 
 # To retrieve role definition IDs
 (Get-AzRoleDefinition -Name '<roleName>').id


### PR DESCRIPTION
Fix Powershell code to get the service principal ID for the AAD Application, rather than the ObjectID for the AAD App.

Using the AAD App's ObjectID in a Lighthouse definition results in an error from AAD.