### PR TITLE
Wrong variable name in the sample code

### DIFF
--- a/articles/machine-learning/how-to-deploy-and-where.md
+++ b/articles/machine-learning/how-to-deploy-and-where.md
@@ -269,7 +269,7 @@ python_packages = ['nltk', 'numpy', 'onnxruntime']
 for package in python_packages:
     env.python.conda_dependencies.add_pip_package(package)
 
-inf_config = InferenceConfig(environment=env, source_directory='./source_dir', entry_script='./score.py')
+inference_config = InferenceConfig(environment=env, source_directory='./source_dir', entry_script='./score.py')
 ```
 
 For more information, see the documentation for [LocalWebservice](/python/api/azureml-core/azureml.core.webservice.local.localwebservice), [Model.deploy()](/python/api/azureml-core/azureml.core.model.model#deploy-workspace--name--models--inference-config-none--deployment-config-none--deployment-target-none--overwrite-false-), and [Webservice](/python/api/azureml-core/azureml.core.webservice.webservice).


### PR DESCRIPTION
Due to different variable name, sample codes doesn't run.
Need to change variable name to 'inference_config' which is the same name from the notebook sample.