### PR TITLE
Update vmware-hcx-mon-guidance.md

### DIFF
--- a/articles/azure-vmware/vmware-hcx-mon-guidance.md
+++ b/articles/azure-vmware/vmware-hcx-mon-guidance.md
@@ -20,7 +20,9 @@ ms.date: 10/04/2021
 >[Limitations for any HCX deployment including MON](https://docs.vmware.com/en/VMware-HCX/4.2/hcx-user-guide/GUID-BEC26054-D560-46D0-98B4-7FF09501F801.html)
 
 
-[HCX Mobility Optimized Networking (MON)](https://docs.vmware.com/en/VMware-HCX/4.2/hcx-user-guide/GUID-0E254D74-60A9-479C-825D-F373C41F40BC.html) is an optional feature to enable when using [HCX Network Extensions (NE)](configure-hcx-network-extension.md). MON provides optimal traffic routing under certain scenarios to prevent network tromboning between the on-premises and cloud-based resources on extended networks. 
+[HCX Mobility Optimized Networking (MON)](https://docs.vmware.com/en/VMware-HCX/4.2/hcx-user-guide/GUID-0E254D74-60A9-479C-825D-F373C41F40BC.html) is an optional feature to enable when using [HCX Network Extensions (NE)](configure-hcx-network-extension.md). MON provides optimal traffic routing under certain scenarios to prevent network tromboning between the on-premises and cloud-based resources on extended networks.
+
+As MON is an enterprise capability of the NE feature, make sure you've enabled the [VMware HCX Enterprise](https://cloud.vmware.com/community/2019/08/08/introducing-hcx-enterprise/) add-on through a [support request](https://portal.azure.com/#create/Microsoft.Support). VMware HCX Enterprise Edition will be available for customers to add and run with their Azure VMware Solution environment free of charge until 10/1/2022.
 
 Throughout the migration cycle, MON optimizes application mobility for:
 


### PR DESCRIPTION
According to VMware HCX documentation an HCX enterprise license is required for mobility optimized networking which should be reflected in our docs:
HCX Mobility Optimized Networking (MON) is an enterprise capability of the VMware HCX Network Extension (HCX-NE) feature.
https://docs.vmware.com/en/VMware-HCX/4.2/hcx-user-guide/GUID-D06ABBEE-CF8D-4506-A5DC-61B63D9B9EE5.html