### PR TITLE
Remove `migration` directory command is updated

### DIFF
--- a/articles/app-service/tutorial-dotnetcore-sqldb-app.md
+++ b/articles/app-service/tutorial-dotnetcore-sqldb-app.md
@@ -186,7 +186,7 @@ From the repository root, run the following commands. Replace *\<connection-stri
 
 ```
 # Delete old migrations
-rm Migrations -r
+rm -r Migrations
 # Recreate migrations
 dotnet ef migrations add InitialCreate
 


### PR DESCRIPTION
The `remove migration directory` command is updated.

The bash command for removing a directory recursively would be `rm -r <directoryName>`  or  `rm -rf <directoryName>`.