### PR TITLE
Fix link to App Insights docs rendering incorrectly

### DIFF
--- a/articles/batch/monitor-application-insights.md
+++ b/articles/batch/monitor-application-insights.md
@@ -36,7 +36,7 @@ A sample C# solution with code to accompany this article is available on [GitHub
    * Use the Azure portal to create an Application Insights *resource*. Select the *General* **Application type**.
 
    * Copy the [instrumentation 
-key](../azure-monitor/app/create-new-resource.md #copy-the-instrumentation-key) from the portal. It is required later in this article.
+key](../azure-monitor/app/create-new-resource.md#copy-the-instrumentation-key) from the portal. It is required later in this article.
   
   > [!NOTE]
   > You may be [charged](https://azure.microsoft.com/pricing/details/application-insights/) for the data stored in Application Insights. 


### PR DESCRIPTION
This change fixes a link to a section of the App Insights documentation which was displaying incorrectly. This file is under the Azure Batch documentation.

An extra space was added in the URL which made it invalid and also broke the markdown formatting. To fix the issue, this extra space was removed. The URL should now link and render correctly (and does in the GitHub preview).