### PR TITLE
Add AMD Simultaneous multithreading footnotes mark

### DIFF
--- a/articles/virtual-machines/acu.md
+++ b/articles/virtual-machines/acu.md
@@ -43,7 +43,7 @@ The concept of the Azure Compute Unit (ACU) provides a way of comparing compute 
 | [D_v3](dv3-dsv3-series.md) |160 - 190* | 2:1\*\*\* |
 | [Ds_v3](dv3-dsv3-series.md) |160 - 190* | 2:1\*\*\* |
 | [Dav4](dav4-dasv4-series.md) |230 - 260** | 2:1\*\*\*\* |
-| [Dasv4](dav4-dasv4-series.md) |230 - 260** | 2:1 |
+| [Dasv4](dav4-dasv4-series.md) |230 - 260** | 2:1\*\*\*\* |
 | [Dv4](dv4-dsv4-series.md) | 195 - 210 | 2:1\*\*\* |
 | [Dsv4](dv4-dsv4-series.md) | 195 - 210 | 2:1\*\*\* |
 | [Ddv4](ddv4-ddsv4-series.md) | 195 -210* | 2:1\*\*\* |
@@ -51,7 +51,7 @@ The concept of the Azure Compute Unit (ACU) provides a way of comparing compute 
 | [E_v3](ev3-esv3-series.md) |160 - 190* | 2:1\*\*\*|
 | [Es_v3](ev3-esv3-series.md) |160 - 190* | 2:1\*\*\* |
 | [Eav4](eav4-easv4-series.md) |230 - 260** | 2:1\*\*\*\* |
-| [Easv4](eav4-easv4-series.md) | 230 - 260** | 2:1 |
+| [Easv4](eav4-easv4-series.md) | 230 - 260** | 2:1\*\*\*\* |
 | [Ev4](ev4-esv4-series.md) | 195 - 210 | 2:1\*\*\* |
 | [Esv4](ev4-esv4-series.md) | 195 - 210 | 2:1\*\*\* |
 | [Edv4](edv4-edsv4-series.md) | 195 - 210* | 2:1\*\*\* |
@@ -67,7 +67,7 @@ The concept of the Azure Compute Unit (ACU) provides a way of comparing compute 
 | [L4s - L32s](sizes-previous-gen.md) |180 - 240* | 1:1 |
 | [L8s_v2 - L80s_v2](lsv2-series.md) |150 - 175** | 2:1\*\*\*\* |
 | [M](m-series.md) | 160 - 180 | 2:1\*\*\* |
-| [NVv4](nvv4-series.md) |230 - 260** | 2:1 |
+| [NVv4](nvv4-series.md) |230 - 260** | 2:1\*\*\*\* |
 
 Here are links to more information about the different sizes:
 


### PR DESCRIPTION
Add the AMD Simultaneous multithreading technology footnotes mark because a few VM size series have missing the mark.

- [Dasv4](https://docs.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series)

    > The Dav4-series and Dasv4-series are new sizes utilizing AMD's 2.35Ghz EPYCTM 7452 processor in a multi-threaded configuration with up to 256 MB L3 cache dedicating 8 MB of that L3 cache to every 8 cores increasing customer options for running their general purpose workloads.

- [Easv4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series)

    > The Eav4-series and Easv4-series utilize AMD's 2.35Ghz EPYCTM 7452 processor in a multi-threaded configuration with up to 256MB L3 cache, increasing options for running most memory optimized workloads.

- [NVv4](https://docs.microsoft.com/en-us/azure/virtual-machines/nvv4-series)

    > NVv4-series VMs feature AMD Simultaneous multithreading Technology