### PR TITLE
Adding update on assistive text.

### DIFF
--- a/articles/active-directory/fundamentals/customize-branding.md
+++ b/articles/active-directory/fundamentals/customize-branding.md
@@ -82,7 +82,7 @@ Your custom branding won't immediately appear when your users go to sites such a
     
         - **Square logo image, dark theme.** Same as the square logo image above. This logo image takes the place of the square logo image when used with a dark background, such as with Windows 10 Azure AD joined screens during the out-of-box experience (OOBE).  If your logo looks good on white, dark blue, and black backgrounds, you don't need to add this image.
          
-        - **Assistive text.** At this time some tenants may be presented with assistive text when exicuting the "change a password" flow (Strong password required. ect...). An example of assistive text is shown below. Currently assistive text is not customizable. Every tenant may not display assistive text.
+        - **Assistive text.** At this time some tenants may be presented with assistive text when executing the "change a password" flow for example, (strong password required). Currently, assistive text isn't customizable and every tenant may not display assistive text. An example of assistive text is shown below.
 
         ![Assistive text](https://user-images.githubusercontent.com/39276631/111838823-1ce38e80-88b7-11eb-8b76-df8c960c952d.PNG)
         

--- a/articles/active-directory/fundamentals/customize-branding.md
+++ b/articles/active-directory/fundamentals/customize-branding.md
@@ -80,7 +80,11 @@ Your custom branding won't immediately appear when your users go to sites such a
         
             The image can't be larger than 240x240 pixels in size and must have a file size of less than 10 KB. We recommend using a transparent image since the background might not match your logo background. We also recommend not adding padding around the image or it might make your logo look small.
     
-        - **Square logo image, dark theme.** Same as the square logo image above. This logo image takes the place of the square logo image when used with a dark background, such as with Windows 10 Azure AD joined screens during the out-of-box experience (OOBE).  If your logo looks good on white, dark blue, and black backgrounds, you don't need to add this image. 
+        - **Square logo image, dark theme.** Same as the square logo image above. This logo image takes the place of the square logo image when used with a dark background, such as with Windows 10 Azure AD joined screens during the out-of-box experience (OOBE).  If your logo looks good on white, dark blue, and black backgrounds, you don't need to add this image.
+         
+        - **Assistive text.** At this time some tenants may be presented with assistive text when exicuting the "change a password" flow (Strong password required. ect...). An example of assistive text is shown below. Currently assistive text is not customizable. Every tenant may not display assistive text.
+
+        ![Assistive text](https://user-images.githubusercontent.com/39276631/111838823-1ce38e80-88b7-11eb-8b76-df8c960c952d.PNG)
         
         - **Show option to remain signed in.** You can choose to let your users remain signed in to Azure AD until explicitly signing out. If you choose **No**,  this option is hidden, and users must sign in each time the browser is closed and reopened.
 


### PR DESCRIPTION
Per customer request adding a note here referencing company branding. Per current product logic for assistive text; If there is customized text available for the tenant (which is not currently supported), we show the customized assistive text in the password change page. If there isn't customized text available for the tenant, we check if the password type for the user if on-perm or not -If the user's password is "on-perm" or "on-perm & on cloud", we don't show any assistive text. Else we show the assistive text. 
At this time we are not supporting configuring assistive text however, it is in the roadmap. Several customers have requested this via support tickets and the feature is being tracked in a work item. Last customer requested it documented here. Resubmitting this after making edits.