### PR TITLE
Update sql-agent-extension-manually-register-single-vm.md

### DIFF
--- a/articles/azure-sql/virtual-machines/windows/sql-agent-extension-manually-register-single-vm.md
+++ b/articles/azure-sql/virtual-machines/windows/sql-agent-extension-manually-register-single-vm.md
@@ -131,7 +131,7 @@ To register your SQL Server VM directly in full mode (and possibly restart your 
   $vm = Get-AzVM -Name <vm_name> -ResourceGroupName <resource_group_name>
         
   # Register with SQL IaaS Agent extension in full mode
-  New-AzSqlVM -Name $vm.Name -ResourceGroupName $vm.ResourceGroupName -SqlManagementType Full
+  New-AzSqlVM -Name $vm.Name -ResourceGroupName $vm.ResourceGroupName -SqlManagementType Full -Location usgovvirginia
   ```
 
 ### NoAgent management mode 


### PR DESCRIPTION
The Location parameter now seems to be a required parameter for New-AzSqlVM.  Otherwise you'll get prompted for Location when you run the command.  Therefore I think the Full Mode sample registration should include the Location parameter for two reasons.  
1. Because it's required.  
2. Because Location is essentially what we typically refer to as the Azure region. It took a while to figure out what Location was asking for here. If we show in the example a region like "westus2" or "usgovvirginia", then it will make more sense.

![image](https://user-images.githubusercontent.com/35743905/109234856-19feed80-7792-11eb-9a1e-88bfd115f231.png)
