### PR TITLE
Fix JSON serialization

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus-trigger.md
+++ b/articles/azure-functions/functions-bindings-service-bus-trigger.md
@@ -223,7 +223,7 @@ def main(msg: func.ServiceBusMessage):
         'to': msg.to,
         'user_properties': msg.user_properties,
         'metadata' : msg.metadata
-    })
+    }, default=str)
 
     logging.info(result)
 ```


### PR DESCRIPTION
The dictionary in the current form can't be serialized by `json.dumps` and raises and exception because it contains datetimes.