### PR TITLE
Typo "Azure function"→"Azure Function"

### DIFF
--- a/articles/logic-apps/logic-apps-azure-functions.md
+++ b/articles/logic-apps/logic-apps-azure-functions.md
@@ -9,15 +9,15 @@ ms.date: 10/01/2019
 ms.custom: devx-track-js
 ---
 
-# Call Azure functions from Azure Logic Apps
+# Call Azure Functions from Azure Logic Apps
 
-When you want to run code that performs a specific job in your logic apps, you can create your own function by using [Azure Functions](../azure-functions/functions-overview.md). This service helps you create Node.js, C#, and F# functions so you don't have to build a complete app or infrastructure to run code. You can also [call logic apps from inside Azure functions](#call-logic-app). Azure Functions provides serverless computing in the cloud and is useful for performing tasks such as these examples:
+When you want to run code that performs a specific job in your logic apps, you can create your own function by using [Azure Functions](../azure-functions/functions-overview.md). This service helps you create Node.js, C#, and F# functions so you don't have to build a complete app or infrastructure to run code. You can also [call logic apps from inside Azure Functions](#call-logic-app). Azure Functions provides serverless computing in the cloud and is useful for performing tasks such as these examples:
 
 * Extend your logic app's behavior with functions in Node.js or C#.
 * Perform calculations in your logic app workflow.
 * Apply advanced formatting or compute fields in your logic apps.
 
-To run code snippets without creating Azure functions, learn how to [add and run inline code](../logic-apps/logic-apps-add-run-inline-code.md).
+To run code snippets without creating Azure Functions, learn how to [add and run inline code](../logic-apps/logic-apps-add-run-inline-code.md).
 
 > [!NOTE]
 > Integration between Logic Apps and Azure Functions currently doesn't work with Slots enabled.
@@ -26,7 +26,7 @@ To run code snippets without creating Azure functions, learn how to [add and run
 
 * An Azure subscription. If you don't have an Azure subscription, [sign up for a free Azure account](https://azure.microsoft.com/free/).
 
-* An Azure function app, which is a container for Azure functions, along with your Azure function. If you don't have a function app, [create your function app first](../azure-functions/functions-create-first-azure-function.md). You can then create your function either outside your logic app in the Azure portal, or [from inside your logic app](#create-function-designer) in the Logic App Designer.
+* An Azure Function app, which is a container for Azure Functions, along with your Azure Function. If you don't have a function app, [create your function app first](../azure-functions/functions-create-first-azure-function.md). You can then create your function either outside your logic app in the Azure portal, or [from inside your logic app](#create-function-designer) in the Logic App Designer.
 
 * When working with logic apps, the same requirements apply to function apps and functions whether they are existing or new:
 
@@ -36,7 +36,7 @@ To run code snippets without creating Azure functions, learn how to [add and run
 
   * Your function uses the **HTTP trigger** template.
 
-    The HTTP trigger template can accept content that has `application/json` type from your logic app. When you add an Azure function to your logic app, the Logic App Designer shows custom functions that are created from this template within your Azure subscription.
+    The HTTP trigger template can accept content that has `application/json` type from your logic app. When you add an Azure Function to your logic app, the Logic App Designer shows custom functions that are created from this template within your Azure subscription.
 
   * Your function doesn't use custom routes unless you've defined an [OpenAPI definition](../azure-functions/functions-openapi-definition.md) (formerly known as a [Swagger file](https://swagger.io/)).
 
@@ -91,15 +91,15 @@ Here's what happens inside this function:
    body: data.date.ToDateString();
    ```
 
-Now that you've created your Azure function, follow the steps for how to [add functions to logic apps](#add-function-logic-app).
+Now that you've created your Azure Function, follow the steps for how to [add functions to logic apps](#add-function-logic-app).
 
 <a name="create-function-designer"></a>
 
 ## Create functions inside logic apps
 
-You can create Azure functions directly from your logic app's workflow by using the built-in Azure Functions action in the Logic App Designer, but you can use this method only for Azure functions written in JavaScript. For other languages, you can create Azure functions through the Azure Functions experience in the Azure portal. For more information, see [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
+You can create Azure Functions directly from your logic app's workflow by using the built-in Azure Functions action in the Logic App Designer, but you can use this method only for Azure Functions written in JavaScript. For other languages, you can create Azure Functions through the Azure Functions experience in the Azure portal. For more information, see [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
 
-However, before you can create any Azure function, you must already have an Azure function app, which is a container for your functions. If you don't have a function app, create that function app first. See [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
+However, before you can create any Azure Function, you must already have an Azure Function app, which is a container for your functions. If you don't have a function app, create that function app first. See [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
 
 1. In the [Azure portal](https://portal.azure.com), open your logic app in the Logic App Designer.
 
@@ -111,7 +111,7 @@ However, before you can create any Azure function, you must already have an Azur
 
 1. In the search box, enter "azure functions" as your filter. From the actions list, select the **Choose an Azure function** action, for example:
 
-   ![Find "Azure functions"](./media/logic-apps-azure-functions/find-azure-functions-action.png)
+   ![Find "Azure Functions"](./media/logic-apps-azure-functions/find-azure-functions-action.png)
 
 1. From the function apps list, select your function app. After the actions list opens, select this action: **Create New Function**
 
@@ -152,13 +152,13 @@ However, before you can create any Azure function, you must already have an Azur
 
    ![Cast object as string](./media/logic-apps-azure-functions/function-request-body-string-cast-example.png)
 
-1. To specify other details such as the method to use, request headers, or query parameters, or authentication, open the **Add new parameter** list, and select the options that you want. For authentication, your options differ based on your selected function. See [Enable authentication for Azure functions](#enable-authentication-functions).
+1. To specify other details such as the method to use, request headers, or query parameters, or authentication, open the **Add new parameter** list, and select the options that you want. For authentication, your options differ based on your selected function. See [Enable authentication for Azure Functions](#enable-authentication-functions).
 
 <a name="add-function-logic-app"></a>
 
 ## Add existing functions to logic apps
 
-To call existing Azure functions from your logic apps, you can add Azure functions like any other action in the Logic App Designer.
+To call existing Azure Functions from your logic apps, you can add Azure Functions like any other action in the Logic App Designer.
 
 1. In the [Azure portal](https://portal.azure.com), open your logic app in the Logic App Designer.
 
@@ -166,15 +166,15 @@ To call existing Azure functions from your logic apps, you can add Azure functio
 
 1. Under **Choose an action**, in the search box, enter "azure functions" as your filter. From the actions list, select the **Choose an Azure function** action.
 
-   ![Find "Azure functions"](./media/logic-apps-azure-functions/find-azure-functions-action.png)
+   ![Find "Azure Functions"](./media/logic-apps-azure-functions/find-azure-functions-action.png)
 
 1. From the function apps list, select your function app. After the functions list appears, select your function.
 
-   ![Select your function app and Azure function](./media/logic-apps-azure-functions/select-function-app-existing-function.png)
+   ![Select your function app and Azure Function](./media/logic-apps-azure-functions/select-function-app-existing-function.png)
 
    For functions that have API definitions (Swagger descriptions) and are [set up so your logic app can find and access those functions](#function-swagger), you can select **Swagger actions**.
 
-   ![Select your function app, "Swagger actions", and your Azure function](./media/logic-apps-azure-functions/select-function-app-existing-function-swagger.png)
+   ![Select your function app, "Swagger actions", and your Azure Function](./media/logic-apps-azure-functions/select-function-app-existing-function-swagger.png)
 
 1. In the **Request Body** box, provide your function's input, which must be formatted as a JavaScript Object Notation (JSON) object.
 
@@ -186,27 +186,27 @@ To call existing Azure functions from your logic apps, you can add Azure functio
 
    ![Cast object as string](./media/logic-apps-azure-functions/function-request-body-string-cast-example.png)
 
-1. To specify other details such as the method to use, request headers, query parameters, or authentication, open the **Add new parameter** list, and select the options that you want. For authentication, your options differ based on your selected function. See [Enable authentication in Azure functions](#enable-authentication-functions).
+1. To specify other details such as the method to use, request headers, query parameters, or authentication, open the **Add new parameter** list, and select the options that you want. For authentication, your options differ based on your selected function. See [Enable authentication in Azure Functions](#enable-authentication-functions).
 
 <a name="call-logic-app"></a>
 
-## Call logic apps from Azure functions
+## Call logic apps from Azure Functions
 
-When you want to trigger a logic app from inside an Azure function, the logic app must start with a trigger that provides a callable endpoint. For example, you can start the logic app with the **HTTP**, **Request**, **Azure Queues**, or **Event Grid** trigger. Inside your function, send an HTTP POST request to the trigger's URL, and include the payload you want that logic app to process. For more information, see [Call, trigger, or nest logic apps](../logic-apps/logic-apps-http-endpoint.md).
+When you want to trigger a logic app from inside an Azure Function, the logic app must start with a trigger that provides a callable endpoint. For example, you can start the logic app with the **HTTP**, **Request**, **Azure Queues**, or **Event Grid** trigger. Inside your function, send an HTTP POST request to the trigger's URL, and include the payload you want that logic app to process. For more information, see [Call, trigger, or nest logic apps](../logic-apps/logic-apps-http-endpoint.md).
 
 <a name="enable-authentication-functions"></a>
 
-## Enable authentication for Azure functions
+## Enable authentication for Azure Functions
 
 To easily authenticate access to other resources that are protected by Azure Active Directory (Azure AD) without having to sign in and provide credentials or secrets, your logic app can use a [managed identity](../active-directory/managed-identities-azure-resources/overview.md) (formerly known as Managed Service Identity or MSI). Azure manages this identity for you and helps secure your credentials because you don't have to provide or rotate secrets. Learn more about [Azure services that support managed identities for Azure AD authentication](../active-directory/managed-identities-azure-resources/services-support-managed-identities.md#azure-services-that-support-azure-ad-authentication).
 
-If you set up your logic app to use the system-assigned identity or a manually-created user-assigned identity, the Azure functions in your logic app can also use that same identity for authentication. For more information about authentication support for Azure functions in logic apps, see [Add authentication to outbound calls](../logic-apps/logic-apps-securing-a-logic-app.md#add-authentication-outbound).
+If you set up your logic app to use the system-assigned identity or a manually-created user-assigned identity, the Azure Functions in your logic app can also use that same identity for authentication. For more information about authentication support for Azure Functions in logic apps, see [Add authentication to outbound calls](../logic-apps/logic-apps-securing-a-logic-app.md#add-authentication-outbound).
 
 To set up and use the managed identity with your function, follow these steps:
 
 1. Enable the managed identity on your logic app, and set up that identity's access to the target resource. See [Authenticate access to Azure resources by using managed identities in Azure Logic Apps](../logic-apps/create-managed-service-identity.md).
 
-1. Enable authentication in your Azure function and function app by following these steps:
+1. Enable authentication in your Azure Function and function app by following these steps:
 
    * [Set up anonymous authentication in your function](#set-authentication-function-app)
    * [Set up Azure AD authentication in your function app](#set-azure-ad-authentication)
@@ -215,7 +215,7 @@ To set up and use the managed identity with your function, follow these steps:
 
 ### Set up anonymous authentication in your function
 
-To use your logic app's managed identity in your Azure function, you have set your function's authentication level to anonymous. Otherwise, your logic app throws a "BadRequest" error.
+To use your logic app's managed identity in your Azure Function, you have set your function's authentication level to anonymous. Otherwise, your logic app throws a "BadRequest" error.
 
 1. In the [Azure portal](https://portal.azure.com), find and select your function app. These steps use "FabrikamFunctionApp" as the example function app.
 

--- a/articles/logic-apps/logic-apps-azure-functions.md
+++ b/articles/logic-apps/logic-apps-azure-functions.md
@@ -26,7 +26,7 @@ To run code snippets without creating Azure Functions, learn how to [add and run
 
 * An Azure subscription. If you don't have an Azure subscription, [sign up for a free Azure account](https://azure.microsoft.com/free/).
 
-* An Azure Function app, which is a container for Azure Functions, along with your Azure Function. If you don't have a function app, [create your function app first](../azure-functions/functions-create-first-azure-function.md). You can then create your function either outside your logic app in the Azure portal, or [from inside your logic app](#create-function-designer) in the Logic App Designer.
+* An Azure Function App, which is a container for Azure Functions, along with your Azure Function. If you don't have a function app, [create your function app first](../azure-functions/functions-create-first-azure-function.md). You can then create your function either outside your logic app in the Azure portal, or [from inside your logic app](#create-function-designer) in the Logic App Designer.
 
 * When working with logic apps, the same requirements apply to function apps and functions whether they are existing or new:
 
@@ -99,7 +99,7 @@ Now that you've created your Azure Function, follow the steps for how to [add fu
 
 You can create Azure Functions directly from your logic app's workflow by using the built-in Azure Functions action in the Logic App Designer, but you can use this method only for Azure Functions written in JavaScript. For other languages, you can create Azure Functions through the Azure Functions experience in the Azure portal. For more information, see [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
 
-However, before you can create any Azure Function, you must already have an Azure Function app, which is a container for your functions. If you don't have a function app, create that function app first. See [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
+However, before you can create any Azure Function, you must already have an Azure Function App, which is a container for your functions. If you don't have a function app, create that function app first. See [Create your first function in the Azure portal](../azure-functions/functions-create-first-azure-function.md).
 
 1. In the [Azure portal](https://portal.azure.com), open your logic app in the Logic App Designer.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-azure-functions