### PR TITLE
Typo "Azure storage emulator"→"Azure Storage Emulator"

### DIFF
--- a/articles/cosmos-db/table-storage-how-to-use-c-plus.md
+++ b/articles/cosmos-db/table-storage-how-to-use-c-plus.md
@@ -85,14 +85,14 @@ const utility::string_t storage_connection_string(U("DefaultEndpointsProtocol=ht
 
 Use the name of your Azure Cosmos DB account for `<your_cosmos_db_account>`. Enter your primary key for `<your_cosmos_db_account_key>`. Enter the endpoint listed in the [Azure portal](https://portal.azure.com) for `<your_cosmos_db_endpoint>`.
 
-To test your application in your local Windows-based computer, you can use the Azure storage emulator that is installed with the [Azure SDK](https://azure.microsoft.com/downloads/). The storage emulator is a utility that simulates the Azure Blob, Queue, and Table services available on your local development machine. The following example shows how to declare a static field to hold the connection string to your local storage emulator:  
+To test your application in your local Windows-based computer, you can use the Azure Storage Emulator that is installed with the [Azure SDK](https://azure.microsoft.com/downloads/). The Storage Emulator is a utility that simulates the Azure Blob, Queue, and Table services available on your local development machine. The following example shows how to declare a static field to hold the connection string to your local storage emulator:  
 
 ```cpp
 // Define the connection string with Azure storage emulator.
 const utility::string_t storage_connection_string(U("UseDevelopmentStorage=true;"));  
 ```
 
-To start the Azure storage emulator, from your Windows desktop, select the **Start** button or the Windows key. Enter and run *Microsoft Azure Storage Emulator*. For more information, see [Use the Azure storage emulator for development and testing](../storage/common/storage-use-emulator.md).
+To start the Azure Storage Emulator, from your Windows desktop, select the **Start** button or the Windows key. Enter and run *Microsoft Azure Storage Emulator*. For more information, see [Use the Azure Storage Emulator for development and testing](../storage/common/storage-use-emulator.md).
 
 ### Retrieve your connection string
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/cosmos-db/table-storage-how-to-use-c-plus