### PR TITLE
Added note with Microsoft recommendations

### DIFF
--- a/articles/active-directory/privileged-identity-management/groups-features.md
+++ b/articles/active-directory/privileged-identity-management/groups-features.md
@@ -29,8 +29,8 @@ In Privileged Identity Management (PIM), you can now assign eligibility for memb
 >[!Important]
 > To assign a privileged access group to a role for administrative access to Exchange, Security & Compliance Center, or SharePoint, use the Azure AD portal **Roles and Administrators** experience and not in the Privileged Access Groups experience to make the user or group eligible for activation into the group.
 
->[!Note]
->For privileged access groups used for elevating into Azure AD roles, Microsoft recommends that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators. For example, the Helpdesk Administrator has permission to reset an eligible user's passwords.
+> [!NOTE]
+> For privileged access groups that are used to elevate into Azure AD roles, we recommend that you require an approval process for eligible member assignments. Assignments that can be activated without approval might create a security risk from administrators who have a lower level of permissions. For example, the Helpdesk Administrator has permissions to reset an eligible user's password.
 
 ## Require different policies for each role assignable group
 

--- a/articles/active-directory/privileged-identity-management/groups-features.md
+++ b/articles/active-directory/privileged-identity-management/groups-features.md
@@ -29,6 +29,9 @@ In Privileged Identity Management (PIM), you can now assign eligibility for memb
 >[!Important]
 > To assign a privileged access group to a role for administrative access to Exchange, Security & Compliance Center, or SharePoint, use the Azure AD portal **Roles and Administrators** experience and not in the Privileged Access Groups experience to make the user or group eligible for activation into the group.
 
+>[!Note]
+>For privileged access groups used for elevating into Azure AD roles, Microsoft recommends that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators. For example, the Helpdesk Administrator has permission to reset an eligible user's passwords.
+
 ## Require different policies for each role assignable group
 
 Some organizations use tools like Azure AD business-to-business (B2B) collaboration to invite their partners as guests to their Azure AD organization. Instead of a single just-in-time policy for all assignments to a privileged role, you can create two different privileged access groups with their own policies. You can enforce less strict requirements for your trusted employees, and stricter requirements like approval workflow for your partners when they request activation into their assigned group.


### PR DESCRIPTION
On the following page (https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/concept-privileged-access-versus-role-assignable#what-are-privileged-access-groups) there is a note with Microsoft recommendation for an approval process for eligible assignments on privileged access groups granting Azure AD roles. The same note should be on this page, as it is an important piece of information.
#ATCP