### PR TITLE
added missing ending ] in bicep loop syntax

### DIFF
--- a/articles/azure-resource-manager/templates/copy-properties.md
+++ b/articles/azure-resource-manager/templates/copy-properties.md
@@ -43,7 +43,7 @@ Loops can be used declare multiple properties by:
   ```bicep
   <property-name>: [for <item> in <collection>: {
     <properties>
-  }
+  }]
   ```
 
 - Iterating over the elements of an array
@@ -51,7 +51,7 @@ Loops can be used declare multiple properties by:
   ```bicep
   <property-name>: [for (<item>, <index>) in <collection>: {
     <properties>
-  }
+  }]
   ```
 
 - Using loop index
@@ -59,7 +59,7 @@ Loops can be used declare multiple properties by:
   ```bicep
   <property-name>: [for <index> in range(<start>, <stop>): {
     <properties>
-  }
+  }]
   ```
 
 ---


### PR DESCRIPTION
All property iteration syntax examples in Bicep are missing an ending square bracket. This change adds it.