### PR TITLE
Fix incorrect argument name `--ssh-key-value`

### DIFF
--- a/articles/virtual-machines/linux/quick-create-cli.md
+++ b/articles/virtual-machines/linux/quick-create-cli.md
@@ -41,7 +41,7 @@ az group create --name myResourceGroup --location eastus
 
 Create a VM with the [az vm create](/cli/azure/vm) command.
 
-The following example creates a VM named *myVM* and adds a user account named *azureuser*. The `--generate-ssh-keys` parameter is used to automatically generate an SSH key, and put it in the default key location (*~/.ssh*). To use a specific set of keys instead, use the `--ssh-key-value` option.
+The following example creates a VM named *myVM* and adds a user account named *azureuser*. The `--generate-ssh-keys` parameter is used to automatically generate an SSH key, and put it in the default key location (*~/.ssh*). To use a specific set of keys instead, use the `--ssh-key-values` option.
 
 ```azurecli-interactive
 az vm create \


### PR DESCRIPTION
Fix incorrect argument name `--ssh-key-value` in https://docs.microsoft.com/en-us/azure/virtual-machines/linux/quick-create-cli

https://docs.microsoft.com/en-us/cli/azure/vm?view=azure-cli-latest#az_vm_create

> --ssh-key-values
> Space-separated list of SSH public keys or public key file paths.