### PR TITLE
Adding missing user error messages

### DIFF
--- a/articles/active-directory/authentication/concept-password-ban-bad.md
+++ b/articles/active-directory/authentication/concept-password-ban-bad.md
@@ -203,9 +203,13 @@ Let's look a slightly different example to show how additional complexity in a p
 
 ## What do users see
 
-When a user attempts to reset a password to something that would be banned, the following error message is displayed:
+When a user attempts to reset or change a password to something that would be banned, one of the following error messages are displayed:
 
 *"Unfortunately, your password contains a word, phrase, or pattern that makes your password easily guessable. Please try again with a different password."*
+
+*"We've seen that password too many times before. Choose something harder to guess."*
+
+*"Choose a password that's harder for people to guess."*
 
 ## License requirements
 


### PR DESCRIPTION
Under What do users see - the error message currently in the doc is only what users receive from Azure AD SSPR; there is not a consistent error message across Azure AD. If users fail banned password protection at sign-on password changes, they receive "We've seen that password too many times before. Choose something harder to guess.", and if they change their password from myaccount, they receive "Choose a password that's harder for people to guess."

Suggesting adding these additional error messages to the list of what the errors the user might see from Azure AD password protection so that the article is more accurate.

#ATCP