### PR TITLE
Update quickstart-create-redis-enterprise.md

### DIFF
--- a/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
+++ b/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
@@ -41,7 +41,18 @@ You'll need an Azure subscription before you begin. If you don't have one, creat
 
    > [!NOTE] 
    > Be sure to check the box under "Terms" before proceeding.
-   >
+   > The current list of Redis Enterprise supported regions are :
+   > 	• Australia East
+	> 	• East US
+	> 	• East US 2
+	> 	• North Europe
+	> 	• South Central US
+	> 	• Southeast Asia
+	> 	• UK South
+	> 	• West Europe
+	> 	• West US
+	> 	• West US 2
+   >  Redis DRAM and Flash tiers won't show up in the list if you pick a region not supported by Redis Enterprise.
 
 1. Select **Next: Networking** and skip.
 

--- a/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
+++ b/articles/azure-cache-for-redis/quickstart-create-redis-enterprise.md
@@ -42,7 +42,8 @@ You'll need an Azure subscription before you begin. If you don't have one, creat
    > [!NOTE] 
    > Be sure to check the box under "Terms" before proceeding.
    > The current list of Redis Enterprise supported regions are :
-   > 	• Australia East
+   	> 	• Australia East
+   	> 	• Central US
 	> 	• East US
 	> 	• East US 2
 	> 	• North Europe
@@ -52,7 +53,7 @@ You'll need an Azure subscription before you begin. If you don't have one, creat
 	> 	• West Europe
 	> 	• West US
 	> 	• West US 2
-   >  Redis DRAM and Flash tiers won't show up in the list if you pick a region not supported by Redis Enterprise.
+   >  Redis DRAM and Flash tiers won't show up in the list if you pick a region not supported by Redis Enterprise or VM series has limited regional availability.
 
 1. Select **Next: Networking** and skip.
 


### PR DESCRIPTION
Based on TSG, only below locations had support for the REDIS Enterprise Tier during Public Preview 
	• Australia East
	• East US
	• East US 2
	• North Europe
	• South Central US
	• Southeast Asia
	• UK South
	• West Europe
	• West US
West US 2

Proposing the changes to let the customer know which regions are supported so that they are aware and spin up cache in supported region only. In case there is any change w.r.t support in a particular region, please review and have it updated accordingly then.