### PR TITLE
Fix bug at "Using a client secret" section

### DIFF
--- a/articles/storage/common/storage-use-azcopy-v10.md
+++ b/articles/storage/common/storage-use-azcopy-v10.md
@@ -153,7 +153,7 @@ $env:AZCOPY_SPA_CLIENT_SECRET="$(Read-Host -prompt "Enter key")"
 Next, type the following command, and then press the ENTER key.
 
 ```azcopy
-azcopy login --service-principal --certificate-path path-to-certificate-file --application-id application-id --tenant-id=tenant-id
+azcopy login --service-principal  --application-id application-id --tenant-id=tenant-id
 ```
 
 Replace the `<application-id>` placeholder with the application ID of your service principal's app registration. Replace the `<tenant-id>` placeholder with the tenant ID of the organization to which the storage account belongs. To find the tenant ID, select **Azure Active Directory > Properties > Directory ID** in the Azure portal. 


### PR DESCRIPTION
Remove --certificate-path path-to-certificate-file in command line.
The parameter --certificate-path path-to-certificate-file is not needed when login by client secret. --certificate-path only available when login by certificate.

User will be confused to offer --certificate-path parameter when login by client secret.