### PR TITLE
Update sbd RA interval and timeout to sane values

### DIFF
--- a/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
+++ b/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
@@ -562,7 +562,7 @@ sudo crm resource stop stonith-sbd
 sudo crm configure delete <b>stonith-sbd</b>
 sudo crm configure primitive <b>stonith-sbd</b> stonith:external/sbd \
    params pcmk_delay_max="15" \
-   op monitor interval="15" timeout="15"
+   op monitor interval="3600" timeout="20"
 </code></pre>
 
 ## Create Azure Fence agent STONITH device


### PR DESCRIPTION
The existing stonith:external/sbd monitor interval causes unnecessary stonith-sbd resource failure logging in multi-SBD configurations if only one SBD node fails.  The stonith-sbd monitor timeout is also set below the default of 20, which could lead to SBD monitor operation being more failure-prone on a busy cluster.

After running tests, I found this failure is only cosmetic, as fencing via "crm node fence _node-name_" still works when the stonith-sbd RA is Stopped or in "FAILED" state after one sbd node goes offline, but failures in the logs have led to unnecessary Support Requests to the Azure CSS team.  This scenario could realistically happen to a customer if the HyperV host node on which the SBD VM runs fails and the VM needs to be reallocated on a different host or if one of the SBD nodes experiences a kernel panic and is not set up for kdump which will cause it to hang indefinitely.  To clear these errors, one must make sure the SBD node is back online and run "crm resource cleanup stonith-sbd".

Putting in PR to adjust the fence agent params back to stonith:external/sbd defaults (interval 3600 timeout 20) to help mitigate unnecessary SRs about these failures.  I can attach a video showing the RA monitor timeout and start failure after migration roughly 2 minutes into one SBD node going down if that helps with the POC here.  With default RA values, clusters are only at risk of these logs/failures once per hour whereas current values make that 240 times per hour.