### PR TITLE
Update pip extra installs for explain/interpret

### DIFF
--- a/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
+++ b/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
@@ -129,7 +129,7 @@ else:
     # Add some packages relied on by data prep step
     aml_run_config.environment.python.conda_dependencies = CondaDependencies.create(
         conda_packages=['pandas','scikit-learn'], 
-        pip_packages=['azureml-sdk[automl,interpret]', 'azureml-dataprep[fuse,pandas]'], 
+        pip_packages=['azureml-sdk[automl]', 'azureml-dataprep[fuse,pandas]'], 
         pin_sdk_version=False)
 ```
 

--- a/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
+++ b/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
@@ -129,7 +129,7 @@ else:
     # Add some packages relied on by data prep step
     aml_run_config.environment.python.conda_dependencies = CondaDependencies.create(
         conda_packages=['pandas','scikit-learn'], 
-        pip_packages=['azureml-sdk[automl,explain]', 'azureml-dataprep[fuse,pandas]'], 
+        pip_packages=['azureml-sdk[automl,interpret]', 'azureml-dataprep[fuse,pandas]'], 
         pin_sdk_version=False)
 ```
 


### PR DESCRIPTION
The azureml-explain-model package is being deprecated. All public documentation should reflect the use of the new package azureml-interpret or stop using explain. This particular doc does not rely on interpret/explain, so this PR removes the reference entirely.