### PR TITLE
Fixed writing mistake.

### DIFF
--- a/articles/active-directory/develop/configure-token-lifetimes.md
+++ b/articles/active-directory/develop/configure-token-lifetimes.md
@@ -80,7 +80,7 @@ In this example, you create a policy that requires users to authenticate more fr
 
 ## Create token lifetime policies for refresh and session tokens
 > [!IMPORTANT]
-> As of May 2020, new tenants can not configure refresh and session token lifetimes.  Tenants with existing configuration can modify refresh and session token policies until January 30, 2021.  Azure Active Directory will stop honoring existing refresh and session token configuration in policies after January 30, 2021. You can still configure access, SAML, and ID token lifetimes after the retirement.
+> As of May 2020, new tenants cannot configure refresh and session token lifetimes.  Tenants with existing configuration can modify refresh and session token policies until January 30, 2021.  Azure Active Directory will stop honoring existing refresh and session token configuration in policies after January 30, 2021. You can still configure access, SAML, and ID token lifetimes after the retirement.
 >
 > If you need to continue to define the time period before a user is asked to sign in again, configure sign-in frequency in Conditional Access. To learn more about Conditional Access, read [Configure authentication session management with Conditional Access](../conditional-access/howto-conditional-access-session-lifetime.md).
 >


### PR DESCRIPTION
"Can not" is for the rare circumstance where a writer wishes to say "there is an option not to do something."
"Cannot" is the word meaning "something is unable to be done."
Nota bene: It's best to avoid "can not" in anything but the most informal of writing, as there are countless more-elegant ways to express that not doing something is an option.