### PR TITLE
Update: Identify legacy authentication use

### DIFF
--- a/articles/active-directory/conditional-access/block-legacy-authentication.md
+++ b/articles/active-directory/conditional-access/block-legacy-authentication.md
@@ -80,6 +80,7 @@ Before you can block legacy authentication in your directory, you need to first 
 1. Navigate to the **Azure portal** > **Azure Active Directory** > **Sign-ins**.
 1. Add the Client App column if it is not shown by clicking on **Columns** > **Client App**.
 1. **Add filters** > **Client App** > select all of the legacy authentication protocols. Select outside the filtering dialog box to apply your selections and close the dialog box.
+1. If you have activated the [new sign-in activity reports preview](https://docs.microsoft.com/en-us/azure/active-directory/reports-monitoring/concept-all-sign-ins), repeat the above steps also on the **User sign-ins (non-interactive)** tab.
 
 Filtering will only show you sign-in attempts that were made by legacy authentication protocols. Clicking on each individual sign-in attempt will show you additional details. The **Client App** field under the **Basic Info** tab will indicate which legacy authentication protocol was used.
 


### PR DESCRIPTION
It should be clarified to also look during legacy authentication discovery on the **non-interactive sign-ins** page. 
There are cases where for instance POP connections stay alive after the initial interactive sign-in for many days/weeks, and don't show up again in interactive sign-in reports, even though there are hundreds of daily **non-interactive** sign-ins for the same POP connection. Given that the interactive sign-in report only goes back for 30 days, the importance of these legacy auth connections that appear only sporadically in the interactive sign-in logs could be easily missed.