### PR TITLE
Update quickstart-translator.md

### DIFF
--- a/articles/cognitive-services/Translator/quickstart-translator.md
+++ b/articles/cognitive-services/Translator/quickstart-translator.md
@@ -137,6 +137,7 @@ class Program
 {
     private static readonly string subscriptionKey = "YOUR-SUBSCRIPTION-KEY";
     private static readonly string endpoint = "https://api.cognitive.microsofttranslator.com/";
+    private static readonly string region = "YOUR-REGION-HERE";
     
     static async Task Main(string[] args)
     {
@@ -154,6 +155,7 @@ class Program
             request.RequestUri = new Uri(endpoint + route);
             request.Content = new StringContent(requestBody, Encoding.UTF8, "application/json");
             request.Headers.Add("Ocp-Apim-Subscription-Key", subscriptionKey);
+            request.Headers.Add("Ocp-Apim-Subscription-Region", region);
     
             // Send the request and get response.
             HttpResponseMessage response = await client.SendAsync(request).ConfigureAwait(false);


### PR DESCRIPTION
Add region to header, otherwise it will throw the following error:

{"code":401000,"message":"The request is not authorized because credentials are missing or invalid."}