### PR TITLE
Update time-sync.md

### DIFF
--- a/articles/virtual-machines/linux/time-sync.md
+++ b/articles/virtual-machines/linux/time-sync.md
@@ -13,7 +13,7 @@ ms.service: virtual-machines-linux
 ms.topic: how-to
 ms.tgt_pltfrm: vm-linux
 ms.workload: infrastructure-services
-ms.date: 09/17/2018
+ms.date: 08/20/2020
 ms.author: cynthn
 ---
 
@@ -62,7 +62,7 @@ By default, most Azure Marketplace images for Linux are configured to sync from 
 - NTP as primary, which gets time from an NTP server. For example, Ubuntu 16.04 LTS Marketplace images use **ntp.ubuntu.com**.
 - The VMICTimeSync service as secondary, used to communicate the host time to the VMs and make corrections after the VM is paused for maintenance. Azure hosts use Microsoft-owned Stratum 1 devices to keep accurate time.
 
-In newer Linux distributions, the VMICTimeSync service uses the precision time protocol (PTP), but earlier distributions may not support PTP and will fall-back to NTP for getting time from the host.
+In newer Linux distributions, the VMICTimeSync service provides a Precision Time Protocol (PTP) hardware clock source, but earlier distributions may not provide this clock source and will fall-back to NTP for getting time from the host.
 
 To confirm NTP is synchronizing correctly, run the `ntpq -p` command.
 
@@ -110,9 +110,9 @@ root        391      2  0 17:52 ?        00:00:00 [hv_balloon]
 ```
 
 
-### Check for PTP
+### Check for PTP Clock Source
 
-With newer versions of Linux, a Precision Time Protocol (PTP) clock source is available as part of the VMICTimeSync provider. On older versions of Red Hat Enterprise Linux or CentOS 7.x the [Linux Integration Services](https://github.com/LIS/lis-next) can be downloaded and used to install the updated driver. When using PTP, the Linux device will be of the form /dev/ptp*x*. 
+With newer versions of Linux, a Precision Time Protocol (PTP) clock source is available as part of the VMICTimeSync provider. On older versions of Red Hat Enterprise Linux or CentOS 7.x the [Linux Integration Services](https://github.com/LIS/lis-next) can be downloaded and used to install the updated driver. When the PTP clock source is available, the Linux device will be of the form /dev/ptp*x*. 
 
 See which PTP clock sources are available.
 


### PR DESCRIPTION
Tweak the text slightly to refer to a PTP clock source, which is what Linux guests have, rather than the PTP protocol, which is related but is really something completely different.