### PR TITLE
State the access level for staticwebapp github access token

### DIFF
--- a/articles/static-web-apps/get-started-cli.md
+++ b/articles/static-web-apps/get-started-cli.md
@@ -111,7 +111,7 @@ Now that the repository is created, you can create a static web app from the Azu
 
     - `<LOCATION>`: Replace this value with the location nearest you. Options include: _CentralUS_, _EastAsia_, _EastUS2_, _WestEurope_, and _WestUS2_.
 
-    - `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>`: Replace this  value with the [GitHub personal access token](https://docs.github.com/github/authenticating-to-github/creating-a-personal-access-token) you previously generated.
+    - `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>`: Replace this  value with the [GitHub personal access token](https://docs.github.com/github/authenticating-to-github/creating-a-personal-access-token) you previously generated. (minimal permissions are `Workflow` scope)
 
     You can now view the created app in Azure.
 


### PR DESCRIPTION
I was able to create a static site using the workflow scope.  That seems to be the minimal setting to get things deployed.

I didn't check workflow initially and got:

```
az staticwebapp create -n sample-app -g sample-app -s https://github.com/jsturtevant/sampleapp -l westus2 -b main --app-artifact-location dist --token sometoken


Command group 'staticwebapp' is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
Operation returned an invalid status code 'Bad Request'
```

Could probably improve the error message for cli as well.