### PR TITLE
Comparison vs contrast grammar

### DIFF
--- a/articles/virtual-network/virtual-networks-overview.md
+++ b/articles/virtual-network/virtual-networks-overview.md
@@ -32,7 +32,7 @@ As you build your network in Azure, it is important to keep in mind the followin
 
 - Ensure non-overlapping address spaces. Make sure your VNet address space (CIDR block) does not overlap with your organization's other network ranges.
 - Your subnets should not cover the entire address space of the VNet. Plan ahead and reserve some address space for the future.
-- It is recommended you have fewer large VNets than multiple small VNets. This will prevent management overhead.
+- It is recommended you have fewer large VNets rather than multiple small VNets. This will prevent management overhead.
 - Secure your VNet's by assigning Network Security Groups (NSGs) to the subnets beneath them.
 
 ## Communicate with the internet


### PR DESCRIPTION
Another alternative would be to use "instead of" i.e. "It is recommended you have fewer large VNets instead of multiple small VNets."