### PR TITLE
Remove deprecated label from node-updates-kured.md

### DIFF
--- a/articles/aks/node-updates-kured.md
+++ b/articles/aks/node-updates-kured.md
@@ -63,7 +63,7 @@ helm repo update
 kubectl create namespace kured
 
 # Install kured in that namespace with Helm 3 (only on Linux nodes, kured is not working on Windows nodes)
-helm install kured kured/kured --namespace kured --set nodeSelector."beta\.kubernetes\.io/os"=linux
+helm install kured kured/kured --namespace kured --set nodeSelector."kubernetes\.io/os"=linux
 ```
 
 You can also configure additional parameters for `kured`, such as integration with Prometheus or Slack. For more information about additional configuration parameters, see the [kured Helm chart][kured-install].


### PR DESCRIPTION
The beta.kubernetes.io/os label has been deprecated since v1.14 so we should replace it with the correct kubernetes.io/os label in the kured deployment example.