### PR TITLE
Update howto-vm-sign-in-azure-ad-windows.md - managed identity under oid and not appid

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
@@ -261,7 +261,7 @@ The AADLoginForWindows extension must install successfully in order for the VM t
    | `curl -H @{"Metadata"="true"} "http://169.254.169.254/metadata/identity/oauth2/token?resource=urn:ms-drs:enterpriseregistration.windows.net&api-version=2018-02-01"` | Valid access token issued by Azure Active Directory for the managed identity that is assigned to this VM |
 
    > [!NOTE]
-   > The access token can be decoded using a tool like [calebb.net](http://calebb.net/). Verify the `appid` in the access token matches the managed identity assigned to the VM.
+   > The access token can be decoded using a tool like [calebb.net](http://calebb.net/). Verify the `oid` in the access token matches the managed identity assigned to the VM.
 
 1. Ensure the required endpoints are accessible from the VM using PowerShell:
    


### PR DESCRIPTION
Based on my tests, the access token contains the managed identity of the VM under oid and not appid as originally documented.