### PR TITLE
Fix metrics for burstable instances

### DIFF
--- a/articles/virtual-machines/sizes-b-series-burstable.md
+++ b/articles/virtual-machines/sizes-b-series-burstable.md
@@ -100,6 +100,8 @@ For a D16s_v3 which has 16 vCPUs and 64 GiB of memory the hourly rate is $0.936 
 
 **A**: We will be introducing 2 new metrics in the coming weeks, the **Credit** metric will allow you to view how many credits your VM has banked and the **ConsumedCredit** metric will show how many CPU credits your VM has consumed from the bank.    You will be able to view these metrics from the metrics pane in the portal or programmatically through the Azure Monitor APIs.
 
+Also note the "CPU Credits Consumed" and "CPU Credits Remaining" metrics that are currently provided by some Azure resources.
+
 For more information on how to access the metrics data for Azure, see [Overview of metrics in Microsoft Azure](../azure-monitor/platform/data-platform.md).
 
 ### Q: How are credits accumulated and consumed?


### PR DESCRIPTION
I deeply hope that the way in which this paragraph is edited does not correspond to Azure standards. It has been edited as if it was a blog note relevant at the moment, but it is an important element of the service documentation. I think that the review process should be evaluated in this case in order to avoid the phrases "now", "in the coming 2 weeks", because the documentation is not created for a week, but for months or years. Paragraphs that refer to time in the documentation should be avoided so that you do not have to constantly update the documentation.