### PR TITLE
Correct unsupported parentheses.

### DIFF
--- a/articles/media-services/azure-media-player/azure-media-player-full-setup.md
+++ b/articles/media-services/azure-media-player/azure-media-player-full-setup.md
@@ -88,7 +88,7 @@ If your web page or application loads the video tag dynamically (ajax, appendChi
                // add an event listener
               this.addEventListener('ended', function() {
                 console.log('Finished!');
-            }
+            });
           }
     );
     myPlayer.src([{


### PR DESCRIPTION
There are unsupported parentheses in the manual setup sample script that cause a script run-time error.
So I suggest to correct it.

Which I reported in Issue #72640.

**wrong**
```
              console.log('Good to go!');
               // add an event listener
              this.addEventListener('ended', function() {
                console.log('Finished!');
            } //this code segment cause run-time error.
```

**correct**
```
              console.log('Good to go!');
               // add an event listener
              this.addEventListener('ended', function() {
                console.log('Finished!');
            }); //correct unsupported partheses.
```