### PR TITLE
Abort and Commit doesn't support CreateNewVirtualNetwork switch, upda…

### DIFF
--- a/articles/cloud-services-extended-support/in-place-migration-powershell.md
+++ b/articles/cloud-services-extended-support/in-place-migration-powershell.md
@@ -152,12 +152,12 @@ Move-AzureService -Prepare -ServiceName $serviceName -DeploymentName $deployment
 
 Check the configuration for the prepared Cloud Service (extended support) by using either Azure PowerShell or the Azure portal. If you're not ready for migration and you want to go back to the old state, abort the migration.
 ```powershell
-Move-AzureService -Abort -ServiceName $serviceName -DeploymentName $deploymentName -CreateNewVirtualNetwork
+Move-AzureService -Abort -ServiceName $serviceName -DeploymentName $deploymentName
 ```
 If you're ready to complete the migration, commit the migration
 
 ```powershell
-Move-AzureService -Commit -ServiceName $serviceName -DeploymentName $deploymentName -CreateNewVirtualNetwork
+Move-AzureService -Commit -ServiceName $serviceName -DeploymentName $deploymentName
 ```
 
 ### 5.1) Option 2 - Migrate a Cloud Service in a virtual network


### PR DESCRIPTION
…ting the command

Abort and Commit doesn't support CreateNewVirtualNetwork switch, updating the command, updating the below two commands
Move-AzureService -Abort -ServiceName $serviceName -DeploymentName $deploymentName -CreateNewVirtualNetwork

```powershell
Move-AzureService -Commit -ServiceName $serviceName -DeploymentName $deploymentName -CreateNewVirtualNetwork

// Abort and Commit doesn't support CreateNewVirtualNetwork switch, can this commands be updated?