### PR TITLE
Clarification on AIP Plan

### DIFF
--- a/articles/purview/sensitivity-labels-frequently-asked-questions.yml
+++ b/articles/purview/sensitivity-labels-frequently-asked-questions.yml
@@ -30,7 +30,7 @@ sections:
           * Microsoft 365 E5/A5/G5
           * Microsoft 365 E5/A5/G5 Compliance 
           * Microsoft 365 E5/A5/G5 Information Protection, and Governance,  
-          * Office 365 E5, Enterprise Mobility + Security E5/A5/G5, and AIP Plan  
+          * Office 365 E5, Enterprise Mobility + Security E5/A5/G5, and AIP Plan 2 
           
           For more information, see [Microsoft 365 service descriptions](/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#information-protection).
 


### PR DESCRIPTION
We mention "Office 365 E5, Enterprise Mobility + Security E5/A5/G5" + "and AIP Plan", without specifyin P1 or P2, so I suppose this is the AIP P2 that is requiered (as EMS E5), so to be sure there is no confusion with AIP P1. it's better to clarify it.