### PR TITLE
Modification of basic LB script - public IP

### DIFF
--- a/articles/load-balancer/quickstart-load-balancer-standard-internal-powershell.md
+++ b/articles/load-balancer/quickstart-load-balancer-standard-internal-powershell.md
@@ -427,9 +427,6 @@ $lbip = @{
 }
 $feip = New-AzLoadBalancerFrontendIpConfig @lbip
 
-## Create load balancer frontend configuration and place in variable. ##
-$feip = New-AzLoadBalancerFrontendIpConfig -Name 'myFrontEnd' -PublicIpAddress $publicIp
-
 ## Create backend address pool configuration and place in variable. ##
 $bepool = New-AzLoadBalancerBackendAddressPoolConfig -Name 'myBackEndPool'
 


### PR DESCRIPTION
Removal of ## Create load balancer frontend configuration and place in variable. ##
$feip = New-AzLoadBalancerFrontendIpConfig -Name 'myFrontEnd' -PublicIpAddress $publicIp

This piece of PowerShell script adds a public IP which is not in scope and causes a SKU mismatch
A public IP is not as part of this script and there would a SKU mismatch between the resources.