### PR TITLE
add ports for Table service to sample Azurite Docker commands

### DIFF
--- a/articles/storage/common/storage-use-azurite.md
+++ b/articles/storage/common/storage-use-azurite.md
@@ -124,7 +124,7 @@ docker pull mcr.microsoft.com/azure-storage/azurite
 The following command runs the Azurite Docker image. The `-p 10000:10000` parameter redirects requests from host machine's port 10000 to the Docker instance.
 
 ```console
-docker run -p 10000:10000 -p 10001:10001 \
+docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 \
     mcr.microsoft.com/azure-storage/azurite
 ```
 
@@ -133,7 +133,7 @@ docker run -p 10000:10000 -p 10001:10001 \
 In the following example, the `-v c:/azurite:/data` parameter specifies *c:/azurite* as the Azurite persisted data location. The directory, *c:/azurite*, must be created before running the Docker command.
 
 ```console
-docker run -p 10000:10000 -p 10001:10001 - p 10002:10002 \
+docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 \
     -v c:/azurite:/data mcr.microsoft.com/azure-storage/azurite
 ```
 


### PR DESCRIPTION
The current sample commands don't set the ports for the Table service, so it is inaccessible.