### PR TITLE
Fix typo in docker tagging example

### DIFF
--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -199,7 +199,7 @@ For the following examples, pull the `hello-world` and `alpine` images from Dock
 docker pull hello-world
 docker pull alpine
 docker tag hello-world myregistry.azurecr.io/samples/hello-world:v1
-docker tag hello-world myregistry.azurecr.io/samples/alpine:v1
+docker tag alpine myregistry.azurecr.io/samples/alpine:v1
 ```
 
 ### Authenticate using token


### PR DESCRIPTION
Presumably this didn't intend to tag the same hello-world source image as both myregistry.azurecr.io/samples/alpine and myregistry.azurecr.io/samples/hello-world, although it's not terribly important given that these images are never run in the examples below...