### PR TITLE
Updated number of Replicas for Azure Cache for Redis

### DIFF
--- a/articles/azure-cache-for-redis/includes/redis-cache-service-limits.md
+++ b/articles/azure-cache-for-redis/includes/redis-cache-service-limits.md
@@ -10,7 +10,7 @@ ms.author: cauribeg
 | Cache size |1.2 TB |
 | Databases |64 |
 | Maximum connected clients |40,000 |
-| Azure Cache for Redis replicas, for high availability |1 |
+| Azure Cache for Redis replicas, for high availability |3 |
 | Shards in a premium cache with clustering |10 |
 
 Azure Cache for Redis limits and sizes are different for each pricing tier. To see the pricing tiers and their associated sizes, see [Azure Cache for Redis pricing](https://azure.microsoft.com/pricing/details/cache/).


### PR DESCRIPTION
The maximum number of replicas that Azure Cache for Redis can have for high availability is 3 as we have Zone Redundant caches now.
More information on : https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-multi-replicas