### PR TITLE
Add clarification to RBAC section

### DIFF
--- a/articles/governance/policy/overview.md
+++ b/articles/governance/policy/overview.md
@@ -118,7 +118,7 @@ role includes most Azure Policy operations. **Owner** has full rights. Both **Co
 **Reader** have access to all _read_ Azure Policy operations. **Contributor** may trigger resource
 remediation, but can't _create_ definitions or assignments. **User Access Administrator** is
 necessary to grant the managed identity on **deployIfNotExists** or **modify** assignments necessary
-permissions.
+permissions. All policy objects will be readable to all roles over the scope.
 
 If none of the Built-in roles have the permissions required, create a
 [custom role](../../role-based-access-control/custom-roles.md).


### PR DESCRIPTION
Any roles in Azure will allow users to see Policy objects. This is by design. Added clarification to RBAC section in the Policy overview