### PR TITLE
Append powershell execution policy

### DIFF
--- a/articles/remote-rendering/quickstarts/render-model.md
+++ b/articles/remote-rendering/quickstarts/render-model.md
@@ -44,7 +44,7 @@ Run the following commands:
 mkdir ARR
 cd ARR
 git clone https://github.com/Azure/azure-remote-rendering
-powershell azure-remote-rendering\Scripts\DownloadUnityPackages.ps1
+powershell -ExecutionPolicy RemoteSigned -File azure-remote-rendering\Scripts\DownloadUnityPackages.ps1
 ```
 
 The last command creates a subdirectory in the ARR directory containing the various sample projects for Azure Remote Rendering.


### PR DESCRIPTION
The changeing consider the default value of PowerShell execution policy.

# Reason

A reader who isn't accustomed to using PowerShell get stuck in the execution policy of PowerShell. 
By passing quickly the QuickStart tutorial, the number of users of remote rendering services may increase.
Therefore, I'd like to change to the code sample that specifies the authority here.

**Unspecified execution policy**

```ps1
powershell azure-remote-rendering\Scripts\DownloadUnityPackages.ps1
```

![Screen Shot 2021-07-09 at 16 05 14](https://user-images.githubusercontent.com/359823/125037738-76becd00-e0cf-11eb-969b-7486cda768ca.png)

**Specified execution policy**

```ps1
powershell -ExecutionPolicy RemoteSigned -File azure-remote-rendering\Scripts\DownloadUnityPackages.ps1
```

![Screen Shot 2021-07-09 at 16 09 14](https://user-images.githubusercontent.com/359823/125038151-09f80280-e0d0-11eb-8fdc-5890b926d8fb.png)

# Reference case

- https://github.com/Azure/azure-remote-rendering/issues/40#issuecomment-876802979