### PR TITLE
Fix typo

### DIFF
--- a/articles/storage/blobs/quickstart-blobs-javascript-browser.md
+++ b/articles/storage/blobs/quickstart-blobs-javascript-browser.md
@@ -70,10 +70,10 @@ The following table describes each CORS setting and explains the values used to 
 
 |Setting  |Value  | Description |
 |---------|---------|---------|
-| **ALLOWED ORIGINS** | **\*** | Accepts a comma-delimited list of domains set as acceptable origins. Setting the value to `*` allows all domains access to the storage account. |
+| **ALLOWED ORIGINS** | * | Accepts a comma-delimited list of domains set as acceptable origins. Setting the value to `*` allows all domains access to the storage account. |
 | **ALLOWED METHODS** | **DELETE**, **GET**, **HEAD**, **MERGE**, **POST**, **OPTIONS**, and **PUT** | Lists the HTTP verbs allowed to execute against the storage account. For the purposes of this quickstart, select all available options. |
-| **ALLOWED HEADERS** | **\*** | Defines a list of request headers (including prefixed headers) allowed by the storage account. Setting the value to `*` allows all headers access. |
-| **EXPOSED HEADERS** | **\*** | Lists the allowed response headers by the account. Setting the value to `*` allows the account to send any header. |
+| **ALLOWED HEADERS** | * | Defines a list of request headers (including prefixed headers) allowed by the storage account. Setting the value to `*` allows all headers access. |
+| **EXPOSED HEADERS** | * | Lists the allowed response headers by the account. Setting the value to `*` allows the account to send any header. |
 | **MAX AGE** | **86400** | The maximum amount of time the browser caches the preflight OPTIONS request in seconds. A value of *86400* allows the cache to remain for a full day. |
 
 After you fill in the fields with the values from this table, click the **Save** button.


### PR DESCRIPTION
Since the description is different from the following, it has been unified.
https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/storage/blobs/storage-quickstart-blobs-javascript-client-libraries-legacy.md