### PR TITLE
Update backup-and-restore.md

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/backup-and-restore.md
+++ b/articles/synapse-analytics/sql-data-warehouse/backup-and-restore.md
@@ -52,7 +52,7 @@ The following lists details for restore point retention periods:
 1. Dedicated SQL pool deletes a restore point when it hits the 7-day retention period **and** when there are at least 42 total restore points (including both user-defined and automatic).
 2. Snapshots are not taken when a dedicated SQL pool is paused.
 3. The age of a restore point is measured by the absolute calendar days from the time the restore point is taken including when the SQL pool is paused.
-4. At any point in time, a dedicated SQL pool is guaranteed to be able to store up to 42 user-defined restore points and 42 automatic restore points as long as these restore points have not reached the 7-day retention period
+4. At any point in time, a dedicated SQL pool is guaranteed to be able to store up to 42 user-defined restore points or 42 automatic restore points as long as these restore points have not reached the 7-day retention period
 5. If a snapshot is taken, the dedicated SQL pool is then paused for greater than 7 days, and then resumed, the restore point will persist until there are 42 total restore points (including both user-defined and automatic)
 
 ### Snapshot retention when a SQL pool is dropped


### PR DESCRIPTION
Based on the comment on bullet 1 that we can have a total of 42 restore points ((including both user-defined and automatic), I am suggesting the change on bullet 4.
Changing and to or. Currently, with **and** it reads like we can keep 84 restore points.