### PR TITLE
Improvement to IoTEdge documentation

### DIFF
--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -661,9 +661,22 @@ Replace $upstream:8000/azureiotedge-simulated-temperature-sensor:1.0 by $upstrea
        auth: {}
    ```
 ## IotEdge check
-Iotedge check can be performed in nested hierarchy, even if the children doesn't have direct internet access
+Iotedge check can be performed in nested hierarchy, even if the children doesn't have direct internet access.
+When running "iotedge check" from the lower layer the program will try to pull the image from the parent through port 443.
 
+If the IoTEdgeAPIProxy is listen on port 443 then "iotedge check" command will just work.
+If the IoTEdgeAPIProxy is listening on a different port (8000 for example) then the correct port need to be specified:
 
+   ```bash
+   iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:<port>/azureiotedge-diagnostics:1.2.0-rc2
+   ```
+   
+The azureiotedge-diagnostics is pulled from the container registry that is linked with the registry module. This tutorial has it set by default to https://mcr.microsoft.com:
+    | Name | Value |
+    | - | - |
+    | `REGISTRY_PROXY_REMOTEURL` | `https://mcr.microsoft.com` |
+If you are using you own private container registry, make sure all the images (IoTEdgeAPIProxy, edgeAgent, edgeHub, diagnostics ...) are present in it.    
+    
 ## View generated data
 
 The **Simulated Temperature Sensor** module that you pushed generates sample environment data. It sends messages that include ambient temperature and humidity, machine temperature and pressure, and a timestamp.

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -230,12 +230,14 @@ Install IoT Edge by following these steps on both devices.
    sudo apt-get install moby-engine
    ```
 ### Configure Virtual Machine
-If you use azure Virtual Machine to create a hierarchy of IoT Edge devices, make sure the the following port are opened inbound: 8000,443,5671,8883.
+If you use azure Virtual Machine to create a hierarchy of IoT Edge devices, make sure the the following ports are opened inbound: 8000,443,5671,8883.
 8000: Is used to pull docker container images through API proxy
 443: Is used between parent and child edgehub for Rest API calls.
 5671,8883: Are used for AMQP and MQTT
 
-Note: It is possible to use only one port to pull images and make API calls, follow [Using one port for HTTP calls](#Using one port for HTTP calls)
+[How to open ports to a virtual machine with the Azure portal](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nsg-quickstart-portal).
+
+It is possible to use a single port to pull images and make API calls, the process is described here: [Using one port for HTTP calls](#Using one port for HTTP calls)
 
 ### Configure the IoT Edge runtime
 

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -630,47 +630,13 @@ Notice that the image URI that we used for the simulated temperature sensor modu
 
 On the device details page for your lower layer IoT Edge device, you should now see the temperature sensor module listed along the system modules as **Specified in deployment**. It may take a few minutes for the device to receive its new deployment, request the container image, and start the module. Refresh the page until you see the temperature sensor module listed as **Reported by device**.
 
-## Using one port for HTTP calls
-It is possible to use only one port for HTTP calls:
-1. Remove NGINX_DEFAULT_PORT environment variable in IoTEdgeAPIProxy module. This will default use of port 443.
-1. Change IoTEdgeAPIProxy module port bindings to 443:
- ```json
-"settings": {
-    "image": "mcr.microsoft.com/azureiotedge-api-proxy",
-    "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"443/tcp\": [{\"HostPort\":\"443\"}]}}}"
-}
- ```
-1. Remove port 443 binding in edgeHub to avoid conflict with IoTEdgeAPIProxy:
- ```json
-"settings": {
-   "image": "$upstream:8000/azureiotedge-hub:1.2.0-rc2",
-   "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}],\"8883/tcp\":[{\"HostPort\":\"8883\"}]}}}"
-}
- ```
-1. For the child iotedge
-Replace $upstream:8000/azureiotedge-hub:1.2.0-rc2 by $upstream:443/azureiotedge-hub:1.2.0-rc2
-Replace $upstream:8000/azureiotedge-agent:1.2.0-rc2 by $upstream:443/azureiotedge-agent:1.2.0-rc2
-Replace $upstream:8000/azureiotedge-simulated-temperature-sensor:1.0 by $upstream:443/azureiotedge-simulated-temperature-sensor:1.0
- 
-1. Change mention to 8000 port in the child config.yaml:
-   ```yml
-   agent:
-     name: "edgeAgent"
-     type: "docker"
-     env: {}
-     config:
-       image: "<parent_device_fqdn_or_ip>:443/azureiotedge-agent:1.2.0-rc2"
-       auth: {}
-   ```
 ## IotEdge check
 Iotedge check can be performed in nested hierarchy, even if the children doesn't have direct internet access.
 When running "iotedge check" from the lower layer the program will try to pull the image from the parent through port 443.
-
-If the IoTEdgeAPIProxy is listen on port 443 then "iotedge check" command will just work.
-If the IoTEdgeAPIProxy is listening on a different port (8000 for example) then the correct port need to be specified:
+In this How-to, we use port 8000, so we need to specify it:
 
    ```bash
-   iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:<port>/azureiotedge-diagnostics:1.2.0-rc2
+   iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:8000/azureiotedge-diagnostics:1.2.0-rc2
    ```
    
 The azureiotedge-diagnostics is pulled from the container registry that is linked with the registry module. This tutorial has it set by default to https://mcr.microsoft.com:

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -237,8 +237,6 @@ If you use azure Virtual Machine to create a hierarchy of IoT Edge devices, make
 
 [How to open ports to a virtual machine with the Azure portal](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nsg-quickstart-portal).
 
-It is possible to use a single port to pull images and make API calls, the process is described here: [Using one port for HTTP calls](#Using one port for HTTP calls)
-
 ### Configure the IoT Edge runtime
 
 Configure the IoT Edge runtime by following these steps on both your devices. Configuring the IoT Edge runtime for your devices consists of four steps, all accomplished by editing the IoT Edge configuration file:

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -633,7 +633,7 @@ On the device details page for your lower layer IoT Edge device, you should now 
 Run the iotedge check command to verify the configuration and troubleshoot errors.
 Iotedge check can be performed in nested hierarchy, even if the children doesn't have direct internet access.
 When running "iotedge check" from the lower layer the program will try to pull the image from the parent through port 443.
-In this How-to, we use port 8000, so we need to specify it:
+In this tutorial, we use port 8000, so we need to specify it:
 
    ```bash
    iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:8000/azureiotedge-diagnostics:1.2.0-rc2

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -636,7 +636,7 @@ When running "iotedge check" from the lower layer the program will try to pull t
 In this tutorial, we use port 8000, so we need to specify it:
 
    ```bash
-   iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:8000/azureiotedge-diagnostics:1.2.0-rc2
+   sudo iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:8000/azureiotedge-diagnostics:1.2.0-rc2
    ```
    
 The azureiotedge-diagnostics is pulled from the container registry that is linked with the registry module. This tutorial has it set by default to https://mcr.microsoft.com:

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -216,15 +216,7 @@ Install IoT Edge by following these steps on both devices.
    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
    sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
    ```
-
-1. Install the hsmlib and IoT Edge daemon. To see the assets for other Linux distributions, [visit the GitHub release](https://github.com/Azure/azure-iotedge/releases/tag/1.2.0-rc1). <!-- Update with proper image links on release -->
-
-   ```bash
-   curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/libiothsm-std_1.2.0_rc1-1-1_debian9_amd64.deb -o libiothsm-std.deb
-   curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/iotedge_1.2.0_rc1-1_debian9_amd64.deb -o iotedge.deb
-   sudo dpkg -i ./libiothsm-std.deb
-   sudo dpkg -i ./iotedge.deb
-   ```
+   
 1. Update package lists on your device.
 
    ```bash
@@ -235,6 +227,15 @@ Install IoT Edge by following these steps on both devices.
 
    ```bash
    sudo apt-get install moby-engine
+   ```
+
+1. Install the hsmlib and IoT Edge daemon. To see the assets for other Linux distributions, [visit the GitHub release](https://github.com/Azure/azure-iotedge/releases/tag/1.2.0-rc1). <!-- Update with proper image links on release -->
+
+   ```bash
+   curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/libiothsm-std_1.2.0_rc1-1-1_debian9_amd64.deb -o libiothsm-std.deb
+   curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/iotedge_1.2.0_rc1-1_debian9_amd64.deb -o iotedge.deb
+   sudo dpkg -i ./libiothsm-std.deb
+   sudo dpkg -i ./iotedge.deb
    ```
 
 ### Configure the IoT Edge runtime

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -220,7 +220,7 @@ Install IoT Edge by following these steps on both devices.
 1. Install the hsmlib and IoT Edge daemon. To see the assets for other Linux distributions, [visit the GitHub release](https://github.com/Azure/azure-iotedge/releases/tag/1.2.0-rc1). <!-- Update with proper image links on release -->
 
    ```bash
-   curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/libiothsm-std_1.2.0.rc1-1-1_debian9_amd64.deb -o libiothsm-std.deb
+   curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/libiothsm-std_1.2.0_rc1-1-1_debian9_amd64.deb -o libiothsm-std.deb
    curl -L https://github.com/Azure/azure-iotedge/releases/download/1.2.0-rc1/iotedge_1.2.0_rc1-1_debian9_amd64.deb -o iotedge.deb
    sudo dpkg -i ./libiothsm-std.deb
    sudo dpkg -i ./iotedge.deb

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -59,6 +59,13 @@ To create a hierarchy of IoT Edge devices, you will need:
     --admin-password <REPLACE_WITH_PASSWORD>
    ```
 
+Make sure the the following ports are opened inbound: 8000,443,5671,8883.
+8000: Is used to pull docker container images through API proxy
+443: Is used between parent and child edgehub for Rest API calls.
+5671,8883: Are used for AMQP and MQTT
+
+[How to open ports to a virtual machine with the Azure portal](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nsg-quickstart-portal).
+
 You can also try out this scenario by following the scripted [Azure IoT Edge for Industrial IoT sample](https://aka.ms/iotedge-nested-sample), which deploys Azure virtual machines as preconfigured devices to simulate a factory environment.
 
 ## Configure your IoT Edge device hierarchy
@@ -229,13 +236,6 @@ Install IoT Edge by following these steps on both devices.
    ```bash
    sudo apt-get install moby-engine
    ```
-### Configure Virtual Machine
-If you use azure Virtual Machine to create a hierarchy of IoT Edge devices, make sure the the following ports are opened inbound: 8000,443,5671,8883.
-8000: Is used to pull docker container images through API proxy
-443: Is used between parent and child edgehub for Rest API calls.
-5671,8883: Are used for AMQP and MQTT
-
-[How to open ports to a virtual machine with the Azure portal](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nsg-quickstart-portal).
 
 ### Configure the IoT Edge runtime
 
@@ -629,6 +629,7 @@ Notice that the image URI that we used for the simulated temperature sensor modu
 On the device details page for your lower layer IoT Edge device, you should now see the temperature sensor module listed along the system modules as **Specified in deployment**. It may take a few minutes for the device to receive its new deployment, request the container image, and start the module. Refresh the page until you see the temperature sensor module listed as **Reported by device**.
 
 ## IotEdge check
+Run the iotedge check command to verify the configuration and troubleshoot errors.
 Iotedge check can be performed in nested hierarchy, even if the children doesn't have direct internet access.
 When running "iotedge check" from the lower layer the program will try to pull the image from the parent through port 443.
 In this How-to, we use port 8000, so we need to specify it:

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -59,12 +59,12 @@ To create a hierarchy of IoT Edge devices, you will need:
     --admin-password <REPLACE_WITH_PASSWORD>
    ```
 
-Make sure the the following ports are opened inbound: 8000,443,5671,8883.
-8000: Is used to pull docker container images through API proxy
-443: Is used between parent and child edgehub for Rest API calls.
-5671,8883: Are used for AMQP and MQTT
+* Make sure that the following ports are open inbound: 8000, 443, 5671, 8883:
+  * 8000: Used to pull Docker container images through the API proxy.
+  * 443: Used between parent and child edge hubs for REST API calls.
+  * 5671, 8883: Used for AMQP and MQTT.
 
-[How to open ports to a virtual machine with the Azure portal](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nsg-quickstart-portal).
+  For more information, see [How to open ports to a virtual machine with the Azure portal](../virtual-machines/windows/nsg-quickstart-portal.md).
 
 You can also try out this scenario by following the scripted [Azure IoT Edge for Industrial IoT sample](https://aka.ms/iotedge-nested-sample), which deploys Azure virtual machines as preconfigured devices to simulate a factory environment.
 
@@ -630,20 +630,26 @@ Notice that the image URI that we used for the simulated temperature sensor modu
 On the device details page for your lower layer IoT Edge device, you should now see the temperature sensor module listed along the system modules as **Specified in deployment**. It may take a few minutes for the device to receive its new deployment, request the container image, and start the module. Refresh the page until you see the temperature sensor module listed as **Reported by device**.
 
 ## IotEdge check
-Run the iotedge check command to verify the configuration and troubleshoot errors.
-Iotedge check can be performed in nested hierarchy, even if the children doesn't have direct internet access.
-When running "iotedge check" from the lower layer the program will try to pull the image from the parent through port 443.
+
+Run the `iotedge check` command to verify the configuration and to troubleshoot errors.
+
+You can run `iotedge check` in a nested hierarchy, even if the child machines don't have direct internet access.
+
+When you run `iotedge check` from the lower layer, the program tries to pull the image from the parent through port 443.
+
 In this tutorial, we use port 8000, so we need to specify it:
 
-   ```bash
-   sudo iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:8000/azureiotedge-diagnostics:1.2.0-rc2
-   ```
+```bash
+sudo iotedge check --diagnostics-image-name <parent_device_fqdn_or_ip>:8000/azureiotedge-diagnostics:1.2.0-rc2
+```
    
-The azureiotedge-diagnostics is pulled from the container registry that is linked with the registry module. This tutorial has it set by default to https://mcr.microsoft.com:
-    | Name | Value |
-    | - | - |
-    | `REGISTRY_PROXY_REMOTEURL` | `https://mcr.microsoft.com` |
-If you are using you own private container registry, make sure all the images (IoTEdgeAPIProxy, edgeAgent, edgeHub, diagnostics ...) are present in it.    
+The `azureiotedge-diagnostics` value is pulled from the container registry that's linked with the registry module. This tutorial has it set by default to https://mcr.microsoft.com:
+
+| Name | Value |
+| - | - |
+| `REGISTRY_PROXY_REMOTEURL` | `https://mcr.microsoft.com` |
+
+If you're using a private container registry, make sure that all the images (for example, IoTEdgeAPIProxy, edgeAgent, edgeHub, and diagnostics) are present in the container registry.    
     
 ## View generated data
 


### PR DESCRIPTION
1. Added GPG key section prior to installing moby
2. Mention that port 443,5671,8000 need to be opened if azure VM are used
3. Section how to use IoTEdge check.
( Artifact no being generated for rc2 was fixed yesterday.)