### PR TITLE
Ingress-Basic: Error starting patch image

### DIFF
--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -106,6 +106,7 @@ helm install nginx-ingress ingress-nginx/ingress-nginx \
     --set controller.admissionWebhooks.patch.image.registry=$ACR_URL \
     --set controller.admissionWebhooks.patch.image.image=$PATCH_IMAGE \
     --set controller.admissionWebhooks.patch.image.tag=$PATCH_TAG \
+    --set controller.admissionWebhooks.patch.image.digest="" \
     --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux \
     --set defaultBackend.image.registry=$ACR_URL \
     --set defaultBackend.image.image=$DEFAULTBACKEND_IMAGE \


### PR DESCRIPTION
Following the tutorial,  using the ingress-nginx in the private ACR was not working due to the fact that now the nginx ingress chart uses a digest for the patch image. With this addition, it will ignore the digest like it does already for the controller image