### PR TITLE
updating interactive command

### DIFF
--- a/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
+++ b/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
@@ -144,7 +144,7 @@ Helm release deployment succeeded
 Run the following command:  
 
 ```azurecli-interactive
-az connectedk8s list -resource-group AzureArcTest -output table
+az connectedk8s list --resource-group AzureArcTest --output table
 ```
 
 Output:


### PR DESCRIPTION
Current command results in error

```
$ az connectedk8s list -resource-group AzureArcTest -output table
az connectedk8s list: 'utput' is not a valid value for '--output'. Allowed values: json, jsonc, yaml, yamlc, table, tsv, none.

```

