### PR TITLE
Update virtual-machine-scale-sets-autoscale-portal.md

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-autoscale-portal.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-autoscale-portal.md
@@ -52,6 +52,8 @@ If your application demand increases, the load on the VM instances in your scale
     | *Cool down (minutes)*  | The amount of time to wait before the rule is applied again so that the autoscale actions have time to take effect. | 5 minutes      |
 
     The following examples show a rule created in the Azure portal that matches these settings:
+    
+  *Note : Tasks running inside the instance will abruply stop and the instance scales down once it completes the cooling period.*
 
     ![Create an autoscale rule to increase the number of VM instances](media/virtual-machine-scale-sets-autoscale-portal/rule-increase.png)
 


### PR DESCRIPTION
*Note: Tasks running inside the instance will abruptly stop and the instance scales down once it completes the cooling period.*

I have few customers who are looking for this information on a public document. Hence requesting to add this note, as it adds clarity to this concept.