### PR TITLE
Update azure-stack-edge-gpu-create-certificates-tool.md

### DIFF
--- a/articles/databox-online/azure-stack-edge-gpu-create-certificates-tool.md
+++ b/articles/databox-online/azure-stack-edge-gpu-create-certificates-tool.md
@@ -136,7 +136,7 @@ First, you'll generate a proper folder structure and place the certificates in t
 
 2. To generate the appropriate folder structure, at the prompt type:
 
-    `New-AzsCertificateFolder -CertificateType AzureStackEdge -OutputPath "$ENV:USERPROFILE\Documents\AzureStackCSR"`
+    `New-AzsCertificateFolder -CertificateType AzureStackEdgeDevice -OutputPath "$ENV:USERPROFILE\Documents\AzureStackCSR"`
 
 3. Convert the PFX password into a secure string. Type:       
 
@@ -144,7 +144,7 @@ First, you'll generate a proper folder structure and place the certificates in t
 
 4. Next, validate the certificates. Type:
 
-    `Invoke-AzsCertificateValidation -CertificateType AzureStackEdge -DeviceName mytea1 -NodeSerialNumber VM1500-00025 -externalFQDN azurestackedge.contoso.com -CertificatePath $ENV:USERPROFILE\Documents\AzureStackCSR\AzureStackEdge -pfxPassword $pfxPassword`
+    `Invoke-AzsCertificateValidation -CertificateType AzureStackEdgeDevice -DeviceName mytea1 -NodeSerialNumber VM1500-00025 -externalFQDN azurestackedge.contoso.com -CertificatePath $ENV:USERPROFILE\Documents\AzureStackCSR\AzureStackEdge -pfxPassword $pfxPassword`
 
 ## Next steps
 


### PR DESCRIPTION
On line 139 the -CertificateType may have changed. At least with the version of the modules I am running.  It is listed AzureStackEdge but the option is now AzureStackEdgeDevice.

This is the same for line 147