### PR TITLE
UseApplicationInsights() in Program.cs has been deprecated. AddApplic…

### DIFF
--- a/articles/azure-monitor/app/profiler-aspnetcore-linux.md
+++ b/articles/azure-monitor/app/profiler-aspnetcore-linux.md
@@ -44,20 +44,12 @@ The following instructions apply to all Windows, Linux, and Mac development envi
    dotnet add package Microsoft.ApplicationInsights.Profiler.AspNetCore
    ```
 
-1. Enable Application Insights in Program.cs:
-
-    ```csharp
-    public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-        WebHost.CreateDefaultBuilder(args)
-            .UseApplicationInsights() // Add this line of code to Enable Application Insights
-            .UseStartup<Startup>();
-    ```
-
-1. Enable Profiler in Startup.cs:
+1. Enable Application Insights and Profiler in Startup.cs:
 
     ```csharp
     public void ConfigureServices(IServiceCollection services)
     {
+        services.AddApplicationInsightsTelemetry(); // Add this line of code to enable Application Insights.
         services.AddServiceProfiler(); // Add this line of code to Enable Profiler
         services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
     }


### PR DESCRIPTION
UseApplicationInsights() has been deprecated. AddApplicationInsightsTelemetry() should be used intead.