### PR TITLE
Azure CLI commands for Azure Monitor Agent failing

### DIFF
--- a/articles/azure-monitor/agents/azure-monitor-agent-install.md
+++ b/articles/azure-monitor/agents/azure-monitor-agent-install.md
@@ -113,11 +113,11 @@ Use the following CLI commands to install the Azure Monitor agent onAzure Arc en
 
 # [Windows](#tab/CLIWindowsArc)
 ```azurecli
-az connectedmachine extension create --name AzureMonitorAgent --publisher Microsoft.Azure.Monitor --type AzureMonitorWindowsAgent --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
+az connectedmachine extension create --name AzureMonitorWindowsAgent --publisher Microsoft.Azure.Monitor --type AzureMonitorWindowsAgent --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
 ```
 # [Linux](#tab/CLILinuxArc)
 ```azurecli
-az connectedmachine extension create --name AzureMonitorAgent --publisher Microsoft.Azure.Monitor --type AzureMonitorLinuxAgent --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
+az connectedmachine extension create --name AzureMonitorLinuxAgent --publisher Microsoft.Azure.Monitor --type AzureMonitorLinuxAgent --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
 ```
 ---
 

--- a/articles/azure-monitor/agents/azure-monitor-agent-install.md
+++ b/articles/azure-monitor/agents/azure-monitor-agent-install.md
@@ -113,11 +113,11 @@ Use the following CLI commands to install the Azure Monitor agent onAzure Arc en
 
 # [Windows](#tab/CLIWindowsArc)
 ```azurecli
-az connectedmachine extension create --name AzureMonitorWindowsAgent --publisher Microsoft.Azure.Monitor --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
+az connectedmachine extension create --name AzureMonitorAgent --publisher Microsoft.Azure.Monitor --type AzureMonitorWindowsAgent --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
 ```
 # [Linux](#tab/CLILinuxArc)
 ```azurecli
-az connectedmachine extension create --name AzureMonitorLinuxAgent --publisher Microsoft.Azure.Monitor --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
+az connectedmachine extension create --name AzureMonitorAgent --publisher Microsoft.Azure.Monitor --type AzureMonitorLinuxAgent --machine-name <arc-server-name> --resource-group <resource-group-name> --location <arc-server-location>
 ```
 ---
 


### PR DESCRIPTION
I have put in reworked versions that work fine. 

Note that the most recent versions seem to be:

* Linux 1.12
* Windows 1.1

As these will change regularly then it may be better to list the commands to show the versions, e.g. 

az vm extension image list --publisher Microsoft.Azure.Monitor --name AzureMonitorLinuxAgent --location uksouth --output table