### PR TITLE
changed support for managed identity and sql user

### DIFF
--- a/articles/synapse-analytics/sql/develop-storage-files-storage-access-control.md
+++ b/articles/synapse-analytics/sql/develop-storage-files-storage-access-control.md
@@ -83,7 +83,7 @@ In the table below you can find the available authorization types:
 | ------------------------------------- | ------------- | -----------    |
 | [User Identity](?tabs=user-identity#supported-storage-authorization-types)       | Not supported | Supported      |
 | [SAS](?tabs=shared-access-signature#supported-storage-authorization-types)       | Supported     | Supported      |
-| [Managed Identity](?tabs=managed-identity#supported-storage-authorization-types) | Not supported | Supported      |
+| [Managed Identity](?tabs=managed-identity#supported-storage-authorization-types) | Supported | Supported      |
 
 ### Supported storages and authorization types
 


### PR DESCRIPTION
We have an error on this section: Supported authorization types for databases users
Managed Identity is supported for sql user. 
Discussed the change with Synapse SQL Serverless team and agreed upon changing this.

