### PR TITLE
Add info to two settings...

### DIFF
--- a/articles/service-fabric/service-fabric-cluster-fabric-settings.md
+++ b/articles/service-fabric/service-fabric-cluster-fabric-settings.md
@@ -857,8 +857,8 @@ The following is a list of Fabric settings that you can customize, organized by 
 | --- | --- | --- | --- |
 |ContainerNetworkName|string, default is ""| Static |The network name to use when setting up a container network.|
 |ContainerNetworkSetup|bool, default is FALSE (Linux) and default is TRUE (Windows)| Static |Whether to set up a container network.|
-|FabricDataRoot |String | Not Allowed |Service Fabric data root directory. Default for Azure is d:\svcfab |
-|FabricLogRoot |String | Not Allowed |Service fabric log root directory. This is where SF logs and traces are placed. |
+|FabricDataRoot |String | Not Allowed |Service Fabric data root directory. Default for Azure is d:\svcfab (Only for Standalone Deployments)|
+|FabricLogRoot |String | Not Allowed |Service fabric log root directory. This is where SF logs and traces are placed. (Only for Standalone Deployments)|
 |NodesToBeRemoved|string, default is ""| Dynamic |The nodes which should be removed as part of configuration upgrade. (Only for Standalone Deployments)|
 |ServiceRunAsAccountName |String | Not Allowed |The account name under which to run fabric host service. |
 |SkipContainerNetworkResetOnReboot|bool, default is FALSE|NotAllowed|Whether to skip resetting container network on reboot.|


### PR DESCRIPTION
Add "(Only for Standalone Deployments)" to FabricDataRoot and FabricLogRoot to help indicate where they are available.