### PR TITLE
Fix typos in Iot Central Overview page

### DIFF
--- a/articles/iot-central/core/overview-iot-central.md
+++ b/articles/iot-central/core/overview-iot-central.md
@@ -88,7 +88,7 @@ As an operator, you use the IoT Central application to [manage the devices](howt
 
 You can [define custom rules and actions](howto-configure-rules.md) that operate over data streaming from connected devices. An operator can enable or disable these rules at the device level to control and automate tasks within the application.
 
-With any IoT solution designed to operate at scale, a structured approach to device management is important. It's not enough just to connect your devices to the cloud, you need to keep your devices connected and healthy. Use the following IoT Central capabilities to manage your devices throughout the application life cycle:
+As with any IoT solution designed to operate at scale, a structured approach to device management is important. It's not enough just to connect your devices to the cloud, you need to keep your devices connected and healthy. Use the following IoT Central capabilities to manage your devices throughout the application life cycle:
 
 ### Dashboards
 

--- a/articles/iot-central/core/overview-iot-central.md
+++ b/articles/iot-central/core/overview-iot-central.md
@@ -42,7 +42,7 @@ See the [Create a new application](quick-deploy-iot-central.md) quickstart for a
 
 ## Connect devices
 
-After creating your application, the first step is to create an connect devices. Every device connected to IoT Central uses a _device template_. A device template is the blueprint that defines the characteristics and behavior of a type of device such as the:
+After creating your application, the first step is to create and connect devices. Every device connected to IoT Central uses a _device template_. A device template is the blueprint that defines the characteristics and behavior of a type of device such as the:
 
 - Telemetry it sends. Examples include temperature and humidity. Telemetry is streaming data.
 - Business properties that an operator can modify. Examples include a customer address and a last serviced date.


### PR DESCRIPTION
This PR is meant to fix spelling error in the following page https://docs.microsoft.com/en-us/azure/iot-central/core/overview-iot-central.