### PR TITLE
Remove reference to missing image

### DIFF
--- a/articles/virtual-desktop/app-attach.md
+++ b/articles/virtual-desktop/app-attach.md
@@ -26,7 +26,7 @@ You must install certificates on all session hosts in the host pool that will ho
 If your app uses a certificate that isn't public-trusted or was self-signed, here's how to install it:
 
 1. Right-click the package and select **Properties**.
-2. In the window that appears, select the **Digital signatures** tab. There should be only one item in the list on the tab, as shown in the following image. Select that item to highlight the item, then select **Details**.
+2. In the window that appears, select the **Digital signatures** tab. There should be only one item in the list on the tab. Select that item to highlight the item, then select **Details**.
 3. When the digital signature details window appears, select the **General** tab, then select **View Certificate**, then select **Install certificate**.
 4. When the installer opens, select **local machine** as your storage location, then select **Next**.
 5. If the installer asks you if you want to allow the app to make changes to your device, select **Yes**.


### PR DESCRIPTION
There is a reference to an image not present in the document.  For now an easy fix is just remove the image reference; an alternative fix is to generate the image and place it in, but this is a quicker fix, and there are no other images referenced in the process.  If this image is added, images should be added for each step.