### PR TITLE
Typo fix: necesary to necessary

### DIFF
--- a/articles/virtual-machines/linux/redhat-create-upload-vhd.md
+++ b/articles/virtual-machines/linux/redhat-create-upload-vhd.md
@@ -235,7 +235,7 @@ This section assumes that you have already obtained an ISO file from the Red Hat
     # subscription-manager repos --enable=rhel-7-server-extras-rpms
     ```
 
-1. Install the Azure Linux Agent, cloud-init and other necesary utilities by running the following command:
+1. Install the Azure Linux Agent, cloud-init and other necessary utilities by running the following command:
 
     ```console
     # sudo yum install -y WALinuxAgent cloud-init cloud-utils-growpart gdisk hyperv-daemons
@@ -424,7 +424,7 @@ This section assumes that you have already obtained an ISO file from the Red Hat
     ClientAliveInterval 180
     ```
 
-1. Install the Azure Linux Agent, cloud-init and other necesary utilities by running the following command:
+1. Install the Azure Linux Agent, cloud-init and other necessary utilities by running the following command:
 
     ```console
     # sudo yum install -y WALinuxAgent cloud-init cloud-utils-growpart gdisk hyperv-daemons


### PR DESCRIPTION
Fix for this issue: [#69600](https://github.com/MicrosoftDocs/azure-docs/issues/69600).

- Fixing typo: `necesary` to `necessary`
- on the clarification asked by the customer:
![image](https://user-images.githubusercontent.com/41027427/137225518-9ec5c5e4-66fc-491f-a9a6-2950596a7f18.png)
I believe the information provided in the document here allows for waagent to be skipped and directly use cloud-init. 
Please correct me if I am wrong as I am not too familiar with the topic.