### PR TITLE
Fix Az.Accounts parameter name

### DIFF
--- a/articles/azure-government/documentation-government-get-started-connect-with-ps.md
+++ b/articles/azure-government/documentation-government-get-started-connect-with-ps.md
@@ -41,7 +41,7 @@ When you start PowerShell, you have to tell Azure PowerShell to connect to Azure
 
 | Connection type | Command |
 | --- | --- |
-| [Azure](/powershell/module/az.accounts/Connect-AzAccount) commands |`Connect-AzAccount -EnvironmentName AzureUSGovernment` |
+| [Azure](/powershell/module/az.accounts/Connect-AzAccount) commands |`Connect-AzAccount -Environment AzureUSGovernment` |
 | [Azure Active Directory](/powershell/module/azuread/connect-azuread) commands |`Connect-AzureAD -AzureEnvironmentName AzureUSGovernment` |
 | [Azure (Classic deployment model)](/powershell/module/servicemanagement/azure.service/add-azureaccount) commands |`Add-AzureAccount -Environment AzureUSGovernment` |
 | [Azure Active Directory (Classic deployment model)](/previous-versions/azure/jj151815(v=azure.100)) commands |`Connect-MsolService -AzureEnvironment UsGovernment` |


### PR DESCRIPTION
The parameter name for Connect-AzAccount is `Environment`, not `EnvironmentName`.