### PR TITLE
Update send-sms-python.md

### DIFF
--- a/articles/communication-services/quickstarts/telephony-sms/includes/send-sms-python.md
+++ b/articles/communication-services/quickstarts/telephony-sms/includes/send-sms-python.md
@@ -63,7 +63,7 @@ except Exception as ex:
 While still in the application directory, install the Azure Communication Services SMS client library for Python package by using the `pip install` command.
 
 ```console
-pip install azure-communication-sms
+pip install azure-communication-sms --pre
 ```
 
 ## Object model


### PR DESCRIPTION
Adding the `--pre` argument to the installation command for azure-communication-sms to be consistent with it's SDK docs and to ensure that users don't face dependency errors while installing this SDK.