### PR TITLE
Update resource name limit for Policyassignments

### DIFF
--- a/articles/azure-resource-manager/management/resource-name-rules.md
+++ b/articles/azure-resource-manager/management/resource-name-rules.md
@@ -78,7 +78,7 @@ In the following tables, the term alphanumeric refers to:
 > | Entity | Scope | Length | Valid Characters |
 > | --- | --- | --- | --- |
 > | locks | scope of assignment | 1-90 | Alphanumerics, periods, underscores, hyphens, and parenthesis.<br><br>Can't end in period. |
-> | policyAssignments | scope of assignment | 1-128 display name<br><br>1-64 resource name | Display name can contain any characters.<br><br>Resource name can't include `%` and can't end with period or space. |
+> | policyAssignments | scope of assignment | 1-128 display name<br><br>1-64 resource name<br><br>1-24 resource name at management group scope | Display name can contain any characters.<br><br>Resource name can't include `%` and can't end with period or space. |
 > | policyDefinitions | scope of definition | 1-128 display name<br><br>1-64 resource name | Display name can contain any characters.<br><br>Resource name can't include `%` and can't end with period or space. |
 > | policySetDefinitions | scope of definition | 1-128 display name<br><br>1-64 resource name<br><br>1-24 resource name at management group scope | Display name can contain any characters.<br><br>Resource name can't include `%` and can't end with period or space.  |
 


### PR DESCRIPTION
As per the documentation, we have highlighted that the resource naming limit for policyassignment resource name can be between 1-64 characters. 

The resource name for the policyassignment resource when assigned at Management group scope is limited to 1-24 characters like what we have explained for policySetDefinition resource in the documentation. 

The limit for policyassignments resource name at Management group scope should be added to the documentation