### PR TITLE
Updating the Connect Downstream Device documentation for using IoT devices as gateways

### DIFF
--- a/articles/iot-edge/how-to-connect-downstream-device.md
+++ b/articles/iot-edge/how-to-connect-downstream-device.md
@@ -160,11 +160,15 @@ This section introduces a sample application to connect an Azure IoT C device cl
 3. In the iotedge_downstream_device_sample.c file, update the **connectionString** and **edge_ca_cert_path** variables.
 4. Refer to the SDK documentation for instructions on how to run the sample on your device.
 
+
 The Azure IoT device SDK for C provides an option to register a CA certificate when setting up the client. This operation doesn't install the certificate anywhere, but rather uses a string format of the certificate in memory. The saved certificate is provided to the underlying TLS stack when establishing a connection.
 
 ```C
 (void)IoTHubDeviceClient_SetOption(device_handle, OPTION_TRUSTED_CERT, cert_string);
 ```
+
+>[!NOTE]
+> The method to register a CA certificate when setting up the client can change if using a [managed](https://github.com/Azure/azure-iot-sdk-c#packages-and-libraries) package or library. For example, the [Arduino IDE based library](https://github.com/azure/azure-iot-arduino) will require adding the CA certificate to a certificates array defined in a global [certs.c](https://github.com/Azure/azure-iot-sdk-c/blob/master/certs/certs.c) file, rather than using the `IoTHubDeviceClient_LL_SetOption` operation.  
 
 On Windows hosts, if you're not using OpenSSL or another TLS library, the SDK default to using Schannel. For Schannel to work, the IoT Edge root CA certificate should be installed in the Windows certificate store, not set using the `IoTHubDeviceClient_SetOption` operation.
 


### PR DESCRIPTION
Updating the Connect Downstream Device documentation for using IoT devices as gateways with the Azure IoT Edge runtime to reflect that the methods for setting custom CA certificates on downstream devices will change depending on the library used.