### PR TITLE
Update get-started-partners.md

### DIFF
--- a/articles/cost-management-billing/costs/get-started-partners.md
+++ b/articles/cost-management-billing/costs/get-started-partners.md
@@ -146,9 +146,11 @@ To view costs for a subscription, open **Cost Management + Billing** in the cust
 
 Cost analysis, budgets, and alerts are available for the subscription and resource group Azure RBAC scopes at pay-as-you-go rate-based costs.
 
-Amortized views and actual costs for reserved instances in the Azure RBAC scopes show zero charges. Reserved instance costs are only showing in billing scopes where the purchases were made.
+Amortized views and actual costs for reserved instances in the Azure RBAC scopes show zero charges. Purchase costs for entitlements such as Reserved instances and Marketplace fees are only shown in billing scopes in the partner's tenant where the purchases were made.
 
 The retail rates used to compute costs shown in the view are the same prices shown in the Azure Pricing Calculator for all customers. Costs shown don't include any discounts or credits that the partner may have like Partner Earned Credits, Tier Discounts, and Global Service discounts.
+
+ 
 
 ## Analyze costs in cost analysis
 


### PR DESCRIPTION
made a change to ensure that reservation costs and purchase are available only in the partner tenant to handle support ticket volumes