### PR TITLE
Updated LTR copy PS commands to remove whitespaces

### DIFF
--- a/articles/germany/germany-migration-databases.md
+++ b/articles/germany/germany-migration-databases.md
@@ -173,7 +173,7 @@ Copy-AzSqlDatabaseLongTermRetentionBackup
     -TargetDatabaseName $targetDatabaseName 
     -TargetSubscriptionId $targetSubscriptionId
     -TargetResourceGroupName $targetRGName
-    - TargetServerFullyQualifiedDomainName $targetServerFQDN 
+    -TargetServerFullyQualifiedDomainName $targetServerFQDN 
 ```
 
 2. **Copy LTR backup using backup resourceID**
@@ -199,7 +199,7 @@ Copy-AzSqlDatabaseLongTermRetentionBackup
     -TargetDatabaseName $targetDatabaseName 
     -TargetSubscriptionId $targetSubscriptionId
     -TargetResourceGroupName $targetRGName
-    - TargetServerFullyQualifiedDomainName $targetServerFQDN
+    -TargetServerFullyQualifiedDomainName $targetServerFQDN
 ```
 
 


### PR DESCRIPTION
Updated the Copy-AzSqlDatabaseLongTermRetentionBackup PS commands for LTR copies to remove whitespaces to correct the syntax.