### PR TITLE
suggested minimum instance count value should be 3

### DIFF
--- a/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
+++ b/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
@@ -57,7 +57,7 @@ Azure Application Gateways are always deployed in a highly available fashion. Th
 
 Please note that even if you configure autoscaling with zero minimum instances the service will still be highly available, which is always included with the fixed price.
 
-However, creating a new instance can take some time (around six or seven minutes). Hence, if you do not want to cope with this downtime you can configure a minimum instance count of 2, ideally with Availability Zone support. This way you will have at least two instances inside of your Azure Application Gateway under normal circumstances, so if one of them had a problem the other will try to cope with the traffic, during the time a new instance is being created. Note that an Azure Application Gateway instance can support around 10 Capacity Units, so depending on how much traffic you typically have you might want to configure your minimum instance autoscaling setting to a value higher than 2.
+However, creating a new instance can take some time (around six or seven minutes). Hence, if you do not want to cope with this downtime you can configure a minimum instance count of at least 3, ideally with Availability Zone support. This way you will have at least two instances inside of your Azure Application Gateway under normal circumstances, so if one of them had a problem the other will try to cope with the traffic, during the time a new instance is being created. Note that an Azure Application Gateway instance can support around 10 Capacity Units, so depending on how much traffic you typically have you might want to configure your minimum instance autoscaling setting to a value higher than 3.
 
 ## Feature comparison between v1 SKU and v2 SKU
 


### PR DESCRIPTION
we know that even configured minimum instance as 0, there are always 2 instance running internally. Thus there is no such difference configured minimum instance count from 0 to 2. So the downtime of scaling out “from 0 to 5” and “from 2 to 5” will be the same. I suppose that we should edit this part minimum instance count of at least 3 instead.