### PR TITLE
Fixed typo in decodeUriComponent example

### DIFF
--- a/articles/logic-apps/workflow-definition-language-functions-reference.md
+++ b/articles/logic-apps/workflow-definition-language-functions-reference.md
@@ -1735,7 +1735,7 @@ decodeUriComponent('<value>')
 This example replaces the escape characters in this string with decoded versions:
 
 ```
-decodeUriComponent('http%3A%2F%2Fcontoso.com')
+decodeUriComponent('https%3A%2F%2Fcontoso.com')
 ```
 
 And returns this result: `"https://contoso.com"`


### PR DESCRIPTION
Hello - while working on unit tests for my [expression language emulator](http://nonodename.com/el) I realized that the worked example for [decodeUriComponent](https://docs.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference#decodeUriComponent) is missing an S in the http