### PR TITLE
Update S2S connection limit for VpnGW4 and VpnGw5 from 30 to 100 tunnels

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps.md
+++ b/articles/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps.md
@@ -33,12 +33,12 @@ The following diagrams highlight the two models:
 ### Azure support for policy-based VPN
 Currently, Azure supports both modes of VPN gateways: route-based VPN gateways and policy-based VPN gateways. They are built on different internal platforms, which result in different specifications:
 
-| Category | PolicyBased VPN Gateway | RouteBased VPN Gateway | RouteBased VPN Gateway |
-| -------- | ----------------------- | ---------------------- | ---------------------- |---                                                 |
-| **Azure Gateway SKU**    | Basic                       | Basic                            | VpnGw1, VpnGw2, VpnGw3, VpnGw4, VpnGw5  |
-| **IKE version**          | IKEv1                       | IKEv2                            | IKEv1 and IKEv2                         |
-| **Max. S2S connections** | **1**                       | 10                               | 30                     |
-|                          |                             |                                  |                                                    |
+| Category | PolicyBased VPN Gateway | RouteBased VPN Gateway | RouteBased VPN Gateway |  RouteBased VPN Gateway
+| -------- | ----------------------- | ---------------------- | ---------------------- | ----------------------- |
+| **Azure Gateway SKU**    | Basic                       | Basic                            | VpnGw1, VpnGw2, VpnGw3  | VpnGw4 and VpnGw5 |
+| **IKE version**          | IKEv1                       | IKEv2                            | IKEv1 and IKEv2         | IKEv1 and IKEv2   |
+| **Max. S2S connections** | **1**                       | 10                               | 30                      | 100               |
+|                          |                             |                                  |                         |                   |
 
 With the custom IPsec/IKE policy, you can now configure Azure route-based VPN gateways to use prefix-based traffic selectors with option "**PolicyBasedTrafficSelectors**", to connect to on-premises policy-based VPN devices. This capability allows you to connect from an Azure virtual network and VPN gateway to multiple on-premises policy-based VPN/firewall devices, removing the single connection limit from the current Azure policy-based VPN gateways.
 

--- a/articles/vpn-gateway/vpn-gateway-highlyavailable.md
+++ b/articles/vpn-gateway/vpn-gateway-highlyavailable.md
@@ -42,7 +42,7 @@ This configuration provides multiple active tunnels from the same Azure VPN gate
 1. BGP is required for this configuration. Each local network gateway representing a VPN device must have a unique BGP peer IP address specified in the "BgpPeerIpAddress" property.
 1. You should use BGP to advertise the same prefixes of the same on-premises network prefixes to your Azure VPN gateway, and the traffic will be forwarded through these tunnels simultaneously.
 1. You must use Equal-cost multi-path routing (ECMP).
-1. Each connection is counted against the maximum number of tunnels for your Azure VPN gateway, 10 for Basic and Standard SKUs, and 30 for HighPerformance SKU. 
+1. Each connection is counted against the maximum number of tunnels for your Azure VPN gateway, 10 for Basic and Standard SKUs, and 100 for HighPerformance SKU. 
 
 In this configuration, the Azure VPN gateway is still in active-standby mode, so the same failover behavior and brief interruption will still happen as described [above](#activestandby). But this setup guards against failures or interruptions on your on-premises network and VPN devices.
 

--- a/articles/vpn-gateway/vpn-gateway-highlyavailable.md
+++ b/articles/vpn-gateway/vpn-gateway-highlyavailable.md
@@ -42,7 +42,7 @@ This configuration provides multiple active tunnels from the same Azure VPN gate
 1. BGP is required for this configuration. Each local network gateway representing a VPN device must have a unique BGP peer IP address specified in the "BgpPeerIpAddress" property.
 1. You should use BGP to advertise the same prefixes of the same on-premises network prefixes to your Azure VPN gateway, and the traffic will be forwarded through these tunnels simultaneously.
 1. You must use Equal-cost multi-path routing (ECMP).
-1. Each connection is counted against the maximum number of tunnels for your Azure VPN gateway, 10 for Basic and Standard SKUs, and 100 for HighPerformance SKU. 
+1. Each connection is counted against the maximum number of tunnels for your Azure VPN gateway, 10 for Basic and Standard SKUs, and 30 for HighPerformance SKU. 
 
 In this configuration, the Azure VPN gateway is still in active-standby mode, so the same failover behavior and brief interruption will still happen as described [above](#activestandby). But this setup guards against failures or interruptions on your on-premises network and VPN devices.
 

--- a/includes/vpn-gateway-gwsku-include.md
+++ b/includes/vpn-gateway-gwsku-include.md
@@ -29,7 +29,7 @@ The new VPN gateway SKUs streamline the feature sets offered on the gateways:
 | **SKU**| **Features**|
 | ---    | ---         |
 |**Basic** (**)   | **Route-based VPN**: 10 tunnels for S2S/connections; no RADIUS authentication for P2S; no IKEv2 for P2S<br>**Policy-based VPN**: (IKEv1): 1 S2S/connection tunnel; no P2S|
-| **All Generation1 and Generation2 SKUs except Basic** | **Route-based VPN**: up to 30 tunnels (*), P2S, BGP, active-active, custom IPsec/IKE policy, ExpressRoute/VPN coexistence |
+| **All Generation1 and Generation2 SKUs except Basic** | **Route-based VPN**: up to 100 tunnels (*), P2S, BGP, active-active, custom IPsec/IKE policy, ExpressRoute/VPN coexistence |
 |        |             |
 
 (*) You can configure "PolicyBasedTrafficSelectors" to connect a route-based VPN gateway to multiple on-premises policy-based firewall devices. Refer to [Connect VPN gateways to multiple on-premises policy-based VPN devices using PowerShell](../articles/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps.md) for details.

--- a/includes/vpn-gateway-table-gwtype-aggtput-include.md
+++ b/includes/vpn-gateway-table-gwtype-aggtput-include.md
@@ -13,23 +13,23 @@
 |**VPN<br>Gateway<br>Generation** |**SKU**   | **S2S/VNet-to-VNet<br>Tunnels** | **P2S<br> SSTP Connections** | **P2S<br> IKEv2/OpenVPN Connections** | **Aggregate<br>Throughput Benchmark** | **BGP** | **Zone-redundant** |
 |---            |---         | ---        | ---       | ---            | ---       | ---       | ---|
 |**Generation1**|**Basic**   | Max. 10    | Max. 128  | Not Supported  | 100 Mbps  | Not Supported| No |
-|**Generation1**|**VpnGw1**  | Max. 30*   | Max. 128  | Max. 250       | 650 Mbps  | Supported | No |
-|**Generation1**|**VpnGw2**  | Max. 30*   | Max. 128  | Max. 500       | 1 Gbps    | Supported | No |
-|**Generation1**|**VpnGw3**  | Max. 30*   | Max. 128  | Max. 1000      | 1.25 Gbps | Supported | No |
-|**Generation1**|**VpnGw1AZ**| Max. 30*   | Max. 128  | Max. 250       | 650 Mbps  | Supported | Yes |
-|**Generation1**|**VpnGw2AZ**| Max. 30*   | Max. 128  | Max. 500       | 1 Gbps    | Supported | Yes |
-|**Generation1**|**VpnGw3AZ**| Max. 30*   | Max. 128  | Max. 1000      | 1.25 Gbps | Supported | Yes |
+|**Generation1**|**VpnGw1**  | Max. 30   | Max. 128  | Max. 250       | 650 Mbps  | Supported | No |
+|**Generation1**|**VpnGw2**  | Max. 30   | Max. 128  | Max. 500       | 1 Gbps    | Supported | No |
+|**Generation1**|**VpnGw3**  | Max. 30   | Max. 128  | Max. 1000      | 1.25 Gbps | Supported | No |
+|**Generation1**|**VpnGw1AZ**| Max. 30   | Max. 128  | Max. 250       | 650 Mbps  | Supported | Yes |
+|**Generation1**|**VpnGw2AZ**| Max. 30   | Max. 128  | Max. 500       | 1 Gbps    | Supported | Yes |
+|**Generation1**|**VpnGw3AZ**| Max. 30   | Max. 128  | Max. 1000      | 1.25 Gbps | Supported | Yes |
 |        |            |            |           |                |           |           |     |
-|**Generation2**|**VpnGw2**  | Max. 30*   | Max. 128  | Max. 500       | 1.25 Gbps | Supported | No |
-|**Generation2**|**VpnGw3**  | Max. 30*   | Max. 128  | Max. 1000      | 2.5 Gbps  | Supported | No |
-|**Generation2**|**VpnGw4**  | Max. 30*   | Max. 128  | Max. 5000      | 5 Gbps    | Supported | No |
-|**Generation2**|**VpnGw5**  | Max. 30*   | Max. 128  | Max. 10000      | 10 Gbps   | Supported | No |
-|**Generation2**|**VpnGw2AZ**| Max. 30*   | Max. 128  | Max. 500       | 1.25 Gbps | Supported | Yes |
-|**Generation2**|**VpnGw3AZ**| Max. 30*   | Max. 128  | Max. 1000      | 2.5 Gbps  | Supported | Yes |
-|**Generation2**|**VpnGw4AZ**| Max. 30*   | Max. 128  | Max. 5000      | 5 Gbps    | Supported | Yes |
-|**Generation2**|**VpnGw5AZ**| Max. 30*   | Max. 128  | Max. 10000      | 10 Gbps   | Supported | Yes |
+|**Generation2**|**VpnGw2**  | Max. 30   | Max. 128  | Max. 500       | 1.25 Gbps | Supported | No |
+|**Generation2**|**VpnGw3**  | Max. 30   | Max. 128  | Max. 1000      | 2.5 Gbps  | Supported | No |
+|**Generation2**|**VpnGw4**  | Max. 100*   | Max. 128  | Max. 5000      | 5 Gbps    | Supported | No |
+|**Generation2**|**VpnGw5**  | Max. 100*   | Max. 128  | Max. 10000      | 10 Gbps   | Supported | No |
+|**Generation2**|**VpnGw2AZ**| Max. 30   | Max. 128  | Max. 500       | 1.25 Gbps | Supported | Yes |
+|**Generation2**|**VpnGw3AZ**| Max. 30   | Max. 128  | Max. 1000      | 2.5 Gbps  | Supported | Yes |
+|**Generation2**|**VpnGw4AZ**| Max. 100*   | Max. 128  | Max. 5000      | 5 Gbps    | Supported | Yes |
+|**Generation2**|**VpnGw5AZ**| Max. 100*   | Max. 128  | Max. 10000      | 10 Gbps   | Supported | Yes |
 
-(*) Use [Virtual WAN](../articles/virtual-wan/virtual-wan-about.md) if you need more than 30 S2S VPN tunnels.
+(*) Use [Virtual WAN](../articles/virtual-wan/virtual-wan-about.md) if you need more than 100 S2S VPN tunnels.
 
 * The resizing of VpnGw SKUs is allowed within the same generation, except resizing of the Basic SKU. The Basic SKU is a legacy SKU and has feature limitations. In order to move from Basic to another VpnGw SKU, you must delete the Basic SKU VPN gateway and create a new gateway with the desired Generation and SKU size combination. You can only resize a Basic gateway to another legacy SKU (see [Working with Legacy SKUs](../articles/vpn-gateway/vpn-gateway-about-skus-legacy.md)).
 


### PR DESCRIPTION
**DO NOT MERGE** - waiting on change from PG

Changed connection limit for site-to-site (S2S) VPN Gateways from 30 to 100 tunnels for VpnGW4, VpnGw5 SKUs

- Edited main SKU include file to use 100 max tunnels for VpnGW4, VpnGw5, VpnGW4AZ, VpnGw5AZ
- Edited additional SKU include file to use 100 tunnel limit
- Added new column in connecting multiple gateways article for VpnGW4, VpnGw5 (also fix table formatting issue)

**Note that there is no connection limit change for the classic deployment model "HighPerformance" SKU**