### PR TITLE
Update hdinsight-management-ip-addresses.md

### DIFF
--- a/articles/hdinsight/hdinsight-management-ip-addresses.md
+++ b/articles/hdinsight/hdinsight-management-ip-addresses.md
@@ -47,39 +47,39 @@ Allow traffic from the IP addresses listed for the Azure HDInsight health and ma
 
 | Country | Region | Allowed Source IP addresses | Allowed Destination | Direction |
 | ---- | ---- | ---- | ---- | ----- |
-| Asia | East Asia | 23.102.235.122</br>52.175.38.134 | \*:443 | Inbound |
-| &nbsp; | Southeast Asia | 13.76.245.160</br>13.76.136.249 | \*:443 | Inbound |
-| Australia | Australia East | 104.210.84.115</br>13.75.152.195 | \*:443 | Inbound |
-| &nbsp; | Australia Southeast | 13.77.2.56</br>13.77.2.94 | \*:443 | Inbound |
-| Brazil | Brazil South | 191.235.84.104</br>191.235.87.113 | \*:443 | Inbound |
-| Canada | Canada East | 52.229.127.96</br>52.229.123.172 | \*:443 | Inbound |
-| &nbsp; | Canada Central | 52.228.37.66</br>52.228.45.222 |\*: 443 | Inbound |
-| China | China North | 42.159.96.170</br>139.217.2.219</br></br>42.159.198.178</br>42.159.234.157 | \*:443 | Inbound |
-| &nbsp; | China East | 42.159.198.178</br>42.159.234.157</br></br>42.159.96.170</br>139.217.2.219 | \*:443 | Inbound |
-| &nbsp; | China North 2 | 40.73.37.141</br>40.73.38.172 | \*:443 | Inbound |
-| &nbsp; | China East 2 | 139.217.227.106</br>139.217.228.187 | \*:443 | Inbound |
-| Europe | North Europe | 52.164.210.96</br>13.74.153.132 | \*:443 | Inbound |
-| &nbsp; | West Europe| 52.166.243.90</br>52.174.36.244 | \*:443 | Inbound |
-| France | France Central| 20.188.39.64</br>40.89.157.135 | \*:443 | Inbound |
-| Germany | Germany Central | 51.4.146.68</br>51.4.146.80 | \*:443 | Inbound |
-| &nbsp; | Germany Northeast | 51.5.150.132</br>51.5.144.101 | \*:443 | Inbound |
-| India | Central India | 52.172.153.209</br>52.172.152.49 | \*:443 | Inbound |
-| &nbsp; | South India | 104.211.223.67<br/>104.211.216.210 | \*:443 | Inbound |
-| Japan | Japan East | 13.78.125.90</br>13.78.89.60 | \*:443 | Inbound |
-| &nbsp; | Japan West | 40.74.125.69</br>138.91.29.150 | \*:443 | Inbound |
-| Korea | Korea Central | 52.231.39.142</br>52.231.36.209 | \*:443 | Inbound |
-| &nbsp; | Korea South | 52.231.203.16</br>52.231.205.214 | \*:443 | Inbound
-| United Kingdom | UK West | 51.141.13.110</br>51.141.7.20 | \*:443 | Inbound |
-| &nbsp; | UK South | 51.140.47.39</br>51.140.52.16 | \*:443 | Inbound |
-| United States | Central US | 13.89.171.122</br>13.89.171.124 | \*:443 | Inbound |
-| &nbsp; | East US | 13.82.225.233</br>40.71.175.99 | \*:443 | Inbound |
-| &nbsp; | East US2 | 20.44.16.8/29</br>20.49.102.48/29 | \*:443 | Inbound |
-| &nbsp; | North Central US | 157.56.8.38</br>157.55.213.99 | \*:443 | Inbound |
-| &nbsp; | West Central US | 52.161.23.15</br>52.161.10.167 | \*:443 | Inbound |
-| &nbsp; | West US | 13.64.254.98</br>23.101.196.19 | \*:443 | Inbound |
-| &nbsp; | West US 2 | 52.175.211.210</br>52.175.222.222 | \*:443 | Inbound |
-| &nbsp; | UAE North | 65.52.252.96</br>65.52.252.97 | \*:443 | Inbound |
-| &nbsp; | UAE Central | 20.37.76.96</br>20.37.76.99 | \*:443 | Inbound |
+| Asia | East Asia | 23.102.235.122<br>52.175.38.134 | \*:443 | Inbound |
+| &nbsp; | Southeast Asia | 13.76.245.160<br>13.76.136.249 | \*:443 | Inbound |
+| Australia | Australia East | 104.210.84.115<br>13.75.152.195 | \*:443 | Inbound |
+| &nbsp; | Australia Southeast | 13.77.2.56<br>13.77.2.94 | \*:443 | Inbound |
+| Brazil | Brazil South | 191.235.84.104<br>191.235.87.113 | \*:443 | Inbound |
+| Canada | Canada East | 52.229.127.96<br>52.229.123.172 | \*:443 | Inbound |
+| &nbsp; | Canada Central | 52.228.37.66<br>52.228.45.222 |\*: 443 | Inbound |
+| China | China North | 42.159.96.170<br>139.217.2.219</br></br>42.159.198.178</br>42.159.234.157 | \*:443 | Inbound |
+| &nbsp; | China East | 42.159.198.178<br>42.159.234.157</br></br>42.159.96.170</br>139.217.2.219 | \*:443 | Inbound |
+| &nbsp; | China North 2 | 40.73.37.141<br>40.73.38.172 | \*:443 | Inbound |
+| &nbsp; | China East 2 | 139.217.227.106<br>139.217.228.187 | \*:443 | Inbound |
+| Europe | North Europe | 52.164.210.96<br>13.74.153.132 | \*:443 | Inbound |
+| &nbsp; | West Europe| 52.166.243.90<br>52.174.36.244 | \*:443 | Inbound |
+| France | France Central| 20.188.39.64<br>40.89.157.135 | \*:443 | Inbound |
+| Germany | Germany Central | 51.4.146.68<br>51.4.146.80 | \*:443 | Inbound |
+| &nbsp; | Germany Northeast | 51.5.150.132<br>51.5.144.101 | \*:443 | Inbound |
+| India | Central India | 52.172.153.209<br>52.172.152.49 | \*:443 | Inbound |
+| &nbsp; | South India | 104.211.223.67<br>104.211.216.210 | \*:443 | Inbound |
+| Japan | Japan East | 13.78.125.90<br>13.78.89.60 | \*:443 | Inbound |
+| &nbsp; | Japan West | 40.74.125.69<br>138.91.29.150 | \*:443 | Inbound |
+| Korea | Korea Central | 52.231.39.142<br>52.231.36.209 | \*:443 | Inbound |
+| &nbsp; | Korea South | 52.231.203.16<br>52.231.205.214 | \*:443 | Inbound
+| United Kingdom | UK West | 51.141.13.110<br>51.141.7.20 | \*:443 | Inbound |
+| &nbsp; | UK South | 51.140.47.39<br>51.140.52.16 | \*:443 | Inbound |
+| United States | Central US | 13.89.171.122<br>13.89.171.124 | \*:443 | Inbound |
+| &nbsp; | East US | 13.82.225.233<br>40.71.175.99 | \*:443 | Inbound |
+| &nbsp; | East US2 | 20.44.16.8/29<br>20.49.102.48/29 | \*:443 | Inbound |
+| &nbsp; | North Central US | 157.56.8.38<br>157.55.213.99 | \*:443 | Inbound |
+| &nbsp; | West Central US | 52.161.23.15<br>52.161.10.167 | \*:443 | Inbound |
+| &nbsp; | West US | 13.64.254.98<br>23.101.196.19 | \*:443 | Inbound |
+| &nbsp; | West US 2 | 52.175.211.210<br>52.175.222.222 | \*:443 | Inbound |
+| &nbsp; | UAE North | 65.52.252.96<br>65.52.252.97 | \*:443 | Inbound |
+| &nbsp; | UAE Central | 20.37.76.96<br>20.37.76.99 | \*:443 | Inbound |
 
 For information on the IP addresses to use for Azure Government, see the [Azure Government Intelligence + Analytics](../azure-government/compare-azure-government-global-azure.md) document.
 


### PR DESCRIPTION
&lt;br&gt; tags used in between 2 IPs in the second long table were inconsistent. Some were using &lt;/br&gt; and some were &lt;br/&gt; . This inconsistency causes problems if you are programmatically "scraping" this HTML table using a parser.