### PR TITLE
added hint referring to the password policy

### DIFF
--- a/articles/active-directory/enterprise-users/users-bulk-add.md
+++ b/articles/active-directory/enterprise-users/users-bulk-add.md
@@ -49,6 +49,7 @@ The rows in a downloaded CSV template are as follows:
 - We don't recommend adding new columns to the template. Any additional columns you add are ignored and not processed.
 - We recommend that you download the latest version of the CSV template as often as possible.
 - Make sure to check there is no unintended whitespace before/after any field. For **User principal name**, having such whitespace would cause import failure.
+- Ensure that values in the **Initial password** field must comply with the currently active [Password Policy](https://docs.microsoft.com/en-in/azure/active-directory/authentication/concept-sspr-policy#password-policies-that-only-apply-to-cloud-user-accounts).
 
 ## To create users in bulk
 

--- a/articles/active-directory/enterprise-users/users-bulk-add.md
+++ b/articles/active-directory/enterprise-users/users-bulk-add.md
@@ -49,7 +49,7 @@ The rows in a downloaded CSV template are as follows:
 - We don't recommend adding new columns to the template. Any additional columns you add are ignored and not processed.
 - We recommend that you download the latest version of the CSV template as often as possible.
 - Make sure to check there is no unintended whitespace before/after any field. For **User principal name**, having such whitespace would cause import failure.
-- Ensure that values in the **Initial password** field must comply with the currently active [Password Policy](https://docs.microsoft.com/en-in/azure/active-directory/authentication/concept-sspr-policy#password-policies-that-only-apply-to-cloud-user-accounts).
+- Ensure that values in **Initial password** comply with the currently active [password policy](../authentication/concept-sspr-policy.md#password-policies-that-only-apply-to-cloud-user-accounts).
 
 ## To create users in bulk
 


### PR DESCRIPTION
Good day! I just wasted almost an hour with failing bulk creation figuring out what was wrong.
The error message was `Request was unsuccessful.` with no additional details provided. Turned out that my initial passwords in the CSV file were not complex enough (i.e. did not adhere to the password policy)

I hope this hint will help others to save some time.