### PR TITLE
Fixing a stray screenshot at the start

### DIFF
--- a/articles/app-service/quickstart-multi-container.md
+++ b/articles/app-service/quickstart-multi-container.md
@@ -17,8 +17,6 @@ ms.custom: mvc, seodec18, devx-track-azurecli
 
 [Web App for Containers](overview.md#app-service-on-linux) provides a flexible way to use Docker images. This quickstart shows how to deploy a multi-container app (preview) to Web App for Containers in the [Cloud Shell](../cloud-shell/overview.md) using a Docker Compose configuration.
 
-![Sample multi-container app on Web App for Containers][1]
-
 [!INCLUDE [quickstarts-free-trial-note](../../includes/quickstarts-free-trial-note.md)]
 
 [!INCLUDE [azure-cli-prepare-your-environment.md](../../includes/azure-cli-prepare-your-environment.md)]


### PR DESCRIPTION
The original article has a screenshot of the Wordpress language selector at the very start, this change removes it as it seems out of place.

![image](https://user-images.githubusercontent.com/603112/136843037-342f540e-ad5e-4617-ae76-cde81f71b1b8.png)
