### PR TITLE
Fix issue with Azure Batch Env vars for Linux

### DIFF
--- a/articles/batch/batch-compute-node-environment-variables.md
+++ b/articles/batch/batch-compute-node-environment-variables.md
@@ -19,7 +19,7 @@ To get the current value of an environment variable, launch `cmd.exe` on a Windo
 
 `cmd /c set <ENV_VARIABLE_NAME>`
 
-`/bin/sh printenv <ENV_VARIABLE_NAME>`
+`/bin/sh -c "printenv <ENV_VARIABLE_NAME>"`
 
 ## Command-line expansion of environment variables
 
@@ -27,7 +27,7 @@ The command lines executed by tasks on compute nodes do not run under a shell. T
 
 `cmd /c MyTaskApplication.exe %MY_ENV_VAR%`
 
-`/bin/sh -c MyTaskApplication $MY_ENV_VAR`
+`/bin/sh -c "MyTaskApplication $MY_ENV_VAR"`
 
 ## Environment variables
 


### PR DESCRIPTION
The quotes are necessary, otherwise the command executed isn't properly parsed.