### PR TITLE
Adding unsupported scenario for ACI VNET integration

### DIFF
--- a/articles/container-instances/container-instances-virtual-network-concepts.md
+++ b/articles/container-instances/container-instances-virtual-network-concepts.md
@@ -36,6 +36,9 @@ Container groups deployed into an Azure virtual network enable scenarios like:
 * You can't use a [managed identity](container-instances-managed-identity.md) in a container group deployed to a virtual network.
 * You can't enable a [liveness probe](container-instances-liveness-probe.md) or [readiness probe](container-instances-readiness-probe.md) in a container group deployed to a virtual network.
 * Due to the additional networking resources involved, deployments to a virtual network are typically slower than deploying a standard container instance.
+* Pulling images using vnet connectivity, such as [ACR with private link](articles/container-registry/container-registry-private-link.md), is not supported.
+* Service endpoint whitelisting for Key Vault secret and Azure File mount is not supported.
+* Key Vault and Azure File mount with Private endpoint is not supported.
 
 [!INCLUDE [container-instances-restart-ip](../../includes/container-instances-restart-ip.md)]
 

--- a/articles/container-instances/container-instances-virtual-network-concepts.md
+++ b/articles/container-instances/container-instances-virtual-network-concepts.md
@@ -37,7 +37,7 @@ Container groups deployed into an Azure virtual network enable scenarios like:
 * You can't enable a [liveness probe](container-instances-liveness-probe.md) or [readiness probe](container-instances-readiness-probe.md) in a container group deployed to a virtual network.
 * Due to the additional networking resources involved, deployments to a virtual network are typically slower than deploying a standard container instance.
 * Pulling images using Vnet connectivity, such as [ACR with private link](articles/container-registry/container-registry-private-link.md), is not supported.
-* Key Vault and Azure File mount with Private endpoint is not supported.
+* Azure File mount with Private endpoint is not supported.
 
 [!INCLUDE [container-instances-restart-ip](../../includes/container-instances-restart-ip.md)]
 

--- a/articles/container-instances/container-instances-virtual-network-concepts.md
+++ b/articles/container-instances/container-instances-virtual-network-concepts.md
@@ -36,7 +36,7 @@ Container groups deployed into an Azure virtual network enable scenarios like:
 * You can't use a [managed identity](container-instances-managed-identity.md) in a container group deployed to a virtual network.
 * You can't enable a [liveness probe](container-instances-liveness-probe.md) or [readiness probe](container-instances-readiness-probe.md) in a container group deployed to a virtual network.
 * Due to the additional networking resources involved, deployments to a virtual network are typically slower than deploying a standard container instance.
-* Pulling images using vnet connectivity, such as [ACR with private link](articles/container-registry/container-registry-private-link.md), is not supported.
+* Pulling images using Vnet connectivity, such as [ACR with private link](articles/container-registry/container-registry-private-link.md), is not supported.
 * Key Vault and Azure File mount with Private endpoint is not supported.
 
 [!INCLUDE [container-instances-restart-ip](../../includes/container-instances-restart-ip.md)]

--- a/articles/container-instances/container-instances-virtual-network-concepts.md
+++ b/articles/container-instances/container-instances-virtual-network-concepts.md
@@ -37,7 +37,6 @@ Container groups deployed into an Azure virtual network enable scenarios like:
 * You can't enable a [liveness probe](container-instances-liveness-probe.md) or [readiness probe](container-instances-readiness-probe.md) in a container group deployed to a virtual network.
 * Due to the additional networking resources involved, deployments to a virtual network are typically slower than deploying a standard container instance.
 * Pulling images using vnet connectivity, such as [ACR with private link](articles/container-registry/container-registry-private-link.md), is not supported.
-* Service endpoint whitelisting for Key Vault secret and Azure File mount is not supported.
 * Key Vault and Azure File mount with Private endpoint is not supported.
 
 [!INCLUDE [container-instances-restart-ip](../../includes/container-instances-restart-ip.md)]


### PR DESCRIPTION
Add information that is not supported in ACI VNET integration due to happens before container running:

* Image pulling inside vnet;
* KeyVault, AzureFile mount with service endpoint or private endpoint.