### PR TITLE
GraphAPIAuthorizationMessageHandler.cs name incorrect

### DIFF
--- a/articles/active-directory/develop/tutorial-blazor-webassembly.md
+++ b/articles/active-directory/develop/tutorial-blazor-webassembly.md
@@ -99,7 +99,7 @@ Next, add the following to your project's *.csproj* file in the netstandard2.1 *
 
 Then modify the code as specified in the next few steps. These changes will add [access tokens](access-tokens.md) to the outgoing requests sent to the Microsoft Graph API. This pattern is discussed in more detail in [ASP.NET Core Blazor WebAssembly additional security scenarios](/aspnet/core/blazor/security/webassembly/additional-scenarios).
 
-First, create a new file named *GraphAuthorizationMessageHandler.cs* with the following code. This handler will be user to add an access token for the `User.Read` and `Mail.Read` scopes to outgoing requests to the Microsoft Graph API.
+First, create a new file named *GraphAPIAuthorizationMessageHandler.cs* with the following code. This handler will be user to add an access token for the `User.Read` and `Mail.Read` scopes to outgoing requests to the Microsoft Graph API.
 
 ```csharp
 using Microsoft.AspNetCore.Components;


### PR DESCRIPTION
Added the 'API' text into the name of the new .cs file to match the rest of the code.