### PR TITLE
Change Azure AD MFA usage from 30 to 7 days

### DIFF
--- a/articles/active-directory/reports-monitoring/reference-reports-data-retention.md
+++ b/articles/active-directory/reports-monitoring/reference-reports-data-retention.md
@@ -61,7 +61,7 @@ For security signals, the collection process starts when you opt-in to use the *
 | :--                    | :--           | :--                 | :--                 |
 | Audit logs             | 7 days        | 30 days             | 30 days             |
 | Sign-ins               | 7 days        | 30 days             | 30 days             |
-| Azure AD MFA usage        | 30 days       | 30 days             | 30 days             |
+| Azure AD MFA usage        | 7 days       | 30 days             | 30 days             |
 
 You can retain the audit and sign-in activity data for longer than the default retention period outlined above by routing it to an Azure storage account using Azure Monitor. For more information, see [Archive Azure AD logs to an Azure storage account](quickstart-azure-monitor-route-logs-to-storage-account.md).
 


### PR DESCRIPTION
There is no way that I can find to output/display Azure AD MFA usage data further back than 7 days for a tenant with only Azure AD Free.