### PR TITLE
Update cache-troubleshoot-timeouts.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-troubleshoot-timeouts.md
+++ b/articles/azure-cache-for-redis/cache-troubleshoot-timeouts.md
@@ -44,8 +44,7 @@ This error message contains metrics that can help point you to the cause and pos
 | wr |There's an active writer (meaning the 6 unsent requests aren't being ignored) bytes/activewriters |
 | in |There are no active readers and zero bytes are available to be read on the NIC bytes/activereaders |
 
-In the above exception, also notice that in the IOCP section and the WORKER section you have a Busy value that is greater than the Min value. This difference means your ThreadPool settings need adjusting.
-You can [configure your `ThreadPool` Settings](cache-management-faq.md#important-details-about-threadpool-growth) to make sure that your thread pool scales up quickly under burst scenarios.
+In the preceding exception example, the `IOCP` and `WORKER` sections each include a `Busy` value that is greater than the `Min` value. The difference means that you should adjust your `ThreadPool` settings. You can [configure your ThreadPool settings](cache-management-faq.md#important-details-about-threadpool-growth) to ensure that your thread pool scales up quickly under burst scenarios.
 
 You can use the following steps to investigate possible root causes.
 

--- a/articles/azure-cache-for-redis/cache-troubleshoot-timeouts.md
+++ b/articles/azure-cache-for-redis/cache-troubleshoot-timeouts.md
@@ -44,6 +44,9 @@ This error message contains metrics that can help point you to the cause and pos
 | wr |There's an active writer (meaning the 6 unsent requests aren't being ignored) bytes/activewriters |
 | in |There are no active readers and zero bytes are available to be read on the NIC bytes/activereaders |
 
+In the above exception, also notice that in the IOCP section and the WORKER section you have a Busy value that is greater than the Min value. This difference means your ThreadPool settings need adjusting.
+You can [configure your `ThreadPool` Settings](cache-management-faq.md#important-details-about-threadpool-growth) to make sure that your thread pool scales up quickly under burst scenarios.
+
 You can use the following steps to investigate possible root causes.
 
 1. As a best practice, make sure you're using the following pattern to connect when using the StackExchange.Redis client.


### PR DESCRIPTION
In the exception shared as an example, it points to threadpool exhaustion happening and is among the common scenarios for which cases are raised.

This is also mentioned under the below documentation as well:
https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-troubleshoot-client#traffic-burst

Hence, proposing this changes to have this added to this document as well which points at troubleshooting of REDIS Timeouts as well.

Kindly review