### PR TITLE
Update cache-overview.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-overview.md
+++ b/articles/azure-cache-for-redis/cache-overview.md
@@ -94,7 +94,7 @@ The Enterprise tiers rely on Redis Enterprise, a commercial variant of Redis fro
 > separately from cache instances themselves. For more information, see [Load Balancer pricing](https://azure.microsoft.com/pricing/details/load-balancer/).
 > If an Enterprise cache is configured for multiple Availability Zones, data
 > transfer will be billed at the [standard network bandwidth rates](https://azure.microsoft.com/pricing/details/bandwidth/)
-> starting from July 1, 2021.
+> starting from July 1, 2022.
 >
 > In addition, data persistence adds Managed Disks. The use of these resources will be free during
 > the public preview of Enterprise data persistence. This may change when the feature becomes


### PR DESCRIPTION
Based on the reference link documentation :  https://azure.microsoft.com/en-us/pricing/details/bandwidth/ 
It states "*Starting from July 1, 2022, Data transfer billing between Virtual machines across availability zones will begin. Please see FAQ for additional details."
However the REDIS doc points to 2021.
Hence proposing this change to ensure both documents are in sync.  Kindly review