### PR TITLE
Issue in the powershell

### DIFF
--- a/articles/active-directory/hybrid/tshoot-connect-password-hash-synchronization.md
+++ b/articles/active-directory/hybrid/tshoot-connect-password-hash-synchronization.md
@@ -377,7 +377,7 @@ if ($aadConnectors -ne $null -and $adConnectors -ne $null)
 {
     if ($aadConnectors.Count -eq 1)
     {
-        $features = Get-ADSyncAADCompanyFeature -ConnectorName $aadConnectors[0].Name
+        $features = Get-ADSyncAADCompanyFeature
         Write-Host
         Write-Host "Password sync feature enabled in your Azure AD directory: "  $features.PasswordHashSync
         foreach ($adConnector in $adConnectors)


### PR DESCRIPTION
in this section is a PowerShell script: https://docs.microsoft.com/en-us/azure/active-directory/hybrid/tshoot-connect-password-hash-synchronization#get-the-status-of-password-sync-settings
where the script has an issue in the 
line  9:  $features = Get-ADSyncAADCompanyFeature -ConnectorName $aadConnectors[0].Name

This is not correct, because there is no parameters on the Get-ADSyncAADCompanyFeature commandlet.

The line should looks like as:
$features = Get-ADSyncAADCompanyFeature