### PR TITLE
Update best-practices-availability-paired-regions.md

### DIFF
--- a/articles/best-practices-availability-paired-regions.md
+++ b/articles/best-practices-availability-paired-regions.md
@@ -48,7 +48,7 @@ No. Customers can leverage Azure services to architect a resilient service witho
 | Australia |Australia East |Australia Southeast |
 | Australia |Australia Central |Australia Central 2* |
 | Brazil |Brazil South |South Central US |
-| Brazil |Brazil Southeast* |Brazil South |
+| Brazil |Brazil South |Brazil Southeast* |
 | Canada |Canada Central |Canada East |
 | China |China North |China East|
 | China |China North 2 |China East 2|


### PR DESCRIPTION
The original positioning made it look like Brazil Southeast was the primary region, however after discussing with the Product Group (at the behest of a confused customer) this is not the case and Brazil Southeast is the secondary region (upon approval/creation of a support request) for Brazil South.

There was already an issue raised about this: [Issue #77071](https://github.com/MicrosoftDocs/azure-docs/issues/77071)