### PR TITLE
RestorefromURLMI_Kekiran.md

### DIFF
--- a/articles/azure-sql/managed-instance/restore-sample-database-quickstart.md
+++ b/articles/azure-sql/managed-instance/restore-sample-database-quickstart.md
@@ -45,6 +45,11 @@ In SQL Server Management Studio, follow these steps to restore the Wide World Im
 1. Open SSMS and connect to your managed instance.
 2. In **Object Explorer**, right-click your managed instance and select **New Query** to open a new query window.
 3. Run the following SQL script, which uses a pre-configured storage account and SAS key to [create a credential](/sql/t-sql/statements/create-credential-transact-sql) in your managed instance.
+ 
+ Important
+
+THE CREDENTIAL NAME argument requires that the name match the container path, start with https and not contain a trailing forward slash. The IDENTITY argument requires the name, SHARED ACCESS SIGNATURE. The SECRET argument requires the shared access signature token.
+The SHARED ACCESS SIGNATURE secret should not have the leading ?.
 
    ```sql
    CREATE CREDENTIAL [https://mitutorials.blob.core.windows.net/databases]

--- a/articles/azure-sql/managed-instance/restore-sample-database-quickstart.md
+++ b/articles/azure-sql/managed-instance/restore-sample-database-quickstart.md
@@ -46,10 +46,8 @@ In SQL Server Management Studio, follow these steps to restore the Wide World Im
 2. In **Object Explorer**, right-click your managed instance and select **New Query** to open a new query window.
 3. Run the following SQL script, which uses a pre-configured storage account and SAS key to [create a credential](/sql/t-sql/statements/create-credential-transact-sql) in your managed instance.
  
- Important
-
-THE CREDENTIAL NAME argument requires that the name match the container path, start with https and not contain a trailing forward slash. The IDENTITY argument requires the name, SHARED ACCESS SIGNATURE. The SECRET argument requires the shared access signature token.
-The SHARED ACCESS SIGNATURE secret should not have the leading ?.
+   > [!IMPORTANT]
+   > `CREDENTIAL` must match the container path, begin with `https`, and can't contain a trailing forward slash. `IDENTITY` must be `SHARED ACCESS SIGNATURE`. `SECRET` must be the Shared Access Signature token and can't contain a leading `?`.
 
    ```sql
    CREATE CREDENTIAL [https://mitutorials.blob.core.windows.net/databases]


### PR DESCRIPTION
Though it is clearly written in the reference article shared for the Create Credential that the Secret Should not start with (?) but many of the customer doesn't go the reference article shared in the same link and they try creating credential with ? .   If we can add the note in this page only regarding omitting the question mark in the Secret, this will help to reduce customer making mistake and less customer reaching out to us for fixing the issue.