### PR TITLE
Update launchdarkly-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/launchdarkly-tutorial.md
+++ b/articles/active-directory/saas-apps/launchdarkly-tutorial.md
@@ -83,7 +83,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
     `https://app.launchdarkly.com/trust/saml2/acs/<customers-unique-id>`
 
 	> [!NOTE]
-	> The Reply URL value is not real. You will update the value with the actual Reply URL, which is explained later in the tutorial. If you are intending to use the application in **IDP** mode you need to leave the **Sign on URL** field blank, otherwise you will not be able to initiate the login from the **IDP**. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+	> The Reply URL value is not real. You will update the value with the actual Reply URL, which is explained later in the tutorial. LaunchDarkly currently supports **IDP** initiated SSO. To use this application in **IDP** mode, you need to leave the **Sign on URL** field blank, otherwise you will not be able to initiate the login from the **IDP**. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 6. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, click **Download** to download the **Certificate (Base64)** from the given options as per your requirement and save it on your computer.
 


### PR DESCRIPTION
Making it clearer the Sign-on URL in Azure AD must be blank with LaunchDarkly, or else it will not provision new licenses at all in the Service Provider. The current wording seems a little ambiguous.