### PR TITLE
added Python tab and sample to set cloud role name

### DIFF
--- a/articles/azure-monitor/app/app-map.md
+++ b/articles/azure-monitor/app/app-map.md
@@ -220,6 +220,21 @@ appInsights.addTelemetryInitializer((envelope) => {
 });
 });
 ```
+
+# [Python](#tab/python)
+
+For Python, [OpenCensus Python telemetry processors](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-filtering-sampling#opencensus-python-telemetry-processors) can be used.
+
+```python
+def callback_function(envelope):
+   envelope.tags['ai.cloud.role'] = 'new_role_name'
+   
+// AzureLogHandler
+handler.add_telemetry_processor(callback_function)
+
+// AzureExporter
+exporter.add_telemetry_processor(callback_function)
+```
 ---
 
 ### Understanding cloud role name within the context of the Application Map

--- a/articles/azure-monitor/app/app-map.md
+++ b/articles/azure-monitor/app/app-map.md
@@ -223,7 +223,7 @@ appInsights.addTelemetryInitializer((envelope) => {
 
 # [Python](#tab/python)
 
-For Python, [OpenCensus Python telemetry processors]((api-filtering-sampling.md#opencensus-python-telemetry-processors) can be used.
+For Python, [OpenCensus Python telemetry processors](api-filtering-sampling.md#opencensus-python-telemetry-processors) can be used.
 
 ```python
 def callback_function(envelope):

--- a/articles/azure-monitor/app/app-map.md
+++ b/articles/azure-monitor/app/app-map.md
@@ -223,7 +223,7 @@ appInsights.addTelemetryInitializer((envelope) => {
 
 # [Python](#tab/python)
 
-For Python, [OpenCensus Python telemetry processors](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-filtering-sampling#opencensus-python-telemetry-processors) can be used.
+For Python, [OpenCensus Python telemetry processors]((api-filtering-sampling.md#opencensus-python-telemetry-processors) can be used.
 
 ```python
 def callback_function(envelope):


### PR DESCRIPTION
Added section (another tab) for Python -in addition to .NET, Java, Node.js and JavaScript on how to set or override cloud role name. 