### PR TITLE
Update PreReq to call out access Azure AD

### DIFF
--- a/articles/role-based-access-control/role-assignments-powershell.md
+++ b/articles/role-based-access-control/role-assignments-powershell.md
@@ -23,6 +23,7 @@ To add or remove role assignments, you must have:
 
 - `Microsoft.Authorization/roleAssignments/write` and `Microsoft.Authorization/roleAssignments/delete` permissions, such as [User Access Administrator](built-in-roles.md#user-access-administrator) or [Owner](built-in-roles.md#owner)
 - [PowerShell in Azure Cloud Shell](../cloud-shell/overview.md) or [Azure PowerShell](/powershell/azure/install-az-ps)
+- Accout running the Powershell command must have access to Azure Active Directory Graph `Directory.Read.All`
 
 ## Steps to add a role assignment
 

--- a/articles/role-based-access-control/role-assignments-powershell.md
+++ b/articles/role-based-access-control/role-assignments-powershell.md
@@ -23,7 +23,7 @@ To add or remove role assignments, you must have:
 
 - `Microsoft.Authorization/roleAssignments/write` and `Microsoft.Authorization/roleAssignments/delete` permissions, such as [User Access Administrator](built-in-roles.md#user-access-administrator) or [Owner](built-in-roles.md#owner)
 - [PowerShell in Azure Cloud Shell](../cloud-shell/overview.md) or [Azure PowerShell](/powershell/azure/install-az-ps)
-- Accout running the Powershell command must have access to Azure Active Directory Graph `Directory.Read.All`
+- The account you use to run the PowerShell command must have the Azure Active Directory Graph `Directory.Read.All` permission.
 
 ## Steps to add a role assignment
 

--- a/articles/role-based-access-control/role-assignments-powershell.md
+++ b/articles/role-based-access-control/role-assignments-powershell.md
@@ -23,7 +23,7 @@ To add or remove role assignments, you must have:
 
 - `Microsoft.Authorization/roleAssignments/write` and `Microsoft.Authorization/roleAssignments/delete` permissions, such as [User Access Administrator](built-in-roles.md#user-access-administrator) or [Owner](built-in-roles.md#owner)
 - [PowerShell in Azure Cloud Shell](../cloud-shell/overview.md) or [Azure PowerShell](/powershell/azure/install-az-ps)
-- The account you use to run the PowerShell command must have the Azure Active Directory Graph `Directory.Read.All` permission.
+- The account you use to run the PowerShell command must have the Microsoft Graph `Directory.Read.All` permission.
 
 ## Steps to add a role assignment
 


### PR DESCRIPTION
Updated prereq for account running the query be able to query Azure AD.  This was a problem for me using a Run As Automation account as it kept saying information provided was not found in Active Directory.