### PR TITLE
When you enable data persistence, geo-replication cannot be enabled f…

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -87,6 +87,9 @@ Persistence writes Redis data into an Azure Storage account that you own and man
 
 It takes a while for the cache to create. You can monitor progress on the Azure Cache for Redis **Overview** page. When **Status** shows as **Running**, the cache is ready to use.
 
+> [!NOTE]
+> If you enable data persistence, geo-replication cannot be enabled for you Premium Redis cache.
+
 ## Persistence FAQ
 
 The following list contains answers to commonly asked questions about Azure Cache for Redis persistence.


### PR DESCRIPTION
…or you Premium Redis cache.

When my premium Redis Cache has data persistence as disabled, I was able to avail geo-replication feature, but when I enable data persistence feature in my Premium Redis Cache, I am unable to enable geo-replication and this message comes up : "Geo-replication can be enabled for this cache if you scale it to 'Premium' pricing tier and disable data persistence. This feature is not available at this time when using extra replicas"

![image](https://user-images.githubusercontent.com/96826042/147681662-69c938e0-739f-4236-9296-4adef54674ab.png)
