### PR TITLE
Correct Azure CDN from Verizon description (it does not support brotli)

### DIFF
--- a/articles/cdn/cdn-improve-performance.md
+++ b/articles/cdn/cdn-improve-performance.md
@@ -117,11 +117,8 @@ These profiles support the following compression encodings:
 - gzip (GNU zip)
 - DEFLATE
 - bzip2
-- brotli 
 
-If the request supports more than one compression type, those compression types take precedence over brotli compression.
-
-When a request for an asset specifies brotli compression (HTTP header is `Accept-Encoding: br`) and the request results in a cache miss, Azure CDN performs brotli compression of the asset directly on the POP server. Afterward, the compressed file is served from the cache.
+Azure CDN from Verizon does not support brotli compression. When the HTTP request has the header `Accept-Encoding: br` the CDN responds with an uncompressed response.
 
 ### Azure CDN Standard from Akamai profiles
 

--- a/articles/cdn/cdn-improve-performance.md
+++ b/articles/cdn/cdn-improve-performance.md
@@ -118,7 +118,7 @@ These profiles support the following compression encodings:
 - DEFLATE
 - bzip2
 
-Azure CDN from Verizon does not support brotli compression. When the HTTP request has the header `Accept-Encoding: br` the CDN responds with an uncompressed response.
+Azure CDN from Verizon does not support brotli compression. When the HTTP request has the header `Accept-Encoding: br`, the CDN responds with an uncompressed response.
 
 ### Azure CDN Standard from Akamai profiles
 


### PR DESCRIPTION
See issue https://github.com/MicrosoftDocs/azure-docs/issues/52449

The Azure CDN from Verizon does not support brotli. This has been true for more than a year. It does not do compression itself, and even if the origin can produce brotli responses, the Azure CDN from Verizon will not cache these, but will respond with an uncompressed response when the request specifies Accept-Encoding: br.