### PR TITLE
Note about deviceOwnership as 'Company' incorrect

### DIFF
--- a/articles/active-directory/enterprise-users/groups-dynamic-membership.md
+++ b/articles/active-directory/enterprise-users/groups-dynamic-membership.md
@@ -395,9 +395,6 @@ The following device attributes can be used.
  devicePhysicalIds | any string value used by Autopilot, such as all Autopilot devices, OrderID, or PurchaseOrderID  | (device.devicePhysicalIDs -any _ -contains "[ZTDId]") (device.devicePhysicalIds -any _ -eq "[OrderID]:179887111881") (device.devicePhysicalIds -any _ -eq "[PurchaseOrderId]:76222342342")
  systemLabels | any string matching the Intune device property for tagging Modern Workplace devices | (device.systemLabels -contains "M365Managed")
 
-> [!Note]  
-> For the deviceOwnership when creating Dynamic Groups for devices you need to set the value equal to "Company". On Intune the device ownership is represented instead as Corporate. Refer to [OwnerTypes](/intune/reports-ref-devices#ownertypes) for more details. 
-
 ## Next steps
 
 These articles provide additional information on groups in Azure Active Directory.


### PR DESCRIPTION
OwnerTypes page now shows 'Corporate', not 'Company', so this purple note block is no longer relevant.

[OwnerTypes](https://docs.microsoft.com/en-us/mem/intune/developer/reports-ref-devices#ownertypes) for more details.