### PR TITLE
New tenants cannot revert to legacy registration

### DIFF
--- a/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/howto-registration-mfa-sspr-combined.md
@@ -20,7 +20,7 @@ ms.collection: M365-identity-device-management
 Before combined registration, users registered authentication methods for Azure AD Multi-Factor Authentication and self-service password reset (SSPR) separately. People were confused that similar methods were used for Azure AD Multi-Factor Authentication and SSPR but they had to register for both features. Now, with combined registration, users can register once and get the benefits of both Azure AD Multi-Factor Authentication and SSPR.
 
 > [!NOTE]
-> Starting on August 15th 2020, all new Azure AD tenants will be automatically enabled for combined registration. 
+> Starting on August 15th 2020, all new Azure AD tenants will be automatically enabled for combined registration. Tenants created after this date will be unable to utilize the legacy registration workflows.
 
 To make sure you understand the functionality and effects before you enable the new experience, see the [Combined security information registration concepts](concept-registration-mfa-sspr-combined.md).
 


### PR DESCRIPTION
Existing tenants have the ability to scope combined registration and can revert back to legacy registration.  New tenants have that option greyed out.  Added information specifying that new tenant behavior is expected to be different than existing tenant behavior.