### PR TITLE
Added example of AFD Rule Filtering via X-Azure-FDID

### DIFF
--- a/articles/frontdoor/front-door-faq.md
+++ b/articles/frontdoor/front-door-faq.md
@@ -95,7 +95,9 @@ To lock down your application to accept traffic only from your specific Front Do
 
 -    Perform a GET operation on your Front Door with the API version `2020-01-01` or higher. In the API call, look for `frontdoorID` field. Filter on the incoming header '**X-Azure-FDID**' sent by Front Door to your backend with the value as that of the field `frontdoorID`. You can also find `Front Door ID` value under the Overview section from Front Door portal page. 
 
-- Apply rule filtering in your backend web server to restrict traffic based on the resulting 'X-Azure-FDID' header value. Below is an example for [Microsoft Internet Information Services (IIS)](https://www.iis.net/):
+- Apply rule filtering in your backend web server to restrict traffic based on the resulting 'X-Azure-FDID' header value.
+
+  Here's an example for [Microsoft Internet Information Services (IIS)](https://www.iis.net/):
 
 	``` xml
 	<?xml version="1.0" encoding="UTF-8"?>

--- a/articles/frontdoor/front-door-faq.md
+++ b/articles/frontdoor/front-door-faq.md
@@ -95,6 +95,29 @@ To lock down your application to accept traffic only from your specific Front Do
 
 -    Perform a GET operation on your Front Door with the API version `2020-01-01` or higher. In the API call, look for `frontdoorID` field. Filter on the incoming header '**X-Azure-FDID**' sent by Front Door to your backend with the value as that of the field `frontdoorID`. You can also find `Front Door ID` value under the Overview section from Front Door portal page. 
 
+- Apply rule filtering in your backend web server to restrict traffic based on the resulting 'X-Azure-FDID' header value. Below is an example for [Microsoft Internet Information Services (IIS)](https://www.iis.net/):
+
+	``` xml
+	<?xml version="1.0" encoding="UTF-8"?>
+	<configuration>
+		<system.webServer>
+			<rewrite>
+				<rules>
+					<rule name="Filter_X-Azure-FDID" patternSyntax="Wildcard" stopProcessing="true">
+						<match url="*" />
+						<conditions>
+							<add input="{HTTP_X_AZURE_FDID}" pattern="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" negate="true" />
+						</conditions>
+						<action type="AbortRequest" />
+					</rule>
+				</rules>
+			</rewrite>
+		</system.webServer>
+	</configuration>
+	```
+
+
+
 ### Can the anycast IP change over the lifetime of my Front Door?
 
 The frontend anycast IP for your Front Door should typically not change and may remain static for the lifetime of the Front Door. However, there are **no guarantees** for the same. Kindly do not take any direct dependencies on the IP.


### PR DESCRIPTION
Provided an example for IIS on how a user could restrict traffic to their AFD instance based on the X-Azure-FDID header that is unique to their AFD.