### PR TITLE
Add SSL.com to Certificate Authority Providers

### DIFF
--- a/articles/key-vault/certificates/certificate-scenarios.md
+++ b/articles/key-vault/certificates/certificate-scenarios.md
@@ -36,6 +36,7 @@ Certificates are composed of three interrelated resources linked together as a K
     The following CAs are the current partnered providers with Key Vault. Learn more [here](./create-certificate.md#partnered-ca-providers)   
     -   DigiCert - Key Vault offers OV TLS/SSL certificates with DigiCert.  
     -   GlobalSign - Key Vault offers OV TLS/SSL certificates with GlobalSign.  
+    -   SSL.com - Key Vault offers OV and EV TLS/SSL certificates with SSL.com.  
 
 **Step 2** - An account admin for a CA provider creates credentials to be used by Key Vault to enroll, renew, and use TLS/SSL certificates via Key Vault.
 


### PR DESCRIPTION
I'd like to propose adding SSL.com to the Certificate Authority Providers list. SSL.com is a participant in the Microsoft Trusted Root Program (see https://ccadb-public.secure.force.com/microsoft/IncludedCACertificateReportForMSFT ), and SSL.com currently issues trusted certificates for a number of Microsoft products including EV Code Signing, SMIME, SSL/TLS, and Document Signing for Office365.

Many Microsoft/Azure customers currently depend on SSL.com products, and we've seen increasing requests for support for Key Vault specifically. As a Microsoft trusted CA, adding SSL.com to this list will give Azure Key Vault customers more options when choosing which Microsoft-partnered CA vendor to use.