### PR TITLE
Update troubleshoot-not-found.md to fix a bug

### DIFF
--- a/articles/cosmos-db/troubleshoot-not-found.md
+++ b/articles/cosmos-db/troubleshoot-not-found.md
@@ -38,7 +38,7 @@ Fix the application logic that's causing the incorrect combination.
 An item is inserted into Azure Cosmos DB with an [invalid character](/dotnet/api/microsoft.azure.documents.resource.id?preserve-view=true&view=azure-dotnet#remarks) in the item ID.
 
 #### Solution:
-Change the ID to a different value that doesn't contain the special characters. If changing the ID isn't an option, you can Base64 encode the ID to escape the special characters.
+Change the ID to a different value that doesn't contain the special characters. If changing the ID isn't an option, you can Base64 encode the ID to escape the special characters. Base64 can still produce names with invalid characters like '/' which need to be replaced.
 
 Items already inserted in the container for the ID can be replaced by using RID values instead of name-based references.
 ```c#
@@ -60,7 +60,7 @@ while (invalidItemsIterator.HasMoreResults)
         // Choose a new ID that doesn't contain special characters.
         // If that isn't possible, then Base64 encode the ID to escape the special characters.
         byte[] plainTextBytes = Encoding.UTF8.GetBytes(itemWithInvalidId["id"].ToString());
-        itemWithInvalidId["id"] = Convert.ToBase64String(plainTextBytes);
+        itemWithInvalidId["id"] = Convert.ToBase64String(plainTextBytes).Replace('/', '!');
 
         // Update the item with the new ID value by using the RID-based container reference.
         JObject item = await containerByRid.ReplaceItemAsync<JObject>(


### PR DESCRIPTION
The base64 can return an illegal character that needs to be replaced.

Fixes: https://github.com/MicrosoftDocs/azure-docs/issues/64959