### PR TITLE
Link to model docs from relationship limits.

### DIFF
--- a/includes/digital-twins-limits.md
+++ b/includes/digital-twins-limits.md
@@ -9,14 +9,16 @@ ms.author: baanders
 
 ### Functional limits
 
-The table below lists the functional limits of Azure Digital Twins.
+The table below lists the functional limits of Azure Digital Twins. See 
+[Best Practices for Designing Models](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models)
+for modeling recommendations to operate within these functional limits.
 
 | Area | Capability | Default limit | Adjustable? |
 | --- | --- | --- | --- |
 | Azure resource | Number of Azure Digital Twins instances in a region, per subscription | 10 | Yes |
 | Digital twins | Number of twins in an Azure Digital Twins instance | 200,000 | Yes |
-| Digital twins | Number of incoming relationships to a single twin. See [Modeling Best Practices](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models) for alternatives. | 5,000 | No |
-| Digital twins | Number of outgoing relationships from a single twin. See [Modeling Best Practices](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models) for alternatives. | 5,000 | No |
+| Digital twins | Number of incoming relationships to a single twin. | 5,000 | No |
+| Digital twins | Number of outgoing relationships from a single twin. | 5,000 | No |
 | Digital twins | Maximum size (of JSON body in a PUT or PATCH request) of a single twin | 32 KB | No |
 | Digital twins | Maximum request payload size | 32 KB | No | 
 | Routing | Number of endpoints for a single Azure Digital Twins instance | 6 | No |

--- a/includes/digital-twins-limits.md
+++ b/includes/digital-twins-limits.md
@@ -17,8 +17,8 @@ for modeling recommendations to operate within these functional limits.
 | --- | --- | --- | --- |
 | Azure resource | Number of Azure Digital Twins instances in a region, per subscription | 10 | Yes |
 | Digital twins | Number of twins in an Azure Digital Twins instance | 200,000 | Yes |
-| Digital twins | Number of incoming relationships to a single twin. | 5,000 | No |
-| Digital twins | Number of outgoing relationships from a single twin. | 5,000 | No |
+| Digital twins | Number of incoming relationships to a single twin | 5,000 | No |
+| Digital twins | Number of outgoing relationships from a single twin | 5,000 | No |
 | Digital twins | Maximum size (of JSON body in a PUT or PATCH request) of a single twin | 32 KB | No |
 | Digital twins | Maximum request payload size | 32 KB | No | 
 | Routing | Number of endpoints for a single Azure Digital Twins instance | 6 | No |

--- a/includes/digital-twins-limits.md
+++ b/includes/digital-twins-limits.md
@@ -9,10 +9,10 @@ ms.author: baanders
 
 ### Functional limits
 
-The table below lists the functional limits of Azure Digital Twins. 
+The following table lists the functional limits of Azure Digital Twins. 
 
 > [!TIP]
-> See [Best Practices for Designing Models](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models) for modeling recommendations to operate within these functional limits.
+> For modeling recommendations to operate within these functional limits, see [Best practices for designing models](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models).
 
 | Area | Capability | Default limit | Adjustable? |
 | --- | --- | --- | --- |

--- a/includes/digital-twins-limits.md
+++ b/includes/digital-twins-limits.md
@@ -9,9 +9,10 @@ ms.author: baanders
 
 ### Functional limits
 
-The table below lists the functional limits of Azure Digital Twins. See 
-[Best Practices for Designing Models](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models)
-for modeling recommendations to operate within these functional limits.
+The table below lists the functional limits of Azure Digital Twins. 
+
+> [!TIP]
+> See [Best Practices for Designing Models](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models) for modeling recommendations to operate within these functional limits.
 
 | Area | Capability | Default limit | Adjustable? |
 | --- | --- | --- | --- |

--- a/includes/digital-twins-limits.md
+++ b/includes/digital-twins-limits.md
@@ -15,8 +15,8 @@ The table below lists the functional limits of Azure Digital Twins.
 | --- | --- | --- | --- |
 | Azure resource | Number of Azure Digital Twins instances in a region, per subscription | 10 | Yes |
 | Digital twins | Number of twins in an Azure Digital Twins instance | 200,000 | Yes |
-| Digital twins | Number of incoming relationships to a single twin | 5,000 | No |
-| Digital twins | Number of outgoing relationships from a single twin | 5,000 | No |
+| Digital twins | Number of incoming relationships to a single twin. See [Modeling Best Practices](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models) for alternatives. | 5,000 | No |
+| Digital twins | Number of outgoing relationships from a single twin. See [Modeling Best Practices](../articles/digital-twins/concepts-models.md#best-practices-for-designing-models) for alternatives. | 5,000 | No |
 | Digital twins | Maximum size (of JSON body in a PUT or PATCH request) of a single twin | 32 KB | No |
 | Digital twins | Maximum request payload size | 32 KB | No | 
 | Routing | Number of endpoints for a single Azure Digital Twins instance | 6 | No |


### PR DESCRIPTION
Reference our modeling best practices in regards to the limits on maximum number of outgoing and incoming relationships from a single twins. Customers will have more success in many cases by modeling these as properties rather than relationships.