### PR TITLE
Fix broken Azure portal link at active-directory/develop/brokered-auth.md

### DIFF
--- a/articles/active-directory/develop/brokered-auth.md
+++ b/articles/active-directory/develop/brokered-auth.md
@@ -90,7 +90,7 @@ keytool -exportcert -alias androiddebugkey -keystore %HOMEPATH%\.android\debug.k
 
 Once you've generated a signature hash with *keytool*, use the Azure portal to generate the redirect URI:
 
-1. Sign in to the [Azure portal](https://protal.azure.com) and select your Android app in **App registrations**.
+1. Sign in to the [Azure portal](https://portal.azure.com) and select your Android app in **App registrations**.
 1. Select **Authentication** > **Add a platform** > **Android**.
 1. In the **Configure your Android app** pane that opens, enter the **Signature hash** that you generated earlier and a **Package name**.
 1. Select the **Configure** button.


### PR DESCRIPTION
Looks like a typo made it into this link.
Before: https://**protal**.azure.com
After: https://portal.azure.com