### PR TITLE
Update Get ACLs Section and add parameters list

### DIFF
--- a/articles/storage/blobs/data-lake-storage-acl-cli.md
+++ b/articles/storage/blobs/data-lake-storage-acl-cli.md
@@ -83,6 +83,18 @@ This example gets the ACL of a directory, and then prints the ACL to the console
 az storage fs access show -p my-directory -f my-file-system --account-name mystorageaccount --auth-mode login
 ```
 
+Parameters
+
+```
+--file-system -f
+```
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;File system name (i.e. your container name)
+
+```
+--path -p
+```
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The path to a file or directory in the specified file system.
+
 Get the access permissions of a **file** by using the `az storage fs access show` command. 
 
 This example gets the ACL of a file and then prints the ACL to the console.

--- a/articles/storage/blobs/data-lake-storage-acl-cli.md
+++ b/articles/storage/blobs/data-lake-storage-acl-cli.md
@@ -83,7 +83,7 @@ This example gets the ACL of a directory, and then prints the ACL to the console
 az storage fs access show -p my-directory -f my-file-system --account-name mystorageaccount --auth-mode login
 ```
 
-Parameters
+#### Parameters
 
 ```
 --file-system -f


### PR DESCRIPTION
A number of customers have mentioned that they don't understand what the '**_-f my-file-system_**' parameter should be. It would be nice to mention in the Get ACLs example section that the _-file-system -f_ parameter should be the **container** they are trying to get back or access.