### PR TITLE
Update tutorial-enable-cloud-sync-sspr-writeback.md

### DIFF
--- a/articles/active-directory/authentication/tutorial-enable-cloud-sync-sspr-writeback.md
+++ b/articles/active-directory/authentication/tutorial-enable-cloud-sync-sspr-writeback.md
@@ -26,7 +26,7 @@ Azure Active Directory Connect cloud sync self-service password reset writeback 
   - [Authentication Policy Administrator](../roles/permissions-reference.md#authentication-policy-administrator) and [Hybrid Identity Administrator](../roles/permissions-reference.md#hybrid-identity-administrator) roles
   - [Global Administrator](../roles/permissions-reference.md#global-administrator) role 
 - Azure AD configured for self-service password reset. If needed, complete this tutorial to enable Azure AD SSPR. 
-- An on-premises AD DS environment configured with Azure AD Connect cloud sync version 1.1.587 or later. See [here](https://docs.microsoft.com/en-us/azure/active-directory/cloud-sync/how-to-automatic-upgrade) to identify the agents current version.  If needed, configure Azure AD Connect cloud sync using [this tutorial](tutorial-enable-sspr.md). 
+- An on-premises AD DS environment configured with Azure AD Connect cloud sync version 1.1.587 or later. Learn how to [identify the agent's current version](../cloud-sync/how-to-automatic-upgrade.md). If needed, configure Azure AD Connect cloud sync using [this tutorial](tutorial-enable-sspr.md). 
 - Enabling password writeback in Azure AD Connect cloud sync requires executing signed PowerShell scripts.
   - Ensure that the PowerShell execution policy will allow running of scripts. 
   - The recommended execution policy during installation is "RemoteSigned". 

--- a/articles/active-directory/authentication/tutorial-enable-cloud-sync-sspr-writeback.md
+++ b/articles/active-directory/authentication/tutorial-enable-cloud-sync-sspr-writeback.md
@@ -26,7 +26,7 @@ Azure Active Directory Connect cloud sync self-service password reset writeback 
   - [Authentication Policy Administrator](../roles/permissions-reference.md#authentication-policy-administrator) and [Hybrid Identity Administrator](../roles/permissions-reference.md#hybrid-identity-administrator) roles
   - [Global Administrator](../roles/permissions-reference.md#global-administrator) role 
 - Azure AD configured for self-service password reset. If needed, complete this tutorial to enable Azure AD SSPR. 
-- An on-premises AD DS environment configured with Azure AD Connect cloud sync version 1.1.587 or later. If needed, configure Azure AD Connect cloud sync using [this tutorial](tutorial-enable-sspr.md). 
+- An on-premises AD DS environment configured with Azure AD Connect cloud sync version 1.1.587 or later. See [here](https://docs.microsoft.com/en-us/azure/active-directory/cloud-sync/how-to-automatic-upgrade) to identify the agents current version.  If needed, configure Azure AD Connect cloud sync using [this tutorial](tutorial-enable-sspr.md). 
 - Enabling password writeback in Azure AD Connect cloud sync requires executing signed PowerShell scripts.
   - Ensure that the PowerShell execution policy will allow running of scripts. 
   - The recommended execution policy during installation is "RemoteSigned". 


### PR DESCRIPTION
Adding link so that customers know how to check what version they have. I would also like to add a section somewhere that says "If you don't meet the minimum version requirement, you'll get an error when you try to run the cmdlets that says Set-AADCloudSyncPasswordWritebackConfiguration is not recognized." This would help customers when they run into this issue.