### PR TITLE
Update query example

### DIFF
--- a/articles/governance/policy/concepts/policy-for-kubernetes.md
+++ b/articles/governance/policy/concepts/policy-for-kubernetes.md
@@ -196,11 +196,10 @@ Lastly, verify that the latest add-on is installed by running this Azure CLI com
 similar to the following output:
 
 ```output
-"addonProfiles": {
-    "azurepolicy": {
+{
+        "config": null,
         "enabled": true,
         "identity": null
-    },
 }
 ```
 


### PR DESCRIPTION
Updating the expected output - if the command from the example is used ( with the `--query addonProfiles.azurepolicy` flag ), only the output for the queried object is returned.
If the --query flag is omitted, a much larger JSON object is returned which includes the keys in the old example.