### PR TITLE
Update note on RBAC on granting KeyVault access

### DIFF
--- a/articles/app-service/app-service-key-vault-references.md
+++ b/articles/app-service/app-service-key-vault-references.md
@@ -23,7 +23,7 @@ In order to read secrets from Key Vault, you need to have a vault created and gi
 1. Create a [system-assigned managed identity](overview-managed-identity.md) for your application.
 
    > [!NOTE] 
-   > Key Vault references currently only support system-assigned managed identities. User-assigned identities cannot be used.
+   > Key Vault references currently only support system-assigned managed identities. User-assigned identities cannot be used. [Azure role-based authentication is in preview](https://azure.microsoft.com/en-us/updates/azure-rolebased-access-control-rbac-for-azure-key-vault-data-plane-authorization-is-now-in-preview/). When this is in general-availability, this constraint will no longer exist.
 
 1. Create an [access policy in Key Vault](../key-vault/general/secure-your-key-vault.md#key-vault-access-policies) for the application identity you created earlier. Enable the "Get" secret permission on this policy. Do not configure the "authorized application" or `applicationId` settings, as this is not compatible with a managed identity.
 


### PR DESCRIPTION
Update note about using User-Assigned Identities when granting App Config access to KeyVault.