### PR TITLE
patch: Change resp --> res

### DIFF
--- a/articles/cognitive-services/immersive-reader/includes/quickstarts/immersive-reader-client-library-nodejs.md
+++ b/articles/cognitive-services/immersive-reader/includes/quickstarts/immersive-reader-client-library-nodejs.md
@@ -93,7 +93,7 @@ router.get('/GetTokenAndSubdomain', function(req, res) {
                 resource: 'https://cognitiveservices.azure.com/'
             }
         },
-        function(err, resp, tokenResult) {
+        function(err, res, tokenResult) {
             if (err) {
                 console.log(err);
                 return res.status(500).send('CogSvcs IssueToken error');


### PR DESCRIPTION
Fixed the response call back argument when requesting the auth token. Since this is an HTTP call which we would be making in almost every stack (C#, Swift, Kotlin, Java), I advise checking other templates for the same issue. MS doesn't seem to be using the same template to generate all of the other quickstart guides, so maybe I am wrong. Nonetheless, great experience reading through the docs. Used Immersive Reader to work on a small proj. 