### PR TITLE
Use correct casing for the assumeOrderByHighWaterMarkColumn configura…

### DIFF
--- a/articles/search/cognitive-search-common-errors-warnings.md
+++ b/articles/search/cognitive-search-common-errors-warnings.md
@@ -301,7 +301,7 @@ Incremental progress during indexing ensures that if indexer execution is interr
 
 The ability to resume an unfinished indexing job is predicated on having documents ordered by the `_ts` column. The indexer uses the timestamp to determine which document to pick up next. If the `_ts` column is missing or if the indexer can't determine if a custom query is ordered by it, the indexer starts at beginning and you'll see this warning.
 
-It is possible to override this behavior, enabling incremental progress and suppressing this warning by using the `assumeOrderByHighWatermarkColumn` configuration property.
+It is possible to override this behavior, enabling incremental progress and suppressing this warning by using the `assumeOrderByHighWaterMarkColumn` configuration property.
 
 For more information, see [Incremental progress and custom queries](search-howto-index-cosmosdb.md#IncrementalProgress).
 


### PR DESCRIPTION
…tion property

The casing was off, which might cause issues when copying the string for use in code.