### PR TITLE
Incorrect file size

### DIFF
--- a/articles/active-directory/fundamentals/customize-branding.md
+++ b/articles/active-directory/fundamentals/customize-branding.md
@@ -48,7 +48,7 @@ Your custom branding won't immediately appear when your users go to sites such a
 
         - **Language.** The language is automatically set as your default and can't be changed.
         
-        - **Sign-in page background image.** Select a .png or .jpg image file to appear as the background for your sign-in pages. The image will be anchored to the center of the browser, and will scale to the size of the viewable space. You can't select an image larger than 1920x1080 pixels in size or that has a file size more than 300 KB.
+        - **Sign-in page background image.** Select a .png or .jpg image file to appear as the background for your sign-in pages. The image will be anchored to the center of the browser, and will scale to the size of the viewable space. You can't select an image larger than 1920x1080 pixels in size or that has a file size more than 300,000 Bytes.
         
             It's recommended to use images without a strong subject focus, e.g., an opaque white box appears in the center of the screen, and could cover any part of the image depending on the dimensions of the viewable space.
 

--- a/articles/active-directory/fundamentals/customize-branding.md
+++ b/articles/active-directory/fundamentals/customize-branding.md
@@ -48,7 +48,7 @@ Your custom branding won't immediately appear when your users go to sites such a
 
         - **Language.** The language is automatically set as your default and can't be changed.
         
-        - **Sign-in page background image.** Select a .png or .jpg image file to appear as the background for your sign-in pages. The image will be anchored to the center of the browser, and will scale to the size of the viewable space. You can't select an image larger than 1920x1080 pixels in size or that has a file size more than 300,000 Bytes.
+        - **Sign-in page background image.** Select a .png or .jpg image file to appear as the background for your sign-in pages. The image will be anchored to the center of the browser, and will scale to the size of the viewable space. You can't select an image larger than 1920x1080 pixels in size or that has a file size more than 300,000 bytes.
         
             It's recommended to use images without a strong subject focus, e.g., an opaque white box appears in the center of the screen, and could cover any part of the image depending on the dimensions of the viewable space.
 


### PR DESCRIPTION
The actual information displayed by Microsoft within the branding section is misleading/incorrect.  It says "File size: <300KB" which is 307,200 Bytes. When you have an image file that Windows shows is 299KB (306,176 Bytes) the Azure portal rejects the image as too large with an error displayed that says "Selected file <name> must be between 1 and 300000 bytes" which is less than 293KB.  I know this is not the correct way to get the actual portal functionality updated so let's update the documentation to reflect what the portal actually accepts. The problem is caused by the use of KB = 1024 bytes or 1000 bytes and is inconsistent.