### PR TITLE
Update sas-expiration-policy.md

### DIFF
--- a/articles/storage/common/sas-expiration-policy.md
+++ b/articles/storage/common/sas-expiration-policy.md
@@ -105,7 +105,7 @@ The SAS expiration period appears in the console output.
 
 To log the creation of a SAS that is valid over a longer interval than the SAS expiration policy recommends, first create a diagnostic setting that sends logs to an Azure Log Analytics workspace. For more information, see [Send logs to Azure Log Analytics](../blobs/monitor-blob-storage.md#send-logs-to-azure-log-analytics).
 
-Next, use an Azure Monitor log query to determine whether a SAS has expired. Create a new query in your Log Analytics workspace, add the following query text, and press **Run**.
+Next, use an Azure Monitor log query to monitor if policy has been violated. Create a new query in your Log Analytics workspace, add the following query text, and press **Run**.
 
 ```kusto
 StorageBlobLogs | where SasExpiryStatus startswith "Policy Violated" 

--- a/articles/storage/common/sas-expiration-policy.md
+++ b/articles/storage/common/sas-expiration-policy.md
@@ -105,7 +105,7 @@ The SAS expiration period appears in the console output.
 
 To log the creation of a SAS that is valid over a longer interval than the SAS expiration policy recommends, first create a diagnostic setting that sends logs to an Azure Log Analytics workspace. For more information, see [Send logs to Azure Log Analytics](../blobs/monitor-blob-storage.md#send-logs-to-azure-log-analytics).
 
-Next, use an Azure Monitor log query to monitor if policy has been violated. Create a new query in your Log Analytics workspace, add the following query text, and press **Run**.
+Next, use an Azure Monitor log query to monitor whether policy has been violated. Create a new query in your Log Analytics workspace, add the following query text, and press **Run**.
 
 ```kusto
 StorageBlobLogs | where SasExpiryStatus startswith "Policy Violated" 


### PR DESCRIPTION
The feature puts a check on specifying a maximum window for which SAS can been created, although we can still create a SAS with longer expiry.

If there is a SAS which breaches the policy of  max window specified, it will help mapping to those instances only as Policy violation. If a SAS gets expired, the calls are expected to fails. However, this feature won't be helpful in reading the expiry value of the expiry parameter and notify CX. CX need to track the expiry manually at their end.

Proposing suggestion to remove  that part. Kindly review