### PR TITLE
Added WS 2016 and later as PRT doc

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sso.md
+++ b/articles/active-directory/hybrid/how-to-connect-sso.md
@@ -31,7 +31,7 @@ Seamless SSO can be combined with either the [Password Hash Synchronization](how
 
 ## SSO via primary refresh token vs. Seamless SSO
 
-For Windows 10, it’s recommended to use SSO via primary refresh token (PRT). For windows 7 and 8.1 it’s recommended to use Seamless SSO.
+For Windows 10, Windows Server 2016 and later versions, it’s recommended to use SSO via primary refresh token (PRT). For windows 7 and 8.1 it’s recommended to use Seamless SSO.
 Seamless SSO needs the user's device to be domain-joined, but it is not used on Windows 10 [Azure AD joined devices](../devices/concept-azure-ad-join.md) or [hybrid Azure AD joined devices](../devices/concept-azure-ad-join-hybrid.md). SSO on Azure AD joined, Hybrid Azure AD joined, and Azure AD registered devices works based on the [Primary Refresh Token (PRT)](../devices/concept-primary-refresh-token.md)
 
 SSO via PRT works once devices are registered with Azure AD for hybrid Azure AD joined, Azure AD joined or personal registered devices via Add Work or School Account. 


### PR DESCRIPTION
Added 'Windows Server 2016 and later' as the following PRT doc to make it more clearer to customer:
https://docs.microsoft.com/en-us/azure/active-directory/devices/concept-primary-refresh-token