### PR TITLE
adding a link to the transparency note for LVA

### DIFF
--- a/articles/media-services/live-video-analytics-edge/toc.yml
+++ b/articles/media-services/live-video-analytics-edge/toc.yml
@@ -115,4 +115,6 @@
     href: faq.md
   - name: Production readiness and best practices
     href: production-readiness.md
+  - name: Transparency and responsible AI principles
+    href: https://azure.microsoft.com/resources/transparency-note-live-video-analytics-lva/
 


### PR DESCRIPTION
The documentation for LVA needs to link to the associated transparency note.