### PR TITLE
Made config names correct - case sensitive

### DIFF
--- a/articles/hdinsight/optimize-hbase-ambari.md
+++ b/articles/hdinsight/optimize-hbase-ambari.md
@@ -84,7 +84,7 @@ The larger the region file size, the smaller the number of splits. You can incre
 
 ## Define Memstore size
 
-Memstore size is defined by the `hbase.regionserver.global.memstore.UpperLimit` and `hbase.regionserver.global.memstore.LowerLimit` parameters. Setting these values equal to each other reduces pauses during writes (also causing more frequent flushing) and results in increased write performance.
+Memstore size is defined by the `hbase.regionserver.global.memstore.upperLimit` and `hbase.regionserver.global.memstore.lowerLimit` parameters. Setting these values equal to each other reduces pauses during writes (also causing more frequent flushing) and results in increased write performance.
 
 ## Set Memstore local allocation buffer
 


### PR DESCRIPTION
The config nameswere incorrect - they need to be case-sensitive. Corrected this.