### PR TITLE
Fix Kubernetes size notation link at azure-arc/data/sizing-guidance.md

### DIFF
--- a/articles/azure-arc/data/sizing-guidance.md
+++ b/articles/azure-arc/data/sizing-guidance.md
@@ -22,7 +22,7 @@ When planning for the deployment of Azure Arc data services you should plan for 
 ## General sizing requirements
 
 > [!NOTE]
-> If you are not familiar with the concepts in this article, you can read more about [Kubernetes resource governance](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) and [Kubernetes size notation](https://kubernetes.io/docs/concepts/configuration/.manage-resources-containers/#resource-units-in-kubernetes).
+> If you are not familiar with the concepts in this article, you can read more about [Kubernetes resource governance](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) and [Kubernetes size notation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes).
 
 Cores numbers must be an integer value greater than or equal to one.
 


### PR DESCRIPTION
An accidental '.' character made it into the URL referencing Kubernetes docs breaking the link.
The '.' has been removed and the URL works as expected.