### PR TITLE
ConfigureWebJobs method is added twice

### DIFF
--- a/articles/app-service/webjobs-sdk-get-started.md
+++ b/articles/app-service/webjobs-sdk-get-started.md
@@ -196,10 +196,6 @@ Starting with version 3 of the WebJobs SDK, to connect to Azure Storage services
     {
         var builder = new HostBuilder();
         builder.UseEnvironment(EnvironmentName.Development);
-        builder.ConfigureWebJobs(b =>
-        {
-            b.AddAzureStorageCoreServices();
-        });
         builder.ConfigureLogging((context, b) =>
         {
             b.AddConsole();


### PR DESCRIPTION
`ConfigureWebJobs` method is added twice while the filnale code should only one call of that method. Th one that contains `b.AddAzureStorage();`