### PR TITLE
Change the input language to Italian

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/how-to/speech-translation-basics/speech-translation-basics-python.md
+++ b/articles/cognitive-services/Speech-Service/includes/how-to/speech-translation-basics/speech-translation-basics-python.md
@@ -75,7 +75,7 @@ def translate_speech_to_text():
             subscription=speech_key, region=service_region)
 
     # Source (input) language
-    translation_config.speech_recognition_language = from_language
+    translation_config.speech_recognition_language = "it-IT"
 ```
 
 The [`speech_recognition_language`][recognitionlang] property expects a language-locale format string. You can provide any value in the **Locale** column in the list of supported [locales/languages](../../../language-support.md).

--- a/articles/cognitive-services/Speech-Service/includes/how-to/speech-translation-basics/speech-translation-basics-python.md
+++ b/articles/cognitive-services/Speech-Service/includes/how-to/speech-translation-basics/speech-translation-basics-python.md
@@ -75,7 +75,8 @@ def translate_speech_to_text():
             subscription=speech_key, region=service_region)
 
     # Source (input) language
-    translation_config.speech_recognition_language = "it-IT"
+    from_language = "it-IT"
+    translation_config.speech_recognition_language = from_language
 ```
 
 The [`speech_recognition_language`][recognitionlang] property expects a language-locale format string. You can provide any value in the **Locale** column in the list of supported [locales/languages](../../../language-support.md).


### PR DESCRIPTION
In this section you explain how to change the input language to italian, but you assign it to the "from_language", which is equal to "en-US"