### PR TITLE
Update virtual-machines-common-isolation.md

### DIFF
--- a/includes/virtual-machines-common-isolation.md
+++ b/includes/virtual-machines-common-isolation.md
@@ -26,6 +26,7 @@ The current Isolated virtual machine offerings include:
 * Standard_M128ms
 * Standard_GS5
 * Standard_G5
+* Standard_DC8_v2
 
 
 > [!NOTE]
@@ -43,6 +44,7 @@ Isolated VM sizes have a hardware limited lifespan. Azure will issue reminders 1
 | Standard_GS5  | February 15, 2022 |
 | Standard_E64i_v3  | February 15, 2022 |
 | Standard_E64is_v3  | February 15, 2022 |
+| Standard_DC8_v2 | February 15, 2022 |
 
 
 ## FAQ


### PR DESCRIPTION
Added DC8_v2 to the list, DC8_v2 is the maximum size node for DCsv2-series machines.