### PR TITLE
Clarify Active Directory Install subtitle

### DIFF
--- a/articles/cognitive-services/immersive-reader/includes/quickstarts/immersive-reader-client-library-csharp.md
+++ b/articles/cognitive-services/immersive-reader/includes/quickstarts/immersive-reader-client-library-csharp.md
@@ -48,7 +48,7 @@ Right-click on the project in the _Solution Explorer_ and choose **Manage User S
 }
 ```
 
-### Install Active Directory
+### Install Active Directory NuGet package
 
 The following code uses objects from the **Microsoft.IdentityModel.Clients.ActiveDirectory** NuGet package so you'll need to add a reference to that package in your project.
 


### PR DESCRIPTION
Small correction to the subtitle regarding the Active Directory, to clarify that we are installing the nuget not Active directory itself.