### PR TITLE
Updating consistency levels with clarification on majorities

### DIFF
--- a/articles/cosmos-db/consistency-levels.md
+++ b/articles/cosmos-db/consistency-levels.md
@@ -148,7 +148,7 @@ The exact RTT latency is a function of speed-of-light distance and the Azure net
 
 - For strong and bounded staleness, reads are done against two replicas in a four replica set (minority quorum) to provide consistency guarantees. Session, consistent prefix and eventual do single replica reads. The result is that, for the same number of request units, read throughput for strong and bounded staleness is half of the other consistency levels.
 
-- For a given type of write operation, such as insert, replace, upsert, and delete, the write throughput for request units is identical for all consistency levels.
+- For a given type of write operation, such as insert, replace, upsert, and delete, the write throughput for request units is identical for all consistency levels. For strong consistency, changes need to be committed in every region (global majority) while for all other consistency levels, local majority (three replicas in a four replica set) is being used. 
 
 |**Consistency Level**|**Quorum Reads**|**Quorum Writes**|
 |--|--|--|


### PR DESCRIPTION
While reading the docs on consistency, the terms "local minority", "local majority" and "global majority" are not self-explanatory, even after knowing about the replica-set idea. Searching for an explanation I found [issue #55108](https://github.com/MicrosoftDocs/azure-docs/issues/55108) where the original author clarifies. With this PR I simply incorporate their answer in the official docs. 

Specifically a point of confusion is around the word "majority": when used in the "global majority" context it means all (?) regions while in "local majority" it means 3 out of 4 replicas. As a side-note: I think this way also the text on writes and reads has the same information (throughput/RUs used and explanation on how many nodes need to read-from/commit changes).