### PR TITLE
Add netstat.exe command example

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -334,11 +334,24 @@ Make sure the VM is healthy, secure, and RDP accessible:
 
    If the repository is corrupted, see [WMI: Repository corruption or not](https://techcommunity.microsoft.com/t5/ask-the-performance-team/wmi-repository-corruption-or-not/ba-p/375484).
 
-1. Make sure no other application is using port 3389. This port is used for the RDP service in
+1. Make sure no other applications than TermService are using port 3389. This port is used for the RDP service in
    Azure. To see which ports are used on the VM, run `netstat.exe -anob`:
 
    ```powershell
    netstat.exe -anob
+   ```
+   
+   The following is an example.
+
+   ```powershell
+   netstat.exe -anob | findstr 3389
+   TCP    0.0.0.0:3389           0.0.0.0:0              LISTENING       4056
+   TCP    [::]:3389              [::]:0                 LISTENING       4056
+   UDP    0.0.0.0:3389           *:*                                    4056
+   UDP    [::]:3389              *:*                                    4056
+
+   tasklist /svc | findstr 4056
+   svchost.exe                   4056 TermService
    ```
 
 1. To upload a Windows VHD that's a domain controller:


### PR DESCRIPTION
Added a verification example for the applications that using port 3389. Because some customers don't know that how to check **the other applications**.