### PR TITLE
add SSL.com to CA list

### DIFF
--- a/includes/cdn-front-door-allowed-ca.md
+++ b/includes/cdn-front-door-allowed-ca.md
@@ -57,6 +57,8 @@ The following CAs are allowed when you create your own certificate:
 - Security Communication RootCA1
 - Security Communication RootCA2
 - Security Communication RootCA3
+- SSL.com Root Certification Authority RSA
+- SSL.com EV Root Certification Authority RSA R2
 - Staat der Nederlanden EV Root CA
 - Symantec Class 3 EV SSL CA - G3
 - Symantec Class 3 Secure Server CA - G4


### PR DESCRIPTION
SSL.com is a participant in the Microsoft Trusted Root Program relied upon throughout the suite of Microsoft products and services

https://ccadb-public.secure.force.com/microsoft/IncludedCACertificateReportForMSFT
https://docs.microsoft.com/en-us/security/trusted-root/participants-list