### PR TITLE
Update account-overview.md

### DIFF
--- a/articles/cosmos-db/account-overview.md
+++ b/articles/cosmos-db/account-overview.md
@@ -23,7 +23,7 @@ To securely manage access to all the data within your Azure Cosmos account, you 
 
 Azure Cosmos container is the fundamental unit of scalability. You can virtually have an unlimited provisioned throughput (RU/s) and storage on a container. Azure Cosmos DB transparently partitions your container using the logical partition key that you specify in order to elastically scale your provisioned throughput and storage. For more information, see [working with Azure Cosmos containers and items](databases-containers-items.md).
 
-Currently, you can create a maximum of 100 Azure Cosmos accounts under an Azure subscription. A single Azure Cosmos account can virtually manage unlimited amount of data and provisioned throughput. To manage your data and provisioned throughput, you can create one or more Azure Cosmos databases under your account and within that database, you can create one or more containers. The following image shows the hierarchy of elements in an Azure Cosmos account:
+Currently, you can create a maximum of 50 Azure Cosmos accounts under an Azure subscription. A single Azure Cosmos account can virtually manage unlimited amount of data and provisioned throughput. To manage your data and provisioned throughput, you can create one or more Azure Cosmos databases under your account and within that database, you can create one or more containers. The following image shows the hierarchy of elements in an Azure Cosmos account:
 
 :::image type="content" source="./media/account-overview/hierarchy.png" alt-text="Hierarchy of an Azure Cosmos account" border="false":::
 


### PR DESCRIPTION
Resolving a discrepancy with https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits

This page mentioned 100 accounts per subscription, where as the limits page mentions 50 accounts per subscription - as the default limit.

I just checked our source code - 50 accounts per subscription is correct. Fixing this page.