### PR TITLE
Update control-flow-expression-language-functions.md

### DIFF
--- a/articles/data-factory/control-flow-expression-language-functions.md
+++ b/articles/data-factory/control-flow-expression-language-functions.md
@@ -969,7 +969,7 @@ And returns this result: `"2018-01-01T00:00:00.0000000"`
 This example converts a time zone to the specified time zone and format:
 
 ```
-convertTimeZone('2018-01-01T80:00:00.0000000Z', 'UTC', 'Pacific Standard Time', 'D')
+convertTimeZone('2018-01-01T08:00:00.0000000Z', 'UTC', 'Pacific Standard Time', 'D')
 ```
 
 And returns this result: `"Monday, January 1, 2018"`


### PR DESCRIPTION
Corrected typo. Value in example for datetime string '2018-01-01T80:00:00.0000000Z' is not valid. The datetime string must match ISO 8601 format.