### PR TITLE
Make status consistent with comment

### DIFF
--- a/articles/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2.md
+++ b/articles/marketplace/partner-center-portal/pc-saas-fulfillment-api-v2.md
@@ -987,7 +987,7 @@ The publisher must implement a webhook in the SaaS service to keep the SaaS subs
   "quantity": " 20",
   "timeStamp": "2019-04-15T20:17:31.7350641Z",
   "action": "Reinstate",
-  "status": "In Progress"
+  "status": "InProgress"
 }
 ```
 


### PR DESCRIPTION
The status `InProgress` is spelled without a space in the comment on line 974

>  "status": "Success" // Can be either InProgress or Success

This updates the string in the example to be inline with what the comment says. 

Note: I don't really know if the API returns the string with or without the space.