### PR TITLE
Update how-to-connect-install-existing-tenant.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-install-existing-tenant.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-existing-tenant.md
@@ -34,7 +34,7 @@ When you install Azure AD Connect and you start synchronizing, the Azure AD sync
 
 The match is only evaluated for new objects coming from Connect. If you change an existing object so it is matching any of these attributes, then you see an error instead.
 
-If Azure AD finds an object where the attribute values are the same for an object coming from Connect and that it is already present in Azure AD, then the object in Azure AD is taken over by Connect. The previously cloud-managed object is flagged as on-premises managed. All attributes in Azure AD with a value in on-premises AD are overwritten with the on-premises value. The exception is when an attribute has a **NULL** value on-premises. In this case, the value in Azure AD remains, but you can still only change it on-premises to something else.
+If Azure AD finds an object where the attribute values are the same for an object coming from Connect and that it is already present in Azure AD, then the object in Azure AD is taken over by Connect. The previously cloud-managed object is flagged as on-premises managed. All attributes in Azure AD with a value in on-premises AD are overwritten with the on-premises value.
 
 > [!WARNING]
 > Since all attributes in Azure AD are going to be overwritten by the on-premises value, make sure you have good data on-premises. For example, if you only have managed email address in Microsoft 365 and not kept it updated in on-premises AD DS, then you lose any values in Azure AD/Microsoft 365 not present in AD DS.


### PR DESCRIPTION
Removing an incorrect statement.  The values are not overwritten initially when the match occurs, but on the following sync cycle AADConnect imports the data from AAD (including the attributes containing values) and determines that these attributes do not have any values on-prem, so it Exports the null values from on-prem to AAD to put the user "in-sync". The SoA of the object is on-premises so all values must come from onpremises. If the documentation was correct then the user would become "inconsistent" with the SoA (onprem AD).
Please check the internal discussion on Teams for more details:
https://teams.microsoft.com/l/message/19:6443acc4b72c471bac9e2ba039fa713a@thread.skype/1602757841750?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=70b122d3-4d70-4357-b412-a8051556c3a4&parentMessageId=1602757841750&teamName=CSS%20Azure%20Identity%20-%20User%20Provisioning%20%2F%20Health&channelName=AAD%20Connect&createdTime=1602757841750