### PR TITLE
Update groups-assign-role.md

### DIFF
--- a/articles/active-directory/roles/groups-assign-role.md
+++ b/articles/active-directory/roles/groups-assign-role.md
@@ -78,13 +78,11 @@ POST https://graph.microsoft.com/beta/groups
 {
 "description": "This group is assigned to Helpdesk Administrator built-in role of Azure AD.",
 "displayName": "Contoso_Helpdesk_Administrators",
-"groupTypes": [
-"Unified"
-],
-"mailEnabled": true,
-"securityEnabled": true
+"groupTypes": [],
+"mailEnabled": false,
+"securityEnabled": true,
 "mailNickname": "contosohelpdeskadministrators",
-"isAssignableToRole": true,
+"isAssignableToRole": true
 }
 ```
 


### PR DESCRIPTION
Fixed Graph API example syntax, and changed it to create a security group instead of a unified group.