### PR TITLE
correct rendering of output of kubectl cmd

### DIFF
--- a/articles/aks/tutorial-kubernetes-deploy-application.md
+++ b/articles/aks/tutorial-kubernetes-deploy-application.md
@@ -75,9 +75,7 @@ kubectl apply -f azure-vote-all-in-one-redis.yaml
 
 The following example output shows the resources successfully created in the AKS cluster:
 
-```console
-$ kubectl apply -f azure-vote-all-in-one-redis.yaml
-
+```output
 deployment "azure-vote-back" created
 service "azure-vote-back" created
 deployment "azure-vote-front" created


### PR DESCRIPTION
The output was both not labeled as "output" and also needlessly repeated the command within the output box.

Signed-off-by: Charlie Arehart <charlie@carehart.org>