### PR TITLE
Adding note about Dependency Tool compatibility with AWS Kernel

### DIFF
--- a/articles/azure-monitor/platform/agents-overview.md
+++ b/articles/azure-monitor/platform/agents-overview.md
@@ -201,6 +201,9 @@ Since the Dependency agent works at the kernel level, support is also dependent 
 | Debian                          | 9      | 4.9  | 
 
 
+> [!NOTE]
+> Amazon Tuned Kernel is not supported. Switch to Stock Kernel to run the Dependency Tool!
+
 ## Next steps
 
 Get more details on each of the agents at the following:


### PR DESCRIPTION
The Migration Documentation states this requirement while the Assessment documentation does not.

Assessment documentation:
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-monitor/platform/agents-overview.md#dependency-agent-linux-kernel-support

Migration documentation:
Discover, assess, and migrate Amazon Web Services (AWS) VMs to Azure
https://docs.microsoft.com/en-us/azure/migrate/tutorial-migrate-aws-virtual-machines
Prerequisites
https://docs.microsoft.com/en-us/azure/site-recovery/vmware-physical-azure-support-matrix#replicated-machines
Support matrix for disaster recovery of VMware VMs and physical servers to Azure
For Linux
On Linux distributions, only the stock kernels that are part of the distribution minor version release/update are supported.