### PR TITLE
adding Embedded C SDK references to documents

### DIFF
--- a/articles/iot-hub/about-iot-hub.md
+++ b/articles/iot-hub/about-iot-hub.md
@@ -81,6 +81,7 @@ There's a 99.9% [Service Level Agreement for IoT Hub](https://azure.microsoft.co
 Use the [Azure IoT device SDK](./iot-hub-devguide-sdks.md) libraries to build applications that run on your devices and interact with IoT Hub. Supported platforms include multiple Linux distributions, Windows, and real-time operating systems. Supported languages include:
 
 * C
+* Embedded C
 * C#
 * Java
 * Python

--- a/articles/iot-hub/iot-hub-devguide-develop-for-constrained-devices.md
+++ b/articles/iot-hub/iot-hub-devguide-develop-for-constrained-devices.md
@@ -23,6 +23,8 @@ C SDK is available in package form from apt-get, NuGet, and MBED. To target cons
 
 Build the C SDK for constrained devices.
 
+**Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
+
 ### Prerequisites
 
 Follow this [C SDK setup guide](https://github.com/Azure/azure-iot-sdk-c/blob/master/doc/devbox_setup.md) to prepare your development environment for building the C SDK. Before you get to the step for building with cmake, you can invoke cmake flags to remove unused features.

--- a/articles/iot-hub/iot-hub-devguide-develop-for-constrained-devices.md
+++ b/articles/iot-hub/iot-hub-devguide-develop-for-constrained-devices.md
@@ -23,7 +23,8 @@ C SDK is available in package form from apt-get, NuGet, and MBED. To target cons
 
 Build the C SDK for constrained devices.
 
-**Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
+> [!NOTE]
+> The Embedded C SDK is an alternative for constrained devices that supports the bring your own network (BYON) approach. IoT developers have the freedom to bring the MQTT client, TLS, and socket of their choice to create a device solution. [Learn more about the Embedded C SDK](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
 
 ### Prerequisites
 

--- a/articles/iot-hub/iot-hub-devguide-sdks.md
+++ b/articles/iot-hub/iot-hub-devguide-sdks.md
@@ -46,6 +46,14 @@ Azure IoT Hub device SDK for .NET:
 * [API reference](/dotnet/api/microsoft.azure.devices?view=azure-dotnet)
 * [Module reference](/dotnet/api/microsoft.azure.devices.client.moduleclient?view=azure-dotnet)
 
+
+Azure IoT Hub device SDK for Embedded C (ANSI C - C99):
+* [Building the Embedded C SDK](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#build)
+* [Source code](https://github.com/Azure/azure-sdk-for-c)
+* [Size Chart](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#size-chart) for constrained devices.
+* [API reference](https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0/index.html)
+
+
 Azure IoT Hub device SDK for C (ANSI C - C99):
 
 * Install from [apt-get, MBED, Arduino IDE or iOS](https://github.com/Azure/azure-iot-sdk-c/blob/master/readme.md#packages-and-libraries)

--- a/articles/iot-hub/iot-hub-devguide-sdks.md
+++ b/articles/iot-hub/iot-hub-devguide-sdks.md
@@ -48,9 +48,9 @@ Azure IoT Hub device SDK for .NET:
 
 
 Azure IoT Hub device SDK for Embedded C (ANSI C - C99):
-* [Building the Embedded C SDK](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#build)
+* [Build the Embedded C SDK](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#build)
 * [Source code](https://github.com/Azure/azure-sdk-for-c)
-* [Size Chart](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#size-chart) for constrained devices.
+* [Size chart](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot#size-chart) for constrained devices.
 * [API reference](https://azuresdkdocs.blob.core.windows.net/$web/c/docs/1.0.0/index.html)
 
 

--- a/articles/iot-hub/iot-hub-device-sdk-c-intro.md
+++ b/articles/iot-hub/iot-hub-device-sdk-c-intro.md
@@ -15,6 +15,8 @@ ms.custom: [amqp, mqtt, 'Role: Cloud Development', 'Role: IoT Device']
 
 The **Azure IoT device SDK** is a set of libraries designed to simplify the process of sending messages to and receiving messages from the **Azure IoT Hub** service. There are different variations of the SDK, each targeting a specific platform, but this article describes the **Azure IoT device SDK for C**.
 
+**Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
+
 [!INCLUDE [iot-hub-basic](../../includes/iot-hub-basic-partial.md)]
 
 The Azure IoT device SDK for C is written in ANSI C (C99) to maximize portability. This feature makes the libraries well suited to operate on multiple platforms and devices, especially where minimizing disk and memory footprint is a priority.

--- a/articles/iot-hub/iot-hub-device-sdk-c-intro.md
+++ b/articles/iot-hub/iot-hub-device-sdk-c-intro.md
@@ -15,7 +15,8 @@ ms.custom: [amqp, mqtt, 'Role: Cloud Development', 'Role: IoT Device']
 
 The **Azure IoT device SDK** is a set of libraries designed to simplify the process of sending messages to and receiving messages from the **Azure IoT Hub** service. There are different variations of the SDK, each targeting a specific platform, but this article describes the **Azure IoT device SDK for C**.
 
-**Note on constrained devices**: The `Embedded C SDK` is an alternative for constrained devices which enables the BYO (bring your own) network approach: IoT developers have the freedom of choice to bring MQTT client, TLS and Socket of their choice to create a device solution. Find more information about the Embedded C SDK [here](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
+> [!NOTE]
+> The Embedded C SDK is an alternative for constrained devices that supports the bring your own network (BYON) approach. IoT developers have the freedom to bring the MQTT client, TLS, and socket of their choice to create a device solution. [Learn more about the Embedded C SDK](https://github.com/Azure/azure-sdk-for-c/tree/master/sdk/docs/iot).
 
 [!INCLUDE [iot-hub-basic](../../includes/iot-hub-basic-partial.md)]
 


### PR DESCRIPTION
These documents need an update to add a reference to the new Embedded C SDK, focused on constrained devices. 