### PR TITLE
Corrected CLI script syntax on line 135

### DIFF
--- a/articles/sentinel/sap-deploy-solution.md
+++ b/articles/sentinel/sap-deploy-solution.md
@@ -132,7 +132,7 @@ This procedure describes how to use the Azure CLI to deploy an Ubuntu server 18.
 1. Use the following command as an example, inserting the values for your resource group and VM name:
 
     ```azurecli
-    az vm create  --resource-group [resource group name]   --name [VM Name] --image UbuntuLTS  --admin-username AzureUser --data-disk-sizes-gb 10 – --size Standard_DS2_– --generate-ssh-keys  --assign-identity
+    az vm create  --resource-group [resource group name]   --name [VM Name] --image UbuntuLTS  --admin-username azureuser --data-disk-sizes-gb 10 – --size Standard_DS2 --generate-ssh-keys  --assign-identity
     ```
 
 1. On your new VM, install:


### PR DESCRIPTION
CLI script throws the following errors as the syntax is incorrect:
"admin user name cannot contain upper case character A-Z, special characters \/"[]:|<>+=;,?*@#()! or start with $ or -"
"The value Standard_DS2_- provided for the VM size is not valid.

Hence corrected the syntax