### PR TITLE
Update troubleshoot document for correct IOTEDGE_LOG

### DIFF
--- a/articles/iot-edge/troubleshoot.md
+++ b/articles/iot-edge/troubleshoot.md
@@ -156,7 +156,7 @@ On Linux:
 
      ```bash
      [Service]
-     Environment=IOTEDGE_LOG=edgelet=debug
+     Environment=IOTEDGE_LOG=debug
      ```
 
   3. Restart the IoT Edge security daemon:


### PR DESCRIPTION
It should be `IOTEDGE_LOG=debug` not `IOTEDGE_LOG=edgelet=debug`. This fixes #71563