### PR TITLE
Changing Debian image to Alpine

### DIFF
--- a/articles/aks/ssh.md
+++ b/articles/aks/ssh.md
@@ -139,20 +139,20 @@ To create an SSH connection to an AKS node, you run a helper pod in your AKS clu
 1. Run a `debian` container image and attach a terminal session to it. This container can be used to create an SSH session with any node in the AKS cluster:
 
     ```console
-    kubectl run -it --rm aks-ssh --image=debian
+    kubectl run -it --rm aks-ssh --image=alpine
     ```
 
     > [!TIP]
     > If you use Windows Server nodes, add a node selector to the command to schedule the Debian container on a Linux node:
     >
     > ```console
-    > kubectl run -it --rm aks-ssh --image=debian --overrides='{"apiVersion":"v1","spec":{"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}'
+    > kubectl run -it --rm aks-ssh --image=alpine --overrides='{"apiVersion":"v1","spec":{"nodeSelector":{"beta.kubernetes.io/os":"linux"}}}'
     > ```
 
 1. Once the terminal session is connected to the container, install an SSH client using `apt-get`:
 
     ```console
-    apt-get update && apt-get install openssh-client -y
+    apk update && apk add openssh-client
     ```
 
 1. Open a new terminal window, not connected to your container, copy your private SSH key into the helper pod. This private key is used to create the SSH into the AKS node. 
@@ -160,7 +160,7 @@ To create an SSH connection to an AKS node, you run a helper pod in your AKS clu
    If needed, change *~/.ssh/id_rsa* to location of your private SSH key:
 
     ```console
-    kubectl cp ~/.ssh/id_rsa $(kubectl get pod -l run=aks-ssh -o jsonpath='{.items[0].metadata.name}'):/id_rsa
+    kubectl cp ~/.ssh/id_rsa aks-ssh:/id_rsa
     ```
 
 1. Return to the terminal session to your container, update the permissions on the copied `id_rsa` private SSH key so that it is user read-only:


### PR DESCRIPTION
Debian and Ubuntu images have an issue with kubectl cp. The Alpine image works.
Also simplifying kubectl cp line since there is an issue with powershell parsing this line and in this article we have been using the container name "aks-ssh" anyways.