### PR TITLE
Update to use the Azure AD Kerberos PowerShell Module for FIDO2 provisioning

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -65,7 +65,7 @@ The following scenarios aren't supported:
 - Log in to a server using security key.
 
 ## Install the Azure AD Kerberos PowerShell Module
-The Azure AD Kerberos PowerShell Module provides FIDO2 management features for administrators.
+[The Azure AD Kerberos PowerShell Module](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) provides FIDO2 management features for administrators.
 
 1. Open a PowerShell prompt with **"Run as administrator"** option.
 1. Install the Azure AD Kerberos PowerShell Module.

--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -113,7 +113,7 @@ Set-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCre
 ```
 
 > [!NOTE]
-> If you are working on a domain-joined machine with domain administrator privileged account, you can skip the "-DomainCredential" parameter. If the "-DomainCredential" parameter is not provided, the current windows login credential is used to access your on-premises Active Directory Domain Controller.
+> If you're working on a domain-joined machine with an account that has domain administrator privileges, you can skip the "-DomainCredential" parameter. If the "-DomainCredential" parameter isn't provided, the current Windows login credential is used to access your on-premises Active Directory Domain Controller.
 
 ```powerShell
 # Specify the on-premises Active Directory domain. A new Azure AD

--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -84,7 +84,7 @@ The [Azure AD Kerberos PowerShell module](https://www.powershellgallery.com/pack
 > - You can install the Azure AD Kerberos PowerShell module on any computer from which you can access your on-premises Active Directory Domain Controller, without dependency on the Azure AD Connect solution.
 > - The Azure AD Kerberos PowerShell module is distributed through the [PowerShell Gallery](https://www.powershellgallery.com/). The PowerShell Gallery is the central repository for PowerShell content. In it, you can find useful PowerShell modules that contain PowerShell commands and Desired State Configuration (DSC) resources.
 
-## Create Kerberos server object
+## Create Kerberos Server object
 
 Administrators use the Azure AD Kerberos PowerShell module to create an Azure AD Kerberos Server object in their on-premises directory.
 
@@ -96,7 +96,7 @@ Run the following steps in each domain and forest in your organization that cont
 > [!NOTE]
 > Replace `contoso.corp.com` in the following example with your on-premises Active Directory domain name.
 
-```powerShell
+```powershell
 # Specify the on-premises Active Directory domain. A new Azure AD
 # Kerberos Server object will be created in this Active Directory domain.
 $domain = "contoso.corp.com"
@@ -115,7 +115,7 @@ Set-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCre
 > [!NOTE]
 > If you're working on a domain-joined machine with an account that has domain administrator privileges, you can skip the "-DomainCredential" parameter. If the "-DomainCredential" parameter isn't provided, the current Windows login credential is used to access your on-premises Active Directory Domain Controller.
 
-```powerShell
+```powershell
 # Specify the on-premises Active Directory domain. A new Azure AD
 # Kerberos Server object will be created in this Active Directory domain.
 $domain = "contoso.corp.com"
@@ -134,7 +134,7 @@ Set-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred
 >    - Replace `contoso.corp.com` in the following example with your on-premises Active Directory domain name.
 >    - Replace `administrator@contoso.onmicrosoft.com` in the following example with the User Principal Name of a Global administrator.
 
-```powerShell
+```powershell
 # Specify the on-premises Active Directory domain. A new Azure AD
 # Kerberos Server object will be created in this Active Directory domain.
 $domain = "contoso.corp.com"
@@ -155,7 +155,7 @@ Set-AzureADKerberosServer -Domain $domain -UserPrincipalName $userPrincipalName 
 
 You can view and verify the newly created Azure AD Kerberos Server using the following command:
 
-```powerShell
+```powershell
 Get-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCredential $domainCred
 ```
 
@@ -185,7 +185,7 @@ The Azure AD Kerberos Server encryption krbtgt keys should be rotated on a regul
 > [!WARNING]
 > There are other tools that could rotate the krbtgt keys, however, you must use the tools mentioned in this document to rotate the krbtgt keys of your Azure AD Kerberos Server. This ensures the keys are updated in both on-premises AD and Azure AD.
 
-```powerShell
+```powershell
 Set-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCredential $domainCred -RotateServerKey
 ```
 
@@ -193,7 +193,7 @@ Set-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCre
 
 If you'd like to revert the scenario and remove the Azure AD Kerberos Server from both on-premises Active Directory and Azure Active Directory, run the following command:
 
-```powerShell
+```powershell
 Remove-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCredential $domainCred
 ```
 

--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -64,30 +64,34 @@ The following scenarios aren't supported:
 - "Run as" using a security key.
 - Log in to a server using security key.
 
-## Install the Azure AD Kerberos PowerShell Module
-[The Azure AD Kerberos PowerShell Module](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) provides FIDO2 management features for administrators.
+## Install the Azure AD Kerberos PowerShell module
 
-1. Open a PowerShell prompt with **"Run as administrator"** option.
-1. Install the Azure AD Kerberos PowerShell Module.
-```powershell
-# First, ensure TLS 1.2 for PowerShell gallery access.
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+The [Azure AD Kerberos PowerShell module](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) provides FIDO2 management features for administrators.
 
-# Install the Azure AD Kerberos PowerShell Module.
-Install-Module -Name AzureADHybridAuthenticationManagement -AllowClobber
-```
+1. Open a PowerShell prompt using the Run as administrator option.
+1. Install the Azure AD Kerberos PowerShell module:
+
+   ```powershell
+   # First, ensure TLS 1.2 for PowerShell gallery access.
+   [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+   # Install the Azure AD Kerberos PowerShell Module.
+   Install-Module -Name AzureADHybridAuthenticationManagement -AllowClobber
+   ```
 
 > [!NOTE]
->   - The Azure AD Kerberos PowerShell Module uses [the AzureADPreview PowerShell Module](https://www.powershellgallery.com/packages/AzureADPreview) providing advanced Azure Active Directory management features. If [the AzureAD PowerShell Module](https://www.powershellgallery.com/packages/AzureAD) is already existing in your local machine, this installation can fail due to conflict. To prevent any conflicts during installation, be sure to include the **-AllowClobber** option flag.
->   - You can install the Azure AD Kerberos PowerShell Module in any machine where you can access your on-premises Active Directory Domain Controller without dependency on the Azure AD Connect solution.
->   - The Azure AD Kerberos PowerShell Module is distributed using [the PowerShell Gallery](https://docs.microsoft.com/en-us/azure/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises). The PowerShell Gallery is the central repository for PowerShell content. In it, you can find useful PowerShell modules containing PowerShell commands and Desired State Configuration (DSC) resources.
+> - The Azure AD Kerberos PowerShell module uses the [AzureADPreview PowerShell module](https://www.powershellgallery.com/packages/AzureADPreview) to provide advanced Azure Active Directory management features. If the [AzureAD PowerShell module](https://www.powershellgallery.com/packages/AzureAD) is already installed on your local computer, the installation described here might fail because of conflict. To prevent any conflicts during installation, be sure to include the "-AllowClobber" option flag.
+> - You can install the Azure AD Kerberos PowerShell module on any computer from which you can access your on-premises Active Directory Domain Controller, without dependency on the Azure AD Connect solution.
+> - The Azure AD Kerberos PowerShell module is distributed through the [PowerShell Gallery](https://www.powershellgallery.com/). The PowerShell Gallery is the central repository for PowerShell content. In it, you can find useful PowerShell modules that contain PowerShell commands and Desired State Configuration (DSC) resources.
 
 ## Create Kerberos server object
-Administrators use The Azure AD Kerberos PowerShell Module to create an Azure AD Kerberos Server object in their on-premises directory.
+
+Administrators use the Azure AD Kerberos PowerShell module to create an Azure AD Kerberos Server object in their on-premises directory.
+
 Run the following steps in each domain and forest in your organization that contain Azure AD users:
 
-1. Open a PowerShell prompt using **"Run as administrator"** option.
-1. Run the following PowerShell commands to create a new Azure AD Kerberos server object in both your on-premises Active Directory domain and Azure Active Directory tenant.
+1. Open a PowerShell prompt using the Run as administrator option.
+1. Run the following PowerShell commands to create a new Azure AD Kerberos Server object both in your on-premises Active Directory domain and in your Azure Active Directory tenant.
 
 > [!NOTE]
 > Replace `contoso.corp.com` in the following example with your on-premises Active Directory domain name.
@@ -158,10 +162,7 @@ Get-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCre
 This command outputs the properties of the Azure AD Kerberos Server. You can review the properties to verify that everything is in good order.
 
 > [!NOTE]
-
-Running against another domain by supplying the credential will connect over NTLM and then it would fails. if the users are part of "Protected Users" Security Group in AD
-Workaround: login with another domain user into ADConnect box and don’t supply -domainCredential . it would consume the kerebros ticket of the current logon user. 
-you can confirm by executing whoami /groups to validate if the user has required privelege in AD to execute the above command
+> Running against another domain by supplying the credential will connect over NTLM, and then it fails. If the users are in the Protected Users security group in Active Directory, complete these steps to resolve the issue: Sign in as another domain user in **ADConnect** and don’t supply "-domainCredential". The Kereberos ticket of the user that's currently signed in is used. You can confirm by executing `whoami /groups` to validate whether the user has the required permissions in Active Directory to execute the preceding command.
  
 | Property | Description |
 | --- | --- |


### PR DESCRIPTION
The Azure AD Kerberos PowerShell Module is ready for official release which is a replacement of current Azure AD Connect Solution based PowerShell module.
 - The Azure AD Connect solution is too big and have long-term update schedule.
 - The Azure AD Kerberos PowerShell Module provides the same FIDO2 provisioning feature and can be distributed via the PowerShell Gallery independent of the Azure AD Connect solution.
 - The Azure AD Kerberos PowerShell Module can be installed and used in any client machine where the customer can connect to their on-premises Active Directory Domain Controller.
 
Document is updated to use the new Azure AD Kerberos PowerShell Module for FIDO2 management.