### PR TITLE
Fix broken web job history link

### DIFF
--- a/articles/app-service/webjobs-create-ieux-conceptual.md
+++ b/articles/app-service/webjobs-create-ieux-conceptual.md
@@ -57,4 +57,4 @@ The following file types are supported:
 ## Next steps
 
 * Learn how to [create a WebJob](./webjobs-create-ieux.md)
-* View log history of WebJobs](./webjobs-create-ieux-view-log.md)
+* View log history of [WebJobs](./webjobs-create-ieux-view-log.md)


### PR DESCRIPTION
There seems to be a broken markdown link in the next steps section. This PR fixes this broken markdown link.