### PR TITLE
Update how-to-visual-studio-develop-module.md

### DIFF
--- a/articles/iot-edge/how-to-visual-studio-develop-module.md
+++ b/articles/iot-edge/how-to-visual-studio-develop-module.md
@@ -158,6 +158,8 @@ To initialize the tool, provide an IoT Edge device connection string from IoT Hu
 
 Typically, you'll want to test and debug each module before running it within an entire solution with multiple modules.
 
+[!TIP] Make sure you have switched over to the correct Docker container mode (i.e. Linux Container Mode or Windows Container Mode) depending on the type of IoT Edge Module you are developing. From the Docker Desktop menu, you can toggle between the two types of modes. Select Switch to Windows containers to use Windows containers, or select Switch to Linux containers to use Linux containers. 
+
 1. In **Solution Explorer**, right-click the module folder and select **Set as StartUp Project** from the menu.
 
    ![Set Start-up Project](./media/how-to-visual-studio-develop-csharp-module/module-start-up-project.png)

--- a/articles/iot-edge/how-to-visual-studio-develop-module.md
+++ b/articles/iot-edge/how-to-visual-studio-develop-module.md
@@ -158,7 +158,8 @@ To initialize the tool, provide an IoT Edge device connection string from IoT Hu
 
 Typically, you'll want to test and debug each module before running it within an entire solution with multiple modules.
 
-[!TIP] Make sure you have switched over to the correct Docker container mode (i.e. Linux Container Mode or Windows Container Mode) depending on the type of IoT Edge Module you are developing. From the Docker Desktop menu, you can toggle between the two types of modes. Select Switch to Windows containers to use Windows containers, or select Switch to Linux containers to use Linux containers. 
+>[!TIP]
+>Make sure you have switched over to the correct Docker container mode, either Linux container mode or Windows container mode, depending on the type of IoT Edge module you are developing. From the Docker Desktop menu, you can toggle between the two types of modes. Select **Switch to Windows containers** to use Windows containers, or select **Switch to Linux containers** to use Linux containers. 
 
 1. In **Solution Explorer**, right-click the module folder and select **Set as StartUp Project** from the menu.
 


### PR DESCRIPTION
I see a lot of new IoT Edge Module Developers get sidetracked or bottlenecked because they are not pointing to the correct Docker Mode (Linux containers vs Windows Containers mode). We should emphasize in the documentation/article that to save yourself some time and effort please make sure you are pointing to the correct Docker Container mode. I know we mention this in the Prerequisites section, but we should re-emphasize it again in the Building and Debugging sections later in the article.
Thanks, and let me know if you have any questions.
-Andres