### PR TITLE
Fixed Computer Vision quickstarts for C#

### DIFF
--- a/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-analyze.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-analyze.md
@@ -51,10 +51,10 @@ namespace CSHttpClientSample
 {
     static class Program
     {
-        // Add your Computer Vision subscription key and endpoint to your environment variables.
-        static string subscriptionKey = Environment.GetEnvironmentVariable("COMPUTER_VISION_SUBSCRIPTION_KEY");
+        // Add your Computer Vision subscription key and endpoint as  variables.
+        static string subscriptionKey = "COMPUTER_VISION_SUBSCRIPTION_KEY";
 
-        static string endpoint = Environment.GetEnvironmentVariable("COMPUTER_VISION_ENDPOINT");
+        static string endpoint = "COMPUTER_VISION_ENDPOINT";
         
         // the Analyze method endpoint
         static string uriBase = endpoint + "vision/v3.0/analyze";

--- a/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-analyze.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-analyze.md
@@ -51,7 +51,7 @@ namespace CSHttpClientSample
 {
     static class Program
     {
-        // Add your Computer Vision subscription key and endpoint as  variables.
+        // Add your Computer Vision subscription key and endpoint as class variables.
         static string subscriptionKey = "COMPUTER_VISION_SUBSCRIPTION_KEY";
 
         static string endpoint = "COMPUTER_VISION_ENDPOINT";

--- a/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-hand-text.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-hand-text.md
@@ -56,11 +56,11 @@ namespace CSHttpClientSample
 {
     static class Program
     {
-        // Add your Computer Vision subscription key and endpoint to your environment variables.
-        static string subscriptionKey = Environment.GetEnvironmentVariable("COMPUTER_VISION_SUBSCRIPTION_KEY");
+        // Add your Computer Vision subscription key and endpoint as class variables
+        static string subscriptionKey = "COMPUTER_VISION_SUBSCRIPTION_KEY";
 
         // An endpoint should have a format like "https://westus.api.cognitive.microsoft.com"
-        static string endpoint = Environment.GetEnvironmentVariable("COMPUTER_VISION_ENDPOINT");
+        static string endpoint = "COMPUTER_VISION_ENDPOINT";
 
         // the Batch Read method endpoint
         static string uriBase = endpoint + "/vision/v3.0/read/analyze";

--- a/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-print-text.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-print-text.md
@@ -53,10 +53,10 @@ namespace CSHttpClientSample
 {
     static class Program
     {
-        // Add your Computer Vision subscription key and endpoint to your environment variables.
-        static string subscriptionKey = Environment.GetEnvironmentVariable("COMPUTER_VISION_SUBSCRIPTION_KEY");
+        // Add your Computer Vision subscription key and endpoint as class variables
+        static string subscriptionKey = "COMPUTER_VISION_SUBSCRIPTION_KEY";
 
-        static string endpoint = Environment.GetEnvironmentVariable("COMPUTER_VISION_ENDPOINT");
+        static string endpoint = "COMPUTER_VISION_ENDPOINT";
         
         // the OCR method endpoint
         static string uriBase = endpoint + "vision/v2.1/ocr";

--- a/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-thumb.md
+++ b/articles/cognitive-services/Computer-vision/QuickStarts/CSharp-thumb.md
@@ -50,9 +50,9 @@ namespace CSHttpClientSample
 {
     static class Program
     {
-        // Add your Computer Vision subscription key and base endpoint to your environment variables.
-        static string subscriptionKey = Environment.GetEnvironmentVariable("COMPUTER_VISION_SUBSCRIPTION_KEY");
-        static string endpoint = Environment.GetEnvironmentVariable("COMPUTER_VISION_ENDPOINT");
+        // Add your Computer Vision subscription key and endpoint as class variables
+        static string subscriptionKey = "COMPUTER_VISION_SUBSCRIPTION_KEY";
+        static string endpoint = "COMPUTER_VISION_ENDPOINT";
         
         // The GenerateThumbnail method endpoint
         static string uriBase = endpoint + "vision/v3.0/generateThumbnail";


### PR DESCRIPTION
The C# quickstarts did not run when I tried to use the exact same code. 

This issue is taking place because the Environment.GetEnvironmentVariable(String) method that is used to retrieve the value of the environment variable returns null.

I then tried using class variables instead, which manage to solve the issue in all the C# quickstarts for Computer Vision