### PR TITLE
Including azureml-sdk as a pip dependency

### DIFF
--- a/articles/machine-learning/tutorial-1st-experiment-sdk-train.md
+++ b/articles/machine-learning/tutorial-1st-experiment-sdk-train.md
@@ -165,6 +165,8 @@ dependencies:
     - python=3.6.2
     - pytorch
     - torchvision
+    - pip
+        - azureml-sdk
 ```
 
 This environment has all the dependencies that your model and training script require. Notice there's no dependency on the Azure Machine Learning SDK for Python.


### PR DESCRIPTION
Adding this dependency ensures that azureml.core and azureml.core Dataset are included when running in AML service.  When excluded AML can error out and state that an azureml module is missing (Usually core and dataset). 

An example error message:
```
ModuleNotFoundError: No module named 'azureml'
```