### PR TITLE
fix links to demo code in verifiable-credentials/get-started-request-api

### DIFF
--- a/articles/active-directory/verifiable-credentials/get-started-request-api.md
+++ b/articles/active-directory/verifiable-credentials/get-started-request-api.md
@@ -318,7 +318,7 @@ try
 }
 ```
 
-For the complete code, see the [issuance](https://github.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/blob/main/1-asp-net-core-api-idtokenhint/IssuerController.cs) and [presentation](https://github.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/blob/main/1-asp-net-core-api-idtokenhint/VerifierController.cs) code on the GitHub repo.
+For the complete code, see the [issuance](https://github.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/blob/main/AspNetCoreVerifiableCredentials/IssuerController.cs) and [presentation](https://github.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/blob/main/AspNetCoreVerifiableCredentials/VerifierController.cs) code on the GitHub repo.
 
 # [Node.js](#tab/nodejs)
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/active-directory/verifiable-credentials/get-started-request-api?tabs=csharp

Reason: rename proj in demo

https://github.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/pull/2