### PR TITLE
Fix Typo for edgeAgent metric endpoint

### DIFF
--- a/articles/iot-edge/how-to-access-built-in-metrics.md
+++ b/articles/iot-edge/how-to-access-built-in-metrics.md
@@ -15,7 +15,7 @@ services: iot-edge
 
 The IoT Edge runtime components, IoT Edge Hub and IoT Edge Agent, produce built-in metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/). Access these metrics remotely to monitor and understand the health of an IoT Edge device.
 
-As of release 1.0.10, metrics are automatically exposed by default on **port 9600** of the **edgeHub** and **edgeAgent** modules (`http://edgeHub:9600/metrics` and `http://edgeAgent:9600/metics`). They aren't port mapped to the host by default.
+As of release 1.0.10, metrics are automatically exposed by default on **port 9600** of the **edgeHub** and **edgeAgent** modules (`http://edgeHub:9600/metrics` and `http://edgeAgent:9600/metrics`). They aren't port mapped to the host by default.
 
 Access metrics from the host by exposing and mapping the metrics port from the module's `createOptions`. The example below maps the default metrics port to port 9601 on the host:
 


### PR DESCRIPTION
As defined in https://github.com/Azure/iotedge/blob/master/doc/BuiltInMetrics.md