### PR TITLE
Fix App service subresource typo

### DIFF
--- a/articles/private-link/private-endpoint-overview.md
+++ b/articles/private-link/private-endpoint-overview.md
@@ -98,7 +98,7 @@ A private link resource is the destination target of a given private endpoint. T
 | **Azure Synapse** | Microsoft.Synapse/privateLinkHubs | synapse |
 | **Azure Synapse Analytics** | Microsoft.Synapse/workspaces | Sql, SqlOnDemand, Dev | 
 | **Azure App Service** | Microsoft.Web/hostingEnvironments | hosting environment |
-| **Azure App Service** | Microsoft.Web/sites | site |
+| **Azure App Service** | Microsoft.Web/sites | sites |
 | **Azure App Service** | Microsoft.Web/staticSites | staticSite |
  
 ## Network security of private endpoints 


### PR DESCRIPTION
Update private-endpoint-overview.md - typo on subresource for App Service should be sites instead of site. As per this documentation https://docs.microsoft.com/en-us/azure/private-link/create-private-endpoint-cli#create-private-endpoint