### PR TITLE
missing character

### DIFF
--- a/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
+++ b/articles/virtual-machines/windows/disks-upload-vhd-to-managed-disk-powershell.md
@@ -51,7 +51,7 @@ $vhdSizeBytes = (Get-Item "<fullFilePathHere>").length
 
 $diskconfig = New-AzDiskConfig -SkuName 'Standard_LRS' -OsType 'Windows' -UploadSizeInBytes $vhdSizeBytes -Location '<yourregion>' -CreateOption 'Upload'
 
-New-AzDisk -ResourceGroupName '<yourresourcegroupname' -DiskName '<yourdiskname>' -Disk $diskconfig
+New-AzDisk -ResourceGroupName '<yourresourcegroupname>' -DiskName '<yourdiskname>' -Disk $diskconfig
 ```
 
 If you would like to upload either a premium SSD or a standard SSD, replace **Standard_LRS** with either **Premium_LRS** or **StandardSSD_LRS**. Ultra disks are not yet supported.


### PR DESCRIPTION
missing character change '<yourresourcegroupname' to '<yourresourcegroupname>'