### PR TITLE
add sign in page display explanation

### DIFF
--- a/articles/active-directory/external-identities/conditional-access.md
+++ b/articles/active-directory/external-identities/conditional-access.md
@@ -67,7 +67,9 @@ The resource tenant is always responsible for Azure AD Multi-Factor Authenticati
 6. Fabrikam must have sufficient premium Azure AD licenses that support Azure AD Multi-Factor Authentication. The user from Contoso then consumes this license from Fabrikam. See [billing model for Azure AD external identities](./external-identities-pricing.md) for information on the B2B licensing.
 
 >[!NOTE]
->Azure AD Multi-Factor Authentication is done at resource tenancy to ensure predictability. This can be seen when logging into the resource tenant the background sign in page from the resource tenatn will desplayed. The company logo of the users home tenant will be displayed above the users accound name in the login prompt as seen here.![Sign in page example](https://user-images.githubusercontent.com/39276631/112702895-40c44880-8e52-11eb-83ed-141c95ee04f8.png)
+>Azure AD Multi-Factor Authentication is done at resource tenancy to ensure predictability. When the guest user signs in, they'll see the resource tenant sign-in page displayed in the background, and their own home tenant sign-in page and company logo in the foreground, as shown in the following example.
+>
+>![Sign-in page example](./media/conditional-access-b2b/resource-tenant-mfa.png)
 
 
 ### Set up Azure AD Multi-Factor Authentication for B2B users

--- a/articles/active-directory/external-identities/conditional-access.md
+++ b/articles/active-directory/external-identities/conditional-access.md
@@ -67,7 +67,8 @@ The resource tenant is always responsible for Azure AD Multi-Factor Authenticati
 6. Fabrikam must have sufficient premium Azure AD licenses that support Azure AD Multi-Factor Authentication. The user from Contoso then consumes this license from Fabrikam. See [billing model for Azure AD external identities](./external-identities-pricing.md) for information on the B2B licensing.
 
 >[!NOTE]
->Azure AD Multi-Factor Authentication is done at resource tenancy to ensure predictability.
+>Azure AD Multi-Factor Authentication is done at resource tenancy to ensure predictability. This can be seen when logging into the resource tenant the background sign in page from the resource tenatn will desplayed. The company logo of the users home tenant will be displayed above the users accound name in the login prompt as seen here.![Sign in page example](https://user-images.githubusercontent.com/39276631/112702895-40c44880-8e52-11eb-83ed-141c95ee04f8.png)
+
 
 ### Set up Azure AD Multi-Factor Authentication for B2B users
 


### PR DESCRIPTION
Added a reference with an example on how sign in page is displayed with guest users. Several support tickets have been raised due to confusion on what tenant needs to edit/reconfigure MFA account details for users. The confusion on ownership comes from both companies branding being shown. This is also being complicated with other features behavior the customers have experienced due to private preview features.