### PR TITLE
#81836 example code not use 'import cmd'

### DIFF
--- a/articles/key-vault/secrets/quick-create-python.md
+++ b/articles/key-vault/secrets/quick-create-python.md
@@ -89,7 +89,6 @@ Create a file named *kv_secrets.py* that contains this code.
 
 ```python
 import os
-import cmd
 from azure.keyvault.secrets import SecretClient
 from azure.identity import DefaultAzureCredential
 


### PR DESCRIPTION
remove `import cmd`. Because it is not used. 

Have a nice day!👍 