### PR TITLE
Include a section about a common error

### DIFF
--- a/articles/virtual-machines/azure-vms-no-temp-disk.md
+++ b/articles/virtual-machines/azure-vms-no-temp-disk.md
@@ -59,6 +59,9 @@ Yes.
 ## Will this break my custom scripts, custom images or OS images that have scratch files or page files on a local temp disk?
 If the custom OS image points to the local temp disk, the image might not work correctly with this diskless size.
 
+## Error "changing from resource disk to non-resource disk VM size and vice-versa is not allowed"
+When receiving this error in the Portal, ensure you are resizing a VM to another VM in the same family. For example, if you are resizing from Standard_E8s_v4, ensure you select Standard_E32s_v4 and not Standard_E32s_v3. In the context of the above error, resource disk refers to a VM SKU with a temporary disk, and non-resource disk refers to a VM SKU without a temporary disk.
+
 ## Have questions or feedback?
 Fill out the [feedback form]( https://forms.office.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR_Y3toRKxchLjARedqtguBRUMzdCQkw0OVVRTldFUUtXSTlLQVBPUkVHSy4u). 
 


### PR DESCRIPTION
I've received two support cases where customers have received this error: "Failed to resize virtual machine 'gcdmgccprod04cmkt3-4f9b-0' to size 'Standard E32s v3'. Error: Unable to resize the VM 'gcdmgccprod04cmkt3-4f9b-0' since changing from resource disk to non-resource disk VM size and vice-versa is not allowed. Please refer to https://aka.ms/AAah4sj for more details."
The core of the error "resource disk to non-resource disk VM size and vice-versa is not allowed" doesn't inform customers that non-resource disk and resource disk refer to VMs without a temp disk and VMs with a temp disk respectively. We should include an update to this documentation to have a section dedicated to this common error that can happen during resizing. Alternatively, updating the error message the Portal returns would be helpful, too. The main goal of this update to reduce the number of cases that the ambiguous error causes.