### PR TITLE
Update how-to-upgrade-using-dump-and-restore.md

### DIFF
--- a/articles/postgresql/how-to-upgrade-using-dump-and-restore.md
+++ b/articles/postgresql/how-to-upgrade-using-dump-and-restore.md
@@ -91,7 +91,7 @@ Roles (Users) are global objects and needed to be migrated separately to the new
 To dump all the roles from the source server:
 
 ```azurecli-interactive
-pg_dumpall -r --host=mySourceServer --port=5432 --username=myUser -- dbname=mySourceDB > roles.sql
+pg_dumpall -r --host=mySourceServer --port=5432 --username=myUser --database=mySourceDB > roles.sql
 ```
 
 and restore it using psql to the target server:


### PR DESCRIPTION
Incorrect space and incorrect argument.
```
Connection options:
  -d, --dbname=CONNSTR     connect using connection string
  -h, --host=HOSTNAME      database server host or socket directory
  -l, --database=DBNAME    alternative default database
  -p, --port=PORT          database server port number
  -U, --username=NAME      connect as specified database user
  -w, --no-password        never prompt for password
  -W, --password           force password prompt (should happen automatically)
  --role=ROLENAME          do SET ROLE before dump
```