### PR TITLE
Fix in script "add UDR rules to Route Table"

### DIFF
--- a/articles/data-factory/azure-ssis-integration-runtime-virtual-network-configuration.md
+++ b/articles/data-factory/azure-ssis-integration-runtime-virtual-network-configuration.md
@@ -131,12 +131,12 @@ $RouteTableResourceGroupName = "[name of Azure resource group that contains your
 $RouteTableResourceName = "[resource name of your Azure Route Table ]"
 $RouteTable = Get-AzRouteTable -ResourceGroupName $RouteTableResourceGroupName -Name $RouteTableResourceName
 $ServiceTags = Get-AzNetworkServiceTag -Location $Location
-$BatchServiceTagName = "BatchNodeManagement." + $Location
+$BatchServiceTagName = "BatchNodeManagement"
 $UdrRulePrefixForBatch = $BatchServiceTagName
-if ($ServiceTags -ne $null)
+if ($null -ne $ServiceTags)
 {
     $BatchIPRanges = $ServiceTags.Values | Where-Object { $_.Name -ieq $BatchServiceTagName }
-    if ($BatchIPRanges -ne $null)
+    if ($null -ne $BatchIPRanges)
     {
         Write-Host "Start to add rule for your route table..."
         for ($i = 0; $i -lt $BatchIPRanges.Properties.AddressPrefixes.Count; $i++)


### PR DESCRIPTION
This commit fixes a problem that the IP addresses of service tag "BatchNodeManagement" are not found. The output of `Get-AzNetworkServiceTag` does not include "BatchNodeManagement.WestEurope" (or any other location). By removing the location it returns the IP addresses that are necessary for the routing table.

The other changes are suggestions from the PSScriptAnalyzer.