### PR TITLE
Update with correctly working example

### DIFF
--- a/articles/virtual-machines/windows/build-image-with-packer.md
+++ b/articles/virtual-machines/windows/build-image-with-packer.md
@@ -98,7 +98,7 @@ Create a file named *windows.json* and paste the following content. Enter your o
         "task": "Image deployment"
     },
 
-    "location": "East US",
+    "build_resource_group_name": "myPackerGroup",
     "vm_size": "Standard_D2_v2"
   }],
   "provisioners": [{


### PR DESCRIPTION
This example will not work, fails with a 403 -
```
==> azure-arm: Running builder ...
==> azure-arm: Getting tokens using client secret
==> azure-arm: Getting tokens using client secret
    azure-arm: Creating Azure Resource Manager (ARM) client ...
==> azure-arm: WARNING: Zone resiliency may not be supported in UK South, checkout the docs at https://docs.microsoft.com/en-us/azure/availability-zones/
==> azure-arm: ERROR: -> ResourceNotFound : The Resource 'Microsoft.Compute/images/WIN2016BASE' under resource group 'MY-RG' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix
==> azure-arm:
==> azure-arm: resources.GroupsClient#CheckExistence: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: error response cannot be parsed: "" error: EOF
Build 'azure-arm' errored: resources.GroupsClient#CheckExistence: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: error response cannot be parsed: "" error: EOF

==> Some builds didn't complete successfully and had errors:
--> azure-arm: resources.GroupsClient#CheckExistence: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: error response cannot be parsed: "" error: EOF

Fails unless the following is set -
```
"build_resource_group_name": "myPackerGroup" is set.

```$ packer version
Packer v1.6.1
```