### PR TITLE
Add Azure CLI command to delete diagnostic setting

### DIFF
--- a/articles/spring-cloud/spring-cloud-faq.md
+++ b/articles/spring-cloud/spring-cloud-faq.md
@@ -84,6 +84,12 @@ Yes.
 
 It depends on the logic of resource providers that own the extension resources. The extension resources of a `Microsoft.AppPlatform` instance do not belong to the same namespace, so the behavior varies by resource provider. For example, the delete/move operation will not cascade to the **diagnostics settings** resources. If a new Azure Spring Cloud instance is provisioned with the same resource ID as the deleted one, or if the previous Azure Spring Cloud instance is moved back, the previous **diagnostics settings** resources continue extending it.
 
+You can delete Spring Cloud's diagnostic settings by using Azure CLI:
+
+```azurecli
+ az monitor diagnostic-settings delete --name $diagnosticSettingName --resource $azureSpringCloudResourceId
+```
+
 ## Java runtime and OS versions
 
 ### Which versions of Java runtime are supported in Azure Spring Cloud?


### PR DESCRIPTION
One of our customers struggled to figure out how to delete the unremoved diagnostic setting. The "already exists" error message provides the resource ID of the diagnostic setting, but using `az resource delete` does not work. Hence, adding less obvious but effective instructions for how to delete the stale diagnostic setting.