### PR TITLE
Update ssh commands for Windows

### DIFF
--- a/articles/aks/ssh.md
+++ b/articles/aks/ssh.md
@@ -73,13 +73,16 @@ node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx   1/1     Running   0     
 
 In the above example, *node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx* is the name of the pod started by `kubectl debug`.
 
-Copy your private SSH key into the pod created by `kubectl debug`. This private key is used to create the SSH to the Windows Server AKS node. If needed, change `~/.ssh/id_rsa` to location of your private SSH key:
+Using portforwarding you can open a connnection to the pod deployed above:
 
-```azurecli-interactive
-kubectl cp ~/.ssh/id_rsa node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx:/id_rsa
+```
+kubectl port-forward node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx 2022:22
+
+Forwarding from 127.0.0.1:2022 -> 22
+Forwarding from [::1]:2022 -> 22
 ```
 
-Use `kubectl get nodes` to show the internal IP address of the Windows Server node:
+Open a third terminal window and use `kubectl get nodes` to show the internal IP address of the Windows Server node:
 
 ```output
 $ kubectl get nodes -o wide
@@ -92,16 +95,10 @@ aksnpwin000000                      Ready    agent   87s     v1.19.9   10.240.0.
 
 In the above example, *10.240.0.67* is the internal IP address of the Windows Server node.
 
-Return to the terminal started by `kubectl debug` and update the permission of the private SSH key you copied to the pod.
-
-```azurecli-interactive
-chmod 0400 id_rsa
-```
-
 Create an SSH connection to the Windows Server node using the internal IP address. The default username for AKS nodes is *azureuser*. Accept the prompt to continue with the connection. You are then provided with the bash prompt of your Windows Server node:
 
 ```output
-$ ssh -i id_rsa azureuser@10.240.0.67
+$ ssh -o 'ProxyCommand ssh -p 2022 -W %h:%p azureuser@127.0.0.1' azureuser@10.240.0.67
 
 The authenticity of host '10.240.0.67 (10.240.0.67)' can't be established.
 ECDSA key fingerprint is SHA256:1234567890abcdefghijklmnopqrstuvwxyzABCDEFG.
@@ -117,7 +114,7 @@ azureuser@aksnpwin000000 C:\Users\azureuser>
 
 ## Remove SSH access
 
-When done, `exit` the SSH session and then `exit` the interactive container session. When this container session closes, the pod used for SSH access from the AKS cluster is deleted.
+When done, `exit` the SSH session, type `ctrl-c` in the port-forwarding terminal (for Windows) and type `exit` in the debug container. When this container session closes, the pod used for SSH access from the AKS cluster is deleted.
 
 ## Next steps
 

--- a/articles/aks/ssh.md
+++ b/articles/aks/ssh.md
@@ -114,7 +114,7 @@ azureuser@aksnpwin000000 C:\Users\azureuser>
 
 ## Remove SSH access
 
-When done, enter `exit` in the SSH session, select **Ctrl+C** in the port forwarding terminal (for Windows), and enter `exit` in the debug container. When this container session closes, the pod used for SSH access from the AKS cluster is deleted.
+When done, `exit` the SSH session, and then `exit` the interactive container session. Finally, enter `exit` in the debug container. When this container session closes, the pod used for SSH access from the AKS cluster is deleted.
 
 ## Next steps
 

--- a/articles/aks/ssh.md
+++ b/articles/aks/ssh.md
@@ -73,7 +73,7 @@ node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx   1/1     Running   0     
 
 In the above example, *node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx* is the name of the pod started by `kubectl debug`.
 
-Using portforwarding you can open a connnection to the pod deployed above:
+Using port forwarding, you can open a connnection to the deployed pod:
 
 ```
 kubectl port-forward node-debugger-aks-nodepool1-12345678-vmss000000-bkmmx 2022:22
@@ -114,7 +114,7 @@ azureuser@aksnpwin000000 C:\Users\azureuser>
 
 ## Remove SSH access
 
-When done, `exit` the SSH session, type `ctrl-c` in the port-forwarding terminal (for Windows) and type `exit` in the debug container. When this container session closes, the pod used for SSH access from the AKS cluster is deleted.
+When done, enter `exit` in the SSH session, select **Ctrl+C** in the port forwarding terminal (for Windows), and enter `exit` in the debug container. When this container session closes, the pod used for SSH access from the AKS cluster is deleted.
 
 ## Next steps
 


### PR DESCRIPTION
This removes the requirement to copy your private ssh key to a pod running in the cluster for Windows