### PR TITLE
corrected Semi annual channel

### DIFF
--- a/articles/active-directory/devices/hybrid-azuread-join-plan.md
+++ b/articles/active-directory/devices/hybrid-azuread-join-plan.md
@@ -53,7 +53,7 @@ Hybrid Azure AD join supports a broad range of Windows devices. Because the conf
 
 - Windows 10
 - Windows Server 2016
-  - **Note**: Azure National cloud customers require version 1809
+  - **Note**: Azure National cloud customers require version 1803
 - Windows Server 2019
 
 For devices running the Windows desktop operating system, supported version are listed in this article [Windows 10 release information](/windows/release-information/). As a best practice, Microsoft recommends you upgrade to the latest version of Windows 10.


### PR DESCRIPTION
Server 2016 Semi-Annual release is v1803 not v1809 , Since v1809 maps to Server 2019. it must be a typo and correcting it

https://docs.microsoft.com/en-us/windows-server/get-started/whats-new-in-windows-server-1803