### PR TITLE
Fixed erroneous variable reference in example.

### DIFF
--- a/articles/storage/queues/storage-nodejs-how-to-use-queues.md
+++ b/articles/storage/queues/storage-nodejs-how-to-use-queues.md
@@ -207,7 +207,7 @@ each message using a for loop. It also sets the invisibility timeout to five min
 queueSvc.getMessages('myqueue', {numOfMessages: 15, visibilityTimeout: 5 * 60}, function(error, results, getResponse){
   if(!error){
     // Messages retrieved
-    for(var index in result){
+    for(var index in results){
       // text is available in result[index].messageText
       var message = results[index];
       queueSvc.deleteMessage(queueName, message.messageId, message.popReceipt, function(error, deleteResponse){


### PR DESCRIPTION
Dequeuing messages refers to `result` instead of `results`.