### PR TITLE
Fix Formatting Of JSON Code Example

### DIFF
--- a/articles/active-directory/app-provisioning/customize-application-attributes.md
+++ b/articles/active-directory/app-provisioning/customize-application-attributes.md
@@ -228,16 +228,16 @@ Use the steps below to provision roles for a user to your application. Note that
   
   - **Example output (PATCH)** 
     
-   ```
+   ```json
    "Operations": [
-   {
-   "op": "Add",
-   "path": "roles",
-   "value": [
-   {
-   "value": "{\"id\":\"06b07648-ecfe-589f-9d2f-6325724a46ee\",\"value\":\"25\",\"displayName\":\"Role1234\"}"
-   }
-   ]
+     {
+       "op": "Add",
+       "path": "roles",
+       "value": [
+         {
+           "value": "{\"id\":\"06b07648-ecfe-589f-9d2f-6325724a46ee\",\"value\":\"25\",\"displayName\":\"Role1234\"}"
+         }
+       ]
    ```  
 The request format in the PATCH and POST differ. To ensure that POST and PATCH are sent in the same format, you can use the feature flag described [here](./application-provisioning-config-problem-scim-compatibility.md#flags-to-alter-the-scim-behavior). 
 


### PR DESCRIPTION
The affected code sample had not been formatted. By formatting the code example it will be easier for readers to quickly understand how the `PATCH` JSON example differs from the `POST` example.