### PR TITLE
Updated ' to "

### DIFF
--- a/articles/key-vault/secrets/overview-storage-keys.md
+++ b/articles/key-vault/secrets/overview-storage-keys.md
@@ -67,7 +67,7 @@ Use the Azure CLI [az role assignment create](/cli/azure/role/assignment) comman
 - `--scope`: Pass your storage account resource ID, which is in the form `/subscriptions/<subscriptionID>/resourceGroups/<StorageAccountResourceGroupName>/providers/Microsoft.Storage/storageAccounts/<YourStorageAccountName>`. To find your subscription ID, use the Azure CLI [az account list](/cli/azure/account?#az_account_list) command; to find your storage account name and storage account resource group, use the Azure CLI [az storage account list](/cli/azure/storage/account?#az_storage_account_list) command.
 
 ```azurecli-interactive
-az role assignment create --role "Storage Account Key Operator Service Role" --assignee 'https://vault.azure.net' --scope "/subscriptions/<subscriptionID>/resourceGroups/<StorageAccountResourceGroupName>/providers/Microsoft.Storage/storageAccounts/<YourStorageAccountName>"
+az role assignment create --role "Storage Account Key Operator Service Role" --assignee "https://vault.azure.net" --scope "/subscriptions/<subscriptionID>/resourceGroups/<StorageAccountResourceGroupName>/providers/Microsoft.Storage/storageAccounts/<YourStorageAccountName>"
  ```
 ### Give your user account permission to managed storage accounts
 


### PR DESCRIPTION
Using existing command gave error:
C:\Users\visagarwal>az role assignment create --role "Storage Account Key Operator Service Role" --assignee 'https://vault.azure.net' --scope "/subscriptions/f1ee2647-e5d4-4c50-9e76-0a42f00dc90c/resourceGroups/My_Stuff/providers/Microsoft.Storage/storageAccounts/antarestest"
')' or ',' expected at position 35 in 'servicePrincipalNames/any(c:c eq ''https://vault.azure.net'')'.