### PR TITLE
Update how-to-create-tumbling-window-trigger.md

### DIFF
--- a/articles/data-factory/how-to-create-tumbling-window-trigger.md
+++ b/articles/data-factory/how-to-create-tumbling-window-trigger.md
@@ -142,7 +142,7 @@ To use the **WindowStart** and **WindowEnd** system variable values in the pipel
 
 ### Execution order of windows in a backfill scenario
 
-If the startTime of trigger is in the past, then based on this formula, M=(CurrentTime- TriggerStartTime)/TriggerSliceSize, the trigger will generate {M} backfill(past) runs in parallel, honoring trigger concurrency, before executing the future runs. The order of execution for windows is deterministic, from oldest to newest intervals. Currently, this behavior can't be modified.
+If the startTime of trigger is in the past, then based on this formula, M=(CurrentTime- TriggerStartTime)/TumblingWindowSize, the trigger will generate {M} backfill(past) runs in parallel, honoring trigger concurrency, before executing the future runs. The order of execution for windows is deterministic, from oldest to newest intervals. Currently, this behavior can't be modified.
 
 ### Existing TriggerResource elements
 


### PR DESCRIPTION
Replacing term TriggerSliceSize with TumblingWindowSize. Nowhere in document is TriggerSliceSize or Slice defined. Not sure what this is meant to be. If the slice size is really referring to TumblingWindowSize then we should stick with the universally set naming convention to reduce confusion.