### PR TITLE
Update devtest-lab-faq.md

### DIFF
--- a/articles/devtest-labs/devtest-lab-faq.md
+++ b/articles/devtest-labs/devtest-lab-faq.md
@@ -103,7 +103,7 @@ $policyRoleDef.Id = $null
 $policyRoleDef.Name = "DevTest Labs Advanced User"
 $policyRoleDef.IsCustom = $true
 $policyRoleDef.AssignableScopes.Clear()
-$policyRoleDef.AssignableScopes.Add("subscriptions/<subscription Id>")
+$policyRoleDef.AssignableScopes.Add("/subscriptions/<subscription Id>")
 $policyRoleDef.Actions.Add("Microsoft.DevTestLab/labs/virtualMachines/Start/action")
 $policyRoleDef.Actions.Add("Microsoft.DevTestLab/labs/virtualMachines/Stop/action")
 $policyRoleDef = New-AzRoleDefinition -Role $policyRoleDef  


### PR DESCRIPTION
Fixed a typo in the script as under:

When you execute following script after replacing <subscription Id>, you get "New-AzRoleDefinition: Scope 'subscriptions/4a1cd4de-3bfa-49db-bfa6-ea23a330eb8a' should begin with '/subscriptions' or '/providers'." error:

$policyRoleDef = Get-AzRoleDefinition "DevTest Labs User"
$policyRoleDef.Actions.Remove('Microsoft.DevTestLab/Environments/*')
$policyRoleDef.Id = $null
$policyRoleDef.Name = "DevTest Labs Advanced User"
$policyRoleDef.IsCustom = $true
$policyRoleDef.AssignableScopes.Clear()
$policyRoleDef.AssignableScopes.Add("/subscriptions/<subscription Id>")
$policyRoleDef.Actions.Add("Microsoft.DevTestLab/labs/virtualMachines/Start/action")
$policyRoleDef.Actions.Add("Microsoft.DevTestLab/labs/virtualMachines/Stop/action")
$policyRoleDef = New-AzRoleDefinition -Role $policyRoleDef

This proposed change will fix this issue.