### PR TITLE
Correction of "Example code" typos (`mlfow`)

### DIFF
--- a/articles/machine-learning/how-to-log-view-metrics.md
+++ b/articles/machine-learning/how-to-log-view-metrics.md
@@ -75,9 +75,9 @@ mlflow_run = mlflow.start_run()
 
 |Logged Value|Example code| Notes|
 |----|----|----|
-|Log a numeric value (int or float) | `mlfow.log_metric('my_metric', 1)`| |
-|Log a boolean value | `mlfow.log_metric('my_metric', 0)`| 0 = True, 1 = False|
-|Log a string | `mlfow.log_text('foo', 'my_string')`| Logged as an artifact|
+|Log a numeric value (int or float) | `mlflow.log_metric('my_metric', 1)`| |
+|Log a boolean value | `mlflow.log_metric('my_metric', 0)`| 0 = True, 1 = False|
+|Log a string | `mlflow.log_text('foo', 'my_string')`| Logged as an artifact|
 |Log numpy metrics or PIL image objects|`mlflow.log_image(img, 'figure.png')`||
 |Log matlotlib plot or image file|` mlflow.log_figure(fig, "figure.png")`||
 


### PR DESCRIPTION
Minor typos (`mlfow` corrected to `mlflow`) for example code in first 3 example lines of table under Subsection "Logging with MLflow". Corrections are proposed for column "Example code" for the following examples:
- Log a numeric value (int or float)
- Log a boolean value
- Log a string