### PR TITLE
Update quickstart-linux.md

### DIFF
--- a/articles/iot-edge/quickstart-linux.md
+++ b/articles/iot-edge/quickstart-linux.md
@@ -88,7 +88,7 @@ Since IoT Edge devices behave and can be managed differently than typical IoT de
 2. View the connection string for your device, which links your physical device with its identity in IoT Hub. It contains the name of your IoT hub, the name of your device, and then a shared key that authenticates connections between the two. We'll refer to this connection string again in the next section when you set up your IoT Edge device.
 
    ```azurecli-interactive
-   az iot hub device-identity show-connection-string --device-id myEdgeDevice --hub-name {hub_name}
+   az iot hub device-identity connection-string show --device-id myEdgeDevice --hub-name {hub_name}
    ```
 
    ![View connection string from CLI output](./media/quickstart/retrieve-connection-string.png)


### PR DESCRIPTION
This command is deprecated:
az iot hub device-identity show-connection-string --device-id myEdgeDevice --hub-name {hub_name}

So replaced it with the new command:
az iot hub device-identity connection-string show --device-id myEdgeDevice --hub-name {hub_name}