### PR TITLE
Fix server name variable for SQL connection

### DIFF
--- a/articles/azure-sql/database/connect-query-python.md
+++ b/articles/azure-sql/database/connect-query-python.md
@@ -51,12 +51,12 @@ To further explore Python and the database in Azure SQL Database, see [Azure SQL
    ```python
    import pyodbc
    server = '<server>.database.windows.net'
-   database = 'tcp:<database>'
+   database = '<database>'
    username = '<username>'
    password = '{<password>}'   
    driver= '{ODBC Driver 17 for SQL Server}'
    
-   with pyodbc.connect('DRIVER='+driver+';SERVER='+server+';PORT=1433;DATABASE='+database+';UID='+username+';PWD='+ password) as conn:
+   with pyodbc.connect('DRIVER='+driver+';SERVER=tcp:'+server+';PORT=1433;DATABASE='+database+';UID='+username+';PWD='+ password) as conn:
        with conn.cursor() as cursor:
            cursor.execute("SELECT TOP 3 name, collation_name FROM sys.databases")
            row = cursor.fetchone()

--- a/articles/azure-sql/database/connect-query-python.md
+++ b/articles/azure-sql/database/connect-query-python.md
@@ -51,9 +51,9 @@ To further explore Python and the database in Azure SQL Database, see [Azure SQL
    ```python
    import pyodbc
    server = '<server>.database.windows.net'
-   database = '<database>'
+   database = 'tcp:<database>'
    username = '<username>'
-   password = '<password>'   
+   password = '{<password>}'   
    driver= '{ODBC Driver 17 for SQL Server}'
    
    with pyodbc.connect('DRIVER='+driver+';SERVER='+server+';PORT=1433;DATABASE='+database+';UID='+username+';PWD='+ password) as conn:


### PR DESCRIPTION
adding 'tcp:' as a prefix for server name while connecting as that what works with pyodbc .
 --> also good practices to wrap password with curly braces if password contains special characters 
tried and tested