### PR TITLE
Add output json to cli with grep

### DIFF
--- a/articles/virtual-machines/linux/image-builder.md
+++ b/articles/virtual-machines/linux/image-builder.md
@@ -33,16 +33,16 @@ az feature register --namespace Microsoft.VirtualMachineImages --name VirtualMac
 Check the status of the feature registration.
 
 ```azurecli-interactive
-az feature show --namespace Microsoft.VirtualMachineImages --name VirtualMachineTemplatePreview | grep state
+az feature show --namespace Microsoft.VirtualMachineImages --name VirtualMachineTemplatePreview -o json | grep state
 ```
 
 Check your registration.
 
 ```azurecli-interactive
-az provider show -n Microsoft.VirtualMachineImages | grep registrationState
-az provider show -n Microsoft.KeyVault | grep registrationState
-az provider show -n Microsoft.Compute | grep registrationState
-az provider show -n Microsoft.Storage | grep registrationState
+az provider show -n Microsoft.VirtualMachineImages -o json  | grep registrationState
+az provider show -n Microsoft.KeyVault -o json | grep registrationState
+az provider show -n Microsoft.Compute -o json | grep registrationState
+az provider show -n Microsoft.Storage -o json | grep registrationState
 ```
 
 If they do not say registered, run the following:
@@ -75,7 +75,7 @@ imageDefName=myIbImageDef
 runOutputName=aibLinuxSIG
 ```
 
-Create a variable for your subscription ID. You can get this using `az account show | grep id`.
+Create a variable for your subscription ID. You can get this using `az account show -o json | grep id`.
 
 ```azurecli-interactive
 subscriptionID=<Subscription ID>
@@ -96,7 +96,7 @@ identityName=aibBuiUserId$(date +'%s')
 az identity create -g $sigResourceGroup -n $identityName
 
 # get identity id
-imgBuilderCliId=$(az identity show -g $sigResourceGroup -n $identityName | grep "clientId" | cut -c16- | tr -d '",')
+imgBuilderCliId=$(az identity show -g $sigResourceGroup -n $identityName -o json | grep "clientId" | cut -c16- | tr -d '",')
 
 # get the user identity URI, needed for the template
 imgBuilderId=/subscriptions/$subscriptionID/resourcegroups/$sigResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$identityName

--- a/articles/virtual-machines/linux/image-builder.md
+++ b/articles/virtual-machines/linux/image-builder.md
@@ -39,7 +39,7 @@ az feature show --namespace Microsoft.VirtualMachineImages --name VirtualMachine
 Check your registration.
 
 ```azurecli-interactive
-az provider show -n Microsoft.VirtualMachineImages -o json  | grep registrationState
+az provider show -n Microsoft.VirtualMachineImages -o json | grep registrationState
 az provider show -n Microsoft.KeyVault -o json | grep registrationState
 az provider show -n Microsoft.Compute -o json | grep registrationState
 az provider show -n Microsoft.Storage -o json | grep registrationState


### PR DESCRIPTION
The az cli can be configured to return non-json format by invoking `az configure`. In my case, I configured the output to be a table, as this is more readable to me.

```txt
# az configure
Your settings can be found at /home/<User>/.azure/config

[core]
output = table
```

In my opinion, we should not assume the output to be JSON for everyone, but rather be explicit when using a follow-up like `grep` as it is case-sensitive. 
Given the changed code it will always return a value, no matter the default configuration of az,