### PR TITLE
Typo "Azure function app"→"Azure Function App"

### DIFF
--- a/articles/azure-functions/functions-create-maven-eclipse.md
+++ b/articles/azure-functions/functions-create-maven-eclipse.md
@@ -71,7 +71,7 @@ az login
 
 Deploy your code into a new Function app using the `azure-functions:deploy` Maven goal in a new **Run As** configuration.
 
-When the deploy is complete, you see the URL you can use to access your Azure function app:
+When the deploy is complete, you see the URL you can use to access your Azure Function App:
 
 ```output
 [INFO] Successfully deployed Function App with package.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-maven-eclipse
#PingMSFTDocs