### PR TITLE
Fixed metric alerts CLI docs

### DIFF
--- a/articles/azure-monitor/alerts/alerts-metric.md
+++ b/articles/azure-monitor/alerts/alerts-metric.md
@@ -119,7 +119,7 @@ The previous sections described how to create, view, and manage metric alert rul
 6. You can disable a metric alert rule using the following command.
 
     ```azurecli
-    az monitor metrics alert update -g {ResourceGroup} -n {AlertRuleName} --enabled false
+    az monitor metrics alert update -g {ResourceGroup} -n {AlertRuleName} --disabled false
     ```
 
 7. You can delete a metric alert rule using the following command.


### PR DESCRIPTION
The option name is 'disabled', not 'enabled':
https://docs.microsoft.com/en-us/cli/azure/monitor/metrics/alert?view=azure-cli-latest#az_monitor_metrics_alert_create-optional-parameters