### PR TITLE
Fix role name (Cognitive Service"s")

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/role-based-access-control.md
+++ b/articles/cognitive-services/Custom-Vision-Service/role-based-access-control.md
@@ -38,8 +38,8 @@ Use the following table to determine access needs for your Custom Vision resourc
 
 |Role  |Permissions  |
 |---------|---------|
-|`Cognitive Service Custom Vision Contributor`     | Full access to the projects, including the ability to create, edit, or delete a project.        |
-|`Cognitive Service Custom Vision Trainer`     | Full access except the ability to create or delete a project. Trainers can view and edit projects and train, publish, unpublish, or export the models.        |
-|`Cognitive Service Custom Vision Labeler`     | Ability to upload, edit, or delete training images and create, add, remove, or delete tags. Labelers can view projects but can't update anything other than training images and tags.         |
-|`Cognitive Service Custom Vision Deployment`     | Ability to publish, unpublish, or export the models. Deployers can view projects but can't update a project, training images, or tags.        |
-|`Cognitive Service Custom Vision Reader`     | Ability to view projects. Readers can't make any changes.        |
+|`Cognitive Services Custom Vision Contributor`     | Full access to the projects, including the ability to create, edit, or delete a project.        |
+|`Cognitive Services Custom Vision Trainer`     | Full access except the ability to create or delete a project. Trainers can view and edit projects and train, publish, unpublish, or export the models.        |
+|`Cognitive Services Custom Vision Labeler`     | Ability to upload, edit, or delete training images and create, add, remove, or delete tags. Labelers can view projects but can't update anything other than training images and tags.         |
+|`Cognitive Services Custom Vision Deployment`     | Ability to publish, unpublish, or export the models. Deployers can view projects but can't update a project, training images, or tags.        |
+|`Cognitive Services Custom Vision Reader`     | Ability to view projects. Readers can't make any changes.        |


### PR DESCRIPTION
Correct role name is Cognitive Services Custom Vision ***, not Cognitive Service Custom Vision ***.