### PR TITLE
Update storage-lifecycle-management-concepts.md

### DIFF
--- a/articles/storage/blobs/storage-lifecycle-management-concepts.md
+++ b/articles/storage/blobs/storage-lifecycle-management-concepts.md
@@ -579,6 +579,9 @@ The updated policy takes up to 24 hours to go into effect. Once the policy is in
 
 When a blob is moved from one access tier to another, its last modification time doesn't change. If you manually rehydrate an archived blob to hot tier, it would be moved back to archive tier by the lifecycle management engine. Disable the rule that affects this blob temporarily to prevent it from being archived again. Re-enable the rule when the blob can be safely moved back to archive tier. You may also copy the blob to another location if it needs to stay in hot or cool tier permanently.
 
+**Is there a way to identify at which time the policy will be executing?**
+Unfortunately, there is no way to track at which time the policy will be executing as it is a background scheduling process. However, the platform will be running the policy once a day.
+
 ## Next steps
 
 Learn how to recover data after accidental deletion:


### PR DESCRIPTION
A lot many times there is ask from the customer at which time the Lifecycle management policy will be executing. There is no way to track that as it is a background scheduling process however the platform will be running it once a day. Hence, proposing this as part of FAQ. Please review