### PR TITLE
Typo "Azure function app"→"Azure Function App"

### DIFF
--- a/articles/azure-functions/functions-create-first-kotlin-maven.md
+++ b/articles/azure-functions/functions-create-first-kotlin-maven.md
@@ -168,7 +168,7 @@ Deploy your code into a new Function app using the `azure-functions:deploy` Mave
 mvn azure-functions:deploy
 ```
 
-When the deploy is complete, you see the URL you can use to access your Azure function app:
+When the deploy is complete, you see the URL you can use to access your Azure Function App:
 
 <pre>
 [INFO] Successfully deployed Function App with package.

--- a/articles/azure-functions/functions-create-first-kotlin-maven.md
+++ b/articles/azure-functions/functions-create-first-kotlin-maven.md
@@ -27,9 +27,9 @@ To develop functions using Kotlin, you must have the following installed:
 > [!IMPORTANT]
 > The JAVA_HOME environment variable must be set to the install location of the JDK to complete this quickstart.
 
-## Generate a new Functions project
+## Generate a new Azure Functions project
 
-In an empty folder, run the following command to generate the Functions project from a [Maven archetype](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html).
+In an empty folder, run the following command to generate the Azure Functions project from a [Maven archetype](https://maven.apache.org/guides/introduction/introduction-to-archetypes.html).
 
 # [bash](#tab/bash)
 ```bash
@@ -159,16 +159,16 @@ The deploy process to Azure Functions uses account credentials from the Azure CL
 az login
 ```
 
-Deploy your code into a new Function app using the `azure-functions:deploy` Maven target.
+Deploy your code into a new function app using the `azure-functions:deploy` Maven target.
 
 > [!NOTE]
-> When you use Visual Studio Code to deploy your Function app, remember to choose a non-free subscription, or you will get an error. You can watch your subscription on the left side of the IDE.
+> When you use Visual Studio Code to deploy your function app, remember to choose a non-free subscription, or you will get an error. You can watch your subscription on the left side of the IDE.
 
 ```
 mvn azure-functions:deploy
 ```
 
-When the deploy is complete, you see the URL you can use to access your Azure Function App:
+When the deploy is complete, you see the URL you can use to access your function app:
 
 <pre>
 [INFO] Successfully deployed Function App with package.
@@ -193,7 +193,7 @@ Hello AzureFunctions!
 
 ## Make changes and redeploy
 
-Edit the `src/main.../Function.java` source file in the generated project to alter the text returned by your Function app. Change this line:
+Edit the `src/main.../Function.java` source file in the generated project to alter the text returned by your function app. Change this line:
 
 ```kotlin
 return request
@@ -226,7 +226,7 @@ Hi, AzureFunctionsTest
 
 ## Reference bindings
 
-To work with [Functions triggers and bindings](functions-triggers-bindings.md) other than HTTP trigger and Timer trigger, you need to install binding extensions. While not required by this article, you'll need to know how to do enable extensions when working with other binding types.
+To work with [Azure Functions triggers and bindings](functions-triggers-bindings.md) other than HTTP trigger and Timer trigger, you need to install binding extensions. While not required by this article, you'll need to know how to do enable extensions when working with other binding types.
 
 [!INCLUDE [functions-extension-bundles](../../includes/functions-extension-bundles.md)]
 
@@ -234,7 +234,7 @@ To work with [Functions triggers and bindings](functions-triggers-bindings.md) o
 
 You've created a Kotlin function app with a simple HTTP trigger and deployed it to Azure Functions.
 
-- Review the  [Java Functions developer guide](functions-reference-java.md) for more information on developing Java and Kotlin functions.
+- Review the [Java functions developer guide](functions-reference-java.md) for more information on developing Java and Kotlin functions.
 - Add additional functions with different triggers to your project using the `azure-functions:add` Maven target.
 - Write and debug functions locally with [Visual Studio Code](https://code.visualstudio.com/docs/java/java-azurefunctions), [IntelliJ](functions-create-maven-intellij.md), and [Eclipse](functions-create-maven-eclipse.md). 
 - Debug functions deployed in Azure with Visual Studio Code. See the Visual Studio Code [serverless Java applications](https://code.visualstudio.com/docs/java/java-serverless#_remote-debug-functions-running-in-the-cloud) documentation for instructions.

--- a/articles/azure-functions/functions-create-first-kotlin-maven.md
+++ b/articles/azure-functions/functions-create-first-kotlin-maven.md
@@ -234,7 +234,7 @@ To work with [Azure Functions triggers and bindings](functions-triggers-bindings
 
 You've created a Kotlin function app with a simple HTTP trigger and deployed it to Azure Functions.
 
-- Review the [Java functions developer guide](functions-reference-java.md) for more information on developing Java and Kotlin functions.
+- Review the [Java function developer guide](functions-reference-java.md) for more information on developing Java and Kotlin functions.
 - Add additional functions with different triggers to your project using the `azure-functions:add` Maven target.
 - Write and debug functions locally with [Visual Studio Code](https://code.visualstudio.com/docs/java/java-azurefunctions), [IntelliJ](functions-create-maven-intellij.md), and [Eclipse](functions-create-maven-eclipse.md). 
 - Debug functions deployed in Azure with Visual Studio Code. See the Visual Studio Code [serverless Java applications](https://code.visualstudio.com/docs/java/java-serverless#_remote-debug-functions-running-in-the-cloud) documentation for instructions.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-kotlin-maven?tabs=bash