### PR TITLE
Update concept-audit-logs.md

### DIFF
--- a/articles/active-directory/reports-monitoring/concept-audit-logs.md
+++ b/articles/active-directory/reports-monitoring/concept-audit-logs.md
@@ -225,6 +225,8 @@ You can view Microsoft 365 activity logs from the [Microsoft 365 admin center](/
 
 You can also access the Microsoft 365 activity logs programmatically by using the [Office 365 Management APIs](/office/office-365-management-api/office-365-management-apis-overview).
 
+Note: For most of standalone or bundled M365 subscriptions, there are backend dependencies on some sub-systems within M365 data center boundary, which require to write-back some information to keep directories in sync, which essentially help in enabling hassle free onboarding when a subscription opt for Exchange Online. Hence, you will see audit log entries with actions taken by “Microsoft Substrate Management” for such write-backs. These audit log entries refer to create/update/delete operations executed by EXO to AAD. These entries are informational in nature and do not require any action.
+
 ## Next steps
 
 - [Azure AD audit activity reference](reference-audit-activities.md)


### PR DESCRIPTION
There are a subset of tenants that Exchange syncs for ‘Substrate-only’ scenarios from AAD that do not have office subscriptions/licenses and do not have cloud mailboxes. Whenever new objects (users, group, contacts) are added in AAD, Exchange attempts to Back-Sync the properties: “CloudMSExchRecipientDisplayType”, “CloudLegacyExchangeDN”, these properties do get updated in AAD. These values are technically not meaningful in a tenant without EXO mailboxes but do come into play if the tenant acquires EXO in the future. Customers will see audit log entries with actions taken by “Microsoft Substrate Management” for such write-backs. Hence, updating the documentation to make Customer aware of this.