### PR TITLE
Fix typo in DeleteAnchorAsync snippet

### DIFF
--- a/articles/spatial-anchors/how-tos/create-locate-anchors-unity.md
+++ b/articles/spatial-anchors/how-tos/create-locate-anchors-unity.md
@@ -295,7 +295,7 @@ Learn more about the [AnchorLocatedDelegate](https://docs.microsoft.com/dotnet/a
 Learn more about the [DeleteAnchorAsync](https://docs.microsoft.com/dotnet/api/microsoft.azure.spatialanchors.cloudspatialanchorsession.deleteanchorasync) method.
 
 ```csharp
-    await this.cloudSession..DeleteAnchorAsync(cloudAnchor);
+    await this.cloudSession.DeleteAnchorAsync(cloudAnchor);
     // Perform any processing you may want when delete finishes
 ```
 


### PR DESCRIPTION
Fixes #64058 

Snippet link: https://docs.microsoft.com/en-us/azure/spatial-anchors/how-tos/create-locate-anchors-unity#delete-anchors

Current:
```
await this.cloudSession..DeleteAnchorAsync(cloudAnchor);
    // Perform any processing you may want when delete finishes
```

Should be:
```
await this.cloudSession.DeleteAnchorAsync(cloudAnchor);
    // Perform any processing you may want when delete finishes
```