### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#64973

### DIFF
--- a/articles/service-fabric/service-fabric-scale-up-primary-node-type.md
+++ b/articles/service-fabric/service-fabric-scale-up-primary-node-type.md
@@ -329,7 +329,7 @@ Connect-ServiceFabricCluster -ConnectionEndpoint $ClusterConnectionEndpoint `
 Write-Host "Connected to cluster"
 
 
-$nodeType = "nt1vm" # specify the name of node type
+$nodeType = "nt0vm" # specify the name of node type
 $nodes = Get-ServiceFabricNode 
 
 Write-Host "Disabling nodes..."


### PR DESCRIPTION
This is a miss type here:

$nodeType = "nt1vm" # specify the name of node type
$nodes = Get-ServiceFabricNode

The "nt1vm" should be "nt0vm".