### PR TITLE
Add csHost, csBytes to IIS log record properties

### DIFF
--- a/articles/azure-monitor/agents/data-sources-iis-logs.md
+++ b/articles/azure-monitor/agents/data-sources-iis-logs.md
@@ -56,6 +56,8 @@ IIS log records have a type of **W3CIISLog** and have the properties in the foll
 | sSiteName |Name of the IIS site. |
 | TimeGenerated |Date and time the entry was logged. |
 | TimeTaken |Length of time to process the request in milliseconds. |
+| csHost | Host name. |
+| csBytes | Number of bytes that the server received. |
 
 ## Log queries with IIS logs
 The following table provides different examples of log queries that retrieve IIS log records.


### PR DESCRIPTION
csHost and csBytes are used in the log query example in this page, but it does not explain in the IIS log record properties table.

I was confirmed these properties existence in the actual my environment and the following docs page.

https://docs.microsoft.com/en-us/iis/manage/provisioning-and-managing-iis/configure-logging-in-iis#to-select-w3c-fields-to-log-by-using-the-ui