### PR TITLE
Update azure-netapp-files-configure-export-policy.md

### DIFF
--- a/articles/azure-netapp-files/azure-netapp-files-configure-export-policy.md
+++ b/articles/azure-netapp-files/azure-netapp-files-configure-export-policy.md
@@ -28,8 +28,9 @@ You can create up to five export policy rules.
 
     * **Allowed Clients**   
         Specify the value in one of the following formats:  
-        * IPv4 address, for example, `10.1.12.24` 
+        * IPv4 address, for example, `10.1.12.24`
         * IPv4 address with a subnet mask expressed as a number of bits, for example, `10.1.12.10/4`
+        * Rule supports comma separated IP addresses. You can enter multiple hosts IPs in single rule by separating them buy comma"," for example '10.1.12.25,10.1.12.28,10.1.12.29"
 
     * **Access**  
         Select one of the following access types:  

--- a/articles/azure-netapp-files/azure-netapp-files-configure-export-policy.md
+++ b/articles/azure-netapp-files/azure-netapp-files-configure-export-policy.md
@@ -15,40 +15,32 @@ You can configure export policy to control access to an Azure NetApp Files volum
 
 You can create up to five export policy rules.
 
-## Steps 
+## Configure the policy 
 
-1.	From the Volumes page, select the volume for which you want to configure the export policy, and click **Export policy**. 
+1.	On the **Volumes** page, select the volume for which you want to configure the export policy, and then select **Export policy**. You can also configure the export policy during the creation of the volume.
 
-    You can also configure the export policy during the creation of the volume.
+2.	To create an export policy rule, specify the following information:   
+    * **Index**: Specify the index number for the rule.  
+      
+      An export policy can consist of up to five rules. Rules are evaluated according to their order in the list of index numbers. Rules with lower index numbers are evaluated first. For example, the rule with index number 1 is evaluated before the rule with index number 2. 
 
-2.	Specify information for the following fields to create an export policy rule:   
-    *  **Index**   
-        Specify the index number for the rule.  
-        An export policy can consist of up to five rules. Rules are evaluated according to their order in the list of index numbers. Rules with lower index numbers are evaluated first. For example, the rule with index number 1 is evaluated before the rule with index number 2. 
+    * **Allowed Clients**: Specify the value in one of the following formats:  
+      * IPv4 address. Example: `10.1.12.24`
+      * IPv4 address with a subnet mask expressed as a number of bits. Example: `10.1.12.10/4`
+      * Comma-separated IP addresses. You can enter multiple host IPs in a single rule by separating them with commas. Example: `10.1.12.25,10.1.12.28,10.1.12.29`
 
-    * **Allowed Clients**   
-        Specify the value in one of the following formats:  
-        * IPv4 address, for example, `10.1.12.24`
-        * IPv4 address with a subnet mask expressed as a number of bits, for example, `10.1.12.10/4`
-        * Rule supports comma separated IP addresses. You can enter multiple hosts IPs in single rule by separating them buy comma"," for example '10.1.12.25,10.1.12.28,10.1.12.29"
+    * **Access**: Select one of the following access types:  
+      * No Access 
+      * Read & Write
+      * Read Only
 
-    * **Access**  
-        Select one of the following access types:  
-        * No Access 
-        * Read & Write
-        * Read Only
+    * **Read-only** and **Read/Write**: If you use Kerberos encryption with NFSv4.1, follow the instructions in [Configure NFSv4.1 Kerberos encryption](configure-kerberos-encryption.md).  For performance impact of Kerberos, see [Performance impact of Kerberos on NFSv4.1](configure-kerberos-encryption.md#kerberos_performance). 
 
-    * **Read-only** and **Read/Write**  
-        If you use Kerberos encryption with NFSv4.1, follow the instructions in [Configure NFSv4.1 Kerberos encryption](configure-kerberos-encryption.md).  For performance impact of Kerberos, see [Performance impact of Kerberos on NFSv4.1](configure-kerberos-encryption.md#kerberos_performance). 
+      ![Kerberos security options](../media/azure-netapp-files/kerberos-security-options.png) 
 
-        ![Kerberos security options](../media/azure-netapp-files/kerberos-security-options.png) 
+    * **Root Access**: Specify whether the `root` account can access the volume.  By default, Root Access is set to **On**, and the `root` account has access to the volume.
 
-    * **Root Access**  
-        Specify whether the `root` account can access the volume.  By default, Root Access is set to **On**, and the `root` account has access to the volume.
-
-![Export policy](../media/azure-netapp-files/azure-netapp-files-export-policy.png) 
-
-
+      ![Export policy](../media/azure-netapp-files/azure-netapp-files-export-policy.png) 
 
 ## Next steps 
 * [Mount or unmount a volume for virtual machines](azure-netapp-files-mount-unmount-volumes-for-virtual-machines.md)


### PR DESCRIPTION
Allowed clients field supports comma separated IP or Subnet, I am requesting to update document with example I have entered . This is important for customer to know, since export policy supports only 5 rules.