### PR TITLE
Document reservation scenario that's in the portal

### DIFF
--- a/articles/virtual-machines/reserved-vm-instance-size-flexibility.md
+++ b/articles/virtual-machines/reserved-vm-instance-size-flexibility.md
@@ -35,6 +35,7 @@ You buy a reserved VM instance with the size Standard_DS4_v2 where the ratio or 
 - Scenario 2: Run two Standard_DS2_v2 sized VMs with a ratio of 2 each. Also run a Standard_DS3_v2 sized VM with a ratio of 4. The total footprint is 2+2+4=8. So your reservation discount applies to all three of those VMs.
 - Scenario 3: Run one Standard_DS5_v2 with a ratio of 16. Your reservation discount applies to half that VM's compute cost.
 - Scenario 4: Run one Standard_DS5_v2 with a ratio of 16 and purchase an additional Standard_DS4_v2 reservation with a ratio of 8. Both reservations combine and apply the discount to entire VM.
+- Scenario 5: Run one Standard_DS5_v2 with a ratio of 16 for 12 hours per day. Standard_DS4_v2 is consumed at double rate.
 
 The following sections show what sizes are in the same size series group when you buy a reserved VM instance optimized for instance size flexibility.
 


### PR DESCRIPTION
None of the scenarios listed on this page document the use case of purchasing a smaller reservation and using it at an accelerated rate for only a portion of the day which is documented in the portal as seen in this screenshot:

![image](https://user-images.githubusercontent.com/301208/123484063-bf598f00-d5d5-11eb-9cd9-00ff738947fa.png)
