### PR TITLE
Update concept-all-sign-ins.md

### DIFF
--- a/articles/active-directory/reports-monitoring/concept-all-sign-ins.md
+++ b/articles/active-directory/reports-monitoring/concept-all-sign-ins.md
@@ -123,6 +123,8 @@ Interactive user sign-ins are sign-ins where a user provides an authentication f
 
 This report also includes federated sign-ins from identity providers that are federated to Azure AD.  
 
+Note: The interactive user sign-ins report used to contain some non-interactive sign-ins from Microsoft Exchange clients. Although those sign-ins were non interactive, they were included in the interactive user sign-ins report for additional visibility. Once the non-interactive user sign-ins report entered public preview in November 2020, those non-interactive sign-in event logs were moved to the non-interactive user sign in report for increased accuracy. 
+
 
 **Report size:** small <br> 
 **Examples:**


### PR DESCRIPTION
Before we had a non-interactive report, we included some non-interactive exchange sign ins in the interactive report so customers would have visibility. When we created the non-interactive sign ins report, we moved legacy Exchange sign-ins to the non-interactive report since they're non interactive. This confused some customers and led to an ICM here: https://portal.microsofticm.com/imp/v3/incidents/details/230478719/home

I added a note about this change that happened in Nov 2020. We should keep that in the docs for some time