### PR TITLE
Update recursive-access-control-lists.md

### DIFF
--- a/articles/storage/blobs/recursive-access-control-lists.md
+++ b/articles/storage/blobs/recursive-access-control-lists.md
@@ -180,8 +180,7 @@ The following table shows each of the supported roles and their ACL setting capa
 With this approach, the system doesn't check Azure RBAC or ACL permissions.
 
 ```powershell
-$storageAccount = Get-AzStorageAccount -ResourceGroupName "<resource-group-name>" -AccountName "<storage-account-name>"
-$ctx = $storageAccount.Context
+$ctx = New-AzStorageContext -StorageAccountName "<storage-account-name>" -StorageAccountKey "<storage-account-key>"
 ```
 
 ### [Azure CLI](#tab/azure-cli)


### PR DESCRIPTION
Updated command for obtaining authorization context using storage account key
The sample was using Get-AzStorageAccount which takes ResourceGroup and AccountName as parameters. There is no option to use storage account key.
https://docs.microsoft.com/en-us/powershell/module/az.storage/get-azstorageaccount?view=azps-5.2.0
image
![image](https://user-images.githubusercontent.com/72929864/103993667-fb31a100-51bb-11eb-99d3-e8682126e7b7.png)


Replaced it New-AzStorageContext
https://docs.microsoft.com/en-us/powershell/module/az.storage/new-azstoragecontext?view=azps-5.2.0
image
![image](https://user-images.githubusercontent.com/72929864/103993690-008eeb80-51bc-11eb-9a04-235d521e5141.png)

Note: similar to PR https://github.com/MicrosoftDocs/azure-docs/pull/68199