### PR TITLE
Updating Cloud Shell documentation table for SDK versions

### DIFF
--- a/articles/cloud-shell/features.md
+++ b/articles/cloud-shell/features.md
@@ -80,7 +80,7 @@ Cloud Shell includes pre-configured authentication for open-source tools such as
 
 |Language   |Version   |
 |---|---|
-|.NET Core  |2.2.402       |
+|.NET Core  |[1.0.1](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-sdk-release-notes.md), [2.2.402](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.7/2.2.402-download.md), and [3.1.302](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.6/3.1.302-download.md) (default)       |
 |Go         |1.9        |
 |Java       |1.8        |
 |Node.js    |8.16.0      |

--- a/articles/cloud-shell/features.md
+++ b/articles/cloud-shell/features.md
@@ -80,7 +80,7 @@ Cloud Shell includes pre-configured authentication for open-source tools such as
 
 |Language   |Version   |
 |---|---|
-|.NET Core  |[1.0.1](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-sdk-release-notes.md), [2.2.402](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2.7/2.2.402-download.md), and [3.1.302](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.6/3.1.302-download.md) (default)       |
+|.NET Core  |[3.1.302](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.6/3.1.302-download.md)       |
 |Go         |1.9        |
 |Java       |1.8        |
 |Node.js    |8.16.0      |


### PR DESCRIPTION
The Cloud Shell documentation still indicates that the version of .NET Core installed is ``2.2.402``.

Recently a change rolled out that updated the .NET Core version to ``3.1.302``:

![image](https://user-images.githubusercontent.com/5067401/90639311-7dfd9380-e1fc-11ea-833d-da3a70185fe8.png)

This PR proposes a change to the single Markdown file that includes:

- Update the .NET version in the table to [3.1.302](https://dotnet.microsoft.com/download/dotnet-core/3.1#sdk-3.1.302)
- Add a hyperlink to the appropriate [release](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.6/3.1.302-download.md) in the [dotnet/core](https://github.com/dotnet/core) repository