### PR TITLE
Update iot-hub-live-data-visualization-in-web-apps.md

### DIFF
--- a/articles/iot-hub/iot-hub-live-data-visualization-in-web-apps.md
+++ b/articles/iot-hub/iot-hub-live-data-visualization-in-web-apps.md
@@ -176,7 +176,7 @@ In this section, you provision a web app in App Service and deploy your code to 
 
 5. To deploy the code to App Service, you'll use your [user-level deployment credentials](../app-service/deploy-configure-credentials.md). Your user-level deployment credentials are different from your Azure credentials and are used for Git local and FTP deployments to a web app. Once set, they're valid across all of your App Service apps in all subscriptions in your Azure account. If you've previously set user-level deployment credentials, you can use them.
 
-   If you haven't previously set user-level deployment credentials or you can't remember your password, run the following command. Your deployment user name must be unique within Azure, and it must not contain the ‘@’ symbol for local Git pushes. When you're prompted, enter and confirm your new password. The password must be at least eight characters long, with two of the following three elements: letters, numbers, and symbols.
+   If you haven't previously set user-level deployment credentials or you can't remember your password, run the following command. Your deployment user name must be unique within Azure, and it must not contain the &quot;@&quot; symbol for local Git pushes. When you're prompted, enter and confirm your new password. The password must be at least eight characters long, with two of the following three elements: letters, numbers, and symbols.
 
    ```azurecli-interactive
    az webapp deployment user set --user-name <your deployment user name>


### PR DESCRIPTION
According to OPS team, @ character have special meanings in OPS and it will lead a syntax of “XrefInlineShort”. Normally it should be used to ref to an uid, like “@System.String”. Since "@" is causing how the localized content gets published, we would like to suggest changing to "@" to &quot;@&quot; or adding \