### PR TITLE
Update resources-self-help-sql-on-demand.md

### DIFF
--- a/articles/synapse-analytics/sql/resources-self-help-sql-on-demand.md
+++ b/articles/synapse-analytics/sql/resources-self-help-sql-on-demand.md
@@ -79,7 +79,7 @@ If your query fails with the error message 'This query can't be executed due to 
 
 - Make sure data types of reasonable sizes are used.  
 
-- If your query targets Parquet files, consider defining explicit types for string columns as they'll be VARCHAR(8000) by default. [Check inferred data types](./best-practices-serverless-sql-pool#check-inferred-data-types)
+- If your query targets Parquet files, consider defining explicit types for string columns because they'll be VARCHAR(8000) by default. [Check inferred data types](./best-practices-serverless-sql-pool.md#check-inferred-data-types).
 
 - If your query targets CSV files, consider [creating statistics](develop-tables-statistics.md#statistics-in-serverless-sql-pool). 
 

--- a/articles/synapse-analytics/sql/resources-self-help-sql-on-demand.md
+++ b/articles/synapse-analytics/sql/resources-self-help-sql-on-demand.md
@@ -77,7 +77,9 @@ If you would like to query data2.csv in this example, the following permissions 
 
 If your query fails with the error message 'This query can't be executed due to current resource constraints', it means that serverless SQL pool isn't able to execute it at this moment due to resource constraints: 
 
-- Make sure data types of reasonable sizes are used. Also, specify schema for Parquet files for string columns as they'll be VARCHAR(8000) by default. 
+- Make sure data types of reasonable sizes are used.  
+
+- If your query targets Parquet files, consider defining explicit types for string columns as they'll be VARCHAR(8000) by default. [Check inferred data types](./best-practices-serverless-sql-pool#check-inferred-data-types)
 
 - If your query targets CSV files, consider [creating statistics](develop-tables-statistics.md#statistics-in-serverless-sql-pool). 
 


### PR DESCRIPTION
the inferred data types issue needs to be highlighted a more and I added a link to the section on inferred types in the best practices document for serverless pools. there should probably be a note that varchar data types potentially need to be double sized if the data contains non-latin characters (not sure how to write this up clearly) here is a link: https://docs.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver15#converting