### PR TITLE
Clarify that contributor role is superset of Data Factory Contributor role.

### DIFF
--- a/articles/data-factory/concepts-roles-permissions.md
+++ b/articles/data-factory/concepts-roles-permissions.md
@@ -22,6 +22,8 @@ To create Data Factory instances, the user account that you use to sign in to Az
 
 To create and manage child resources for Data Factory - including datasets, linked services, pipelines, triggers, and integration runtimes - the following requirements are applicable:
 - To create and manage child resources in the Azure portal, you must belong to the **Data Factory Contributor** role at the **Resource Group** level or above.
+  > [!NOTE]
+  > If you already have the **Contributor** role at the **Resource Group** level or above, you do not need the **Data Factory Contributor** role. The [Contributor role](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor) is a superset role that includes all permissions granted to the [Data Factory Contributor role](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#data-factory-contributor).
 - To create and manage child resources with PowerShell or the SDK, the **contributor** role at the resource level or above is sufficient.
 
 For sample instructions about how to add a user to a role, see the [Add roles](../cost-management-billing/manage/add-change-subscription-administrator.md) article.

--- a/articles/data-factory/concepts-roles-permissions.md
+++ b/articles/data-factory/concepts-roles-permissions.md
@@ -22,8 +22,9 @@ To create Data Factory instances, the user account that you use to sign in to Az
 
 To create and manage child resources for Data Factory - including datasets, linked services, pipelines, triggers, and integration runtimes - the following requirements are applicable:
 - To create and manage child resources in the Azure portal, you must belong to the **Data Factory Contributor** role at the **Resource Group** level or above.
+
   > [!NOTE]
-  > If you already have the **Contributor** role at the **Resource Group** level or above, you do not need the **Data Factory Contributor** role. The [Contributor role](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor) is a superset role that includes all permissions granted to the [Data Factory Contributor role](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#data-factory-contributor).
+  > If you already have the **Contributor** role at the **Resource Group** level or above, you do not need the **Data Factory Contributor** role. The [Contributor role](../role-based-access-control/built-in-roles.md#contributor) is a superset role that includes all permissions granted to the [Data Factory Contributor role](../role-based-access-control/built-in-roles.md#data-factory-contributor).
 - To create and manage child resources with PowerShell or the SDK, the **contributor** role at the resource level or above is sufficient.
 
 For sample instructions about how to add a user to a role, see the [Add roles](../cost-management-billing/manage/add-change-subscription-administrator.md) article.


### PR DESCRIPTION
The [best practices article](https://docs.microsoft.com/azure/data-factory/source-control#permissions) mentions correctly that team members that need to publish the Data Factory, "must have the Data Factory contributor role on the Resource Group". Data Factory contributor role is the least role they need to grand. If the user is already a contributor at a resource group level, they do not need to be granted the Data Factory Contributor role.

Without the specific note, our customers are assigning both permissions and they mistakenly think that Contributors cannot publish the ADF pipeline.
