### PR TITLE
Indicate generation 2 support for Esv4 series.

### DIFF
--- a/articles/virtual-machines/generation-2.md
+++ b/articles/virtual-machines/generation-2.md
@@ -31,6 +31,7 @@ Generation 1 VMs are supported by all VM sizes in Azure (except for Mv2-series V
 * [Dasv4-series](dav4-dasv4-series.md)
 * [Ddsv4-series](ddv4-ddsv4-series.md)
 * [Esv3-series](ev3-esv3-series.md)
+* [Esv4-series](ev4-esv4-series.md)
 * [Easv4-series](eav4-easv4-series.md)
 * [Fsv2-series](fsv2-series.md)
 * [GS-series](sizes-previous-gen.md#gs-series)


### PR DESCRIPTION
Esv4 supports gen 2 (see recent update in 2221164), so updating the generation-2 page to indicate it.