### PR TITLE
Updated to use UserAssignedIdentities

### DIFF
--- a/articles/batch/managed-identity-pools.md
+++ b/articles/batch/managed-identity-pools.md
@@ -48,10 +48,10 @@ var poolParameters = new Pool(name: "yourPoolName")
         Identity = new BatchPoolIdentity
         {
             Type = PoolIdentityType.UserAssigned,
-            UserAssignedIdentities = new Dictionary<string, BatchPoolIdentityUserAssignedIdentitiesValue>
+            UserAssignedIdentities = new Dictionary<string, UserAssignedIdentities>
             {
                 ["Your Identity Resource Id"] =
-                    new BatchPoolIdentityUserAssignedIdentitiesValue()
+                    new UserAssignedIdentities()
             }
         }
     };


### PR DESCRIPTION
In v14.0.0 of the  `Microsoft.Azure.Management.Batch` .NET SDK, the `Microsoft.Azure.Management.Batch.Models.BatchPoolIdentityUserAssignedIdentitiesValue` class was removed. Instead, you should now use `Microsoft.Azure.Management.Batch.Models.UserAssignedIdentities`. I have updated the sample code with this change