### PR TITLE
Added consent per device terms-of-use.md

### DIFF
--- a/articles/active-directory/conditional-access/terms-of-use.md
+++ b/articles/active-directory/conditional-access/terms-of-use.md
@@ -266,6 +266,8 @@ Per-device terms of use has the following constraints:
 
 If the user's device is not joined, they will receive a message that they need to join their device. Their experience will be dependent on the platform and software.
 
+Note:- Consent per device is not supported when you have Intune enrollment app included in conditional access policy. We need to exclude Intune enrollment app from CA policy to support the feature consent per device in TOU.
+
 ### Join a Windows 10 device
 
 If a user is using Windows 10 and Microsoft Edge, they will receive a message similar to the following to [join their device](../user-help/user-help-join-device-on-network.md#to-join-an-already-configured-windows-10-device).


### PR DESCRIPTION
Note:- Consent per device is not supported when you have Intune enrollment app included in conditional access policy. We need to exclude Intune enrollment app from CA policy to support the feature consent per device in TOU.