### PR TITLE
Update database-copy.md

### DIFF
--- a/articles/azure-sql/database/database-copy.md
+++ b/articles/azure-sql/database/database-copy.md
@@ -137,6 +137,8 @@ CREATE LOGIN loginname WITH PASSWORD = 'xxxxxxxxx'
 GO
 CREATE USER [loginname] FOR LOGIN [loginname] WITH DEFAULT_SCHEMA=[dbo]
 GO
+exec sp_addrolemember 'dbmanager','loginname'
+GO
 
 Step# 2
 Create the user in the source database and grant dbowner permission to the database.

--- a/articles/azure-sql/database/database-copy.md
+++ b/articles/azure-sql/database/database-copy.md
@@ -186,7 +186,7 @@ Monitor the copying process by querying the [sys.databases](/sql/relational-data
 > If you decide to cancel the copying while it is in progress, execute the [DROP DATABASE](/sql/t-sql/statements/drop-database-transact-sql) statement on the new database.
 
 > [!IMPORTANT]
-> If you need to create a copy with a substantially smaller service objective than the source, the target database may not have sufficient resources to complete the seeding process and it can cause the copy operaion to fail. In this scenario use a geo-restore request to create a copy in a different server and/or a different region. See [Recover an Azure SQL Database using database backups](recovery-using-backups.md#geo-restore) for more information.
+> If you need to create a copy with a substantially smaller service objective than the source, the target database may not have sufficient resources to complete the seeding process and it can cause the copy operation to fail. In this scenario use a geo-restore request to create a copy in a different server and/or a different region. See [Recover an Azure SQL Database using database backups](recovery-using-backups.md#geo-restore) for more information.
 
 ## Azure roles to manage database copy
 


### PR DESCRIPTION
One further thing, in the "Copy to a different subscription" section it explains that the login must be a member of the dbmanager role on BOTH source and target servers. In the example SQL only the target login is added to that role. In this example script the source login has no permissions.