### PR TITLE
Remove exporting remote skill link

### DIFF
--- a/articles/cognitive-services/Speech-Service/toc.yml
+++ b/articles/cognitive-services/Speech-Service/toc.yml
@@ -469,8 +469,6 @@ items:
                       href: how-to-custom-commands-send-activity-to-client.md
                     - name: Set up web endpoints
                       href: how-to-custom-commands-setup-web-endpoints.md
-                    - name: Export your Custom Commands app as a skill
-                      href: how-to-custom-commands-integrate-remote-skills.md
                     - name: Update a command from the client app
                       href: how-to-custom-commands-update-command-from-client.md
                     - name: Update a command from a web endpoint


### PR DESCRIPTION
The remote skill is a preview feature and not enabled on PROD. Remove the link from public folder. 
The instruction page itself is not deleted since we may pick it up later when the feature is published.