### PR TITLE
Update connection string to include correct port number for Table Storage emulator

### DIFF
--- a/includes/storage-emulator-connection-string-include.md
+++ b/includes/storage-emulator-connection-string-include.md
@@ -28,7 +28,7 @@ DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;
 AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;
 BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;
-TableEndpoint=http://127.0.0.1:10001/devstoreaccount1;
+TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;
 ```
 
 The following .NET code snippet shows how you can use the shortcut from a method that takes a connection string. For example, the [BlobContainerClient(String, String)](/dotnet/api/azure.storage.blobs.blobcontainerclient.-ctor#Azure_Storage_Blobs_BlobContainerClient__ctor_System_String_System_String_) constructor takes a connection string.


### PR DESCRIPTION
Hi,

The storage account emulator is configured to listen on 10001 for queues & 10002 for tables by default.
This fixes the connection string for tables to point against the table storage emulator.


Thanks,