### PR TITLE
Update howto-manage-inactive-user-accounts.md

### DIFF
--- a/articles/active-directory/reports-monitoring/howto-manage-inactive-user-accounts.md
+++ b/articles/active-directory/reports-monitoring/howto-manage-inactive-user-accounts.md
@@ -37,7 +37,7 @@ The last successful sign-in provides potential insights into a user's continued 
     
 ## How to detect inactive user accounts
 
-You detect inactive accounts by evaluating the **lastSignInDateTime** property exposed by the **signInActivity** resource type of the **Microsoft Graph** API. Using this property, you can implement a solution for the following scenarios:
+You detect inactive accounts by evaluating the **lastSignInDateTime** property exposed by the **signInActivity** resource type of the **Microsoft Graph** API. The **lastSignInDateTime** property shows the last time a user made a successful interactive sign-in to Azure AD. Using this property, you can implement a solution for the following scenarios:
 
 - **Users by name**: In this scenario, you search for a specific user by name, which enables you to evaluate the lastSignInDateTime: `https://graph.microsoft.com/beta/users?$filter=startswith(displayName,'markvi')&$select=displayName,signInActivity`
 


### PR DESCRIPTION
This doc already said that the lastSignInDateTime property is only updated when users do interactive sign ins, but customers were still confused why non-interactive sign ins also did not cause updates. They complained that the docs was misleading. I added an additional sentence calling out that it's interactive only to help clarify