### PR TITLE
Updating the call to get the connection string

### DIFF
--- a/articles/iot-hub/quickstart-device-streams-proxy-nodejs.md
+++ b/articles/iot-hub/quickstart-device-streams-proxy-nodejs.md
@@ -83,7 +83,7 @@ A device must be registered with your IoT hub before it can connect. In this sec
    > Replace the *YourIoTHubName* placeholder with the name you chose for your IoT hub.
 
     ```azurecli-interactive
-    az iot hub show-connection-string --policy-name service --name {YourIoTHubName} --output table
+    az iot hub connection-string show --policy-name service --hub-name {YourIoTHubName} --output table
     ```
 
    Note the returned service connection string for later use in this quickstart. It looks like the following example:


### PR DESCRIPTION
`az iot hub show-connection-string` gives a deprecation warning, so updated this call to use the new`as iot hub connection-string show` syntax.