### PR TITLE
Updated pre-requisite for from.email

### DIFF
--- a/articles/active-directory-b2c/custom-email-sendgrid.md
+++ b/articles/active-directory-b2c/custom-email-sendgrid.md
@@ -202,7 +202,7 @@ The JSON object's structure is defined by the IDs in dot notation of the InputPa
 Add the following claims transformation to the `<ClaimsTransformations>` element within `<BuildingBlocks>`. Make the following updates to the claims transformation XML:
 
 * Update the `template_id` InputParameter value with the ID of the SendGrid transactional template you created earlier in [Create SendGrid template](#create-sendgrid-template).
-* Update the `from.email` address value. Use a valid email address to help prevent the verification email from being marked as spam.
+* Update the `from.email` address value. Use a valid email address to help prevent the verification email from being marked as spam. **NOTE**: The email address that you are going to use here needs to verified in Send Grid under sender authentication either with Domain Authentication or with Single Sender Authentication.
 * Update the value of the `personalizations.0.dynamic_template_data.subject` subject line input parameter with a subject line appropriate for your organization.
 
 ```xml

--- a/articles/active-directory-b2c/custom-email-sendgrid.md
+++ b/articles/active-directory-b2c/custom-email-sendgrid.md
@@ -202,7 +202,9 @@ The JSON object's structure is defined by the IDs in dot notation of the InputPa
 Add the following claims transformation to the `<ClaimsTransformations>` element within `<BuildingBlocks>`. Make the following updates to the claims transformation XML:
 
 * Update the `template_id` InputParameter value with the ID of the SendGrid transactional template you created earlier in [Create SendGrid template](#create-sendgrid-template).
-* Update the `from.email` address value. Use a valid email address to help prevent the verification email from being marked as spam. **NOTE**: The email address that you are going to use here needs to verified in Send Grid under sender authentication either with Domain Authentication or with Single Sender Authentication.
+* Update the `from.email` address value. Use a valid email address to help prevent the verification email from being marked as spam. 
+   > [!NOTE]
+   > This email address must be verified in SendGrid under Sender Authentication with either domain authentication or Single Sender Authentication.
 * Update the value of the `personalizations.0.dynamic_template_data.subject` subject line input parameter with a subject line appropriate for your organization.
 
 ```xml


### PR DESCRIPTION
This has been causing multiple cases where customers are not able to send email because of the from.email not being verified in sendgrid and B2C throws a generic error.