### PR TITLE
ConditionalAccess Policy Doc Sample - Proper case sensitive ClaimEquals comparison on Boolean types

### DIFF
--- a/articles/active-directory-b2c/conditional-access-technical-profile.md
+++ b/articles/active-directory-b2c/conditional-access-technical-profile.md
@@ -424,7 +424,7 @@ Add a user journey that uses the new claims, as shown in the following example:
             </Precondition>
             <Precondition Type="ClaimEquals" ExecuteActionsIf="true">
               <Value>CAChallengeIsMfa</Value>
-              <Value>false</Value>
+              <Value>False</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
           </Preconditions>
@@ -454,7 +454,7 @@ Add a user journey that uses the new claims, as shown in the following example:
             </Precondition>
             <Precondition Type="ClaimEquals" ExecuteActionsIf="false">
               <Value>CAChallengeIsBlock</Value>
-              <Value>true</Value>
+              <Value>True</Value>
               <Action>SkipThisOrchestrationStep</Action>
             </Precondition>
           </Preconditions>


### PR DESCRIPTION
Fix logic bomb in policy precondition on boolean claim types.  After some head scratching, figured out this issue was due to treating boolean in precondition logic as string.  Valid values are case sensitive `True` and `False`.

Most interesting here is how this psuedo behaves as you want it, until you test out all the use cases.  Since `True` =ClaimEquals= "true" just evaluates to a logical `False` - which is 1/2 the scenarios :)

Ref1: https://stackoverflow.com/a/51957101/343347
Ref2: https://stackoverflow.com/a/58821069/343347


See Also: https://github.com/azure-ad-b2c/samples/pull/135