### PR TITLE
Corrections to the recognitionStatus example

### DIFF
--- a/articles/cognitive-services/Speech-Service/batch-transcription.md
+++ b/articles/cognitive-services/Speech-Service/batch-transcription.md
@@ -209,7 +209,7 @@ Each transcription result file has this format:
   ],
   "recognizedPhrases": [                // results for each phrase and each channel individually
     {
-      "recognitionStatus": "Success",   // recognition state, e.g. "Success", "Failure"          
+      "recognitionStatus": "Success",   // recognition state, e.g. "Success", "Error"          
       "speaker": 1,                     // if `diarizationEnabled` is `true`, this is the identified speaker (1 or 2), otherwise this property is not present
       "channel": 0,                     // channel number of the result
       "offset": "PT0.07S",              // offset in audio of this phrase, ISO 8601 encoded duration 


### PR DESCRIPTION
There is no "Failure" among the possible values of "recognitionStatus".
Needed to be fixed to prevent confusion for the user.

- Speech-to-text REST API：Response parameters
https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-speech-to-text#response-parameters
![image](https://user-images.githubusercontent.com/65746722/121831763-4455c600-cd03-11eb-858a-493fc0979f38.png)
