### PR TITLE
VM TOC: Dedupe Instances -> Sizes articles

### DIFF
--- a/articles/virtual-machines/TOC.yml
+++ b/articles/virtual-machines/TOC.yml
@@ -320,9 +320,6 @@
     - name: Isolated sizes
       displayName: isolated VM, sole-tenant, sole
       href: isolation.md
-    - name: Previous generations
-      displayName: older, retired, expired, deprecated
-      href: sizes-previous-gen.md
     - name: Azure compute units (ACU)
       href: acu.md
     - name: Benchmark scores
@@ -332,25 +329,11 @@
         href: ./linux/compute-benchmark-scores.md
       - name: Windows
         href: ./windows/compute-benchmark-scores.md
-    - name: vCPU quotas
-      items:
-      - name: CLI
-        displayName: vCPU, quota, limit
-        href: ./linux/quotas.md
-      - name: PowerShell
-        displayName: vCPU, quota, limit
-        href: ./windows/quotas.md
     - name: Virtual machines selector tool
       href: https://aka.ms/vm-selector
     - name: Change the VM size
       displayName: Change, resize, update size
       href: resize-vm.md
-    - name: States and billing
-      href: states-billing.md
-    - name: Azure VMs with no temp disk
-      href: azure-vms-no-temp-disk.yml
-    - name: Azure VM sizes naming conventions
-      href: vm-naming-conventions.md
   - name: Dedicated hosts
     displayName: sole-tenant, sole tenant, isolated, isolation
     items:


### PR DESCRIPTION
Removed duplicates from `Instances` -> `Sizes` node in `articles/virtual-machines` TOC:
* States and Billing
* vCPU quotas
* Azure VMs with no temp disk
* Azure VM sizes naming conventions
* Previous generations

As there doesn't appear to be any implicit sort/ordering to this TOC, I simply removed the second instance of these articles.

Fixes MicrosoftDocs/azure-docs#82163.