### PR TITLE
Add 'Ole Automation Procedures' as an unsupported option

### DIFF
--- a/articles/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server.md
+++ b/articles/azure-sql/managed-instance/transact-sql-tsql-differences-sql-server.md
@@ -486,6 +486,8 @@ Service broker is enabled by default and cannot be disabled. The following ALTER
   - `remote data archive`
   - `remote proc trans`
   - `scan for startup procs`
+- The following [sp_configure](/sql/relational-databases/system-stored-procedures/sp-configure-transact-sql) options are ignored and have no effect: 
+  - `Ole Automation Procedures`
 - `sp_execute_external_scripts` isn't supported. See [sp_execute_external_scripts](/sql/relational-databases/system-stored-procedures/sp-execute-external-script-transact-sql#examples).
 - `xp_cmdshell` isn't supported. See [xp_cmdshell](/sql/relational-databases/system-stored-procedures/xp-cmdshell-transact-sql).
 - `Extended stored procedures` aren't supported, and this includes `sp_addextendedproc` and `sp_dropextendedproc`. This functionality won't be supported because it's on a deprecation path for SQL Server. For more details, see [Extended Stored Procedures](/sql/relational-databases/extended-stored-procedures-programming/database-engine-extended-stored-procedures-programming).


### PR DESCRIPTION
Adding 'Ole Automation Procedures' as per https://github.com/MicrosoftDocs/azure-docs/issues/46081 . This option can be set, but has no effect.