### PR TITLE
fix <api> tag

### DIFF
--- a/articles/api-management/api-management-access-restriction-policies.md
+++ b/articles/api-management/api-management-access-restriction-policies.md
@@ -93,7 +93,7 @@ The `rate-limit` policy prevents API usage spikes on a per subscription basis by
 
 ```xml
 <rate-limit calls="number" renewal-period="seconds">
-    <api name="API name" id="API id" calls="number" renewal-period="seconds" />
+    <api name="API name" id="API id" calls="number" renewal-period="seconds">
         <operation name="operation name" id="operation id" calls="number" renewal-period="seconds" 
         retry-after-header-name="header name" 
         retry-after-variable-name="policy expression variable name"


### PR DESCRIPTION
`<api>` tag was closed earlier then it was needed. It was closed in it's start tag itself (i.e. `<api />`). Whereas there was already an explicit closing api tag below.
It leaded to error while saving policy in APIM portal. Now, it works fine.