### PR TITLE
Update the URLs to be the correct pattern

### DIFF
--- a/articles/active-directory/saas-apps/workplacebyfacebook-tutorial.md
+++ b/articles/active-directory/saas-apps/workplacebyfacebook-tutorial.md
@@ -79,13 +79,13 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 1. On the **Basic SAML Configuration** section, enter the values for the following fields:
 
     a. In the **Sign on URL** (found in WorkPlace as the Recipient URL) text box, type a URL using the following pattern:
-    `https://.workplace.com/work/saml.php`
+    `https://.facebook.com/work/saml.php`
 
     b. In the **Identifier (Entity ID)** (found in WorkPlace as the Audience URL) text box, type a URL using the following pattern: 
-    `https://www.workplace.com/company/`
+    `https://www.facebook.com/company/`
 
     c. In the **Reply URL** (found in WorkPlace as the Assertion Consumer Service) text box, type a URL using the following pattern: 
-    `https://.workplace.com/work/saml.php`
+    `https://.facebook.com/work/saml.php`
 
     > [!NOTE]
     > These values are not the real. Update these values with the actual Sign-On URL, Identifier and Reply URL. See the Authentication page of the Workplace Company Dashboard for the correct values for your Workplace community, this is explained later in the tutorial.


### PR DESCRIPTION
Looked on Workplace instructions and the URLs are actually .facebook and not .workplace. Example from Workplace's website: https://scontent-sea1-1.xx.fbcdn.net/v/t39.2365-6/37012077_246547099267969_7227001504584957952_n.pdf?_nc_cat=102&ccb=1-5&_nc_sid=ad8a9d&_nc_ohc=PcxIdltRsPMAX_nllZX&_nc_ht=scontent-sea1-1.xx&oh=e022043bdf92c1988259598fa2ac922d&oe=6176177D