### PR TITLE
Added subtle clarification to ClaimsMappingPolicy

### DIFF
--- a/articles/active-directory/develop/active-directory-claims-mapping.md
+++ b/articles/active-directory/develop/active-directory-claims-mapping.md
@@ -94,6 +94,9 @@ In this example, you create a policy that adds the EmployeeID and TenantCountry 
       New-AzureADPolicy -Definition @('{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":"true", "ClaimsSchema": [{"Source":"user","ID":"employeeid","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/employeeid","JwtClaimType":"name"},{"Source":"company","ID":"tenantcountry","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country","JwtClaimType":"country"}]}}') -DisplayName "ExtraClaimsExample" -Type "ClaimsMappingPolicy"
       ```
 
+> [!WARNING]
+> Use the `ExtensionID` property instead of the `ID` property within the body of the `ClaimsSchema` array when defining a claims mapping policy for a directory extension attribute.
+
    2. To see your new policy, and to get the policy ObjectId, run the following command:
 
       ``` powershell

--- a/articles/active-directory/develop/active-directory-claims-mapping.md
+++ b/articles/active-directory/develop/active-directory-claims-mapping.md
@@ -94,8 +94,8 @@ In this example, you create a policy that adds the EmployeeID and TenantCountry 
       New-AzureADPolicy -Definition @('{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":"true", "ClaimsSchema": [{"Source":"user","ID":"employeeid","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/employeeid","JwtClaimType":"name"},{"Source":"company","ID":"tenantcountry","SamlClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/country","JwtClaimType":"country"}]}}') -DisplayName "ExtraClaimsExample" -Type "ClaimsMappingPolicy"
       ```
 
-> [!WARNING]
-> Use the `ExtensionID` property instead of the `ID` property within the body of the `ClaimsSchema` array when defining a claims mapping policy for a directory extension attribute.
+      > [!WARNING]
+      > When you define a claims mapping policy for a directory extension attribute, use the `ExtensionID` property instead of the `ID` property within the body of the `ClaimsSchema` array.
 
    2. To see your new policy, and to get the policy ObjectId, run the following command:
 


### PR DESCRIPTION
This subtle difference isn't highlighted in the documentation making it easy for implementers to overlook. I have personally spent countless hours looking at this problem when trying to include directory extensions coming from Azure AD Connect.