### PR TITLE
Update scale-streaming-cdn.md

### DIFF
--- a/articles/media-services/latest/scale-streaming-cdn.md
+++ b/articles/media-services/latest/scale-streaming-cdn.md
@@ -43,7 +43,7 @@ This topic discusses enabling [CDN integration](#enable-azure-cdn-integration). 
 
 After a streaming endpoint is provisioned with CDN enabled, there's a defined wait time on Media Services before DNS update is done to map the streaming endpoint to CDN endpoint.
 
-If you later want to disable/enable the CDN, your streaming endpoint must be in the **stopped** state. Once the streaming endpoint is started it could take up to two hours for the Azure CDN integration to be enabled and for the changes to be active across all the CDN POPs. However, you can start your streaming endpoint and stream without interruptions from the streaming endpoint. Once the integration is complete, the stream is delivered from the CDN. During the provisioning period, your streaming endpoint will be in the **starting** state and you might observe degraded performance.
+If you later want to disable/enable the CDN, your streaming endpoint must be in the **stopped** state. Once the streaming endpoint is started it could take up to four hours for the Azure CDN integration to be enabled and for the changes to be active across all the CDN POPs. However, you can start your streaming endpoint and stream without interruptions from the streaming endpoint. Once the integration is complete, the stream is delivered from the CDN. During the provisioning period, your streaming endpoint will be in the **starting** state and you might observe degraded performance.
 
 When the Standard streaming endpoint is created, it's configured by default with Standard Verizon. You can configure Premium Verizon or Standard Akamai providers using REST APIs.
 


### PR DESCRIPTION
Changed CDN enable propagation time from two to four hours based on feedback from support. Customers report consistently that it takes 4 hours.