### PR TITLE
Add HashTable Az pwsh syntax for AKV settings

### DIFF
--- a/articles/virtual-machines/extensions/key-vault-windows.md
+++ b/articles/virtual-machines/extensions/key-vault-windows.md
@@ -171,9 +171,11 @@ To turn this on set the following:
 > Using this feature is not compatible with an ARM template that creates a system assigned identity and updates a Key Vault access policy with that identity. Doing so will result in a deadlock as the vault access policy cannot be updated until all extensions have started. You should instead use a *single user assigned MSI identity* and pre-ACL your vaults with that identity before deploying.
 
 ## Azure PowerShell deployment
+
 > [!WARNING]
-> PowerShell clients often add `\` to `"` in the settings.json which will cause akvvm_service fails with error: `[CertificateManagementConfiguration] Failed to parse the configuration settings with:not an object.`
-> The extra `\` and `"` characters will be visible in the portal, under "Extensions", in the "Settings" box. To avoid this behavior initialize `$settings` as a PowerShell `HashTable`:
+> PowerShell clients often add `\` to `"` in the settings.json, which causes akvvm_service to fail with the error `[CertificateManagementConfiguration] Failed to parse the configuration settings with:not an object.`
+> The extra `\` and `"` characters will be visible in the portal, in **Extensions** under **Settings**. To avoid this, initialize `$settings` as a PowerShell `HashTable`:
+> 
 > ```powershell
 > $settings = @{
 >     "secretsManagementSettings" = @{ 
@@ -182,7 +184,8 @@ To turn this on set the following:
 >         "certificateStoreLocation" = "<certStoreLoc>"; 
 >         "observedCertificates"     = @("<observedCert1>", "<observedCert2>") } }
 > ```
-
+>
+  
 The Azure PowerShell can be used to deploy the Key Vault VM extension to an existing virtual machine or virtual machine scale set. 
 
 * To deploy the extension on a VM:

--- a/articles/virtual-machines/extensions/key-vault-windows.md
+++ b/articles/virtual-machines/extensions/key-vault-windows.md
@@ -173,6 +173,15 @@ To turn this on set the following:
 ## Azure PowerShell deployment
 > [!WARNING]
 > PowerShell clients often add `\` to `"` in the settings.json which will cause akvvm_service fails with error: `[CertificateManagementConfiguration] Failed to parse the configuration settings with:not an object.`
+> The extra `\` and `"` characters will be visible in the portal, under "Extensions", in the "Settings" box. To avoid this behavior initialize `$settings` as a PowerShell `HashTable`:
+> ```powershell
+> $settings = @{
+>     "secretsManagementSettings" = @{ 
+>         "pollingIntervalInS"       = "<pollingInterval>"; 
+>         "certificateStoreName"     = "<certStoreName>"; 
+>         "certificateStoreLocation" = "<certStoreLoc>"; 
+>         "observedCertificates"     = @("<observedCert1>", "<observedCert2>") } }
+> ```
 
 The Azure PowerShell can be used to deploy the Key Vault VM extension to an existing virtual machine or virtual machine scale set. 
 


### PR DESCRIPTION
The document had an explanation of a possible error with pwsh
escaping JSON configs, but offerend no solution.