### PR TITLE
Fix the URL of the Sample Drawing package

### DIFF
--- a/articles/azure-maps/tutorial-creator-indoor-maps.md
+++ b/articles/azure-maps/tutorial-creator-indoor-maps.md
@@ -30,7 +30,7 @@ To create indoor maps:
 1. [Make an Azure Maps account](quick-demo-map-app.md#create-an-azure-maps-account)
 2. [Obtain a primary subscription key](quick-demo-map-app.md#get-the-primary-key-for-your-account), also known as the primary key or the subscription key.
 3. [Create a Creator resource](how-to-manage-creator.md)
-4. Download the [Sample Drawing package](https://github.com/Azure-Samples/am-creator-indoor-data-examples).
+4. Download the [Sample Drawing package](https://github.com/Azure-Samples/am-creator-indoor-data-examples/blob/master/Sample%20-%20Contoso%20Drawing%20Package.zip).
 
 This tutorial uses the [Postman](https://www.postman.com/) application, but you may choose a different API development environment.
 


### PR DESCRIPTION
The link of the Sample Drawing package is linked to a top page of the repository.
If accidentally download the zip file of the entire repository and upload it to Azure Maps Creator resource, an error occurs during the conversion steps within this tutorial.
The link of the Sample Drawing package should be the URL of the Sample Drawing package.