### PR TITLE
Clarify the counting scope of file system objects

### DIFF
--- a/articles/storage/files/storage-files-scale-targets.md
+++ b/articles/storage/files/storage-files-scale-targets.md
@@ -92,7 +92,7 @@ The following table indicates the boundaries of Microsoft's testing and also ind
 | Server endpoints per sync group | 100 server endpoints | Yes |
 | Server endpoints per server | 30 server endpoints | Yes |
 | File system objects (directories and files) per sync group | 100 million objects | No |
-| Maximum number of file system objects (directories and files) in a directory | 5 million objects | Yes |
+| Maximum number of file system objects (directories and files) in a directory (not recursive) | 5 million objects | Yes |
 | Maximum object (directories and files) security descriptor size | 64 KiB | Yes |
 | File size | 100 GiB | No |
 | Minimum file size for a file to be tiered | V9 and newer: Based on file system cluster size (double file system cluster size). For example, if the file system cluster size is 4 KiB, the minimum file size will be 8 KiB.<br> V8 and older: 64 KiB  | Yes |


### PR DESCRIPTION
To clarify the counting scope of file system objects.