### PR TITLE
Drawing attention to -ADObjectDN parameter.

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-group-writeback.md
+++ b/articles/active-directory/hybrid/how-to-connect-group-writeback.md
@@ -42,7 +42,13 @@ To enable group writeback, use the following steps:
 ```Powershell
 $AzureADConnectSWritebackAccountDN =  <MSOL_ account DN>
 Import-Module "C:\Program Files\Microsoft Azure Active Directory Connect\AdSyncConfig\AdSyncConfig.psm1"
+
+# To grant the <MSOL_account> permission to all domains in the forest:
 Set-ADSyncUnifiedGroupWritebackPermissions -ADConnectorAccountDN $AzureADConnectSWritebackAccountDN
+
+# To grant the <MSOL_account> permission to specific OU (eg. the OU chosen to writeback Office 365 Groups to):
+$GroupWritebackOU = <DN of OU where groups are to be written back to>
+Set-ADSyncUnifiedGroupWritebackPermissions -ADConnectorAccountDN $AzureADConnectSWritebackAccountDN -ADObjectDN $GroupWritebackOU
 ```
 
 For additional information on configuring the Microsoft 365 groups see [Configure Microsoft 365 Groups with on-premises Exchange hybrid](/exchange/hybrid-deployment/set-up-microsoft-365-groups#enable-group-writeback-in-azure-ad-connect).


### PR DESCRIPTION
I noticed in AdSyncConfig.psm1, the comment-based help for the `Set-ADSyncUnifiedGroupWritebackpermissions` function doesn't include a .Parameter keyword for `-ADObjectDN` parameter, however, the parameter is there:

```powershell
        # DistinguishedName of the target AD object to set permissions (optional)
        [string] $ADobjectDN = $null,
```
And the description also covers it:
```powershell
 .DESCRIPTION
        The Set-ADSyncUnifiedGroupWritebackPermissions Function will give required permissions to the AD synchronization account, which include the following:
        1. Generic Read/Write, Delete, Delete Tree and Create\Delete Child for Group Object types and SubObjects

        These permissions are applied to all domains in the forest.
        Optionally you can provide a DistinguishedName in ADobjectDN parameter to set these permissions on that AD Object only (including inheritance to sub objects).
        In this case, ADobjectDN will be the Distinguished Name of the Container that you desire to link with the GroupWriteback feature.
```
...and also one of the examples covers it:
```powershell
.EXAMPLE
       Set-ADSyncUnifiedGroupWritebackPermissions -ADConnectorAccountName 'ADConnector' -ADConnectorAccountDomain 'Contoso.com' -ADobjectDN 'OU=AzureAD,DC=Contoso,DC=com'
```
It is a good idea to use it, vs granting permissions all through the entire forest which won't be necessary (only the chosen OU needs the permissions set).