### PR TITLE
Fix link: Configuring federation with PingFederate

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-install-custom.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-custom.md
@@ -347,7 +347,7 @@ When you select the domain that you want to federate, Azure AD Connect provides 
 
 ## Configuring federation with PingFederate
 You can configure PingFederate with Azure AD Connect in just a few clicks. The following prerequisites are required:
-- PingFederate 8.4 or later.  For more information, see [PingFederate integration with Azure Active Directory and Microsoft 365](https://docs.pingidentity.com/bundle/O365IG20_sm_integrationGuide/page/O365IG_c_integrationGuide.html).
+- PingFederate 8.4 or later.  For more information, see [PingFederate integration with Azure Active Directory and Microsoft 365](https://docs.pingidentity.com/bundle/pingfederate-azuread-office365-integration/).
 - A TLS/SSL certificate for the federation service name that you intend to use (for example, sts.contoso.com).
 
 ### Verify the domain


### PR DESCRIPTION
I am on the Knowledge Management team at Ping Identity. We require this reference link to point to the new location for the integration documentation.