### PR TITLE
Correct API permissions in api-management-howto-aad.md

### DIFF
--- a/articles/api-management/api-management-howto-aad.md
+++ b/articles/api-management/api-management-howto-aad.md
@@ -89,12 +89,14 @@ After the changes are saved, users in the specified Azure AD instance can sign i
 
 After you enable access for users in an Azure AD tenant, you can add Azure AD groups into API Management. As a result, you can control product visibility using Azure AD groups.
 
-To add an external Azure AD group into APIM, you must first complete the previous section. Additionally, the application you registered must be granted access to the Microsoft Graph API with `Directory.Read.All` permission by following these steps: 
+To add an external Azure AD group into APIM, you must first complete the previous section. By default, the application you registered will have access granted to the Microsoft Graph API with the needed `User.Read` Delegated permission. Additionally, the application must be granted access to the Microsoft Graph API and Azure Active Directory Graph API with the `Directory.Read.All` Application permission by following these steps: 
 
 1. Go back to your App Registration that was created in the previous section.
 2. Select **API Permissions**, and then click **+Add a permission**. 
-3. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, scroll down and then select the **Azure Active Directory Graph** tile. Select **Application permissions**, search for **Directory**, and then select the **Directory.Read.All** permission. 
-4. Click **Add permissions** at the bottom of the pane, and then click **Grant admin consent for {tenantname}** so that you grant access for all users in this directory. 
+3. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, and then select the **Microsoft Graph** tile. Select **Application permissions**, search for **Directory**, select the **Directory.Read.All** permission, and then click **Add permissions** at the bottom of the pane.
+4. Click **+Add a permission**. 
+5. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, scroll down, and then select the **Azure Active Directory Graph** tile. Select **Application permissions**, search for **Directory**, select the **Directory.Read.All** permission, and then click **Add permissions** at the bottom of the pane. 
+6. Click **Grant admin consent for {tenantname}** so that you grant access for all users in this directory. 
 
 Now you can add external Azure AD groups from the **Groups** tab of your API Management instance.
 

--- a/articles/api-management/api-management-howto-aad.md
+++ b/articles/api-management/api-management-howto-aad.md
@@ -89,20 +89,21 @@ After the changes are saved, users in the specified Azure AD instance can sign i
 
 After you enable access for users in an Azure AD tenant, you can add Azure AD groups into API Management. As a result, you can control product visibility using Azure AD groups.
 
-To add an external Azure AD group into APIM, you must first complete the previous section. By default, the application you registered will have access granted to the Microsoft Graph API with the needed `User.Read` Delegated permission. Additionally, the application must be granted access to the Microsoft Graph API and Azure Active Directory Graph API with the `Directory.Read.All` Application permission by following these steps: 
+To add an external Azure AD group into APIM, you must first complete the previous section. By default, the application you registered has access to the Microsoft Graph API with the required `User.Read` Delegated permission. You must also give the application access to the Microsoft Graph API and Azure Active Directory Graph API with the `Directory.Read.All` Application permission by following these steps: 
 
-1. Go back to your App Registration that was created in the previous section.
-2. Select **API Permissions**, and then click **+Add a permission**. 
-3. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, and then select the **Microsoft Graph** tile. Select **Application permissions**, search for **Directory**, select the **Directory.Read.All** permission, and then click **Add permissions** at the bottom of the pane.
-4. Click **+Add a permission**. 
-5. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, scroll down, and then select the **Azure Active Directory Graph** tile. Select **Application permissions**, search for **Directory**, select the **Directory.Read.All** permission, and then click **Add permissions** at the bottom of the pane. 
-6. Click **Grant admin consent for {tenantname}** so that you grant access for all users in this directory. 
+1. Go back to your app registration that was created in the previous section.
+2. Select **API Permissions**, and then select **Add a permission**. 
+3. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, and then select the **Microsoft Graph** tile. Select **Application permissions** and search for **Directory**. Select the **Directory.Read.All** permission, and then select **Add permissions** at the bottom of the pane.
+4. Select **Add a permission**. 
+5. In the **Request API Permissions** pane, select the **Microsoft APIs** tab, scroll down, and then select the **Azure Active Directory Graph** tile. Select **Application permissions** and search for **Directory**. Select the **Directory.Read.All** permission, and then select **Add permissions**. 
+6. Select **Grant admin consent for {tenantname}** so that you grant access for all users in this directory. 
 
 Now you can add external Azure AD groups from the **Groups** tab of your API Management instance.
 
 1. Select the **Groups** tab.
 2. Select the **Add AAD group** button.
-    !["Add AAD group" button](./media/api-management-howto-aad/api-management-with-aad008.png)
+
+   !["Add A A D group" button](./media/api-management-howto-aad/api-management-with-aad008.png)
 3. Select the group that you want to add.
 4. Press the **Select** button.
 


### PR DESCRIPTION
Corrected API permissions needed by app registration used for APIM's Azure Active Directory identity provider to:

- Microsoft Graph API Delegated `User.Read`
- Microsoft Graph API Application `Directory.Read.All`
- Azure Active Directory Graph API (legacy) Application `Directory.Read.All`