### PR TITLE
replace mention of acr with amr

### DIFF
--- a/articles/active-directory/develop/access-tokens.md
+++ b/articles/active-directory/develop/access-tokens.md
@@ -237,7 +237,7 @@ Your application's business logic will dictate this step, some common authorizat
 * Validate the authentication status of the calling client using `appidacr` - it shouldn't be 0 if public clients aren't allowed to call your API.
 * Check against a list of past `nonce` claims to verify the token isn't being replayed.
 * Check that the `tid` matches a tenant that is allowed to call your API.
-* Use the `acr` claim to verify the user has performed MFA. This should be enforced using [Conditional Access](../conditional-access/overview.md).
+* Use the `amr` claim to verify the user has performed MFA. This should be enforced using [Conditional Access](../conditional-access/overview.md).
 * If you've requested the `roles` or `groups` claims in the access token, verify that the user is in the group allowed to do this action.
   * For tokens retrieved using the implicit flow, you'll likely need to query the [Microsoft Graph](https://developer.microsoft.com/graph/) for this data, as it's often too large to fit in the token.
 


### PR DESCRIPTION
If what I'm reading in various places is correct, amr is now what should be used to validate a user has preformed MFA. Alternatively instead of replacing acr with amr, it could say "Use the `amr` or  `acr` claim to verify..."