### PR TITLE
Specify the US locale for Java sample and clarify date format

### DIFF
--- a/articles/azure-monitor/logs/data-collector-api.md
+++ b/articles/azure-monitor/logs/data-collector-api.md
@@ -48,7 +48,7 @@ To use the HTTP Data Collector API, you create a POST request that includes the 
 |:--- |:--- |
 | Authorization |The authorization signature. Later in the article, you can read about how to create an HMAC-SHA256 header. |
 | Log-Type |Specify the record type of the data that is being submitted. Can only contain letters, numbers, and underscore (_), and may not exceed 100 characters. |
-| x-ms-date |The date that the request was processed, in RFC 1123 format. |
+| x-ms-date |The date that the request was processed, in RFC 7234 format. |
 | x-ms-AzureResourceId | Resource ID of the Azure resource the data should be associated with. This populates the [_ResourceId](./log-standard-columns.md#_resourceid) property and allows the data to be included in [resource-context](./design-logs-deployment.md#access-mode) queries. If this field isn't specified, the data will not be included in resource-context queries. |
 | time-generated-field | The name of a field in the data that contains the timestamp of the data item. If you specify a field then its contents are used for **TimeGenerated**. If this field isn’t specified, the default for **TimeGenerated** is the time that the message is ingested. The contents of the message field should follow the ISO 8601 format YYYY-MM-DDThh:mm:ssZ. |
 
@@ -593,7 +593,7 @@ public class ApiExample {
     String stringToHash = String
         .join("\n", httpMethod, String.valueOf(json.getBytes(StandardCharsets.UTF_8).length), contentType,
             xmsDate , resource);
-    String hashedString = getHMAC254(stringToHash, sharedKey);
+    String hashedString = getHMAC256(stringToHash, sharedKey);
     String signature = "SharedKey " + workspaceId + ":" + hashedString;
 
     postData(signature, dateString, json);
@@ -601,7 +601,7 @@ public class ApiExample {
 
   private static String getServerTime() {
     Calendar calendar = Calendar.getInstance();
-    SimpleDateFormat dateFormat = new SimpleDateFormat(RFC_1123_DATE);
+    SimpleDateFormat dateFormat = new SimpleDateFormat(RFC_1123_DATE, Locale.US);
     dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
     return dateFormat.format(calendar.getTime());
   }
@@ -622,14 +622,14 @@ public class ApiExample {
     }
   }
 
-  private static String getHMAC254(String input, String key) throws InvalidKeyException, NoSuchAlgorithmException {
+  private static String getHMAC256(String input, String key) throws InvalidKeyException, NoSuchAlgorithmException {
     String hash;
-    Mac sha254HMAC = Mac.getInstance("HmacSHA256");
+    Mac sha256HMAC = Mac.getInstance("HmacSHA256");
     Base64.Decoder decoder = Base64.getDecoder();
     SecretKeySpec secretKey = new SecretKeySpec(decoder.decode(key.getBytes(StandardCharsets.UTF_8)), "HmacSHA256");
-    sha254HMAC.init(secretKey);
+    sha256HMAC.init(secretKey);
     Base64.Encoder encoder = Base64.getEncoder();
-    hash = new String(encoder.encode(sha254HMAC.doFinal(input.getBytes(StandardCharsets.UTF_8))));
+    hash = new String(encoder.encode(sha256HMAC.doFinal(input.getBytes(StandardCharsets.UTF_8))));
     return hash;
   }
 


### PR DESCRIPTION
If the locale on your machine is not US, then the date gets generated differently and Azure Monitor Data Collector API rejects the message with an invalid date format message.

I'm in Australia and the date format ended up looking like `Fri., 02 Jul. 2021 07:28:21 GMT` which has extra full stops after the day and month. Adding the locale fixed that so the date became `Fri, 02 Jul 2021 07:29:15 GMT`.

Ultimately I switched to `DateTimeFormatter` because it's more modern and performant (it's thread safe so you can share a formatter between threads). But it's a little fiddly to get to work. 
Out of the box there is a formatter that almost works, `DateTimeFormatter.RFC_1123_DATE_TIME`, but it doesn't have leading zeros for the day of the month (I'm fairly certain RFC 1123 allows for 1 or 2 digits for day of month), which causes the API to fail. Since the Data Collector API is quite strict about the dates, I think it should say that the date format is [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1) instead of [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123#page-55). RFC 7231 is the same format used for HTTP Expires headers, which is more in line with how the header is used.