### PR TITLE
Improve AppService mutual TLS example code

### DIFF
--- a/articles/app-service/app-service-web-configure-tls-mutual-auth.md
+++ b/articles/app-service/app-service-web-configure-tls-mutual-auth.md
@@ -78,6 +78,9 @@ public class Startup
         {
             options.ForwardedHeaders =
                 ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            // Only loopback proxies are allowed by default. Clear that restriction to enable this explicit configuration.
+            options.KnownNetworks.Clear();
+            options.KnownProxies.Clear();
         });       
         
         // Configure the application to client certificate forwarded the frontend load balancer


### PR DESCRIPTION
Include the required `Clear()` calls to properly register the mTLS forwarding headers per [the source code](https://github.com/dotnet/aspnetcore/blob/18a926850f7374248e687ee64390e7f10514403f/src/DefaultBuilder/src/ForwardedHeadersOptionsSetup.cs#L27-L31)