### PR TITLE
fix typo in property name

### DIFF
--- a/articles/service-fabric/tutorial-managed-cluster-deploy-app.md
+++ b/articles/service-fabric/tutorial-managed-cluster-deploy-app.md
@@ -34,7 +34,7 @@ To connect to your cluster, you'll need the cluster certificate thumbprint. You 
 The following command can be used to query your cluster resource for the cluster certificate thumbprint.
 
 ```powershell
-$serverThumbprint = (Get-AzResource -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ServiceFabric/managedclusters/mysfcluster).Properties.clusterCertificateThumbprint
+$serverThumbprint = (Get-AzResource -ResourceId /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.ServiceFabric/managedclusters/mysfcluster).Properties.clusterCertificateThumbprints
 ```
 
 With the cluster certificate thumbprint, you're ready to connect to your cluster.


### PR DESCRIPTION
clusterCertificateThumbprints property name has changed or this doc was missing the 's'