### PR TITLE
Updated steps to include MacOS and Linux support

### DIFF
--- a/articles/azure-arc/data/upload-metrics.md
+++ b/articles/azure-arc/data/upload-metrics.md
@@ -33,19 +33,35 @@ The Arc data services extension managed identity is used for uploading metrics. 
 
 ### (1) Retrieve managed identity of the Arc data controller extension
 
+# [PowerShell](#tab/powershell)
 ```powershell
 $Env:MSI_OBJECT_ID = (az k8s-extension show --resource-group <resource group>  --cluster-name <connectedclustername> --cluster-type connectedClusters --name <name of extension> | convertFrom-json).identity.principalId
 #Example
 $Env:MSI_OBJECT_ID = (az k8s-extension show --resource-group myresourcegroup  --cluster-name myconnectedcluster --cluster-type connectedClusters --name ads-extension | convertFrom-json).identity.principalId
 ```
 
+# [macOS & Linux](#tab/linux)
+```console
+export MSI_OBJECT_ID=`az k8s-extension show --resource-group <resource group>  --cluster-name <connectedclustername>  --cluster-type connectedClusters --name <name of extension> | jq '.identity.principalId' | tr -d \"`
+#Example
+export MSI_OBJECT_ID=`az k8s-extension show --resource-group myresourcegroup  --cluster-name myconnectedcluster --cluster-type connectedClusters --name ads-extension | jq '.identity.principalId' | tr -d \"`
+```
+
+---
+
 ### (2) Assign role to the managed identity
 
 Run the below command to assign the **Monitoring Metrics Publisher** role:
+# [PowerShell](#tab/powershell)
 ```powershell
 az role assignment create --assignee $Env:MSI_OBJECT_ID --role 'Monitoring Metrics Publisher' --scope "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME"
-
 ```
+
+# [macOS & Linux](#tab/linux)
+```console
+az role assignment create --assignee ${MSI_OBJECT_ID} --role 'Monitoring Metrics Publisher' --scope "/subscriptions/${subscription}/resourceGroups/${resourceGroup}"
+```
+---
 
 ### Automatic upload of metrics can be enabled as follows:
 ```


### PR DESCRIPTION
Added MacOS and Linux steps for "Retrieve managed identity of the Arc Data Controller Extension" and "Assign role to the managed identity"