### PR TITLE
Clarify API access and permission

### DIFF
--- a/articles/cognitive-services/QnAMaker/includes/role-based-access-control.md
+++ b/articles/cognitive-services/QnAMaker/includes/role-based-access-control.md
@@ -14,4 +14,4 @@ The following roles are provided for collaboration:
 |Contributor|All except ability to add new members to roles|Authentication Key|All except ability to add new members to roles|
 |QnA Maker Read<br>(read)|Export/Download<br>Test|Bearer token|1. Download KB API<br>2. List KBs for user API<br>3. Get Knowledge base details<br>4. Download Alterations<br>Generate Answer |
 |QnA Maker Editor<br>(read/write)|Export/Download<br>Test<br>Update KB<br>Export KB<br>Import KB<br>Replace KB<br>Create KB|Bearer token|1. Create KB API<br>2. Update KB API<br>3. Replace KB API<br>4. Replace Alterations<br>5. "Train API" [in new service model v5]|
-|Cognitive Service User<br>(read/write/publish)|All|Authentication Key|All access to Cognitive Services resource except ability to <br>1. Add new members to roles.<br>2. Create new resources.|
+|Cognitive Service User<br>(read/write/publish)|All|Authentication Key|All access to Cognitive Services resource except for ability to: <br>1. Add new members to roles.<br>2. Create new resources.|

--- a/articles/cognitive-services/QnAMaker/includes/role-based-access-control.md
+++ b/articles/cognitive-services/QnAMaker/includes/role-based-access-control.md
@@ -14,4 +14,4 @@ The following roles are provided for collaboration:
 |Contributor|All except ability to add new members to roles|Authentication Key|All except ability to add new members to roles|
 |QnA Maker Read<br>(read)|Export/Download<br>Test|Bearer token|1. Download KB API<br>2. List KBs for user API<br>3. Get Knowledge base details<br>4. Download Alterations<br>Generate Answer |
 |QnA Maker Editor<br>(read/write)|Export/Download<br>Test<br>Update KB<br>Export KB<br>Import KB<br>Replace KB<br>Create KB|Bearer token|1. Create KB API<br>2. Update KB API<br>3. Replace KB API<br>4. Replace Alterations<br>5. "Train API" [in new service model v5]|
-|Cognitive Service User<br>(read/write/publish)|All|Authentication Key|All access to Cognitive Services resource except ability to <br>1. add new members to roles<br>2. create new resources|
+|Cognitive Service User<br>(read/write/publish)|All|Authentication Key|All access to Cognitive Services resource except ability to <br>1. Add new members to roles.<br>2. Create new resources.|

--- a/articles/cognitive-services/QnAMaker/includes/role-based-access-control.md
+++ b/articles/cognitive-services/QnAMaker/includes/role-based-access-control.md
@@ -14,4 +14,4 @@ The following roles are provided for collaboration:
 |Contributor|All except ability to add new members to roles|Authentication Key|All except ability to add new members to roles|
 |QnA Maker Read<br>(read)|Export/Download<br>Test|Bearer token|1. Download KB API<br>2. List KBs for user API<br>3. Get Knowledge base details<br>4. Download Alterations<br>Generate Answer |
 |QnA Maker Editor<br>(read/write)|Export/Download<br>Test<br>Update KB<br>Export KB<br>Import KB<br>Replace KB<br>Create KB|Bearer token|1. Create KB API<br>2. Update KB API<br>3. Replace KB API<br>4. Replace Alterations<br>5. "Train API" [in new service model v5]|
-|Cognitive Service User<br>(read/write/publish)|All|Bearer token|All|
+|Cognitive Service User<br>(read/write/publish)|All|Authentication Key|All access to Cognitive Services resource except ability to <br>1. add new members to roles<br>2. create new resources|


### PR DESCRIPTION
Clarify API access and permission for Cognitive Service User. Because this role can read API key, API access should be "Authentication Key". And this role does not have full permission like Owner role.