### PR TITLE
Update a reference to URLs in DNS allow lists

### DIFF
--- a/articles/active-directory/manage-apps/application-proxy-add-on-premises-application.md
+++ b/articles/active-directory/manage-apps/application-proxy-add-on-premises-application.md
@@ -111,7 +111,7 @@ Allow access to the following URLs:
 | login.windows.net<br>secure.aadcdn.microsoftonline-p.com<br>&ast;.microsoftonline.com<br>&ast;.microsoftonline-p.com<br>&ast;.msauth.net<br>&ast;.msauthimages.net<br>&ast;.msecnd.net<br>&ast;.msftauth.net<br>&ast;.msftauthimages.net<br>&ast;.phonefactor.net<br>enterpriseregistration.windows.net<br>management.azure.com<br>policykeyservice.dc.ad.msft.net<br>ctldl.windowsupdate.com | 443/HTTPS |The connector uses these URLs during the registration process. |
 | ctldl.windowsupdate.com | 80/HTTP |The connector uses this URL during the registration process. |
 
-You can allow connections to &ast;.msappproxy.net and &ast;.servicebus.windows.net if your firewall or proxy lets you configure DNS allow lists. If not, you need to allow access to the [Azure IP ranges and Service Tags - Public Cloud](https://www.microsoft.com/download/details.aspx?id=56519). The IP ranges are updated each week.
+You can allow connections to &ast;.msappproxy.net, &ast;.servicebus.windows.net, and other URLs above if your firewall or proxy lets you configure DNS allow lists. If not, you need to allow access to the [Azure IP ranges and Service Tags - Public Cloud](https://www.microsoft.com/download/details.aspx?id=56519). The IP ranges are updated each week.
 
 ## Install and register a connector
 


### PR DESCRIPTION
My customer is confused because only  *.msappproxy.net and *.servicebus.windows.net were mentioned while they need to allow connections to lots of other URLs. So I mentioned other URLs in addition to *.msappproxy.net and *.servicebus.windows.net.