### PR TITLE
Update documentation for cognitive service - Read on-prem container

### DIFF
--- a/articles/cognitive-services/Computer-vision/computer-vision-how-to-install-containers.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-how-to-install-containers.md
@@ -181,6 +181,9 @@ The `operation-location` is the fully qualified URL and is accessed via an HTTP 
 }
 ```
 
+> [!IMPORTANT]
+> When deploying multiple Read containers behind a load balancer, for example, under docker compose or Kubernetes, an external cache is needed. Because the processing container and the GET request container may not be the same one, an external cache is used to store the results and share accross containers. The detail of cache setting can be found at [Configure Computer Vision Docker containers](https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/computer-vision-resource-container-config).
+
 ### Synchronous read
 
 You can use the `POST /vision/v2.0/read/core/Analyze` operation to synchronously read an image. When the image is read in its entirety, then and only then does the API return a JSON response. The only exception to this is if an error occurs. When an error occurs the following JSON is returned:

--- a/articles/cognitive-services/Computer-vision/computer-vision-how-to-install-containers.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-how-to-install-containers.md
@@ -50,6 +50,7 @@ The **host** computer is the computer that runs the docker container. The host *
 ```console
 grep -q avx2 /proc/cpuinfo && echo AVX2 supported || echo No AVX2 support detected
 ```
+
 > [!WARNING]
 > The host computer is *required* to support AVX2. The container *will not* function correctly without AVX2 support.
 
@@ -182,7 +183,7 @@ The `operation-location` is the fully qualified URL and is accessed via an HTTP 
 ```
 
 > [!IMPORTANT]
-> When deploying multiple Read containers behind a load balancer, for example, under docker compose or Kubernetes, an external cache is needed. Because the processing container and the GET request container may not be the same one, an external cache is used to store the results and share accross containers. The detail of cache setting can be found at [Configure Computer Vision Docker containers](https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/computer-vision-resource-container-config).
+> If you deploy multiple Read containers behind a load balancer, for example, under Docker Compose or Kubernetes, you must have an external cache. Because the processing container and the GET request container might not be the same, an external cache stores the results and shares them across containers. For details about cache settings, see [Configure Computer Vision Docker containers](https://docs.microsoft.com/azure/cognitive-services/computer-vision/computer-vision-resource-container-config).
 
 ### Synchronous read
 
@@ -190,7 +191,7 @@ You can use the `POST /vision/v2.0/read/core/Analyze` operation to synchronously
 
 ```json
 {
-    status: "Failed"
+    "status": "Failed"
 }
 ```
 

--- a/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
@@ -24,14 +24,14 @@ You configure the Computer Vision container's runtime environment by using the `
 > [!IMPORTANT]
 > The [`ApiKey`](#apikey-configuration-setting), [`Billing`](#billing-configuration-setting), and [`Eula`](#eula-setting) settings are used together, and you must provide valid values for all three of them; otherwise your container won't start. For more information about using these configuration settings to instantiate a container, see [Billing](computer-vision-how-to-install-containers.md).
 
-The container also has the following container specific configuration settings:
+The container also has the following container-specific configuration settings:
 
 |Required|Setting|Purpose|
 |--|--|--|
-|No|ReadEngineConfig:ResultExpirationPeriod|Result expiration period in hours. Default is 48 hours. The setting specifies when the system should clear recognition results. For example, resultExpirationPeriod=1, the system will clear the recognition result 1hr after the process. resultExpirationPeriod=0, the system will clear the recognition result after result retrieval.|
-|No|Cache:Redis|Enables Redis storage for result storing. A cache is **REQUIRED** if multiple read containers are placed behind load balancer.|
-|No|Queue:RabbitMQ|Enables RabbitMQ for tasks dispatching. This can be useful when multiple read containers are placed behind load balancer.|
-|No|Storage::DocumentStore::MongoDB|Enables MongoDB for permanent result storing.|
+|No|ReadEngineConfig:ResultExpirationPeriod|Result expiration period in hours. The default is 48 hours. The setting specifies when the system should clear recognition results. For example, for `resultExpirationPeriod=1`, the system clears the recognition result 1 hour after the process. For `resultExpirationPeriod=0`, the system clears the recognition result after the result is retrieved.|
+|No|Cache:Redis|Enables Redis storage for storing results. A cache is *required* if multiple read containers are placed behind a load balancer.|
+|No|Queue:RabbitMQ|Enables RabbitMQ for dispatching tasks. The setting is useful when multiple read containers are placed behind a load balancer.|
+|No|Storage::DocumentStore::MongoDB|Enables MongoDB for permanent result storage.|
 
 ## ApiKey configuration setting
 

--- a/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
@@ -24,6 +24,15 @@ You configure the Computer Vision container's runtime environment by using the `
 > [!IMPORTANT]
 > The [`ApiKey`](#apikey-configuration-setting), [`Billing`](#billing-configuration-setting), and [`Eula`](#eula-setting) settings are used together, and you must provide valid values for all three of them; otherwise your container won't start. For more information about using these configuration settings to instantiate a container, see [Billing](computer-vision-how-to-install-containers.md).
 
+The container also has the following container specific configuration settings:
+
+|Required|Setting|Purpose|
+|--|--|--|
+|No|ReadEngineConfig:ResultExpirationPeriod|Result expiration period in hours. Default is 48 hours. The setting specifies when the system should clear recognition results. For example, resultExpirationPeriod=1, the system will clear the recognition result 1hr after the process. resultExpirationPeriod=0, the system will clear the recognition result after result retrieval.|
+|No|Cache:Redis|Enablse Redis storage for result storing. A cache is **REQUIRED** if multiple read containers are placed behind load balancer.|
+|No|Queue:RabbitMQ|Eables RabbitMQ for tasks dispatching. This can be useful when multiple read containers are placed behind load balancer.|
+|No|Storage::DocumentStore::MongoDB|Enables MongoDB for permenant result storing.|
+
 ## ApiKey configuration setting
 
 The `ApiKey` setting specifies the Azure `Cognitive Services` resource key used to track billing information for the container. You must specify a value for the ApiKey and the value must be a valid key for the _Cognitive Services_ resource specified for the [`Billing`](#billing-configuration-setting) configuration setting.

--- a/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
@@ -29,9 +29,9 @@ The container also has the following container specific configuration settings:
 |Required|Setting|Purpose|
 |--|--|--|
 |No|ReadEngineConfig:ResultExpirationPeriod|Result expiration period in hours. Default is 48 hours. The setting specifies when the system should clear recognition results. For example, resultExpirationPeriod=1, the system will clear the recognition result 1hr after the process. resultExpirationPeriod=0, the system will clear the recognition result after result retrieval.|
-|No|Cache:Redis|Enablse Redis storage for result storing. A cache is **REQUIRED** if multiple read containers are placed behind load balancer.|
-|No|Queue:RabbitMQ|Eables RabbitMQ for tasks dispatching. This can be useful when multiple read containers are placed behind load balancer.|
-|No|Storage::DocumentStore::MongoDB|Enables MongoDB for permenant result storing.|
+|No|Cache:Redis|Enables Redis storage for result storing. A cache is **REQUIRED** if multiple read containers are placed behind load balancer.|
+|No|Queue:RabbitMQ|Enables RabbitMQ for tasks dispatching. This can be useful when multiple read containers are placed behind load balancer.|
+|No|Storage::DocumentStore::MongoDB|Enables MongoDB for permanent result storing.|
 
 ## ApiKey configuration setting
 

--- a/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
+++ b/articles/cognitive-services/Computer-vision/computer-vision-resource-container-config.md
@@ -28,7 +28,7 @@ The container also has the following container-specific configuration settings:
 
 |Required|Setting|Purpose|
 |--|--|--|
-|No|ReadEngineConfig:ResultExpirationPeriod|Result expiration period in hours. The default is 48 hours. The setting specifies when the system should clear recognition results. For example, for `resultExpirationPeriod=1`, the system clears the recognition result 1 hour after the process. For `resultExpirationPeriod=0`, the system clears the recognition result after the result is retrieved.|
+|No|ReadEngineConfig:ResultExpirationPeriod|Result expiration period in hours. The default is 48 hours. The setting specifies when the system should clear recognition results. For example, if `resultExpirationPeriod=1`, the system clears the recognition result 1 hour after the process. If `resultExpirationPeriod=0`, the system clears the recognition result after the result is retrieved.|
 |No|Cache:Redis|Enables Redis storage for storing results. A cache is *required* if multiple read containers are placed behind a load balancer.|
 |No|Queue:RabbitMQ|Enables RabbitMQ for dispatching tasks. The setting is useful when multiple read containers are placed behind a load balancer.|
 |No|Storage::DocumentStore::MongoDB|Enables MongoDB for permanent result storage.|

--- a/articles/cognitive-services/Computer-vision/deploy-computer-vision-on-premises.md
+++ b/articles/cognitive-services/Computer-vision/deploy-computer-vision-on-premises.md
@@ -143,6 +143,9 @@ read:
 > [!IMPORTANT]
 > If the `billing` and `apikey` values are not provided, the services will expire after 15 min. Likewise, verification will fail as the services will not be available.
 
+> [!IMPORTANT]
+> When deploying multiple Read containers behind a load balancer, for example, under docker compose or Kubernetes, an external cache is needed. Because the processing container and the GET request container may not be the same one, an external cache is used to store the results and share accross containers. The detail of cache setting can be found at [Configure Computer Vision Docker containers](https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/computer-vision-resource-container-config).
+
 Create a *templates* folder under the *read* directory. Copy and paste the following YAML into a file named `deployment.yaml`. The `deployment.yaml` file will serve as a Helm template.
 
 > Templates generate manifest files, which are YAML-formatted resource descriptions that Kubernetes can understand. [- Helm Chart Template Guide][chart-template-guide]

--- a/articles/cognitive-services/Computer-vision/deploy-computer-vision-on-premises.md
+++ b/articles/cognitive-services/Computer-vision/deploy-computer-vision-on-premises.md
@@ -84,7 +84,7 @@ containerpreview      kubernetes.io/dockerconfigjson        1         30s
 
 ## Configure Helm chart values for deployment
 
-Start by creating a folder named *read*, then paste the following YAML content into a new file named *Chart.yaml*.
+Begin by creating a folder named *read*. Then, paste the following YAML content in a new file named `chart.yaml`:
 
 ```yaml
 apiVersion: v2
@@ -141,10 +141,10 @@ read:
 ```
 
 > [!IMPORTANT]
-> If the `billing` and `apikey` values are not provided, the services will expire after 15 min. Likewise, verification will fail as the services will not be available.
-
-> [!IMPORTANT]
-> When deploying multiple Read containers behind a load balancer, for example, under docker compose or Kubernetes, an external cache is needed. Because the processing container and the GET request container may not be the same one, an external cache is used to store the results and share accross containers. The detail of cache setting can be found at [Configure Computer Vision Docker containers](https://docs.microsoft.com/en-us/azure/cognitive-services/computer-vision/computer-vision-resource-container-config).
+> - If the `billing` and `apikey` values aren't provided, the services expire after 15 minutes. Likewise, verification fails because the services aren't available.
+> 
+> - If you deploy multiple Read containers behind a load balancer, for example, under Docker Compose or Kubernetes, you must have an external cache. Because the processing container and the GET request container might not be the same, an external cache stores the results and shares them across containers. For details about cache settings, see [Configure Computer Vision Docker containers](https://docs.microsoft.com/azure/cognitive-services/computer-vision/computer-vision-resource-container-config).
+>
 
 Create a *templates* folder under the *read* directory. Copy and paste the following YAML into a file named `deployment.yaml`. The `deployment.yaml` file will serve as a Helm template.
 
@@ -202,6 +202,7 @@ spec:
   selector:
     app: read-app
 ```
+
 In the same *templates* folder, copy and paste the following helper functions into `helpers.tpl`. `helpers.tpl` defines useful functions to help generate Helm template.
 
 ```yaml

--- a/articles/cognitive-services/Computer-vision/deploy-computer-vision-on-premises.md
+++ b/articles/cognitive-services/Computer-vision/deploy-computer-vision-on-premises.md
@@ -84,16 +84,25 @@ containerpreview      kubernetes.io/dockerconfigjson        1         30s
 
 ## Configure Helm chart values for deployment
 
-Start by creating a folder named *read*, then paste the following YAML content into a new file named *Chart.yml*.
+Start by creating a folder named *read*, then paste the following YAML content into a new file named *Chart.yaml*.
 
 ```yaml
-apiVersion: v1
+apiVersion: v2
 name: read
 version: 1.0.0
 description: A Helm chart to deploy the microsoft/cognitive-services-read to a Kubernetes cluster
+dependencies:
+- name: rabbitmq
+  condition: read.image.args.rabbitmq.enabled
+  version: ^6.12.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
+- name: redis
+  condition: read.image.args.redis.enabled
+  version: ^6.0.0
+  repository: https://kubernetes-charts.storage.googleapis.com/
 ```
 
-To configure the Helm chart default values, copy and paste the following YAML into a file named `values.yaml`. Replace the `# {ENDPOINT_URI}` and `# {API_KEY}` comments with your own values.
+To configure the Helm chart default values, copy and paste the following YAML into a file named `values.yaml`. Replace the `# {ENDPOINT_URI}` and `# {API_KEY}` comments with your own values. Configure resultExpirationPeriod, Redis, and RabbitMQ if needed.
 
 ```yaml
 # These settings are deployment specific and users can provide customizations
@@ -102,7 +111,7 @@ read:
   enabled: true
   image:
     name: cognitive-services-read
-    registry: containerpreview.azurecr.io/
+    registry:  containerpreview.azurecr.io/
     repository: microsoft/cognitive-services-read
     tag: latest
     pullSecret: containerpreview # Or an existing secret
@@ -110,6 +119,25 @@ read:
       eula: accept
       billing: # {ENDPOINT_URI}
       apikey: # {API_KEY}
+      
+      # Result expiration period setting. Specify when the system should clean up recognition results.
+      # For example, resultExpirationPeriod=1, the system will clear the recognition result 1hr after the process.
+      # resultExpirationPeriod=0, the system will clear the recognition result after result retrieval.
+      resultExpirationPeriod: 1
+      
+      # Redis storage, if configured, will be used by read container to store result records.
+      # A cache is required if multiple read containers are placed behind load balancer.
+      redis:
+        enabled: false # {true/false}
+        password: password
+
+      # RabbitMQ is used for dispatching tasks. This can be useful when multiple read containers are
+      # placed behind load balancer.
+      rabbitmq:
+        enabled: false # {true/false}
+        rabbitmq:
+          username: user
+          password: password
 ```
 
 > [!IMPORTANT]
@@ -120,15 +148,20 @@ Create a *templates* folder under the *read* directory. Copy and paste the follo
 > Templates generate manifest files, which are YAML-formatted resource descriptions that Kubernetes can understand. [- Helm Chart Template Guide][chart-template-guide]
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: read
+  labels:
+    app: read-deployment
 spec:
+  selector:
+    matchLabels:
+      app: read-app
   template:
     metadata:
       labels:
-        app: read-app
+        app: read-app       
     spec:
       containers:
       - name: {{.Values.read.image.name}}
@@ -142,14 +175,23 @@ spec:
           value: {{.Values.read.image.args.billing}}
         - name: apikey
           value: {{.Values.read.image.args.apikey}}
+        args:        
+        - ReadEngineConfig:ResultExpirationPeriod={{ .Values.read.image.args.resultExpirationPeriod }}
+        {{- if .Values.read.image.args.rabbitmq.enabled }}
+        - Queue:RabbitMQ:HostName={{ include "rabbitmq.hostname" . }}
+        - Queue:RabbitMQ:Username={{ .Values.read.image.args.rabbitmq.rabbitmq.username }}
+        - Queue:RabbitMQ:Password={{ .Values.read.image.args.rabbitmq.rabbitmq.password }}
+        {{- end }}      
+        {{- if .Values.read.image.args.redis.enabled }}
+        - Cache:Redis:Configuration={{ include "redis.connStr" . }}
+        {{- end }}
       imagePullSecrets:
-      - name: {{.Values.read.image.pullSecret}}
-
+      - name: {{.Values.read.image.pullSecret}}      
 --- 
 apiVersion: v1
 kind: Service
 metadata:
-  name: read
+  name: read-service
 spec:
   type: LoadBalancer
   ports:
@@ -157,7 +199,21 @@ spec:
   selector:
     app: read-app
 ```
+In the same *templates* folder, copy and paste the following helper functions into `helpers.tpl`. `helpers.tpl` defines useful functions to help generate Helm template.
 
+```yaml
+{{- define "rabbitmq.hostname" -}}
+{{- printf "%s-rabbitmq" .Release.Name -}}
+{{- end -}}
+
+{{- define "redis.connStr" -}}
+{{- $hostMaster := printf "%s-redis-master:6379" .Release.Name }}
+{{- $hostSlave := printf "%s-redis-slave:6379" .Release.Name -}}
+{{- $passWord := printf "password=%s" .Values.read.image.args.redis.password -}}
+{{- $connTail := "ssl=False,abortConnect=False" -}}
+{{- printf "%s,%s,%s,%s" $hostMaster $hostSlave $passWord $connTail -}}
+{{- end -}}
+```
 The template specifies a load balancer service and the deployment of your container/image for Read.
 
 ### The Kubernetes package (Helm chart)


### PR DESCRIPTION
This PR adds more documentation for recent Read on-prem container updates.
This includes:

- Configuration for cache, queue, storage, and expiration settings
- Sample helm charts
- Emphasis on cache requirement for multi-pod scenario