### PR TITLE
Modify "Reset failed logon attempts count after"

### DIFF
--- a/articles/active-directory-domain-services/password-policy.md
+++ b/articles/active-directory-domain-services/password-policy.md
@@ -59,7 +59,7 @@ All users, regardless of how they're created, have the following account lockout
 
 * **Account lockout duration:** 30
 * **Number of failed logon attempts allowed:** 5
-* **Reset failed logon attempts count after:** 30 minutes
+* **Reset failed logon attempts count after:** 2 minutes
 * **Maximum password age (lifetime):** 90 days
 
 With these default settings, user accounts are locked out for 30 minutes if five invalid passwords are used within 2 minutes. Accounts are automatically unlocked after 30 minutes.


### PR DESCRIPTION
"Reset failed logon attempts count after" is 2 minutes, not 30 minutes.
*Confirmed FGPP shows 2 minutes under "Reset failed logon attempts count after" as well.