### PR TITLE
Add Antimalware extension for Windows

### DIFF
--- a/articles/azure-arc/servers/manage-vm-extensions.md
+++ b/articles/azure-arc/servers/manage-vm-extensions.md
@@ -54,6 +54,7 @@ Arc-enabled servers support moving machines with one or more VM extensions insta
 |Extension |Publisher |Type |Additional information |
 |----------|----------|-----|-----------------------|
 |Azure Defender integrated vulnerability scanner |Qualys |WindowsAgent.AzureSecurityCenter |[Azure Defender’s integrated vulnerability assessment solution for Azure and hybrid machines](../../security-center/deploy-vulnerability-assessment-vm.md)|
+|Microsoft Antimalware Extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware Extension for Windows](../..//virtual-machines/extensions/iaas-antimalware-windows)
 |Custom Script extension |Microsoft.Compute | CustomScriptExtension |[Windows Custom Script Extension](../../virtual-machines/extensions/custom-script-windows.md)|
 |Log Analytics agent |Microsoft.EnterpriseCloud.Monitoring |MicrosoftMonitoringAgent |[Log Analytics VM extension for Windows](../../virtual-machines/extensions/oms-windows.md)|
 |Azure Monitor for VMs (insights) |Microsoft.Azure.Monitoring.DependencyAgent |DependencyAgentWindows | [Dependency agent virtual machine extension for Windows](../../virtual-machines/extensions/agent-dependency-windows.md)|

--- a/articles/azure-arc/servers/manage-vm-extensions.md
+++ b/articles/azure-arc/servers/manage-vm-extensions.md
@@ -54,7 +54,7 @@ Arc-enabled servers support moving machines with one or more VM extensions insta
 |Extension |Publisher |Type |Additional information |
 |----------|----------|-----|-----------------------|
 |Azure Defender integrated vulnerability scanner |Qualys |WindowsAgent.AzureSecurityCenter |[Azure Defender’s integrated vulnerability assessment solution for Azure and hybrid machines](../../security-center/deploy-vulnerability-assessment-vm.md)|
-|Microsoft Antimalware Extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware Extension for Windows](../..//virtual-machines/extensions/iaas-antimalware-windows)
+|Microsoft Antimalware extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware Extension for Windows](../../virtual-machines/extensions/iaas-antimalware-windows)
 |Custom Script extension |Microsoft.Compute | CustomScriptExtension |[Windows Custom Script Extension](../../virtual-machines/extensions/custom-script-windows.md)|
 |Log Analytics agent |Microsoft.EnterpriseCloud.Monitoring |MicrosoftMonitoringAgent |[Log Analytics VM extension for Windows](../../virtual-machines/extensions/oms-windows.md)|
 |Azure Monitor for VMs (insights) |Microsoft.Azure.Monitoring.DependencyAgent |DependencyAgentWindows | [Dependency agent virtual machine extension for Windows](../../virtual-machines/extensions/agent-dependency-windows.md)|

--- a/articles/azure-arc/servers/manage-vm-extensions.md
+++ b/articles/azure-arc/servers/manage-vm-extensions.md
@@ -54,7 +54,7 @@ Arc-enabled servers support moving machines with one or more VM extensions insta
 |Extension |Publisher |Type |Additional information |
 |----------|----------|-----|-----------------------|
 |Azure Defender integrated vulnerability scanner |Qualys |WindowsAgent.AzureSecurityCenter |[Azure Defender’s integrated vulnerability assessment solution for Azure and hybrid machines](../../security-center/deploy-vulnerability-assessment-vm.md)|
-|Microsoft Antimalware extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware Extension for Windows](../../virtual-machines/extensions/iaas-antimalware-windows)
+|Microsoft Antimalware extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware extension for Windows](../../virtual-machines/extensions/iaas-antimalware-windows.md)
 |Custom Script extension |Microsoft.Compute | CustomScriptExtension |[Windows Custom Script Extension](../../virtual-machines/extensions/custom-script-windows.md)|
 |Log Analytics agent |Microsoft.EnterpriseCloud.Monitoring |MicrosoftMonitoringAgent |[Log Analytics VM extension for Windows](../../virtual-machines/extensions/oms-windows.md)|
 |Azure Monitor for VMs (insights) |Microsoft.Azure.Monitoring.DependencyAgent |DependencyAgentWindows | [Dependency agent virtual machine extension for Windows](../../virtual-machines/extensions/agent-dependency-windows.md)|

--- a/articles/azure-arc/servers/manage-vm-extensions.md
+++ b/articles/azure-arc/servers/manage-vm-extensions.md
@@ -54,7 +54,7 @@ Arc-enabled servers support moving machines with one or more VM extensions insta
 |Extension |Publisher |Type |Additional information |
 |----------|----------|-----|-----------------------|
 |Azure Defender integrated vulnerability scanner |Qualys |WindowsAgent.AzureSecurityCenter |[Azure Defender’s integrated vulnerability assessment solution for Azure and hybrid machines](../../security-center/deploy-vulnerability-assessment-vm.md)|
-|Microsoft Antimalware extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware extension for Windows](../../virtual-machines/extensions/iaas-antimalware-windows.md)
+|Microsoft Antimalware extension |Microsoft.Azure.Security |IaaSAntimalware |[Microsoft Antimalware extension for Windows](../../virtual-machines/extensions/iaas-antimalware-windows.md) |
 |Custom Script extension |Microsoft.Compute | CustomScriptExtension |[Windows Custom Script Extension](../../virtual-machines/extensions/custom-script-windows.md)|
 |Log Analytics agent |Microsoft.EnterpriseCloud.Monitoring |MicrosoftMonitoringAgent |[Log Analytics VM extension for Windows](../../virtual-machines/extensions/oms-windows.md)|
 |Azure Monitor for VMs (insights) |Microsoft.Azure.Monitoring.DependencyAgent |DependencyAgentWindows | [Dependency agent virtual machine extension for Windows](../../virtual-machines/extensions/agent-dependency-windows.md)|


### PR DESCRIPTION
Antimalware extension for Windows is missing from the table, yet is shown as available here: <https://docs.microsoft.com/azure/security/fundamentals/antimalware#enable-and-configure-antimalware-using-powershell-cmdlets-for-azure-arc-enabled-servers>.

I will add a corresponding example to the CLI and PowerShell pages.