### PR TITLE
Update key-vault-sp-creation.md

### DIFF
--- a/includes/key-vault-sp-creation.md
+++ b/includes/key-vault-sp-creation.md
@@ -16,7 +16,7 @@ For the sake of simplicity however, this quickstart creates a desktop applicatio
 Create a service principal using the Azure CLI [az ad sp create-for-rbac](/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac) command:
 
 ```azurecli
-az ad sp create-for-rbac -n "http://<my-unique-service-principal-name>" --sdk-auth
+az ad sp create-for-rbac --skip-assignment -n "http://<my-unique-service-principal-name>" --sdk-auth
 ```
 
 This operation will return a series of key / value pairs.


### PR DESCRIPTION
The Service Principle creation is too much open for the permission (Contributor by default), so it should put --skip-assignment for only use of Key Vault.