### PR TITLE
docs: add consumption budgets naming rules

### DIFF
--- a/articles/azure-resource-manager/management/resource-name-rules.md
+++ b/articles/azure-resource-manager/management/resource-name-rules.md
@@ -188,6 +188,13 @@ In the following tables, the term alphanumeric refers to:
 > | --- | --- | --- | --- |
 > | communicationServices | global | 1-63 | Alphanumerics, hyphens, and underscores. |
 
+## Microsoft.Consumption
+
+> [!div class="mx-tableFixed"]
+> | Entity | Scope | Length | Valid Characters |
+> | --- | --- | --- | --- |
+> | budgets | subscription or resource group | 1-63 | Alphanumerics, hyphens, and underscores. |
+
 ## Microsoft.ContainerInstance
 
 > [!div class="mx-tableFixed"]


### PR DESCRIPTION
# Naming restrictions from the portal

![image](https://user-images.githubusercontent.com/31919569/123500879-c8993900-d673-11eb-9324-e7e6ea5aaeac.png)

# Scope

`budgets` can be defined at the subscription or resource group scope

At `subscription` scope:

![image](https://user-images.githubusercontent.com/31919569/123500893-da7adc00-d673-11eb-9e63-15682747f2a8.png)

At `resource group` scope

![image](https://user-images.githubusercontent.com/31919569/123500902-f2eaf680-d673-11eb-9cc6-1ddf16c6cbba.png)

# References

- Azure template reference: https://docs.microsoft.com/en-us/azure/templates/microsoft.consumption/budgets?tabs=json

<img src="https://user-images.githubusercontent.com/31919569/123500946-39d8ec00-d674-11eb-8289-509b3b78e778.png" width="400">
