### PR TITLE
Update automate-responses-with-playbooks.md

### DIFF
--- a/articles/sentinel/automate-responses-with-playbooks.md
+++ b/articles/sentinel/automate-responses-with-playbooks.md
@@ -31,7 +31,7 @@ Many, if not most, of these alerts and incidents conform to recurring patterns t
 
 A playbook is a collection of these remediation actions that can be run from Azure Sentinel as a routine. A playbook can help [**automate and orchestrate your threat response**](tutorial-respond-threats-playbook.md); it can be run manually or set to run automatically in response to specific alerts or incidents, when triggered by an analytics rule or an automation rule, respectively.
 
-Playbooks are created and applied at the subscription level, but the **Playbooks** tab (in the new **Automation** blade) displays all the playbooks available across any selected subscriptions.
+Playbooks are created inside a resource group, but the **Playbooks** tab (in the new **Automation** blade) displays all the playbooks available across any selected subscriptions.
 
 ### Azure Logic Apps basic concepts
 


### PR DESCRIPTION
Playbook creation is controlled at the resource group level, not subscription.  The current wording indicates you need subscription level permissions to create a playbook.