### PR TITLE
Update durable-functions-sub-orchestrations.md

### DIFF
--- a/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
@@ -73,7 +73,7 @@ def orchestrator_function(context: df.DurableOrchestrationContext):
     device_id = context.get_input()
 
     # Step 1: Create an installation package in blob storage and return a SAS URL.
-    sas_url = yield context.call_activity"CreateInstallationPackage", device_id)
+    sas_url = yield context.call_activity("CreateInstallationPackage", device_id)
 
     # Step 2: Notify the device that the installation package is ready.
     yield context.call_activity("SendPackageUrlToDevice", { "id": device_id, "url": sas_url })
@@ -153,12 +153,9 @@ def orchestrator_function(context: df.DurableOrchestrationContext):
 
     # Run multiple device provisioning flows in parallel
     provisioning_tasks = []
-    id_ = 0
     for device_id in device_IDs:
-        child_id = context.instance_id + ":" + id_
-        provision_task = context.call_sub_orchestrator("DeviceProvisioningOrchestration", device_id, child_id)
+        provision_task = context.call_sub_orchestrator("DeviceProvisioningOrchestration", device_id)
         provisioning_tasks.append(provision_task)
-        id_ += 1
 
     yield context.task_all(provisioning_tasks)
 

--- a/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-sub-orchestrations.md
@@ -153,9 +153,12 @@ def orchestrator_function(context: df.DurableOrchestrationContext):
 
     # Run multiple device provisioning flows in parallel
     provisioning_tasks = []
+    id_ = 0
     for device_id in device_IDs:
-        provision_task = context.call_sub_orchestrator("DeviceProvisioningOrchestration", device_id)
+        child_id = f"{context.instance_id}:{id_}"
+        provision_task = context.call_sub_orchestrator("DeviceProvisioningOrchestration", device_id, child_id)
         provisioning_tasks.append(provision_task)
+        id_ += 1
 
     yield context.task_all(provisioning_tasks)
 


### PR DESCRIPTION
Calling context.call_sub_orchestrator() with a child instance ID results in this error:

System.Private.CoreLib: Exception while executing function: Functions.ProvisionNewDevices. Microsoft.Azure.WebJobs.Extensions.DurableTask: Orchestrator function 'ProvisionNewDevices' failed: The sub-orchestration call (n = 1) should be executed with an instance id of DeviceProvisioningOrchestration instead of the provided instance id of DeviceProvisioningOrchestration. Check your code for non-deterministic behavior.

^It would be nice to know the correct way of doing this though, I'm sure the author of this doc didn't just make that scenario up ;)

Also fixed a missing opening parentheses.