### PR TITLE
Update virtual-machines-move-limitations.md

### DIFF
--- a/articles/azure-resource-manager/management/move-limitations/virtual-machines-move-limitations.md
+++ b/articles/azure-resource-manager/management/move-limitations/virtual-machines-move-limitations.md
@@ -51,7 +51,7 @@ Virtual machines created from Marketplace resources with plans attached can't be
 
 ## Virtual machines with Azure Backup
 
-To move virtual machines configured with Azure Backup, you must delete the restore points from the vault.
+To move virtual machines configured with Azure Backup, you must delete the restore points collections (snapshots) from the vault. Restore points already copied to the vault can be retained and moved.
 
 If [soft delete](../../../backup/soft-delete-virtual-machines.md) is enabled for your virtual machine, you can't move the virtual machine while those restore points are kept. Either [disable soft delete](../../../backup/backup-azure-security-feature-cloud.md#enabling-and-disabling-soft-delete) or wait 14 days after deleting the restore points.
 


### PR DESCRIPTION
The original sentence in the first paragraph of the Azure VMs with Backup is confusing... takes people to think that ALL backups need to be removed from the vault (so, they would not be possible to move to the new subscription and the vault would be moved empty, with not historical backups...) I believe this way becomes clearer.