### PR TITLE
Update msal-net-token-cache-serialization.md

### DIFF
--- a/articles/active-directory/develop/msal-net-token-cache-serialization.md
+++ b/articles/active-directory/develop/msal-net-token-cache-serialization.md
@@ -150,16 +150,16 @@ public static async Task<AuthenticationResult> GetTokenAsync(string clientId, X5
      app.AddInMemoryTokenCache();  // Microsoft.Identity.Web 1.16 or over
    
      // Make the call to get a token for client_credentials flow (app to app scenario) 
-     return await app.AcquireTokenForClient(scopes);
+     return await app.AcquireTokenForClient(scopes).ExecuteAsync();
      
      // OR Make the call to get a token for OBO (web api scenario)
-     return await app.AcquireTokenOnBehalfOf(scopes, userAssertion);
+     return await app.AcquireTokenOnBehalfOf(scopes, userAssertion).ExecuteAsync();
      
      // OR Make the call to get a token via auth code (web app scenario)
      try
      {          
-          var account = await app.GetAccount(homeAccountId);
-          return await app.AcquireTokenSilent(scopes, account); 
+          var account = await app.GetAccountsAsync(homeAccountId);
+          return await app.AcquireTokenSilent(scopes, account).ExecuteAsync();; 
      } 
      catch (MsalUiRequiredException)
      {

--- a/articles/active-directory/develop/msal-net-token-cache-serialization.md
+++ b/articles/active-directory/develop/msal-net-token-cache-serialization.md
@@ -134,8 +134,6 @@ using Microsoft.Extensions.DependencyInjection;
 
 ```CSharp
 
- 
-
 public static async Task<AuthenticationResult> GetTokenAsync(string clientId, X509Certificate cert, string authority, string[] scopes)
  {
      // Create the confidential client application

--- a/articles/active-directory/develop/msal-net-token-cache-serialization.md
+++ b/articles/active-directory/develop/msal-net-token-cache-serialization.md
@@ -134,27 +134,37 @@ using Microsoft.Extensions.DependencyInjection;
 
 ```CSharp
 
- private static IConfidentialClientApplication app;
+ 
 
-public static async Task<IConfidentialClientApplication> BuildConfidentialClientApplication(
-  string clientId,
-  CertificateDescription certDescription,
-  string tenant)
+public static async Task<AuthenticationResult> GetTokenAsync(string clientId, X509Certificate cert, string authority, string[] scopes)
  {
-  if (app== null)
-  {
      // Create the confidential client application
      app= ConfidentialClientApplicationBuilder.Create(clientId)
        // Alternatively to the certificate you can use .WithClientSecret(clientSecret)
-       .WithCertificate(certDescription.Certificate)
+       .WithCertificate(cert)
        .WithLegacyCacheCompatibility(false)
-       .WithTenantId(tenant)
+       .WithAuthority(authority)
        .Build();
 
-     // Add an in-memory token cache. Other options available: see below
-     app.AddInMemoryTokenCache();
-   }
-   return app;
+     // Add a static in-memory token cache. Other options available: see below
+     app.AddInMemoryTokenCache();  // Microsoft.Identity.Web 1.16 or over
+   
+     // Make the call to get a token for client_credentials flow (app to app scenario) 
+     return await app.AcquireTokenForClient(scopes);
+     
+     // OR Make the call to get a token for OBO (web api scenario)
+     return await app.AcquireTokenOnBehalfOf(scopes, userAssertion);
+     
+     // OR Make the call to get a token via auth code (web app scenario)
+     try
+     {          
+          var account = await app.GetAccount(homeAccountId);
+          return await app.AcquireTokenSilent(scopes, account); 
+     } 
+     catch (MsalUiRequiredException)
+     {
+          return await app.AcquireTokenByAuthorizationCode(scopes, authCode);    
+     }
   }
 ```
 

--- a/articles/active-directory/develop/msal-net-token-cache-serialization.md
+++ b/articles/active-directory/develop/msal-net-token-cache-serialization.md
@@ -158,7 +158,7 @@ public static async Task<AuthenticationResult> GetTokenAsync(string clientId, X5
      
      // OR, when the user has previously logged in, get a token silently
      var homeAccountId = GetHomeAccountIdFromClaimsPrincipal(); // uid and utid claims
-     var account = await app.GetAccountsAsync(homeAccountId);
+     var account = await app.GetAccountAsync(homeAccountId);
      try
      {
           return await app.AcquireTokenSilent(scopes, account).ExecuteAsync();; 


### PR DESCRIPTION
In non-asp.net core scenario, do not use a static CCA object. Instead, create 1 app per request.