### PR TITLE
FAQ Update

### DIFF
--- a/articles/active-directory-b2c/custom-domain.md
+++ b/articles/active-directory-b2c/custom-domain.md
@@ -260,7 +260,7 @@ Azure Front Door passes the user's original IP address. This is the IP address t
 
 ### Can I use a third-party web application firewall (WAF) with B2C?
 
-Currently, Azure AD B2C supports a custom domain through the use of Azure Front Door only. If you want to use your own WAF in front of Azure Front Door, then you will need to evaluate and test your integration.
+Currently, Azure AD B2C supports a custom domain through the use of Azure Front Door only. If you want to use your own WAF in front of Azure Front Door, you'll need to evaluate and test your integration.
 
 
 ## Next steps

--- a/articles/active-directory-b2c/custom-domain.md
+++ b/articles/active-directory-b2c/custom-domain.md
@@ -260,7 +260,7 @@ Azure Front Door passes the user's original IP address. This is the IP address t
 
 ### Can I use a third-party web application firewall (WAF) with B2C?
 
-Currently, Azure AD B2C supports a custom domain through the use of Azure Front Door only. Don't add another WAF in front of Azure Front Door.
+Currently, Azure AD B2C supports a custom domain through the use of Azure Front Door only. If you want to use your own WAF in front of Azure Front Door, then you will need to evaluate and test your integration.
 
 
 ## Next steps


### PR DESCRIPTION
Can I use a third-party web application firewall (WAF) with B2C? 

Currently, Azure AD B2C supports a custom domain through the use of Azure Front Door only.  If you want to use your own WAF in front of Azure Front Door, then you will need to evaluate and test your integration.