### PR TITLE
Update quickstart-dotnet-core-app.md

### DIFF
--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -40,7 +40,7 @@ You use the [.NET Core command-line interface (CLI)](https://docs.microsoft.com/
 
 1. Create a new folder for your project.
 
-2. In the new folder, run the following command to create a new ASP.NET Core console app project:
+2. In the new folder, run the following command to create a new .NET Core console app project:
 
     ```dotnetcli
     dotnet new console


### PR DESCRIPTION
Fix a naming typo from ASP.NET Core console app to .NET Core console app.