### PR TITLE
Update expand-os-disk.md

### DIFF
--- a/articles/virtual-machines/windows/expand-os-disk.md
+++ b/articles/virtual-machines/windows/expand-os-disk.md
@@ -222,7 +222,7 @@ Similarly, you can reference other data disks attached to the VM, either by usin
 **Unmanaged disk**
 
 ```powershell
-($vm.StorageProfile.DataDisks | Where ({$_.Name -eq 'my-second-data-disk'}).DiskSizeGB = 1023
+($vm.StorageProfile.DataDisks | Where ({$_.Name -eq 'my-second-data-disk'})).DiskSizeGB = 1023
 ```
 
 ## Expand the volume within the OS


### PR DESCRIPTION
The line 225 has a closing brace missing in it, making an incomplete command.

PS C:\Users\> ($vm.StorageProfile.DataDisks | Where ({$_.Name -eq 'Disk Name'}).disksizegb
Missing closing ')' in expression.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordExcep 
   tion
    + FullyQualifiedErrorId : MissingEndParenthesisInExpression
 

PS C:\Users\> ($vm.StorageProfile.DataDisks | Where ({$_.Name -eq 'Disk Name'})).disksizegb
256

Thank you.