### PR TITLE
Update add-sign-in-policy.md

### DIFF
--- a/articles/active-directory-b2c/add-sign-in-policy.md
+++ b/articles/active-directory-b2c/add-sign-in-policy.md
@@ -25,7 +25,7 @@ zone_pivot_groups: b2c-policy-type
 The sign-in policy lets users:
 
 * Users can sign in with an Azure AD B2C Local Account
-* Sign-up or sign-in with a social account
+* Users can sign-in with a social account
 * Password reset
 * Users cannot sign up for an Azure AD B2C Local Account. To create an account, an administrator can use [Azure portal](manage-users-portal.md#create-a-consumer-user), or [MS Graph API](microsoft-graph-operations.md).
 

--- a/articles/active-directory-b2c/add-sign-in-policy.md
+++ b/articles/active-directory-b2c/add-sign-in-policy.md
@@ -24,7 +24,7 @@ zone_pivot_groups: b2c-policy-type
 
 The sign-in policy lets users:
 
-* Users can sign in with an Azure AD B2C Local Account
+* Sign in with an Azure AD B2C Local Account
 * Users can sign-in with a social account
 * Password reset
 * Users cannot sign up for an Azure AD B2C Local Account. To create an account, an administrator can use [Azure portal](manage-users-portal.md#create-a-consumer-user), or [MS Graph API](microsoft-graph-operations.md).


### PR DESCRIPTION
Users can not sign-up with a social account via Sign-in flow.
If user try to sign in as the user does not exist B2C tenant, Azure AD B2C raise an AADB2C99002 error.

https://jwt.ms/#error=server_error&error_description=AADB2C99002%3a+User+does+not+exist.+Please+sign+up+before+you+can+sign+in.%0d%0aCorrelation+ID%3a+cebb9766-0d94-46f7-a82f-a1f5fc0d3875%0d%0aTimestamp%3a+2021-11-17+03%3a00%3a40Z%0d%0a

![image](https://user-images.githubusercontent.com/28978715/142127113-f991769b-bce7-45f6-919d-3c3658ea4ffe.png)
