### PR TITLE
Fixed two critical typos for the RDP Shortpath feature.

### DIFF
--- a/articles/virtual-desktop/shortpath.md
+++ b/articles/virtual-desktop/shortpath.md
@@ -88,7 +88,7 @@ To allow inbound network traffic for RDP Shortpath, use the Windows Defender Fir
 2. In the navigation pane, select **Inbound Rules**.
 3. Select **Action**, and then select **New rule**.
 4. On the **Rule Type** page of the New Inbound Rule Wizard, select **Custom**, and then select **Next**.
-5. On the **Program** page, select **This program path**, and type "%SystemRoot%\s ystem32\svchost.exe' then select **Next**.
+5. On the **Program** page, select **This program path**, and type "%SystemRoot%\system32\svchost.exe' then select **Next**.
 6. On the **Protocol and Ports** page, select the UDP protocol type. In the **Local port**, select "Specific ports" and enter the configured UDP port. If you've left the default settings on, the port number will be 3390.
 7. On the **Scope** page, you can specify that the rule applies only to network traffic to or from the IP addresses entered on this page. Configure as appropriate for your design, and then select **Next**.
 8. On the **Action** page, select **Allow the connection**, and then select **Next**.
@@ -225,7 +225,7 @@ To disable RDP Shortpath for a specific client, you can use the following Group 
 To disable RDP Shortpath for a specific session host, you can use the following Group Policy to disable the UDP support:
 
 1. On the Session Host Run **gpedit.msc**.
-2. Go to **Computer Configuration > Administration Templates > Windows Components > Remote Desktop Services > Remote Desktop Connection Host > Connections**.
+2. Go to **Computer Configuration > Administration Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Connections**.
 3. Set the **"Select RDP Transport Protocols"** setting to **TCP Only**.
 
 ## Next steps


### PR DESCRIPTION
There were two typos present in the RDP Shortpath article.
=======
Typo no. 1:  
Received: type "%SystemRoot%\s ystem32\svchost.exe' then select Next.
Expected: type "%SystemRoot%\system32\svchost.exe' then select Next.

Typo no. 2: 
Received: Computer Configuration > Administration Templates > Windows Components > Remote Desktop Services > Remote Desktop Connection Host > Connections.
Expected: Computer Configuration > Administration Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Connections.