### PR TITLE
Fix profile name in default storage class example

### DIFF
--- a/articles/azure-arc/data/create-data-controller-using-azdata.md
+++ b/articles/azure-arc/data/create-data-controller-using-azdata.md
@@ -96,7 +96,7 @@ If you want to use the `default` storage class, then you can run this command:
 azdata arc dc create --profile-name azure-arc-aks-default-storage --namespace arc --name arc --subscription <subscription id> --resource-group <resource group name> --location <location> --connectivity-mode indirect
 
 #Example:
-#azdata arc dc create --profile-name azure-arc-aks-premium-storage --namespace arc --name arc --subscription 1e5ff510-76cf-44cc-9820-82f2d9b51951 --resource-group my-resource-group --location eastus --connectivity-mode indirect
+#azdata arc dc create --profile-name azure-arc-aks-default-storage --namespace arc --name arc --subscription 1e5ff510-76cf-44cc-9820-82f2d9b51951 --resource-group my-resource-group --location eastus --connectivity-mode indirect
 ```
 
 Once you have run the command, continue on to [Monitoring the creation status](#monitoring-the-creation-status).


### PR DESCRIPTION
Fix the profile name in the `default` storage class example.