### PR TITLE
Update how-to-clean-up-ssisdb-logs-with-elastic-jobs.md

### DIFF
--- a/articles/data-factory/how-to-clean-up-ssisdb-logs-with-elastic-jobs.md
+++ b/articles/data-factory/how-to-clean-up-ssisdb-logs-with-elastic-jobs.md
@@ -137,7 +137,7 @@ $SqlText = "EXEC internal.cleanup_server_retention_window_exclusive"
 $Job | Add-AzureRmSqlElasticJobStep -Name "step to execute cleanup stored procedure" -TargetGroupName $SSISDBTargetGroup.TargetGroupName -CredentialName $JobCred.CredentialName -CommandText $SqlText
 
 # Run the job to immediately start cleanup stored procedure execution for once
-IF(($RunJobOrNot = "Y") -Or ($RunJobOrNot = "y"))
+IF(($RunJobOrNot -eq "Y") -Or ($RunJobOrNot -eq "y"))
 {
 Write-Output "Start a new execution of the stored procedure for SSISDB log cleanup immediately..."
 $JobExecution = $Job | Start-AzureRmSqlElasticJob

--- a/articles/data-factory/how-to-clean-up-ssisdb-logs-with-elastic-jobs.md
+++ b/articles/data-factory/how-to-clean-up-ssisdb-logs-with-elastic-jobs.md
@@ -50,7 +50,7 @@ $SSISDBServerAdminPassword = $(Read-Host "Please enter the target server admin p
 $SSISDBName = "SSISDB",
 
 # Parameters needed to set job scheduling to trigger execution of cleanup stored procedure
-$RunJobOrNot = $(Read-Host "Please indicate whether you want to run the job to cleanup SSISDB logs outside the log retention window immediately(Y/N). Make sure the retention window is set appropriately before running the following powershell scripts. Those removed SSISDB logs cannot be recoverd"),
+$RunJobOrNot = $(Read-Host "Please indicate whether you want to run the job to cleanup SSISDB logs outside the log retention window immediately(Y/N). Make sure the retention window is set appropriately before running the following powershell scripts. Those removed SSISDB logs cannot be recovered"),
 $IntervalType = $(Read-Host "Please enter the interval type for the execution schedule of SSISDB log cleanup stored procedure. For the interval type, Year, Month, Day, Hour, Minute, Second can be supported."),
 $IntervalCount = $(Read-Host "Please enter the detailed interval value in the given interval type for the execution schedule of SSISDB log cleanup stored procedure"),
 # StartTime of the execution schedule is set as the current time as default. 
@@ -112,7 +112,7 @@ $TargetDatabase = $SSISDBName
 $CreateJobUser = "CREATE USER SSISDBLogCleanupUser FROM LOGIN SSISDBLogCleanupUser"
 $GrantStoredProcedureExecution = "GRANT EXECUTE ON internal.cleanup_server_retention_window_exclusive TO SSISDBLogCleanupUser"
 
-$TargetDatabase | % {
+$TargetDatabase | ForEach-Object -Process {
   $Params.Database = $_
   $Params.Query = $CreateJobUser
   Invoke-SqlCmd @Params
@@ -137,7 +137,7 @@ $SqlText = "EXEC internal.cleanup_server_retention_window_exclusive"
 $Job | Add-AzureRmSqlElasticJobStep -Name "step to execute cleanup stored procedure" -TargetGroupName $SSISDBTargetGroup.TargetGroupName -CredentialName $JobCred.CredentialName -CommandText $SqlText
 
 # Run the job to immediately start cleanup stored procedure execution for once
-IF(($RunJobOrNot -eq "Y") -Or ($RunJobOrNot -eq "y"))
+if ($RunJobOrNot -eq 'Y')
 {
 Write-Output "Start a new execution of the stored procedure for SSISDB log cleanup immediately..."
 $JobExecution = $Job | Start-AzureRmSqlElasticJob


### PR DESCRIPTION
Fixed PowerShell script where the code starting with comment ` Run the job to immediately start cleanup stored procedure execution for once` would run, regardless of whether `$RunJobOrNot` was set to "N"