### PR TITLE
Trivial Fix: Syntax error with a floating trailing quote

### DIFF
--- a/articles/resource-mover/tutorial-move-region-powershell.md
+++ b/articles/resource-mover/tutorial-move-region-powershell.md
@@ -210,7 +210,7 @@ Check whether the resources you added have any dependencies on other resources, 
     - To retrieve a list of all missing dependencies:
 
         ```azurepowershell-interactive
-        Get-AzResourceMoverUnresolvedDependency -MoveCollectionName "PS-centralus-westcentralus-demoRMS" -ResourceGroupName "RG-MoveCollection-demoRMS" -DependencyLevel Descendant"
+        Get-AzResourceMoverUnresolvedDependency -MoveCollectionName "PS-centralus-westcentralus-demoRMS" -ResourceGroupName "RG-MoveCollection-demoRMS" -DependencyLevel Descendant
         ```
         **Output**
           ![Output text after retrieving a list of all dependencies](./media/tutorial-move-region-powershell/dependencies-list.png)  


### PR DESCRIPTION
No need for a trailing quote when there's no leading quote. Quoting the word "Descendant" would also be fine but is not required for this to work on PowerShell Core 7.