### PR TITLE
Updating NFSv3 support documentation

### DIFF
--- a/articles/storage/blobs/network-file-system-protocol-known-issues.md
+++ b/articles/storage/blobs/network-file-system-protocol-known-issues.md
@@ -23,7 +23,7 @@ This article describes limitations and known issues of Network File System (NFS)
 
 - NFS 3.0 support can't be disabled in a storage account after you've enabled it.
 
-- GRS, GZRS and RA-GRS redundancy options are not supported when creating an NFSv3 storage account.
+- GRS, GZRS, and RA-GRS redundancy options aren't supported when you create an NFS 3.0 storage account.
 
 ## NFS 3.0 features
 

--- a/articles/storage/blobs/network-file-system-protocol-known-issues.md
+++ b/articles/storage/blobs/network-file-system-protocol-known-issues.md
@@ -23,6 +23,8 @@ This article describes limitations and known issues of Network File System (NFS)
 
 - NFS 3.0 support can't be disabled in a storage account after you've enabled it.
 
+- GRS, GZRS and RA-GRS redundancy options are not supported when creating an NFSv3 storage account.
+
 ## NFS 3.0 features
 
 The following NFS 3.0 features aren't yet supported.


### PR DESCRIPTION
Currently, only LRS and ZRS options are supported when creating a NFSv3 account. However, there is no explicit mention for unsupported GRS, GZRS & RAGRS. Added the same in this documentation.
https://docs.microsoft.com/en-us/azure/storage/blobs/network-file-system-protocol-support-how-to#step-3-create-and-configure-a-storage-account
![image](https://user-images.githubusercontent.com/72929864/139053296-8d74a37b-8b98-4662-917b-d1218142e5e0.png)
