### PR TITLE
Update how-to-assign-roles.md

### DIFF
--- a/articles/machine-learning/how-to-assign-roles.md
+++ b/articles/machine-learning/how-to-assign-roles.md
@@ -118,7 +118,7 @@ az role definition create --role-definition data_scientist_role.json
 After deployment, this role becomes available in the specified workspace. Now you can add and assign this role in the Azure portal. Or, you can assign this role to a user by using the `az ml workspace share` CLI command:
 
 ```azurecli-interactive
-az ml workspace share -w my_workspace -g my_resource_group --role "Data Scientist" --user jdoe@contoson.com
+az ml workspace share -w my_workspace -g my_resource_group --role "Data Scientist Custom" --user jdoe@contoson.com
 ```
 
 For more information on custom roles, see [Azure custom roles](../role-based-access-control/custom-roles.md). 


### PR DESCRIPTION
The custom data scientist role had the name defined as "Data Scientist Custom"

Later in the script, when we are assigning the name, it shows up only as "Data Scientist". 

The azure cli command to assign the role to the use was not using the correct name defined in the JSON.