### PR TITLE
changing links to node repo for pnp samples

### DIFF
--- a/includes/iot-pnp-connect-device-node.md
+++ b/includes/iot-pnp-connect-device-node.md
@@ -36,7 +36,7 @@ git clone https://github.com/Azure/azure-iot-sdk-node
 
 You use the device SDK to build the included sample code. The application you build simulates a device that connects to an IoT hub. The application sends telemetry and properties and receives commands.
 
-1. In a local terminal window, go to the folder of your cloned repository and navigate to the */azure-iot-sdk-node/device/samples/pnp* folder. Then run the following command to install the required libraries:
+1. In a local terminal window, go to the folder of your cloned repository and navigate to the */azure-iot-sdk-node/device/samples/javascript* folder. Then run the following command to install the required libraries:
 
     ```cmd/sh
     npm install
@@ -52,7 +52,7 @@ You use the device SDK to build the included sample code. The application you bu
 
 This sample implements a simple IoT Plug and Play thermostat device. The model this sample implements doesn't use IoT Plug and Play [components](../articles/iot-develop/concepts-modeling-guide.md). The [DTDL model file for the thermostat device](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/samples/Thermostat.json) defines the telemetry, properties, and commands the device implements.
 
-Open the _simple_thermostat.js_ file. In this file, you can see how to:
+Open the _pnp_simple_thermostat.js_ file. In this file, you can see how to:
 
 1. Import the required interfaces.
 1. Write a property update handler and a command handler.
@@ -75,7 +75,7 @@ To learn more about the sample configuration, see the [sample readme](https://gi
 Run the sample application to simulate an IoT Plug and Play device that sends telemetry to your IoT hub. To run the sample application, use the following command:
 
 ```cmd\sh
-node simple_thermostat.js
+node pnp_simple_thermostat.js
 ```
 
 You see the following output, indicating the device has begun sending telemetry data to the hub, and is now ready to receive commands and property updates.

--- a/includes/iot-pnp-connect-device-node.md
+++ b/includes/iot-pnp-connect-device-node.md
@@ -8,7 +8,7 @@ ms.date: 11/20/2020
 
 This quickstart shows you how to build a sample IoT Plug and Play device application, connect it to your IoT hub, and use the Azure IoT explorer tool to view the telemetry it sends. The sample application is written in Node.js and is included in the Azure IoT device SDK for Node.js. A solution builder can use the Azure IoT explorer tool to understand the capabilities of an IoT Plug and Play device without the need to view any device code.
 
-[![Browse code](../articles/iot-central/core/media/common/browse-code.svg)](https://github.com/Azure/azure-iot-sdk-node/tree/master/device/samples/javascript/pnp)
+[![Browse code](../articles/iot-central/core/media/common/browse-code.svg)](https://github.com/Azure/azure-iot-sdk-node/tree/master/device/samples)
 
 ## Prerequisites
 
@@ -70,7 +70,7 @@ In the main function, you can see how it all comes together:
 
 [!INCLUDE [iot-pnp-environment](iot-pnp-environment.md)]
 
-To learn more about the sample configuration, see the [sample readme](https://github.com/Azure/azure-iot-sdk-node/blob/master/device/samples/javascript/pnp/readme.md).
+To learn more about the sample configuration, see the [sample readme](https://github.com/Azure/azure-iot-sdk-node/blob/master/device/samples/readme.md#iot-plug-and-play-device-samples).
 
 Run the sample application to simulate an IoT Plug and Play device that sends telemetry to your IoT hub. To run the sample application, use the following command:
 


### PR DESCRIPTION
Moved the PnP examples out of their own folder and into the other samples.

https://github.com/Azure/azure-iot-sdk-node/pull/1062