### PR TITLE
Update waagent.conf sed commands to cover newer Provisioning.Agent directive

### DIFF
--- a/articles/virtual-machines/linux/cloudinit-prepare-custom-image.md
+++ b/articles/virtual-machines/linux/cloudinit-prepare-custom-image.md
@@ -55,6 +55,7 @@ A number of tasks relating to provisioning and handling ephemeral disks need to 
 ```bash
 sed -i 's/Provisioning.Enabled=y/Provisioning.Enabled=n/g' /etc/waagent.conf
 sed -i 's/Provisioning.UseCloudInit=n/Provisioning.UseCloudInit=y/g' /etc/waagent.conf
+sed -i 's/Provisioning.Agent=.*/Provisioning.Agent=cloud-init/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.Format=y/ResourceDisk.Format=n/g' /etc/waagent.conf
 sed -i 's/ResourceDisk.EnableSwap=y/ResourceDisk.EnableSwap=n/g' /etc/waagent.conf
 cloud-init clean


### PR DESCRIPTION
My recent waagent.conf has no `Provisioning.UseCloudInit` directive, rather it has `Provisioning.Agent`. Add a sed command to cover that case. Leave the old sed command in (under the assumption that we may find that directive in older waagent.conf files).