### PR TITLE
Updates to the GitHub provisioning tutorial

### DIFF
--- a/articles/active-directory/saas-apps/github-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/github-provisioning-tutorial.md
@@ -35,21 +35,21 @@ Azure Active Directory uses a concept called "assignments" to determine which us
 
 Before configuring and enabling the provisioning service, you need to decide what users and/or groups in Azure AD represent the users who need access to your GitHub app. Once decided, you can assign these users to your GitHub app by following the instructions here:
 
-[Assign a user or group to an enterprise app](../manage-apps/assign-user-or-group-access-portal.md)
+For more information, see [Assign a user or group to an enterprise app](../manage-apps/assign-user-or-group-access-portal.md).
 
 ### Important tips for assigning users to GitHub
 
-* It is recommended that a single Azure AD user is assigned to GitHub to test the provisioning configuration. Additional users and/or groups may be assigned later.
+* We recommend that you assign a single Azure AD user to GitHub to test the provisioning configuration. Additional users and/or groups may be assigned later.
 
 * When assigning a user to GitHub, you must select either the **User** role, or another valid application-specific role (if available) in the assignment dialog. The **Default Access** role does not work for provisioning, and these users are skipped.
 
 ## Configuring user provisioning to GitHub
 
-This section guides you through connecting your Azure AD to GitHub's SCIM provisioning API to automate provisioning of GitHub organization membership. This integration, which leverages an OAuth app](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/authorizing-oauth-apps#oauth-apps-and-organizations), automatically adds, manages, and removes members' access to a GitHub Enterprise Cloud organization based on user and group assignment in Azure AD. When users are [provisioned to a GitHub organization via SCIM](https://docs.github.com/en/free-pro-team@latest/rest/reference/scim#provision-and-invite-a-scim-user), an email invitation is sent to the user's email address.
+This section guides you through connecting your Azure AD to GitHub's SCIM provisioning API to automate provisioning of GitHub organization membership. This integration, which leverages an [OAuth app](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/authorizing-oauth-apps#oauth-apps-and-organizations), automatically adds, manages, and removes members' access to a GitHub Enterprise Cloud organization based on user and group assignment in Azure AD. When users are [provisioned to a GitHub organization via SCIM](https://docs.github.com/en/free-pro-team@latest/rest/reference/scim#provision-and-invite-a-scim-user), an email invitation is sent to the user's email address.
 
 ### Configure automatic user account provisioning to GitHub in Azure AD
 
-1. In the [Azure portal](https://portal.azure.com), browse to the **Azure Active Directory > Enterprise Apps > All applications**  section.
+1. In the [Azure portal](https://portal.azure.com), browse to the **Azure Active Directory > Enterprise Apps > All applications** section.
 
 2. If you have already configured GitHub for single sign-on, search for your instance of GitHub using the search field. Otherwise, select **Add** and search for **GitHub** in the application gallery. Select GitHub from the search results, and add it to your list of applications.
 
@@ -57,17 +57,17 @@ This section guides you through connecting your Azure AD to GitHub's SCIM provis
 
 4. Set the **Provisioning Mode** to **Automatic**.
 
-	![GitHub Provisioning](./media/github-provisioning-tutorial/GitHub1.png)
+   ![GitHub Provisioning](./media/github-provisioning-tutorial/github1.png)
 
 5. Under the **Admin Credentials** section, click **Authorize**. This operation opens a GitHub authorization dialog in a new browser window. Note that you need to ensure you are approved to authorize access. Follow the directions described [here](https://help.github.com/github/setting-up-and-managing-organizations-and-teams/approving-oauth-apps-for-your-organization).
 
 6. In the new window, sign into GitHub using your Admin account. In the resulting authorization dialog, select the GitHub team that you want to enable provisioning for, and then select **Authorize**. Once completed, return to the Azure portal to complete the provisioning configuration.
 
-	![Screenshot shows the sign-in page for GitHub.](./media/github-provisioning-tutorial/GitHub2.png)
+   ![Screenshot shows the sign-in page for GitHub.](./media/github-provisioning-tutorial/github2.png)
 
 7. In the Azure portal, input **Tenant URL** and click **Test Connection** to ensure Azure AD can connect to your GitHub app. If the connection fails, ensure your GitHub account has Admin permissions and **Tenant URl** is inputted correctly, then try the "Authorize" step again (you can constitute **Tenant URL** by rule: `https://api.github.com/scim/v2/organizations/<Organization_name>`, you can find your organizations under your GitHub account: **Settings** > **Organizations**).
 
-	![Screenshot shows Organizations page in GitHub.](./media/github-provisioning-tutorial/GitHub3.png)
+   ![Screenshot shows Organizations page in GitHub.](./media/github-provisioning-tutorial/github3.png)
 
 8. Enter the email address of a person or group who should receive provisioning error notifications in the **Notification Email** field, and check the checkbox "Send an email notification when a failure occurs."
 
@@ -75,9 +75,9 @@ This section guides you through connecting your Azure AD to GitHub's SCIM provis
 
 10. Under the Mappings section, select **Synchronize Azure Active Directory Users to GitHub**.
 
-11. In the **Attribute Mappings** section, review the user attributes that are synchronized from Azure AD to GitHub. The attributes selected as **Matching** properties are used to match the user accounts in GitHub for update operations. Do not enable the _Matching precendence_ setting for the other default attributes in the Provisioning section as this may result in errors. Select the Save button to commit any changes.
+11. In the **Attribute Mappings** section, review the user attributes that are synchronized from Azure AD to GitHub. The attributes selected as **Matching** properties are used to match the user accounts in GitHub for update operations. Do not enable the **Matching precendence** setting for the other default attributes in the **Provisioning** section because errors might occur. Select **Save** to commit any changes.
 
-12. To enable the Azure AD provisioning service for GitHub, change the **Provisioning Status** to **On** in the **Settings** section
+12. To enable the Azure AD provisioning service for GitHub, change the **Provisioning Status** to **On** in the **Settings** section.
 
 13. Click **Save**.
 

--- a/articles/active-directory/saas-apps/github-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/github-provisioning-tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: 'Tutorial: User provisioning for GitHub - Azure AD'
-description: Learn how to configure Azure Active Directory to automatically provision and de-provision user accounts to GitHub.
+description: Learn how to configure Azure Active Directory to automatically provision and de-provision user organization membership in GitHub Enterprise Cloud.
 services: active-directory
 author: ArvindHarinder1
 manager: CelesteDG
@@ -13,7 +13,7 @@ ms.author: arvinh
 ---
 # Tutorial: Configure GitHub for automatic user provisioning
 
-The objective of this tutorial is to show you the steps you need to perform in GitHub and Azure AD to automatically provision and de-provision user accounts from Azure AD to GitHub.
+The objective of this tutorial is to show you the steps you need to perform in GitHub and Azure AD to automate provisioning of GitHub Enterprise Cloud organization membership.
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ Before configuring and enabling the provisioning service, you need to decide wha
 
 ## Configuring user provisioning to GitHub
 
-This section guides you through connecting your Azure AD to GitHub's user account provisioning API, and configuring the provisioning service to create, update, and disable assigned user accounts in GitHub based on user and group assignment in Azure AD.
+This section guides you through connecting your Azure AD to GitHub's SCIM provisioning API to automate provisioning of GitHub organization membership. This integration, which leverages an OAuth app](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/authorizing-oauth-apps#oauth-apps-and-organizations), automatically adds, manages, and removes members' access to a GitHub Enterprise Cloud organization based on user and group assignment in Azure AD. When users are [provisioned to a GitHub organization via SCIM](https://docs.github.com/en/free-pro-team@latest/rest/reference/scim#provision-and-invite-a-scim-user), an email invitation is sent to the user's email address.
 
 ### Configure automatic user account provisioning to GitHub in Azure AD
 
@@ -75,13 +75,13 @@ This section guides you through connecting your Azure AD to GitHub's user accoun
 
 10. Under the Mappings section, select **Synchronize Azure Active Directory Users to GitHub**.
 
-11. In the **Attribute Mappings** section, review the user attributes that are synchronized from Azure AD to GitHub. The attributes selected as **Matching** properties are used to match the user accounts in GitHub for update operations. Select the Save button to commit any changes.
+11. In the **Attribute Mappings** section, review the user attributes that are synchronized from Azure AD to GitHub. The attributes selected as **Matching** properties are used to match the user accounts in GitHub for update operations. Do not enable the _Matching precendence_ setting for the other default attributes in the Provisioning section as this may result in errors. Select the Save button to commit any changes.
 
 12. To enable the Azure AD provisioning service for GitHub, change the **Provisioning Status** to **On** in the **Settings** section
 
 13. Click **Save**.
 
-This operation starts the initial synchronization of any users and/or groups assigned to GitHub in the Users and Groups section. The initial sync takes longer to perform than subsequent syncs, which occur approximately every 40 minutes as long as the service is running. You can use the **Synchronization Details** section to monitor progress and follow links to provisioning activity logs, which describe all actions performed by the provisioning service.
+This operation starts the initial synchronization of any users and/or groups assigned to GitHub in the Users and Groups section. The initial sync takes longer to perform than subsequent syncs, which occur approximately every 40 minutes as long as the service is running. You can use the **Synchronization Details** section to monitor progress and follow links to provisioning activity logs, which describe all actions performed by the provisioning service. 
 
 For more information on how to read the Azure AD provisioning logs, see [Reporting on automatic user account provisioning](../app-provisioning/check-status-user-account-provisioning.md).
 


### PR DESCRIPTION
I am proposing updates to more accurately reflect what the integration does on the GitHub side. For example, the integration does not create user accounts in GitHub, rather it automates adding (inviting) and removing users to and from a GitHub organization. 

Also, added a note to step 11 about not enabling _Matching precedence_ for the other provisioning attribute mappings.

cc/ @inpreman @cjs @jamccree @cottonball @djdefi 