### PR TITLE
Update docs about APIServerIP

### DIFF
--- a/articles/aks/limit-egress-traffic.md
+++ b/articles/aks/limit-egress-traffic.md
@@ -52,6 +52,9 @@ The required network rules and IP address dependencies are:
 | **`CustomDNSIP:53`** `(if using custom DNS servers)`                             | UDP      | 53      | If you're using custom DNS servers, you must ensure they're accessible by the cluster nodes. |
 | **`APIServerIP:443`** `(if running pods/deployments that access the API Server)` | TCP      | 443     | Required if running pods/deployments that access the API Server, those pods/deployments would use the API IP. This is not required for [private clusters](private-clusters.md)  |
 
+> [!IMPORTANT]
+> Note that `APIServerIP` is the public IP of your AKS cluster, not the internal one.
+
 ### Azure Global required FQDN / application rules 
 
 The following FQDN / application rules are required:


### PR DESCRIPTION
Add a note: it should be the Public IP of the cluster.

More context: after spending some time with Msft Black Belt team on this, it seems the docs should make clear that "APIServerIP" stands for AKS Public IP, not the internal `kubernetes` service IP.