### PR TITLE
Update ingress-tls.md

### DIFF
--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -126,7 +126,6 @@ helm repo update
 # Install the cert-manager Helm chart
 helm install cert-manager jetstack/cert-manager \
   --namespace ingress-basic \
-  --version v0.16.1 \
   --set installCRDs=true \
   --set nodeSelector."kubernetes\.io/os"=linux \
   --set webhook.nodeSelector."kubernetes\.io/os"=linux \
@@ -142,7 +141,7 @@ Before certificates can be issued, cert-manager requires an [Issuer][cert-manage
 Create a cluster issuer, such as `cluster-issuer.yaml`, using the following example manifest. Update the email address with a valid address from your organization:
 
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt


### PR DESCRIPTION
The version for cert-manager in this examples returns '**no matches for kind "ClusterIssuer" in version "cert-manager.io/v1"**' (https://github.com/jetstack/cert-manager/issues/3246)

The latest ( or v1.0.1+) version works correctly and the install guide on on cert-manager.io has been updated to link to the v1.0 deployment yaml. I didn’t need to do anything apart from re-test using the new config (https://cert-manager.io/docs/configuration/acme/http01/).