### PR TITLE
Added a failure reason as per PG recommendations

### DIFF
--- a/articles/active-directory/devices/troubleshoot-hybrid-join-windows-legacy.md
+++ b/articles/active-directory/devices/troubleshoot-hybrid-join-windows-legacy.md
@@ -74,6 +74,7 @@ If the device was not hybrid Azure AD joined, you can attempt to do hybrid Azure
    - Network connectivity issues may be preventing **autoworkplace.exe** from reaching AD FS or the Azure AD URLs. 
    - **Autoworkplace.exe** requires the client to have direct line of sight from the client to the organization's on-premises AD domain controller, which means that hybrid Azure AD join succeeds only when the client is connected to organization's intranet.
    - Your organization uses Azure AD Seamless Single Sign-On, `https://autologon.microsoftazuread-sso.com` or `https://aadg.windows.net.nsatc.net` are not present on the device's IE intranet settings, and **Allow updates to status bar via script** is not enabled for the Intranet zone.
+   - Your organization uses Azure AD Seamless Single Sign-On, Internet Explorer Enhanced Security Configuration (IE SEC) is enabled and Desktop/Seamless SSO domains are not whitelisted.
 - You are not signed on as a domain user
 
    :::image type="content" source="./media/troubleshoot-hybrid-join-windows-legacy/03.png" alt-text="Screenshot of the Workplace Join for Windows dialog box. Text reports that an error occurred during account verification." border="false":::


### PR DESCRIPTION
Added a failure reason as per PG recommendations: If Internet Explorer Enhanced Security Configuration (IE SEC) is enabled, Desktop/Seamless SSO domains should be whitelisted.