### PR TITLE
Update how-to-use-stored-procedures-triggers-udfs.md

### DIFF
--- a/articles/cosmos-db/how-to-use-stored-procedures-triggers-udfs.md
+++ b/articles/cosmos-db/how-to-use-stored-procedures-triggers-udfs.md
@@ -188,7 +188,7 @@ const newItem = [{
 }];
 const container = client.database("myDatabase").container("myContainer");
 const sprocId = "spCreateToDoItems";
-const {body: result} = await container.scripts.storedProcedure(sprocId).execute(newItem, {partitionKey: newItem[0].category});
+const {resource: result} = await container.scripts.storedProcedure(sprocId).execute(newItem, {partitionKey: newItem[0].category});
 ```
 
 ### Stored procedures - Python SDK


### PR DESCRIPTION
Fix wrong example for how to call a stored procedure by using the JavaScript SDK.

[storedProcedure.execute](https://docs.microsoft.com/ja-jp/javascript/api/@azure/cosmos/storedprocedure?view=azure-node-latest#execute_T__PartitionKey__any____RequestOptions_) returns `Promise<ResourceResponse<T>>`
[ResourceResponse](https://docs.microsoft.com/ja-jp/javascript/api/@azure/cosmos/resourceresponse?view=azure-node-latest#constructor-details) does not have `body` but `resource`