### PR TITLE
Fix casing in 'vote.key' to '.Key'

### DIFF
--- a/articles/service-fabric/service-fabric-tutorial-create-dotnet-app.md
+++ b/articles/service-fabric/service-fabric-tutorial-create-dotnet-app.md
@@ -143,7 +143,7 @@ Open **Views/Home/Index.cshtml**, the view specific to the Home controller.  Rep
                 </div>
                 <div class="row top-buffer" ng-repeat="vote in votes.data">
                     <div class="col-xs-8">
-                        <button class="btn btn-success text-left btn-block" ng-click="add(vote.key)">
+                        <button class="btn btn-success text-left btn-block" ng-click="add(vote.Key)">
                             <span class="pull-left">
                                 {{vote.Key}}
                             </span>
@@ -153,7 +153,7 @@ Open **Views/Home/Index.cshtml**, the view specific to the Home controller.  Rep
                         </button>
                     </div>
                     <div class="col-xs-4">
-                        <button class="btn btn-danger pull-right btn-block" ng-click="remove(vote.key)">
+                        <button class="btn btn-danger pull-right btn-block" ng-click="remove(vote.Key)">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                             Remove
                         </button>


### PR DESCRIPTION
The lowercase 'key' led to a non-running application within my local Service Fabric Cluster Manager. Lowercase 'key' leads to `undefined`.