### PR TITLE
Update severity level and azmonwvdi hyperlink

### DIFF
--- a/articles/virtual-desktop/azure-monitor-glossary.md
+++ b/articles/virtual-desktop/azure-monitor-glossary.md
@@ -35,7 +35,7 @@ The total number of users that have started a session in the last 24 hours.
 
 ## Daily alerts
 
-The total number of alerts triggered day to day.
+The total number of alerts triggered each day.
 
 ## Daily connections and reconnections
 

--- a/articles/virtual-desktop/azure-monitor-glossary.md
+++ b/articles/virtual-desktop/azure-monitor-glossary.md
@@ -19,7 +19,7 @@ This article lists and briefly describes key terms and concepts related to Azure
 
 ## Alerts
 
-Any active Azure Monitor alerts that you've configured on the subscription and classified as [severity 1](#severity-1-alerts) will appear in the Overview page. To learn how to set up alerts, see [Respond to events with Azure Monitor Alerts](../azure-monitor/alerts/tutorial-response.md).
+Any active Azure Monitor alerts that you've configured on the subscription and classified as [severity 0](#severity-0-alerts) will appear in the Overview page. To learn how to set up alerts, see [Respond to events with Azure Monitor Alerts](../azure-monitor/alerts/tutorial-response.md).
 
 ## Available sessions
 
@@ -35,7 +35,7 @@ The total number of users that have started a session in the last 24 hours.
 
 ## Daily alerts
 
-The total number of [severity 1 alerts](#severity-1-alerts) triggered in the last 24 hours.
+The total number of alerts triggered day to day.
 
 ## Daily connections and reconnections
 
@@ -73,7 +73,7 @@ Each diagnostics issue or error includes a message that explains what went wrong
 
 ## Input delay
 
-"Input delay" in Azure Monitor for Windows Virtual Desktop means the input delay per process performance counter for each session. In the host performance page at <aka.ms/azmonwvdi>, this performance counter is configured to send a report to the service once every 30 seconds. These 30-second intervals are called "samples," and the report the worst case in that window. The median and p95 values reflect the median and 95th percentile across all samples.
+"Input delay" in Azure Monitor for Windows Virtual Desktop means the input delay per process performance counter for each session. In the host performance page at [aka.ms/azmonwvdi](https://portal.azure.com/#blade/Microsoft_Azure_WVD/WvdManagerMenuBlade/workbooks), this performance counter is configured to send a report to the service once every 30 seconds. These 30-second intervals are called "samples," and the report the worst case in that window. The median and p95 values reflect the median and 95th percentile across all samples.
 
 Under **Input delay by host**, you can select a session host row to filter all other visuals in the page to that host. You can also select a process name to filter the median input delay over time chart.
 
@@ -150,7 +150,7 @@ Round-trip time (RTT) is an estimate of the connection's round-trip time between
 
 The **Sessions** item shows the status of all sessions, connected and disconnected. **Idle sessions** only shows the disconnected sessions.
 
-## Severity 1 alerts
+## Severity 0 alerts
 
 The most urgent items that you need to take care of right away. If you don't address these issues, they could cause your Windows Virtual Desktop deployment to stop working.
 


### PR DESCRIPTION
Update guidance to reflect that Windows Virtual Desktop Insights tracks severity 0 (not severity 1) incidents at the top of the Overview page
Capture that the Daily alerts chart tracks all severities over time, not just a specific severity (e.g. severity 1)
Ensure that one reference to aka.ms/azmonwvdi is hyperlinked