### PR TITLE
Should be modified a variable name.

### DIFF
--- a/articles/storage/files/storage-sync-files-planning.md
+++ b/articles/storage/files/storage-sync-files-planning.md
@@ -131,9 +131,8 @@ Invoke-AzStorageSyncCompatibilityCheck -ComputerName <computer name> -SkipNamesp
  
 To display the results in CSV:
 ```powershell
-$errors = Invoke-AzStorageSyncCompatibilityCheck […]
-$validation.Results | Select-Object -Property Type, Path, Level, Description, Result | Export-Csv -Path
-    C:\results.csv -Encoding utf8
+$validation = Invoke-AzStorageSyncCompatibilityCheck C:\DATA
+$validation.Results | Select-Object -Property Type, Path, Level, Description, Result | Export-Csv -Path C:\results.csv -Encoding utf8
 ```
 
 ### File system compatibility


### PR DESCRIPTION
"$errors" is not appropriate variable. Appropriate name might be "$validation".
Copied from example-3 from https://docs.microsoft.com/en-us/powershell/module/az.storagesync/invoke-azstoragesynccompatibilitycheck?view=azps-4.6.1#example-3.

Japanese Docs page also should be modified.
https://docs.microsoft.com/ja-jp/azure/storage/files/storage-sync-files-planning#usage