### PR TITLE
fix typo

### DIFF
--- a/articles/azure-functions/functions-triggers-bindings.md
+++ b/articles/azure-functions/functions-triggers-bindings.md
@@ -47,7 +47,7 @@ For languages that rely on function.json, the portal provides a UI for adding bi
 
 In .NET and Java, the parameter type defines the data type for input data. For instance, use `string` to bind to the text of a queue trigger, a byte array to read as binary, and a custom type to de-serialize to an object. Since .NET class library functions and Java functions don't rely on *function.json* for binding definitions, they can't be created and edited in the portal. C# portal editing is based on C# script, which uses *function.json* instead of attributes.
 
-To learn more about how to adding bindings to existing functions, see [Connect functions to Azure services using bindings](add-bindings-existing-function.md).
+To learn more about how to add bindings to existing functions, see [Connect functions to Azure services using bindings](add-bindings-existing-function.md).
 
 For languages that are dynamically typed such as JavaScript, use the `dataType` property in the *function.json* file. For example, to read the content of an HTTP request in binary format, set `dataType` to `binary`:
 


### PR DESCRIPTION
"How to adding bindings" should be "how to add bindings" in the below line -
"To learn more about how to adding bindings to existing functions, see Connect functions to Azure services using bindings."