### PR TITLE
Clarify the Section about NCRONTAB expressions

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -296,7 +296,7 @@ Each field can have one of the following types of values:
 |Type  |Example  |When triggered  |
 |---------|---------|---------|
 |A specific value |<nobr>"0 5 * * * *"</nobr>|at hh:05:00 where hh is every hour (once an hour)|
-|All values (`*`)|<nobr>"0 * 5 * * *"</nobr>|at 5:mm:00 every day, where mm is every minute of the hour (60 times a day)|
+|All values (`*`)|<nobr>"0 * 5 * * *"</nobr>|at 5:mm:00 every day, where mm is every minute of the hour (60 times within the specified hour)|
 |A range (`-` operator)|<nobr>"5-7 * * * * *"</nobr>|at hh:mm:05,hh:mm:06, and hh:mm:07 where hh:mm is every minute of every hour (3 times a minute)|
 |A set of values (`,` operator)|<nobr>"5,8,10 * * * * *"</nobr>|at hh:mm:05,hh:mm:08, and hh:mm:10 where hh:mm is every minute of every hour (3 times a minute)|
 |An interval value (`/` operator)|<nobr>"0 */5 * * * *"</nobr>|at hh:00:00, hh:05:00, hh:10:00, and so on through hh:55:00 where hh is every hour (12 times an hour)|


### PR DESCRIPTION
The NCRONTAB expressions section needed improvement in my opinion. Specifically the second entry about a timer that runs every day at hour 5 and executes every minute. The previous explanation made a confusing statement about this running 60 times a day. My change aims to clarify that this execution will happen 60 times within the specified hour.