### PR TITLE
Update fido2-compatibility.md

### DIFF
--- a/articles/active-directory/authentication/fido2-compatibility.md
+++ b/articles/active-directory/authentication/fido2-compatibility.md
@@ -36,7 +36,7 @@ The information in the table above was tested for the following operating system
 
 | Operating system | Latest tested version |
 | --- | --- |
-| Windows | Windows 10 20H2 1904 |
+| Windows | Windows 10 20H2 |
 | macOS | OS X 11 Big Sur |
 | Linux | Fedora 32 Workstation |
 


### PR DESCRIPTION
Windows Version tested: is it 20H2 or 1904. I think 1904 can be removed.