### PR TITLE
Rename exportTrailingSlash option to trailingSlash

### DIFF
--- a/articles/static-web-apps/deploy-nextjs.md
+++ b/articles/static-web-apps/deploy-nextjs.md
@@ -69,7 +69,7 @@ When you build a Next.js site using `npm run build`, the app is built as a tradi
 
     ```javascript
     module.exports = {
-      exportTrailingSlash: true,
+      trailingSlash: true,
       exportPathMap: function() {
         return {
           '/': { page: '/' }

--- a/articles/static-web-apps/deploy-nextjs.md
+++ b/articles/static-web-apps/deploy-nextjs.md
@@ -203,7 +203,7 @@ The reason for this error is because Next.js only generated the home page based 
    const data = require('./utils/projectsData');
 
    module.exports = {
-     exportTrailingSlash: true,
+     trailingSlash: true,
      exportPathMap: async function () {
        const { projects } = data;
        const paths = {


### PR DESCRIPTION
This PR is a simple doc fix to capture the change recommended by the CLI when using the latest npm 6.14.6 on Node LTS 12.18.3 on Windows 10 Enterprise and running a `next build && next export`:

```sh
> next build && next export

Warning: The "exportTrailingSlash" option has been renamed to "trailingSlash". Please update your next.config.js.
Failed to compile.
```
