### PR TITLE
Revert "Add optional network requirements for third party apm" due to feature is not avaiable for now

### DIFF
--- a/articles/spring-cloud/vnet-customer-responsibilities.md
+++ b/articles/spring-cloud/vnet-customer-responsibilities.md
@@ -28,7 +28,7 @@ The following is a list of resource requirements for Azure Spring Cloud services
 ## Azure Spring Cloud network requirements
 
   | Destination Endpoint | Port | Use | Note |
-  |------|------|------|
+  |------|------|------|------|
   | *:1194 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - AzureCloud:1194 | UDP:1194 | Underlying Kubernetes Cluster management. | |
   | *:443 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - AzureCloud:443 | TCP:443 | Azure Spring Cloud Service Management. | Information of service instance "requiredTraffics" could be known in resource payload, under "networkProfile" section. |
   | *:9000 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - AzureCloud:9000 | TCP:9000 | Underlying Kubernetes Cluster management. |

--- a/articles/spring-cloud/vnet-customer-responsibilities.md
+++ b/articles/spring-cloud/vnet-customer-responsibilities.md
@@ -28,7 +28,7 @@ The following is a list of resource requirements for Azure Spring Cloud services
 ## Azure Spring Cloud network requirements
 
   | Destination Endpoint | Port | Use | Note |
-  |------|------|------|------|
+  |------|------|------|
   | *:1194 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - AzureCloud:1194 | UDP:1194 | Underlying Kubernetes Cluster management. | |
   | *:443 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - AzureCloud:443 | TCP:443 | Azure Spring Cloud Service Management. | Information of service instance "requiredTraffics" could be known in resource payload, under "networkProfile" section. |
   | *:9000 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - AzureCloud:9000 | TCP:9000 | Underlying Kubernetes Cluster management. |
@@ -38,9 +38,9 @@ The following is a list of resource requirements for Azure Spring Cloud services
   | *.servicebus.windows.net:443 *Or* [ServiceTag](../virtual-network/service-tags-overview.md#available-service-tags) - EventHub:443 | TCP:443 | Azure Event Hub. | Can be replaced by enabling *Azure Event Hubs* [service endpoint in virtual network](../virtual-network/virtual-network-service-endpoints-overview.md). |
   
 
-## Azure Spring Cloud FQDN requirements/application rules
+## Azure Spring Cloud FQDN requirements / application rules
 
-Azure Firewall provides the FQDN tag **AzureKubernetesService** to simplify the following configurations:
+Azure Firewall provides a fully qualified domain name (FQDN) tag **AzureKubernetesService** to simplify the following configurations.
 
   | Destination FQDN | Port | Use |
   |------|------|------|
@@ -48,23 +48,14 @@ Azure Firewall provides the FQDN tag **AzureKubernetesService** to simplify the 
   | <i>mcr.microsoft.com</i> | HTTPS:443 | Microsoft Container Registry (MCR). |
   | *.cdn.mscr.io | HTTPS:443 | MCR storage backed by the Azure CDN. |
   | *.data.mcr.microsoft.com | HTTPS:443 | MCR storage backed by the Azure CDN. |
-  | <i>management.azure.com</i> | HTTPS:443 | Underlying Kubernetes Cluster management. |
-  | <i>*login.microsoftonline.com</i> | HTTPS:443 | Azure Active Directory authentication. |
-  | <i>*login.microsoft.com</i> | HTTPS:443 | Azure Active Directory authentication. |
+  | <i>management.azure.com</i> | HTTPS:443 | Underlying Kubernetes Cluster management. ​|
+  | <i>*login.microsoftonline.com</i> | HTTPS:443 | Azure Active Directory authentication.​ |
+  | <i>*login.microsoft.com</i> | HTTPS:443 | Azure Active Directory authentication.​ |
   |<i>packages.microsoft.com</i>    | HTTPS:443 | Microsoft packages repository. |
   | <i>acs-mirror.azureedge.net</i> | HTTPS:443 | Repository required to install required binaries like kubenet and Azure CNI.​ |
   | *mscrl.microsoft.com* | HTTPS:80 | Required Microsoft Certificate Chain Paths. |
   | *crl.microsoft.com* | HTTPS:80 | Required Microsoft Certificate Chain Paths. |
   | *crl3.digicert.com* | HTTPS:80 | 3rd Party SSL Certificate Chain Paths. |
-  
-## Azure Spring Cloud optional FQDN for third-party application performance management
-
-Azure Firewall provides the FQDN tag **AzureKubernetesService** to simplify the following configurations:
-
-  | Destination FQDN | Port | Use                                                          |
-  | ---------------- | ---- | ------------------------------------------------------------ |
-  | collector*.newrelic.com | TCP:443/80 | Required networks of New Relic APM agents from US region, also see [APM Agents Networks](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/networks/#agents). |
-  | collector*.eu01.nr-data.net | TCP:443/80 | Required networks of New Relic APM agents from EU region, also see [APM Agents Networks](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/networks/#agents). |
 
 ## See also
 * [Access your application in a private network](access-app-virtual-network.md)


### PR DESCRIPTION
Reverts MicrosoftDocs/azure-docs#73496