### PR TITLE
Added 'customer-initiated' to 'account failover'

### DIFF
--- a/articles/storage/blobs/data-lake-storage-supported-blob-storage-features.md
+++ b/articles/storage/blobs/data-lake-storage-supported-blob-storage-features.md
@@ -41,7 +41,7 @@ The following table shows how each Blob storage feature is supported with Data L
 |Container soft delete|Preview|Preview|[Soft delete for containers (preview)](soft-delete-container-overview.md)|
 |Blob soft delete|Not yet supported|Not yet supported|[Soft delete for blobs](./soft-delete-blob-overview.md)|
 |Blobfuse|Generally available|Generally available|[How to mount Blob storage as a file system with blobfuse](storage-how-to-mount-container-linux.md)|
-|Account failover|Not yet supported|Not yet supported|[Disaster recovery and account failover](../common/storage-disaster-recovery-guidance.md?toc=%2fazure%2fstorage%2fblobs%2ftoc.json)|
+|Customer-initiated account failover|Not yet supported|Not yet supported|[Disaster recovery and account failover](../common/storage-disaster-recovery-guidance.md?toc=%2fazure%2fstorage%2fblobs%2ftoc.json)|
 |Blob container ACL|Not supported<div role="complementary" aria-labelledby="blob-container-ACL"><sup>1</sup></div>|Not supported<div role="complementary" aria-labelledby="blob-container-ACL"><sup>2</sup></div>|See the related note below this table.|
 |Customer-provided keys|Not yet supported|Not yet supported|[Provide an encryption key on a request to Blob storage](encryption-customer-provided-keys.md)|
 |Custom domains|Not yet supported|Not yet supported|[Map a custom domain to an Azure Blob storage endpoint](storage-custom-domain-name.md)|

--- a/articles/storage/blobs/data-lake-storage-supported-blob-storage-features.md
+++ b/articles/storage/blobs/data-lake-storage-supported-blob-storage-features.md
@@ -41,7 +41,7 @@ The following table shows how each Blob storage feature is supported with Data L
 |Container soft delete|Preview|Preview|[Soft delete for containers (preview)](soft-delete-container-overview.md)|
 |Blob soft delete|Not yet supported|Not yet supported|[Soft delete for blobs](./soft-delete-blob-overview.md)|
 |Blobfuse|Generally available|Generally available|[How to mount Blob storage as a file system with blobfuse](storage-how-to-mount-container-linux.md)|
-|Customer-initiated account failover|Not yet supported|Not yet supported|[Disaster recovery and account failover](../common/storage-disaster-recovery-guidance.md?toc=%2fazure%2fstorage%2fblobs%2ftoc.json)|
+|Customer-managed account failover|Not yet supported|Not yet supported|[Disaster recovery and account failover](../common/storage-disaster-recovery-guidance.md?toc=%2fazure%2fstorage%2fblobs%2ftoc.json)|
 |Blob container ACL|Not supported<div role="complementary" aria-labelledby="blob-container-ACL"><sup>1</sup></div>|Not supported<div role="complementary" aria-labelledby="blob-container-ACL"><sup>2</sup></div>|See the related note below this table.|
 |Customer-provided keys|Not yet supported|Not yet supported|[Provide an encryption key on a request to Blob storage](encryption-customer-provided-keys.md)|
 |Custom domains|Not yet supported|Not yet supported|[Map a custom domain to an Azure Blob storage endpoint](storage-custom-domain-name.md)|


### PR DESCRIPTION
Changed 'Account failover' to 'Customer-initiated account failover' to make it clear that Microsoft-initiated account failover is not included in this table entry.