### PR TITLE
Remove links to ref docs in duplicate detection article

### DIFF
--- a/articles/service-bus-messaging/duplicate-detection.md
+++ b/articles/service-bus-messaging/duplicate-detection.md
@@ -2,7 +2,7 @@
 title: Azure Service Bus duplicate message detection | Microsoft Docs
 description: This article explains how you can detect duplicates in Azure Service Bus messages. The duplicate message can be ignored and dropped.
 ms.topic: article
-ms.date: 01/13/2021
+ms.date: 04/12/2021
 ---
 
 # Duplicate detection
@@ -34,24 +34,34 @@ The *MessageId* can always be some GUID, but anchoring the identifier to the bus
 
 ## Enable duplicate detection
 
-In the portal, the feature is turned on during entity creation with the **Enable duplicate detection** check box, which is off by default. The setting for creating new topics is equivalent.
+Apart from just enabling duplicate detection, you can also configure the size of the duplicate detection history time window during which message-ids are retained.
+This value defaults to 10 minutes for queues and topics, with a minimum value of 20 seconds to maximum value of 7 days.
+
+Enabling duplicate detection and the size of the window directly impact the queue (and topic) throughput, since all recorded message-ids must be matched against the newly submitted message identifier.
+
+Keeping the window small means that fewer message-ids must be retained and matched, and throughput is impacted less. For high throughput entities that require duplicate detection, you should keep the window as small as possible.
+
+### Using the portal
+
+In the portal, the duplicate detection feature is turned on during entity creation with the **Enable duplicate detection** check box, which is off by default. The setting for creating new topics is equivalent.
 
 ![Screenshot of the Create queue dialog box with the Enable duplicate detection option selected and outlined in red.][1]
 
 > [!IMPORTANT]
 > You can't enable/disable duplicate detection after the queue is created. You can only do so at the time of creating the queue. 
 
-Programmatically, you set the flag with the [QueueDescription.requiresDuplicateDetection](/dotnet/api/microsoft.servicebus.messaging.queuedescription.requiresduplicatedetection#Microsoft_ServiceBus_Messaging_QueueDescription_RequiresDuplicateDetection) property on the full framework .NET API. With the Azure Resource Manager API, the value is set with the [queueProperties.requiresDuplicateDetection](/azure/templates/microsoft.servicebus/namespaces/queues#property-values) property.
-
-The duplicate detection time history defaults to 10 minutes for queues and topics, with a minimum value of 20 seconds to maximum value of 7 days. You can change this setting in the queue and topic properties window in the Azure portal.
+The duplicate detection history time window can be changed in the queue and topic properties window in the Azure portal.
 
 ![Screenshot of the Service Bus feature with the Properties setting highlighted adn the Duplicate detection history option outlined in red.][2]
 
-Programmatically, you can configure the size of the duplicate detection window during which message-ids are retained, using the [QueueDescription.DuplicateDetectionHistoryTimeWindow](/dotnet/api/microsoft.servicebus.messaging.queuedescription.duplicatedetectionhistorytimewindow#Microsoft_ServiceBus_Messaging_QueueDescription_DuplicateDetectionHistoryTimeWindow) property with the full .NET Framework API. With the Azure Resource Manager API, the value is set with the [queueProperties.duplicateDetectionHistoryTimeWindow](/azure/templates/microsoft.servicebus/namespaces/queues#property-values) property.
+### Using SDKs
 
-Enabling duplicate detection and the size of the window directly impact the queue (and topic) throughput, since all recorded message-ids must be matched against the newly submitted message identifier.
+You can any of our SDKs across .NET, Java, JavaScript, Python and Go to enable duplicate detection feature when creating queues and topics. You can also change the duplicate detection history time window.
+The properties to update when creating queues and topics to achieve this are:
+- `RequiresDuplicateDetection`
+- `DuplicateDetectionHistoryTimeWindow`
 
-Keeping the window small means that fewer message-ids must be retained and matched, and throughput is impacted less. For high throughput entities that require duplicate detection, you should keep the window as small as possible.
+Please note that while the property names are provided in pascal casing here, JavaScript and Python SDKs will be using camel casing and snake casing respectively.
 
 ## Next steps
 


### PR DESCRIPTION
This PR updates the [Duplicate Detection](https://docs.microsoft.com/en-us/azure/service-bus-messaging/duplicate-detection) article to not use links to ref docs of the older WindowsAzure.ServiceBus package.

Instead, the text is updated to stay conceptual, but also list the property names that need to be used.

Net changes:

- Create separate sections for portal vs programmatic changes
- Re-arrange text for better readability
- Replace links to the older WindowsAzure.ServiceBus package with text that would be language and package agnostic

cc @spelluru, @axisc 