### PR TITLE
modules.md - spelling correction

### DIFF
--- a/articles/azure-resource-manager/bicep/modules.md
+++ b/articles/azure-resource-manager/bicep/modules.md
@@ -61,7 +61,7 @@ Like resources, modules are deployed in parallel unless they depend on other mod
 
 ## Path to module
 
-The file for the module can be either a local file or an external file. The external file can be in template spec or a Bicep module registry. All fo these options are shown below.
+The file for the module can be either a local file or an external file. The external file can be in template spec or a Bicep module registry. All of these options are shown below.
 
 ### Local file
 


### PR DESCRIPTION
Update spelling error in the `Path to Module` section.

![image](https://user-images.githubusercontent.com/11204251/145924711-ba61c303-4a72-42f9-95c5-791c994dc4cc.png)
