### PR TITLE
Line 327 - change link to align with statement on line 324

### DIFF
--- a/articles/active-directory-b2c/saml-service-provider.md
+++ b/articles/active-directory-b2c/saml-service-provider.md
@@ -324,7 +324,7 @@ The following example shows the `entityID` value in the SAML metadata:
 The `identifierUris` property will accept URLs only on the domain `tenant-name.onmicrosoft.com`.
 
 ```json
-"identifierUris":"https://samltestapp2.azurewebsites.net",
+"identifierUris":"https://tenant-name.onmicrosoft.com",
 ```
 
 #### Share the application's metadata with Azure AD B2C


### PR DESCRIPTION
Since the Azure AD Change the identifier URI has to be a verified domain The example still shows a non-verified domain. The document should be changed to reflect the new requirement
#ATCP