### PR TITLE
Update availability-group-manually-configure-tutorial.md

### DIFF
--- a/articles/azure-sql/virtual-machines/windows/availability-group-manually-configure-tutorial.md
+++ b/articles/azure-sql/virtual-machines/windows/availability-group-manually-configure-tutorial.md
@@ -60,6 +60,9 @@ The following table lists the prerequisites that you need to complete before sta
 
 ## Create the cluster
 
+  > [!NOTE]
+  > On Windows Server 2019, the cluster creates a **Distributed Server Name** instead of the **Cluster Network Name**. If you're using Windows Server 2019, skip any steps that refer to the cluster core name in this tutorial. You can create a cluster network name using [PowerShell](failover-cluster-instance-storage-spaces-direct-manually-configure.md#create-failover-cluster). Review the blog [Failover Cluster: Cluster Network Object](https://blogs.windows.com/windowsexperience/2018/08/14/announcing-windows-server-2019-insider-preview-build-17733/#W0YAxO8BfwBRbkzG.97) for more information. 
+
 After the prerequisites are completed, the first step is to create a Windows Server Failover Cluster that includes two SQL Severs and a witness server.
 
 1. Use Remote Desktop Protocol (RDP) to connect to the first SQL Server. Use a domain account that is an administrator on both SQL Servers and the witness server.
@@ -83,9 +86,6 @@ After the prerequisites are completed, the first step is to create a Windows Ser
    | Confirmation |Use defaults unless you are using Storage Spaces. See the note following this table. |
 
 ### Set the Windows server failover cluster IP address
-
-  > [!NOTE]
-  > On Windows Server 2019, the cluster creates a **Distributed Server Name** instead of the **Cluster Network Name**. If you're using Windows Server 2019, skip any steps that refer to the cluster core name in this tutorial. You can create a cluster network name using [PowerShell](failover-cluster-instance-storage-spaces-direct-manually-configure.md#create-failover-cluster). Review the blog [Failover Cluster: Cluster Network Object](https://blogs.windows.com/windowsexperience/2018/08/14/announcing-windows-server-2019-insider-preview-build-17733/#W0YAxO8BfwBRbkzG.97) for more information. 
 
 1. In **Failover Cluster Manager**, scroll down to **Cluster Core Resources** and expand the cluster details. You should see both the **Name** and the **IP Address** resources in the **Failed** state. The IP address resource cannot be brought online because the cluster is assigned the same IP address as the machine itself, therefore it is a duplicate address.
 


### PR DESCRIPTION
Windows Server 2019 creates a distributed server name by default and not the cluster network name if we need a static IP address, so the change with the note mentioning this makes more sense to be notified before creating the cluster and not after, because then you need to destroy the cluster and use the PowerShell to create the cluster again with static IP. 

Either we can use a new note there or use the existing one as modified above.