### PR TITLE
Correct typo (trailing slash after subscription id)

### DIFF
--- a/articles/governance/policy/how-to/programmatically-create.md
+++ b/articles/governance/policy/how-to/programmatically-create.md
@@ -111,7 +111,7 @@ HTTP requests.
 
    - Resource - `/subscriptions/{subID}/resourceGroups/{rgName}/providers/{rType}/{rName}`
    - Resource group - `/subscriptions/{subId}/resourceGroups/{rgName}`
-   - Subscription - `/subscriptions/{subId}/`
+   - Subscription - `/subscriptions/{subId}`
    - Management group - `/providers/Microsoft.Management/managementGroups/{mgName}`
 
 For more information about managing resource policies using the Resource Manager PowerShell


### PR DESCRIPTION
-Scope: subscriptions should not include trailing slash after subId