### PR TITLE
Update docs to match new version of cli

### DIFF
--- a/articles/iot-hub/quickstart-send-telemetry-dotnet.md
+++ b/articles/iot-hub/quickstart-send-telemetry-dotnet.md
@@ -70,7 +70,7 @@ A device must be registered with your IoT hub before it can connect. In this qui
    **YourIoTHubName**: Replace this placeholder below with the name you chose for your IoT hub.
 
     ```azurecli-interactive
-    az iot hub device-identity show-connection-string --hub-name {YourIoTHubName} --device-id MyDotnetDevice --output table
+    az iot hub device-identity connection-string show --hub-name {YourIoTHubName} --device-id MyDotnetDevice --output table
     ```
 
     Make a note of the device connection string, which looks like:


### PR DESCRIPTION
When running the command: 
```az iot hub device-identity show-connection-string --hub-name {YourIoTHubName} --device-id MyDotnetDevice --output table```
I got the following warning:
```This command has been deprecated and will be removed in a future release. Use 'az iot hub device-identity connection-string show' instead.```