### PR TITLE
Update monitor-blob-storage.md

### DIFF
--- a/articles/storage/blobs/monitor-blob-storage.md
+++ b/articles/storage/blobs/monitor-blob-storage.md
@@ -106,7 +106,7 @@ If you choose to archive your logs to a storage account, you'll pay for the volu
 2. In the **Storage account** drop-down list, select the storage account that you want to archive your logs to, click the **OK** button, and then click the **Save** button.
 
    > [!NOTE]
-   > Before you choose a storage account as the export destination, see [Archive Azure resource logs](../../azure-monitor/platform/resource-logs.md#send-to-azure-storage) to understand prerequisites on the storage account.
+   > Before you choose a storage account as the export destination, see [Archive Azure resource logs](../../azure-monitor/platform/resource-logs.md#send-to-azure-storage) to understand prerequisites on the storage account. Also, when archiving logs to storage, it doesn't provide an option to set retention period currently as available in classic metrics.
 
 #### Stream logs to Azure Event Hubs
 


### PR DESCRIPTION
When streaming the logs to storage account, it doesn't provide any option to set retention period as to for how much time the logs should be maintained. This option is however available in storage analytics hence proposing this as a pointer for differentiation
https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-a-Storage-Analytics-Data-Retention-Policy

Also, the diagnostic settings usually provides a retention period when storing diagnostics logs into storage account but this doesn't seem to be the case with Diagnostic settings preview for storage account. Hence, I have made use of word "currently" in case this is to be a future work item.
https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings