### PR TITLE
Update functions-bindings-storage-table.md

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-table.md
+++ b/articles/azure-functions/functions-bindings-storage-table.md
@@ -268,8 +268,8 @@ public class Person : TableEntity
 ```
 
 ```csharp
-#r "Microsoft.Azure.Cosmos"
-using Microsoft.Azure.Cosmos.Table;
+#r "Microsoft.WindowsAzure.Storage"
+using Microsoft.WindowsAzure.Storage.Table;
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
Microsoft.Azure.Cosmos namespace doesn't bind with table storage when using CloudTable with either version of the extension bundle.

Changes the meta file and namespace references for the sample.