### PR TITLE
Update steps for B2C article example on Python 

### DIFF
--- a/articles/active-directory-b2c/tutorial-web-app-python.md
+++ b/articles/active-directory-b2c/tutorial-web-app-python.md
@@ -126,14 +126,53 @@ CLIENT_SECRET = "22222222-2222-2222-2222-222222222222" # Placeholder - for use O
     ```console
     cd ms-identity-python-webapp
     ```
+
 1. Run the following commands to install the required packages from PyPI and run the web app on your local machine:
 
-    ```console
-    pip install -r requirements.txt
-    flask run --host localhost --port 5000
-    ```
 
-    The console window displays the port number of the locally running application:
+# [bash](#tab/bash)
+
+```bash
+# Configure the Python virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+# Run the dev server
+flask run --host localhost --port 5000
+```
+
+# [PowerShell](#tab/powershell)
+
+```powershell
+# Configure the Python virtual environment
+py -3 -m venv venv
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned -Force
+venv\scripts\activate
+
+# Install dependencies
+pip install -r requirements.txt
+# Run the dev server
+flask run --host localhost --port 5000
+```
+
+# [CMD](#tab/cmd)
+
+```cmd
+:: Configure the Python virtual environment
+py -3 -m venv venv
+venv\scripts\activate
+
+:: Install dependencies
+pip install -r requirements.txt
+:: Run the dev server
+flask run --host localhost --port 5000
+```
+---
+
+
+1. The console window displays the port number of the locally running application:
 
     ```console
      * Serving Flask app "app" (lazy loading)

--- a/articles/active-directory-b2c/tutorial-web-app-python.md
+++ b/articles/active-directory-b2c/tutorial-web-app-python.md
@@ -7,7 +7,7 @@ author: msmimart
 manager: celestedg
 
 ms.author: mimart
-ms.date: 06/12/2020
+ms.date: 04/01/2021
 ms.topic: tutorial
 ms.service: active-directory
 ms.subservice: B2C
@@ -39,7 +39,7 @@ You need the following Azure AD B2C resources in place before continuing with th
 Additionally, you need the following in your local development environment:
 
 * [Visual Studio Code](https://code.visualstudio.com/) or another code editor
-* [Python](https://nodejs.org/en/download/) 2.7+ or 3+
+* [Python](https://www.python.org/downloads/)
 
 ## Add a redirect URI
 
@@ -126,7 +126,7 @@ CLIENT_SECRET = "22222222-2222-2222-2222-222222222222" # Placeholder - for use O
     ```console
     cd ms-identity-python-webapp
     ```
-1. Run the following commands to install the required packages from PyPi and run the web app on your local machine:
+1. Run the following commands to install the required packages from PyPI and run the web app on your local machine:
 
     ```console
     pip install -r requirements.txt


### PR DESCRIPTION
- Correct link for Python download
- Correct capitalisation of PyPI
- Removed suggestion of Python 2 as the sample project doesn't support it and its EOL
- Added a step to configure a virtual environment before installing the prerequisites

Cc @msmimart 