### PR TITLE
Fix link to swagger documentation

### DIFF
--- a/includes/virtual-machines-imds.md
+++ b/includes/virtual-machines-imds.md
@@ -256,7 +256,7 @@ When you don't specify a version, you get an error with a list of the newest sup
 
 ### Swagger
 
-A full Swagger definition for IMDS is available at: https://github.com/Azure/azure-rest-api-specs/blob/master/specification/imds/data-plane/readme.md
+A full Swagger definition for IMDS is available at: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/imds/data-plane/readme.md
 
 ## Regional availability
 


### PR DESCRIPTION
AutoRest has switched from master -> main for mainline development. See https://github.com/Azure/azure-rest-api-specs/pull/15465.