### PR TITLE
fix syntax error in example

### DIFF
--- a/articles/azure-sql/database/connect-query-go.md
+++ b/articles/azure-sql/database/connect-query-go.md
@@ -194,8 +194,10 @@ Get the connection information you need to connect to the database. You'll need 
            return -1, err
        }
 
-       tsql := "INSERT INTO TestSchema.Employees (Name, Location) VALUES (@Name, @Location); "
-       tsql += select isNull(SCOPE_IDENTITY(), -1);"
+       tsql := `
+         INSERT INTO TestSchema.Employees (Name, Location) VALUES (@Name, @Location);
+         select isNull(SCOPE_IDENTITY(), -1);
+       `
 
        stmt, err := db.Prepare(tsql)
        if err != nil {


### PR DESCRIPTION
there was a missing " in the example one one of the strings throwing off the highlighting for the rest of the block.