### PR TITLE
Update app insights react plugin install docs

### DIFF
--- a/articles/azure-monitor/app/javascript-react-plugin.md
+++ b/articles/azure-monitor/app/javascript-react-plugin.md
@@ -22,8 +22,7 @@ Install npm package:
 
 ```bash
 
-npm install @microsoft/applicationinsights-react-js
-npm install @microsoft/applicationinsights-web
+npm install @microsoft/applicationinsights-react-js @microsoft/applicationinsights-web --save
 
 ```
 


### PR DESCRIPTION
Changed `npm` command since installing the packages in two commands did not work in my local (Ubuntu 20.04) environment. After running `npm install` again after running the commands, I had this error:
```
could not find dependency 'bindings' of 'watchpack-chokidar2/node_modules/fsevents'
```
Installing the two packages in one command did not produce this error.

Also added the `--save` option to reflect current npm best practices.