### PR TITLE
Update how-to-use-environments.md

### DIFF
--- a/articles/machine-learning/how-to-use-environments.md
+++ b/articles/machine-learning/how-to-use-environments.md
@@ -203,7 +203,8 @@ myenv = Environment.from_existing_conda_environment(name="myenv",
 An environment definition can be saved to a directory in an easily editable format with the [`save_to_directory()`](/python/api/azureml-core/azureml.core.environment.environment?preserve-view=true&view=azure-ml-py#&preserve-view=truesave-to-directory-path--overwrite-false-) method. Once modified, a new environment can be instantiated by loading files from the directory.
 
 ```python
-myenv = Environment.save_to_directory(path="path-to-destination-directory", overwrite=False)
+# save the enviroment
+myenv.save_to_directory(path="path-to-destination-directory", overwrite=False)
 # modify the environment definition
 newenv = Environment.load_from_directory(path="path-to-source-directory")
 ```


### PR DESCRIPTION
Proper syntax for saving an environment with ```Environment.save_to_directory(path="path-to-destination-directory", overwrite=False)```.