### PR TITLE
(forumsteam) fixes MicrosoftDocs/azure-docs#61163

### DIFF
--- a/articles/service-bus-messaging/service-bus-auto-forwarding.md
+++ b/articles/service-bus-messaging/service-bus-auto-forwarding.md
@@ -47,6 +47,9 @@ Service Bus bills one operation for each forwarded message. For example, sending
 
 To create a subscription that is chained to another queue or topic, the creator of the subscription must have **Manage** permissions on both the source and the destination entity. Sending messages to the source topic only requires **Send** permissions on the source topic.
 
+> [!Note]
+> Autoforwarding cannot be enabled on session-aware queues or subscriptions.
+
 ## Next steps
 
 For detailed information about autoforwarding, see the following reference topics:


### PR DESCRIPTION
Since Azure Portal shows that autoforwarding cannot be enabled on session-aware queues or subscriptions. I have added a note to reflect it on the document.