### PR TITLE
Fixed incorrect message about vnet link

### DIFF
--- a/articles/key-vault/general/private-link-service.md
+++ b/articles/key-vault/general/private-link-service.md
@@ -230,7 +230,7 @@ Aliases:  <your-key-vault-name>.vault.azure.net
     1. You must have a Private DNS Zone resource with the exact name: privatelink.vaultcore.azure.net. 
     2. To learn how to set this up please see the following link. [Private DNS Zones](../../dns/private-dns-privatednszone.md)
     
-* Check to make sure the Private DNS Zone is not linked to the Virtual Network. This may be the issue if you are still getting the public IP address returned. 
+* Check to make sure the Private DNS Zone is linked to the Virtual Network. This may be the issue if you are still getting the public IP address returned. 
     1. If the Private Zone DNS is not linked to the virtual network, the DNS query originating from the virtual network will return the public IP address of the key vault. 
     2. Navigate to the Private DNS Zone resource in the Azure portal and click the virtual network links option. 
     4. The virtual network that will perform calls to the key vault must be listed. 


### PR DESCRIPTION
The Private DNS Zone should be linked to the Virtual Network as also explained in the first step of the troubleshooting description.