### PR TITLE
includes: Return SSL Enter-PSSession instructions for Linux

### DIFF
--- a/includes/azure-stack-edge-gateway-connect-minishell.md
+++ b/includes/azure-stack-edge-gateway-connect-minishell.md
@@ -79,12 +79,9 @@ Follow these steps to remotely connect from a Windows client.
     [10.100.10.10]: PS>
     ```
 
-> [!IMPORTANT]
-> In the current release, you can connect to the PowerShell interface of the device only via a Windows client. The `-UseSSL` option does not work with the Linux clients.
+### Remotely connect from a Linux client
 
-<!--### Remotely connect from a Linux client-->
-
-<!--On the Linux client that you'll use to connect:
+On the Linux client that you'll use to connect:
 
 - [Install the latest PowerShell Core for Linux](/powershell/scripting/install/installing-powershell-core-on-linux) from GitHub to get the SSH remoting feature. 
 - [Install only the `gss-ntlmssp` package from the NTLM module](https://github.com/Microsoft/omi/blob/master/Unix/doc/setup-ntlm-omi.md). For Ubuntu clients, use the following command:
@@ -97,12 +94,16 @@ Follow these steps to remotely connect from an NFS client.
 1. To open PowerShell session, type:
 
     `pwsh`
- 
+
 2. For connecting using the remote client, type:
 
-    `Enter-PSSession -ComputerName $ip -Authentication Negotiate -ConfigurationName Minishell -Credential ~\EdgeUser`
+    `$pso = New-PSSessionOption -SkipCACheck -SkipCNCheck`
+
+    Followed by:
+
+    `Enter-PSSession -ComputerName $ip -Authentication Negotiate -ConfigurationName Minishell -Credential ~\EdgeUser -UseSSL -SessionOption $pso`
 
     When prompted, provide the password used to sign into your device.
- 
+
 > [!NOTE]
-> This procedure does not work on Mac OS.-->
+> This procedure does not work on Mac OS.


### PR DESCRIPTION
When adding the `-UseSSL` option on Linux, the following error appeared (PowerShell 7.1.3):

```
Enter-PSSession: HTTPS on Unix does not currently support CA or CN checks.
Use the PSSessionOption -SkipCACheck and -SkipCNCheck if you are certain you
trust the server you are connecting to and the network in between.
```

For ASE Sowtware version 2101, simply removing the `-UseSSL` option worked (and it was removed in commit e41827bdf08b3c421bbcdc7fcb46f11cc80581e5). However, upon update to Software 2103, if connecting without the `-UseSSL` option, The following error appears:

```
Enter-PSSession: Connecting to remote server 172.16.139.10 failed with the
following error message : MI_RESULT_FAILED For more information,
see the about_Remote_Troubleshooting Help topic.
```

Therefore, in this commit, an additional line is added to allow connecting from a Linux client. This is done instead of discarding the instructions for connecting from a Linux client altogether, as some ASE users work mainly from Linux clients. This is verified on PowerShell 7.1.3.