### PR TITLE
missing step

### DIFF
--- a/articles/data-factory/quickstart-create-data-factory-portal.md
+++ b/articles/data-factory/quickstart-create-data-factory-portal.md
@@ -57,7 +57,7 @@ Watching this video helps you understand the Data Factory UI:
 
    The list shows only locations that Data Factory supports, and where your Azure Data Factory meta data will be stored. The associated data stores (like Azure Storage and Azure SQL Database) and computes (like Azure HDInsight) that Data Factory uses can run in other regions.
 
-1. Click on "Next : Git configuration >" and mark "Configure Git later"
+1. Select **Next: Git configuration**, and then select **Configure Git later**.
 
 1. Select **Create**. After the creation is complete, select **Go to resource** to navigate to the **Data Factory** page. 
 

--- a/articles/data-factory/quickstart-create-data-factory-portal.md
+++ b/articles/data-factory/quickstart-create-data-factory-portal.md
@@ -57,6 +57,8 @@ Watching this video helps you understand the Data Factory UI:
 
    The list shows only locations that Data Factory supports, and where your Azure Data Factory meta data will be stored. The associated data stores (like Azure Storage and Azure SQL Database) and computes (like Azure HDInsight) that Data Factory uses can run in other regions.
 
+1. Click on "Next : Git configuration >" and mark "Configure Git later"
+
 1. Select **Create**. After the creation is complete, select **Go to resource** to navigate to the **Data Factory** page. 
 
 1. Select the **Author & Monitor** tile to start the Azure Data Factory user interface (UI) application on a separate tab.


### PR DESCRIPTION
There was missing step. Maybe in the past the default was "Configure Git later", but I tested it after someone asked in the forums, and we must configure "Next : Git configuration >" or we will get error on Create. 

I added the step: Click on "Next : Git configuration >" and mark "Configure Git later"