### PR TITLE
wrong Update Agent configuration path in device-update-raspberry-pi.md

### DIFF
--- a/articles/iot-hub-device-update/device-update-raspberry-pi.md
+++ b/articles/iot-hub-device-update/device-update-raspberry-pi.md
@@ -1,7 +1,7 @@
 ---
 title: Device Update for Azure IoT Hub tutorial using the Raspberry Pi 3 B+ Reference Yocto Image | Microsoft Docs
 description: Get started with Device Update for Azure IoT Hub using the Raspberry Pi 3 B+ Reference Yocto Image.
-author: valls
+author: ValOlson
 ms.author: valls
 ms.date: 2/11/2021
 ms.topic: tutorial

--- a/articles/iot-hub-device-update/device-update-raspberry-pi.md
+++ b/articles/iot-hub-device-update/device-update-raspberry-pi.md
@@ -112,9 +112,9 @@ IoT Hub, a connection string will be generated for the device.
  
 Replace `<device connection string>` with your connection string
  ```markdown
-	echo "connection_string=<device connection string>" > adu-conf.txt  
-	echo "aduc_manufacturer=ADUTeam" >> adu-conf.txt
-	echo "aduc_model=RefDevice" >> adu-conf.txt
+	echo "connection_string=<device connection string>" > /adu/adu-conf.txt  
+	echo "aduc_manufacturer=ADUTeam" >> /adu/adu-conf.txt
+	echo "aduc_model=RefDevice" >> /adu/adu-conf.txt
    ```
 
 ## Connect the device in Device Update IoT Hub


### PR DESCRIPTION
The agent built into the [demo base image](https://github.com/Azure/iot-hub-device-update/releases/tag/0.6.0) seems to have been built with `ADUC_CONF_FILE_PATH=/adu/adu-conf.txt` causing the agent to look for its config file in `/adu/adu-conf.txt`. 
However, the steps described in this documentation page lead to write the agent config file in `/home/root/adu-conf.txt`.