### PR TITLE
Add section for HDI Private Link setup

### DIFF
--- a/articles/hdinsight/hadoop/troubleshoot-invalidnetworkconfigurationerrorcode-cluster-creation-fails.md
+++ b/articles/hdinsight/hadoop/troubleshoot-invalidnetworkconfigurationerrorcode-cluster-creation-fails.md
@@ -63,6 +63,19 @@ Azure Storage and SQL don't have fixed IP Addresses, so we need to allow outboun
 
     If there are routes defined, make sure that there are routes for IP addresses for the region where the cluster was deployed, and the **NextHopType** for each route is **Internet**. There should be a route defined for each required IP Address documented in the aforementioned article.
 
+## "Failed to establish an outbound connection from the cluster for the communication with the HDInsight resource provider. Please ensure that outbound connectivity is allowed.”
+
+### Issue
+
+Error description contains "Failed to establish an outbound connection from the cluster for the communication with the HDInsight resource provider. Please ensure that outbound connectivity is allowed.”
+
+### Cause
+
+When using Private Linked HDInsight clusters, outbound access from the cluster must be configured to allow connection to be made to the HDInsight resource provider.
+
+### Resolution
+
+* To resolve this issue, refer to the HDInsight Private Link setup steps at [private link setup](../hdinsight-private-link.md)
 ---
 
 ## "Virtual network configuration is not compatible with HDInsight requirement"

--- a/articles/hdinsight/hadoop/troubleshoot-invalidnetworkconfigurationerrorcode-cluster-creation-fails.md
+++ b/articles/hdinsight/hadoop/troubleshoot-invalidnetworkconfigurationerrorcode-cluster-creation-fails.md
@@ -63,7 +63,7 @@ Azure Storage and SQL don't have fixed IP Addresses, so we need to allow outboun
 
     If there are routes defined, make sure that there are routes for IP addresses for the region where the cluster was deployed, and the **NextHopType** for each route is **Internet**. There should be a route defined for each required IP Address documented in the aforementioned article.
 
-## "Failed to establish an outbound connection from the cluster for the communication with the HDInsight resource provider. Please ensure that outbound connectivity is allowed.”
+## "Failed to establish an outbound connection from the cluster for the communication with the HDInsight resource provider. Please ensure that outbound connectivity is allowed."
 
 ### Issue
 

--- a/articles/hdinsight/hadoop/troubleshoot-invalidnetworkconfigurationerrorcode-cluster-creation-fails.md
+++ b/articles/hdinsight/hadoop/troubleshoot-invalidnetworkconfigurationerrorcode-cluster-creation-fails.md
@@ -71,7 +71,7 @@ Error description contains "Failed to establish an outbound connection from the 
 
 ### Cause
 
-When using Private Linked HDInsight clusters, outbound access from the cluster must be configured to allow connection to be made to the HDInsight resource provider.
+When using Private Linked HDInsight clusters, outbound access from the cluster must be configured to allow connections to be made to the HDInsight resource provider.
 
 ### Resolution
 


### PR DESCRIPTION
Include changes for explaining new error message "Failed to establish an outbound connection from the cluster for the communication with the HDInsight resource provider. Please ensure that outbound connectivity is allowed." which will be reported at cluster creation time if a Private Link cluster is created without outbound access to the HDInsight relay service bus.