### PR TITLE
Remove a redundant step

### DIFF
--- a/articles/ddos-protection/manage-ddos-protection.md
+++ b/articles/ddos-protection/manage-ddos-protection.md
@@ -67,10 +67,9 @@ You cannot move a virtual network to another resource group or subscription when
 ### Enable DDoS protection for an existing virtual network
 
 1. Create a DDoS protection plan by completing the steps in [Create a DDoS protection plan](#create-a-ddos-protection-plan), if you don't have an existing DDoS protection plan.
-2. Select **Create a resource** in the upper left corner of the Azure portal.
-3. Enter the name of the virtual network that you want to enable DDoS Protection Standard for in the **Search resources, services, and docs box** at the top of the portal. When the name of the virtual network appears in the search results, select it.
-4. Select **DDoS protection**, under **SETTINGS**.
-5. Select **Standard**. Under **DDoS protection plan**, select an existing DDoS protection plan, or the plan you created in step 1, and then select **Save**. The plan you select can be in the same, or different subscription than the virtual network, but both subscriptions must be associated to the same Azure Active Directory tenant.
+2. Enter the name of the virtual network that you want to enable DDoS Protection Standard for in the **Search resources, services, and docs box** at the top of the Azure portal. When the name of the virtual network appears in the search results, select it.
+3. Select **DDoS protection**, under **SETTINGS**.
+4. Select **Standard**. Under **DDoS protection plan**, select an existing DDoS protection plan, or the plan you created in step 1, and then select **Save**. The plan you select can be in the same, or different subscription than the virtual network, but both subscriptions must be associated to the same Azure Active Directory tenant.
 
 ### Enable DDoS protection for all virtual networks
 


### PR DESCRIPTION
There is no need to click "Create a resource" to find an existing virtual network.