### PR TITLE
Change `https://localhost` to `http://localhost` in Auth Code flow

### DIFF
--- a/articles/active-directory/develop/v2-oauth2-auth-code-flow.md
+++ b/articles/active-directory/develop/v2-oauth2-auth-code-flow.md
@@ -63,7 +63,7 @@ client_id=6731de76-14a6-49ae-97bc-6eba6914391e
 ```
 
 > [!TIP]
-> Click the link below to execute this request! After signing in, your browser should be redirected to `https://localhost/myapp/` with a `code` in the address bar.
+> Click the link below to execute this request! After signing in, your browser should be redirected to `http://localhost/myapp/` with a `code` in the address bar.
 > <a href="https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=6731de76-14a6-49ae-97bc-6eba6914391e&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%2Fmyapp%2F&response_mode=query&scope=openid%20offline_access%20https%3A%2F%2Fgraph.microsoft.com%2Fmail.read&state=12345" target="_blank">https://login.microsoftonline.com/common/oauth2/v2.0/authorize...</a>
 
 | Parameter    | Required/optional | Description |


### PR DESCRIPTION
It should be `http` instead of `https` according to the `href` url:

```
...redirect_uri=http%3A%2F%2Flocalhost%2Fmyapp%2F...
                ^^^^
```

`https` will fail on `localhost` with `ERR_SSL_PROTOCOL_ERROR` (https://github.com/Azure/azure-cli/issues/10426).