### PR TITLE
Clarify usage of apple ext sso profile when not on InTune

### DIFF
--- a/articles/active-directory/develop/apple-sso-plugin.md
+++ b/articles/active-directory/develop/apple-sso-plugin.md
@@ -71,7 +71,7 @@ The profile settings that enable the SSO plug-in are automatically applied to th
 
 ### Manual configuration for other MDM services
 
-If you don't use Intune for MDM, use the following parameters to configure the Microsoft Enterprise SSO plug-in for Apple devices.
+If you don't use Intune for MDM, you can configure an Extensible Single Sign On profile payload for Apple devices. Use the following parameters to configure the Microsoft Enterprise SSO plug-in and its configuration options.
 
 iOS settings:
 


### PR DESCRIPTION
Had a discution while implementing the Microsoft entreprise SSO plugin on where these configuration should be set.
When not used to apple management and aware of the extensible SSO profile, it is easy to wonder where all this should be set (on the app side maybe).

The changes proposed intent is to mention the apple payload used and that the additional configuration options are to be set in this profile.