### PR TITLE
Update fhir-paas-cli-quickstart.md

### DIFF
--- a/articles/healthcare-apis/fhir/fhir-paas-cli-quickstart.md
+++ b/articles/healthcare-apis/fhir/fhir-paas-cli-quickstart.md
@@ -42,7 +42,7 @@ az group create --name "myResourceGroup" --location westus2
 ## Deploy the Azure API for FHIR
 
 ```azurecli-interactive
-az healthcareapis create --resource-group myResourceGroup --name nameoffhiraccount --kind fhir-r4 --location westus2 
+az healthcareapis service create --resource-group myResourceGroup --name nameoffhiraccount --kind fhir-r4 --location westus2 --identity-type SystemAssigned
 ```
 
 ## Fetch FHIR API capability statement


### PR DESCRIPTION
Based on documentation from https://docs.microsoft.com/en-us/cli/azure/healthcareapis/service?view=azure-cli-latest#az_healthcareapis_service_create.
Identity-type seems to be required even though not stated as a required parameter in the docs.