### PR TITLE
Update api-management-howto-protect-backend-with-aad.md

### DIFF
--- a/articles/api-management/api-management-howto-protect-backend-with-aad.md
+++ b/articles/api-management/api-management-howto-protect-backend-with-aad.md
@@ -241,7 +241,7 @@ The following example policy, when added to the `<inbound>` policy section, chec
     <openid-config url="https://login.microsoftonline.com/{aad-tenant}/v2.0/.well-known/openid-configuration" />
     <required-claims>
         <claim name="aud">
-            <value>insert aud claim value expected in the token</value>
+            <value>{backend-api-application-client-id}</value>
         </claim>
     </required-claims>
 </validate-jwt>


### PR DESCRIPTION
changing the value of the claim from "aud" to {backend-api-application-client-id}, making it clearer for the reader which value should be used in the field