### PR TITLE
Removed dual linkage to authentication.md

### DIFF
--- a/articles/key-vault/general/toc.yml
+++ b/articles/key-vault/general/toc.yml
@@ -53,9 +53,7 @@
   - name: Security
     items:
     - name: Security features
-      href: security-features.md
-    - name: Key Vault authentication fundamentals
-      href: authentication.md
+      href: security-features.md    
     - name: Key Vault authentication
       href: authentication.md
     - name: Security worlds and geographies


### PR DESCRIPTION
Menu items Key Vault authentication and Key Vault authentication fundamentals both pointed to Authentication.md 

I have removed Key Vault authentication fundamentals link as it made things confusing rather than just having one line saying Key Vault authentication. 

![image](https://user-images.githubusercontent.com/2480085/117930085-dda54d00-b2fd-11eb-8b04-2c49cf48806d.png)
