### PR TITLE
Update detach-disk.md to reflect portal changes

### DIFF
--- a/articles/virtual-machines/windows/detach-disk.md
+++ b/articles/virtual-machines/windows/detach-disk.md
@@ -48,8 +48,8 @@ You can *hot* remove a data disk, but make sure nothing is actively using the di
 1. In the left menu, select **Virtual Machines**.
 1. Select the virtual machine that has the data disk you want to detach.
 1. Under **Settings**, select **Disks**.
-1. At the top of the **Disks** pane, select **Edit**.
-1. In the **Disks** pane, to the far right of the data disk that you would like to detach, select **Detach**.
+1. Find the disk you want to detach under the **Data Disks** section.
+1. In the **Data Disks** pane, to the far right of the data disk that you would like to detach, select the blue **X** marked **Delete**.
 1. Select **Save** on the top of the page to save your changes.
 
 The disk stays in storage but is no longer attached to a virtual machine.


### PR DESCRIPTION
Changed the "Detaching disks from portal" to stop confusion with customers on looking for an edit button and to make sure they know that the X that says Delete will not actually Delete the disk but only detach it.