### PR TITLE
Update copy-activity-schema-and-type-mapping.md

### DIFF
--- a/articles/data-factory/copy-activity-schema-and-type-mapping.md
+++ b/articles/data-factory/copy-activity-schema-and-type-mapping.md
@@ -182,7 +182,8 @@ You can define such mapping on Data Factory authoring UI:
 
 3. Map the needed fields to sink. Data Factory automatically determines the corresponding JSON paths for the hierarchical side.
 
-Note that for records where the array marked as collection reference is empty and the checkbox is checked - the whole record is skipped.
+> [!NOTE]
+> For records where the array marked as collection reference is empty and the check box is selected, the entire record is skipped.
 
 ![Map hierarchical to tabular using UI](media/copy-activity-schema-and-type-mapping/map-hierarchical-to-tabular-ui.png)
 

--- a/articles/data-factory/copy-activity-schema-and-type-mapping.md
+++ b/articles/data-factory/copy-activity-schema-and-type-mapping.md
@@ -182,6 +182,8 @@ You can define such mapping on Data Factory authoring UI:
 
 3. Map the needed fields to sink. Data Factory automatically determines the corresponding JSON paths for the hierarchical side.
 
+Note that for records where the array marked as collection reference is empty and the checkbox is checked - the whole record is skipped.
+
 ![Map hierarchical to tabular using UI](media/copy-activity-schema-and-type-mapping/map-hierarchical-to-tabular-ui.png)
 
 You can also switch to **Advanced editor**, in which case you can directly see and edit the fields' JSON paths. If you choose to add new mapping in this view, specify the JSON path.


### PR DESCRIPTION
Added mention of default behavior if the collection reference array is empty.
Research and details described here:
https://stackoverflow.com/questions/65731324/azure-data-factory-skipped-rows-with-empty-collection-reference-when-flattenin