### PR TITLE
The number of instances is always two.

### DIFF
--- a/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
+++ b/articles/application-gateway/application-gateway-autoscaling-zone-redundant.md
@@ -57,7 +57,7 @@ Azure Application Gateways are always deployed in a highly available fashion. Th
 
 Please note that even if you configure autoscaling with zero minimum instances the service will still be highly available, which is always included with the fixed price.
 
-However, creating a new instance can take some time (around six or seven minutes). Hence, if you do not want to cope with this downtime you can configure a minimum instance count of 2, ideally with Availability Zone support. This way you will have at least two instances inside of your Azure Application Gateway under normal circumstances, so if one of them had a problem the other will try to cope with the traffic, during the time a new instance is being created. Note that an Azure Application Gateway instance can support around 10 Capacity Units, so depending on how much traffic you typically have you might want to configure your minimum instance autoscaling setting to a value higher than 2.
+However, creating a new instance can take some time (around six or seven minutes). Ideally with Availability Zone support. This way you will have at least two instances inside of your Azure Application Gateway under normal circumstances, so if one of them had a problem the other will try to cope with the traffic, during the time a new instance is being created. Note that an Azure Application Gateway instance can support around 10 Capacity Units, so depending on how much traffic you typically have you might want to configure your minimum instance autoscaling setting to a value higher than 2.
 
 ## Feature comparison between v1 SKU and v2 SKU
 


### PR DESCRIPTION
According to the below sentence, the number of instances is always 2 event though the number of minimum instances is 0.

"Please note that even if you configure autoscaling with zero minimum instances the service will still be highly available, which is always included with the fixed price."

 I think below sentence is not correct because Zero minimum instances have 2 instances internally so downtime is not different. Could you delete this sentence ? It is very confusion.

"Hence, if you do not want to cope with this downtime you can configure a minimum instance count of 2"