### PR TITLE
Fix issue from quick-create-powershell.md

### DIFF
--- a/articles/virtual-machines/linux/quick-create-powershell.md
+++ b/articles/virtual-machines/linux/quick-create-powershell.md
@@ -137,7 +137,7 @@ $cred = New-Object System.Management.Automation.PSCredential ("azureuser", $secu
 # Create a virtual machine configuration
 $vmConfig = New-AzVMConfig `
   -VMName "myVM" `
-  -VMSize "Standard_D1" | `
+  -VMSize "Standard_D1_v2" | `
 Set-AzVMOperatingSystem `
   -Linux `
   -ComputerName "myVM" `


### PR DESCRIPTION
Hello 

VMSize "Standard_D1" was not available in EastUS zone .
If powershell example can work normally, VMSize paramter modify from "Standard_D1" to "Standard_D1_v2". 

If you don't mind, Could you push code on quick-create-powershell.md?

```
New-AzVM: The requested size for resource '/subscriptions/5de711c7-cead-4c86-951d-e5bf50b1a0fb/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM' is currently not available in location 'eastus' zones '' for subscription '5de711c7-cead-4c86-951d-e5bf50b1a0fb'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.
ErrorCode: SkuNotAvailable
ErrorMessage: The requested size for resource '/subscriptions/5de711c7-cead-4c86-951d-e5bf50b1a0fb/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM' is currently not available in location 'eastus' zones '' for subscription'5de711c7-cead-4c86-951d-e5bf50b1a0fb'. Please try another size or deploy to a different location or zones. See https://aka.ms/azureskunotavailable for details.
ErrorTarget:
StatusCode: 409
ReasonPhrase: Conflict
OperationID : aebab4b1-7339-4c97-b371-d51d9ddabccc

Name                  Location Applies to SubscriptionID            Region Restriction Zone Restriction
----                  -------- -------------------------            ------------------ ----------------
Standard_D1           eastus   5de711c7-cead-4c86-951d-e5bf50b1a0fb                    NotAvavalableInZone: 1,2,3
Standard_D1_v2        eastus   5de711c7-cead-4c86-951d-e5bf50b1a0fb                    Available - No zone restrictions appli…



