### PR TITLE
pip should come from envs instead of env

### DIFF
--- a/articles/hdinsight/spark/apache-spark-python-package-installation.md
+++ b/articles/hdinsight/spark/apache-spark-python-package-installation.md
@@ -76,7 +76,7 @@ HDInsight cluster depends on the built-in Python environment, both Python 2.7 an
 
     - Or use PyPi repo, change `seaborn` and `py35new` correspondingly:
         ```bash
-        sudo /usr/bin/anaconda/env/py35new/bin/pip install seaborn
+        sudo /usr/bin/anaconda/envs/py35new/bin/pip install seaborn
         ```
 
     Use below command if you would like to install a library with a specific version:
@@ -93,7 +93,7 @@ HDInsight cluster depends on the built-in Python environment, both Python 2.7 an
     - Or use PyPi repo, change `numpy==1.16.1` and `py35new` correspondingly:
 
         ```bash
-        sudo /usr/bin/anaconda/env/py35new/bin/pip install numpy==1.16.1
+        sudo /usr/bin/anaconda/envs/py35new/bin/pip install numpy==1.16.1
         ```
 
     if you don't know the virtual environment name, you can SSH to the head node of the cluster and run `/usr/bin/anaconda/bin/conda info -e` to show all virtual environments.


### PR DESCRIPTION
Since the virtual environment is created at `/usr/bin/anaconda/envs/py35new`, I am supposing the pip should also be invoked from this directory. Therefore, instead of 

```bash
sudo /usr/bin/anaconda/env/py35new/bin/pip install numpy==1.16.1
```

It might be 
```bash
sudo /usr/bin/anaconda/envs/py35new/bin/pip install numpy==1.16.1
```