### PR TITLE
Update to thick provisioned question

### DIFF
--- a/articles/azure-vmware/faq.yml
+++ b/articles/azure-vmware/faq.yml
@@ -152,7 +152,7 @@ sections:
         answer: The Sentinel Management tab provides you access to download the Sentinel software.  It appears in the HCX Interconnect interface when an HCX Enterprise license is activated, and you have deployed a service mesh with a Sentinel Gateway (SGW) and Sentinel Data Receiver (SDR) pair deployed. Also, in traditional on-premises to cloud deployments, the Sentinel tab is only visible in the Connector, not cloud manager.
 
       - question: If we migrate a VM created with thick provisioning on the on-premises side to Azure VMware Solution, will the VM remain thick?
-        answer: You can specify the type of format you want when migrating a VM to Azure VMware Solution. However, vSAN is primarily the datastore you will be using in Azure VMware Solution, so it depends on the Storage Policy that is selected. The datastore default storage policy is the "vSAN default storage policy" which is thick-provisioned; however the other storage policy options are thin. Run-Commands can be used to change the default datastore storage policy.
+        answer: You can specify the type of format you want when you migrate a VM to Azure VMware Solution. However, vSAN is primarily the datastore you will use in Azure VMware Solution, so it depends on the storage policy that's selected. The datastore default storage policy is the *vSAN default storage policy*, which is thick provisioned; however, the other storage policy options are thin. You can use Run commands to change the default datastore storage policy.
 
 
 

--- a/articles/azure-vmware/faq.yml
+++ b/articles/azure-vmware/faq.yml
@@ -152,7 +152,7 @@ sections:
         answer: The Sentinel Management tab provides you access to download the Sentinel software.  It appears in the HCX Interconnect interface when an HCX Enterprise license is activated, and you have deployed a service mesh with a Sentinel Gateway (SGW) and Sentinel Data Receiver (SDR) pair deployed. Also, in traditional on-premises to cloud deployments, the Sentinel tab is only visible in the Connector, not cloud manager.
 
       - question: If we migrate a VM created with thick provisioning on the on-premises side to Azure VMware Solution, will the VM remain thick?
-        answer: No. Azure VMware Solution uses vSAN as the default storage datastore, which is always thin provisioned.  
+        answer: You can specify the type of format you want when migrating a VM to Azure VMware Solution. However, vSAN is primarily the datastore you will be using in Azure VMware Solution, so it depends on the Storage Policy that is selected. The datastore default storage policy is the "vSAN default storage policy" which is thick-provisioned; however the other storage policy options are thin. Run-Commands can be used to change the default datastore storage policy.
 
 
 


### PR DESCRIPTION
Added more context as there are different storage profiles for vSAN on the AVS clusters and depends on which one is chosen.