### PR TITLE
Add Azure CLI instructions to elevate access

### DIFF
--- a/articles/role-based-access-control/elevate-access-global-admin.md
+++ b/articles/role-based-access-control/elevate-access-global-admin.md
@@ -140,6 +140,22 @@ To remove the User Access Administrator role assignment for yourself or another 
 
 ## Azure CLI
 
+### Elevate access for a Global Administrator
+
+Use the following basic steps to elevate access for a Global Administrator using the Azure CLI.
+
+1. Use the [az rest](/cli/azure/reference-index?view=azure-cli-latest#az-rest) command to call the `elevateAccess` endpoint, which grants you the User Access Administrator role at root scope (`/`).
+
+```azurecli
+az rest --method post --url "/providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01"
+```
+
+1. Make the changes you need to make at elevated access.
+
+    For information about assigning roles, see [Add or remove Azure role assignments using the Azure CLI](role-assignments-cli.md).
+
+1. Perform the steps in a later section to remove your elevated access.
+
 ### List role assignment at root scope (/)
 
 To list the User Access Administrator role assignment for a user at root scope (`/`), use the [az role assignment list](/cli/azure/role/assignment#az-role-assignment-list) command.

--- a/articles/role-based-access-control/elevate-access-global-admin.md
+++ b/articles/role-based-access-control/elevate-access-global-admin.md
@@ -146,9 +146,9 @@ Use the following basic steps to elevate access for a Global Administrator using
 
 1. Use the [az rest](/cli/azure/reference-index?view=azure-cli-latest#az-rest) command to call the `elevateAccess` endpoint, which grants you the User Access Administrator role at root scope (`/`).
 
-```azurecli
-az rest --method post --url "/providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01"
-```
+    ```azurecli
+    az rest --method post --url "/providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01"
+    ```
 
 1. Make the changes you need to make at elevated access.
 


### PR DESCRIPTION
Use the `az rest` command to call the `elevateAccess` endpoint, which grants you the User Access Administrator role at root scope (`/`).