### PR TITLE
Update object-replication-configure.md

### DIFF
--- a/articles/storage/blobs/object-replication-configure.md
+++ b/articles/storage/blobs/object-replication-configure.md
@@ -51,7 +51,7 @@ To create a replication policy in the Azure portal, follow these steps:
 1. Under **Blob service**, select **Object replication**.
 1. Select **Set up replication rules**.
 1. Select the destination subscription and storage account.
-1. In the **Container pairs** section, select a source container from the source account, and a destination container from the destination account. You can create up to 10 container pairs per replication policy.
+1. In the **Container pairs** section, select a source container from the source account, and a destination container from the destination account. You can create up to 10 container pairs per replication policy. In case there are more than 10 containers in source storage account, then you will have to configure them under multiple destination storage accounts capped to 10.
 
     The following image shows a set of replication rules.
 


### PR DESCRIPTION
This is also capped for the destination storage account as well. For e.g. if there are more than 10 containers in source storage account, then only 10 of them can be mapped to destination storage account under a single replication policy. The rest need to be mapped to another destination storage account or accounts (capped to 10).

The destination account can be specified only once and only 10 rules (source and destination container mapping) can be created.

Proposing these changes to be clearer in documentation.

Kindly review. 

Another request has been raised too to update on the other documentation link for replication as well

https://github.com/MicrosoftDocs/azure-docs/pull/74694