### PR TITLE
Update storage-network-security.md

### DIFF
--- a/articles/storage/common/storage-network-security.md
+++ b/articles/storage/common/storage-network-security.md
@@ -471,11 +471,11 @@ You can add or remove resource network rules in the Azure portal.
 
 3. Select **Networking** to display the configuration page for networking.
 
-4. Under **Firewalls and virtual networks** select Allow access from **Selected networks**
+4. Under **Firewalls and virtual networks**, for **Selected networks**, select to allow access.
 
-5. Scroll down to find Resource instances and in the **Resource type** drop-down list, choose the resource type of your resource instance.
+5. Scroll down to find **Resource instances**, and in the **Resource type** dropdown list, choose the resource type of your resource instance.
 
-6. In the **Instance name** drop-down list, choose the resource instance. You can also choose to include all resource instances in the active tenant, subscription, or resource group.
+6. In the **Instance name** dropdown list, choose the resource instance. You can also choose to include all resource instances in the active tenant, subscription, or resource group.
 
 7. Select **Save** to apply your changes. The resource instance appears in the **Resource instances** section of the network settings page.
 

--- a/articles/storage/common/storage-network-security.md
+++ b/articles/storage/common/storage-network-security.md
@@ -471,11 +471,13 @@ You can add or remove resource network rules in the Azure portal.
 
 3. Select **Networking** to display the configuration page for networking.
 
-4. In the **Resource type** drop-down list, choose the resource type of your resource instance.
+4. Under **Firewalls and virtual networks** select Allow access from **Selected networks**
 
-5. In the **Instance name** drop-down list, choose the resource instance. You can also choose to include all resource instances in the active tenant, subscription, or resource group.
+5. Scroll down to find Resource instances and in the **Resource type** drop-down list, choose the resource type of your resource instance.
 
-6. Select **Save** to apply your changes. The resource instance appears in the **Resource instances** section of the network settings page.
+6. In the **Instance name** drop-down list, choose the resource instance. You can also choose to include all resource instances in the active tenant, subscription, or resource group.
+
+7. Select **Save** to apply your changes. The resource instance appears in the **Resource instances** section of the network settings page.
 
 To remove the resource instance, select the delete icon (:::image type="icon" source="media/storage-network-security/delete-icon.png":::) next to the resource instance.
 


### PR DESCRIPTION
In the steps for "Grant access from Azure resource instances" via the portal, a couple of steps are missing which I have added. 
Basically, when you go to the networking configuration page you don't see the resource type drop-down list. This is visible only after you select "selected networks"