### PR TITLE
Update tutorial-incremental-copy-overview.md

### DIFF
--- a/articles/data-factory/tutorial-incremental-copy-overview.md
+++ b/articles/data-factory/tutorial-incremental-copy-overview.md
@@ -38,7 +38,7 @@ For step-by-step instructions, see the following tutorial: <br/>
 - [Incrementally copy data from Azure SQL Database to Azure Blob storage by using Change Tracking technology](tutorial-incremental-copy-change-tracking-feature-powershell.md)
 
 ## Loading new and changed files only by using LastModifiedDate
-You can copy the new and changed files only by using LastModifiedDate to the destination store. ADF will scan all the files from the source store, apply the file filter by their LastModifiedDate, and only copy the new and updated file since last time to the destination store.  Please be aware if you let ADF scan huge amounts of files but only copy a few files to destination, you would still expect the long duration due to file scanning is time consuming as well.   
+You can copy the new and changed files only by using LastModifiedDate to the destination store. ADF will scan all the files from the source store, apply the file filter by their LastModifiedDate, and only copy the new and updated file since last time to the destination store.  Please be aware that if you let ADF scan huge amounts of files but you only copy a few files to the destination, this will still take a long time because of the file scanning process.   
 
 For step-by-step instructions, see the following tutorial: <br/>
 - [Incrementally copy new and changed files based on LastModifiedDate from Azure Blob storage to Azure Blob storage](tutorial-incremental-copy-lastmodified-copy-data-tool.md)


### PR DESCRIPTION
The original grammar is a bit awkward; 

"Please be aware if you let ADF scan huge amounts of files but only copy a few files to destination, you would still expect the long duration due to file scanning is time consuming as well."

I'm not confident that my proposed changes are the perfect way to rephrase this (first ever Docs pull request, woohoo!) but I think it could be worded better.

Here is an alternative, since I'm not familiar with any specific documentation style guides or conventions:

"Note that if you use ADF to scan huge amounts of files, but you only copy a small subset to your destination, the entire operation will still take a while because of the time required for the file scanning process."