### PR TITLE
Public Preview status for durable-python

### DIFF
--- a/articles/azure-functions/durable/durable-functions-overview.md
+++ b/articles/azure-functions/durable/durable-functions-overview.md
@@ -19,7 +19,7 @@ Durable Functions currently supports the following languages:
 
 * **C#**: both [precompiled class libraries](../functions-dotnet-class-library.md) and [C# script](../functions-reference-csharp.md).
 * **JavaScript**: supported only for version 2.x of the Azure Functions runtime. Requires version 1.7.0 of the Durable Functions extension, or a later version. 
-* **Python**: requires version 1.8.5 of the Durable Functions extension, or a later version. 
+* **Python**: requires version 1.8.5 of the Durable Functions extension, or a later version. Support for Durable Functions is currently in public preview.
 * **F#**: precompiled class libraries and F# script. F# script is only supported for version 1.x of the Azure Functions runtime.
 * **PowerShell**: support for Durable Functions is currently in public preview. Supported only for version 3.x of the Azure Functions runtime and PowerShell 7. Requires version 2.2.2 of the Durable Functions extension, or a later version. Only the following patterns are currently supported: [Function chaining](#chaining), [Fan-out/fan-in](#fan-in-out), [Async HTTP APIs](#async-http).
 


### PR DESCRIPTION
Durable function python status was not clear from the this doc. It's mentioned for PowerShell but not for python, therefore reader might get the wrong idea about the status.