### PR TITLE
Typo "Azure function"→"Azure Function"

### DIFF
--- a/articles/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint.md
+++ b/articles/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint.md
@@ -1,6 +1,6 @@
 ---
 title: Custom provider C# RESTful endpoint reference
-description: Provides basic reference for an Azure Custom Providers C# RESTful endpoint. The endpoint is provided through an Azure function app.
+description: Provides basic reference for an Azure Custom Providers C# RESTful endpoint. The endpoint is provided through an Azure Function app.
 ms.topic: conceptual
 ms.custom: devx-track-csharp
 ms.author: jobreen
@@ -12,9 +12,9 @@ ms.date: 06/20/2019
 
 This article is a basic reference for a custom provider C# RESTful endpoint. If you're unfamiliar with Azure Custom Providers, see [the overview on custom resource providers](overview.md).
 
-## Azure function app RESTful endpoint
+## Azure Function app RESTful endpoint
 
-The following code works with an Azure function app. To learn how to set up an Azure function app to work with Azure Custom Providers, see [the tutorial on setting up Azure Functions for Azure Custom Providers](./tutorial-custom-providers-function-setup.md).
+The following code works with an Azure Function app. To learn how to set up an Azure Function app to work with Azure Custom Providers, see [the tutorial on setting up Azure Functions for Azure Custom Providers](./tutorial-custom-providers-function-setup.md).
 
 ```csharp
 #r "Newtonsoft.Json"


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint