### PR TITLE
section moving a blob to a new tier

### DIFF
--- a/articles/storage/blobs/snapshots-overview.md
+++ b/articles/storage/blobs/snapshots-overview.md
@@ -127,6 +127,8 @@ The following table describes the billing behavior for a blob or snapshot when i
 
 The following diagram illustrates how objects are billed when a blob with snapshots is moved to a different tier.
 
+(modify image)
+
 :::image type="content" source="media/snapshots-overview/snapshot-billing-tiers.png" alt-text="Diagram showing how objects are billed when a blob with snapshots is explicitly tiered.":::
 
 Explicitly setting the tier for a blob, version, or snapshot cannot be undone. If you move a blob to a new tier and then move it back to its original tier, you are charged for the full content length of the object even if it shares blocks with other objects in the original tier.


### PR DESCRIPTION
the image in the section “moving a blob to a new tier” is not clear. In other parts of the text, snapshot1 has been used as the first snapshot taken so it should continue to be considered the “oldest snapshot”. The proposed changes are:
1. Snapshot2 should become Snapshot1 and Snapshot1 becomes Snapshot2.
2. The new Snapshot2 should have the las 2 blocks selected (blocks with IDs 4 and 5) which are the ones that represent the “unique blocks in other objects”.