### PR TITLE
Strip double quotes by Azure CLI itself

### DIFF
--- a/articles/backup/selective-disk-backup-restore.md
+++ b/articles/backup/selective-disk-backup-restore.md
@@ -54,7 +54,7 @@ az backup protection enable-for-vm --resource-group {resourcegroup} --vault-name
 If the VM isn't in the same resource group as the vault, then **ResourceGroup** refers to the resource group where the vault was created. Instead of the VM name, provide the VM ID as indicated below.
 
 ```azurecli
-az backup protection enable-for-vm  --resource-group {ResourceGroup} --vault-name {vaultname} --vm $(az vm show -g VMResourceGroup -n MyVm --query id | tr -d '"') --policy-name {policyname} --disk-list-setting include --diskslist {LUN number(s) separated by space}
+az backup protection enable-for-vm  --resource-group {ResourceGroup} --vault-name {vaultname} --vm $(az vm show -g VMResourceGroup -n MyVm --query id --output tsv) --policy-name {policyname} --disk-list-setting include --diskslist {LUN number(s) separated by space}
 ```
 
 ### Modify protection for already backed up VMs with Azure CLI


### PR DESCRIPTION
`tr` is a Linux command and doesn't work on Windows PowerShell (#63136). 

Azure CLI has its own mechanism to strip JSON string's double quotes with `--output tsv`.

```sh
$ az group show -n rg1 --query name
"rg1"
$ az group show -n rg1 --query name | tr -d '"'
rg1
$ az group show -n rg1 --query name --output tsv
rg1
```

This works on both Linux and Windows PowerShell. 