### PR TITLE
Added AVS template reference

### DIFF
--- a/articles/azure-vmware/index.yml
+++ b/articles/azure-vmware/index.yml
@@ -205,6 +205,8 @@ landingContent:
             url: /cli/azure/vmware
           - text: Azure PowerShell
             url: /powershell/module/az.vmware
+          - text: Resource Manager template
+            url: /azure/templates/microsoft.avs/privateclouds
           - text: Terraform Azure provider
             url: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/vmware_private_cloud
       - linkListType: video

--- a/articles/azure-vmware/toc.yml
+++ b/articles/azure-vmware/toc.yml
@@ -226,5 +226,7 @@
     href: /cli/azure/vmware
   - name: Azure PowerShell
     href: /powershell/module/az.vmware/
+  - name: Resource Manager template
+    href: /azure/templates/microsoft.avs/privateclouds
   - name: Terraform Azure provider
     href: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/vmware_private_cloud


### PR DESCRIPTION
The ARM & Bicep templates have just been published for AVS (https://docs.microsoft.com/en-us/azure/templates/microsoft.avs/privateclouds)

This PR adds the relevant links to the reference section of the documentation.