### PR TITLE
Minor typo fix on Backend-pools examples

### DIFF
--- a/articles/load-balancer/backend-pool-management.md
+++ b/articles/load-balancer/backend-pool-management.md
@@ -110,7 +110,7 @@ Create the backend pool:
 
 ```azurecli-interactive
 az network lb address-pool create \
---resourceGroup myResourceGroup \
+--resource-group myResourceGroup \
 --lb-name myLB \
 --name myBackendPool 
 ```


### PR DESCRIPTION
Fixed line 113, using correct parameter syntax --resource-group instead of --resourceGroup
