### PR TITLE
Geo-replication is not available at this time when using extra replicas.

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-geo-replication.md
+++ b/articles/azure-cache-for-redis/cache-how-to-geo-replication.md
@@ -83,6 +83,9 @@ After geo-replication is configured, the following restrictions apply to your li
     :::image type="content" source="media/cache-how-to-geo-replication/cache-geo-location-link-successful.png" alt-text="Cache status":::
 
     The primary linked cache remains available for use during the linking process. The secondary linked cache isn't available until the linking process completes.
+    
+> [!NOTE]
+> Geo-replication can be enabled for this cache if you scale it to 'Premium' pricing tier and disable data persistence. This feature is not available at this time when using extra replicas.
 
 ## Remove a geo-replication link
 

--- a/articles/azure-cache-for-redis/cache-how-to-geo-replication.md
+++ b/articles/azure-cache-for-redis/cache-how-to-geo-replication.md
@@ -85,7 +85,7 @@ After geo-replication is configured, the following restrictions apply to your li
     The primary linked cache remains available for use during the linking process. The secondary linked cache isn't available until the linking process completes.
     
 > [!NOTE]
-> Geo-replication can be enabled for this cache if you scale it to 'Premium' pricing tier and disable data persistence. This feature is not available at this time when using extra replicas.
+> Geo-replication is not available at this time when using extra replicas.
 
 ## Remove a geo-replication link
 


### PR DESCRIPTION
Geo-replication is not available at this time when using extra replicas.

I have a Premium Redis Cache with a single replica and data persistence disabled, there I got an option to add cache replication link after going to Geo-replication section. But I have another Premium Redis Cache with two replicas and data persistence enabled(only one availability zone), I could see this when I tried to avail Geo-replication:-> "Geo-replication can be enabled for this cache if you scale it to 'Premium' pricing tier and disable data persistence. This feature is not available at this time when using extra replicas"
![image](https://user-images.githubusercontent.com/96826042/147680824-e7ba5445-6701-4c51-86b8-19399d27ff9c.png)
