### PR TITLE
Update search-get-started-python.md

### DIFF
--- a/articles/search/search-get-started-python.md
+++ b/articles/search/search-get-started-python.md
@@ -172,8 +172,7 @@ To load documents, create a documents collection, using an [index action](/pytho
 1. In a new cell, provide four documents that conform to the index schema. Specify an upload action for each document.
 
     ```python
-    documents = {
-        "value": [
+    documents = [
         {
         "@search.action": "upload",
         "HotelId": "1",
@@ -251,7 +250,6 @@ To load documents, create a documents collection, using an [index action](/pytho
             }
         }
     ]
-    }
     ```  
 
 1. In another cell, formulate the request. This upload_documents request targets the docs collection of the hotels-quickstart index and pushes the documents provided in the previous step into the Cognitive Search index.


### PR DESCRIPTION
Removing the property "value" from the documents declaration as that is failing in Python with the error “() The request is invalid. Details: parameters : A resource without a type name was found, but no expected type was specified. To allow entries without type information, the expected type must also be specified when the model is specified.”