### PR TITLE
Add SSL.com to Key Vault Partners list

### DIFF
--- a/articles/key-vault/certificates/create-certificate-signing-request.md
+++ b/articles/key-vault/certificates/create-certificate-signing-request.md
@@ -28,6 +28,7 @@ Key Vault partners with following two Certificate Authorities to simplify the cr
 |--------------|----------------------|------------------|  
 |DigiCert|Key Vault offers OV or EV SSL certificates with DigiCert| [Integration Guide](./how-to-integrate-certificate-authority.md)
 |GlobalSign|Key Vault offers OV or EV SSL certificates with GlobalSign| [Integration Guide](https://support.globalsign.com/digital-certificates/digital-certificate-installation/generating-and-importing-certificate-microsoft-azure-key-vault)
+|SSL.com|Key Vault offers OV or EV SSL certificates with SSL.com| [Integration Guide](https://www.ssl.com/how-to/generate-csr-install-certificate-microsoft-azure-key-vault/)
 
 ## Adding Certificate in Key Vault issued by non-partnered CA
 


### PR DESCRIPTION
I'd like to propose adding SSL.com to the like Key Vault partners. SSL.com is a participant in the Microsoft Trusted Root Program (see https://ccadb-public.secure.force.com/microsoft/IncludedCACertificateReportForMSFT ), and SSL.com currently issues trusted certificates for a number of Microsoft products including EV Code Signing, SMIME, SSL/TLS, and Document Signing for Office365. 

Many Microsoft/Azure customers currently depend on SSL.com products, and we've seen increasing requests for support for Key Vault specifically. As a Microsoft trusted CA, adding SSL.com to this list will give Azure Key Vault customers more options when choosing which Microsoft-partnered CA vendor to use.