### PR TITLE
Format JSON examples (SaaS Fulfillment API v2)

### DIFF
--- a/articles/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2.md
+++ b/articles/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2.md
@@ -201,12 +201,12 @@ Response body example:
 
 ```json
 {
-    "id": "<guid>",  // purchased SaaS subscription ID 
-    "subscriptionName": "Contoso Cloud Solution", // SaaS subscription name 
-    "offerId": "offer1", // purchased offer ID
-    "planId": "silver", // purchased offer's plan ID
-    "quantity": "20", // number of purchased seats, might be empty if the plan is not per seat
-    "subscription": { // full SaaS subscription details, see Get Subscription APIs response body for full description
+  "id": "<guid>", // purchased SaaS subscription ID
+  "subscriptionName": "Contoso Cloud Solution", // SaaS subscription name
+  "offerId": "offer1", // purchased offer ID
+  "planId": "silver", // purchased offer's plan ID
+  "quantity": "20", // number of purchased seats, might be empty if the plan is not per seat
+  "subscription": { // full SaaS subscription details, see Get Subscription APIs response body for full description
     "id": "<guid>",
     "publisherId": "contoso",
     "offerId": "offer1",
@@ -216,27 +216,23 @@ Response body example:
       "emailId": "test@test.com",
       "objectId": "<guid>",
       "tenantId": "<guid>",
-"pid": "<ID of the user>"
+      "pid": "<ID of the user>"
     },
     "purchaser": {
       "emailId": "test@test.com",
       "objectId": "<guid>",
       "tenantId": "<guid>",
-"pid": "<ID of the user>"
+      "pid": "<ID of the user>"
     },
     "planId": "silver",
     "term": {
       "termUnit": "P1M",
-                   startDate": "2019-05-31", 
-   "endDate": "2019-06-29",
+      "startDate": "2019-05-31",
+      "endDate": "2019-06-29"
     },
     "isTest": true,
     "isFreeTrial": false,
-    "allowedCustomerOperations": [
-      "Delete",
-      "Update",
-      "Read"
-    ],
+    "allowedCustomerOperations": ["Delete", "Update", "Read"],
     "sandboxType": "None",
     "sessionMode": "None"
   }
@@ -281,9 +277,9 @@ Once the SaaS account is configured for an end customer, the publisher must call
 *Request payload example:*
 
 ```json
-{ // needed for validation of the activation request
-    "planId": "gold", // purchased plan, cannot be empty
-    "quantity": "" // purchased number of seats, can be empty if plan is not per seat
+{  // needed for validation of the activation request
+  "planId": "gold", // purchased plan, cannot be empty
+  "quantity": "" // purchased number of seats, can be empty if plan is not per seat
 }
 ```
 
@@ -347,73 +343,69 @@ Returns the list of all existing subscriptions for all offers of this publisher,
 ```json
 {
   "subscriptions": [
-      {
-          "id": "<guid>", // purchased SaaS subscription ID
-          "name": "Contoso Cloud Solution", // SaaS subscription name
-          "publisherId": "contoso", // publisher ID
-          "offerId": "offer1", // purchased offer ID
-          "planId": "silver", // purchased plan ID
-          "quantity": "10", // purchased amount of seats, will be empty if plan is not per seat
-          "beneficiary": { // email address, user ID and tenant ID for which SaaS subscription was purchased.
-              "emailId": " test@contoso.com",
-              "objectId": "<guid>",
-              "tenantId": "<guid>",
-              "pid": "<ID of the user>"
-          },
-          "purchaser": { // email address, user ID and tenant ID that purchased the SaaS subscription. These could be different from beneficiary information for reseller (CSP) purchase
-              "emailId": " test@contoso.com",
-              "objectId": "<guid>",
-              "tenantId": "<guid>",
-              "pid": "<ID of the user>"
-          },
-            "term": { // The period for which the subscription was purchased. 
-                "startDate": "2019-05-31", //format: YYYY-MM-DD. This is the date when the subscription was activated by the ISV and the billing started. This field is relevant only for Active and Suspended subscriptions.
-                "endDate": "2019-06-30", // This is the last day the subscription is valid. Unless stated otherwise, the automatic renew will happen the next day. This field is relevant only for Active and Suspended subscriptions.
-                "termUnit": "P1M" // where P1M is monthly and P1Y is yearly. Also reflected in the startDate and endDate values
-          },
-          "allowedCustomerOperations": [
-              "Read", "Update", "Delete" 
-          ], // Indicates operations allowed on the SaaS subscription for beneficiary. For CSP-initiated purchases, this will always be "Read" because the customer cannot update or delete subscription in this flow.  Purchaser can perform all operations on the subscription.
-          "sessionMode": "None", // not relevant
-          "isFreeTrial": true, // true - the customer subscription is currently in free trial, false - the customer subscription is not currently in free trial. (Optional field -– if not returned, the value is false.)
-          "isTest": false, // not relevant
-          "sandboxType": "None", // not relevant
-          "saasSubscriptionStatus": "Subscribed" // Indicates the status of the operation. Can be one of the following: PendingFulfillmentStart, Subscribed, Suspended or Unsubscribed.
+    {
+      "id": "<guid>", // purchased SaaS subscription ID
+      "name": "Contoso Cloud Solution", // SaaS subscription name
+      "publisherId": "contoso", // publisher ID
+      "offerId": "offer1", // purchased offer ID
+      "planId": "silver", // purchased plan ID
+      "quantity": "10", // purchased amount of seats, will be empty if plan is not per seat
+      "beneficiary": { // email address, user ID and tenant ID for which SaaS subscription was purchased.
+        "emailId": " test@contoso.com",
+        "objectId": "<guid>",
+        "tenantId": "<guid>",
+        "pid": "<ID of the user>"
       },
-// next SaaS subscription details, might be a different offer
-{
-          "id": "<guid1>", 
-          "name": "Contoso Cloud Solution1", 
-          "publisherId": "contoso", 
-          "offerId": "offer2", 
-          "planId": "gold", 
-          "quantity": "", 
-          "beneficiary": {
-              "emailId": " test@contoso.com",
-              "objectId": "<guid>",
-              "tenantId": "<guid>",
-              "pid": "<ID of the user>"
-          },
-          "purchaser": { 
-              "emailId": "purchase@csp.com ",
-              "objectId": "<guid>",
-              "tenantId": "<guid>",
-               "pid": "<ID of the user>"
-          },
-            "term": { 
-                "startDate": "2019-05-31",
-                "endDate": "2020-04-30",
-                "termUnit": "P1Y"
-          },
-          "allowedCustomerOperations": [
-              "Read" 
-          ], 
-          "sessionMode": "None",
-          "isFreeTrial": false,
-          "isTest": false,
-          "sandboxType": "None",
-          "saasSubscriptionStatus": "Suspended"
-      }
+      "purchaser": { // email address, user ID and tenant ID that purchased the SaaS subscription. These could be different from beneficiary information for reseller (CSP) purchase
+        "emailId": " test@contoso.com",
+        "objectId": "<guid>",
+        "tenantId": "<guid>",
+        "pid": "<ID of the user>"
+      },
+      "term": { // The period for which the subscription was purchased.
+        "startDate": "2019-05-31", //format: YYYY-MM-DD. This is the date when the subscription was activated by the ISV and the billing started. This field is relevant only for Active and Suspended subscriptions.
+        "endDate": "2019-06-30", // This is the last day the subscription is valid. Unless stated otherwise, the automatic renew will happen the next day. This field is relevant only for Active and Suspended subscriptions.
+        "termUnit": "P1M" // where P1M is monthly and P1Y is yearly. Also reflected in the startDate and endDate values
+      },
+      "allowedCustomerOperations": ["Read", "Update", "Delete"], // Indicates operations allowed on the SaaS subscription for beneficiary. For CSP-initiated purchases, this will always be "Read" because the customer cannot update or delete subscription in this flow.  Purchaser can perform all operations on the subscription.
+      "sessionMode": "None", // not relevant
+      "isFreeTrial": true, // true - the customer subscription is currently in free trial, false - the customer subscription is not currently in free trial. (Optional field -– if not returned, the value is false.)
+      "isTest": false, // not relevant
+      "sandboxType": "None", // not relevant
+      "saasSubscriptionStatus": "Subscribed" // Indicates the status of the operation. Can be one of the following: PendingFulfillmentStart, Subscribed, Suspended or Unsubscribed.
+    },
+    // next SaaS subscription details, might be a different offer
+    {
+      "id": "<guid1>",
+      "name": "Contoso Cloud Solution1",
+      "publisherId": "contoso",
+      "offerId": "offer2",
+      "planId": "gold",
+      "quantity": "",
+      "beneficiary": {
+        "emailId": " test@contoso.com",
+        "objectId": "<guid>",
+        "tenantId": "<guid>",
+        "pid": "<ID of the user>"
+      },
+      "purchaser": {
+        "emailId": "purchase@csp.com ",
+        "objectId": "<guid>",
+        "tenantId": "<guid>",
+        "pid": "<ID of the user>"
+      },
+      "term": {
+        "startDate": "2019-05-31",
+        "endDate": "2020-04-30",
+        "termUnit": "P1Y"
+      },
+      "allowedCustomerOperations": ["Read"],
+      "sessionMode": "None",
+      "isFreeTrial": false,
+      "isTest": false,
+      "sandboxType": "None",
+      "saasSubscriptionStatus": "Suspended"
+    }
   ],
   "@nextLink": "https:// https://marketplaceapi.microsoft.com/api/saas/subscriptions/?continuationToken=%5b%7b%22token%22%3a%22%2bRID%3a%7eYeUDAIahsn22AAAAAAAAAA%3d%3d%23RT%3a1%23TRC%3a2%23ISV%3a1%23FPC%3aAgEAAAAQALEAwP8zQP9%2fFwD%2b%2f2FC%2fwc%3d%22%2c%22range%22%3a%7b%22min%22%3a%22%22%2c%22max%22%3a%2205C1C9CD673398%22%7d%7d%5d&api-version=2018-08-31" // url that contains continuation token to retrieve next page of the SaaS subscriptions list, if empty or absent, this is the last page. ISV can use this url as is to retrieve the next page or extract the value of continuation token from this url.
 }
@@ -460,35 +452,35 @@ Returns details for a SaaS subscription based on the `subscriptionId` provided.
 
 ```json
 {
-        "id":<guid>, // purchased SaaS subscription ID
-        "name":"Contoso Cloud Solution", // SaaS subscription name
-         "publisherId": "contoso", // publisher ID
-          "offerId": "offer1", // purchased offer ID
-          "planId": "silver", // purchased plan ID
-          "quantity": "10", // purchased amount of seats, will be empty if plan is not per seat
-         "beneficiary": { // email address, user ID and tenant ID for which SaaS subscription is purchased.
-              "emailId": "test@contoso.com",
-              "objectId": "<guid>",
-              "tenantId": "<guid>",
-              "pid": "<ID of the user>"
-          },
-          "purchaser": { // email address ,user ID and tenant ID that purchased the SaaS subscription.  These could be different from beneficiary information for reseller (CSP) scenario
-              "emailId": "test@test.com",
-              "objectId": "<guid>",
-              "tenantId": "<guid>",
-              "pid": "<ID of the user>"
-          },
-        "allowedCustomerOperations": ["Read", "Update", "Delete"], // Indicates operations allowed on the SaaS subscription for beneficiary.  For CSP-initiated purchases, this will always be "Read" because the customer cannot update or delete subscription in this flow.  Purchaser can perform all operations on the subscription.
-        "sessionMode": "None", // not relevant
-        "isFreeTrial": false, // true - the customer subscription is currently in free trial, false - the customer subscription is not currently in free trial. Optional field – if not returned the value is false.
-          "isTest": false, // not relevant
-          "sandboxType": "None", // not relevant
-          "saasSubscriptionStatus": " Subscribed " // Indicates the status of the operation: PendingFulfillmentStart, Subscribed, Suspended or Unsubscribed.
-          "term": { // the period for which the subscription was purchased 
-            "startDate": "2019-05-31", //format: YYYY-MM-DD. This is the date when the subscription was activated by the ISV and the billing started. This field is relevant only for Active and Suspended subscriptions.
-            "endDate": "2019-06-29", // This is the last day the subscription is valid. Unless stated otherwise, the automatic renew will happen the next day. This field is relevant only for Active and Suspended subscriptions.
-            "termUnit": "P1M" //where P1M is monthly and P1Y is yearly. Also reflected in the startDate and endDate values.
-        }
+  "id": "<guid>", // purchased SaaS subscription ID
+  "name": "Contoso Cloud Solution", // SaaS subscription name
+  "publisherId": "contoso", // publisher ID
+  "offerId": "offer1", // purchased offer ID
+  "planId": "silver", // purchased plan ID
+  "quantity": "10", // purchased amount of seats, will be empty if plan is not per seat
+  "beneficiary": { // email address, user ID and tenant ID for which SaaS subscription is purchased.
+    "emailId": "test@contoso.com",
+    "objectId": "<guid>",
+    "tenantId": "<guid>",
+    "pid": "<ID of the user>"
+  },
+  "purchaser": { // email address ,user ID and tenant ID that purchased the SaaS subscription.  These could be different from beneficiary information for reseller (CSP) scenario
+    "emailId": "test@test.com",
+    "objectId": "<guid>",
+    "tenantId": "<guid>",
+    "pid": "<ID of the user>"
+  },
+  "allowedCustomerOperations": ["Read", "Update", "Delete"], // Indicates operations allowed on the SaaS subscription for beneficiary.  For CSP-initiated purchases, this will always be "Read" because the customer cannot update or delete subscription in this flow.  Purchaser can perform all operations on the subscription.
+  "sessionMode": "None", // not relevant
+  "isFreeTrial": false, // true - the customer subscription is currently in free trial, false - the customer subscription is not currently in free trial. Optional field – if not returned the value is false.
+  "isTest": false, // not relevant
+  "sandboxType": "None", // not relevant
+  "saasSubscriptionStatus": " Subscribed ", // Indicates the status of the operation: PendingFulfillmentStart, Subscribed, Suspended or Unsubscribed.
+  "term": { // the period for which the subscription was purchased
+    "startDate": "2019-05-31", //format: YYYY-MM-DD. This is the date when the subscription was activated by the ISV and the billing started. This field is relevant only for Active and Suspended subscriptions.
+    "endDate": "2019-06-29", // This is the last day the subscription is valid. Unless stated otherwise, the automatic renew will happen the next day. This field is relevant only for Active and Suspended subscriptions.
+    "termUnit": "P1M" //where P1M is monthly and P1Y is yearly. Also reflected in the startDate and endDate values.
+  }
 }
 ```
 
@@ -536,17 +528,18 @@ Response body example:
 
 ```json
 {
-    "plans": [{
-        "planId": "Platinum001",
-        "displayName": "Private platinum plan for Contoso", // display name of the plan as it appears in the marketplace
-        "isPrivate": true //true or false
+  "plans": [
+    {
+      "planId": "Platinum001",
+      "displayName": "Private platinum plan for Contoso", // display name of the plan as it appears in the marketplace
+      "isPrivate": true //true or false
     },
-{ 
-        "planId": "gold",
-        "displayName": "Gold plan for Contoso", 
-        "isPrivate": false //true or false
+    {
+      "planId": "gold",
+      "displayName": "Gold plan for Contoso",
+      "isPrivate": false //true or false
     }
-]
+  ]
 }
 ```
 
@@ -588,7 +581,7 @@ This API can be called only for Active subscriptions.  Any plan can be changed t
 
 ```json
 {
-    "planId": "gold" // the ID of the new plan to be purchased
+  "planId": "gold" // the ID of the new plan to be purchased
 }
 ```
 
@@ -658,7 +651,7 @@ Quantity of seats cannot be more than what is allowed in the current plan.  In t
 
 ```json
 {
-    "quantity": 5 // the new amount of seats to be purchased
+  "quantity": 5 // the new amount of seats to be purchased
 }
 ```
 
@@ -793,18 +786,21 @@ Returns pending Reinstate operation on the specified SaaS subscription.
 *Response payload example:*
 
 ```json
-{"operations": [{
-    "id": "<guid>",  //Operation ID, should be provided in the operations patch API call
-    "activityId": "<guid>", //not relevant
-    "subscriptionId": "<guid>", // subscriptionId of the SaaS subscription that is being reinstated
-    "offerId": "offer1",  // purchased offer ID
-    "publisherId": "contoso",  
-    "planId": "silver",  // purchased plan ID
-    "quantity": "20", // purchased amount of seats, will be empty is not relevant
-    "action": "Reinstate", 
-    "timeStamp": "2018-12-01T00:00:00",  // UTC
-    "status": "InProgress" // the only status that can be returned in this case
-}]
+{
+  "operations": [
+    {
+      "id": "<guid>", //Operation ID, should be provided in the operations patch API call
+      "activityId": "<guid>", //not relevant
+      "subscriptionId": "<guid>", // subscriptionId of the SaaS subscription that is being reinstated
+      "offerId": "offer1", // purchased offer ID
+      "publisherId": "contoso",
+      "planId": "silver", // purchased plan ID
+      "quantity": "20", // purchased amount of seats, will be empty is not relevant
+      "action": "Reinstate",
+      "timeStamp": "2018-12-01T00:00:00", // UTC
+      "status": "InProgress" // the only status that can be returned in this case
+    }
+  ]
 }
 ```
 
@@ -859,19 +855,18 @@ Gets details for the specified SaaS operation.
 ```json
 Response body:
 {
-    "id  ": "<guid>", //Operation ID, should be provided in the patch operation API call
-    "activityId": "<guid>", //not relevant
-    "subscriptionId":"<guid>", // subscriptionId of the SaaS subscription for which this operation is relevant
-    "offerId": "offer1", // purchased offer ID
-    "publisherId": "contoso",  
-    "planId": "silver", // purchased plan ID
-    "quantity": "20", // purchased amount of seats 
-    "action": "ChangePlan", // Can be ChangePlan, ChangeQuantity or Reinstate
-    "timeStamp": "2018-12-01T00:00:00", // UTC
-    "status": "InProgress", // Possible values: NotStarted, InProgress, Failed, Succeed, Conflict (new quantity / plan is the same as existing)
-
-"errorStatusCode": "",
-"errorMessage": ""
+  "id  ": "<guid>", //Operation ID, should be provided in the patch operation API call
+  "activityId": "<guid>", //not relevant
+  "subscriptionId": "<guid>", // subscriptionId of the SaaS subscription for which this operation is relevant
+  "offerId": "offer1", // purchased offer ID
+  "publisherId": "contoso",
+  "planId": "silver", // purchased plan ID
+  "quantity": "20", // purchased amount of seats
+  "action": "ChangePlan", // Can be ChangePlan, ChangeQuantity or Reinstate
+  "timeStamp": "2018-12-01T00:00:00", // UTC
+  "status": "InProgress", // Possible values: NotStarted, InProgress, Failed, Succeed, Conflict (new quantity / plan is the same as existing)
+  "errorStatusCode": "",
+  "errorMessage": ""
 }
 ```
 
@@ -917,8 +912,8 @@ The `operationId` for this API call can be retrieved from the value returned by 
 *Request payload example:*
 
 ```json
-{ 
-    "status": "Success"    // Allowed Values: Success/Failure. Indicates the status of the operation on ISV side.
+{
+  "status": "Success" // Allowed Values: Success/Failure. Indicates the status of the operation on ISV side.
 }
 ```
 
@@ -968,7 +963,7 @@ The publisher must implement a webhook in the SaaS service to keep the SaaS subs
 ```json
 // end customer changed a quantity of purchased seats for a plan on Microsoft side
 {
-  "id": <guid>, // this is the operation ID to call with get operation API
+  "id": "<guid>", // this is the operation ID to call with get operation API
   "activityId": "<guid>", // do not use
   "subscriptionId": "guid", // The GUID identifier for the SaaS resource which status changes
   "publisherId": "contoso", // A unique string identifier for each publisher
@@ -977,24 +972,24 @@ The publisher must implement a webhook in the SaaS service to keep the SaaS subs
   "quantity": " 25", // the most up-to-date number of seats, can be empty if not relevant
   "timeStamp": "2019-04-15T20:17:31.7350641Z", // UTC time when the webhook was called
   "action": "ChangeQuantity", // the operation the webhook notifies about
-  "status": "Success" // Can be either InProgress or Success  
+  "status": "Success" // Can be either InProgress or Success
 }
 ```
 
 ```json
 // end customer's payment instrument became valid again, after being suspended, and the SaaS subscription is being reinstated
 {
-  "id": <guid>, 
-  "activityId": <guid>, 
-  "subscriptionId": "guid", 
+  "id": "<guid>",
+  "activityId": "<guid>",
+  "subscriptionId": "<guid>",
   "publisherId": "contoso",
   "offerId": "offer2 ",
-  "planId": "gold", 
-  "quantity": " 20", 
+  "planId": "gold",
+  "quantity": " 20",
   "timeStamp": "2019-04-15T20:17:31.7350641Z",
   "action": "Reinstate",
-  "status": "In Progress" 
-} 
+  "status": "In Progress"
+}
 ```
 
 ## Development and testing


### PR DESCRIPTION
JSON examples within **pc-saas-fulfillment-api-v2.md** are inconsistently formatted, making them difficult to read:

![image](https://user-images.githubusercontent.com/52547292/94708534-92ec3d00-02f9-11eb-8937-0e715ec5bd92.png)

This proposal reformats these examples to follow a consistent format.