### PR TITLE
No info provided about the Private IP if exists

### DIFF
--- a/articles/virtual-machines/windows/change-availability-set.md
+++ b/articles/virtual-machines/windows/change-availability-set.md
@@ -75,7 +75,7 @@ The following script provides an example of gathering the required information, 
        -CreateOption Attach
     }
     
-# Add NIC(s) and keep the same NIC as primary
+# Add NIC(s) and keep the same NIC as primary; keep the Private IP too if exists  
     foreach ($nic in $originalVM.NetworkProfile.NetworkInterfaces) {	
     if ($nic.Primary -eq "True")
     {


### PR DESCRIPTION
In the above context, it mentions about the NIC but not about the Private IP which confuses the customer to proceed to move the VM to a new Availability set or not. As the customer might need the VM along with the private IP when moving to a new Availability set, more clarification helps as my customers(Azure Support Chat Team's Cxs) were confused with no clue.