### PR TITLE
b2c-support update Description of dateTime

### DIFF
--- a/articles/active-directory-b2c/claimsschema.md
+++ b/articles/active-directory-b2c/claimsschema.md
@@ -11,6 +11,7 @@ ms.topic: reference
 ms.date: 03/05/2020
 ms.author: kengaderdus
 ms.subservice: B2C
+ms.custom:"b2c-support"
 ---
 
 # ClaimsSchema
@@ -66,7 +67,7 @@ The **DataType** element supports the following values:
 | ------- | ----------- |
 |boolean|Represents a Boolean (`true` or `false`) value.|
 |date| Represents an instant in time, typically expressed as a date of a day. The value of the date follows ISO 8601 convention.|
-|dateTime|Represents an instant in time, typically expressed as a date and time of day. The value of the date follows ISO 8601 convention.|
+|dateTime|Represents an instant in time, typically expressed as a date and time of day. The value of the date follows ISO 8601 convention during runtime.When a dateTime is sent in a JWT token, it gets converted to UNIX epoch time to match other datetime claims specified in the JWT standard, similar to the "nbf" and "exp" dateTime claims.|
 |duration|Represents a time interval in years, months, days, hours, minutes, and seconds. The format of is `PnYnMnDTnHnMnS`, where `P` indicates positive, or `N` for negative value. `nY` is the number of years followed by a literal `Y`. `nMo` is the number of months followed by a literal `Mo`. `nD` is the number of days followed by a literal `D`. Examples: `P21Y` represents 21 years. `P1Y2Mo` represents one year, and two months. `P1Y2Mo5D` represents one year, two months, and five days.  `P1Y2M5DT8H5M620S` represents one year, two months, five days, eight hours, five minutes, and twenty seconds.  |
 |phoneNumber|Represents a phone number. |
 |int| Represents number between -2,147,483,648 and 2,147,483,647|

--- a/articles/active-directory-b2c/claimsschema.md
+++ b/articles/active-directory-b2c/claimsschema.md
@@ -67,7 +67,7 @@ The **DataType** element supports the following values:
 | ------- | ----------- |
 |boolean|Represents a Boolean (`true` or `false`) value.|
 |date| Represents an instant in time, typically expressed as a date of a day. The value of the date follows ISO 8601 convention.|
-|dateTime|Represents an instant in time, typically expressed as a date and time of day. The value of the date follows ISO 8601 convention during runtime.When a dateTime is sent in a JWT token, it gets converted to UNIX epoch time to match other datetime claims specified in the JWT standard, similar to the "nbf" and "exp" dateTime claims.|
+|dateTime|Represents an instant in time, typically expressed as a date and time of day. The value of the date follows ISO 8601 convention during runtime,and converted to UNIX epoch time when issued as a claim into the token.|
 |duration|Represents a time interval in years, months, days, hours, minutes, and seconds. The format of is `PnYnMnDTnHnMnS`, where `P` indicates positive, or `N` for negative value. `nY` is the number of years followed by a literal `Y`. `nMo` is the number of months followed by a literal `Mo`. `nD` is the number of days followed by a literal `D`. Examples: `P21Y` represents 21 years. `P1Y2Mo` represents one year, and two months. `P1Y2Mo5D` represents one year, two months, and five days.  `P1Y2M5DT8H5M620S` represents one year, two months, five days, eight hours, five minutes, and twenty seconds.  |
 |phoneNumber|Represents a phone number. |
 |int| Represents number between -2,147,483,648 and 2,147,483,647|

--- a/articles/active-directory-b2c/claimsschema.md
+++ b/articles/active-directory-b2c/claimsschema.md
@@ -67,7 +67,7 @@ The **DataType** element supports the following values:
 | ------- | ----------- |
 |boolean|Represents a Boolean (`true` or `false`) value.|
 |date| Represents an instant in time, typically expressed as a date of a day. The value of the date follows ISO 8601 convention.|
-|dateTime|Represents an instant in time, typically expressed as a date and time of day. The value of the date follows ISO 8601 convention during runtime,and converted to UNIX epoch time when issued as a claim into the token.|
+|dateTime|Represents an instant in time, typically expressed as a date and time of day. The value of the date follows ISO 8601 convention during runtime and is converted to UNIX epoch time when issued as a claim into the token.|
 |duration|Represents a time interval in years, months, days, hours, minutes, and seconds. The format of is `PnYnMnDTnHnMnS`, where `P` indicates positive, or `N` for negative value. `nY` is the number of years followed by a literal `Y`. `nMo` is the number of months followed by a literal `Mo`. `nD` is the number of days followed by a literal `D`. Examples: `P21Y` represents 21 years. `P1Y2Mo` represents one year, and two months. `P1Y2Mo5D` represents one year, two months, and five days.  `P1Y2M5DT8H5M620S` represents one year, two months, five days, eight hours, five minutes, and twenty seconds.  |
 |phoneNumber|Represents a phone number. |
 |int| Represents number between -2,147,483,648 and 2,147,483,647|


### PR DESCRIPTION
update Description of dateTime that it follows ISO 8601 Convention during runtime and is converted to it gets converted to UNIX epoch time to match other datetime claims specified in the JWT standard, similar to the "nbf" and "exp" dateTime claims