### PR TITLE
Update storage-emulator-connection-string-include.md

### DIFF
--- a/includes/storage-emulator-connection-string-include.md
+++ b/includes/storage-emulator-connection-string-include.md
@@ -5,7 +5,7 @@ ms.topic: include
 ms.date: 07/17/2020
 ms.author: tamram
 ---
-Azurite supports a single fixed account and a well-known authentication key for Shared Key authentication. This account and key are the only Shared Key credentials permitted for use with Azurite. They are:
+The emulator supports a single fixed account and a well-known authentication key for Shared Key authentication. This account and key are the only Shared Key credentials permitted for use with the emulator. They are:
 
 ```
 Account name: devstoreaccount1
@@ -13,13 +13,13 @@ Account key: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZ
 ```
 
 > [!NOTE]
-> The authentication key supported by Azurite is intended only for testing the functionality of your client authentication code. It does not serve any security purpose. You cannot use your production storage account and key with Azurite. You should not use the development account with production data.
+> The authentication key supported by the emulator is intended only for testing the functionality of your client authentication code. It does not serve any security purpose. You cannot use your production storage account and key with the emulator. You should not use the development account with production data.
 > 
-> Azurite supports connection via HTTP only. However, HTTPS is the recommended protocol for accessing resources in a production Azure storage account.
+> The emulator supports connection via HTTP only. However, HTTPS is the recommended protocol for accessing resources in a production Azure storage account.
 > 
 
 #### Connect to the emulator account using a shortcut
-The easiest way to connect to Azurite from your application is to configure a connection string in your application's configuration file that references the shortcut `UseDevelopmentStorage=true`. Here's an example of a connection string to Azurite in an *app.config* file: 
+The easiest way to connect to the emulator from your application is to configure a connection string in your application's configuration file that references the shortcut `UseDevelopmentStorage=true`. Here's an example of a connection string to the emulator in an *app.config* file: 
 
 ```xml
 <appSettings>
@@ -27,8 +27,7 @@ The easiest way to connect to Azurite from your application is to configure a co
 </appSettings>
 ```
 
-#### Connect to the emulator account using the well-known account name and key
-To create a connection string that references the emulator account name and key, you must specify the endpoints for each of the services you wish to use from the emulator in the connection string. This is necessary so that the connection string will reference the emulator endpoints, which are different than those for a production storage account. For example, the value of your connection string will look like this:
+The is equivalent to fully specifying the account name, the account key and the endpoints for each of the emulator services you wish to use in the connection string. This is necessary so that the connection string will reference the emulator endpoints, which are different than those for a production storage account. For example, the value of your connection string will look like this:
 
 ```
 DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;
@@ -36,5 +35,3 @@ AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFP
 BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;
 ```
-
-This value is identical to the shortcut shown above, `UseDevelopmentStorage=true`.


### PR DESCRIPTION
1. When included in https://docs.microsoft.com/en-us/azure/storage/common/storage-use-emulator, suddenly referencing Azurite is confusing.  By using 'the emulator' instead, a majority of the text is reusable without being too specific.

2. I reworded the connection string section to focus on the use of the shortcut and explaining what it's equivalent to.