### PR TITLE
Updating the right words to avoid confusion

### DIFF
--- a/articles/virtual-machines/troubleshooting/troubleshoot-recovery-disks-portal-windows.md
+++ b/articles/virtual-machines/troubleshooting/troubleshoot-recovery-disks-portal-windows.md
@@ -116,11 +116,11 @@ Once your errors are resolved, detach the existing virtual hard disk from your t
     ![Set the data disk as offline in Server Manager](./media/troubleshoot-recovery-disks-portal-windows/server-manager-set-disk-offline.png)
 
 3. Now detach the virtual hard disk from the VM. Select your VM in the Azure portal and click **Disks**. 
-4. Select **Edit**, select the OS disk you attached and then click **Detach**:
+4. Select **Edit**, select the OS disk you attached and then click **Delete**:
 
     ![Detach existing virtual hard disk](./media/troubleshoot-recovery-disks-portal-windows/detach-disk.png)
 
-    Wait until the VM has successfully detached the data disk before continuing.
+    Wait until the VM has successfully deleted in the VM ie., detached the data disk before continuing.
 
 ## Swap the OS disk for the VM
 


### PR DESCRIPTION
Updating with 'delete' as per the new Azure portal changes. Its no more detach but delete.
Delete word creates a confusion if its deleting the disk completely, so giving a detail description that "the disk is deleted in the VM i.e., detaching the disk", gives more clarification on the action performed. Image also should be changed as per the new portal changes with delete symbol.