### PR TITLE
Add missing method call in code snippet.

### DIFF
--- a/articles/azure-app-configuration/enable-dynamic-configuration-aspnet-core.md
+++ b/articles/azure-app-configuration/enable-dynamic-configuration-aspnet-core.md
@@ -183,6 +183,7 @@ A *sentinel key* is a special key used to signal when configuration has changed.
     {
         services.Configure<Settings>(Configuration.GetSection("TestApp:Settings"));
         services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+        services.AddAzureAppConfiguration();
     }
     ```
     ---


### PR DESCRIPTION
The example code snippet is broken because of this missing method call.