### PR TITLE
Update az aks create examples

### DIFF
--- a/articles/aks/use-managed-identity.md
+++ b/articles/aks/use-managed-identity.md
@@ -57,10 +57,18 @@ First, create an Azure resource group:
 az group create --name myResourceGroup --location westus2
 ```
 
-Then, create an AKS cluster:
+Then, create an AKS cluster by either providing an SSH key or allowing Azure AD integration.
+
+The following example show the first option to create an AKS cluster using the `--generate-ssh-keys` parameter to create an SSH Key for you. The example puts the private key in the default location on your local device.
 
 ```azurecli-interactive
-az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity
+az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --generate-ssh-keys
+```
+
+If you want to allow Azure AD integration, you can [create a new cluster using Azure RBAC and managed Azure AD integration](https://docs.microsoft.com/en-us/azure/aks/manage-azure-rbac#create-a-new-cluster-using-azure-rbac-and-managed-azure-ad-integration). The following example shows how you can create the AKS cluster and enable Azure AD with RBAC enabled by default. 
+
+```azurecli-interactive
+az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --enable-aad
 ```
 
 A successful cluster creation using managed identities contains this service principal profile information:


### PR DESCRIPTION
When I ran the az aks create example as written, I received the following error:

```text
An RSA key file or key value must be supplied to SSH Key Value. You can use --generate-ssh-keys to let CLI generate one for you
```

However, I eventually want to use Azure AD integration and thought this might be a better solution.

The feature `--enable-aad` seemed to work in the Azure CLI 2.9.1,  But I am wondering if the feature still needs the preview mentioned on my reference page.  

In any case, I was hoping this might be a fix to an issue my error. If it is too soon because the feature is in preview, then I do understand.