### PR TITLE
Fix Uptime SLA page link to `az aks update`

### DIFF
--- a/articles/aks/uptime-sla.md
+++ b/articles/aks/uptime-sla.md
@@ -90,7 +90,7 @@ Create a new cluster, and don't use Uptime SLA:
 az aks create --resource-group myResourceGroup --name myAKSCluster--node-count 1
 ```
 
-Use the [`az aks update`][az-aks-nodepool-update] command to update the existing cluster:
+Use the [`az aks update`][az-aks-update] command to update the existing cluster:
 
 ```azurecli-interactive
 # Update an existing cluster to use Uptime SLA
@@ -135,5 +135,5 @@ Configure your cluster to [limit egress traffic](limit-egress-traffic.md).
 [limit-egress-traffic]: ./limit-egress-traffic.md
 [az-extension-add]: /cli/azure/extension#az-extension-add
 [az-extension-update]: /cli/azure/extension#az-extension-update
-[az-aks-nodepool-update]: /cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-update
+[az-aks-update]: /cli/azure/aks?view=azure-cli-latest#az-aks-update
 [az-group-delete]: /cli/azure/group#az-group-delete


### PR DESCRIPTION
The link in question is supposed to go to the docs for `az aks update` but incorrectly goes to `az aks nodepool update`.