### PR TITLE
Disabling --api-server-authorized-ip-ranges

### DIFF
--- a/articles/aks/api-server-authorized-ip-ranges.md
+++ b/articles/aks/api-server-authorized-ip-ranges.md
@@ -124,7 +124,7 @@ To disable authorized IP ranges, use [az aks update][az-aks-update] and specify 
 az aks update \
     --resource-group myResourceGroup \
     --name myAKSCluster \
-    --api-server-authorized-ip-ranges ""
+    --api-server-authorized-ip-ranges=""
 ```
 
 ## Find existing authorized IP ranges


### PR DESCRIPTION
Disabling --api-server-authorized-ip-ranges doesnt work with double quotes "" . It should be mentioned as --api-server-authorized-ip-ranges="" (https://github.com/Azure/azure-cli/issues/12565#issuecomment-603269364)

Otherwise it throws the below error even on using Azure CLI command.
PS C:\WINDOWS\system32> az aks update --resource-group rg-wb --name kubeexax2 --api-server-authorized-ip-ranges ""
ArgumentParseError: argument --api-server-authorized-ip-ranges: expected one argument
Try this: 'az aks update -g MyResourceGroup -n MyManagedCluster --api-server-authorized-ip-ranges ""'
Still stuck? Run 'az aks update --help' to view all commands or go to 'https://docs.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest' to learn more