### PR TITLE
remove slack workspace prefix from plan overview link

### DIFF
--- a/articles/active-directory/saas-apps/slack-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/slack-provisioning-tutorial.md
@@ -32,7 +32,7 @@ The scenario outlined in this tutorial assumes that you already have the followi
 
 * [An Azure AD tenant](../develop/quickstart-create-new-tenant.md).
 * A user account in Azure AD with [permission](../roles/permissions-reference.md) to configure provisioning (for example, Application Administrator, Cloud Application administrator, Application Owner, or Global Administrator).
-* A Slack tenant with the [Plus plan](https://aadsyncfabric.slack.com/pricing) or better enabled.
+* A Slack tenant with the [Plus plan](https://slack.com/pricing) or better enabled.
 * A user account in Slack with Team Admin permissions.
 
 > [!NOTE]


### PR DESCRIPTION
The workspace prefix/subdomain on this link results in a login-page being displayed if the user is not logged into that workspace, without the workspace prefix/subdomain the page can be displayed normally.

It can be argued that the Text "plus plan" is also misleading/outdated, but that should be handled elsewhere since i do not know the minimum needed Slack plan for this feature/integration to work.