### PR TITLE
Update tutorial-create-instance.md

### DIFF
--- a/articles/active-directory-domain-services/tutorial-create-instance.md
+++ b/articles/active-directory-domain-services/tutorial-create-instance.md
@@ -156,7 +156,7 @@ To authenticate users on the managed domain, Azure AD DS needs password hashes i
 >
 > Synchronized credential information in Azure AD can't be re-used if you later create a managed domain - you must reconfigure the password hash synchronization to store the password hashes again. Previously domain-joined VMs or users won't be able to immediately authenticate - Azure AD needs to generate and store the password hashes in the new managed domain.
 >
-> Please note that [Azure AD Connect Cloud Sync is not supported with Azure AD DS][https://docs.microsoft.com/en-us/azure/active-directory/cloud-sync/what-is-cloud-sync#comparison-between-azure-ad-connect-and-cloud-sync]. On-premises users need to be synced using Azure AD Connect in order to be able to access domain-joined VMs. For more information, see [Password hash sync process for Azure AD DS and Azure AD Connect][password-hash-sync-process].
+> Please note that [Azure AD Connect Cloud Sync is not supported with Azure AD DS][https://docs.microsoft.com/azure/active-directory/cloud-sync/what-is-cloud-sync#comparison-between-azure-ad-connect-and-cloud-sync]. On-premises users need to be synced using Azure AD Connect in order to be able to access domain-joined VMs. For more information, see [Password hash sync process for Azure AD DS and Azure AD Connect][password-hash-sync-process].
 
 The steps to generate and store these password hashes are different for cloud-only user accounts created in Azure AD versus user accounts that are synchronized from your on-premises directory using Azure AD Connect.
 

--- a/articles/active-directory-domain-services/tutorial-create-instance.md
+++ b/articles/active-directory-domain-services/tutorial-create-instance.md
@@ -156,7 +156,7 @@ To authenticate users on the managed domain, Azure AD DS needs password hashes i
 >
 > Synchronized credential information in Azure AD can't be re-used if you later create a managed domain - you must reconfigure the password hash synchronization to store the password hashes again. Previously domain-joined VMs or users won't be able to immediately authenticate - Azure AD needs to generate and store the password hashes in the new managed domain.
 >
-> Please note that [Azure AD Connect Cloud Sync is not supported with Azure AD DS][https://docs.microsoft.com/azure/active-directory/cloud-sync/what-is-cloud-sync#comparison-between-azure-ad-connect-and-cloud-sync]. On-premises users need to be synced using Azure AD Connect in order to be able to access domain-joined VMs. For more information, see [Password hash sync process for Azure AD DS and Azure AD Connect][password-hash-sync-process].
+> [Azure AD Connect Cloud Sync is not supported with Azure AD DS][/azure/active-directory/cloud-sync/what-is-cloud-sync#comparison-between-azure-ad-connect-and-cloud-sync]. On-premises users need to be synced using Azure AD Connect in order to be able to access domain-joined VMs. For more information, see [Password hash sync process for Azure AD DS and Azure AD Connect][password-hash-sync-process].
 
 The steps to generate and store these password hashes are different for cloud-only user accounts created in Azure AD versus user accounts that are synchronized from your on-premises directory using Azure AD Connect.
 

--- a/articles/active-directory-domain-services/tutorial-create-instance.md
+++ b/articles/active-directory-domain-services/tutorial-create-instance.md
@@ -156,7 +156,7 @@ To authenticate users on the managed domain, Azure AD DS needs password hashes i
 >
 > Synchronized credential information in Azure AD can't be re-used if you later create a managed domain - you must reconfigure the password hash synchronization to store the password hashes again. Previously domain-joined VMs or users won't be able to immediately authenticate - Azure AD needs to generate and store the password hashes in the new managed domain.
 >
-> For more information, see [Password hash sync process for Azure AD DS and Azure AD Connect][password-hash-sync-process].
+> Please note that [Azure AD Connect Cloud Sync is not supported with Azure AD DS][https://docs.microsoft.com/en-us/azure/active-directory/cloud-sync/what-is-cloud-sync#comparison-between-azure-ad-connect-and-cloud-sync]. On-premises users need to be synced using Azure AD Connect in order to be able to access domain-joined VMs. For more information, see [Password hash sync process for Azure AD DS and Azure AD Connect][password-hash-sync-process].
 
 The steps to generate and store these password hashes are different for cloud-only user accounts created in Azure AD versus user accounts that are synchronized from your on-premises directory using Azure AD Connect.
 


### PR DESCRIPTION
We need to add in our Azure AD DS documentation that Azure AD Connect Cloud Sync is not supported with AADDS as per Cloud Sync documentation: What is Azure AD Connect cloud sync. | Microsoft Docs

A "note" or "Important" box should be included stating that customers should use Azure AD Connect and not cloud sync when they want to let on-prem users access AADDS. Looking at the current AADDS documentation (https://docs.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-create-instance#enable-user-accounts-for-azure-ad-ds), we can add this information in the existing note section.