### PR TITLE
Add workspace authentication instructions

### DIFF
--- a/articles/machine-learning/tutorial-train-models-with-aml.md
+++ b/articles/machine-learning/tutorial-train-models-with-aml.md
@@ -90,7 +90,7 @@ print(ws.name, ws.location, ws.resource_group, sep='\t')
 ```
 
 >[!NOTE]
-> It depends on your development environment (for example, your computer), you'll be asked to authenticate to your workspace by using a *device code* the first time you run the following code. Follow the on-screen instructions.
+> You may be asked to authenticate to your workspace the first time you run the following code. Follow the on-screen instructions.
 
 ### Create an experiment
 

--- a/articles/machine-learning/tutorial-train-models-with-aml.md
+++ b/articles/machine-learning/tutorial-train-models-with-aml.md
@@ -89,6 +89,9 @@ ws = Workspace.from_config()
 print(ws.name, ws.location, ws.resource_group, sep='\t')
 ```
 
+>[!NOTE]
+> It depends on your development environment (for example, your computer), you'll be asked to authenticate to your workspace by using a *device code* the first time you run the following code. Follow the on-screen instructions.
+
 ### Create an experiment
 
 Create an experiment to track the runs in your workspace. A workspace can have multiple experiments:


### PR DESCRIPTION
The most of customer environment run this sample even if Aml Computing instance, authentication instructions shows up. Some customers doesn't aware of it. Note section probably help them.