### PR TITLE
update PL doc based on feedback

### DIFF
--- a/articles/hdinsight/hdinsight-private-link.md
+++ b/articles/hdinsight/hdinsight-private-link.md
@@ -23,7 +23,7 @@ The basic load balancers used in the default virtual network architecture automa
 
 Configuring `resourceProviderConnection` to outbound also allows you to access cluster-specific resources, such as Azure Data Lake Storage Gen2 or external metastores, using private endpoints. Using private endpoints for these resources is not mandatory, but if you plan to have private endpoints for these resources, you must configure the private endpoints and DNS entries `before` you create the HDInsight cluster. We recommend you create and provide all of the external SQL databases you need, such as Apache Ranger, Ambari, Oozie and Hive metastores, at cluster creation time. The requirement is that all of these resources must be accessible from inside the cluster subnet, either through their own private endpoint or otherwise.
 
-Using private endpoints for Azure Key Vault is not supported. If you're using Azure Key Vault for CMK encryption at rest, the Azure Key Vault endpoint must be accessible from within the HDInsight subnet with no private endpoint.
+When connecting to Azure Data Lake Storage Gen2 over Private Endpoint, make sure the Gen2 storage account has an endpoint set for both ‘blob’ and ‘dfs’. For more information please see https://docs.microsoft.com/en-us/azure/storage/common/storage-private-endpoints#creating-a-private-endpoint
 
 The following diagram shows what a potential HDInsight virtual network architecture could look like when `resourceProviderConnection` is set to outbound:
 


### PR DESCRIPTION
Remove the section stating AKV is not supported as this is no longer true. 
Add a section pointing out that Gen2 PE requires blob and dfs endpoints, point to relevant storage doc