### PR TITLE
Update how-to-configure-proxy-support.md

### DIFF
--- a/articles/iot-edge/how-to-configure-proxy-support.md
+++ b/articles/iot-edge/how-to-configure-proxy-support.md
@@ -266,6 +266,11 @@ If you included the **UpstreamProtocol** environment variable in the confige.yam
 }
 ```
 
+## Working with traffic-inspecting proxies
+If the proxy you're attempting to use performs traffic inspection on TLS secured connections, it's important to note that authentication with X.509 certificates will not work.  IoT Edge establishes a TLS channel that's encrypted end-to-end with the provided certificate and key, and if that channel is broken for traffic inspection then the proxy will not be able to reestablish it with the proper credentials and IoT Hub and DPS will return an Unauthorized error.
+
+If you would like to use a proxy that performs traffic inspection you must either use SAS authentication or have DPS and IoT Hub added to an allowlist for avoiding inspection.
+
 ## Next steps
 
 Learn more about the roles of the [IoT Edge runtime](iot-edge-runtime.md).

--- a/articles/iot-edge/how-to-configure-proxy-support.md
+++ b/articles/iot-edge/how-to-configure-proxy-support.md
@@ -267,9 +267,10 @@ If you included the **UpstreamProtocol** environment variable in the confige.yam
 ```
 
 ## Working with traffic-inspecting proxies
-If the proxy you're attempting to use performs traffic inspection on TLS secured connections, it's important to note that authentication with X.509 certificates will not work.  IoT Edge establishes a TLS channel that's encrypted end-to-end with the provided certificate and key, and if that channel is broken for traffic inspection then the proxy will not be able to reestablish it with the proper credentials and IoT Hub and DPS will return an Unauthorized error.
 
-If you would like to use a proxy that performs traffic inspection you must either use SAS authentication or have DPS and IoT Hub added to an allowlist for avoiding inspection.
+If the proxy you're attempting to use performs traffic inspection on TLS-secured connections, it's important to note that authentication with X.509 certificates doesn't work. IoT Edge establishes a TLS channel that's encrypted end to end with the provided certificate and key. If that channel is broken for traffic inspection, the proxy can't reestablish the channel with the proper credentials, and IoT Hub and the IoT Hub device provisioning service return an `Unauthorized` error.
+
+To use a proxy that performs traffic inspection, you must use either shared access signature authentication or have IoT Hub and the IoT Hub device provisioning service added to an allowlist to avoid inspection.
 
 ## Next steps
 


### PR DESCRIPTION
Added details of how traffic-inspecting proxies can break connectivity to IoT Hub and DPS when using x509 certificates, as well as the possible workarounds.