### PR TITLE
fix typo

### DIFF
--- a/articles/azure-maps/zoom-levels-and-tile-grid.md
+++ b/articles/azure-maps/zoom-levels-and-tile-grid.md
@@ -95,7 +95,7 @@ var numberOfTilesWide = Math.pow(2, zoom);
 var numberOfTilesHigh = numberOfTilesWide;
 ```
 
-Each tile is given XY coordinates ranging from (0, 0) in the upper left to *(2<sup>zoom</sup>–1, 2<sup>zoom</sup>–1)* in the lower right. For example, at zoom level 2, the tile coordinates range from (0, 0) to (7, 7) as follows:
+Each tile is given XY coordinates ranging from (0, 0) in the upper left to *(2<sup>zoom</sup>–1, 2<sup>zoom</sup>–1)* in the lower right. For example, at zoom level 3, the tile coordinates range from (0, 0) to (7, 7) as follows:
 
 :::image type="content" border="false" source="./media/zoom-levels-and-tile-grid/map-tiles-x-y-coordinates-7x7.png" alt-text="Map of tile coordinates":::
 
@@ -131,7 +131,7 @@ To convert tile coordinates into a `quadkey`, the bits of the Y and X coordinate
 ```
 tileX = 3 = 011 (base 2)
 
-tileY = 5 = 1012 (base 2)
+tileY = 5 = 101 (base 2)
 
 quadkey = 100111 (base 2) = 213 (base 4) = "213"
 ```


### PR DESCRIPTION
this pull request include 2 fixes

- fix zoom level.

- A following image shows zoom level 3 tiles(from https://docs.microsoft.com/ja-jp/azure/azure-maps/zoom-levels-and-tile-grid?tabs=csharp)
![image](https://user-images.githubusercontent.com/30842360/95078339-f1794700-074f-11eb-9f0d-17384b5b75e9.png)

## fix source code typo