### PR TITLE
Update cross-region-replication-introduction.md

### DIFF
--- a/articles/azure-netapp-files/cross-region-replication-introduction.md
+++ b/articles/azure-netapp-files/cross-region-replication-introduction.md
@@ -18,7 +18,7 @@ ms.author: b-juche
 ---
 # Cross-region replication of Azure NetApp Files volumes
 
-The Azure NetApp Files replication functionality provides data protection through cross-region volume replication. You can asynchronously replicate data from an Azure NetApp Files volume (source) in one region to another Azure NetApp Files volume (destination) in another region.  This capability enables you to failover your critical application in case of a region-wide outage or disaster.
+The Azure NetApp Files replication functionality provides data protection through cross-region volume replication. You can asynchronously replicate data from an Azure NetApp Files volume (source) in one region to another Azure NetApp Files volume (destination) in another region.  This capability enables you to failover your critical application in case of a region-wide outage or disaster. Note: * The Azure NetApp Files destination volume is read-only until you fail-over to your destination region enabling the destination ANF volume for read and write. 
 
 > [!IMPORTANT]
 > The cross-region replication feature is currently in public preview. You need to submit a waitlist request for accessing the feature through the [Azure NetApp Files cross-region replication waitlist submission page](https://aka.ms/anfcrrpreviewsignup). Wait for an official confirmation email from the Azure NetApp Files team before using the cross-region replication feature.


### PR DESCRIPTION
I have a customer who requested we clearly state that the destination volume is read-only until failover in our documentation. I realize it's on the fail-over page, but it may be good on this page too as this explains CRR versus the how-to. 
 
"Note: * The Azure NetApp Files destination volume is read-only until you fail-over to your destination region enabling the destination ANF volume for read and write. "