### PR TITLE
Update about-vpn-profile-download.md

### DIFF
--- a/articles/vpn-gateway/about-vpn-profile-download.md
+++ b/articles/vpn-gateway/about-vpn-profile-download.md
@@ -16,7 +16,7 @@ The downloaded profile file contains information that is necessary to configure 
 
 [!INCLUDE [client profiles](../../includes/vpn-gateway-vwan-vpn-profile-download.md)]
 
-* The **OpenVPN folder** contains the *ovpn* profile that needs to be modified to include the key and the certificate. For more information, see [Configure OpenVPN clients for Azure VPN Gateway](vpn-gateway-howto-openvpn-clients.md#windows). If Azure AD authentication is selected on the VPN gateway, this folder is not present in the zip file. Instead, navigate to the AzureVPN folder and locate azurevpnconfig.xml.
+* The **OpenVPN folder** contains the *ovpn* profile that needs to be modified to include the key and the certificate. For more information, see [Configure OpenVPN clients for Azure VPN Gateway](vpn-gateway-howto-openvpn-clients.md#windows). If Azure AD authentication is selected on the VPN gateway, this folder is not present in the zip file. Instead, navigate to the AzureVPN folder and locate azurevpnconfig.xml. Native Azure AD authentication is only supported for OpenVPN protocol and Windows 10 and requires the use of the [Azure VPN Client](https://go.microsoft.com/fwlink/?linkid=2117554).
 
 ## Next steps
 


### PR DESCRIPTION
This is similar to recent updates to https://docs.microsoft.com/en-us/azure/vpn-gateway/openvpn-azure-ad-client and https://docs.microsoft.com/en-us/azure/vpn-gateway/openvpn-azure-ad-tenant.

This edit adds a sentence copy/pasted from https://docs.microsoft.com/en-us/azure/vpn-gateway/point-to-site-about#authenticate-using-native-azure-active-directory-authentication

MacOS, iOS, and Linux clients cannot use Azure AD authentication because there is no version of Azure VPN Client for those OS's. This can lead to lost hours of labor and lost calendar days during planning, attempting implementation, and troubleshooting if an org is not aware of the limitation.