### PR TITLE
Fix: Powershell command rendered as  HTML encoded

### DIFF
--- a/articles/key-vault/general/quick-create-powershell.md
+++ b/articles/key-vault/general/quick-create-powershell.md
@@ -50,7 +50,7 @@ Create a Key Vault in the resource group from the previous step. You will need t
 - The location: **EastUS**.
 
 ```azurepowershell-interactive
-New-AzKeyVault -Name "&lt;your-unique-key-vault-name&gt; -ResourceGroupName "myResourceGroup" -Location "East US"
+New-AzKeyVault -Name "<your-unique-key-vault-name>" -ResourceGroupName "myResourceGroup" -Location "East US"
 ```
 
 The output of this cmdlet shows properties of the newly created key vault. Take note of the two properties listed below:

--- a/articles/key-vault/general/quick-create-powershell.md
+++ b/articles/key-vault/general/quick-create-powershell.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Quickstart - Create an Azure Key Vault with Azure PowerShell
 description: Quickstart showing how to create an Azure Key Vault using Azure PowerShell
 services: key-vault


### PR DESCRIPTION
Powershell command rendered  as ``` "&lt;your-unique-key-vault-name&gt; ``` instead of ``` "<your-unique-key-vault-name>" ```

Not a functional issue (considering end user is going to modify at their end) just a rendering issue.