### PR TITLE
Update storage-sas-overview.md

### DIFF
--- a/articles/storage/common/storage-sas-overview.md
+++ b/articles/storage/common/storage-sas-overview.md
@@ -198,6 +198,9 @@ To get started with shared access signatures, see the following articles for eac
 
 - [Create an account SAS with .NET](storage-account-sas-create-dotnet.md)
 
+> [!NOTE]
+> If you are planning to Generate SAS from Azure Portal and the button seems greyed out, kindly ensure you have selected the appropriate resource type i.e. Service, Container or Object. Once selected, the button to Generate SAS and Connection String will come as enabled.
+
 ## Next steps
 
 - [Delegate access with a shared access signature (REST API)](/rest/api/storageservices/delegate-access-with-shared-access-signature)


### PR DESCRIPTION
We have seen cases at times where in Customer want to generate SAS from the Azure Portal however the the button comes as Greyed out. The most common cause for this is they are not selecting the resource type at the top of the page. Post selection of appropriate resource type such as Service, Container or Objects, the button shall come as enabled. It will be good to let customers know this and the first place via documentation itself. 

Hence, proposing the changes. Please review.