### PR TITLE
Provided context around why Key Vault Splitting

### DIFF
--- a/articles/key-vault/general/best-practices.md
+++ b/articles/key-vault/general/best-practices.md
@@ -18,8 +18,9 @@ ms.author: mbaldwin
 
 Our recommendation is to use a vault per application per environment (Development, Pre-Production and Production). This helps you not share secrets across environments and also reduces the threat in case of a breach.
 
-### Why we recommend separate key vaults?
-Access Policies are an "all or nothing" concept within Key Vault. If a given identity has a certain permission (**Get** example) it can get _ANY_ secret/key/certificate in the vault. This means, grouping sensitive data into the same vault increases the _blast radius_ of a security event as attacks may be able to access sensitive information across concerns. To mitigate this, consider what sensitive information a given application _SHOULD_ have access to and separate your key vaults based on this delineation - by app is the most common boundary.
+### Why we recommend separate key vaults
+
+Access policies are an "all or nothing" concept in Azure Key Vault. If an identity has a specific permission (**Get**, for example), the identity can get *any* secret, key, or certificate in the vault. This means that grouping sensitive data into the same vault increases the *blast radius* of a security event because attacks might be able to access sensitive information across concerns. To mitigate this, consider what sensitive information a specific application *should* have access to, and then separate your key vaults based on this delineation. Separating key vaults by app is the most common boundary.
 
 ## Control Access to your vault
 

--- a/articles/key-vault/general/best-practices.md
+++ b/articles/key-vault/general/best-practices.md
@@ -18,6 +18,9 @@ ms.author: mbaldwin
 
 Our recommendation is to use a vault per application per environment (Development, Pre-Production and Production). This helps you not share secrets across environments and also reduces the threat in case of a breach.
 
+### Why we recommend separate key vaults?
+Access Policies are an "all or nothing" concept within Key Vault. If a given identity has a certain permission (**Get** example) it can get _ANY_ secret/key/certificate in the vault. This means, grouping sensitive data into the same vault increases the _blast radius_ of a security event as attacks may be able to access sensitive information across concerns. To mitigate this, consider what sensitive information a given application _SHOULD_ have access to and separate your key vaults based on this delineation - by app is the most common boundary.
+
 ## Control Access to your vault
 
 Azure Key Vault is a cloud service that safeguards encryption keys and secrets like certificates, connection strings, and passwords. Because this data is sensitive and business critical, you need to secure access to your key vaults by allowing only authorized applications and users. This [article](security-features.md) provides an overview of the Key Vault access model. It explains authentication and authorization, and describes how to secure access to your key vaults.


### PR DESCRIPTION
Added more context around why separate key vaults are necessary. Included that while "by app" is the most common, the greater concern is the visibility of the secret/key/certificate.

We see a lot of customers who do not fully grasp the important of splitting key vaults. This addition is aimed at increasing the awareness through our documentation.

Thanks