### PR TITLE
Update storage-sas-overview.md

### DIFF
--- a/articles/storage/common/storage-sas-overview.md
+++ b/articles/storage/common/storage-sas-overview.md
@@ -178,7 +178,7 @@ The following recommendations for using shared access signatures can help mitiga
 - **Use Azure Monitor and Azure Storage logs to monitor your application.** Authorization failures can occur because of an outage in your SAS provider service. They can also occur from an inadvertent removal of a stored access policy. You can use Azure Monitor and storage analytics logging to observe any spike in these types of authorization failures. For more information, see [Azure Storage metrics in Azure Monitor](../blobs/monitor-blob-storage.md?toc=%252fazure%252fstorage%252fblobs%252ftoc.json) and [Azure Storage Analytics logging](storage-analytics-logging.md?toc=%2fazure%2fstorage%2fblobs%2ftoc.json).
 
 > [!NOTE]
-> Storage doesn't maintains how many SAS have been generated for a storage account nor any API can provide such details. In case, there is any such requirement, then you need to track that manually.
+> Storage doesn't track the number of shared access signatures that have been generated for a storage account, and no API can provide this detail. If you need to know the number of shared access signatures that have been generated for a storage account, you must track the number manually.
 
 ## Get started with SAS
 

--- a/articles/storage/common/storage-sas-overview.md
+++ b/articles/storage/common/storage-sas-overview.md
@@ -177,6 +177,9 @@ The following recommendations for using shared access signatures can help mitiga
 
 - **Use Azure Monitor and Azure Storage logs to monitor your application.** Authorization failures can occur because of an outage in your SAS provider service. They can also occur from an inadvertent removal of a stored access policy. You can use Azure Monitor and storage analytics logging to observe any spike in these types of authorization failures. For more information, see [Azure Storage metrics in Azure Monitor](../blobs/monitor-blob-storage.md?toc=%252fazure%252fstorage%252fblobs%252ftoc.json) and [Azure Storage Analytics logging](storage-analytics-logging.md?toc=%2fazure%2fstorage%2fblobs%2ftoc.json).
 
+> [!NOTE]
+> Storage doesn't maintains how many SAS have been generated for a storage account nor any API can provide such details. In case, there is any such requirement, then you need to track that manually.
+
 ## Get started with SAS
 
 To get started with shared access signatures, see the following articles for each SAS type.


### PR DESCRIPTION
At times, there are requests from queries whether we can know how many SAS have been generated for a storage account. This is not maintained at storage end nor any API can provide such details. If customer have any such requirement, they need to track it manually at their end.

Proposing changes to let the customer know this information at the first place itself via documentation..

Please review.