### PR TITLE
(Azure CXP) resolves MicrosoftDocs/azure-docs#78125

### DIFF
--- a/articles/virtual-machines/linux/compute-benchmark-scores.md
+++ b/articles/virtual-machines/linux/compute-benchmark-scores.md
@@ -686,7 +686,7 @@ The following CoreMark benchmark scores show compute performance for Azure's hig
 
 ## About CoreMark
 
-[CoreMark](https://www.eembc.org/coremark/faq.php) is a benchmark that tests the functionality of a microctronoller (MCU) or central processing unit (CPU). CoreMark is not system dependent, so it functions the same regardless of the platform (e.g. big or little endian, high-end or low-end processor). 
+[CoreMark](https://www.eembc.org/coremark/faq.php) is a benchmark that tests the functionality of a microcontroller (MCU) or central processing unit (CPU). CoreMark is not system dependent, so it functions the same regardless of the platform (e.g. big or little endian, high-end or low-end processor). 
 
 Linux numbers were computed by running CoreMark on Ubuntu 18.04. CoreMark was configured with the number of threads set to the number of virtual CPUs, and concurrency set to `PThreads`. The target number of iterations was adjusted based on expected performance to provide a runtime of at least 20 seconds (typically much longer). The final score represents the number of iterations completed divided by the number of seconds it took to run the test. Each test was run at least seven times on each VM. Test run dates shown above. Tests run on multiple VMs across Azure public regions the VM was supported in on the date run. 
 


### PR DESCRIPTION
Fixed typo on Line 689: microctronoller -> microcontroller