### PR TITLE
Local.Settings.Json - Minor Change / Note Required.

### DIFF
--- a/articles/azure-functions/durable/quickstart-powershell-vscode.md
+++ b/articles/azure-functions/durable/quickstart-powershell-vscode.md
@@ -68,6 +68,8 @@ Open the *local.settings.json* file and confirm that a setting named `FUNCTIONS_
 }
 ```
 
+> Note: To test the function locally, set the value if AzureWebJobsStorage to "UseDevelopmentStorage=true"
+
 ## Create your functions
 
 The most basic Durable Functions app contains three functions:


### PR DESCRIPTION
**Storage Account is a pre-requistes for durable function.** 
Users need to set the local.settings.json as shown below to test it locally. 
```PowerShell
{
  "IsEncrypted": false,
  "Values": {
    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
    "FUNCTIONS_WORKER_RUNTIME": "powershell",
    "FUNCTIONS_WORKER_RUNTIME_VERSION": "~7"
  }
}
```
If not, the below error appears
**_Missing value for AzureWebJobsStorage in local.settings.json. This is required for all triggers other than httptrigger, kafkatrigger. You can run 'func azure functionapp fetch-app-settings <functionAppName>' or specify a connection string in local.settings.json._**