### PR TITLE
Fix spelling error in deploy-to-hololens.md

### DIFF
--- a/articles/remote-rendering/quickstarts/deploy-to-hololens.md
+++ b/articles/remote-rendering/quickstarts/deploy-to-hololens.md
@@ -43,7 +43,7 @@ Make sure your credentials are saved properly with the scene and you can connect
 1. For the project 'Quickstart', go to *Properties > Debugging*
     1. Make sure the configuration *Release* is active
     1. Set *Debugger to Launch* to **Remote Machine**
-    1. Change *Machine Name* to the **IP of your HoleLens**
+    1. Change *Machine Name* to the **IP of your HoloLens**
 
 ## Launch the sample project
 


### PR DESCRIPTION
I corrected "HoleLens" to "HoloLens" on line 46 of the deploy to HoloLens quick start.