### PR TITLE
SSO example URL added.

### DIFF
--- a/articles/active-directory/saas-apps/cisco-anyconnect.md
+++ b/articles/active-directory/saas-apps/cisco-anyconnect.md
@@ -68,16 +68,16 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
    ![Edit Basic SAML Configuration](common/edit-urls.png)
 
-1. On the **Set up single sign-on with SAML** page, enter the values for the following fields:
+1. On the **Set up single sign-on with SAML** page, enter the values for the following fields, please note case sensitivity:
 
     a. In the **Identifier** text box, type a URL using the following pattern:
-    `< YOUR CISCO ANYCONNECT VPN VALUE >`
+    `https://*.YourCiscoServer.com/saml/sp/metadata/TGTGroup`
 
     b. In the **Reply URL** text box, type a URL using the following pattern:
-    `< YOUR CISCO ANYCONNECT VPN VALUE >`
+    `https://YOUR_CISCO_ANYCONNECT_FQDN/+CSCOE+/saml/sp/acs?tgname=TGTGroup`
 
     > [!NOTE]
-	> These values are not real. Update these values with the actual Identifier and Reply URL. Contact [Cisco AnyConnect Client support team](https://www.cisco.com/c/en/us/support/index.html) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+	> For clarification on these values contact Cisco TAC support. Update these values with the actual Identifier and Reply URL provided by Cisco TAC. Contact [Cisco AnyConnect Client support team](https://www.cisco.com/c/en/us/support/index.html) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Certificate (Base64)** and select **Download** to download the certificate file and save it on your computer.
 

--- a/articles/active-directory/saas-apps/cisco-anyconnect.md
+++ b/articles/active-directory/saas-apps/cisco-anyconnect.md
@@ -68,16 +68,16 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
    ![Edit Basic SAML Configuration](common/edit-urls.png)
 
-1. On the **Set up single sign-on with SAML** page, enter the values for the following fields, please note case sensitivity:
+1. On the **Set up single sign-on with SAML** page, enter the values for the following fields (note that the values are case-sensitive):
 
-    a. In the **Identifier** text box, type a URL using the following pattern:
-    `https://*.YourCiscoServer.com/saml/sp/metadata/TGTGroup`
+   1. In the **Identifier** text box, type a URL using the following pattern:  
+      `https://*.YourCiscoServer.com/saml/sp/metadata/TGTGroup`
 
-    b. In the **Reply URL** text box, type a URL using the following pattern:
-    `https://YOUR_CISCO_ANYCONNECT_FQDN/+CSCOE+/saml/sp/acs?tgname=TGTGroup`
+   1. In the **Reply URL** text box, type a URL using the following pattern:  
+      `https://YOUR_CISCO_ANYCONNECT_FQDN/+CSCOE+/saml/sp/acs?tgname=TGTGroup`
 
     > [!NOTE]
-	> For clarification on these values contact Cisco TAC support. Update these values with the actual Identifier and Reply URL provided by Cisco TAC. Contact [Cisco AnyConnect Client support team](https://www.cisco.com/c/en/us/support/index.html) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+    > For clarification about these values, contact Cisco TAC support. Update these values with the actual Identifier and Reply URL provided by Cisco TAC. Contact the [Cisco AnyConnect Client support team](https://www.cisco.com/c/en/us/support/index.html) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Certificate (Base64)** and select **Download** to download the certificate file and save it on your computer.
 
@@ -178,6 +178,6 @@ In this section, you test your Azure AD single sign-on configuration with follow
 * Click on Test this application in Azure portal and you should be automatically signed in to the Cisco AnyConnect for which you set up the SSO
 * You can use Microsoft Access Panel. When you click the Cisco AnyConnect tile in the Access Panel, you should be automatically signed in to the Cisco AnyConnect for which you set up the SSO. For more information about the Access Panel, see [Introduction to the Access Panel](../user-help/my-apps-portal-end-user-access.md).
 
-## Next Steps
+## Next steps
 
 Once you configure Cisco AnyConnect you can enforce session control, which protects exfiltration and infiltration of your organization’s sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Cloud App Security](/cloud-app-security/proxy-deployment-any-app).


### PR DESCRIPTION
Examples were added to section 4 on the Azure AD SSO Section.

This is a fix for the following issue.

Issue #75625 



Issue description below. 
-----------------------------

In the following link, you will find the "Configure Azure AD SSO" Which is used for configuring Cisco AnyConnect with Azure AD for MFA/SSO

https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/cisco-anyconnect#configure-azure-ad-sso

In step 4 these could be more concise. When you are configuring this on the Azure UI they give you some example URL that you should be using.

![image](https://user-images.githubusercontent.com/38886930/118990349-69dff180-b948-11eb-974d-d033a012d40a.png)

The example should be given due to the examples on the Azure UI side, the examples are not clear and can lead to some errors as well.


### Example 1 
This one is good and straight to the point, a good example of how we can configure the Identifier (Entity ID)

![image](https://user-images.githubusercontent.com/38886930/118990719-bf1c0300-b948-11eb-8893-c5d140cb7c93.png)

### Example 2 

In this example we show the following URL which is not complete, the URL is missing `?tgname=` followed by the `TGTGroup` name the was used in the **Identifier** URL shown above,  this URL is also case sensitive on the Cisco side, so using the following URL with `https://YOUR_CISCO_ANYCONNECT_FQDN/+CSCOE+/SAML/SP/ACS?tgname=TGTGroup` will result in a `file not found` error when trying to connect to over the VPN via AnyConnect.

![image](https://user-images.githubusercontent.com/38886930/118990185-474dd880-b948-11eb-87b1-f07bb38f8997.png)


All together this example should be `https://YOUR_CISCO_ANYCONNECT_FQDN/+CSCOE+/saml/sp/acs?tgname=TGTGroup`, we can leave the `+CSCOE+` in because Cisco is expecting this on the AnyConnect side.
