### PR TITLE
Documents that cannot be edited need improvement

### DIFF
--- a/articles/active-directory-b2c/microsoft-graph-operations.md
+++ b/articles/active-directory-b2c/microsoft-graph-operations.md
@@ -235,3 +235,5 @@ public static async Task ListUsers(GraphServiceClient graphClient)
 
 [graph-objectIdentity]: /graph/api/resources/objectidentity
 [graph-user]: (https://docs.microsoft.com/graph/api/resources/user)
+
+This is for submitting the pull request only. Please read the description and ignore this.


### PR DESCRIPTION
Hello

I came across few B2C documents that need improvement but the documents cannot be edited. Please find them below:

1. https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/create#security : In the security section, it mentions that the service principal needs to have user_impersonation API delegated permission. Customers are confused about this point as they are not aware of the fact that a present signed-in user is needed in this process in order for the service principal to impersonate. Customers are expecting the B2C tenant to be created and the service principal added as the global admin. There should be a Note or Important box that indicates the importance of user involvement in this process, given that the user should at least have Contributor on the subscription to create the tenant as per the requirements to create a B2C tenant, generally speaking.

2. In the following list of documents, all of them mention that the service principal needs user impersonation API permission. I've done multiple tests on my end and concluded that it is not needed. However, the service principal needs to have at least the Contributor on the role in order for the call to be successful. Without the Contributor role or the user impersonation API permission, and when running List B2C tenants by Resource Group, I faced the following error message:

 ""The client 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx' with object id 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx' does not have authorization to perform action 'Microsoft.AzureActiveDirectory/b2cDirectories/read' over scope '/subscriptions/xxxxxxx-xxxx-xxxx-xxxxx-xxxxxxxxx/resourceGroups/"new"/providers/Microsoft.AzureActiveDirectory' or the scope is invalid. If access was recently granted, please refresh your credentials.""

So it does look like the only needed permission is the one listed above for listing B2C tenants.

Docs: 
- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/get#security
- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/list-by-resource-group#security
- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/list-by-subscription#security
- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/check-name-availability#security

3. For the below two documents, along with document mentioned in point (1), the user impersonation API permission needs to be admin consented on the tenant, otherwise it does not work. It is mentioned in the portal that it does not require admin consent. I believe this point needs to be added in the docs as well.

Docs:

- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/create#security (This is the same document mentioned in point 1)
- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/delete#security
- https://docs.microsoft.com/en-us/rest/api/activedirectory/b2c-tenants/update#security