### PR TITLE
Updates to howto-migrate-single-flexible-minimum-downtime.md

### DIFF
--- a/articles/mysql/howto-migrate-single-flexible-minimum-downtime.md
+++ b/articles/mysql/howto-migrate-single-flexible-minimum-downtime.md
@@ -10,7 +10,7 @@ ms.date: 06/18/2021
 
 # Tutorial: Migrate Azure Database for MySQL – Single Server to Azure Database for MySQL – Flexible Server with minimal downtime
 
-You can migrate an instance of Azure Database for MySQL – Single Server to Azure Database for MySQL – Flexible Server with minimum downtime to your applications by using a combination of open-source tools such as mydumper/myloader and Data-in replication.
+You can migrate an instance of Azure Database for MySQL – Single Server to Azure Database for MySQL – Flexible Server with minimum downtime to your applications by using a combination of open-source tools such as mydumper/myloader and Data-in replication. Note that this method can also be used for migrations from on-premises MySQL servers to Azure Database for MySQL.
 
 > [!NOTE]
 > This article contains references to the term *slave*, a term that Microsoft no longer uses. When the term is removed from the software, we'll remove it from this article.


### PR DESCRIPTION
Data-in replication along with mydumper/ myloader can also be used to do external migrations. We do not have separate doc explaining it in detail and this particular documentation is for single to flex server migration. 
So added an update to this doc which calls out that this approach can also be used to do external migrations.