### PR TITLE
Change output file extension to mp3

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/how-to/text-to-speech-basics/text-to-speech-basics-curl.md
+++ b/articles/cognitive-services/Speech-Service/includes/how-to/text-to-speech-basics/text-to-speech-basics-curl.md
@@ -23,7 +23,7 @@ At a command prompt, run the following command. You will need to insert the foll
 You might also wish to change the following values.
 - The `X-Microsoft-OutputFormat` header value, which controls the audio output format. You can find a list of supported audio output formats in the [text-to-speech REST API reference](../../../rest-text-to-speech.md#audio-outputs).
 - The output voice. To get a list of voices available for your Speech endpoint, see the next section.
-- The output file. In this example, we direct the response from the server into a file named `output.wav`.
+- The output file. In this example, we direct the response from the server into a file named `output.mp3`.
 
 :::code language="curl" source="~/cognitive-services-quickstart-code/curl/speech/text-to-speech.sh":::
 


### PR DESCRIPTION
Change output file extension to be consistent with code snippet that shows pipe to a mp3 file instead of wav.