### PR TITLE
Add a "C is not supported" warning for the Speech SDK

### DIFF
--- a/includes/cognitive-services-speech-service-speech-sdk-platforms.md
+++ b/includes/cognitive-services-speech-service-speech-sdk-platforms.md
@@ -19,3 +19,6 @@ ms.author: trbye
 <sup>1 The .NET Speech SDK is based on .NET Standard 2.0, thus it supports many platforms. For more information, see [.NET implementation support](/dotnet/standard/net-standard#net-implementation-support).</sup>
 
 <sup>2 The Java Speech SDK is also available as part of the [Speech Devices SDK](../articles/cognitive-services/speech-service/speech-devices-sdk.md).</sup>
+
+> [!IMPORTANT]
+> C is not a supported programming language for the Speech SDK. Several supported programming languages, e.g. C++, include C headers that are part of a common Application Binary Interface (ABI) layer. These ABI headers are **not** intended for direct use and are subject to change across versions.


### PR DESCRIPTION
The use of C API headers is an increasingly common problem with expanding scenario use of the Speech SDK. This isn't a supported language and it's difficult for us and our customers when solutions go too far along that path.

This is a simple component of a broader set of changes to make it more clear that direct use of the C API isn't intended for product usage.