### PR TITLE
Removing Azure AD Groups

### DIFF
--- a/articles/active-directory/roles/custom-overview.md
+++ b/articles/active-directory/roles/custom-overview.md
@@ -83,7 +83,6 @@ When you assign a role, you specify one of the following types of scope:
 
 If you specify an Azure AD resource as a scope, it can be one of the following:
 
-- Azure AD groups
 - Enterprise applications
 - Application registrations
 


### PR DESCRIPTION
Are we sure that we can **scope** an Azure AD Role Assignment to an Azure AD Group? I've removed it because I think this is actually referring to assignment, not scope.