### PR TITLE
Update configure-connect-to-azure-storage.md

### DIFF
--- a/articles/app-service/configure-connect-to-azure-storage.md
+++ b/articles/app-service/configure-connect-to-azure-storage.md
@@ -60,7 +60,6 @@ This guide shows how to attach Azure Storage to a Linux container App Service. B
 
 - Azure Storage in App Service is **in preview** for App Service on Linux and Web App for Containers. It's **not supported** for **production scenarios**.
 - Azure Storage in App Service supports mounting **Azure Files containers** (Read / Write) and **Azure Blob containers** (Read Only)
-- Azure Storage in App Service **doesn't support** using the **Storage Firewall** configuration because of infrastructure limitations.
 - Azure Storage in App Service lets you specify **up to five** mount points per app.
 - Azure Storage mounted to an app is not accessible through App Service FTP/FTPs endpoints. Use [Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/).
 


### PR DESCRIPTION
Removed the below line from Limitations
- Azure Storage in App Service **doesn't support** using the **Storage Firewall** configuration because of infrastructure limitations.

With Regional VNet Integration, this is no longer valid. 

We probably need to include a new section for Regional Vnet Integration