### PR TITLE
Ensure App Gateway uses the TLS 1.2 policy

### DIFF
--- a/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
+++ b/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
@@ -446,6 +446,14 @@ Configure WAF to be in "Prevention" mode.
 $config = New-AzApplicationGatewayWebApplicationFirewallConfiguration -Enabled $true -FirewallMode "Prevention"
 ```
 
+### Step 13
+
+As TLS 1.0 is presently still the default, it's prudent to define that the application gateway will use the newest [TLS 1.2 policy](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview#appgwsslpolicy20170401s).
+
+```powershell
+$policy = New-AzApplicationGatewaySslPolicy -PolicyType Predefined -PolicyName AppGwSslPolicy20170401S
+```
+
 ## Create Application Gateway
 
 Create an Application Gateway with all the configuration objects from the preceding steps.
@@ -459,7 +467,8 @@ $appgw = New-AzApplicationGateway -Name $appgwName -ResourceGroupName $resGroupN
   -HttpListeners $gatewayListener,$portalListener,$managementListener `
   -RequestRoutingRules $gatewayRule,$portalRule,$managementRule `
   -Sku $sku -WebApplicationFirewallConfig $config -SslCertificates $certGateway,$certPortal,$certManagement `
-  -TrustedRootCertificate $trustedRootCert -Probes $apimGatewayProbe,$apimPortalProbe,$apimManagementProbe
+  -TrustedRootCertificate $trustedRootCert -Probes $apimGatewayProbe,$apimPortalProbe,$apimManagementProbe `
+  -SslPolicy $policy
 ```
 
 After deployment of the application gateway completes, confirm the health status of the API Management backends in the portal or by running the following command:

--- a/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
+++ b/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
@@ -448,7 +448,7 @@ $config = New-AzApplicationGatewayWebApplicationFirewallConfiguration -Enabled $
 
 ### Step 13
 
-As TLS 1.0 is presently still the default, it's prudent to define that the application gateway will use the newest [TLS 1.2 policy](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-ssl-policy-overview#appgwsslpolicy20170401s).
+As TLS 1.0 is presently still the default, it's prudent to define that the application gateway will use the newest [TLS 1.2 policy](../application-gateway/application-gateway-ssl-policy-overview.md#appgwsslpolicy20170401s).
 
 ```powershell
 $policy = New-AzApplicationGatewaySslPolicy -PolicyType Predefined -PolicyName AppGwSslPolicy20170401S

--- a/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
+++ b/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
@@ -448,7 +448,7 @@ $config = New-AzApplicationGatewayWebApplicationFirewallConfiguration -Enabled $
 
 ### Step 13
 
-As TLS 1.0 is presently still the default, it's prudent to define that the application gateway will use the newest [TLS 1.2 policy](../application-gateway/application-gateway-ssl-policy-overview.md#appgwsslpolicy20170401s).
+Because TLS 1.0 currently is the default, it's a good idea to set the application gateway to use the most recent [TLS 1.2 policy](../application-gateway/application-gateway-ssl-policy-overview.md#appgwsslpolicy20170401s).
 
 ```powershell
 $policy = New-AzApplicationGatewaySslPolicy -PolicyType Predefined -PolicyName AppGwSslPolicy20170401S


### PR DESCRIPTION
App Gateway V2 still uses TLS 1.0 as its default policy. Our own documentation points out that we should use TLS 1.2.

https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-configure-ssl-policy-powershell

![image](https://user-images.githubusercontent.com/84809797/142019054-a15b1b81-299b-41f3-acc1-4b2f94af1f8f.png)
