### PR TITLE
add missing parameter

### DIFF
--- a/articles/aks/ingress-internal-ip.md
+++ b/articles/aks/ingress-internal-ip.md
@@ -103,6 +103,7 @@ helm install nginx-ingress ingress-nginx/ingress-nginx \
     --set defaultBackend.image.image=$DEFAULTBACKEND_IMAGE \
     --set defaultBackend.image.tag=$DEFAULTBACKEND_TAG \
     --set defaultBackend.image.digest=""
+    -f internal-ingress.yaml
 ```
 
 When the Kubernetes load balancer service is created for the NGINX ingress controller, your internal IP address is assigned. To get the public IP address, use the `kubectl get service` command.


### PR DESCRIPTION
There seemed to be a parameter (`-f`) missing.
I think this parameter is necessary because we are using the IP of 10.240.0.42 later on.

If you are showing this in the case without parameters, please reject it.