### PR TITLE
Update the Azure.Monitor installation command

### DIFF
--- a/articles/communication-services/quickstarts/includes/telemetry-app-insights-net.md
+++ b/articles/communication-services/quickstarts/includes/telemetry-app-insights-net.md
@@ -2,7 +2,7 @@
 title: include file
 description: include file
 services: azure-communication-services
-author: peiliu
+author: minnieliu
 manager: vravikumar
 
 ms.service: azure-communication-services

--- a/articles/communication-services/quickstarts/includes/telemetry-app-insights-net.md
+++ b/articles/communication-services/quickstarts/includes/telemetry-app-insights-net.md
@@ -48,7 +48,7 @@ dotnet add package Azure.Communication.Identity --version 1.0.0
 You will also need to install the Azure Monitor Exporter for OpenTelemetry library.
 
 ```console
-dotnet add package Azure.Monitor.OpenTelemetry.Exporter
+dotnet add package Azure.Monitor.OpenTelemetry.Exporter -v 1.0.0-beta.3
 ```
 
 ### Set up the app framework


### PR DESCRIPTION
If not specify the released version, installation of Azure.Monitor will return error:There are no stable versions available.
Update the command by specifying the latest version -v 1.0.0-beta.3