### PR TITLE
Modify custom name resolver

### DIFF
--- a/articles/app-service/webjobs-sdk-how-to.md
+++ b/articles/app-service/webjobs-sdk-how-to.md
@@ -605,7 +605,12 @@ public class CustomNameResolver : INameResolver
 {
     public string Resolve(string name)
     {
-        return ConfigurationManager.AppSettings[name].ToString();
+        var config = new ConfigurationBuilder()
+             .SetBasePath(Directory.GetCurrentDirectory())
+             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+             .AddEnvironmentVariables()
+             .Build();
+            return config[name].ToString();
     }
 }
 ```


### PR DESCRIPTION
The existing custom name resolver implementation throws an error for .Net Core 3.1 webjobs.  I found this SO post that works for me.  Seeing if it would be possible to update the code here.
https://stackoverflow.com/a/61794569/1970551