### PR TITLE
FIxed wrong DN for the created service account

### DIFF
--- a/includes/active-directory-app-provisioning-ldap.md
+++ b/includes/active-directory-app-provisioning-ldap.md
@@ -163,7 +163,7 @@ Now that we have configured the certificate and granted the network service acco
      |Port|636|
      |Connection Timeout|180|
      |Binding|SSL|
-     |User Name|CN=svcAccount,CN=ServiceAccounts,CN=App,DC=contoso,DC=lab|
+     |User Name|CN=svcAccountLDAP,CN=ServiceAccounts,CN=App,DC=contoso,DC=lab|
      |Password|The password of the user name specified|
 
      >[!NOTE]


### PR DESCRIPTION
The service account created with the Powershell script in Appendix C is 'svcAccountLDAP' and not 'svcAccount'. Quick fix so people won't run into issues when following the setup guide.

#ATCP