### PR TITLE
Moved the line into a NOTE to remove confusion

### DIFF
--- a/articles/app-service/app-service-ip-restrictions.md
+++ b/articles/app-service/app-service-ip-restrictions.md
@@ -20,7 +20,11 @@ When a request is made to your app, the FROM address is evaluated against the IP
 
 The access restrictions capability is implemented in the App Service front-end roles, which are upstream of the worker hosts where your code runs. Therefore, access restrictions are effectively network ACLs.
 
-The ability to restrict access to your web app from an Azure Virtual Network (VNet) is called [service endpoints][serviceendpoints]. Service endpoints enable you to restrict access to a multi-tenant service from selected subnets. It must be enabled on both the networking side as well as the service that it is being enabled with. It does not work to restrict traffic to apps that are hosted in an App Service Environment. If you are in an App Service Environment, you can control access to your app with IP address rules.
+The ability to restrict access to your web app from an Azure Virtual Network (VNet) is called [service endpoints][serviceendpoints]. Service endpoints enable you to restrict access to a multi-tenant service from selected subnets. It does not work to restrict traffic to apps that are hosted in an App Service Environment. If you are in an App Service Environment, you can control access to your app with IP address rules.
+
+> [!NOTE]
+> Service endpoints must be enabled on both the networking side as well as the Azure service that it is being enabled with. Azure services that support Service Endpoints are available [here](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview)
+>
 
 ![access restrictions flow](media/app-service-ip-restrictions/access-restrictions-flow.png)
 

--- a/articles/app-service/app-service-ip-restrictions.md
+++ b/articles/app-service/app-service-ip-restrictions.md
@@ -23,7 +23,7 @@ The access restrictions capability is implemented in the App Service front-end r
 The ability to restrict access to your web app from an Azure Virtual Network (VNet) is called [service endpoints][serviceendpoints]. Service endpoints enable you to restrict access to a multi-tenant service from selected subnets. It does not work to restrict traffic to apps that are hosted in an App Service Environment. If you are in an App Service Environment, you can control access to your app with IP address rules.
 
 > [!NOTE]
-> Service endpoints must be enabled on both the networking side as well as the Azure service that it is being enabled with. Azure services that support Service Endpoints are available [here](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview)
+> Service endpoints must be enabled on both the networking side and for the Azure service that it's being enabled with. For a list of Azure services that support service endpoints, see [Virtual Network service endpoints](../virtual-network/virtual-network-service-endpoints-overview.md).
 >
 
 ![access restrictions flow](media/app-service-ip-restrictions/access-restrictions-flow.png)


### PR DESCRIPTION
The text currently says this (see below), which can be misleading for customers who are not familiar with the concept of Service Endpoints

"It must be enabled on both the networking side as well as the service that it is being enabled with."

On a CSS support ticket, customer misread the above text and is under the assumption that in order for service endpoints to work, they need to enable it on the subnet, and on the web app.