### PR TITLE
Need to change the location on where the NPS Extension Stores it's event logs for troubleshooting

### DIFF
--- a/articles/active-directory/authentication/howto-mfa-nps-extension-errors.md
+++ b/articles/active-directory/authentication/howto-mfa-nps-extension-errors.md
@@ -18,7 +18,7 @@ ms.custom: has-adal-ref
 ---
 # Resolve error messages from the NPS extension for Azure AD Multi-Factor Authentication
 
-If you encounter errors with the NPS extension for Azure AD Multi-Factor Authentication, use this article to reach a resolution faster. NPS extension logs are found in Event Viewer under **Custom Views** > **Server Roles** > **Network Policy and Access Services** on the server where the NPS Extension is installed.
+If you encounter errors with the NPS extension for Azure AD Multi-Factor Authentication, use this article to reach a resolution faster. NPS extension logs are found in Event Viewer under **CApplications and Services Logs** > **Microsoft** > **AzureMfa** > **AuthN** > **AuthZ** on the server where the NPS Extension is installed.
 
 ## Troubleshooting steps for common errors
 

--- a/articles/active-directory/authentication/howto-mfa-nps-extension-errors.md
+++ b/articles/active-directory/authentication/howto-mfa-nps-extension-errors.md
@@ -18,7 +18,7 @@ ms.custom: has-adal-ref
 ---
 # Resolve error messages from the NPS extension for Azure AD Multi-Factor Authentication
 
-If you encounter errors with the NPS extension for Azure AD Multi-Factor Authentication, use this article to reach a resolution faster. NPS extension logs are found in Event Viewer under **CApplications and Services Logs** > **Microsoft** > **AzureMfa** > **AuthN** > **AuthZ** on the server where the NPS Extension is installed.
+If you encounter errors with the NPS extension for Azure AD Multi-Factor Authentication, use this article to reach a resolution faster. NPS extension logs are found in Event Viewer under **Applications and Services Logs** > **Microsoft** > **AzureMfa** > **AuthN** > **AuthZ** on the server where the NPS Extension is installed.
 
 ## Troubleshooting steps for common errors
 


### PR DESCRIPTION
Need to change the location of where the Event logs are stored for NPS Extension errors. 

Applications and Services logs > Microsoft > AzureMfa 
AuthN & AuthZ