### PR TITLE
Update how-to-connect-health-operations.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-health-operations.md
+++ b/articles/active-directory/hybrid/how-to-connect-health-operations.md
@@ -41,7 +41,7 @@ You can configure the Azure AD Connect Health service to send email notification
 >[!NOTE] 
 > When there are issues processing synchronization requests in our backend service, this service sends a notification email with the details of the error to the administrative contact email address(es) of your tenant. We heard feedback from customers that in certain cases the volume of these messages is prohibitively large so we are changing the way we send these messages. 
 >
-> Instead of sending a message for every sync error every time it occurs we will send out a daily digest of all errors the backend service has returned. This enables customers to process these errors in a more efficient manner and reduces the number of duplicate error messages.
+> Instead of sending a message for every sync error every time it occurs we will send out a daily digest of all errors the backend service has returned.(Can we include the date here from when Microsoft implemeneted the change?) This enables customers to process these errors in a more efficient manner and reduces the number of duplicate error messages.
 
 ## Delete a server or service instance
 


### PR DESCRIPTION
Can we know when this Note "Instead of sending a message for every sync error every time it occurs we will send out a daily digest of all errors the backend service has returned" was included in this document and by whom ?
Can we include when this change was implemented?