### PR TITLE
Fix note about 404 with no ingress rules

### DIFF
--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -64,7 +64,7 @@ nginx-ingress-controller         LoadBalancer   10.0.61.144    EXTERNAL_IP   80:
 nginx-ingress-default-backend    ClusterIP      10.0.192.145   <none>        80/TCP                       6m2s
 ```
 
-No ingress rules have been created yet, so the NGINX ingress controller's default 404 page is displayed if you browse to the internal IP address. Ingress rules are configured in the following steps.
+No ingress rules have been created yet, so the NGINX ingress controller's default 404 page is displayed if you browse to the external IP address. Ingress rules are configured in the following steps.
 
 ## Run demo applications
 


### PR DESCRIPTION
The existing note explains to expect a 404 when navigating to the internal ip address.

I believe the intention is that users should expect a 404 when navigating to the *external* ip address, which I've confirmed is the case at this stage in the guide.