### PR TITLE
edited ADUC reference

### DIFF
--- a/articles/active-directory/devices/azuread-join-sso.md
+++ b/articles/active-directory/devices/azuread-join-sso.md
@@ -57,7 +57,7 @@ If you want to manage your on-premises AD from a Windows device, install the [Re
 
 You can use:
 
-- The Active Directory Users and Computers (ADUC) snap-in to administer all AD objects. However, you have to  specify the domain that you want to connect to manually.
+- The Active Directory Administrative Center (DSAC) snap-in to administer all AD objects. However, you have to  specify the domain that you want to connect to manually.
 - The DHCP snap-in to administer an AD-joined DHCP server. However, you may need to specify the DHCP server name or address.
  
 ## What you should know


### PR DESCRIPTION
ADUC is an outdated and very limited tool. DSAC is much more versatile and powerful. We should do everything in our hands to get people off ADUC. It has even received a bugfix in Server 2022.
There are only 3 limitations of DSAC vs ADUC.
- DSAC does not have a rights delegation on AD OUs
- you cannot copy user accounts (you should not)
- you cannot add contacts (somethings that should be pretty rare by now)

on the other hand the list of things you cannot do with ADUC is very much longer.