### PR TITLE
Update change-sku.md

### DIFF
--- a/articles/active-directory-domain-services/change-sku.md
+++ b/articles/active-directory-domain-services/change-sku.md
@@ -40,7 +40,7 @@ You can change SKUs up or down after the managed domain has been deployed. Howev
 
 For example:
 
-* You can't change down to the *Standard* SKU. AADDS resource forest doesn't support the *Standard* SKU. 
+* You can't change down to the *Standard* SKU. Azure AD DS resource forest doesn't support the *Standard* SKU. 
 * Or, if you have created seven trusts on the *Premium* SKU, you can't change down to the *Enterprise* SKU. The *Enterprise* SKU supports a maximum of five trusts.
 
 For more information on these limits, see [Azure AD DS SKU features and limits][concepts-sku].

--- a/articles/active-directory-domain-services/change-sku.md
+++ b/articles/active-directory-domain-services/change-sku.md
@@ -40,7 +40,7 @@ You can change SKUs up or down after the managed domain has been deployed. Howev
 
 For example:
 
-* If you have created two forest trusts on the *Premium* SKU, you can't change down to the *Standard* SKU. The *Standard* SKU doesn't support forest trusts.
+* You can't change down to the *Standard* SKU. AADDS resource forest doesn't support the *Standard* SKU. 
 * Or, if you have created seven trusts on the *Premium* SKU, you can't change down to the *Enterprise* SKU. The *Enterprise* SKU supports a maximum of five trusts.
 
 For more information on these limits, see [Azure AD DS SKU features and limits][concepts-sku].


### PR DESCRIPTION
This part is confusing as it leads to believe you can change the SKU to Standard which is not possible, if you try to do so the Standard SKU will be grayed out, for the same reason you cannot create a resource forest AADDS in Standard, this was confirmed by PG in case 2104130010005312

[12:56 PM] Kenneth Rodriguez
    Hey Sarat, quick question. The minimum SKU for resource forest deployments is Enterprise, correct? in other words, you cannot change the SKU of an already deployed AADDS resource trusting forest to standard even if there are no trusts set up, for the same reason you can't deploy it to standard. I am correct or just convinced with a false idea?
​[12:57 PM] Sarat Maruvada
    it sounds right but i need to confirm
​[12:59 PM] Kenneth Rodriguez
    It would make sense for me, but it is  a little conflicting with this: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/change-sku#sku-change-limitations. and there is a case going around precisely because standard is grayed out for change, if you could help me get confirmation I'd appreciate it a lot.
Change the SKU for an Azure AD Domain ServicesLearn how to the SKU tier for an Azure AD Domain Services managed domain if your business requirements changedocs.microsoft.com​[1:14 PM] Sarat Maruvada
    yes confirmed. this is the right behaviour for now. even with no trusts setup it is a one way operation. delete and recreate is the only way to go back to standard
​[1:18 PM] Sarat Maruvada
    but that said if you have 3 trusts and are in premier sku, you can change it down to enterprise