### PR TITLE
add deprecation notice for AzMon connector in ConfigMgr 2010

### DIFF
--- a/articles/azure-monitor/platform/collect-sccm.md
+++ b/articles/azure-monitor/platform/collect-sccm.md
@@ -12,7 +12,7 @@ ms.date: 11/30/2020
 You can connect your Microsoft Endpoint Configuration Manager environment to Azure Monitor to sync device collection data and reference these collections in Azure Monitor and Azure Automation.  
 
 > [!IMPORTANT]
-> Starting in Configuration Manager version 2010, this feature is deprecated.<!-- 8269855 --> For more information, see, [Removed and deprecated features for Configuration Manager](deprecated/removed-and-deprecated-cmfeatures.md).
+> Starting in Configuration Manager version 2010, this feature is deprecated.<!-- 8269855 --> For more information, see [Removed and deprecated features for Configuration Manager](/mem/configmgr/core/plan-design/changes/deprecated/removed-and-deprecated-cmfeatures).
 
 ## Prerequisites
 

--- a/articles/azure-monitor/platform/collect-sccm.md
+++ b/articles/azure-monitor/platform/collect-sccm.md
@@ -5,12 +5,14 @@ ms.subservice: logs
 ms.topic: conceptual
 author: bwren
 ms.author: bwren
-ms.date: 08/28/2019
-
+ms.date: 11/30/2020
 ---
 
 # Connect Configuration Manager to Azure Monitor
 You can connect your Microsoft Endpoint Configuration Manager environment to Azure Monitor to sync device collection data and reference these collections in Azure Monitor and Azure Automation.  
+
+> [!IMPORTANT]
+> Starting in Configuration Manager version 2010, this feature is deprecated.<!-- 8269855 --> For more information, see, [Removed and deprecated features for Configuration Manager](deprecated/removed-and-deprecated-cmfeatures.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
Per ConfigMgr engineering team user story https://msazure.visualstudio.com/Configmgr/_workitems/edit/8269855, the Azure Monitor connector is deprecated as of version 2010. As of right now, we plan to remove it entirely in the 2107 release (July 2021). ConfigMgr support lifecycle is 18 months, so we'll need to keep the article until the last supported version (2103) is out of support (~October 2022).