### PR TITLE
Add OS version information for TLS 1.2 cipher suites

### DIFF
--- a/articles/frontdoor/front-door-faq.yml
+++ b/articles/frontdoor/front-door-faq.yml
@@ -226,6 +226,9 @@ sections:
           - TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
           - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
           
+          > [!Note]  
+          > For Windows 10 and above, we recommend enabling one or both of the ECDHE cipher suites for better security. Windows 7, 8, and 8.1 are not compatible with these ECDHE cipher suites and the DHE cipher suites have been provided for compatibility with those operating systems.
+          
           When using custom domains with TLS1.0/1.1 enabled the following cipher suites are supported:
           
           - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/articles/frontdoor/front-door-faq.yml
+++ b/articles/frontdoor/front-door-faq.yml
@@ -226,8 +226,8 @@ sections:
           - TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
           - TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
           
-          > [!Note]  
-          > For Windows 10 and above, we recommend enabling one or both of the ECDHE cipher suites for better security. Windows 7, 8, and 8.1 are not compatible with these ECDHE cipher suites and the DHE cipher suites have been provided for compatibility with those operating systems.
+          > [!NOTE]  
+          > For Windows 10 and later versions, we recommend enabling one or both of the ECDHE cipher suites for better security. Windows 8.1, 8, and 7 aren't compatible with these ECDHE cipher suites. The DHE cipher suites have been provided for compatibility with those operating systems.
           
           When using custom domains with TLS1.0/1.1 enabled the following cipher suites are supported:
           


### PR DESCRIPTION
Better clarify the OS support for AFD's four TLS 1.2 cipher suites. For better security, Windows 10 customers should prefer the EDCHE cipher suites while Windows 7, 8, and 8.1 customers must use the DHE cipher suites.