### PR TITLE
Missing quotes in step 2.8 - automation-tutorial-runbook-graphical.md

### DIFF
--- a/articles/automation/learn/automation-tutorial-runbook-graphical.md
+++ b/articles/automation/learn/automation-tutorial-runbook-graphical.md
@@ -72,7 +72,7 @@ The Library control on the left side of the editor allows you to select activiti
 
    You can use output from such sources as another activity, an Automation asset, or a PowerShell expression. In this case, the output is just `Hello World`. You can use a PowerShell expression and specify a string.
 
-8. In the **Expression** field, type `Hello World` and then click **OK** twice to return to the canvas.
+8. In the **Expression** field, type `"Hello World"` and then click **OK** twice to return to the canvas.
 
 9. Save the runbook by clicking **Save**.
 


### PR DESCRIPTION
Missing quotes (double or single) in step 2.8 for expression needed for the Write-Output parameter expression. It fails without the quotes