### PR TITLE
Added a Step to Change Key permissions before SSH

### DIFF
--- a/articles/virtual-machines/linux/quick-create-portal.md
+++ b/articles/virtual-machines/linux/quick-create-portal.md
@@ -67,7 +67,13 @@ Create an SSH connection with the VM.
 
 1. If you are on a Mac or Linux machine, open a Bash prompt. If you are on a Windows machine, open a PowerShell prompt. 
 
-1. At your prompt, open an SSH connection to your virtual machine. Replace the IP address with the one from your VM, and replace the path to the `.pem` with the path to where the key file was downloaded.
+1. Ensure you have read-only access to the private key.
+
+```console
+chmod 400 myKey1.pem
+```
+
+3. At your prompt, open an SSH connection to your virtual machine. Replace the IP address with the one from your VM, and replace the path to the `.pem` with the path to where the key file was downloaded.
 
 ```console
 ssh -i .\Downloads\myKey1.pem azureuser@10.111.12.123


### PR DESCRIPTION
Common error "It's required that your private keys are not accessible by others" and also, "Permission Denied (Public Key)" when trying to ssh the VM. As stated in the Azure portal, we should check the permissions through chmod first. Added instructions and code to do so before the ssh step.