### PR TITLE
"Risky" is now confusing

### DIFF
--- a/articles/active-directory/conditional-access/overview.md
+++ b/articles/active-directory/conditional-access/overview.md
@@ -77,7 +77,7 @@ Many organizations have [common access concerns that Conditional Access policies
 - Blocking sign-ins for users attempting to use legacy authentication protocols
 - Requiring trusted locations for Azure Multi-Factor Authentication registration
 - Blocking or granting access from specific locations
-- Blocking risky sign-in behaviors
+- Blocking undesired sign-in behaviors
 - Requiring organization-managed devices for specific applications
 
 ## Customer case studies


### PR DESCRIPTION
I received some feedback from the field that the use of "Risky" here is now confusing with availability of CA policies based on Sign-in Risk (which requires P2 license). Later in the article we correctly state that CA only requires P1.