### PR TITLE
fixed formatting

### DIFF
--- a/articles/virtual-network/virtual-network-peering-overview.md
+++ b/articles/virtual-network/virtual-network-peering-overview.md
@@ -20,8 +20,8 @@ Virtual network peering enables you to seamlessly connect two or more [Virtual N
 
 Azure supports the following types of peering:
 
-* Virtual network peering: Connect virtual networks within the same Azure region.
-* Global virtual network peering: Connecting virtual networks across Azure regions.
+* **Virtual network peering**: Connect virtual networks within the same Azure region.
+* **Global virtual network peering**: Connecting virtual networks across Azure regions.
 
 The benefits of using virtual network peering, whether local or global, include:
 


### PR DESCRIPTION
Made "Virtual network peering" and "Global virtual network peering" bold. 

This seemed to be the formatting guideline I had seen on other pages of the documentation:
- https://docs.microsoft.com/en-us/azure/backup/backup-overview
- https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface