### PR TITLE
fix: wrong folder name

### DIFF
--- a/articles/azure-web-pubsub/tutorial-pub-sub-messages.md
+++ b/articles/azure-web-pubsub/tutorial-pub-sub-messages.md
@@ -68,7 +68,7 @@ Clients connect to the Azure Web PubSub service through the standard WebSocket p
 
 # [C#](#tab/csharp)
 
-1. First let's create a new folder `subscribe` for this project and install required dependencies:
+1. First let's create a new folder `subscriber` for this project and install required dependencies:
     * The package [Websocket.Client](https://github.com/Marfusios/websocket-client) is a third-party package supporting WebSocket connection. You can use any API/library that supports WebSocket to do so.
     * The SDK package `Azure.Messaging.WebPubSub` helps to generate the JWT token. 
 


### PR DESCRIPTION
The description (in C#) seemed to be incorrect.
https://docs.microsoft.com/en-us/azure/azure-web-pubsub/tutorial-pub-sub-messages?tabs=csharp#set-up-the-subscriber

create a new folder `subscribe` 
-> create a new folder `subscriber`