### PR TITLE
168.63.129.16 and 169.254.169.254 are not correct

### DIFF
--- a/articles/firewall/protect-azure-virtual-desktop.md
+++ b/articles/firewall/protect-azure-virtual-desktop.md
@@ -36,7 +36,6 @@ You will need to create an Azure Firewall Policy and create Rule Collections for
 
 | Name      | Source type | Source                    | Protocol | Destination ports | Destination type | Destination                       |
 | --------- | ----------- | ------------------------- | -------- | ----------------- | ---------------- | --------------------------------- |
-| Rule Name | IP Address  | VNet or Subnet IP Address | TCP      | 80                | IP Address       | 169.254.169.254, 168.63.129.16    |
 | Rule Name | IP Address  | VNet or Subnet IP Address | TCP      | 443               | Service Tag      | AzureCloud, WindowsVirtualDesktop |
 | Rule Name | IP Address  | VNet or Subnet IP Address | TCP, UDP | 53                | IP Address       | *                                 |
 |Rule name  | IP Address  | VNet or Subnet IP Address | TCP      | 1688              | IP address       | 23.102.135.246                    |


### PR DESCRIPTION
I know 168.63.129.16 and 169.254.169.254 are not routed to AzFW. Those traffic always follow system route not UDR. There is a same sentence in below document.

https://docs.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16#scope-of-ip-address-1686312916

"168.63.129.16 is a virtual IP of the host node and as such it is not subject to user defined routes."

This document is a little confusing. Could fix this document ?