### PR TITLE
Update configure-connect-python-howto.md

### DIFF
--- a/articles/media-services/latest/configure-connect-python-howto.md
+++ b/articles/media-services/latest/configure-connect-python-howto.md
@@ -28,7 +28,7 @@ This article shows you how to connect to the Azure Media Services v3 Python SDK 
 - Download Python from [python.org](https://www.python.org/downloads/)
 - Make sure to set the `PATH` environment variable
 - [Create a Media Services account](./create-account-howto.md). Be sure to remember the resource group name and the Media Services account name.
-- Follow the steps in the [Access APIs](./access-api-howto.md) topic. Record the subscription ID, application ID (client ID), the authentication key (secret), and the tenant ID that you need in the later step.
+- Follow the steps in the [Access APIs](./access-api-howto.md) topic, selecting the Service principal authentication method. Record the subscription ID (`SubscriptionId`), application client ID (`AadClientId`), the authentication key (`AadSecret`), and the tenant ID (`AadTenantId`) that you need in the later steps.
 
 > [!IMPORTANT]
 > Review [naming conventions](media-services-apis-overview.md#naming-conventions).
@@ -55,38 +55,34 @@ pip3 install azure-mgmt-media==3.0.0
 1. Open the file in your favorite editor
 1. Add the code that follows to the file. The code imports the required modules and creates the Active Directory credentials object you need to connect to Media Services.
 
-      Set the variables' values to the values you got from [Access APIs](./access-api-howto.md)
+      Set the variables' values to the values you got from [Access APIs](./access-api-howto.md). Update the `ACCOUNT_NAME` and `RESOUCE_GROUP_NAME` variables to the Media Services account name and Resource Group names used when creating those resources.
 
       ```
       import adal
+      from azure.mgmt.media import AzureMediaServices
       from msrestazure.azure_active_directory import AdalAuthentication
       from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
-      from azure.mgmt.media import AzureMediaServices
-      from azure.mgmt.media.models import MediaService
 
-      RESOURCE = 'https://management.core.windows.net/'
-      # Tenant ID for your Azure Subscription
-      TENANT_ID = '00000000-0000-0000-000000000000'
-      # Your Service Principal App ID
-      CLIENT = '00000000-0000-0000-000000000000'
-      # Your Service Principal Password
-      KEY = '00000000-0000-0000-000000000000'
-      # Your Azure Subscription ID
-      SUBSCRIPTION_ID = '00000000-0000-0000-000000000000'
+      RESOURCE = "https://management.core.windows.net/"
+      # Tenant ID for your Azure Subscription (AadTenantId)
+      TENANT_ID = "00000000-0000-0000-000000000000"
+      # Your Service Principal App ID (AadClientId)
+      CLIENT = "00000000-0000-0000-000000000000"
+      # Your Service Principal Password (AadSecret)
+      KEY = "00000000-0000-0000-000000000000"
+      # Your Azure Subscription ID (SubscriptionId)
+      SUBSCRIPTION_ID = "00000000-0000-0000-000000000000"
       # Your Azure Media Service (AMS) Account Name
-      ACCOUNT_NAME = 'amsv3account'
+      ACCOUNT_NAME = "amsaccount"
       # Your Resource Group Name
-      RESOUCE_GROUP_NAME = 'AMSv3ResourceGroup'
+      RESOUCE_GROUP_NAME = "amsResourceGroup"
 
       LOGIN_ENDPOINT = AZURE_PUBLIC_CLOUD.endpoints.active_directory
       RESOURCE = AZURE_PUBLIC_CLOUD.endpoints.active_directory_resource_id
 
-      context = adal.AuthenticationContext(LOGIN_ENDPOINT + '/' + TENANT_ID)
+      context = adal.AuthenticationContext(LOGIN_ENDPOINT + "/" + TENANT_ID)
       credentials = AdalAuthentication(
-          context.acquire_token_with_client_credentials,
-          RESOURCE,
-          CLIENT,
-          KEY
+          context.acquire_token_with_client_credentials, RESOURCE, CLIENT, KEY
       )
 
       # The AMS Client
@@ -97,7 +93,7 @@ pip3 install azure-mgmt-media==3.0.0
 
       # Now that you are authenticated, you can manipulate the entities.
       # For example, list assets in your AMS account
-      print (client.assets.list(RESOUCE_GROUP_NAME, ACCOUNT_NAME).get(0))
+      print(client.assets.list(RESOUCE_GROUP_NAME, ACCOUNT_NAME).get(0))
       ```
 
 1. Run the file


### PR DESCRIPTION
Made some minor changes to the documentation to make the steps clearer.

I also made the following changes to the code sample:
- Removed an unused import
- Formatted the code with the black formatter
- Included the names of the returned variables on resource creation in the comments
- Renamed the default `RESOUCE_GROUP_NAME` and `ACCOUNT_NAME` values to match the examples given when setting up the account.

Currently, the code sample always returns an empty list when running `client.assets.list(RESOUCE_GROUP_NAME, ACCOUNT_NAME).get(0)` because no assets were created. A better example for this docs page would create some assets first, and then list them. 