### PR TITLE
Create a new billing profile - In order to clarify the limitation.

### DIFF
--- a/articles/cost-management-billing/manage/mca-section-invoice.md
+++ b/articles/cost-management-billing/manage/mca-section-invoice.md
@@ -111,7 +111,7 @@ To create a billing profile, you need to be a **billing account owner** or a **b
 
     > [!Note]
     >
-    > If you don't see the Add button in the Billing profile page, the feature is not available for your account. Currently, it is only available for accounts that have been set up while working with a Microsoft representative.
+    > If you don't see the Add button in the Billing profile page, the feature is not available for your account. Currently, it is only available for EA customers that have been set up while working with a Microsoft representative.
 
 4. Fill the form and click **Create**.
 


### PR DESCRIPTION
This change request is because some users ( such as Web Direct Customers ) might misunderstand that they could create additional billing profile.