### PR TITLE
Update management-groups-roles.md

### DIFF
--- a/articles/security-center/management-groups-roles.md
+++ b/articles/security-center/management-groups-roles.md
@@ -125,7 +125,7 @@ You can add subscriptions to the management group that you created.
 
 ## Remove elevated access 
 
-Once the Azure roles have been assigned to the users, the tenant administrator should remove itself from the user access administrator role.
+Once the Azure roles have been assigned to the users, the tenant administrator should remove themself from the user access administrator role.
 
 1. Sign in to the [Azure portal](https://portal.azure.com) or the [Azure Active Directory admin center](https://aad.portal.azure.com).
 


### PR DESCRIPTION
Edited sentence references an administrator as being "it"...

"Once the Azure roles have been assigned to the users, the tenant administrator should remove _**itself**_ from the user access administrator role."

Themself would be a better choice of reflexive pronoun and is considered a proper non-gender specific term for humans.  If the preference is to indicate all living beings are together in this world and we are all things, no changes are required.