### PR TITLE
fix: corrected option used to create a docker file

### DIFF
--- a/articles/azure-functions/functions-run-local.md
+++ b/articles/azure-functions/functions-run-local.md
@@ -218,7 +218,7 @@ The following considerations apply to project initialization:
 
 + When you don't provide a project name, the current folder is initialized. 
 
-+ If you plan to publish your project to a custom Linux container, use the `--dockerfile` option to make sure that a Dockerfile is generated for your project. To learn more, see [Create a function on Linux using a custom image](functions-create-function-linux-custom-image.md). 
++ If you plan to publish your project to a custom Linux container, use the `--docker` option to make sure that a Dockerfile is generated for your project. To learn more, see [Create a function on Linux using a custom image](functions-create-function-linux-custom-image.md). 
 
 Certain languages may have additional considerations:
 


### PR DESCRIPTION
The option to create a dockerfile in the documentation doesn't match what the cli help menu says. 
using the option in the documentation i.e. `--dockerfile` results in an error

The help menu of the cli show the following for creating a docker file
```
--docker               Create a Dockerfile based on the selected worker runtime
```