### PR TITLE
Update howto-authorize-rest-api.md

### DIFF
--- a/articles/iot-central/core/howto-authorize-rest-api.md
+++ b/articles/iot-central/core/howto-authorize-rest-api.md
@@ -109,7 +109,7 @@ Using the REST API:
 1. Use the REST API to create an API token for a role. For example, to create an API token called `operator-token` for the operator role:
 
     ```http
-    PUT https://{your app subdomain}.azureiotcentral.com/api/roles/operator-token?api-version=1.0
+    PUT https://{your app subdomain}.azureiotcentral.com/api/apiToken/operator-token?api-version=1.0
     ```
 
     Request body:


### PR DESCRIPTION
To create the token the correct endpoint after querying for roles is 
https://{your app subdomain}.azureiotcentral.com/api/apiToken/operator-token?api-version=1.0
as described here: https://docs.microsoft.com/en-us/rest/api/iotcentral/1.0dataplane/api-tokens/create