### PR TITLE
Fix typo

### DIFF
--- a/includes/active-directory-b2c-choose-user-flow-or-custom-policy.md
+++ b/includes/active-directory-b2c-choose-user-flow-or-custom-policy.md
@@ -5,4 +5,4 @@ ms.topic: include
 ms.date: 12/08/2020
 ms.author: mimart
 ---
-***Before you begin***, use the selector above to choose the type of policy you’re configuring. Azure AD B2C offers two methods of defining how users interact with your applications: though predefined [user flows](../articles/active-directory-b2c/user-flow-overview.md), or through fully configurable [custom policies](../articles/active-directory-b2c/custom-policy-overview.md). The steps required in this article are different for each method. 	
+***Before you begin***, use the selector above to choose the type of policy you’re configuring. Azure AD B2C offers two methods of defining how users interact with your applications: through predefined [user flows](../articles/active-directory-b2c/user-flow-overview.md), or through fully configurable [custom policies](../articles/active-directory-b2c/custom-policy-overview.md). The steps required in this article are different for each method. 	


### PR DESCRIPTION
Fixing typo in the text - it is '`through` predefined user flows...' and not '`though` predefined user flows ...'