### PR TITLE
Replace mention of "azureml-dataprep"

### DIFF
--- a/articles/machine-learning/how-to-create-machine-learning-pipelines.md
+++ b/articles/machine-learning/how-to-create-machine-learning-pipelines.md
@@ -167,7 +167,7 @@ else:
     # Add some packages relied on by data prep step
     aml_run_config.environment.python.conda_dependencies = CondaDependencies.create(
         conda_packages=['pandas','scikit-learn'], 
-        pip_packages=['azureml-sdk', 'azureml-dataprep[fuse,pandas]'], 
+        pip_packages=['azureml-sdk', 'azureml-dataset-runtime[fuse,pandas]'], 
         pin_sdk_version=False)
 ```
 


### PR DESCRIPTION
Replace mention of "azureml-dataprep" with "azureml-dataset-runtime". We have made "azureml-dataprep" private and do not recommend users interact directly with it. Instead, "azureml-dataset-runtime" controls the version of dataprep to depend on.