### PR TITLE
Correct type of roleAssignmentName to variable

### DIFF
--- a/articles/role-based-access-control/quickstart-role-assignments-template.md
+++ b/articles/role-based-access-control/quickstart-role-assignments-template.md
@@ -35,7 +35,7 @@ To assign Azure roles and remove role assignments, you must have:
 
 ## Review the template
 
-The template used in this quickstart is from [Azure Quickstart Templates](https://azure.microsoft.com/resources/templates/rbac-builtinrole-resourcegroup/). The template has three parameters and a resources section. In the resources section, notice that it has the three elements of a role assignment: security principal, role definition, and scope.
+The template used in this quickstart is from [Azure Quickstart Templates](https://azure.microsoft.com/resources/templates/rbac-builtinrole-resourcegroup/). The template has two parameters and a resources section. In the resources section, notice that it has the three elements of a role assignment: security principal, role definition, and scope.
 
 :::code language="json" source="~/quickstart-templates/quickstarts/microsoft.authorization/rbac-builtinrole-resourcegroup/azuredeploy.json":::
 
@@ -64,7 +64,7 @@ The resource defined in the template is:
     $templateUri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/quickstarts/microsoft.authorization/rbac-builtinrole-resourcegroup/azuredeploy.json"
 
     New-AzResourceGroup -Name $resourceGroupName -Location $location
-    New-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateUri $templateUri -roleAssignmentName $roleAssignmentName -roleDefinitionID $roleDefinitionId -principalId $principalId
+    New-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateUri $templateUri -roleDefinitionID $roleDefinitionId -principalId $principalId
     ```
 
 1. Enter a resource group name such as ExampleGrouprg.
@@ -94,7 +94,6 @@ The resource defined in the template is:
     Parameters              :
                               Name                  Type                       Value
                               ====================  =========================  ==========
-                              roleAssignmentName    String                     {roleAssignmentName}
                               roleDefinitionID      String                     9980e02c-c2be-4d73-94e8-173b1dc7cf3c
                               principalId           String                     {principalId}
 


### PR DESCRIPTION
The `roleAssignmentName` is a variable (not a parameter) in the ARM template.
Therefore there are only two parameters in the ARM template and `roleAssignmentName` cannot be passed in as an argument to `New-AzResourceGroupDeployment`.
The original version of the PS script failed with the error message

> A parameter cannot be found that matches parameter name 'roleAssignmentName'.

the new version works correctly.