### PR TITLE
Permission to scan serverless databases

### DIFF
--- a/articles/purview/register-scan-synapse-workspace.md
+++ b/articles/purview/register-scan-synapse-workspace.md
@@ -126,7 +126,7 @@ You can set up authentication for an Azure Synapse source in either of two ways:
 > These steps for serverless databases **do not** apply to replicated databases. Currently in Synapse, serverless databases that are replicated from Spark databases are read-only. For more information, go [here](../synapse-analytics/sql/resources-self-help-sql-on-demand.md#operation-is-not-allowed-for-a-replicated-database).
 
 > [!NOTE]
-> You must set up authentication on each dedicated SQL database in your Azure Synapse workspace that you intend to register and scan. The permissions that are mentioned in the following sections for serverless SQL database apply to all databases within your workspace. That is, you'll have to set up authentication only once.
+> You must set up authentication on each dedicated SQL database in your Azure Synapse workspace that you intend to register and scan. The permissions that are mentioned in the following sections for serverless SQL database apply to all databases within your workspace. That is, you'll have to set up authentication separately on each serverless database.
 
 #### Use a managed identity for dedicated SQL databases
 


### PR DESCRIPTION
Line 129 seems to imply the permissions for serverless pool databases should be set only once but line 153 contradicts it and asks to repeat the permission granting step to each database that should be scanned which is correct. Line 129 needs changes