### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#74721

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
+++ b/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
@@ -79,7 +79,7 @@ This example uses [CTAS](/sql/t-sql/statements/create-table-as-select-azure-sql-
 CREATE TABLE [dbo].[DimSalesTerritory_REPLICATE]
 WITH
   (
-    CLUSTERED COLUMNSTORE INDEX,  
+    HEAP,  
     DISTRIBUTION = REPLICATE  
   )  
 AS SELECT * FROM [dbo].[DimSalesTerritory]


### PR DESCRIPTION
In both https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-index#clustered-columnstore-indexes and https://docs.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/cheat-sheet#distributed-or-replicated-tables it's mentioned that if you are using replicated tables for their intended use, small dimensions, then HEAP index will outperform CLUSTERED COLUMNSTORE and CLUSTERED INDEX. Using HEAP in this code example keeps our documentation consistent with how we recommend using this type of table.