### PR TITLE
Add notes about project domain setting

### DIFF
--- a/articles/azure-percept/how-to-deploy-model.md
+++ b/articles/azure-percept/how-to-deploy-model.md
@@ -33,7 +33,7 @@ Follow this guide to deploy a vision AI model to your Azure Percept DK from with
 
     :::image type="content" source="./media/how-to-deploy-model/select-device.png" alt-text="Percept devices list.":::
 
-1. On the next page, click **Deploy a sample model** if you would like to deploy one of the pre-trained sample vision models. If you would like to deploy an existing [custom no-code vision solution](./tutorial-nocode-vision.md), click **Deploy a Custom Vision project**.
+1. On the next page, click **Deploy a sample model** if you would like to deploy one of the pre-trained sample vision models. If you would like to deploy an existing [custom no-code vision solution](./tutorial-nocode-vision.md), click **Deploy a Custom Vision project**. If you do not see your Custom Vision projects, set project's domain to one of Compact domains on [Custom Vision portal](https://www.customvision.ai/) and train a model again. Only Compact domains support model export to edge devices.
 
     :::image type="content" source="./media/how-to-deploy-model/deploy-model.png" alt-text="Model choices for deployment.":::
 


### PR DESCRIPTION
Add notes about Custom Vision project domain setting. Percept Studio requires Compact domains to export models.