### PR TITLE
Fix doc about private cluster publicFQDN feature

### DIFF
--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -95,7 +95,8 @@ The Public DNS option can be leveraged to simplify routing options for your Priv
 
 ![Public DNS](https://user-images.githubusercontent.com/50749048/124776520-82629600-df0d-11eb-8f6b-71c473b6bd01.png)
 
-1. By specifying "None" for the Private DNS Zone when a private cluster is provisioned, a private endpoint (1) and a public DNS zone (2) are created in the cluster-managed resource group. The cluster uses an A record in the private zone to resolve the IP of the private endpoint for communication to the API server.
+1. By specifying `--enable-public-fqdn` when a private cluster is provisioned, we add an addition A record for the new FQDN in AKS public dns zone. The agentnodes still uses A record in the private zone to resolve the IP of the private endpoint for communication to the API server.
+2. Please note when using `--enable-public-fqdn` together with `--private-dns-zone none`, cluster public FQDN and private FQDN will have the same value and it's in AKS public dns zone `hcp.{REGION}.azmk8s.io`.
 
 ### Register the `EnablePrivateClusterPublicFQDN` preview feature
 
@@ -122,7 +123,7 @@ az provider register --namespace Microsoft.ContainerService
 ### Create a private AKS cluster with a Public DNS address
 
 ```azurecli-interactive
-az aks create -n <private-cluster-name> -g <private-cluster-resource-group> --load-balancer-sku standard --enable-private-cluster --enable-managed-identity --assign-identity <ResourceId> --private-dns-zone none --enable-public-fqdn
+az aks create -n <private-cluster-name> -g <private-cluster-resource-group> --load-balancer-sku standard --enable-private-cluster --enable-managed-identity --assign-identity <ResourceId> --private-dns-zone <private-dns-zone-mode> --enable-public-fqdn
 ```
 
 ## Options for connecting to the private cluster

--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -96,7 +96,7 @@ The Public DNS option can be leveraged to simplify routing options for your Priv
 ![Public DNS](https://user-images.githubusercontent.com/50749048/124776520-82629600-df0d-11eb-8f6b-71c473b6bd01.png)
 
 1. By specifying `--enable-public-fqdn` when a private cluster is provisioned, we add an addition A record for the new FQDN in AKS public dns zone. The agentnodes still uses A record in the private zone to resolve the IP of the private endpoint for communication to the API server.
-2. Please note when using `--enable-public-fqdn` together with `--private-dns-zone none`, cluster public FQDN and private FQDN will have the same value and it's in AKS public dns zone `hcp.{REGION}.azmk8s.io`.
+2. Please note when using `--enable-public-fqdn` together with `--private-dns-zone none`, cluster public FQDN and private FQDN will have the same value and it's in AKS public dns zone `hcp.{REGION}.azmk8s.io`. It's a breaking change behavior for none private dns zone mode cluster. 
 
 ### Register the `EnablePrivateClusterPublicFQDN` preview feature
 

--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -95,8 +95,9 @@ The Public DNS option can be leveraged to simplify routing options for your Priv
 
 ![Public DNS](https://user-images.githubusercontent.com/50749048/124776520-82629600-df0d-11eb-8f6b-71c473b6bd01.png)
 
-1. By specifying `--enable-public-fqdn` when a private cluster is provisioned, we add an addition A record for the new FQDN in AKS public dns zone. The agentnodes still uses A record in the private zone to resolve the IP of the private endpoint for communication to the API server.
-2. Please note when using `--enable-public-fqdn` together with `--private-dns-zone none`, cluster public FQDN and private FQDN will have the same value and it's in AKS public dns zone `hcp.{REGION}.azmk8s.io`. It's a breaking change behavior for none private dns zone mode cluster. 
+1. By specifying `--enable-public-fqdn` when you provision a private cluster, you create an additional A record for the new FQDN in the AKS public DNS zone. The agentnode still uses the A record in the private zone to resolve the IP address of the private endpoint for communication to the API server.
+
+2. If you use both `--enable-public-fqdn` and `--private-dns-zone none`, the cluster public FQDN and private FQDN have the same value. The value is in the AKS public DNS zone `hcp.{REGION}.azmk8s.io`. It's a breaking change for the private DNS zone mode cluster. 
 
 ### Register the `EnablePrivateClusterPublicFQDN` preview feature
 


### PR DESCRIPTION
Some misleading part, 
1. we don't provision public dns zone in cluster resource group. This public dns zone locates in AKS underlay.
2. Public fqdn feature can be used with any value for private dns zone, not only `none` mode.