### PR TITLE
Added "Assign Roles to Groups, not Users"

### DIFF
--- a/articles/role-based-access-control/best-practices.md
+++ b/articles/role-based-access-control/best-practices.md
@@ -41,7 +41,7 @@ For more information, see [What is Azure AD Privileged Identity Management?](../
 
 ## Assign Roles to Groups, not Users
 
-Users should never be assigned roles directly, because it would make roles assignments less manageable. Moreover, assigning the roles to Groups helps to never hit the limit of 2000 role assignments per subscription. For more information, see [Azure role assignments limit](https://docs.microsoft.com/en-us/azure/role-based-access-control/troubleshooting#azure-role-assignments-limit). 
+You should avoid assigning roles directly to users because it makes role assignments less manageable. Also, it increases the number of role assignments, which has a [limit of 2000 role assignments per subscription](troubleshooting.md#azure-role-assignments-limit). Instead, you should assign role to groups.
 
 ## Next steps
 

--- a/articles/role-based-access-control/best-practices.md
+++ b/articles/role-based-access-control/best-practices.md
@@ -39,6 +39,10 @@ To protect privileged accounts from malicious cyber-attacks, you can use Azure A
 
 For more information, see [What is Azure AD Privileged Identity Management?](../active-directory/privileged-identity-management/pim-configure.md).
 
+## Assign Roles to Groups, not Users
+
+Users should never be assigned roles directly, because it would make roles assignments less manageable. Moreover, assigning the roles to Groups helps to never hit the limit of 2000 role assignments per subscription. For more information, see [Azure role assignments limit](https://docs.microsoft.com/en-us/azure/role-based-access-control/troubleshooting#azure-role-assignments-limit). 
+
 ## Next steps
 
 - [Troubleshoot Azure RBAC](troubleshooting.md)

--- a/articles/role-based-access-control/best-practices.md
+++ b/articles/role-based-access-control/best-practices.md
@@ -39,9 +39,9 @@ To protect privileged accounts from malicious cyber-attacks, you can use Azure A
 
 For more information, see [What is Azure AD Privileged Identity Management?](../active-directory/privileged-identity-management/pim-configure.md).
 
-## Assign Roles to Groups, not Users
+## Assign roles to groups, not users
 
-You should avoid assigning roles directly to users because it makes role assignments less manageable. Also, it increases the number of role assignments, which has a [limit of 2000 role assignments per subscription](troubleshooting.md#azure-role-assignments-limit). Instead, you should assign role to groups.
+To make role assignments more manageable, avoid assigning roles directly to users. Instead, assign roles to groups. Assigning roles to groups instead of users also helps minimize the number of role assignments, which has a [limit of 2,000 role assignments per subscription](troubleshooting.md#azure-role-assignments-limit). 
 
 ## Next steps
 


### PR DESCRIPTION
I am a MS employee (simonec).
I propose to add the best practice "Assign Roles to Groups, not Users".