### PR TITLE
Updated- Unsupported with firewall Storage Accounts

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -23,7 +23,7 @@ Persistence writes Redis data into an Azure Storage account that you own and man
 > 
 > Azure Storage automatically encrypts data when it is persisted. You can use your own keys for the encryption. For more information, see [Customer-managed keys with Azure Key Vault](../storage/common/storage-service-encryption.md).
 > 
-> Redis persistence to a firewall storage account isn't supported. For more information, see [Azure Cache for Redis with Azure Private Link](cache-private-link.md#prerequisites).
+> Redis persistence to a firewall storage account isn't supported. For more information, see the prerequisites in [Azure Cache for Redis with Azure Private Link](cache-private-link.md#prerequisites).
 > 
 
 ## Set up data persistence

--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -23,7 +23,8 @@ Persistence writes Redis data into an Azure Storage account that you own and man
 > 
 > Azure Storage automatically encrypts data when it is persisted. You can use your own keys for the encryption. For more information, see [Customer-managed keys with Azure Key Vault](../storage/common/storage-service-encryption.md).
 > 
-> Redis Persistence to firewall storage accounts are not supported. Refer https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link#prerequisites for more details.
+> Redis persistence to a firewall storage account isn't supported. For more information, see [Azure Cache for Redis with Azure Private Link](cache-private-link.md#prerequisites).
+> 
 
 ## Set up data persistence
 

--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -23,7 +23,7 @@ Persistence writes Redis data into an Azure Storage account that you own and man
 > 
 > Azure Storage automatically encrypts data when it is persisted. You can use your own keys for the encryption. For more information, see [Customer-managed keys with Azure Key Vault](../storage/common/storage-service-encryption.md).
 > 
-> 
+> Redis Persistence to firewall storage accounts are not supported. Refer https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link#prerequisites for more details.
 
 ## Set up data persistence
 


### PR DESCRIPTION
Redis Persistence to firewall storage accounts are not supported. The same is mentioned here https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link#prerequisites but was missing in this specific document.