### PR TITLE
Update custom classification minimum match threshold

### DIFF
--- a/articles/purview/create-a-custom-classification-and-classification-rule.md
+++ b/articles/purview/create-a-custom-classification-and-classification-rule.md
@@ -119,7 +119,7 @@ To create a custom classification rule:
    |Data Pattern    |Optional. A regular expression that represents the data that's stored in the data field. The limit is very large. In the previous example, the data patterns test for an employee ID that's literally the word `Employee{GUID}`.  |
    |Column Pattern    |Optional. A regular expression that represents the column names that you want to match. The limit is very large. |
 
-1. Under **Data Pattern** you can use the **Minimum match threshold** to set the minimum percentage of the distinct data value matches in a column that must be found by the scanner for the classification to be applied. The suggested value is 60%. You need to be careful with this setting. If you reduce the level below 60%, you might introduce false-positive classifications into your catalog. If you specify multiple data patterns, this setting is disabled and the value is fixed at 60%.
+1. Under **Data Pattern** you can use the **Minimum match threshold** to set the minimum percentage of the distinct data value matches in a column that must be found by the scanner for the classification to be applied. The suggested value is 60%. If you specify multiple data patterns, this setting is disabled and the value is fixed at 60%.
 
    > [!Note]
    > The Minimum match threshold must be at least 1%.


### PR DESCRIPTION
There are no false-positives when it comes to custom classification.
We ask the customer to define the percentage match they need for the custom classification to be applied.
If match % >= customer defined %, the tag is applied.
If match % < customer defined %, the tag is not applied.

So, there are no false positives here. We should let the customers define whatever match % they want.