### PR TITLE
Update code sample on how to switch back to ACR

### DIFF
--- a/articles/machine-learning/how-to-secure-workspace-vnet.md
+++ b/articles/machine-learning/how-to-secure-workspace-vnet.md
@@ -226,7 +226,7 @@ Once those requirements are fulfilled, use the following steps to enable Azure C
     # Update the workspace to use an existing compute cluster
     ws.update(image_build_compute = 'mycomputecluster')
     # To switch back to using ACR to build (if ACR is not in the VNet):
-    # ws.update(image_build_compute = None)
+    # ws.update(image_build_compute = '')
     ```
 
     > [!IMPORTANT]


### PR DESCRIPTION
`ws.update(image_build_compute = None)` doesn't change the **imageBuildCompute** property of the AzureML Workspace. Passing an empty string did the trick.