### PR TITLE
Change use parameters to the environment language independent parameters

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -240,20 +240,20 @@ Make sure the following settings are configured correctly for remote access:
 
    ```powershell
    Enable-PSRemoting -Force
-   Set-NetFirewallRule -DisplayName 'Windows Remote Management (HTTP-In)' -Enabled True
+   Set-NetFirewallRule -Name WINRM-HTTP-In-TCP, WINRM-HTTP-In-TCP-PUBLIC -Enabled True
    ```
 
 1. Enable the following firewall rules to allow the RDP traffic:
 
    ```powershell
-   Set-NetFirewallRule -DisplayGroup 'Remote Desktop' -Enabled True
+   Set-NetFirewallRule -Group '@FirewallAPI.dll,-28752' -Enabled True
    ```
 
 1. Enable the rule for file and printer sharing so the VM can respond to ping requests inside the
    virtual network:
 
    ```powershell
-   Set-NetFirewallRule -DisplayName 'File and Printer Sharing (Echo Request - ICMPv4-In)' -Enabled True
+   Set-NetFirewallRule -Name FPS-ICMP4-ERQ-In -Enabled True
    ```
 
 1. Create a rule for the Azure platform network:


### PR DESCRIPTION
Use `Name` and `Group` parameters in `Set-NetFirewallRule` cmdlet is better than use `DisplayName` and `DisplayGroup` parameters because `DisplayName` and `DisplayGroup` parameters are depends on the environment/OS language. `Name` and `Group` parameter values are environment independent.

In English environment:
![image](https://user-images.githubusercontent.com/1618784/118921866-e76d2700-b973-11eb-9dad-847580dc3eaf.png)

In Japanese environment:
![image](https://user-images.githubusercontent.com/1618784/118922327-cc4ee700-b974-11eb-9dd3-0df4c202514c.png)
