### PR TITLE
Add limitation for StringNotContains operator

### DIFF
--- a/articles/event-grid/event-filtering.md
+++ b/articles/event-grid/event-filtering.md
@@ -350,6 +350,7 @@ FOR_EACH filter IN (a, b, c)
         IF key CONTAINS filter
             FAIL_MATCH
 ```
+See [Limitations](#limitations) section for current limitation of this operator.
 
 ## StringBeginsWith
 The **StringBeginsWith** operator evaluates to true if the **key** value **begins with** any of the specified **filter** values. In the following example, it checks whether the value of the `key1` attribute in the `data` section begins with `event` or `grid`. For example, `event hubs` begins with `event`.  
@@ -629,6 +630,7 @@ Advanced filtering has the following limitations:
 * 5 advanced filters and 25 filter values across all the filters per event grid subscription
 * 512 characters per string value
 * Five values for **in** and **not in** operators
+* The `StringNotContains` operator is currently not available in the portal.
 * Keys with **`.` (dot)** character in them. For example: `http://schemas.microsoft.com/claims/authnclassreference` or `john.doe@contoso.com`. Currently, there's no support for escape characters in keys. 
 
 The same key can be used in more than one filter.


### PR DESCRIPTION
The `StringNotContains` operator is not yet available in the portal so it should be noted as a limitation.
![event-grid_string-not-contains-operator](https://iambryancs.github.io/static/event-grid_string-not-contains-operator.png "event-grid_string-not-contains-operator")
This took me awhile to figure out because there's not a single piece of documentation that mentions this.
Kinda weird to have this documented when it's not available in tutorials because most uses the portal for quick start.