### PR TITLE
guidance to delete azureml-fe related resources before re-attaching

### DIFF
--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -386,15 +386,24 @@ In Azure Machine Learning studio, select __Compute__, __Inference clusters__, an
 
 Updates to Azure Machine Learning components installed in an Azure Kubernetes Service cluster must be manually applied. 
 
-You can apply these updates by detaching the cluster from the Azure Machine Learning workspace, deleting the azureml-fe related resources, and then reattaching the cluster to the workspace.
+You can apply these updates by detaching the cluster from the Azure Machine Learning workspace and reattaching the cluster to the workspace. 
 
 ```python
 compute_target = ComputeTarget(workspace=ws, name=clusterWorkspaceName)
 compute_target.detach()
 compute_target.wait_for_completion(show_output=True)
 ```
+Before you can re-attach the cluster to your workspace, you need to first delete any `azureml-fe` related resources. If there is no active service in the cluster, you can delete your `azureml-fe` related resources with the following code. 
 
-If there is none active service in cluster, follow the [guidance](how-to-create-attach-kubernetes.md#delete-azureml-fe-related-resources) to delete azureml-fe related resources.
+```shell
+kubectl delete sa azureml-fe
+kubectl delete clusterrole azureml-fe-role
+kubectl delete clusterrolebinding azureml-fe-binding
+kubectl delete svc azureml-fe
+kubectl delete svc azureml-fe-int-http
+kubectl delete deploy azureml-fe
+kubectl delete secret azuremlfessl
+kubectl delete cm azuremlfeconfig
 
 If TLS is enabled in the cluster, you will need to supply the TLS/SSL certificate and private key when reattaching the cluster.
 

--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -393,6 +393,7 @@ compute_target = ComputeTarget(workspace=ws, name=clusterWorkspaceName)
 compute_target.detach()
 compute_target.wait_for_completion(show_output=True)
 ```
+
 Before you can re-attach the cluster to your workspace, you need to first delete any `azureml-fe` related resources. If there is no active service in the cluster, you can delete your `azureml-fe` related resources with the following code. 
 
 ```shell
@@ -404,13 +405,14 @@ kubectl delete svc azureml-fe-int-http
 kubectl delete deploy azureml-fe
 kubectl delete secret azuremlfessl
 kubectl delete cm azuremlfeconfig
+```
 
 If TLS is enabled in the cluster, you will need to supply the TLS/SSL certificate and private key when reattaching the cluster.
 
 ```python
 attach_config = AksCompute.attach_configuration(resource_group=resourceGroup, cluster_name=kubernetesClusterName)
 
-## If SSL is enabled.
+# If SSL is enabled.
 attach_config.enable_ssl(
     ssl_cert_pem_file="cert.pem",
     ssl_key_pem_file="key.pem",
@@ -428,8 +430,8 @@ If you no longer have the TLS/SSL certificate and private key, or you are using 
 kubectl get secret/azuremlfessl -o yaml
 ```
 
->[!Note]
->Kubernetes stores the secrets in base-64 encoded format. You will need to base-64 decode the `cert.pem` and `key.pem` components of the secrets prior to providing them to `attach_config.enable_ssl`. 
+> [!NOTE]
+> Kubernetes stores the secrets in Base64-encoded format. You will need to Base64-decode the `cert.pem` and `key.pem` components of the secrets prior to providing them to `attach_config.enable_ssl`. 
 
 ### Webservice failures
 
@@ -441,7 +443,7 @@ az aks get-credentials -g <rg> -n <aks cluster name>
 
 ### Delete azureml-fe related resources
 
-After detaching cluster, if there is none active service in cluster, please delete the azureml-fe related resources before attaching again
+After detaching cluster, if there is none active service in cluster, please delete the `azureml-fe` related resources before attaching again:
 
 ```shell
 kubectl delete sa azureml-fe

--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -432,7 +432,7 @@ az aks get-credentials -g <rg> -n <aks cluster name>
 
 ### Delete azureml-fe related resources
 
-After detaching cluster, if you don't have any active service in cluster, please delete the azureml-fe related resources before attaching again
+After detaching cluster, if there is none active service in cluster, please delete the azureml-fe related resources before attaching again
 
 ```shell
 kubectl delete sa azureml-fe

--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -386,13 +386,26 @@ In Azure Machine Learning studio, select __Compute__, __Inference clusters__, an
 
 Updates to Azure Machine Learning components installed in an Azure Kubernetes Service cluster must be manually applied. 
 
-You can apply these updates by detaching the cluster from the Azure Machine Learning workspace, and then reattaching the cluster to the workspace. If TLS is enabled in the cluster, you will need to supply the TLS/SSL certificate and private key when reattaching the cluster. 
+You can apply these updates by detaching the cluster from the Azure Machine Learning workspace, deleting the azureml-fe related resources, and then reattaching the cluster to the workspace. If TLS is enabled in the cluster, you will need to supply the TLS/SSL certificate and private key when reattaching the cluster. 
 
 ```python
 compute_target = ComputeTarget(workspace=ws, name=clusterWorkspaceName)
 compute_target.detach()
 compute_target.wait_for_completion(show_output=True)
+```
 
+```shell
+kubectl delete sa azureml-fe
+kubectl delete clusterrole azureml-fe-role
+kubectl delete clusterrolebinding azureml-fe-binding
+kubectl delete svc azureml-fe
+kubectl delete svc azureml-fe-int-http
+kubectl delete deploy azureml-fe
+kubectl delete secret azuremlfessl
+kubectl delete cm azuremlfeconfig
+```
+
+```python
 attach_config = AksCompute.attach_configuration(resource_group=resourceGroup, cluster_name=kubernetesClusterName)
 
 ## If SSL is enabled.

--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -422,6 +422,14 @@ kubectl get secret/azuremlfessl -o yaml
 >[!Note]
 >Kubernetes stores the secrets in base-64 encoded format. You will need to base-64 decode the `cert.pem` and `key.pem` components of the secrets prior to providing them to `attach_config.enable_ssl`. 
 
+### Webservice failures
+
+Many webservice failures in AKS can be debugged by connecting to the cluster using `kubectl`. You can get the `kubeconfig.json` for an AKS cluster by running
+
+```azurecli-interactive
+az aks get-credentials -g <rg> -n <aks cluster name>
+```
+
 ### Delete azureml-fe related resources
 
 After detaching cluster, if you don't have any active service in cluster, please delete the azureml-fe related resources before attaching again
@@ -435,14 +443,6 @@ kubectl delete svc azureml-fe-int-http
 kubectl delete deploy azureml-fe
 kubectl delete secret azuremlfessl
 kubectl delete cm azuremlfeconfig
-```
-
-### Webservice failures
-
-Many webservice failures in AKS can be debugged by connecting to the cluster using `kubectl`. You can get the `kubeconfig.json` for an AKS cluster by running
-
-```azurecli-interactive
-az aks get-credentials -g <rg> -n <aks cluster name>
 ```
 
 ## Next steps

--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -394,16 +394,7 @@ compute_target.detach()
 compute_target.wait_for_completion(show_output=True)
 ```
 
-```shell
-kubectl delete sa azureml-fe
-kubectl delete clusterrole azureml-fe-role
-kubectl delete clusterrolebinding azureml-fe-binding
-kubectl delete svc azureml-fe
-kubectl delete svc azureml-fe-int-http
-kubectl delete deploy azureml-fe
-kubectl delete secret azuremlfessl
-kubectl delete cm azuremlfeconfig
-```
+If you don't have any active service in cluster, follow the [guidance](how-to-create-attach-kubernetes.md#delete-azureml-fe-related-resources) to delete azureml-fe related resources
 
 ```python
 attach_config = AksCompute.attach_configuration(resource_group=resourceGroup, cluster_name=kubernetesClusterName)
@@ -428,6 +419,21 @@ kubectl get secret/azuremlfessl -o yaml
 
 >[!Note]
 >Kubernetes stores the secrets in base-64 encoded format. You will need to base-64 decode the `cert.pem` and `key.pem` components of the secrets prior to providing them to `attach_config.enable_ssl`. 
+
+### Delete azureml-fe related resources
+
+After detaching cluster, if you don't have any active service in cluster, please delete the azureml-fe related resources before attaching again
+
+```shell
+kubectl delete sa azureml-fe
+kubectl delete clusterrole azureml-fe-role
+kubectl delete clusterrolebinding azureml-fe-binding
+kubectl delete svc azureml-fe
+kubectl delete svc azureml-fe-int-http
+kubectl delete deploy azureml-fe
+kubectl delete secret azuremlfessl
+kubectl delete cm azuremlfeconfig
+```
 
 ### Webservice failures
 

--- a/articles/machine-learning/how-to-create-attach-kubernetes.md
+++ b/articles/machine-learning/how-to-create-attach-kubernetes.md
@@ -386,7 +386,7 @@ In Azure Machine Learning studio, select __Compute__, __Inference clusters__, an
 
 Updates to Azure Machine Learning components installed in an Azure Kubernetes Service cluster must be manually applied. 
 
-You can apply these updates by detaching the cluster from the Azure Machine Learning workspace, deleting the azureml-fe related resources, and then reattaching the cluster to the workspace. If TLS is enabled in the cluster, you will need to supply the TLS/SSL certificate and private key when reattaching the cluster. 
+You can apply these updates by detaching the cluster from the Azure Machine Learning workspace, deleting the azureml-fe related resources, and then reattaching the cluster to the workspace.
 
 ```python
 compute_target = ComputeTarget(workspace=ws, name=clusterWorkspaceName)
@@ -394,7 +394,9 @@ compute_target.detach()
 compute_target.wait_for_completion(show_output=True)
 ```
 
-If you don't have any active service in cluster, follow the [guidance](how-to-create-attach-kubernetes.md#delete-azureml-fe-related-resources) to delete azureml-fe related resources
+If there is none active service in cluster, follow the [guidance](how-to-create-attach-kubernetes.md#delete-azureml-fe-related-resources) to delete azureml-fe related resources.
+
+If TLS is enabled in the cluster, you will need to supply the TLS/SSL certificate and private key when reattaching the cluster.
 
 ```python
 attach_config = AksCompute.attach_configuration(resource_group=resourceGroup, cluster_name=kubernetesClusterName)


### PR DESCRIPTION
make this change to make sure when customers want to reattach ws to aks cluster, they need to cleanup azureml-fe related resources when there is no active service