### PR TITLE
Fix typo

### DIFF
--- a/articles/postgresql/flexible-server/tutorial-django-aks-database.md
+++ b/articles/postgresql/flexible-server/tutorial-django-aks-database.md
@@ -237,7 +237,7 @@ spec:
         env:
         - name: DATABASE_HOST
           value: "SERVERNAME.postgres.database.azure.com"
-        - name: DATABASE_USERNAME
+        - name: DATABASE_USER
           value: "YOUR-DATABASE-USERNAME"
         - name: DATABASE_PASSWORD
           value: "YOUR-DATABASE-PASSWORD"


### PR DESCRIPTION
The parameter name is wrong.

Line 147 : `'USER': os.getenv ('DATABASE_USER'),`.
So, `DATABASE_USERNAME` is incorrect and `DATABASE_USER` is correct.