### PR TITLE
Removing duplicate tables

### DIFF
--- a/articles/azure-monitor/platform/logs-data-export.md
+++ b/articles/azure-monitor/platform/logs-data-export.md
@@ -321,7 +321,6 @@ Supported tables are currently limited to those specified below. All data from t
 | ContainerImageInventory | |
 | ContainerInventory | |
 | ContainerLog | |
-| ContainerLog | |
 | ContainerNodeInventory | |
 | ContainerServiceLog | |
 | CoreAzureBackup | |
@@ -339,7 +338,6 @@ Supported tables are currently limited to those specified below. All data from t
 | DnsInventory | |
 | Dynamics365Activity | |
 | Event | Partial support. Some of the data to this table is ingested through storage account. This data is currently not exported. |
-| ExchangeAssessmentRecommendation | |
 | ExchangeAssessmentRecommendation | |
 | FailedIngestion | |
 | FunctionAppLogs | |


### PR DESCRIPTION
The following 2 tables appear twice in the list of supported tables. One instance of each has been removed.
- ContainerLog
- ExchangeAssessmentRecommendation