### PR TITLE
change the namespace to lowercase

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-new.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-new.md
@@ -36,17 +36,17 @@ In this tutorial, you learn how to:
 
  - Register the *AKS-IngressApplicationGatewayAddon* feature flag by using the [az feature register](/cli/azure/feature#az-feature-register) command as shown in the following example. You'll need to do this only once per subscription while the add-on is still in preview.
     ```azurecli-interactive
-    az feature register --name AKS-IngressApplicationGatewayAddon --namespace Microsoft.ContainerService
+    az feature register --name AKS-IngressApplicationGatewayAddon --namespace microsoft.containerService
     ```
 
    It might take a few minutes for the status to show `Registered`. You can check the registration status by using the [az feature list](/cli/azure/feature#az-feature-register) command:
     ```azurecli-interactive
-    az feature list -o table --query "[?contains(name, 'Microsoft.ContainerService/AKS-IngressApplicationGatewayAddon')].{Name:name,State:properties.state}"
+    az feature list -o table --query "[?contains(name, 'microsoft.containerService/AKS-IngressApplicationGatewayAddon')].{Name:name,State:properties.state}"
     ```
 
- - When you're ready, refresh the registration of the Microsoft.ContainerService resource provider by using the [az provider register](/cli/azure/provider#az-provider-register) command:
+ - When you're ready, refresh the registration of the microsoft.containerService resource provider by using the [az provider register](/cli/azure/provider#az-provider-register) command:
     ```azurecli-interactive
-    az provider register --namespace Microsoft.ContainerService
+    az provider register --namespace microsoft.containerService
     ```
 
 ## Create a resource group


### PR DESCRIPTION
The camelcase namespace is making issues while listing the az feature, It's better to have a lowercase namespace, streamlined to the brownfield documentation