### PR TITLE
Update SQL_Vulnerability_assessment_new_section.md

### DIFF
--- a/articles/azure-sql/database/sql-database-vulnerability-assessment-storage.md
+++ b/articles/azure-sql/database/sql-database-vulnerability-assessment-storage.md
@@ -57,6 +57,34 @@ To support VA scans on Managed Instances, follow the below steps:
 
 You should now be able to store your VA scans for Managed Instances in your storage account.
 
+## Troubleshooting Vulnerability assessment scan related issues 
+
+Failure to save vulnerability assessment settings
+Storage mismatch: The storage account in which vulnerability assessment scan results are saved, should meet the following requirements:
+Type: StorageV2 (general purpose V2) or Storage (general purpose V1)
+Performance: Standard (only)
+Region: The storage must be in the same region as the Azure SQL Server
+If any of these requirements not met, saving vulnerability assessment settings will fail.
+
+Insufficient permissions: The following permissions are required for these operations:
+
+SQL Security Manager
+Storage Blob Data Reader
+One of the role are allowed to set a new role assignment (owner or user access admin for storage account)
+Storage Blob Data Owner
+My storage account is not visible for selection (vulnerability assessment settings)
+The storage account may not appear in the storage picker for several reasons:
+
+The storage account you are looking for is not in the selected subscription
+The storage account you are looking for is not in the same region as the Azure SQL Server
+You do not have Microsoft.Storage/storageAccounts/read permissions on the storage account
+Failure to open email link for scan result / view scan results
+Insufficient permissions The following permissions are required for these operations:
+
+SQL Security Manager
+Storage Blob Data Reader
+Browser issue
+
 ## Next steps
 
 - [Vulnerability Assessment](sql-vulnerability-assessment.md)

--- a/articles/azure-sql/database/sql-database-vulnerability-assessment-storage.md
+++ b/articles/azure-sql/database/sql-database-vulnerability-assessment-storage.md
@@ -96,12 +96,18 @@ The storage account might not appear in the storage account picker for several r
 
 ### Failure to open an email link for scan results or can't view scan results
 
+You might not be able to open a link in a notification email about scan results or to view scan results if you don't have the required permissions or if you use a browser that doesn't support opening or displaying scan results.
+
+#### Permissions
+
 The following permissions are required to open links in email notifications about scan results or to view scan results:
 
 - SQL Security Manager
 - Storage Blob Data Reader
 
-You also might be experiencing a browser issue.
+#### Browser requirements
+
+The Firefox browser doesn't support opening or displaying scan results view. We recommend that you use Chrome or Microsoft Edge to view vulnerability assessment scan results.
 
 ## Next steps
 

--- a/articles/azure-sql/database/sql-database-vulnerability-assessment-storage.md
+++ b/articles/azure-sql/database/sql-database-vulnerability-assessment-storage.md
@@ -57,33 +57,51 @@ To support VA scans on Managed Instances, follow the below steps:
 
 You should now be able to store your VA scans for Managed Instances in your storage account.
 
-## Troubleshooting Vulnerability assessment scan related issues 
+## Troubleshoot vulnerability assessment scan-related issues 
 
-Failure to save vulnerability assessment settings
-Storage mismatch: The storage account in which vulnerability assessment scan results are saved, should meet the following requirements:
-Type: StorageV2 (general purpose V2) or Storage (general purpose V1)
-Performance: Standard (only)
-Region: The storage must be in the same region as the Azure SQL Server
-If any of these requirements not met, saving vulnerability assessment settings will fail.
+Troubleshoot common issues related to vulnerability assessment scans.
 
-Insufficient permissions: The following permissions are required for these operations:
+### Failure to save vulnerability assessment settings
 
-SQL Security Manager
-Storage Blob Data Reader
-One of the role are allowed to set a new role assignment (owner or user access admin for storage account)
-Storage Blob Data Owner
-My storage account is not visible for selection (vulnerability assessment settings)
-The storage account may not appear in the storage picker for several reasons:
+You might not be able to save changes to vulnerability assessment settings if your storage account doesn't meet some prerequisites or if you have insufficient permissions.
 
-The storage account you are looking for is not in the selected subscription
-The storage account you are looking for is not in the same region as the Azure SQL Server
-You do not have Microsoft.Storage/storageAccounts/read permissions on the storage account
-Failure to open email link for scan result / view scan results
-Insufficient permissions The following permissions are required for these operations:
+#### Storage account requirements
 
-SQL Security Manager
-Storage Blob Data Reader
-Browser issue
+The storage account in which vulnerability assessment scan results are saved must meet the following requirements:
+
+- **Type**: StorageV2 (General Purpose V2) or Storage (General Purpose V1)
+- **Performance**: Standard (only)
+- **Region**: The storage must be in the same region as the instance of Azure SQL Server.
+
+If any of these requirements aren't met, saving changes to vulnerability assessment settings fails.
+
+#### Permissions 
+
+The following permissions are required to save changes to vulnerability assessment settings:
+
+- SQL Security Manager
+- Storage Blob Data Reader
+
+Setting a new role assignment requires owner or user administrator access to the storage account and the following permissions:
+
+- Storage Blob Data Owner
+
+### Storage account isn't visible for selection in vulnerability assessment settings
+
+The storage account might not appear in the storage account picker for several reasons:
+
+- The storage account you're looking for isn't in the selected subscription.
+- The storage account you're looking for isn't in the same region as the instance of Azure SQL Server.
+- You don't have Microsoft.Storage/storageAccounts/read permissions on the storage account.
+
+### Failure to open an email link for scan results or can't view scan results
+
+The following permissions are required to open links in email notifications about scan results or to view scan results:
+
+- SQL Security Manager
+- Storage Blob Data Reader
+
+You also might be experiencing a browser issue.
 
 ## Next steps
 


### PR DESCRIPTION
Apologies if the formatting is incorrect, however i'm sharing the content here : <<The below content is available in self help before customer raises support ticket , but it could be implemented in public docs to avoid support tickets >>

Failure to save vulnerability assessment settings
Storage mismatch: The storage account in which vulnerability assessment scan results are saved, should meet the following requirements:
Type: StorageV2 (general purpose V2) or Storage (general purpose V1)
Performance: Standard (only)
Region: The storage must be in the same region as the Azure SQL Server
If any of these requirements not met, saving vulnerability assessment settings will fail.

Insufficient permissions: The following permissions are required for these operations:

SQL Security Manager
Storage Blob Data Reader
One of the role are allowed to set a new role assignment (owner or user access admin for storage account)
Storage Blob Data Owner
My storage account is not visible for selection (vulnerability assessment settings)
The storage account may not appear in the storage picker for several reasons:

The storage account you are looking for is not in the selected subscription
The storage account you are looking for is not in the same region as the Azure SQL Server
You do not have Microsoft.Storage/storageAccounts/read permissions on the storage account
Failure to open email link for scan result / view scan results
Insufficient permissions The following permissions are required for these operations:

SQL Security Manager
Storage Blob Data Reader
Browser issue

Firefox browser does not support scan results view. We recommend customers use Chrome or Edge.