### PR TITLE
Removed unneccessary $ symbol from 2 bash snippets

### DIFF
--- a/articles/virtual-machines/workloads/oracle/oracle-database-quick-create.md
+++ b/articles/virtual-machines/workloads/oracle/oracle-database-quick-create.md
@@ -217,12 +217,12 @@ The Oracle software is already installed on the Marketplace image. Create a samp
 1.  Switch to the **oracle** user:
 
     ```bash
-    $ sudo su - oracle
+    sudo su - oracle
     ```
 2. Start the database listener
 
    ```bash
-   $ lsnrctl start
+   lsnrctl start
    ```
    The output is similar to the following:
   


### PR DESCRIPTION
This made copy & paste fail, eg:

```
[azureuser@vmoracle19c` ~]$ $ sudo su oracle
-bash: $: command not found
```