### PR TITLE
Add note about ListInstancesAsync returning first page only

### DIFF
--- a/articles/azure-functions/durable/durable-functions-instance-management.md
+++ b/articles/azure-functions/durable/durable-functions-instance-management.md
@@ -296,6 +296,10 @@ public static async Task Run(
     {
         log.LogInformation(JsonConvert.SerializeObject(instance));
     }
+    
+    // Note: ListInstancesAsync only returns the first page of results.
+    // To request additional pages provide the result.ContinuationToken
+    // to the OrchestrationStatusQueryCondition's ContinuationToken property.
 }
 ```
 


### PR DESCRIPTION
I don't know if this is the best way to express this in documentation but it's something I found. This change happened in https://github.com/Azure/azure-functions-durable-extension/pull/1168.