### PR TITLE
Update doc with equivalent prompt behavior in MSAL

### DIFF
--- a/articles/active-directory/develop/msal-net-differences-adal-net.md
+++ b/articles/active-directory/develop/msal-net-differences-adal-net.md
@@ -157,6 +157,14 @@ catch(AdalException exception)
 
 For details, see [the recommended pattern to acquire a token in public client applications](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AcquireTokenSilentAsync-using-a-cached-token#recommended-pattern-to-acquire-a-token) with ADAL.NET.
 
+### Prompt Behavior in MSAL equivalent to that in ADAL -
+ADAL --> MSAL
+PromptBehavior.Auto -> NoPrompt
+PromptBehavior.Always -> ForceLogin
+PromptBehavior.RefreshSession --> Consent 
+PromptBehavior.Never --> Never, but it should not be used, instead try AcquireTokenSilent / catch MsalUiRequriedException and that should cover for it.
+Ref docs - https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-tokens-interactively
+
 ### Handling claim challenge exceptions
 
 At times when acquiring a token, Azure AD throws an exception in case a resource requires more claims from the user (for instance two-factor authentication).

--- a/articles/active-directory/develop/msal-net-differences-adal-net.md
+++ b/articles/active-directory/develop/msal-net-differences-adal-net.md
@@ -157,15 +157,17 @@ catch(AdalException exception)
 
 For details, see [the recommended pattern to acquire a token in public client applications](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AcquireTokenSilentAsync-using-a-cached-token#recommended-pattern-to-acquire-a-token) with ADAL.NET.
 
-### Prompt Behavior in MSAL equivalent to that in ADAL -
-Prompt Behavior - 
-|  ADAL        | MSAL        | Description |
+### Prompt behavior
+
+Prompt behavior in MSAL.NET is equivalent to prompt behavior in ADAL.NET:
+
+|  ADAL.NET | MSAL.NET | Description |
 | ----------- | ----------- | -------------|
-| `PromptBehavior.Auto`| `NoPrompt`| Azure AD chooses the best behavior (signing users silently if they are signed-in with only one account, or displaying the account selector if they are signed in with several accounts) |
-| `PromptBehavior.Always`| `ForceLogin`        | resets the login box and forces the user to re-enter their login and credentials |
-| `PromptBehavior.RefreshSession`| `Consent`| forces the user to re-consent to all permissions |
-| `PromptBehavior.Never`| `Never`|  should not be used, instead use the [recommended pattern for public client apps](scenario-desktop-acquire-token.md?tabs=dotnet)        |
-| `PromptBehavior.SelectAccount`| `SelectAccount`| displays the account selector and forces the user to select an account |
+| `PromptBehavior.Auto`| `NoPrompt`| Azure AD chooses the best behavior (signing in users silently if they are signed in with only one account, or displaying the account selector if they are signed in with several accounts). |
+| `PromptBehavior.Always`| `ForceLogin` | Resets the sign-in box and forces the user to reenter their credentials. |
+| `PromptBehavior.RefreshSession`| `Consent`| Forces the user to consent again to all permissions. |
+| `PromptBehavior.Never`| `Never`| Don't use; instead, use the [recommended pattern for public client apps](scenario-desktop-acquire-token.md?tabs=dotnet). |
+| `PromptBehavior.SelectAccount`| `SelectAccount`| Displays the account selector and forces the user to select an account. |
 
 ### Handling claim challenge exceptions
 

--- a/articles/active-directory/develop/msal-net-differences-adal-net.md
+++ b/articles/active-directory/develop/msal-net-differences-adal-net.md
@@ -158,12 +158,14 @@ catch(AdalException exception)
 For details, see [the recommended pattern to acquire a token in public client applications](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/AcquireTokenSilentAsync-using-a-cached-token#recommended-pattern-to-acquire-a-token) with ADAL.NET.
 
 ### Prompt Behavior in MSAL equivalent to that in ADAL -
-ADAL --> MSAL
-PromptBehavior.Auto -> NoPrompt
-PromptBehavior.Always -> ForceLogin
-PromptBehavior.RefreshSession --> Consent 
-PromptBehavior.Never --> Never, but it should not be used, instead try AcquireTokenSilent / catch MsalUiRequriedException and that should cover for it.
-Ref docs - https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-tokens-interactively
+Prompt Behavior - 
+|  ADAL        | MSAL        | Description |
+| ----------- | ----------- | -------------|
+| `PromptBehavior.Auto`| `NoPrompt`| Azure AD chooses the best behavior (signing users silently if they are signed-in with only one account, or displaying the account selector if they are signed in with several accounts) |
+| `PromptBehavior.Always`| `ForceLogin`        | resets the login box and forces the user to re-enter their login and credentials |
+| `PromptBehavior.RefreshSession`| `Consent`| forces the user to re-consent to all permissions |
+| `PromptBehavior.Never`| `Never`|  should not be used, instead use the [recommended pattern for public client apps](scenario-desktop-acquire-token.md?tabs=dotnet)        |
+| `PromptBehavior.SelectAccount`| `SelectAccount`| displays the account selector and forces the user to select an account |
 
 ### Handling claim challenge exceptions
 

--- a/articles/active-directory/develop/msal-net-differences-adal-net.md
+++ b/articles/active-directory/develop/msal-net-differences-adal-net.md
@@ -136,7 +136,7 @@ Using MSAL.NET, you catch `MsalUiRequiredException` as described in [AcquireToke
 ```csharp
 catch(MsalUiRequiredException exception)
 {
- try {“try to authenticate interactively”}
+ try {"try to authenticate interactively"}
 }
 ```
 


### PR DESCRIPTION
Propose to add the below differences in prompt behavior between MSAL and ADAL. 
ADAL is to MSAL --
PromptBehavior.Auto -> NoPrompt
PromptBehavior.Always -> ForceLogin
PromptBehavior.RefreshSession --> Consent 
PromptBehavior.Never --> Never, but it should not be used, instead try AcquireTokenSilent / catch MsalUiRequriedException and that should cover for it.
Ref docs - https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-tokens-interactively

@mmacy and @jmprieur