### PR TITLE
Corrected curated image

### DIFF
--- a/articles/machine-learning/tutorial-1st-experiment-sdk-train.md
+++ b/articles/machine-learning/tutorial-1st-experiment-sdk-train.md
@@ -162,7 +162,7 @@ if __name__ == "__main__":
                              compute_target='cpu-cluster')
 
     # use curated pytorch environment 
-    env = ws.environments['AzureML-PyTorch-1.6-CPU']
+    env = ws.environments['AzureML-pytorch-1.7-ubuntu18.04-py37-cuda11-gpu']
     config.run_config.environment = env
 
     run = experiment.submit(config)


### PR DESCRIPTION
The referenced "AzureML-PyTorch-1.6-CPU" curated image no longer exists, and direct pytorch 1.6 version "AzureML-pytorch-1.6-ubuntu18.04-py37-cpu-inference" is missing torchvision package.  Assuming you don't want custom package environment setup or using GPU backed in this walk through, "AzureML-pytorch-1.7-ubuntu18.04-py37-cpu-inference" curated image works.