### PR TITLE
Mentioning default bitness as 32-bit for App Services created from th…

### DIFF
--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -195,7 +195,7 @@ Here, you can configure some common settings for the app. Some settings require 
     ![General settings for Linux containers](./media/configure-common/open-general-linux.png)
 
 - **Platform settings**: Lets you configure settings for the hosting platform, including:
-    - **Bitness**: 32-bit or 64-bit.
+    - **Bitness**: 32-bit or 64-bit. (Defaults to 32-bit for App Service created from the portal)
     - **WebSocket protocol**: For [ASP.NET SignalR] or [socket.io](https://socket.io/), for example.
     - **Always On**: Keeps the app loaded even when there's no traffic. It's required for continuous WebJobs or for WebJobs that are triggered using a CRON expression.
       > [!NOTE]

--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -195,7 +195,7 @@ Here, you can configure some common settings for the app. Some settings require 
     ![General settings for Linux containers](./media/configure-common/open-general-linux.png)
 
 - **Platform settings**: Lets you configure settings for the hosting platform, including:
-    - **Bitness**: 32-bit or 64-bit. (Defaults to 32-bit for App Service created from the portal)
+    - **Bitness**: 32-bit or 64-bit. (Defaults to 32-bit for App Service created in the portal.)
     - **WebSocket protocol**: For [ASP.NET SignalR] or [socket.io](https://socket.io/), for example.
     - **Always On**: Keeps the app loaded even when there's no traffic. It's required for continuous WebJobs or for WebJobs that are triggered using a CRON expression.
       > [!NOTE]


### PR DESCRIPTION
The documentation should mention the default bitness as 32-bit for App Services created from the portal. This can be added to the 'bitness' field under Platform Settings (https://docs.microsoft.com/en-us/azure/app-service/configure-common#configure-general-settings)