### PR TITLE
Example for VM policy query

### DIFF
--- a/articles/backup/query-backups-using-azure-resource-graph.md
+++ b/articles/backup/query-backups-using-azure-resource-graph.md
@@ -95,6 +95,17 @@ Resources
 
 ```
 
+### List all Backup policies used for Azure VMs
+
+```dotnetcli
+RecoveryServicesResources
+| where type == 'microsoft.recoveryservices/vaults/backuppolicies'
+| extend vaultName = case(type == 'microsoft.recoveryservices/vaults/backuppolicies', split(split(id, 'microsoft.recoveryservices/vaults/')[1],'/')[0],type == 'microsoft.recoveryservices/vaults/backuppolicies', split(split(id, 'microsoft.recoveryservices/vaults/')[1],'/')[0],'--')
+| extend datasourceType = case(type == 'microsoft.recoveryservices/vaults/backuppolicies', properties.backupManagementType,type == 'microsoft.dataprotection/backupVaults/backupPolicies',properties.datasourceTypes[0],'--')
+| project id,name,vaultName,resourceGroup,properties,datasourceType
+| where datasourceType == 'AzureIaasVM'
+```
+
 ### List all Backup policies used for Azure Databases for PostgreSQL Servers
 
 ```dotnetcli

--- a/articles/backup/query-backups-using-azure-resource-graph.md
+++ b/articles/backup/query-backups-using-azure-resource-graph.md
@@ -42,7 +42,7 @@ The following are some sample ARG queries on your backup data that you can use i
 
 ### List all Azure VMs that have been configured for backup
 
-```dotnetcli
+```kusto
 RecoveryServicesResources 
 | where type in~ ('Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems')
 | extend vaultName = case(type =~ 'microsoft.dataprotection/backupVaults/backupInstances',split(split(id, '/Microsoft.DataProtection/backupVaults/')[1],'/')[0],type =~ 'Microsoft.RecoveryServices/vaults/backupFabrics/protectionContainers/protectedItems',split(split(id, '/Microsoft.RecoveryServices/vaults/')[1],'/')[0],'--')
@@ -61,7 +61,7 @@ RecoveryServicesResources
 
 ### List all backup jobs on Azure Databases for PostgreSQL Servers in the last one week
 
-```dotnetcli
+```kusto
 RecoveryServicesResources 
 | where type in~ ('Microsoft.DataProtection/backupVaults/backupJobs')
 | extend vaultName = case(type =~ 'microsoft.dataprotection/backupVaults/backupJobs',properties.vaultName,type =~ 'Microsoft.RecoveryServices/vaults/backupJobs',split(split(id, '/Microsoft.RecoveryServices/vaults/')[1],'/')[0],'--')
@@ -81,7 +81,7 @@ RecoveryServicesResources
 
 ### List all Azure VMs that have not been configured for backup
 
-```dotnetcli
+```kusto
 Resources
 | where type in~ ('microsoft.compute/virtualmachines','microsoft.classiccompute/virtualmachines') 
 | extend resourceId=tolower(id) 
@@ -97,7 +97,7 @@ Resources
 
 ### List all Backup policies used for Azure VMs
 
-```dotnetcli
+```kusto
 RecoveryServicesResources
 | where type == 'microsoft.recoveryservices/vaults/backuppolicies'
 | extend vaultName = case(type == 'microsoft.recoveryservices/vaults/backuppolicies', split(split(id, 'microsoft.recoveryservices/vaults/')[1],'/')[0],type == 'microsoft.recoveryservices/vaults/backuppolicies', split(split(id, 'microsoft.recoveryservices/vaults/')[1],'/')[0],'--')
@@ -108,7 +108,7 @@ RecoveryServicesResources
 
 ### List all Backup policies used for Azure Databases for PostgreSQL Servers
 
-```dotnetcli
+```kusto
 RecoveryServicesResources 
 | where type in~ ('Microsoft.DataProtection/BackupVaults/backupPolicies')
 | extend vaultName = case(type =~ 'microsoft.dataprotection/backupVaults/backupPolicies', split(split(id, '/Microsoft.DataProtection/backupVaults/')[1],'/')[0],type =~ 'microsoft.recoveryservices/vaults/backupPolicies', split(split(id, '/Microsoft.RecoveryServices/vaults/')[1],'/')[0],'--')


### PR DESCRIPTION
This is based on the PostgreSQL example but for VMs. Note the changes in type names to reflect current info. The PostgreSQL query likely also needs an update.

Using == to make the query a tiny bit faster compared to the PostgreSQL example.