### PR TITLE
Added --show-next-marker to az storage query

### DIFF
--- a/articles/virtual-machines/linux/find-unattached-disks.md
+++ b/articles/virtual-machines/linux/find-unattached-disks.md
@@ -66,7 +66,7 @@ do
     for container in ${containers[@]}
     do 
         
-        blobs=$(az storage blob list -c $container --connection-string $connectionString --query "[?properties.blobType=='PageBlob' && ends_with(name,'.vhd')].[name]" -o tsv)
+        blobs=$(az storage blob list --show-next-marker -c $container --connection-string $connectionString --query "[?properties.blobType=='PageBlob' && ends_with(name,'.vhd')].[name]" -o tsv)
         
         for blob in ${blobs[@]}
         do


### PR DESCRIPTION
Added --show-next-marker to `az storage` query to prevent `WARNING: Next Marker:` message.

https://github.com/Azure/azure-cli/issues/13704
https://github.com/Azure/azure-cli/issues/11657#issuecomment-799624904