### PR TITLE
Typo "Azure function app"→"Azure Function App"

### DIFF
--- a/articles/iot-central/core/howto-build-iotc-device-bridge.md
+++ b/articles/iot-central/core/howto-build-iotc-device-bridge.md
@@ -32,7 +32,7 @@ Complete the [Create an Azure IoT Central application](./quick-deploy-iot-centra
 
 ## Overview
 
-The IoT Central device bridge is an open-source solution in GitHub. It uses a custom Azure Resource Manager template deploy several resources to your Azure subscription, including an Azure function app.
+The IoT Central device bridge is an open-source solution in GitHub. It uses a custom Azure Resource Manager template deploy several resources to your Azure subscription, including an Azure Function App.
 
 The function app is the core piece of the device bridge. It receives HTTP POST requests from other IoT platforms through a simple webhook. The [Azure IoT Central Device Bridge](https://github.com/Azure/iotc-device-bridge) repository includes examples that show how to connect Sigfox, Particle, and The Things Network clouds. You can extend this solution to connect to your custom IoT cloud if your platform can send HTTP POST requests to your function app.
 
@@ -186,7 +186,7 @@ To connect a Particle device through the device bridge to IoT Central, go to the
 }
 ```
 
-Paste in the **function URL** from your Azure function app, and you see Particle devices appear as unassociated devices in IoT Central. To learn more, see the [Here's how to integrate your Particle-powered projects with Azure IoT Central](https://blog.particle.io/2019/09/26/integrate-particle-with-azure-iot-central/) blog post.
+Paste in the **function URL** from your Azure Function App, and you see Particle devices appear as unassociated devices in IoT Central. To learn more, see the [Here's how to integrate your Particle-powered projects with Azure IoT Central](https://blog.particle.io/2019/09/26/integrate-particle-with-azure-iot-central/) blog post.
 
 ### Example 2: Connecting Sigfox devices through the device bridge
 
@@ -267,7 +267,7 @@ function Decoder(bytes, port) {
 }
 ```
 
-After you define the integration, add the following code before the call to `handleMessage` in line 21 of the *IoTCIntegration/index.js* file of your Azure function app. This code translates the body of your HTTP integration to the expected format.
+After you define the integration, add the following code before the call to `handleMessage` in line 21 of the *IoTCIntegration/index.js* file of your Azure Function App. This code translates the body of your HTTP integration to the expected format.
 
 ```javascript
 device: {

--- a/articles/iot-central/core/howto-build-iotc-device-bridge.md
+++ b/articles/iot-central/core/howto-build-iotc-device-bridge.md
@@ -32,13 +32,13 @@ Complete the [Create an Azure IoT Central application](./quick-deploy-iot-centra
 
 ## Overview
 
-The IoT Central device bridge is an open-source solution in GitHub. It uses a custom Azure Resource Manager template deploy several resources to your Azure subscription, including an Azure Function App.
+The IoT Central device bridge is an open-source solution in GitHub. It uses a custom Azure Resource Manager template to deploy several resources to your Azure subscription, including a function app in Azure Functions.
 
 The function app is the core piece of the device bridge. It receives HTTP POST requests from other IoT platforms through a simple webhook. The [Azure IoT Central Device Bridge](https://github.com/Azure/iotc-device-bridge) repository includes examples that show how to connect Sigfox, Particle, and The Things Network clouds. You can extend this solution to connect to your custom IoT cloud if your platform can send HTTP POST requests to your function app.
 
 The function app transforms the data into a format accepted by IoT Central and forwards it using the device provisioning service and device client APIs:
 
-:::image type="content" source="media/howto-build-iotc-device-bridge/azure-function.png" alt-text="Screenshot of Azure functions screenshot.":::
+:::image type="content" source="media/howto-build-iotc-device-bridge/azure-function.png" alt-text="Screenshot of Azure Functions.":::
 
 If your IoT Central application recognizes the device ID in the forwarded message, the telemetry from the device appears in IoT Central. If the device ID isn't recognized by your IoT Central application, the function app attempts to register a new device with the device ID. The new device appears as an **Unassociated device** on the **Devices** page in your IoT Central application. From the **Devices** page, you can associate the new device with a device template and then view the telemetry.
 
@@ -58,7 +58,7 @@ To deploy the device bridge to your subscription:
 
 After the deployment is completed, you need to install the NPM packages the function requires:
 
-1. In the Azure portal, open the function app that was deployed to your subscription. Then navigate to **Development Tools > Console**. In the console, run the following commands to install the packages:
+1. In the Azure portal, open the function app that was deployed to your subscription. Then, go to **Development Tools** > **Console**. In the console, run the following commands to install the packages:
 
     ```bash
     cd IoTCIntegration
@@ -110,16 +110,16 @@ To switch on logging for the function app with Application Insights, navigate to
 
 The Resource Manager template provisions the following resources in your Azure subscription:
 
-* Function App
+* Function app
 * App Service plan
 * Storage account
 * Key vault
 
 The key vault stores the SAS group key for your IoT Central application.
 
-The Function App runs on a [consumption plan](https://azure.microsoft.com/pricing/details/functions/). While this option doesn't offer dedicated compute resources, it enables the device bridge to handle hundreds of device messages per minute, suitable for smaller fleets of devices or devices that send messages less frequently. If your application depends on streaming a large number of device messages, replace the consumption plan with a dedicated a [App service plan](https://azure.microsoft.com/pricing/details/app-service/windows/). This plan offers dedicated compute resources, which give faster server response times. Using a standard App Service Plan, the maximum observed performance of the Azure function in this repository was around 1,500 device messages per minute. To learn more, see [Azure Function hosting options](../../azure-functions/functions-scale.md).
+The function app runs on a [consumption plan](https://azure.microsoft.com/pricing/details/functions/). While this option doesn't offer dedicated compute resources, it enables the device bridge to handle hundreds of device messages per minute, suitable for smaller fleets of devices or devices that send messages less frequently. If your application depends on streaming a large number of device messages, replace the consumption plan with a dedicated a [App service plan](https://azure.microsoft.com/pricing/details/app-service/windows/). This plan offers dedicated compute resources, which give faster server response times. Using a standard App Service Plan, the maximum observed performance of the function from Azure in this repository was around 1,500 device messages per minute. To learn more, see [Azure Functions hosting options](../../azure-functions/functions-scale.md).
 
-To use a dedicated App Service Plan instead of a consumption plan, edit the custom template before deploying. Select  **Edit template**.
+To use a dedicated App Service plan instead of a consumption plan, edit the custom template before deploying. Select  **Edit template**.
 
 :::image type="content" source="media/howto-build-iotc-device-bridge/edit-template.png" alt-text="Screenshot of Edit Template.":::
 
@@ -181,16 +181,16 @@ To connect a Particle device through the device bridge to IoT Central, go to the
     "deviceId": "{{{PARTICLE_DEVICE_ID}}}"
   },
   "measurements": {
-    "{{{PARTICLE_EVENT_NAME}}}": {{{PARTICLE_EVENT_VALUE}}}
+    "{{{PARTICLE_EVENT_NAME}}}": "{{{PARTICLE_EVENT_VALUE}}}"
   }
 }
 ```
 
-Paste in the **function URL** from your Azure Function App, and you see Particle devices appear as unassociated devices in IoT Central. To learn more, see the [Here's how to integrate your Particle-powered projects with Azure IoT Central](https://blog.particle.io/2019/09/26/integrate-particle-with-azure-iot-central/) blog post.
+Paste in the **function URL** from your function app, and you see Particle devices appear as unassociated devices in IoT Central. To learn more, see the [Here's how to integrate your Particle-powered projects with Azure IoT Central](https://blog.particle.io/2019/09/26/integrate-particle-with-azure-iot-central/) blog post.
 
 ### Example 2: Connecting Sigfox devices through the device bridge
 
-Some platforms may not allow you to specify the format of device messages sent through a webhook. For such systems, you must convert the message payload to the expected body format before the device bridge processes it. You can do the conversion in same Azure function that runs the device bridge.
+Some platforms may not allow you to specify the format of device messages sent through a webhook. For such systems, you must convert the message payload to the expected body format before the device bridge processes it. You can do the conversion in the same function that runs the device bridge.
 
 This section shows how to convert the payload of a Sigfox webhook integration to the body format expected by the device bridge. The Sigfox cloud transmits device data in a hexadecimal string format. For convenience, the device bridge includes a conversion function for this format, which accepts a subset of the possible field types in a Sigfox device payload: `int` and `uint` of 8, 16, 32, or 64 bits; `float` of 32 bits or 64 bits; little-endian and big-endian. To process messages from a Sigfox webhook integration, make the following changes to the _IoTCIntegration/index.js_ file in the function app.
 
@@ -220,7 +220,7 @@ context.res = {
 To connect The Things Network devices to IoT Central:
 
 * Add a new HTTP integration to your application in The Things Network: **Application > Integrations > add integration > HTTP Integration**.
-* Make sure your application includes a decoder function that automatically converts the payload of your device messages to JSON before it's sent to the Azure Function: **Application > Payload Functions > decoder**.
+* Make sure your application includes a decoder function that automatically converts the payload of your device messages to JSON before it's sent to the function: **Application > Payload Functions > decoder**.
 
 The following sample shows a JavaScript decoder function you can use to decode common numeric types from binary data:
 
@@ -267,7 +267,7 @@ function Decoder(bytes, port) {
 }
 ```
 
-After you define the integration, add the following code before the call to `handleMessage` in line 21 of the *IoTCIntegration/index.js* file of your Azure Function App. This code translates the body of your HTTP integration to the expected format.
+After you define the integration, add the following code before the call to `handleMessage` in line 21 of the *IoTCIntegration/index.js* file of your function app. This code translates the body of your HTTP integration to the expected format.
 
 ```javascript
 device: {


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/iot-central/core/howto-build-iotc-device-bridge
#PingMSFTDocs