### PR TITLE
Update python versions

### DIFF
--- a/articles/azure-functions/durable/quickstart-python-vscode.md
+++ b/articles/azure-functions/durable/quickstart-python-vscode.md
@@ -29,7 +29,7 @@ To complete this tutorial:
 
 * Durable Functions require an Azure storage account. You need an Azure subscription.
 
-* Make sure that you have version 3.6, 3.7, or 3.8 of [Python](https://www.python.org/) installed.
+* Make sure that you have version 3.7, 3.8, or 3.9 of [Python](https://www.python.org/) installed.
 
 [!INCLUDE [quickstarts-free-trial-note](../../../includes/quickstarts-free-trial-note.md)]
 


### PR DESCRIPTION
The docs state that Python version should either be 3.6, 3.7 or 3.8. But in the portal the options 3.7, 3.8 and 3.9 are given. This PR updates the documentation accordingly.

![image](https://user-images.githubusercontent.com/34067903/147785907-caebe5e5-65e8-415f-babb-fc6cdb8fbf4d.png)
