### PR TITLE
Ordering depends on event arrival, not when sent

### DIFF
--- a/includes/event-hubs-partitions.md
+++ b/includes/event-hubs-partitions.md
@@ -63,7 +63,7 @@ You can use a partition key to map incoming event data into specific partitions 
 
 The event publisher is only aware of its partition key, not the partition to which the events are published. This decoupling of key and partition insulates the sender from needing to know too much about the downstream processing. A per-device or user unique identity makes a good partition key, but other attributes such as geography can also be used to group related events into a single partition.
 
-Specifying a partition key enables keeping related events together in the same partition and in the exact order in which they were sent. The partition key is some string that is derived from your application context and identifies the interrelationship of the events. A sequence of events identified by a partition key is a *stream*. A partition is a multiplexed log store for many such streams. 
+Specifying a partition key enables keeping related events together in the same partition and in the exact order in which they arrived. The partition key is some string that is derived from your application context and identifies the interrelationship of the events. A sequence of events identified by a partition key is a *stream*. A partition is a multiplexed log store for many such streams. 
 
 > [!NOTE]
 > While you can send events directly to partitions, we don't recommend it, especially when high availability is important to you. It downgrades the availability of an event hub to partition-level. For more information, see [Availability and Consistency](../articles/event-hubs/event-hubs-availability-and-consistency.md).


### PR DESCRIPTION
This PR changes the wording "were sent" to "arrived", since a message can be delayed in transit from the client to the Event Hub.