### PR TITLE
Add missing url to link

### DIFF
--- a/articles/event-grid/manage-event-delivery.md
+++ b/articles/event-grid/manage-event-delivery.md
@@ -12,7 +12,7 @@ When creating an event subscription, you can customize the settings for event de
 [!INCLUDE [updated-for-az](../../includes/updated-for-az.md)]
 
 > [!NOTE]
-> To learn about message delivery, retries, and dead-lettering, see the conceptual article: [Event Grid message delivery and retry]().
+> To learn about message delivery, retries, and dead-lettering, see the conceptual article: [Event Grid message delivery and retry](delivery-and-retry.md).
 
 ## Set dead-letter location
 


### PR DESCRIPTION
The empty link currently sends you to the same page. This change sets the path to the conceptual article to match the paragraph above