### PR TITLE
Update emulator-command-line-parameters.md

### DIFF
--- a/articles/cosmos-db/emulator-command-line-parameters.md
+++ b/articles/cosmos-db/emulator-command-line-parameters.md
@@ -73,7 +73,7 @@ Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Az
 or place the `PSModules` directory on your `PSModulePath` and import it as shown in the following command:
 
 ```powershell
-$env:PSModulePath += "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules"
+$env:PSModulePath += ";$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules"
 Import-Module Microsoft.Azure.CosmosDB.Emulator
 ```
 


### PR DESCRIPTION
added semi-colon to PowerShell snippet to prevent the environment variable 'contaminating' itself by directly appending the new module path to the tail of the previous path