### PR TITLE
Make cross-link more apparent.

### DIFF
--- a/articles/app-service/tutorial-python-postgresql-app.md
+++ b/articles/app-service/tutorial-python-postgresql-app.md
@@ -20,7 +20,7 @@ In this tutorial, you use the Azure CLI to complete the following tasks:
 > * View diagnostic logs
 > * Manage the web app in the Azure portal
 
-You can also use the [Azure portal version of this tutorial](/azure/developer/python/tutorial-python-postgresql-app-portal).
+#### You can also use the [Azure portal version of this tutorial](/azure/developer/python/tutorial-python-postgresql-app-portal).
 
 
 ## Set up your initial environment


### PR DESCRIPTION
Make the option for using the portal more apparent. Only 1% of total users click this link but we know 60% of new users create in the portal first. I think it's a discoverability issue (hard to see when scanning). Bolding might help.