### PR TITLE
Updated "Configure role assignments" section

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
@@ -155,7 +155,7 @@ Now that you have created the VM, you need to configure Azure RBAC policy to det
 - **Virtual Machine User Login**: Users with this role assigned can log in to an Azure virtual machine with regular user privileges.
 
 > [!NOTE]
-> To allow a user to log in to the VM over RDP, you must assign either the Virtual Machine Administrator Login or Virtual Machine User Login role. An Azure user with the Owner or Contributor roles assigned for a VM do not automatically have privileges to log in to the VM over RDP. This is to provide audited separation between the set of people who control virtual machines versus the set of people who can access virtual machines.
+> To allow a user to log in to the VM over RDP, you must assign either the Virtual Machine Administrator Login or Virtual Machine User Login role to the Resource Group containing the VM and its associated Virtual Network, Network Interface, Public IP Address or Load Balancer resources. An Azure user with the Owner or Contributor roles assigned for a VM do not automatically have privileges to log in to the VM over RDP. This is to provide audited separation between the set of people who control virtual machines versus the set of people who can access virtual machines.
 
 There are multiple ways you can configure role assignments for VM:
 
@@ -168,6 +168,8 @@ There are multiple ways you can configure role assignments for VM:
 ### Using Azure AD Portal experience
 
 To configure role assignments for your Azure AD enabled Windows Server 2019 Datacenter VMs:
+
+1. Select the **Resource Group** containing the VM and its associated Virtual Network, Network Interface, Public IP Address or Load Balancer resource.
 
 1. Select **Access control (IAM)**.
 
@@ -188,12 +190,12 @@ The following example uses [az role assignment create](/cli/azure/role/assignmen
 
 ```   AzureCLI
 $username=$(az account show --query user.name --output tsv)
-$vm=$(az vm show --resource-group myResourceGroup --name myVM --query id -o tsv)
+$rg=$(az group show --resource-group myResourceGroup --query id -o tsv)
 
 az role assignment create \
     --role "Virtual Machine Administrator Login" \
     --assignee $username \
-    --scope $vm
+    --scope $rg
 ```
 
 > [!NOTE]


### PR DESCRIPTION
The "Configure role assignments for the VM" has incorrect instructions to apply the RBAC policy at the VM level. The roles "Virtual Machine Administrator Login" and "Virtual Machine User Login" also require access to the following resource types Microsoft.Network/virtualNetworks, Microsoft.Network/publicIPAddresses, Microsoft.Network/networkInterfaces, Microsoft.Network/loadBalancers in addition to Microsoft.Compute/virtualMachines. 

Assigning these roles at the VM level does not provide the required access for a user to sign in to the VM.