### PR TITLE
Fix typo in azure-stack-edge-gpu-deploy-prep.md

### DIFF
--- a/articles/databox-online/azure-stack-edge-gpu-deploy-prep.md
+++ b/articles/databox-online/azure-stack-edge-gpu-deploy-prep.md
@@ -67,7 +67,7 @@ Before you begin, make sure that:
 - You have owner or contributor access at resource group level for the Azure Stack Edge Pro, IoT Hub, and Azure Storage resources.
 
     - To create any Azure Stack Edge resource, you should have permissions as a contributor (or higher) scoped at resource group level. 
-    - You also need to make sure that the `Microsoft.DataBoxEdge` and `MicrosoftKeyVault` resource providers are registered. To create any IoT Hub resource, `Microsoft.Devices` provider should be registered. 
+    - You also need to make sure that the `Microsoft.DataBoxEdge` and `Microsoft.KeyVault` resource providers are registered. To create any IoT Hub resource, `Microsoft.Devices` provider should be registered. 
         - To register a resource provider, in the Azure portal, go to **Home > Subscriptions > Your-subscription > Resource providers**. 
         - Search for the specific resource provider, for example, `Microsoft.DataBoxEdge`, and register the resource provider. 
     - To create a Storage account resource, again you need contributor or higher access scoped at the resource group level. Azure Storage is by default a registered resource provider.


### PR DESCRIPTION
Unlike names of other resource providers, a dot was missing for KeyVault.