### PR TITLE
Update concept-workspace.md

### DIFF
--- a/articles/machine-learning/concept-workspace.md
+++ b/articles/machine-learning/concept-workspace.md
@@ -102,7 +102,8 @@ When you create a new workspace, it automatically creates several Azure resource
   
   > [!IMPORTANT]
   > By default, the storage account is a general-purpose v1 account. You can [upgrade this to general-purpose v2](../storage/common/storage-account-upgrade.md) after the workspace has been created. 
-  > Do not enable hierarchical namespace on the storage account after upgrading to general-purpose v2.
+  > Do not enable hierarchical namespace on the storage account after upgrading to general-purpose v2. 
+  > The storage accoount cannot be of type "BlobStorage".
 
   To use an existing Azure Storage account, it cannot be a premium account (Premium_LRS and Premium_GRS). It also cannot have a hierarchical namespace (used with Azure Data Lake Storage Gen2). Neither premium storage or hierarchical namespaces are supported with the _default_ storage account of the workspace. You can use premium storage or hierarchical namespace with _non-default_ storage accounts.
   

--- a/articles/machine-learning/concept-workspace.md
+++ b/articles/machine-learning/concept-workspace.md
@@ -102,8 +102,7 @@ When you create a new workspace, it automatically creates several Azure resource
   
   > [!IMPORTANT]
   > By default, the storage account is a general-purpose v1 account. You can [upgrade this to general-purpose v2](../storage/common/storage-account-upgrade.md) after the workspace has been created. 
-  > Do not enable hierarchical namespace on the storage account after upgrading to general-purpose v2. 
-  > The storage accoount cannot be of type "BlobStorage".
+  > Do not enable hierarchical namespace on the storage account after upgrading to general-purpose v2.
 
   To use an existing Azure Storage account, it cannot be of type BlobStorage or a premium account (Premium_LRS and Premium_GRS). It also cannot have a hierarchical namespace (used with Azure Data Lake Storage Gen2). Neither premium storage or hierarchical namespaces are supported with the _default_ storage account of the workspace. You can use premium storage or hierarchical namespace with _non-default_ storage accounts.
   

--- a/articles/machine-learning/concept-workspace.md
+++ b/articles/machine-learning/concept-workspace.md
@@ -105,7 +105,7 @@ When you create a new workspace, it automatically creates several Azure resource
   > Do not enable hierarchical namespace on the storage account after upgrading to general-purpose v2. 
   > The storage accoount cannot be of type "BlobStorage".
 
-  To use an existing Azure Storage account, it cannot be a premium account (Premium_LRS and Premium_GRS). It also cannot have a hierarchical namespace (used with Azure Data Lake Storage Gen2). Neither premium storage or hierarchical namespaces are supported with the _default_ storage account of the workspace. You can use premium storage or hierarchical namespace with _non-default_ storage accounts.
+  To use an existing Azure Storage account, it cannot be of type BlobStorage or a premium account (Premium_LRS and Premium_GRS). It also cannot have a hierarchical namespace (used with Azure Data Lake Storage Gen2). Neither premium storage or hierarchical namespaces are supported with the _default_ storage account of the workspace. You can use premium storage or hierarchical namespace with _non-default_ storage accounts.
   
 + [Azure Container Registry](https://azure.microsoft.com/services/container-registry/): Registers docker containers that you use during training and when you deploy a model. To minimize costs, ACR is **lazy-loaded** until deployment images are created.
 


### PR DESCRIPTION
We've had a couple of support cases that resulted from customers using storage account of type "BlobStorage".
This can be very impactful if the issue is only uncovered after some time, as the customer will have to recreate the ML workspace with the correct storage account type.
Discussions with these customers are tough and unpleasant due to the lack of clear statement that directly addresses this requirement.
Propose to add a sentence that makes it as clear as possible that this storage account type cannot be used with Azure ML workspace.