### PR TITLE
Readability typographical / grammatical error

### DIFF
--- a/articles/active-directory/develop/includes/remind-not-to-validate-access-tokens.md
+++ b/articles/active-directory/develop/includes/remind-not-to-validate-access-tokens.md
@@ -16,4 +16,4 @@ ms.custom: aaddev
 ---
 
 > [!WARNING]
-> Don't attempt to validate or read tokens for any API you don't own, including the tokens in this example, in your code.  Tokens for Microsoft services can use a special format that will not validate as a JWT, and may also encrypted for consumer (Microsoft account) users. While reading tokens is a useful debugging and learning tool, do not take dependencies on this in your code or assume specifics about tokens that aren't for an API you control.
+> Don't attempt to validate or read tokens for any API you don't own, including the tokens in this example, in your code. Tokens for Microsoft services can use a special format that will not validate as a JWT, and may also be encrypted for consumer (Microsoft account) users. While reading tokens is a useful debugging and learning tool, do not take dependencies on this in your code or assume specifics about tokens that aren't for an API you control.


### PR DESCRIPTION
There is a message with a potential readability issue. This message is shown in a warning reminder tooltip on https://github.com/MicrosoftDocs/azure-docs/edit/master/articles/active-directory/develop/v2-protocols-oidc.md (at the bottom of the "[Successful token response](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-protocols-oidc#successful-token-response)" section).

# Current Sentence
>Tokens for Microsoft services can use a special format that will not validate as a JWT, and may also encrypted for consumer (Microsoft account) users.

# Proposed Change to Sentence
*From:*
>.. and may also encrypted ...
*To:*
>... and may also be encrypted ...

# Updated Sentence
>Tokens for Microsoft services can use a special format that will not validate as a JWT, and may also be encrypted for consumer (Microsoft account) users.

# Scope
_Improve readability with minimal modification._ No major structural changes made (in order to preserve the original intent).