### PR TITLE
Update sap-hana-high-availability-scale-out-hsr-rhel.md

### DIFF
--- a/articles/virtual-machines/workloads/sap/sap-hana-high-availability-scale-out-hsr-rhel.md
+++ b/articles/virtual-machines/workloads/sap/sap-hana-high-availability-scale-out-hsr-rhel.md
@@ -196,7 +196,7 @@ For the configuration presented in this document, deploy seven virtual machines:
       1. Enter the name of the new back-end pool (for example, **hana-backend**).
       1. Select **Add a virtual machine**.
       1. Select **Virtual machine**.
-      1. Select the virtual machines of the SAP HANA cluster and their IP addresses for the `client` subnet.
+      1. Select the virtual machines acting as Master node from both site of the SAP HANA cluster and their IP addresses for the `client` subnet.
       1. Select **Add**.
 
    1. Next, create a health probe:


### PR DESCRIPTION
Virtual IP always can fail-over to Master node. No need to add worker node in backend pool