### PR TITLE
Fix DEPLOYMENT_BRANCH value

### DIFF
--- a/articles/app-service/tutorial-auth-aad.md
+++ b/articles/app-service/tutorial-auth-aad.md
@@ -128,8 +128,8 @@ az webapp create --resource-group myAuthResourceGroup --plan myAuthAppServicePla
 1. Since you're deploying the `main` branch, you need to set the default deployment branch for your two App Service apps to `main` (see [Change deployment branch](deploy-local-git.md#change-deployment-branch)). In the Cloud Shell, set the `DEPLOYMENT_BRANCH` app setting with the [`az webapp config appsettings set`](/cli/azure/webapp/config/appsettings#az_webapp_config_appsettings_set) command. 
 
     ```azurecli-interactive
-    az webapp config appsettings set --name <front-end-app-name> --resource-group myAuthResourceGroup --settings DEPLOYMENT_BRANCH='main'
-    az webapp config appsettings set --name <back-end-app-name> --resource-group myAuthResourceGroup --settings DEPLOYMENT_BRANCH='main'
+    az webapp config appsettings set --name <front-end-app-name> --resource-group myAuthResourceGroup --settings DEPLOYMENT_BRANCH=main
+    az webapp config appsettings set --name <back-end-app-name> --resource-group myAuthResourceGroup --settings DEPLOYMENT_BRANCH=main
     ```
 
 1. Back in the _local terminal window_, run the following Git commands to deploy to the back-end app. Replace _\<deploymentLocalGitUrl-of-back-end-app>_ with the URL of the Git remote that you saved from [Create Azure resources](#create-azure-resources). When prompted for credentials by Git Credential Manager, make sure that you enter [your deployment credentials](deploy-configure-credentials.md), not the credentials you use to sign in to the Azure portal.


### PR DESCRIPTION
Setting branch name value with single quotes prevents Azure from deploying after git push command.

```
C:\dotnet-core-api>git push betest main
Enumerating objects: 82, done.
Counting objects: 100% (82/82), done.
Delta compression using up to 8 threads
Compressing objects: 100% (77/77), done.
Writing objects: 100% (82/82), 22.55 KiB | 721.00 KiB/s, done.
Total 82 (delta 25), reused 0 (delta 0)
remote: The current deployment branch is ''main'', but nothing has been pushed to it
remote: Error - Changes committed to remote repository but deployment to website failed.
To https://mybeapptest-0.scm.azurewebsites.net/mybeapptest-0.git
 * [new branch]      main -> main
```