### PR TITLE
Specify .NET Core 3.1 requirement

### DIFF
--- a/articles/static-web-apps/publish-devops.md
+++ b/articles/static-web-apps/publish-devops.md
@@ -29,7 +29,7 @@ In this tutorial, you learn to:
 ## Create a static web app in an Azure DevOps
 
   > [!NOTE]
-  > If you have an existing app in your repository, you may skip to the next section.
+  > If you have an existing app in your repository, you may skip to the next section. The existing app must target .NET Core 3.1 for the pipeline to publish the app correctly.
 
 1. Navigate to your repository in Azure Repos.
 

--- a/articles/static-web-apps/publish-devops.md
+++ b/articles/static-web-apps/publish-devops.md
@@ -29,7 +29,7 @@ In this tutorial, you learn to:
 ## Create a static web app in an Azure DevOps
 
   > [!NOTE]
-  > If you have an existing app in your repository, you may skip to the next section. The existing app must target .NET Core 3.1 for the pipeline to publish the app correctly.
+  > If you have an existing app in your repository, you may skip to the next section. NOTE: The existing app must target .NET Core 3.1 for the pipeline to publish the app correctly.
 
 1. Navigate to your repository in Azure Repos.
 

--- a/articles/static-web-apps/publish-devops.md
+++ b/articles/static-web-apps/publish-devops.md
@@ -29,7 +29,10 @@ In this tutorial, you learn to:
 ## Create a static web app in an Azure DevOps
 
   > [!NOTE]
-  > If you have an existing app in your repository, you may skip to the next section. NOTE: The existing app must target .NET Core 3.1 for the pipeline to publish the app correctly.
+  > If you have an existing app in your repository, you may skip to the next section.
+  
+  > [!NOTE]
+  > The application must target .NET Core 3.1 for the pipeline to succeed.
 
 1. Navigate to your repository in Azure Repos.
 


### PR DESCRIPTION
Adding the note that if you want to use an existing project for this tutorial, it must target .NET Core 3.1. This tutorial does not work with apps that target .NET 5.0 and higher.