### PR TITLE
Clarify connector type for SQL Server

### DIFF
--- a/articles/logic-apps/logic-apps-gateway-connection.md
+++ b/articles/logic-apps/logic-apps-gateway-connection.md
@@ -101,7 +101,7 @@ After you create your gateway resource and associate your Azure subscription wit
 
 1. In the Azure portal, create or open your logic app in the Logic App Designer.
 
-1. Add a connector that supports on-premises connections, for example, **SQL Server**.
+1. Add a connector that supports on-premises connections, for example, **SQL Server**. Specifcally, this needs to be a [managed connector](/azure/connectors/managed#on-premises-connectors), not a [built-in connector](/azure/connectors/built-in).
 
 1. Select **Connect via on-premises data gateway**.
 

--- a/articles/logic-apps/logic-apps-gateway-connection.md
+++ b/articles/logic-apps/logic-apps-gateway-connection.md
@@ -101,7 +101,7 @@ After you create your gateway resource and associate your Azure subscription wit
 
 1. In the Azure portal, create or open your logic app in the Logic App Designer.
 
-1. Add a connector that supports on-premises connections, for example, **SQL Server**. Specifcally, this needs to be a [managed connector](/azure/connectors/managed#on-premises-connectors), not a [built-in connector](/azure/connectors/built-in).
+1. Add a connector that supports on-premises connections. If this connector has both a [managed version](../connectors/managed.md#on-premises-connectors) and a [built-in version](../connectors/built-in.md), make sure that you use the managed version.
 
 1. Select **Connect via on-premises data gateway**.
 


### PR DESCRIPTION
I was trying to set this up as a demo and ran into some confusion with the SQL Server connector. By default the list of connectors shows the built-in ones, and the one for SQL Server doesn't support data gateways.