### PR TITLE
Deploy-Template.ps1 -> Deploy-AzTemplate.ps1

### DIFF
--- a/articles/azure-resource-manager/templates/add-template-to-azure-pipelines.md
+++ b/articles/azure-resource-manager/templates/add-template-to-azure-pipelines.md
@@ -64,7 +64,7 @@ steps:
   inputs:
     azureSubscription: 'script-connection'
     ScriptType: 'FilePath'
-    ScriptPath: './Deploy-Template.ps1'
+    ScriptPath: './Deploy-AzTemplate.ps1'
     ScriptArguments: -Location 'centralus' -ResourceGroupName 'demogroup' -TemplateFile templates\mainTemplate.json
     azurePowerShellVersion: 'LatestVersion'
 ```


### PR DESCRIPTION
Renamed the targeted script because it causes confusion.
In the notes above the YAML the text is specifically targeted at "Deploy-AzTemplate.ps1"