### PR TITLE
Update query-json-files.md

### DIFF
--- a/articles/synapse-analytics/sql/query-json-files.md
+++ b/articles/synapse-analytics/sql/query-json-files.md
@@ -53,7 +53,7 @@ from openrowset(
     ) with (doc nvarchar(max)) as rows
 ```
 
-The JSON document in the above demo includes an array of objects. This query will return each object as a separate row in the result set. Make sure that you can access this file. If your file is protected with SAS key or custom identity, you would need to set up [server level credential for sql login](develop-storage-files-storage-access-control.md?tabs=shared-access-signature#server-scoped-credential). 
+The JSON document in the preceding sample query includes an array of objects. The query returns each object as a separate row in the result set. Make sure that you can access this file. If your file is protected with SAS key or custom identity, you would need to set up [server level credential for sql login](develop-storage-files-storage-access-control.md?tabs=shared-access-signature#server-scoped-credential). 
 
 ### Data source usage
 

--- a/articles/synapse-analytics/sql/query-json-files.md
+++ b/articles/synapse-analytics/sql/query-json-files.md
@@ -53,7 +53,7 @@ from openrowset(
     ) with (doc nvarchar(max)) as rows
 ```
 
-This query will return each JSON document as a separate row of the result set. Make sure that you can access this file. If your file is protected with SAS key or custom identity, you would need to set up [server level credential for sql login](develop-storage-files-storage-access-control.md?tabs=shared-access-signature#server-scoped-credential). 
+The JSON document in the above demo includes an array of objects. This query will return each object as a separate row in the result set. Make sure that you can access this file. If your file is protected with SAS key or custom identity, you would need to set up [server level credential for sql login](develop-storage-files-storage-access-control.md?tabs=shared-access-signature#server-scoped-credential). 
 
 ### Data source usage
 


### PR DESCRIPTION
Before my fix, the document said "This query will return **each JSON document** as a separate row of the result set.", but the above code includes URL to a document which only **includes a single JSON document.** Therefore, this is not accurate. There is only one JSON document in the source file. The JSON document includes an array of objects and each object is a record which should be converted to a row in the table.

I changed the text to: "The JSON document in the above demo includes an array of objects. This query will return each object as a separate row in the result set."