### PR TITLE
Update AutoMLStep docs

### DIFF
--- a/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
+++ b/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
@@ -104,7 +104,7 @@ The code blocks until the target is provisioned and then prints some details of 
 
 ### Configure the training run
 
-The AutoMLStep confiugres its dependencies automatically during job submission. The runtime context is set by creating and configuring a `RunConfiguration` object. Here we set the compute target.
+The AutoMLStep configures its dependencies automatically during job submission. The runtime context is set by creating and configuring a `RunConfiguration` object. Here we set the compute target.
 
 ```python
 from azureml.core.runconfig import RunConfiguration

--- a/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
+++ b/articles/machine-learning/how-to-use-automlstep-in-pipelines.md
@@ -104,32 +104,15 @@ The code blocks until the target is provisioned and then prints some details of 
 
 ### Configure the training run
 
-The next step is making sure that the remote training run has all the dependencies that are required by the training steps. Dependencies and the runtime context are set by creating and configuring a `RunConfiguration` object. 
+The AutoMLStep confiugres its dependencies automatically during job submission. The runtime context is set by creating and configuring a `RunConfiguration` object. Here we set the compute target.
 
 ```python
 from azureml.core.runconfig import RunConfiguration
-from azureml.core.conda_dependencies import CondaDependencies
-from azureml.core import Environment 
 
 aml_run_config = RunConfiguration()
 # Use just-specified compute target ("cpu-cluster")
 aml_run_config.target = compute_target
-
-USE_CURATED_ENV = True
-if USE_CURATED_ENV :
-    curated_environment = Environment.get(workspace=ws, name="AzureML-Tutorial")
-    aml_run_config.environment = curated_environment
-else:
-    aml_run_config.environment.python.user_managed_dependencies = False
-    
-    # Add some packages relied on by data prep step
-    aml_run_config.environment.python.conda_dependencies = CondaDependencies.create(
-        conda_packages=['pandas','scikit-learn'], 
-        pip_packages=['azureml-sdk[automl]', 'azureml-dataprep[fuse,pandas]'], 
-        pin_sdk_version=False)
 ```
-
-The code above shows two options for handling dependencies. As presented, with `USE_CURATED_ENV = True`, the configuration is based on a curated environment. Curated environments are "prebaked" with common inter-dependent libraries and can be significantly faster to bring online. Curated environments have prebuilt Docker images in the [Microsoft Container Registry](https://hub.docker.com/publishers/microsoftowner). The path taken if you change `USE_CURATED_ENV` to `False` shows the pattern for explicitly setting your dependencies. In that scenario, a new custom Docker image will be created and registered in an Azure Container Registry within your resource group (see [Introduction to private Docker container registries in Azure](../container-registry/container-registry-intro.md)). Building and registering this image can take quite a few minutes. 
 
 ## Prepare data for automated machine learning
 


### PR DESCRIPTION
AutoMLStep currently configures it's own dependencies. Using CE AzureML-Tutorial is not necessarily correct as that environment is not always tested against AutoMLSteps internally. 

Additionally, an image build will always be triggered as AutoML modifies other dependencies on the CE anyway.

There are some long term plans around updating the CE interaction and the AutoMLStep which are currently still being planned.