### PR TITLE
server 2016 LTSC with v1607 missing some feature

### DIFF
--- a/articles/active-directory/devices/howto-device-identity-virtual-desktop-infrastructure.md
+++ b/articles/active-directory/devices/howto-device-identity-virtual-desktop-infrastructure.md
@@ -60,7 +60,7 @@ Before configuring device identities in Azure AD for your VDI environment, famil
 | Azure AD registered | Federated/Managed | Windows current/Windows down-level | Persistent/Non-Persistent | Not Applicable |
 
 <sup>1</sup> **Windows current** devices represent Windows 10, Windows Server 2016, and Windows Server 2019.
-
+</sup> Note: You may not have latest features and product improvement. if you are on Server 2016 Version 1607. We did recommend to use Windows Server 2016 v1803 or future versions of windows server
 <sup>2</sup> **Windows down-level** devices represent Windows 7, Windows 8.1, Windows Server 2008 R2, Windows Server 2012, and Windows Server 2012 R2. For support information on Windows 7, see [Support for Windows 7 is ending](https://www.microsoft.com/microsoft-365/windows/end-of-windows-7-support). For support information on Windows Server 2008 R2, see [Prepare for Windows Server 2008 end of support](https://www.microsoft.com/cloud-platform/windows-server-2008).
 
 <sup>3</sup> A **Federated** identity infrastructure environment represents an environment with an identity provider such as AD FS or other third-party IDP.

--- a/articles/active-directory/devices/howto-device-identity-virtual-desktop-infrastructure.md
+++ b/articles/active-directory/devices/howto-device-identity-virtual-desktop-infrastructure.md
@@ -59,8 +59,7 @@ Before configuring device identities in Azure AD for your VDI environment, famil
 |   |   |   | Non-Persistent | No |
 | Azure AD registered | Federated/Managed | Windows current/Windows down-level | Persistent/Non-Persistent | Not Applicable |
 
-<sup>1</sup> **Windows current** devices represent Windows 10, Windows Server 2016, and Windows Server 2019.
-</sup> Note: You may not have latest features and product improvement. if you are on Server 2016 Version 1607. We did recommend to use Windows Server 2016 v1803 or future versions of windows server
+<sup>1</sup> **Windows current** devices represent Windows 10, Windows Server 2016 v1803 or higher, and Windows Server 2019.
 <sup>2</sup> **Windows down-level** devices represent Windows 7, Windows 8.1, Windows Server 2008 R2, Windows Server 2012, and Windows Server 2012 R2. For support information on Windows 7, see [Support for Windows 7 is ending](https://www.microsoft.com/microsoft-365/windows/end-of-windows-7-support). For support information on Windows Server 2008 R2, see [Prepare for Windows Server 2008 end of support](https://www.microsoft.com/cloud-platform/windows-server-2008).
 
 <sup>3</sup> A **Federated** identity infrastructure environment represents an environment with an identity provider such as AD FS or other third-party IDP.


### PR DESCRIPTION
Hi John,
Many customer doesn't take sub version in the Windows Server 2016, they are looking as supported OS 2016 level. not the sub level v1607 or v1803. I discussed with Ravi Vennapusa and opened this PR to update
FYI: many customer on Windows server LSTC branch. which supported with v1607. They never be on Windows Server v1803. which is not LSTC, which is on Semi-annual phase plan.