### PR TITLE
change icacls example

### DIFF
--- a/articles/storage/files/storage-files-identity-ad-ds-configure-permissions.md
+++ b/articles/storage/files/storage-files-identity-ad-ds-configure-permissions.md
@@ -100,7 +100,7 @@ If you have directories or files in on-premises file servers with Windows DACLs 
 Use the following Windows command to grant full permissions to all directories and files under the file share, including the root directory. Remember to replace the placeholder values in the example with your own values.
 
 ```
-icacls <mounted-drive-letter>: /grant <user-email>:(f)
+icacls <mounted-drive-letter>: /grant <user-upn>:(f)
 ```
 
 For more information on how to use icacls to set Windows ACLs and on the different types of supported permissions, see [the command-line reference for icacls](/windows-server/administration/windows-commands/icacls).


### PR DESCRIPTION
icacls can use UPN for account lookup. email address is not used.