### PR TITLE
Updated claim resolver overview in OAuth2 section

### DIFF
--- a/articles/active-directory-b2c/claim-resolver-overview.md
+++ b/articles/active-directory-b2c/claim-resolver-overview.md
@@ -109,6 +109,7 @@ Any parameter name included as part of an OIDC or OAuth2 request can be mapped t
 | Claim | Description | Example |
 | ----- | ----------------------- | --------|
 | {oauth2:access_token} | The access token. | N/A |
+| {oauth2:refresh_token} | The refresh token. | N/A |
 
 
 ### SAML


### PR DESCRIPTION
Added `refresh_token` claim resolver for `OAuth2`which was missing in the documentation.