### PR TITLE
Update compression MIME types for Azure CDN from Microsoft.

### DIFF
--- a/articles/cdn/cdn-features.md
+++ b/articles/cdn/cdn-features.md
@@ -67,7 +67,7 @@ The following table compares the features available with each product.
 | **Ease of use** | **Standard Microsoft** | **Standard Akamai** | **Standard Verizon** | **Premium Verizon** | 
 | Easy integration with Azure services, such as [Storage](cdn-create-a-storage-account-with-cdn.md), [Web Apps](cdn-add-to-web-app.md), and [Media Services](../media-services/previous/media-services-portal-manage-streaming-endpoints.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | Management via [REST API](/rest/api/cdn/), [.NET](cdn-app-dev-net.md), [Node.js](cdn-app-dev-node.md), or [PowerShell](cdn-manage-powershell.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
-| [Compression MIME types](./cdn-improve-performance.md)  |Default only |Configurable |Configurable  |Configurable  |
+| [Compression MIME types](./cdn-improve-performance.md)  |Configurable |Configurable |Configurable  |Configurable  |
 | Compression encodings  |gzip, brotli |gzip |gzip, deflate, bzip2, brotli  |gzip, deflate, bzip2, brotli  |
 
 ## Migration


### PR DESCRIPTION
See issue #71763 and commit 73e8483ae3c111a6ccdb48850dd0a99b7a03940e. Configuring MIME types eligible for compression is now supported by Azure CDN from Microsoft. So the feature comparison table needs to be updated.

I noticed that this page is localized. So updating for other languages is probably also required.
