### PR TITLE
Fix bind path inside the container for OPC publisher

### DIFF
--- a/articles/iot-accelerators/howto-opc-publisher-run.md
+++ b/articles/iot-accelerators/howto-opc-publisher-run.md
@@ -411,7 +411,7 @@ To make the IoT Edge module configuration files accessible in the host file syst
 {
     "Hostname": "publisher",
     "Cmd": [
-        "--pf=./pn.json",
+        "--pf=/appdata/pn.json",
         "--aa"
     ],
     "HostConfig": {


### PR DESCRIPTION
The OPC Publisher container uses /app as the working directory, so we need to either bind /app under Binds or adjust --pf path. Currently the config file is not picked up if you copy the --pf path used in the docs.