### PR TITLE
Change Github action example to always log out

### DIFF
--- a/articles/storage/blobs/storage-blobs-static-site-github-actions.md
+++ b/articles/storage/blobs/storage-blobs-static-site-github-actions.md
@@ -167,7 +167,7 @@ In the example above, replace the placeholders with your subscription ID and res
         - name: logout
           run: |
                 az logout
-          if: ${{ always() }}
+          if: always()
     ```
 
 ## Review your deployment

--- a/articles/storage/blobs/storage-blobs-static-site-github-actions.md
+++ b/articles/storage/blobs/storage-blobs-static-site-github-actions.md
@@ -167,6 +167,7 @@ In the example above, replace the placeholders with your subscription ID and res
         - name: logout
           run: |
                 az logout
+          if: ${{ always() }}
     ```
 
 ## Review your deployment


### PR DESCRIPTION
If logging out is a necessary step, then it follows that we should always log out regardless of whether the previous steps were successful or not.