### PR TITLE
Clarifying Table Storage Wording

### DIFF
--- a/articles/cosmos-db/table/tutorial-develop-table-dotnet.md
+++ b/articles/cosmos-db/table/tutorial-develop-table-dotnet.md
@@ -17,9 +17,12 @@ ms.custom: devx-track-csharp
 
 [!INCLUDE [storage-table-applies-to-storagetable-and-cosmos](../../../includes/storage-table-applies-to-storagetable-and-cosmos.md)]
 
+
 You can use the Azure Cosmos DB Table API or Azure Table storage to store structured NoSQL data in the cloud, providing a key/attribute store with a schema less design. Because Azure Cosmos DB Table API and Table storage are schema less, it's easy to adapt your data as the needs of your application evolve. You can use Azure Cosmos DB Table API or the Table storage to store flexible datasets such as user data for web applications, address books, device information, or other types of metadata your service requires. 
 
-This tutorial describes a sample that shows you how to use the [Microsoft Azure Cosmos DB Table Library for .NET](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Table) with Azure Cosmos DB Table API and Azure Table storage scenarios. You must use the connection specific to the Azure service. These scenarios are explored using C# examples that illustrate how to create tables, insert/ update data, query data and delete the tables.
+This tutorial describes a sample that shows you how to use the [Microsoft Azure Cosmos DB Table Library for .NET](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Table) with Azure Cosmos DB Table API and Azure Table storage scenarios. These scenarios are explored using C# examples that illustrate how to create tables, insert/ update data, query data and delete the tables.
+
+While this walkthrough will discuss the specifics of the Cosmos DB implementation, you can create a Table Storage resource and use the same NuGet package and API to access the resource; only the resource creation is different. Regardless of which resource type you choose, you must use the connection string specific to the Azure service you have created.
 
 ## Prerequisites
 


### PR DESCRIPTION
This is a suggested improvement to the wording around the use of Table Storage. 

- added new paragraph at tail end of intro explicitly naming the equivalent API, pointing out the difference in resource creation
- clarified terminology around connection string and moved to new paragraph