### PR TITLE
Parameters passed to curl should be url-encoded

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/copy-move-projects.md
+++ b/articles/cognitive-services/Custom-Vision-Service/copy-move-projects.md
@@ -100,8 +100,9 @@ You'll get a `200/OK` response with metadata about the exported project and a re
 Call **[ImportProject](https://southcentralus.dev.cognitive.microsoft.com/docs/services/Custom_Vision_Training_3.3/operations/5eb0bcc7548b571998fddee3)** using your target training key and endpoint, along with the reference token. You can also give your project a name in its new account.
 
 ```curl
-curl -v -X POST "{endpoint}/customvision/v3.3/Training/projects/import?token={token}?name={name}"
--H "Training-key: {training key}"
+curl -v -G -X POST "{endpoint}/customvision/v3.3/Training/projects/import"
+--data-urlencode "token={token}" --data-urlencode "name={name}"
+-H "Training-key: {training key}" -H "Content-Length: 0"
 ```
 
 You'll get a `200/OK` response with metadata about your newly imported project.


### PR DESCRIPTION
Because the token (which is actually SAS URI) and the project name contain characters which should be url-encoded usually, current curl command snippet will not work.
And also "Content-Length: 0" header should be specified for POST request. I checked with the curl installed on Azure Cloud Shell (Bash).