### PR TITLE
Typo "Azure repo"→"Azure Repos"

### DIFF
--- a/articles/azure-resource-manager/templates/deploy-to-azure-button.md
+++ b/articles/azure-resource-manager/templates/deploy-to-azure-button.md
@@ -99,7 +99,7 @@ For HTML, use:
 </a>
 ```
 
-For Git with Azure repo, the button is in the format:
+For Git with Azure Repos, the button is in the format:
 
 ```markdown
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fdev.azure.com%2Forgname%2Fprojectname%2F_apis%2Fgit%2Frepositories%2Freponame%2Fitems%3FscopePath%3D%2freponame%2fazuredeploy.json%26api-version%3D6.0)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-to-azure-button
#PingMSFTDocs