### PR TITLE
Fix model registration AZ CLI command

### DIFF
--- a/articles/machine-learning/how-to-deploy-and-where.md
+++ b/articles/machine-learning/how-to-deploy-and-where.md
@@ -103,7 +103,7 @@ For more information on `az ml model register`, consult the [reference documenta
 ### Register a model from an Azure ML training run
 
 ```azurecli-interactive
-az ml model register -bidaf_onnx  --asset-path outputs/model.onnx  --experiment-name myexperiment --run-id myrunid --tag area=qna
+az ml model register -n bidaf_onnx --asset-path outputs/model.onnx --experiment-name myexperiment --run-id myrunid --tag area=qna
 ```
 
 [!INCLUDE [install extension](../../includes/machine-learning-service-install-extension.md)]


### PR DESCRIPTION
The AZ CLI command did not correctly pass the name of the model with the `-n` command line flag. This PR fixes it, and removes some unnecessary whitespaces.

For reference on the `az ml model register` command, please see https://docs.microsoft.com/en-us/cli/azure/ml/model?view=azure-cli-latest#az_ml_model_register.