### PR TITLE
Update howto-deny-public-network-access.md

### DIFF
--- a/articles/postgresql/howto-deny-public-network-access.md
+++ b/articles/postgresql/howto-deny-public-network-access.md
@@ -12,6 +12,8 @@ ms.date: 03/10/2020
 
 This article describes how you can configure an Azure Database for PostgreSQL Single server to deny all public configurations and allow only connections through private endpoints to further enhance the network security.
 
+Note that clients from where connections to PostgreSQL Single server were made prior to the configuration described here will continue to have access to the server.
+
 ## Prerequisites
 
 To complete this how-to guide, you need:


### PR DESCRIPTION
Added note based on investigation for a customer who observed that PostgreSQL Single server was accessible from certain clients even after the deny-public-network-access was configured.
ms.custom: fasttrack-edit