### PR TITLE
Update nodes per node pool limit from 100 to 1000

### DIFF
--- a/includes/container-service-limits.md
+++ b/includes/container-service-limits.md
@@ -15,7 +15,7 @@ ms.custom: include file
 | --- | :--- |
 | Maximum clusters per subscription | 1000 |
 | Maximum nodes per cluster with Virtual Machine Availability Sets and Basic Load Balancer SKU  | 100 |
-| Maximum nodes per cluster with Virtual Machine Scale Sets and [Standard Load Balancer SKU][standard-load-balancer] | 1000 (100 nodes per [node pool][node-pool]) |
+| Maximum nodes per cluster with Virtual Machine Scale Sets and [Standard Load Balancer SKU][standard-load-balancer] | 1000 (1000 nodes per [node pool][node-pool]) |
 | Maximum pods per node: [Basic networking][basic-networking] with Kubenet | 110 |
 | Maximum pods per node: [Advanced networking][advanced-networking] with Azure Container Networking Interface | Azure CLI deployment: 30<sup>1</sup><br />Azure Resource Manager template: 30<sup>1</sup><br />Portal deployment: 30 |
 


### PR DESCRIPTION
[This issue](https://github.com/terraform-providers/terraform-provider-azurerm/issues/9198) show that AKS now allows for node pool of max 1000 nodes, but only VMSS document mention about this update. Therefore, I would like to update this information to AKS node pool limitation document.