### PR TITLE
B-series does not support Ephemeral OS

### DIFF
--- a/articles/virtual-machines/sizes-b-series-burstable.md
+++ b/articles/virtual-machines/sizes-b-series-burstable.md
@@ -25,7 +25,7 @@ The B-series comes in the following VM sizes:
 [Memory Preserving Updates](maintenance-and-updates.md): Supported<br>
 [VM Generation Support](generation-2.md): Generation 1 and 2<br>
 [Accelerated Networking](../virtual-network/create-vm-accelerated-networking-cli.md): Supported**<br>
-[Ephemeral OS Disks](ephemeral-os-disks.md): Supported <br>
+[Ephemeral OS Disks](ephemeral-os-disks.md): Not Supported <br>
 
 *B-series VMs are burstable and thus ACU numbers will vary depending on workloads and core usage.<br>
 **Accelerated Networking is only supported for *Standard_B12ms*, *Standard_B16ms* and *Standard_B20ms*.


### PR DESCRIPTION
Since B-Series does not support Premium Storage Caching, I do not think they support Ephemeral OS Disks.