### PR TITLE
Adding default value for ClaimsEndpointAccessTokenName

### DIFF
--- a/articles/active-directory-b2c/oauth2-technical-profile.md
+++ b/articles/active-directory-b2c/oauth2-technical-profile.md
@@ -82,7 +82,7 @@ The technical profile also returns claims that aren't returned by the identity p
 | ClaimsEndpoint | Yes | The URL of the user information endpoint as per RFC 6749. |
 | AccessTokenResponseFormat | No | The format of the access token endpoint call. For example, Facebook requires an HTTP GET method, but the access token response is in JSON format. |
 | AdditionalRequestQueryParameters | No | Additional request query parameters. For example, you may want to send additional parameters to your identity provider. You can include multiple parameters using comma delimiter. |
-| ClaimsEndpointAccessTokenName | No | The name of the access token query string parameter. Some identity providers' claims endpoints support GET HTTP request. In this case, the bearer token is sent by using a query string parameter instead of the authorization header. |
+| ClaimsEndpointAccessTokenName | No | The name of the access token query string parameter. Some identity providers' claims endpoints support GET HTTP request. In this case, the bearer token is sent by using a query string parameter instead of the authorization header. Default value: `access_token`. |
 | ClaimsEndpointFormatName | No | The name of the format query string parameter. For example, you can set the name as `format` in this LinkedIn claims endpoint `https://api.linkedin.com/v1/people/~?format=json`. |
 | ClaimsEndpointFormat | No | The value of the format query string parameter. For example, you can set the value as `json` in this LinkedIn claims endpoint `https://api.linkedin.com/v1/people/~?format=json`. |
 | ProviderName | No | The name of the identity provider. |


### PR DESCRIPTION
Adding default value for B2C Technical Profile OAuth / ClaimsEndpointAccessTokenName metadata.