### PR TITLE
Typo "Azure functions"→"Azure Functions"

### DIFF
--- a/articles/media-services/previous/media-services-dotnet-how-to-use-azure-functions.md
+++ b/articles/media-services/previous/media-services-dotnet-how-to-use-azure-functions.md
@@ -22,7 +22,7 @@ ms.custom: devx-track-csharp
 
 [!INCLUDE [media services api v2 logo](./includes/v2-hr.md)]
 
-This article shows you how to get started with creating Azure Functions that use Media Services. The Azure Function defined in this article monitors a storage account container named **input** for new MP4 files. Once a file is dropped into the storage container, the blob trigger executes the function. To review Azure functions, see  [Overview](../../azure-functions/functions-overview.md) and other topics in the **Azure functions** section.
+This article shows you how to get started with creating Azure Functions that use Media Services. The Azure Function defined in this article monitors a storage account container named **input** for new MP4 files. Once a file is dropped into the storage container, the blob trigger executes the function. To review Azure Functions, see  [Overview](../../azure-functions/functions-overview.md) and other topics in the **Azure Functions** section.
 
 If you want to explore and deploy existing Azure Functions that use Azure Media Services, check out [Media Services Azure Functions](https://github.com/Azure-Samples/media-services-dotnet-functions-integration). This repository contains examples that use Media Services to show workflows related to ingesting content directly from blob storage, encoding, and writing content back to blob storage. It also includes examples of how to monitor job notifications via WebHooks and Azure Queues. You can also develop your Functions based on the examples in the [Media Services Azure Functions](https://github.com/Azure-Samples/media-services-dotnet-functions-integration) repository. To deploy the functions, press the **Deploy to Azure** button.
 
@@ -73,13 +73,13 @@ Once your function app is deployed, you can find it among **App Services** Azure
 
 ## Files
 
-Your Azure function is associated with code files and other files that are described in this section. When you use the Azure portal to create a function, **function.json** and **run.csx** are created for you. You need to add or upload a **project.json** file. The rest of this section gives a brief explanation of each file and shows their definitions.
+Your Azure Function is associated with code files and other files that are described in this section. When you use the Azure portal to create a function, **function.json** and **run.csx** are created for you. You need to add or upload a **project.json** file. The rest of this section gives a brief explanation of each file and shows their definitions.
 
 ![Screenshot shows the json files in your project.](./media/media-services-azure-functions/media-services-azure-functions003.png)
 
 ### function.json
 
-The function.json file defines the function bindings and other configuration settings. The runtime uses this file to determine the events to monitor and how to pass data into and return data from function execution. For more information, see [Azure functions HTTP and webhook bindings](../../azure-functions/functions-reference.md#function-code).
+The function.json file defines the function bindings and other configuration settings. The runtime uses this file to determine the events to monitor and how to pass data into and return data from function execution. For more information, see [Azure Functions HTTP and webhook bindings](../../azure-functions/functions-reference.md#function-code).
 
 >[!NOTE]
 >Set the **disabled** property to **true** to prevent the function from being executed. 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/media-services/previous/media-services-dotnet-how-to-use-azure-functions