### PR TITLE
Updating Azure SQL (types of assessments) section

### DIFF
--- a/articles/migrate/concepts-azure-sql-assessment-calculation.md
+++ b/articles/migrate/concepts-azure-sql-assessment-calculation.md
@@ -22,7 +22,8 @@ There are three types of assessments you can create using the Azure Migrate: Dis
 **Assessment Type** | **Details**
 --- | --- 
 **Azure VM** | Assessments to migrate your on-premises servers to Azure virtual machines. <br/><br/> You can assess your on-premises servers in [VMware](how-to-set-up-appliance-vmware.md) and [Hyper-V](how-to-set-up-appliance-hyper-v.md) environment, and [physical servers](how-to-set-up-appliance-physical.md) for migration to Azure VMs using this assessment type.
-**Azure SQL** | Assessments to migrate your on-premises SQL servers from your VMware environment to Azure SQL Database or Azure SQL Managed Instance.
+**Azure SQL** | Assessments to migrate your on-premises SQL servers from your VMware environment to Azure SQL Database or Azure SQL Managed Instance (Note: If SQL Servers are running on non-VMware platform assess the readiness using the [Data Migration Assistant](/sql/dma/dma-assess-sql-data-estate-to-sqldb)).
+
 **Azure VMware Solution (AVS)** | Assessments to migrate your on-premises servers to [Azure VMware Solution (AVS)](../azure-vmware/introduction.md). <br/><br/> You can assess your on-premises [VMware VMs](how-to-set-up-appliance-vmware.md) for migration to Azure VMware Solution (AVS) using this assessment type. [Learn more](concepts-azure-vmware-solution-assessment-calculation.md)
 
 > [!NOTE]

--- a/articles/migrate/concepts-azure-sql-assessment-calculation.md
+++ b/articles/migrate/concepts-azure-sql-assessment-calculation.md
@@ -22,7 +22,7 @@ There are three types of assessments you can create using the Azure Migrate: Dis
 **Assessment Type** | **Details**
 --- | --- 
 **Azure VM** | Assessments to migrate your on-premises servers to Azure virtual machines. <br/><br/> You can assess your on-premises servers in [VMware](how-to-set-up-appliance-vmware.md) and [Hyper-V](how-to-set-up-appliance-hyper-v.md) environment, and [physical servers](how-to-set-up-appliance-physical.md) for migration to Azure VMs using this assessment type.
-**Azure SQL** | Assessments to migrate your on-premises SQL servers from your VMware environment to Azure SQL Database or Azure SQL Managed Instance (Note: If SQL Servers are running on non-VMware platform assess the readiness using the [Data Migration Assistant](/sql/dma/dma-assess-sql-data-estate-to-sqldb)).
+**Azure SQL** | Assessments to migrate your on-premises SQL servers from your VMware environment to Azure SQL Database or Azure SQL Managed Instance. <br/><br/> If your SQL servers are running on a non-VMware platform, you can assess readiness by using the [Data Migration Assistant](/sql/dma/dma-assess-sql-data-estate-to-sqldb).
 
 **Azure VMware Solution (AVS)** | Assessments to migrate your on-premises servers to [Azure VMware Solution (AVS)](../azure-vmware/introduction.md). <br/><br/> You can assess your on-premises [VMware VMs](how-to-set-up-appliance-vmware.md) for migration to Azure VMware Solution (AVS) using this assessment type. [Learn more](concepts-azure-vmware-solution-assessment-calculation.md)
 


### PR DESCRIPTION
Adding an extra note to Azure SQL under the types of assessments section to reflect the note from this document regarding the use of VMware only.

Note:  If SQL Servers are running on non-VMware platforms. Assess the readiness of a SQL Server data estate migrating to Azure SQL Database using the Data Migration Assistant.

This note was taken from this link https://docs.microsoft.com/en-us/azure/migrate/tutorial-assess-sql?view=sql-server-ver15