### PR TITLE
Update pstn-call-js.md

### DIFF
--- a/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-js.md
+++ b/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-js.md
@@ -62,9 +62,9 @@ const hangUpPhoneButton = document.getElementById("hang-up-phone-button");
 
 async function init() {
     const callClient = new CallClient();
-    const tokenCredential = new AzureCommunicationUserCredential('your-token-here');
+    const tokenCredential = new AzureCommunicationTokenCredential('<USER ACCESS TOKEN with PSTN scope>');
     callAgent = await callClient.createCallAgent(tokenCredential);
-  //  callButton.disabled = false;
+  //  callPhoneButton.disabled = false;
 }
 
 init();


### PR DESCRIPTION
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-js.md
there are 3 places to improve
1. AzureCommunicationUserCredential is out of date. it is used in 1.0.0-beta.3 version or before. now we should use https://docs.microsoft.com/en-us/javascript/api/@azure/communication-common/azurecommunicationtokencredential?view=azure-node-preview 
2. // callButton.disabled is incorrect object. the code snippet created callPhoneButton object instead of callButton object
3. ('your-token-here') is not clear to customer. we should use the matching format for other doc something like '<USER ACCESS TOKEN with PSTN scope>'