### PR TITLE
Add reference to using node max surge

### DIFF
--- a/articles/aks/update-credentials.md
+++ b/articles/aks/update-credentials.md
@@ -94,6 +94,7 @@ Now continue on to [update AKS cluster with new service principal credentials](#
 
 > [!IMPORTANT]
 > For large clusters, updating the AKS cluster with a new service principal may take a long time to complete.
+> To speed up updates considering tuning [node max surge](upgrade-cluster#customize-node-surge-upgrade) to suit your requirements.
 
 Regardless of whether you chose to update the credentials for the existing service principal or create a service principal, you now update the AKS cluster with your new credentials using the [az aks update-credentials][az-aks-update-credentials] command. The variables for the *--service-principal* and *--client-secret* are used:
 


### PR DESCRIPTION
Update this document to note that az aks update-credentials utilizes AKS' node max surge.