### PR TITLE
Update faq.yml

### DIFF
--- a/articles/azure-vmware/faq.yml
+++ b/articles/azure-vmware/faq.yml
@@ -110,16 +110,16 @@ sections:
         answer: No. To meet the VM prerequisites, follow the [instructions provided by VMware](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-89E7E8F0-DB2B-437F-8F70-BA34C505053F.html). 
 
       - question: Can I use vRealize Suite running on-premises? 
-        answer: Specific integrations and use cases are evaluated on a case-by-case basis.
+        answer: vRealize Automation, vRealize Operations Manager, and vRealize Network Insight are certified for use with Azure VMware Solution when those products are installed in an on-premises datacenter. The cloud-based versions of these products--vRealize Automation Cloud, vRealize Operations Cloud, and vRealize Network Insight Cloud--are also certified for use. Installing these products within an Azure VMware Solution private cloud is not supported.
 
       - question: Can I migrate vSphere VMs from on-premises environments to Azure VMware Solution private clouds?
         answer: Yes. VM migration and vMotion can be used to move VMs to a private cloud if standard cross vCenter [vMotion requirements](https://kb.vmware.com/s/article/2106952?lang=en_US&queryTerm=2106952) are met.
           
       - question: Is a specific version of vSphere required in on-premises environments?
-        answer: All cloud environments come with VMware HCX, vSphere 5.5, or later in on-premises environments for vMotion.
+        answer: The on-premises environment must be running vSphere 6.0 or later if VMware HCX will be used to migrate VMs.
 
       - question: Is VMware HCX supported on VPNs?
-        answer: No, because of bandwidth and latency requirements.
+        answer: Yes, provided VMware HCX [Network Underlay Minimum Requirements](https://docs.vmware.com/en/VMware-HCX/4.2/hcx-user-guide/GUID-8128EB85-4E3F-4E0C-A32C-4F9B15DACC6D.html) are met.
 
       - question: What versions of VMware software are used in private clouds?
         answer: |


### PR DESCRIPTION
Updates from recent and semi-recent announcements:

Support for vRealize Suite components running on-prem: https://blogs.vmware.com/management/2021/05/vrealize-cloud-management-tested-and-certified-with-azure-vmware-solution.html

Minimum versions required on-prem: vSphere 5.5 is out of support, HCX 4.2 requires vSphere 6.0 or later.

HCX is supported over VPN: https://azure.microsoft.com/en-us/updates/hx-enterprise-edition-is-now-generally-available-for-azure-vmware-solution/