### PR TITLE
Update quickstart-create-redis-enterprise.md

### DIFF
--- a/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
+++ b/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
@@ -50,7 +50,7 @@ You'll need an Azure subscription before you begin. If you don't have one, creat
    :::image type="content" source="media/cache-create/enterprise-tier-advanced.png" alt-text="Screenshot that shows the Enterprise tier Advanced tab.":::
 
    > [!NOTE] 
-   > You can't change modules after you create the cache instance. This is a create-only setting.
+   > You can't change modules after you create the cache instance. The setting is create-only.
    >
  
 1. Select **Next: Tags** and skip.

--- a/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
+++ b/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
@@ -40,17 +40,17 @@ You'll need an Azure subscription before you begin. If you don't have one, creat
    :::image type="content" source="media/cache-create/enterprise-tier-basics.png" alt-text="Enterprise tier Basics tab":::
 
    > [!NOTE] 
-   > Be sure to check the box under "Terms" before proceeding.
+   > Be sure to select **Terms** before you proceed.
    >
 
 1. Select **Next: Networking** and skip.
 
 1. Select **Next: Advanced** and set **Clustering policy** to **Enterprise**. Enable **Non-TLS access only** if you plan to connect to the new cache without using TLS. This is not recommended, however.
 
-   :::image type="content" source="media/cache-create/enterprise-tier-advanced.png" alt-text="Enterprise tier Advanced tab":::
+   :::image type="content" source="media/cache-create/enterprise-tier-advanced.png" alt-text="Screenshot that shows the Enterprise tier Advanced tab.":::
 
    > [!NOTE] 
-   > Changing modules after the cache instance is created is not supported, it is a create-only setting.
+   > You can't change modules after you create the cache instance. This is a create-only setting.
    >
  
 1. Select **Next: Tags** and skip.

--- a/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
+++ b/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
@@ -49,6 +49,10 @@ You'll need an Azure subscription before you begin. If you don't have one, creat
 
    :::image type="content" source="media/cache-create/enterprise-tier-advanced.png" alt-text="Enterprise tier Advanced tab":::
 
+   > [!NOTE] 
+   > Changing modules after the cache instance is created is not supported, it is a create-only setting.
+   >
+ 
 1. Select **Next: Tags** and skip.
 
 1. Select **Next: Review + create**.


### PR DESCRIPTION
Selection of Modules is a setting only available at cache creation time and there is not an option to set that once the cache has been created. Hence, pointing a note for the same