### PR TITLE
Add details about how to capture PTA Agent ID

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-pta-faq.yml
+++ b/articles/active-directory/hybrid/how-to-connect-pta-faq.yml
@@ -26,7 +26,7 @@ sections:
   - name: Ignored
     questions:
       - question: |
-          Which of the methods to sign in to Azure AD, Pass-through Authentication, password hash synchronization, and Active Directory Federation Services (AD FS), should I choose?
+          Which of the methods to sign in to Azure AD, Pass-through Authentication, password hash synchronization, and Active Directory Federation Services (AD FS) should I choose?
         answer: |
           Review [this guide](./choose-ad-authn.md) for a comparison of the various Azure AD sign-in methods and how to choose the right sign-in method for your organization.
           
@@ -172,30 +172,33 @@ sections:
           If you uninstall a Pass-through Authentication Agent from a server, it causes the server to stop accepting sign-in requests. To avoid breaking the user sign-in capability on your tenant, ensure that you have another Authentication Agent running before you uninstall a Pass-through Authentication Agent.
 
       - question: |
-          I have an older tenant that was originally setup using AD FS.  We recently migrated to PTA but now are not seeing our UPN changes synchronizing to Azure AD.  Why are our UPN changes not being synchronized?
+          I have an older tenant that was originally setup using AD FS. We recently migrated to PTA, but now are not seeing our UPN changes synchronizing to Azure AD. Why are our UPN changes not being synchronized?
         answer: |
-          A: Under the following circumstances your on-premises UPN changes may not synchronize if:
+          Under the following circumstances your on-premises UPN changes might not synchronize if:
           
-          - Your Azure AD tenant was created prior to June 15th 2015
-          - You initially were federated with your Azure AD tenant using AD FS for authentication
-          - You switched to having managed users using PTA as authentication
+          - Your Azure AD tenant was created prior to June 15, 2015.
+          - You initially were federated with your Azure AD tenant using AD FS for authentication.
+          - You switched to having managed users using PTA as authentication.
           
-          This is because the default behavior of tenants created prior to June 15th 2015 was to block UPN changes.  If you need to un-block UPN changes you need to run the following PowerShell cmdlt:  
+          This is because the default behavior of tenants created prior to June 15, 2015 was to block UPN changes. If you need to un-block UPN changes you need to run the following PowerShell cmdlet:  
           
           `Set-MsolDirSyncFeature -Feature SynchronizeUpnForManagedUsers -Enable $True`
           
-          Tenants created after June 15th 2015 have the default behavior of synchronizing UPN changes.   
+          Tenants created after June 15, 2015 have the default behavior of synchronizing UPN changes.   
           
-          - question: |
-            How to capture PTA Agent ID from Azure AD Sign-In logs and PTA Server to validate which PTA Server was used for a sign-in event?
-            A: If you would like to validate which Local Server/Authentication Agent was used for a particular Sign-In event, you can try following steps to capture the details:
+      - question: |
+          How do I capture the PTA Agent ID from Azure AD sign-in logs and the PTA server to validate which PTA server was used for a sign-in event?
+        answer: |
+          To validate which local server or authentication agent was used for a specific sign-in event:
 
-	          - Browse to Sign-In event on Azure Portal.
-	          - Click on Authentication Details and under Authentication Method Detail column, you would see Agent ID details in following format: "Pass-through Authentication; PTA AgentId: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
-	          - To get Agent ID details for installed agent on your local server, Login to your local server and use following command: 
-		            ○ Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Azure AD Connect Agents\Azure AD Connect Authentication Agent' | Select *Instance*
-	          - The GUID value returned by above command, is the Agent ID of Authentication Agent installed on that particular server. If you have multiple agents in your environment, you can run this command on each Agent Server and capture the Agent ID details.
-	          - You can later correlate these Agent Id's obtained from local server as well as Azure AD Sign-In log to validate which Agent/Server is the Sign-request being acknowledged by.
+          1. In the Azure portal, go to the sign-in event.
+          2. Select **Authentication Details**. In the **Authentication Method Detail** column, Agent ID details are shown in the format "Pass-through Authentication; PTA AgentId: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".
+          3. To get Agent ID details for the agent that's installed on your local server, log in to your local server and run following cmdlet: 
+          
+              `Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Azure AD Connect Agents\Azure AD Connect Authentication Agent' | Select *Instance*`
+          
+              The GUID value that's returned is the Agent ID of the authentication agent that's installed on that specific server. If you have multiple agents in your environment, you can run this cmdlet on each agent server and capture the Agent ID details.
+          4. Correlate the Agent ID that you get from the local server and from the Azure AD sign-in logs to validate which agent or server acknowledged the sign-request.
             
 additionalContent: |
 

--- a/articles/active-directory/hybrid/how-to-connect-pta-faq.yml
+++ b/articles/active-directory/hybrid/how-to-connect-pta-faq.yml
@@ -186,6 +186,17 @@ sections:
           
           Tenants created after June 15th 2015 have the default behavior of synchronizing UPN changes.   
           
+          - question: |
+            How to capture PTA Agent ID from Azure AD Sign-In logs and PTA Server to validate which PTA Server was used for a sign-in event?
+            A: If you would like to validate which Local Server/Authentication Agent was used for a particular Sign-In event, you can try following steps to capture the details:
+
+	          - Browse to Sign-In event on Azure Portal.
+	          - Click on Authentication Details and under Authentication Method Detail column, you would see Agent ID details in following format: "Pass-through Authentication; PTA AgentId: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+	          - To get Agent ID details for installed agent on your local server, Login to your local server and use following command: 
+		            ○ Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Azure AD Connect Agents\Azure AD Connect Authentication Agent' | Select *Instance*
+	          - The GUID value returned by above command, is the Agent ID of Authentication Agent installed on that particular server. If you have multiple agents in your environment, you can run this command on each Agent Server and capture the Agent ID details.
+	          - You can later correlate these Agent Id's obtained from local server as well as Azure AD Sign-In log to validate which Agent/Server is the Sign-request being acknowledged by.
+            
 additionalContent: |
 
   ## Next steps


### PR DESCRIPTION
This is was identified as a potential information been looked up by customers. This update would shed some light on how customers can find PTA Agent ID details on Azure AD Sign-In logs and on Server were Agent is deployed. Later it can be used to validate which server is the sign-in requests hit and customer's can utilize this for performance troubleshooting.