### PR TITLE
docs: Fix link to Azure Event Grid in API Management

### DIFF
--- a/articles/api-management/how-to-event-grid.md
+++ b/articles/api-management/how-to-event-grid.md
@@ -11,7 +11,7 @@ ms.custom:
 
 # Send events from API Management to Event Grid (Preview)
 
-API Management integrates with Azure [Event Grid](../event-grid/overview.md) so that you can send event notifications to other services and trigger downstream processes. Event Grid is a fully managed event routing service that uses a publish-subscribe model. Event Grid has built-in support for Azure services like [Azure Functions](../azure-functions/functions-overview.md) and [Azure Logic Apps](../logic-apps/logic-apps-overview.md), and can deliver event alerts to non-Azure services using webhooks.
+API Management integrates with [Azure Event Grid](../event-grid/overview.md) so that you can send event notifications to other services and trigger downstream processes. Event Grid is a fully managed event routing service that uses a publish-subscribe model. Event Grid has built-in support for Azure services like [Azure Functions](../azure-functions/functions-overview.md) and [Azure Logic Apps](../logic-apps/logic-apps-overview.md), and can deliver event alerts to non-Azure services using webhooks.
 
 For example, using integration with Event Grid, you can build an application that updates a database, creates a billing account, and sends an email notification each time a user is added to your API Management instance.
 


### PR DESCRIPTION
Fix link to Azure Event Grid in API Management to align with other docs (nit)