### PR TITLE
Added step to identify MFA preventing login for all clients

### DIFF
--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -38,6 +38,8 @@ If you are able to access your Azure AD Sign-in logs through Log Analytics you c
 
 You can access your sign-in logs by running the following Kusto query:
 
+You can access your sign-in logs by running the following Kusto query:
+
 ```kusto
 let UPN = "userupn";
 AADNonInteractiveUserSignInLogs

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -29,7 +29,7 @@ If you come across an error saying **Your account is configured to prevent you f
 
 ### I can't sign in even though I'm using the right credentials
 
-If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Also verify that you have assigned the **Virtual Machine User Login** RBAC permissions on the VM or Resource Group for each user. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
+If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors, verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Also verify that you have assigned the **Virtual Machine User Login** RBAC permissions on the VM or Resource Group for each user. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
 
 > [!WARNING] 
 > VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, then you won't be able to sign in and will receive an error message.

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -38,8 +38,6 @@ If you are able to access your Azure AD Sign-in logs through Log Analytics you c
 
 You can access your sign-in logs by running the following Kusto query:
 
-You can access your sign-in logs by running the following Kusto query:
-
 ```kusto
 let UPN = "userupn";
 AADNonInteractiveUserSignInLogs

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -27,7 +27,7 @@ Visit the [Azure Virtual Desktop Tech Community](https://techcommunity.microsoft
 
 If you come across an error saying **Your account is configured to prevent you from using this device. For more information, contact your system administrator**, ensure the user account was given the [Virtual Machine User Login role](../active-directory/devices/howto-vm-sign-in-azure-ad-windows.md#azure-role-not-assigned) on the VMs. 
 
-### Sign in failed. Incorrect username and password or your credentials did not work
+### I can't sign in even though I'm using the right credentials
 
 If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
 

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -15,7 +15,7 @@ ms.author: helohr
 >[!IMPORTANT]
 >This content applies to Azure Virtual Desktop with Azure Resource Manager Azure Virtual Desktop objects.
 
-Use this article to resolve issues with connections to Azure AD-joined VMs in Azure Virtual Desktop.
+Use this article to resolve issues with connections to Azure Active Directory (Azure AD)-joined VMs in Azure Virtual Desktop.
 
 ## Provide feedback
 
@@ -27,19 +27,19 @@ Visit the [Azure Virtual Desktop Tech Community](https://techcommunity.microsoft
 
 If you come across an error saying **Your account is configured to prevent you from using this device. For more information, contact your system administrator**, ensure the user account was given the [Virtual Machine User Login role](../active-directory/devices/howto-vm-sign-in-azure-ad-windows.md#azure-role-not-assigned) on the VMs. 
 
-### I can't sign in even though I'm using the right credentials
+### I can't sign in, even though I'm using the right credentials
 
 If you can't sign in and keep receiving an error message that says your credentials are incorrect, first make sure you're using the right credentials. If you keep seeing error messages, ask yourself the following questions:
 
-- Does your Conditional Access policy exclude multifactor authentication (MFA) requirements for the Azure Windows VM sign-in cloud application?
+- Does your Conditional Access policy exclude multifactor authentication requirements for the Azure Windows VM sign-in cloud application?
 - Have you assigned the **Virtual Machine User Login** role-based access control (RBAC) permission to the VM or resource group for each user? 
 
 If you answered "no" to either of these questions, follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms) to reconfigure your multifactor authentication.
 
 > [!WARNING] 
-> VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, then you won't be able to sign in and will receive an error message.
+> VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, you won't be able to sign in and will receive an error message.
 
-If you can access your Azure Active Director (AD) Sign-in logs through Log Analytics, you can see if you've enabled MFA and which Conditional Access policy is triggering the event. The events shown are non-interactive user login events for the VM, which means the IP address will appear to come from the external IP address that your VM accesses Azure AD from. 
+If you can access your Azure AD sign-in logs through Log Analytics, you can see if you've enabled multifactor authentication and which Conditional Access policy is triggering the event. The events shown are non-interactive user login events for the VM, which means the IP address will appear to come from the external IP address that your VM accesses Azure AD from. 
 
 You can access your sign-in logs by running the following Kusto query:
 
@@ -61,7 +61,7 @@ If you come across an error saying **The logon attempt failed** on the Windows S
 - You are on a device that is Azure AD-joined or hybrid Azure AD-joined to the same Azure AD tenant as the session host OR
 - You are on a device running Windows 10 2004 or later that is Azure AD registered to the same Azure AD tenant as the session host
 - The [PKU2U protocol is enabled](/windows/security/threat-protection/security-policy-settings/network-security-allow-pku2u-authentication-requests-to-this-computer-to-use-online-identities) on both the local PC and the session host
-- [Per-user MFA is disabled](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms) for the user account as it's not supported for Azure AD-joined VMs.
+- [Per-user multifactor authentication is disabled](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms) for the user account as it's not supported for Azure AD-joined VMs.
 
 ### The sign-in method you're trying to use isn't allowed
 

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -39,7 +39,7 @@ If you answered "no" to either of these questions, follow the instructions in [E
 > [!WARNING] 
 > VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, then you won't be able to sign in and will receive an error message.
 
-If you are able to access your Azure AD Sign-in logs through Log Analytics you can verify whether MFA is being applied and what Conditional Access policy is triggering the event. The events shown are the non-interactive user login events that are performed at the VM and therefore the IP address will appear to come from the external IP address that your virtual machine accesses Azure AD from. 
+If you can access your Azure Active Director (AD) Sign-in logs through Log Analytics, you can see if you've enabled MFA and which Conditional Access policy is triggering the event. The events shown are non-interactive user login events for the VM, which means the IP address will appear to come from the external IP address that your VM accesses Azure AD from. 
 
 You can access your sign-in logs by running the following Kusto query:
 

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -29,7 +29,7 @@ If you come across an error saying **Your account is configured to prevent you f
 
 ### I can't sign in even though I'm using the right credentials
 
-If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
+If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Also verify that you have assigned the **Virtual Machine User Login** RBAC permissions on the VM or Resource Group for each user. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
 
 > [!WARNING] 
 > Per-user Enabled/Enforced Azure AD Multi-Factor Authentication is not supported for VM Sign-In. This setting causes Sign-in to fail with “Your credentials do not work.” error message.

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -29,7 +29,12 @@ If you come across an error saying **Your account is configured to prevent you f
 
 ### I can't sign in even though I'm using the right credentials
 
-If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors, verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Also verify that you have assigned the **Virtual Machine User Login** RBAC permissions on the VM or Resource Group for each user. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
+If you can't sign in and keep receiving an error message that says your credentials are incorrect, first make sure you're using the right credentials. If you keep seeing error messages, ask yourself the following questions:
+
+- Does your Conditional Access policy exclude multifactor authentication (MFA) requirements for the Azure Windows VM sign-in cloud application?
+- Have you assigned the **Virtual Machine User Login** role-based access control (RBAC) permission to the VM or resource group for each user? 
+
+If you answered "no" to either of these questions, follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms) to reconfigure your multifactor authentication.
 
 > [!WARNING] 
 > VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, then you won't be able to sign in and will receive an error message.

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -36,6 +36,8 @@ If you experience a login problem presented by incorrect user credentials and ha
 
 If you are able to access your Azure AD Sign-in logs through Log Analytics you can verify whether MFA is being applied and what Conditional Access policy is triggering the event. The events shown are the non-interactive user login events that are performed at the VM and therefore the IP address will appear to come from the external IP address that your virtual machine accesses Azure AD from. 
 
+You can access your sign-in logs by running the following Kusto query:
+
 ```kusto
 let UPN = "userupn";
 AADNonInteractiveUserSignInLogs

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -32,7 +32,7 @@ If you come across an error saying **Your account is configured to prevent you f
 If you experience a login problem presented by incorrect user credentials and have verified they are correct and have ruled out other errors verify that Conditional Access policies excludes multifactor authentication requirements on the **Azure Windows VM Sign-in** cloud application. Also verify that you have assigned the **Virtual Machine User Login** RBAC permissions on the VM or Resource Group for each user. Follow the instructions in [Enable multifactor authentication](deploy-azure-ad-joined-vm.md#enabling-mfa-for-azure-ad-joined-vms)
 
 > [!WARNING] 
-> Per-user Enabled/Enforced Azure AD Multi-Factor Authentication is not supported for VM Sign-In. This setting causes Sign-in to fail with “Your credentials do not work.” error message.
+> VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, then you won't be able to sign in and will receive an error message.
 
 If you are able to access your AAD Sign-in logs through Log Analytics you can verify whether MFA is being applied and what Conditional Access policy is triggering the event. The events shown are the non-interactice user login event that is performed at the VM and therefore the IP address will appear to come from the external IP address that your virtual machine accesses AAD from. 
 

--- a/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
+++ b/articles/virtual-desktop/troubleshoot-azure-ad-connections.md
@@ -34,7 +34,7 @@ If you experience a login problem presented by incorrect user credentials and ha
 > [!WARNING] 
 > VM sign-ins don't support per-user enabled or enforced Azure AD multifactor authentication. If you try to sign in with multifactor authentication on a VM, then you won't be able to sign in and will receive an error message.
 
-If you are able to access your AAD Sign-in logs through Log Analytics you can verify whether MFA is being applied and what Conditional Access policy is triggering the event. The events shown are the non-interactice user login event that is performed at the VM and therefore the IP address will appear to come from the external IP address that your virtual machine accesses AAD from. 
+If you are able to access your Azure AD Sign-in logs through Log Analytics you can verify whether MFA is being applied and what Conditional Access policy is triggering the event. The events shown are the non-interactive user login events that are performed at the VM and therefore the IP address will appear to come from the external IP address that your virtual machine accesses Azure AD from. 
 
 ```kusto
 let UPN = "userupn";


### PR DESCRIPTION
MFA applied to the Azure Windows VM Sign in Cloud app can cause a username and password error so have added a step to all clients to help identify this. Have also included a basic KQL query to help find the cause.