### PR TITLE
fix the parameter name as in latest azure cli

### DIFF
--- a/articles/container-apps/github-actions-cli.md
+++ b/articles/container-apps/github-actions-cli.md
@@ -66,7 +66,7 @@ az containerapp github-action add \
   --docker-file-path "./dockerfile" \
   --branch <BRANCH_NAME> \
   --registry-url <URL_TO_CONTAINER_REGISTRY> \
-  --registry-user-name <REGISTRY_USER_NAME> \
+  --registry-username <REGISTRY_USER_NAME> \
   --registry-password <REGISTRY_PASSWORD> \
   --service-principal-client-id <CLIENT_ID> \
   --service-principal-client-secret <CLIENT_SECRET> \


### PR DESCRIPTION
In the example, 
```
az containerapp github-action add \
  --repo-url "https://github.com/<OWNER>/<REPOSITORY_NAME>" \
  --docker-file-path "./dockerfile" \
  --branch <BRANCH_NAME> \
  --registry-url <URL_TO_CONTAINER_REGISTRY> \
  --registry-user-name <REGISTRY_USER_NAME> \
  --registry-password <REGISTRY_PASSWORD> \
  --service-principal-client-id <CLIENT_ID> \
  --service-principal-client-secret <CLIENT_SECRET> \
  --service-principal-tenant-id <TENANT_ID> \
  --token <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>
```
the parameter name is **--registry-username** instead of **--registry-user-name**. Updated the example to match with azure cli parameters.