### PR TITLE
Setting `groupId` has invalid syntax because of $

### DIFF
--- a/articles/container-instances/container-instances-github-action.md
+++ b/articles/container-instances/container-instances-github-action.md
@@ -51,7 +51,7 @@ In the GitHub workflow, you need to supply Azure credentials to authenticate to 
 First, get the resource ID of your resource group. Substitute the name of your group in the following [az group show][az-group-show] command:
 
 ```azurecli
-$groupId=$(az group show \
+groupId=$(az group show \
   --name <resource-group-name> \
   --query id --output tsv)
 ```


### PR DESCRIPTION
zsh doesn't like `$groupId=...`, should be `groupId=...`