### PR TITLE
Help keep advice in context

### DIFF
--- a/articles/azure-monitor/agents/agent-linux.md
+++ b/articles/azure-monitor/agents/agent-linux.md
@@ -52,7 +52,7 @@ If you are using an older version of the agent, you must have the Virtual Machin
  - Ubuntu, Debian: `apt-get install -y python2`
  - SUSE: `zypper install -y python2`
 
-The python2 executable must be aliased to *python*. Following is one method that you can use to set this alias:
+Again, only if you are using an older version of the agent, the python2 executable must be aliased to *python*. Following is one method that you can use to set this alias:
 
 1. Run the following command to remove any existing aliases.
  


### PR DESCRIPTION
As part of an internal conversation around https://github.com/microsoft/PowerShell-DSC-for-Linux/issues/764 it was suggested that we use python2 on RHEL8 since it was "recommended by Microsoft" in this document. This seems to be a misunderstanding of the context of this fix and goes against the strong preference for python3 in RHEL8. Help clarify that with this trivial improvement.