### PR TITLE
Trusted IP feature table displaying incorrectly

### DIFF
--- a/articles/active-directory/authentication/howto-mfa-mfasettings.md
+++ b/articles/active-directory/authentication/howto-mfa-mfasettings.md
@@ -240,7 +240,7 @@ The _Trusted IPs_ feature of Azure Multi-Factor Authentication bypasses multi-fa
 If your organization deploys the NPS extension to provide MFA to on-premises applications note the source IP address will always appear to be the NPS server the authentication attempt flows through.
 
 | Azure AD tenant type | Trusted IP feature options |
-|:--- |:--- |two-step
+|:--- |:--- |
 | Managed |**Specific range of IP addresses**: Administrators specify a range of IP addresses that can bypass multi-factor authentication for users who sign in from the company intranet. A maximum of 50 trusted IP ranges can be configured.|
 | Federated |**All Federated Users**: All federated users who sign in from inside of the organization can bypass multi-factor authentication. The users bypass verification by using a claim that is issued by Active Directory Federation Services (AD FS).<br/>**Specific range of IP addresses**: Administrators specify a range of IP addresses that can bypass multi-factor authentication for users who sign in from the company intranet. |
 


### PR DESCRIPTION
Having double checked the screen and the file history I can't see why the third column of "two-step" was present
This is what was throwing the table out, it looks more like a note. Removed so that table is rendered correctly.