### PR TITLE
Fix section for Shared access signature

### DIFF
--- a/articles/storage/blobs/quickstart-blobs-javascript-browser.md
+++ b/articles/storage/blobs/quickstart-blobs-javascript-browser.md
@@ -91,7 +91,7 @@ The shared access signature (SAS) is used by code running in the browser to auth
 Follow these steps to get the Blob service SAS URL:
 
 1. In the Azure portal, select your storage account.
-2. Navigate to the **Settings** section and select **Shared access signature**.
+2. Navigate to the **Security + networking** section and select **Shared access signature**.
 3. Scroll down and click the **Generate SAS and connection string** button.
 4. Scroll down further and locate the **Blob service SAS URL** field
 5. Click the **Copy to clipboard** button at the far-right end of the **Blob service SAS URL** field.


### PR DESCRIPTION
Documentation seems to point to the wrong section for "Shared access signature", it is under "Security + networking" and not under "Settings".