### PR TITLE
Include $ next to variables in CLI sections.

### DIFF
--- a/articles/virtual-machines/disks-enable-ultra-ssd.md
+++ b/articles/virtual-machines/disks-enable-ultra-ssd.md
@@ -29,11 +29,11 @@ To leverage ultra disks, you need to determine which availability zone you are i
 #### CLI
 
 ```azurecli
-subscription="<yourSubID>"
+$subscription="<yourSubID>"
 # example value is southeastasia
-region="<yourLocation>"
+$region="<yourLocation>"
 # example value is Standard_E64s_v3
-vmSize="<yourVMSize>"
+$vmSize="<yourVMSize>"
 
 az vm list-skus --resource-type virtualMachines  --location $region --query "[?name=='$vmSize'].locationInfo[0].zoneDetails[0].Name" --subscription $subscription
 ```


### PR DESCRIPTION
We need to add $ next to the variables in the CLI sections of this document. If a user pastes the variables as they are currently, the CLI won't save the variables. The CLI needs the $ to save the variables. Also, the PowerShell sections in this document already includes $ next to the variables. At minimum, we should include a note to tell users they need to include $ next to the variables so the CLI will save the variables and data.