### PR TITLE
Update resize-images-on-storage-blob-upload-event.md

### DIFF
--- a/articles/event-grid/resize-images-on-storage-blob-upload-event.md
+++ b/articles/event-grid/resize-images-on-storage-blob-upload-event.md
@@ -162,9 +162,9 @@ Update-AzFunctionAppSetting -Name $functionapp -ResourceGroupName $resourceGroup
 # [Node.js v10 SDK](#tab/nodejsv10)
 
 ```azurecli-interactive
-blobStorageAccountKey=$(az storage account keys list -g $resourceGroupName -n $blobStorageAccount --query [0].value --output tsv)
+$blobStorageAccountKey=$(az storage account keys list -g $resourceGroupName -n $blobStorageAccount --query [0].value --output tsv)
 
-storageConnectionString=$(az storage account show-connection-string --resource-group $resourceGroupName --name $blobStorageAccount --query connectionString --output tsv)
+$storageConnectionString=$(az storage account show-connection-string --resource-group $resourceGroupName --name $blobStorageAccount --query connectionString --output tsv)
 
 az functionapp config appsettings set --name $functionapp --resource-group $resourceGroupName --settings FUNCTIONS_EXTENSION_VERSION=~2 BLOB_CONTAINER_NAME=thumbnails AZURE_STORAGE_ACCOUNT_NAME=$blobStorageAccount AZURE_STORAGE_ACCOUNT_ACCESS_KEY=$blobStorageAccountKey AZURE_STORAGE_CONNECTION_STRING=$storageConnectionString
 ```


### PR DESCRIPTION
blobStorageAccountKey and storageConnectionString variable names are supposed to be preceded by $ for the code to run on the Cloud shell.