### PR TITLE
Correct wording of Import tests from NPM tab

### DIFF
--- a/articles/network-watcher/migrate-to-connection-monitor-from-network-performance-monitor.md
+++ b/articles/network-watcher/migrate-to-connection-monitor-from-network-performance-monitor.md
@@ -46,7 +46,7 @@ The migration helps produce the following results:
 
 To migrate the tests from Network Performance Monitor to Connection Monitor, do the following:
 
-1. In Network Watcher, select **Connection Monitor**, and then select the **Migrate tests from NPM** tab. 
+1. In Network Watcher, select **Connection Monitor**, and then select the **Import tests from NPM** tab. 
 
 	:::image type="content" source="./media/connection-monitor-2-preview/migrate-npm-to-cm-preview.png" alt-text="Migrate tests from Network Performance Monitor to Connection Monitor" lightbox="./media/connection-monitor-2-preview/migrate-npm-to-cm-preview.png":::
 	


### PR DESCRIPTION
Changed 'Migrate' to 'Import' in the mention of the tab name, as per the picture immediately below it.