### PR TITLE
two options presented as one set of steps

### DIFF
--- a/articles/azure-sql/database/elastic-pool-overview.md
+++ b/articles/azure-sql/database/elastic-pool-overview.md
@@ -131,13 +131,17 @@ Pooled databases generally support the same [business continuity features](busin
 
 There are two ways you can create an elastic pool in the Azure portal.
 
+Option one: Create elastic pool and select existing or new server.
+
 1. Go to the [Azure portal](https://portal.azure.com) to create an elastic pool. Search for and select **Azure SQL**.
-2. Select **+Add** to open the **Select SQL deployment option** page. You can view additional information about elastic pools by selecting **Show details** on the **Databases** tile.
+2. Select **+Create** to open the **Select SQL deployment option** page. You can view additional information about elastic pools by selecting **Show details** on the **Databases** tile.
 3. On the **Databases** tile, select **Elastic pool** in the **Resource type** dropdown, then select **Create**:
 
    ![Create an elastic pool](./media/elastic-pool-overview/create-elastic-pool.png)
 
-4. Or you can create an elastic pool by navigating to an existing server and clicking **+ New pool** to create a pool directly into that server.
+Option two: create an elastic pool from existing server
+
+1. Navigate to an existing server and click **+ New pool** to create a pool directly into that server.
 
 > [!NOTE]
 > You can create multiple pools on a server, but you can't add databases from different servers into the same pool.

--- a/articles/azure-sql/database/elastic-pool-overview.md
+++ b/articles/azure-sql/database/elastic-pool-overview.md
@@ -129,19 +129,22 @@ Pooled databases generally support the same [business continuity features](busin
 
 ## Creating a new SQL Database elastic pool using the Azure portal
 
-There are two ways you can create an elastic pool in the Azure portal.
+You can create an elastic pool in the Azure portal in two ways:
 
-Option one: Create elastic pool and select existing or new server.
+- Create an elastic pool and select an existing or new server.
+- Create an elastic pool from an existing server.
+
+To create an elastic pool and select an existing or new server:
 
 1. Go to the [Azure portal](https://portal.azure.com) to create an elastic pool. Search for and select **Azure SQL**.
-2. Select **+Create** to open the **Select SQL deployment option** page. You can view additional information about elastic pools by selecting **Show details** on the **Databases** tile.
-3. On the **Databases** tile, select **Elastic pool** in the **Resource type** dropdown, then select **Create**:
+2. Select **Create** to open the **Select SQL deployment option** pane. To view more information about elastic pools, on the **Databases** tile, select **Show details**.
+3. On the **Databases** tile, in the **Resource type** dropdown, select **Elastic pool**, and then select **Create**.
 
    ![Create an elastic pool](./media/elastic-pool-overview/create-elastic-pool.png)
 
-Option two: create an elastic pool from existing server
+To create an elastic pool from an existing server:
 
-1. Navigate to an existing server and click **+ New pool** to create a pool directly into that server.
+- Go to an existing server and select **New pool** to create a pool directly in that server.
 
 > [!NOTE]
 > You can create multiple pools on a server, but you can't add databases from different servers into the same pool.


### PR DESCRIPTION
The two options to create elastic pool are presented as one set of steps. Option 2 is presented as step 4 instead as a new step.
In addition, just replace one word: "add" with "create" as changed in the portal