### PR TITLE
Fix incorrect instructions for publishing .NET for Apache Spark binaries

### DIFF
--- a/articles/synapse-analytics/spark/spark-dotnet.md
+++ b/articles/synapse-analytics/spark/spark-dotnet.md
@@ -46,6 +46,7 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
     1. Download 7-Zip from [here](https://www.7-zip.org/) and add path to `7z.exe` to the `PATH` environment variable.
     2. Open command prompt window and cd into the bin directory with all the published binaries and run the following command.
 
+
       ```cmd
       7z a -tzip <ZIP file name> .
       ```
@@ -53,6 +54,7 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
      **On Linux:**
 
      1. Open a bash shell and cd into the bin directory with all the published binaries and run the following command.
+
 
        ```bash
        zip -r publish.zip

--- a/articles/synapse-analytics/spark/spark-dotnet.md
+++ b/articles/synapse-analytics/spark/spark-dotnet.md
@@ -46,7 +46,6 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
     1. Download 7-Zip from [here](https://www.7-zip.org/) and add path to `7z.exe` to the `PATH` environment variable.
     2. Open command prompt window and cd into the bin directory with all the published binaries and run the following command.
 
-
       ```cmd
       7z a -tzip <ZIP file name> .
       ```
@@ -54,7 +53,6 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
      **On Linux:**
 
      1. Open a bash shell and cd into the bin directory with all the published binaries and run the following command.
-
 
        ```bash
        zip -r publish.zip

--- a/articles/synapse-analytics/spark/spark-dotnet.md
+++ b/articles/synapse-analytics/spark/spark-dotnet.md
@@ -29,10 +29,30 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
 
    ```dotnetcli
    cd mySparkApp
+   dotnet publish -c Release -f netcoreapp3.1 -r win-x64
+   ```
+   
+   **On Linux:**
+
+   ```dotnetcli
+   cd mySparkApp
    dotnet publish -c Release -f netcoreapp3.1 -r ubuntu.16.04-x64
    ```
 
+2. Zip up the contents of the publish folder (say `publish.zip`) created as a result of Step 1 such that all the assemblies are in the first layer of the ZIP file and there is no intermediate folder layer. This means when unzipping `publish.zip` all assemblies should be extracted into the current working directory.
+
+  **On Windows:**
+  
+  1. Download 7-Zip from [here](https://www.7-zip.org/) and add path to `7z.exe` to the `PATH` environment variable.
+  2. Open command prompt window and cd into the bin directory with all the published binaries and run the following command.
+  
+  ```cmd
+  7z a -tzip <ZIP file name> .
+  ```
+  
    **On Linux:**
+   
+   1. Open a bash shell and cd into the bin directory with all the published binaries and run the following command.
 
    ```bash
    zip -r publish.zip

--- a/articles/synapse-analytics/spark/spark-dotnet.md
+++ b/articles/synapse-analytics/spark/spark-dotnet.md
@@ -39,7 +39,7 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
    dotnet publish -c Release -f netcoreapp3.1 -r ubuntu.16.04-x64
    ```
 
-2. Zip up the contents of the publish folder (say `publish.zip`) created as a result of Step 1 such that all the assemblies are in the first layer of the ZIP file and there is no intermediate folder layer. This means when unzipping `publish.zip` all assemblies should be extracted into the current working directory.
+2. Zip the contents of the publish folder, `publish.zip` for example, that was created as a result of Step 1. All the assemblies should be in the first layer of the ZIP file and there should be no intermediate folder layer. This means when you unzip `publish.zip`, all assemblies are extracted into your current working directory.
 
     **On Windows:**
 

--- a/articles/synapse-analytics/spark/spark-dotnet.md
+++ b/articles/synapse-analytics/spark/spark-dotnet.md
@@ -43,12 +43,7 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
 
     **On Windows:**
 
-    1. Download 7-Zip from [here](https://www.7-zip.org/) and add path to `7z.exe` to the `PATH` environment variable.
-    2. Open command prompt window and cd into the bin directory with all the published binaries and run the following command.
-
-      ```cmd
-      7z a -tzip <ZIP file name> .
-      ```
+Use an extraction program, like [7-Zip](https://www.7-zip.org/) or [WinZip](https://www.winzip.com/), to extract the file into the bin directory with all the published binaries.
 
      **On Linux:**
 

--- a/articles/synapse-analytics/spark/spark-dotnet.md
+++ b/articles/synapse-analytics/spark/spark-dotnet.md
@@ -41,22 +41,22 @@ Visit the tutorial to learn how to use Azure Synapse Analytics to [create Apache
 
 2. Zip up the contents of the publish folder (say `publish.zip`) created as a result of Step 1 such that all the assemblies are in the first layer of the ZIP file and there is no intermediate folder layer. This means when unzipping `publish.zip` all assemblies should be extracted into the current working directory.
 
-  **On Windows:**
-  
-  1. Download 7-Zip from [here](https://www.7-zip.org/) and add path to `7z.exe` to the `PATH` environment variable.
-  2. Open command prompt window and cd into the bin directory with all the published binaries and run the following command.
-  
-  ```cmd
-  7z a -tzip <ZIP file name> .
-  ```
-  
-   **On Linux:**
-   
-   1. Open a bash shell and cd into the bin directory with all the published binaries and run the following command.
+    **On Windows:**
 
-   ```bash
-   zip -r publish.zip
-   ```
+    1. Download 7-Zip from [here](https://www.7-zip.org/) and add path to `7z.exe` to the `PATH` environment variable.
+    2. Open command prompt window and cd into the bin directory with all the published binaries and run the following command.
+
+      ```cmd
+      7z a -tzip <ZIP file name> .
+      ```
+
+     **On Linux:**
+
+     1. Open a bash shell and cd into the bin directory with all the published binaries and run the following command.
+
+       ```bash
+       zip -r publish.zip
+       ```
 
 ## .NET for Apache Spark in Azure Synapse Analytics notebooks 
 


### PR DESCRIPTION
Fix incorrect instructions for publishing .NET for Apache Spark binaries.

This fixes part of issue https://github.com/dotnet/spark/issues/671