### PR TITLE
Updating Private Endpoint for SQL Backups

### DIFF
--- a/articles/backup/private-endpoints.md
+++ b/articles/backup/private-endpoints.md
@@ -27,7 +27,7 @@ This article will help you understand the process of creating private endpoints 
 
 While private endpoints are enabled for the vault, they're used for backup and restore of SQL and SAP HANA workloads in an Azure VM and MARS agent backup only. You can use the vault for backup of other workloads as well (they won't require private endpoints though). In addition to backup of SQL and SAP HANA workloads and backup using the MARS agent, private endpoints are also used to perform file recovery for Azure VM backup. For more information, see the following table:
 
-| Backup of workloads in Azure VM (SQL, SAP HANA), Backup  using MARS Agent | Use of private endpoints is recommended to allow backup  and restore without needing to allow-list any IPs/FQDNs for Azure Backup or Azure  Storage  from your virtual networks. |
+| Backup of workloads in Azure VM (SQL, SAP HANA), Backup  using MARS Agent | Use of private endpoints is recommended to allow backup  and restore without needing to allow-list any IPs/FQDNs for Azure Backup or Azure  Storage  from your virtual networks. You will however, need to ensure the VM's hosting SQL databases can reach AzureActiveDirectory IP's/FQDNs |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | **Azure  VM backup**                                         | VM backup doesn't require you to allow access to any IPs or FQDNs. So it doesn't require private endpoints for backup and restore  of disks.  <br><br>   However, file recovery from a vault containing private endpoints would be restricted to virtual networks that contain a private endpoint for the vault. <br><br>    When using ACL’ed unmanaged disks, ensure the  storage account containing the disks allows access to **trusted Microsoft services** if it's ACL’ed. |
 | **Azure  Files backup**                                      | Azure Files backups are stored in the local  storage account. So it doesn't require private endpoints for backup and  restore. |
@@ -385,7 +385,7 @@ $privateEndpoint = New-AzPrivateEndpoint `
 
 #### Create DNS zones for custom DNS servers
 
-You need to create three private DNS zones and link them to your virtual network.
+You need to create three private DNS zones and link them to your virtual network. Keep in mind, the Backup Service Public URL's will not register in Azure Public DNS for the redirection to the privatelink DNS zones like Blob, and Queue will. 
 
 | **Zone**                                                     | **Service** |
 | ------------------------------------------------------------ | ----------- |

--- a/articles/backup/private-endpoints.md
+++ b/articles/backup/private-endpoints.md
@@ -27,7 +27,7 @@ This article will help you understand the process of creating private endpoints 
 
 While private endpoints are enabled for the vault, they're used for backup and restore of SQL and SAP HANA workloads in an Azure VM and MARS agent backup only. You can use the vault for backup of other workloads as well (they won't require private endpoints though). In addition to backup of SQL and SAP HANA workloads and backup using the MARS agent, private endpoints are also used to perform file recovery for Azure VM backup. For more information, see the following table:
 
-| Backup of workloads in Azure VM (SQL, SAP HANA), Backup  using MARS Agent | Use of private endpoints is recommended to allow backup  and restore without needing to allow-list any IPs/FQDNs for Azure Backup or Azure  Storage  from your virtual networks. You will however, need to ensure the VM's hosting SQL databases can reach AzureActiveDirectory IP's/FQDNs |
+| Backup of workloads in Azure VM (SQL, SAP HANA), Backup using MARS Agent | Use of private endpoints is recommended to allow backup and restore without needing to allowlist any IPs/FQDNs for Azure Backup or Azure Storage from your virtual networks. In that scenario, ensure that VMs that host SQL databases can reach Azure AD IPs or FQDNs. |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | **Azure  VM backup**                                         | VM backup doesn't require you to allow access to any IPs or FQDNs. So it doesn't require private endpoints for backup and restore  of disks.  <br><br>   However, file recovery from a vault containing private endpoints would be restricted to virtual networks that contain a private endpoint for the vault. <br><br>    When using ACL’ed unmanaged disks, ensure the  storage account containing the disks allows access to **trusted Microsoft services** if it's ACL’ed. |
 | **Azure  Files backup**                                      | Azure Files backups are stored in the local  storage account. So it doesn't require private endpoints for backup and  restore. |
@@ -385,7 +385,7 @@ $privateEndpoint = New-AzPrivateEndpoint `
 
 #### Create DNS zones for custom DNS servers
 
-You need to create three private DNS zones and link them to your virtual network. Keep in mind, the Backup Service Public URL's will not register in Azure Public DNS for the redirection to the privatelink DNS zones like Blob, and Queue will. 
+You need to create three private DNS zones and link them to your virtual network. Keep in mind that, unlike Blob and Queue, the Backup service public URLs don't register in Azure Public DNS for the redirection to the Private Link DNS zones. 
 
 | **Zone**                                                     | **Service** |
 | ------------------------------------------------------------ | ----------- |


### PR DESCRIPTION
* Adding another location highlighting the importance\ need to add AzureActiveDirectory IP's / FQDN's to the machines you wish to backup SQL Databases on for private endpoints to work
* clarifying the AzureBackup endpoints will not have any public DNS redirection to the privatelink DNS zones