### PR TITLE
Update to SSPK Final Licensee List

### DIFF
--- a/articles/media-services/previous/media-services-sspk.md
+++ b/articles/media-services/previous/media-services-sspk.md
@@ -129,6 +129,7 @@ Interim and Final SSPK licensees can submit technical questions to [smoothpk@mic
 * KDDI Corporation
 * Mega Fame Electronics Co. Limited
 * MIRC Electronics Limited
+* MOKA INTERNATIONAL LIMITED
 * Nintendo Co., Ltd.
 * ONEPLUS ELECTRONICS (SHENZHEN) CO., LTD.
 * Panasonic Corporation
@@ -149,6 +150,7 @@ Interim and Final SSPK licensees can submit technical questions to [smoothpk@mic
 * Technicolor Delivery Technologies, SAS
 * Top Victory Investments, Ltd.
 * UMC Poland sp. z .o.o.
+* Vizio, Inc.
 * ZTE Corporation
 
 ## Media Services learning paths


### PR DESCRIPTION
Please process the following update to SSPK Final Licensee List. Two new companies have been added. This update is a legal requirement to comply with licensing terms of program. I do not have access to fix/correct other issues with the page. Thanks.