### PR TITLE
Remove Windows Only for Integrated License

### DIFF
--- a/articles/security-center/defender-for-servers-introduction.md
+++ b/articles/security-center/defender-for-servers-introduction.md
@@ -23,7 +23,7 @@ For Linux, Azure Defender collects audit records from Linux machines by using **
 
 The threat detection and protection capabilities provided with Azure Defender for servers include:
 
-- **Integrated license for Microsoft Defender for Endpoint (Windows only)** - Azure Defender for servers includes  [Microsoft Defender for Endpoint](https://www.microsoft.com/microsoft-365/security/endpoint-defender). Together, they provide comprehensive endpoint detection and response (EDR) capabilities. For more information, see [Protect your endpoints](security-center-wdatp.md).
+- **Integrated license for Microsoft Defender for Endpoint** - Azure Defender for servers includes  [Microsoft Defender for Endpoint](https://www.microsoft.com/microsoft-365/security/endpoint-defender). Together, they provide comprehensive endpoint detection and response (EDR) capabilities. For more information, see [Protect your endpoints](security-center-wdatp.md).
 
     When Defender for Endpoint detects a threat, it triggers an alert. The alert is shown in Security Center. From Security Center, you can also pivot to the Defender for Endpoint console, and perform a detailed investigation to uncover the scope of the attack. Learn more about Microsoft Defender for Endpoint.
 


### PR DESCRIPTION
The Defender for Endpoint integrated license with Azure Defender should include a license for any supported Azure Defender server VM.  Windows / Linux servers should be included (license-wise) and not just windows anymore?

Removed the Windows only comment in the article if this is still true?

https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/minimum-requirements?view=o365-worldwide

As far as this article: https://docs.microsoft.com/en-us/azure/security-center/security-center-wdatp, it references Linux is unsupported but only for automatically deploy Defender for Endpoint through Azure Defender, this is still true and would need to be deployed following the steps here: https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-endpoint-linux?view=o365-worldwide#how-to-install-microsoft-defender-for-endpoint-for-linux

However to license this Linux server it would need to be licensed through Azure Defender?