### PR TITLE
Update samsung-knox-and-business-services-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/samsung-knox-and-business-services-tutorial.md
+++ b/articles/active-directory/saas-apps/samsung-knox-and-business-services-tutorial.md
@@ -27,7 +27,7 @@ In this tutorial, you'll learn how to integrate Samsung Knox and Business Servic
 To get started, you need the following items:
 
 * An Azure AD subscription. If you don't have a subscription, you can get a [free account](https://azure.microsoft.com/free/).
-* Samsung Knox and Business Services single sign-on (SSO) enabled subscription.
+* A Samsung Knox account.
 
 ## Scenario description
 
@@ -51,7 +51,7 @@ To configure the integration of Samsung Knox and Business Services into Azure AD
 
 ## Configure and test Azure AD SSO for Samsung Knox and Business Services
 
-Configure and test Azure AD SSO with Samsung Knox and Business Services using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between an Azure AD user and the related user in Samsung Knox and Business Services.
+Configure and test Azure AD SSO with Samsung Knox and Business Services using a test user called **B.Simon**. For SSO to work, you need to establish a link relationship between an Azure AD user and the related user in [SamsungKnox.com](https://samsungknox.com/).
 
 To configure and test Azure AD SSO with Samsung Knox and Business Services, perform the following steps:
 
@@ -74,8 +74,12 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
 1. On the **Basic SAML Configuration** section, enter the values for the following fields:
 
-	In the **Sign on URL** text box, type the URL:
-    `https://www.samsungknox.com`
+	* In the **Sign on URL** text box, type the URL:
+	`https://www.samsungknox.com`
+	* In the **Reply URL (assertion consumer service URL)** text box, type the URL: 
+	`https://central.samsungknox.com/ams/ad/saml/acs`
+	
+	![Basic SAML Configuration values](https://docs.samsungknox.com/assets/merge/ad-sso/basic-saml-configuration.png)
 
 1. On the **Set up single sign-on with SAML** page, In the **SAML Signing Certificate** section, click copy button to copy **App Federation Metadata Url** and save it on your computer.
 
@@ -107,7 +111,7 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 ## Configure Samsung Knox and Business Services SSO
 
-1. In a different web browser window, sign in to your Samsung Knox and Business Services company site as an administrator.
+1. In a different web browser window, sign in to [SamsungKnox.com](https://samsungknox.com/) as an administrator.
 
 1. Click on the **Avatar** on the top right corner.
 
@@ -115,28 +119,27 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 1. In the left sidebar, click **ACTIVE DIRECTORY SETTINGS** and perform the following steps.
 
-    ![ACTIVE DIRECTORY SETTINGS](./media/samsung-knox-and-business-services-tutorial/sso-settings.png)
+    ![ACTIVE DIRECTORY SETTINGS](https://docs.samsungknox.com/assets/merge/ad-sso/ad-5.png)
 
     a. In the **Identifier(entity ID)** textbox, paste the **Identifier** value which you have entered in the Azure portal.
 
     b. In the **App federation metadata URL** textbox, paste the **App Federation Metadata Url** value which you have copied from the Azure portal.
 
-    c. click on **CONNECT TO AD SSO**.
+    c. Click on **CONNECT TO AD SSO**.
 
 ### Create Samsung Knox and Business Services test user
 
-In this section, you create a user called Britta Simon in Samsung Knox and Business Services. Work with [Samsung Knox and Business Services support team](mailto:noreplyk.sec@samsung.com) to add the users in the Samsung Knox and Business Services platform. Users must be created and activated before you use single sign-on.
+In this section, you create a user called Britta Simon in Samsung Knox and Business Services. Refer to the [Knox Configure](https://docs.samsungknox.com/admin/knox-configure/Administrators.htm) or [Knox Mobile Enrollment](https://docs.samsungknox.com/admin/knox-mobile-enrollment/kme-add-an-admin.htm) admin guides for instructions on how to invite a sub-administrator, or test user, to your Samsung Knox organization. Users must be created and activated before you use single sign-on.
 
 ## Test SSO 
 
 In this section, you test your Azure AD single sign-on configuration with following options. 
 
-* Click on **Test this application** in Azure portal. This will redirect to Samsung Knox and Business Services Sign-on URL where you can initiate the login flow. 
+* Click on **Test this application** in Azure portal. This will redirect to [SamsungKnox.com](https://samsungknox.com/), where you can initiate the login flow. 
 
-* Go to Samsung Knox and Business Services Sign-on URL directly and initiate the login flow from there.
+* Go to [SamsungKnox.com](https://samsungknox.com/) directly and initiate the login flow from there.
 
-* You can use Microsoft My Apps. When you click the Samsung Knox and Business Services tile in the My Apps, this will redirect to Samsung Knox and Business Services Sign-on URL. For more information about the My Apps, see [Introduction to the My Apps](https://docs.microsoft.com/azure/active-directory/active-directory-saas-access-panel-introduction).
-
+* You can use Microsoft My Apps. When you click the Samsung Knox and Business Services tile in the My Apps, this will redirect to [SamsungKnox.com](https://samsungknox.com/). For more information about the My Apps, see [Introduction to the My Apps](https://docs.microsoft.com/azure/active-directory/active-directory-saas-access-panel-introduction).
 
 ## Next steps
 


### PR DESCRIPTION
I'm a technical writer for Samsung, handling the Azure AD SSO documentation on our side. I'd like to propose a few changes to clarify the integration process further:

- Update the "Create Samsung Knox and Business test user" section to reflect our sub-admin sign-up flow.  For more info, see: https://docs.samsungknox.com/admin/ad-sso/step-4-invite-sub-admins.htm
- Provided links to updated screenshots. The new versions show the prod environment instead of stg—feel free to upload these to your own domain. 
- Update several instances of "Samsung Knox and Business Services Sign-on URL" to "SamsungKnox.com" for brevity.

If you have any questions about these changes, please let me know.