### PR TITLE
Update speech-devices-sdk-windows-quickstart.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/speech-devices-sdk-windows-quickstart.md
+++ b/articles/cognitive-services/Speech-Service/includes/speech-devices-sdk-windows-quickstart.md
@@ -29,8 +29,6 @@ This quickstart requires:
    > [!NOTE]
    > This quickstart assumes that the app is extracted to C:\SDSDK\JRE-Sample-Release
 
-Conversation Transcription is currently only available for "en-US" and "zh-CN", in the "centralus" and "eastasia" regions. You must have a speech key in one of those regions to use Conversation Transcription.
-
 If you plan to use the intents you'll need a [Language Understanding Service (LUIS)](../../luis/luis-how-to-azure-subscription.md) subscription. To learn more about LUIS and intent recognition, see [Recognize speech intents with LUIS, C#](../how-to-recognize-intents-from-speech-csharp.md). A [sample LUIS model](https://aka.ms/sdsdk-luis) is available for this app.
 
 ## Create and configure the project


### PR DESCRIPTION
this is not accurate anymore. the ground truth of  conversation transcription should always refer to Conversation Transcription main document.