### PR TITLE
Fixed [parameters('certificatesPermissions')] missing brackets in Access Policy ARM Template

### DIFF
--- a/articles/key-vault/general/vault-create-template.md
+++ b/articles/key-vault/general/vault-create-template.md
@@ -148,7 +148,7 @@ You can deploy access policies to an existing key vault without redeploying the 
             "permissions": {
               "keys": "[parameters('keysPermissions')]",
               "secrets": "[parameters('secretsPermissions')]",
-              "certificates": [parameters('certificatesPermissions')]
+              "certificates": "[parameters('certificatesPermissions')]"
             }
           }
         ]

--- a/articles/key-vault/general/vault-create-template.md
+++ b/articles/key-vault/general/vault-create-template.md
@@ -158,6 +158,7 @@ You can deploy access policies to an existing key vault without redeploying the 
 }
 
 ```
+
 For more information about Key Vault template settings, see [Key Vault ARM template reference](/azure/templates/microsoft.keyvault/vaults/accesspolicies).
 
 ## More Key Vault Resource Manager templates


### PR DESCRIPTION
As seen, in the example there are missing brackets

![image](https://user-images.githubusercontent.com/8051297/105331655-ffa28480-5bd3-11eb-84f2-97bb9d6895f2.png)
