### PR TITLE
JIT requires classic rules with FW

### DIFF
--- a/articles/security-center/just-in-time-explained.md
+++ b/articles/security-center/just-in-time-explained.md
@@ -43,7 +43,7 @@ If other rules already exist for the selected ports, then those existing rules t
 When a user requests access to a VM, Security Center checks that the user has [Azure role-based access control (Azure RBAC)](../role-based-access-control/role-assignments-portal.md) permissions for that VM. If the request is approved, Security Center configures the NSGs and Azure Firewall to allow inbound traffic to the selected ports from the relevant IP address (or range), for the amount of time that was specified. After the time has expired, Security Center restores the NSGs to their previous states. Connections that are already established are not interrupted.
 
 > [!NOTE]
-> JIT does not support VMs protected by Azure Firewalls controlled by [Azure Firewall Manager](../firewall-manager/overview.md).
+> JIT does not support VMs protected by Azure Firewalls controlled by [Azure Firewall Manager](../firewall-manager/overview.md).  The Azure Firewall must be configured with Rules (Classic) and cannot use Firewall policies.
 
 
 


### PR DESCRIPTION
While JIT will not work with Firewalls managed with Firewall Manager, the Firewall must also be managed via Rules (classic) as there is an option to still deploy a Firewall with Policies and not explicitly use the Firewall Manager.  The NOTE as is implies that either mode of the firewall (Policy or classic) would work, but he Policy version also fails.