### PR TITLE
Fix. Typo `Angular LCI` to `Angular CLI`

### DIFF
--- a/articles/active-directory-b2c/configure-authentication-sample-angular-spa-app.md
+++ b/articles/active-directory-b2c/configure-authentication-sample-angular-spa-app.md
@@ -59,7 +59,7 @@ Before you follow the procedures in this article, make sure that your computer i
 
 * [Visual Studio Code](https://code.visualstudio.com/) or another code editor.
 * [Node.js runtime](https://nodejs.org/en/download/) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
-* [Angular LCI](https://angular.io/cli).
+* [Angular CLI](https://angular.io/cli).
 
 ## Step 1: Configure your user flow
 


### PR DESCRIPTION

Changing link title from `Angular LCI` to `Angular CLI`