### PR TITLE
create-upload-ubuntu.md: ensure gdisk dependency is installed

### DIFF
--- a/articles/virtual-machines/linux/create-upload-ubuntu.md
+++ b/articles/virtual-machines/linux/create-upload-ubuntu.md
@@ -77,11 +77,11 @@ This article assumes that you have already installed an Ubuntu Linux operating s
 
 6. Ensure that the SSH server is installed and configured to start at boot time.  This is usually the default.
 
-7. Install cloud-init (the provisioning agent) and the Azure Linux Agent (the guest extensions handler). Cloud-init uses `netplan` to configure the system network configuration during provisioning and each subsequent boot.
+7. Install cloud-init (the provisioning agent) and the Azure Linux Agent (the guest extensions handler). Cloud-init uses `netplan` to configure the system network configuration (during provisioning and each subsequent boot) and `gdisk` to partition resource disks.
 
     ```console
     # sudo apt update
-    # sudo apt install cloud-init netplan.io walinuxagent && systemctl stop walinuxagent
+    # sudo apt install cloud-init gdisk netplan.io walinuxagent && systemctl stop walinuxagent
     ```
 
    > [!Note]


### PR DESCRIPTION
If gdisk is not installed, cloud-init may fail to check/partition the disk.  Custom images that do not include it may fail during cloud-init.  Update doc to include it in the list of packages to install with cloud-init.