### PR TITLE
 Typo "Azure Container instances"→"Azure Container Instances"

### DIFF
--- a/articles/container-instances/tutorial-docker-compose.md
+++ b/articles/container-instances/tutorial-docker-compose.md
@@ -169,7 +169,7 @@ az acr repository show --name <acrName> --repository azure-vote-front
 
 [!INCLUDE [container-instances-create-docker-context](../../includes/container-instances-create-docker-context.md)]
 
-## Deploy application to Azure Container instances
+## Deploy application to Azure Container Instances
 
 Next, change to the ACI context. Subsequent Docker commands run in this context.
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/container-instances/tutorial-docker-compose
#PingMSFTDocs