### PR TITLE
Fix variable name in container-registry-transfer-images.md

### DIFF
--- a/articles/container-registry/container-registry-transfer-images.md
+++ b/articles/container-registry/container-registry-transfer-images.md
@@ -245,7 +245,7 @@ It can take several minutes for artifacts to export. When deployment completes s
 
 ```azurecli
 az storage blob list \
-  --account-name $SA_SOURCE
+  --account-name $SOURCE_SA
   --container transfer
   --output table
 ```


### PR DESCRIPTION
Minor fix: `SA_SOURCE` should be `SOURCE_SA`.