### PR TITLE
Authentication phone number deletion

### DIFF
--- a/articles/active-directory/enterprise-users/users-bulk-download.md
+++ b/articles/active-directory/enterprise-users/users-bulk-download.md
@@ -56,7 +56,7 @@ To download the list of users from the Azure AD admin center, you must be signed
    - postalCode
    - telephoneNumber
    - mobile
-   - authenticationPhoneNumber
+   - authenticationPhoneNumber. This part needs to be deleted or updated. 
    - authenticationAlternativePhoneNumber
    - authenticationEmail
    - alternateEmailAddress


### PR DESCRIPTION
Authentication phone number needs to be deleted from the list above because user authentication phone number is not pulling out after following the documentation.