### PR TITLE
[Service Bus] TypeScript samples link missing

### DIFF
--- a/articles/service-bus-messaging/service-bus-samples.md
+++ b/articles/service-bus-messaging/service-bus-samples.md
@@ -31,12 +31,12 @@ The Service Bus messaging samples demonstrate key features in [Service Bus messa
 ## TypeScript samples
 | Package | Samples location | 
 | ------- | ---------------- | 
-| azure/service-bus | https://docs.microsoft.com/samples/azure/azure-sdk-for-js/service-bus-typescript/ | 
+| @azure/service-bus | https://docs.microsoft.com/samples/azure/azure-sdk-for-js/service-bus-typescript/ | 
 
 ## JavaScript samples
 | Package | Samples location | 
 | ------- | ---------------- | 
-| azure/service-bus | https://docs.microsoft.com/samples/azure/azure-sdk-for-js/service-bus-javascript/ | 
+| @azure/service-bus | https://docs.microsoft.com/samples/azure/azure-sdk-for-js/service-bus-javascript/ | 
 
 ## Go samples
 | Package | Samples location | 

--- a/articles/service-bus-messaging/service-bus-samples.md
+++ b/articles/service-bus-messaging/service-bus-samples.md
@@ -28,6 +28,11 @@ The Service Bus messaging samples demonstrate key features in [Service Bus messa
 | -------------------- | ----------------------- |
 | azure.servicebus | https://docs.microsoft.com/samples/azure/azure-sdk-for-python/servicebus-samples/ |
 
+## TypeScript samples
+| Package | Samples location | 
+| ------- | ---------------- | 
+| azure/service-bus | https://docs.microsoft.com/samples/azure/azure-sdk-for-js/service-bus-typescript/ | 
+
 ## JavaScript samples
 | Package | Samples location | 
 | ------- | ---------------- | 


### PR DESCRIPTION
Typescript link is missing for service-bus samples.
I'm unsure if this document is auto-generated.
In case this is manually written, this PR would add the link in the document.

@ramya-rao-a 