### PR TITLE
Resolves #63529

### DIFF
--- a/articles/azure-resource-manager/templates/deployment-history-deletions.md
+++ b/articles/azure-resource-manager/templates/deployment-history-deletions.md
@@ -17,7 +17,7 @@ Azure Resource Manager automatically deletes deployments from your history as yo
 
 ## When deployments are deleted
 
-Deployments are deleted from your history when you reach 775 or more deployments. Azure Resource Manager deletes deployments until the history is down to 750. The oldest deployments are always deleted first.
+Deployments are deleted from your history when you reach 776 or more deployments. Azure Resource Manager deletes deployments until the history is down to 750. The oldest deployments are always deleted first.
 
 :::image type="content" border="false" source="./media/deployment-history-deletions/deployment-history.svg" alt-text="Deletions from deployment history":::
 


### PR DESCRIPTION
Updates section about "When deployments are deleted" to clarify that 776 deployments is what triggers the automatic deletion of historical entries.