### PR TITLE
Remove outdated statement about IoT Plug and Play

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-quotas-throttling.md
+++ b/articles/iot-hub/iot-hub-devguide-quotas-throttling.md
@@ -23,10 +23,6 @@ Each IoT hub is provisioned with a certain number of units in a specific tier. T
 
 The tier also determines the throttling limits that IoT Hub enforces on all operations.
 
-## IoT Plug and Play
-
-IoT Plug and Play devices send at least one telemetry message for each interface, including the root, which may increase the number of messages counted towards your message quota.
-
 ## Operation throttles
 
 Operation throttles are rate limitations that are applied in minute ranges and are intended to prevent abuse. They're also subject to [traffic shaping](#traffic-shaping).


### PR DESCRIPTION
The statement was only true in the 2019 preview of IoT Plug and Play. Since GA in 2020 the described behavior no longer applies and should be removed.