### PR TITLE
Fix Twilio Documentation link at partner-twilio-php-how-to-use-voice-…

### DIFF
--- a/articles/partner-twilio-php-how-to-use-voice-sms.md
+++ b/articles/partner-twilio-php-how-to-use-voice-sms.md
@@ -142,7 +142,7 @@ catch (Exception $e)
 
 As mentioned, this code uses a Twilio-provided site to return the TwiML response. You could instead use your own site to provide the TwiML response; for more information, see [How to Provide TwiML Responses from Your Own Web Site](#howto_provide_twiml_responses).
 
-* **Note**: To troubleshoot TLS/SSL certificate validation errors, see [http://readthedocs.org/docs/twilio-php/en/latest/usage/rest.html][ssl_validation] 
+* **Note**: To troubleshoot TLS/SSL certificate validation errors, see [https://www.twilio.com/docs/api/errors][ssl_validation] 
 
 ## <a id="howto_send_sms"></a>How to: Send an SMS message
 The following shows how to send an SMS message using the **Services_Twilio** class. The **From** number is provided by Twilio for trial accounts to send SMS messages. The **To** number must be verified for your Twilio account prior to running the code.


### PR DESCRIPTION
On the doc website page, the ssl_validation-link navigates to https://www.twilio.com/docs/api/errors.
The original http://readthedocs.org/docs/twilio-php/en/latest/usage/rest.html does not exist anymore.