### PR TITLE
Update storage-tutorial-queues.md

### DIFF
--- a/articles/storage/queues/storage-tutorial-queues.md
+++ b/articles/storage/queues/storage-tutorial-queues.md
@@ -306,7 +306,7 @@ Here is the complete code listing for this project.
 
    ```output
    C:\Tutorials\QueueApp>dotnet run First queue message
-   The queue was created.
+   The queue got created.
    Sent: First queue message
    Press Enter..._
    ```
@@ -321,7 +321,7 @@ Here is the complete code listing for this project.
 
    ```output
    C:\Tutorials\QueueApp>dotnet run First queue message
-   The queue was created.
+   The queue got created.
    Sent: First queue message
    Press Enter...
 


### PR DESCRIPTION
"The queue was created" is grammatically correct, though it has a semantic issue when used here. It can be mistaken with "The queue was (already) created," which means the opposite of the queue did not exist, so according to your request it "got created."