### PR TITLE
Included the "includes" for .env

### DIFF
--- a/articles/media-services/latest/stream-live-tutorial-with-api.md
+++ b/articles/media-services/latest/stream-live-tutorial-with-api.md
@@ -65,11 +65,7 @@ git clone https://github.com/Azure-Samples/media-services-v3-dotnet.git
 
 The live-streaming sample is in the [Live](https://github.com/Azure-Samples/media-services-v3-dotnet/tree/main/Live) folder.
 
-Open [appsettings.json](https://github.com/Azure-Samples/media-services-v3-dotnet/blob/main/Live/LiveEventWithDVR/appsettings.json) in your downloaded project. Replace the values with the credentials that you got from [Access the Azure Media Services API with the Azure CLI](./access-api-howto.md).
-
-Note that you can also use the *.env* file format at the root of the project to set your environment variables only once for all projects in the .NET samples repository. Just copy the *sample.env* file, and then fill out the information that you got from the Media Services **API Access** page in the Azure portal or from the Azure CLI. Rename the *sample.env* file to just *.env* to use it across all projects.
-
-The *.gitignore* file is already configured to prevent publishing this file into your forked repository. 
+[!INCLUDE [appsettings or .env file](./includes/note-appsettings-or-env-file.md)]
 
 > [!IMPORTANT]
 > This sample uses a unique suffix for each resource. If you cancel the debugging or terminate the app without running it through, you'll end up with multiple live events in your account.


### PR DESCRIPTION
Instructions were typed in previously, changed to "includes" format