### PR TITLE
Add a note about the expected error message

### DIFF
--- a/articles/iot-hub/iot-hub-public-network-access.md
+++ b/articles/iot-hub/iot-hub-public-network-access.md
@@ -82,6 +82,8 @@ If you have trouble accessing your IoT hub, your network configuration could be 
   Unable to retrieve devices. Please ensure that your network connection is online and network settings allow connections from your IP address.
 ```
 
+When trying to access your IoT hub with other tools, such as the Azure CLI, the error message may include `{"errorCode": 401002, "message": "Unauthorized"}` in the case where the request is not routed correctly to your IoT hub.
+
 To get access to the IoT hub, request permission from your IT administrator to add your IP address in the IP address range or to enable public network access to all networks. If that fails to resolve the issue, check your local network settings or contact your local network administrator to fix connectivity to the IoT Hub. For example, sometimes a proxy in the local network can interfere with access to IoT Hub.
 
 If the preceding commands do not work or you cannot turn on all network ranges, contact Microsoft support.


### PR DESCRIPTION
When disabling IoT hub public network access, the expected error message is
`Unauthorized`.

Add a note about this in the documentation, because it might not be the most
intuitive error to receive if the service is not accessible from the networking
perspective.