### PR TITLE
The API for getting the status of the cluster is wrong

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-manage-compute-rest-api.md
+++ b/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-manage-compute-rest-api.md
@@ -55,7 +55,7 @@ POST https://management.azure.com/subscriptions/{subscription-id}/resourceGroups
 > Currently Check database state might return ONLINE while the database is completing the online workflow, resulting in connection errors. You might need to add a 2 to 3 minutes delay in your application code if you are using this API call to trigger connection attempts.
 
 ```
-GET https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}?api-version=2020-08-01-preview
+GET https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/Microsoft.Synapse/workspaces/{workspace-name}/sqlPools/{sql-pool-name}?api-version=2019-06-01-preview
 ```
 
 ## Get maintenance schedule


### PR DESCRIPTION
The correct one is 
GET https://management.azure.com/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/Microsoft.Synapse/workspaces/{workspace-name}/sqlPools/{sql-pool-name}?api-version=2019-06-01-preview

probably the others are wrong as well but I didn't test them.