### PR TITLE
Update static-website-content-delivery-network.md

### DIFF
--- a/articles/storage/blobs/static-website-content-delivery-network.md
+++ b/articles/storage/blobs/static-website-content-delivery-network.md
@@ -21,7 +21,7 @@ You can enable Azure CDN for your static website directly from your storage acco
 
 1. Locate your storage account in the Azure portal and display the account overview.
 
-1. Under the **Blob Service** menu, select **Azure CDN** to open the **Azure CDN** page:
+1. Under the **Security + Networking** menu, select **Azure CDN** to open the **Azure CDN** page:
 
     ![Create CDN endpoint](media/storage-blob-static-website-custom-domain/cdn-storage-new.png)
 


### PR DESCRIPTION
Blob Services menu goes to the Data Storage section which isn't where Azure CDN is. Azure CDN is under Security + Networking (Networking link on the overview page). 

Regards