### PR TITLE
Update api-management-using-with-internal-vnet.md

### DIFF
--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -70,7 +70,7 @@ After successful deployment, you should see your API Management service's **priv
 | Virtual IP address | Description |
 | ----- | ----- |
 | **Private virtual IP address** | A load balanced IP address from within the API Management-delegated subnet, over which you can access `gateway`, `portal`, `management`, and `scm` endpoints. |  
-| **Public virtual IP address** | Used *mainly* for control plane traffic to `management` endpoint over `port 3443`. Can be locked down to the [ApiManagement][ServiceTags] service tag. In the external VNet configuration, they are also used for runtime API traffic. |  
+| **Public virtual IP address** | Used for control plane traffic to `management` endpoint over `port 3443`. Can be locked down to the [ApiManagement][ServiceTags] service tag. In the none and external VNet configurations, they are used for incoming runtime API traffic. They are also used for outgoing runtime traffic on the internet in all VNet configurations. |  
 
 ![API Management dashboard with an internal VNET configured][api-management-internal-vnet-dashboard]
 


### PR DESCRIPTION
I created an issue, #79834, for this and the article was updated but I still think the text isn't correct. Since it is absolutely critical that to know what determines the source IP addresses for runtime traffic from APIM when you are using IP whitelisting I created this PR. The update also aligns with https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-ip-addresses which states: 

> When a request is sent from API Management to a public-facing (Internet-facing) backend, a public IP address will be visible as the origin of the request.