### PR TITLE
Update app-service-deployment-slots-settings.md

### DIFF
--- a/includes/app-service-deployment-slots-settings.md
+++ b/includes/app-service-deployment-slots-settings.md
@@ -34,6 +34,7 @@ Features marked with an asterisk (*) are planned to be unswapped.
 * Diagnostic settings
 * Cross-origin resource sharing (CORS)
 * Virtual network integration
+* Settings that end with the suffix  _EXTENSION_VERSION 
 
 > [!NOTE]
 > To make these settings swappable, add the app setting `WEBSITE_OVERRIDE_PRESERVE_DEFAULT_STICKY_SLOT_SETTINGS` in every slot of the app and set its value to `0` or `false`. These settings are either all swappable or not at all. You can’t make just some settings swappable and not the others.


### PR DESCRIPTION
Added an additional line to Settings that aren't swapped ..  "Settings that end with the suffix  _EXTENSION_VERSION "