### PR TITLE
Update automation-windows-hrw-install.md

### DIFF
--- a/articles/automation/automation-windows-hrw-install.md
+++ b/articles/automation/automation-windows-hrw-install.md
@@ -8,7 +8,7 @@ ms.topic: conceptual
 ---
 # Deploy a Windows Hybrid Runbook Worker
 
-You can use the user Hybrid Runbook Worker feature of Azure Automation to run runbooks directly on the Azure or non-Azure machine, including servers registered with [Azure Arc enabled servers](../azure-arc/servers/overview.md). From the machine or server that's hosting the role, you can run runbooks directly it and against resources in the environment to manage those local resources.
+You can use the user Hybrid Runbook Worker feature of Azure Automation to run runbooks directly on an Azure or non-Azure machine, including servers registered with [Azure Arc enabled servers](../azure-arc/servers/overview.md). From the machine or server that's hosting the role, you can run runbooks directly against it and against resources in the environment to manage those local resources.
 
 Azure Automation stores and manages runbooks and then delivers them to one or more designated machines. This article describes how to deploy a user Hybrid Runbook Worker on a Windows machine, how to remove the worker, and how to remove a Hybrid Runbook Worker group.
 


### PR DESCRIPTION
I wondered for a while what you meant by "run runbooks directly on the Azure or non-Azure machine". 
THE Azure or non-Azure machine? So there is only one machine? THE machine, and we can run runbooks on that particular machine? Which one, where is it?
After some time I realised perhaps you meant "an". Run runbooks directly on an Azure or non-Azure machine. Any machine, not "the" machine.
Maybe I'm wrong.