### PR TITLE
Fixed API version

### DIFF
--- a/articles/virtual-machines/extensions/dsc-template.md
+++ b/articles/virtual-machines/extensions/dsc-template.md
@@ -38,7 +38,7 @@ For more information, see
 {
   "type": "Microsoft.Compute/virtualMachines/extensions",
   "name": "Microsoft.Powershell.DSC",
-  "apiVersion": "2018-06-30",
+  "apiVersion": "2018-06-01",
   "location": "[parameters('location')]",
   "dependsOn": [
     "[concat('Microsoft.Compute/virtualMachines/', parameters('VMName'))]"


### PR DESCRIPTION
"error": {
                            "code": "NoRegisteredProviderFound",
                            "message": "No registered resource provider found for location 'eastus' and API version '2018-06-30' for type 'virtualMachines/extensions'. The supported api-versions are 
                        '2015-05-01-preview, 2015-06-15, 2016-03-30, 2016-04-30-preview, 2016-08-30, 2017-03-30, 2017-12-01, 2018-04-01, 2018-06-01, 2018-10-01, 2019-03-01, 2019-07-01, 2019-12-01, 
                        2020-06-01'. The supported locations are 'eastus, eastus2, westus, centralus, northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia, japaneast, 
                        japanwest, australiaeast, australiasoutheast, australiacentral, brazilsouth, southindia, centralindia, westindia, canadacentral, canadaeast, westus2, westcentralus, uksouth, 
                        ukwest, koreacentral, koreasouth, francecentral, southafricanorth, uaenorth, switzerlandnorth, germanywestcentral, norwayeast'."