### PR TITLE
Update concepts-security.md

### DIFF
--- a/articles/aks/concepts-security.md
+++ b/articles/aks/concepts-security.md
@@ -106,7 +106,7 @@ For connectivity and security with on-premises networks, you can deploy your AKS
 
 To filter virtual network traffic flow, Azure uses network security group rules. These rules define the source and destination IP ranges, ports, and protocols allowed or denied access to resources. Default rules are created to allow TLS traffic to the Kubernetes API server. You create services with load balancers, port mappings, or ingress routes. AKS automatically modifies the network security group for traffic flow.
 
-If you provide your own subnet for your AKS cluster, **do not** modify the subnet-level network security group managed by AKS. Instead, create more subnet-level network security groups to modify the flow of traffic. Make sure they don't interfere with necessary traffic managing the cluster, such as load balancer access, communication with the control plane, and [egress][aks-limit-egress-traffic].
+If you provide your own subnet for your AKS cluster (whether using Azure CNI or Kubenet), **do not** modify the NIC-level network security group managed by AKS. Instead, create more subnet-level network security groups to modify the flow of traffic. Make sure they don't interfere with necessary traffic managing the cluster, such as load balancer access, communication with the control plane, and [egress][aks-limit-egress-traffic].
 
 ### Kubernetes network policy
 


### PR DESCRIPTION
Proposing adding a small clarification that when using your own subnet for AKS the NSG is actually attached to the Nodes NIC instead of the AKS Subnet.  This applies for both, Azure CNI and Kubenet. Here's is quick table that compares both:

## Network Security Groups

| Networking Option | VNET | NSG 
| - | - | - | 
| Kubenet | Created by Azure | NSG attached to the AgentPool subnet
| Kubenet | Existing VNET/Subnet | NSG attached to the Nodes NICs 
| Azure CNI | Created by Azure |  NSG attached to the AgentPool subnet
| Azure CNI | Existing VNET/Subnet |  NSG attached to the Nodes NICs