### PR TITLE
Update networking-move-limitations.md

### DIFF
--- a/articles/azure-resource-manager/management/move-limitations/networking-move-limitations.md
+++ b/articles/azure-resource-manager/management/move-limitations/networking-move-limitations.md
@@ -12,7 +12,7 @@ This article describes how to move virtual networks and other networking resourc
 ## Dependent resources
 
 > [!NOTE]
-> Please note that VPN Gateways associated with public IP addresses are not currently able to move between resource groups or subscriptions.
+> Please note that VPN Gateways associated with Public IP Standard SKU addresses are not currently able to move between resource groups or subscriptions.
 
 When moving a resource, you must also move its dependent resources (e.g. public IP addresses, virtual network gateways, all associated connection resources). Local network gateways can be in a different resource group.
 


### PR DESCRIPTION
Par internal discussion with PG, seems that Virtual Network Gateways are supported for move. They are only not supported for move if they are associated to a Public IP Standard SKU (because the limitation is on these types of ips)... with Basic Public IPs. This current document makes someone think that the gateways will never be possible to move, because in no situation we have a gateway without a public IP (it is a requirement for creating them)... so please update this doc to make it clearer.