### PR TITLE
Update capture-image-resource.md

### DIFF
--- a/articles/virtual-machines/windows/capture-image-resource.md
+++ b/articles/virtual-machines/windows/capture-image-resource.md
@@ -28,7 +28,7 @@ Make sure the server roles running on the machine are supported by Sysprep. For 
 >
 >Sysprep requires the drives to be fully decrypted. If you have enabled encryption on your VM, disable encryption from Azure before you run Sysprep. 
 >
->To disable Azure Disk Encryption with PowerShell, use Disable-AzVMDiskEncryption followed by Remove-AzVMDiskEncryptionExtension. Running Remove-AzVMDiskEncryptionExtension before the encryption is disabled will fail. The higher level commands not only unencrypt the disk from within the VM, but outside of the VM they also update important platform level encryption settings and extension settings associated with the VM. If these are not kept in alignment, the platform will not be able to report encryption status or provision the VM properly.
+>To disable Azure Disk Encryption with PowerShell, use Disable-AzVMDiskEncryption followed by Remove-AzVMDiskEncryptionExtension. Running Remove-AzVMDiskEncryptionExtension before the encryption is disabled fails. The higher-level commands not only unencrypt the disk from within the VM, but outside the VM, they also update important platform-level encryption settings and extension settings that are associated with the VM. If these settings aren't kept in alignment, the platform can't report encryption status or provision the VM properly.
 >
 > If you plan to run Sysprep before uploading your virtual hard disk (VHD) to Azure for the first time, make sure you have [prepared your VM](prepare-for-upload-vhd-image.md).  
 > 

--- a/articles/virtual-machines/windows/capture-image-resource.md
+++ b/articles/virtual-machines/windows/capture-image-resource.md
@@ -26,7 +26,9 @@ Make sure the server roles running on the machine are supported by Sysprep. For 
 > [!IMPORTANT]
 > After you have run Sysprep on a VM, that VM is considered *generalized* and cannot be restarted. The process of generalizing a VM is not reversible. If you need to keep the original VM functioning, you should create a [copy of the VM](create-vm-specialized.md#option-3-copy-an-existing-azure-vm) and generalize its copy. 
 >
->Sysprep requires the drives to be fully decrypted. If you have enabled encryption on your VM, disable encryption before you run Sysprep.
+>Sysprep requires the drives to be fully decrypted. If you have enabled encryption on your VM, disable encryption from Azure before you run Sysprep. 
+>
+>To disable Azure Disk Encryption with PowerShell, use Disable-AzVMDiskEncryption followed by Remove-AzVMDiskEncryptionExtension. Running Remove-AzVMDiskEncryptionExtension before the encryption is disabled will fail. The higher level commands not only unencrypt the disk from within the VM, but outside of the VM they also update important platform level encryption settings and extension settings associated with the VM. If these are not kept in alignment, the platform will not be able to report encryption status or provision the VM properly.
 >
 > If you plan to run Sysprep before uploading your virtual hard disk (VHD) to Azure for the first time, make sure you have [prepared your VM](prepare-for-upload-vhd-image.md).  
 > 


### PR DESCRIPTION
Sysprep requires to disable encryption, and disabling bitlocker from Guest OS causes more issues. The encryption should be disabled from Azure end. The higher level commands not only unencrypt the disk from within the VM, but outside of the VM they also update important platform level encryption settings and extension settings associated with the VM.