### PR TITLE
Rename Automatic featurization column title

### DIFF
--- a/articles/machine-learning/concept-automated-ml.md
+++ b/articles/machine-learning/concept-automated-ml.md
@@ -115,7 +115,7 @@ For automated machine learning experiments, featurization is applied automatical
 
 In every automated machine learning experiment, your data is automatically scaled or normalized to help algorithms perform well. During model training, one of the following scaling or normalization techniques will be applied to each model. Learn how AutoML helps [prevent over-fitting and imbalanced data](concept-manage-ml-pitfalls.md) in your models.
 
-|Scaling&nbsp;&&nbsp;normalization| Description |
+|Scaling&nbsp;&&nbsp;processing| Description |
 | ------------- | ------------- |
 | [StandardScaleWrapper](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html)  | Standardize features by removing the mean and scaling to unit variance  |
 | [MinMaxScalar](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MinMaxScaler.html)  | Transforms features by scaling each feature by that column's minimum and maximum  |


### PR DESCRIPTION
Renames the column title from `Scaling & normalization` to `Scaling & processing`.
