### PR TITLE
Missing information about disks

### DIFF
--- a/articles/resource-mover/move-region-within-resource-group.md
+++ b/articles/resource-mover/move-region-within-resource-group.md
@@ -54,7 +54,7 @@ In this article, learn how to move resources in a specific resource group to a d
 Select resources you want to move. You move resources to a target region in the source region subscription. If you want to change the subscription, you can do that after the resources are moved.
 
 > [!NOTE]
->  Do not select associated disks, as the operation would fail. Associated disks are automatically included in the move of a VM.
+>  Don't select associated disks or the operation will fail. Associated disks are automatically included in a VM move.
 
 1. In the Azure portal, open the relevant resource group.
 2. In the resource group page, select the resources that you want to move.

--- a/articles/resource-mover/move-region-within-resource-group.md
+++ b/articles/resource-mover/move-region-within-resource-group.md
@@ -53,6 +53,9 @@ In this article, learn how to move resources in a specific resource group to a d
 
 Select resources you want to move. You move resources to a target region in the source region subscription. If you want to change the subscription, you can do that after the resources are moved.
 
+> [!NOTE]
+>  Do not select associated disks, as the operation would fail. Associated disks are automatically included in the move of a VM.
+
 1. In the Azure portal, open the relevant resource group.
 2. In the resource group page, select the resources that you want to move.
 3. Select **Move** > **Move to another region**.


### PR DESCRIPTION
Associated disks will move, but you can not select them in the move operation. An error would appear saying that this type of resource is not supported for move operations. Anyway, the associated disks will automatically be moved (recreated) to the new region.