### PR TITLE
Update 'drop trigger' SQL to include table name

### DIFF
--- a/articles/dms/tutorial-rds-postgresql-server-azure-db-for-postgresql-online.md
+++ b/articles/dms/tutorial-rds-postgresql-server-azure-db-for-postgresql-online.md
@@ -136,7 +136,7 @@ To complete this tutorial, you need to:
     To disable triggers in target database:
 
     ```
-    SELECT Concat('DROP TRIGGER ', Trigger_Name, ';') FROM  information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = 'your_schema';
+    SELECT Concat('DROP TRIGGER ', Trigger_Name,' ON ', event_object_table, ';') FROM  information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = 'your_schema';
     ```
 
 ## Register the Microsoft.DataMigration resource provider


### PR DESCRIPTION
The PostgreSQL documentation (https://www.postgresql.org/docs/9.6/sql-droptrigger.html) seems to say that the table name is non-optional. I encountered an issue trying to use the commands generated by the original SQL drop trigger command wherein Postgres complained that it expected to see 'ON', not a statement terminator. I believe that this change to the generation SQL command will solve the issue as it includes the table name from the column event_object_table from the information_schema.TRIGGERS view.