### PR TITLE
remove the etcd certs from the public document

### DIFF
--- a/articles/aks/certificate-rotation.md
+++ b/articles/aks/certificate-rotation.md
@@ -23,8 +23,6 @@ AKS generates and uses the following certificates, Certificate Authorities, and 
 * The AKS API server creates a Certificate Authority (CA) called the Cluster CA.
 * The API server has a Cluster CA, which signs certificates for one-way communication from the API server to kubelets.
 * Each kubelet also creates a Certificate Signing Request (CSR), which is signed by the Cluster CA, for communication from the kubelet to the API server.
-* The etcd key value store has a certificate signed by the Cluster CA for communication from etcd to the API server.
-* The etcd key value store creates a CA that signs certificates to authenticate and authorize data replication between etcd replicas in the AKS cluster.
 * The API aggregator uses the Cluster CA to issue certificates for communication with other APIs. The API aggregator can also have its own CA for issuing those certificates, but it currently uses the Cluster CA.
 * Each node uses a Service Account (SA) token, which is signed by the Cluster CA.
 * The `kubectl` client has a certificate for communicating with the AKS cluster.


### PR DESCRIPTION
remove the etcd certs from the public document, because it's fully managed/rotated by AKS, and not visible to customer.