### PR TITLE
Adding clarity and examples

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-registration.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-registration.md
@@ -17,13 +17,17 @@ ms.collection: M365-identity-device-management
 ---
 # Conditional Access: Securing security info registration
 
-Securing when and how users register for Azure AD Multi-Factor Authentication and self-service password reset is possible with user actions in a Conditional Access policy. This feature is available to organizations who have enabled the [combined registration](../authentication/concept-registration-mfa-sspr-combined.md). This functionality allows organizations to treat the registration process like any application in a Conditional Access policy and use the full power of Conditional Access to secure the experience. Users signing in to the Microsoft Authenticator app or enabling passwordless phone sign-in are subject to this policy.
+Securing when and how users register for Azure AD Multi-Factor Authentication and self-service password reset is possible with user actions in a Conditional Access policy. This feature is available to organizations who have enabled [combined security information registration](../authentication/concept-registration-mfa-sspr-combined.md). This functionality allows organizations to treat the registration process like any application in a Conditional Access policy and use the full power of Conditional Access to secure the experience. Users signing in to the Microsoft Authenticator app or enabling passwordless phone sign-in are subject to this policy.
 
-Some organizations in the past may have used trusted network location or device compliance as a means to secure the registration experience. With the addition of [Temporary Access Pass](../authentication/howto-authentication-temporary-access-pass.md) in Azure AD, administrators can provision time-limited credentials to their users that allow them to register from any device or location. Temporary Access Pass credentials satisfy Conditional Access requirements for multi-factor authentication.
+Organizations may find that they need to take multiple approaches to securing registration based on their user personas and whether the organization has [guest users](../external-identities/what-is-b2b.md). An organization may choose to require other grant controls in addition to or in place of the examples below. When selecting multiple controls be sure to select the appropriate radio button toggle to require **all** or **one** of the selected controls when making this change.
 
-## Create a policy to secure registration
+> [!WARNING]
+> If you use Temporary Acess Pass (**require multi-factor authentication**) or **device state** as a condition in your policy this may impact guest users in the directory. [Report-only mode](concept-conditional-access-report-only.md) can help determine the impact of policy decisions.
+> Note that report-only mode is not applicable for CA policies with **User Actions** scope. 
 
-The following policy applies to the selected users, who attempt to register using the combined registration experience. The policy requires users to perform multi-factor authentication or use Temporary Access Pass credentials.
+## Create a policy to secure registration using Temporary Access Pass
+
+The following policy applies to the selected users, who attempt to register using the combined registration experience. The policy requires users to perform multi-factor authentication or use Temporary Access Pass credentials. With the addition of [Temporary Access Pass](../authentication/howto-authentication-temporary-access-pass.md) in Azure AD, administrators can provision time-limited credentials to their users that allow them to register from any device or location. Temporary Access Pass credentials satisfy Conditional Access requirements for multi-factor authentication.
 
 1. In the **Azure portal**, browse to **Azure Active Directory** > **Security** > **Conditional Access**.
 1. Select **New policy**.
@@ -51,17 +55,26 @@ The following policy applies to the selected users, who attempt to register usin
 
 Administrators will now have to issue Temporary Access Pass credentials to new users so they can satisfy the requirements for multi-factor authentication to register. Steps to accomplish this task, are found in the section [Create a Temporary Access Pass in the Azure AD Portal](../authentication/howto-authentication-temporary-access-pass.md#create-a-temporary-access-pass).
 
-Organizations may choose to require other grant controls in addition to or in place of **Require multi-factor authentication** at step 6b. When selecting multiple controls be sure to select the appropriate radio button toggle to require **all** or **one** of the selected controls when making this change.
+## Create a policy to require registration from a trusted location
 
-### Guest user registration
-
-For [guest users](../external-identities/what-is-b2b.md) who need to register for multi-factor authentication in your directory you may choose to block registration from outside of [trusted network locations](concept-conditional-access-conditions.md#locations) using the following guide.
+The following policy applies to the selected users, who attempt to register using the combined registration experience, and blocks access unless they are connecting from a [trusted network location](concept-conditional-access-conditions.md#locations).
 
 1. In the **Azure portal**, browse to **Azure Active Directory** > **Security** > **Conditional Access**.
 1. Select **New policy**.
 1. In Name, Enter a Name for this policy. For example, **Combined Security Info Registration on Trusted Networks**.
 1. Under **Assignments**, select **Users and groups**, and select the users and groups you want this policy to apply to.
-   1. Under **Include**, select **All guest and external users**.
+   1. Under **Include**, select **All users**.
+
+      > [!WARNING]
+      > Users must be enabled for the [combined registration](../authentication/howto-registration-mfa-sspr-combined.md).
+
+   1. Under **Exclude**.
+      1. Select **Users and groups** and choose your organization's emergency access or break-glass accounts. 
+1. Under **Cloud apps or actions**, select **User actions**, check **Register security information**.
+
+   > [!WARNING]
+   > Users must be enabled for the [combined registration](../authentication/howto-registration-mfa-sspr-combined.md).
+
 1. Under **Cloud apps or actions**, select **User actions**, check **Register security information**.
 1. Under **Conditions** > **Locations**.
    1. Configure **Yes**.
@@ -69,11 +82,45 @@ For [guest users](../external-identities/what-is-b2b.md) who need to register fo
    1. Exclude **All trusted locations**.
    1. Select **Done** on the Locations blade.
    1. Select **Done** on the Conditions blade.
+1. Under **Conditions** > **Client apps**, set **Configure** to **Yes**, and select **Done**.
 1. Under **Access controls** > **Grant**.
    1. Select **Block access**.
    1. Then click **Select**.
 1. Set **Enable policy** to **On**.
 1. Then select **Save**.
+
+## Create a policy to require registration from a compliant device
+
+The following policy applies to the selected users, who attempt to register using the combined registration experience, and blocks access unless they are connecting from a device that is marked as compliant.
+
+1. In the **Azure portal**, browse to **Azure Active Directory** > **Security** > **Conditional Access**.
+1. Select **New policy**.
+1. In Name, Enter a Name for this policy. For example, **Combined Security Info Registration from Compliant Devices**.
+1. Under **Assignments**, select **Users and groups**, and select the users and groups you want this policy to apply to.
+   1. Under **Include**, select **All users**.
+
+      > [!WARNING]
+      > Users must be enabled for the [combined registration](../authentication/howto-registration-mfa-sspr-combined.md).
+
+   1. Under **Exclude**.
+      1. Select **All guest and external users**.
+      1. Select **Users and groups** and choose your organization's emergency access or break-glass accounts. 
+1. Under **Cloud apps or actions**, select **User actions**, check **Register security information**.
+1. Under **Conditions** > **Client apps**, set **Configure** to **Yes**, and select **Done**.
+1. Under **Conditions** > **Filter for devices**.
+   1. Configure **Yes**.
+   2. Select **Exclude filtered devices from policy**
+   3. Create an expression.
+      1. **Property** set to **IsCompliant**.
+      2. **Operator** set to **Equals**.
+      3. **Value** set to **True**.
+   4. Select **Done** on the **Filter for devices** blade.
+   5. Select **Done** on the Conditions blade.
+4. Under **Access controls** > **Grant**.
+   1. Select **Block access**.
+   1. Then click **Select**.
+5. Set **Enable policy** to **On**.
+6. Then select **Save**.
 
 ## Next steps
 


### PR DESCRIPTION
Customers tend to use the examples within this literally, and do not want to necessarily build policies using TAP, especially since it's in Preview. I resurrected the old examples that defined network location so that it shows it can be used for either employees or guests, and also built-out an example for device compliance using Filter for devices. Also added some clarity that organizations may need to build a series of policies relying on some or all of the examples depending on their user personas. 
#ATCP