### PR TITLE
removed a problematic setting till the regression is addressed

### DIFF
--- a/articles/active-directory/develop/developer-guide-conditional-access-authentication-context.md
+++ b/articles/active-directory/develop/developer-guide-conditional-access-authentication-context.md
@@ -84,23 +84,7 @@ These steps are the changes that you need to carry in your code base. The steps 
 
 Third: Your application, and for this example, we’d assume it’s a web API, then needs to evaluate calls against the saved mapping and accordingly raise claim challenges for its client apps. To prepare for this action, the following steps are to be taken:
 
-1. Request the Authentication Context Class Reference (acrs) as an optional claim in its [Access token](access-tokens.md) by requesting it in the [Web APIs app manifest](reference-app-manifest.md).
 
-   ```json
-   "optionalClaims": 
-   {
-     "accessToken": [
-       {
-         "additionalProperties": [],
-         "essential": false,
-         "name": "acrs",
-         "source": null
-       }
-     ],
-     "idToken": [],
-     "saml2Token": []
-   }
-   ```
 
 1. In a sensitive and protected by auth context operation, evaluate the values in the acrs claim against the auth context ID mapping saved earlier and raise a claims challenge as provided in the code snippet below. 
 1. The following diagram shows the interaction between the user, client app, and the web API.


### PR DESCRIPTION
1. Request the Authentication Context Class Reference (acrs) as an optional claim in its [Access token](access-tokens.md) by requesting it in the [Web APIs app manifest](reference-app-manifest.md).

   ```json
   "optionalClaims": 
   {
     "accessToken": [
       {
         "additionalProperties": [],
         "essential": false,
         "name": "acrs",
         "source": null
       }
     ],
     "idToken": [],
     "saml2Token": []
   }
   ```