### PR TITLE
Updated CSE VMSS instructions

### DIFF
--- a/articles/virtual-machines/extensions/custom-script-linux.md
+++ b/articles/virtual-machines/extensions/custom-script-linux.md
@@ -376,7 +376,7 @@ az vm extension set \
 >[!NOTE]
 >When deploying the Custom Script Extension from the Azure Portal you don't have control over the expiration of the SAS token for accessing the script in your storage account. So this means that the initial deployment will work, but then after the storage account SAS token expires any subsequent scaling operation will fail as the CSE can no longer access the storage account.
 >
->For this reason it is highly recommended to use PowerShell, CLI, or an ARM template when deploying the Custom Script Extension on a VMSS. This way you can choose to use a managed identity or have direct control of the expiration of the SAS token for accessing the script in your storage account for as long as you need.
+>For this reason it is highly recommended to use [PowerShell](https://docs.microsoft.com/en-us/powershell/module/az.Compute/Add-azVmssExtension?view=azps-7.0.0), [CLI](https://docs.microsoft.com/en-us/cli/azure/vmss/extension?view=azure-cli-latest), or an ARM template when deploying the Custom Script Extension on a VMSS. This way you can choose to use a managed identity or have direct control of the expiration of the SAS token for accessing the script in your storage account for as long as you need.
 
 ## Troubleshooting
 When the Custom Script Extension runs, the script is created or downloaded into a directory that's similar to the following example. The command output is also saved into this directory in `stdout` and `stderr` files.

--- a/articles/virtual-machines/extensions/custom-script-linux.md
+++ b/articles/virtual-machines/extensions/custom-script-linux.md
@@ -52,7 +52,6 @@ If your script is on a local server, then you may still need additional firewall
 * When the script is running, you will only see a 'transitioning' extension status from the Azure portal or CLI. If you want more frequent status updates of a running script, you will need to create your own solution.
 * Custom Script extension does not natively support proxy servers, however you can use a file transfer tool that supports proxy servers within your script, such as *Curl*. 
 * Be aware of non default directory locations that your scripts or commands may rely on, have logic to handle this.
-*  When deploying custom script to production VMSS instances it is suggested to deploy via json template and store your script storage account where you have control over the SAS token. 
 
 
 ## Extension schema
@@ -372,6 +371,12 @@ az vm extension set \
   --settings ./script-config.json \
   --protected-settings ./protected-config.json
 ```
+
+## Virtual Machine Scale Sets
+>[!NOTE]
+>When deploying the Custom Script Extension from the Azure Portal you don't have control over the expiration of the SAS token for accessing the script in your storage account. So this means that the initial deployment will work, but then after the storage account SAS token expires any subsequent scaling operation will fail as the CSE can no longer access the storage account.
+>
+>For this reason it is highly recommended to use PowerShell, CLI, or an ARM template when deploying the Custom Script Extension on a VMSS. This way you can choose to use a managed identity or have direct control of the expiration of the SAS token for accessing the script in your storage account for as long as you need.
 
 ## Troubleshooting
 When the Custom Script Extension runs, the script is created or downloaded into a directory that's similar to the following example. The command output is also saved into this directory in `stdout` and `stderr` files.

--- a/articles/virtual-machines/extensions/custom-script-linux.md
+++ b/articles/virtual-machines/extensions/custom-script-linux.md
@@ -372,11 +372,11 @@ az vm extension set \
   --protected-settings ./protected-config.json
 ```
 
-## Virtual Machine Scale Sets
->[!NOTE]
->When deploying the Custom Script Extension from the Azure Portal you don't have control over the expiration of the SAS token for accessing the script in your storage account. So this means that the initial deployment will work, but then after the storage account SAS token expires any subsequent scaling operation will fail as the CSE can no longer access the storage account.
->
->For this reason it is highly recommended to use [PowerShell](https://docs.microsoft.com/en-us/powershell/module/az.Compute/Add-azVmssExtension?view=azps-7.0.0), [CLI](https://docs.microsoft.com/en-us/cli/azure/vmss/extension?view=azure-cli-latest), or an ARM template when deploying the Custom Script Extension on a VMSS. This way you can choose to use a managed identity or have direct control of the expiration of the SAS token for accessing the script in your storage account for as long as you need.
+## Virtual machine scale sets
+
+If you deploy the Custom Script Extension from the Azure portal, you don't have control over the expiration of the shared access signature token for accessing the script in your storage account. The result is that the initial deployment works, but when the storage account shared access signature token expires, any subsequent scaling operation fails because the Custom Script Extension can no longer access the storage account.
+
+We recommend that you use [PowerShell](/powershell/module/az.Compute/Add-azVmssExtension?view=azps-7.0.0), the [Azure CLI](/cli/azure/vmss/extension?view=azure-cli-latest), or an Azure Resource Manager template when you deploy the Custom Script Extension on a virtual machine scale set. This way, you can choose to use a managed identity or have direct control of the expiration of the shared access signature token for accessing the script in your storage account for as long as you need.
 
 ## Troubleshooting
 When the Custom Script Extension runs, the script is created or downloaded into a directory that's similar to the following example. The command output is also saved into this directory in `stdout` and `stderr` files.

--- a/articles/virtual-machines/extensions/custom-script-windows.md
+++ b/articles/virtual-machines/extensions/custom-script-windows.md
@@ -287,12 +287,12 @@ If you are using [Invoke-WebRequest](/powershell/module/microsoft.powershell.uti
 ```error
 The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
 ```
-## Virtual Machine Scale Sets
 
->[!NOTE]
->When deploying the Custom Script Extension from the Azure Portal you don't have control over the expiration of the SAS token for accessing the script in your storage account. So this means that the initial deployment will work, but then after the storage account SAS token expires any subsequent scaling operation will fail as the CSE can no longer access the storage account.
->
->For this reason it is highly recommended to use [PowerShell](https://docs.microsoft.com/en-us/powershell/module/az.Compute/Add-azVmssExtension?view=azps-7.0.0), [CLI](https://docs.microsoft.com/en-us/cli/azure/vmss/extension?view=azure-cli-latest), or an ARM template when deploying the Custom Script Extension on a VMSS. This way you can choose to use a managed identity or have direct control of the expiration of the SAS token for accessing the script in your storage account for as long as you need.
+## Virtual machine scale sets
+
+If you deploy the Custom Script Extension from the Azure portal, you don't have control over the expiration of the shared access signature token for accessing the script in your storage account. The result is that the initial deployment works, but when the storage account shared access signature token expires, any subsequent scaling operation fails because the Custom Script Extension can no longer access the storage account.
+
+We recommend that you use [PowerShell](/powershell/module/az.Compute/Add-azVmssExtension?view=azps-7.0.0), the [Azure CLI](/cli/azure/vmss/extension?view=azure-cli-latest), or an Azure Resource Manager template when you deploy the Custom Script Extension on a virtual machine scale set. This way, you can choose to use a managed identity or have direct control of the expiration of the shared access signature token for accessing the script in your storage account for as long as you need.
 
 ## Classic VMs
 

--- a/articles/virtual-machines/extensions/custom-script-windows.md
+++ b/articles/virtual-machines/extensions/custom-script-windows.md
@@ -289,7 +289,10 @@ The response content cannot be parsed because the Internet Explorer engine is no
 ```
 ## Virtual Machine Scale Sets
 
-To deploy the Custom Script Extension on a Scale Set, see [Add-AzVmssExtension](/powershell/module/az.compute/add-azvmssextension)
+>[!NOTE]
+>When deploying the Custom Script Extension from the Azure Portal you don't have control over the expiration of the SAS token for accessing the script in your storage account. So this means that the initial deployment will work, but then after the storage account SAS token expires any subsequent scaling operation will fail as the CSE can no longer access the storage account.
+>
+>For this reason it is highly recommended to use [PowerShell](https://docs.microsoft.com/en-us/powershell/module/az.Compute/Add-azVmssExtension?view=azps-7.0.0), [CLI](https://docs.microsoft.com/en-us/cli/azure/vmss/extension?view=azure-cli-latest), or an ARM template when deploying the Custom Script Extension on a VMSS. This way you can choose to use a managed identity or have direct control of the expiration of the SAS token for accessing the script in your storage account for as long as you need.
 
 ## Classic VMs
 


### PR DESCRIPTION
Added clarification in both the Linux and Windows Custom Script Extension documents to point out the best practice is to use PowerShell/CLI/template instead of the Portal.