### PR TITLE
Update storage-ref-azcopy-copy.md

### DIFF
--- a/articles/storage/common/storage-ref-azcopy-copy.md
+++ b/articles/storage/common/storage-ref-azcopy-copy.md
@@ -39,7 +39,7 @@ For more information, see the examples section of this article.
 
 ## Advanced
 
-AzCopy automatically detects the content type of the files when you upload them from the local disk. AzCopy detects the content type based on the file extension or content (if no extension is specified).
+AzCopy automatically detects the content type of the files based on the file extension or content (if no extension is specified) when you upload them from the local disk.
 
 The built-in lookup table is small, but on Unix, it is augmented by the local system's `mime.types` file(s) if they are available under one or more of these names:
 


### PR DESCRIPTION
It is kind of redundant to mention the AzCopy command twice to say that it detects the content type automatically and that it does it based on the file extension or content in two separate sentences.