### PR TITLE
Added note with Microsoft recommendations

### DIFF
--- a/articles/active-directory/roles/groups-concept.md
+++ b/articles/active-directory/roles/groups-concept.md
@@ -58,6 +58,9 @@ Role-assignable groups are designed to help prevent potential breaches by having
 
 If you do not want members of the group to have standing access to a role, you can use [Azure AD Privileged Identity Management (PIM)](../privileged-identity-management/pim-configure.md) to make a group eligible for a role assignment. Each member of the group is then eligible to activate the role assignment for a fixed time duration.
 
+>[!Note]
+>For privileged access groups used for elevating into Azure AD roles, Microsoft recommends that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators. For example, the Helpdesk Administrator has permission to reset an eligible user's passwords.
+
 ## Scenarios not supported
 
 The following scenarios are not supported:  

--- a/articles/active-directory/roles/groups-concept.md
+++ b/articles/active-directory/roles/groups-concept.md
@@ -58,8 +58,8 @@ Role-assignable groups are designed to help prevent potential breaches by having
 
 If you do not want members of the group to have standing access to a role, you can use [Azure AD Privileged Identity Management (PIM)](../privileged-identity-management/pim-configure.md) to make a group eligible for a role assignment. Each member of the group is then eligible to activate the role assignment for a fixed time duration.
 
->[!Note]
->For privileged access groups used for elevating into Azure AD roles, Microsoft recommends that you require an approval process for eligible member assignments. Assignments that can be activated without approval can leave you vulnerable to a security risk from less-privileged administrators. For example, the Helpdesk Administrator has permission to reset an eligible user's passwords.
+> [!NOTE]
+> For privileged access groups that are used to elevate into Azure AD roles, we recommend that you require an approval process for eligible member assignments. Assignments that can be activated without approval might create a security risk from administrators who have a lower level of permissions. For example, the Helpdesk Administrator has permissions to reset an eligible user's password.
 
 ## Scenarios not supported
 


### PR DESCRIPTION
On the following page (https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/concept-privileged-access-versus-role-assignable#what-are-privileged-access-groups) there is a note with Microsoft recommendation for an approval process for eligible assignments on privileged access groups granting Azure AD roles. The same note should be on this page, as it is an important piece of information.
#ATCP