### PR TITLE
Fixed appId variable typo

### DIFF
--- a/articles/virtual-machines/workloads/sap/automation-tutorial.md
+++ b/articles/virtual-machines/workloads/sap/automation-tutorial.md
@@ -264,7 +264,7 @@ The sample SAP Library configuration file `MGMT-NOEU-SAP_LIBRARY.tfvars` is in t
 cd ~/Azure_SAP_Automated_Deployment/WORKSPACES
 
 export subscriptionID="<subscriptionID>"
-export appId="<appID>"
+export spn_id="<appID>"
 export spn_secret="<password>"
 export tenant_id="<tenant>"
 export region_code="NOEU"


### PR DESCRIPTION
Fixed typo of exporting a variable name (appId) that does not match the variable passed into the prepare_region.sh command (spn_id).