### PR TITLE
Adding to notes for delegating permissions for System Managed Identity cluster

### DIFF
--- a/articles/aks/kubernetes-service-principal.md
+++ b/articles/aks/kubernetes-service-principal.md
@@ -186,6 +186,7 @@ The `Scope` for a resource needs to be a full resource ID, such as */subscriptio
 
 > [!NOTE]
 > If you have removed the Contributor role assignment from the node resource group, the operations below may fail.
+> Permission grants to clusters using System Managed Identity may take up 60 minutes to populate.
 
 The following sections detail common delegations that you may need to make.
 


### PR DESCRIPTION
There is a small note on this [page](https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#obtain-and-use-the-system-assigned-managed-identity-for-your-aks-cluster) regarding System Managed Identity cluster that states that it takes 60 minutes for changes to delegated permissions to propogate.

As System Managed Identity is the default when deploying AKS clusters I would suggest that this note is brought into this page as it took me quite some time trying to work out how to refresh credentials for System Managed Identites (it appears this is unncecesary as it refreshes periodically).