### PR TITLE
Fixed irrelevant "Microsoft.DesktopVirtualization/hostpools/sessionho…

### DIFF
--- a/articles/virtual-desktop/autoscale-scaling-plan.md
+++ b/articles/virtual-desktop/autoscale-scaling-plan.md
@@ -111,7 +111,6 @@ To create and assign the custom role to your subscription with the Azure portal:
 				 "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/delete"
 				 "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read"
 				 "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/sendMessage/action"
-				 "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read"
     ```
 
 5. When you're finished, select **Ok**.


### PR DESCRIPTION
There was a typo present in the "Assign custom roles with the Azure portal" section of the article.

We can see the value "Microsoft.DesktopVirtualization/hostpools/sessionhosts/usersessions/read" being repeated twice, on the step 4 of the chapter.