### PR TITLE
Please consider - Adding the Microsoft Authenticator App as supported Apps.

### DIFF
--- a/articles/active-directory/authentication/how-to-authentication-sms-supported-apps.md
+++ b/articles/active-directory/authentication/how-to-authentication-sms-supported-apps.md
@@ -32,6 +32,7 @@ SMS-based authentication is available to Microsoft apps integrated with the Micr
 | Microsoft Stream | ● |   |
 | Microsoft Power Apps | ● |   |
 | Microsoft Azure | ● | ● |
+| Microsoft Authenticator | ● |   |
 | Azure Virtual Desktop | ● |  | 
 
 *_SMS sign-in isn't available for office applications, such as Word, Excel, etc., when accessed directly on the web, but is available when accessed through the [Office 365 web app](https://www.office.com)_

--- a/articles/active-directory/authentication/how-to-authentication-sms-supported-apps.md
+++ b/articles/active-directory/authentication/how-to-authentication-sms-supported-apps.md
@@ -32,7 +32,7 @@ SMS-based authentication is available to Microsoft apps integrated with the Micr
 | Microsoft Stream | ● |   |
 | Microsoft Power Apps | ● |   |
 | Microsoft Azure | ● | ● |
-| Microsoft Authenticator | ● |   |
+| Microsoft Authenticator |   | ● |
 | Azure Virtual Desktop | ● |  | 
 
 *_SMS sign-in isn't available for office applications, such as Word, Excel, etc., when accessed directly on the web, but is available when accessed through the [Office 365 web app](https://www.office.com)_


### PR DESCRIPTION
In a current project, we have successfully used SMS authentication, to enable front-line workers to sign in to the Microsoft Authenticator app on iOS and Android (currently >100 users.) 
They have now been running using only password-less sign-in via the authenticator app since (now 22 days).
We have not had any issues with this solution, and it is a great and seamless way to onboard new users.
I fear that other customers will hold back on this approach if the authenticator app is not directly listed as supported.

Best Regards Kenneth