### PR TITLE
Update PRT renew requirements

### DIFF
--- a/articles/active-directory/devices/concept-primary-refresh-token.md
+++ b/articles/active-directory/devices/concept-primary-refresh-token.md
@@ -83,10 +83,10 @@ A PRT is renewed in two different methods:
    * An app requests WAM for an access token silently but there’s no refresh token available for that app. In this case, WAM uses the PRT to request a token for the app and gets back a new PRT in the response.
    * An app requests WAM for an access token but the PRT is invalid or Azure AD requires additional authorization (for example, Azure Multi-Factor Authentication). In this scenario, WAM initiates an interactive logon requiring the user to reauthenticate or provide additional verification and a new PRT is issued on successful authentication.
 
-With ADFS environments, direct line of sight to the Domain Controller is not required to renew the PRT. PRT renewal requires only /adfs/services/trust/2005/usernamemixed and
-/adfs/services/trust/13/usernamemixed endpoints enabled on proxy using WS-Trust protocol. 
+In an ADFS environment, direct line of sight to the domain controller isn't required to renew the PRT. PRT renewal requires only /adfs/services/trust/2005/usernamemixed and
+/adfs/services/trust/13/usernamemixed endpoints enabled on proxy by using WS-Trust protocol.
 
-Windowstransport endpoints are only required for password authentication when password is changed but not for PRT renewal.
+Windows transport endpoints are required for password authentication only when a password is changed, not for PRT renewal.
 
 ### Key considerations
 

--- a/articles/active-directory/devices/concept-primary-refresh-token.md
+++ b/articles/active-directory/devices/concept-primary-refresh-token.md
@@ -83,8 +83,10 @@ A PRT is renewed in two different methods:
    * An app requests WAM for an access token silently but there’s no refresh token available for that app. In this case, WAM uses the PRT to request a token for the app and gets back a new PRT in the response.
    * An app requests WAM for an access token but the PRT is invalid or Azure AD requires additional authorization (for example, Azure Multi-Factor Authentication). In this scenario, WAM initiates an interactive logon requiring the user to reauthenticate or provide additional verification and a new PRT is issued on successful authentication.
 
-With ADFS environments, direct line of sight to the Domain Controller is not required to renew the PRT. This requires /adfs/services/trust/2005/usernamemixed
-/adfs/services/trust/13/usernamemixed endpoints enabled on proxy.
+With ADFS environments, direct line of sight to the Domain Controller is not required to renew the PRT. PRT renewal requires only /adfs/services/trust/2005/usernamemixed and
+/adfs/services/trust/13/usernamemixed endpoints enabled on proxy using WS-Trust protocol. 
+
+Windowstransport endpoints are only required for password authentication when password is changed but not for PRT renewal.
 
 ### Key considerations
 

--- a/articles/active-directory/devices/concept-primary-refresh-token.md
+++ b/articles/active-directory/devices/concept-primary-refresh-token.md
@@ -83,6 +83,9 @@ A PRT is renewed in two different methods:
    * An app requests WAM for an access token silently but there’s no refresh token available for that app. In this case, WAM uses the PRT to request a token for the app and gets back a new PRT in the response.
    * An app requests WAM for an access token but the PRT is invalid or Azure AD requires additional authorization (for example, Azure Multi-Factor Authentication). In this scenario, WAM initiates an interactive logon requiring the user to reauthenticate or provide additional verification and a new PRT is issued on successful authentication.
 
+With ADFS environments, direct line of sight to the Domain Controller is not required to renew the PRT. This requires /adfs/services/trust/2005/usernamemixed
+/adfs/services/trust/13/usernamemixed endpoints enabled on proxy.
+
 ### Key considerations
 
 * A PRT is only issued and renewed during native app authentication. A PRT is not renewed or issued during a browser session.


### PR DESCRIPTION
Hi team, as per internal conversations PRT can be renewed externally without being in corp network but as per one customer, windowstransport endpoints are required externally to be able to renew the PRT but as per PG these are not required externally. Please clarify and add the correct information