### PR TITLE
includes: Do not request root privileges for Enter-PSSession in Linux

### DIFF
--- a/includes/azure-stack-edge-gateway-connect-minishell.md
+++ b/includes/azure-stack-edge-gateway-connect-minishell.md
@@ -63,7 +63,7 @@ Follow these steps to remotely connect from an NFS client.
 
 1. To open PowerShell session, type:
 
-    `sudo pwsh`
+    `pwsh`
  
 2. For connecting using the remote client, type:
 

--- a/includes/data-box-edge-gateway-connect-minishell.md
+++ b/includes/data-box-edge-gateway-connect-minishell.md
@@ -65,7 +65,7 @@ Follow these steps to remotely connect from an NFS client.
 
 1. To open PowerShell session, type:
 
-    `sudo pwsh`
+    `pwsh`
  
 2. For connecting using the remote client, type:
 

--- a/includes/data-box-gateway-connect-minishell.md
+++ b/includes/data-box-gateway-connect-minishell.md
@@ -63,7 +63,7 @@ Follow these steps to remotely connect from an NFS client.
 
 1. To open PowerShell session, type:
 
-    `sudo pwsh`
+    `pwsh`
  
 2. For connecting using the remote client, type:
 


### PR DESCRIPTION
`Enter-PSSession` in Linux does not require `sudo`. Using it if not necessary creates a security vulnerability.

This resolves https://github.com/MicrosoftDocs/azure-docs/issues/71453.