### PR TITLE
Update openvpn-azure-ad-client.md w/AAD auth info

### DIFF
--- a/articles/vpn-gateway/openvpn-azure-ad-client.md
+++ b/articles/vpn-gateway/openvpn-azure-ad-client.md
@@ -16,6 +16,7 @@ This article helps you configure a VPN client to connect to a virtual network us
 
 > [!NOTE]
 > Azure AD authentication is supported only for OpenVPN® protocol connections.
+> Azure AD authentication requires the Azure VPN client which is available only for Windows 10.
 >
 
 ## <a name="profile"></a>Working with client profiles

--- a/articles/vpn-gateway/openvpn-azure-ad-client.md
+++ b/articles/vpn-gateway/openvpn-azure-ad-client.md
@@ -16,7 +16,8 @@ This article helps you configure a VPN client to connect to a virtual network us
 
 > [!NOTE]
 > Azure AD authentication is supported only for OpenVPN® protocol connections.
-> Azure AD authentication requires the Azure VPN client which is available only for Windows 10.
+>
+> Azure AD authentication requires the Azure VPN client, which is available only for Windows 10.
 >
 
 ## <a name="profile"></a>Working with client profiles


### PR DESCRIPTION
Azure AD authentication requires the Azure VPN Client which is only available for Windows 10. People with other OSs such as MacOS, iOS, Linux, and Android do not have a clearly stated notification that Azure AD auth is not supported on their operating system.

This can lead to many lost hours in planning, attempting implementation, and troubleshooting if using unsupported OS with Azure AD auth.

There is a Note near top of the page saying "Azure AD authentication is supported only for OpenVPN protocol connections" but that is misleading because the other OSs can support OpenVPN connections. They just do not support Azure AD auth.

I suggest adding another line to that Note saying something similar to "Azure AD authentication requires the Azure VPN Client which is available only for Windows 10."