### PR TITLE
Fixing syntax error in example

### DIFF
--- a/articles/synapse-analytics/sql/develop-stored-procedures.md
+++ b/articles/synapse-analytics/sql/develop-stored-procedures.md
@@ -57,7 +57,7 @@ If the second procedure then executes some dynamic SQL, the nest level increases
 ```sql
 CREATE PROCEDURE prc_nesting_2
 AS
-EXEC sp_executesql 'SELECT 'another nest level'  -- This call is nest level 2
+EXEC sp_executesql N'SELECT ''another nest level'''  -- This call is nest level 2
 GO
 EXEC prc_nesting
 ```


### PR DESCRIPTION
Previously, the example couldn't be executed, as it had bad quotation marks.
![image](https://user-images.githubusercontent.com/18459277/92599837-1098cc00-f2ab-11ea-8d20-54106d3afc33.png)

Now it shouldn't have any errors (tested on SQL DB).