### PR TITLE
Correcting PSModulesPath to PSModulePath

### DIFF
--- a/articles/cosmos-db/emulator-command-line-parameters.md
+++ b/articles/cosmos-db/emulator-command-line-parameters.md
@@ -70,10 +70,10 @@ The emulator comes with a PowerShell module to start, stop, uninstall, and retri
 Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
 ```
 
-or place the `PSModules` directory on your `PSModulesPath` and import it as shown in the following command:
+or place the `PSModules` directory on your `PSModulePath` and import it as shown in the following command:
 
 ```powershell
-$env:PSModulesPath += "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules"
+$env:PSModulePath += "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules"
 Import-Module Microsoft.Azure.CosmosDB.Emulator
 ```
 


### PR DESCRIPTION
Per the [powershell documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath?view=powershell-7.1), this variable should be PSModulePath, not PSModule**s**Path