### PR TITLE
includes: Fix New SSL Enter-PSSession instructions for Linux

### DIFF
--- a/includes/azure-stack-edge-gateway-connect-minishell.md
+++ b/includes/azure-stack-edge-gateway-connect-minishell.md
@@ -90,7 +90,7 @@ Follow these steps to remotely connect from an NFS client.
  
 2. For connecting using the remote client, type:
 
-    `Enter-PSSession -ComputerName $ip -Authentication Negotiate -ConfigurationName Minishell -Credential ~\EdgeUser -UseSSL`
+    `Enter-PSSession -ComputerName $ip -Authentication Negotiate -ConfigurationName Minishell -Credential ~\EdgeUser`
 
     When prompted, provide the password used to sign into your device.
  


### PR DESCRIPTION
In commit f59311b23ce585ee1d2e82db2aab5a270d7e6290, the option `-UseSSL` was added to the `Enter-PSSession` line for Linux. However, if added, it returns the following error (PowerShell 7.1.2):

```
Enter-PSSession: HTTPS on Unix does not currently support CA or CN checks.
Use the PSSessionOption -SkipCACheck and -SkipCNCheck if you are certain you
trust the server you are connecting to and the network in between.
```

Therefore, in this commit the `-UseSSL` flag is removed from the Linux instructions.