### PR TITLE
Additional tip related to auto-populating tables in system databases

### DIFF
--- a/articles/connectors/connectors-create-api-sqlazure.md
+++ b/articles/connectors/connectors-create-api-sqlazure.md
@@ -91,14 +91,15 @@ The first time that you add either a [SQL trigger](#add-sql-trigger) or [SQL act
    ||||
 
    > [!TIP]
-   > 1. You can find this information in your database's connection string. For example, 
-   > in the Azure portal, find and open your database. On the database menu, 
-   > select either **Connection strings** or **Properties** where you can find this string:
+   > To provide your database and table information, you have these options:
+   > 
+   > * Find this information in your database's connection string. For example, in the Azure portal, find and open your database. 
+   >   On the database menu, select either **Connection strings** or **Properties** where you can find this string: 
    >
    > `Server=tcp:{your-server-address}.database.windows.net,1433;Initial Catalog={your-database-name};Persist Security Info=False;User ID={your-user-name};Password={your-password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
    >
-   > 2. Tables in the System Databases are filtered out by default. They might not be auto-populated when the system database is selected. 
-    As an alternative, you can enter the table name manually by using "Enter custom value" option in the drop-down.
+   > * By default, tables in system databases are filtered out, so they might not automatically appear when you select a system database. 
+   >   As an alternative, you can manually enter the table name after you select **Enter custom value** from the database list.
 
    This example shows how these values might look:
 

--- a/articles/connectors/connectors-create-api-sqlazure.md
+++ b/articles/connectors/connectors-create-api-sqlazure.md
@@ -93,13 +93,11 @@ The first time that you add either a [SQL trigger](#add-sql-trigger) or [SQL act
    > [!TIP]
    > To provide your database and table information, you have these options:
    > 
-   > * Find this information in your database's connection string. For example, in the Azure portal, find and open your database. 
-   >   On the database menu, select either **Connection strings** or **Properties** where you can find this string: 
+   > * Find this information in your database's connection string. For example, in the Azure portal, find and open your database. On the database menu, select either **Connection strings** or **Properties**, where you can find this string: 
+   >   `Server=tcp:{your-server-address}.database.windows.net,1433;Initial Catalog={your-database-name};Persist Security Info=False;User ID={your-user-name};Password={your-password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
    >
-   > `Server=tcp:{your-server-address}.database.windows.net,1433;Initial Catalog={your-database-name};Persist Security Info=False;User ID={your-user-name};Password={your-password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
+   > * By default, tables in system databases are filtered out, so they might not automatically appear when you select a system database. As an alternative, you can manually enter the table name after you select **Enter custom value** from the database list.
    >
-   > * By default, tables in system databases are filtered out, so they might not automatically appear when you select a system database. 
-   >   As an alternative, you can manually enter the table name after you select **Enter custom value** from the database list.
 
    This example shows how these values might look:
 

--- a/articles/connectors/connectors-create-api-sqlazure.md
+++ b/articles/connectors/connectors-create-api-sqlazure.md
@@ -93,7 +93,8 @@ The first time that you add either a [SQL trigger](#add-sql-trigger) or [SQL act
    > [!TIP]
    > To provide your database and table information, you have these options:
    > 
-   > * Find this information in your database's connection string. For example, in the Azure portal, find and open your database. On the database menu, select either **Connection strings** or **Properties**, where you can find this string: 
+   > * Find this information in your database's connection string. For example, in the Azure portal, find and open your database. On the database menu, select either **Connection strings** or **Properties**, where you can find this string:
+   >
    >   `Server=tcp:{your-server-address}.database.windows.net,1433;Initial Catalog={your-database-name};Persist Security Info=False;User ID={your-user-name};Password={your-password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
    >
    > * By default, tables in system databases are filtered out, so they might not automatically appear when you select a system database. As an alternative, you can manually enter the table name after you select **Enter custom value** from the database list.

--- a/articles/connectors/connectors-create-api-sqlazure.md
+++ b/articles/connectors/connectors-create-api-sqlazure.md
@@ -91,11 +91,14 @@ The first time that you add either a [SQL trigger](#add-sql-trigger) or [SQL act
    ||||
 
    > [!TIP]
-   > You can find this information in your database's connection string. For example, 
+   > 1. You can find this information in your database's connection string. For example, 
    > in the Azure portal, find and open your database. On the database menu, 
    > select either **Connection strings** or **Properties** where you can find this string:
    >
    > `Server=tcp:{your-server-address}.database.windows.net,1433;Initial Catalog={your-database-name};Persist Security Info=False;User ID={your-user-name};Password={your-password};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
+   >
+   > 2. Tables in the System Databases are filtered out by default. They might not be auto-populated when the system database is selected. 
+    As an alternative, you can enter the table name manually by using "Enter custom value" option in the drop-down.
 
    This example shows how these values might look:
 


### PR DESCRIPTION
Added this additional tip after discussing with one of our Principal Software Engineer, Cameron Stillion:
Tables in the System Databases are filtered out by default. They might not be auto-populated when the system database is selected. As an alternative, you can enter the table name manually by using "Enter custom value" option in the drop down.

Please note that this question is raised by a few customers in a couple of different scenarios.