### PR TITLE
Fix incorrect usage of `--enable-files-aadds`

### DIFF
--- a/articles/storage/files/storage-files-identity-auth-active-directory-domain-service-enable.md
+++ b/articles/storage/files/storage-files-identity-auth-active-directory-domain-service-enable.md
@@ -130,18 +130,18 @@ Set-AzStorageAccount -ResourceGroupName "<resource-group-name>" `
 
 To enable Azure AD authentication over SMB with Azure CLI, install the latest CLI version (Version 2.0.70 or newer). For more information about installing Azure CLI, see [Install the Azure CLI](/cli/azure/install-azure-cli).
 
-To create a new storage account, call [az storage account create](/cli/azure/storage/account#az_storage_account_create), and set the `--enable-files-aadds` property to **true**. In the following example, remember to replace the placeholder values with your own values. (If you were using the previous preview module, the parameter for feature enablement is **file-aad**.)
+To create a new storage account, call [az storage account create](/cli/azure/storage/account#az_storage_account_create), and set the `--enable-files-aadds` argument. In the following example, remember to replace the placeholder values with your own values. (If you were using the previous preview module, the parameter for feature enablement is **file-aad**.)
 
 ```azurecli-interactive
 # Create a new storage account
-az storage account create -n <storage-account-name> -g <resource-group-name> --enable-files-aadds $true
+az storage account create -n <storage-account-name> -g <resource-group-name> --enable-files-aadds
 ```
 
 To enable this feature on existing storage accounts, use the following command:
 
 ```azurecli-interactive
 # Update a new storage account
-az storage account update -n <storage-account-name> -g <resource-group-name> --enable-files-aadds $true
+az storage account update -n <storage-account-name> -g <resource-group-name> --enable-files-aadds
 ```
 ---
 


### PR DESCRIPTION
Fix doc: https://docs.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-active-directory-domain-service-enable?tabs=azure-cli#enable-azure-ad-ds-authentication-for-your-account

For `az storage account create`, `--enable-files-aadds` is defined as a `get_three_state_flag`:

https://github.com/Azure/azure-cli/blob/7ea256aa1960cdb2846aae41d5b4e8349ddf25b5/src/azure-cli/azure/cli/command_modules/storage/_params.py#L88

```py
    aadds_type = CLIArgumentType(arg_type=get_three_state_flag(), min_api='2018-11-01',
                                 arg_group='Azure Files Identity Based Authentication',
                                 help='Enable Azure Active Directory Domain Services authentication for Azure Files')
```

It can be specified using 

- `--enable-files-aadds`
- `--enable-files-aadds true`
- `--enable-files-aadds false`

In Bash, `$true` is not a valid built-in Booleans value, unlike `$true` in PowerShell: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_booleans?view=powershell-7.1

When not initialized, `$true` is empty/undefined:

```
$ echo $true

$
```

In such case,

```
az storage account create -n <storage-account-name> -g <resource-group-name> --enable-files-aadds $true
```

degenerates into

```
az storage account create -n <storage-account-name> -g <resource-group-name> --enable-files-aadds
```
