### PR TITLE
Fixing mqtt broker enabled env var

### DIFF
--- a/articles/iot-edge/how-to-publish-subscribe.md
+++ b/articles/iot-edge/how-to-publish-subscribe.md
@@ -27,8 +27,10 @@ You can use Azure IoT Edge MQTT broker to publish and subscribe messages. This a
 - An **IoT Hub** of SKU either F1, S1, S2 or S3.
 - Have an **IoT Edge device with version 1.2 or above**. Since IoT Edge MQTT broker is currently in public preview, set the following environment variables to true on the edgeHub container to enable the MQTT broker:
 
-    - experimentalFeatures__enabled
-    - experimentalFeatures__mqttBrokerEnabled
+   | Name | Value |
+   | - | - |
+   | `experimentalFeatures__enabled` | `true` |
+   | `experimentalFeatures__mqttBrokerEnabled` | `true` |
 
 - **Mosquitto clients** installed on the IoT Edge device. This article uses the popular Mosquitto clients that includes [MOSQUITTO_PUB](https://mosquitto.org/man/mosquitto_pub-1.html) and [MOSQUITTO_SUB](https://mosquitto.org/man/mosquitto_sub-1.html). Other MQTT clients could be used instead. To install the Mosquitto clients on an Ubuntu device, run the following command:
 

--- a/articles/iot-edge/how-to-publish-subscribe.md
+++ b/articles/iot-edge/how-to-publish-subscribe.md
@@ -28,7 +28,7 @@ You can use Azure IoT Edge MQTT broker to publish and subscribe messages. This a
 - Have an **IoT Edge device with version 1.2 or above**. Since IoT Edge MQTT broker is currently in public preview, set the following environment variables to true on the edgeHub container to enable the MQTT broker:
 
     - experimentalFeatures__enabled
-    - mqttbroker__enabled
+    - experimentalFeatures__mqttBrokerEnabled
 
 - **Mosquitto clients** installed on the IoT Edge device. This article uses the popular Mosquitto clients that includes [MOSQUITTO_PUB](https://mosquitto.org/man/mosquitto_pub-1.html) and [MOSQUITTO_SUB](https://mosquitto.org/man/mosquitto_sub-1.html). Other MQTT clients could be used instead. To install the Mosquitto clients on an Ubuntu device, run the following command:
 


### PR DESCRIPTION
The correct environment variable to use the mqtt broker is experimentalFeatures__mqttBrokerEnabled. thanks!