### PR TITLE
Update manage-automation.md

### DIFF
--- a/articles/cost-management-billing/costs/manage-automation.md
+++ b/articles/cost-management-billing/costs/manage-automation.md
@@ -91,7 +91,7 @@ GET https://management.azure.com/{scope}/providers/Microsoft.Consumption/usageDe
 For modern customers with a Microsoft Customer Agreement, use the following call:
 
 ```http
-GET https://management.azure.com/{scope}/providers/Microsoft.Consumption/usageDetails?startDate=2020-08-01&endDate=&2020-08-05$top=1000&api-version=2019-10-01
+GET https://management.azure.com/{scope}/providers/Microsoft.Consumption/usageDetails?startDate=2020-08-01&endDate=2020-08-05$top=1000&api-version=2019-10-01
 ```
 
 ### Get amortized cost details


### PR DESCRIPTION
Typo in the Get Usage Details for a scope during specific date range for modern subscriptions. I believe it shouldn't have "&" in front of the value for the endDate