### PR TITLE
Add description of `dataType` parameter

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-blob-input.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-input.md
@@ -171,7 +171,13 @@ In the *function.json* file, the `queueTrigger` metadata property is used to spe
 The [configuration](#configuration) section explains these properties.
 
 > [!NOTE]
-> If you want to read binary data from the blob, make sure to specify `dataType` as `binary`. The default value for `dataType` is `string`, which means that data is interpreted as unicode.
+The `dataType` property determines which binding is used. The following values are available to support different binding strategies.
+
+| Binding Value | Default | Description | Example |
+| --- | --- | --- | --- |
+| `undefined` | Y | Uses rich binding | `def main(input: func.InputStream)` |
+| `string` | N | Uses generic binding and casts the input type as a `string` | `def main(input: str)` |
+| `binary` | N | Uses generic binding and casts the input blob as `bytes` Python object | `def main(input: bytes)` |
 
 Here's the Python code:
 

--- a/articles/azure-functions/functions-bindings-storage-blob-input.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-input.md
@@ -171,13 +171,14 @@ In the *function.json* file, the `queueTrigger` metadata property is used to spe
 The [configuration](#configuration) section explains these properties.
 
 > [!NOTE]
-The `dataType` property determines which binding is used. The following values are available to support different binding strategies.
-
-| Binding Value | Default | Description | Example |
-| --- | --- | --- | --- |
-| `undefined` | Y | Uses rich binding | `def main(input: func.InputStream)` |
-| `string` | N | Uses generic binding and casts the input type as a `string` | `def main(input: str)` |
-| `binary` | N | Uses generic binding and casts the input blob as `bytes` Python object | `def main(input: bytes)` |
+> The `dataType` property determines which binding is used. The following values are available to support different binding strategies:
+> 
+> | Binding value | Default | Description | Example |
+> | --- | --- | --- | --- |
+> | `undefined` | Y | Uses rich binding | `def main(input: func.InputStream)` |
+> | `string` | N | Uses generic binding and casts the input type as a `string` | `def main(input: str)` |
+> | `binary` | N | Uses generic binding and casts the input blob as `bytes` Python object | `def main(input: bytes)` |
+>
 
 Here's the Python code:
 

--- a/articles/azure-functions/functions-bindings-storage-blob-input.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-input.md
@@ -170,15 +170,14 @@ In the *function.json* file, the `queueTrigger` metadata property is used to spe
 
 The [configuration](#configuration) section explains these properties.
 
-> [!NOTE]
-> The `dataType` property determines which binding is used. The following values are available to support different binding strategies:
-> 
-> | Binding value | Default | Description | Example |
-> | --- | --- | --- | --- |
-> | `undefined` | Y | Uses rich binding | `def main(input: func.InputStream)` |
-> | `string` | N | Uses generic binding and casts the input type as a `string` | `def main(input: str)` |
-> | `binary` | N | Uses generic binding and casts the input blob as `bytes` Python object | `def main(input: bytes)` |
->
+The `dataType` property determines which binding is used. The following values are available to support different binding strategies:
+
+| Binding value | Default | Description | Example |
+| --- | --- | --- | --- |
+| `undefined` | Y | Uses rich binding | `def main(input: func.InputStream)` |
+| `string` | N | Uses generic binding and casts the input type as a `string` | `def main(input: str)` |
+| `binary` | N | Uses generic binding and casts the input blob as `bytes` Python object | `def main(input: bytes)` |
+
 
 Here's the Python code:
 

--- a/articles/azure-functions/functions-bindings-storage-blob-input.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-input.md
@@ -171,7 +171,7 @@ In the *function.json* file, the `queueTrigger` metadata property is used to spe
 The [configuration](#configuration) section explains these properties.
 
 > [!NOTE]
-> If you want to read binary data from the blob, make sure to specify `dataType` as `binary`. The default value for `dataType` is `string`, which means that data will be interpreted as unicode.
+> If you want to read binary data from the blob, make sure to specify `dataType` as `binary`. The default value for `dataType` is `string`, which means that data is interpreted as unicode.
 
 Here's the Python code:
 

--- a/articles/azure-functions/functions-bindings-storage-blob-input.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-input.md
@@ -307,7 +307,7 @@ The following table explains the binding configuration properties that you set i
 |**name** | n/a | The name of the variable that represents the blob in function code.|
 |**path** |**BlobPath** | The path to the blob. |
 |**connection** |**Connection**| The name of an app setting that contains the [Storage connection string](../storage/common/storage-configure-connection-string.md) to use for this binding. If the app setting name begins with "AzureWebJobs", you can specify only the remainder of the name here. For example, if you set `connection` to "MyStorage", the Functions runtime looks for an app setting that is named "AzureWebJobsMyStorage". If you leave `connection` empty, the Functions runtime uses the default Storage connection string in the app setting that is named `AzureWebJobsStorage`.<br><br>The connection string must be for a general-purpose storage account, not a [blob-only storage account](../storage/common/storage-account-overview.md#types-of-storage-accounts).|
-|**dataType**| n/a | For dynamically typed languages, specifies the underlying data type. Possible values are `string`, `binary`, or `stream`. More details [here](functions-triggers-bindings?tabs=python#trigger-and-binding-definitions) |
+|**dataType**| n/a | For dynamically typed languages, specifies the underlying data type. Possible values are `string`, `binary`, or `stream`. For more more detail, refer to the [triggers and bindings concepts](functions-triggers-bindings?tabs=python#trigger-and-binding-definitions). |
 |n/a | **Access** | Indicates whether you will be reading or writing. |
 
 [!INCLUDE [app settings to local.settings.json](../../includes/functions-app-settings-local.md)]

--- a/articles/azure-functions/functions-bindings-storage-blob-input.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-input.md
@@ -170,6 +170,9 @@ In the *function.json* file, the `queueTrigger` metadata property is used to spe
 
 The [configuration](#configuration) section explains these properties.
 
+> [!NOTE]
+> If you want to read binary data from the blob, make sure to specify `dataType` as `binary`. The default value for `dataType` is `string`, which means that data will be interpreted as unicode.
+
 Here's the Python code:
 
 ```python
@@ -304,6 +307,7 @@ The following table explains the binding configuration properties that you set i
 |**name** | n/a | The name of the variable that represents the blob in function code.|
 |**path** |**BlobPath** | The path to the blob. |
 |**connection** |**Connection**| The name of an app setting that contains the [Storage connection string](../storage/common/storage-configure-connection-string.md) to use for this binding. If the app setting name begins with "AzureWebJobs", you can specify only the remainder of the name here. For example, if you set `connection` to "MyStorage", the Functions runtime looks for an app setting that is named "AzureWebJobsMyStorage". If you leave `connection` empty, the Functions runtime uses the default Storage connection string in the app setting that is named `AzureWebJobsStorage`.<br><br>The connection string must be for a general-purpose storage account, not a [blob-only storage account](../storage/common/storage-account-overview.md#types-of-storage-accounts).|
+|**dataType**| n/a | For dynamically typed languages, specifies the underlying data type. Possible values are `string`, `binary`, or `stream`. More details [here](functions-triggers-bindings?tabs=python#trigger-and-binding-definitions) |
 |n/a | **Access** | Indicates whether you will be reading or writing. |
 
 [!INCLUDE [app settings to local.settings.json](../../includes/functions-app-settings-local.md)]


### PR DESCRIPTION
Without setting dataType parameter, one cannot read binary data from blobs in Python, as described in [this issue](https://github.com/Azure/azure-functions-python-worker/issues/720).