### PR TITLE
Typo "Azure functions"→"Azure Functions"

### DIFF
--- a/articles/event-grid/handler-functions.md
+++ b/articles/event-grid/handler-functions.md
@@ -1,19 +1,19 @@
 ---
-title: Azure function as an event handler for Azure Event Grid events
-description: Describes how you can use Azure functions as event handlers for Event Grid events. 
+title: Azure Function as an event handler for Azure Event Grid events
+description: Describes how you can use Azure Functions as event handlers for Event Grid events. 
 ms.topic: conceptual
 ms.date: 09/18/2020
 ---
 
-# Azure function as an event handler for Event Grid events
+# Azure Function as an event handler for Event Grid events
 
 An event handler is the place where the event is sent. The handler takes an action to process the event. Several Azure services are automatically configured to handle events and **Azure Functions** is one of them. 
 
 
-To use an Azure function as a handler for events, follow one of these approaches: 
+To use an Azure Function as a handler for events, follow one of these approaches: 
 
--	Use [Event Grid trigger](../azure-functions/functions-bindings-event-grid-trigger.md).  Specify **Azure Function** as the **endpoint type**. Then, specify the Azure function app and the function that will handle events. 
--	Use [HTTP trigger](../azure-functions/functions-bindings-http-webhook.md).  Specify **Web Hook** as the **endpoint type**. Then, specify the URL for the Azure function that will handle events. 
+-	Use [Event Grid trigger](../azure-functions/functions-bindings-event-grid-trigger.md).  Specify **Azure Function** as the **endpoint type**. Then, specify the Azure Function app and the function that will handle events. 
+-	Use [HTTP trigger](../azure-functions/functions-bindings-http-webhook.md).  Specify **Web Hook** as the **endpoint type**. Then, specify the URL for the Azure Function that will handle events. 
 
 We recommend that you use the first approach (Event Grid trigger) as it has the following advantages over the second approach:
 -	Event Grid automatically validates Event Grid triggers. With generic HTTP triggers, you must implement the [validation response](webhook-event-delivery.md) yourself.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/event-grid/handler-functions