### PR TITLE
Fix API version and scope for resource group

### DIFF
--- a/articles/azure-resource-manager/bicep/modules.md
+++ b/articles/azure-resource-manager/bicep/modules.md
@@ -145,10 +145,9 @@ param namePrefix string
 param location string = deployment().location
 
 var resourceGroupName = '${namePrefix}rg'
-resource myResourceGroup 'Microsoft.Resources/resourceGroups@2020-01-01' = {
+resource myResourceGroup 'Microsoft.Resources/resourceGroups@2021-01-01' = {
   name: resourceGroupName
   location: location
-  scope: subscription()
 }
 
 module stgModule './storageAccount.bicep' = {


### PR DESCRIPTION
API version `2020-01-01` doesn't exist, assume it was meant to be `2021-01-01`.
In that API version, `scope` is not allowed as a parameter (it would automatically be `subscription`?).