### PR TITLE
Wrong operator it must be 'Not equals'

### DIFF
--- a/articles/active-directory/conditional-access/concept-condition-filters-for-devices.md
+++ b/articles/active-directory/conditional-access/concept-condition-filters-for-devices.md
@@ -83,7 +83,7 @@ Policy 2: All users with the directory role of Global administrator, accessing t
 1. Under **Conditions**, **Filters for devices (Preview)**.
    1. Toggle **Configure** to **Yes**.
    1. Set **Devices matching the rule** to **Exclude filtered devices from policy**.
-   1. Set the property to `ExtensionAttribute1`, the operator to `Equals` and the value to `SAW`.
+   1. Set the property to `ExtensionAttribute1`, the operator to `Not equals` and the value to `SAW`.
    1. Select **Done**.
 1. Under **Access controls** > **Grant**, select **Block access**, then select **Select**.
 1. Confirm your settings and set **Enable policy** to **On**.


### PR DESCRIPTION
The policy 2 description explains it correct to set it to "Not Equals", but the step-by-step instruction listed it as "Equals". The operator should be Not Equal otherwise the idea is not accomplished.