### PR TITLE
Replace EdgelessRT with EGo

### DIFF
--- a/articles/confidential-computing/enclave-aware-containers.md
+++ b/articles/confidential-computing/enclave-aware-containers.md
@@ -47,10 +47,9 @@ This solution allows you to bring existing ML trained model and run them confide
 
 Get started with ML model lift and shift to ONNX runtime [here](https://aka.ms/confidentialinference)
 
-### Edgeless RT
+### EGo
 
-Edgeless RT is an open-source project that builds upon the Open Enclave SDK. It adds support for Go and additional C++ features. Get started with a simple confidential Go application using your familiar VS Code environment [here](https://github.com/edgelesssys/edgelessrt). For Edgeless applications on AKS follow instructions [here](https://github.com/edgelesssys/edgelessrt/blob/master/docs/ERTAzureAKSDeployment.md)
-
+The open source [EGo SDK](https://www.ego.dev) brings support for the Go programming language to enclaves. EGo builds upon the Open Enclave SDK and aims at making it easy to bring cloud-native services to the enclave world. For instance, if your goal is to make a Go-based microservice deployment on AKS confidential, then EGo can be a starting point.
 
 ## Container Based Sample Implementations
 

--- a/articles/confidential-computing/enclave-aware-containers.md
+++ b/articles/confidential-computing/enclave-aware-containers.md
@@ -49,7 +49,7 @@ Get started with ML model lift and shift to ONNX runtime [here](https://aka.ms/c
 
 ### EGo
 
-The open source [EGo SDK](https://www.ego.dev) brings support for the Go programming language to enclaves. EGo builds upon the Open Enclave SDK and aims at making it easy to bring cloud-native services to the enclave world. For instance, if your goal is to make a Go-based microservice deployment on AKS confidential, then EGo can be a starting point.
+The open source [EGo SDK](https://www.ego.dev) brings support for the Go programming language to enclaves. EGo builds upon the Open Enclave SDK. It aims to make it easy to build confidential microservices. Follow this [step-by-step guide](https://github.com/edgelesssys/ego/tree/master/samples/aks), to deploy an EGo-based service on AKS.
 
 ## Container Based Sample Implementations
 


### PR DESCRIPTION
EGo is more user friendly than EdgelessRT. With its microservice-focus, EGo also is a good fit for AKS. I am therefore proposing to replace EdgelessRT with EGo here.