### PR TITLE
Added punctuation and better context.

### DIFF
--- a/articles/virtual-desktop/getting-started-feature.md
+++ b/articles/virtual-desktop/getting-started-feature.md
@@ -14,26 +14,26 @@ The Azure portal's new getting started feature is a quick, easy way to install a
 
 ## Requirements
 
-You'll need the following things to use getting started:
+You'll need to meet the following requirements to be able to use getting started:
 
-- An Azure Active Directory (AD) tenant
-- An account with global admin permissions on Azure AD
+- An Azure Active Directory (AD) tenant.
+- An account with global admin permissions on Azure AD.
 
    >[!NOTE]
    >The getting started feature doesn't currently support MSA, B2B, or guest accounts at this time.
 
-- An active Azure subscription
+- An active Azure subscription.
 
    >[!NOTE]
    >The getting started feature doesn't currently support accounts with multi-factor authentication.
 
-- An account with **Owner permissions** on the subscription
+- An account with **Owner permissions** on the subscription.
 
 If you're using the getting started feature in an environment with Active Directory Domain Services (AD DS), you'll also need to meet these requirements:
 
-- AD DS domain admin credentials
-- You must configure Azure AD connect on your subscription and make sure the "USERS" container is syncing with Azure AD
-- The domain controller in your virtual machine (VM) must not have DSC extensions of type **Microsoft.Powershell.DSC**
+- AD DS domain admin credentials.
+- You must configure Azure AD connect on your subscription and make sure the "USERS" container is syncing with Azure AD.
+- The domain controller in your virtual machine (VM) must not have DSC extensions of type **Microsoft.Powershell.DSC**.
 
 If you're using the getting started feature in an environment without an identity provider, these are the extra requirements you should follow:
 


### PR DESCRIPTION
I have added punctuation to the bullet points for the Requirements category.

I have also done the following change:

Change:
Old value: "You'll need the following **things** to use getting started:"
New value: "You'll need **to meet the following requirements to be able** to use getting started:"