### PR TITLE
fix: update AKS cluster to enable OIDC issuer

### DIFF
--- a/articles/aks/cluster-configuration.md
+++ b/articles/aks/cluster-configuration.md
@@ -173,9 +173,9 @@ az group create --name myResourceGroup --location eastus
 az aks create -n aks -g myResourceGroup --enable-oidc-issuer
 ```
 
-### Upgrade an AKS cluster with OIDC Issuer
+### Update an AKS cluster with OIDC Issuer
 
-To upgrade a cluster to use OIDC Issuer.
+To update a cluster to use OIDC Issuer.
 
 ```azurecli-interactive
 az aks update -n aks -g myResourceGroup --enable-oidc-issuer


### PR DESCRIPTION
There is a typo in the section header: the actual action is to update the cluster instead of upgrading it.

Fix #86120