### PR TITLE
Update high-availability-guide-suse-nfs.md interleave="true" for clone nfsserver

### DIFF
--- a/articles/virtual-machines/workloads/sap/high-availability-guide-suse-nfs.md
+++ b/articles/virtual-machines/workloads/sap/high-availability-guide-suse-nfs.md
@@ -510,7 +510,8 @@ The following items are prefixed with either **[A]** - applicable to all nodes, 
    
    sudo crm configure primitive nfsserver systemd:nfs-server \
      op monitor interval="30s"
-   sudo crm configure clone cl-nfsserver nfsserver
+   sudo crm configure clone cl-nfsserver nfsserver \
+     meta interleave="true"
 
    sudo crm configure primitive exportfs_<b>NW1</b> \
      ocf:heartbeat:exportfs \


### PR DESCRIPTION
Suggest interleave="true" here, though pacemaker use the default "false" which implies the stop on a node will stop all clone instances on all other nodes too. Practically, "true" is used more often.