### PR TITLE
Update service-fabric-backuprestoreservice-quickstart-standaloneclust…

### DIFF
--- a/articles/service-fabric/service-fabric-backuprestoreservice-quickstart-standalonecluster.md
+++ b/articles/service-fabric/service-fabric-backuprestoreservice-quickstart-standalonecluster.md
@@ -98,6 +98,10 @@ First you need to enable the _backup and restore service_ in your cluster. Get t
             "parameters":  [{
                 "name": "SecretEncryptionCertThumbprint",
                 "value": "[Thumbprint]"
+            },
+            {
+                "name": "SecretEncryptionCertX509StoreName",
+                "value": "My"
             }]
         }
         ...


### PR DESCRIPTION
…er.md

Without providing SecretEncryptionCertX509StoreName argument cluster throws Invalid argument error. I put "My" as a default value, which is recommended according to: https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-cluster-fabric-settings .
For more info please contact marcinmi@microsoft.com.