### PR TITLE
Javascript and Typescrypt samples links 404

### DIFF
--- a/articles/service-bus-messaging/service-bus-nodejs-how-to-use-queues.md
+++ b/articles/service-bus-messaging/service-bus-nodejs-how-to-use-queues.md
@@ -203,6 +203,6 @@ Select the queue on this **Overview** page to navigate to the **Service Bus Queu
 See the following documentation and samples: 
 
 - [Azure Service Bus client library for JavaScript](https://www.npmjs.com/package/@azure/service-bus)
-- [JavaScript samples](/samples/azure/azure-sdk-for-js/service-bus-javascript/)
-- [TypeScript samples](/samples/azure/azure-sdk-for-js/service-bus-typescript/)
+- [JavaScript samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples/v7/javascript)
+- [TypeScript samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples/v7/typescript)
 - [API reference documentation](/javascript/api/overview/azure/service-bus)


### PR DESCRIPTION
Hi Service Bus team
The two links Javascript Sample and Typescript samples (at the bottom of the page) are pointing to pages that doesn't exist anymore. I recommend to redirect the user to the latest samples in the github repository.
Thanks
Francesco De Liva