### PR TITLE
Update: Identify legacy authentication use

### DIFF
--- a/articles/active-directory/fundamentals/concept-fundamentals-block-legacy-authentication.md
+++ b/articles/active-directory/fundamentals/concept-fundamentals-block-legacy-authentication.md
@@ -34,6 +34,7 @@ Before you can block legacy authentication in your directory, you need to first 
 1. Filter by **Client App** > check all the **Legacy Authentication Clients** options presented.
 1. Filter by **Status** > **Success**. 
 1. Expand your date range if necessary using the **Date** filter.
+1. If you are activated the [new sign-in activity reports preview](https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/concept-all-sign-ins), repeat the above steps also on the **User sign-ins (non-interactive)** tab.
 
 Filtering will only show you successful sign-in attempts that were made by the selected legacy authentication protocols. Clicking on each individual sign-in attempt will show you additional details. The Client App column or the Client App field under the Basic Info tab after selecting an individual row of data will indicate which legacy authentication protocol was used. 
 These logs will indicate which users are still depending on legacy authentication and which applications are using legacy protocols to make authentication requests. For users that do not appear in these logs and are confirmed to not be using legacy authentication, implement a Conditional Access policy or enable the Baseline policy: block legacy authentication for these users only.

--- a/articles/active-directory/fundamentals/concept-fundamentals-block-legacy-authentication.md
+++ b/articles/active-directory/fundamentals/concept-fundamentals-block-legacy-authentication.md
@@ -34,7 +34,7 @@ Before you can block legacy authentication in your directory, you need to first 
 1. Filter by **Client App** > check all the **Legacy Authentication Clients** options presented.
 1. Filter by **Status** > **Success**. 
 1. Expand your date range if necessary using the **Date** filter.
-1. If you are activated the [new sign-in activity reports preview](https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/concept-all-sign-ins), repeat the above steps also on the **User sign-ins (non-interactive)** tab.
+1. If you have activated the [new sign-in activity reports preview](https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/concept-all-sign-ins), repeat the above steps also on the **User sign-ins (non-interactive)** tab.
 
 Filtering will only show you successful sign-in attempts that were made by the selected legacy authentication protocols. Clicking on each individual sign-in attempt will show you additional details. The Client App column or the Client App field under the Basic Info tab after selecting an individual row of data will indicate which legacy authentication protocol was used. 
 These logs will indicate which users are still depending on legacy authentication and which applications are using legacy protocols to make authentication requests. For users that do not appear in these logs and are confirmed to not be using legacy authentication, implement a Conditional Access policy or enable the Baseline policy: block legacy authentication for these users only.


### PR DESCRIPTION
It should be clarified to also look during legacy authentication discovery on the **non-interactive sign-ins** page. 
There are cases where for instance POP connections stay alive after the initial interactive sign-in for many days/weeks, and don't show up again in interactive sign-in reports, even though there are hundreds of daily **non-interactive** sign-ins for the same POP connection. Given that the interactive sign-in report only goes back for 30 days, the importance of these legacy auth connections that appear only sporadically in the interactive sign-in logs could be easily missed.