### PR TITLE
Update azure-messaging-eventhubs-checkpointstore-blob dependency to latest

### DIFF
--- a/articles/event-hubs/event-hubs-java-get-started-send.md
+++ b/articles/event-hubs/event-hubs-java-get-started-send.md
@@ -164,7 +164,7 @@ Add the following dependencies in the pom.xml file.
     <dependency>
         <groupId>com.azure</groupId>
         <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
-        <version>1.1.1</version>
+        <version>1.5.0</version>
     </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
BlobCheckpointStore is not present in azure-messaging-eventhubs-checkpointstore-blob version 1.1.1 so updating to the latest version