### PR TITLE
fix tip syntax for markdown display formatting

### DIFF
--- a/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
+++ b/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
@@ -44,7 +44,7 @@ Now, on your local shell, create an empty standard HDD for uploading by specifyi
 Replace `<yourdiskname>`, `<yourresourcegroupname>`, and `<yourregion>` then run the following commands:
 
 > [!TIP]
-> If you are creating an OS disk, add -HyperVGeneration '<yourGeneration>' to `New-AzDiskConfig`.
+> If you are creating an OS disk, add `-HyperVGeneration '<yourGeneration>'`  to `New-AzDiskConfig`.
 
 ```powershell
 $vhdSizeBytes = (Get-Item "<fullFilePathHere>").length

--- a/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
+++ b/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
@@ -44,7 +44,7 @@ Now, on your local shell, create an empty standard HDD for uploading by specifyi
 Replace `<yourdiskname>`, `<yourresourcegroupname>`, and `<yourregion>` then run the following commands:
 
 > [!TIP]
-> If you are creating an OS disk, add `-HyperVGeneration '<yourGeneration>'`  to `New-AzDiskConfig`.
+> If you are creating an OS disk, add `-HyperVGeneration '<yourGeneration>'` to `New-AzDiskConfig`.
 
 ```powershell
 $vhdSizeBytes = (Get-Item "<fullFilePathHere>").length


### PR DESCRIPTION
markdown format corrected to allow display of parameter by fixing quotation syntax and placement for tip on adding hypervgeneration