### PR TITLE
Update howto-configure-privatelink-cli.md

### DIFF
--- a/articles/mysql/howto-configure-privatelink-cli.md
+++ b/articles/mysql/howto-configure-privatelink-cli.md
@@ -117,7 +117,7 @@ az network private-dns link vnet create --resource-group myResourceGroup \
    --registration-enabled false 
 
 # Query for the network interface ID  
-networkInterfaceId=$(az network private-endpoint show --name myPrivateEndpoint --resource-group myResourceGroup --query 'networkInterfaces[0].id' -o tsv)
+$networkInterfaceId=$(az network private-endpoint show --name myPrivateEndpoint --resource-group myResourceGroup --query 'networkInterfaces[0].id' -o tsv)
 
 az resource show --ids $networkInterfaceId --api-version 2019-04-01 -o json 
 # Copy the content for privateIPAddress and FQDN matching the Azure database for MySQL name 


### PR DESCRIPTION
Proposing this change in the command: # Query for the network interface ID  
$networkInterfaceId=$(az network private-endpoint show --name myPrivateEndpoint --resource-group myResourceGroup --query 'networkInterfaces[0].id' -o tsv)

When I tried the same, got this error below as seen below.
PS C:\WINDOWS\system32> networkInterfaceId=$(az network private-endpoint show --name myPrivateEndpoint --resource-group sqltest --query 'networkInterfaces[0].id' -o tsv)
networkInterfaceId=$(az network private-endpoint show --name myPrivateEndpoint --resource-group sqltest --query
'networkInterfaces[0].id' -o tsv) : The term 'networkInterfaceId=$(az network private-endpoint show --name
myPrivateEndpoint --resource-group sqltest --query 'networkInterfaces[0].id' -o tsv)' is not recognized as the name of
a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included,
verify that the path is correct and try again.
At line:1 char:1
+ networkInterfaceId=$(az network private-endpoint show --name myPrivat ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (networkInterfac...[0].id' -o tsv):String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
When I tried this it worked. 
PS C:\WINDOWS\system32> $networkInterfaceId=$(az network private-endpoint show --name myPrivateEndpoint --resource-group sqltest --query 'networkInterfaces[0].id' -o tsv)
PS C:\WINDOWS\system32>

Please edit the document.