### PR TITLE
Update entitlement-management-onboard-external-user.md - Mandatory setting sounds changeable

### DIFF
--- a/articles/active-directory/governance/entitlement-management-onboard-external-user.md
+++ b/articles/active-directory/governance/entitlement-management-onboard-external-user.md
@@ -63,7 +63,7 @@ For more information, see [License requirements](entitlement-management-overview
 
 2. In the **Users who can request access** section, click **For users not in your directory** and then click **All users (All connected organizations + any new external users)**.
 
-3. Since any user not yet in your directory can view and submit a request for this access package, **Yes** is mandatory for the **Require approval** setting.
+3. Because any user who is not yet in your directory can view and submit a request for this access package, **Yes** is mandatory for the **Require approval** setting.
 
 4. The following settings allow you to configure how your approvals work for your external users:
 

--- a/articles/active-directory/governance/entitlement-management-onboard-external-user.md
+++ b/articles/active-directory/governance/entitlement-management-onboard-external-user.md
@@ -63,7 +63,7 @@ For more information, see [License requirements](entitlement-management-overview
 
 2. In the **Users who can request access** section, click **For users not in your directory** and then click **All users (All connected organizations + any new external users)**.
 
-3. Ensure that **Require approval** is set to **Yes**.
+3. Since any user not yet in your directory can view and submit a request for this access package, **Yes** is mandatory for the **Require approval** setting.
 
 4. The following settings allow you to configure how your approvals work for your external users:
 

--- a/articles/active-directory/governance/entitlement-management-onboard-external-user.md
+++ b/articles/active-directory/governance/entitlement-management-onboard-external-user.md
@@ -3,7 +3,7 @@ title: Tutorial - Onboard external users to Azure AD through an approval process
 description: Step-by-step tutorial for how to create an access package for external users requiring approvals in Azure Active Directory entitlement management.
 services: active-directory
 documentationCenter: ''
-author: sama
+author: Sammak
 ms.service: active-directory
 ms.workload: identity
 ms.tgt_pltfrm: na


### PR DESCRIPTION
In Step 3, point 3, the article says to "Ensure that Require approval is set to Yes.", but that setting is in fact disabled (and set to Yes) based on the choice in Step 3, point 2. I based my update suggestion on the wording from the blue note box that appears on the setting page when you choose "All users (All connected organizations + any new external users)".
#ATCP