### PR TITLE
Update concept-conditional-access-grant.md

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-grant.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-grant.md
@@ -136,7 +136,7 @@ This setting applies to the following client apps:
 - Nine Mail - Email & Calendar
 
 > [!NOTE]
-> Microsoft Kaizala, Microsoft Skype for Business and Microsoft Visio do not support the **Require app protection policy** grant. If you require these apps to work, please use the **Require approved apps** grant exclusively. The use of the or clause between the two grants will not work for these three applications.
+> Microsoft Teams, Microsoft Kaizala, Microsoft Skype for Business and Microsoft Visio do not support the **Require app protection policy** grant. If you require these apps to work, please use the **Require approved apps** grant exclusively. The use of the or clause between the two grants will not work for these three applications.
 
 **Remarks**
 


### PR DESCRIPTION
Microsoft Teams is not currently supported by require app protection policy control.  It should be added to this special note as it is probably more widely used than other apps in this note.