### PR TITLE
Correct unsupported parentheses.

### DIFF
--- a/articles/media-services/azure-media-player/azure-media-player-quickstart.md
+++ b/articles/media-services/azure-media-player/azure-media-player-quickstart.md
@@ -47,7 +47,7 @@ If you don't want to use auto-setup, you can omit the `data-setup` attribute and
                // add an event listener
               this.addEventListener('ended', function() {
                 console.log('Finished!');
-            }
+            });
           }
     );
     myPlayer.src([{

--- a/articles/media-services/azure-media-player/azure-media-player-quickstart.md
+++ b/articles/media-services/azure-media-player/azure-media-player-quickstart.md
@@ -34,7 +34,7 @@ Next, simply use the `<video>` element as you normally would, but with an additi
 
 If you don't want to use auto-setup, you can omit the `data-setup` attribute and initialize a video element manually.
 
-```html
+```javascript
     var myPlayer = amp('vid1', { /* Options */
             "nativeControlsForTouch": false,
             autoplay: false,


### PR DESCRIPTION
There are unsupported parentheses in the manual setup sample script that cause a script run-time error.
So I suggest to correct it.

Which I reported in Issue #72639.

**wrong**
```
              console.log('Good to go!');
               // add an event listener
              this.addEventListener('ended', function() {
                console.log('Finished!');
            } //this code segment cause run-time error.
```

**correct**
```
              console.log('Good to go!');
               // add an event listener
              this.addEventListener('ended', function() {
                console.log('Finished!');
            }); //correct unsupported partheses.
```