### PR TITLE
Update configure-identity-source-vcenter.md

### DIFF
--- a/articles/azure-vmware/configure-identity-source-vcenter.md
+++ b/articles/azure-vmware/configure-identity-source-vcenter.md
@@ -87,7 +87,7 @@ You'll run the `New-AvsLDAPSIdentitySource` cmdlet to add an AD over LDAP with S
    | **SecondaryURL**  | Secondary fall-back URL if there's primary failure.  |
    | **BaseDNUsers**  |  Where to look for valid users, for example, **CN=users,DC=yourserver,DC=internal**.  Base DN is needed to use LDAP Authentication.  |
    | **BaseDNGroups**  | Where to look for groups, for example, **CN=group1, DC=yourserver,DC= internal**. Base DN is needed to use LDAP Authentication.  |
-   | **Credential**  | The username and password used for authentication with the AD source (not cloudadmin).  |
+   | **Credential**  | The username and password used for authentication with the AD source (not cloudadmin). The user must be in the **username@avsldap.local** format. |
    | **CertificateSAS** | Path to SAS strings with the certificates for authentication to the AD source. If you're using multiple certificates, separate each SAS string with a comma. For example, **pathtocert1,pathtocert2**.  |
    | **GroupName**  | Group in the external identity source that gives the cloudadmin access. For example, **avs-admins**.  |
    | **Retain up to**  | Retention period of the cmdlet output. The default value is 60 days.   |


### PR DESCRIPTION
Support team is getting service requests from clients who are trying to add LDAP(s) identity providing the user in the domain\user form and it fails with the message “Failed to probe provider connectivity”. Added the clarification that this needs to be provided as username@domain.suffix