### PR TITLE
Update refresh-tokens.md -> Token timeouts

### DIFF
--- a/articles/active-directory/develop/refresh-tokens.md
+++ b/articles/active-directory/develop/refresh-tokens.md
@@ -37,15 +37,15 @@ Refresh tokens can be revoked at any time, because of timeouts and revocations. 
 
 ### Token timeouts
 
-Using [token lifetime configuration](active-directory-configurable-token-lifetimes.md#refresh-and-session-token-lifetime-policy-properties), the lifetime of refresh tokens can be reduced or lengthened. This setting changes the length of time that a refresh token can go without use. For example, consider a scenario where a user doesn't open an app for more than 90 days. When the app attempts to use that 90+ day old refresh token, it will find that it has expired. Additionally, an admin can  require that second factors be used on a regular cadence, forcing the user to manually sign in at specific intervals. These scenarios include:
+> [!IMPORTANT]
+> As of January 30, 2021 you can not configure refresh token lifetimes. Azure Active Directory no longer honors refresh token configuration in existing policies.  New tokens issued after existing tokens have expired are now set to the [default configuration](#configurable-token-lifetime-properties).
+>
+> Existing token’s lifetime will not be changed. After they expire, a new token will be issued based on the default value.
+>
+> If you need to continue to define the time period before a user is asked to sign in again, configure sign-in frequency in Conditional Access. To learn more about Conditional Access, read [Configure authentication session management with Conditional Access](../conditional-access/howto-conditional-access-session-lifetime.md).
+> You can learn more about refresh token lifetime policy properties by reading [Refresh and session token lifetime policy properties](/active-directory-configurable-token-lifetimes#refresh-and-session-token-lifetime-policy-properties)
 
-* Inactivity: refresh tokens are only valid for a period dictated by the `MaxInactiveTime`.  If the token isn't used (and replaced by the new token) within that time period, it will no longer be usable.
-* Session age-out: If `MaxAgeSessionMultiFactor` or `MaxAgeSessionSingleFactor` have been set to something other than their default (Until-revoked), then reauthentication will be required after the time set in the MaxAgeSession* elapses.  This is used to force users to reauthenticate with a first or second factor periodically. 
-* Examples:
-  * The tenant has a MaxInactiveTime of five days, and the user went on vacation for a week. As such, Azure AD hasn't seen a new token request from the user in seven days. The next time the user requests a new token, they'll find their Refresh Token has been revoked, and they must enter their credentials again.
-  * A sensitive application has a `MaxAgeSessionMultiFactor` of one day. A user will be required to go through MFA once more through an interactive prompt if they sign in again after a period of one day. For example, if a user logs in on Monday, and on Tuesday after 25 hours have elapsed. 
 
-Not all refresh tokens follow the rules set in the token lifetime policy. Specifically, refresh tokens used in [single page apps](reference-third-party-cookies-spas.md) are always limited to 24 hours of activity, as if they have a `MaxAgeSessionSingleFactor` policy of 24 hours applied to them. 
 
 ### Revocation
 


### PR DESCRIPTION
Doc states "Using token lifetime configuration, the lifetime of refresh tokens can be reduced or lengthened. ", but this no longer verifies, as it is not possible anymore to configure token lifetimes for refresh tokens (https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-configurable-token-lifetimes#token-lifetime-policies-for-refresh-tokens-and-session-tokens).
Due to this, information is outdated, and might be replaced with the info in the aforementioned link, pointing to the new way of doing it and to information about default lifetime properties for refresh tokens.