### PR TITLE
Update data-lake-storage-directory-file-acl-powershell.md

### DIFF
--- a/articles/storage/blobs/data-lake-storage-directory-file-acl-powershell.md
+++ b/articles/storage/blobs/data-lake-storage-directory-file-acl-powershell.md
@@ -73,7 +73,7 @@ $ctx = New-AzStorageContext -StorageAccountName '<storage-account-name>' -UseCon
 With this approach, the system doesn't check Azure RBAC or ACL permissions.
 
 ```powershell
-$storageAccount = Get-AzStorageAccount -ResourceGroupName "<resource-group-name>" -AccountName "<storage-account-name>"
+$storageAccount = New-AzStorageContext -StorageAccountName "<storage-account-name>" -StorageAccountKey "<storage-account-key>"
 $ctx = $storageAccount.Context
 ```
 

--- a/articles/storage/blobs/data-lake-storage-directory-file-acl-powershell.md
+++ b/articles/storage/blobs/data-lake-storage-directory-file-acl-powershell.md
@@ -73,8 +73,7 @@ $ctx = New-AzStorageContext -StorageAccountName '<storage-account-name>' -UseCon
 With this approach, the system doesn't check Azure RBAC or ACL permissions.
 
 ```powershell
-$storageAccount = New-AzStorageContext -StorageAccountName "<storage-account-name>" -StorageAccountKey "<storage-account-key>"
-$ctx = $storageAccount.Context
+$ctx = New-AzStorageContext -StorageAccountName "<storage-account-name>" -StorageAccountKey "<storage-account-key>"
 ```
 
 ## Create a container


### PR DESCRIPTION
Updated command for obtaining authorization context using storage account key
The sample was using Get-AzStorageAccount which takes ResourceGroup and AccountName as parameters. There is no option to use storage account key.
https://docs.microsoft.com/en-us/powershell/module/az.storage/get-azstorageaccount?view=azps-5.2.0
![image](https://user-images.githubusercontent.com/72929864/103282843-f838f280-49fc-11eb-9865-197df129de9b.png)


Replaced it New-AzStorageContext
https://docs.microsoft.com/en-us/powershell/module/az.storage/new-azstoragecontext?view=azps-5.2.0
![image](https://user-images.githubusercontent.com/72929864/103282828-f111e480-49fc-11eb-9d93-ce253ebafd74.png)

