### PR TITLE
Update dcv2-series.md

### DIFF
--- a/articles/virtual-machines/dcv2-series.md
+++ b/articles/virtual-machines/dcv2-series.md
@@ -20,7 +20,7 @@ Example use cases include: confidential multiparty data sharing, fraud detection
 [Premium Storage caching](premium-storage-performance.md): Supported<br>
 [Live Migration](maintenance-and-updates.md): Not Supported<br>
 [Memory Preserving Updates](maintenance-and-updates.md): Not Supported<br>
-[VM Generation Support](generation-2.md): Generation 1 and 2<br>
+[VM Generation Support](generation-2.md): Generation 2<br>
 
 *Except for Standard_DC8_v2
 


### PR DESCRIPTION
Removed reference to Gen 1 VM in the summary chart at the top, as this VM sku only supports Gen 2.