### PR TITLE
Update miro-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/miro-tutorial.md
+++ b/articles/active-directory/saas-apps/miro-tutorial.md
@@ -15,7 +15,7 @@ ms.author: jeedes
 
 # Tutorial: Integrate Miro with Azure Active Directory
 
-In this tutorial, you'll learn how to integrate Miro with Azure Active Directory (Azure AD). When you integrate Miro with Azure AD, you can:
+In this tutorial, you'll learn how to integrate Miro with Azure Active Directory (Azure AD). Another version of this tutorial can be found at help.miro.com. When you integrate Miro with Azure AD, you can:
 
 * Control in Azure AD who has access to Miro.
 * Enable your users to be automatically signed-in to Miro with their Azure AD accounts.
@@ -70,20 +70,21 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 4. On the **Basic SAML Configuration** section, if you wish to configure the application in **IDP** initiated mode, perform the following step:
 
     In the **Identifier** text box, type the URL:
-    `https://miro.com`
+    `https://miro.com/`
 
-5. Click **Set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
+5. If you wish to configure the application in **SP** initiated mode then in the **Sign-on URL** text box, type the URL:
+    `https://miro.com/sso/login/`:
 
-    In the **Sign-on URL** text box, type the URL:
-    `https://miro.com/sso/saml`
 
-1. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, find **Federation Metadata XML** and select **Download** to download the certificate and save it on your computer.
+1. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, find **Certificate (Base64)** and select **Download** to download the certificate and save it on your computer. You will need it to configure SSO on the Miro side.
 
-   ![The Certificate download link](common/metadataxml.png)
+   ![The Certificate download link](https://user-images.githubusercontent.com/63736609/118323812-a19b0380-b51a-11eb-8600-83822d155c0a.png)
 
-1. On the **Set up Miro** section, copy the appropriate URL(s) based on your requirement.
 
-   ![Copy configuration URLs](common/copy-configuration-urls.png)
+1. On the **Set up Miro** section, copy the the Login URL. You will need it to configure SSO on the Miro side.
+
+   ![Copy Login URL](https://user-images.githubusercontent.com/63736609/118324286-4289be80-b51b-11eb-9a2c-56900dcbf518.png)
+
 
 ### Create an Azure AD test user
 
@@ -109,30 +110,42 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 1. If you are expecting a role to be assigned to the users, you can select it from the **Select a role** dropdown. If no role has been set up for this app, you see "Default Access" role selected.
 1. In the **Add Assignment** dialog, click the **Assign** button.
 
+Alternatively go to the application's **Properties** and toggle off **User assignment required**
+![Disable assignment requirement](https://user-images.githubusercontent.com/63736609/118325063-541f9600-b51c-11eb-941b-2225a46b97da.png)
+
+
 ## Configure Miro SSO
 
-To configure single sign-on on **Miro** side, you need to send the downloaded **Federation Metadata XML** and appropriate copied URLs from Azure portal to Miro support team. They set this setting to have the SAML SSO connection set properly on both sides.
+To configure single sign-on on **Miro** side, use the certificate you previously downloaded and the Login URL you previously copied. 
+In the Miro account settings go to the **Security** section and toggle on **Enable SSO/SAML**. 
+
+1. Paste the Login URL in the **SAML Sign-in URL** field.
+1. Open the certifcate file with a text editor and copy the certificate sequence. Paste the sequence in the **Key x509 Certificate** field.
+![Miro settings](https://user-images.githubusercontent.com/63736609/118325829-7b2a9780-b51d-11eb-94b0-21bc73542323.png)
+1. In the **Domains** field type in your domain address, click **Add** and follow the verification procedure. Repeat for your other domain addresses if you have any. The Miro SSO feature will be working for the end-users which domains are on the list. 
+![Domain](https://user-images.githubusercontent.com/63736609/118326032-cba1f500-b51d-11eb-9645-f76a1e09853e.png)
+1. Decide if you will be using Just in Time provisioning (pulling your users into your subscription during their registration in Miro)
+![Just in Time Provisioning](https://user-images.githubusercontent.com/63736609/118326528-88945180-b51e-11eb-95fd-2b3e3c3122f4.png)
+
+Click **Save** to complete the SSO configuration on the Miro side. 
+
 
 ### Create Miro test user
 
-In this section, a user called B.Simon is created in Miro. Miro supports just-in-time provisioning, which can be enabled as per requirement. There is no action item for you in this section. If a user doesn't already exist in Miro, a new one is created when you attempt to access Miro.
+In this section, a user called B.Simon is created in Miro. Miro supports just-in-time provisioning, which can be enabled as per requirement. 
+If just-in-time provisioning is enabled, a new user is created and added to your Miro subscription when you attempt to access Miro. After that they can access Miro via SSO.
+If just-in-time provisioning is not enabled, you will need to register a test user the standard way and then manually invite them to your subscription before they can access Miro via SSO. Tutorials on how to invite users in Miro can be found at help.miro.com.
 
 ## Test SSO
 
-In this section, you test your Azure AD single sign-on configuration with following options. 
+In this section, you test your Azure AD single sign-on configuration with following options using the test user B.Simon. 
 
 #### SP initiated:
-
-* Click on **Test this application** in Azure portal. This will redirect to Miro Sign on URL where you can initiate the login flow.  
 
 * Go to Miro Sign-on URL directly and initiate the login flow from there.
 
 #### IDP initiated:
 
-* Click on **Test this application** in Azure portal and you should be automatically signed in to the Miro for which you set up the SSO. 
+* Click on **Test this application** in Azure portal and choose to log in as B.Simon. You should be automatically signed in to the Miro subscription for which you set up the SSO. 
 
 You can also use Microsoft My Apps to test the application in any mode. When you click the Miro tile in the My Apps, if configured in SP mode you would be redirected to the application sign on page for initiating the login flow and if configured in IDP mode, you should be automatically signed in to the Miro for which you set up the SSO. For more information about the My Apps, see [Introduction to the My Apps](../user-help/my-apps-portal-end-user-access.md).
-
-## Next steps
-
-Once you configure Miro you can enforce session control, which protects exfiltration and infiltration of your organization’s sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Cloud App Security](/cloud-app-security/proxy-deployment-any-app).


### PR DESCRIPTION
The current instruction is incorrect and confuses users. Miro support receives user issues reports referencing this article. Proposed changes are made by a Miro engineer. Miro tutorial on how to configure Azure can be found at https://help.miro.com/hc/en-us/articles/360022722233-How-to-Configure-Azure-AD-SSO We suggest that this Azure tutorial links to the Miro article directly in the Configure Miro SSO subsection. Our article contains solutions to common issues that customers encounter (for instance Unique User ID-related ones).

The Next Steps section is removed because Miro SSO does not support Single Sign-Out or transference of Azure Session control: if Session control is enabled the user's Azure session might be terminated, but Miro working session will stay active. Miro has the Session Idle Time out feature that limits the active working session to 90 minutes https://help.miro.com/hc/en-us/articles/360017571454-Session-Idle-Timeout and it's independent from the SSO processes.
Please also note that the previous and the current version does not include steps on how to generate the x509 certificate if it's not yet present. This can be very important for the customer's success because Miro **requires** Signed Assertion. This step is described in our article https://help.miro.com/hc/en-us/articles/360022722233-How-to-Configure-Azure-AD-SSO

If you have questions, please create a ticket at https://help.miro.com/hc/en-us/requests/new? and ask for Catherine