### PR TITLE
Update howto-authentication-methods-usage-insights.md

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-methods-usage-insights.md
+++ b/articles/active-directory/authentication/howto-authentication-methods-usage-insights.md
@@ -28,7 +28,7 @@ The following roles can access usage and insights:
 - Security Administrator
 - Reports Reader
 
-No additional licensing is required to access usage and insights. Azure Multi-Factor Authentication and self-service password reset (SSPR) licensing information can be found on the [Azure Active Directory pricing site](https://azure.microsoft.com/pricing/details/active-directory/).
+Azure AD Premium license is required to view usage and insights reports. Azure Multi-Factor Authentication and self-service password reset (SSPR) licensing information can be found on the [Azure Active Directory pricing site](https://azure.microsoft.com/pricing/details/active-directory/).
 
 ## How it works
 


### PR DESCRIPTION
CSS wiki implies AAD Premium license is required. In test tenant, I confirmed that I cannot see actual usages information without AAD Premium licenses in the tenant.

https://supportability.visualstudio.com/AzureAD/_wiki/wikis/AzureAD/214228/Data-Insights-for-Self-Service-Password-Reset-(SSPR)-Multi-Factor-Authentication-(MFA)?anchor=roles-and-licensing

>If you do not have the appropriate licensing, users will not be able to reset their passwords and you will not see password reset data in the reports.