### PR TITLE
Typo "git repo"→"Git repo"

### DIFF
--- a/articles/static-web-apps/publish-gatsby.md
+++ b/articles/static-web-apps/publish-gatsby.md
@@ -48,7 +48,7 @@ Create a Gatsby app using the Gatsby Command Line Interface (CLI):
    cd static-web-app
    ```
 
-1. Initialize a git repo
+1. Initialize a Git repo
 
    ```bash
    git init


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/static-web-apps/publish-gatsby