### PR TITLE
Update pstn-call-js.md

### DIFF
--- a/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-android.md
+++ b/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-android.md
@@ -51,7 +51,7 @@ Modify `startCall()` event handler in **MainActivity.java**, so that it handles 
         StartCallOptions options = new StartCallOptions();
         options.setAlternateCallerId(callerPhone);
         options.setVideoOptions(new VideoOptions(null));
-        call = agent.call(
+        call = agent.startCall(
                 getApplicationContext(),
                 new PhoneNumber[] {new PhoneNumber(calleePhone)},
                 options);

--- a/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-ios.md
+++ b/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-ios.md
@@ -36,7 +36,7 @@ func startCall() {
         if granted {
             let startCallOptions = ACSStartCallOptions()
             startCallOptions!.alternateCallerID = PhoneNumber(phoneNumber: "+12223334444")
-            self.call = self.callAgent!.call([PhoneNumber(phoneNumber: self.callee)], options: startCallOptions)
+            self.call = self.callAgent!.startCall([PhoneNumber(phoneNumber: self.callee)], options: startCallOptions)
             self.callDelegate = CallDelegate(self)
             self.call!.delegate = self.callDelegate
         }

--- a/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-js.md
+++ b/articles/communication-services/quickstarts/voice-video-calling/includes/pstn-call-js.md
@@ -84,7 +84,7 @@ Add an event handler to initiate a call to the phone number you provided when th
 callPhoneButton.addEventListener("click", () => {
   // start a call to phone
   const phoneToCall = calleePhoneInput.value;
-  call = callAgent.call(
+  call = callAgent.startCall(
     [{phoneNumber: phoneToCall}], { alternateCallerId: {phoneNumber: 'YOUR AZURE REGISTERED PHONE NUMBER HERE: +12223334444'}
   });
   // toggle button states


### PR DESCRIPTION
Quickstart code to make an outbound PSTN call is outdated:
Calling library changed method Call() to StartCall()