### PR TITLE
Update kubernetes-helm.md with new location for source; 

### DIFF
--- a/articles/aks/kubernetes-helm.md
+++ b/articles/aks/kubernetes-helm.md
@@ -48,7 +48,7 @@ version.BuildInfo{Version:"v3.0.0", GitCommit:"e29ce2a54e96cd02ccfce88bee4f58bb6
 Use the [helm repo][helm-repo-add] command to add the official Helm stable charts and *ingress-nginx* repositories.
 
 ```console
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 ```
 


### PR DESCRIPTION
Add link to new location for helm, 
gary_ciampa@Azure:~/source$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
Error: repo "https://kubernetes-charts.storage.googleapis.com/" is no longer available; try "https://charts.helm.sh/stable" instead
gary_ciampa@Azure:~/source$ helm repo add stable  "https://charts.helm.sh/stable"
"stable" has been added to your repositories