### PR TITLE
Update for Username claim value

### DIFF
--- a/articles/active-directory/saas-apps/policystat-tutorial.md
+++ b/articles/active-directory/saas-apps/policystat-tutorial.md
@@ -166,15 +166,15 @@ To configure Azure AD single sign-on with PolicyStat, perform the following step
 
     b. Click **Save Changes**.
 
-4. Click **Configure Attributes**, and then, in the **Configure Attributes** section, perform the following steps:
+4. Click **Configure Attributes**, and then, in the **Configure Attributes** section, perform the following steps using the **CLAIM NAMES** found in your Azure configuration:
    
-    a. In the **Username Attribute** textbox, type **uid**.
+    a. In the **Username Attribute** textbox, type the username claim value you are passing over as the key username attribute. The default value in Azure is UPN, but if you already have accounts in PolicyStat, you will need to match those username values to avoid duplicate accounts or update the existing accounts in PolicyStat to the UPN value. Default value to enter to pass the UPN **http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name** .
 
-    b. In the **First Name Attribute** textbox, type your First Name Attribute claim name from Azure **`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`**.
+    b. In the **First Name Attribute** textbox, type the First Name Attribute claim name from Azure **`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname`**.
 
-    c. In the **Last Name Attribute** textbox, type your Last Name Attribute claim name from Azure **`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`**.
+    c. In the **Last Name Attribute** textbox, type The Last Name Attribute claim name from Azure **`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname`**.
 
-    d. In the **Email Attribute** textbox, type your Email Attribute claim name from Azure **`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`**.
+    d. In the **Email Attribute** textbox, type the Email Attribute claim name from Azure **`http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress`**.
 
     e. Click **Save Changes**.
 


### PR DESCRIPTION
Update to clarify the recurring issue clients have been having with the username attribute claim. For new clients they would want to pass the UPN value but existing clients may be using the on-prem samaccountname or another attribute from AD. This username mismatch will cause duplicate accounts in the PolicyStat user database when the user authenticates and they will want to ensure the values match.