### PR TITLE
Remove reference to default Azure File based Storage Class

### DIFF
--- a/articles/aks/azure-files-volume.md
+++ b/articles/aks/azure-files-volume.md
@@ -144,7 +144,6 @@ spec:
     storage: 5Gi
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
   azureFile:
     secretName: azure-secret
     shareName: aksshare
@@ -172,7 +171,6 @@ spec:
     storage: 5Gi
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
   azureFile:
     secretName: azure-secret
     shareName: aksshare
@@ -196,7 +194,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: azurefile
+  storageClassName: ""
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
## Purpose
> This PR performs $subject based on the suggestions in https://github.com/MicrosoftDocs/azure-docs/issues/64114.

## Goals
> Remove reference to default Azure File based Storage Class in [documentation](https://docs.microsoft.com/en-us/azure/aks/azure-files-volume)