### PR TITLE
FIDO2 cachedlogon

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key.md
@@ -87,6 +87,8 @@ If you'd like to share feedback or encounter issues with this feature, share via
 
 Administrator provisioning and de-provisioning of security keys is not available.
 
+**Note:** FIDO2 Hybrid device cached logon (without LOS to DC) will fail on 20H2, Investigation going on. we will update here once its fixed.
+
 ### UPN changes
 
 We are working on supporting a feature that allows UPN change on hybrid Azure AD joined and Azure AD joined devices. If a user's UPN changes, you can no longer modify FIDO2 security keys to account for the change. The resolution is to reset the device and the user has to re-register.


### PR DESCRIPTION
Bug -20H2 Bug 32219927: FIDO2 cached logon-fails on HAADJ specific to version 20H2 - Boards (visualstudio.com)