### PR TITLE
Update tutorial-build-chat.md

### DIFF
--- a/articles/azure-web-pubsub/tutorial-build-chat.md
+++ b/articles/azure-web-pubsub/tutorial-build-chat.md
@@ -145,7 +145,7 @@ You may remember in the [publish and subscribe message tutorial](./tutorial-pub-
                 return;
             }
             var serviceClient = context.RequestServices.GetRequiredService<WebPubSubServiceClient>();
-            await context.Response.WriteAsync(serviceClient.GenerateClientAccessUri(userId: id).AbsoluteUri);
+            await context.Response.WriteAsync(serviceClient.GetClientAccessUri(userId: id).AbsoluteUri);
         });
     });
     ```


### PR DESCRIPTION
Fixed typo - method `GenerateClientAccessUri` is not available on the `WebPubSubServiceClient` class.