### PR TITLE
Update start-stop-cluster.md

### DIFF
--- a/articles/aks/start-stop-cluster.md
+++ b/articles/aks/start-stop-cluster.md
@@ -8,12 +8,10 @@ author: palma21
 
 ---
 
-# Stop and Start an Azure Kubernetes Service (AKS) cluster (preview)
+# Stop and Start an Azure Kubernetes Service (AKS) cluster
 
 Your AKS workloads may not need to run continuously, for example a development cluster that is used only during business hours. This leads to times where your Azure Kubernetes Service (AKS) cluster might be idle, running no more than the system components. You can reduce the cluster footprint by [scaling all the `User` node pools to 0](scale-cluster.md#scale-user-node-pools-to-0), but your [`System` pool](use-system-pools.md) is still required to run the system components while the cluster is running. 
 To optimize your costs further during these periods, you can completely turn off (stop) your cluster. This action will stop your control plane and agent nodes altogether, allowing you to save on all the compute costs, while maintaining all your objects and cluster state stored for when you start it again. You can then pick up right where you left of after a weekend or to have your cluster running only while you run your batch jobs.
-
-[!INCLUDE [preview features callout](./includes/preview/preview-callout.md)]
 
 ## Before you begin
 
@@ -28,40 +26,6 @@ When using the cluster start/stop feature, the following restrictions apply:
 - The cluster state of a stopped AKS cluster is preserved for up to 12 months. If your cluster is stopped for more than 12 months, the cluster state cannot be recovered. For more information, see the [AKS Support Policies](support-policies.md).
 - During preview, you need to stop the cluster autoscaler (CA) before attempting to stop the cluster.
 - You can only start or delete a stopped AKS cluster. To perform any operation like scale or upgrade, start your cluster first.
-
-### Install the `aks-preview` Azure CLI 
-
-You also need the *aks-preview* Azure CLI extension version 0.4.64 or later. Install the *aks-preview* Azure CLI extension by using the [az extension add][az-extension-add] command. Or install any available updates by using the [az extension update][az-extension-update] command.
-
-```azurecli-interactive
-# Install the aks-preview extension
-az extension add --name aks-preview
-
-# Update the extension to make sure you have the latest version installed
-az extension update --name aks-preview
-``` 
-
-### Register the `StartStopPreview` preview feature
-
-To use the start/stop cluster feature, you must enable the `StartStopPreview` feature flag on your subscription.
-
-Register the `StartStopPreview` feature flag by using the [az feature register][az-feature-register] command, as shown in the following example:
-
-```azurecli-interactive
-az feature register --namespace "Microsoft.ContainerService" --name "StartStopPreview"
-```
-
-It takes a few minutes for the status to show *Registered*. Verify the registration status by using the [az feature list][az-feature-list] command:
-
-```azurecli-interactive
-az feature list -o table --query "[?contains(name, 'Microsoft.ContainerService/StartStopPreview')].{Name:name,State:properties.state}"
-```
-
-When ready, refresh the registration of the *Microsoft.ContainerService* resource provider by using the [az provider register][az-provider-register] command:
-
-```azurecli-interactive
-az provider register --namespace Microsoft.ContainerService
-```
 
 ## Stop an AKS Cluster
 


### PR DESCRIPTION
This feature is no longer in preview.

However I'm not 100% sure about:
"During preview, you need to stop the cluster autoscaler (CA) before attempting to stop the cluster."

So i left it in the documentation