### PR TITLE
Update vmware-software-update-frequency.md

### DIFF
--- a/articles/azure-vmware/includes/vmware-software-update-frequency.md
+++ b/articles/azure-vmware/includes/vmware-software-update-frequency.md
@@ -10,9 +10,7 @@ ms.service: azure-vmware
 
 <!-- Used in faq.md and concepts-private-clouds-clusters.md -->
 
-Host maintenance and lifecycle management have no impact on the private cloud clusters' capacity or performance. Upgrades to the private cloud software are on a schedule that tracks the software bundle's release from VMware.  As a result, your private cloud doesn't require downtime for upgrades.
-
-The private cloud software bundle upgrades keep the software within one version of the most recent software bundle release from VMware. The private cloud software versions may differ from the most recent versions of the individual software components (ESXi, NSX-T, vCenter, vSAN). Updates also include drivers, software on the network switches, and firmware on the bare-metal nodes.
+Updates also include drivers, software on the network switches, and firmware on the bare-metal nodes.
 
 You'll be notified before and after patches are applied to your private clouds. We'll also work with you to schedule a maintenance window before applying updates or upgrades to your private cloud. 
 


### PR DESCRIPTION
Remove following as this is incorrect information.
Host maintenance and lifecycle management have no impact on the private cloud clusters' capacity or performance. Upgrades to the private cloud software are on a schedule that tracks the software bundle's release from VMware. As a result, your private cloud doesn't require downtime for upgrades.
The private cloud software bundle upgrades keep the software within one version of the most recent software bundle release from VMware. The private cloud software versions may differ from the most recent versions of the individual software components (ESXi, NSX-T, vCenter, vSAN). 

Correct information: The impact of ESXi patches, vCenter patches or updates and upgrades is different.
ESXi Patch/Update - Degraded Service (Workloads migrate to another node while a node is being patched).  There is no workload downtime. Access to vCenter/NSX-T is not blocked during this time, but we recommend customers to not make any changes such as Scale up/Scale down clusters.
vCenter Update - No workload downtime but vCenter access is blocked during the time of update.
NSX-T Patches/Upgrades - There is workload downtime and NSX-T access is blocked during the time of upgrade.