### PR TITLE
Highlight limitations earlier in doc

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-blob-trigger.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-trigger.md
@@ -16,6 +16,16 @@ The Azure Blob storage trigger requires a general-purpose storage account. Stora
 
 For information on setup and configuration details, see the [overview](./functions-bindings-storage-blob.md).
 
+## Polling
+
+Polling works as a hybrid between inspecting logs and running periodic container scans. Blobs are scanned in groups of 10,000 at a time with a continuation token used between intervals.
+
+> [!WARNING]
+> In addition, [storage logs are created on a "best effort"](/rest/api/storageservices/About-Storage-Analytics-Logging) basis. There's no guarantee that all events are captured. Under some conditions, logs may be missed.
+> 
+> If you require faster or more reliable blob processing, consider creating a [queue message](../storage/queues/storage-dotnet-how-to-use-queues.md) when you create the blob. Then use a [queue trigger](functions-bindings-storage-queue.md) instead of a blob trigger to process the blob. Another option is to use Event Grid; see the tutorial [Automate resizing uploaded images using Event Grid](../event-grid/resize-images-on-storage-blob-upload-event.md).
+>
+
 ## Alternatives
 
 ### Event Grid trigger
@@ -408,16 +418,6 @@ The blob trigger uses a queue internally, so the maximum number of concurrent fu
 [The Consumption plan](functions-scale.md#how-the-consumption-and-premium-plans-work) limits a function app on one virtual machine (VM) to 1.5 GB of memory. Memory is used by each concurrently executing function instance and by the Functions runtime itself. If a blob-triggered function loads the entire blob into memory, the maximum memory used by that function just for blobs is 24 * maximum blob size. For example, a function app with three blob-triggered functions and the default settings would have a maximum per-VM concurrency of 3*24 = 72 function invocations.
 
 JavaScript and Java functions load the entire blob into memory, and C# functions do that if you bind to `string`, or `Byte[]`.
-
-## Polling
-
-Polling works as a hybrid between inspecting logs and running periodic container scans. Blobs are scanned in groups of 10,000 at a time with a continuation token used between intervals.
-
-> [!WARNING]
-> In addition, [storage logs are created on a "best effort"](/rest/api/storageservices/About-Storage-Analytics-Logging) basis. There's no guarantee that all events are captured. Under some conditions, logs may be missed.
-> 
-> If you require faster or more reliable blob processing, consider creating a [queue message](../storage/queues/storage-dotnet-how-to-use-queues.md) when you create the blob. Then use a [queue trigger](functions-bindings-storage-queue.md) instead of a blob trigger to process the blob. Another option is to use Event Grid; see the tutorial [Automate resizing uploaded images using Event Grid](../event-grid/resize-images-on-storage-blob-upload-event.md).
->
 
 ## Next steps
 


### PR DESCRIPTION
Our team recently hit an issue where the Trigger didn't fire or would fire but after 10-15mins in some cases. 

When reviewing the doc I found the limitations listed but currently at the very bottom! This PR simply moves these to the top to make it more apparent to users that this, in some cases, may not trigger.