### PR TITLE
Requirements may mislead macOS users

### DIFF
--- a/articles/azure-functions/openapi-apim-integrate-visual-studio.md
+++ b/articles/azure-functions/openapi-apim-integrate-visual-studio.md
@@ -25,7 +25,7 @@ The serverless function you create provides an API that lets you determine wheth
 
 ## Prerequisites
 
-+ [Visual Studio 2019](https://azure.microsoft.com/downloads/), version 16.10, or a later version. Make sure you select the **Azure development** workload during installation. 
++ [Visual Studio 2019](https://azure.microsoft.com/downloads/), version 16.10, or a later non-macOS version. Make sure you select the **Azure development** workload during installation. 
 
 + An active [Azure subscription](../guides/developer/azure-developer-guide.md#understanding-accounts-subscriptions-and-billing), create a [free account](https://azure.microsoft.com/free/dotnet/) before you begin.
 


### PR DESCRIPTION
Now that the latest version of Visual Studio for Mac is 17.0, up from 8.10 in the previous release the prerequisites will have macOS users looking for a template that isn't there.