### PR TITLE
Update hdinsight-hadoop-access-yarn-app-logs-linux.md

### DIFF
--- a/articles/hdinsight/hdinsight-hadoop-access-yarn-app-logs-linux.md
+++ b/articles/hdinsight/hdinsight-hadoop-access-yarn-app-logs-linux.md
@@ -32,7 +32,7 @@ YARN Timeline Server includes the following type of data:
 
 ## YARN applications and logs
 
-Application logs (and the associated container logs) are critical in debugging problematic Hadoop applications. YARN provides a nice framework for collecting, aggregating, and storing application logs with [Log Aggregation](https://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/).
+Application logs (and the associated container logs) are critical in debugging problematic Hadoop applications. YARN provides a nice framework for collecting, aggregating, and storing application logs with Log Aggregation.
 
 The Log Aggregation feature makes accessing application logs more deterministic. It aggregates logs across all containers on a worker node and stores them as one aggregated log file per worker node. The log is stored on the default file system after an application finishes. Your application may use hundreds or thousands of containers, but logs for all containers run on a single worker node are always aggregated to a single file. So there's only 1 log per worker node used by your application. Log Aggregation is enabled by default on HDInsight clusters version 3.0 and above. Aggregated logs are located in default storage for the cluster. The following path is the HDFS path to the logs:
 


### PR DESCRIPTION
Changed from [Log Aggregation](https://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/) to Log aggregation, removed the link as the link is broken and refers to Hortonworks