### PR TITLE
fix: update scope of overlapping role assignments

### DIFF
--- a/articles/role-based-access-control/overview.md
+++ b/articles/role-based-access-control/overview.md
@@ -83,7 +83,7 @@ For more information, see [Steps to add a role assignment](role-assignments-step
 
 ## Multiple role assignments
 
-So what happens if you have multiple overlapping role assignments? Azure RBAC is an additive model, so your effective permissions are the sum of your role assignments. Consider the following example where a user is granted the Contributor role at the subscription scope and the Reader role on a resource group. The sum of the Contributor permissions and the Reader permissions is effectively the Contributor role for the resource group. Therefore, in this case, the Reader role assignment has no impact.
+So what happens if you have multiple overlapping role assignments? Azure RBAC is an additive model, so your effective permissions are the sum of your role assignments. Consider the following example where a user is granted the Contributor role at the subscription scope and the Reader role on a resource group. The sum of the Contributor permissions and the Reader permissions is effectively the Contributor role for the subscription. Therefore, in this case, the Reader role assignment has no impact.
 
 ![Multiple role assignments](./media/overview/rbac-multiple-roles.png)
 


### PR DESCRIPTION
The sum of the two role assignments amounts to the contributor role on the subscription, which is more even than just the resource group.