### PR TITLE
Updating AWS tutorial with info about Linux shell

### DIFF
--- a/articles/migrate/tutorial-discover-aws.md
+++ b/articles/migrate/tutorial-discover-aws.md
@@ -35,7 +35,7 @@ Before you start this tutorial, check you have these prerequisites in place.
 --- | ---
 **Appliance** | You need an EC2 VM on which to run the Azure Migrate appliance. The machine should have:<br/><br/> - Windows Server 2016 installed. Running the appliance on a machine with Windows Server 2019 isn't supported.<br/><br/> - 16-GB RAM, 8 vCPUs, around 80 GB of disk storage, and an external virtual switch.<br/><br/> - A static or dynamic IP address, with internet access, either directly or through a proxy.
 **Windows instances** | Allow inbound connections on WinRM port 5985 (HTTP), so that the appliance can pull configuration and performance metadata.
-**Linux instances** | Allow inbound connections on port 22 (TCP).
+**Linux instances** | Allow inbound connections on port 22 (TCP).<br/><br/> The instances should use `bash` as the default shell, otherwise discovery will fail.
 
 ## Prepare an Azure user account
 


### PR DESCRIPTION
In case the default shell if something other than bash, discovery will fail with „Internal Server Error: the template deployment operation failed for this discovery source…”, as some of the commands have some bash specific features: http://mywiki.wooledge.org/Bashism
![image](https://user-images.githubusercontent.com/3098994/99070991-98ec6380-25b1-11eb-817c-34fa9cad1b52.png)
