### PR TITLE
Removing requirement to update MeshConfig with the prometheus_scraping key

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-arc-enabled-open-service-mesh.md
+++ b/articles/azure-arc/kubernetes/tutorial-arc-enabled-open-service-mesh.md
@@ -388,24 +388,22 @@ Both Azure Monitor and Azure Application Insights helps you maximize the availab
 
 Arc enabled Open Service Mesh will have deep integrations into both of these Azure services, and provide a seemless Azure experience for viewing and responding to critical KPIs provided by OSM metrics. Follow the steps below to allow Azure Monitor to scrape prometheus endpoints for collecting application metrics. 
 
-1. Ensure that prometheus_scraping is set to true in the `osm-mesh-config`.
+1. Ensure that the application namespaces that you wish to be monitored are onboarded to the mesh. Follow the guidance [available here](#onboard-namespaces-to-the-service-mesh).
 
-2. Ensure that the application namespaces that you wish to be monitored are onboarded to the mesh. Follow the guidance [available here](#onboard-namespaces-to-the-service-mesh).
-
-3. Expose the prometheus endpoints for application namespaces.
+2. Expose the prometheus endpoints for application namespaces.
     ```azurecli-interactive
     osm metrics enable --namespace <namespace1>
     osm metrics enable --namespace <namespace2>
     ```
 
-4. Install the Azure Monitor extension using the guidance available [here](../../azure-monitor/containers/container-insights-enable-arc-enabled-clusters.md?toc=/azure/azure-arc/kubernetes/toc.json).
+3. Install the Azure Monitor extension using the guidance available [here](../../azure-monitor/containers/container-insights-enable-arc-enabled-clusters.md?toc=/azure/azure-arc/kubernetes/toc.json).
 
-5. Add the namespaces you want to monitor in container-azm-ms-osmconfig ConfigMap. Download the ConfigMap from [here](https://github.com/microsoft/Docker-Provider/blob/ci_prod/kubernetes/container-azm-ms-osmconfig.yaml).
+4. Add the namespaces you want to monitor in container-azm-ms-osmconfig ConfigMap. Download the ConfigMap from [here](https://github.com/microsoft/Docker-Provider/blob/ci_prod/kubernetes/container-azm-ms-osmconfig.yaml).
     ```azurecli-interactive
     monitor_namespaces = ["namespace1", "namespace2"]
     ```
 
-6. Run the following kubectl command
+5. Run the following kubectl command
     ```azurecli-interactive
     kubectl apply -f container-azm-ms-osmconfig.yaml
     ```

--- a/articles/azure-arc/kubernetes/tutorial-arc-enabled-open-service-mesh.md
+++ b/articles/azure-arc/kubernetes/tutorial-arc-enabled-open-service-mesh.md
@@ -409,8 +409,6 @@ Arc enabled Open Service Mesh will have deep integrations into both of these Azu
     ```
 
 6. For OSM v0.8 and earlier: ensure that `prometheus_scraping` is set to `true` in the `osm-mesh-config`.
-
-
 It may take up to 15 minutes for the metrics to show up in Log Analytics. You can try querying the InsightsMetrics table.
 
 ```azurecli-interactive

--- a/articles/azure-arc/kubernetes/tutorial-arc-enabled-open-service-mesh.md
+++ b/articles/azure-arc/kubernetes/tutorial-arc-enabled-open-service-mesh.md
@@ -408,6 +408,9 @@ Arc enabled Open Service Mesh will have deep integrations into both of these Azu
     kubectl apply -f container-azm-ms-osmconfig.yaml
     ```
 
+6. For OSM v0.8 and earlier: ensure that `prometheus_scraping` is set to `true` in the `osm-mesh-config`.
+
+
 It may take up to 15 minutes for the metrics to show up in Log Analytics. You can try querying the InsightsMetrics table.
 
 ```azurecli-interactive


### PR DESCRIPTION
The prometheus_scraping key in MeshConfig is no longer needed to enable Prometheus scraping.