### PR TITLE
Update howto-leverage-json-content-type.md

### DIFF
--- a/articles/azure-app-configuration/howto-leverage-json-content-type.md
+++ b/articles/azure-app-configuration/howto-leverage-json-content-type.md
@@ -168,7 +168,7 @@ az appconfig kv export -d file --format json --path "~/Export.json" --separator 
 ```
 
 > [!NOTE]
-> If your App Configuration store has some key-values without JSON content-type, they will also be exported to the same file in string format. If you want to export only the JSON key-values, assign a unique label or prefix to your JSON key-values and use label or prefix filtering during export.
+> If your App Configuration store has some key-values without JSON content-type, they will also be exported to the same file in string format.
 
 
 ## Consuming JSON key-values in applications


### PR DESCRIPTION
"If you want to export only the JSON key-values, assign a unique label or prefix to your JSON key-values and use label or prefix filtering during export."

That goes against AppConfiguration best practices. Key+Label is fundamental to the configuration model and shouldn't be suggested for other purpose. Export shouldn't promote changes of configuration model.