### PR TITLE
Fixed link

### DIFF
--- a/articles/security-center/defender-for-container-registries-introduction.md
+++ b/articles/security-center/defender-for-container-registries-introduction.md
@@ -24,7 +24,7 @@ Security Center identifies Azure Resource Manager based ACR registries in your s
 
 **Azure Defender for container registries** includes a vulnerability scanner to scan the images in your Azure Resource Manager-based Azure Container Registry registries and provide deeper visibility into your images'  vulnerabilities. The integrated scanner is powered by Qualys, the industry-leading vulnerability scanning vendor.
 
-When issues are found – by Qualys or Security Center – you'll get notified in the Security Center dashboard. For every vulnerability, Security Center provides actionable recommendations, along with a severity classification, and guidance for how to remediate the issue. For details of Security Center's recommendations for containers, see the [reference list of recommendations](recommendations-reference.md#recs-compute).
+When issues are found – by Qualys or Security Center – you'll get notified in the Security Center dashboard. For every vulnerability, Security Center provides actionable recommendations, along with a severity classification, and guidance for how to remediate the issue. For details of Security Center's recommendations for containers, see the [reference list of recommendations](recommendations-reference.md#recs-container).
 
 Security Center filters and classifies findings from the scanner. When an image is healthy, Security Center marks it as such. Security Center generates security recommendations only for images that have issues to be resolved. Security Center provides details of each reported vulnerability and a severity classification. Additionally, it gives guidance for how to remediate the specific vulnerabilities found on each image.
 


### PR DESCRIPTION
Fixed anchor link that led to https://docs.microsoft.com/en-us/azure/security-center/recommendations-reference#compute-recommendations instead of https://docs.microsoft.com/en-us/azure/security-center/recommendations-reference#container-recommendations.