### PR TITLE
Update storage-account-keys-manage.md

### DIFF
--- a/articles/storage/common/storage-account-keys-manage.md
+++ b/articles/storage/common/storage-account-keys-manage.md
@@ -237,13 +237,13 @@ To rotate your storage account access keys with Azure CLI:
     ```azurecli-interactive
     az storage account keys renew \
       --resource-group <resource-group> \
-      --account-name <storage-account>
+      --account-name <storage-account> \
       --key primary
     ```
 
 1. Update the connection strings in your code to reference the new primary access key.
 
-2. Regenerate the secondary access key in the same manner. To regenerate the secondary key, use `key2` as the key name instead of `key1`.
+2. Regenerate the secondary access key in the same manner. To regenerate the secondary key, use `secondary` as the key name instead of `primary`.
 
 ---
 


### PR DESCRIPTION
From the Azure CLI, as https://docs.microsoft.com/en-US/cli/azure/storage/account/keys?view=azure-cli-latest#az_storage_account_keys_renew suggests, "primary" and "secondary" work, but "key1" and "key2" do not.  I've no idea if the other access flavours (e.g. Powershell) also need changing.