### PR TITLE
Fix arguments attribute case

### DIFF
--- a/articles/machine-learning/how-to-tune-hyperparameters.md
+++ b/articles/machine-learning/how-to-tune-hyperparameters.md
@@ -462,7 +462,7 @@ Once all of the hyperparameter tuning runs have completed, identify the best per
 ```Python
 best_run = hyperdrive_run.get_best_run_by_primary_metric()
 best_run_metrics = best_run.get_metrics()
-parameter_values = best_run.get_details()['runDefinition']['Arguments']
+parameter_values = best_run.get_details()['runDefinition']['arguments']
 
 print('Best Run Id: ', best_run.id)
 print('\n Accuracy:', best_run_metrics['accuracy'])


### PR DESCRIPTION
The runDefinition has an arguments property. It was accidentally set to Arguments which throws a KeyError: 'Arguments'