### PR TITLE
Remove spaces trailing line-continuation backslashes and final line continuation

### DIFF
--- a/articles/private-link/disable-private-endpoint-network-policy.md
+++ b/articles/private-link/disable-private-endpoint-network-policy.md
@@ -71,11 +71,11 @@ $vnet | Set-AzVirtualNetwork
 This section describes how to disable subnet private endpoint policies using Azure CLI. Use [az network vnet subnet update](/cli/azure/network/vnet/subnet#az_network_vnet_subnet_update) to disable the policy.
 
 ```azurecli
-az network vnet subnet update \ 
+az network vnet subnet update \
   --disable-private-endpoint-network-policies true \
-  --name default \ 
-  --resource-group myResourceGroup \ 
-  --vnet-name myVirtualNetwork \ 
+  --name default \
+  --resource-group myResourceGroup \
+  --vnet-name myVirtualNetwork
   
 ```
 
@@ -84,11 +84,11 @@ az network vnet subnet update \
 This section describes how to enable subnet private endpoint policies using Azure CLI. Use [az network vnet subnet update](/cli/azure/network/vnet/subnet#az_network_vnet_subnet_update) to enable the policy.
 
 ```azurecli
-az network vnet subnet update \ 
+az network vnet subnet update \
   --disable-private-endpoint-network-policies false \
-  --name default \ 
-  --resource-group myResourceGroup \ 
-  --vnet-name myVirtualNetwork \ 
+  --name default \
+  --resource-group myResourceGroup \
+  --vnet-name myVirtualNetwork
   
 ```
 ## Resource Manager template


### PR DESCRIPTION
Most shells won't accept a \ for line-continuation when followed by a space before EOL.

This patch fixes command copy-from-docs issues where the line-continuation won't work.