### PR TITLE
Changed path for grub config on Azure Linux VM

### DIFF
--- a/articles/virtual-network/setup-dpdk.md
+++ b/articles/virtual-network/setup-dpdk.md
@@ -156,7 +156,7 @@ After restarting, run the following commands once:
    * Check that hugepages are reserved with `grep Huge /proc/meminfo`.
 
      > [NOTE]
-     > There is a way to modify the grub file so that hugepages are reserved on boot by following the [instructions](https://dpdk.org/doc/guides/linux_gsg/sys_reqs.html#use-of-hugepages-in-the-linux-environment) for the DPDK. The instructions are at the bottom of the page. When you're using an Azure Linux virtual machine, modify files under **/etc/config/grub.d** instead, to reserve hugepages across reboots.
+     > There is a way to modify the grub file so that hugepages are reserved on boot by following the [instructions](https://dpdk.org/doc/guides/linux_gsg/sys_reqs.html#use-of-hugepages-in-the-linux-environment) for the DPDK. The instructions are at the bottom of the page. When you're using an Azure Linux virtual machine, modify files under **/etc/default/grub.d/50-cloudimg-settings.cfg** instead, to reserve hugepages across reboots.
 
 2. MAC & IP addresses: Use `ifconfig –a` to view the MAC and IP address of the network interfaces. The *VF* network interface and *NETVSC* network interface have the same MAC address, but only the *NETVSC* network interface has an IP address. *VF* interfaces are running as subordinate interfaces of *NETVSC* interfaces.
 


### PR DESCRIPTION
Changed the incorrect path /etc/config/grub.d to correct path /etc/default/grub.d/50-cloudimg-settings.cfg in the documentation for grub config on Azure Linux VM