### PR TITLE
Update ncv3-series.md

### DIFF
--- a/articles/virtual-machines/ncv3-series.md
+++ b/articles/virtual-machines/ncv3-series.md
@@ -20,8 +20,9 @@ NCv3-series VMs are powered by NVIDIA Tesla V100 GPUs. These GPUs can provide 1.
 [VM Generation Support](generation-2.md): Generation 1 and 2<br>
 
 > [!IMPORTANT]
-> For this VM series, the vCPU (core) quota in your subscription is initially set to 0 in each region. [Request a vCPU quota increase](../azure-portal/supportability/resource-manager-core-quotas-request.md) for this series in an [available region](https://azure.microsoft.com/regions/services/). Your subscription level may not allow for deployment or selection of these SKUs as they are not available to trial or Visual Studio Subscriber Azure subscriptions. 
+> For this VM series, the vCPU (core) quota in your subscription is initially set to 0 in each region. [Request a vCPU quota increase](../azure-portal/supportability/resource-manager-core-quotas-request.md) for this series in an [available region](https://azure.microsoft.com/regions/services/). These SKUs aren't available to trial or Visual Studio Subscriber Azure subscriptions. Your subscription level might not support selecting or deploying these SKUs. 
 >
+
 | Size | vCPU | Memory: GiB | Temp storage (SSD) GiB | GPU | GPU memory: GiB | Max data disks | Max uncached disk throughput: IOPS/MBps | Max NICs |
 |---|---|---|---|---|---|---|---|---|
 | Standard_NC6s_v3    | 6  | 112 | 736  | 1 | 16 | 12 | 20000/200 | 4 |

--- a/articles/virtual-machines/ncv3-series.md
+++ b/articles/virtual-machines/ncv3-series.md
@@ -20,7 +20,7 @@ NCv3-series VMs are powered by NVIDIA Tesla V100 GPUs. These GPUs can provide 1.
 [VM Generation Support](generation-2.md): Generation 1 and 2<br>
 
 > [!IMPORTANT]
-> For this VM series, the vCPU (core) quota in your subscription is initially set to 0 in each region. [Request a vCPU quota increase](../azure-portal/supportability/resource-manager-core-quotas-request.md) for this series in an [available region](https://azure.microsoft.com/regions/services/).
+> For this VM series, the vCPU (core) quota in your subscription is initially set to 0 in each region. [Request a vCPU quota increase](../azure-portal/supportability/resource-manager-core-quotas-request.md) for this series in an [available region](https://azure.microsoft.com/regions/services/). Your subscription level may not allow for deployment or selection of these SKUs as they are not available to trial or Visual Studio Subscriber Azure subscriptions. 
 >
 | Size | vCPU | Memory: GiB | Temp storage (SSD) GiB | GPU | GPU memory: GiB | Max data disks | Max uncached disk throughput: IOPS/MBps | Max NICs |
 |---|---|---|---|---|---|---|---|---|


### PR DESCRIPTION
I have an Enterprise Visual Studio MSDN subscription and I get azure $$ each month - the line above - 

> [!IMPORTANT]
> For this VM series, the vCPU (core) quota in your subscription is initially set to 0 in each region. [Request a vCPU quota increase](../azure-portal/supportability/resource-manager-core-quotas-request.md) for this series in an [available region](https://azure.microsoft.com/regions/services/).

I found out this is also required if you wish to try "spot" VM instances. The support team is also refusing to add vCPU quotas for individuals with my subscription level. I do have an email chain back and forth, I did appreciate the ability to find the line about the increasing of the quota of vCPUs.