### PR TITLE
ARM deployment() function: login.windows.net -> login.microsoftonline.com

### DIFF
--- a/articles/azure-resource-manager/templates/template-functions-deployment.md
+++ b/articles/azure-resource-manager/templates/template-functions-deployment.md
@@ -236,7 +236,7 @@ The preceding example returns the following object when deployed to global Azure
   "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
   "resourceManager": "https://management.azure.com/",
   "authentication": {
-    "loginEndpoint": "https://login.windows.net/",
+    "loginEndpoint": "https://login.microsoftonline.com/",
     "audiences": [
       "https://management.core.windows.net/",
       "https://management.azure.com/"


### PR DESCRIPTION
Just tried it out today and deployment().authentication.loginEndpoint returns `https://login.microsoftonline.com/`, not `https://login.windows.net`.