### PR TITLE
Distinct limits for Dedicated Serverless SQL pool

### DIFF
--- a/articles/azure-sql/database/resource-limits-logical-server.md
+++ b/articles/azure-sql/database/resource-limits-logical-server.md
@@ -25,7 +25,9 @@ This article provides an overview of the resource limits for the [logical server
 
 | Resource | Limit |
 | :--- | :--- |
-| Databases per logical server | 5000 |
+| Dedicated SQL Pool databases | 5,000 |
+| Serverless SQL Pool databases | 20 |
+| Spark Pool databases | ???? |
 | Default number of logical servers per subscription in a region | 20 |
 | Max number of logical servers per subscription in a region | 200 |  
 | DTU / eDTU quota per logical server | 54,000 |  


### PR DESCRIPTION
Serverless SQL pool in Synapse Analytics only support 20 databases, according to this page: https://docs.microsoft.com/en-us/azure/synapse-analytics/sql/resources-self-help-sql-on-demand#constraints
I don't know how many Spark Pool databases are supported. Please document that as well.