### PR TITLE
Update code snippet for component telemetry

### DIFF
--- a/articles/iot-pnp/concepts-developer-guide-device-csharp.md
+++ b/articles/iot-pnp/concepts-developer-guide-device-csharp.md
@@ -55,7 +55,7 @@ When using nested components, devices must set a message property with the compo
 public async Task SendComponentTelemetryValueAsync(string componentName, string serializedTelemetry)
 {
   var message = new Message(Encoding.UTF8.GetBytes(serializedTelemetry));
-  message.Properties.Add("$.sub", componentName);
+  message.ComponentName = componentName;
   message.ContentType = "application/json";
   message.ContentEncoding = "utf-8";
   await client.SendEventAsync(message);


### PR DESCRIPTION
With the GA SDK we now have a 'ComponentName' property on the 'Message' object. So no need to set the '$.sub' property directly.