### PR TITLE
Added missing required property -ManagementGroupId

### DIFF
--- a/articles/azure-resource-manager/bicep/deploy-powershell.md
+++ b/articles/azure-resource-manager/bicep/deploy-powershell.md
@@ -20,7 +20,7 @@ You need a Bicep file to deploy. The local file name used in this article is _C:
 You need to install Azure PowerShell and connect to Azure:
 
 - **Install Azure PowerShell cmdlets on your local computer.** For more information, see [Get started with Azure PowerShell](/powershell/azure/get-started-azureps).
-- **Connect to Azure by using [Connect-AZAccount](/powershell/module/az.accounts/connect-azaccount)**. If you have multiple Azure subscriptions, you might also need to run [Set-AzContext](/powershell/module/Az.Accounts/Set-AzContext). For more information, see [Use multiple Azure subscriptions](/powershell/azure/manage-subscriptions-azureps).
+- **Connect to Azure by using [Connect-AzAccount](/powershell/module/az.accounts/connect-azaccount)**. If you have multiple Azure subscriptions, you might also need to run [Set-AzContext](/powershell/module/Az.Accounts/Set-AzContext). For more information, see [Use multiple Azure subscriptions](/powershell/azure/manage-subscriptions-azureps).
 
 If you don't have PowerShell installed, you can use Azure Cloud Shell. For more information, see [Deploy Bicep files from Azure Cloud Shell](./deploy-cloud-shell.md).
 
@@ -45,7 +45,7 @@ You can target your deployment to a resource group, subscription, management gro
 - To deploy to a **management group**, use [New-AzManagementGroupDeployment](/powershell/module/az.resources/New-AzManagementGroupDeployment).
 
   ```azurepowershell
-  New-AzManagementGroupDeployment -Location <location> -TemplateFile <path-to-bicep>
+  New-AzManagementGroupDeployment -ManagementGroupId <management-group-id> -Location <location> -TemplateFile <path-to-bicep>
   ```
 
   For more information about management group level deployments, see [Create resources at the management group level](deploy-to-management-group.md).
@@ -70,7 +70,7 @@ If you're deploying to a resource group that doesn't exist, create the resource 
 New-AzResourceGroup -Name ExampleGroup -Location "Central US"
 ```
 
-To deploy a local Bicep file, use the `-TemplateFile` parameter in the deployment command. The following example also shows how to set a parameter value that comes from the Bicep file.
+To deploy a local Bicep file, use the `-TemplateFile` parameter in the deployment command. 
 
 ```azurepowershell
 New-AzResourceGroupDeployment `


### PR DESCRIPTION
Made some minor improvements and added a missing required property to example:

- Changed `Connect-AZAccount` to `Connect-AzAccount`

- Added missing **required** property `-ManagementGroupId` to `New-AzManagementGroupDeployment` example

Removed the line `The following example also shows how to set a parameter value that comes from the Bicep file.` since the following example did not show how to set a parameter.