### PR TITLE
Update configure-waf-custom-rules.md

### DIFF
--- a/articles/web-application-firewall/ag/configure-waf-custom-rules.md
+++ b/articles/web-application-firewall/ag/configure-waf-custom-rules.md
@@ -113,7 +113,7 @@ $condition = New-AzApplicationGatewayFirewallCondition -MatchVariable $variable 
 $rule = New-AzApplicationGatewayFirewallCustomRule -Name blockEvilBot -Priority 2 -RuleType MatchRule -MatchCondition $condition -Action Block
  
 # Create a geo-match custom rule
-$var2 = New-AzApplicationGatewayFirewallMatchVariable -VariableName RequestUri
+$var2 = New-AzApplicationGatewayFirewallMatchVariable -VariableName RemoteAddr
 $condition2 = New-AzApplicationGatewayFirewallCondition -MatchVariable $var2 -Operator GeoMatch -MatchValue "US"  -NegationCondition $False
 $rule2 = New-AzApplicationGatewayFirewallCustomRule -Name allowUS -Priority 14 -RuleType MatchRule -MatchCondition $condition2 -Action Allow
 


### PR DESCRIPTION
Need to use 'RemoteAddr' match variable instead of 'RequestUri' for geo-matching ruling to work correctly.  This is correctly referenced here also: https://docs.microsoft.com/en-us/azure/web-application-firewall/ag/create-custom-waf-rules#example-2