### PR TITLE
Clarify x5t header calculation algorithm

### DIFF
--- a/articles/active-directory/develop/active-directory-certificate-credentials.md
+++ b/articles/active-directory/develop/active-directory-certificate-credentials.md
@@ -32,7 +32,7 @@ To compute the assertion, you can use one of the many JWT libraries in the langu
 | --- | --- |
 | `alg` | Should be **RS256** |
 | `typ` | Should be **JWT** |
-| `x5t` | The X.509 certificate hash (also known as the cert's SHA-1 *thumbprint*) encoded as a Base64 string value. For example, given an X.509 certificate hash of `84E05C1D98BCE3A5421D225B140B36E86A3D5534`, the `x5t` claim would be `hOBcHZi846VCHSJbFAs26Go9VTQ`. |
+| `x5t` | The X.509 certificate hash's (also known as the cert's SHA-1 *thumbprint*) Hex representation encoded as a Base64 string value. For example, given an X.509 certificate hash of `84E05C1D98BCE3A5421D225B140B36E86A3D5534` (Hex), the `x5t` claim would be `hOBcHZi846VCHSJbFAs26Go9VTQ=` (Base64). |
 
 ### Claims (payload)
 


### PR DESCRIPTION
Hi,

while trying this out myself it was not obvious to see that it is not the Base64 of the Thumbprint string, but rather of the Hexadecimal representation of it. After some trial and error I figured it out. 
This is the node.js based code for generating the correct value from the Thumbprint:
```js
var thumbprintBase64 = Buffer.from('84E05C1D98BCE3A5421D225B140B36E86A3D5534', 'hex').toString('base64');
```