### PR TITLE
Issue #81234 - Clarity in SSO Documentation

### DIFF
--- a/articles/active-directory-b2c/custom-policy-reference-sso.md
+++ b/articles/active-directory-b2c/custom-policy-reference-sso.md
@@ -24,14 +24,11 @@ Azure AD B2C has defined a number of SSO session providers that can be used:
 
 |Session provider  |Scope  |
 |---------|---------|
-|[NoopSSOSessionProvider](#noopssosessionprovider)     |  None       |       
-|[DefaultSSOSessionProvider](#defaultssosessionprovider)    | Azure AD B2C internal session manager.      |       
-|[ExternalLoginSSOSessionProvider](#externalloginssosessionprovider)     | Between Azure AD B2C and OAuth1, OAuth2, or OpenId Connect identity provider.        | 
-|[OAuthSSOSessionProvider](#oauthssosessionprovider)     | Between an OAuth2 or OpenId connect relying party application and Azure AD B2C.        |        
-|[SamlSSOSessionProvider](#samlssosessionprovider)     | Between Azure AD B2C and SAML identity provider. And between a SAML service provider (relying party application) and Azure AD B2C.  |        
-
-
-
+|[NoopSSOSessionProvider](#noopssosessionprovider)     |  None       |
+|[DefaultSSOSessionProvider](#defaultssosessionprovider)    | Azure AD B2C internal session manager.      |
+|[ExternalLoginSSOSessionProvider](#externalloginssosessionprovider)     | Between Azure AD B2C and OAuth1, OAuth2, or OpenId Connect identity provider.        |
+|[OAuthSSOSessionProvider](#oauthssosessionprovider)     | Between an OAuth2 or OpenId connect relying party application and Azure AD B2C.        |
+|[SamlSSOSessionProvider](#samlssosessionprovider)     | Between Azure AD B2C and SAML identity provider. And between a SAML service provider (relying party application) and Azure AD B2C.  |
 
 SSO management classes are specified using the `<UseTechnicalProfileForSessionManagement ReferenceId="{ID}" />` element of a technical profile.
 
@@ -51,7 +48,23 @@ The `<OutputClaims>` is used for retrieving claims from the session.
 
 ### NoopSSOSessionProvider
 
-As the name dictates, this provider does nothing. This provider can be used for suppressing SSO behavior for a specific technical profile. The following `SM-Noop` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack).
+As the name dictates, this provider does nothing. This provider can be used for suppressing SSO behavior for a specific technical profile. Unlike the other SSO session providers, Noop does not allow for SSO so that the technical profile can be processed, even when the user has an active session. This provider can't persist claims and should be implemented using the code snippet below.
+
+The use of the NoopSSOSessionProvider may not be obvious, so here are a few examples where a technical profile would benefit from using SM-Noop:
+
+* Claims transformation provider
+* Restful provider
+* Self asserted attribute provider
+
+A claims transformation provider can be used to create, or transform, claims to determine which orchestration steps to skip or to process, for example when triggering a [sub journey](subjourneys.md).
+
+Restful providers can perform API queries that initates backend processes, for example for extended logging or for gathering claims used for authorization.
+
+Self asserted providers can be configured to send and verify verification emails with one-time passcodes every time a [user journey](userjourneys.md) is triggered.
+
+To use the NoopSSOSessionProvider it must be referenced like this in the technical profile: `<UseTechnicalProfileForSessionManagement ReferenceId="SM-Noop" />`. If no session management technical profile is defined the DefaultSSOSessionProvider SSO behavior will apply. This is worth noting as technical profiles that are processed when the user is a session participant of the DefaultSSOSessionProvider will be subject to SSO.
+
+The following `SM-Noop` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack).
 
 ```xml
 <TechnicalProfile Id="SM-Noop">
@@ -62,7 +75,13 @@ As the name dictates, this provider does nothing. This provider can be used for 
 
 ### DefaultSSOSessionProvider
 
-This provider can be used for storing claims in a session. This provider is typically referenced in a technical profile used for managing local and federated accounts. The following `SM-AAD` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack).
+This provider can be used for storing claims in a session. It is recommended to start with the claims provided in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack) and rather continue to remove or add claims as needed. Be aware that SSO will not function without the inclusion of the `objectId` claim. The `signInName` claim is also very useful. These claims must be added to the claims bag, so that the SSO session management provider will be able to repopulate them. The `objectId` claim allows applications to uniquely identity users and must be included in `id_token`. The `signInName`, often an email address, lets applications know how users identify themselves when signing in. This session provider is typically referenced in a technical profile used for managing local and federated accounts.
+
+Technical profiles that inlucde `<UseTechnicalProfileForSessionManagement ReferenceId="SM-AAD" />` will execute as configured when the user is signing in. On subsequent executions, the user will be found to be a session participant and SSO will trigger. The SSO behavior will repopulate the claims bag and skip configured actions, as these are only executed when the user is not already signed in.
+
+Claims persisted to the claims bag are stored in the session and can be used in subsequent [user journeys](userjourneys.md) for the lifetime of the session. Claims can be output to the session by adding `<OutputClaim ClaimTypeReferenceId="{Name}" DefaultValue="{Value}" />`, where `{Name}` must exist in the [ClaimsSchema](claimsschema.md) and `{Value}` is a static value. OutputClaim `objectIdFromSession` is often used to skip or execute orchestration steps, when the user is a session participant.
+
+The following `SM-AAD` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack).
 
 ```xml
 <TechnicalProfile Id="SM-AAD">
@@ -82,8 +101,7 @@ This provider can be used for storing claims in a session. This provider is typi
 </TechnicalProfile>
 ```
 
-
-The following `SM-MFA` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack) `SocialAndLocalAccountsWithMfa`. This technical profile manages the multi-factor authentication session.
+The following `SM-MFA` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack) `SocialAndLocalAccountsWithMfa`. This technical profile manages the multi-factor authentication session. `SM-MFA` adds claims to the claims bag the same way `SM-AAD` does. By having seperate definitions for these session providers `SM-AAD` can be used in a  standard user authentication flow and `SM-MFA` when a user is required to step up. OutputClaim `isActiveMFASession` can be used as a [precondition](userjourneys.md#preconditions) for evaluating the execution of orchestration steps.
 
 ```xml
 <TechnicalProfile Id="SM-MFA">
@@ -100,7 +118,7 @@ The following `SM-MFA` technical profile is included in the [custom policy start
 
 ### ExternalLoginSSOSessionProvider
 
-This provider is used to suppress the "choose identity provider" screen and sign-out from a federated identity provider. It is typically referenced in a technical profile configured for a federated identity provider, such as Facebook, or Azure Active Directory. The following `SM-SocialLogin` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack).
+This provider is used to suppress the "choose identity provider" screen and sign-out from a federated identity provider. It is typically referenced in a technical profile configured for a federated identity provider, such as Facebook, or Azure Active Directory. [AlternativeSecurityId](social-transformations.md#createalternativesecurityid) is a claim generated when a user signs in with an external identity provider. The [AlternativeSecurityId](social-transformations.md#createalternativesecurityid) claim is built from the user's unique identifier with the external identity provider. One or more of these identifier claims can be added to a single account in Azure AD B2C. The following `SM-SocialLogin` technical profile is included in the [custom policy starter pack](tutorial-create-user-flows.md?pivots=b2c-custom-policy#custom-policy-starter-pack).
 
 ```xml
 <TechnicalProfile Id="SM-SocialLogin">
@@ -120,7 +138,7 @@ This provider is used to suppress the "choose identity provider" screen and sign
 
 ### OAuthSSOSessionProvider
 
-This provider is used for managing the Azure AD B2C sessions between a OAuth2 or OpenId Connect relying party and Azure AD B2C.
+This provider is used for managing the Azure AD B2C sessions between a OAuth2 or OpenId Connect relying party and Azure AD B2C. Using this provider the relying party session will be closed when the user signs out from Azure AD B2C using [Single sign-out](session-behavior.md#single-sign-out). This provider does not interact with the claims bag.
 
 ```xml
 <TechnicalProfile Id="SM-jwt-issuer">
@@ -160,7 +178,6 @@ The following `SM-Saml-issuer` technical profile is used by [SAML issuer technic
 | --- | --- | --- |
 | IncludeSessionIndex | No | Not currently used, can be ignored.|
 | RegisterServiceProviders | No | Indicates that the provider should register all SAML service providers that have been issued an assertion. Possible values: `true` (default), or `false`.|
-
 
 ## Next steps
 


### PR DESCRIPTION
Documentation is filled out answer questions asked in issue #81234.
The intention was also to bring more clarity into how these SSO sessions providers work and how they can be used.

#ATCP