### PR TITLE
Remove "supported dotnet runtime table"

### DIFF
--- a/articles/service-fabric/service-fabric-versions.md
+++ b/articles/service-fabric/service-fabric-versions.md
@@ -71,15 +71,6 @@ Support for Service Fabric on a specific OS ends when support for the OS version
 | Ubuntu 18.04 | April 2028 | <a href="https://wiki.ubuntu.com/Releases">Ubuntu lifecycle</a>|
 | Ubuntu 16.04 | April 2024 | <a href="https://wiki.ubuntu.com/Releases">Ubuntu lifecycle</a>|
 
-## Supported .NET runtimes
-
-The following table lists the .NET runtimes supported by Service Fabric:
-
-| Service Fabric runtime | Supported .NET runtimes for Windows |Supported .NET runtimes for Linux |
-| --- | --- | --- |
-| 8.0 CU1 | .NET 5.0, >= .NET Core 2.1, All >= .NET Framework 4.5 | >= .NET Core 2.1|
-| 8.0 RTO | .NET 5.0, >= .NET Core 2.1, All >= .NET Framework 4.5 | >= .NET Core 2.1|
-
 ## Service Fabric version name and number reference
 The following table lists the version names of Service Fabric and their corresponding version numbers.
 


### PR DESCRIPTION
Supported dotnet runtime information was added in "Service Fabric supported versions" table in a separate commit.