### PR TITLE
Update how-to-configure-custom-bgp-communities.md

### DIFF
--- a/articles/expressroute/how-to-configure-custom-bgp-communities.md
+++ b/articles/expressroute/how-to-configure-custom-bgp-communities.md
@@ -86,7 +86,7 @@ BGP communities are groupings of IP prefixes tagged with a community value. This
 1. Update the `VirtualNetworkCommunity` value for your virtual network.
 
     ```azurepowershell-interactive
-    $vnet.BgpCommunities.VirtualNetworkCommunity = '12076:20002'
+    $vnet.BgpCommunities = @{VirtualNetworkCommunity = '12076:20002'}
     $vnet | Set-AzVirtualNetwork
     ```
 


### PR DESCRIPTION
Existing step for adding BGP Community to a vnet doesn't work.

```
PS> $vnet.BgpCommunities.VirtualNetworkCommunity = '12076:20001'
InvalidOperation: The property 'VirtualNetworkCommunity' cannot be found on this object. Verify that the property exists and can be set.
```