### PR TITLE
Update integrate-with-nat-gateway.md

### DIFF
--- a/articles/firewall/integrate-with-nat-gateway.md
+++ b/articles/firewall/integrate-with-nat-gateway.md
@@ -11,7 +11,7 @@ ms.author: jocorte
 
 # Scale SNAT ports with Azure NAT Gateway
 
-Azure Firewall provides 2048 SNAT ports per public IP address configured, and you can associate up to [250 public IP addresses](./deploy-multi-public-ip-powershell.md). Depending on your architecture and traffic patterns, you might need more than the 512,000 available SNAT ports with this configuration. For example, when you use it to protect large [Windows Virtual Desktop deployments](./protect-windows-virtual-desktop.md) that integrate with Microsoft 365 Apps.
+Azure Firewall provides 1024 SNAT ports per public IP address configured, and you can associate up to [250 public IP addresses](./deploy-multi-public-ip-powershell.md). Depending on your architecture and traffic patterns, you might need more than the 512,000 available SNAT ports with this configuration. For example, when you use it to protect large [Windows Virtual Desktop deployments](./protect-windows-virtual-desktop.md) that integrate with Microsoft 365 Apps.
 
 Another challenge with using a large number of public IP addresses is when there are downstream IP address filtering requirements. Azure Firewall randomly selects the source public IP address to use for a connection, so you need to allow all public IP addresses associated with it. Even if you use [Public IP address prefixes](../virtual-network/public-ip-address-prefix.md) and you need to associate 250 public IP addresses to meet your outbound SNAT port requirements, you still need to create and allow 16 public IP address prefixes.
 


### PR DESCRIPTION
would it make sense to change 2048 to 1024 as described here: https://docs.microsoft.com/en-us/azure/firewall/overview#known-issues or explain why it's 2048 instead of 1024 ("By default, there are two VMSS instances.")

> Azure Firewall currently supports 1024 ports per Public IP address per backend virtual machine scale set instance. By default, there are two VMSS instances