### PR TITLE
Correction the number of characters in the whole FQDN.

### DIFF
--- a/articles/machine-learning/how-to-custom-dns.md
+++ b/articles/machine-learning/how-to-custom-dns.md
@@ -41,7 +41,7 @@ The following list contains the fully qualified domain names (FQDN) used by your
 * `ml-<workspace-name, truncated>-<region>-<workspace-guid>.notebooks.azure.net`
 
     > [!NOTE]
-    > The workspace name for this FQDN may be truncated. Truncation is done to keep the FQDN less than or equal to 83 characters.
+    > The workspace name for this FQDN may be truncated. Truncation is done to keep `ml-<workspace-name, truncated>-<region>-<workspace-guid>` 63 characters.
 * `<instance-name>.<region>.instances.azureml.ms`
 
     > [!NOTE]
@@ -56,7 +56,7 @@ The following FQDNs are for Azure China 21Vianet regions:
 * `ml-<workspace-name, truncated>-<region>-<workspace-guid>.notebooks.chinacloudapi.cn`
 
     > [!NOTE]
-    > The workspace name for this FQDN may be truncated. Truncation is done to keep the FQDN less than or equal to 90 characters.
+    > The workspace name for this FQDN may be truncated. Truncation is done to keep `ml-<workspace-name, truncated>-<region>-<workspace-guid>` 63 characters.
 * `<instance-name>.<region>.instances.ml.azure.cn`
 ## Find the IP addresses
 

--- a/articles/machine-learning/how-to-custom-dns.md
+++ b/articles/machine-learning/how-to-custom-dns.md
@@ -41,7 +41,7 @@ The following list contains the fully qualified domain names (FQDN) used by your
 * `ml-<workspace-name, truncated>-<region>-<workspace-guid>.notebooks.azure.net`
 
     > [!NOTE]
-    > The workspace name for this FQDN may be truncated. Truncation is done to keep the FQDN less than or equal to 63 characters.
+    > The workspace name for this FQDN may be truncated. Truncation is done to keep the FQDN less than or equal to 83 characters.
 * `<instance-name>.<region>.instances.azureml.ms`
 
     > [!NOTE]
@@ -56,7 +56,7 @@ The following FQDNs are for Azure China 21Vianet regions:
 * `ml-<workspace-name, truncated>-<region>-<workspace-guid>.notebooks.chinacloudapi.cn`
 
     > [!NOTE]
-    > The workspace name for this FQDN may be truncated. Truncation is done to keep the FQDN less than or equal to 63 characters.
+    > The workspace name for this FQDN may be truncated. Truncation is done to keep the FQDN less than or equal to 90 characters.
 * `<instance-name>.<region>.instances.ml.azure.cn`
 ## Find the IP addresses
 


### PR DESCRIPTION
The specification is that `ml-<workspace-name, truncated>-<region>-<workspace-guid>` till will be 63 characters long.