### PR TITLE
Update the command

### DIFF
--- a/articles/communication-services/quickstarts/includes/telemetry-app-insights-python.md
+++ b/articles/communication-services/quickstarts/includes/telemetry-app-insights-python.md
@@ -66,7 +66,7 @@ Add this code inside the `try` block:
 
 ```python
 connection_string = os.environ["COMMUNICATION_SERVICES_CONNECTION_STRING"]
-client = CommunicationIdentityClient.from_connection_string(connection_string)
+identity_client = CommunicationIdentityClient.from_connection_string(connection_string)
 ```
 
 First, in order to create the span that will allow you to trace the requests in the Azure Monitor, you will have to create an instance of an `AzureMonitorTraceExporter` object. You will need to provide the connection string from your Application Insights Resource.


### PR DESCRIPTION
In line 69 command "client = CommunicationIdentityClient.from_connection_string(connection_string)", change "client" to "identity_client" to avoid the confusion.
Because in the following line 92 command "user = identity_client.create_user()", where "identity_client" should be the one created from CommunicationIdentityClient.