### PR TITLE
Typo "Jupyter Notebooks"→"notebooks"

### DIFF
--- a/articles/search/search-get-started-python.md
+++ b/articles/search/search-get-started-python.md
@@ -1,7 +1,7 @@
 ---
 title: 'Quickstart: Create a search index in Python'
 titleSuffix: Azure Cognitive Search
-description: Explains how to create an index, load data, and run queries using Python, Jupyter Notebooks, and the Azure.Documents.Search library.
+description: Explains how to create an index, load data, and run queries using Python, notebooks, and the Azure.Documents.Search library.
 
 author: HeidiSteen
 manager: nitinme
@@ -12,7 +12,7 @@ ms.date: 11/19/2020
 ms.custom: devx-track-python
 ---
 
-# Quickstart: Create an Azure Cognitive Search index in Python using Jupyter notebooks
+# Quickstart: Create an Azure Cognitive Search index in Python using Jupyter Notebooks
 
 > [!div class="op_single_selector"]
 > * [Python](search-get-started-python.md)
@@ -22,7 +22,7 @@ ms.custom: devx-track-python
 > * [Portal](search-get-started-portal.md)
 >
 
-Build a Jupyter notebook that creates, loads, and queries an Azure Cognitive Search index using Python and the [azure-search-documents library](/python/api/overview/azure/search-documents-readme) in the Azure SDK for Python. This article explains how to build a notebook step by step. Alternatively, you can [download and run a finished Jupyter Python notebook](https://github.com/Azure-Samples/azure-search-python-samples).
+Build a Jupyter Notebook that creates, loads, and queries an Azure Cognitive Search index using Python and the [azure-search-documents library](/python/api/overview/azure/search-documents-readme) in the Azure SDK for Python. This article explains how to build a notebook step by step. Alternatively, you can [download and run a finished Jupyter Python notebook](https://github.com/Azure-Samples/azure-search-python-samples).
 
 If you don't have an Azure subscription, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F) before you begin.
 
@@ -50,7 +50,7 @@ All requests require an api-key on every request sent to your service. Having a 
 
 ## Connect to Azure Cognitive Search
 
-In this task, start a Jupyter notebook and verify that you can connect to Azure Cognitive Search. You'll do this by requesting a list of indexes from your service. On Windows with Anaconda3, you can use Anaconda Navigator to launch a notebook.
+In this task, start a Jupyter Notebook and verify that you can connect to Azure Cognitive Search. You'll do this by requesting a list of indexes from your service. On Windows with Anaconda3, you can use Anaconda Navigator to launch a notebook.
 
 1. Create a new Python3 notebook.
 


### PR DESCRIPTION
@HeidiSteen  Fixed ＜"remove "Jupyter" and leave "notebooks"＞.