### PR TITLE
Update security-hardened-vm-host-image.md

### DIFF
--- a/articles/aks/security-hardened-vm-host-image.md
+++ b/articles/aks/security-hardened-vm-host-image.md
@@ -16,7 +16,7 @@ As a secure service, Azure Kubernetes Service (AKS) complies with SOC, ISO, PCI 
 > [!Note]
 > This document is scoped to Linux agents in AKS only.
 
-AKS clusters are deployed on host VMs, which run a security-optimized OS used for containers running on AKS. This host OS is based on an **Ubuntu 16.04.LTS** image with more [security hardening](#security-hardening-features) and optimizations applied.
+AKS clusters are deployed on host VMs, which run a security-optimized OS used for containers running on AKS. This host OS is based on an **Ubuntu 18.04.LTS** image with more [security hardening](#security-hardening-features) and optimizations applied.
 
 The goal of the security hardened host OS is to reduce the surface area of attack and optimize for the deployment of containers in a secure manner.
 


### PR DESCRIPTION
Update to Ubuntu 18.04 as Ubuntu 16.04 is not used after upgrading to minimum supported AKS version 1.18.x
Reference: https://docs.microsoft.com/en-us/azure/aks/cluster-configuration#os-configuration