### PR TITLE
Fixed Link Destination

### DIFF
--- a/articles/key-vault/certificates/tutorial-rotate-certificates.md
+++ b/articles/key-vault/certificates/tutorial-rotate-certificates.md
@@ -42,7 +42,7 @@ Create an Azure Key Vault using [Azure portal](../general/quick-create-portal.md
 
 ## Create a certificate in Key Vault
 
-Create a certificate or import a certificate into the key vault (see [Steps to create a certificate in Key Vault](../secrets/quick-create-portal.md)). In this case, you'll work on a certificate called **ExampleCertificate**.
+Create a certificate or import a certificate into the key vault (see [Steps to create a certificate in Key Vault](../certificates/quick-create-portal.md). In this case, you'll work on a certificate called **ExampleCertificate**.
 
 ## Update certificate lifecycle attributes
 


### PR DESCRIPTION
The removed link was redirecting to the article "Quickstart: Set and retrieve a secret from Azure Key Vault using the Azure portal", but should instead redirect to the article "Quickstart: Set and retrieve a certificate from Azure Key Vault using the Azure portal", as this is what is being discussed at that point in the documentation. This change modifies the directory in the relative link (from /secrets to /certificates) - the concerned documents otherwise have the same filename.