### PR TITLE
Fix Windows azcopy static download link for PS Core

### DIFF
--- a/articles/storage/common/storage-use-azcopy-v10.md
+++ b/articles/storage/common/storage-use-azcopy-v10.md
@@ -147,7 +147,7 @@ To obtain the link, run this command:
 | Operating system  | Command |
 |--------|-----------|
 | **Linux** | `curl -s -D- https://aka.ms/downloadazcopy-v10-linux | grep ^Location` |
-| **Windows** | `(curl https://aka.ms/downloadazcopy-v10-windows -MaximumRedirection 0 -ErrorAction silentlycontinue).headers.location` |
+| **Windows** | `try { Invoke-RestMethod -Method HEAD -MaximumRedirection 0 -Uri "https://aka.ms/downloadazcopy-v10-windows" -ErrorAction Stop } catch { $_.Exception.Response.Headers.Location }` |
 
 > [!NOTE]
 > For Linux, `--strip-components=1` on the `tar` command removes the top-level folder that contains the version name, and instead extracts the binary directly into the current folder. This allows the script to be updated with a new version of `azcopy` by only updating the `wget` URL.


### PR DESCRIPTION
The previous command to get the static download link for azcopy on Windows had two issues:

1. It used the `curl` alias for brevity, however that adds confusion if the user has curl on their path
2. PowerShell Core has a behavior change that turns 3xx HTTP responses into terminating errors (see https://github.com/PowerShell/PowerShell/issues/4534)

Unfortunately the workaround appears to require a `try...catch` in order to get access to the response headers.