### PR TITLE
Add double quotes around `$SP_*` variables

### DIFF
--- a/articles/aks/update-credentials.md
+++ b/articles/aks/update-credentials.md
@@ -37,7 +37,7 @@ To check the expiration date of your service principal, use the [az ad sp creden
 ```azurecli
 SP_ID=$(az aks show --resource-group myResourceGroup --name myAKSCluster \
     --query servicePrincipalProfile.clientId -o tsv)
-az ad sp credential list --id $SP_ID --query "[].endDate" -o tsv
+az ad sp credential list --id "$SP_ID" --query "[].endDate" -o tsv
 ```
 
 ### Reset the existing service principal credential
@@ -55,7 +55,7 @@ SP_ID=$(az aks show --resource-group myResourceGroup --name myAKSCluster \
 With a variable set that contains the service principal ID, now reset the credentials using [az ad sp credential reset][az-ad-sp-credential-reset]. The following example lets the Azure platform generate a new secure secret for the service principal. This new secure secret is also stored as a variable.
 
 ```azurecli-interactive
-SP_SECRET=$(az ad sp credential reset --name $SP_ID --query password -o tsv)
+SP_SECRET=$(az ad sp credential reset --name "$SP_ID" --query password -o tsv)
 ```
 
 Now continue on to [update AKS cluster with new service principal credentials](#update-aks-cluster-with-new-service-principal-credentials). This step is necessary for the Service Principal changes to reflect on the AKS cluster.
@@ -102,8 +102,8 @@ az aks update-credentials \
     --resource-group myResourceGroup \
     --name myAKSCluster \
     --reset-service-principal \
-    --service-principal $SP_ID \
-    --client-secret $SP_SECRET
+    --service-principal "$SP_ID" \
+    --client-secret "$SP_SECRET"
 ```
 
 For small and midsize clusters, it takes a few moments for the service principal credentials to be updated in the AKS.


### PR DESCRIPTION
Thanks for this nice documentation!

The current commands are not using double quotes so any special character in the variables `$SP_ID` and `$SP_SECRET` will end in error when executing the commands.

It looks like `$SP_ID` is a standard UUID with no special characters, but we just ended in error because of a `~` in our secret.


