### PR TITLE
Adding FireFox to list of browsers supporting device ID

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-conditions.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-conditions.md
@@ -104,7 +104,7 @@ This setting works with all browsers. However, to satisfy a device policy, like 
 
 | OS | Browsers |
 | :-- | :-- |
-| Windows 10 | Microsoft Edge, Internet Explorer, Chrome |
+| Windows 10 | Microsoft Edge, Internet Explorer, Chrome, Firefox |
 | Windows 8 / 8.1 | Internet Explorer, Chrome |
 | Windows 7 | Internet Explorer, Chrome |
 | iOS | Microsoft Edge, Intune Managed Browser, Safari |


### PR DESCRIPTION
Firefox now supports sending the device token through a firefox extension on Windows 10.  Not sure if Server versions are support at the moment.