### PR TITLE
Added RBAC scope

### DIFF
--- a/articles/storage/files/storage-files-identity-ad-ds-enable.md
+++ b/articles/storage/files/storage-files-identity-ad-ds-enable.md
@@ -25,7 +25,7 @@ The cmdlets in the AzFilesHybrid PowerShell module make the necessary modificati
 
 - [Download and unzip the AzFilesHybrid module](https://github.com/Azure-Samples/azure-files-samples/releases) (GA module: v0.2.0+)
 - Install and execute the module in a device that is domain joined to on-premises AD DS with AD DS credentials that have permissions to create a service logon account or a computer account in the target AD.
--  Run the script using an on-premises AD DS credential that is synced to your Azure AD. The on-premises AD DS credential must have either the storage account owner or the contributor Azure role permissions.
+-  Run the script using an on-premises AD DS credential that is synced to your Azure AD. The on-premises AD DS credential must have either the storage account owner or the contributor Azure role permissions scoped at the resource group, subscription, or management group.
 
 ### Run Join-AzStorageAccountForAuth
 


### PR DESCRIPTION
I tested the permissions at the resource scope, with the principle of least privilege in mind, and received an error stating the resource group does not exist.  Once I gave the user principal the contributor role, scoped at the resource group, I was able to successfully run the Join-AzStorageAccountForAuth cmdlet.