### PR TITLE
Added the case of using Azure cloud shell

### DIFF
--- a/articles/iot-dps/quick-setup-auto-provision-cli.md
+++ b/articles/iot-dps/quick-setup-auto-provision-cli.md
@@ -80,8 +80,11 @@ echo $hubConnectionString
 
 > [!NOTE]
 > These two commands are valid for a host running under Bash.
-> If you are using a local Windows/CMD shell or a PowerShell host, you need to modify the commands to use the correct syntax for that environment.
-> If you are using Azure Cloud Shell, check that the environment drop-down from the left-hand side of shell window says `Bash`.
+> 
+> If you're using a local Windows/CMD shell or a PowerShell host, modify the commands to use the correct syntax for that environment.
+>
+> If you're using Azure Cloud Shell, check that the environment drop-down on the left side of the shell window says **Bash**.
+>
 
 ## Link the IoT hub and the provisioning service
 

--- a/articles/iot-dps/quick-setup-auto-provision-cli.md
+++ b/articles/iot-dps/quick-setup-auto-provision-cli.md
@@ -79,8 +79,9 @@ echo $hubConnectionString
 ```
 
 > [!NOTE]
-> These two commands are valid for a host running under Bash. If you are using a local Windows/CMD shell or a PowerShell host, you need to modify the commands to use  the correct syntax for that environment.
->
+> These two commands are valid for a host running under Bash.
+> If you are using a local Windows/CMD shell or a PowerShell host, you need to modify the commands to use the correct syntax for that environment.
+> If you are using Azure Cloud Shell, check that the environment drop-down from the left-hand side of shell window says `Bash`.
 
 ## Link the IoT hub and the provisioning service
 


### PR DESCRIPTION
Even though this document has a chapter on using Azure Cloud Shell at the beginning, it was missing a note on using Azure Cloud Shell.
The text I added is based on the following.

- [docs.microsoft.com] Quickstart for Bash in Azure Cloud Shell : Select the Bash environment
https://docs.microsoft.com/en-us/azure/cloud-shell/quickstart#select-the-bash-environment