### PR TITLE
Remove Support Dependency Agent for Suse 12 SP2

### DIFF
--- a/articles/azure-monitor/agents/agents-overview.md
+++ b/articles/azure-monitor/agents/agents-overview.md
@@ -214,7 +214,6 @@ Since the Dependency agent works at the kernel level, support is also dependent 
 | SUSE Linux 12 Enterprise Server | 15     | 4.12.14-150\*
 |                                 | 12 SP4 | 4.12.* (includes Azure-tuned kernel) |
 |                                 | 12 SP3 | 4.4.* |
-|                                 | 12 SP2 | 4.4.* |
 | Debian                          | 9      | 4.9  | 
 
 ## Next steps


### PR DESCRIPTION
Per support ticket, Suse 12 SP2 with 4.4.* is not supported for the dependency agent.  matdavi internally if you need the ticket number.