### PR TITLE
Fix Spark documentation link

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-3-runtime.md
+++ b/articles/synapse-analytics/spark/apache-spark-3-runtime.md
@@ -1272,5 +1272,5 @@ zipp=0.6.0
 ## Next steps
 
 - [Azure Synapse Analytics](../overview-what-is.md)
-- [Apache Spark Documentation](https://spark.apache.org/docs/2.4.4/)
+- [Apache Spark Documentation](https://spark.apache.org/docs/3.0.2/)
 - [Apache Spark Concepts](apache-spark-concepts.md)


### PR DESCRIPTION
The Spark 3 preview page includes a link to Spark 2 docs. Update link to 3.0.2.