### PR TITLE
DOC: corrected documentation regarding how to stream files with Azure Media Services

### DIFF
--- a/articles/media-services/latest/stream-files-tutorial-with-rest.md
+++ b/articles/media-services/latest/stream-files-tutorial-with-rest.md
@@ -174,7 +174,7 @@ The output [Asset](/rest/api/media/assets) stores the result of your encoding jo
         ```
 
 > [!NOTE]
-> Be sure to either replace the storage account and container names with those from the environment file or supply your own.
+> Be sure to replace the storage account and container names either with those from the environment file or supply your own.
 >
 > As you complete the steps described in the rest of this article, make sure that you supply valid parameters in request bodies.
 

--- a/articles/media-services/latest/stream-files-tutorial-with-rest.md
+++ b/articles/media-services/latest/stream-files-tutorial-with-rest.md
@@ -166,10 +166,16 @@ The output [Asset](/rest/api/media/assets) stores the result of your encoding jo
         {
         "properties": {
             "description": "My Asset",
-            "alternateId" : "some GUID"
+            "alternateId" : "some GUID",
+            "storageAccountName": "<replace from environment file>",
+            "container": "<supply any valid container name of your choosing>"
          }
         }
         ```
+
+> [!NOTE]
+> Please make sure that you either replace the storage account and container names with those from the environment file or you supply your own.
+> Going forward, please make sure that you are supplying valid parameters in request bodies in all future steps.
 
 ### Create a transform
 
@@ -351,8 +357,9 @@ In this section, let's build an HLS streaming URL. URLs consist of the following
     To get the hostname, you can use the following GET operation:
     
     ```
-    https://management.azure.com/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/amsResourceGroup/providers/Microsoft.Media/mediaservices/amsaccount/streamingEndpoints/default?api-version={{api-version}}
+    https://management.azure.com/subscriptions/00000000-0000-0000-0000-0000000000000/resourceGroups/:resourceGroupName/providers/Microsoft.Media/mediaservices/:accountName/streamingEndpoints/default?api-version={{api-version}}
     ```
+    and make sure that you set the `resourceGroupName` and `accountName` parameters to match the environment file. 
     
 3. A path that you got in the previous (List paths) section.  
 

--- a/articles/media-services/latest/stream-files-tutorial-with-rest.md
+++ b/articles/media-services/latest/stream-files-tutorial-with-rest.md
@@ -174,8 +174,9 @@ The output [Asset](/rest/api/media/assets) stores the result of your encoding jo
         ```
 
 > [!NOTE]
-> Please make sure that you either replace the storage account and container names with those from the environment file or you supply your own.
-> Going forward, please make sure that you are supplying valid parameters in request bodies in all future steps.
+> Be sure to either replace the storage account and container names with those from the environment file or supply your own.
+>
+> As you complete the steps described in the rest of this article, make sure that you supply valid parameters in request bodies.
 
 ### Create a transform
 


### PR DESCRIPTION
Corrections regarding how to stream files with Azure Media Services:
- explained how to set request bodies
- corrected hardcoded names in GET request URL for the hostname 