### PR TITLE
Changed Azure AD B2C UserJourneyBehaviorScopeType value Disabled to Suppressed

### DIFF
--- a/articles/active-directory-b2c/session-behavior.md
+++ b/articles/active-directory-b2c/session-behavior.md
@@ -78,7 +78,7 @@ You can configure the Azure AD B2C session behavior, including:
   - **Tenant** - This setting is the default. Using this setting allows multiple applications and user flows in your B2C tenant to share the same user session. For example, once a user signs into an application, the user can also seamlessly sign into another one upon accessing it.
   - **Application** - This setting allows you to maintain a user session exclusively for an application, independent of other applications. For example, you can use this setting if you want the user to sign in to Contoso Pharmacy regardless of whether the user is already signed into Contoso Groceries.
   - **Policy** - This setting allows you to maintain a user session exclusively for a user flow, independent of the applications using it. For example, if the user has already signed in and completed a multi-factor authentication (MFA) step, the user can be given access to higher-security parts of multiple applications, as long as the session tied to the user flow doesn't expire.
-  - **Disabled** - This setting forces the user to run through the entire user flow upon every execution of the policy.
+  - **Suppressed** - This setting forces the user to run through the entire user flow upon every execution of the policy.
 - **Keep me signed in (KMSI)** - Extends the session lifetime through the use of a persistent cookie. If this feature is enabled and the user selects it, the session remains active even after the user closes and reopens the browser. The session is revoked only when the user signs out. The KMSI feature only applies to sign-in with local accounts. The KMSI feature takes precedence over the session lifetime.
 
 ::: zone pivot="b2c-user-flow"


### PR DESCRIPTION
If you use documented Scope value 'Disabled' you'll get an error: "The 'Scope' attribute is invalid - The value 'Disabled' is invalid according to its datatype 'http://schemas.microsoft.com/online/cpim/schemas/2013/06:UserJourneyBehaviorScopeType' - The Enumeration constraint failed". According to schema https://github.com/Azure-Samples/active-directory-b2c-advanced-policies/blob/d740d68f2f5433883e75f5bc662b661f553d836a/B2CPolicies/Advanced%20Policies%20Starter%20pack/TrustFrameworkPolicy_0.3.0.0.xsd#L1996 right value is 'Suppressed'.