### PR TITLE
Fix a command syntax

### DIFF
--- a/articles/databox-online/azure-stack-edge-gpu-deploy-virtual-machine-high-performance-network.md
+++ b/articles/databox-online/azure-stack-edge-gpu-deploy-virtual-machine-high-performance-network.md
@@ -72,7 +72,7 @@ In addition to the above prerequisites that are used for VM creation, you'll als
     1. Identify all the VMs running on your device. This includes Kubernetes VMs, or any VM workloads that you may have deployed.
 
         ```powershell
-        get-vm -force
+        get-vm
         ```
     1. Stop all the running VMs.
     


### PR DESCRIPTION
The `get-vm` command does not accept `-force` argument:

```
PS>get-vm -force
A parameter cannot be found that matches parameter name 'force'.
    + CategoryInfo          : InvalidArgument: (:) [Get-VM], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.HyperV.PowerShell.Commands.GetVM

PS>get-vm

Name                                 State   CPUUsage(%) MemoryAssigned(M) Uptime             Status             Version
----                                 -----   ----------- ----------------- ------             ------             -------
XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX Running 0           32768             1.21:22:28.8680000 Operating normally 9.0
```