### PR TITLE
Updated to point to stable version of service bus samples

### DIFF
--- a/articles/service-bus-messaging/service-bus-java-how-to-use-queues.md
+++ b/articles/service-bus-messaging/service-bus-java-how-to-use-queues.md
@@ -216,9 +216,7 @@ See the following documentation and samples:
 
 - [Azure Service Bus client library for Java - Readme](https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/servicebus/azure-messaging-servicebus/README.md)
 - [Samples on GitHub](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/servicebus/azure-messaging-servicebus/src/samples)
-- [Java API reference](/java/api/overview/azure/servicebus?preserve-view=true&view=azure-java-preview)
-
-See [more samples on GitHub](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/servicebus/azure-messaging-servicebus). 
+- [Java API reference](/java/api/overview/azure/servicebus?preserve-view=true&view=azure-java-stable)
 
 [Azure SDK for Java]: /azure/developer/java/sdk/java-sdk-azure-get-started
 [Azure Toolkit for Eclipse]: /azure/developer/java/toolkit-for-eclipse/installation


### PR DESCRIPTION
Service Bus Track 2 v 7.0.0 is already releases. 
We should point to stable version now instead of pointing to samples/preview