### PR TITLE
Add AAS logs information

### DIFF
--- a/articles/communication-services/concepts/logging-and-diagnostics.md
+++ b/articles/communication-services/concepts/logging-and-diagnostics.md
@@ -36,6 +36,7 @@ Communication Services offers three types of logs that you can enable:
 * **Usage logs** - provides usage data associated with each billed service offering
 * **Chat operational logs** - provides basic information related to the chat service
 * **SMS operational logs** - provides basic information related to the SMS service
+* **Autentication operational logs** - provides basic information related to the Authentication service
 
 ### Usage logs schema
 
@@ -97,3 +98,23 @@ Communication Services offers three types of logs that you can enable:
 | SdkType | The SDK type used in the request. |
 | PlatformType | The platform type used in the request. |
 | Method | The method used in the request. |
+
+### Authentication operational logs
+
+| Property | Description |
+| -------- | ---------------|
+| TimeGenerated | The timestamp (UTC) of when the log was generated. |
+| OperationName | The operation associated with log record. |
+| CorrelationID | The ID for correlated events. Can be used to identify correlated events between multiple tables. |
+| OperationVersion | The api-version associated with the operation, if the operationName was performed using an API. If there is no API that corresponds to this operation, the version represents the version of that operation in case the properties associated with the operation change in the future. |
+| Category | The log category of the event. Category is the granularity at which you can enable or disable logs on a particular resource. The properties that appear within the properties blob of an event are the same within a particular log category and resource type. |
+| ResultType | The status of the operation. |
+| ResultSignature | The sub status of the operation. If this operation corresponds to a REST API call, this field is the HTTP status code of the corresponding REST call. |
+| DurationMs | The duration of the operation in milliseconds. |
+| CallerIpAddress | The caller IP address, if the operation corresponds to an API call that would come from an entity with a publicly available IP address. |
+| Level | The severity level of the event. |
+| URI | The URI of the request. |
+| SdkType | The SDK type used in the request. |
+| PlatformType | The platform type used in the request. |
+| Idetity | The ACS idenity related to the operation. |
+| Scopes | The ACS scopes present in the access token. |


### PR DESCRIPTION
Acs Authentication Service (AAS) is going to emit logs with operational information. This PR adds changes in public documentation. Most of the items are common to the other services already emitting these logs, except two specific items:

Identity - identity is a definite descriptor of a user. If an operation related to an identity is performed, the identity is logged.
Scopes - some operations are only allowed for certain scopes. These scopes are logged if relevant.