### PR TITLE
Added a failure reason as per PG recommendations

### DIFF
--- a/articles/active-directory/hybrid/tshoot-connect-sso.md
+++ b/articles/active-directory/hybrid/tshoot-connect-sso.md
@@ -72,6 +72,7 @@ Use the following checklist to troubleshoot Seamless SSO problems:
 - Ensure that the Seamless SSO feature is enabled in Azure AD Connect. If you can't enable the feature (for example, due to a blocked port), ensure that you have all the [prerequisites](how-to-connect-sso-quick-start.md#step-1-check-the-prerequisites) in place.
 - If you have enabled both [Azure AD Join](../devices/overview.md) and Seamless SSO on your tenant, ensure that the issue is not with Azure AD Join. SSO from Azure AD Join takes precedence over Seamless SSO if the device is both registered with Azure AD and domain-joined. With SSO from Azure AD Join the user sees a sign-in tile that says "Connected to Windows".
 - Ensure that the Azure AD URL (`https://autologon.microsoftazuread-sso.com`) is part of the user's Intranet zone settings.
+- If Internet Explorer Enhanced Security Configuration (IE SEC) is enabled, Desktop/Seamless SSO domains should be whitelisted.
 - Ensure that the corporate device is joined to the Active Directory domain. The device _doesn't_ need to be [Azure AD Joined](../devices/overview.md) for Seamless SSO to work.
 - Ensure that the user is logged on to the device through an Active Directory domain account.
 - Ensure that the user's account is from an Active Directory forest where Seamless SSO has been set up.


### PR DESCRIPTION
Added a failure reason as per PG recommendations: If Internet Explorer Enhanced Security Configuration (IE SEC) is enabled, Desktop/Seamless SSO domains should be whitelisted.