### PR TITLE
Update link in migrate-python-adal-msal.md

### DIFF
--- a/articles/active-directory/develop/migrate-python-adal-msal.md
+++ b/articles/active-directory/develop/migrate-python-adal-msal.md
@@ -106,7 +106,7 @@ app = msal.PublicClientApplication(
     "client_id", authority="...",
     # token_cache=...  # Default cache is in memory only.
                        # You can learn how to use SerializableTokenCache from
-                       # https://msal-python.rtfd.io/en/latest/#msal.SerializableTokenCache
+                       # https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache
     )
 
 # We choose a migration strategy of migrating all RTs in one loop


### PR DESCRIPTION
readthedocs has multiple endpoints, 

rtfd.io is the old endpoint, readthedocs.io is the new endpoint