### PR TITLE
Adding note about pricing tier of Text Analytics

### DIFF
--- a/articles/cognitive-services/QnAMaker/custom-question-answering.md
+++ b/articles/cognitive-services/QnAMaker/custom-question-answering.md
@@ -36,7 +36,7 @@ You can no longer create a QnA Maker managed resource from the QnA Maker create 
 
 - All existing QnA Maker managed (preview) resources continue to work as before. There is no action required for these resources at this time.
 - The creation flow for Custom question answering (preview) is the primary change. The service, portal, endpoints, SDK, etc. remain as before.
-- Custom question answering (preview) continues to be offered as a free public preview. But only available for Text Analytics Standard resources. Do not change your pricing tier for Text Analytics resources to free.
+- Custom question answering (preview) continues to be offered as a free public preview. This feature is only available as part of Text Analytics Standard resources. Do not change your pricing tier for Text Analytics resources to free.
 - Custom question answering (preview) is available in the following regions:
     - South Central US
 	- North Europe
@@ -46,5 +46,4 @@ You can no longer create a QnA Maker managed resource from the QnA Maker create 
 
 * [Get started with QnA Maker client library](./quickstarts/quickstart-sdk.md)
 * [Get started with QnA Maker portal](./quickstarts/create-publish-knowledge-base.md)
-
 

--- a/articles/cognitive-services/QnAMaker/custom-question-answering.md
+++ b/articles/cognitive-services/QnAMaker/custom-question-answering.md
@@ -36,7 +36,7 @@ You can no longer create a QnA Maker managed resource from the QnA Maker create 
 
 - All existing QnA Maker managed (preview) resources continue to work as before. There is no action required for these resources at this time.
 - The creation flow for Custom question answering (preview) is the primary change. The service, portal, endpoints, SDK, etc. remain as before.
-- Custom question answering (preview) continues to be offered as a free public preview.
+- Custom question answering (preview) continues to be offered as a free public preview. But only available for Text Analytics Standard resources. Do not change your pricing tier for Text Analytics resources to free.
 - Custom question answering (preview) is available in the following regions:
     - South Central US
 	- North Europe


### PR DESCRIPTION
If change pricing tier of Text Analytics resource Standard(S) to Free(F0), the existing knowledge base associated with that resource will no longer be displayed on QnAPortal.
A note about pricing tier is needed to avoid annoying users.
https://azure.microsoft.com/en-us/pricing/details/cognitive-services/text-analytics/
![image](https://user-images.githubusercontent.com/65746722/121143855-7042f880-c878-11eb-8ae1-0994d6d9fcad.png)
