### PR TITLE
Update ea-portal-enrollment-invoices.md

### DIFF
--- a/articles/cost-management-billing/manage/ea-portal-enrollment-invoices.md
+++ b/articles/cost-management-billing/manage/ea-portal-enrollment-invoices.md
@@ -226,7 +226,7 @@ To apply your Azure Prepayment to overages, you must meet the following criteria
 - Your available Azure Prepayment amount covers the full number of incurred charges, including all past unpaid Azure invoices.
 - The billing term that you want to complete must be fully closed. Billing fully closes after the fifth day of each month.
 - The billing period that you want to offset must be fully closed.
-- Your Azure Prepayment Discount (ACD) is based on the actual new Prepayment minus any funds planned for the previous consumption. This requirement applies only to overage charges incurred. It's only valid for services that consume Azure Prepayment, so doesn't apply to Azure Marketplace charges. Azure Marketplace charges are billed separately.
+- Your Azure Prepayment Discount (APD) is based on the actual new Prepayment minus any funds planned for the previous consumption. This requirement applies only to overage charges incurred. It's only valid for services that consume Azure Prepayment, so doesn't apply to Azure Marketplace charges. Azure Marketplace charges are billed separately.
 
 To complete an overage offset, you or the account team can open a support request. An emailed approval from your enterprise administrator or Bill to Contact is required.
 


### PR DESCRIPTION
ACD appears to be a typo to Azure Prepayment Discount. This is confusing internal support documentation, especially since application of the Monetary Commitment (MC) change appears uneven in support tooling. No other instances of ACD appear in the documentation.
Change: Updated ACD to APD.