### PR TITLE
Update storage-files-quick-create-use-windows.md to reflect changes to Azure Portal UI and options

### DIFF
--- a/articles/storage/files/storage-files-quick-create-use-windows.md
+++ b/articles/storage/files/storage-files-quick-create-use-windows.md
@@ -59,12 +59,13 @@ So far, you've created an Azure storage account and a file share with one file i
 ### Deploy a VM
 
 1. Next, expand the menu on the left side of the portal and choose **Create a resource** in the upper left-hand corner of the Azure portal.
-1. In the search box above the list of **Azure Marketplace** resources, search for and select **Windows Server 2016 Datacenter**.
+1. In the search box above the list of **Azure Marketplace** resources, search for and select **Windows Server 2019 Datacenter**.
 1. In the **Basics** tab, under **Project details**, select the resource group you created for this quickstart.
 
    ![Enter basic information about your VM in the portal blade.](./media/storage-files-quick-create-use-windows/vm-resource-group-and-subscription.png)
 
 1. Under **Instance details**, name the VM *qsVM*.
+1. In the **Image** drop-down, select **Windows Server 2016 Datacenter - Gen1**.
 1. Leave the default settings for **Region**, **Availability options**, **Image**, and **Size**.
 1. Under **Administrator account**, add a **Username** and enter a **Password** for the VM.
 1. Under **Inbound port rules**, choose **Allow selected ports** and then select **RDP (3389)** and **HTTP** from the drop-down.


### PR DESCRIPTION
This is my first proposed change, so please bear with me if I've done something wrong. It's equally possible that the change I've suggested doesn't appear for everyone. That said, when I walked through the quickstart, I was not presented with the Windows Server 2016 Datacenter option. Instead, I had to select the Windows Server 2019 Datacenter option, and then select the "Windows Server 2016 Datacenter - Gen1" option from the "Image" drop-down. I made the update by making as few changes as possible, so the order of the fields is not accurate. If the field order should be maintained, it'll involve making another change. Thanks for you consideration!