### PR TITLE
clientRetryOptions instead of retryOptions

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus.md
+++ b/articles/azure-functions/functions-bindings-service-bus.md
@@ -116,7 +116,7 @@ The example host.json file below contains only the settings for version 5.0.0 an
     "version": "2.0",
     "extensions": {
         "serviceBus": {
-            "retryOptions":{
+            "clientRetryOptions":{
                 "mode": "exponential",
                 "tryTimeout": "00:01:00",
                 "delay": "00:00:00.80",


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.webjobs.servicebus.servicebusoptions.clientretryoptions?view=azure-dotnet-preview . 

retryOptions does not exist in this version.