### PR TITLE
Update source-control.md

### DIFF
--- a/articles/data-factory/source-control.md
+++ b/articles/data-factory/source-control.md
@@ -25,7 +25,7 @@ By default, the Azure Data Factory user interface experience (UX) authors direct
 To provide a better authoring experience, Azure Data Factory allows you to configure a Git repository with either Azure Repos or GitHub. Git is a version control system that allows for easier change tracking and collaboration. This article will outline how to configure and work in a git repository along with highlighting best practices and a troubleshooting guide.
 
 > [!NOTE]
-> Azure Data Factory git integration is only available for GitHub Enterprise in the Azure Government Cloud.
+> For Azure Government Cloud, only GitHub Enterprise is available.
 
 To learn more about how Azure Data Factory integrates with Git, view the 15-minute tutorial video below:
 


### PR DESCRIPTION
Customer has become confused on the wording around GovCloud and believe they must use GovCloud for GitHub Enterprise. They currently (and want to only) use public Azure but also want to use GitHub Enterprise on-premises. Please see changed wording for the Note at the top of the page.