### PR TITLE
Change example command to use public key

### DIFF
--- a/articles/virtual-machines/linux/ssh-from-windows.md
+++ b/articles/virtual-machines/linux/ssh-from-windows.md
@@ -63,7 +63,7 @@ az vm create \
    --name myVM \
    --image UbuntuLTS\
    --admin-username azureuser \
-   --ssh-key-value ~/.ssh/id_rsa
+   --ssh-key-value ~/.ssh/id_rsa.pub
 ```
 
 With PowerShell, use `New-AzVM` and add the SSH key to the VM configuration using`. For an example, see [Quickstart: Create a Linux virtual machine in Azure with PowerShell](quick-create-powershell.md).


### PR DESCRIPTION
I was using this example to create a vm and got the error:

```
Deployment failed. Correlation ID: 406f837a-f403-4d10-8618-4fab44556c95. {
  "error": {
    "code": "InvalidParameter",
    "message": "The value of parameter linuxConfiguration.ssh.publicKeys.keyData is invalid.",
    "target": "linuxConfiguration.ssh.publicKeys.keyData"
  }
}
```

Indicating that a public key is expected, which worked.