### PR TITLE
Added PowerShell example to bindings return value

### DIFF
--- a/articles/azure-functions/functions-bindings-return-value.md
+++ b/articles/azure-functions/functions-bindings-return-value.md
@@ -126,6 +126,27 @@ module.exports = function (context, input) {
     context.done(null, json);
 }
 ```
+# [PowerShell](#tab/PowerShell)
+
+Here's the output binding in the *function.json* file:
+
+```json
+{
+    "name": "Response",
+    "type": "blob",
+    "direction": "out",
+    "path": "output-container/{blobname}"
+}
+```
+
+Here's the PowerShell code that uses the return value for an http output binding:
+
+```powershell
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [HttpStatusCode]::OK
+    Body = $blobname
+    })
+```
 
 # [Python](#tab/python)
 


### PR DESCRIPTION
Added HTTP output PowerShell example to the bindings return value page. Cheers. I have a blob example too if thats better or can also be added. Ta
