### PR TITLE
Remove Windows instruction in speech-batch-kit

### DIFF
--- a/articles/cognitive-services/Speech-Service/speech-container-batch-processing.md
+++ b/articles/cognitive-services/Speech-Service/speech-container-batch-processing.md
@@ -91,15 +91,6 @@ To run the batch client and container in a single command:
 docker run --rm -ti -v  /mnt/my_nfs:/my_nfs docker.io/batchkit/speech-batch-kit:latest  -config /my_nfs/config.yaml -input_folder /my_nfs/audio_files -output_folder /my_nfs/transcriptions -log_folder  /my_nfs/logs -log_level DEBUG -nbest 1 -m ONESHOT -diarization  None -language en-US -strict_config   
 ```
 
-#### [Windows](#tab/windows)
-
-To run the batch client and container in a single command:
-
-```Docker
-docker run --rm -ti -v   c:\my_nfs:/my_nfs docker.io/batchkit/speech-batch-kit:latest  -config  /my_nfs/config.yaml -input_folder /my_nfs/audio_files -output_folder /my_nfs/transcriptions -log_folder  /my_nfs/logs -nbest 1 -m ONESHOT -diarization  None -language en-US -strict_config
-
-```
-
 ---
 
 


### PR DESCRIPTION
Windows is not supported in the speech batch kit, so removing this instruction. It's Linux-only.