### PR TITLE
Update Assertion Consumer URL

### DIFF
--- a/articles/active-directory/saas-apps/new-relic-tutorial.md
+++ b/articles/active-directory/saas-apps/new-relic-tutorial.md
@@ -75,7 +75,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
 	a. In the **Sign on URL** text box, type a URL using the following pattern:
 
-    `https://rpm.newrelic.com/accounts/{acc_id}/sso/saml/login` - Be sure to substitute `acc_id` with your own Account ID of New Relic by Account.
+    `https://rpm.newrelic.com:443/accounts/{acc_id}/sso/saml/finalize` - Be sure to substitute `acc_id` with your own Account ID of New Relic by Account.
 
     b. In the **Identifier (Entity ID)** text box, type a URL:
     `rpm.newrelic.com`


### PR DESCRIPTION
New Relic has changed the Assertion Consumer URL in our SAML configuration.  It will be necessary for customers of Azure Active Directory to use this new URL as Sign In URL.  I am a New Relic employee, and this change is authorized by New Relic, Inc.