### PR TITLE
Update apache-spark-secure-credentials-with-tokenlibrary.md

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -135,7 +135,7 @@ display(df.limit(10))
 %%pyspark
 # Python code
 spark.conf.set("spark.storage.synapse.linkedServiceName", "<lINKED SERVICE NAME>")
-spark.conf.set("fs.azure.sas.token.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider")
+spark.conf.set("fs.azure.account.oauth.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider")
 
 df = spark.read.csv('abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<DIRECTORY PATH>')
 


### PR DESCRIPTION
A typo in spark.conf paramater name for python example: ADLS with Managed Identity/Service Principal.