### PR TITLE
Add note for analytical store private dns zone

### DIFF
--- a/articles/cosmos-db/analytical-store-private-endpoints.md
+++ b/articles/cosmos-db/analytical-store-private-endpoints.md
@@ -14,6 +14,9 @@ ms.author: anithaa
 
 In this article, you will learn how to set up managed private endpoints for Azure Cosmos DB analytical store. If you are using the transactional store, see [Private endpoints for the transactional store](how-to-configure-private-endpoints.md) article. Using [managed private endpoints](../synapse-analytics/security/synapse-workspace-managed-private-endpoints.md), you can restrict network access of your Azure Cosmos DB analytical store, to a Managed Virtual Network associated with your Azure Synapse workspace. Managed private endpoints establish a private link to your analytical store.
 
+> [!NOTE]
+> If you are using Private DNS Zones for Cosmos DB and wish to create a Synapse managed private endpoint to the analytical store sub-resource, you must first create a DNS zone for the analytical store (`privatelink.analytics.cosmos.azure.com`) linked to your Cosmos DB's virtual network.
+
 ## Enable a private endpoint for the analytical store
 
 ### Set up Azure Synapse Analytics workspace with a managed virtual network


### PR DESCRIPTION
If you are using Private DNS Zones with Cosmos DB, you need to add a zone for the analytical store in order for the Synapse managed private endpoint to be able to connect; otherwise this will cause DNS lookup failures upon mpe creation.