### PR TITLE
Fix '*' in sample command, should be * without quotes

### DIFF
--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -83,7 +83,7 @@ Add an *A* record to your DNS zone with the external IP address of the NGINX ser
 az network dns record-set a add-record \
     --resource-group myResourceGroup \
     --zone-name MY_CUSTOM_DOMAIN \
-    --record-set-name '*' \
+    --record-set-name * \
     --ipv4-address MY_EXTERNAL_IP
 ```
 


### PR DESCRIPTION
Can someone please verify this. This command was failing until the quotes were removed.