### PR TITLE
Fixed a minor typo

### DIFF
--- a/articles/cognitive-services/QnAMaker/Quickstarts/create-publish-knowledge-base.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/create-publish-knowledge-base.md
@@ -43,7 +43,7 @@ You can create a QnA Maker knowledge base (KB) from your own content, such as FA
     |Setting|Value|
     |--|--|
     |**Enable multi-turn extraction from URLs, .pdf or .docx files.**|Checked|
-    |**Multi-turn default text**| Select and option|
+    |**Multi-turn default text**| Select an option|
     |**+ Add URL**|`https://www.microsoft.com/en-us/software-download/faq`|
     |**Chit-chat**|Select **Professional**|
 
@@ -78,7 +78,7 @@ You can create a QnA Maker knowledge base (KB) from your own content, such as FA
     |Setting|Value|
     |--|--|
     |**Enable multi-turn extraction from URLs, .pdf or .docx files.**|Checked|
-    |**Multi-turn default text**| Select and option|
+    |**Multi-turn default text**| Select an option|
     |**+ Add File**| Download Surface laptop manual from: 'https://download.microsoft.com/download/7/B/1/7B10C82E-F520-4080-8516-5CF0D803EEE0/surface-book-user-guide-EN.pdf' 
     |**Chit-chat**|Select **Professional**|
 


### PR DESCRIPTION
`Muti-trun` default text should be `Select an option` instead of `Select and option`