### PR TITLE
Update use-azure-ad-pod-identity.md

### DIFF
--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -52,7 +52,7 @@ Create an AKS cluster with a managed identity and pod-managed identity enabled. 
 
 ```azurecli-interactive
 az group create --name myResourceGroup --location eastus
-az aks create -g myResourceGroup -n myAKSCluster --enable-managed-identity --enable-pod-identity
+az aks create -g myResourceGroup -n myAKSCluster --enable-managed-identity --enable-pod-identity --network-plugin azure
 ```
 
 Use [az aks get-credentials][az-aks-get-credentials] to sign in to your AKS cluster. This command also downloads and configures the `kubectl` client certificate on your development computer.


### PR DESCRIPTION
I tried without azure network plugin and got the following error:
```
BadRequestError: Operation failed with status: 'Bad Request'. Details: Network plugin kubenet is not supported to use with PodIdentity addon.
```
Hence adding the network-plugin parameter to this documentation.