### PR TITLE
Updated `master` to `main`

### DIFF
--- a/articles/storage/blobs/storage-blobs-static-site-github-actions.md
+++ b/articles/storage/blobs/storage-blobs-static-site-github-actions.md
@@ -87,7 +87,7 @@ In the example above, replace the placeholders with your subscription ID and res
 
     on:
         push:
-            branches: [ master ]
+            branches: [ main ]
     ```
 
 1. Rename your workflow `Blob storage website CI` and add the checkout and login actions. These actions will checkout your site code and authenticate with Azure using the `AZURE_CREDENTIALS` GitHub secret you created earlier.
@@ -97,7 +97,7 @@ In the example above, replace the placeholders with your subscription ID and res
 
     on:
         push:
-            branches: [ master ]
+            branches: [ main ]
 
     jobs:
       build:
@@ -131,7 +131,7 @@ In the example above, replace the placeholders with your subscription ID and res
 
     on:
         push:
-            branches: [ master ]
+            branches: [ main ]
 
     jobs:
       build:


### PR DESCRIPTION
Was reading through the article and noticed the `master` branch, changed it to `main` as this is the defacto standard nowadays.

Not sure what the policy is on this in the docs, but thought it wouldn't hurt to make this change.