### PR TITLE
Fix wrong client secret string in MSAL migration sample code

### DIFF
--- a/articles/active-directory/develop/msal-node-migration.md
+++ b/articles/active-directory/develop/msal-node-migration.md
@@ -122,7 +122,7 @@ const msalConfig = {
     auth: {
         clientId: "YOUR_CLIENT_ID",
         authority: "https://login.microsoftonline.com/YOUR_TENANT_ID",
-        clientSecret: "YOUR_TENANT_ID",
+        clientSecret: "YOUR_CLIENT_SECRET",
         knownAuthorities: [], 
     },
     cache: {


### PR DESCRIPTION
I found this little typo during the migration process.