### PR TITLE
IP address prefixes per WAF rule for AppGW.

### DIFF
--- a/includes/application-gateway-limits.md
+++ b/includes/application-gateway-limits.md
@@ -34,5 +34,6 @@ ms.author: victorh
 | WAF body size limit, without files|128 KB||
 | Maximum WAF custom rules|100||
 | Maximum WAF exclusions|100||
+| IP address prefixes per WAF custom rule|450||
 
 <sup>1</sup> In case of WAF-enabled SKUs, you must limit the number of resources to 40.


### PR DESCRIPTION
About WAF V2 SKU, I know the number of IP address prefixes per WAF rule is 450. Could you add this limitation into this document ?