### PR TITLE
Update Free tier limitation to 3 environments

### DIFF
--- a/articles/static-web-apps/review-publish-pull-requests.md
+++ b/articles/static-web-apps/review-publish-pull-requests.md
@@ -104,7 +104,7 @@ Staged versions of your application are currently accessible publicly by their U
 > [!WARNING]
 > Be careful when publishing sensitive content to staged versions, as access to pre-production environments are not restricted.
 
-The number of pre-production environments available for each app deployed with Static Web Apps depends of the SKU tier you are using. For example, with the Free tier you can have 1 pre-production environment in addition to the production environment.
+The number of pre-production environments available for each app deployed with Static Web Apps depends of the SKU tier you are using. For example, with the Free tier you can have 3 pre-production environments in addition to the production environment.
 
 ## Next steps
 


### PR DESCRIPTION
While using the service, I noticed I am now getting three pre-production environments as part of the Free tier.