### PR TITLE
Update how-to-connect-sync-change-serviceacct-pass.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
@@ -105,7 +105,7 @@ As the existing passwords stored inside the database can no longer be decrypted,
 You cannot directly provide the password of the Azure AD service account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Azure AD service account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
 1. Start a new PowerShell session on the Azure AD Connect server.
-2. Run cmdlet `Add-ADSyncAADServiceAccount`.
+2. Run cmdlet: `Add-ADSyncAADServiceAccount -AADCredential <pscredential>`
 3. In the pop-up dialog, provide the Azure AD Global admin credentials for your Azure AD tenant.
 ![Azure AD Connect Sync Encryption Key Utility](./media/how-to-connect-sync-change-serviceacct-pass/key7.png)
 4. If it is successful, you will see the PowerShell command prompt.


### PR DESCRIPTION
Updating the cmdlet syntax with mandatory parameters, otherwise new build 1.6. will throw the error: Add-ADSyncAADServiceAccount : Parameter set cannot be resolved using the specified named parameters. Also removing the dot in the end to prevent copy/paste issues.