### PR TITLE
Fix host.json examples

### DIFF
--- a/includes/functions-host-json-durabletask.md
+++ b/includes/functions-host-json-durabletask.md
@@ -12,7 +12,7 @@ ms.custom: include file
 Configuration settings for [Durable Functions](../articles/azure-functions/durable-functions-overview.md).
 
 > [!NOTE]
-> The below examples are for use with Azure Functions V2 or V3. If using Azure Functions V1, the "durableTask" section of the host.json should go in the root, rather than as a field under "extensions".
+> All major versions of Durable Functions are supported on all versions of the Azure Functions runtime. However, the schema of the host.json configuration is slightly different depending on the version of the Azure Functions runtime as well as the Durable Functions extension version being used. The below examples are for use with Azure Functions 2.0 and 3.0. in both examples, if using Azure Functions 1.0, the available settings are the same but the "durableTask" section of the host.json should go in the root of the host.json configuration, rather than as a field under "extensions".
 
 
 ### Durable Functions 1.x

--- a/includes/functions-host-json-durabletask.md
+++ b/includes/functions-host-json-durabletask.md
@@ -39,7 +39,7 @@ Configuration settings for [Durable Functions](../articles/azure-functions/durab
       "eventGridPublishRetryCount": 3,
       "eventGridPublishRetryInterval": "00:00:30",
       "eventGridPublishEventTypes": ["Started", "Completed", "Failed", "Terminated"]
-  }
+    }
   }
 }
 ```

--- a/includes/functions-host-json-durabletask.md
+++ b/includes/functions-host-json-durabletask.md
@@ -14,36 +14,6 @@ Configuration settings for [Durable Functions](../articles/azure-functions/durab
 > [!NOTE]
 > All major versions of Durable Functions are supported on all versions of the Azure Functions runtime. However, the schema of the host.json configuration is slightly different depending on the version of the Azure Functions runtime as well as the Durable Functions extension version being used. The below examples are for use with Azure Functions 2.0 and 3.0. in both examples, if using Azure Functions 1.0, the available settings are the same but the "durableTask" section of the host.json should go in the root of the host.json configuration, rather than as a field under "extensions".
 
-
-### Durable Functions 1.x
-
-```json
-{
-  "extensions": {
-    "durableTask": {
-      "hubName": "MyTaskHub",
-      "controlQueueBatchSize": 32,
-      "partitionCount": 4,
-      "controlQueueVisibilityTimeout": "00:05:00",
-      "workItemQueueVisibilityTimeout": "00:05:00",
-      "maxConcurrentActivityFunctions": 10,
-      "maxConcurrentOrchestratorFunctions": 10,
-      "maxQueuePollingInterval": "00:00:30",
-      "azureStorageConnectionStringName": "AzureWebJobsStorage",
-      "trackingStoreConnectionStringName": "TrackingStorage",
-      "trackingStoreNamePrefix": "DurableTask",
-      "traceInputsAndOutputs": false,
-      "logReplayEvents": false,
-      "eventGridTopicEndpoint": "https://topic_name.westus2-1.eventgrid.azure.net/api/events",
-      "eventGridKeySettingName":  "EventGridKey",
-      "eventGridPublishRetryCount": 3,
-      "eventGridPublishRetryInterval": "00:00:30",
-      "eventGridPublishEventTypes": ["Started", "Completed", "Failed", "Terminated"]
-    }
-  }
-}
-```
-
 ### <a name="durable-functions-2-0-host-json"></a>Durable Functions 2.x
 
 ```json
@@ -91,6 +61,35 @@ Configuration settings for [Durable Functions](../articles/azure-functions/durab
  }
 }
 
+```
+
+### Durable Functions 1.x
+
+```json
+{
+  "extensions": {
+    "durableTask": {
+      "hubName": "MyTaskHub",
+      "controlQueueBatchSize": 32,
+      "partitionCount": 4,
+      "controlQueueVisibilityTimeout": "00:05:00",
+      "workItemQueueVisibilityTimeout": "00:05:00",
+      "maxConcurrentActivityFunctions": 10,
+      "maxConcurrentOrchestratorFunctions": 10,
+      "maxQueuePollingInterval": "00:00:30",
+      "azureStorageConnectionStringName": "AzureWebJobsStorage",
+      "trackingStoreConnectionStringName": "TrackingStorage",
+      "trackingStoreNamePrefix": "DurableTask",
+      "traceInputsAndOutputs": false,
+      "logReplayEvents": false,
+      "eventGridTopicEndpoint": "https://topic_name.westus2-1.eventgrid.azure.net/api/events",
+      "eventGridKeySettingName":  "EventGridKey",
+      "eventGridPublishRetryCount": 3,
+      "eventGridPublishRetryInterval": "00:00:30",
+      "eventGridPublishEventTypes": ["Started", "Completed", "Failed", "Terminated"]
+    }
+  }
+}
 ```
 
 Task hub names must start with a letter and consist of only letters and numbers. If not specified, the default task hub name for a function app is **DurableFunctionsHub**. For  more information, see [Task hubs](../articles/azure-functions/durable-functions-task-hubs.md).

--- a/includes/functions-host-json-durabletask.md
+++ b/includes/functions-host-json-durabletask.md
@@ -11,29 +11,35 @@ ms.custom: include file
 
 Configuration settings for [Durable Functions](../articles/azure-functions/durable-functions-overview.md).
 
+> [!NOTE]
+> The below examples are for use with Azure Functions V2 or V3. If using Azure Functions V1, the "durableTask" section of the host.json should go in the root, rather than as a field under "extensions".
+
+
 ### Durable Functions 1.x
 
 ```json
 {
-  "durableTask": {
-    "hubName": "MyTaskHub",
-    "controlQueueBatchSize": 32,
-    "partitionCount": 4,
-    "controlQueueVisibilityTimeout": "00:05:00",
-    "workItemQueueVisibilityTimeout": "00:05:00",
-    "maxConcurrentActivityFunctions": 10,
-    "maxConcurrentOrchestratorFunctions": 10,
-    "maxQueuePollingInterval": "00:00:30",
-    "azureStorageConnectionStringName": "AzureWebJobsStorage",
-    "trackingStoreConnectionStringName": "TrackingStorage",
-    "trackingStoreNamePrefix": "DurableTask",
-    "traceInputsAndOutputs": false,
-    "logReplayEvents": false,
-    "eventGridTopicEndpoint": "https://topic_name.westus2-1.eventgrid.azure.net/api/events",
-    "eventGridKeySettingName":  "EventGridKey",
-    "eventGridPublishRetryCount": 3,
-    "eventGridPublishRetryInterval": "00:00:30",
-    "eventGridPublishEventTypes": ["Started", "Completed", "Failed", "Terminated"]
+  "extensions" {
+    "durableTask": {
+      "hubName": "MyTaskHub",
+      "controlQueueBatchSize": 32,
+      "partitionCount": 4,
+      "controlQueueVisibilityTimeout": "00:05:00",
+      "workItemQueueVisibilityTimeout": "00:05:00",
+      "maxConcurrentActivityFunctions": 10,
+      "maxConcurrentOrchestratorFunctions": 10,
+      "maxQueuePollingInterval": "00:00:30",
+      "azureStorageConnectionStringName": "AzureWebJobsStorage",
+      "trackingStoreConnectionStringName": "TrackingStorage",
+      "trackingStoreNamePrefix": "DurableTask",
+      "traceInputsAndOutputs": false,
+      "logReplayEvents": false,
+      "eventGridTopicEndpoint": "https://topic_name.westus2-1.eventgrid.azure.net/api/events",
+      "eventGridKeySettingName":  "EventGridKey",
+      "eventGridPublishRetryCount": 3,
+      "eventGridPublishRetryInterval": "00:00:30",
+      "eventGridPublishEventTypes": ["Started", "Completed", "Failed", "Terminated"]
+  }
   }
 }
 ```

--- a/includes/functions-host-json-durabletask.md
+++ b/includes/functions-host-json-durabletask.md
@@ -12,7 +12,7 @@ ms.custom: include file
 Configuration settings for [Durable Functions](../articles/azure-functions/durable-functions-overview.md).
 
 > [!NOTE]
-> All major versions of Durable Functions are supported on all versions of the Azure Functions runtime. However, the schema of the host.json configuration is slightly different depending on the version of the Azure Functions runtime as well as the Durable Functions extension version being used. The below examples are for use with Azure Functions 2.0 and 3.0. in both examples, if using Azure Functions 1.0, the available settings are the same but the "durableTask" section of the host.json should go in the root of the host.json configuration, rather than as a field under "extensions".
+> All major versions of Durable Functions are supported on all versions of the Azure Functions runtime. However, the schema of the host.json configuration is slightly different depending on the version of the Azure Functions runtime and the Durable Functions extension version you use. The following examples are for use with Azure Functions 2.0 and 3.0. In both examples, if you're using Azure Functions 1.0, the available settings are the same, but the "durableTask" section of the host.json should go in the root of the host.json configuration instead of as a field under "extensions".
 
 ### <a name="durable-functions-2-0-host-json"></a>Durable Functions 2.x
 

--- a/includes/functions-host-json-durabletask.md
+++ b/includes/functions-host-json-durabletask.md
@@ -19,7 +19,7 @@ Configuration settings for [Durable Functions](../articles/azure-functions/durab
 
 ```json
 {
-  "extensions" {
+  "extensions": {
     "durableTask": {
       "hubName": "MyTaskHub",
       "controlQueueBatchSize": 32,


### PR DESCRIPTION
Durable 1.x was correct for Functions V1, and Durable 2.x was correct for Functions V2/V3.

Now both examples are for Functions V2/V3, with a note of how to transform these examples if using Functions V1.