### PR TITLE
Fix typo "enine" to "engine"

### DIFF
--- a/articles/azure-monitor/log-query/query-optimization.md
+++ b/articles/azure-monitor/log-query/query-optimization.md
@@ -106,7 +106,7 @@ Syslog
 | count 
 ```
 
-In some cases the evaluated column is created implicitly by the query processing enine since the filtering is done not just on the field:
+In some cases the evaluated column is created implicitly by the query processing engine since the filtering is done not just on the field:
 ```Kusto
 //less efficient
 SecurityEvent


### PR DESCRIPTION
Fix typo "enine" to "engine"