### PR TITLE
replaces 'bundle --path' with 'bundle config set --local path'

### DIFF
--- a/articles/app-service/configure-language-ruby.md
+++ b/articles/app-service/configure-language-ruby.md
@@ -62,7 +62,7 @@ When you deploy a [Git repository](deploy-local-git.md), or a [Zip package](depl
 
 1. Check if a *Gemfile* exists.
 1. Run `bundle clean`. 
-1. Run `bundle install --path "vendor/bundle"`.
+1. Run `bundle config set --local path '"vendor/bundle"`.
 1. Run `bundle package` to package gems into vendor/cache folder.
 
 ### Use --without flag


### PR DESCRIPTION
The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag