### PR TITLE
clarify gen1 vs gen2

### DIFF
--- a/articles/virtual-machines/workloads/hpc/configure.md
+++ b/articles/virtual-machines/workloads/hpc/configure.md
@@ -48,7 +48,7 @@ The VM size support matrix for the GPU drivers in supported HPC VM images is as 
 - [N-series](../../sizes-gpu.md): NDv2, NDv4 VM sizes are supported with the Nvidia GPU drivers and GPU compute software stack (CUDA, NCCL).
 - The other 'NC' and 'ND' VM sizes in the [N-series](../../sizes-gpu.md) are supported with the Nvidia GPU drivers.
 
-Also note that all the above VM sizes support "Gen 2" VMs, though some older ones also support "Gen 1" VMs. "Gen 2" support is also indicated with a "01" at the end of the VMI URN or version.
+Also note that all the VM sizes from the N-series support ["Gen 2" VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/generation-2), though some older ones also support "Gen 1" VMs. "Gen 2" support is also indicated with a "01" at the end of the VMI URN or version.
 
 ### CentOS-HPC VM images
 


### PR DESCRIPTION
The sentence "all the above VM sizes" could be understood to include the H-series mentioned just a few lines above (but they do *not* support gen2).
Also added link to explanation of gen2.