### PR TITLE
Reporting a bug with Safari crash when user switch camera view.

### DIFF
--- a/articles/communication-services/concepts/known-issues.md
+++ b/articles/communication-services/concepts/known-issues.md
@@ -22,6 +22,14 @@ This article provides information about limitations and known issues related to 
 
 The following sections provide information about known issues associated with the Communication Services JavaScript voice and video calling SDKs.
 
+### iOS with Safari crashes and refreshes the page if a user tries to switch from front camera to back back camera.
+
+ACS Calling SDK version 1.2.3-beta.1 introduced a bug that affects all the calls made with from iOS Safari. The problem occurs when a user tries to switch the camera video stream from front to back. Switching camera results in Safari browe to crash.
+
+This issue is fixed in ACS Calling SDK version 1.3.1-beta.1.
+
+* iOS Safari version: 15.1
+
 ### iOS with Safari crashes and refreshes the page if a user tries to send video in a call
 
 iOS 15.1 introduced a bug that affects the majority of Communication Services calls with video that are placed in iOS with Safari. Specifically, the problem occurs when a user joins a Communication Services call or a meeting in Microsoft Teams by using Communication Services on iOS 15.1 on any browser with video turned on. This set of circumstances causes the Safari browser to crash.


### PR DESCRIPTION
There's a bug in SDK version: 1.2.3-beta.1, that crashes users iOS Safari browsers when  user switches view from front camera to back camera.