### PR TITLE
Update policy.md for Linux VMs

### DIFF
--- a/articles/virtual-machines/linux/policy.md
+++ b/articles/virtual-machines/linux/policy.md
@@ -26,7 +26,6 @@ To ensure that virtual machines for your organization are compatible with an app
       {
         "field": "type",
         "in": [
-          "Microsoft.Compute/disks",
           "Microsoft.Compute/virtualMachines",
           "Microsoft.Compute/VirtualMachineScaleSets"
         ]


### PR DESCRIPTION
Updated Azure Policy for Linux VMs not to require disk resource check.

Currently there is a discrepancy between Windows and Linux VMs when it comes to this Azure Policy and I don't believe there is a reason for the policy to check Microsoft.Compute/disks.