### PR TITLE
Update iot-hub-arduino-iot-devkit-az3166-get-started.md

### DIFF
--- a/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
+++ b/articles/iot-hub/iot-hub-arduino-iot-devkit-az3166-get-started.md
@@ -91,7 +91,7 @@ A device must be registered with your IoT hub before it can connect. In this qui
    **YourIoTHubName**: Replace this placeholder below with the name you choose for your IoT hub.
 
     ```azurecli-interactive
-    az iot hub device-identity show-connection-string --hub-name YourIoTHubName --device-id MyNodeDevice --output table
+    az iot hub device-identity connection-string show --hub-name YourIoTHubName --device-id MyNodeDevice --output table
     ```
 
     Make a note of the device connection string, which looks like:


### PR DESCRIPTION
According to az cli, this command is deprecated

az iot hub device-identity show-connection-string --hub-name YourIoTHubName --device-id MyNodeDevice --output table

should be 

az iot hub device-identity connection-string show --hub-name YourIoTHubName --device-id MyNodeDevice --output table