### PR TITLE
Add information about asynchronous zip deployment

### DIFF
--- a/includes/app-service-deploy-zip-push-rest.md
+++ b/includes/app-service-deploy-zip-push-rest.md
@@ -26,6 +26,10 @@ This request triggers push deployment from the uploaded .zip file. You can revie
 curl -u <deployment_user> https://<app_name>.scm.azurewebsites.net/api/deployments
 ```
 
+#### Asynchronous zip deployment
+
+While deploying synchronously you may receive errors related to connection timeouts. Add `?isAsync=true` to the URL to deploy asynchronously. You will receive a response as soon as the zip file is uploaded with a `Location` header pointing to the pollable deployment status URL. When polling the URL provided in the `Location` header, you will receive a HTTP 202 (Accepted) response while the process is ongoing and a HTTP 200 (OK) response once the archive has been expanded and the deployment has completed successfully.
+
 ### With PowerShell
 
 The following example uses [Publish-AzWebapp](/powershell/module/az.websites/publish-azwebapp) upload the .zip file. Replace the placeholders `<group-name>`, `<app-name>`, and `<zip-file-path>`.


### PR DESCRIPTION
This copies the description of asynchronous deployment from https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url and includes an additional description of why asynchronous deployment might be preferred (I.e. a timeout error). It also includes information about the expected result codes from the asynchronous result as proposed in https://github.com/projectkudu/kudu/issues/3305.