### PR TITLE
qstore1

### DIFF
--- a/articles/mysql/concepts-query-store.md
+++ b/articles/mysql/concepts-query-store.md
@@ -167,7 +167,7 @@ This view returns wait events data in Query Store. There is one row for each dis
 
 ## Limitations and known issues
 
-- If a MySQL server has the parameter `default_transaction_read_only` on, Query Store cannot capture data.
+- If a MySQL server has the parameter `read_only` on, Query Store cannot capture data.
 - Query Store functionality can be interrupted if it encounters long Unicode queries (\>= 6000 bytes).
 - The retention period for wait statistics is 24 hours.
 - Wait statistics uses sample to capture a fraction of events. The frequency can be modified using the parameter `query_store_wait_sampling_frequency`.


### PR DESCRIPTION
default_transaction_read_only is a postgresql parameter , should be replaced by read_only