### PR TITLE
Fixed typo in service-fabric-stateless-node-types.md

### DIFF
--- a/articles/service-fabric/service-fabric-stateless-node-types.md
+++ b/articles/service-fabric/service-fabric-stateless-node-types.md
@@ -39,7 +39,7 @@ To set one or more node types as stateless in a cluster resource, set the **isSt
         },
         "httpGatewayEndpointPort": "[parameters('nt0fabricHttpGatewayPort')]",
         "isPrimary": true,
-        "isStateles": false,
+        "isStateless": false,
         "vmInstanceCount": "[parameters('nt0InstanceCount')]"
     },
     {


### PR DESCRIPTION
`isStateles` -> `isStateless`