### PR TITLE
Fixing permission set error in roles-quickstart-app-registration-limits.md

### DIFF
--- a/articles/active-directory/users-groups-roles/roles-quickstart-app-registration-limits.md
+++ b/articles/active-directory/users-groups-roles/roles-quickstart-app-registration-limits.md
@@ -55,7 +55,7 @@ Done! In this quickstart, you successfully created a custom role with permission
 There are two permissions available for granting the ability to create application registrations, each with different behavior.
 
 - microsoft.directory/applications/createAsOwner: Assigning this permission results in the creator being added as the first owner of the created app registration, and the created app registration will count against the creator's 250 created objects quota.
-- microsoft.directory/applicationPolicies/create: Assigning this permission results in the creator not being added as the first owner of the created app registration, and the created app registration will not count against the creator's 250 created objects quota. Use this permission carefully, because there is nothing preventing the assignee from creating app registrations until the directory-level quota is hit. If both permissions are assigned, this permission takes precedence.
+- microsoft.directory/applications/create: Assigning this permission results in the creator not being added as the first owner of the created app registration, and the created app registration will not count against the creator's 250 created objects quota. Use this permission carefully, because there is nothing preventing the assignee from creating app registrations until the directory-level quota is hit. If both permissions are assigned, this permission takes precedence.
 
 ## Create a custom role in Azure AD PowerShell
 


### PR DESCRIPTION
Fixing an error.  Changing "microsoft.directory/applicationpolicies/create" to "microsoft.directory/applications/create"

Appregistration related permission sets should read applications and not applicationpolicies