### PR TITLE
AKS Update credentials: Quote the secret

### DIFF
--- a/articles/aks/update-credentials.md
+++ b/articles/aks/update-credentials.md
@@ -103,7 +103,7 @@ az aks update-credentials \
     --name myAKSCluster \
     --reset-service-principal \
     --service-principal $SP_ID \
-    --client-secret $SP_SECRET
+    --client-secret "$SP_SECRET"
 ```
 
 For small and midsize clusters, it takes a few moments for the service principal credentials to be updated in the AKS.


### PR DESCRIPTION
Not quoting  the secret results in an error:

> Operation failed with status: 'Bad Request'. Details: The credentials in ServicePrincipalProfile were invalid. Please see https://aka.ms/aks-sp-help for more details.