### PR TITLE
Allow kubectl commands to be copy and pasted

### DIFF
--- a/articles/aks/ingress-static-ip.md
+++ b/articles/aks/ingress-static-ip.md
@@ -167,8 +167,12 @@ spec:
 To create the issuer, use the `kubectl apply` command.
 
 ```
-$ kubectl apply -f cluster-issuer.yaml --namespace ingress-basic
+kubectl apply -f cluster-issuer.yaml --namespace ingress-basic
+```
 
+This should produce an output similar to:
+
+```
 clusterissuer.cert-manager.io/letsencrypt-staging created
 ```
 
@@ -305,8 +309,12 @@ spec:
 Create the ingress resource using the `kubectl apply` command.
 
 ```
-$ kubectl apply -f hello-world-ingress.yaml --namespace ingress-basic
+kubectl apply -f hello-world-ingress.yaml --namespace ingress-basic
+```
 
+This should return an output similar to:
+
+```
 ingress.extensions/hello-world-ingress created
 ```
 

--- a/articles/aks/ingress-static-ip.md
+++ b/articles/aks/ingress-static-ip.md
@@ -170,7 +170,7 @@ To create the issuer, use the `kubectl apply` command.
 kubectl apply -f cluster-issuer.yaml --namespace ingress-basic
 ```
 
-This should produce an output similar to:
+The output should be similar to this example:
 
 ```
 clusterissuer.cert-manager.io/letsencrypt-staging created
@@ -312,7 +312,7 @@ Create the ingress resource using the `kubectl apply` command.
 kubectl apply -f hello-world-ingress.yaml --namespace ingress-basic
 ```
 
-This should return an output similar to:
+The output should be similar to this example:
 
 ```
 ingress.extensions/hello-world-ingress created


### PR DESCRIPTION
There are two kubectl commands that are buried behind a shell prompt and followed by the output. A straight copy and paste fails because of the leading $ sign, and adds the sample output as a new command.

This pull request splits the command in the actual command and the expected output.