### PR TITLE
Double entry removed

### DIFF
--- a/articles/migrate/whats-new.md
+++ b/articles/migrate/whats-new.md
@@ -22,8 +22,8 @@ ms.custom: mvc
 -  Azure Migrate: Server Migration tool now lets you migrate VMware virtual machines, physical servers, and virtual machines from other clouds to Azure virtual machines with disks encrypted with server-side encryption with customer-managed keys (CMK).
 
 ## Update (December 2020)
-- Azure Migrate now automatically installs the Azure VM agent on the VMware VMs while migrating them to Azure using the agentless method of VMware migration. (Windows Server 2012 and higher)
-- Migration of VMware VMs to Azure virtual machines with disks encrypted using server-side encryption (SSE) with customer-managed keys(CMK), using Azure Migrate Server Migration (agentless replication) is now available through Azure portal.
+- Azure Migrate now automatically installs the Azure VM agent on the VMware VMs while migrating them to Azure using the agentless method of VMware migration. (Windows Server 2008 R2 and later)
+- Migration of VMware VMs to Azure virtual machines with disks encrypted using server-side encryption (SSE) with customer-managed keys (CMK), using Azure Migrate Server Migration (agentless replication) is now available through Azure portal.
 
 ## Update (September 2020)
 - Migration of servers to Availability Zones is now supported.

--- a/articles/migrate/whats-new.md
+++ b/articles/migrate/whats-new.md
@@ -17,13 +17,12 @@ ms.custom: mvc
 - Support to provide multiple server credentials on Azure Migrate appliance to discover installed applications (software inventory), agentless dependency analysis and discover SQL Server instances and databases in your VMware environment. [Learn more](tutorial-discover-vmware.md#provide-server-credentials)
 - Discovery and assessment of SQL Server instances and databases running in your VMware environment is now in preview. [Learn More](concepts-azure-sql-assessment-calculation.md) Refer to the [Discovery](tutorial-discover-vmware.md) and [assessment](tutorial-assess-sql.md) tutorials to get started.
 - Agentless VMware migration now supports concurrent replication of 500 VMs per vCenter.
-- Azure Migrate now automatically installs the Azure VM agent on the VMware VMs while migrating them to Azure using the agentless method of VMware migration.
 
 ## Update (January 2021)
 -  Azure Migrate: Server Migration tool now lets you migrate VMware virtual machines, physical servers, and virtual machines from other clouds to Azure virtual machines with disks encrypted with server-side encryption with customer-managed keys (CMK).
 
 ## Update (December 2020)
-- Azure Migrate now automatically installs the Azure VM agent on the VMware VMs while migrating them to Azure using the agentless method of VMware migration.
+- Azure Migrate now automatically installs the Azure VM agent on the VMware VMs while migrating them to Azure using the agentless method of VMware migration. (Windows Server 2012 and higher)
 - Migration of VMware VMs to Azure virtual machines with disks encrypted using server-side encryption (SSE) with customer-managed keys(CMK), using Azure Migrate Server Migration (agentless replication) is now available through Azure portal.
 
 ## Update (September 2020)


### PR DESCRIPTION
There was a double entry stating the following.
"- Azure Migrate now automatically installs the Azure VM agent on the VMware VMs while migrating them to Azure using the agentless method of VMware migration." This w<as already introduced in the December 2020 update. Added a remark to the update that it only applies to systems running Windows Server 2012 and higher.)