### PR TITLE
Aligning suggested roles within file

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-admin-mfa.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-admin-mfa.md
@@ -21,11 +21,12 @@ Accounts that are assigned administrative rights are targeted by attackers. Requ
 
 Microsoft recommends you require MFA on the following roles at a minimum:
 
+* Authentication Administrator
 * Billing administrator
 * Conditional Access administrator
 * Exchange administrator
 * Global administrator
-* Helpdesk (Password) administrator
+* Helpdesk administrator
 * Password administrator
 * Security administrator
 * SharePoint administrator
@@ -69,7 +70,7 @@ The following steps will help create a Conditional Access policy to require thos
    1. Under **Exclude**, select **Users and groups** and choose your organization's emergency access or break-glass accounts. 
    1. Select **Done**.
 1. Under **Cloud apps or actions** > **Include**, select **All cloud apps**, and select **Done**.
-1. Under **Conditions** > **Client apps (Preview)**, under **Select the client apps this policy will apply to** leave all defaults selected and select **Done**.
+1. Under **Conditions** > **Client apps**, switch **Configure** to **Yes** and under **Select the client apps this policy will apply to** leave all defaults selected and select **Done**.
 1. Under **Access controls** > **Grant**, select **Grant access**, **Require multi-factor authentication**, and select **Select**.
 1. Confirm your settings and set **Enable policy** to **On**.
 1. Select **Create** to create to enable your policy.


### PR DESCRIPTION
The first list in this article doesn't mention the "Authenticaiton Administrator" role, the List in the step-by-step guide does though. and the "Client Apps" in Step 7 is out of Preview. Sorry for proposing unrelated changes in the same commit, cloning the repo for such a small change felt overkill.