### PR TITLE
Provide common alternative to jq for minimal use

### DIFF
--- a/includes/virtual-machines-imds.md
+++ b/includes/virtual-machines-imds.md
@@ -46,6 +46,8 @@ Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -NoProxy -Uri "http:
 curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq
 ```
 
+The `jq` utility is available in many cases but not all. If this is missing use `| python -m json.tool` instead.
+
 ---
 
 **Response**
@@ -568,6 +570,8 @@ Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -NoProxy -Uri "http:
 ```bash
 curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute/tagsList?api-version=2019-06-04" | jq
 ```
+
+The `jq` utility is available in many cases but not all. If this is missing use `| python -m json.tool` instead.
 
 ---
 

--- a/includes/virtual-machines-imds.md
+++ b/includes/virtual-machines-imds.md
@@ -46,7 +46,7 @@ Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -NoProxy -Uri "http:
 curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | jq
 ```
 
-The `jq` utility is available in many cases but not all. If this is missing use `| python -m json.tool` instead.
+The `jq` utility is available in many cases, but not all. If the `jq` utility is missing, use `| python -m json.tool` instead.
 
 ---
 
@@ -571,7 +571,7 @@ Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -NoProxy -Uri "http:
 curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/compute/tagsList?api-version=2019-06-04" | jq
 ```
 
-The `jq` utility is available in many cases but not all. If this is missing use `| python -m json.tool` instead.
+The `jq` utility is available in many cases, but not all. If the `jq` utility is missing, use `| python -m json.tool` instead.
 
 ---
 


### PR DESCRIPTION
The `json.tool` python module is going to be installed a lot more commonly than JSON query ("jq".) This is clearly subjective, but providing an example that's likely to work on a large cross-section of Linux hosts makes good sense.