### PR TITLE
Typo "Azure Function app"→"Azure Function App"

### DIFF
--- a/articles/azure-functions/scripts/functions-cli-mount-files-storage-linux.md
+++ b/articles/azure-functions/scripts/functions-cli-mount-files-storage-linux.md
@@ -21,7 +21,7 @@ This Azure Functions sample script creates a function app and creates a share in
 
 ## Sample script
 
-This script creates an Azure Function app using the [Consumption plan](../functions-scale.md#consumption-plan).
+This script creates an Azure Function App using the [Consumption plan](../functions-scale.md#consumption-plan).
 
 [!code-azurecli-interactive[main](../../../cli_scripts/azure-functions/functions-cli-mount-files-storage-linux/functions-cli-mount-files-storage-linux.sh "Create an Azure Function on a Consumption plan")]
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-functions/scripts/functions-cli-mount-files-storage-linux