### PR TITLE
Updated Config Server section for Spring Boot 2.4+

### DIFF
--- a/articles/spring-cloud/how-to-prepare-app-deployment.md
+++ b/articles/spring-cloud/how-to-prepare-app-deployment.md
@@ -261,6 +261,10 @@ To enable Distributed Configuration, include the following `spring-cloud-config-
 > [!WARNING]
 > Don't specify `spring.cloud.config.enabled=false` in your bootstrap configuration. Otherwise, your application stops working with Config Server.
 
+> [!WARNING]
+> In case Spring Boot 2.4+ is used the following configuration has to be added to the application properties: `spring.config.import=configserver:${SPRING_CLOUD_CONFIG_URI}`
+> The environment variable `SPRING_CLOUD_CONFIG_URI` will automatically be injected into the application runtime. This is necessary as Spring Boot 2.4+ requires this property to be defined, otherwise, the configuration server property source can not be loaded and the application startup will fail.
+
 ### Metrics
 
 Include the `spring-boot-starter-actuator` dependency in the dependencies section of your pom.xml file as shown here:


### PR DESCRIPTION
Currently, the documentation does not state anything about the new config server property configuration (ref.: https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_client_side_usage -> "If you use Spring Cloud Config Client, you need to set the spring.config.import property in order to bind to Config Server. You can read more about it in the Spring Cloud Config Reference Guide.")

Hence, all Spring Boot 2.4 apps break when just adding the config-client dependency. In order to resolve the issue, the above-mentioned configuration has to be added.

A better approach would probably be to let Azure Spring Cloud handle this requirement by injecting those properties automatically, but I guess we arent there yet for this change right?