### PR TITLE
Fix Indentation Error in "Purge CDN endpoint" Sample Actions in GitHub Actions Static Site Deployment Guide

### DIFF
--- a/articles/storage/blobs/storage-blobs-static-site-github-actions.md
+++ b/articles/storage/blobs/storage-blobs-static-site-github-actions.md
@@ -127,7 +127,7 @@ In the example above, replace the placeholders with your subscription ID and res
           with:
             azcliversion: 2.0.72
             inlineScript: |
-            az cdn endpoint purge --content-paths  "/*" --profile-name "CDN_PROFILE_NAME" --name "CDN_ENDPOINT" --resource-group "RESOURCE_GROUP"
+               az cdn endpoint purge --content-paths  "/*" --profile-name "CDN_PROFILE_NAME" --name "CDN_ENDPOINT" --resource-group "RESOURCE_GROUP"
     ``` 
 
 1. Complete your workflow by adding an action to logout of Azure. Here is the completed workflow. The file will appear in the `.github/workflows` folder of your repository.
@@ -161,7 +161,7 @@ In the example above, replace the placeholders with your subscription ID and res
           with:
             azcliversion: 2.0.72
             inlineScript: |
-            az cdn endpoint purge --content-paths  "/*" --profile-name "CDN_PROFILE_NAME" --name "CDN_ENDPOINT" --resource-group "RESOURCE_GROUP"
+               az cdn endpoint purge --content-paths  "/*" --profile-name "CDN_PROFILE_NAME" --name "CDN_ENDPOINT" --resource-group "RESOURCE_GROUP"
       
       # Azure logout 
         - name: logout


### PR DESCRIPTION
Fixed indentation errors in the sample workflow code provided in the "Set up a GitHub Actions workflow to deploy your static website in Azure Storage" guide that prevent the "Purge CDN endpoint" actions from running successfully when placeholder values are replaced with "real" values. Specifically, added an additional level of indentation to the Azure CLI commands on lines 130 and 164 to correct these errors.