### PR TITLE
Typo "Azure function app"→"Azure Function App"

### DIFF
--- a/articles/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint.md
+++ b/articles/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint.md
@@ -12,9 +12,9 @@ ms.date: 01/14/2021
 
 This article is a basic reference for a custom provider C# RESTful endpoint. If you're unfamiliar with Azure Custom Providers, see [the overview on custom resource providers](overview.md).
 
-## Azure Function App RESTful endpoint
+## Azure Functions RESTful endpoint
 
-The following code works with an Azure Function App. To learn how to set up an Azure Function App to work with Azure Custom Providers, see [the tutorial on setting up Azure Functions for Azure Custom Providers](./tutorial-custom-providers-function-setup.md).
+The following code works with a function app in Azure. To learn how to set up an function app to work with Azure Custom Providers, see [the tutorial on setting up Azure Functions for Azure Custom Providers](./tutorial-custom-providers-function-setup.md).
 
 ```csharp
 #r "Newtonsoft.Json"

--- a/articles/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint.md
+++ b/articles/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint.md
@@ -12,9 +12,9 @@ ms.date: 01/14/2021
 
 This article is a basic reference for a custom provider C# RESTful endpoint. If you're unfamiliar with Azure Custom Providers, see [the overview on custom resource providers](overview.md).
 
-## Azure function app RESTful endpoint
+## Azure Function App RESTful endpoint
 
-The following code works with an Azure function app. To learn how to set up an Azure function app to work with Azure Custom Providers, see [the tutorial on setting up Azure Functions for Azure Custom Providers](./tutorial-custom-providers-function-setup.md).
+The following code works with an Azure Function App. To learn how to set up an Azure Function App to work with Azure Custom Providers, see [the tutorial on setting up Azure Functions for Azure Custom Providers](./tutorial-custom-providers-function-setup.md).
 
 ```csharp
 #r "Newtonsoft.Json"


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-resource-manager/custom-providers/reference-custom-providers-csharp-endpoint
#PingMSFTDocs