### PR TITLE
Add Custom Payload Detail

### DIFF
--- a/articles/azure-monitor/alerts/alerts-common-schema-definitions.md
+++ b/articles/azure-monitor/alerts/alerts-common-schema-definitions.md
@@ -144,7 +144,7 @@ Any alert instance describes the resource that was affected and the cause of the
 ### Log alerts
 
 > [!NOTE]
-> For log alerts that have a custom email subject and/or JSON payload defined, enabling the common schema reverts email subject and/or payload schema to the one described as follows. Alerts with the common schema enabled have an upper size limit of 256 KB per alert. Search results aren't embedded in the log alerts payload if they cause the alert size to cross this threshold. You can determine this by checking the flag `IncludeSearchResults`. When the search results aren't included, you should use the `LinkToFilteredSearchResultsAPI` or `LinkToSearchResultsAPI` to access query results with the [Log Analytics API](/rest/api/loganalytics/dataaccess/query/get).
+> For log alerts that have a custom email subject and/or JSON payload defined, enabling the common schema reverts email subject and/or payload schema to the one described as follows. This means that if you want to have a custom JSON payload defined, the webhook cannot use the common alert schema. Alerts with the common schema enabled have an upper size limit of 256 KB per alert. Search results aren't embedded in the log alerts payload if they cause the alert size to cross this threshold. You can determine this by checking the flag `IncludeSearchResults`. When the search results aren't included, you should use the `LinkToFilteredSearchResultsAPI` or `LinkToSearchResultsAPI` to access query results with the [Log Analytics API](/rest/api/loganalytics/dataaccess/query/get).
 
 #### `monitoringService` = `Log Analytics`
 


### PR DESCRIPTION
Added additional verbiage around the fact that if you want a custom json payload in your webhook, you cannot use the common alert schema as it will override your custom one. Would be nice to actually see a warning in the UI when you check the box for a custom payload. I just set this up and felt this was not clear enough in the documentation.