### PR TITLE
Update service-fabric-cluster-capacity.md

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-capacity.md
+++ b/articles/service-fabric/service-fabric-cluster-capacity.md
@@ -29,7 +29,7 @@ Each cluster requires one **primary node type**, which runs critical system serv
 
 **Non-primary node types** can be used to define application roles (such as *front-end* and *back-end* services) and to physically isolate services within a cluster. Service Fabric clusters can have zero or more non-primary node types.
 
-The primary node type is configured using the `isPrimary` attribute under the node type definition in the Azure Resource Manager deployment template. See the [NodeTypeDescription object](/azure/templates/microsoft.servicefabric/clusters#nodetypedescription-object) for the full list of node type properties. For example usage, open any *AzureDeploy.json* file in [Service Fabric cluster samples](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/) and *Find on Page* search for the `nodetTypes` object.
+The primary node type is configured using the `isPrimary` attribute under the node type definition in the Azure Resource Manager deployment template. See the [NodeTypeDescription object](/azure/templates/microsoft.servicefabric/clusters#nodetypedescription-object) for the full list of node type properties. For example usage, open any *AzureDeploy.json* file in [Service Fabric cluster samples](https://github.com/Azure-Samples/service-fabric-cluster-templates/tree/master/) and *Find on Page* search for the `nodeTypes` object.
 
 ### Node type planning considerations
 


### PR DESCRIPTION
Spelling correction "nodetTypes" to "nodeTypes",  that is referencing the fallowing object: https://github.com/Azure-Samples/service-fabric-cluster-templates/blob/3d71184d0368bf3b9f7f07ce1367291f1fc01ab7/5-VM-RHEL-1-NodeTypes-Secure/AzureDeploy.json#L618