### PR TITLE
Update active-directory-data-storage-australia-newzealand.md

### DIFF
--- a/articles/active-directory/fundamentals/active-directory-data-storage-australia-newzealand.md
+++ b/articles/active-directory/fundamentals/active-directory-data-storage-australia-newzealand.md
@@ -21,7 +21,7 @@ Azure Active Directory (Azure AD) stores its Customer Data in a geographical loc
 
 For information about where Azure AD and other Microsoft services' data is located, see the [Where is your data located?](https://www.microsoft.com/trustcenter/privacy/where-your-data-is-located) section of the Microsoft Trust Center.
 
-From February 26, 2020, Microsoft began storing Azure AD’s Customer Data for new tenants with an Australian or New Zealand billing address within the Australian datacenters. Between May 1, 2020 and March 31, 2021, Microsoft will migrate existing tenants who have an Australian or New Zealand billing address to the Australian datacenters without requiring any customer action. The migration process doesn’t involve any downtime for customers and won’t impact any functionality of a tenant during the migration.
+From February 26, 2020, Microsoft began storing Azure AD’s Customer Data for new tenants with an Australian or New Zealand billing address within the Australian datacenters.
 
 Additionally, certain Azure AD features do not yet support storage of Customer Data in Australia. Please go to the [Azure AD data map](https://msit.powerbi.com/view?r=eyJrIjoiYzEyZTc5OTgtNTdlZS00ZTVkLWExN2ItOTM0OWU4NjljOGVjIiwidCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsImMiOjV9), for specific feature information. For example, Microsoft Azure AD Multi-Factor Authentication stores Customer Data in the US and processes it globally. See [Data residency and customer data for Azure AD Multi-Factor Authentication](../authentication/concept-mfa-data-residency.md).
 


### PR DESCRIPTION
Migration dates have slipped and we do not know a new completion date. As such we want to remove any reference to tenant migrations and dates in our public docs. I have removed the offending paragraph that contains this information in this update. 