### PR TITLE
Conflicting info on ability to change Minimum TLS

### DIFF
--- a/articles/azure-sql/database/connectivity-settings.md
+++ b/articles/azure-sql/database/connectivity-settings.md
@@ -14,9 +14,9 @@ ms.custom: devx-track-azurepowershell
 ---
 
 # Azure SQL connectivity settings
-[!INCLUDE[appliesto-sqldb-asa](../includes/appliesto-sqldb-asa-formerly-sqldw.md)]
+[!INCLUDE[appliesto-sqldb-asa]]
 
-This article introduces settings that control connectivity to the server for Azure SQL Database and [dedicated SQL pool (formerly SQL DW)](../../synapse-analytics\sql-data-warehouse\sql-data-warehouse-overview-what-is.md) in Azure Synapse Analytics. These settings apply to all SQL Database and dedicated SQL pool (formerly SQL DW) databases associated with the server.
+This article introduces settings that control connectivity to the server for Azure SQL Database. These settings apply to all SQL Database and dedicated SQL pool (formerly SQL DW) databases associated with the server.
 
 > [!IMPORTANT]
 > This article doesn't apply to Azure SQL Managed Instance. This article also does not apply to dedicated SQL pools in Azure Synapse Analytics workspaces. See [Azure Synapse Analytics IP firewall rules](../../synapse-analytics/security/synapse-workspace-ip-firewall.md) for guidance on how to configure IP firewall rules for Azure Synapse Analytics with workspaces.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/synapse-analytics/security/connectivity-settings#minimal-tls-version

Azure Synapse Analytics Dedicated pools do not allow configuration of minimum TLS being used. 
https://docs.microsoft.com/en-us/azure/synapse-analytics/security/connectivity-settings#minimal-tls-version
"These settings apply to all SQL Database and dedicated SQL pool (formerly SQL DW) databases associated with the server."

The Get-AzSQLServer command is for Azure SQL only right? Not an expert, but I cannot change minimum TLS on Synapse and their documentation says it's not possible.

![image](https://user-images.githubusercontent.com/46201919/139735286-4fbca21c-2bb4-4e75-b1f7-d54094c1b2da.png)
 Dedicated SQL Pool (formerly SQL DW) is the "older" version but the current setup with Dedicated Pools being under Azure Synapse does not allow it.  The wording is really confusing.