### PR TITLE
Update move-resource-group-and-subscription.md

### DIFF
--- a/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
+++ b/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
@@ -229,7 +229,7 @@ To move to a new subscription, provide the `--destination-subscription-id` param
 
 ### Validate
 
-The [validate move operation](/rest/api/resources/resources/moveresources) lets you test your move scenario without actually moving the resources. Use this operation to check if the move will succeed. Validation is automatically called when you send a move request. Use this operation only when you need to predetermine the results. To run this operation, you need the:
+The [validate move operation](/rest/api/resources/resources/validate-move-resources) lets you test your move scenario without actually moving the resources. Use this operation to check if the move will succeed. Validation is automatically called when you send a move request. Use this operation only when you need to predetermine the results. To run this operation, you need the:
 
 * name of the source resource group
 * resource ID of the target resource group


### PR DESCRIPTION
#232 - 'validate move' link was linking to /move-resources instead of /validate-move-resources. Caused issues - the 'try it' feature results in live resource moves rather than non-impacting moves as should be.