### PR TITLE
Update to reflect correct min CLI Version

### DIFF
--- a/articles/azure-resource-manager/templates/template-deploy-what-if.md
+++ b/articles/azure-resource-manager/templates/template-deploy-what-if.md
@@ -26,7 +26,7 @@ For more information about installing modules, see [Install Azure PowerShell](/p
 
 ## Install Azure CLI module
 
-To use what-if in Azure CLI, you must have Azure CLI 2.5.0 or later. If needed, [install the latest version of Azure CLI](/cli/azure/install-azure-cli).
+To use what-if in Azure CLI, you must have Azure CLI 2.14.0 or later. If needed, [install the latest version of Azure CLI](/cli/azure/install-azure-cli).
 
 ## See results
 


### PR DESCRIPTION
Documentation says 2.5 version of Azure CLI.  This is not a valid version as latest is 2.22.  Looked at release notes and what-if was introduced in 2.14 https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli?tabs=azure-cli#october-27-2020