### PR TITLE
Update cdn-features.md

### DIFF
--- a/articles/cdn/cdn-features.md
+++ b/articles/cdn/cdn-features.md
@@ -68,7 +68,7 @@ The following table compares the features available with each product.
 | Easy integration with Azure services, such as [Storage](cdn-create-a-storage-account-with-cdn.md), [Web Apps](cdn-add-to-web-app.md), and [Media Services](../media-services/previous/media-services-portal-manage-streaming-endpoints.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | Management via [REST API](/rest/api/cdn/), [.NET](cdn-app-dev-net.md), [Node.js](cdn-app-dev-node.md), or [PowerShell](cdn-manage-powershell.md)  | **&#x2713;** |**&#x2713;** |**&#x2713;** |**&#x2713;** |
 | [Compression MIME types](./cdn-improve-performance.md)  |Configurable |Configurable |Configurable  |Configurable  |
-| Compression encodings  |gzip, brotli |gzip |gzip, deflate, bzip2, brotli  |gzip, deflate, bzip2, brotli  |
+| Compression encodings  |gzip, brotli |gzip |gzip, deflate, bzip2  |gzip, deflate, bzip2  |
 
 ## Migration
 


### PR DESCRIPTION
DOC: https://docs.microsoft.com/en-us/azure/cdn/cdn-improve-performance#azure-cdn-from-verizon-profiles 
Clearly calls out Brotli compression is not supported by Azure verizon CDN. The info in CDN-features.md is just contradicting the same.
Further investigation on this revealed, Brotli compression is not supported by default by Azure Verizon and is "Off the Menu" feature. Only verizon can enable on request and to enforce it few changes needs to be done, so its better to not list this as supported, be in the sync with the other MS document mentioned above,