### PR TITLE
Removed Office 365 apps preview

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
@@ -64,15 +64,15 @@ Administrators can assign a Conditional Access policy to the following cloud app
 - Virtual Private Network (VPN)
 - Windows Defender ATP
 
-### Office 365 (preview)
+### Office 365
 
 Microsoft 365 provides cloud-based productivity and collaboration services like Exchange, SharePoint, and Microsoft Teams. Microsoft 365 cloud services are deeply integrated to ensure smooth and collaborative experiences. This integration can cause confusion when creating policies as some apps such as Microsoft Teams have dependencies on others such as SharePoint or Exchange.
 
-The Office 365 (preview) app makes it possible to target these services all at once. We recommend using the new Office 365 (preview) app, instead of targeting individual cloud apps to avoid issues with [service dependencies](service-dependencies.md). Targeting this group of applications helps to avoid issues that may arise due to inconsistent policies and dependencies.
+The Office 365 app makes it possible to target these services all at once. We recommend using the new Office 365 app, instead of targeting individual cloud apps to avoid issues with [service dependencies](service-dependencies.md). Targeting this group of applications helps to avoid issues that may arise due to inconsistent policies and dependencies.
 
-Administrators can choose to exclude specific apps from policy if they wish by including the Office 365 (preview) app and excluding the specific apps of their choice in policy.
+Administrators can choose to exclude specific apps from policy if they wish by including the Office 365 app and excluding the specific apps of their choice in policy.
 
-Key applications that are included in the Office 365 (preview) client app:
+Key applications that are included in the Office 365 client app:
 
    - Microsoft Flow
    - Microsoft Forms


### PR DESCRIPTION
Azure portal is no longer showing the Office 365 cloud app with the (preview) designation.