### PR TITLE
Updates snippet to reflect the correct order of middleware for static…

### DIFF
--- a/articles/app-service/configure-language-python.md
+++ b/articles/app-service/configure-language-python.md
@@ -164,8 +164,10 @@ For App Service, you then make the following modifications:
 1. Also modify the `MIDDLEWARE` and `INSTALLED_APPS` lists to include Whitenoise:
 
     ```python
-    MIDDLEWARE = [
-        "whitenoise.middleware.WhiteNoiseMiddleware",
+    MIDDLEWARE = [                                                                   
+        'django.middleware.security.SecurityMiddleware',
+        # Add whitenoise middleware after the security middleware                             
+        'whitenoise.middleware.WhiteNoiseMiddleware',
         # Other values follow
     ]
 


### PR DESCRIPTION
… asset serving

The current snippet (whitenoise middleware at the top of the middleware list) is incorrect and contradicts what is outlined both in the [official documentation for the library](http://whitenoise.evans.io/en/stable/django.html#enable-whitenoise) and the [djangoapp sample](https://github.com/Azure-Samples/djangoapp/blob/6355d9eb50c37d053dd261620423205b02b9ce74/azuresite/production.py#L11) provided as part of the Python Azure-Samples.