### PR TITLE
Update cosmosdb naming convention

### DIFF
--- a/articles/azure-resource-manager/management/resource-name-rules.md
+++ b/articles/azure-resource-manager/management/resource-name-rules.md
@@ -343,6 +343,7 @@ In the following tables, the term alphanumeric refers to:
 > [!div class="mx-tableFixed"]
 > | Entity | Scope | Length | Valid Characters |
 > | --- | --- | --- | --- |
+> | account | global | 3-31 | The name can only contain lowercase letters, numbers, and the hyphen (-) character. Globally unique. |
 > | databaseAccounts | global | 3-44 | Lowercase letters, numbers, and hyphens.<br><br>Start with lowercase letter or number. |
 
 ## Microsoft.EventGrid


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/azure/cosmos-db/create-cosmosdb-resources-portal the account name must be between 3 and 31 characters, not 44. Does the 44 character limit apply to the Microsoft.DocumentDB/databaseAccounts/sqlDatabases or other database types?