### PR TITLE
Update faq-app-service-linux.yml

### DIFF
--- a/articles/app-service/faq-app-service-linux.yml
+++ b/articles/app-service/faq-app-service-linux.yml
@@ -244,9 +244,9 @@ sections:
       - question: |
           How does the container warmup request work?
         answer: |
-          When Azure App Services starts your container, the warmup request will send an HTTP request to the [/robots933456.txt](https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#robots933456-in-logs) endpoint of your application. This is simply a dummy endpoint, but your application needs to reply with any non 5XX status code. If your application logic does not reply with any HTTP status code to non-existent endpoints, the warmup request will not be able to receive a response, hence perpetually restarting your container.
+          When Azure App Services starts your container, the warmup request sends an HTTP request to the [/robots933456.txt](configure-custom-container.md?pivots=container-linux#robots933456-in-logs) endpoint of your application. This is simply a dummy endpoint, but your application needs to reply with any non-5XX status code. If your application logic doesn't reply with any HTTP status code to nonexistent endpoints, the warmup request can't receive a response and it perpetually restarts your container.
 
-          The warmup request may also fail due to port misconfiguration. To ensure that the port is correctly configured on Azure App Services please refer to the question *How do I specify port in my Linux container?* below.
+          The warmup request also might fail due to port misconfiguration. To ensure that the port is correctly configured on Azure App Services, see the question *How do I specify port in my Linux container?*
       - question: |
           Is it possible to increase the container warmup request timeout?
         answer:

--- a/articles/app-service/faq-app-service-linux.yml
+++ b/articles/app-service/faq-app-service-linux.yml
@@ -241,6 +241,16 @@ sections:
           
   - name: Other questions
     questions:
+      - question: |
+          How does the container warmup request work?
+        answer: |
+          When Azure App Services starts your container, the warmup request will send an HTTP request to the [/robots933456.txt](https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#robots933456-in-logs) endpoint of your application. This is simply a dummy endpoint, but your application needs to reply with any non 5XX status code. If your application logic does not reply with any HTTP status code to non-existent endpoints, the warmup request will not be able to receive a response, hence perpetually restarting your container.
+
+          The warmup request may also fail due to port misconfiguration. To ensure that the port is correctly configured on Azure App Services please refer to the question *How do I specify port in my Linux container?* below.
+      - question: |
+          Is it possible to increase the container warmup request timeout?
+        answer:
+          The warmup request by default fails after waiting 240 seconds for a reply from the container. You may increase the container warmup request timeout by adding the application setting `WEBSITES_CONTAINER_START_TIME_LIMIT` with a value between 240 and 1800 seconds.
       - question: |    
           How do I specify port in my Linux container?
         answer: |


### PR DESCRIPTION
Add Container Warmup Request documentation to 'App Service on Linux FAQ'. Current documentation regarding the warmup request is scattered across the following pages:

- [robots933456 in logs - Azure App Service | Microsoft Docs](https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#robots933456-in-logs)
- [How do I specify port in my Linux container? - Azure App Service | Microsoft Docs](https://docs.microsoft.com/en-us/azure/app-service/faq-app-service-linux#how-do-i-specify-port-in-my-linux-container-)
- [Configure port number - Azure App Service | Microsoft Docs](https://docs.microsoft.com/en-us/azure/app-service/configure-custom-container?pivots=container-linux#configure-port-number)
- [WEBSITES_CONTAINER_START_TIME_LIMIT - Azure App Service | Microsoft Docs](https://docs.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#custom-containers)