### PR TITLE
Update DateTime format for iotedge logs

### DIFF
--- a/articles/iot-edge/how-to-retrieve-iot-edge-logs.md
+++ b/articles/iot-edge/how-to-retrieve-iot-edge-logs.md
@@ -29,7 +29,7 @@ While not required, for best compatibility with this feature, the recommended lo
 <{Log Level}> {Timestamp} {Message Text}
 ```
 
-`{Timestamp}` should be formatted as `yyyy-MM-dd hh:mm:ss.fff zzz`, and `{Log Level}` should follow the table below, which derives its severity levels from the [Severity code in the Syslog standard](https://wikipedia.org/wiki/Syslog#Severity_level).
+`{Timestamp}` should be formatted as `yyyy-MM-dd HH:mm:ss.fff zzz`, and `{Log Level}` should follow the table below, which derives its severity levels from the [Severity code in the Syslog standard](https://wikipedia.org/wiki/Syslog#Severity_level).
 
 | Value | Severity |
 |-|-|


### PR DESCRIPTION
The DateTime format suggested in the iot-edge-logger https://github.com/Azure/iotedge/blob/master/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Logger.cs is using 24 hour format ('HH'), whereas in the current doc there is a 12 hour format ('hh').