### PR TITLE
Update ClientId settings

### DIFF
--- a/articles/active-directory/develop/scenario-protected-web-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-protected-web-api-app-configuration.md
@@ -66,7 +66,7 @@ This section describes how to configure a bearer token.
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "ClientId": "[Client_id-of-web-api-eg-2ec40e65-ba09-4853-bcde-bcb60029e596]",
+    "ClientId": "api://[Client_id-of-web-api-eg-2ec40e65-ba09-4853-bcde-bcb60029e596]",
     /*
       You need specify the TenantId only if you want to accept access tokens from a single tenant
      (line-of-business app).


### PR DESCRIPTION
Here is what I have found. Scenario: SPA using JWT token to authenticate an API. The spa gets the token successfully, inside we have all information required, the audience (aud) is: "api://clientid-guid". But then with the basic configuration, JWT validations fails and the error said "audience incorrect 'api://clientid-guid' ". Adding Audience parameter to appsettings.json did not help. The only thing that worked for me was to change in appsettings.json ClientId to: "api://clientid-guid". For me, it looks like it took ClientId as valid Audience. I'm not sure this behavior is expected or not. Cheers.