### PR TITLE
Update failover-cluster-instance-premium-file-share-manually-configur…

### DIFF
--- a/articles/azure-sql/virtual-machines/windows/failover-cluster-instance-premium-file-share-manually-configure.md
+++ b/articles/azure-sql/virtual-machines/windows/failover-cluster-instance-premium-file-share-manually-configure.md
@@ -209,6 +209,7 @@ For more details about cluster connectivity options, see [Route HADR connections
 - Microsoft Distributed Transaction Coordinator (MSDTC) is not supported on Windows Server 2016 and earlier. 
 - Filestream isn't supported for a failover cluster with a premium file share. To use filestream, deploy your cluster by using [Storage Spaces Direct](failover-cluster-instance-storage-spaces-direct-manually-configure.md) or [Azure shared disks](failover-cluster-instance-azure-shared-disks-manually-configure.md) instead.
 - Only registering with the SQL IaaS Agent extension in [lightweight management mode](sql-server-iaas-agent-extension-automate-management.md#management-modes) is supported. 
+- Database Snapshots are not supported with Azure Files at this time because of Sparse File limitations.  
 
 ## Next steps
 

--- a/articles/azure-sql/virtual-machines/windows/failover-cluster-instance-premium-file-share-manually-configure.md
+++ b/articles/azure-sql/virtual-machines/windows/failover-cluster-instance-premium-file-share-manually-configure.md
@@ -209,7 +209,7 @@ For more details about cluster connectivity options, see [Route HADR connections
 - Microsoft Distributed Transaction Coordinator (MSDTC) is not supported on Windows Server 2016 and earlier. 
 - Filestream isn't supported for a failover cluster with a premium file share. To use filestream, deploy your cluster by using [Storage Spaces Direct](failover-cluster-instance-storage-spaces-direct-manually-configure.md) or [Azure shared disks](failover-cluster-instance-azure-shared-disks-manually-configure.md) instead.
 - Only registering with the SQL IaaS Agent extension in [lightweight management mode](sql-server-iaas-agent-extension-automate-management.md#management-modes) is supported. 
-- Database Snapshots are not supported with Azure Files at this time because of Sparse File limitations.  
+- Database Snapshots are not currently supported with [Azure Files due to sparse files limitations](/rest/api/storageservices/features-not-supported-by-the-azure-file-service).  
 
 ## Next steps
 


### PR DESCRIPTION
…e.md

Added a limitation for Premium File Share.  SQL Database Snapshots do not work with Premium File Shares because Sparse Files are not supported.  https://docs.microsoft.com/en-us/rest/api/storageservices/features-not-supported-by-the-azure-file-service