### PR TITLE
Update unsupported scenarios explicitly

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-staged-rollout.md
+++ b/articles/active-directory/hybrid/how-to-connect-staged-rollout.md
@@ -63,6 +63,8 @@ The following scenarios are supported for staged rollout. The feature works only
 
 The following scenarios are not supported for staged rollout:
 
+- Applications or cloud services use legacy authentication such as POP3 and SMTP.
+
 - Certain applications send the "domain_hint" query parameter to Azure AD during authentication. These flows will continue, and users who are enabled for staged rollout will continue to use federation for authentication.
 
 <!-- -->


### PR DESCRIPTION
My customer gave feedback telling me that "Unsupported scenarios" should explicitly refer to legacy authentication.  So I clearly mentioned legacy authentication in the "Unsupported scenario" section.