### PR TITLE
mention of 443 creates a confusion with customer

### DIFF
--- a/articles/virtual-network/troubleshoot-outbound-smtp-connectivity.md
+++ b/articles/virtual-network/troubleshoot-outbound-smtp-connectivity.md
@@ -24,7 +24,7 @@ This change in behavior applies only to subscriptions and deployments that were 
 
 ## Recommended method of sending email
 
-We recommend you use authenticated SMTP relay services to send email from Azure VMs or from Azure App Service. (These relay services typically connect through TCP port 587 or 443, but they support other ports.) These services are used to maintain IP or domain reputation to minimize the possibility that third-party email providers will reject messages. [SendGrid](https://sendgrid.com/partners/azure/) is one such SMTP relay service, but there are others. You might also have a secure SMTP relay service running on-premises that you can use.
+We recommend you use authenticated SMTP relay services to send email from Azure VMs or from Azure App Service. (These relay services typically connect through TCP port 587, but they support other ports.) These services are used to maintain IP or domain reputation to minimize the possibility that third-party email providers will reject messages. [SendGrid](https://sendgrid.com/partners/azure/) is one such SMTP relay service, but there are others. You might also have a secure SMTP relay service running on-premises that you can use.
 
 Using these email delivery services isn't restricted in Azure, regardless of the subscription type.
 


### PR DESCRIPTION
TCP Port 443 is used only for HTTP communications. Either we should remove this mention of 443 is not per standards or else we should put a disclaimer that this port on the application server should not be utilized by any other service then they can use. We had a customer coming with receive connector configuration with 443 and because 443 is used by IIS for Exchange Webservices, frontend transport service fails to start. Even though you mention that this is non-standard they keep coming back with this article mentioning for SMTP you can use 443. Need to fix this.