### PR TITLE
Fix hyphens in sample code

### DIFF
--- a/articles/storage/common/storage-use-azcopy-files.md
+++ b/articles/storage/common/storage-use-azcopy-files.md
@@ -119,7 +119,7 @@ Use the [azcopy copy](storage-ref-azcopy-copy.md) command with the `--include-pa
 
 You can also exclude files by using the `--exclude-pattern` option. To learn more, see [azcopy copy](storage-ref-azcopy-copy.md) reference docs.
 
-The `--include-pattern` and `--exclude-pattern` options apply only to filenames and not to the path.  If you want to copy all of the text files that exist in a directory tree, use the `–recursive` option to get the entire directory tree, and then use the `–include-pattern` and specify `*.txt` to get all of the text files.
+The `--include-pattern` and `--exclude-pattern` options apply only to filenames and not to the path.  If you want to copy all of the text files that exist in a directory tree, use the `--recursive` option to get the entire directory tree, and then use the `--include-pattern` and specify `*.txt` to get all of the text files.
 
 #### Upload files that were modified after a date and time 
 
@@ -214,7 +214,7 @@ Use the [azcopy copy](storage-ref-azcopy-copy.md) command with the `--include-pa
 
 You can also exclude files by using the `--exclude-pattern` option. To learn more, see [azcopy copy](storage-ref-azcopy-copy.md) reference docs.
 
-The `--include-pattern` and `--exclude-pattern` options apply only to filenames and not to the path.  If you want to copy all of the text files that exist in a directory tree, use the `–recursive` option to get the entire directory tree, and then use the `–include-pattern` and specify `*.txt` to get all of the text files.
+The `--include-pattern` and `--exclude-pattern` options apply only to filenames and not to the path.  If you want to copy all of the text files that exist in a directory tree, use the `--recursive` option to get the entire directory tree, and then use the `--include-pattern` and specify `*.txt` to get all of the text files.
 
 #### Download files that were modified after a date and time 
 


### PR DESCRIPTION
Some of the same code has a wide unicode hyphen (instead of `–` instead of `--`). This PR corrects those.