### PR TITLE
Update StaticWebAppsAuth.Parse snippet to accommodate for missing header

### DIFF
--- a/articles/static-web-apps/user-information.md
+++ b/articles/static-web-apps/user-information.md
@@ -112,23 +112,28 @@ In a C# function, the user information is available from the `x-ms-client-princi
 
     public static ClaimsPrincipal Parse(HttpRequest req)
     {
-        var header = req.Headers["x-ms-client-principal"];
-        var data = header.Value[0];
-        var decoded = System.Convert.FromBase64String(data);
-        var json = System.Text.ASCIIEncoding.ASCII.GetString(decoded);
-        var principal = JsonSerializer.Deserialize<ClientPrincipal>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-  
-        principal.UserRoles = principal.UserRoles.Except(new string[] { "anonymous" }, StringComparer.CurrentCultureIgnoreCase);
-  
-        if (!principal.UserRoles.Any())
+        var principal = new ClientPrincipal();
+
+        if (req.Headers.TryGetValue("x-ms-client-principal", out var header))
+        {
+            var data = header[0];
+            var decoded = Convert.FromBase64String(data);
+            var json = Encoding.ASCII.GetString(decoded);
+            principal = JsonSerializer.Deserialize<ClientPrincipal>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+
+        principal.UserRoles = principal.UserRoles?.Except(new string[] { "anonymous" }, StringComparer.CurrentCultureIgnoreCase);
+
+        if (!principal.UserRoles?.Any() ?? true)
         {
             return new ClaimsPrincipal();
         }
-  
+
         var identity = new ClaimsIdentity(principal.IdentityProvider);
         identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, principal.UserId));
         identity.AddClaim(new Claim(ClaimTypes.Name, principal.UserDetails));
         identity.AddClaims(principal.UserRoles.Select(r => new Claim(ClaimTypes.Role, r)));
+
         return new ClaimsPrincipal(identity);
     }
   }


### PR DESCRIPTION
I was implementing this in an Azure Functions .Net Core 3.1 app and noticed that when this header is not present the function would 500, this takes care of this issue.