### PR TITLE
separate output from command, for kubectl statement

### DIFF
--- a/articles/aks/tutorial-kubernetes-deploy-cluster.md
+++ b/articles/aks/tutorial-kubernetes-deploy-cluster.md
@@ -73,6 +73,12 @@ To verify the connection to your cluster, run the [kubectl get nodes][kubectl-ge
 
 ```
 $ kubectl get nodes
+```
+The following example output shows the nodes in the cluster:
+
+```output
+Result
+----------------
 
 NAME                                STATUS   ROLES   AGE     VERSION
 aks-nodepool1-37463671-vmss000000   Ready    agent   2m37s   v1.18.10


### PR DESCRIPTION
Because the current documentation fails to separate the command output from the command, when we use the "copy" feature (as offered in the deployment of the docs) we end up getting both the command and the output copied to the clipboard. I have separated the two in this PR.

Signed-off-by: Charlie Arehart <charlie@carehart.org>