### PR TITLE
Removing setting SQL admin password when setting TLS

### DIFF
--- a/articles/azure-sql/database/connectivity-settings.md
+++ b/articles/azure-sql/database/connectivity-settings.md
@@ -129,9 +129,7 @@ The following PowerShell script shows how to `Get` and `Set` the **Minimal TLS V
 (Get-AzSqlServer -ServerName sql-server-name -ResourceGroupName sql-server-group).MinimalTlsVersion
 
 # Update Minimal TLS Version to 1.2
-$SecureString = ConvertTo-SecureString "password" -AsPlainText -Force
-
-Set-AzSqlServer -ServerName sql-server-name -ResourceGroupName sql-server-group -SqlAdministratorPassword $SecureString  -MinimalTlsVersion "1.2"
+Set-AzSqlServer -ServerName sql-server-name -ResourceGroupName sql-server-group -MinimalTlsVersion "1.2"
 ```
 
 ## Set the minimal TLS version via the Azure CLI


### PR DESCRIPTION
There's no need for that and the text doesn't explain why it's done.