### PR TITLE
Update connector-jira.md

### DIFF
--- a/articles/data-factory/connector-jira.md
+++ b/articles/data-factory/connector-jira.md
@@ -68,7 +68,7 @@ The following properties are supported for Jira linked service:
 | host | The IP address or host name of the Jira service. (for example, jira.example.com)  | Yes |
 | port | The TCP port that the Jira server uses to listen for client connections. The default value is 443 if connecting through HTTPS, or 8080 if connecting through HTTP.  | No |
 | username | The user name that you use to access Jira Service.  | Yes |
-| password | The password corresponding to the user name that you provided in the username field. Mark this field as a SecureString to store it securely, or [reference a secret stored in Azure Key Vault](store-credentials-in-key-vault.md). | Yes |
+| password | Use API token to authenticate instead of the password, More information in  https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/ | Yes |
 | useEncryptedEndpoints | Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.  | No |
 | useHostVerification | Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting over TLS. The default value is true.  | No |
 | usePeerVerification | Specifies whether to verify the identity of the server when connecting over TLS. The default value is true.  | No |


### PR DESCRIPTION
The connection from ADF to the JIRA uses API token to authenticate instead of the password and we will need to pass the value of the API token in the password field..
https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/