### PR TITLE
Update azure-portal-safelist-urls.md

### DIFF
--- a/articles/azure-portal/azure-portal-safelist-urls.md
+++ b/articles/azure-portal/azure-portal-safelist-urls.md
@@ -51,6 +51,7 @@ The URL endpoints to safelist for the Azure portal are specific to the Azure clo
 *.usgovcloudapi.net
 *.usgovtrafficmanager.net
 *.windowsazure.us
+crl3.digicert.com
 ```
 
 #### [China Government Cloud](#tab/china-government-cloud)


### PR DESCRIPTION
The portal's SSL certificate and certificates for the backend Azure services use DigiCert in the US Gov (Fairfax) cloud. Without this, the CRL check will fail, which impacts the portal as well as services like Azure AD Connect, MSAL libraries, and various PowerShell modules in locked down environments (e.g. DoD).