### PR TITLE
Fix suggested config overriding default scopes

### DIFF
--- a/articles/app-service/configure-authentication-oauth-tokens.md
+++ b/articles/app-service/configure-authentication-oauth-tokens.md
@@ -46,13 +46,16 @@ When your provider's access token (not the [session token](#extend-session-token
         "identityProviders": {
           "azureActiveDirectory": {
             "login": {
-              "loginParameters": ["scope=openid offline_access"]
+              "loginParameters": ["scope=openid profile email offline_access"]
             }
           }
         }
         ```
 
     5. Click **Put**.
+    
+> [!NOTE]
+> Further information on the modified scope value can be found on the Microsoft Identity [OpenID Connection Scopes](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#openid-connect-scopes).
 
 > [!NOTE]
 > If you configured your application with the Authentication (Classic) blade, instead of navigating to the the **authSettingsV2** section in [https://resources.azure.com](https://resources.azure.com), navigate to **authsettings**. Then edit the setting ```"additionalLoginParams": ["scope=openid offline_access"]```.


### PR DESCRIPTION
Fix the suggested configuration for enabling refresh tokens to not remove the scopes of profile and email that are there by default.  
Adding a link to additional information about what the suggested change to AzureAD is actually doing for further background on the subject.