### PR TITLE
Virtual network integration are swapped

### DIFF
--- a/includes/app-service-deployment-slots-settings.md
+++ b/includes/app-service-deployment-slots-settings.md
@@ -19,6 +19,7 @@ When you clone configuration from another deployment slot, the cloned configurat
 * Hybrid connections *
 * Service endpoints *
 * Azure Content Delivery Network *
+* Virtual network integration *
 * Path mappings
 
 Features marked with an asterisk (*) are planned to be unswapped. 
@@ -34,7 +35,6 @@ Features marked with an asterisk (*) are planned to be unswapped.
 * Always On
 * Diagnostic settings
 * Cross-origin resource sharing (CORS)
-* Virtual network integration
 * Managed identities
 * Settings that end with the suffix _EXTENSION_VERSION
 


### PR DESCRIPTION
based on my test,  it is swapped with the config WEBSITE_OVERRIDE_PRESERVE_DEFAULT_STICKY_SLOT_SETTINGS set to 0

And in another page, it is as I said:
https://docs.microsoft.com/en-us/learn/modules/understand-app-service-deployment-slots/3-app-service-slot-swapping