### PR TITLE
Resetting the ClientSecret the correct way

### DIFF
--- a/articles/app-service/app-service-authentication-how-to.md
+++ b/articles/app-service/app-service-authentication-how-to.md
@@ -346,7 +346,7 @@ There are two versions of the management API for the Authentication / Authorizat
            "allowedExternalRedirectUrls": null,
            "defaultProvider": "AzureActiveDirectory",
            "clientId": "3197c8ed-2470-480a-8fae-58c25558ac9b",
-           "clientSecret": null,
+           "clientSecret": "",
            "clientSecretSettingName": "MICROSOFT_IDENTITY_AUTHENTICATION_SECRET",
            "clientSecretCertificateThumbprint": null,
            "issuer": "https://sts.windows.net/0b2ef922-672a-4707-9643-9a5726eec524/",


### PR DESCRIPTION
When I try to reset the ClientSecred by setting the property to null I get an error. The online ResourceExplorer prompted me to use an empty string instead of null, and that request passed and the update went through correctly.