### PR TITLE
Update hdinsight-management-ip-addresses.md

### DIFF
--- a/articles/hdinsight/hdinsight-management-ip-addresses.md
+++ b/articles/hdinsight/hdinsight-management-ip-addresses.md
@@ -26,7 +26,7 @@ The following sections discuss the specific IP addresses that must be allowed.
 
 ## Azure DNS service
 
-If you're using the Azure-provided DNS service, allow access from __168.63.129.16__ on port 53. For more information, see the [Name resolution for VMs and Role instances](../virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md) document. If you're using custom DNS, skip this step.
+If you're using the Azure-provided DNS service, allow access to __168.63.129.16__ on port 53 for both TCP and UDP. For more information, see the [Name resolution for VMs and Role instances](../virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md) document. If you're using custom DNS, skip this step.
 
 ## Health and management services: All regions
 


### PR DESCRIPTION
Azure-provided DNS service explanation under "Azure DNS service" part was telling allow access "FROM" 168.63.129.16 (Azure-provided DNS IP address) . But HDI cluster nodes are DNS clients and they need access to 168.63.129.16 in "outbound" direction. So I changed "FROM" to "TO" and also added "for both TCP and UDP" to be more clearly state that this is DNS traffic and should be in both TCP 53 and UDP 53