### PR TITLE
Add SAML 2.0 reference link

### DIFF
--- a/articles/active-directory/develop/v2-howto-app-gallery-listing.md
+++ b/articles/active-directory/develop/v2-howto-app-gallery-listing.md
@@ -93,7 +93,7 @@ OAuth 2.0 is an [industry-standard](https://oauth.net/2/) protocol for authoriza
 
 ### SAML 2.0 or WS-Fed
 
-SAML is a mature, and widely adopted, single sign-on standard for web applications. To learn more about how Azure uses SAML, see [How Azure uses the SAML protocol](active-directory-saml-protocol-reference.md). 
+SAML is a mature, and widely adopted, [single sign-on standard](https://www.oasis-open.org/standards#samlv2.0) for web applications. To learn more about how Azure uses SAML, see [How Azure uses the SAML protocol](active-directory-saml-protocol-reference.md). 
 
 Web Services Federation (WS-Fed) is an [industry standard](https://docs.oasis-open.org/wsfed/federation/v1.2/ws-federation.html) generally used for web applications that are developed using the .NET platform.
 


### PR DESCRIPTION
The document has an OASIS reference link for WS-Federation but not for SAML 2.0.  This PR fixes that oversight.