### PR TITLE
Updated example twin

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-device-twins.md
+++ b/articles/iot-hub/iot-hub-devguide-device-twins.md
@@ -332,7 +332,9 @@ For example:
             "batteryLevel": "55%",
             "$metadata": {
                 "telemetryConfig": {
-                    "sendFrequency": "5m",
+                    "sendFrequency": {
+                        "$lastUpdated": "2016-03-31T16:35:48.789Z"
+                    },
                     "status": {
                         "$lastUpdated": "2016-03-31T16:35:48.789Z"
                     },


### PR DESCRIPTION
$metadata keys value should be timestamp rather than the original value of the Twin. Updated that in this PR.