### PR TITLE
Fix broken link to sample code

### DIFF
--- a/articles/static-web-apps/deploy-blazor.md
+++ b/articles/static-web-apps/deploy-blazor.md
@@ -28,7 +28,7 @@ Azure Static Web Apps allows you to create static web applications supported by 
 
 The app featured in this tutorial is made up from three different Visual Studio projects:
 
-- **Api**: The C# Azure Functions application which implements the API endpoint that provides weather information to the static app. The [`WeatherForecastFunction`](https://github.com/staticwebev/blazor-starter/blob/main/Api/WeatherForecastFunction.cs) returns an array of `WeatherForecast` objects.
+- **Api**: The C# Azure Functions application which implements the API endpoint that provides weather information to the static app. The [`WeatherForecastFunction`](https://github.com/staticwebdev/blazor-starter/blob/main/Api/WeatherForecastFunction.cs) returns an array of `WeatherForecast` objects.
 
 - **Client**: The front-end Blazor web assembly project. A [fallback route](#fallback-route) is implemented to ensure all routes are served the _index.html_ file.
 


### PR DESCRIPTION
I went through the Blazor Azure SWA tutorial and ran into this broken link.
This pull request fixes the broken link to sample code:
Before:  https://github.com/staticwebev/blazor-starter/blob/main/Api/WeatherForecastFunction.cs
After:    https://github.com/staticwebdev/blazor-starter/blob/main/Api/WeatherForecastFunction.cs