### PR TITLE
Update Enable MPS on Azure Stack Edge Section

### DIFF
--- a/articles/cognitive-services/Computer-vision/spatial-analysis-container.md
+++ b/articles/cognitive-services/Computer-vision/spatial-analysis-container.md
@@ -119,35 +119,89 @@ When the Edge compute role is set up on the Edge device, it creates two devices:
 
 ###  Enable MPS on Azure Stack Edge 
 
-1. Run a Windows PowerShell session as an Administrator. 
+**This section needs to be updated.  This will no longer work with the latest update that was released.  Please see the following link with the new commands to connect to an Edge device via PowerShell:
+https://docs.microsoft.com/en-us/azure/databox-online/azure-stack-edge-gpu-connect-powershell-interface
 
-2. Make sure that the Windows Remote Management service is running on your client. In the PowerShell terminal, use the following command 
-    
+**So section 1 - 6 will need to change to align with the new way to configure your client to connect via PowerShell.
+
+
+
+1. Run a Windows PowerShell session as an administrator.
+2. Make sure that the Windows Remote Management service is running on your client. At the command prompt, type:
+
+    `winrm quickconfig`
+
+    For more information, see [Installation and configuration for Windows Remote Management](/windows/win32/winrm/installation-and-configuration-for-windows-remote-management#quick-default-configuration).
+
+3. Assign a variable to the device IP address.
+
+    $ip = "<device_ip>"
+
+    Replace `<device_ip>` with the IP address of your device.
+
+4. To add the IP address of your device to the client’s trusted hosts list, type the following command:
+
+    `Set-Item WSMan:\localhost\Client\TrustedHosts $ip -Concatenate -Force`
+
+5. Start a Windows PowerShell session on the device:
+
+    `Enter-PSSession -ComputerName $ip -Credential $ip\EdgeUser -ConfigurationName Minishell -UseSSL`
+
+    If you see an error related to trust relationship, then check if the signing chain of the node certificate uploaded to your device is also installed on the client accessing your device.
+
+    If you are not using the certificates (we recommend that you use the certificates!), you can skip this check by using the session options: `-SkipCACheck -SkipCNCheck -SkipRevocationCheck`.
+
     ```powershell
-    winrm quickconfig
-    ```
-    
-    If you see warnings about a firewall exception, check your network connection type, and see the [Windows Remote Management](/windows/win32/winrm/installation-and-configuration-for-windows-remote-management) documentation.
-
-3. Assign a variable to the device IP address. 
-    
-    ```powershell
-    $ip = "<device-IP-address>" 
-    ```
-    
-4. To add the IP address of your device to the client's trusted hosts list, use the following command: 
-    
-    ```powershell
-    Set-Item WSMan:\localhost\Client\TrustedHosts $ip -Concatenate -Force 
+    $sessOptions = New-PSSessionOption -SkipCACheck -SkipCNCheck -SkipRevocationCheck 
+    Enter-PSSession -ComputerName $ip -Credential $ip\EdgeUser -ConfigurationName Minishell -UseSSL -SessionOption $sessOptions    
     ```
 
-5. Start a Windows PowerShell session on the device. 
+    > [!NOTE] 
+    > When you use the `-UseSSL` option, you are remoting via PowerShell over *https*. We recommend that you always use *https* to remotely connect via PowerShell. 
 
-    ```powershell
-    Enter-PSSession -ComputerName $ip -Credential $ip\EdgeUser -ConfigurationName Minishell 
+6. Provide the password when prompted. Use the same password that is used to sign into the local web UI. The default local web UI password is *Password1*. When you successfully connect to the device using remote PowerShell, you see the following sample output:  
+
+    ```
+    Windows PowerShell
+    Copyright (C) Microsoft Corporation. All rights reserved.
+    
+    PS C:\WINDOWS\system32> winrm quickconfig
+    WinRM service is already running on this machine.
+    PS C:\WINDOWS\system32> $ip = "10.100.10.10"
+    PS C:\WINDOWS\system32> Set-Item WSMan:\localhost\Client\TrustedHosts $ip -Concatenate -Force
+    PS C:\WINDOWS\system32> Enter-PSSession -ComputerName $ip -Credential $ip\EdgeUser -ConfigurationName Minishell -UseSSL
+
+    WARNING: The Windows PowerShell interface of your device is intended to be used only for the initial network configuration. Please engage Microsoft Support if you need to access this interface to troubleshoot any potential issues you may be experiencing. Changes made through this interface without involving Microsoft Support could result in an unsupported configuration.
+    [10.100.10.10]: PS>
     ```
 
-6. Provide the password when prompted. Use the same password that is used to sign into the local web UI. The default local web UI password is `Password1`.
+> [!IMPORTANT]
+> In the current release, you can connect to the PowerShell interface of the device only via a Windows client. The `-UseSSL` option does not work with the Linux clients.
+
+<!--### Remotely connect from a Linux client-->
+
+<!--On the Linux client that you'll use to connect:
+
+- [Install the latest PowerShell Core for Linux](/powershell/scripting/install/installing-powershell-core-on-linux) from GitHub to get the SSH remoting feature. 
+- [Install only the `gss-ntlmssp` package from the NTLM module](https://github.com/Microsoft/omi/blob/master/Unix/doc/setup-ntlm-omi.md). For Ubuntu clients, use the following command:
+    - `sudo apt-get install gss-ntlmssp`
+
+For more information, go to [PowerShell remoting over SSH](/powershell/scripting/learn/remoting/ssh-remoting-in-powershell-core).
+
+Follow these steps to remotely connect from an NFS client.
+
+1. To open PowerShell session, type:
+
+    `pwsh`
+ 
+2. For connecting using the remote client, type:
+
+    `Enter-PSSession -ComputerName $ip -Authentication Negotiate -ConfigurationName Minishell -Credential ~\EdgeUser`
+
+    When prompted, provide the password used to sign into your device.
+ 
+> [!NOTE]
+> This procedure does not work on Mac OS.-->
 
 Type `Start-HcsGpuMPS` to start the MPS service on the device. 
 


### PR DESCRIPTION
The section Enable MPS on Azure Stack Edge needs to be updated.  

**This section needs to be updated.  This will no longer work with the latest update that was released.  Please see the following link with the new commands to connect to an Edge device via PowerShell:
https://docs.microsoft.com/en-us/azure/databox-online/azure-stack-edge-gpu-connect-powershell-interface

**So sections 1 - 6 will need to change to align with the new way to configure your client to connect via PowerShell.