### PR TITLE
Made the description for lastIndexOf more clear

### DIFF
--- a/articles/logic-apps/workflow-definition-language-functions-reference.md
+++ b/articles/logic-apps/workflow-definition-language-functions-reference.md
@@ -2811,7 +2811,7 @@ If the string or substring value is empty, the following behavior occurs:
 
 * If the string and substring values are both empty, the function returns `0`.
 
-* If only the substring value is empty, the length of the string, minus 1 is returned.
+* If only the substring value is empty, the function returns the string length minus 1.
 
 *Examples*
 

--- a/articles/logic-apps/workflow-definition-language-functions-reference.md
+++ b/articles/logic-apps/workflow-definition-language-functions-reference.md
@@ -2809,7 +2809,7 @@ If the string or substring value is empty, the following behavior occurs:
 
 * If only the string value is empty, `-1` is returned:
 
-* If the string and substring values are both empty, `0` is returned.
+* If the string and substring values are both empty, the function returns `0`.
 
 * If only the substring value is empty, the length of the string, minus 1 is returned.
 

--- a/articles/logic-apps/workflow-definition-language-functions-reference.md
+++ b/articles/logic-apps/workflow-definition-language-functions-reference.md
@@ -2807,7 +2807,7 @@ lastIndexOf('<text>', '<searchText>')
 
 If the string or substring value is empty, the following behavior occurs:
 
-* If only the string value is empty, `-1` is returned:
+* If only the string value is empty, the function returns `-1`.
 
 * If the string and substring values are both empty, the function returns `0`.
 

--- a/articles/logic-apps/workflow-definition-language-functions-reference.md
+++ b/articles/logic-apps/workflow-definition-language-functions-reference.md
@@ -2807,15 +2807,11 @@ lastIndexOf('<text>', '<searchText>')
 
 If the string or substring value is empty, the following behavior occurs:
 
-* If the string value is empty, `-1` is returned:
+* If only the string value is empty, `-1` is returned:
 
 * If the string and substring values are both empty, `0` is returned.
 
-* If only the substring value is empty, the greater of the following two values is returned:
-
-  * `0`
-
-  * The length of the string, minus 1.
+* If only the substring value is empty, the length of the string, minus 1 is returned.
 
 *Examples*
 


### PR DESCRIPTION
It is stated in the cases above, what happens when the string is empty or both the string and substring are empty. 

So it is not possible to have a case, where the length of the string -1 is less than zero, since the string must have at least 1 character, to enter this case. 
The two subcases are removed and the only possible case is stated instead, making it more clear for the reader, what will happen.