### PR TITLE
Update functions-bindings-timer.md

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -272,14 +272,15 @@ When a timer trigger function is invoked, a timer object is passed into the func
 
 ```json
 {
-    "schedule":{
+    "Schedule":{
+        "AdjustForDST": true
     },
-    "scheduleStatus": {
-        "last":"2016-10-04T10:15:00+00:00",
-        "lastUpdated":"2016-10-04T10:16:00+00:00",
-        "next":"2016-10-04T10:20:00+00:00"
+    "ScheduleStatus": {
+        "Last":"2016-10-04T10:15:00+00:00",
+        "LastUpdated":"2016-10-04T10:16:00+00:00",
+        "Next":"2016-10-04T10:20:00+00:00"
     },
-    "isPastDue":false
+    "IsPastDue":false
 }
 ```
 


### PR DESCRIPTION
Fixed capitalization on $Timer object as it is case sensitive and it was incorrectly cased in the sample causing the values not to be retrieved. Also added AdjustForDST which is being returned in the $Timer instance but was not mentioned in the sample.