### PR TITLE
Update bridge settings for inPrefix and outPrefix

### DIFF
--- a/articles/iot-edge/how-to-publish-subscribe.md
+++ b/articles/iot-edge/how-to-publish-subscribe.md
@@ -426,9 +426,9 @@ Below is an example of an IoT Edge MQTT bridge configuration that republishes al
 				},
 				{
 					"direction": "out",
-					"topic": "",
-					"inPrefix": "/local/telemetry",
-					"outPrefix": "/remote/messages"
+					"topic": "#",
+					"inPrefix": "/local/telemetry/",
+					"outPrefix": "/remote/messages/"
 				}
 			]
 		}]


### PR DESCRIPTION
The code was changed and it doesn't add the topic separator by default so it needs to be explicitly included in inPrefix, outPrefix.
Based on the description that it subscribes to /local/telemetry/# I added # to the topic. If # is not present it subscribes to /local/telemetry/, not /local/telemetry/#