### PR TITLE
Removed reference to the preview

### DIFF
--- a/articles/sentinel/connect-zscaler.md
+++ b/articles/sentinel/connect-zscaler.md
@@ -19,11 +19,6 @@ ms.author: yelevin
 ---
 # Connect Zscaler Internet Access to Azure Sentinel
 
-> [!IMPORTANT]
-> The Zscaler data connector in Azure Sentinel is currently in public preview.
-> This feature is provided without a service level agreement, and it's not recommended for production workloads. Certain features might not be supported or might have constrained capabilities. 
-> For more information, see [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
-
 This article explains how to connect your Zscaler Internet Access appliance to Azure Sentinel. The Zscaler data connector allows you to easily connect your Zscaler Internet Access (ZIA) logs with Azure Sentinel, to view dashboards, create custom alerts, and improve investigation. Using Zscaler on Azure Sentinel will provide you more insights into your organization’s Internet usage, and will enhance its security operation capabilities.​ 
 
 


### PR DESCRIPTION
NOTE:  This connector was promoted to GA quite some time ago but the documentation still reflected "Preview" state.   

I removed the preview reference.  (Partner requested correction.)

Eric

> [!IMPORTANT]
> The Zscaler data connector in Azure Sentinel is currently in public preview.
> This feature is provided without a service level agreement, and it's not recommended for production workloads. Certain features might not be supported or might have constrained capabilities. 
> For more information, see [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).