### PR TITLE
Remove duplicate tutorial link

### DIFF
--- a/articles/static-web-apps/index.yml
+++ b/articles/static-web-apps/index.yml
@@ -63,8 +63,6 @@ landingContent:
             url: deploy-nextjs.md
           - text: Deploy from Nuxt.js
             url: deploy-nuxtjs.md
-          - text: Deploy from Blazor
-            url: deploy-blazor.md
       - linkListType: learn
         links:
           - text: Publish a static web app with Gatsby


### PR DESCRIPTION
Saw two identical tutorial options and figured one might be a mistake. Not sure if folks want the top or bottom one, but I removed the bottom one here.

## How it looks now

![Screenshot of docs.microsoft.com showing two Deploy from Blazor options.](https://user-images.githubusercontent.com/713665/111644845-d2361980-87c5-11eb-950e-f37e0261fde8.png)
