### PR TITLE
Update functions-event-hub-cosmos-db.md

### DIFF
--- a/articles/azure-functions/functions-event-hub-cosmos-db.md
+++ b/articles/azure-functions/functions-event-hub-cosmos-db.md
@@ -176,7 +176,7 @@ COSMOS_DB_CONNECTION_STRING=$( \
         --resource-group $RESOURCE_GROUP \
         --name $COSMOS_DB_ACCOUNT \
         --type connection-strings \
-        --query connectionStrings[0].connectionString \
+        --query 'connectionStrings[0].connectionString' \
         --output tsv)
 echo $COSMOS_DB_CONNECTION_STRING
 ```


### PR DESCRIPTION
to make it work for all developers, I added single quotes. Otherwise the command is not working as said in the github issue here https://github.com/MicrosoftDocs/azure-docs/issues/66592 and here https://stackoverflow.com/questions/60833940/problem-to-get-a-connectionstring-for-cosmosdb-in-azure?noredirect=1#comment107636632_60833940