### PR TITLE
Add Select OK to avoid any confusion

### DIFF
--- a/articles/synapse-analytics/get-started-pipelines.md
+++ b/articles/synapse-analytics/get-started-pipelines.md
@@ -36,6 +36,7 @@ Once the pipeline is published, you may want to run it immediately without waiti
 
 1. Open the pipeline.
 1. Click **Add trigger** > **Trigger now**.
+1. Select **OK**. 
 
 ## Monitor pipeline execution
 


### PR DESCRIPTION
Some customers confuse after the click "Trigger now" because there is NO navigation. Of course, there is "OK" button at the bottom in the screen.
I believe this step help some of them.