### PR TITLE
Fix syntax errors when creating UDR and route for Azure Firewall

### DIFF
--- a/articles/aks/limit-egress-traffic.md
+++ b/articles/aks/limit-egress-traffic.md
@@ -364,8 +364,8 @@ Create an empty route table to be associated with a given subnet. The route tabl
 ```azurecli
 # Create UDR and add a route for Azure Firewall
 
-az network route-table create -g $RG -$LOC --name $FWROUTE_TABLE_NAME
-az network route-table route create -g $RG --name $FWROUTE_NAME --route-table-name $FWROUTE_TABLE_NAME --address-prefix 0.0.0.0/0 --next-hop-type VirtualAppliance --next-hop-ip-address $FWPRIVATE_IP --subscription $SUBID
+az network route-table create -g $RG -l $LOC --name $FWROUTE_TABLE_NAME
+az network route-table route create -g $RG --name $FWROUTE_NAME --route-table-name $FWROUTE_TABLE_NAME --address-prefix 0.0.0.0/0 --next-hop-type VirtualAppliance --next-hop-ip-address $FWPRIVATE_IP --subscription $(az account show --query id -o tsv)
 az network route-table route create -g $RG --name $FWROUTE_NAME_INTERNET --route-table-name $FWROUTE_TABLE_NAME --address-prefix $FWPUBLIC_IP/32 --next-hop-type Internet
 ```
 


### PR DESCRIPTION
There was an error using the location in the following command (line 367):

```az network route-table create -g $RG -$LOC --name $FWROUTE_TABLE_NAME```

Additionally, the variable for subscription ID wasn't initialized (line 368). Substituted it with:

```az network route-table route create -g $RG --name $FWROUTE_NAME --route-table-name $FWROUTE_TABLE_NAME --address-prefix 0.0.0.0/0 --next-hop-type VirtualAppliance --next-hop-ip-address $FWPRIVATE_IP --subscription $(az account show --query id -otsv)```

I chose that way, because that's the only command where subscription ID is needed.