### PR TITLE
Remove link between .default and permissions

### DIFF
--- a/articles/active-directory/develop/msal-v1-app-scopes.md
+++ b/articles/active-directory/develop/msal-v1-app-scopes.md
@@ -80,4 +80,6 @@ var scopes = [ ResourceId + "/.default"];
 
 ## Scopes to request for a client credential flow/daemon app
 
-In the case of client credential flow, the scope to pass would also be `/.default`. This tells to Azure AD: "all the app-level permissions that the admin has consented to in the application registration.
+For the standard client credentials flow, use `/.default` (for example, `https:\//graph.microsoft.com/.default.`).
+
+Azure AD will automatically include all the app-level permissions the admin has consented to in the access token for the client credentials flow.

--- a/articles/active-directory/develop/msal-v1-app-scopes.md
+++ b/articles/active-directory/develop/msal-v1-app-scopes.md
@@ -80,6 +80,6 @@ var scopes = [ ResourceId + "/.default"];
 
 ## Scopes to request for a client credential flow/daemon app
 
-For the standard client credentials flow, use `/.default` (for example, `https:\//graph.microsoft.com/.default.`).
+For the standard client credentials flow, use `/.default`. For example, `https://graph.microsoft.com/.default`.
 
 Azure AD will automatically include all the app-level permissions the admin has consented to in the access token for the client credentials flow.


### PR DESCRIPTION
/.default really has nothing to do with application permissions. We decided to use /.default on the client credentials flow as a forward compatibility mechanism - it means we can now use /.something-else in the future, because we know nobody is using that. Completely independently of this, on the client credentials flow, we happen to always include all your application permissions in the token (if you have any - it's also possible to do the client credentials flow without any application permissions, for authentication but not authorization). These behaviors aren't related, and so the documentation should not imply they are related.