### PR TITLE
make code sample consistent with others samples

### DIFF
--- a/articles/azure-monitor/app/api-custom-events-metrics.md
+++ b/articles/azure-monitor/app/api-custom-events-metrics.md
@@ -181,7 +181,7 @@ appInsights.trackMetric("queueLength", 42.0);
 
 ```csharp
 var sample = new MetricTelemetry();
-sample.Name = "metric name";
+sample.Name = "queueLength";
 sample.Value = 42.3;
 telemetryClient.TrackMetric(sample);
 ```


### PR DESCRIPTION
the metric name used in each of the code samples was `queueLength`.