### PR TITLE
Rename docker container registry module name in tutorial-nested-iot-edge.md

### DIFF
--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -521,7 +521,7 @@ In the [Azure portal](https://ms.portal.azure.com/):
            "$edgeAgent": {
                "properties.desired": {
                    "modules": {
-                       "dockerContainerRegistry": {
+                       "registry": {
                            "settings": {
                                "image": "registry:latest",
                                "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5000/tcp\":[{\"HostPort\":\"5000\"}]}}}"


### PR DESCRIPTION
Using "dockerContainerRegistry" as a module name when deployed on top level causes 502 response code when attempting to pull image from child device. Should be just "registry" because how API proxy module configured.