### PR TITLE
Update cache-configure.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-configure.md
+++ b/articles/azure-cache-for-redis/cache-configure.md
@@ -144,9 +144,9 @@ The **maxfragmentationmemory-reserved** setting configures the amount of memory,
 One thing to consider when choosing a new memory reservation value (**maxmemory-reserved** or **maxfragmentationmemory-reserved**) is how this change might affect a cache that is already running with large amounts of data in it. For instance, if you have a 53 GB cache with 49 GB of data, then change the reservation value to 8 GB, this change will drop the max available memory for the system down to 45 GB. If either your current `used_memory` or your `used_memory_rss` values are higher than the new limit of 45 GB, then the system will have to evict data until both `used_memory` and `used_memory_rss` are below 45 GB. Eviction can increase server load and memory fragmentation. For more information on cache metrics such as `used_memory` and `used_memory_rss`, see [Available metrics and reporting intervals](cache-how-to-monitor.md#available-metrics-and-reporting-intervals).
 
 > [!IMPORTANT]
-> The **maxmemory-reserved** and **maxfragmentationmemory-reserved** settings are only available for Standard and Premium caches.
-> Noeviction is the only Memory Policy available for Enterprise Tier cache 
->
+> The **maxmemory-reserved** and **maxfragmentationmemory-reserved** settings are available only for Standard and Premium caches.
+> 
+> The `noeviction` eviction policy is the only memory policy that's available for an Enterprise tier cache.
 >
 
 #### Keyspace notifications (advanced settings)

--- a/articles/azure-cache-for-redis/cache-configure.md
+++ b/articles/azure-cache-for-redis/cache-configure.md
@@ -145,6 +145,7 @@ One thing to consider when choosing a new memory reservation value (**maxmemory-
 
 > [!IMPORTANT]
 > The **maxmemory-reserved** and **maxfragmentationmemory-reserved** settings are only available for Standard and Premium caches.
+> Noeviction is the only Memory Policy available for Enterprise Tier cache 
 >
 >
 


### PR DESCRIPTION
There doesn't seem to be any memory policy available for Enterprise Tier cache and the only one present is Noeviction.  Added a note for the same