### PR TITLE
Change `az set account` command to `az account set`

### DIFF
--- a/articles/iot-central/core/troubleshoot-connection.md
+++ b/articles/iot-central/core/troubleshoot-connection.md
@@ -49,7 +49,7 @@ Use the following commands to sign in the subscription where you have your IoT C
 
 ```azurecli
 az login
-az set account --subscription <your-subscription-id>
+az account set --subscription <your-subscription-id>
 ```
 
 To monitor the telemetry your device is sending, use the following command:


### PR DESCRIPTION
The command to set the account subscription should be `az account set --subscription <mysubcription>` not `az set account --subscription <mysubscription>` so I've updated the page to reflect that.