### PR TITLE
WVD Agent Build version identification

### DIFF
--- a/articles/virtual-desktop/safe-url-list.md
+++ b/articles/virtual-desktop/safe-url-list.md
@@ -30,7 +30,14 @@ You need the following things to use the Required URL Check tool:
 
 - Your VM must have a .NET 4.6.2 framework
 - RDAgent version 1.0.2944.400 or higher
+- Identify the current WVD Agent version (build) running within the Host pool.
 - The WVDAgentUrlTool.exe file must be in the same folder as the WVDAgentUrlTool.config file
+
+  Here's where you would find the current WVD Agent Version:
+
+    > [!div class="mx-imgBorder"]
+    > ![Screenshot of WVD agent Version within a Host pool](https://user-images.githubusercontent.com/48697709/117975727-e3fbef00-b326-11eb-9472-49cac5b34c96.jpg)
+
 
 ### How to use the Required URL Check tool
 


### PR DESCRIPTION
The current guidance is not very clear in the following section:

https://docs.microsoft.com/en-us/azure/virtual-desktop/safe-url-list?source=docs#how-to-use-the-required-url-check-tool

The document does not state that the "URL Check tool" is found in the specific build version on the session host. There is also no guidance to identify the build version.

Here are my comments:

It is important to note that the WVDAgentURLTool.exe is located within the C:\Program Files\Microsoft RDInfra\"Current Build" folder and not  "cd C:\Program Files\Microsoft RDInfra\RDAgent_1.0.2944.1200" 

For example "C:\Program Files\Microsoft RDInfra\RDAgent_1.0.2944.1400>WVDAgentUrlTool.exe" is where I found the tool. I also note there were a number of build folders within the folder directory which made it difficult to find. However using the Azure portal > Windows Virtual Desktop > Host Pools > "Select Host Pool required", you will be able to see the current build version in use "WVD Agent Version"

I have made some suggested changed and inserted a screenshot showing the Agent version. 

I trust this helps. 

Best regards,

Ryan