### PR TITLE
helm install needs "generate-name" option.

### DIFF
--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -2,7 +2,7 @@
 title: Creating an ingress controller with a new Application Gateway 
 description: This article provides information on how to deploy an Application Gateway Ingress Controller with a new Application Gateway. 
 services: application-gateway
-author: caya
+author: mscatyao
 ms.service: application-gateway
 ms.topic: how-to
 ms.date: 11/4/2019

--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -277,7 +277,7 @@ Kubernetes. We will leverage it to install the `application-gateway-kubernetes-i
 1. Install the Application Gateway ingress controller package:
 
     ```bash
-    helm install -f helm-config.yaml application-gateway-kubernetes-ingress/ingress-azure
+    helm install -f helm-config.yaml application-gateway-kubernetes-ingress/ingress-azure --generate-name
     ```
 
 ## Install a Sample App


### PR DESCRIPTION
I found following error when I used the command on public document. "helm install -f helm-config.yaml application-gateway-kubernetes-ingress/ingress-azure"


"Error: must either provide a name or specify --generate-name"