### PR TITLE
Update monitor-instances-health-check.md

### DIFF
--- a/articles/app-service/monitor-instances-health-check.md
+++ b/articles/app-service/monitor-instances-health-check.md
@@ -20,7 +20,7 @@ This article uses Health check in the Azure portal to monitor App Service instan
 
 - When given a path on your app, Health check pings this path on all instances of your App Service app at 1-minute intervals.
 - If an instance doesn't respond with a status code between 200-299 (inclusive) after two or more requests, or fails to respond to the ping, the system determines it's unhealthy and removes it.
-- After removal, Health check continues to ping the unhealthy instance. If it continues to respond unsuccessfully, App Service restarts the underlying VM in an effort to return the instance to a healthy state.
+- After removal, Health check continues to ping the unhealthy instance. If the instance begins to respond with a healthy statud code (200-299) then the instance is returned to the load balancer.
 - If an instance remains unhealthy for one hour, it will be replaced with new instance.
 - Furthermore, when scaling up or out, App Service pings the Health check path to ensure new instances are ready.
 


### PR DESCRIPTION
The instance won't be restarted. The only events are:

1. The app fails 2 health check pings --> it gets removed from LB rotation
2. The app is unhealthy for 1 hour --> Get new VM

There's no intermediate restart between 1 and 2