### PR TITLE
Fix link to Fluent UI used in the sample

### DIFF
--- a/articles/communication-services/samples/calling-hero-sample.md
+++ b/articles/communication-services/samples/calling-hero-sample.md
@@ -112,6 +112,6 @@ For more information, see the following articles:
 
 - [Azure Communication GitHub](https://github.com/Azure/communication) - Find more examples and information on the official GitHub page
 - [Redux](https://redux.js.org/) - Client-side state management
-- [FluentUI](https://developer.microsoft.com/fluentui#/) - Microsoft powered UI library
+- [FluentUI](https://aka.ms/fluent-ui) - Microsoft powered UI library
 - [React](https://reactjs.org/) - Library for building user interfaces
 - [ASP.NET Core](https://docs.microsoft.com/aspnet/core/introduction-to-aspnet-core?view=aspnetcore-3.1&preserve-view=true) - Framework for building web applications

--- a/articles/communication-services/samples/chat-hero-sample.md
+++ b/articles/communication-services/samples/chat-hero-sample.md
@@ -113,6 +113,6 @@ For more information, see the following articles:
 
 - [Azure Communication GitHub](https://github.com/Azure/communication) - Find more examples and information on the official GitHub page
 - [Redux](https://redux.js.org/) - Client-side state management
-- [FluentUI](https://developer.microsoft.com/fluentui#/) - Microsoft powered UI library
+- [FluentUI](https://aka.ms/fluent-ui) - Microsoft powered UI library
 - [React](https://reactjs.org/) - Library for building user interfaces
 - [ASP.NET Core](https://docs.microsoft.com/aspnet/core/introduction-to-aspnet-core?view=aspnetcore-3.1&preserve-view=true) - Framework for building web applications


### PR DESCRIPTION
Changing the link to Fluent UI library used in the samples to avoid confusion.
Removed link was pointing to Fluent UI v7, which does not have some of the components used in the sample code (like `Chat`). 
Added link is pointing to Fluent UI v0, which was actually used in the sample code.