### PR TITLE
Documentation fixes for Azure Notification Hubs

### DIFF
--- a/articles/notification-hubs/TOC.yml
+++ b/articles/notification-hubs/TOC.yml
@@ -24,9 +24,9 @@
     items:
     - name: Firebase Cloud Messaging
       items:
-      - name: Send push notifications to all registrations (SDK version 1.0.0-preview1)
+      - name: Send push notifications to all registrations (Current SDK)
         href: android-sdk.md
-      - name: Send push notifications to all registrations (SDK version 0.6)
+      - name: Send push notifications to all registrations (Legacy SDK)
         href: notification-hubs-android-push-notification-google-fcm-get-started.md
       - name: Send push notifications to specific devices
         href: push-notifications-android-specific-devices-firebase-cloud-messaging.md
@@ -50,10 +50,10 @@
       items:
       - name: Prerequisites for iOS tutorials
         href: ios-sdk-get-started.md
-      - name: Objective-C (version 3.0.0-preview1)
-        href: ios-sdk-300.md
-      - name: Objective-C (version 2.0.4)
-        href: ios-sdk-204.md
+      - name: Objective-C (Current SDK)
+        href: ios-sdk-current.md
+      - name: Objective-C (Legacy SDK)
+        href: ios-sdk-legacy.md
     - name: Send push notifications to specific devices
       href: notification-hubs-ios-xplat-segmented-apns-push-notification.md
     - name: Send push notifications to specific users

--- a/articles/notification-hubs/android-sdk.md
+++ b/articles/notification-hubs/android-sdk.md
@@ -160,7 +160,7 @@ also have the connection strings that are necessary to send notifications to a d
 1. In the **build.gradle** file for the app, add the following lines in the dependencies section:
 
    ```gradle
-   implementation 'com.microsoft.azure:notification-hubs-android-sdk:1.0.0-preview1@aar'
+   implementation 'com.microsoft.azure:notification-hubs-android-sdk:1.1.4'
    implementation 'androidx.appcompat:appcompat:1.0.0'
 
    implementation 'com.google.firebase:firebase-messaging:20.1.5'
@@ -196,18 +196,17 @@ also have the connection strings that are necessary to send notifications to a d
    public class CustomNotificationListener implements NotificationHubListener {
 
       @override
-
-      public void onNotificationReceived(Context context, NotificationMessage message) {
-
-      /* The following notification properties are available. */
-
-      String title = message.getTitle();
-      String message = message.getMessage();
-      Map<String, String> data = message.getData();
-
-      if (message != null) {
-         Log.d(TAG, "Message Notification Title: " + title);
-         Log.d(TAG, "Message Notification Body: " + message);
+      public void onNotificationReceived(Context context, RemoteMessage message) {
+    
+         /* The following notification properties are available. */
+         Notification notification = message.getNotification();
+         String title = notification.getTitle();
+         String body = notification.getBody();
+         Map<String, String> data = message.getData();
+    
+         if (message != null) {
+            Log.d(TAG, "Message Notification Title: " + title);
+            Log.d(TAG, "Message Notification Body: " + message);
          }
       }
    }

--- a/articles/notification-hubs/android-sdk.md
+++ b/articles/notification-hubs/android-sdk.md
@@ -33,7 +33,7 @@ To complete this tutorial, you must have an active Azure account. If you don't h
 You also need the following items:
 
 - The latest version of [Android Studio](https://go.microsoft.com/fwlink/?LinkId=389797) is recommended.
-- Minimum support is API level 16.
+- Minimum support is API level 19.
 
 ## Create an Android Studio project
 

--- a/articles/notification-hubs/android-sdk.md
+++ b/articles/notification-hubs/android-sdk.md
@@ -160,12 +160,8 @@ also have the connection strings that are necessary to send notifications to a d
 1. In the **build.gradle** file for the app, add the following lines in the dependencies section:
 
    ```gradle
-   implementation 'com.microsoft.azure:notification-hubs-android-sdk:1.1.4'
+   implementation 'com.microsoft.azure:notification-hubs-android-sdk-fcm:1.1.4'
    implementation 'androidx.appcompat:appcompat:1.0.0'
-
-   implementation 'com.google.firebase:firebase-messaging:20.1.5'
-
-   implementation 'com.android.volley:volley:1.1.1'
    ```
 
 2. Add the following repository after the dependencies section:
@@ -207,6 +203,12 @@ also have the connection strings that are necessary to send notifications to a d
          if (message != null) {
             Log.d(TAG, "Message Notification Title: " + title);
             Log.d(TAG, "Message Notification Body: " + message);
+         }
+
+         if (data != null) {
+             for (Map.Entry<String, String> entry : data.entrySet()) {
+                 Log.d(TAG, "key, " + entry.getKey() + " value " + entry.getValue());
+             }
          }
       }
    }

--- a/articles/notification-hubs/ios-sdk-current.md
+++ b/articles/notification-hubs/ios-sdk-current.md
@@ -70,6 +70,20 @@ configure push credentials in your notification hub. Even if you have no prior e
 
          If you see an error such as **Unable to find a specification for AzureNotificationHubs-iOS** while running pod install, run `pod repo update` to get the latest pods from the Cocoapods repository, and then run pod install.
 
+   - Integration via Carthage: Add the following dependencies to your Cartfile to include the Azure Notification Hubs SDK in your app:
+
+      ```ruby
+      github "Azure/azure-notificationhubs-ios"
+      ```
+
+      - Next, update build dependencies:
+
+      ```shell
+      $ carthage update
+      ```
+
+      For more information about using Carthage, see the [Carthage GitHub repository](https://github.com/Carthage/Carthage).
+
    - Integration by copying the binaries into your project:
 
       You can integrate by copying the binaries into your project, as follows:
@@ -186,6 +200,22 @@ configure push credentials in your notification hub. Even if you have no prior e
         [[NSNotificationCenter defaultCenter] removeObserver:self name:kNHMessageReceived object:nil];
     }
 
+    - (void)didReceivePushNotification:(NSNotification *)notification {
+        MSNotificationHubMessage *message = [notification.userInfo objectForKey:@"message"];
+
+        // Create UI Alert controller with message title and body
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:message.title
+                             message:message.body
+                      preferredStyle:UIAlertControllerStyleAlert];
+        [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alertController animated:YES completion:nil];
+        
+        // Dismiss after 2 seconds
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [alertController dismissViewControllerAnimated:YES completion: nil];
+        });
+
+    }
 
     @end
    ```

--- a/articles/notification-hubs/ios-sdk-legacy.md
+++ b/articles/notification-hubs/ios-sdk-legacy.md
@@ -92,34 +92,22 @@ configure push credentials in your notification hub. Even if you have no prior e
 
           :::image type="content" source="media/ios-sdk/image4.png" alt-text="Add framework":::
 
-6. Add a new header file to your project named **Constants.h**. To do so, right-click the project name and select **New File...**. Then select **Header File**. This file holds the constants for your notification hub. Then select **Next**. Name the file **Constants.h**.
+6. Add the information for connecting to Azure Notification Hubs in the appropriate `<string></string>` section.  Replace the string literal placeholders `--HUB-NAME--` and `--CONNECTION-STRING--` with the hub name and the **DefaultListenSharedAccessSignature**, respectively, as you previously obtained from the portal:
 
-7. Add the following code to the Constants.h file:
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+    	<key>HUB_NAME</key>
+    	<string>--HUB-NAME--</string>
+    	<key>CONNECTION_STRING</key>
+    	<string>--CONNECTION-STRING--</string>
+    </dict>
+    </plist>
+    ```
 
-   ```objc
-   #ifndef Constants_h
-   #define Constants_h
-   extern NSString* const NHInfoConnectionString;
-   extern NSString* const NHInfoHubName;
-   extern NSString* const NHUserDefaultTags;
-   #endif /* Constants_h */
-   ```
-
-8. Add the implementation file for Constants.h. To do so, right-click the project name and select **New File...**. Select **Objective-C File**, and then select **Next**. Name the file **Constants.m**.
-
-   :::image type="content" source="media/ios-sdk/image5.png" alt-text="Add implementation file":::
-
-9. Open the **Constants.m** file and replace its contents with the following code. Replace the string literal placeholders `NotificationHubConnectionString` and `NotificationHubConnectionString` with the hub name and the **DefaultListenSharedAccessSignature**, respectively, as you previously obtained from the portal:
-
-   ```objc
-   #import <Foundation/Foundation.h>
-   #import "Constants.h"
-
-   NSString* const NHInfoConnectionString = @"NotificationHubConnectionString";
-   NSString* const NHInfoHubName = @"NotificationHubName";NSString* const NHUserDefaultTags = @"notification_tags";
-   ```
-
-10. Open your project **AppDelegate.h** file and replace its contents with the following code:
+7. Open your project **AppDelegate.h** file and replace its contents with the following code:
 
     ```objc
     #import <UIKit/UIKit.h>
@@ -136,10 +124,9 @@ configure push credentials in your notification hub. Even if you have no prior e
     @end
     ```
 
-11. In the project **AppDelegate.m** file, add the following `import` statements:
+8. In the project **AppDelegate.m** file, add the following `import` statements:
 
     ```objc
-    #import "Constants.h"
     #import "NotificationDetailViewController.h"
     ```
 
@@ -155,39 +142,39 @@ configure push credentials in your notification hub. Even if you have no prior e
     // Tells the app that a remote notification arrived that indicates there is data to be fetched.
 
     - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-    NSLog(@"Received remote (silent) notification");
-    [self logNotificationDetails:userInfo];
-
-    //
-    // Let the system know the silent notification has been processed.
-    //
-    completionHandler(UIBackgroundFetchResultNoData);
+        NSLog(@"Received remote (silent) notification");
+        [self logNotificationDetails:userInfo];
+        
+        //
+        // Let the system know the silent notification has been processed.
+        //
+        completionHandler(UIBackgroundFetchResultNoData);
     }
 
     // Tells the delegate that the app successfully registered with Apple Push Notification service (APNs).
 
     - (void) application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    NSMutableSet *tags = [[NSMutableSet alloc] init];
-
-    // Load and parse stored tags
-    NSString *unparsedTags = [[NSUserDefaults standardUserDefaults] valueForKey:NHUserDefaultTags];
-    if (unparsedTags.length > 0) {
-        NSArray *tagsArray = [unparsedTags componentsSeparatedByString: @","];
-        [tags addObjectsFromArray:tagsArray];
-    }
-
-    // Register the device with the Notification Hub.
-    // If the device has not already been registered, this will create the registration.
-    // If the device has already been registered, this will update the existing registration.
-    //
-    SBNotificationHub* hub = [self getNotificationHub];
-    [hub registerNativeWithDeviceToken:deviceToken tags:tags completion:^(NSError* error) {
-        if (error != nil) {
-            NSLog(@"Error registering for notifications: %@", error);
-        } else {
-            [self showAlert:@"Registered" withTitle:@"Registration Status"];
+        NSMutableSet *tags = [[NSMutableSet alloc] init];
+        
+        // Load and parse stored tags
+        NSString *unparsedTags = [[NSUserDefaults standardUserDefaults] valueForKey:NHUserDefaultTags];
+        if (unparsedTags.length > 0) {
+            NSArray *tagsArray = [unparsedTags componentsSeparatedByString: @","];
+            [tags addObjectsFromArray:tagsArray];
         }
-    }];
+        
+        // Register the device with the Notification Hub.
+        // If the device has not already been registered, this will create the registration.
+        // If the device has already been registered, this will update the existing registration.
+        //
+        SBNotificationHub* hub = [self getNotificationHub];
+        [hub registerNativeWithDeviceToken:deviceToken tags:tags completion:^(NSError* error) {
+            if (error != nil) {
+                NSLog(@"Error registering for notifications: %@", error);
+            } else {
+                [self showAlert:@"Registered" withTitle:@"Registration Status"];
+            }
+        }];
     }
 
     // UNUserNotificationCenterDelegate methods
@@ -195,99 +182,105 @@ configure push credentials in your notification hub. Even if you have no prior e
     // Asks the delegate how to handle a notification that arrived while the app was running in the  foreground.
 
     - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
-    NSLog(@"Received notification while the application is in the foreground");
-
-    // The system calls this delegate method when the app is in the foreground. This allows the app to handle the notification
-    // itself (and potentially modify the default system behavior).
-
-    // Handle the notification by displaying custom UI.
-    //
-    [self showNotification:notification.request.content.userInfo];
-
-    // Use 'options' to specify which default behaviors to enable.
-    // - UNAuthorizationOptionBadge: Apply the notification's badge value to the app’s icon.
-    // - UNAuthorizationOptionSound: Play the sound associated with the notification.
-    // - UNAuthorizationOptionAlert: Display the alert using the content provided by the notification.
-    //
-    // In this case, do not pass UNAuthorizationOptionAlert because the notification was handled by the app.
-    //
-    completionHandler(UNAuthorizationOptionBadge | UNAuthorizationOptionSound);
+        NSLog(@"Received notification while the application is in the foreground");
+        
+        // The system calls this delegate method when the app is in the foreground. This allows the app to handle the notification
+        // itself (and potentially modify the default system behavior).
+        
+        // Handle the notification by displaying custom UI.
+        //
+        [self showNotification:notification.request.content.userInfo];
+        
+        // Use 'options' to specify which default behaviors to enable.
+        // - UNNotificationPresentationOptionsBadge: Apply the notification's badge value to the app’s icon.
+        // - UNNotificationPresentationOptionList: Show in the Notification Center
+        // - UNNotificationPresentationOptionsSound: Play the sound associated with the notification.
+        //
+        completionHandler(UNNotificationPresentationOptionsBadge | UNNotificationPresentationOptionsSound);
     }
 
     // Asks the delegate to process the user's response to a delivered notification.
     //
 
     - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void(^)(void))completionHandler {
-    NSLog(@"Received notification while the application is in the background");
-
-    // The system calls this delegate method when the user taps or responds to the system notification.
-
-    // Handle the notification response by displaying custom UI
-    //
-    [self showNotification:response.notification.request.content.userInfo];
-
-    // Let the system know the response has been processed.
-    //
-    completionHandler();
+        NSLog(@"Received notification while the application is in the background");
+        
+        // The system calls this delegate method when the user taps or responds to the system notification.
+        
+        // Handle the notification response by displaying custom UI
+        //
+        [self showNotification:response.notification.request.content.userInfo];
+        
+        // Let the system know the response has been processed.
+        //
+        completionHandler();
     }
 
     // App logic and helpers
 
     - (SBNotificationHub *)getNotificationHub {
-    NSString *hubName = [[NSBundle mainBundle] objectForInfoDictionaryKey:NHInfoHubName];
-    NSString *connectionString = [[NSBundle mainBundle] objectForInfoDictionaryKey:NHInfoConnectionString];
-
-    return [[SBNotificationHub alloc] initWithConnectionString:connectionString notificationHubPath:hubName];
+        NSString *path = [[NSBundle mainBundle] pathForResource:@"DevSettings" ofType:@"plist"];
+        NSDictionary *configValues = [NSDictionary dictionaryWithContentsOfFile:path];
+        
+        NSString *connectionString = [configValues objectForKey:@"CONNECTION_STRING"];
+        NSString *hubName = [configValues objectForKey:@"HUB_NAME"];
+        
+        return [[SBNotificationHub alloc] initWithConnectionString:connectionString notificationHubPath:hubName];
     }
 
     - (void)handleRegister {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        
+        UNAuthorizationOptions options =  UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
+        [center requestAuthorizationWithOptions:(options) completionHandler:^(BOOL granted, NSError * _Nullable error) {
+            if (error != nil) {
+                NSLog(@"Error requesting for authorization: %@", error);
+            }
 
-    UNAuthorizationOptions options =  UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
-    [center requestAuthorizationWithOptions:(options) completionHandler:^(BOOL granted, NSError * _Nullable error) {
-        if (error != nil) {
-            NSLog(@"Error requesting for authorization: %@", error);
-        }
-    }];
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
+            if (granted) {
+                NSLog(@"Authorization granted");
+            }
+        }];
+        [[UIApplication sharedApplication] registerForRemoteNotifications];
     }
 
     - (void)handleUnregister {
-    //
-    // Unregister the device with the Notification Hub.
-    //
-    SBNotificationHub *hub = [self getNotificationHub];
-    [hub unregisterNativeWithCompletion:^(NSError* error) {
-        if (error != nil) {
-            NSLog(@"Error unregistering for push: %@", error);
-        } else {
-            [self showAlert:@"Unregistered" withTitle:@"Registration Status"];
-        }
-    }];
+        //
+        // Unregister the device with the Notification Hub.
+        //
+        SBNotificationHub *hub = [self getNotificationHub];
+        [hub unregisterNativeWithCompletion:^(NSError* error) {
+            if (error != nil) {
+                NSLog(@"Error unregistering for push: %@", error);
+            } else {
+                [self showAlert:@"Unregistered" withTitle:@"Registration Status"];
+            }
+        }];
     }
 
     - (void)logNotificationDetails:(NSDictionary *)userInfo {
-    if (userInfo != nil) {
-        UIApplicationState state = [UIApplication sharedApplication].applicationState;
-        BOOL background = state != UIApplicationStateActive;
-        NSLog(@"Received %@notification: \n%@", background ? @"(background) " : @"", userInfo);
-    }
+        if (userInfo != nil) {
+            UIApplicationState state = [UIApplication sharedApplication].applicationState;
+            BOOL background = state != UIApplicationStateActive;
+            NSLog(@"Received %@notification: \n%@", background ? @"(background) " : @"", userInfo);
+        }
     }
 
     - (void)showAlert:(NSString *)message withTitle:(NSString *)title {
-    if (title == nil) {
-        title = @"Alert";
-    }
-    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-    [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:alert animated:YES completion:nil];
+        if (title == nil) {
+            title = @"Alert";
+        }
+
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+        [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:alert animated:YES completion:nil];
     }
 
     - (void)showNotification:(NSDictionary *)userInfo {
-    [self logNotificationDetails:userInfo];
-
-    NotificationDetailViewController *notificationDetail = [[NotificationDetailViewController alloc] initWithUserInfo:userInfo];
-    [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:notificationDetail animated:YES completion:nil];
+        [self logNotificationDetails:userInfo];
+        
+        NotificationDetailViewController *notificationDetail = [[NotificationDetailViewController alloc] initWithUserInfo:userInfo];
+        [[[[UIApplication sharedApplication] keyWindow] rootViewController] presentViewController:notificationDetail animated:YES completion:nil];
     }
 
     @end
@@ -331,52 +324,52 @@ configure push credentials in your notification hub. Even if you have no prior e
    @implementation NotificationDetailViewController
 
    - (id)initWithUserInfo:(NSDictionary *)userInfo {
-    self = [super initWithNibName:@"NotificationDetail" bundle:nil];
-    if (self) {
-        _userInfo = userInfo;
-    }
-    return self;
+        self = [super initWithNibName:@"NotificationDetail" bundle:nil];
+        if (self) {
+            _userInfo = userInfo;
+        }
+        return self;
    }
 
    - (void)viewDidLayoutSubviews {
-    [self.titleLabel sizeToFit];
-    [self.bodyLabel sizeToFit];
+        [self.titleLabel sizeToFit];
+        [self.bodyLabel sizeToFit];
    }
 
    - (void)viewDidLoad {
-    [super viewDidLoad];
-
-    NSString *title = nil;
-    NSString *body = nil;
-
-    NSDictionary *aps = [_userInfo valueForKey:@"aps"];
-    NSObject *alertObject = [aps valueForKey:@"alert"];
-    if (alertObject != nil) {
-        if ([alertObject isKindOfClass:[NSDictionary class]]) {
-            NSDictionary *alertDict = (NSDictionary *)alertObject;
-            title = [alertDict valueForKey:@"title"];
-            body = [alertObject valueForKey:@"body"];
-        } else if ([alertObject isKindOfClass:[NSString class]]) {
-            body = (NSString *)alertObject;
-        } else {
-            NSLog(@"Unable to parse notification content. Unexpected format: %@", alertObject);
+        [super viewDidLoad];
+        
+        NSString *title = nil;
+        NSString *body = nil;
+        
+        NSDictionary *aps = [_userInfo valueForKey:@"aps"];
+        NSObject *alertObject = [aps valueForKey:@"alert"];
+        if (alertObject != nil) {
+            if ([alertObject isKindOfClass:[NSDictionary class]]) {
+                NSDictionary *alertDict = (NSDictionary *)alertObject;
+                title = [alertDict valueForKey:@"title"];
+                body = [alertObject valueForKey:@"body"];
+            } else if ([alertObject isKindOfClass:[NSString class]]) {
+                body = (NSString *)alertObject;
+            } else {
+                NSLog(@"Unable to parse notification content. Unexpected format: %@", alertObject);
+            }
         }
-    }
-
-    if (title == nil) {
-        title = @"<unset>";
-    }
-
-    if (body == nil) {
-        body = @"<unset>";
-    }
-
-    self.titleLabel.text = title;
-    self.bodyLabel.text = body;
+        
+        if (title == nil) {
+            title = @"<unset>";
+        }
+        
+        if (body == nil) {
+            body = @"<unset>";
+        }
+        
+        self.titleLabel.text = title;
+        self.bodyLabel.text = body;
    }
 
    - (IBAction)handleDismiss:(id)sender {
-    [self dismissViewControllerAnimated:YES completion:nil];
+        [self dismissViewControllerAnimated:YES completion:nil];
    }
 
    @end
@@ -403,8 +396,9 @@ configure push credentials in your notification hub. Even if you have no prior e
 
    ```objc
    #import "ViewController.h"
-   #import "Constants.h"
    #import "AppDelegate.h"
+
+    static NSString *const kNHUserDefaultTags = @"notification_tags";
 
    @interface ViewController ()
 
@@ -415,27 +409,27 @@ configure push credentials in your notification hub. Even if you have no prior e
    // UIViewController methods
 
    - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    // Simple method to dismiss keyboard when user taps outside of the UITextField.
-    [self.view endEditing:YES];
+        // Simple method to dismiss keyboard when user taps outside of the UITextField.
+        [self.view endEditing:YES];
    }
 
    - (void)viewDidLoad {
-    [super viewDidLoad];
-
-    // Load raw tags text from storage and initialize the text field
-    self.tagsTextField.text = [[NSUserDefaults standardUserDefaults] valueForKey:NHUserDefaultTags];
+        [super viewDidLoad];
+        
+        // Load raw tags text from storage and initialize the text field
+        self.tagsTextField.text = [[NSUserDefaults standardUserDefaults] valueForKey:kNHUserDefaultTags];
    }
 
    - (IBAction)handleRegister:(id)sender {
-    // Save raw tags text in storage
-    [[NSUserDefaults standardUserDefaults] setValue:self.tagsTextField.text forKey:NHUserDefaultTags];
-
-   // Delegate processing the register action to the app delegate.
-   [[[UIApplication sharedApplication] delegate] performSelector:@selector(handleRegister)];
+        // Save raw tags text in storage
+        [[NSUserDefaults standardUserDefaults] setValue:self.tagsTextField.text forKey:kNHUserDefaultTags];
+        
+        // Delegate processing the register action to the app delegate.
+        [[[UIApplication sharedApplication] delegate] performSelector:@selector(handleRegister)];
    }
 
    - (IBAction)handleUnregister:(id)sender {
-    [[[UIApplication sharedApplication] delegate] performSelector:@selector(handleUnregister)];
+        [[[UIApplication sharedApplication] delegate] performSelector:@selector(handleUnregister)];
    }
 
    @end

--- a/articles/notification-hubs/ios-sdk-legacy.md
+++ b/articles/notification-hubs/ios-sdk-legacy.md
@@ -11,9 +11,9 @@ ms.reviewer: thsomasu
 ms.lastreviewed: 06/01/2020
 ---
 
-# Tutorial: Send push notifications to iOS apps using Azure Notification Hubs (version 2.0.4)
+# Tutorial: Send push notifications to iOS apps using Azure Notification Hubs (Legacy API)
 
-This tutorial shows you how to use Azure Notification Hubs to send push notifications to an iOS application, using the Azure Notification Hubs SDK version 2.0.4.
+This tutorial shows you how to use Azure Notification Hubs to send push notifications to an iOS application, using the Azure Notification Hubs SDK for Apple Legacy APIs.
 
 This tutorial covers the following steps:
 
@@ -22,7 +22,7 @@ This tutorial covers the following steps:
 - Send test push notifications.
 - Verify that your app receives notifications.
 
-You can download the complete code for this tutorial [from GitHub](https://github.com/Azure/azure-notificationhubs-ios/tree/v3-preview2/Samples).
+You can download the complete code for this tutorial [from GitHub](https://github.com/Azure/azure-notificationhubs-ios/tree/main/SampleNHAppLegacyObjC).
 
 ## Prerequisites
 

--- a/articles/notification-hubs/notification-hubs-ios-xplat-segmented-apns-push-notification.md
+++ b/articles/notification-hubs/notification-hubs-ios-xplat-segmented-apns-push-notification.md
@@ -121,8 +121,6 @@ The first step is to add the UI elements to your existing storyboard that enable
 
     - (void)subscribeWithCategories:(NSSet *)categories completion:(void (^)(NSError *))completion
     {
-        //[hub registerNativeWithDeviceToken:self.deviceToken tags:categories completion: completion];
-
         NSString* templateBodyAPNS = @"{\"aps\":{\"alert\":\"$(messageParam)\"}}";
 
         [hub registerTemplateWithDeviceToken:self.deviceToken name:@"simpleAPNSTemplate" 


### PR DESCRIPTION
This PR makes the following changes:

Renames:
- Renames the 0.06 Android SDK to Legacy SDK
- Renames the 1.x Android SDK to Current SDK
- Renames the 2.x iOS SDK to Legacy SDK
- Renames the 3.x iOS SDK to Current SDK

Doc Updates:
- Fix Current Android SDK to use `RemoteMessage` instead of custom `NotificationHubMessage`
- Fix Current Apple SDK based upon our sample NH App