### PR TITLE
The Location should be used as app region

### DIFF
--- a/articles/azure-functions/functions-event-hub-cosmos-db.md
+++ b/articles/azure-functions/functions-event-hub-cosmos-db.md
@@ -367,6 +367,7 @@ mvn archetype:generate --batch-mode \
     -DarchetypeArtifactId=azure-functions-archetype \
     -DappName=$FUNCTION_APP \
     -DresourceGroup=$RESOURCE_GROUP \
+    -DappRegion=$LOCATION \
     -DgroupId=com.example \
     -DartifactId=telemetry-functions
 ```
@@ -379,6 +380,7 @@ mvn archetype:generate --batch-mode ^
     -DarchetypeArtifactId=azure-functions-archetype ^
     -DappName=%FUNCTION_APP% ^
     -DresourceGroup=%RESOURCE_GROUP% ^
+    -DappRegion=%LOCATION% ^ 
     -DgroupId=com.example ^
     -DartifactId=telemetry-functions
 ```


### PR DESCRIPTION
The Location should be used as app region to generate the function otherwise it will always fall back to west-us. (and would have to be changed in pom.xml.)