### PR TITLE
Use standard Unicode character for dashes

### DIFF
--- a/articles/container-registry/container-registry-import-images.md
+++ b/articles/container-registry/container-registry-import-images.md
@@ -139,7 +139,7 @@ az acr import \
   --source sourceregistry.azurecr.io/sourcerrepo:tag \
   --image targetimage:tag \
   --username <SP_App_ID> \
-  –-password <SP_Passwd>
+  --password <SP_Passwd>
 ```
 
 ## Import from an Azure container registry in a different AD tenant
@@ -152,7 +152,7 @@ az acr import \
   --source sourceregistry.azurecr.io/sourcerrepo:tag \
   --image targetimage:tag \
   --username <SP_App_ID> \
-  –-password <SP_Passwd>
+  --password <SP_Passwd>
 ```
 
 ## Import from a non-Azure private container registry


### PR DESCRIPTION
The non-standard Unicode character was causing issues when copy pasting into a command shell where the shell (or cli) could not correctly parse it as a dash, causing the command to not work