### PR TITLE
Corrected maxMessages to maxMessageBatchSize

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus.md
+++ b/articles/azure-functions/functions-bindings-service-bus.md
@@ -136,7 +136,7 @@ The example host.json file below contains only the settings for version 5.0.0 an
             "maxAutoLockRenewalDuration": "00:05:00",
             "maxConcurrentCalls": 16,
             "maxConcurrentSessions": 8,
-            "maxMessages": 1000,
+            "maxMessageBatchSize": 1000,
             "sessionIdleTimeout": "00:01:00",
             "enableCrossEntityTransactions": false
         }
@@ -153,7 +153,7 @@ When using service bus extension version 5.x and higher, the following global co
 |maxAutoLockRenewalDuration|00:05:00|This should be used in place of `maxAutoRenewDuration`|
 |maxConcurrentCalls|16|The maximum number of concurrent calls to the callback that the message pump should initiate per scaled instance. By default, the Functions runtime processes multiple messages concurrently.|
 |maxConcurrentSessions|8|The maximum number of sessions that can be handled concurrently per scaled instance.|
-|maxMessages|1000|The maximum number of messages that will be passed to each function call. This only applies for functions that receive a batch of messages.|
+|maxMessageBatchSize|1000|The maximum number of messages that will be passed to each function call. This only applies for functions that receive a batch of messages.|
 |sessionIdleTimeout|n/a|The maximum amount of time to wait for a message to be received for the currently active session. After this time has elapsed, the processor will close the session and attempt to process another session.|
 |enableCrossEntityTransactions|false|Whether or not to enable transactions that span multiple entities on a Service Bus namespace.|
 


### PR DESCRIPTION
The ServiceBusOptions property which sets the maximum size for a batch is MaxMessageBatchSize, rather than MaxMessages.  ServiceBusOptions contains no such property 'MaxMessages'.