### PR TITLE
fixing error

### DIFF
--- a/articles/app-service/quickstart-dotnetcore.md
+++ b/articles/app-service/quickstart-dotnetcore.md
@@ -317,7 +317,7 @@ await context.Response.WriteAsync("Hello Azure!");
 Save your changes, then redeploy the app using the `az webapp up` command again:
 
 ```azurecli
-az webapp up
+az webapp up --os-type linux
 ```
 
 This command uses values that are cached locally in the *.azure/config* file, including the app name, resource group, and App Service plan.


### PR DESCRIPTION
If you run this, you will get this error.
The webapp '<appname>' is a Linux app. The code detected at '<app location>' will default to 'Windows'. Please create a new app to continue this operation.

For linux apps, you need to specify the OS.

See https://github.com/Azure/azure-cli/issues/12135