### PR TITLE
Correct DNS record-set-name

### DIFF
--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -85,7 +85,7 @@ Add an *A* record to your DNS zone with the external IP address of the NGINX ser
 az network dns record-set a add-record \
     --resource-group myResourceGroup \
     --zone-name MY_CUSTOM_DOMAIN \
-    --record-set-name |*" \
+    --record-set-name "*" \
     --ipv4-address MY_EXTERNAL_IP
 ```
 

--- a/articles/aks/ingress-tls.md
+++ b/articles/aks/ingress-tls.md
@@ -85,7 +85,7 @@ Add an *A* record to your DNS zone with the external IP address of the NGINX ser
 az network dns record-set a add-record \
     --resource-group myResourceGroup \
     --zone-name MY_CUSTOM_DOMAIN \
-    --record-set-name * \
+    --record-set-name |*" \
     --ipv4-address MY_EXTERNAL_IP
 ```
 


### PR DESCRIPTION
By default on a shell, * will expand to all files in the current directory.  I surrounded * with a quote so that the record will be created with a * character.