### PR TITLE
Remove un-needed } in sample code.

### DIFF
--- a/articles/governance/resource-graph/first-query-rest-api.md
+++ b/articles/governance/resource-graph/first-query-rest-api.md
@@ -114,7 +114,6 @@ with your own value:
              "{subscriptionID}"
          ],
          "query": "Resources | project name, type | limit 5 | order by name asc"
-         }
      }
      ```
 


### PR DESCRIPTION
The removed } is not required in the block. Results in JSON parse error.