### PR TITLE
Update reference-connect-sync-attributes-synchronized.md

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-sync-attributes-synchronized.md
+++ b/articles/active-directory/hybrid/reference-connect-sync-attributes-synchronized.md
@@ -50,7 +50,6 @@ In this case, start with the list of attributes in this topic and identify those
 | Attribute Name | User | Contact | Group | Comment |
 | --- |:---:|:---:|:---:| --- |
 | accountEnabled |X | | |Defines if an account is enabled. |
-| assistant |X |X | | |
 | altRecipient |X | | |Requires Azure AD Connect build 1.1.552.0 or after. |
 | authOrig |X |X |X | |
 | c |X |X | | |


### PR DESCRIPTION
Although the 'assistant' attribute is synced from on-prem AD to Azure AD by AADConnect (no idea why!), I was able to confirm with my EEE peers in Exchange Online that 'assistant' attribute is not synced to Exchange Online. So I'm updating this page to exclude 'assistant' attribute from the attributes synced to Exchange Online.