### PR TITLE
fix connection for Managed Identity examples

### DIFF
--- a/articles/azure-sql/database/connect-query-nodejs.md
+++ b/articles/azure-sql/database/connect-query-nodejs.md
@@ -111,29 +111,30 @@ Open a command prompt and create a folder named *sqltest*. Open the folder you c
     
     /* 
         //Use Azure VM Managed Identity to connect to the SQL database
-        const connection = new Connection({
-        server: process.env["db_server"],
-        authentication: {
-            type: 'azure-active-directory-msi-vm',
-        },
-        options: {
-            database: process.env["db_database"],
-            encrypt: true,
-            port: 1433
-        }
-    });
+        const config = {
+            server: process.env["db_server"],
+            authentication: {
+                type: 'azure-active-directory-msi-vm',
+            },
+            options: {
+                database: process.env["db_database"],
+                encrypt: true,
+                port: 1433
+            }
+        };
+        
         //Use Azure App Service Managed Identity to connect to the SQL database
-        const connection = new Connection({
-        server: process.env["db_server"],
-        authentication: {
-            type: 'azure-active-directory-msi-app-service',
-        },
-        options: {
-            database: process.env["db_database"],
-            encrypt: true,
-            port: 1433
-        }
-    });
+        const config = {
+            server: process.env["db_server"],
+            authentication: {
+                type: 'azure-active-directory-msi-app-service',
+            },
+            options: {
+                database: process.env["db_database"],
+                encrypt: true,
+                port: 1433
+            }
+        });
 
     */
 


### PR DESCRIPTION
the examples for Managed Identities is not correct. It should not be trying to create a Connection. It should build the config structure and pass it along to "const connection = new Connection(config);" .. just like the first example.