### PR TITLE
"Azure Machine Learning" service is not available

### DIFF
--- a/articles/machine-learning/concept-plan-manage-cost.md
+++ b/articles/machine-learning/concept-plan-manage-cost.md
@@ -130,7 +130,7 @@ Actual monthly costs are shown when you initially open cost analysis. Here's an 
 :::image type="content" source="media/concept-plan-manage-cost/all-costs.png" alt-text="Example showing accumulated costs for a subscription." lightbox="media/concept-plan-manage-cost/all-costs.png" :::
 
 
-To narrow costs for a single service, like Azure Machine Learning, select **Add filter** and then select **Service name**. Then, select **Azure Machine Learning**.
+To narrow costs for a single service, like Azure Machine Learning, select **Add filter** and then select **Service name**. Then, select **virtual machines**.
 
 Here's an example showing costs for just Azure Machine Learning.
 


### PR DESCRIPTION
Suggesting to make the text consistent with what the user should do. There is no "Azure Machine Learning" service name, and the screenshot below shows "virtual machines".