### PR TITLE
PM2 doesn't start automatically in Node 14 and 16

### DIFF
--- a/articles/app-service/configure-language-nodejs.md
+++ b/articles/app-service/configure-language-nodejs.md
@@ -167,7 +167,7 @@ You can also configure a custom start file with the following extensions:
 - A [PM2 file](https://pm2.keymetrics.io/docs/usage/application-declaration/#process-file) with the extension *.json*, *.config.js*, *.yaml*, or *.yml*
 
 > [!NOTE]
-> Starting from **Node 14 LTS**, the container does not automatically start your app with PM2. To start your app with PM2, set the Startup Command to: `pm2 start <.js-file-or-PM2-file> --no-daemon`. Mind the `--no-daemon` argument, PM2 needs to run in foreground for the container to work properly.
+> Starting from **Node 14 LTS**, the container doesn't automatically start your app with PM2. To start your app with PM2, set the startup command to `pm2 start <.js-file-or-PM2-file> --no-daemon`. Be sure to use the `--no-daemon` argument because PM2 needs to run in the foreground for the container to work properly.
 
 To add a custom start file, run the following command in the [Cloud Shell](https://shell.azure.com):
 

--- a/articles/app-service/configure-language-nodejs.md
+++ b/articles/app-service/configure-language-nodejs.md
@@ -166,6 +166,9 @@ You can also configure a custom start file with the following extensions:
 - A *.js* file
 - A [PM2 file](https://pm2.keymetrics.io/docs/usage/application-declaration/#process-file) with the extension *.json*, *.config.js*, *.yaml*, or *.yml*
 
+> [!NOTE]
+> Starting from **Node 14 LTS**, the container does not automatically start your app with PM2. To start your app with PM2, set the Startup Command to: `pm2 start <.js-file-or-PM2-file> --no-daemon`. Mind the `--no-daemon` argument, PM2 needs to run in foreground for the container to work properly.
+
 To add a custom start file, run the following command in the [Cloud Shell](https://shell.azure.com):
 
 ```azurecli-interactive


### PR DESCRIPTION
We don't start PM2 automatically in Node 14 and 16 images. This change could result in a down time if a user doesn't follow the standard naming for the main file and relies on the image to detect the PM2 file to start the app. I added a note with a PM2 startup command example.