### PR TITLE
Typo in Distribute settings of the image builder

### DIFF
--- a/articles/virtual-machines/linux/image-builder-json.md
+++ b/articles/virtual-machines/linux/image-builder-json.md
@@ -565,7 +565,7 @@ Before you can distribute to the Image Gallery, you must create a gallery and an
 
 ```json
 {
-    "type": "sharedImage",
+    "type": "SharedImage",
     "galleryImageId": "<resource ID>",
     "runOutputName": "<name>",
     "artifactTags": {


### PR DESCRIPTION
Using sharedImage in the ARM template instead of SharedImage results in a validation error:

`"message": "Validation failed: 'ImageTemplate.properties': Field 'distribute[0].type' has a bad value: ''.`