### PR TITLE
Update howto-password-ban-bad-on-premises-deploy.md

### DIFF
--- a/articles/active-directory/authentication/howto-password-ban-bad-on-premises-deploy.md
+++ b/articles/active-directory/authentication/howto-password-ban-bad-on-premises-deploy.md
@@ -335,7 +335,7 @@ The proxy service doesn't support the use of specific credentials for connecting
 
 ### Configure the proxy service to listen on a specific port
 
-The Azure AD Password Protection DC agent software uses RPC over TCP to communicate with the proxy service. By default, the Azure AD Password Protection proxy service listens on any available dynamic RPC endpoint. You can configure the service to listen on a specific TCP port, if necessary due to networking topology or firewall requirements in your environment. When configuring a static port, you will need to open the ports 135 and the static port of your choice.
+The Azure AD Password Protection DC agent software uses RPC over TCP to communicate with the proxy service. By default, the Azure AD Password Protection proxy service listens on any available dynamic RPC endpoint. You can configure the service to listen on a specific TCP port, if necessary due to networking topology or firewall requirements in your environment. When you configure a static port, you must open port 135 and the static port of your choice.
 
 <a id="static" /></a>To configure the service to run under a static port, use the `Set-AzureADPasswordProtectionProxyConfiguration` cmdlet as follows:
 

--- a/articles/active-directory/authentication/howto-password-ban-bad-on-premises-deploy.md
+++ b/articles/active-directory/authentication/howto-password-ban-bad-on-premises-deploy.md
@@ -335,7 +335,7 @@ The proxy service doesn't support the use of specific credentials for connecting
 
 ### Configure the proxy service to listen on a specific port
 
-The Azure AD Password Protection DC agent software uses RPC over TCP to communicate with the proxy service. By default, the Azure AD Password Protection proxy service listens on any available dynamic RPC endpoint. You can configure the service to listen on a specific TCP port, if necessary due to networking topology or firewall requirements in your environment.
+The Azure AD Password Protection DC agent software uses RPC over TCP to communicate with the proxy service. By default, the Azure AD Password Protection proxy service listens on any available dynamic RPC endpoint. You can configure the service to listen on a specific TCP port, if necessary due to networking topology or firewall requirements in your environment. When configuring a static port, you will need to open the ports 135 and the static port of your choice.
 
 <a id="static" /></a>To configure the service to run under a static port, use the `Set-AzureADPasswordProtectionProxyConfiguration` cmdlet as follows:
 


### PR DESCRIPTION
I´ve received a case from a customer with a static port set, with no communication between the DC and Proxy agents. The customer´s environment had only the static port opened. After opening the port 135, the customer´s environment started working fine!