### PR TITLE
Format table bloat query so it is more readable

### DIFF
--- a/articles/postgresql/howto-optimize-autovacuum.md
+++ b/articles/postgresql/howto-optimize-autovacuum.md
@@ -37,7 +37,15 @@ If you don't vacuum from time to time, the dead tuples that accumulate can resul
 The following sample query is designed to identify the number of dead and live tuples in a table named XYZ:
 
 ```sql
-SELECT relname, n_dead_tup, n_live_tup, (n_dead_tup/ n_live_tup) AS DeadTuplesRatio, last_vacuum, last_autovacuum FROM pg_catalog.pg_stat_all_tables WHERE relname = 'XYZ' order by n_dead_tup DESC;
+SELECT relname,
+       n_dead_tup,
+       n_live_tup,
+       (n_dead_tup / n_live_tup) AS DeadTuplesRatio,
+       last_vacuum,
+       last_autovacuum
+FROM pg_catalog.pg_stat_all_tables
+WHERE relname = 'XYZ'
+ORDER BY n_dead_tup DESC;
 ```
 
 ## Autovacuum configurations


### PR DESCRIPTION
Before I couldn't read it because it was too wide. All the keywords are UPPERCASE now too.