### PR TITLE
Update a broken link in the SQL Data Load page

### DIFF
--- a/articles/azure-sql/load-from-csv-with-bcp.md
+++ b/articles/azure-sql/load-from-csv-with-bcp.md
@@ -27,7 +27,7 @@ To complete the steps in this article, you need:
 * The bcp command-line utility installed
 * The sqlcmd command-line utility installed
 
-You can download the bcp and sqlcmd utilities from the [Microsoft sqlcmd Documentation][https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility?view=sql-server-ver15].
+You can download the bcp and sqlcmd utilities from the [Microsoft sqlcmd Documentation][https://docs.microsoft.com/sql/tools/sqlcmd-utility?view=sql-server-ver15].
 
 ### Data in ASCII or UTF-16 format
 

--- a/articles/azure-sql/load-from-csv-with-bcp.md
+++ b/articles/azure-sql/load-from-csv-with-bcp.md
@@ -27,7 +27,7 @@ To complete the steps in this article, you need:
 * The bcp command-line utility installed
 * The sqlcmd command-line utility installed
 
-You can download the bcp and sqlcmd utilities from the [Microsoft Download Center][Microsoft Download Center].
+You can download the bcp and sqlcmd utilities from the [Microsoft sqlcmd Documentation][https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility?view=sql-server-ver15].
 
 ### Data in ASCII or UTF-16 format
 


### PR DESCRIPTION
A very minor fix to ensure that the download links don't point to an unsupported version of SQL Command Line Utilities.

This is in reference to Issue #71889 