### PR TITLE
Fix copy paste error in tutorial-nested-iot-edge.md

### DIFF
--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -441,7 +441,7 @@ Once you are satisfied your configurations are correct on each device, you are r
 
 ## Deploy modules to the top layer device
 
-Modules serve to complete the deployment and the IoT Edge runtime to your devices and further define the structure of your hierarchy. The IoT Edge API Proxy module securely routs HTTP traffic over a single port from your lower layer devices. The Docker Registry module allows for a repository of Docker images that your lower layer devices can access by routing image pulls to the top layer device.
+Modules serve to complete the deployment and the IoT Edge runtime to your devices and further define the structure of your hierarchy. The IoT Edge API Proxy module securely routes HTTP traffic over a single port from your lower layer devices. The Docker Registry module allows for a repository of Docker images that your lower layer devices can access by routing image pulls to the top layer device.
 
 To deploy modules to your top layer device, you can use the Azure portal or Azure CLI.
 

--- a/articles/iot-edge/tutorial-nested-iot-edge.md
+++ b/articles/iot-edge/tutorial-nested-iot-edge.md
@@ -618,7 +618,7 @@ In the [Azure portal](https://ms.portal.azure.com/):
 
 ---
 
-If you completed the above steps correctly, your **top layer device** should report the four modules: the IoT Edge API Proxy Module, the Docker Container Registry module, and the system modules, as **Specified in Deployment**. It may take a few minutes for the device to receive its new deployment and start the modules. Refresh the page until you see the temperature sensor module listed as **Reported by Device**. Once the modules are reported by the device, you are ready to continue.
+If you completed the above steps correctly, your **top layer device** should report the four modules: the IoT Edge API Proxy Module, the Docker Container Registry module, and the system modules, as **Specified in Deployment**. It may take a few minutes for the device to receive its new deployment and start the modules. Refresh the page until you see the IoTEdgeAPIProxy and registry modules listed as **Reported by Device**. Once the modules are reported by the device, you are ready to continue.
 
 ## Deploy modules to the lower layer device
 


### PR DESCRIPTION
Copy paste error where it was saying to refresh until lower layer modules were deployed instead of top layer modules deployed.