### PR TITLE
remove obsoleted --export arg on kubectl get

### DIFF
--- a/articles/aks/aks-migration.md
+++ b/articles/aks/aks-migration.md
@@ -168,7 +168,7 @@ We recommend that you use your existing Continuous Integration (CI) and Continuo
 If that's not possible, export resource definitions from your existing Kubernetes cluster and then apply them to AKS. You can use `kubectl` to export objects.
 
 ```console
-kubectl get deployment -o=yaml --export > deployments.yaml
+kubectl get deployment -o=yaml > deployments.yaml
 ```
 
 ### Moving existing resources to another region


### PR DESCRIPTION
This no longer works in Azure, as it was removed by Kubernetes 1.18. Simply removing the argument is enough for the command to work as expected.

Signed-off-by: Charlie Arehart <charlie@carehart.org>