### PR TITLE
Update load-balancer-outbound-connections.md

### DIFF
--- a/articles/load-balancer/load-balancer-outbound-connections.md
+++ b/articles/load-balancer/load-balancer-outbound-connections.md
@@ -87,7 +87,7 @@ The following <a name="snatporttable"></a>table shows the SNAT port preallocatio
 | 801-1,000 | 32 | 
 
 >[!NOTE]
-> If you have a backend pool with a max size of 6, each instance can have 64,000/10 = 6,400 ports if you define an explicit outbound rule. According to the above table each will only have 1,024 if you choose automatic allocation.
+> If you have a backend pool with a max size of 10, each instance can have 64,000/10 = 6,400 ports if you define an explicit outbound rule. According to the above table each will only have 1,024 if you choose automatic allocation.
 
 ## <a name="outboundrules"></a> Outbound rules and Virtual Network NAT
 


### PR DESCRIPTION
Clarifying the note and making it in line with other documentation as here https://docs.microsoft.com/en-us/azure/load-balancer/troubleshoot-outbound-connection#manually-allocate-snat-ports-to-maximize-snat-ports-per-vm

As defined in preallocated ports, the load balancer will automatically allocate ports based on the number of VMs in the backend. By default, this is done conservatively to ensure scalability. If you know the maximum number of VMs you will have in the backend, you can manually allocate SNAT ports in each outbound rule. For example, if you know you will have a maximum of 10 VMs you can allocate 6,400 SNAT ports per VM rather than the default 1,024.