### PR TITLE
Adding a note relating the copy-unmatched-params situation

### DIFF
--- a/articles/api-management/api-management-caching-policies.md
+++ b/articles/api-management/api-management-caching-policies.md
@@ -50,7 +50,7 @@ Use the `cache-lookup` policy to perform cache look up and return a valid cached
 ```
 
 > [!NOTE]
-> When using **vary-by-query-parameter** you might need to declare the parameters in the rewrite-uri template or set the attribute **copy-unmatched-params** to false - Note that by deactivating this flag, not declared parameters are going to be send to the back-end.
+> When using **vary-by-query-parameter** you might want to declare the parameters in the rewrite-uri template or set the attribute **copy-unmatched-params** to false - Note that by deactivating this flag, not declared parameters are going to be send to the back-end.
 
 ### Examples
 

--- a/articles/api-management/api-management-caching-policies.md
+++ b/articles/api-management/api-management-caching-policies.md
@@ -49,6 +49,9 @@ Use the `cache-lookup` policy to perform cache look up and return a valid cached
 </cache-lookup>
 ```
 
+> [!NOTE]
+> When using **vary-by-query-parameter** you might need to declare the parameters in the rewrite-uri template or set the attribute **copy-unmatched-params** to false - Note that by deactivating this flag, not declared parameters are going to be send to the back-end.
+
 ### Examples
 
 #### Example

--- a/articles/api-management/api-management-caching-policies.md
+++ b/articles/api-management/api-management-caching-policies.md
@@ -11,7 +11,8 @@ ms.date: 03/08/2021
 ms.author: apimpm
 ---
 # API Management caching policies
-This topic provides a reference for the following API Management policies. For information on adding and configuring policies, see [Policies in API Management](./api-management-policies.md).
+
+This article provides a reference for the following API Management policies. For information on adding and configuring policies, see [Policies in API Management](./api-management-policies.md).
 
 > [!IMPORTANT]
 > Built-in cache is volatile and is shared by all units in the same region in the same API Management service.
@@ -50,7 +51,7 @@ Use the `cache-lookup` policy to perform cache look up and return a valid cached
 ```
 
 > [!NOTE]
-> When using **vary-by-query-parameter** you might want to declare the parameters in the rewrite-uri template or set the attribute **copy-unmatched-params** to false - Note that by deactivating this flag, not declared parameters are going to be send to the back-end.
+> When using `vary-by-query-parameter`, you might want to declare the parameters in the rewrite-uri template or set the attribute `copy-unmatched-params` to `false`. By deactivating this flag, parameters that aren't declared are sent to the back end.
 
 ### Examples
 


### PR DESCRIPTION
Adding a note relating the "copy-unmatched-params" conflict which makes the cache not work when not declared parameters are used.