### PR TITLE
Replace $tomorrowDate PowerShell with bash

### DIFF
--- a/articles/key-vault/secrets/tutorial-rotation-dual.md
+++ b/articles/key-vault/secrets/tutorial-rotation-dual.md
@@ -180,7 +180,7 @@ az storage account keys list -n akvrotationstorage2
 Populate retrieved values for **key2Value** and **storageAccountResourceId**
 
 ```azurecli
-$tomorrowDate = (get-date).AddDays(+1).ToString("yyy-MM-ddThh:mm:ssZ")
+tomorrowDate=`date -d tomorrow -Iseconds -u | awk -F'+' '{print $1"Z"}'`
 az keyvault secret set --name storageKey2 --vault-name akvrotation-kv --value <key2Value> --tags "CredentialId=key2" "ProviderAddress=<storageAccountResourceId>" "ValidityPeriodDays=60" --expires $tomorrowDate
 ```
 


### PR DESCRIPTION
Recommending we change this to use the GNU date util. The PowerShell cmdlet is great, except if we are using bash/az clil without PowerShell. If PowerShell is desired, I recommend the rest of the tutorial be rewritten in powershell.