### PR TITLE
Update new-relic-limited-release-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/new-relic-limited-release-tutorial.md
+++ b/articles/active-directory/saas-apps/new-relic-limited-release-tutorial.md
@@ -1,6 +1,6 @@
 ---
-title: 'Tutorial: Azure Active Directory single sign-on (SSO) integration with New Relic (By Organization) | Microsoft Docs'
-description: Learn how to configure single sign-on between Azure Active Directory and New Relic (By Organization).
+title: 'Tutorial: Azure Active Directory single sign-on (SSO) integration with New Relic | Microsoft Docs'
+description: Learn how to configure single sign-on between Azure Active Directory and New Relic.
 services: active-directory
 author: jeevansd
 manager: CelesteDG
@@ -13,12 +13,12 @@ ms.date: 02/04/2020
 ms.author: jeedes
 ---
 
-# Tutorial: Azure Active Directory single sign-on (SSO) integration with New Relic (By Organization)
+# Tutorial: Azure Active Directory single sign-on (SSO) integration with New Relic
 
-In this tutorial, you'll learn how to integrate New Relic (By Organization) with Azure Active Directory (Azure AD). When you integrate New Relic (By Organization) with Azure AD, you can:
+In this tutorial, you'll learn how to integrate New Relic with Azure Active Directory (Azure AD). When you integrate New Relic with Azure AD, you can:
 
-* Control in Azure AD who has access to New Relic (By Organization).
-* Enable your users to be automatically signed-in to New Relic (By Organization) with their Azure AD accounts.
+* Control in Azure AD who has access to New Relic.
+* Enable your users to be automatically signed-in to New Relic with their Azure AD accounts.
 * Manage your accounts in one central location - the Azure portal.
 
 To learn more about SaaS app integration with Azure AD, see [What is application access and single sign-on with Azure Active Directory](../manage-apps/what-is-single-sign-on.md).
@@ -28,116 +28,149 @@ To learn more about SaaS app integration with Azure AD, see [What is application
 To get started, you need the following items:
 
 * An Azure AD subscription. If you don't have a subscription, you can get a [free account](https://azure.microsoft.com/free/).
-* New Relic (By Organization) single sign-on (SSO) enabled subscription.
+* New Relic single sign-on (SSO) enabled subscription.
 
 ## Scenario description
 
 In this tutorial, you configure and test Azure AD SSO in a test environment.
 
-* New Relic (By Organization) supports **IDP** initiated SSO
+* New Relic supports **SP and IDP** initiated SSO.
+* Once you configure New Relic you can enforce session control, which protects against exfiltration and infiltration of your organization’s sensitive data in real-time. Session control extend from Conditional Access. [Learn how to enforce session control with Microsoft Cloud App Security](/cloud-app-security/proxy-deployment-any-app).
 
-* Once you configure the New Relic you can enforce session controls, which protect exfiltration and infiltration of your organization’s sensitive data in real-time. Session controls extend from Conditional Access. [Learn how to enforce session control with Microsoft Cloud App Security](/cloud-app-security/proxy-deployment-any-app).
+## Add New Relic application from the gallery
 
-## Adding New Relic (By Organization) from the gallery
-
-To configure the integration of New Relic (By Organization) into Azure AD, you need to add New Relic (By Organization) from the gallery to your list of managed SaaS apps.
+To configure the integration of New Relic into Azure AD, you need to add **New Relic (By Organization)** from the gallery to your list of managed SaaS apps.
 
 1. Sign in to the [Azure portal](https://portal.azure.com) using either a work or school account, or a personal Microsoft account.
-1. On the left navigation pane, select the **Azure Active Directory** service.
-1. Navigate to **Enterprise Applications** and then select **All Applications**.
-1. To add new application, select **New application**.
-1. In the **Add from the gallery** section, type **New Relic (By Organization)** in the search box.
-1. Select **New Relic (By Organization)** from results panel and then add the app. Wait a few seconds while the app is added to your tenant.
+1. Select the **Azure Active Directory** service.
+1. Select **Enterprise applications**.
+1. To add a new application, select **New application**.
+1. On the **Browse Azure AD Gallery** page, type **New Relic (By Organization)** in the search box.
+1. Select **New Relic (By Organization)** from the results panel and then select **Create**. Wait a few seconds while the app is added to your tenant.
 
+## Configure and test Azure AD SSO for New Relic
 
-## Configure and test Azure AD single sign-on for New Relic (By Organization)
+Configure and test Azure AD SSO with New Relic using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between an Azure AD user and the related user in New Relic.
 
-Configure and test Azure AD SSO with New Relic (By Organization) using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between an Azure AD user and the related user in New Relic (By Organization).
-
-To configure and test Azure AD SSO with New Relic (By Organization), complete the following building blocks:
+To configure and test Azure AD SSO with New Relic, complete the following steps:
 
 1. **[Configure Azure AD SSO](#configure-azure-ad-sso)** - to enable your users to use this feature.
-    * **[Create an Azure AD test user](#create-an-azure-ad-test-user)** - to test Azure AD single sign-on with B.Simon.
-    * **[Assign the Azure AD test user](#assign-the-azure-ad-test-user)** - to enable B.Simon to use Azure AD single sign-on.
-1. **[Configure New Relic (By Organization) SSO](#configure-new-relic-by-organization-sso)** - to configure the single sign-on settings on application side.
-    * **[Create New Relic (By Organization) test user](#create-new-relic-by-organization-test-user)** - to have a counterpart of B.Simon in New Relic (By Organization) that is linked to the Azure AD representation of user.
+   1. **[Create an Azure AD test user](#create-an-azure-ad-test-user)** - to test Azure AD single sign-on with B.Simon.
+   1. **[Assign the Azure AD test user](#assign-the-azure-ad-test-user)** - to enable B.Simon to use Azure AD single sign-on.
+1. **[Configure New Relic SSO](#configure-new-relic-sso)** - to configure the single sign-on settings on the New Relic side.
+   1. **[Create a New Relic test user](#create-a-new-relic-test-user)** - to have a counterpart for B.Simon in New Relic that is linked to the Azure AD user.
 1. **[Test SSO](#test-sso)** - to verify whether the configuration works.
 
 ## Configure Azure AD SSO
 
 Follow these steps to enable Azure AD SSO in the Azure portal.
 
-1. In the [Azure portal](https://portal.azure.com/), on the **New Relic (By Organization)** application integration page, find the **Manage** section and select **single sign-on**.
+1. In the [Azure portal](https://portal.azure.com/), on the **New Relic by Organization** application integration page, find the **Manage** section and select **Single sign-on**.
+
 1. On the **Select a single sign-on method** page, select **SAML**.
-1. On the **Set up single sign-on with SAML** page, click the edit/pen icon for **Basic SAML Configuration** to edit the settings.
+
+1. On the **Set up Single Sign-On with SAML** page, click the edit/pen icon for **Basic SAML Configuration** to edit the settings.
 
    ![Edit Basic SAML Configuration](common/edit-urls.png)
 
-1. On the **Basic SAML Configuration** section, if you have **Service Provider metadata file**, perform the following steps:
+1. In the **Basic SAML Configuration** section, fill in values for **Identifier** and **Reply URL**.
 
-	a. Click **Upload metadata file**.
+   * These values my be retrieved using the New Relic **My Organization** application. To use this application, perform these steps:
+      * [Log in](https://login.newrelic.com/) to New Relic.
+      * On the top menu, select **Apps**.
+      * In the **Your apps** section, select **My Organization**.
+      * Click on **Authentication domains**.
+      * Choose the authentication domain to which you wish Azure AD SSO to connect (if you have more than one authentication domain). Most companies only have one authentication domain called **Default**. With only one authentication domain, there is no need to select.
+      * In the **Authentication** section, **Assertion consumer URL** contains the value to use for **Reply URL**.
+      * In the **Authentication** section, **Our entity ID** contains the value to use for **Identifier**.
 
-    ![Screenshot shows Basic SAML Configuration with the Upload metadata file link.](common/upload-metadata.png)
+1. In the **User Attributes & Claims** section, make sure **Unique User Identifier** is mapped to a field containing the email address being used at New Relic.
 
-	b. Click on **folder logo** to select the metadata file and click **Upload**.
+   * The default field **user.userprincipalname** will work for you if it's values are the same as the New Relic email addresses.
+   * The field  **user.mail** may work better for you if **user.userprincipalname** is not the New Relic email address.
 
-	![Screenshot shows a dialog box where you can select and upload a file.](common/browse-upload-metadata.png)
+1. In the **SAML Signing Certificate** section, copy **App Federation Metadata Url** and save it's value for later use.
 
-	c. Once the metadata file is successfully uploaded, the **Identifier** and **Reply URL** values get auto populated in Basic SAML Configuration section:
-
-	![Screenshot shows the Basic SAML Configuration, where you can enter Identifier, Reply U R L, and select Save.](common/idp-intiated.png)
-
-	> [!Note]
-	> If the **Identifier** and **Reply URL** values are not getting auto polulated, then fill in the values manually according to your requirement.
-
-1. On the **Set up single sign-on with SAML** page, In the **SAML Signing Certificate** section, click copy button to copy **App Federation Metadata Url** and save it on your computer.
-
-	![The Certificate download link](common/copy-metadataurl.png)
+1. In the **Set up New Relic by Organization** section, copy **Login URL** and save it's value for later use.
 
 ### Create an Azure AD test user
 
 In this section, you'll create a test user in the Azure portal called B.Simon.
 
-1. From the left pane in the Azure portal, select **Azure Active Directory**, select **Users**, and then select **All users**.
-1. Select **New user** at the top of the screen.
-1. In the **User** properties, follow these steps:
+1. From the Azure portal, select **Azure Active Directory** service
+1. Select **Users**.
+1. To add a new user, select **New user** at the top of the screen.
+1. On the **New user** page, follow these steps:
+   1. In the **User name** field, enter the username@companydomain.extension. For example, `b.simon@contoso.com`. This should match the email address you will use on the New Relic side.
    1. In the **Name** field, enter `B.Simon`.  
-   1. In the **User name** field, enter the username@companydomain.extension. For example, `B.Simon@contoso.com`.
-   1. Select the **Show password** check box, and then write down the value that's displayed in the **Password** box.
+   1. Check the **Show password** check box, and then save the value that is displayed in the **Initial password** field.
    1. Click **Create**.
 
 ### Assign the Azure AD test user
 
-In this section, you'll enable B.Simon to use Azure single sign-on by granting access to New Relic (By Organization).
+In this section, you'll enable B.Simon to use Azure AD single sign-on by granting access to the **New Relic by Organization** application.
 
-1. In the Azure portal, select **Enterprise Applications**, and then select **All applications**.
-1. In the applications list, select **New Relic (By Organization)**.
+1. From the Azure portal, select **Azure Active Directory** service
+1. Select **Enterprise applications**.
+1. In the applications list, select **New Relic by Organization**.
 1. In the app's overview page, find the **Manage** section and select **Users and groups**.
 
    ![The "Users and groups" link](common/users-groups-blade.png)
 
-1. Select **Add user**, then select **Users and groups** in the **Add Assignment** dialog.
+1. Select **Add user**, then select **Users and groups** (or **Users** depending on your plan level) in the **Add Assignment** dialog.
 
-	![The Add User link](common/add-assign-user.png)
+   ![The Add User link](common/add-assign-user.png)
 
-1. In the **Users and groups** dialog, select **B.Simon** from the Users list, then click the **Select** button at the bottom of the screen.
-1. If you're expecting any role value in the SAML assertion, in the **Select Role** dialog, select the appropriate role for the user from the list and then click the **Select** button at the bottom of the screen.
+1. In the **Users and groups** (or **Users**) dialog, select **B.Simon** from the Users list, then click the **Select** button at the bottom of the screen.
 1. In the **Add Assignment** dialog, click the **Assign** button.
 
-## Configure New Relic (By Organization) SSO
+## Configure New Relic SSO
 
-To configure single sign-on on **New Relic (By Organization)** side, you need to send the **App Federation Metadata Url** to [New Relic (By Organization) support team](https://support.newrelic.com/). They set this setting to have the SAML SSO connection set properly on both sides.
+Follow these steps to configure SSO at New Relic.
 
+1. [Log in](https://login.newrelic.com/) to New Relic.
 
-### Create New Relic (By Organization) test user
+1. On the top menu, select **Apps**.
 
-In this section, you create a user called B.Simon in New Relic (By Organization). Work with [New Relic (By Organization) support team](https://support.newrelic.com/) to add the users in the New Relic (By Organization) platform. Users must be created and activated before you use single sign-on.
+1. In the **Your apps** section, select **My Organization**.
+
+1. Click on **Authentication domains**.
+
+1. Choose the authentication domain to which you wish Azure AD SSO to connect (if you have more than one authentication domain). Most companies only have one authentication domain called **Default**. With only one authentication domain, there is no need to select.
+
+1. In the **Authentication** section, click **Configure**.
+
+   1. In the **Source of SAML metadata** field, enter the value you previously saved from the Azure AD side **App Federation Metadata Url** field.
+
+   1. In the **SSO target URL** field, enter the value you previously saved from the Azure AD side **Login URL** field.
+
+   1. Click **Save** after verifying settings look good on both the Azure AD and New Relic sides. If both sides are not properly configured, your users will not be able to log into New Relic.
+
+### Create a New Relic test user
+
+In this section, you create a user called B.Simon in New Relic. Follow these steps to create the user.
+
+1. [Log in](https://login.newrelic.com/) to New Relic.
+
+1. On the top menu, select **Apps**.
+
+1. In the **Your apps** section, select **User Management**.
+
+1. Click the **Add user** button.
+
+   1. In the **Name** field, enter **B.Simon**.
+   
+   1. In the **Email** field, enter the value that will be sent by Azure AD SSO.
+   
+   1. Choose a user **Type** and a user **Group** for the user. For a test user, **Basic User** for Type and **User** for Group are reasonable choices.
+   
+   1. Click **Add User** to save the user.
 
 ## Test SSO 
 
 In this section, you test your Azure AD single sign-on configuration using the Access Panel.
 
-When you click the New Relic (By Organization) tile in the Access Panel, you should be automatically signed in to the New Relic (By Organization) for which you set up SSO. For more information about the Access Panel, see [Introduction to the Access Panel](../user-help/my-apps-portal-end-user-access.md).
+When you click the **New Relic by Organization** tile in the Access Panel, you should be automatically signed into New Relic. For more information about the Access Panel, see [Introduction to the Access Panel](../user-help/my-apps-portal-end-user-access.md).
 
 ## Additional resources
 
@@ -147,6 +180,6 @@ When you click the New Relic (By Organization) tile in the Access Panel, you sho
 
 - [What is conditional access in Azure Active Directory?](../conditional-access/overview.md)
 
-- [Try New Relic (By Organization) with Azure AD](https://aad.portal.azure.com/)
+- [Try New Relic with Azure AD](https://aad.portal.azure.com/)
 
 - [What is session control in Microsoft Cloud App Security?](/cloud-app-security/proxy-intro-aad)

--- a/articles/active-directory/saas-apps/new-relic-limited-release-tutorial.md
+++ b/articles/active-directory/saas-apps/new-relic-limited-release-tutorial.md
@@ -76,13 +76,13 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 1. In the **Basic SAML Configuration** section, fill in values for **Identifier** and **Reply URL**.
 
    * These values my be retrieved using the New Relic **My Organization** application. To use this application, perform these steps:
-      * [Log in](https://login.newrelic.com/) to New Relic.
-      * On the top menu, select **Apps**.
-      * In the **Your apps** section, select **My Organization**.
-      * Click on **Authentication domains**.
-      * Choose the authentication domain to which you wish Azure AD SSO to connect (if you have more than one authentication domain). Most companies only have one authentication domain called **Default**. With only one authentication domain, there is no need to select.
-      * In the **Authentication** section, **Assertion consumer URL** contains the value to use for **Reply URL**.
-      * In the **Authentication** section, **Our entity ID** contains the value to use for **Identifier**.
+      1. [Log in](https://login.newrelic.com/) to New Relic.
+      1. On the top menu, select **Apps**.
+      1. In the **Your apps** section, select **My Organization**.
+      1. Click on **Authentication domains**.
+      1. Choose the authentication domain to which you wish Azure AD SSO to connect (if you have more than one authentication domain). Most companies only have one authentication domain called **Default**. With only one authentication domain, there is no need to select.
+      1. In the **Authentication** section, **Assertion consumer URL** contains the value to use for **Reply URL**.
+      1. In the **Authentication** section, **Our entity ID** contains the value to use for **Identifier**.
 
 1. In the **User Attributes & Claims** section, make sure **Unique User Identifier** is mapped to a field containing the email address being used at New Relic.
 


### PR DESCRIPTION
Update doc to reflect that the app has left limited release. As part of this, setting up the New Relic side is now self-serve. No need to call New Relic to do that part.

Some of the Microsoft side instructions looked out of date so changed to match the current UI.