### PR TITLE
Add additional reason for using best practice

### DIFF
--- a/articles/azure-monitor/autoscale/autoscale-best-practices.md
+++ b/articles/azure-monitor/autoscale/autoscale-best-practices.md
@@ -30,6 +30,8 @@ If you manually update the instance count to a value above or below the maximum,
 ### Always use a scale-out and scale-in rule combination that performs an increase and decrease
 If you use only one part of the combination, autoscale will only take action in a single direction (scale out, or in) until it reaches the maximum, or minimum instance counts, as defined in the profile. This is not optimal, ideally you want your resource to scale up at times of high usage to ensure availability. Similarly, at times of low usage you want your resource to scale down, so you can realize cost savings.
 
+Another reason for using both a scale-out and a scale-in rule is that, otherwise, the autoscale engine might get stuck in a flapping state because it sometimes meets both a scale-out and a scale-in condition (using different metrics) at the same time.
+
 ### Choose the appropriate statistic for your diagnostics metric
 For diagnostics metrics, you can choose among *Average*, *Minimum*, *Maximum* and *Total* as a metric to scale by. The most common statistic is *Average*.
 

--- a/articles/azure-monitor/autoscale/autoscale-best-practices.md
+++ b/articles/azure-monitor/autoscale/autoscale-best-practices.md
@@ -30,7 +30,13 @@ If you manually update the instance count to a value above or below the maximum,
 ### Always use a scale-out and scale-in rule combination that performs an increase and decrease
 If you use only one part of the combination, autoscale will only take action in a single direction (scale out, or in) until it reaches the maximum, or minimum instance counts, as defined in the profile. This is not optimal, ideally you want your resource to scale up at times of high usage to ensure availability. Similarly, at times of low usage you want your resource to scale down, so you can realize cost savings.
 
-Another reason for using both a scale-out and a scale-in rule is that, otherwise, the autoscale engine might get stuck in a flapping state because it sometimes meets both a scale-out and a scale-in condition (using different metrics) at the same time.
+When you use a scale-in and scale-out rule, ideally use the same metric to control both. Otherwise, it’s possible that the scale-in and scale-out conditions could be met at the same time resulting in some level of flapping. For example, the following rule combination is *not* recommended because there is no scale-in rule for memory usage:
+
+* If CPU > 90%, scale-out by 1
+* If Memory > 90%, scale-out by 1
+* If CPU < 45%, scale-in by 1
+
+In this example, you can have a situation in which the memory usage is over 90% but the CPU usage is under 45%, which can lead to flapping for as long as both conditions are met.
 
 ### Choose the appropriate statistic for your diagnostics metric
 For diagnostics metrics, you can choose among *Average*, *Minimum*, *Maximum* and *Total* as a metric to scale by. The most common statistic is *Average*.


### PR DESCRIPTION
In this PR I added a paragraph to the _Always use a scale-out and scale-in rule combination that performs an increase and decrease_ best practice. This paragraph is another reason for using the best practice, namely the fact that a resource might get stuck in flapping if the best practice is not implemented.

I wrote an essay about this (somewhat obvious) realization: https://florinungur.com/essays/2021/07/25/azure-autoscaling-best-practices-an-addition.

Now I want to integrate it into the official documentation.