### PR TITLE
Update functions-event-grid-blob-trigger.md

### DIFF
--- a/articles/azure-functions/functions-event-grid-blob-trigger.md
+++ b/articles/azure-functions/functions-event-grid-blob-trigger.md
@@ -33,19 +33,19 @@ This article demonstrates how to debug and deploy a local Event Grid Blob trigge
     # [C#](#tab/csharp)
 
     ```http
-    http://localhost:7071/runtime/webhooks/blobs?functionName={functionname}
+    http://localhost:7071/runtime/webhooks/eventgrid?functionName={functionname}
     ```
 
     # [Python](#tab/python)
 
     ```http
-    http://localhost:7071/runtime/webhooks/blobs?functionName=Host.Functions.{functionname}
+    http://localhost:7071/runtime/webhooks/eventgrid?functionName=Host.Functions.{functionname}
     ```
 
     # [Java](#tab/java)
 
     ```http
-    http://localhost:7071/runtime/webhooks/blobs?functionName=Host.Functions.{functionname}
+    http://localhost:7071/runtime/webhooks/eventgrid?functionName=Host.Functions.{functionname}
     ```
 
     ---


### PR DESCRIPTION
It seems like the documentation on blob triggers and event grid triggers got smooshed together.
I had to change my invocation url in the local context to replace blob with event grid for it to work. 
For a python function, this url worked for me: http://localhost:7071/runtime/webhooks/eventgrid?functionName=FuncNameWithNoHostDotFunctionsInIt
I'm using the v3.0.3388 of the func tools.