### PR TITLE
Update concepts-convention.md

### DIFF
--- a/articles/iot-pnp/concepts-convention.md
+++ b/articles/iot-pnp/concepts-convention.md
@@ -122,7 +122,7 @@ The device must add the `{"__t": "c"}` marker to indicate that the element refer
 
 The device should confirm that it received the property by sending a reported property. The reported property should include:
 
-- `value` - the value that the device received.
+- `value` - the actual value of the property (typically the received value, but the device may decide to report a different value).
 - `ac` - an acknowledgment code that uses an HTTP status code.
 - `av` - an acknowledgment version that refers to the `$version` of the desired property.
 - `ad` - an optional acknowledgment description.


### PR DESCRIPTION
Clarify it's not a requirement that the acknowledgement for a writeable property update reports the same value as the received value. Typically that is the case, but ultimately it's up to the device app to decide what is the right value to report. For example if the desired value is actually invalid then the device would not accept it and instead report its current valid value.