### PR TITLE
Add SQL authentication support Note

### DIFF
--- a/articles/dms/tutorial-sql-server-to-azure-sql.md
+++ b/articles/dms/tutorial-sql-server-to-azure-sql.md
@@ -240,6 +240,9 @@ Select either all databases or specific databases that you want to migrate to Az
 1. On the **Select target** screen, provide authentication settings to your Azure SQL Database. 
 
    ![Select target](media/tutorial-sql-server-to-azure-sql/select-target.png)
+   
+   > [!NOTE]
+   > Currently SQL Authentication is the only supported Authentication type
 
 1. Select **Next: Map to target databases** screen, map the source and the target database for migration.
 

--- a/articles/dms/tutorial-sql-server-to-azure-sql.md
+++ b/articles/dms/tutorial-sql-server-to-azure-sql.md
@@ -242,7 +242,7 @@ Select either all databases or specific databases that you want to migrate to Az
    ![Select target](media/tutorial-sql-server-to-azure-sql/select-target.png)
    
    > [!NOTE]
-   > Currently SQL Authentication is the only supported Authentication type
+   > Currently, SQL authentication is the only supported authentication type.
 
 1. Select **Next: Map to target databases** screen, map the source and the target database for migration.
 


### PR DESCRIPTION
Adding a note to explicitly specify that SQL Authentication is the only supported Authentication type for migration to Azure SQL DB