### PR TITLE
Update how-to-expressroute-direct-portal.md

### DIFF
--- a/articles/expressroute/how-to-expressroute-direct-portal.md
+++ b/articles/expressroute/how-to-expressroute-direct-portal.md
@@ -131,5 +131,9 @@ The following steps help you create an ExpressRoute circuit from the ExpressRout
 1. Select **Create**. You will see a message letting you know that your deployment is underway. Status will display on this page as the resources are created. 
 
 ## Next steps
+After you've created the ExpressRoute Circuit, you can link your ExpressRoute Circuit to a VNet Gateway
 
+> [!div class="nextstepaction"]
+> [Link a Virtual Network to an ExpressRoute circuit](expressroute-howto-add-gateway-portal-resource-manager.md)
+> 
 For more information about ExpressRoute Direct, see the [Overview](expressroute-erdirect-about.md).


### PR DESCRIPTION
Adding documentation to show ExpressRoute Circuits provisioned through ExpressRoute Direct can be connected into a Virtual Network Gateway in the same way a regular ExpressRoute Circuit without using ExpressRoute Direct can.