### PR TITLE
Modified duplicated annotation and dependencies

### DIFF
--- a/articles/spring-cloud/how-to-service-registration.md
+++ b/articles/spring-cloud/how-to-service-registration.md
@@ -25,26 +25,26 @@ Before your application can manage service registration and discovery using Spri
 Include dependencies for *spring-cloud-starter-netflix-eureka-client* and *spring-cloud-starter-azure-spring-cloud-client* to your *pom.xml*
 
 ```xml
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-			<version>3.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>com.microsoft.azure</groupId>
-			<artifactId>spring-cloud-starter-azure-spring-cloud-client</artifactId>
-			<version>2.1.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-client</artifactId>
-			<version>1.19.4</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.jersey.contribs</groupId>
-			<artifactId>jersey-apache-client4</artifactId>
-			<version>1.19.4</version>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>spring-cloud-starter-azure-spring-cloud-client</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.19.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey.contribs</groupId>
+            <artifactId>jersey-apache-client4</artifactId>
+            <version>1.19.4</version>
+        </dependency>
 ```
 
 ## Update the top level class

--- a/articles/spring-cloud/how-to-service-registration.md
+++ b/articles/spring-cloud/how-to-service-registration.md
@@ -25,15 +25,26 @@ Before your application can manage service registration and discovery using Spri
 Include dependencies for *spring-cloud-starter-netflix-eureka-client* and *spring-cloud-starter-azure-spring-cloud-client* to your *pom.xml*
 
 ```xml
-    <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>com.microsoft.azure</groupId>
-        <artifactId>spring-cloud-starter-azure-spring-cloud-client</artifactId>
-        <version>2.1.0</version>
-    </dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>com.microsoft.azure</groupId>
+			<artifactId>spring-cloud-starter-azure-spring-cloud-client</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.jersey</groupId>
+			<artifactId>jersey-client</artifactId>
+			<version>1.19.4</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.jersey.contribs</groupId>
+			<artifactId>jersey-apache-client4</artifactId>
+			<version>1.19.4</version>
+		</dependency>
 ```
 
 ## Update the top level class
@@ -44,13 +55,16 @@ Finally, we add an annotation to the top level class of your application
     package foo.bar;
 
     import org.springframework.boot.SpringApplication;
-    import org.springframework.cloud.client.SpringCloudApplication;
+    import org.springframework.boot.autoconfigure.SpringBootApplication;
+    import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 
-    @SpringCloudApplication
+    @SpringBootApplication
+    @EnableEurekaClient
     public class DemoApplication {
-        public static void main(String... args) {
-            SpringApplication.run(DemoApplication.class, args);
-        }
+
+    	public static void main(String[] args) {
+	    	SpringApplication.run(DemoApplication.class, args);
+	    }
     }
  ```
 


### PR DESCRIPTION
1.  Dependencies was not enough
If I use the current stable version of the Spring Boot as 2.4.5, the dependencies was not enough.
In fact, jersey related dependencies is also needed. So it should be included in the document.
 

2.  Duplicated Annotation was used as  @SpringCloudApplication

According the the "Spring Cloud Netflix", @SpringCloudApplication was duplicated.
Instead of it, @EnableEurekaClient annotation is used in following official documents.

https://spring.io/projects/spring-cloud-netflix