### PR TITLE
ncv3 doesn't support ephemeral disk

### DIFF
--- a/articles/virtual-machines/ncv3-series.md
+++ b/articles/virtual-machines/ncv3-series.md
@@ -20,7 +20,7 @@ NCv3-series VMs are powered by NVIDIA Tesla V100 GPUs. These GPUs can provide 1.
 [Memory Preserving Updates](maintenance-and-updates.md): Not Supported<br>
 [VM Generation Support](generation-2.md): Generation 1 and 2<br>
 [Accelerated Networking](../virtual-network/create-vm-accelerated-networking-cli.md): Not Supported<br>
-[Ephemeral OS Disks](ephemeral-os-disks.md): Supported <br>
+[Ephemeral OS Disks](ephemeral-os-disks.md): Not Supported <br>
 Nvidia NVLink Interconnect: Not Supported<br>
 
 > [!IMPORTANT]


### PR DESCRIPTION
When deploying in AKS: 

"message": "{\r\n  \"code\": \"VMCacheSizeTooSmall\",\r\n  \"message\": \"The virtual machine size Standard_NC24s_v3 has a cache size of 0 bytes, but the OS disk requires 137438953472 bytes. Use a VM size with larger cache or disable ephemeral OS.\"\r\n}"