### PR TITLE
Make the pod deployment explicit

### DIFF
--- a/articles/key-vault/general/key-vault-integrate-kubernetes.md
+++ b/articles/key-vault/general/key-vault-integrate-kubernetes.md
@@ -181,6 +181,7 @@ If you're using a service principal, grant permissions for it to access your key
 1. Grant the service principal permissions to get secrets:
     ```azurecli
     az keyvault set-policy -n $KEYVAULT_NAME --secret-permissions get --spn $AZURE_CLIENT_ID
+    az keyvault set-policy -n $KEYVAULT_NAME --key-permissions get --spn $AZURE_CLIENT_ID
     ```
 
 1. You've now configured your service principal with permissions to read secrets from your key vault. The **$AZURE_CLIENT_SECRET** is the password of your service principal. Add your service principal credentials as a Kubernetes secret that's accessible by the Secrets Store CSI driver:
@@ -235,6 +236,7 @@ If you're using managed identities, assign specific roles to the AKS cluster you
     az role assignment create --role "Reader" --assignee $principalId --scope /subscriptions/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/resourceGroups/contosoResourceGroup/providers/Microsoft.KeyVault/vaults/contosoKeyVault5
 
     az keyvault set-policy -n contosoKeyVault5 --secret-permissions get --spn $clientId
+    az keyvault set-policy -n contosoKeyVault5 --key-permissions get --spn $clientId
     ```
 
 ## Deploy your pod with mounted secrets from your key vault

--- a/articles/key-vault/general/key-vault-integrate-kubernetes.md
+++ b/articles/key-vault/general/key-vault-integrate-kubernetes.md
@@ -307,8 +307,8 @@ spec:
         readOnly: true
         volumeAttributes:
           secretProviderClass: azure-kvname
-        nodePublishSecretRef:
-          name: secrets-store-creds 
+        nodePublishSecretRef:           # Only required when using service principal mode
+          name: secrets-store-creds     # Only required when using service principal mode
 ```
 
 Run the following command to deploy your pod:


### PR DESCRIPTION
Make the pod deployment explicit to ensure difference between managed identity & service principal mode is clear