### PR TITLE
Update cache-how-to-premium-persistence.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -62,7 +62,8 @@ Persistence writes Redis data into an Azure Storage account that you own and man
 
     The first backup is initiated once the backup frequency interval elapses.
     
-**NOTE : THE RDB files when backed up to storage are in form of Page Blobs**
+   > [!NOTE]
+   > When RDB files are backed up to storage, they are stored in the form of page blobs.
 
 9. To enable AOF persistence, click **AOF** and configure the settings. 
    

--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -61,6 +61,8 @@ Persistence writes Redis data into an Azure Storage account that you own and man
    | **Storage Key** | Drop-down and choose either the **Primary key** or **Secondary key** to use. | If the storage key for your persistence account is regenerated, you must reconfigure the desired key from the **Storage Key** drop-down. | 
 
     The first backup is initiated once the backup frequency interval elapses.
+    
+**NOTE : THE RDB files when backed up to storage are in form of Page Blobs**
 
 9. To enable AOF persistence, click **AOF** and configure the settings. 
    


### PR DESCRIPTION
RDB files are backed up in storage in form of Page Blobs. 
The documentation does provide an explanation for the AOF type persistence as to how the files are stored in storage but not for RDB. Hence, proposing the changes for explanation of the RDB format as well