### PR TITLE
Update active-directory-optional-claims.md

### DIFF
--- a/articles/active-directory/develop/active-directory-optional-claims.md
+++ b/articles/active-directory/develop/active-directory-optional-claims.md
@@ -55,7 +55,7 @@ The set of optional claims available by default for applications to use are list
 | `verified_secondary_email` | Sourced from the user's SecondaryAuthoritativeEmail   | JWT        |           |        |
 | `vnet`                     | VNET specifier information. | JWT        |           |      |
 | `fwd`                      | IP address.| JWT    |   | Adds the original IPv4 address of the requesting client (when inside a VNET) |
-| `ctry`                     | User's country/region | JWT |  | Azure AD returns the `ctry` optional claim if it's present and the value of the claim is a standard two-letter country/region code, such as FR, JP, SZ, and so on. |
+| `ctry`                     | User's country/region | JWT, SAML |  | Azure AD returns the `ctry` optional claim if it's present and the value of the claim is a standard two-letter country/region code, such as FR, JP, SZ, and so on. |
 | `tenant_ctry`              | Resource tenant's country/region | JWT | | |
 | `xms_pdl`             | Preferred data location   | JWT | | For Multi-Geo tenants, the preferred data location is the three-letter code showing the geographic region the user is in. For more info, see the [Azure AD Connect documentation about preferred data location](../hybrid/how-to-connect-sync-feature-preferreddatalocation.md).<br/>For example: `APC` for Asia Pacific. |
 | `xms_pl`                   | User preferred language  | JWT ||The user's preferred language, if set. Sourced from their home tenant, in guest access scenarios. Formatted LL-CC ("en-us"). |


### PR DESCRIPTION
Recommending this change to reflect SAML protocol as well, since tests are showing two-letter code for SAML token.
| `ctry`                     | User's country/region | JWT, SAML |  | Azure AD returns the `ctry` optional claim if it's present and the value of the claim is a standard two-letter country/region code, such as FR, JP, SZ, and so on. |
