### PR TITLE
Update expressroute-howto-set-global-reach-cli.md

### DIFF
--- a/articles/expressroute/expressroute-howto-set-global-reach-cli.md
+++ b/articles/expressroute/expressroute-howto-set-global-reach-cli.md
@@ -54,7 +54,7 @@ When running the command to enable connectivity, note the following requirements
 
 * *peer-circuit* should be the full resource ID. For example:
 
-  > /subscriptions/{your_subscription_id}/resourceGroups/{your_resource_group}/providers/Microsoft.Network/expressRouteCircuits/{your_circuit_name}
+  > /subscriptions/{your_subscription_id}/resourceGroups/{your_resource_group}/providers/Microsoft.Network/expressRouteCircuits/{your_circuit_name}/peerings/AzurePrivatePeering
 
 * *address-prefix* must be a "/29" IPv4 subnet (for example, "10.0.0.0/29"). We use IP addresses in this subnet to establish connectivity between the two ExpressRoute circuits. You can't use addresses in this subnet in your Azure virtual networks or in your on-premises networks.
 


### PR DESCRIPTION
I have tested that process in my Lab and it is required to specify "/peerings/AzurePrivatePeering" after circuit name. Therefore, recommend include the changes above.