### PR TITLE
Rewrite Rule for X-Forwarded-Proto

### DIFF
--- a/articles/spring-cloud/expose-apps-gateway-azure-firewall.md
+++ b/articles/spring-cloud/expose-apps-gateway-azure-firewall.md
@@ -104,7 +104,7 @@ az network application-gateway rewrite-rule create \
     --resource-group ${RESOURCE_GROUP} \
     --rule-set-name ${APPLICATION_GATEWAY_REWRITE_SET_NAME} \
     --name ${APPLICATION_GATEWAY_REWRITE_RULE_NAME} \
-    --request-headers X-Forwarded-Proto=""
+    --request-headers X-Forwarded-Proto="https"
 az network application-gateway rule update \
     --gateway-name ${APPLICATION_GATEWAY_NAME} \
     --resource-group ${RESOURCE_GROUP} \


### PR DESCRIPTION
I guess there is a small error in the rewrite rule documentation example, it should be 'X-Forwarded-Proto="https"' or am I wrong?

Because the original proto is http and it should be set to https as the downstream service of the azure spring cloud service requires a https connection.