### PR TITLE
Update tutorial-delete-cluster.md

### DIFF
--- a/articles/openshift/tutorial-delete-cluster.md
+++ b/articles/openshift/tutorial-delete-cluster.md
@@ -40,13 +40,13 @@ In previous tutorials, the following variables were set.
 
 ```bash
 CLUSTER=yourclustername
-RESOURCE_GROUP=yourresourcegroup
+RESOURCEGROUP=yourresourcegroup
 ```
 
 Using these values, delete your cluster:
 
 ```bash
-az aro delete --resource-group $RESOURCE_GROUP --name $CLUSTER
+az aro delete --resource-group $RESOURCEGROUP --name $CLUSTER
 ```
 
 You'll then be prompted to confirm if you want to delete the cluster. After you confirm with `y`, it will take several minutes to delete the cluster. When the command finishes, the entire resource group and all resources inside it—including the cluster—will be deleted.


### PR DESCRIPTION
Minor change. 
Changed the variable name from RESOURCE_GROUP to RESOURCEGROUP so that it's in line with the variable name in the Create Cluster page 
https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster#create-a-virtual-network-containing-two-empty-subnets
In case someone is doing a Create, Connect, Delete cluster end to end, this will just simplify the overall experience. 