### PR TITLE
Update transact-sql-tsql-differences-sql-server.md

### DIFF
--- a/articles/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server.md
+++ b/articles/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server.md
@@ -480,6 +480,7 @@ Cross-instance service broker isn't supported:
   - `remote access`
   - `remote data archive`
   - `remote proc trans`
+  - `scan for startup procs`
 - `sp_execute_external_scripts` isn't supported. See [sp_execute_external_scripts](/sql/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql#examples).
 - `xp_cmdshell` isn't supported. See [xp_cmdshell](/sql/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql).
 - `Extended stored procedures` aren't supported, which includes `sp_addextendedproc` and `sp_dropextendedproc`. See [Extended stored procedures](/sql/relational-databases/system-stored-procedures/general-extended-stored-procedures-transact-sql).


### PR DESCRIPTION
scan for startup procs is not supported neither.

EXEC sp_configure 'scan for startup procs', 1;
GO
RECONFIGURE WITH OVERRIDE;
GO

メッセージ 5869、レベル 16、状態 1、プロシージャ sp_configure、行 166 [バッチ開始行 5]
Changes to server configuration option scan for startup procs are not supported in SQL Database Managed Instances.