### PR TITLE
Add access.redhat.com to list of other requirements

### DIFF
--- a/articles/openshift/howto-restrict-egress.md
+++ b/articles/openshift/howto-restrict-egress.md
@@ -77,7 +77,7 @@ In OpenShift Container Platform, customers can opt out of reporting health and u
 - **`storage.googleapis.com/openshift-release`**: Alternative site to download platform release signatures, used by the cluster to know what images to pull from quay.io.
 - **`*.apps.<cluster_name>.<base_domain>`** (OR EQUIVALENT ARO URL): When allowlisting domains, this is use in your corporate network to reach applications deployed in OpenShift, or to access the OpenShift console.
 - **`api.openshift.com`**: Required  by the cluster to check if there are available updates before downloading the image signatures.
-- **`registry.access.redhat.com`**: Registry access is required in your VDI or laptop environment to download dev images when using the ODO CLI tool. (This CLI tool is an alternative CLI tool for developers who aren't familiar with kubernetes). https://docs.openshift.com/container-platform/4.6/cli_reference/developer_cli_odo/understanding-odo.html
+- **`registry.access.redhat.com`** and **`access.redhat.com`**: Registry access is required in your VDI or laptop environment to download dev images when using the ODO CLI tool. (This CLI tool is an alternative CLI tool for developers who aren't familiar with kubernetes). https://docs.openshift.com/container-platform/4.6/cli_reference/developer_cli_odo/understanding-odo.html
 
 ---
 


### PR DESCRIPTION
We use ARO behind a transparent proxy, requiring a full list of URL's for accessing images. while pulling an nginx image from `registry.access.redhat.com` it also tries to pull a blob from `access.redhat.com`.

See the k8s event below:

```
63m Warning Failed pod/nginx Failed to pull image "registry.access.redhat.com/ubi8/nginx-120": rpc error: code = Unknown desc = Error reading signatures: Get "https://access.redhat.com/webassets/docker/content/sigstore/ubi8/nginx-120@sha256=935f5bc33ce390ab06151af12c24edf0ef53bf9acf4c4fb0ad8e733d39c31b42/signature-1": read tcp 10.87.137.6:55290->95.101.23.187:443: read: connection reset by peer
```