### PR TITLE
Application Insights .Net SDK v2.15 - ApplicationInsightsServiceOptions  read from ASP.NET Core IConfiguration 

### DIFF
--- a/articles/azure-monitor/app/asp-net-core.md
+++ b/articles/azure-monitor/app/asp-net-core.md
@@ -222,7 +222,7 @@ See the [configurable settings in `ApplicationInsightsServiceOptions`](https://g
 
 ### Configuration Recommendation for [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore) 2.15.0-beta3 & above
 
-Starting [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore) version 2.15.0-beta3 we offer an additional option to  modify all configuration updates through ASP.NET Core configuration. The recommended approach is to use `services.AddApplicationInsightsTelemetry()` and configure everything including instrumentation key using `Microsoft.Extensions.Configuration.IConfiguration`. All settings part of `ApplicationInsightsServiceOptions` is automatically read from users `Microsoft.Extensions.Configuration.IConfiguration`. For example, the following appsettings.json can be used to set instrumentation key, disable adaptive sampling and performance counter collection. 
+Starting [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore) version 2.15.0-beta3 we offer an additional option to modify all configuration updates through ASP.NET Core configuration. The recommended approach is to use `services.AddApplicationInsightsTelemetry()` and configure everything including instrumentation key using `Microsoft.Extensions.Configuration.IConfiguration`. All settings part of `ApplicationInsightsServiceOptions` is automatically read from users `Microsoft.Extensions.Configuration.IConfiguration`. For example, the following appsettings.json can be used to set instrumentation key, disable adaptive sampling and performance counter collection.
 
 ```json
     {
@@ -234,7 +234,7 @@ Starting [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packag
     }
 ```
 
-If `services.AddApplicationInsightsTelemetry(aiOptions)` is used, this overrides the settings from IConfiguration. 
+If `services.AddApplicationInsightsTelemetry(aiOptions)` is used, this overrides the settings from `Microsoft.Extensions.Configuration.IConfiguration`.
 
 ### Sampling
 

--- a/articles/azure-monitor/app/asp-net-core.md
+++ b/articles/azure-monitor/app/asp-net-core.md
@@ -117,7 +117,7 @@ For Visual Studio for Mac use the [manual guidance](#enable-application-insights
 
 ### User secrets and other configuration providers
 
-If you want to store the instrumentation key in ASP.NET Core user secrets or retrieve it from another configuration provider, you can use the overload with a `Microsoft.Extensions.Configuration.IConfiguration` parameter. For example, `services.AddApplicationInsightsTelemetry(Configuration);`.
+If you want to store the instrumentation key in ASP.NET Core user secrets or retrieve it from another configuration provider, you can use the overload with a `Microsoft.Extensions.Configuration.IConfiguration` parameter. For example, `services.AddApplicationInsightsTelemetry(Configuration);`. Starting [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore) version 2.15.0-beta3, calling `services.AddApplicationInsightsTelemetry()` will read instrumentation key from all [ASP.NET Core supported configuration providers](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#cp) and there is no need to pass `Microsoft.Extensions.Configuration.IConfiguration` parameter explicitly. 
 
 ## Run your application
 
@@ -219,6 +219,22 @@ Full List of settings in `ApplicationInsightsServiceOptions`
 |RequestCollectionOptions.TrackExceptions | Enable/Disable reporting of unhandled Exception tracking by the Request collection module. | false in NETSTANDARD2.0 (because Exceptions are tracked with ApplicationInsightsLoggerProvider), true otherwise.
 
 See the [configurable settings in `ApplicationInsightsServiceOptions`](https://github.com/microsoft/ApplicationInsights-dotnet/blob/develop/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs) for the most up-to-date list.
+
+### Configuration Recommendation for [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore) 2.15.0-beta3 & above
+
+Starting [Microsoft.ApplicationInsights.AspNet SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.AspNetCore) version 2.15.0-beta3 we offer an additional option to  modify all configuration updates through ASP.NET Core configuration. The recommended approach is to use `services.AddApplicationInsightsTelemetry()` and configure everything including instrumentation key using `Microsoft.Extensions.Configuration.IConfiguration`. All settings part of `ApplicationInsightsServiceOptions` is automatically read from users `Microsoft.Extensions.Configuration.IConfiguration`. For example, the following appsettings.json can be used to set instrumentation key, disable adaptive sampling and performance counter collection. 
+
+```json
+    {
+        "ApplicationInsights": {
+        "InstrumentationKey": "putinstrumentationkeyhere",
+        "EnableAdaptiveSampling": false,
+        "EnablePerformanceCounterCollectionModule": false
+        }
+    }
+```
+
+If `services.AddApplicationInsightsTelemetry(aiOptions)` is used, this overrides the settings from IConfiguration. 
 
 ### Sampling
 

--- a/articles/azure-monitor/app/worker-service.md
+++ b/articles/azure-monitor/app/worker-service.md
@@ -360,7 +360,7 @@ See the [configurable settings in `ApplicationInsightsServiceOptions`](https://g
 
 ### Configuration Recommendation for [Microsoft.ApplicationInsights.WorkerService SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.WorkerService) 2.15.0-beta3 & above
 
-Starting [Microsoft.ApplicationInsights.WorkerService SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.WorkerService) version 2.15.0-beta3 we offer an additional option to modify all configuration updates through ASP.NET Core configuration. The recommended approach is to use `services.AddApplicationInsightsTelemetryWorkerService()` and configure everything including instrumentation key using `Microsoft.Extensions.Configuration.IConfiguration`. All settings part of `ApplicationInsightsServiceOptions` is automatically read from users `Microsoft.Extensions.Configuration.IConfiguration`. For example, the following appsettings.json can be used to set instrumentation key, disable adaptive sampling and performance counter collection. 
+Starting [Microsoft.ApplicationInsights.WorkerService SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.WorkerService) version 2.15.0-beta3 we offer an additional option to modify all configuration updates through ASP.NET Core configuration. The recommended approach is to use `services.AddApplicationInsightsTelemetryWorkerService()` and configure everything including instrumentation key using `Microsoft.Extensions.Configuration.IConfiguration`. All settings part of `ApplicationInsightsServiceOptions` is automatically read from users `Microsoft.Extensions.Configuration.IConfiguration`. For example, the following appsettings.json can be used to set instrumentation key, disable adaptive sampling and performance counter collection.
 
 ```json
     {
@@ -372,7 +372,7 @@ Starting [Microsoft.ApplicationInsights.WorkerService SDK](https://www.nuget.org
     }
 ```
 
-If `services.AddApplicationInsightsTelemetryWorkerService(aiOptions)` is used, this overrides the settings from IConfiguration. 
+If `services.AddApplicationInsightsTelemetryWorkerService(aiOptions)` is used, this overrides the settings from `Microsoft.Extensions.Configuration.IConfiguration`.
 
 ### Sampling
 

--- a/articles/azure-monitor/app/worker-service.md
+++ b/articles/azure-monitor/app/worker-service.md
@@ -358,6 +358,22 @@ Commonly used settings in `ApplicationInsightsServiceOptions`
 
 See the [configurable settings in `ApplicationInsightsServiceOptions`](https://github.com/microsoft/ApplicationInsights-dotnet/blob/develop/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs) for the most up-to-date list.
 
+### Configuration Recommendation for [Microsoft.ApplicationInsights.WorkerService SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.WorkerService) 2.15.0-beta3 & above
+
+Starting [Microsoft.ApplicationInsights.WorkerService SDK](https://www.nuget.org/packages/Microsoft.ApplicationInsights.WorkerService) version 2.15.0-beta3 we offer an additional option to modify all configuration updates through ASP.NET Core configuration. The recommended approach is to use `services.AddApplicationInsightsTelemetryWorkerService()` and configure everything including instrumentation key using `Microsoft.Extensions.Configuration.IConfiguration`. All settings part of `ApplicationInsightsServiceOptions` is automatically read from users `Microsoft.Extensions.Configuration.IConfiguration`. For example, the following appsettings.json can be used to set instrumentation key, disable adaptive sampling and performance counter collection. 
+
+```json
+    {
+        "ApplicationInsights": {
+        "InstrumentationKey": "putinstrumentationkeyhere",
+        "EnableAdaptiveSampling": false,
+        "EnablePerformanceCounterCollectionModule": false
+        }
+    }
+```
+
+If `services.AddApplicationInsightsTelemetryWorkerService(aiOptions)` is used, this overrides the settings from IConfiguration. 
+
 ### Sampling
 
 The Application Insights SDK for Worker Service supports both fixed-rate and adaptive sampling. Adaptive sampling is enabled by default. Configuring sampling for Worker Service is done the same way as for [ASP.NET Core Applications](./sampling.md#configuring-adaptive-sampling-for-aspnet-core-applications).


### PR DESCRIPTION
This PR addresses the issue detailed here: MicrosoftDocs/azure-docs#62286