### PR TITLE
Fixed incorrect URL of incoming claim type

### DIFF
--- a/articles/active-directory/saas-apps/sharepoint-on-premises-tutorial.md
+++ b/articles/active-directory/saas-apps/sharepoint-on-premises-tutorial.md
@@ -102,7 +102,7 @@ $realm = "urn:sharepoint:federation"
 $loginUrl = "https://login.microsoftonline.com/dc38a67a-f981-4e24-ba16-4443ada44484/wsfed"
 
 # Define the claim types used for the authorization
-$userIdentifier = New-SPClaimTypeMapping -IncomingClaimType `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` -IncomingClaimTypeDisplayName "name" -LocalClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
+$userIdentifier = New-SPClaimTypeMapping -IncomingClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" -IncomingClaimTypeDisplayName "name" -LocalClaimType "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"
 $role = New-SPClaimTypeMapping "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" -IncomingClaimTypeDisplayName "Role" -SameAsIncoming
 
 # Let SharePoint trust the Azure AD signing certificate


### PR DESCRIPTION
The incoming claim type was provided using \` instead of regular quotation marks. This caused an issue in SharePoint, because the claim type was not just `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` but `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name -IncomingClaimTypeDisplayName` instead. Using quotation marks fixes the issue.