### PR TITLE
clarification on smartcard cert template config

### DIFF
--- a/articles/virtual-desktop/configure-adfs-sso.md
+++ b/articles/virtual-desktop/configure-adfs-sso.md
@@ -48,7 +48,7 @@ You must properly create the following certificate templates so that AD FS can u
 After you create these certificate templates, you'll need to enable the templates on the certificate authority so AD FS can request them.
 
 > [!NOTE]
-> This solution generates new short-term certificates for every time a user signs in, which can fill up the Certificate Authority database if you have many users. You can avoid overloading your database by [setting up a CA for non-persistent certificate processing](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10)). If you do this, make sure to only enable "Do not store certificates and requests in the CA database" on the duplicated smartcard logon certificate template. Don't enable "Do not include revocation information in issued certificates," or else the configuration won't work.
+> This solution generates new short-term certificates every time a user signs in, which can fill up the Certificate Authority database if you have many users. You can avoid overloading your database by [setting up a CA for non-persistent certificate processing](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10)). If you do this, on the duplicated smartcard logon certificate template, make sure you enable only **Do not store certificates and requests in the CA database**. Don't enable **Do not include revocation information in issued certificates** or the configuration won't work.
 
 ### Create the enrollment agent certificate template
 

--- a/articles/virtual-desktop/configure-adfs-sso.md
+++ b/articles/virtual-desktop/configure-adfs-sso.md
@@ -48,7 +48,7 @@ You must properly create the following certificate templates so that AD FS can u
 After you create these certificate templates, you'll need to enable the templates on the certificate authority so AD FS can request them.
 
 > [!NOTE]
-> This solution generates new short term certificates for every user logon which can fill up the Certificate Authority database over time if you have a lot of users. You can avoid this by [setting up a CA for non-persistent certificate processing](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10)). If you do so, please ensure you only click/configure "Do not store certificates and requests in the CA database." on the duplicated smartcard logon certificate template. The "Do not include revocation information in issued certificates." option must NOT be clicked.
+> This solution generates new short-term certificates for every time a user signs in, which can fill up the Certificate Authority database if you have many users. You can avoid overloading your database by [setting up a CA for non-persistent certificate processing](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10)). If you do this, make sure to only enable "Do not store certificates and requests in the CA database" on the duplicated smartcard logon certificate template. Don't enable "Do not include revocation information in issued certificates," or else the configuration won't work.
 
 ### Create the enrollment agent certificate template
 

--- a/articles/virtual-desktop/configure-adfs-sso.md
+++ b/articles/virtual-desktop/configure-adfs-sso.md
@@ -48,7 +48,7 @@ You must properly create the following certificate templates so that AD FS can u
 After you create these certificate templates, you'll need to enable the templates on the certificate authority so AD FS can request them.
 
 > [!NOTE]
-> This solution generates new short term certificates for every user logon which can fill up the Certificate Authority database over time if you have a lot of users. You can avoid this by [setting up a CA for non-persistent certificate processing](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10)).
+> This solution generates new short term certificates for every user logon which can fill up the Certificate Authority database over time if you have a lot of users. You can avoid this by [setting up a CA for non-persistent certificate processing](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10)). If you do so, please ensure you only click/configure "Do not store certificates and requests in the CA database." on the duplicated smartcard logon certificate template. The "Do not include revocation information in issued certificates." option must NOT be clicked.
 
 ### Create the enrollment agent certificate template
 


### PR DESCRIPTION
Clarified configuration of new short term certificates not to be stored persistently in database. The linked article https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ff934598(v=ws.10) suggests selecting both "Click Do not store certificates and requests in the CA database" and "Click Do not include revocation information in issued certificates.". But only the former should be enabled. If the 2nd is configured logon will fail as cert revocation checks are performed during the logon and the missing details will prevent revocation checks.