### PR TITLE
Updating kickstart file to have cloudinit override

### DIFF
--- a/articles/virtual-machines/linux/redhat-create-upload-vhd.md
+++ b/articles/virtual-machines/linux/redhat-create-upload-vhd.md
@@ -1356,8 +1356,7 @@ This section shows you how to prepare a RHEL 7 distro from an ISO using a kickst
     yum install -y cloud-init cloud-utils-growpart gdisk hyperv-daemons
 
     # Configure waagent for cloud-init
-    sed -i 's/Provisioning.UseCloudInit=n/Provisioning.UseCloudInit=y/g' /etc/waagent.conf
-    sed -i 's/Provisioning.Enabled=y/Provisioning.Enabled=n/g' /etc/waagent.conf
+    sed -i 's/Provisioning.Agent=auto/Provisioning.Agent=cloud-init/g' /etc/waagent.conf
     sed -i 's/ResourceDisk.Format=y/ResourceDisk.Format=n/g' /etc/waagent.conf
     sed -i 's/ResourceDisk.EnableSwap=y/ResourceDisk.EnableSwap=n/g' /etc/waagent.conf
 


### PR DESCRIPTION
Since version v2.2.45, options `Provisioning.UseCloudInit` and `Provisioning.Enabled` have no effect.
Waagent automatically detects cloud-init or can have cloud-init specified directly by setting `Provisioning.Agent=cloud-init`.

Sources: 
- https://github.com/Azure/WALinuxAgent/blob/master/README.md#provisioningenabled-removed-in-2245
- https://github.com/Azure/WALinuxAgent/blob/master/README.md#provisioningusecloudinit

![image](https://user-images.githubusercontent.com/41027427/137228601-b5003126-2ec1-43ec-bdc4-7cd2a51cc775.png)
