### PR TITLE
Replace default GUID with substitution value to better illustrate where values are sourced and eliminate errors

### DIFF
--- a/articles/service-fabric/how-to-managed-identity-managed-cluster-virtual-machine-scale-sets.md
+++ b/articles/service-fabric/how-to-managed-identity-managed-cluster-virtual-machine-scale-sets.md
@@ -91,7 +91,7 @@ This role assignment can be defined in the resources section template using the 
   ],
   "properties": {
     "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
-    "principalId": "<Service Fabric Resource Provider Application ID>"
+    "principalId": "<Service Fabric Resource Provider ID>"
   }
 }
 ```
@@ -101,7 +101,7 @@ This role assignment can be defined in the resources section template using the 
 or created via PowerShell using the principal ID and role definition name:
 
 ```powershell
-New-AzRoleAssignment -PrincipalId "<Service Fabric Resource Provider Application ID>" -RoleDefinitionName "Managed Identity Operator" -Scope "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<userAssignedIdentityName>"
+New-AzRoleAssignment -PrincipalId "<Service Fabric Resource Provider ID>" -RoleDefinitionName "Managed Identity Operator" -Scope "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<userAssignedIdentityName>"
 ```
 
 ### Deploy managed identity and role assignment.

--- a/articles/service-fabric/how-to-managed-identity-managed-cluster-virtual-machine-scale-sets.md
+++ b/articles/service-fabric/how-to-managed-identity-managed-cluster-virtual-machine-scale-sets.md
@@ -91,7 +91,7 @@ This role assignment can be defined in the resources section template using the 
   ],
   "properties": {
     "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
-    "principalId": "00000000-0000-0000-0000-000000000000"
+    "principalId": "<Service Fabric Resource Provider Application ID>"
   }
 }
 ```
@@ -101,7 +101,7 @@ This role assignment can be defined in the resources section template using the 
 or created via PowerShell using the principal ID and role definition name:
 
 ```powershell
-New-AzRoleAssignment -PrincipalId 00000000-0000-0000-0000-000000000000 -RoleDefinitionName "Managed Identity Operator" -Scope "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<userAssignedIdentityName>"
+New-AzRoleAssignment -PrincipalId "<Service Fabric Resource Provider Application ID>" -RoleDefinitionName "Managed Identity Operator" -Scope "/subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<userAssignedIdentityName>"
 ```
 
 ### Deploy managed identity and role assignment.


### PR DESCRIPTION
The section "Bring your own virtual network" gives a step for retrieving the "Azure Service Fabric Resource Provider" indicating that the `Id` value should be used as the `principalId` value in a later step. It's nice that it writes this here, but for someone merely skimming the instructions, this is likely going to be missed. Rather, in the example output given for the step, it uses the GUID '00000000-0000-0000-0000-000000000000'. This is a poor fill-in value to use because it actually has a meaning with regards to Principal IDs - it means Everyone, so someone that misses that this value should be replaced will not see any downstream errors about it while simultaneously doing away with any sort of desired least-privilege approach.

Instead, I advise drawing attention to the fact that we care here about the ID value (not the Application ID) by explicitly putting text surrounded by `< >` as is common for fill-in examples (and which is done in the first example itself to illustrate that the SubscriptionId should be inserted where `<SubId>` is found.

Further, most examples in the Azure documentation include a Copy button that copies the contents to ones's clipboard for easy insertion into a separate context. Fast-forwarding a few steps in this section, we see the JSON block demonstrating the all-zero GUID value being inserted in place of the SFRP identifier - again, this will not be rejected since that GUID does mean something in Azure. So once again, I recommend replacing that value with a specific substitution call out as I do in this PR.

This should better clarify to future parties exactly where the values come from for each of the examples.