### PR TITLE
AppService - public DNS for domain validation

### DIFF
--- a/articles/app-service/app-service-web-tutorial-custom-domain.md
+++ b/articles/app-service/app-service-web-tutorial-custom-domain.md
@@ -104,7 +104,9 @@ To add a custom domain to your app, you need to verify your ownership of the dom
 
 ## Map your domain
 
-You can use either a CNAME record or an A record to map a custom DNS name to App Service. Follow the respective steps:
+You can use either a CNAME record or an A record to map a custom DNS name to App Service. The CNAME/A record needs to be registered in public internet DNS zone - private enterprise DNS zone cannot be used for validation of mapping.
+
+Follow the respective steps:
 
 - [Map a CNAME record](#map-a-cname-record)
 - [Map an A record](#map-an-a-record)


### PR DESCRIPTION
added reference that DNS records used for domain mapping needs to be public (internet) DNS record - not private DNS record, resolvable only from enterprise network.
