### PR TITLE
Remove monitor op from stonith-sbd

### DIFF
--- a/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
+++ b/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
@@ -561,8 +561,7 @@ sudo crm resource list
 sudo crm resource stop stonith-sbd
 sudo crm configure delete <b>stonith-sbd</b>
 sudo crm configure primitive <b>stonith-sbd</b> stonith:external/sbd \
-   params pcmk_delay_max="15" \
-   op monitor interval="15" timeout="15"
+   params pcmk_delay_max="15"
 </code></pre>
 
 ## Create Azure Fence agent STONITH device


### PR DESCRIPTION
I removed    op monitor interval="15" timeout="15" from stonith-sbd. 
With multiple SBD disks, in case one disk failed, the monitor operation will detect a failure and pacemaker will try to restart stonith-sbd resource on all node and the start will fail and stonith-sbd become inactive. 
stonith-sbd    (stonith:external/sbd): Stopped

Removing above monitor operation, the system will log failure messages in logs but resource will not restart. 
Oct 25 11:42:38 ora1 sbd[3034]:  warning: inquisitor_child: Servant /dev/disk/by-path/ip-192.168.0.10:3260-iscsi-iqn.2019-11.sbd.local:ora1-sbd-2-lun-1 is outdated (age: 4)
Oct 25 11:42:38 ora1 sbd[3035]: /dev/disk/by-path/ip-192.168.0.10:3260-iscsi-iqn.2019-11.sbd.local:ora1-sbd-2-lun-1:    error: header_get: Unable to read header from device 5
Oct 25 11:42:38 ora1 sbd[3035]: /dev/disk/by-path/ip-192.168.0.10:3260-iscsi-iqn.2019-11.sbd.local:ora1-sbd-2-lun-1:    error: servant_md: No longer found a valid header on /dev/disk/by-path/ip-192.168.0.10:3260-iscsi-iqn.2019-11.sbd.local:ora1-sbd-2-lun-1

Also, in our HAE documentation we don't advice customer to us op monitor for stonith-sbd resource:
https://documentation.suse.com/sle-ha/15-SP3/single-html/SLE-HA-administration/#book-administration 

Thanks