### PR TITLE
Update how-to-connect-password-hash-synchronization.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
+++ b/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
@@ -104,7 +104,7 @@ Continue with this operation?
 [Y] Yes [N] No [S] Suspend [?] Help (default is "Y"): y
 ```
 
-Once enabled, Azure AD does not go to each synchronized user to remove the `DisablePasswordExpiration` value from the PasswordPolicies attribute. Instead, the value is set to `None` during the next password sync for each user when they next change their password in on-premises AD.  
+Once enabled, Azure AD does not go to each synchronized user to remove the `DisablePasswordExpiration` value from the PasswordPolicies attribute. Instead, the `DisablePasswordExpiration` value is removed from PasswordPolicies during the next password hash sync for each user, upon their next password change in on-premises AD.
 
 It is recommended to enable EnforceCloudPasswordPolicyForPasswordSyncedUsers, prior to enabling password hash sync, so that the initial sync of password hashes does not add the `DisablePasswordExpiration` value to the PasswordPolicies attribute for the users.
 


### PR DESCRIPTION
Small adjustment from "Instead, the value is set to None during the next password sync for each user when they next change their password in on-premises AD.” to "Instead, the DisablePasswordExpiration value is removed from the PasswordPolicies during the next password sync for each user when they next change their password in on-premises AD. ” according to AAD Engineering (Dareen Radwan).