### PR TITLE
Updating HDInsight article title to "Manually scale Azure HDInsight clusters"

### DIFF
--- a/articles/hdinsight/hdinsight-scaling-best-practices.md
+++ b/articles/hdinsight/hdinsight-scaling-best-practices.md
@@ -1,6 +1,6 @@
 ---
-title: Scale cluster sizes - Azure HDInsight
-description: Scale an Apache Hadoop cluster elastically to match your workload in Azure HDInsight
+title: Manually scale a cluster - Azure HDInsight
+description: Manually scale an Apache Hadoop cluster elastically to match your workload in Azure HDInsight
 ms.author: ashish
 ms.service: hdinsight
 ms.topic: how-to
@@ -8,7 +8,7 @@ ms.custom: seoapr2020
 ms.date: 04/29/2020
 ---
 
-# Scale Azure HDInsight clusters
+# Manually scale Azure HDInsight clusters
 
 HDInsight provides elasticity with options to scale up and scale down the number of worker nodes in your clusters. This elasticity allows you to shrink a cluster after hours or on weekends. And expand it during peak business demands.
 


### PR DESCRIPTION
The title doesn't indicate that the article is only relevant for manually scaling a cluster. This commit modifies the article title to reflect this change.

[Link to entry in TOC](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/hdinsight/TOC.yml#L201)