### PR TITLE
Code change required, need to be updated to accessToken from result.A…

### DIFF
--- a/articles/active-directory/develop/scenario-web-api-call-api-call-api.md
+++ b/articles/active-directory/develop/scenario-web-api-call-api-call-api.md
@@ -123,7 +123,7 @@ If you've decided to acquire a token manually by using the `ITokenAcquisition` s
 private async Task CallTodoListService(string accessToken)
 {
   // After the token has been returned by Microsoft.Identity.Web, add it to the HTTP authorization header before making the call to access the todolist service.
-  _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", result.AccessToken);
+  _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
   // Call the todolist service.
   HttpResponseMessage response = await _httpClient.GetAsync(TodoListBaseAddress + "/api/todolist");


### PR DESCRIPTION
The code block in Option 3: Call a downstream web API without the helper class should be updated to accessToken from result.AccessToken, as there is only one parameter, string accessToken in the function CallTodoListService. Open issue: https://github.com/MicrosoftDocs/azure-docs/issues/84251