### PR TITLE
My customer feedback

### DIFF
--- a/articles/app-service/configure-connect-to-azure-storage.md
+++ b/articles/app-service/configure-connect-to-azure-storage.md
@@ -56,7 +56,7 @@ The following features are supported for Linux containers:
 
 ::: zone pivot="container-windows"
 
-- [An existing Windows Container app in Azure App Service](quickstart-custom-container.md)
+- [An existing App Service Container or An existing Linux Docker Container on Azure App Service](quickstart-custom-container.md)
 - [Create Azure file share](../storage/files/storage-how-to-use-files-cli.md)
 - [Upload files to Azure File share](../storage/files/storage-how-to-create-file-share.md)
 


### PR DESCRIPTION
I will say that there is some confusion over “Azure App Service (Linux)” and “Azure App Service Container” when deploying your web app with Visual Studio.  When following the original article I sent, it says to pick Linux container or Windows container, but the prerequisites says that you need “An existing App Service on Linux app” which is what made me think that you need to use the “Azure App Service (Linux)” option from Visual Studio.

I think the prerequisite should say “An existing App Service Container” or “An existing Linux Docker Container on Azure App Service.”  It needs to be more clear that the article is talking about a Docker container.

When Andy and I have some time, we’ll try the “Azure App Service Container” option again and use that article you sent us to mount the blob storage.
What we sent the customer.
Please look at this discussion, seems to be possible to locate the mounting with the use of “custom-id”.
mount azure file share to web app for linux containers with docker-compose - Stack Overflow