### PR TITLE
Clean up Pod Identity doc - remove duplication, reorder as needed, fix heading formatting

### DIFF
--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -80,6 +80,9 @@ Use [az aks get-credentials][az-aks-get-credentials] to sign in to your AKS clus
 az aks get-credentials --resource-group myResourceGroup --name myAKSCluster
 ```
 
+> [!NOTE]
+> When you enable pod-managed identity on your AKS cluster, an AzurePodIdentityException named *aks-addon-exception* is added to the *kube-system* namespace. An AzurePodIdentityException allows pods with certain labels to access the Azure Instance Metadata Service (IMDS) endpoint without being intercepted by the node-managed identity (NMI) server. The *aks-addon-exception* allows AKS first-party addons, such as AAD pod-managed identity, to operate without having to manually configure an AzurePodIdentityException. Optionally, you can add, remove, and update an AzurePodIdentityException using `az aks pod-identity exception add`, `az aks pod-identity exception delete`, `az aks pod-identity exception update`, or `kubectl`.
+
 ## Update an existing AKS cluster with Azure CNI
 
 Update an existing AKS cluster with Azure CNI to include pod-managed identity.
@@ -178,7 +181,6 @@ az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSClu
 ```
 
 > [!NOTE]
-> When you enable pod-managed identity on your AKS cluster, an AzurePodIdentityException named *aks-addon-exception* is added to the *kube-system* namespace. An AzurePodIdentityException allows pods with certain labels to access the Azure Instance Metadata Service (IMDS) endpoint without being intercepted by the node-managed identity (NMI) server. The *aks-addon-exception* allows AKS first-party addons, such as AAD pod-managed identity, to operate without having to manually configure an AzurePodIdentityException. Optionally, you can add, remove, and update an AzurePodIdentityException using `az aks pod-identity exception add`, `az aks pod-identity exception delete`, `az aks pod-identity exception update`, or `kubectl`.
 > The "POD_IDENTITY_NAME" has to be a valid [DNS subdomain name] as defined in [RFC 1123]. 
 
 > [!NOTE]

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -90,12 +90,13 @@ Update an existing AKS cluster with Azure CNI to include pod-managed identity.
 ```azurecli-interactive
 az aks update -g $MY_RESOURCE_GROUP -n $MY_CLUSTER --enable-pod-identity
 ```
+
 ## Using Kubenet network plugin with Azure Active Directory pod-managed identities 
 
 > [!IMPORTANT]
 > Running aad-pod-identity in a cluster with Kubenet is not a recommended configuration because of the security implication. Please follow the mitigation steps and configure policies before enabling aad-pod-identity in a cluster with Kubenet.
 
-## Mitigation
+### Mitigation
 
 To mitigate the vulnerability at the cluster level, you can use the Azure built-in policy "Kubernetes cluster containers should only use allowed capabilities" to limit the CAP_NET_RAW attack.  
 

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -145,6 +145,9 @@ az aks update -g $MY_RESOURCE_GROUP -n $MY_CLUSTER --enable-pod-identity --enabl
 
 ## Create an identity
 
+> [!IMPORTANT]
+> You must have the relevant permissions (for example, Owner) on your subscription to create the identity.
+
 Create an identity using [az identity create][az-identity-create] and set the *IDENTITY_CLIENT_ID* and *IDENTITY_RESOURCE_ID* variables.
 
 ```azurecli-interactive
@@ -169,11 +172,6 @@ az role assignment create --role "Virtual Machine Contributor" --assignee "$IDEN
 ## Create a pod identity
 
 Create a pod identity for the cluster using `az aks pod-identity add`.
-
-> [!IMPORTANT]
-> You must have the relevant permissions (for example, Owner) on your subscription to create the identity and assign role binding to the cluster identity.
-> 
-> The cluster identity must have Managed Identity Operator permissions for the identity to be assigned.
 
 ```azurecli-interactive
 export POD_IDENTITY_NAME="my-pod-identity"

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -253,8 +253,8 @@ successfully made GET on instance metadata
 In order to enable an application to use multiple identities, set the `--binding-selector` to the same selector when creating pod identities.
 
 ```azurecli-interactive
-az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_1} --identity-resource-id ${IDENTITY_RESOURCE_ID_1} --binding-selector foo
-az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_2} --identity-resource-id ${IDENTITY_RESOURCE_ID_2} --binding-selector foo
+az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_1} --identity-resource-id ${IDENTITY_RESOURCE_ID_1} --binding-selector myMultiIdentitySelector
+az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_2} --identity-resource-id ${IDENTITY_RESOURCE_ID_2} --binding-selector myMultiIdentitySelector
 ```
 
 Then set the `aadpodidbinding` field in your pod YAML to the binding selector you specified.
@@ -265,7 +265,7 @@ kind: Pod
 metadata:
   name: demo
   labels:
-    aadpodidbinding: foo
+    aadpodidbinding: myMultiIdentitySelector
 ...
 ```
 

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -250,57 +250,14 @@ successfully made GET on instance metadata
 ```
 ## Run an application with multiple identities
 
-## Create multiple identities
-
-Create identities using [az identity create][az-identity-create] and set the *IDENTITY_CLIENT_ID* and *IDENTITY_RESOURCE_ID* variables.
+In order to enable an application to use multiple identities, set the `--binding-selector` flag when creating pod identities.
 
 ```azurecli-interactive
-az group create --name myIdentityResourceGroup --location eastus
-export IDENTITY_RESOURCE_GROUP="myIdentityResourceGroup"
-export IDENTITY_NAME_1="application-identity_1"
-az identity create --resource-group ${IDENTITY_RESOURCE_GROUP} --name ${IDENTITY_NAME_1}
-export IDENTITY_NAME_2="application-identity_2"
-az identity create --resource-group ${IDENTITY_RESOURCE_GROUP} --name ${IDENTITY_NAME_2}
-export IDENTITY_CLIENT_ID="$(az identity show -g ${IDENTITY_RESOURCE_GROUP} -n ${IDENTITY_NAME_1} --query clientId -otsv)"
-export IDENTITY_RESOURCE_ID="$(az identity show -g ${IDENTITY_RESOURCE_GROUP} -n ${IDENTITY_NAME_1} --query id -otsv)"
-export IDENTITY_CLIENT_ID="$(az identity show -g ${IDENTITY_RESOURCE_GROUP} -n ${IDENTITY_NAME_2} --query clientId -otsv)"
-export IDENTITY_RESOURCE_ID="$(az identity show -g ${IDENTITY_RESOURCE_GROUP} -n ${IDENTITY_NAME_2} --query id -otsv)"
+az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_1} --identity-resource-id ${IDENTITY_RESOURCE_ID_1} --binding-selector foo
+az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_2} --identity-resource-id ${IDENTITY_RESOURCE_ID_2} --binding-selector foo
 ```
 
-## Assign permissions for the managed identities
-
-The *IDENTITY_CLIENT_ID* managed identity must have Reader permissions in the resource group that contains the virtual machine scale set of your AKS cluster.
-
-```azurecli-interactive
-NODE_GROUP=$(az aks show -g myResourceGroup -n myAKSCluster --query nodeResourceGroup -o tsv)
-NODES_RESOURCE_ID=$(az group show -n $NODE_GROUP -o tsv --query "id")
-az role assignment create --role "Reader" --assignee "$IDENTITY_CLIENT_ID_1" --scope $NODES_RESOURCE_ID
-az role assignment create --role "Reader" --assignee "$IDENTITY_CLIENT_ID_2" --scope $NODES_RESOURCE_ID
-```
-
-## Create pod identities
-
-Create pod identities for the cluster using `az aks pod-identity add`.
-
-> [!IMPORTANT]
-> You must have the appropriate permissions, such as `Owner`, on your subscription to create the identity and role binding.
-
-```azurecli-interactive
-export POD_IDENTITY_NAME="my-pod-identity"
-export POD_IDENTITY_NAMESPACE="my-app"
-az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME} --identity-resource-id ${IDENTITY_RESOURCE_ID_1} --binding-selector foo
-az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME} --identity-resource-id ${IDENTITY_RESOURCE_ID_2} --binding-selector foo
-```
-
-> [!NOTE]
-> When you enable pod-managed identity on your AKS cluster, an AzurePodIdentityException named *aks-addon-exception* is added to the *kube-system* namespace. An AzurePodIdentityException allows pods with certain labels to access the Azure Instance Metadata Service (IMDS) endpoint without being intercepted by the node-managed identity (NMI) server. The *aks-addon-exception* allows AKS first-party addons, such as AAD pod-managed identity, to operate without having to manually configure an AzurePodIdentityException. Optionally, you can add, remove, and update an AzurePodIdentityException using `az aks pod-identity exception add`, `az aks pod-identity exception delete`, `az aks pod-identity exception update`, or `kubectl`.
-
-## Run a sample application with multiple identities
-
-For a pod to use AAD pod-managed identity, the pod needs an *aadpodidbinding* label with a value that matches a selector from a *AzureIdentityBinding*. To run a sample application using AAD pod-managed identity, create a `demo.yaml` file with the following contents. Replace *POD_IDENTITY_NAME*, *IDENTITY_CLIENT_ID*, and *IDENTITY_RESOURCE_GROUP* with the values from the previous steps. Replace *SUBSCRIPTION_ID* with your subscription ID.
-
-> [!NOTE]
-> In the previous steps, you created the *POD_IDENTITY_NAME*, *IDENTITY_CLIENT_ID*, and *IDENTITY_RESOURCE_GROUP* variables. You can use a command such as `echo` to display the value you set for variables, for example `echo $IDENTITY_NAME`.
+Then set the `aadpodidbinding` field in your pod YAML to the binding selector you specified.
 
 ```yml
 apiVersion: v1
@@ -309,53 +266,6 @@ metadata:
   name: demo
   labels:
     aadpodidbinding: foo
-spec:
-  containers:
-  - name: demo
-    image: mcr.microsoft.com/oss/azure/aad-pod-identity/demo:v1.6.3
-    args:
-      - --subscriptionid=$SUBSCRIPTION_ID
-      - --clientid=$IDENTITY_CLIENT_ID
-      - --resourcegroup=$IDENTITY_RESOURCE_GROUP
-    env:
-      - name: MY_POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: MY_POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-  nodeSelector:
-    kubernetes.io/os: linux
-```
-
-Notice the pod definition has an *aadpodidbinding* label with a value that matches the name of the pod identity you ran `az aks pod-identity add` in the previous step.
-
-Deploy `demo.yaml` to the same namespace as your pod identity using `kubectl apply`:
-
-```azurecli-interactive
-kubectl apply -f demo.yaml --namespace $POD_IDENTITY_NAMESPACE
-```
-
-Verify the sample application successfully runs using `kubectl logs`.
-
-```azurecli-interactive
-kubectl logs demo --follow --namespace $POD_IDENTITY_NAMESPACE
-```
-
-Verify the logs show the a token is successfully acquired and the *GET* operation is successful.
- 
-```output
-...
-successfully doARMOperations vm count 0
-successfully acquired a token using the MSI, msiEndpoint(http://169.254.169.254/metadata/identity/oauth2/token)
-successfully acquired a token, userAssignedID MSI, msiEndpoint(http://169.254.169.254/metadata/identity/oauth2/token) clientID(xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-successfully made GET on instance metadata
 ...
 ```
 

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -250,7 +250,7 @@ successfully made GET on instance metadata
 ```
 ## Run an application with multiple identities
 
-In order to enable an application to use multiple identities, set the `--binding-selector` flag when creating pod identities.
+In order to enable an application to use multiple identities, set the `--binding-selector` to the same selector when creating pod identities.
 
 ```azurecli-interactive
 az aks pod-identity add --resource-group myResourceGroup --cluster-name myAKSCluster --namespace ${POD_IDENTITY_NAMESPACE}  --name ${POD_IDENTITY_NAME_1} --identity-resource-id ${IDENTITY_RESOURCE_ID_1} --binding-selector foo

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -50,6 +50,18 @@ az extension add --name aks-preview
 az extension update --name aks-preview
 ```
 
+### Understand Operation Mode Options
+
+> [!NOTE]
+> Azure Active Directory Pod Identity supports 2 modes of operation:
+> 
+> 1. Standard Mode: In this mode, the following 2 components are deployed to the AKS cluster: 
+>     * [Managed Identity Controller(MIC)](https://azure.github.io/aad-pod-identity/docs/concepts/mic/): A Kubernetes controller that watches for changes to pods, [AzureIdentity](https://azure.github.io/aad-pod-identity/docs/concepts/azureidentity/) and [AzureIdentityBinding](https://azure.github.io/aad-pod-identity/docs/concepts/azureidentitybinding/) through the Kubernetes API Server. When it detects a relevant change, the MIC adds or deletes [AzureAssignedIdentity](https://azure.github.io/aad-pod-identity/docs/concepts/azureassignedidentity/) as needed. Specifically, when a pod is scheduled, the MIC assigns the managed identity on Azure to the underlying VMSS used by the node pool during the creation phase. When all pods using the identity are deleted, it removes the identity from the VMSS of the node pool, unless the same managed identity is used by other pods. The MIC takes similar actions when AzureIdentity or AzureIdentityBinding are created or deleted.
+>     * [Node Managed Identity (NMI)](https://azure.github.io/aad-pod-identity/docs/concepts/nmi/): is a pod that runs as a DaemonSet on each node in the AKS cluster. NMI intercepts security token requests to the [Azure Instance Metadata Service](../virtual-machines/linux/instance-metadata-service.md?tabs=linux) on each node, redirect them to itself and validates if the pod has access to the identity it's requesting a token for and fetch the token from the Azure Active Directory tenant on behalf of the application.
+> 2. Managed Mode: In this mode, there is only NMI. The identity needs to be manually assigned and managed by the user. For more information, see [Pod Identity in Managed Mode](https://azure.github.io/aad-pod-identity/docs/configure/pod_identity_in_managed_mode/).
+>
+>When you install the Azure Active Directory Pod Identity via Helm chart or YAML manifest as shown in the [Installation Guide](https://azure.github.io/aad-pod-identity/docs/getting-started/installation/), you can choose between the `standard` and `managed` mode. If you instead decide to install the Azure Active Directory Pod Identity using the AKS cluster add-on as shown in this article, the setup will use the `managed` mode.
+
 ## Create an AKS cluster with Azure Container Networking Interface (CNI)
 
 > [!NOTE]
@@ -61,15 +73,6 @@ Create an AKS cluster with Azure CNI and pod-managed identity enabled. The follo
 az group create --name myResourceGroup --location eastus
 az aks create -g myResourceGroup -n myAKSCluster --enable-pod-identity --network-plugin azure
 ```
-> [!NOTE]
-> Azure Active Directory Pod Identity supports 2 modes of operation:
-> 
-> 1. Standard Mode: In this mode, the following 2 components are deployed to the AKS cluster: 
->     * [Managed Identity Controller(MIC)](https://azure.github.io/aad-pod-identity/docs/concepts/mic/): A Kubernetes controller that watches for changes to pods, [AzureIdentity](https://azure.github.io/aad-pod-identity/docs/concepts/azureidentity/) and [AzureIdentityBinding](https://azure.github.io/aad-pod-identity/docs/concepts/azureidentitybinding/) through the Kubernetes API Server. When it detects a relevant change, the MIC adds or deletes [AzureAssignedIdentity](https://azure.github.io/aad-pod-identity/docs/concepts/azureassignedidentity/) as needed. Specifically, when a pod is scheduled, the MIC assigns the managed identity on Azure to the underlying VMSS used by the node pool during the creation phase. When all pods using the identity are deleted, it removes the identity from the VMSS of the node pool, unless the same managed identity is used by other pods. The MIC takes similar actions when AzureIdentity or AzureIdentityBinding are created or deleted.
->     * [Node Managed Identity (NMI)](https://azure.github.io/aad-pod-identity/docs/concepts/nmi/): is a pod that runs as a DaemonSet on each node in the AKS cluster. NMI intercepts security token requests to the [Azure Instance Metadata Service](../virtual-machines/linux/instance-metadata-service.md?tabs=linux) on each node, redirect them to itself and validates if the pod has access to the identity it's requesting a token for and fetch the token from the Azure Active Directory tenant on behalf of the application.
-> 2. Managed Mode: In this mode, there is only NMI. The identity needs to be manually assigned and managed by the user. For more information, see [Pod Identity in Managed Mode](https://azure.github.io/aad-pod-identity/docs/configure/pod_identity_in_managed_mode/).
->
->When you install the Azure Active Directory Pod Identity via Helm chart or YAML manifest as shown in the [Installation Guide](https://azure.github.io/aad-pod-identity/docs/getting-started/installation/), you can choose between the `standard` and `managed` mode. If you instead decide to install the Azure Active Directory Pod Identity using the AKS cluster add-on as shown in this article, the setup will use the `managed` mode.
 
 Use [az aks get-credentials][az-aks-get-credentials] to sign in to your AKS cluster. This command also downloads and configures the `kubectl` client certificate on your development computer.
 

--- a/articles/aks/use-azure-ad-pod-identity.md
+++ b/articles/aks/use-azure-ad-pod-identity.md
@@ -358,9 +358,6 @@ successfully acquired a token, userAssignedID MSI, msiEndpoint(http://169.254.16
 successfully made GET on instance metadata
 ...
 ```
-export IDENTITY_CLIENT_ID="$(az identity show -g ${IDENTITY_RESOURCE_GROUP} -n ${IDENTITY_NAME} --query clientId -otsv)"
-export IDENTITY_RESOURCE_ID="$(az identity show -g ${IDENTITY_RESOURCE_GROUP} -n ${IDENTITY_NAME} --query id -otsv)"
-```
 
 ## Clean up
 


### PR DESCRIPTION
This moves some sections around to where they are more relevant, removes information about the previous mode of operation that is not accurate to managed mode, and fixes some heading and structure issues to make the doc more readable. Additionally, it deduplicates a large chunk of the walkthrough which was 1) buggy and 2) illustrated just one new piece of information, and replaces it with a short segment focused on that new information.

In more depth:

- Move the information on the "modes of operation" (standard vs managed) up ahead of the cluster creation/update. This is important information that shouldn't be nested under one particular way to install pod-identity.
- Move the information on AzurePodIdentityExceptions up - the default exception is created immediately after installation and so this information should be mentioned then, not as part of creating a podidentity later on.
- Change the "Mitigation" heading so it is one heading level lower and nested under Kubenet information - it's confusing in the document outline as it offers little context.
- Move the information about necessary permissions for creating identities to the relevant section.
- Replace the "Run an application with multiple identities" section with a short description of what changes to enable this; previously this section was almost entirely a direct duplication of the single identity section and had a lot of small code errors due to copy/pasting that wasn't adjusted for creation/use of two identities. Instead, let's highlight what's relevant to adding more identities - using the binding selector argument and setting both identities to the same selector - without duplicating many identical steps.
- Removes a leftover half code block to fix broken formatting for the "Clean up" heading