### PR TITLE
$convert-data Endpoint uses POST method to convert the HL7 to FHIR JSON

### DIFF
--- a/articles/healthcare-apis/fhir/convert-data.md
+++ b/articles/healthcare-apis/fhir/convert-data.md
@@ -85,7 +85,7 @@ $convert-data takes a [Parameter](http://hl7.org/fhir/parameters.html) resource 
         ...
         ...
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Location/50becdb5-ff56-56c6-40a1-6d554dca80f0"
       }
     }


### PR DESCRIPTION
$convert-data Endpoint uses POST method to convert the HL7 to FHIR JSON

The document uses PUT method, which returns 404 response, instead it should use POST method.
Error when trying with PUT :
{
    "resourceType": "OperationOutcome",
    "id": "3566497594d7cd45a924b1106cf5a9aa",
    "issue": [
        {
            "severity": "error",
            "code": "not-found",
            "diagnostics": "The requested route was not found."
        }
    ]
}
Using POST, we get the converted JSON response.