### PR TITLE
Update custom-script-windows.md

### DIFF
--- a/articles/virtual-machines/extensions/custom-script-windows.md
+++ b/articles/virtual-machines/extensions/custom-script-windows.md
@@ -240,8 +240,8 @@ Set-AzVMExtension -ResourceGroupName <resourceGroupName> `
     -Publisher "Microsoft.Compute" `
     -ExtensionType "CustomScriptExtension" `
     -TypeHandlerVersion "1.10" `
-    -Settings $settings    `
-    -ProtectedSettings $protectedSettings `
+    -Settings $settings `
+    -ProtectedSettings $protectedSettings;
 ```
 
 ### Running scripts from a local share


### PR DESCRIPTION
Removed backtick from the end of and added a semi-colon. Backtick causes an error when running the command. Also placed a semi-colon as per the PowerShell command example https://docs.microsoft.com/en-us/powershell/module/az.compute/set-azvmextension?view=azps-4.7.0#example-1--modify-settings-by-using-hash-tables