### PR TITLE
Update how-to-connect-password-hash-synchronization.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
+++ b/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
@@ -127,7 +127,7 @@ The temporary password functionality helps to ensure that the transfer of owners
 
 To support temporary passwords in Azure AD for synchronized users, you can enable the *ForcePasswordChangeOnLogOn* feature, by running the following command on your Azure AD Connect server:
 
-`Set-ADSyncAADCompanyFeature  -ForcePasswordChangeOnLogOn $true`
+`Set-ADSyncAADCompanyFeature -ForcePasswordChangeOnLogOn $true`
 
 > [!NOTE]
 > Forcing a user to change their password on next logon requires a password change at the same time.  Azure AD Connect will not pick up the force password change flag by itself; it is supplemental to the detected password change that occurs during password hash sync.


### PR DESCRIPTION
Minor fix of the command Set-ADSyncAADCompanyFeature -ForcePasswordChangeOnLogOn $true which had some bad characters in the middle. When copy/pasted from the article, it looks weird and it might cause the cmdlet to fail with a strange error....