### PR TITLE
Add proxy note to Snowflake Connector documentation

### DIFF
--- a/articles/data-factory/connector-snowflake.md
+++ b/articles/data-factory/connector-snowflake.md
@@ -27,7 +27,7 @@ For the Copy activity, this Snowflake connector supports the following functions
 
 - Copy data from Snowflake that utilizes Snowflake's [COPY into [location]](https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html) command to achieve the best performance.
 - Copy data to Snowflake that takes advantage of Snowflake's [COPY into [table]](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html) command to achieve the best performance. It supports Snowflake on Azure.
-- If a proxy is required to connect to Snowflake from a self-hosted Integration Runtime, the environment variables for HTTP_PROXY and HTTPS_PROXY will need to be configured on the Integration Runtime host. 
+- If a proxy is required to connect to Snowflake from a self-hosted Integration Runtime, you must configure the environment variables for HTTP_PROXY and HTTPS_PROXY on the Integration Runtime host. 
 
 ## Get started
 

--- a/articles/data-factory/connector-snowflake.md
+++ b/articles/data-factory/connector-snowflake.md
@@ -26,7 +26,8 @@ This Snowflake connector is supported for the following activities:
 For the Copy activity, this Snowflake connector supports the following functions:
 
 - Copy data from Snowflake that utilizes Snowflake's [COPY into [location]](https://docs.snowflake.com/en/sql-reference/sql/copy-into-location.html) command to achieve the best performance.
-- Copy data to Snowflake that takes advantage of Snowflake's [COPY into [table]](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html) command to achieve the best performance. It supports Snowflake on Azure. 
+- Copy data to Snowflake that takes advantage of Snowflake's [COPY into [table]](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html) command to achieve the best performance. It supports Snowflake on Azure.
+- If a proxy is required to connect to Snowflake from a self-hosted Integration Runtime, the environment variables for HTTP_PROXY and HTTPS_PROXY will need to be configured on the Integration Runtime host. 
 
 ## Get started
 


### PR DESCRIPTION
The Snowflake Connector does NOT use the same proxy configuration that the Integration Runtime does - it requires the "unix-style" environment variables be set to reach outbound across a proxy.  This is a documentation update to indicate this configuration requirement.