### PR TITLE
Update virtual-networks-faq.md

### DIFF
--- a/articles/virtual-network/virtual-networks-faq.md
+++ b/articles/virtual-network/virtual-networks-faq.md
@@ -387,6 +387,9 @@ When virtual network service endpoints are enabled, the source IP addresses of t
 
 ### Does the service endpoint route always take precedence?
 Service endpoints add a system route which takes precedence over BGP routes and provides optimum routing for the service endpoint traffic. Service endpoints always take service traffic directly from your virtual network to the service on the Microsoft Azure backbone network. For more information about how Azure selects a route, see [Azure Virtual network traffic routing](virtual-networks-udr-overview.md).
+
+### Do service endpoints work with ICMP?
+No, ICMP traffic that is sourced from a subnet with service endpoints enabled will not take the service tunnel path to the desired endpoint. Service endpoints will only handle TCP traffic. This means that if you want to test latency or connectivity to an endpoint via service endpoints, tools like ping and tracert will not show the true path that the resources within the subnet will take.
  
 ### How does NSG on a subnet work with service endpoints?
 To reach the Azure service, NSGs need to allow outbound connectivity. If your NSGs are opened to all Internet outbound traffic, then the service endpoint traffic should work. You can also limit the outbound traffic to service IPs only using the Service tags.  


### PR DESCRIPTION
Wanted to add in Considerations that ICMP traffic is not serviced by Service Endpoints. Azure customers open Support Requests after enabling Service Endpoints because they believe their routing is misconfigured after a simple tracert. This detail can lengthen troubleshooting efforts for normal performance/latency issues because the route being worked on is the incorrect one.
Originally added on to virtual-network-service-endpoints-overview.md in Considerations section but asked to send to FAQ.