### PR TITLE
Update gremlin-headers.md

### DIFF
--- a/articles/cosmos-db/gremlin-headers.md
+++ b/articles/cosmos-db/gremlin-headers.md
@@ -31,13 +31,12 @@ Keep in mind that taking dependency on these headers you are limiting portabilit
 
 ## Status codes
 
-Most common status codes returned by the server are listed below.
+Most common codes returned for `x-ms-status-code` status attribute by the server are listed below.
 
 | Status | Explanation |
 | --- | --- |
 | **401** | Error message `"Unauthorized: Invalid credentials provided"` is returned when authentication password doesn't match Cosmos DB account key. Navigate to your Cosmos DB Gremlin account in the Azure portal and confirm that the key is correct.|
 | **404** | Concurrent operations that attempt to delete and update the same edge or vertex simultaneously. Error message `"Owner resource does not exist"` indicates that specified database or collection is incorrect in connection parameters in `/dbs/<database name>/colls/<collection or graph name>` format.|
-| **408** | `"Server timeout"` indicates that traversal took more than **30 seconds** and was canceled by the server. Optimize your traversals to run quickly by filtering vertices or edges on every hop of traversal to narrow down search scope.|
 | **409** | `"Conflicting request to resource has been attempted. Retry to avoid conflicts."` This usually happens when vertex or an edge with an identifier already exists in the graph.| 
 | **412** | Status code is complemented with error message `"PreconditionFailedException": One of the specified pre-condition is not met`. This error is indicative of an optimistic concurrency control violation between reading an edge or vertex and writing it back to the store after modification. Most common situations when this error occurs is property modification, for example `g.V('identifier').property('name','value')`. Gremlin engine would read the vertex, modify it, and write it back. If there is another traversal running in parallel trying to write the same vertex or an edge, one of them will receive this error. Application should submit traversal to the server again.| 
 | **429** | Request was throttled and should be retried after value in **x-ms-retry-after-ms**| 
@@ -48,6 +47,7 @@ Most common status codes returned by the server are listed below.
 | **1004** | This status code indicates malformed graph request. Request can be malformed when it fails deserialization, non-value type is being deserialized as value type or unsupported gremlin operation requested. Application should not retry the request because it will not be successful. | 
 | **1007** | Usually this status code is returned with error message `"Could not process request. Underlying connection has been closed."`. This situation can happen if client driver attempts to use a connection that is being closed by the server. Application should retry the traversal on a different connection.
 | **1008** | Cosmos DB Gremlin server can terminate connections to rebalance traffic in the cluster. Client drivers should handle this situation and use only live connections to send requests to the server. Occasionally client drivers may not detect that connection was closed. When application encounters an error, `"Connection is too busy. Please retry after sometime or open more connections."` it should retry traversal on a different connection.
+| **1009** | The operation did not complete in the allotted time and was canceled by the server. Optimize your traversals to run quickly by filtering vertices or edges on every hop of traversal to narrow down search scope. Request timeout default is **60 seconds** |
 
 ## Samples
 

--- a/articles/cosmos-db/gremlin-headers.md
+++ b/articles/cosmos-db/gremlin-headers.md
@@ -47,7 +47,7 @@ Most common codes returned for `x-ms-status-code` status attribute by the server
 | **1004** | This status code indicates malformed graph request. Request can be malformed when it fails deserialization, non-value type is being deserialized as value type or unsupported gremlin operation requested. Application should not retry the request because it will not be successful. | 
 | **1007** | Usually this status code is returned with error message `"Could not process request. Underlying connection has been closed."`. This situation can happen if client driver attempts to use a connection that is being closed by the server. Application should retry the traversal on a different connection.
 | **1008** | Cosmos DB Gremlin server can terminate connections to rebalance traffic in the cluster. Client drivers should handle this situation and use only live connections to send requests to the server. Occasionally client drivers may not detect that connection was closed. When application encounters an error, `"Connection is too busy. Please retry after sometime or open more connections."` it should retry traversal on a different connection.
-| **1009** | The operation did not complete in the allotted time and was canceled by the server. Optimize your traversals to run quickly by filtering vertices or edges on every hop of traversal to narrow down search scope. Request timeout default is **60 seconds** |
+| **1009** | The operation did not complete in the allotted time and was canceled by the server. Optimize your traversals to run quickly by filtering vertices or edges on every hop of traversal to narrow search scope. Request timeout default is **60 seconds**. |
 
 ## Samples
 


### PR DESCRIPTION
Identify that the status codes are the codes returned for `x-ms-status-code` header.
Remove 408 status code since x-ms-status-code, and replaced it with 1009 which is the expected request timeout status code.
408 is reserved for low-level store timeouts and isn't expected to occur particularly for bad request cases.
Can consider still having a 408 entry listed, but it should be considered a retryable.