### PR TITLE
edit quickstart title to include Call Automation APIs

### DIFF
--- a/articles/communication-services/toc.yml
+++ b/articles/communication-services/toc.yml
@@ -51,7 +51,7 @@ items:
       href: quickstarts/voice-video-calling/calling-client-samples.md
     - name: Join your calling client app to a Teams meeting
       href: quickstarts/voice-video-calling/get-started-teams-interop.md
-    - name: Join a service to a call
+    - name: Join a service to a call using Call Automation APIs
       href: quickstarts/voice-video-calling/call-automation-api-sample.md
     - name: Record calls
       href: quickstarts/voice-video-calling/call-recording-sample.md


### PR DESCRIPTION
rename "Join a service to a call" to "Join a service to a call using Call Automation APIs" in order to make the call automation api quickstart page more discoverable