### PR TITLE
Update application-gateway-waf-configuration.md

### DIFF
--- a/articles/web-application-firewall/ag/application-gateway-waf-configuration.md
+++ b/articles/web-application-firewall/ag/application-gateway-waf-configuration.md
@@ -84,7 +84,7 @@ So if the URL `http://www.contoso.com/?user%281%29=fdafdasfda` is passed to the 
 
 Web Application Firewall allows you to configure request size limits within lower and upper bounds. The following two size limits configurations are available:
 
-- The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field can range from 1-KB minimum to 128-KB maximum value. The default value for request body size is 128 KB.
+- The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field can range from 1KB minimum to 128KB maximum value. The default value for request body size is 128 KB.
 - The file upload limit field is specified in MB and it governs the maximum allowed file upload size. This field can have a minimum value of 1 MB and the following maximums:
 
    - 100 MB for v1 Medium WAF gateways

--- a/articles/web-application-firewall/ag/application-gateway-waf-configuration.md
+++ b/articles/web-application-firewall/ag/application-gateway-waf-configuration.md
@@ -84,7 +84,7 @@ So if the URL `http://www.contoso.com/?user%281%29=fdafdasfda` is passed to the 
 
 Web Application Firewall allows you to configure request size limits within lower and upper bounds. The following two size limits configurations are available:
 
-- The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field has a minimum value of 1 KB a maximum value of 128 KB. The default value for request body size is 128 KB.
+- The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field has a minimum value of 1 KB and a maximum value of 128 KB. The default value for request body size is 128 KB.
 - The file upload limit field is specified in MB and it governs the maximum allowed file upload size. This field can have a minimum value of 1 MB and the following maximums:
 
    - 100 MB for v1 Medium WAF gateways

--- a/articles/web-application-firewall/ag/application-gateway-waf-configuration.md
+++ b/articles/web-application-firewall/ag/application-gateway-waf-configuration.md
@@ -84,7 +84,7 @@ So if the URL `http://www.contoso.com/?user%281%29=fdafdasfda` is passed to the 
 
 Web Application Firewall allows you to configure request size limits within lower and upper bounds. The following two size limits configurations are available:
 
-- The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field can range from 1KB minimum to 128KB maximum value. The default value for request body size is 128 KB.
+- The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field has a minimum value of 1 KB a maximum value of 128 KB. The default value for request body size is 128 KB.
 - The file upload limit field is specified in MB and it governs the maximum allowed file upload size. This field can have a minimum value of 1 MB and the following maximums:
 
    - 100 MB for v1 Medium WAF gateways


### PR DESCRIPTION
Changing 1-KB and 128-KB to 1KB and 128KB in the below. The '-' in there is misleading and causes the reader to read that as a range when it is not.

"The maximum request body size field is specified in kilobytes and controls overall request size limit excluding any file uploads. This field can range from 1-KB minimum to 128-KB maximum value. The default value for request body size is 128 KB"