### PR TITLE
Adding link for log analytics monitoring

### DIFF
--- a/articles/virtual-machines/windows/scheduled-events.md
+++ b/articles/virtual-machines/windows/scheduled-events.md
@@ -242,4 +242,4 @@ if __name__ == '__main__':
 - Review the Scheduled Events code samples in the [Azure Instance Metadata Scheduled Events GitHub repository](https://github.com/Azure-Samples/virtual-machines-scheduled-events-discover-endpoint-for-non-vnet-vm).
 - Read more about the APIs that are available in the [Instance Metadata Service](instance-metadata-service.md).
 - Learn about [planned maintenance for Windows virtual machines in Azure](../maintenance-and-updates.md?bc=/azure/virtual-machines/windows/breadcrumb/toc.json&toc=/azure/virtual-machines/windows/toc.json).
-- Learn how to [monitor scheduled events for your VMs through Log Analytics](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-event-service)
+- Learn how to [monitor scheduled events for your VMs through Log Analytics](./scheduled-event-service.md)

--- a/articles/virtual-machines/windows/scheduled-events.md
+++ b/articles/virtual-machines/windows/scheduled-events.md
@@ -242,3 +242,4 @@ if __name__ == '__main__':
 - Review the Scheduled Events code samples in the [Azure Instance Metadata Scheduled Events GitHub repository](https://github.com/Azure-Samples/virtual-machines-scheduled-events-discover-endpoint-for-non-vnet-vm).
 - Read more about the APIs that are available in the [Instance Metadata Service](instance-metadata-service.md).
 - Learn about [planned maintenance for Windows virtual machines in Azure](../maintenance-and-updates.md?bc=/azure/virtual-machines/windows/breadcrumb/toc.json&toc=/azure/virtual-machines/windows/toc.json).
+- Learn how to [monitor scheduled events for your VMs through Log Analytics](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-event-service)

--- a/articles/virtual-machines/windows/scheduled-events.md
+++ b/articles/virtual-machines/windows/scheduled-events.md
@@ -242,4 +242,4 @@ if __name__ == '__main__':
 - Review the Scheduled Events code samples in the [Azure Instance Metadata Scheduled Events GitHub repository](https://github.com/Azure-Samples/virtual-machines-scheduled-events-discover-endpoint-for-non-vnet-vm).
 - Read more about the APIs that are available in the [Instance Metadata Service](instance-metadata-service.md).
 - Learn about [planned maintenance for Windows virtual machines in Azure](../maintenance-and-updates.md?bc=/azure/virtual-machines/windows/breadcrumb/toc.json&toc=/azure/virtual-machines/windows/toc.json).
-- Learn how to [monitor scheduled events for your VMs through Log Analytics](./scheduled-event-service.md)
+- Learn how to [monitor scheduled events for your VMs through Log Analytics](./scheduled-event-service.md).


### PR DESCRIPTION
This page: [Monitor scheduled events for your Azure VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-event-service) which refers to [this](https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/virtual-machines/windows/scheduled-events.md) GitHub page and discusses how to set up alerting for scheduled events has no links in any other pages. It's like it's orphaned and the search engine has to directly link the user to it because you cannot get to it from any other page.
Therefore, I am adding it here to make it easier to access after the customer learns about scheduled events on Windows