### PR TITLE
Update identity-provider-apple-id.md

### DIFF
--- a/articles/active-directory-b2c/identity-provider-apple-id.md
+++ b/articles/active-directory-b2c/identity-provider-apple-id.md
@@ -53,8 +53,8 @@ To enable sign-in for users with an Apple ID in Azure Active Directory B2C (Azur
 1. From **Identifiers**, select the identifier you created.
 1. Select **Sign In with Apple**, and then select **Configure**.
     1. Select the **Primary App ID** you want to configure Sign in with Apple with.
-    1. In **Domains and Subdomains**, enter `your-tenant-name.b2clogin.com`. Replace your-tenant-name with the name of your tenant. If you use a [custom domain](custom-domain.md), enter `https://your-domain-name`.
-    1. In **Return URLs**, enter `https://your-tenant-name.b2clogin.com/your-tenant-name.onmicrosoft.com/oauth2/authresp`. If you use a [custom domain](custom-domain.md), enter `https://your-domain-name/your-tenant-name.onmicrosoft.com/oauth2/authresp`. Replace `your-tenant-name` with the name of your tenant, and `your-domain-name` with your custom domain.
+    1. In **Domains and Subdomains**, enter `your-tenant-name.b2clogin.com`. Replace your-tenant-name with the name of your tenant. If you use a [custom domain](custom-domain.md), enter `https://your-domain-name`. Make sure that you typed in everything in lower case.
+    1. In **Return URLs**, enter `https://your-tenant-name.b2clogin.com/your-tenant-name.onmicrosoft.com/oauth2/authresp`. If you use a [custom domain](custom-domain.md), enter `https://your-domain-name/your-tenant-name.onmicrosoft.com/oauth2/authresp`. Replace `your-tenant-name` with the name of your tenant, and `your-domain-name` with your custom domain. Make sure that you typed in everything in lower case.
     1. Select **Next**, and then select **Done**.
     1. When the pop-up window is closed, select **Continue**, and then select **Save**.
 


### PR DESCRIPTION
Add the sentense "Make sure that you typed in everything in lower case." because often you "copy n past" the redirects urls. The Apple redirect url is case senstive and B2C will convert his URL to lower case and often you have camel case urls like "MrcsOneId.b2clogin.com...".