### PR TITLE
Added note about https:// prefix for ADT URL

### DIFF
--- a/articles/digital-twins/quickstart-adt-explorer.md
+++ b/articles/digital-twins/quickstart-adt-explorer.md
@@ -109,8 +109,8 @@ Enter the important information you gathered earlier in the [Prerequisites](#pre
 >[!NOTE]
 > You can revisit/edit this information at any time by selecting the same icon to pull up the Sign In box again. It will keep the values that you passed in.
 
->[!NOTE]
-> If you recieve a SignalRService.subscribe error when you connect, make sure that your ADT URL is prefixed with *https://*
+>[!TIP]
+> If you recieve a SignalRService.subscribe error when you connect, make sure that your ADT URL is prefixed with *https://*.
 
 If you see a *Permissions requested* pop-up window from Microsoft, grant consent for this application and accept to continue.
 

--- a/articles/digital-twins/quickstart-adt-explorer.md
+++ b/articles/digital-twins/quickstart-adt-explorer.md
@@ -109,8 +109,8 @@ Enter the important information you gathered earlier in the [Prerequisites](#pre
 >[!NOTE]
 > You can revisit/edit this information at any time by selecting the same icon to pull up the Sign In box again. It will keep the values that you passed in.
 
->[!TIP]
-> If you recieve a SignalRService.subscribe error when you connect, make sure that your ADT URL is prefixed with *https://*.
+> [!TIP]
+> If a SignalRService.subscribe error message is shown when you connect, make sure that your ADT URL is prefixed with *https://*.
 
 If you see a *Permissions requested* pop-up window from Microsoft, grant consent for this application and accept to continue.
 

--- a/articles/digital-twins/quickstart-adt-explorer.md
+++ b/articles/digital-twins/quickstart-adt-explorer.md
@@ -109,6 +109,9 @@ Enter the important information you gathered earlier in the [Prerequisites](#pre
 >[!NOTE]
 > You can revisit/edit this information at any time by selecting the same icon to pull up the Sign In box again. It will keep the values that you passed in.
 
+>[!NOTE]
+> If you recieve a SignalRService.subscribe error when you connect, make sure that your ADT URL is prefixed with *https://*
+
 If you see a *Permissions requested* pop-up window from Microsoft, grant consent for this application and accept to continue.
 
 ## Add the sample data


### PR DESCRIPTION
Copying the ADT URL directly from the portal does so without the https:// prefix. But it's not 100% clear that this will cause a failure. I've also made a pull request to the Explorer Repo to cover this.