### PR TITLE
Updated 'AccountName' to 'StorageAccountName' to avoid confusion.

### DIFF
--- a/articles/azure-functions/functions-identity-based-connections-tutorial.md
+++ b/articles/azure-functions/functions-identity-based-connections-tutorial.md
@@ -10,7 +10,7 @@ ms.date: 10/20/2021
 
 # Tutorial: Create a function app that connects to Azure services using identities instead of secrets
 
-This tutorial shows you how to configure a function app using Azure Active Directory identities instead of secrets or connection strings, where possible. Using identities helps you avoid accidentally leaking sensitive secrets and can provide better visibility into how data is accessed. To learn more about identity-based connections, see [configure an identity-based connection.](functions-reference.md#configure-an-identity-based-connection).
+This tutorial shows you how to configure a function app using Azure Active Directory identities instead of secrets or connection strings, where possible. Using identities helps you avoid accidentally leaking sensitive secrets and can provide better visibility into how data is accessed. To learn more about identity-based connections, see [configure an identity-based connection](functions-reference.md#configure-an-identity-based-connection).
 
 While the procedures shown work generally for all languages, this tutorial currently supports C# class library functions on Windows specifically. 
 

--- a/articles/azure-functions/functions-identity-based-connections-tutorial.md
+++ b/articles/azure-functions/functions-identity-based-connections-tutorial.md
@@ -106,7 +106,7 @@ In order to use Azure Key Vault, your app will need to have an identity that can
 
 1. Select **Save**. It might take a minute or two for the role to show up when you refresh the role assignments list for the identity.
 
-The identity will now be able to read secrets stored in the vault. Later in the tutorial, you will add additional role assignments for different purposes.
+The identity will now be able to read secrets stored in the key vault. Later in the tutorial, you will add additional role assignments for different purposes.
 
 ### Generate a template for creating a function app
 
@@ -304,7 +304,7 @@ Next you will update your function app to use its system-assigned identity when 
     | Option      | Suggested value  | Description |
     | ------------ | ---------------- | ----------- |
     | **Name** |  AzureWebJobsStorage__accountName | Update the name from **AzureWebJobsStorage** to the exact name `AzureWebJobsStorage__accountName`. This setting tells the host to use the identity instead of looking for a stored secret. The new setting uses a double underscore (`__`), which is a special character in application settings.  |
-    | **Value** | Your account name | Update the name from the connection string to just your **AccountName**. |
+    | **Value** | Your account name | Update the name from the connection string to just your **StorageAccountName**. |
 
     This configuration will let the system know that it should use an identity to connect to the resource.
 


### PR DESCRIPTION
In the last step of System-Assigned Identity association with Function. AccountName is used, which is a bit confusing, I changed it to 'StorageAccountName' because only Storage Account Name is required. Article need another update, because it is mentioned as following:

## Use managed identity for AzureWebJobsStorage (Preview)

Next you will use the system-assigned identity you configured in the previous steps for the `AzureWebJobsStorage` connection. 

But in this article, author showed to configure user-assigned identity not 'system-assigned identity'. The above line should have link of article, where 'system-assigned-identity' creation is shown.