### PR TITLE
Suggesting new question to FAQ

### DIFF
--- a/articles/active-directory/authentication/howto-password-ban-bad-on-premises-faq.yml
+++ b/articles/active-directory/authentication/howto-password-ban-bad-on-premises-faq.yml
@@ -64,6 +64,12 @@ sections:
           
           Active Directory supports the ability to test a password to see if it passes the domain's current password complexity requirements, for example using the [NetValidatePasswordPolicy](/windows/win32/api/lmaccess/nf-lmaccess-netvalidatepasswordpolicy) api. When a password is validated in this way, the testing also includes validation by password-filter-dll based products such as Azure AD Password Protection - but the user names passed to a given password filter dll will be empty. In this scenario, Azure AD Password Protection will still validate the password using the currently in-effect password policy and will issue an event log message to capture the outcome, however the event log message will have empty user name fields.
           
+          ### I have hybrid users who attempt to change their password in Azure AD and receive a response "We've seen that password too many times before. Choose something harder to guess", but why do I not see a validation attempt on-premises?
+          
+          When a hybrid user changes their password in Azure AD, whether using Azure AD SSPR, myaccount, or another Azure AD password change mechanism, their password is evaluated against the global banned and custom banned password list in the cloud, when the password reached Active Directory through password-writeback it has already been validated in Azure AD.
+          
+          Password resets and changes initiated in Azure AD that fail validation for hybrid users can be found in the Azure AD Audit logs. See [Troubleshoot self-service password reset in Azure Active Directory](/azure/active-directory/authentication/troubleshoot-sspr).
+          
           ### Is it supported to install Azure AD Password Protection side by side with other password-filter-based products?
           
           Yes. Support for multiple registered password filter dlls is a core Windows feature and not specific to Azure AD Password Protection. All registered password filter dlls must agree before a password is accepted.

--- a/articles/active-directory/authentication/howto-password-ban-bad-on-premises-faq.yml
+++ b/articles/active-directory/authentication/howto-password-ban-bad-on-premises-faq.yml
@@ -66,7 +66,7 @@ sections:
           
           ### I have hybrid users who attempt to change their password in Azure AD and receive a response "We've seen that password too many times before. Choose something harder to guess", but why do I not see a validation attempt on-premises?
           
-          When a hybrid user changes their password in Azure AD, whether using Azure AD SSPR, myaccount, or another Azure AD password change mechanism, their password is evaluated against the global banned and custom banned password list in the cloud, when the password reached Active Directory through password-writeback it has already been validated in Azure AD.
+          When a hybrid user changes their password in Azure AD, whether through Azure AD SSPR, MyAccount, or another Azure AD password change mechanism, their password is evaluated against the global and custom banned password lists in the cloud. When the password reaches Active Directory through password-writeback, it has already been validated in Azure AD.
           
           Password resets and changes initiated in Azure AD that fail validation for hybrid users can be found in the Azure AD Audit logs. See [Troubleshoot self-service password reset in Azure Active Directory](/azure/active-directory/authentication/troubleshoot-sspr).
           

--- a/articles/active-directory/authentication/howto-password-ban-bad-on-premises-faq.yml
+++ b/articles/active-directory/authentication/howto-password-ban-bad-on-premises-faq.yml
@@ -64,7 +64,7 @@ sections:
           
           Active Directory supports the ability to test a password to see if it passes the domain's current password complexity requirements, for example using the [NetValidatePasswordPolicy](/windows/win32/api/lmaccess/nf-lmaccess-netvalidatepasswordpolicy) api. When a password is validated in this way, the testing also includes validation by password-filter-dll based products such as Azure AD Password Protection - but the user names passed to a given password filter dll will be empty. In this scenario, Azure AD Password Protection will still validate the password using the currently in-effect password policy and will issue an event log message to capture the outcome, however the event log message will have empty user name fields.
           
-          ### I have hybrid users who attempt to change their password in Azure AD and receive a response "We've seen that password too many times before. Choose something harder to guess", but why do I not see a validation attempt on-premises?
+          ### I have hybrid users who attempt to change their password in Azure AD and receive the response "We've seen that password too many times before. Choose something harder to guess." In this case, why don't I see a validation attempt on-premises?
           
           When a hybrid user changes their password in Azure AD, whether through Azure AD SSPR, MyAccount, or another Azure AD password change mechanism, their password is evaluated against the global and custom banned password lists in the cloud. When the password reaches Active Directory through password-writeback, it has already been validated in Azure AD.
           


### PR DESCRIPTION
Suggesting a new FAQ regarding hybrid users and password validation. When working with customers implementing this on-premises many do not realize that global and custom password protection validation still happens in the cloud for cloud-initiated password changes and have concern when they do not see the validation events show up in their Active Directory event logs. #ATCP