### PR TITLE
Add 500 limitation for [Selected] option

### DIFF
--- a/articles/active-directory/enterprise-users/groups-lifecycle.md
+++ b/articles/active-directory/enterprise-users/groups-lifecycle.md
@@ -88,6 +88,7 @@ For more information on permissions to restore a deleted group, see [Restore a d
 > - When you first set up expiration, any groups that are older than the expiration interval are set to 35 days until expiration unless the group is automatically renewed or the owner renews it.
 > - When a dynamic group is deleted and restored, it's seen as a new group and re-populated according to the rule. This process can take up to 24 hours.
 > - Expiration notices for groups used in Teams appear in the Teams Owners feed.
+> - When you enabled expiration for selected groups, up to 500 groups can be added in the list. If you need to add more than 500 groups, you can enable expiration for all of your groups. 500 limitation will not be applied in this case.
 
 ## Email notifications
 

--- a/articles/active-directory/enterprise-users/groups-lifecycle.md
+++ b/articles/active-directory/enterprise-users/groups-lifecycle.md
@@ -88,7 +88,7 @@ For more information on permissions to restore a deleted group, see [Restore a d
 > - When you first set up expiration, any groups that are older than the expiration interval are set to 35 days until expiration unless the group is automatically renewed or the owner renews it.
 > - When a dynamic group is deleted and restored, it's seen as a new group and re-populated according to the rule. This process can take up to 24 hours.
 > - Expiration notices for groups used in Teams appear in the Teams Owners feed.
-> - When you enabled expiration for selected groups, up to 500 groups can be added in the list. If you need to add more than 500 groups, you can enable expiration for all of your groups. 500 limitation will not be applied in this case.
+> - When you enabled expiration for selected groups, up to 500 groups can be added to the list. If you need to add more than 500 groups, you can enable expiration for all of your groups. The 500 groups limitation will not be applied in this case.
 
 ## Email notifications
 

--- a/articles/active-directory/enterprise-users/groups-lifecycle.md
+++ b/articles/active-directory/enterprise-users/groups-lifecycle.md
@@ -88,7 +88,7 @@ For more information on permissions to restore a deleted group, see [Restore a d
 > - When you first set up expiration, any groups that are older than the expiration interval are set to 35 days until expiration unless the group is automatically renewed or the owner renews it.
 > - When a dynamic group is deleted and restored, it's seen as a new group and re-populated according to the rule. This process can take up to 24 hours.
 > - Expiration notices for groups used in Teams appear in the Teams Owners feed.
-> - When you enabled expiration for selected groups, up to 500 groups can be added to the list. If you need to add more than 500 groups, you can enable expiration for all of your groups. The 500 groups limitation will not be applied in this case.
+> - When you enable expiration for selected groups, you can add up to 500 groups to the list. If you need to add more than 500 groups, you can enable expiration for all your groups. In that scenario, the 500-group limitation doesn't apply.
 
 ## Email notifications
 


### PR DESCRIPTION
Currently, there is a 500 group limit on the [Selected] option in M365 group expiration notification feature. I added a note to explain this limitation based on the conversation with Somesh Chandra.

PR for M365 doc is also created here: https://github.com/MicrosoftDocs/microsoft-365-docs/pull/4524