### PR TITLE
Bold instead of italic for the configuration steps + punctuation.

### DIFF
--- a/articles/virtual-desktop/screen-capture-protection.md
+++ b/articles/virtual-desktop/screen-capture-protection.md
@@ -27,8 +27,8 @@ Suppose the user attempts to use an unsupported client to connect to the protect
 
 1. To configure screen capture protection, you need to install administrative templates that add rules and settings for Azure Virtual Desktop.
 2. Download the [Azure Virtual Desktop policy templates file](https://aka.ms/avdgpo) (AVDGPTemplate.cab) and extract the contents of the cab file and zip archive.
-3. Copy the *terminalserver-avd.admx* file to *%windir%\PolicyDefinitions* folder
-4. Copy the *en-us\terminalserver-avd.adml* file to *%windir%\PolicyDefinitions\en-us* folder
+3. Copy the **terminalserver-avd.admx** file to **%windir%\PolicyDefinitions** folder.
+4. Copy the **en-us\terminalserver-avd.adml** file to **%windir%\PolicyDefinitions\en-us** folder.
 5. To confirm the files copied correctly, open the Group Policy Editor and navigate to **Computer Configuration** -> **Administrative Templates** -> **Windows Components** -> **Remote Desktop Services** -> **Remote Desktop Session Host** -> **Azure Virtual Desktop**
 6. You should see one or more Azure Virtual Desktop policies, as shown below.
 


### PR DESCRIPTION
As per the previous public documentation link (RDP Shortpath) that features the Azure Virtual Desktop policy template file (AVDGPTemplate.cab), let's try to keep things standardized.

The previous documentation link that also features the "same" configuration steps have the important words marked in bold, instead of italic.
These are my changes:

Change no. 1:
Old value: Copy the *terminalserver-avd.admx* file to *%windir%\PolicyDefinitions* folder
New value: Copy the **terminalserver-avd.admx** file to **%windir%\PolicyDefinitions** folder.

Change no. 2:
Old value: Copy the *en-us\terminalserver-avd.adml* file to *%windir%\PolicyDefinitions\en-us* folder
New value: Copy the **en-us\terminalserver-avd.adml** file to **%windir%\PolicyDefinitions\en-us** folder.