### PR TITLE
Add to select Tenant settings page

### DIFF
--- a/articles/purview/register-scan-power-bi-tenant.md
+++ b/articles/purview/register-scan-power-bi-tenant.md
@@ -45,6 +45,7 @@ To set up authentication, create a security group and add the catalog's managed 
 ## Associate the security group with the tenant
 
 1. Log into the [Power BI admin portal](https://app.powerbi.com/admin-portal/tenantSettings).
+1. Select **Tenant settings** page
 
     > [!Important]
     > You need to be a Power BI Admin to see the tenant settings page.

--- a/articles/purview/register-scan-power-bi-tenant.md
+++ b/articles/purview/register-scan-power-bi-tenant.md
@@ -45,7 +45,7 @@ To set up authentication, create a security group and add the catalog's managed 
 ## Associate the security group with the tenant
 
 1. Log into the [Power BI admin portal](https://app.powerbi.com/admin-portal/tenantSettings).
-1. Select **Tenant settings** page
+1. Select the **Tenant settings** page.
 
     > [!Important]
     > You need to be a Power BI Admin to see the tenant settings page.


### PR DESCRIPTION
If someone doesn't click on the link, but follows along in another window/screen, they won't know to select **Tenant settings** on the left hand side. Adding this makes things clearer.