### PR TITLE
Provide a line break in 'using cloud shell editor' doc.

### DIFF
--- a/articles/cloud-shell/using-cloud-shell-editor.md
+++ b/articles/cloud-shell/using-cloud-shell-editor.md
@@ -48,5 +48,6 @@ To launch the command palette, use the `F1` key when focus is set on the editor.
 Language highlight support in the Cloud Shell editor is supported through upstream functionality in the [Monaco Editor](https://github.com/Microsoft/monaco-editor)'s use of Monarch syntax definitions. To learn how to make contributions, read the [Monaco contributor guide](https://github.com/Microsoft/monaco-editor/blob/master/CONTRIBUTING.md).
 
 ## Next steps
-[Try the quickstart for Bash in Cloud Shell](quickstart.md) <br />
-[View the full list of integrated Cloud Shell tools](features.md)
+
+- [Try the quickstart for Bash in Cloud Shell](quickstart.md)
+- [View the full list of integrated Cloud Shell tools](features.md)

--- a/articles/cloud-shell/using-cloud-shell-editor.md
+++ b/articles/cloud-shell/using-cloud-shell-editor.md
@@ -48,5 +48,5 @@ To launch the command palette, use the `F1` key when focus is set on the editor.
 Language highlight support in the Cloud Shell editor is supported through upstream functionality in the [Monaco Editor](https://github.com/Microsoft/monaco-editor)'s use of Monarch syntax definitions. To learn how to make contributions, read the [Monaco contributor guide](https://github.com/Microsoft/monaco-editor/blob/master/CONTRIBUTING.md).
 
 ## Next steps
-[Try the quickstart for Bash in Cloud Shell](quickstart.md)
+[Try the quickstart for Bash in Cloud Shell](quickstart.md) <br />
 [View the full list of integrated Cloud Shell tools](features.md)


### PR DESCRIPTION
Line break is missing in 'using cloud shell editor' doc.

Document location:
azure-docs/articles/cloud-shell/using-cloud-shell-editor.md

![image](https://user-images.githubusercontent.com/3396447/107174888-63f57e80-69f1-11eb-900d-509216bd25ff.png)


Fixes: #70187