### PR TITLE
Fix Incorrect allowed outbound communication host

### DIFF
--- a/articles/machine-learning/how-to-access-azureml-behind-firewall.md
+++ b/articles/machine-learning/how-to-access-azureml-behind-firewall.md
@@ -349,7 +349,7 @@ To support logging of metrics and other monitoring information to Azure Monitor 
 * **dc.applicationinsights.azure.com**
 * **dc.applicationinsights.microsoft.com**
 * **dc.services.visualstudio.com**
-* **.in.applicationinsights.azure.com**
+* ***.in.applicationinsights.azure.com**
 
 For a list of IP addresses for these hosts, see [IP addresses used by Azure Monitor](../azure-monitor/app/ip-addresses.md).
 


### PR DESCRIPTION
Outbound communication host that should be allowed to use Azure Monitor is incorrect in this doc(`.in.applicationsnsights.azure.com`).  `*.in.applicationinsights.azure.com` should be correct.