### PR TITLE
Update availability-group-manually-configure-multiple-regions.md

### DIFF
--- a/articles/azure-sql/virtual-machines/windows/availability-group-manually-configure-multiple-regions.md
+++ b/articles/azure-sql/virtual-machines/windows/availability-group-manually-configure-multiple-regions.md
@@ -84,6 +84,7 @@ To create a replica in a remote data center, do the following steps:
    - Use a TCP port probe specific to the IP address.
    - Have a load balancing rule specific to the SQL Server in the same region.  
    - Be a Standard Load Balancer if the virtual machines in the backend pool are not part of either a single availability set or virtual machine scale set. For additional information review [Azure Load Balancer Standard overview](../../../load-balancer/load-balancer-overview.md).
+   - Be a Standard Load Balancer if the two virtual networks in two different regions are peered over Global VNet Peering. For additional information review [Azure Virtual Network frequently asked questions (FAQ)](../../../virtual-network/virtual-networks-faq.md#what-are-the-constraints-related-to-global-vnet-peering-and-load-balancers).
 
 1. [Add Failover Clustering feature to the new SQL Server](availability-group-manually-configure-prerequisites-tutorial.md#add-failover-clustering-features-to-both-sql-server-vms).
 

--- a/articles/azure-sql/virtual-machines/windows/availability-group-manually-configure-multiple-regions.md
+++ b/articles/azure-sql/virtual-machines/windows/availability-group-manually-configure-multiple-regions.md
@@ -84,7 +84,7 @@ To create a replica in a remote data center, do the following steps:
    - Use a TCP port probe specific to the IP address.
    - Have a load balancing rule specific to the SQL Server in the same region.  
    - Be a Standard Load Balancer if the virtual machines in the backend pool are not part of either a single availability set or virtual machine scale set. For additional information review [Azure Load Balancer Standard overview](../../../load-balancer/load-balancer-overview.md).
-   - Be a Standard Load Balancer if the two virtual networks in two different regions are peered over Global VNet Peering. For additional information review [Azure Virtual Network frequently asked questions (FAQ)](../../../virtual-network/virtual-networks-faq.md#what-are-the-constraints-related-to-global-vnet-peering-and-load-balancers).
+   - Be a Standard Load Balancer if the two virtual networks in two different regions are peered over global VNet peering. For more information, see [Azure Virtual Network frequently asked questions (FAQ)](../../../virtual-network/virtual-networks-faq.md#what-are-the-constraints-related-to-global-vnet-peering-and-load-balancers).
 
 1. [Add Failover Clustering feature to the new SQL Server](availability-group-manually-configure-prerequisites-tutorial.md#add-failover-clustering-features-to-both-sql-server-vms).
 


### PR DESCRIPTION
Although the doc uses VNet-to-VNet VPN for connectivity, some customers use Global VNet peering and select Basic Load Balancers. This configuration will stop connectivity to the listener in a remote region.

Added additional point to LB selection for clarity.