### PR TITLE
Merge is not supported with Synapse (yet) - documentation is not accurate

### DIFF
--- a/articles/synapse-analytics/sql/overview-features.md
+++ b/articles/synapse-analytics/sql/overview-features.md
@@ -49,7 +49,7 @@ Query languages used in Synapse SQL can have different supported features depend
 | **INSERT statement** | Yes | No |
 | **UPDATE statement** | Yes | No |
 | **DELETE statement** | Yes | No |
-| **MERGE statement** | Yes | No |
+| **MERGE statement** | No | No |
 | **[Transactions](develop-transactions.md)** | Yes | No |
 | **[Labels](develop-label.md)** | Yes | No |
 | **Data load** | Yes. Preferred utility is [COPY](/sql/t-sql/statements/copy-into-transact-sql?toc=/azure/synapse-analytics/toc.json&bc=/azure/synapse-analytics/breadcrumb/toc.json&view=azure-sqldw-latest) statement, but the system supports both BULK load (BCP) and [CETAS](/sql/t-sql/statements/create-external-table-as-select-transact-sql?toc=/azure/synapse-analytics/toc.json&bc=/azure/synapse-analytics/breadcrumb/toc.json&view=azure-sqldw-latest) for data loading. | No |


### PR DESCRIPTION
This conflicts with other documentation as Merge is not supported in Synapse yet. This is confusing to customers as the documentation is not clear because this page says YES for merge under provisioned version of Synapse.

References:
https://docs.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver15
https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-develop-ctas#replace-merge-statements