### PR TITLE
Virtual network integration are swapped

### DIFF
--- a/includes/app-service-deployment-slots-settings.md
+++ b/includes/app-service-deployment-slots-settings.md
@@ -19,6 +19,7 @@ When you clone configuration from another deployment slot, the cloned configurat
 * Hybrid connections *
 * Service endpoints *
 * Azure Content Delivery Network *
+* Virtual network integration *
 * Path mappings
 
 Features marked with an asterisk (*) are planned to be unswapped. 
@@ -34,7 +35,6 @@ Features marked with an asterisk (*) are planned to be unswapped.
 * Always On
 * Diagnostic settings
 * Cross-origin resource sharing (CORS)
-* Virtual network integration
 * Managed identities
 * Settings that end with the suffix _EXTENSION_VERSION
 


### PR DESCRIPTION
based on my test,  _Virtual network integration_ is swapped 
but the document said it is not.

This is the current document https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots#which-settings-are-swapped
<img width="829" alt="image" src="https://user-images.githubusercontent.com/5122476/143804374-7f03ba51-af05-43ab-9cf0-e702c7a5182a.png">



And in another page, it is as I said:
https://docs.microsoft.com/en-us/learn/modules/understand-app-service-deployment-slots/3-app-service-slot-swapping

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/5122476/143804336-5ef5d4b4-1bf9-40ab-b29f-fc07f6f686cb.png">

This description fits my test.

so we should change the   _Virtual network integration_ to the column of **Settings that are swapped**


