### PR TITLE
Update require DNS configuration using custom DNS

### DIFF
--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -50,6 +50,9 @@ Some prerequisites differ depending on the version (`stv2` or `stv1`) of the [co
 [!INCLUDE [api-management-public-ip-for-vnet](../../includes/api-management-public-ip-for-vnet.md)]
 
    > [!NOTE]
+   > If you use customer DNS server and configure it in VNET, you should configure DNS settings to resolve Azure Storage FQDN. When you deploy an Azure API Management instance to a Resource Manager VNET subnet, your API Management instance needs to access to Azure Storage to get essential components. 
+
+   > [!NOTE]
    > When you deploy an API Management service in an internal virtual network on the `stv2` platform, it's hosted behind an internal load balancer in the [Standard SKU](../load-balancer/skus.md), using the public IP address resource.
 
 ### [stv1](#tab/stv1)

--- a/articles/api-management/api-management-using-with-vnet.md
+++ b/articles/api-management/api-management-using-with-vnet.md
@@ -37,6 +37,9 @@ Some prerequisites differ depending on the version (`stv2` or `stv1`) of the [co
 
 [!INCLUDE [api-management-public-ip-for-vnet](../../includes/api-management-public-ip-for-vnet.md)]
 
+   > [!NOTE]
+   > If you use customer DNS server and configure it in VNET, you should configure DNS settings to resolve Azure Storage FQDN. When you deploy an Azure API Management instance to a Resource Manager VNET subnet, your API Management instance needs to access to Azure Storage to get essential components. 
+
 ### [stv1](#tab/stv1)
 
 + **An API Management instance.** For more information, see [Create an Azure API Management instance](get-started-create-service-instance.md).


### PR DESCRIPTION
If you use customer DNS server and configure it in VNET, you should configure DNS settings to resolve Azure Storage FQDN. When you deploy an Azure API Management instance to a Resource Manager VNET subnet, your API Management instance needs to access to Azure Storage to get some essential components.