### PR TITLE
Use Rust const for Ipv4Addr instead of [127, 0, 0, 1]

### DIFF
--- a/articles/azure-functions/create-first-function-vs-code-other.md
+++ b/articles/azure-functions/create-first-function-vs-code-other.md
@@ -145,6 +145,7 @@ The *function.json* file in the *HttpExample* folder declares an HTTP trigger fu
     ```rust
     use std::collections::HashMap;
     use std::env;
+    use std::net::Ipv4Addr;
     use warp::{http::Response, Filter};
 
     #[tokio::main]
@@ -164,7 +165,7 @@ The *function.json* file in the *HttpExample* folder declares an HTTP trigger fu
             Err(_) => 3000,
         };
 
-        warp::serve(example1).run(([127, 0, 0, 1], port)).await
+        warp::serve(example1).run((Ipv4Addr::UNSPECIFIED, port)).await
     }
     ```
 


### PR DESCRIPTION
Update example to utilise `impl ToSocketAddrs for (Ipv4Addr, u16)` with const value for `Ipv4Addr::UNSPECIFIED` for address

There's also `std::net::Ipv4Addr::LOCALHOST` but the go example leaves address blank indicating unspecified so using the same setup here