### PR TITLE
Update procaire-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/procaire-tutorial.md
+++ b/articles/active-directory/saas-apps/procaire-tutorial.md
@@ -72,12 +72,6 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
 1. On the **Basic SAML Configuration** section, the user does not have to perform any step as the app is already pre-integrated with Azure.
 
-1. Click **Set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
-
-    In the **Sign-on URL** text box, type the URL:
-    `https://praisidio.app/auth/login`
-
-
 1. Click **Save**.
 
 1. On the **Set up single sign-on with SAML** page, In the **SAML Signing Certificate** section, click copy button to copy **App Federation Metadata Url** and save it on your computer.


### PR DESCRIPTION
Our customers only use Idp-initiated, but they frequenly add this step (set up for sp), which then breaks our idp-init login. We'd like this removed from our tutorial, and will encourage our customers to use idp-init logins.