### PR TITLE
Global Catalog access is needed to enable Azure Active Directory Seam…

### DIFF
--- a/articles/active-directory/hybrid/reference-connect-ports.md
+++ b/articles/active-directory/hybrid/reference-connect-ports.md
@@ -32,6 +32,7 @@ This table describes the ports and protocols that are required for communication
 | Kerberos |88 (TCP/UDP) |Kerberos authentication to the AD forest. |
 | MS-RPC |135 (TCP) |Used during the initial configuration of the Azure AD Connect wizard when it binds to the AD forest, and also during Password synchronization. |
 | LDAP |389 (TCP/UDP) |Used for data import from AD. Data is encrypted with Kerberos Sign & Seal. |
+| Global Catalog |3268 (TCP/UDP) |Used to configure Azure Active Directory Seamless Single Sign-On. |
 | SMB | 445 (TCP) |Used by Seamless SSO to create a computer account in the AD forest. |
 | LDAP/SSL |636 (TCP/UDP) |Used for data import from AD. The data transfer is signed and encrypted. Only used if you are using TLS. |
 | RPC |49152- 65535 (Random high RPC Port)(TCP) |Used during the initial configuration of Azure AD Connect when it binds to the AD forests, and during Password synchronization. If the dynamic port has been changed, you need to open that port. See [KB929851](https://support.microsoft.com/kb/929851), [KB832017](https://support.microsoft.com/kb/832017), and [KB224196](https://support.microsoft.com/kb/224196) for more information. |


### PR DESCRIPTION
…less Single Sign-On

Without access to the GC the scripts to enable Azure Active Directory Seamless Single Sign-On seen at https://docs.microsoft.com/en-us/azure/active-directory/hybrid/tshoot-connect-sso#manual-reset-of-the-feature do not work because the cmdlets report "[time] [  9] [INFORMATIONAL] GetDesktopSsoComputerAccount: Searching in global catalog(forest) and ad.dcsadvisory.com for computer account AZUREADSSOACC" and then fail to connect. Once GC ports are open this works immediately. Therefore proposing that this is added to this table