### PR TITLE
Redirect url has trailing slash appended during response

### DIFF
--- a/articles/active-directory/develop/reply-url.md
+++ b/articles/active-directory/develop/reply-url.md
@@ -22,6 +22,9 @@ A redirect URI, or reply URL, is the location where the authorization server sen
 
 * The redirect URI is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the redirect URI. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
 
+[!NOTE]
+For redirect URI containing hostnames without a path segment such as https://contoso.com or http://localhost:7071, a trailing slash will be appended when getting a response post authentication (Eg. https://contoso.com/ or http://localhost:7071/. This is specific when using response mode of query or fragment. In case we have a path segment such as https://contoso.com/test, this behavior does not apply. 
+
 ## Maximum number of redirect URIs
 
 This table shows the maximum number of redirect URIs you can add to an app registration in the Microsoft identity platform.

--- a/articles/active-directory/develop/reply-url.md
+++ b/articles/active-directory/develop/reply-url.md
@@ -22,8 +22,8 @@ A redirect URI, or reply URL, is the location where the authorization server sen
 
 * The redirect URI is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the redirect URI. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
 
-[!NOTE]
-For redirect URI containing hostnames without a path segment such as https://contoso.com or http://localhost:7071, a trailing slash will be appended when getting a response post authentication (Eg. https://contoso.com/ or http://localhost:7071/. This is specific when using response mode of query or fragment. In case we have a path segment such as https://contoso.com/test, this behavior does not apply. 
+> [!NOTE]
+> In a redirect URI without a path segment, a trailing slash is appended to the URI in the response. For example, URIs like `https://contoso.com` and `http://localhost:7071` return as `https://contoso.com/` and `http://localhost:7071/`. A trailing slash is appended only when the response mode is either query or fragment. Redirect URIs that contain a path segment are not appended with a trailing slash. 
 
 ## Maximum number of redirect URIs
 


### PR DESCRIPTION
Adding a note on reply URL scheme behavior when it only contains a hostname and not a path segment. 
In such case, we append a trailing slash as per current behavior. This update is to document this.