### PR TITLE
Fix wrong parameter name of Set-AzDiagnosticSetting

### DIFF
--- a/articles/web-application-firewall/ag/tutorial-restrict-web-traffic-powershell.md
+++ b/articles/web-application-firewall/ag/tutorial-restrict-web-traffic-powershell.md
@@ -273,7 +273,7 @@ $store = Get-AzStorageAccount `
 Set-AzDiagnosticSetting `
   -ResourceId $appgw.Id `
   -StorageAccountId $store.Id `
-  -Categories ApplicationGatewayAccessLog, ApplicationGatewayPerformanceLog, ApplicationGatewayFirewallLog `
+  -Category ApplicationGatewayAccessLog, ApplicationGatewayPerformanceLog, ApplicationGatewayFirewallLog `
   -Enabled $true `
   -RetentionEnabled $true `
   -RetentionInDays 30


### PR DESCRIPTION
Replaced  "-Categories" by  "-Category"
Issue: #70736