### PR TITLE
Update azure-sql/database/gateway-migration.md

### DIFF
--- a/articles/azure-sql/database/gateway-migration.md
+++ b/articles/azure-sql/database/gateway-migration.md
@@ -178,7 +178,7 @@ You will not be impacted if you have:
 
 ## What to do you do if you're affected
 
-We recommend that you allow outbound traffic to IP addresses for all the [gateway IP addresses](connectivity-architecture.md#gateway-ip-addresses) in the region on TCP port 1433, and port range 11000-11999. This recommendation is applicable to clients connecting from on-premises and also those connecting via Service Endpoints. For more information on port ranges, see [Connection policy](connectivity-architecture.md#connection-policy).
+We recommend that you allow outbound traffic to IP addresses for all the [gateway IP addresses](connectivity-architecture.md#gateway-ip-addresses) in the region on TCP port 1433. Also add port range 11000-11999 when your SQL CLient is located in Azure (a VM or something else) or when your SQL Service Connection Policy is configured in Redirect-mode. This recommendation is applicable to clients connecting from on-premises and also those connecting via Service Endpoints. For more information on port ranges, see [Connection policy](connectivity-architecture.md#connection-policy).
 
 Connections made from applications using Microsoft JDBC Driver below version 4.0 might fail certificate validation. Lower versions of Microsoft JDBC rely on Common Name (CN) in the Subject field of the certificate. The mitigation is to ensure that the hostNameInCertificate property is set to *.database.windows.net. For more information on how to set the hostNameInCertificate property, see [Connecting with Encryption](/sql/connect/jdbc/connecting-with-ssl-encryption).
 

--- a/articles/azure-sql/database/gateway-migration.md
+++ b/articles/azure-sql/database/gateway-migration.md
@@ -178,7 +178,7 @@ You will not be impacted if you have:
 
 ## What to do you do if you're affected
 
-We recommend that you allow outbound traffic to IP addresses for all the [gateway IP addresses](connectivity-architecture.md#gateway-ip-addresses) in the region on TCP port 1433. Also add port range 11000-11999 when your SQL CLient is located in Azure (a VM or something else) or when your SQL Service Connection Policy is configured in Redirect-mode. This recommendation is applicable to clients connecting from on-premises and also those connecting via Service Endpoints. For more information on port ranges, see [Connection policy](connectivity-architecture.md#connection-policy).
+We recommend that you allow outbound traffic to IP addresses for all the [gateway IP addresses](connectivity-architecture.md#gateway-ip-addresses) in the region on TCP port 1433. Also, allow port range 11000 thru 11999 when connecting from a client located within Azure (for example, an Azure VM) or when your Connection Policy is set to Redirection. This recommendation is applicable to clients connecting from on-premises and also those connecting via Service Endpoints. For more information on port ranges, see [Connection policy](connectivity-architecture.md#connection-policy).
 
 Connections made from applications using Microsoft JDBC Driver below version 4.0 might fail certificate validation. Lower versions of Microsoft JDBC rely on Common Name (CN) in the Subject field of the certificate. The mitigation is to ensure that the hostNameInCertificate property is set to *.database.windows.net. For more information on how to set the hostNameInCertificate property, see [Connecting with Encryption](/sql/connect/jdbc/connecting-with-ssl-encryption).
 


### PR DESCRIPTION
Port range 11000-11999 is not always needed, this confuses people and only on this page it is mentioned it is supposedly needed (which it is not). This is only needed when Azure SQL Server is in Redirect-mode or when your SQL Client (your Compute) is running in Azure itself