### PR TITLE
Limit customer confusion for AD Site Name

### DIFF
--- a/articles/azure-netapp-files/azure-netapp-files-create-volumes-smb.md
+++ b/articles/azure-netapp-files/azure-netapp-files-create-volumes-smb.md
@@ -141,7 +141,7 @@ This setting is configured in the **Active Directory Connections** under **NetAp
     * **AD DNS Domain Name**  
         This is the domain name of your Active Directory Domain Services that you want to join.
     * **AD Site Name**  
-        This is the site name that the domain controller discovery will be limited to.
+        This is the site name that the domain controller discovery will be limited to. This should match the site name in Active Directory Sites and Services.
     * **SMB server (computer account) prefix**  
         This is the naming prefix for the machine account in Active Directory that Azure NetApp Files will use for creation of new accounts.
 


### PR DESCRIPTION
As part of project H ICM scrub, an improvement was identified on AD Site Name in the AD connector.
It should be made more clear in wording this applies to the site name as identified by Active Directory Sites and Services, not just any user input of what they want to call the site.
NetApp Jira ticket: https://jira.ngage.netapp.com/browse/ANF-8070