### PR TITLE
Updated Run Command requirements

### DIFF
--- a/articles/virtual-machines/windows/run-command.md
+++ b/articles/virtual-machines/windows/run-command.md
@@ -36,7 +36,7 @@ The following restrictions apply when you're using Run Command:
 * It is not recommended to run a script that will cause a stop or update of the VM Agent. This can let the extension in a Transitioning state, leading to a timeout.
 
 > [!NOTE]
-> To function correctly, Run Command requires connectivity (port 443) to Azure public IP addresses. If the extension doesn't have access to these endpoints, the scripts might run successfully but not return the results. If you're blocking traffic on the virtual machine, you can use [service tags](../../virtual-network/network-security-groups-overview.md#service-tags) to allow traffic to Azure public IP addresses by using the `AzureCloud` tag.
+> To function correctly, Run Command requires connectivity (port 80 and 32526) to 169.254.169.254 and 168.63.129.16. If the extension doesn't have access to these endpoints, the scripts might run successfully but not return the results.
 > 
 > The Run Command feature doesn't work if the VM agent status is NOT READY. Check the agent status in the VM's properties in the Azure portal.
 


### PR DESCRIPTION
Updated the 'Note' to specify that the Run Command needs connectivity to 169.254.169.254 and 168.63.129.16 on ports 80 and 32526. Through my testing port 443 isn't needed anymore.

Also removed the line specifying to allow access in an NSG as, to my knowledge, access to those IPs/Ports can only be blocked inside the guestOS