### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#75381

### DIFF
--- a/articles/cognitive-services/Bing-Entities-Search/quickstarts/ruby.md
+++ b/articles/cognitive-services/Bing-Entities-Search/quickstarts/ruby.md
@@ -43,8 +43,8 @@ Although this application is written in Ruby, the API is a RESTful Web service c
 2. Create variables for your API endpoint, News search URL, your subscription key, and search query. You can use the global endpoint in the following code, or use the [custom subdomain](../../../cognitive-services/cognitive-services-custom-subdomains.md) endpoint displayed in the Azure portal for your resource.
     
     ```ruby
-    host = 'https://api.cognitive.microsoft.com'
-    path = '/bing/v7.0/entities'
+    host = 'https://api.bing.microsoft.com'
+    path = '/v7.0/search'
     
     mkt = 'en-US'
     query = 'italian restaurants near me'


### PR DESCRIPTION
Update the url for Ruby sample since bing moved to microsoft brand