### PR TITLE
clearly indicate localhost port ignore only for http

### DIFF
--- a/articles/active-directory/develop/reply-url.md
+++ b/articles/active-directory/develop/reply-url.md
@@ -48,7 +48,7 @@ Per [RFC 8252 sections 8.3](https://tools.ietf.org/html/rfc8252#section-8.3) and
 1. `http` URI schemes are acceptable because the redirect never leaves the device. As such, both of these URIs are acceptable:
     - `http://localhost/myApp`
     - `https://localhost/myApp`
-1. Due to ephemeral port ranges often required by native applications, the port component (for example, `:5001` or `:443`) is ignored for the purposes of matching a redirect URI. As a result, all of these URIs are considered equivalent:
+1. Due to ephemeral port ranges often required by native applications, the port component (for example, `:5001` or `:443`) is ignored for the purposes of matching a redirect URI for `http` URI schemes. As a result, all of these URIs are considered equivalent:
     - `http://localhost/MyApp`
     - `http://localhost:1234/MyApp`
     - `http://localhost:5000/MyApp`


### PR DESCRIPTION
Add qualifier to documentation to indicate [documented localhost behavior](https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url#localhost-exceptions) only applies to `http`.

Ports are NOT ignored when using `https` scheme.  If you do not have the port specified for `https://localhost:####` you will get a failure

> "AADB2C90006:+The+redirect+URI+'https://localhost:####/my/path'+provided+in+the+request+is+not+registered+for+the+client+id+'<my-client-id>'.\r\nCorrelation+ID:+<my-correlation-id>\r\nTimestamp:+2021-03-24+15:19:17Z\r\n"


Unclear if this is only a AAD B2C limitation?