### PR TITLE
Adding missing internal link for aks show command

### DIFF
--- a/articles/aks/start-stop-cluster.md
+++ b/articles/aks/start-stop-cluster.md
@@ -133,3 +133,4 @@ If the `provisioningState` shows `Starting` that means your cluster hasn't fully
 [az-feature-register]: /cli/azure/feature?view=azure-cli-latest#az-feature-register&preserve-view=true
 [az-feature-list]: /cli/azure/feature?view=azure-cli-latest#az-feature-list&preserve-view=true
 [az-provider-register]: /cli/azure/provider?view=azure-cli-latest#az-provider-register&preserve-view=true
+[az-aks-show]: /cli/azure/aks?view=azure-cli-latest#az_aks_show&preserve-view=true


### PR DESCRIPTION
Link was missing and therefor not rendered on [https://docs.microsoft.com/en-us/azure/aks/start-stop-cluster](https://docs.microsoft.com/en-us/azure/aks/start-stop-cluster)