### PR TITLE
Update format-json.md

### DIFF
--- a/articles/data-factory/format-json.md
+++ b/articles/data-factory/format-json.md
@@ -252,7 +252,7 @@ If **Document per line** is selected, mapping data flows read one JSON document 
 
 ``` json
 File1.json
-{"json": "record 1 }
+{"json": "record 1"}
 
 File2.json
  {"time":"2015-04-29T07:12:20.9100000Z","callingimsi":"466920403025604","callingnum1":"678948008","callingnum2":"567834760","switch1":"China","switch2":"Germany"}


### PR DESCRIPTION
Just missing a double quote instead of space. It breaks the formatting. very minor.