### PR TITLE
Update on database partitioning.

### DIFF
--- a/articles/healthcare-apis/configure-database.md
+++ b/articles/healthcare-apis/configure-database.md
@@ -20,9 +20,10 @@ Throughput must be provisioned to ensure that sufficient system resources are av
 > As different operations consume different number of RU, we return the actual number of RUs consumed in every API call in response header. This way you can profile the number of RUs consumed by your application.
 
 ## Update throughput
+
 To change this setting in the Azure portal, navigate to your Azure API for FHIR and open the Database blade. Next, change the Provisioned throughput to the desired value depending on your performance needs. You can change the value up to a maximum of 10,000 RU/s. If you need a higher value, contact Azure support.
 
-If the database throughput is higher than 10,000 RU/s, or if the data stored in the database exceeds 50GB, your client application must be capable of handling continuation tokens. A new partition will be created in the database for every 10,000 RU/s increase in throughput or if your data grows beyond 50GB, resulting in multi-page response where pagination is implemented using the continuation tokens.
+If the database throughput is greater than 10,000 RU/s or if the data stored in the database is more than 50 GB, your client application must be capable of handling continuation tokens. A new partition is created in the database for every throughput increase of 10,000 RU/s or if the amount of data stored is more than 50 GB. Multiple partitions creates a multi-page response in which pagination is implemented by using continuation tokens.
 
 > [!NOTE] 
 > Higher value means higher Azure API for FHIR throughput and higher cost of the service.

--- a/articles/healthcare-apis/configure-database.md
+++ b/articles/healthcare-apis/configure-database.md
@@ -22,6 +22,8 @@ Throughput must be provisioned to ensure that sufficient system resources are av
 ## Update throughput
 To change this setting in the Azure portal, navigate to your Azure API for FHIR and open the Database blade. Next, change the Provisioned throughput to the desired value depending on your performance needs. You can change the value up to a maximum of 10,000 RU/s. If you need a higher value, contact Azure support.
 
+If the database throughput is higher than 10,000 RU/s, or if the data stored in the database exceeds 50GB, your client application must be capable of handling continuation tokens. A new partition will be created in the database for every 10,000 RU/s increase in throughput or if your data grows beyond 50GB, resulting in multi-page response where pagination is implemented using the continuation tokens.
+
 > [!NOTE] 
 > Higher value means higher Azure API for FHIR throughput and higher cost of the service.
 


### PR DESCRIPTION
Updated the information where a new partition is provisioned when the throughput is increased beyond 10,000RU/s or 50GB data, resulting in multiple pages being returned, some of which might be empty.