### PR TITLE
[Storage] Clarify FAQ for Static Websites

### DIFF
--- a/articles/storage/blobs/storage-blob-static-website.md
+++ b/articles/storage/blobs/storage-blob-static-website.md
@@ -48,18 +48,12 @@ You can use any of these tools to upload content to the **$web** container:
 
 Users can view site content from a browser by using the public URL of the website. You can find the URL by using the Azure portal, Azure CLI, or PowerShell. See [Find the website URL](storage-blob-static-website-how-to.md#portal-find-url).
 
+The index document that you specify when you enable static website hosting appears when users open the site and don't specify a specific file (For example: `https://contosoblobaccount.z22.web.core.windows.net`).
+
 If the server returns a 404 error, and you have not specified an error document when you enabled the website, then a default 404 page is returned to the user.
 
 > [!NOTE]
 > [Cross-Origin Resource Sharing (CORS) support for Azure Storage](/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services) is not supported with static website.
-
-### Regional codes
-
-The URL of your site contains a regional code. For example, the URL `https://contosoblobaccount.z22.web.core.windows.net/` contains regional code `z22`.
-
-While that code must remain in the URL, it is only for internal use, and you won't have to use that code in any other way.
-
-The index document that you specify when you enable static website hosting, appears when users open the site and don't specify a specific file (For example: `https://contosoblobaccount.z22.web.core.windows.net`).
 
 ### Secondary endpoints
 
@@ -120,11 +114,11 @@ To enable metrics on your static website pages, see [Enable metrics on static we
 
 ##### Does the Azure Storage firewall work with a static website?
 
-The storage account has a built-in [firewall feature](../common/storage-network-security.md), but this firewall does not affect the static website endpoint. It can be used only to protect other storage endpoints, such as the blob, file, table, and queue service endpoints. 
+Yes. Storage account [network security rules](../common/storage-network-security.md), including IP-based and VNET firewalls, are supported for the static website endpoint, and may be used to protect your website.
 
 ##### Do static websites support Azure Active Directory (Azure AD)?
 
-Yes. However, there is no option to use Social Identity Providers, such as Google authentication or Facebook, using OpenID.
+No. A static website only supports anonymous public read access for files in the **$web** container.
 
 ##### How do I use a custom domain with a static website?
 


### PR DESCRIPTION
This corrects a few details in the FAQ section for Azure Storage Static Websites.

Changes:
- Remove the "Region Codes" nomenclature, as this is not an accurate description of the DNS zones used for Static Websites (which are not tied to regions)
- Move the commentary on the `index.html` handling and public URL example to the section above, which already links to the right documentation for Finding a Website URL (via portal or the `primaryEndpoints` field).
- Correct statement about firewalls: they are supported.
- Correct statement about AAD auth: it is not supported