### PR TITLE
Update language-studio.md

### DIFF
--- a/articles/cognitive-services/language-service/conversational-language-understanding/includes/quickstarts/language-studio.md
+++ b/articles/cognitive-services/language-service/conversational-language-understanding/includes/quickstarts/language-studio.md
@@ -122,4 +122,4 @@ You can test other utterances such as:
 You can also test out utterances in other languages such as the following phrases:
 
 * "*Joindre le fichier PDF*" (in French: "*Attach the PDF file*"), 
-* "*lesen sie die e-mail von Macy*" (in German: "*Read Macy's e-mail*")
+* "*Lesen Sie die E-mail von Macy*" (in German: "*Read Macy's e-mail*")


### PR DESCRIPTION
Fixed capitalization in German translation. Potentially even better: "Lies die E-Mail von Macy" (informal version).