### PR TITLE
Corrected scope name for Microsoft Graph

### DIFF
--- a/articles/active-directory/roles/groups-concept.md
+++ b/articles/active-directory/roles/groups-concept.md
@@ -50,7 +50,7 @@ Role-assignable groups are designed to help prevent potential breaches by having
 - Only Global Administrators and Privileged Role Administrators can create a role-assignable group.
 - The membership type for role-assignable groups must be Assigned and can't be an Azure AD dynamic group. Automated population of dynamic groups could lead to an unwanted account being added to the group and thus assigned to the role.
 - By default, only Global Administrators and Privileged Role Administrators can manage the membership of a role-assignable group, but you can delegate the management of role-assignable groups by adding group owners.
-- RoleManagement.ReadWrite.All Microsoft Graph permission is required to be able to manage the membership of such groups; Group.ReadWrite.All won't work.
+- RoleManagement.ReadWrite.Directory Microsoft Graph permission is required to be able to manage the membership of such groups; Group.ReadWrite.All won't work.
 - To prevent elevation of privilege, only a Privileged Authentication Administrator or a Global Administrator can change the credentials or reset MFA for members and owners of a role-assignable group.
 - Group nesting is not supported. A group can't be added as a member of a role-assignable group.
 


### PR DESCRIPTION
As far as I know, there is no Graph scope named 'RoleManagement.ReadWrite.All', not many hits on Google for this value - I only found two articles on docs.microsoft.com and I'm submitting a PR for both of them.

I believe the correct scope name is 'RoleManagement.ReadWrite.Directory'

#ATCP