### PR TITLE
Update how-to-connect-sync-change-serviceacct-pass.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
@@ -104,12 +104,14 @@ As the existing passwords stored inside the database can no longer be decrypted,
 #### Reinitialize the password of the ADSync service account
 You cannot directly provide the password of the Azure AD service account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Azure AD service account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
-1. Sign in to the Azure AD Connect sync server and start PowerShell.
-2. Provide Azure AD Global admin credentials using: `$credential = Get-Credential`
-3. Run cmdlet: `Add-ADSyncAADServiceAccount -AADCredential $credential`
-4. If it is successful, you will see the PowerShell command prompt.
+1. Sign in to the Azure AD Connect sync server and open PowerShell.
+2. To provide the Azure AD Global admin credentials, run `$credential = Get-Credential`.
+3. Run the cmdlet `Add-ADSyncAADServiceAccount -AADCredential $credential`.
+ 
+   If the cmdlet is successful, the PowerShell command prompt appears. 
+   
+The cmdlet resets the password for the service account and updates it both in Azure AD and the sync engine.
 
-This cmdlet resets the password for the service account and update it both in Azure AD and in the sync engine.
 
 #### Start the Synchronization Service
 Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:

--- a/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-change-serviceacct-pass.md
@@ -104,11 +104,12 @@ As the existing passwords stored inside the database can no longer be decrypted,
 #### Reinitialize the password of the ADSync service account
 You cannot directly provide the password of the Azure AD service account to the Synchronization Service. Instead, you need to use the cmdlet **Add-ADSyncAADServiceAccount** to reinitialize the Azure AD service account. The cmdlet resets the account password and makes it available to the Synchronization Service:
 
-1. Start a new PowerShell session on the Azure AD Connect server.
-2. Run cmdlet `Add-ADSyncAADServiceAccount`.
-3. In the pop-up dialog, provide the Azure AD Global admin credentials for your Azure AD tenant.
-![Azure AD Connect Sync Encryption Key Utility](./media/how-to-connect-sync-change-serviceacct-pass/key7.png)
+1. Sign in to the Azure AD Connect sync server and start PowerShell.
+2. Provide Azure AD Global admin credentials using: `$credential = Get-Credential`
+3. Run cmdlet: `Add-ADSyncAADServiceAccount -AADCredential $credential`
 4. If it is successful, you will see the PowerShell command prompt.
+
+This cmdlet resets the password for the service account and update it both in Azure AD and in the sync engine.
 
 #### Start the Synchronization Service
 Now that the Synchronization Service has access to the encryption key and all the passwords it needs, you can restart the service in the Windows Service Control Manager:


### PR DESCRIPTION
Updating the cmdlet syntax with mandatory parameters, otherwise new build 1.6. will throw the error: Add-ADSyncAADServiceAccount : Parameter set cannot be resolved using the specified named parameters. 
Additionally:
- removing the dot at the end of the cmdlet to prevent copy/paste issues
- removing unnecessary picture that is now outdated for builds 1.6. and later
- consolidating the documentation on both pages that refer to Add-ADSyncAADServiceAccount to be the same