### PR TITLE
Fix markdown link typo

### DIFF
--- a/articles/azure-functions/functions-deployment-technologies.md
+++ b/articles/azure-functions/functions-deployment-technologies.md
@@ -114,7 +114,7 @@ Use zip deploy to push a .zip file that contains your function app to Azure. Opt
 
 >__How to use it:__ Deploy by using your favorite client tool: [Visual Studio Code](functions-develop-vs-code.md#publish-to-azure), [Visual Studio](functions-develop-vs.md#publish-to-azure), or from the command line using the [Azure Functions Core Tools](functions-run-local.md#project-file-deployment). By default, these tools use zip deployment and [run from package](run-functions-from-deployment-package.md). Core Tools and the Visual Studio Code extension both enable [remote build](#remote-build) when deploying to Linux. To manually deploy a .zip file to your function app, follow the instructions in [Deploy from a .zip file or URL](https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url).
 
->When you deploy by using zip deploy, you can set your app to [run from package](run-functions-from-deployment-package.md). To run from package, set the [`WEBSITE_RUN_FROM_PACKAGE`](functions-app-settings.md#website_run_from_package application setting value to `1`. We recommend zip deployment. It yields faster loading times for your applications, and it's the default for VS Code, Visual Studio, and the Azure CLI.
+>When you deploy by using zip deploy, you can set your app to [run from package](run-functions-from-deployment-package.md). To run from package, set the [`WEBSITE_RUN_FROM_PACKAGE`](functions-app-settings.md#website_run_from_package) application setting value to `1`. We recommend zip deployment. It yields faster loading times for your applications, and it's the default for VS Code, Visual Studio, and the Azure CLI.
 
 >__When to use it:__ Zip deploy is the recommended deployment technology for Azure Functions.
 


### PR DESCRIPTION
Missing paranthesis for a markdown link in article `Deployment technologies in Azure Functions` at section `Zip Deploy`.
The current documentation article can be viewed at [https://docs.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies#zip-deploy](https://docs.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies#zip-deploy)