### PR TITLE
Adding autoComplete to v1 host.json docs

### DIFF
--- a/articles/azure-functions/functions-host-json-v1.md
+++ b/articles/azure-functions/functions-host-json-v1.md
@@ -88,7 +88,8 @@ The following sample *host.json* files have all possible options specified.
     "serviceBus": {
       "maxConcurrentCalls": 16,
       "prefetchCount": 100,
-      "autoRenewTimeout": "00:05:00"
+      "autoRenewTimeout": "00:05:00",
+      "autoComplete": true
     },
     "singleton": {
       "lockPeriod": "00:00:15",
@@ -296,7 +297,8 @@ Configuration setting for [Service Bus triggers and bindings](functions-bindings
     "serviceBus": {
       "maxConcurrentCalls": 16,
       "prefetchCount": 100,
-      "autoRenewTimeout": "00:05:00"
+      "autoRenewTimeout": "00:05:00",
+      "autoComplete": true
     }
 }
 ```
@@ -305,7 +307,8 @@ Configuration setting for [Service Bus triggers and bindings](functions-bindings
 |---------|---------|---------| 
 |maxConcurrentCalls|16|The maximum number of concurrent calls to the callback that the message pump should initiate. By default, the Functions runtime processes multiple messages concurrently. To direct the runtime to process only a single queue or topic message at a time, set `maxConcurrentCalls` to 1. | 
 |prefetchCount|n/a|The default PrefetchCount that will be used by the underlying MessageReceiver.| 
-|autoRenewTimeout|00:05:00|The maximum duration within which the message lock will be renewed automatically.| 
+|autoRenewTimeout|00:05:00|The maximum duration within which the message lock will be renewed automatically.|
+|autoComplete|true|When true, the trigger will complete the message processing automatically on successful execution of the operation. When false, it is the responsibility of the function to complete the message before returning.|
 
 ## singleton
 

--- a/articles/azure-functions/functions-host-json-v1.md
+++ b/articles/azure-functions/functions-host-json-v1.md
@@ -282,6 +282,7 @@ Configuration setting for the [SendGrind output binding](functions-bindings-send
     "sendGrid": {
         "from": "Contoso Group <admin@contoso.com>"
     }
+}    
 ```
 
 |Property  |Default | Description |


### PR DESCRIPTION
+@mathewc to confirm the details.

Had an incident today that required `autoComplete` in V1 and noticed we had no docs on this. This PR added it: https://github.com/Azure/azure-functions-host/pull/3179