### PR TITLE
command update on pulling runtime container

### DIFF
--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -159,12 +159,12 @@ The IoT Edge agent and IoT Edge hub images are tagged with the IoT Edge version 
 
 You know about storing your container images for custom code modules in your private Azure registry, but you can also use it to store public container images such as for the edgeAgent and edgHub runtime modules. Doing so may be required if you have very tight firewall restrictions as these runtime containers are stored in the Microsoft Container Registry (MCR).
 
-Obtain the images with the Docker pull command to place in your private registry. Be aware that you will need to update the images with each new release of IoT Edge runtime.
+Obtain the images with the Docker pull command to place in your private registry. You will need to specify the container version during the pull operation, find the latest container version at container description page as below, and replace the version in the pull command if needed. Be aware that you will need to update the images with each new release of IoT Edge runtime.
 
 | IoT Edge runtime container | Docker pull command |
 | --- | --- |
-| [Azure IoT Edge Agent](https://hub.docker.com/_/microsoft-azureiotedge-agent) | `docker pull mcr.microsoft.com/azureiotedge-agent` |
-| [Azure IoT Edge Hub](https://hub.docker.com/_/microsoft-azureiotedge-hub) | `docker pull mcr.microsoft.com/azureiotedge-hub` |
+| [Azure IoT Edge Agent](https://hub.docker.com/_/microsoft-azureiotedge-agent) | `docker pull mcr.microsoft.com/azureiotedge-agent:1.0` |
+| [Azure IoT Edge Hub](https://hub.docker.com/_/microsoft-azureiotedge-hub) | `docker pull mcr.microsoft.com/azureiotedge-hub:1.0` |
 
 Next, be sure to update the image references in the deployment.template.json file for the edgeAgent and edgeHub system modules. Replace `mcr.microsoft.com` with your registry name and server for both modules.
 

--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -163,8 +163,8 @@ Obtain the images with the Docker pull command to place in your private registry
 
 | IoT Edge runtime container | Docker pull command |
 | --- | --- |
-| [Azure IoT Edge Agent](https://hub.docker.com/_/microsoft-azureiotedge-agent) | `docker pull mcr.microsoft.com/azureiotedge-agent:1.0` |
-| [Azure IoT Edge Hub](https://hub.docker.com/_/microsoft-azureiotedge-hub) | `docker pull mcr.microsoft.com/azureiotedge-hub:1.0` |
+| [Azure IoT Edge Agent](https://hub.docker.com/_/microsoft-azureiotedge-agent) | `docker pull mcr.microsoft.com/azureiotedge-agent:<VERSION_TAG>` |
+| [Azure IoT Edge Hub](https://hub.docker.com/_/microsoft-azureiotedge-hub) | `docker pull mcr.microsoft.com/azureiotedge-hub:<VERSION_TAG>` |
 
 Next, be sure to update the image references in the deployment.template.json file for the edgeAgent and edgeHub system modules. Replace `mcr.microsoft.com` with your registry name and server for both modules.
 


### PR DESCRIPTION
Under the section "Store runtime containers in your private registry", the docker pull command "docker pull mcr.microsoft.com/azureiotedge-agent" is not accurate now. This command will auto refer to the version "latest", and it will fail to find the container as the "latest" version is not exist. Suggest to change to "docker pull mcr.microsoft.com/azureiotedge-agent:[version]", and suggest user to find the latest version from azureiotedge-agent description page. 
There is a policy changes of Microsoft container version (please correct me if this is not the latest policy), that there will be no default "latest" version, and the version number will be specified for every release.