### PR TITLE
Fix typo: sckit-learn -> scikit-learn

### DIFF
--- a/articles/machine-learning/how-to-configure-auto-train.md
+++ b/articles/machine-learning/how-to-configure-auto-train.md
@@ -419,7 +419,7 @@ For general information on how model explanations and feature importance can be 
   * Attribute errors: Ex. `AttributeError: 'SimpleImputer' object has no attribute 'add_indicator`
   
   To work around this issue, take either of the following two steps depending on your `AutoML` SDK training version:
-    * If your `AutoML` SDK training version is greater than 1.13.0, you need `pandas == 0.25.1` and `sckit-learn==0.22.1`. If there is a version mismatch, upgrade scikit-learn and/or pandas to correct version as shown below:
+    * If your `AutoML` SDK training version is greater than 1.13.0, you need `pandas == 0.25.1` and `scikit-learn==0.22.1`. If there is a version mismatch, upgrade scikit-learn and/or pandas to correct version as shown below:
       
       ```bash
          pip install --upgrade pandas==0.25.1


### PR DESCRIPTION
Found a typo in the Official AzureML Autotrain configuration page.

It mentions that we need to install a specific version of `scikit-learn` in specific circumstances, but a simple copy-and-paste didn't work, and it took me a while to realize that the package name had a typo in it.