### PR TITLE
Update virtual-machines-managed-disks-benchmarking.md

### DIFF
--- a/includes/virtual-machines-managed-disks-benchmarking.md
+++ b/includes/virtual-machines-managed-disks-benchmarking.md
@@ -20,7 +20,7 @@ The disk with ReadOnly host caching are able to give higher IOPS than the disk l
 
 ### Iometer
 
-[Download the Iometer tool](https://sourceforge.net/projects/iometer/files/iometer-stable/2006-07-27/iometer-2006.07.27.win32.i386-setup.exe/download) on the VM.
+[Download the Iometer tool](http://sourceforge.net/projects/iometer/files/iometer-stable/1.1.0/iometer-1.1.0-win64.x86_64-bin.zip/download) on the VM.
 
 #### Test file
 


### PR DESCRIPTION
The original link to download Iometer takes you to the x86 version. That will not work with a 200GB file like the tutorial wants the learner to create. Adjusting in case this proves problematic for others trying to understand storage benchmarks on Azure Disks.