### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-monitor/app/sampling.md
+++ b/articles/azure-monitor/app/sampling.md
@@ -315,7 +315,7 @@ By default no sampling is enabled in the Java agent and SDK. Currently it only s
 ```json
 {
   "sampling": {
-    "percentage": 10 //this is just an example that shows you how to enable only only 10% of transaction 
+    "percentage": 10 //this is just an example that shows you how to enable only 10% of transaction 
   }
 }
 ```


### PR DESCRIPTION
The word "only" was repeated twice in the JSON for the Configuring Java Agent section.