### PR TITLE
Code correction for custom topic subscription edit

### DIFF
--- a/articles/event-grid/custom-event-to-eventhub.md
+++ b/articles/event-grid/custom-event-to-eventhub.md
@@ -57,10 +57,10 @@ The following script gets the resource ID for the event hub, and subscribes to a
 
 ```azurecli-interactive
 hubid=$(az eventhubs eventhub show --name $hubname --namespace-name $namespace --resource-group gridResourceGroup --query id --output tsv)
+topicid=$(az eventgrid topic show --name $topicname -g gridResourceGroup --query id --output tsv)
 
 az eventgrid event-subscription create \
-  --topic-name $topicname \
-  -g gridResourceGroup \
+  --source-resource-id $topicid \
   --name subtoeventhub \
   --endpoint-type eventhub \
   --endpoint $hubid


### PR DESCRIPTION
Under the Subscribe to a custom topic section, the command az eventgrid event-subscription create does not have a --topic-name parameter. However, you can use the topic-name to get its ID and use --source-resource-id.