### PR TITLE
Removed link to Azure government videos

### DIFF
--- a/articles/azure-government/documentation-government-welcome.md
+++ b/articles/azure-government/documentation-government-welcome.md
@@ -47,4 +47,4 @@ Learn more about Azure Government: [Acquiring and accessing Azure Government](ht
 
 [Get started with Azure Government](documentation-government-get-started-connect-with-portal.md).
 
-View [Azure Government Video Library](https://azure.microsoft.com/resources/videos/index/?tag=azure-government) and [YouTube videos](https://www.youtube.com/playlist?list=PLLasX02E8BPA5IgCPjqWms5ne5h4briK7).
+View [YouTube videos](https://www.youtube.com/playlist?list=PLLasX02E8BPA5IgCPjqWms5ne5h4briK7).


### PR DESCRIPTION
The tag has apparently been removed. The link resulted in no videos being shown.