### PR TITLE
Cloud App name for conditional access incorrect

### DIFF
--- a/articles/virtual-machines/linux/login-using-aad.md
+++ b/articles/virtual-machines/linux/login-using-aad.md
@@ -136,7 +136,7 @@ For more information on how to use Azure RBAC to manage access to your Azure sub
 
 ## Using Conditional Access
 
-You can enforce Conditional Access policies such as multi-factor authentication or user sign-in risk check before authorizing access to Linux VMs in Azure that are enabled with Azure AD sign in. To apply Conditional Access policy, you must select "Azure Linux VM Sign-In" app from the cloud apps or actions assignment option and then use Sign-in risk as a condition and/or require multi-factor authentication as a grant access control. 
+You can enforce Conditional Access policies such as multi-factor authentication or user sign-in risk check before authorizing access to Linux VMs in Azure that are enabled with Azure AD sign in. To apply Conditional Access policy, you must select "Microsoft Azure Linux Virtual Machine Sign-In" app from the cloud apps or actions assignment option and then use Sign-in risk as a condition and/or require multi-factor authentication as a grant access control. 
 
 > [!WARNING]
 > Per-user Enabled/Enforced Azure AD Multi-Factor Authentication is not supported for VM sign-in.


### PR DESCRIPTION
The Cloud App name under the "## Using Conditional Access" section is not correct. In my AAD this is "Microsoft Azure Linux Virtual Machine Sign-In" not "Azure Linux VM Sign-In" as per the current document. 

Hope this helps. 

Thanks