### PR TITLE
Move "set NIC network security group" to step 4

### DIFF
--- a/articles/virtual-network/tutorial-restrict-network-access-to-resources.md
+++ b/articles/virtual-network/tutorial-restrict-network-access-to-resources.md
@@ -306,7 +306,7 @@ To test network access to a storage account, deploy a VM to each subnet.
 
 ### Create the second virtual machine
 
-1. Repeat steps 1-5 to create a second virtual machine. In step 3, name the virtual machine *myVmPrivate* and set *NIC network security group* to **None**. In step 4, select the **Private** subnet.
+1. Repeat steps 1-5 to create a second virtual machine. In step 3, name the virtual machine *myVmPrivate*. In step 4, select the **Private** subnet and set *NIC network security group* to **None**.
 
    :::image type="content" source="./media/tutorial-restrict-network-access-to-resources/virtual-machine-2-networking.png" alt-text="Screenshot of create private virtual machine network settings." lightbox="./media/tutorial-restrict-network-access-to-resources/virtual-machine-2-networking-expanded.png":::
 


### PR DESCRIPTION
I saw "set NIC network security group* is in step 4 per my test. It also align with prior step "4. On the Networking tab, enter or select the following information:"