### PR TITLE
Known issue with NTLMv2

### DIFF
--- a/articles/active-directory/authentication/multi-factor-authentication-faq.yml
+++ b/articles/active-directory/authentication/multi-factor-authentication-faq.yml
@@ -247,6 +247,10 @@ sections:
           
           A workaround for this error is to have separate user accounts for admin-related and non-admin operations. Later, you can link mailboxes between your admin account and non-admin account so that you can sign in to Outlook by using your non-admin account. For more details about this solution, learn how to [give an administrator the ability to open and view the contents of a user's mailbox](https://help.outlook.com/141/gg709759.aspx?sl=1).
           
+      - question: |
+      
+      
+          
 additionalContent: |
   ## Next steps
     If your question isn't answered here, the following support options are available:


### PR DESCRIPTION
We need to add the follow information within the FAQ document: 

What are the possible reasons why a user(s) is failing with the error code: LsaLogonUser failed with NTSTATUS -1073741715 for MFA Server. 

Error 1073741715 = Status Logon Failure -> The attempted logon is invalid. This is either due to a bad username or authentication. 

A plausible reason for this: If the primary credentials entered are correct, there could be a mismatch between the supported NTLM version on the MFA server vs. the Domain Controller. MFA Server only supports NTLMv1 (LmCompatabilityLevel=1 thru 4) and not NTLMv2 (LmCompatabilityLevel=5)