### PR TITLE
Properly dispose HMAC in EventHub SAS C# sample

### DIFF
--- a/articles/event-hubs/authenticate-shared-access-signature.md
+++ b/articles/event-hubs/authenticate-shared-access-signature.md
@@ -161,10 +161,12 @@ private static string createToken(string resourceUri, string keyName, string key
     var week = 60 * 60 * 24 * 7;
     var expiry = Convert.ToString((int)sinceEpoch.TotalSeconds + week);
     string stringToSign = HttpUtility.UrlEncode(resourceUri) + "\n" + expiry;
-    HMACSHA256 hmac = new HMACSHA256(Encoding.UTF8.GetBytes(key));
-    var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(stringToSign)));
-    var sasToken = String.Format(CultureInfo.InvariantCulture, "SharedAccessSignature sr={0}&sig={1}&se={2}&skn={3}", HttpUtility.UrlEncode(resourceUri), HttpUtility.UrlEncode(signature), expiry, keyName);
-    return sasToken;
+    using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(key)))
+    {
+        var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(stringToSign)));
+        var sasToken = String.Format(CultureInfo.InvariantCulture, "SharedAccessSignature sr={0}&sig={1}&se={2}&skn={3}", HttpUtility.UrlEncode(resourceUri), HttpUtility.UrlEncode(signature), expiry, keyName);
+        return sasToken;
+    }
 }
 ```
 


### PR DESCRIPTION
HMACSHA256 is not disposed in the sample.
This aligns more with the code used in the EventHub SDK: https://github.com/Azure/azure-sdk-for-net/blob/492acee119e77d0350d73c232cecfafca8f1b2d8/sdk/servicebus/Azure.Messaging.ServiceBus/src/Authorization/SharedAccessSignature.cs#L348-L360