### PR TITLE
line 100, Approver needs to be updated

### DIFF
--- a/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
+++ b/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
@@ -97,7 +97,7 @@ If setting multiple approvers, approval completes as soon as one of them approve
 
     ![Select a user or group pane to select approvers](./media/pim-resource-roles-configure-role-settings/resources-role-settings-select-approvers.png)
 
-1. Select at least one user and then click **Select**. Select at least one approver. There are no default approvers.
+1. Select at least one user and then click **Select**. Select at least one approver. There are no default approvers.(By default If no specific approvers are selected, privileged role administrators/global administrators will become the default approvers.)
 
     Your selections will appear in the list of selected approvers.
 


### PR DESCRIPTION
By default If no specific approvers are selected, privileged role administrators/global administrators will become the default approvers. So I believe we need to update this information in the article as in my lab GA is working if I am  not selecting any approvers but in the Cx environment it is not working so maybe it needs to be updated here or in the portal