### PR TITLE
clarify ambiguities in azure authentication/authorisation

### DIFF
--- a/articles/aks/azure-ad-rbac.md
+++ b/articles/aks/azure-ad-rbac.md
@@ -10,9 +10,9 @@ ms.date: 03/17/2021
 
 # Control access to cluster resources using Kubernetes role-based access control and Azure Active Directory identities in Azure Kubernetes Service
 
-Azure Kubernetes Service (AKS) can be configured to use Azure Active Directory (AD) for user authentication. In this configuration, you sign in to an AKS cluster using an Azure AD authentication token. You can also configure Kubernetes role-based access control (Kubernetes RBAC) to limit access to cluster resources based a user's identity or group membership.
+Azure Kubernetes Service (AKS) can be configured to use Azure Active Directory (AD) for user authentication. In this configuration, you sign in to an AKS cluster using an Azure AD authentication token. Once authenticated, you can use the built-in Kubernetes role-based access control (Kubernetes RBAC) to manage access to namespaces and cluster resources based a user's identity or group membership.
 
-This article shows you how to use Azure AD group membership to control access to namespaces and cluster resources using Kubernetes RBAC in an AKS cluster. Example groups and users are created in Azure AD, then Roles and RoleBindings are created in the AKS cluster to grant the appropriate permissions to create and view resources.
+This article shows you how to control access using Kubernetes RBAC in an AKS cluster based on Azure AD group membership. Example groups and users are created in Azure AD, then Roles and RoleBindings are created in the AKS cluster to grant the appropriate permissions to create and view resources.
 
 ## Before you begin
 

--- a/articles/aks/managed-aad.md
+++ b/articles/aks/managed-aad.md
@@ -9,7 +9,7 @@ ms.author: miwithro
 
 # AKS-managed Azure Active Directory integration
 
-AKS-managed Azure AD integration is designed to simplify the Azure AD integration experience, where users were previously required to create a client app, a server app, and required the Azure AD tenant to grant Directory Read permissions. In the new version, the AKS resource provider manages the client and server apps for you.
+AKS-managed Azure AD integration simplifies the Azure AD integration process. Previously, users were required to create a client and server app, and required the Azure AD tenant to grant Directory Read permissions. In the new version, the AKS resource provider manages the client and server apps for you.
 
 ## Azure AD authentication overview
 
@@ -21,7 +21,7 @@ Learn more about the Azure AD integration flow on the [Azure Active Directory in
 
 * AKS-managed Azure AD integration can't be disabled
 * Changing a AKS-managed Azure AD integrated cluster to legacy AAD is not supported
-* non-Kubernetes RBAC enabled clusters aren't supported for AKS-managed Azure AD integration
+* Clusters without Kubernetes RBAC enabled aren't supported for AKS-managed Azure AD integration
 * Changing the Azure AD tenant associated with AKS-managed Azure AD integration isn't supported
 
 ## Prerequisites
@@ -45,7 +45,7 @@ Use [these instructions](https://kubernetes.io/docs/tasks/tools/install-kubectl/
 
 ## Before you begin
 
-For your cluster, you need an Azure AD group. This group is needed as admin group for the cluster to grant cluster admin permissions. You can use an existing Azure AD group, or create a new one. Record the object ID of your Azure AD group.
+For your cluster, you need an Azure AD group. This group will be registered as an admin group on the cluster to grant cluster admin permissions. You can use an existing Azure AD group, or create a new one. Record the object ID of your Azure AD group.
 
 ```azurecli-interactive
 # List existing groups in the directory
@@ -95,7 +95,7 @@ Once the cluster is created, you can start accessing it.
 
 ## Access an Azure AD enabled cluster
 
-You'll need the [Azure Kubernetes Service Cluster User](../role-based-access-control/built-in-roles.md#azure-kubernetes-service-cluster-user-role) built-in role to do the following steps.
+Before you access the cluster using an Azure AD defined group, you'll need the [Azure Kubernetes Service Cluster User](../role-based-access-control/built-in-roles.md#azure-kubernetes-service-cluster-user-role) built-in role.
 
 Get the user credentials to access the cluster:
  


### PR DESCRIPTION
These change are primarily geared at making the intention of articles around AAD authentication clearer.

I had quite a bit of confusion around which articles were relevant to enabling Azure authentication on AKS, compared to enabling Azure-defined authorisation. The problem stems from three layers of configuration available on the cluster:
  * Enabling RBAC at all
  * Enabling Azure Active Directory
  * Enabling Azure RBAC
And each one requires the previous one.

The articles are clear to say _Kubernetes_ RBAC, but once I've seen that Azure AD defined RBAC exists, I've been hesitant to alter cluster settings that might enable Azure RBAC, for fear that I can't turn it off again. It's easy to imagine that Kubernetes RBAC was just a misnaming of the deeply integrated offering. As such in my mind, any talk of RBAC was offputting -- I just want authentication. 

I also don't really know what the alternatives to AAD authentication are, if any. `managed-aad.md` talks about the underlying OIDC implementation, and originally `managed-aad.md:24` implied there were other non-kubernetes RBAC services available.

Having a place where the config options (both in terms of authn and authz) are clearly enumerated and distinguished as a jumping-off point would go a huge way towards navigating users towards the solution that lets them make the most of AKS.

I still think it's weird to start the managed AAD article talking about the old implementation. But I guess that's just how the article evolved.