### PR TITLE
Update iot-hub-devguide-messages-read-builtin.md

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
@@ -13,7 +13,7 @@ ms.custom: [amqp, 'Role: Cloud Development']
 
 # Read device-to-cloud messages from the built-in endpoint
 
-By default, messages are routed to the built-in service-facing endpoint (**messages/events**) that is compatible with [Event Hubs](https://azure.microsoft.com/documentation/services/event-hubs/). This endpoint is currently only exposed using the [AMQP](https://www.amqp.org/) protocol on port 5671. An IoT hub exposes the following properties to enable you to control the built-in Event Hub-compatible messaging endpoint **messages/events**.
+By default, messages are routed to the built-in service-facing endpoint (**messages/events**) that is compatible with [Event Hubs](https://azure.microsoft.com/documentation/services/event-hubs/). This endpoint is currently only exposed using the [AMQP](https://www.amqp.org/) protocol on port 5671 and [AMQP over WebSockets](http://docs.oasis-open.org/amqp-bindmap/amqp-wsb/v1.0/cs01/amqp-wsb-v1.0-cs01.html) on port 443. An IoT hub exposes the following properties to enable you to control the built-in Event Hub-compatible messaging endpoint **messages/events**.
 
 | Property            | Description |
 | ------------------- | ----------- |

--- a/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
@@ -79,5 +79,3 @@ The product integrations you can use with the built-in Event Hub-compatible endp
 * The [Quickstarts](quickstart-send-telemetry-node.md) show you how to send device-to-cloud messages from simulated devices and read the messages from the built-in endpoint. 
 
 For more detail, see the [Process IoT Hub device-to-cloud messages using routes](tutorial-routing.md) tutorial.
-
-* If you want to route your device-to-cloud messages to custom endpoints, see [Use message routes and custom endpoints for device-to-cloud messages](iot-hub-devguide-messages-read-custom.md).

--- a/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
+++ b/articles/iot-hub/iot-hub-devguide-messages-read-builtin.md
@@ -79,3 +79,5 @@ The product integrations you can use with the built-in Event Hub-compatible endp
 * The [Quickstarts](quickstart-send-telemetry-node.md) show you how to send device-to-cloud messages from simulated devices and read the messages from the built-in endpoint. 
 
 For more detail, see the [Process IoT Hub device-to-cloud messages using routes](tutorial-routing.md) tutorial.
+
+* If you want to route your device-to-cloud messages to custom endpoints, see [Use message routes and custom endpoints for device-to-cloud messages](iot-hub-devguide-messages-read-custom.md).


### PR DESCRIPTION
Updating the available protocols as the current doc is incorrect.  The EventHub compatible endpoint exposes both AMQP on 5671 and AmqpWebsockets on 443.

Though this is not documented elsewhere that I can find, you can find evidence here that it is available: https://github.com/jlorich/azure-iot-eh-endpoint-websocket-test