### PR TITLE
Update Connection to Site-to-Site Connection and also scenario of hav…

### DIFF
--- a/articles/network-watcher/network-watcher-troubleshoot-overview.md
+++ b/articles/network-watcher/network-watcher-troubleshoot-overview.md
@@ -16,7 +16,7 @@ ms.author: damendo
 
 # Introduction to resource troubleshooting in Azure Network Watcher
 
-Virtual Network Gateways provide connectivity between on-premises resources and other virtual networks within Azure. Monitoring gateways and their connections are critical to ensuring communication is not broken. Network Watcher provides the capability to troubleshoot gateways and connections. The capability can be called through the portal, PowerShell, Azure CLI, or REST API. When called, Network Watcher diagnoses the health of the gateway, or connection, and returns the appropriate results. The request is a long running transaction. The results are returned once the diagnosis is complete.
+Virtual Network Gateways provide connectivity between on-premises resources and other virtual networks within Azure. Monitoring gateways and their connections are critical to ensuring communication is not broken. Network Watcher provides the capability to troubleshoot gateways and connections. The capability can be called through the portal, PowerShell, Azure CLI, or REST API. When called, Network Watcher diagnoses the health of the gateway, or Site-to-Site connection, and returns the appropriate results. The request is a long running transaction. In case of having more than one Site-to-Site Connection for the VPN Gateway, only one Site-to-Site Connection should be checked or selected, for running the health results of the Site-to-Site Connection under the VPN Gateway, if more than one is selected at a time, it would result in an error, showing the other Site-to-Site Connection as failed though it is healthy. The results are returned once the diagnosis is complete.
 
 ![Screenshot shows Network Watcher V P N Diagnostics.][2]
 


### PR DESCRIPTION
…ing more than one Site-to-Site Connection

I am proposing this change because it was not clear in the document to only select one Site-to-Site Connection at a time for returning correct health results under the VPN Troubleshoot Diagnostics Tool. It caused confusion to my customer who had selected more than two site-to-site connections at a time, also he felt that this information was missing in the public document that caused failed results on one of the connections, though both connections are showing connected under Site-to-Site Connections Page on the Azure Portal. The Customer recommended having this information to select only one Site-to-Site Connection at a time on VPN Troubleshoot, be updated in the Public documentation for the VPN Troubleshoot.