### PR TITLE
template doc, update Java ARM SDK to 2.x

### DIFF
--- a/articles/azure-resource-manager/management/index.yml
+++ b/articles/azure-resource-manager/management/index.yml
@@ -78,7 +78,7 @@ landingContent:
           - text: .NET
             url: /dotnet/api/microsoft.azure.management.resourcemanager
           - text: Java
-            url: /java/api/com.microsoft.azure.management.resources
+            url: /java/api/com.azure.resourcemanager.resources
           - text: Python
             url: /python/api/overview/azure/resources
 


### PR DESCRIPTION
Update the link of Java SDK for [template doc](https://docs.microsoft.com/azure/azure-resource-manager/templates/template-functions-resource) to latest track2, as SDK owner.

Alternatively, the link can be https://docs.microsoft.com/java/api/com.microsoft.azure.management.resources?view=azure-java-stable