### PR TITLE
Removed redundant apostrophe in page's title

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-nonaad.md
+++ b/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-nonaad.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorial`:` Use a managed identity to access Azure Key Vault - Windows - Azure AD
+title: Tutorial: Use a managed identity to access Azure Key Vault - Windows - Azure AD
 description: A tutorial that walks you through the process of using a Windows VM system-assigned managed identity to access Azure Key Vault. 
 services: active-directory
 documentationcenter: ''

--- a/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-nonaad.md
+++ b/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-nonaad.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorial: Use a managed identity to access Azure Key Vault - Windows - Azure AD
+title: "Tutorial: Use a managed identity to access Azure Key Vault - Windows - Azure AD"
 description: A tutorial that walks you through the process of using a Windows VM system-assigned managed identity to access Azure Key Vault. 
 services: active-directory
 documentationcenter: ''


### PR DESCRIPTION
The page's title is being displayed as:
```
 Tutorial`:` Use a managed identity to access Azure Key Vault - Windows - Azure AD
```
with extra apostrophe  around the colon symbol