### PR TITLE
Change from reconnect to connect

### DIFF
--- a/articles/azure-arc/servers/manage-agent.md
+++ b/articles/azure-arc/servers/manage-agent.md
@@ -155,7 +155,7 @@ The Azcmagent tool (Azcmagent.exe) is used to configure the Azure Arc enabled se
 
 * **-h or --help** - Shows available command-line parameters
 
-    For example, to see detailed help for the **Reconnect** parameter, type `azcmagent reconnect -h`. 
+    For example, to see detailed help for the **Connect** parameter, type `azcmagent connect -h`. 
 
 * **-v or --verbose** - Enable verbose logging
 


### PR DESCRIPTION
This PR intends to change from "reconnect" to "connect" because there is no "reconnect" option in the latest agent.