### PR TITLE
Update backup-rbac-rs-vault.md

### DIFF
--- a/articles/backup/backup-rbac-rs-vault.md
+++ b/articles/backup/backup-rbac-rs-vault.md
@@ -81,10 +81,10 @@ The following table captures the Backup management actions and corresponding rol
 | Management Operation | Role Required | Resources |
 | --- | --- | --- |
 | Enable backup of Azure File shares | Backup Contributor |Recovery Services vault |
-| |Storage Account Contributor | Storage account resource |
+| | Storage Account Backup Contributor | Storage account resource |
 | On-demand backup of VM | Backup Operator | Recovery Services vault |
 | Restore File share | Backup Operator | Recovery Services vault |
-| | Storage Account Contributor | Storage account resources where restore source and Target file shares are present |
+| | Storage Account Backup Contributor | Storage account resources where restore source and Target file shares are present |
 | Restore Individual Files | Backup Operator | Recovery Services vault |
 | |Storage Account Contributor|Storage account resources where restore source and Target file shares are present |
 | Stop protection |Backup Contributor | Recovery Services vault |

--- a/articles/backup/backup-rbac-rs-vault.md
+++ b/articles/backup/backup-rbac-rs-vault.md
@@ -81,7 +81,7 @@ The following table captures the Backup management actions and corresponding rol
 | Management Operation | Role Required | Resources |
 | --- | --- | --- |
 | Enable backup of Azure File shares | Backup Contributor |Recovery Services vault |
-| |Storage Account | Contributor Storage account resource |
+| |Storage Account Contributor | Storage account resource |
 | On-demand backup of VM | Backup Operator | Recovery Services vault |
 | Restore File share | Backup Operator | Recovery Services vault |
 | | Storage Account Contributor | Storage account resources where restore source and Target file shares are present |


### PR DESCRIPTION
Under the heading minimum role requirements for the Azure File share backup, for the operation to enable backup of Azure file shares, the document lists "Storage Account" in the role required column and "Contributor Storage account resource" in the resources column.

The role required should be "Storage Account Contributor" and the resource should be "Storage account resource". This change moves the third pipe on that line to fix it.