### PR TITLE
Update virtual machines java SDK Doc to use latest Azure Java SDK Track2

### DIFF
--- a/articles/virtual-machines/windows/java.md
+++ b/articles/virtual-machines/windows/java.md
@@ -78,7 +78,7 @@ It takes about 20 minutes to do these steps.
 
 ## Set up authentication
 
-Please refer [here](https://docs.microsoft.com/azure/developer/java/sdk/get-started#set-up-authentication) to set up authentication.
+Learn how to [set up authentication](../azure/developer/java/sdk/get-started#set-up-authentication).
 
 ## Create the management client
 

--- a/articles/virtual-machines/windows/java.md
+++ b/articles/virtual-machines/windows/java.md
@@ -6,7 +6,7 @@ author: cynthn
 ms.service: virtual-machines
 ms.workload: infrastructure
 ms.topic: how-to
-ms.date: 07/17/2017
+ms.date: 10/09/2021
 ms.custom: devx-track-java
 ms.author: cynthn
 

--- a/articles/virtual-machines/windows/java.md
+++ b/articles/virtual-machines/windows/java.md
@@ -72,36 +72,6 @@ It takes about 20 minutes to do these steps.
       <artifactId>azure-resourcemanager</artifactId>
       <version>2.8.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.azure.resourcemanager</groupId>
-      <artifactId>azure-resourcemanager-appservice</artifactId>
-      <version>2.8.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.azure.resourcemanager</groupId>
-      <artifactId>azure-resourcemanager-network</artifactId>
-      <version>2.8.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio</artifactId>
-      <version>1.13.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>nimbus-jose-jwt</artifactId>
-      <version>3.6</version>
-    </dependency>
-    <dependency>
-      <groupId>net.minidev</groupId>
-      <artifactId>json-smart</artifactId>
-      <version>1.0.6.3</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
-      <version>1.4.5</version>
-    </dependency>
     ```
 
 3. Save the file.

--- a/articles/virtual-machines/windows/java.md
+++ b/articles/virtual-machines/windows/java.md
@@ -78,7 +78,7 @@ It takes about 20 minutes to do these steps.
 
 ## Set up authentication
 
-Please refer [here](https://docs.microsoft.com/en-us/azure/developer/java/sdk/get-started#set-up-authentication) to set up authentication.
+Please refer [here](https://docs.microsoft.com/azure/developer/java/sdk/get-started#set-up-authentication) to set up authentication.
 
 ## Create the management client
 

--- a/articles/virtual-machines/windows/java.md
+++ b/articles/virtual-machines/windows/java.md
@@ -63,24 +63,24 @@ It takes about 20 minutes to do these steps.
 
     ```xml
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure</artifactId>
-      <version>1.1.0</version>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-identity</artifactId>
+      <version>1.3.6</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-mgmt-compute</artifactId>
-      <version>1.1.0</version>
+      <groupId>com.azure.resourcemanager</groupId>
+      <artifactId>azure-resourcemanager</artifactId>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-mgmt-resources</artifactId>
-      <version>1.1.0</version>
+      <groupId>com.azure.resourcemanager</groupId>
+      <artifactId>azure-resourcemanager-appservice</artifactId>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
-      <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-mgmt-network</artifactId>
-      <version>1.1.0</version>
+      <groupId>com.azure.resourcemanager</groupId>
+      <artifactId>azure-resourcemanager-network</artifactId>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okio</groupId>
@@ -106,31 +106,11 @@ It takes about 20 minutes to do these steps.
 
 3. Save the file.
 
-## Create credentials
+## Set up authentication
 
-Before you start this step, make sure that you have access to an [Active Directory service principal](../../active-directory/develop/howto-create-service-principal-portal.md). You should also record the application ID, the authentication key, and the tenant ID that you need in a later step.
+Please refer [here](https://docs.microsoft.com/en-us/azure/developer/java/sdk/get-started#set-up-authentication) to set up authentication.
 
-### Create the authorization file
-
-1. Create a file named `azureauth.properties` and add these properties to it:
-
-    ```
-    subscription=<subscription-id>
-    client=<application-id>
-    key=<authentication-key>
-    tenant=<tenant-id>
-    managementURI=https://management.core.windows.net/
-    baseURL=https://management.azure.com/
-    authURL=https://login.windows.net/
-    graphURL=https://graph.microsoft.com/
-    ```
-
-    Replace **&lt;subscription-id&gt;** with your subscription identifier, **&lt;application-id&gt;** with the Active Directory application identifier, **&lt;authentication-key&gt;** with the application key, and **&lt;tenant-id&gt;** with the tenant identifier.
-
-2. Save the file.
-3. Set an environment variable named AZURE_AUTH_LOCATION in your shell with the full path to the authentication file.
-
-### Create the management client
+## Create the management client
 
 1. Open the `App.java` file under `src\main\java\com\fabrikam` and make sure this package statement is at the top:
 
@@ -138,42 +118,20 @@ Before you start this step, make sure that you have access to an [Active Directo
     package com.fabrikam.testAzureApp;
     ```
 
-2. Under the package statement, add these import statements:
+2. Create AzureResourceManager：
    
     ```java
-    import com.microsoft.azure.management.Azure;
-    import com.microsoft.azure.management.compute.AvailabilitySet;
-    import com.microsoft.azure.management.compute.AvailabilitySetSkuTypes;
-    import com.microsoft.azure.management.compute.CachingTypes;
-    import com.microsoft.azure.management.compute.InstanceViewStatus;
-    import com.microsoft.azure.management.compute.DiskInstanceView;
-    import com.microsoft.azure.management.compute.VirtualMachine;
-    import com.microsoft.azure.management.compute.VirtualMachineSizeTypes;
-    import com.microsoft.azure.management.network.PublicIPAddress;
-    import com.microsoft.azure.management.network.Network;
-    import com.microsoft.azure.management.network.NetworkInterface;
-    import com.microsoft.azure.management.resources.ResourceGroup;
-    import com.microsoft.azure.management.resources.fluentcore.arm.Region;
-    import com.microsoft.azure.management.resources.fluentcore.model.Creatable;
-    import com.microsoft.rest.LogLevel;
-    import java.io.File;
-    import java.util.Scanner;
-    ```
+    TokenCredential credential = new EnvironmentCredentialBuilder()
+                .authorityHost(AzureAuthorityHosts.AZURE_PUBLIC_CLOUD)
+                .build();
 
-2. To create the Active Directory credentials that you need to make requests, add this code to the main method of the App class:
-   
-    ```java
-    try {
-        final File credFile = new File(System.getenv("AZURE_AUTH_LOCATION"));
-        Azure azure = Azure.configure()
-            .withLogLevel(LogLevel.BASIC)
-            .authenticate(credFile)
+    // Please finish 'Set up authentication' step first to set the four environment variables: AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID
+    AzureProfile profile = new AzureProfile(AzureEnvironment.AZURE);
+
+    AzureResourceManager azureResourceManager = AzureResourceManager.configure()
+            .withLogLevel(HttpLogDetailLevel.BASIC)
+            .authenticate(credential, profile)
             .withDefaultSubscription();
-    } catch (Exception e) {
-        System.out.println(e.getMessage());
-        e.printStackTrace();
-    }
-
     ```
 
 ## Create resources
@@ -204,7 +162,6 @@ AvailabilitySet availabilitySet = azure.availabilitySets()
     .define("myAvailabilitySet")
     .withRegion(Region.US_EAST)
     .withExistingResourceGroup("myResourceGroup")
-    .withSku(AvailabilitySetSkuTypes.MANAGED)
     .create();
 ```
 ### Create the public IP address
@@ -215,7 +172,7 @@ To create the public IP address for the virtual machine, add this code to the tr
 
 ```java
 System.out.println("Creating public IP address...");
-PublicIPAddress publicIPAddress = azure.publicIPAddresses()
+PublicIpAddress publicIPAddress = azure.publicIpAddresses()
     .define("myPublicIP")
     .withRegion(Region.US_EAST)
     .withExistingResourceGroup("myResourceGroup")
@@ -236,7 +193,7 @@ Network network = azure.networks()
     .withRegion(Region.US_EAST)
     .withExistingResourceGroup("myResourceGroup")
     .withAddressSpace("10.0.0.0/16")
-    .withSubnet("mySubnet","10.0.0.0/24")
+    .withSubnet("mySubnet", "10.0.0.0/24")
     .create();
 ```
 
@@ -292,21 +249,22 @@ input.nextLine();
 If you want to use an existing disk instead of a marketplace image, use this code: 
 
 ```java
-ManagedDisk managedDisk = azure.disks.define("myosdisk")
+Disk managedDisk = azure.disks().define("myosdisk")
     .withRegion(Region.US_EAST)
     .withExistingResourceGroup("myResourceGroup")
     .withWindowsFromVhd("https://mystorage.blob.core.windows.net/vhds/myosdisk.vhd")
+    .withStorageAccountName("mystorage")
     .withSizeInGB(128)
-    .withSku(DiskSkuTypes.PremiumLRS)
+    .withSku(DiskSkuTypes.PREMIUM_LRS)
     .create();
 
-azure.virtualMachines.define("myVM")
+azure.virtualMachines().define("myVM")
     .withRegion(Region.US_EAST)
     .withExistingResourceGroup("myResourceGroup")
     .withExistingPrimaryNetworkInterface(networkInterface)
-    .withSpecializedOSDisk(managedDisk, OperatingSystemTypes.Windows)
+    .withSpecializedOSDisk(managedDisk, OperatingSystemTypes.WINDOWS)
     .withExistingAvailabilitySet(availabilitySet)
-    .withSize(VirtualMachineSizeTypes.StandardDS1)
+    .withSize(VirtualMachineSizeTypes.STANDARD_DS1)
     .create();
 ```
 
@@ -342,23 +300,24 @@ System.out.println("osProfile");
 System.out.println("    computerName: " + vm.osProfile().computerName());
 System.out.println("    adminUserName: " + vm.osProfile().adminUsername());
 System.out.println("    provisionVMAgent: " + vm.osProfile().windowsConfiguration().provisionVMAgent());
-System.out.println("    enableAutomaticUpdates: " + vm.osProfile().windowsConfiguration().enableAutomaticUpdates());
+System.out.println(
+        "    enableAutomaticUpdates: " + vm.osProfile().windowsConfiguration().enableAutomaticUpdates());
 System.out.println("networkProfile");
 System.out.println("    networkInterface: " + vm.primaryNetworkInterfaceId());
 System.out.println("vmAgent");
 System.out.println("  vmAgentVersion: " + vm.instanceView().vmAgent().vmAgentVersion());
 System.out.println("    statuses");
-for(InstanceViewStatus status : vm.instanceView().vmAgent().statuses()) {
+for (InstanceViewStatus status : vm.instanceView().vmAgent().statuses()) {
     System.out.println("    code: " + status.code());
     System.out.println("    displayStatus: " + status.displayStatus());
     System.out.println("    message: " + status.message());
     System.out.println("    time: " + status.time());
 }
 System.out.println("disks");
-for(DiskInstanceView disk : vm.instanceView().disks()) {
+for (DiskInstanceView disk : vm.instanceView().disks()) {
     System.out.println("  name: " + disk.name());
     System.out.println("  statuses");
-    for(InstanceViewStatus status : disk.statuses()) {
+    for (InstanceViewStatus status : disk.statuses()) {
         System.out.println("    code: " + status.code());
         System.out.println("    displayStatus: " + status.displayStatus());
         System.out.println("    time: " + status.time());
@@ -370,7 +329,7 @@ System.out.println("  id: " + vm.id());
 System.out.println("  name: " + vm.name());
 System.out.println("  type: " + vm.type());
 System.out.println("VM instance status");
-for(InstanceViewStatus status : vm.instanceView().statuses()) {
+for (InstanceViewStatus status : vm.instanceView().statuses()) {
     System.out.println("  code: " + status.code());
     System.out.println("  displayStatus: " + status.displayStatus());
 }


### PR DESCRIPTION
Azure Java Management SDK has been upgraded to Track2 (version 2.x.x), and we highly recommend customers to use Track2 SDK. 
This article is still using an old version Track1 (version 1.x.x) SDK. I updated the article so that new customers will use Track2 SDK when trying samples in this article. 

The **major change** is to upgrade Azure resource manager package version from com.microsoft.azure **v1.1.0** (released on Jun, 2017) to com.azure.resourcemanager **v2.8.0** (released on Sep, 2021)

Below are my specific changes:
	
1. Update 'Add dependencies' section to use Azure Java Management SDK Track2. 
2. Rename 'Create credentials' section to 'Set up authentication', and point the content to the corresponding [part](https://docs.microsoft.com/en-us/azure/developer/java/sdk/get-started?view=azure-java-stable#set-up-authentication) of [Azure Java SDK Get Started document](https://docs.microsoft.com/en-us/azure/developer/java/sdk/get-started?view=azure-java-stable), as in Track2 Azure SDK, we use this way to do authentication.
3. Update 'Create the management client' section to use Azure Java Management SDK Track2 style and syntax.
4. Update 'Create resources' section to use Azure Java Management SDK Track2 syntax, the code all passed local compilation and can be run successfully.