### PR TITLE
Fix broken link with Azure cloud design patterns

### DIFF
--- a/articles/load-balancer/load-balancer-standard-availability-zones.md
+++ b/articles/load-balancer/load-balancer-standard-availability-zones.md
@@ -77,7 +77,7 @@ Zone-redundancy doesn't imply hitless data plane or control plane. Zone-redundan
 
 Traffic flows using a zone at the time of zone failure may be affected but applications can recover. Traffic continues in the healthy zones within the region upon retransmission when Azure has converged around the zone failure.
 
-Review [Azure cloud design patterns](/azure/architecture/patterns/) to improve the resiliency of your application to failure scenarios.
+Review [Azure cloud design patterns](https://docs.microsoft.com/azure/architecture/patterns/) to improve the resiliency of your application to failure scenarios.
 
 ## Limitations
 
@@ -89,4 +89,4 @@ Review [Azure cloud design patterns](/azure/architecture/patterns/) to improve t
 - Learn more about [Standard Load Balancer](./load-balancer-overview.md)
 - Learn how to [load balance VMs within a zone using a zonal Standard Load Balancer](./quickstart-load-balancer-standard-public-cli.md)
 - Learn how to [load balance VMs across zones using a zone redundant Standard Load Balancer](./quickstart-load-balancer-standard-public-cli.md)
-- Learn about [Azure cloud design patterns](/azure/architecture/patterns/) to improve the resiliency of your application to failure scenarios.
+- Learn about [Azure cloud design patterns](https://docs.microsoft.com/azure/architecture/patterns/) to improve the resiliency of your application to failure scenarios.


### PR DESCRIPTION
`/azure/architecture/patterns/` -> `https://docs.microsoft.com/azure/architecture/patterns/`