### PR TITLE
Update tutorial-migrate-gcp-virtual-machines.md

### DIFF
--- a/articles/migrate/tutorial-migrate-gcp-virtual-machines.md
+++ b/articles/migrate/tutorial-migrate-gcp-virtual-machines.md
@@ -389,7 +389,7 @@ Mobility Agent is installed on the source VM to be migrated and is registered th
 **Answer:** Make sure to review the Azure migrate appliance requirements and URL access needs. Make sure no proxy settings are blocking the appliance registration.
 
 **Question:** Do I have to make any changes before I migrate my GCP VMs to Azure   
-**Answer:** You may have to make these changes before migrating your EC2 VMs to Azure:
+**Answer:** You may have to make these changes before migrating your GCP VMs to Azure:
 
 - If you are using cloud-init for your VM provisioning, you may want to disable cloud-init on the VM before replicating it to Azure. The provisioning steps performed by cloud-init on the VM maybe GCP specific and won't be valid after the migration to Azure. ​
 - Review the [prerequisites](#prerequisites) section to determine whether there are any changes necessary for the operating system before you migrate them to Azure.


### PR DESCRIPTION
## Why

EC2 is a service of AWS. There is no EC2 in GCP.
I think it's a copy from  https://docs.microsoft.com/en-us/azure/migrate/tutorial-migrate-aws-virtual-machines#troubleshooting--tips.

## What

Fix typo