### PR TITLE
Fix link to Kubernetes Pod concept

### DIFF
--- a/articles/container-instances/container-instances-container-groups.md
+++ b/articles/container-instances/container-instances-container-groups.md
@@ -103,7 +103,7 @@ Learn how to deploy a multi-container container group with an Azure Resource Man
 
 <!-- LINKS - External -->
 [dcos-pod]: https://dcos.io/docs/1.10/deploying-services/pods/
-[kubernetes-pod]: https://kubernetes.io/docs/concepts/workloads/pods/pod/
+[kubernetes-pod]: https://kubernetes.io/docs/concepts/workloads/pods/
 
 <!-- LINKS - Internal -->
 [resource-manager template]: container-instances-multi-container-group.md


### PR DESCRIPTION
The existing link works via a redirect. Tidy it so it goes direct to the right page.