### PR TITLE
Add "global"

### DIFF
--- a/articles/load-balancer/cross-region-overview.md
+++ b/articles/load-balancer/cross-region-overview.md
@@ -1,5 +1,5 @@
 ---
-title: Cross-region load balancer (preview)
+title: Cross-region (Global) load balancer (preview)
 titleSuffix: Azure Load Balancer
 description: Overview of cross region load balancer tier for Azure Load Balancer.
 services: load-balancer
@@ -15,7 +15,7 @@ ms.author: allensu
 ms.custom: references_regions
 
 ---
-# Cross-region load balancer (Preview)
+# Cross-region (Global) load balancer (Preview)
 
 Azure Load Balancer distributes inbound traffic that arrives at the load balancer frontend to backend pool instances.
 


### PR DESCRIPTION
The Ignite Book of News at https://news.microsoft.com/ignite-2020-book-of-news/#181-azure-networking-enhancements-include-cisco-sd-wan-with-azure-virtual-and-global-load-balancer-feature- calls this feature the "Global load balancing" feature.  I don't know where we are using what terms, but we need to make sure customers can find what we're announcing quickly.  Right now, it's basically impossible for a customer to get from the announcement to the documentation, because we use different terms.