### PR TITLE
Update service-accounts-group-managed.md

### DIFF
--- a/articles/active-directory/fundamentals/service-accounts-group-managed.md
+++ b/articles/active-directory/fundamentals/service-accounts-group-managed.md
@@ -71,10 +71,10 @@ Uninstall-ADServiceAccount
 ```
 
 
-To work effectively, gMSAs must be in the managed service account's organizational unit (OU).
+To work effectively, gMSAs must be in the Managed Service Accounts AD container.
 
   
-![Screen shot of a gMSA account in the managed service account OU.](./media/securing-service-accounts/secure-gmsa-image-1.png)
+![Screen shot of a gMSA account in the managed service accounts container.](./media/securing-service-accounts/secure-gmsa-image-1.png)
 
 To find service MSAs that might not be in the list, run the following commands:
 


### PR DESCRIPTION
Fixed an incorrect assertion that the Managed Service Accounts container is an Organizational Unit (OU).  This is, in fact, not an OU but an Active Directory container; meaning that it is a different object type.  One key differentiator is that AD containers cannot have group policies linked to them.  They can only be linked to OUs.