### PR TITLE
Eligible Windows VMs

### DIFF
--- a/articles/automanage/automanage-virtual-machines.md
+++ b/articles/automanage/automanage-virtual-machines.md
@@ -36,7 +36,7 @@ Lastly, the experience is incredibly simple.
 
 There are several prerequisites to consider before trying to enable Azure Automanage on your virtual machines.
 
-- Windows Server VMs only
+- Eligible Windows VMs only
 - VMs must be running
 - VMs must be in a supported region
 - User must have correct permissions (see paragraph below)


### PR DESCRIPTION
Adjusted wording to Eligible Windows VMs Only (rather than current wording of Windows Server VMs only which may incorrectly infer Windows Server OS VMs?

Windows 10 VM appears to work when testing this in a demo environment, but please verify if this is accurate