### PR TITLE
Update tag-resources.md

### DIFF
--- a/articles/azure-resource-manager/management/tag-resources.md
+++ b/articles/azure-resource-manager/management/tag-resources.md
@@ -840,6 +840,7 @@ The following limitations apply to tags:
 * Each resource, resource group, and subscription can have a maximum of 50 tag name/value pairs. If you need to apply more tags than the maximum allowed number, use a JSON string for the tag value. The JSON string can contain many values that are applied to a single tag name. A resource group or subscription can contain many resources that each have 50 tag name/value pairs.
 * The tag name is limited to 512 characters, and the tag value is limited to 256 characters. For storage accounts, the tag name is limited to 128 characters, and the tag value is limited to 256 characters.
 * Tags can't be applied to classic resources such as Cloud Services.
+* Azure IP Groups and Azure Firewall Policies do not support PATCH operation.
 * Tag names can't contain these characters: `<`, `>`, `%`, `&`, `\`, `?`, `/`
 
    > [!NOTE]


### PR DESCRIPTION
We have observed that Azure IP Groups and Azure Firewall Policies do not support PATCH operation and customers cant update tags from the portal as it uses PATCH operation. This makes customers think that this is a bug but apparently it's by design. Adding this would help us share the same with customers as this would be a good addition to the known limitations in our public-facing documentation.