### PR TITLE
Updating default and supported Functions runtime versions.

### DIFF
--- a/articles/azure-functions/set-runtime-version.md
+++ b/articles/azure-functions/set-runtime-version.md
@@ -9,7 +9,7 @@ ms.custom: devx-track-azurepowershell
 
 # How to target Azure Functions runtime versions
 
-A function app runs on a specific version of the Azure Functions runtime. There are three major versions: [3.x, 2.x, and 1.x](functions-versions.md). By default, function apps are created in version 3.x of the runtime. This article explains how to configure a function app in Azure to run on the version you choose. For information about how to configure a local development environment for a specific version, see [Code and test Azure Functions locally](functions-run-local.md).
+A function app runs on a specific version of the Azure Functions runtime. There are three major versions: [4.x, 3.x, 2.x, and 1.x](functions-versions.md). By default, function apps are created in version 4.x of the runtime. This article explains how to configure a function app in Azure to run on the version you choose. For information about how to configure a local development environment for a specific version, see [Code and test Azure Functions locally](functions-run-local.md).
 
 The way that you manually target a specific version depends on whether you're running Windows or Linux.
 


### PR DESCRIPTION
We recently [launched v4](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/azure-functions-4-0-and-net-6-support-are-now-generally/ba-p/2933245) of Azure Functions and that's now the default runtime when a customer creates a new function. 