### PR TITLE
Snappy compressed avro files

### DIFF
--- a/articles/purview/sources-and-scans.md
+++ b/articles/purview/sources-and-scans.md
@@ -26,7 +26,7 @@ The following file types are supported for scanning, for schema extraction and c
 - Purview also supports custom file extensions and custom parsers.
  
 > [!Note]
-> Every Gzip file must be mapped to a single csv file within. Gzip files are subject to System and Custom Classification rules. We currently don't support scanning a gzip file mapped to multiple files within, or any file type other than csv. Also, Purview scanner supports scanning snappy compressed PARQUET and AVRO file types for schema extraction and classification.
+> Every Gzip file must be mapped to a single csv file within. Gzip files are subject to System and Custom Classification rules. We currently don't support scanning a gzip file mapped to multiple files within, or any file type other than csv. Also, Purview scanner supports scanning snappy compressed PARQUET types for schema extraction and classification. 
 
 > [!Note]
 > Purview scanner does not support complex data types in AVRO, ORC and PARQUET file types for schema extraction.   


### PR DESCRIPTION
This doc states "Purview scanner supports scanning snappy compressed PARQUET and AVRO file types for schema extraction and classification", From my testing, using ADF dataflows, and Azure Databricks I could not see the schema for snappy compressed avro files (schema was available for default and deflate compression through dataflows and Azure databricks). Since ADF copy activity ignores compression (https://docs.microsoft.com/en-us/azure/data-factory/format-avro#dataset-properties), schema was available