### PR TITLE
Update reference-claims-mapping-policy-type.md

### DIFF
--- a/articles/active-directory/develop/reference-claims-mapping-policy-type.md
+++ b/articles/active-directory/develop/reference-claims-mapping-policy-type.md
@@ -164,6 +164,7 @@ There are certain sets of claims that define how and when they're used in tokens
 | verified_secondary_email |
 | wids |
 | win_ver |
+| nickname |
 
 ### Table 2: SAML restricted claim set
 


### PR DESCRIPTION
unable to populate sAMAccountName in id_token with the nickname ("JwtClaimType": "nickname")

"Source": "user",

"ID": "onpremisessamaccountname",

"JwtClaimType": "nickname"

But when created with nickname2 or any its working as expected ( sAMAccountName is populated in id_token)I don't see any restrictions with 'nickname' https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-claims-mapping-policy-type
tested in multiple labs. looks like 'nickname' is restricted and also confirmed from the code.