### PR TITLE
Update functions-timezone.md

### DIFF
--- a/includes/functions-timezone.md
+++ b/includes/functions-timezone.md
@@ -4,22 +4,16 @@ The value of this setting depends on the operating system and plan on which your
 
 |Operating system |Plan |Value |
 |-|-|-|
-| **Windows** |All | Set the value to the name of the desired time zone as shown in the [Microsoft Time Zone Index](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-vista/cc749073(v=ws.10)). |
+| **Windows** |All | Set the value to the name of the desired time zone as given by the second line from each pair given by the Windows command `tzutil.exe /L` |
 | **Linux** |Premium<br/>Dedicated |Set the value to the name of the desired time zone as shown in the [tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
 
 > [!NOTE]
 > `WEBSITE_TIME_ZONE` is not currently supported on the Linux Consumption plan.
 
-For example, *Eastern Standard Time* (Windows) or *America/New_York* (Linux) is UTC-05:00. To have your timer trigger fire at 10:00 AM EST every day, use the following NCRONTAB expression that accounts for UTC time zone:
-
-```
-"0 0 15 * * *"
-```	
-
-Or create an app setting for your function app named `WEBSITE_TIME_ZONE`, set the value to `Eastern Standard Time` (Windows) or `America/New_York` (Linux), and then use the following NCRONTAB expression: 
+For example, Eastern Time in the US (represented by `Eastern Standard Time` (Windows) or `America/New_York` (Linux)) currently uses UTC-05:00 during standard time and UTC-04:00 during daylight time. To have a timer trigger fire at 10:00 AM Eastern Time every day, create an app setting for your function app named `WEBSITE_TIME_ZONE`, set the value to `Eastern Standard Time` (Windows) or `America/New_York` (Linux), and then use the following NCRONTAB expression: 
 
 ```
 "0 0 10 * * *"
 ```	
 
-When you use `WEBSITE_TIME_ZONE`, the time is adjusted for time changes in the specific timezone, such as daylight savings time. 
+When you use `WEBSITE_TIME_ZONE` the time is adjusted for time changes in the specific timezone, including daylight saving time and changes in standard time.


### PR DESCRIPTION
Improved several aspects of this text:

- Removed the link given for Windows time zones because it is invalid.  It is severely outdated and doesn't apply here.  There is no page to link to for this.  Instead, users can list the time zones on their own up-to-date system by calling `tzutil /L`

- Removed the first NCRONTAB example, because it was showing a fixed UTC-5 offset without setting `WEBSITE_TIME_ZONE`.  Since Eastern Time alternates between UTC-5 and UTC-4, and the whole point of this section is to show using the time zone setting, this just created confusion.

- Updated other wording to be consistent with industry terminology and improve clarity.