### PR TITLE
Update api-management-dapr-policies.md

### DIFF
--- a/articles/api-management/api-management-dapr-policies.md
+++ b/articles/api-management/api-management-dapr-policies.md
@@ -106,7 +106,7 @@ The policy assumes that Dapr runtime is running in a sidecar container in the sa
 ### Policy statement
 
 ```xml
-<publish-to-dapr pubsub-name="pubsub-name" topic=”topic-name” ignore-error="false|true" response-variable-name="resp-var-name" timeout="in seconds" template=”Liquid” content-type="application/json">
+<publish-to-dapr pubsub-name="pubsub-name" topic="topic-name" ignore-error="false|true" response-variable-name="resp-var-name" timeout="in seconds" template="Liquid" content-type="application/json">
     <!-- message content -->
 </publish-to-dapr>
 ```
@@ -178,9 +178,9 @@ The policy assumes that Dapr runtime is running in a sidecar container in the sa
 ### Policy statement
 
 ```xml
-<invoke-dapr-binding name=”bind-name" operation="op-name" ignore-error="false|true" response-variable-name="resp-var-name" timeout="in seconds" template=”Liquid content-type="application/json">
+<invoke-dapr-binding name="bind-name" operation="op-name" ignore-error="false|true" response-variable-name="resp-var-name" timeout="in seconds" template="Liquid" content-type="application/json">
     <metadata>
-        <item key=”item-name”><!-- item-value --></item>
+        <item key="item-name"><!-- item-value --></item>
     </metadata>
     <data>
         <!-- message content -->


### PR DESCRIPTION
- Changed [right double quotation mark](https://www.compart.com/en/unicode/U+201D) to [quotation mark](https://www.compart.com/en/unicode/U+0022).
- Added missing quotation mark in "Trigger output binding" -> "Policy statement".