### PR TITLE
Add Germany to Preferred Data Location Table

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sync-feature-preferreddatalocation.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-feature-preferreddatalocation.md
@@ -42,6 +42,7 @@ The geos in Microsoft 365 available for Multi-Geo are:
 | Canada | CAN |
 | European Union | EUR |
 | France | FRA |
+| Germany | DEU |
 | India | IND |
 | Japan | JPN |
 | Korea | KOR |


### PR DESCRIPTION
Add Germany to the table per the page it looks like it is supported: https://docs.microsoft.com/en-us/microsoft-365/enterprise/microsoft-365-multi-geo?view=o365-worldwide#microsoft-365-multi-geo-availability