### PR TITLE
Add note on lack of support for multiple ApiKeyHeader keys

### DIFF
--- a/articles/active-directory-b2c/restful-technical-profile.md
+++ b/articles/active-directory-b2c/restful-technical-profile.md
@@ -222,6 +222,9 @@ If the type of authentication is set to `ApiKeyHeader`, the **CryptographicKeys*
 | --------- | -------- | ----------- |
 | The name of the HTTP header, such as `x-functions-key`, or `x-api-key`. | Yes | The key that is used to authenticate. |
 
+> [!NOTE]
+> At this time, Azure B2C only supports one HTTP header for authentication. If your RESTful call requires multiple headers, such as a client ID and client secret, you will need to proxy the request in some manner.
+
 ```xml
 <TechnicalProfile Id="REST-API-SignUp">
   <DisplayName>Validate user's input data and return loyaltyNumber claim</DisplayName>

--- a/articles/active-directory-b2c/restful-technical-profile.md
+++ b/articles/active-directory-b2c/restful-technical-profile.md
@@ -223,7 +223,7 @@ If the type of authentication is set to `ApiKeyHeader`, the **CryptographicKeys*
 | The name of the HTTP header, such as `x-functions-key`, or `x-api-key`. | Yes | The key that is used to authenticate. |
 
 > [!NOTE]
-> At this time, Azure B2C only supports one HTTP header for authentication. If your RESTful call requires multiple headers, such as a client ID and client secret, you will need to proxy the request in some manner.
+> At this time, Azure AD B2C supports only one HTTP header for authentication. If your RESTful call requires multiple headers, such as a client ID and client secret, you will need to proxy the request in some manner.
 
 ```xml
 <TechnicalProfile Id="REST-API-SignUp">
@@ -290,4 +290,3 @@ See the following articles for examples of using a RESTful technical profile:
 - [Walkthrough: Integrate REST API claims exchanges in your Azure AD B2C user journey as validation of user input](custom-policy-rest-api-claims-validation.md)
 - [Walkthrough: Add REST API claims exchanges to custom policies in Azure Active Directory B2C](custom-policy-rest-api-claims-validation.md)
 - [Secure your REST API services](secure-rest-api.md)
-


### PR DESCRIPTION
Adding this note because it would have saved me a lot of time in a process. I defined a policy only to see this issue when uploading it to the portal. Everyone would work if the limitation of one header key was removed, so it seems worthwhile to call it out in the docs.