### PR TITLE
Application Insights Windows Agent - fixing json syntax for VMSS

### DIFF
--- a/articles/azure-monitor/app/azure-vm-vmss-apps.md
+++ b/articles/azure-monitor/app/azure-vm-vmss-apps.md
@@ -135,8 +135,8 @@ $publicCfgHashtable =
     "instrumentationKeyMap"= @{
       "filters"= @(
         @{
-          "appFilter"= ".*";
-          "machineFilter"= ".*";
+          "appFilter": ".*",
+          "machineFilter": ".*",
           "virtualPathFilter": ".*",
           "instrumentationSettings" : {
             "connectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/" # Application Insights connection string, create new Application Insights resource if you don't have one. https://ms.portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/microsoft.insights%2Fcomponents

--- a/articles/azure-monitor/app/azure-vm-vmss-apps.md
+++ b/articles/azure-monitor/app/azure-vm-vmss-apps.md
@@ -138,8 +138,8 @@ $publicCfgHashtable =
           "appFilter"= ".*";
           "machineFilter"= ".*";
           "virtualPathFilter"= ".*";
-          "instrumentationSettings" : @{
-            "connectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/" # Application Insights connection string, create new Application Insights resource if you don't have one. https://ms.portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/microsoft.insights%2Fcomponents
+          "instrumentationSettings" = @{
+            "connectionString"= "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/" # Application Insights connection string, create new Application Insights resource if you don't have one. https://ms.portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/microsoft.insights%2Fcomponents
           }
         }
       )

--- a/articles/azure-monitor/app/azure-vm-vmss-apps.md
+++ b/articles/azure-monitor/app/azure-vm-vmss-apps.md
@@ -138,7 +138,7 @@ $publicCfgHashtable =
           "appFilter"= ".*";
           "machineFilter"= ".*";
           "virtualPathFilter"= ".*";
-          "instrumentationSettings" : {
+          "instrumentationSettings" : @{
             "connectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/" # Application Insights connection string, create new Application Insights resource if you don't have one. https://ms.portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/microsoft.insights%2Fcomponents
           }
         }

--- a/articles/azure-monitor/app/azure-vm-vmss-apps.md
+++ b/articles/azure-monitor/app/azure-vm-vmss-apps.md
@@ -135,9 +135,9 @@ $publicCfgHashtable =
     "instrumentationKeyMap"= @{
       "filters"= @(
         @{
-          "appFilter": ".*",
-          "machineFilter": ".*",
-          "virtualPathFilter": ".*",
+          "appFilter"= ".*";
+          "machineFilter"= ".*";
+          "virtualPathFilter"= ".*";
           "instrumentationSettings" : {
             "connectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/" # Application Insights connection string, create new Application Insights resource if you don't have one. https://ms.portal.azure.com/#blade/HubsExtension/BrowseResourceBlade/resourceType/microsoft.insights%2Fcomponents
           }


### PR DESCRIPTION
invalid hash table syntax causes extension to fail deployment (see #86003 )

```
Execution Error:
VmExtensionHandler failed: System.ArgumentException: Cannot parse environment variable 'ConfigSequenceNumber'. Expected non-empty value, got ''
   at Microsoft.ApplicationInsights.VmExtensionHandler.VmExtensionHandlerMain.Execute(String[] args)
   at Microsoft.ApplicationInsights.VmExtensionHandler.VmExtensionHandlerMain.Main(String[] args)
```

Fix is to build a proper hashtable in Powershell. Tested in both PS5 and PS7 ... hashtable now works 

```powershell

$publicCfgHashtable.redfieldConfiguration.instrumentationKeyMap.filters

Name                           Value
----                           -----
virtualPathFilter              .*
instrumentationSettings        {connectionString}
machineFilter                  .*
appFilter                      .*
```

-  Installed on a VMSS and saw perf counters streaming to the App Insights instance
