### PR TITLE
Fix code example to avoid deprecation message

### DIFF
--- a/articles/azure-monitor/app/correlation.md
+++ b/articles/azure-monitor/app/correlation.md
@@ -129,8 +129,9 @@ It's disabled by default. To enable it, set `ApplicationInsightsServiceOptions.R
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddApplicationInsightsTelemetry(o => 
-        o.RequestCollectionOptions.EnableW3CDistributedTracing = true );
+    Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+    Activity.ForceDefaultIdFormat = true;
+    services.AddApplicationInsightsTelemetry();
     // ....
 }
 ```


### PR DESCRIPTION
When implementing this feature in  Microsoft.ApplicationInsights.AspNetCore, Version=2.14.0.17971, it throws the following warning: "This flag is obsolete and noop. Use System.Diagnostics.Activity.DefaultIdFormat (along with ForceDefaultIdFormat) flags instead.". This fix implements the suggested change of the warning.

Fix for #63694 