### PR TITLE
Update link in msal-python-token-cache-serialization.md

### DIFF
--- a/articles/active-directory/develop/msal-python-token-cache-serialization.md
+++ b/articles/active-directory/develop/msal-python-token-cache-serialization.md
@@ -35,4 +35,4 @@ For web apps or web APIs, you might use the session, or a Redis cache, or a data
 
 ## Next steps
 
-See [ms-identity-python-webapp](https://github.com/Azure-Samples/ms-identity-python-webapp/blob/master/app.py#L64-L72) for an example of how to use the token cache for a Windows or Linux Web app or web API. The example is for a web app that calls the Microsoft Graph API.
+See [ms-identity-python-webapp](https://github.com/Azure-Samples/ms-identity-python-webapp/blob/0.3.0/app.py#L66-L74) for an example of how to use the token cache for a Windows or Linux Web app or web API. The example is for a web app that calls the Microsoft Graph API.


### PR DESCRIPTION
The line position that was being linked to is now invalid, so this pins to the latest tag with the correct line positions.