### PR TITLE
Updated max message size of premium tier

### DIFF
--- a/articles/service-bus-messaging/service-bus-faq.yml
+++ b/articles/service-bus-messaging/service-bus-faq.yml
@@ -166,7 +166,7 @@ sections:
       - question: |
           How to handle messages of size > 1 MB?
         answer: |
-          Service Bus messaging services (queues and topics/subscriptions) allow application to send messages of size up to 256 KB (standard tier) or 100 MB (premium tier). If you're dealing with messages of size greater than the allowed size, use the claim check pattern described in [this blog post](https://www.serverless360.com/blog/deal-with-large-service-bus-messages-using-claim-check-pattern).
+          Service Bus messaging services (queues and topics/subscriptions) allow application to send messages of size up to 256 KB (standard tier) or 1 MB (premium tier). If you're dealing with messages of size greater than the allowed size, use the claim check pattern described in [this blog post](https://www.serverless360.com/blog/deal-with-large-service-bus-messages-using-claim-check-pattern).
           
   - name: Troubleshooting
     questions:


### PR DESCRIPTION
I think there is a typo in the maximum message size for premium tier. It stated 100 MB but should be 1 MB.