### PR TITLE
Modified miss spell query argument

### DIFF
--- a/articles/spring-cloud/how-to-outbound-public-ip.md
+++ b/articles/spring-cloud/how-to-outbound-public-ip.md
@@ -35,7 +35,7 @@ To find the outbound public IP addresses currently used by your service instance
 You can find the same information by running the following command in the Cloud Shell
 
 ```Azure CLI
-az spring-cloud show --resource-group <group_name> --name <service_name> --query properties.networkProfile.outboundIPs.publicIPs --output tsv
+az spring-cloud show --resource-group <group_name> --name <service_name> --query properties.networkProfile.outboundIps.publicIps --output tsv
 ```
 
 ## Next steps


### PR DESCRIPTION
In the document, following was wrote.

> az spring-cloud show --resource-group <group_name> --name <service_name> --query properties.networkProfile.outboundIPs.publicIPs --output tsv

However actual query command should be "outboundIps.publicIps" (Not "IPs" but "Ips")
As a result, if user execute the above command, they can't get the result of the ip.

In fact, if I execute the command without the query following was showed.
  "properties": {
    "networkProfile": {
      "appNetworkResourceGroup": null,
      "appSubnetId": null,
      "outboundIps": {
        "publicIps": [
          "20.48.11.93",
          "20.48.11.248"
        ]
      },
      "serviceCidr": null,
      "serviceRuntimeNetworkResourceGroup": null,
      "serviceRuntimeSubnetId": null
    },


It means that "properties.networkProfile.outboundIps.publicIps"