### PR TITLE
Update synchronization.md

### DIFF
--- a/articles/active-directory-domain-services/synchronization.md
+++ b/articles/active-directory-domain-services/synchronization.md
@@ -20,7 +20,7 @@ Objects and credentials in an Azure Active Directory Domain Services (Azure AD D
 
 In a hybrid environment, objects and credentials from an on-premises AD DS domain can be synchronized to Azure AD using Azure AD Connect. Once those objects are successfully synchronized to Azure AD, the automatic background sync then makes those objects and credentials available to applications using the managed domain.
 
-If on-prem AD DS and Azure AD are configured for federated authentication using ADFS  without password hash sync or if 3rd party IdP products and Azure AD are configured for federated authentication without password hash sync then there is no (current/valid) password hash available in Azure DS. Azure AD user accounts created before fed auth was implemented might have an old password hash but this likely doesn't match a hash of their on-prem password. Hence Azure AD DS won't be able to validate the users credentials.
+If on-premises AD DS and Azure AD are configured for federated authentication using ADFS without password hash sync, or if third-party identity protection products and Azure AD are configured for federated authentication without password hash sync, no (current/valid) password hash is available in Azure DS. Azure AD user accounts created before fed auth was implemented might have an old password hash, but this likely doesn't match a hash of their on-premises password. Hence, Azure AD DS won't be able to validate a user's credentials.
 
 The following diagram illustrates how synchronization works between Azure AD DS, Azure AD, and an optional on-premises AD DS environment:
 

--- a/articles/active-directory-domain-services/synchronization.md
+++ b/articles/active-directory-domain-services/synchronization.md
@@ -20,13 +20,14 @@ Objects and credentials in an Azure Active Directory Domain Services (Azure AD D
 
 In a hybrid environment, objects and credentials from an on-premises AD DS domain can be synchronized to Azure AD using Azure AD Connect. Once those objects are successfully synchronized to Azure AD, the automatic background sync then makes those objects and credentials available to applications using the managed domain.
 
-If on-prem AD DS and Azure AD are configured for federated authentication using ADFS then there is no (current/valid) password hash available in Azure DS. Azure AD user accounts created before fed auth was implemented might have an old password hash but this likely doesn't match a hash of their on-prem password. Hence Azure AD DS won't be able to validate the users credentials.
+If on-prem AD DS and Azure AD are configured for federated authentication using ADFS  without password hash sync or if 3rd party IdP products and Azure AD are configured for federated authentication without password hash sync then there is no (current/valid) password hash available in Azure DS. Azure AD user accounts created before fed auth was implemented might have an old password hash but this likely doesn't match a hash of their on-prem password. Hence Azure AD DS won't be able to validate the users credentials.
 
 The following diagram illustrates how synchronization works between Azure AD DS, Azure AD, and an optional on-premises AD DS environment:
 
 ![Synchronization overview for an Azure AD Domain Services managed domain](./media/active-directory-domain-services-design-guide/sync-topology.png)
 
 ## Synchronization from Azure AD to Azure AD DS
+
 
 User accounts, group memberships, and credential hashes are synchronized one way from Azure AD to Azure AD DS. This synchronization process is automatic. You don't need to configure, monitor, or manage this synchronization process. The initial synchronization may take a few hours to a couple of days, depending on the number of objects in the Azure AD directory. After the initial synchronization is complete, changes that are made in Azure AD, such as password or attribute changes, are then automatically synchronized to Azure AD DS.
 


### PR DESCRIPTION
The Customer asks me why federated authentication with the 3rd party Idp cannot sync password hash to Azure AD DS.
When DC and AADC configured federated authentication using AD FS/3rd party IdP products with password hash sync, the password hash are available in Azure AD DS.
I have changed password of the user on premise DC and I can signin Azure AD DS with new password.

And the Customer requests adding description on the public documents.
So I would like to add description why federated authentication users cannot signin on Azure AD DS.