### PR TITLE
Add missing $

### DIFF
--- a/articles/container-instances/container-instances-github-action.md
+++ b/articles/container-instances/container-instances-github-action.md
@@ -51,7 +51,7 @@ In the GitHub workflow, you need to supply Azure credentials to authenticate to 
 First, get the resource ID of your resource group. Substitute the name of your group in the following [az group show][az-group-show] command:
 
 ```azurecli
-groupId=$(az group show \
+$groupId=$(az group show \
   --name <resource-group-name> \
   --query id --output tsv)
 ```

--- a/articles/container-instances/container-instances-github-action.md
+++ b/articles/container-instances/container-instances-github-action.md
@@ -91,7 +91,7 @@ Update the Azure service principal credentials to allow push and pull access to 
 Get the resource ID of your container registry. Substitute the name of your registry in the following [az acr show][az-acr-show] command:
 
 ```azurecli
-registryId=$(az acr show \
+$registryId=$(az acr show \
   --name <registry-name> \
   --query id --output tsv)
 ```


### PR DESCRIPTION
This avoids this error message:

> The term 'groupId=$(az group show --name <my-name> --query id --output tsv)' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.