### PR TITLE
Update test-createuidefinition.md

### DIFF
--- a/articles/azure-resource-manager/managed-applications/test-createuidefinition.md
+++ b/articles/azure-resource-manager/managed-applications/test-createuidefinition.md
@@ -94,7 +94,7 @@ If the portal hangs at the summary screen, there might be a bug in the output se
 
 ## Test your solution files
 
-Now that you've verified your portal interface is working as expected, it's time to validate that your createUiDefinition file is properly integrated with your mainTemplate.json file. You can run a validation script test to test the content of your solution files, including the createUiDefinition file. The script validates the JSON syntax, checks for regex expressions on text fields, and makes sure the output values of the portal interface match the parameters of your template. For information on running this script, see [Run static validation checks for templates](https://github.com/Azure/azure-quickstart-templates/tree/master/test).
+Now that you've verified your portal interface is working as expected, it's time to validate that your createUiDefinition file is properly integrated with your mainTemplate.json file. You can run a validation script test to test the content of your solution files, including the createUiDefinition file. The script validates the JSON syntax, checks for regex expressions on text fields, and makes sure the output values of the portal interface match the parameters of your template. For information on running this script, see [Run static validation checks for templates](https://aka.ms/arm-ttk).
 
 ## Next steps
 


### PR DESCRIPTION
Link for static analysis was still pointing to the QuickStart repo - the TTK has been moved to it's own repo