### PR TITLE
Update logs-dedicated-clusters.md

### DIFF
--- a/articles/azure-monitor/log-query/logs-dedicated-clusters.md
+++ b/articles/azure-monitor/log-query/logs-dedicated-clusters.md
@@ -79,7 +79,7 @@ After you create your *Cluster* resource, you can edit additional properties suc
 You can have up to 2 active clusters per subscription per region. If cluster is deleted, it is still reserved for 14 days. You can have up to 4 reserved clusters per subscription per region (active or recently deleted).
 
 > [!WARNING]
-> Cluster creation triggers resource allocation and provisioning. This operation can take up to an hour to complete. It is recommended to run it asynchronously.
+> Cluster creation triggers resource allocation and provisioning. This operation can take a few hours to complete. It is recommended to run it asynchronously.
 
 The user account that creates the clusters must have the standard Azure resource creation permission: `Microsoft.Resources/deployments/*` and cluster write permission `Microsoft.OperationalInsights/clusters/write` by having in their role assignments this specific action or `Microsoft.OperationalInsights/*` or `*/write`.
 


### PR DESCRIPTION
Changing this sentence:
"This operation can take a few hours to complete"
It was saying "an hour" before and customers raised service requests as cluster was not in succeeded state within the hour and status displays ProvisioningAccount while provisioning