### PR TITLE
Update workspace-data-exfiltration-protection.md

### DIFF
--- a/articles/synapse-analytics/security/workspace-data-exfiltration-protection.md
+++ b/articles/synapse-analytics/security/workspace-data-exfiltration-protection.md
@@ -29,9 +29,7 @@ Let us use an example to illustrate data exfiltration protection for Synapse wor
 
 >[!IMPORTANT]
 >
-> - Resources in tenants other than the workspace's tenant must not have blocking firewall rules in place for the SQL pools to connect to them. Resources within the workspace’s managed virtual network, such as Spark clusters, can connect over managed private links to firewall-protected resources.
->
-> - Metastore is disabled in Synapse workspaces that have Managed Virtual Network with data exfiltration protection enabled. You can't use Spark SQL in these workspaces.
+> Resources in tenants other than the workspace's tenant must not have blocking firewall rules in place for the SQL pools to connect to them. Resources within the workspace’s managed virtual network, such as Spark clusters, can connect over managed private links to firewall-protected resources.
 > >
 
 ## Next Steps


### PR DESCRIPTION
This constraint is no longer valid:
Metastore is disabled in Synapse workspaces that have Managed Virtual Network with data exfiltration protection enabled. You can't use Spark SQL in these workspaces.