### PR TITLE
added missing closing ] in the iteration syntax

### DIFF
--- a/articles/azure-resource-manager/templates/copy-resources.md
+++ b/articles/azure-resource-manager/templates/copy-resources.md
@@ -41,7 +41,7 @@ Loops can be used declare multiple resources by:
   @batchSize(<number>)
   resource <resource-symbolic-name> '<resource-type>@<api-version>' = [for <item> in <collection>: {
     <resource-properties>
-  }
+  }]
   ```
 
 - Iterating over the elements of an array
@@ -50,7 +50,7 @@ Loops can be used declare multiple resources by:
   @batchSize(<number>)
   resource <resource-symbolic-name> '<resource-type>@<api-version>' = [for (<item>, <index>) in <collection>: {
     <resource-properties>
-  }
+  }]
   ```
 
 - Using loop index
@@ -59,7 +59,7 @@ Loops can be used declare multiple resources by:
   @batchSize(<number>)
   resource <resource-symbolic-name> '<resource-type>@<api-version>' = [for <index> in range(<start>, <stop>): {
     <resource-properties>
-  }
+  }]
   ```
 
 ---


### PR DESCRIPTION
General syntax of iterations in Bicep is missing a closing square bracket. Added that.