### PR TITLE
 Windows Explorer doesn't support FTPS deployment

### DIFF
--- a/articles/app-service/deploy-ftp.md
+++ b/articles/app-service/deploy-ftp.md
@@ -79,7 +79,7 @@ $xml.SelectNodes("//publishProfile[@publishMethod=`"FTP`"]/@publishUrl").value
 
 ## Enforce FTPS
 
-For enhanced security, you should allow FTP over TLS/SSL only. You can also disable both FTP and FTPS if you don't use FTP deployment.
+For enhanced security, you should allow FTP over TLS/SSL only. You can also disable both FTP and FTPS if you don't use FTP deployment. Windows Explorer doesn't support FTPS connection by design.
 
 # [Azure portal](#tab/portal)
 


### PR DESCRIPTION
We need to update the documentation to explicitly state that FTPS deployment isn't supported by Windows Explorer, even though FTP deployments can be done. 
During a recent support case interaction, customer had to make extensive changes to adopt a 3rd party FTP client for the developer machines.