### PR TITLE
Users at risk report log duration

### DIFF
--- a/articles/active-directory/reports-monitoring/reference-reports-data-retention.md
+++ b/articles/active-directory/reports-monitoring/reference-reports-data-retention.md
@@ -67,10 +67,10 @@ You can retain the audit and sign-in activity data for longer than the default r
 
 **Security signals**
 
-| Report         | Azure AD Free | Azure AD Premium P1 | Azure AD Premium P2 |
-| :--            | :--           | :--                 | :--                 |
-| Users at risk  | 7 days        | 30 days             | 90 days             |
-| Risky sign-ins | 7 days        | 30 days             | 90 days             |
+| Report         | Azure AD Free | Azure AD Premium P1 | Azure AD Premium P2  |
+| :--            | :--           | :--                 | :--                  |
+| Users at risk  | 7 days        | 30 days             | Duration not defined |
+| Risky sign-ins | 7 days        | 30 days             | 90 days              |
 
 ---
 


### PR DESCRIPTION
P2 has no log duration of  "Users at risk".
Confirmed I can see reports in 2018 with P2 license,
Following article doesn't define duration for "Riskey Users", this is correct,
https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/howto-identity-protection-investigate-risk