### PR TITLE
Minor updates

### DIFF
--- a/articles/azure-monitor/app/windows-desktop.md
+++ b/articles/azure-monitor/app/windows-desktop.md
@@ -3,7 +3,7 @@ title: Monitoring usage and performance for Windows desktop apps
 description: Analyze usage and performance of your Windows desktop app with Application Insights.
 ms.topic: conceptual
 ms.date: 06/11/2020
-
+ms.custom: fasttrack-edit
 ---
 
 # Monitoring usage and performance in Classic Windows Desktop apps
@@ -16,7 +16,7 @@ Applications hosted on premises, in Azure, and in other clouds can all take adva
 3. In Visual Studio, edit the NuGet packages of your app project, and add Microsoft.ApplicationInsights.WindowsServer. (Or choose Microsoft.ApplicationInsights if you just want the base API, without the standard telemetry collection modules.)
 4. Set the instrumentation key either in your code:
    
-    `TelemetryConfiguration.Active.InstrumentationKey = "` *your key* `";`
+    `TelemetryConfiguration.Active.InstrumentationKey = "`*your key*`";`
    
     or in ApplicationInsights.config (if you installed one of the standard telemetry packages):
    
@@ -49,10 +49,8 @@ using Microsoft.ApplicationInsights;
             ...
         }
 
-        protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+        protected override void OnFormClosing(System.Windows.Forms.FormClosingEventArgs e)
         {
-            e.Cancel = true;
-
             if (tc != null)
             {
                 tc.Flush(); // only for desktop apps
@@ -60,9 +58,10 @@ using Microsoft.ApplicationInsights;
                 // Allow time for flushing:
                 System.Threading.Thread.Sleep(1000);
             }
-            base.OnClosing(e);
+            base.OnFormClosing(e);
         }
-
+        
+        ...
 ```
 
 ## Override storage of computer name


### PR DESCRIPTION
Avoid space in between double quotes in the key sample.
OnClosing is obsolete based on https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.form.onclosing?view=netcore-3.1. Use OnFormClosing instead.
Setting e.Cancel to true prevents form from closing.
Added indication that code is missing in Form1 example (including the class closing bracket)
Added FTA meta for internal reporting.