### PR TITLE
Update rust dependencies to use tokio 1.0

### DIFF
--- a/articles/azure-functions/create-first-function-vs-code-other.md
+++ b/articles/azure-functions/create-first-function-vs-code-other.md
@@ -136,8 +136,8 @@ The *function.json* file in the *HttpExample* folder declares an HTTP trigger fu
 
     ```toml
     [dependencies]
-    warp = "0.2"
-    tokio = { version = "0.2", features = ["full"] }
+    warp = "0.3"
+    tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
     ```
 
 1. In *src/main.rs*, add the following code and save the file. This is your Rust custom handler.


### PR DESCRIPTION
- Warp framework and tokio runtime updated to use the tokio 1.0 release
- Also minimised tokio features utilised to run example code