### PR TITLE
Update how-to-connect-fed-hybrid-azure-ad-join-post-config-tasks.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-fed-hybrid-azure-ad-join-post-config-tasks.md
+++ b/articles/active-directory/hybrid/how-to-connect-fed-hybrid-azure-ad-join-post-config-tasks.md
@@ -86,8 +86,5 @@ This installer creates a scheduled task on the device system that runs in the us
 
 For information about how to allow hybrid Azure AD join for individual devices, see [Controlled validation of hybrid Azure AD join](../devices/hybrid-azuread-join-control.md).
 
-> [!NOTE]
-> Policy settings for 2012 R2 are at **Computer Configuration > Policies > Administrative Templates > Windows Components > Workplace Join > Automatically workplace join client computers**.
-
 ## Next steps
 [Configure device writeback](how-to-connect-device-writeback.md)


### PR DESCRIPTION
Number 10 on the article was recently updated to reflect the change away from using GPO to control Hybrid Join to using the controlled validation of hybrid join process. However, the note pointing out where the GPO is on server 2012 R2 remained.

Given that controlling hybrid join via GPO is no longer the preferred method I don't see any reason why we'd keep this note around.