### PR TITLE
Fix swa start command in case of No Framework

### DIFF
--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -275,7 +275,7 @@ Run the frontend app and API together by starting the app with the Static Web Ap
     Pass the current folder (`.`) and the API folder (`api`) to the CLI.
      
     ```bash
-    swa start . --api api
+    swa start src --api api
     ```
 
     # [Angular](#tab/angular)

--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -272,7 +272,7 @@ Run the frontend app and API together by starting the app with the Static Web Ap
 
     # [No Framework](#tab/vanilla-javascript)
 
-    Pass the current folder (`.`) and the API folder (`api`) to the CLI.
+    Pass the current folder (`src`) and the API folder (`api`) to the CLI.
      
     ```bash
     swa start src --api api


### PR DESCRIPTION
If there is no framework used for the frontend then the swa command need to target the src folder to point to the index.html file. The current command point to the root where there is no html content.