### PR TITLE
IoTEdge Host Storage Documentation Update

### DIFF
--- a/articles/iot-edge/how-to-access-host-storage-from-module.md
+++ b/articles/iot-edge/how-to-access-host-storage-from-module.md
@@ -71,14 +71,18 @@ Replace `<HostStoragePath>` and `<ModuleStoragePath>` with your host and module 
 
 For example, on a Linux system, `"Binds":["/etc/iotedge/storage/:/iotedge/storage/"]` means the directory **/etc/iotedge/storage** on your host system is mapped to the directory **/iotedge/storage/** in the container. On a Windows system, as another example, `"Binds":["C:\\temp:C:\\contemp"]` means the directory **C:\\temp** on your host system is mapped to the directory **C:\\contemp** in the container.
 
-Additionally, on Linux devices, make sure that the user profile for your module has the required read, write, and execute permissions to the host system directory. Returning to the earlier example of enabling IoT Edge hub to store messages in your device's local storage, you need to grant permissions to its user profile, UID 1000. (The IoT Edge agent operates as root, so it doesn't need additional permissions.) There are several ways to manage directory permissions on Linux systems, including using `chown` to change the directory owner and then `chmod` to change the permissions, such as:
+You can find more details about create options from [docker docs](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate).
+
+## Host System Permissions
+On Linux devices, make sure that the user profile for your module has the required read, write, and execute permissions to the host system directory. Returning to the earlier example of enabling IoT Edge hub to store messages in your device's local storage, you need to grant permissions to its user profile, UID 1000. There are several ways to manage directory permissions on Linux systems, including using `chown` to change the directory owner and then `chmod` to change the permissions, such as:
 
 ```bash
 sudo chown 1000 <HostStoragePath>
 sudo chmod 700 <HostStoragePath>
 ```
 
-You can find more details about create options from [docker docs](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate).
+On Windows devices, you will also need to configure permissions on the host system directory. This can be done via the File Explorer. You need to grant a principal permission for all `Authenticated Users` to have `Full Control`. 
+
 
 ## Encrypted data in module storage
 

--- a/articles/iot-edge/how-to-access-host-storage-from-module.md
+++ b/articles/iot-edge/how-to-access-host-storage-from-module.md
@@ -73,7 +73,8 @@ For example, on a Linux system, `"Binds":["/etc/iotedge/storage/:/iotedge/storag
 
 You can find more details about create options from [docker docs](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate).
 
-## Host System Permissions
+## Host system permissions
+
 On Linux devices, make sure that the user profile for your module has the required read, write, and execute permissions to the host system directory. Returning to the earlier example of enabling IoT Edge hub to store messages in your device's local storage, you need to grant permissions to its user profile, UID 1000. There are several ways to manage directory permissions on Linux systems, including using `chown` to change the directory owner and then `chmod` to change the permissions, such as:
 
 ```bash
@@ -81,7 +82,8 @@ sudo chown 1000 <HostStoragePath>
 sudo chmod 700 <HostStoragePath>
 ```
 
-On Windows devices, you will also need to configure permissions on the host system directory. This can be done through powershell:
+On Windows devices, you will also need to configure permissions on the host system directory. You can use PowerShell to set permissions:
+
 ```powershell
 $acl = get-acl <HostStoragePath>
 $ace = new-object system.security.AccessControl.FileSystemAccessRule('Authenticated Users','FullControl','Allow')

--- a/articles/iot-edge/how-to-access-host-storage-from-module.md
+++ b/articles/iot-edge/how-to-access-host-storage-from-module.md
@@ -81,8 +81,13 @@ sudo chown 1000 <HostStoragePath>
 sudo chmod 700 <HostStoragePath>
 ```
 
-On Windows devices, you will also need to configure permissions on the host system directory. This can be done via the File Explorer. You need to grant a principal permission for all `Authenticated Users` to have `Full Control`. 
-
+On Windows devices, you will also need to configure permissions on the host system directory. This can be done through powershell:
+```powershell
+$acl = get-acl <HostStoragePath>
+$ace = new-object system.security.AccessControl.FileSystemAccessRule('Authenticated Users','FullControl','Allow')
+$acl.AddAccessRule($ace)
+$acl | Set-Acl
+```
 
 ## Encrypted data in module storage
 


### PR DESCRIPTION
Updating the docs per debugging session with @ancaantochi 

Fixing these things:
- Documentation said that no special host permissions were needed for EdgeAgent since it runs as container admin, but that is not true on Linux and appears to not be true on Windows either (even though it is running as container admin we still need host permissions).
- Supply an example of a way to successfully configure Windows host level permissions.

@ancaantochi I think it would be nice if we could drill down more into the security setting, rather than applying a blanket rule for all `Authenticated Users`. But I took a look at the available principals and there doesn't seem to be a better obvious choice. The fact this worked for us seems to mean that EdgeAgent is an authenticated user that is not covered by the default rule. But I didn't see any other users in the choices available. What is your opinion here? Is this OK or should we attempt more to drill down into permissions?