### PR TITLE
Updating Tier S2 to S3 to match the value of "Operation throttles" Table

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-quotas-throttling.md
+++ b/articles/iot-hub/iot-hub-devguide-quotas-throttling.md
@@ -61,7 +61,7 @@ The following table shows the enforced throttles. Values refer to an individual 
 
    Finally, if your payload size is between 156KB and 160 KB, you'll be able to make only 1 call per second per unit in your hub before hitting the limit of 160 KB/sec/unit.
 
-*  For *Jobs device operations (update twin, invoke direct method)* for tier S2, 50/sec/unit only applies to when you invoke methods using jobs. If you invoke direct methods directly, the original throttling limit of 24 MB/sec/unit (for S2) applies.
+*  For *Jobs device operations (update twin, invoke direct method)* for tier S3, 50/sec/unit only applies to when you invoke methods using jobs. If you invoke direct methods directly, the original throttling limit of 24 MB/sec/unit (for S3) applies.
 
 *  **Quota** is the aggregate number of messages you can send in your hub *per day*. You can find your hub's quota limit under the column **Total number of messages /day** on the [IoT Hub pricing page](https://azure.microsoft.com/pricing/details/iot-hub/).
 


### PR DESCRIPTION
"50/sec/unit" and "24 MB/sec/unit" values applies to Tier S3 not S2 in the "Operation throttles" Table.

![image](https://user-images.githubusercontent.com/65746722/98247638-3b578600-1fb7-11eb-9371-f2c8f029a336.png)
