### PR TITLE
Update deploy-onnx.md

### DIFF
--- a/articles/azure-sql-edge/deploy-onnx.md
+++ b/articles/azure-sql-edge/deploy-onnx.md
@@ -172,7 +172,7 @@ Using `skl2onnx`, convert the LinearRegression model to the ONNX format and save
 
 ```python
 # Convert the scikit model to onnx format
-onnx_model = skl2onnx.convert_sklearn(model, 'Boston Data', convert_dataframe_schema(x_train))
+onnx_model = skl2onnx.convert_sklearn(model, 'Boston Data', convert_dataframe_schema(x_train), final_types=[('variable1',FloatTensorType([1,1]))])
 # Save the onnx model locally
 onnx_model_path = 'boston1.model.onnx'
 onnxmltools.utils.save_model(onnx_model, onnx_model_path)


### PR DESCRIPTION
An issue with the latest packages from sklearn. The problem is that the latest package is creating an output of dimension 1x13, but the Predict statement is expecting a scalar output.  Fixed convert.