### PR TITLE
Fix query in Hyperscale sharding tutorial

### DIFF
--- a/articles/postgresql/tutorial-hyperscale-shard.md
+++ b/articles/postgresql/tutorial-hyperscale-shard.md
@@ -46,7 +46,7 @@ can check the active workers in the
 [pg_dist_node](reference-hyperscale-metadata.md#worker-node-table) table.
 
 ```sql
-select nodeid from pg_dist_node where isactive;
+select nodeid, nodename from pg_dist_node where isactive;
 ```
 ```
  nodeid | nodename


### PR DESCRIPTION
The query to fetch node info from `pg_dist_node` only selects the `nodeid` column, but the results shown include the `nodename` column as well. This PR adds the `nodename` column to make the query text and the query result consistent.