### PR TITLE
Update event-hubs-for-kafka-ecosystem-overview.md

### DIFF
--- a/articles/event-hubs/event-hubs-for-kafka-ecosystem-overview.md
+++ b/articles/event-hubs/event-hubs-for-kafka-ecosystem-overview.md
@@ -61,7 +61,7 @@ bootstrap.servers=NAMESPACENAME.servicebus.windows.net:9093
 security.protocol=SASL_SSL
 sasl.mechanism=OAUTHBEARER
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
-sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler;
+sasl.login.callback.handler.class=CustomAuthenticateCallbackHandler
 ```
 
 #### Shared Access Signature (SAS)


### PR DESCRIPTION
- for jaas example, semicolon works fine, but not for the OAUTHBEARER, so suggested to fix as I've filed also a PR to the samples repo.