### PR TITLE
Corrected the subresource of Microsoft.Web/sites

### DIFF
--- a/articles/private-link/private-endpoint-overview.md
+++ b/articles/private-link/private-endpoint-overview.md
@@ -98,7 +98,7 @@ A private link resource is the destination target of a given private endpoint. T
 | **Azure Synapse** | Microsoft.Synapse/privateLinkHubs | synapse |
 | **Azure Synapse Analytics** | Microsoft.Synapse/workspaces | Sql, SqlOnDemand, Dev | 
 | **Azure App Service** | Microsoft.Web/hostingEnvironments | hosting environment |
-| **Azure App Service** | Microsoft.Web/sites | site |
+| **Azure App Service** | Microsoft.Web/sites | sites |
 | **Azure App Service** | Microsoft.Web/staticSites | staticSite |
  
 ## Network security of private endpoints 


### PR DESCRIPTION
When I was testing private link with a Azure Web Service. The subresource "site" was not working. After analysing the web service it turns out "sites"is the correct subresource and its working.