### PR TITLE
use only maintained repo

### DIFF
--- a/articles/cognitive-services/Speech-Service/how-to-configure-rhel-centos-7.md
+++ b/articles/cognitive-services/Speech-Service/how-to-configure-rhel-centos-7.md
@@ -74,10 +74,6 @@ This is a sample command set that illustrates how to configure RHEL/CentOS 7 x64
 First install all general dependencies:
 
 ```bash
-# Only run ONE of the following two commands
-# - for CentOS 7:
-sudo rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm
-# - for RHEL 7:
 sudo rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
 
 # Install development tools and libraries


### PR DESCRIPTION
The old one gives issues when installing Docker because of the Moby rename.

See an example issue: https://github.com/docker/docker.github.io/issues/11198#issuecomment-667906042
Also, see the official instructions here https://docs.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#enterprise-linux-rhel-and-variants where the centos repo is absent.