### PR TITLE
Update EM adding group to reference M365 groups limits

### DIFF
--- a/articles/active-directory/governance/entitlement-management-access-package-resources.md
+++ b/articles/active-directory/governance/entitlement-management-access-package-resources.md
@@ -75,6 +75,7 @@ You can select any [Azure AD security group or Microsoft 365 Group](../fundament
 - When a user, including a guest, is added as a member to a group or team, they can see all the other members of that group or team.
 - Azure AD cannot change the membership of a group that was synchronized from Windows Server Active Directory using Azure AD Connect, or that was created in Exchange Online as a distribution group.  
 - The membership of dynamic groups cannot be updated by adding or removing a member, so dynamic group memberships are not suitable for use with entitlement management.
+- M365 groups have additional constraints, described in the [overview of Microsoft 365 Groups for administrators](/microsoft-365/admin/create-groups/office-365-groups), including a limit of 100 owners per group, limits on how many members can access Group conversations concurrently, and 7000 groups per member.
 
 For more information, see [Compare groups](/office365/admin/create-groups/compare-groups) and [Microsoft 365 Groups and Microsoft Teams](/microsoftteams/office-365-groups).
 


### PR DESCRIPTION
Add a link to the AAD entitlement management article for adding a group to an access package, to link to the M365 admin description of groups, which includes limits on # of owners, members, and users in groups.