### PR TITLE
Update tutorial-sql-server-managed-instance-online.md

### DIFF
--- a/articles/dms/tutorial-sql-server-managed-instance-online.md
+++ b/articles/dms/tutorial-sql-server-managed-instance-online.md
@@ -67,7 +67,7 @@ To complete this tutorial, you need to:
     > * Choose to allow all network to access the storage account.
     > * Turn on [subnet delegation](https://docs.microsoft.com/azure/virtual-network/manage-subnet-delegation) on MI subnet and update the Storage Account firewall rules to allow this subnet.
 
-* Ensure that your virtual network Network Security Group rules don't block the following inbound communication ports to Azure Database Migration Service: 443, 53, 9354, 445, 12000. For more detail on virtual network NSG traffic filtering, see the article [Filter network traffic with network security groups](https://docs.microsoft.com/azure/virtual-network/virtual-networks-nsg).
+* Ensure that your virtual network Network Security Group rules don't block the following outbound communication ports to Azure Database Migration Service: 443, 53, 9354, 445, 12000. For more detail on virtual network NSG traffic filtering, see the article [Filter network traffic with network security groups](https://docs.microsoft.com/azure/virtual-network/virtual-networks-nsg).
 * Configure your [Windows Firewall for source database engine access](https://docs.microsoft.com/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access).
 * Open your Windows Firewall to allow Azure Database Migration Service to access the source SQL Server, which by default is TCP port 1433.
 * If you're running multiple named SQL Server instances using dynamic ports, you may wish to enable the SQL Browser Service and allow access to UDP port 1434 through your firewalls so that Azure Database Migration Service can connect to a named instance on your source server.


### PR DESCRIPTION
correct typo:  article incorrectly recommends unblocking "inbound" instead of "outbound" communication ports to Azure Database Migration Service: 443, 53, 9354, 445, 12000