### PR TITLE
Update event-grid/sdk-overview.md to point to Track2 Java management SDK

### DIFF
--- a/articles/event-grid/sdk-overview.md
+++ b/articles/event-grid/sdk-overview.md
@@ -15,7 +15,7 @@ The management SDKs enable you to create, update, and delete event grid topics a
 
 * [.NET](https://www.nuget.org/packages/Microsoft.Azure.Management.EventGrid)
 * [Go](https://github.com/Azure/azure-sdk-for-go)
-* [Java](https://search.maven.org/#search%7Cga%7C1%7Cazure-mgmt-eventgrid)
+* [Java](https://search.maven.org/#search%7Cga%7C1%7Cazure-resourcemanager-eventgrid)
 * [Node](https://www.npmjs.com/package/@azure/arm-eventgrid)
 * [Python](https://pypi.python.org/pypi/azure-mgmt-eventgrid)
 * [Ruby](https://rubygems.org/gems/azure_mgmt_event_grid)


### PR DESCRIPTION
Azure Java Management SDK has been upgraded to Track2, but the management SDK in this article still links to Track1 SDK. 
So I update event-grid/sdk-overview.md to point to Track2 Java management SDK: https://search.maven.org/#search%7Cga%7C1%7Cazure-resourcemanager-eventgrid