### PR TITLE
Remove limitation of Azure China 21Vianet for AKS private cluster

### DIFF
--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -17,7 +17,6 @@ The control plane or API server is in an Azure Kubernetes Service (AKS)-managed 
 
 Private cluster is available in public regions where [AKS is supported](https://azure.microsoft.com/global-infrastructure/services/?products=kubernetes-service).
 
-* Azure China 21Vianet isn't currently supported.
 * US Gov Texas isn't currently supported because of missing Private Link support.
 
 ## Prerequisites

--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -17,7 +17,7 @@ The control plane or API server is in an Azure Kubernetes Service (AKS)-managed 
 
 Private cluster is available in public regions where [AKS is supported](https://azure.microsoft.com/global-infrastructure/services/?products=kubernetes-service).
 
-* US Gov Texas isn't currently supported because of missing Private Link support.
+US Gov Texas isn't currently supported because of missing Private Link support.
 
 ## Prerequisites
 


### PR DESCRIPTION
AKS private cluster is now supported on Azure China 21Vianet.