### PR TITLE
updated go SDK location

### DIFF
--- a/articles/service-bus-messaging/service-bus-samples.md
+++ b/articles/service-bus-messaging/service-bus-samples.md
@@ -15,6 +15,7 @@ The Service Bus messaging samples demonstrate key features in [Service Bus messa
 | .NET, Java, and Management | https://github.com/Azure/azure-service-bus/ |
 | Node.js | https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples |
 | Python | https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/servicebus/azure-servicebus |
+| Go| https://github.com/Azure/azure-service-bus-go/ |
 
 ## Service Bus Explorer
 


### PR DESCRIPTION
Hello maintainer,

As I was looking for a sample link of go lang in azure docs of Message service-bus-samples. I didn't find so in order to solve this issue, I have forked the repo and added the links of the SDK source of go lang. 