### PR TITLE
Fix the wrong new line in the script

### DIFF
--- a/articles/event-grid/configure-private-endpoints.md
+++ b/articles/event-grid/configure-private-endpoints.md
@@ -210,8 +210,8 @@ topicName = "<TOPIC NAME>"
 connectionName="<ENDPOINT CONNECTION NAME>"
 endpointName=<ENDPOINT NAME>
 
-# resource ID of the topic. replace <SUBSCRIPTION ID>, <RESOURCE GROUP NAME>, and <TOPIC NAME>
-topicResourceID="/subscriptions/<SUBSCRIPTION ID>/resourceGroups/<RESOURCE GROUP NAME>/providers/Microsoft.EventGrid/topics/<TOPIC NAME>"
+# resource ID of the topic. replace <SUBSCRIPTION ID>, <RESOURCE GROUP NAME>, and <TOPIC NAME> 
+# topicResourceID="/subscriptions/<SUBSCRIPTION ID>/resourceGroups/<RESOURCE GROUP NAME>/providers/Microsoft.EventGrid/topics/<TOPIC NAME>"
 
 # select subscription
 az account set --subscription $subscriptionID
@@ -251,7 +251,7 @@ az eventgrid topic show \
     --name $topicName
 
 # create private endpoint for the topic you created
-az network private-endpoint create 
+az network private-endpoint create \
     --resource-group $resourceGroupName \
     --name $endpointName \
     --vnet-name $vNetName \


### PR DESCRIPTION
There are comments and scripts that are multiple lines but they're not formatted correctly. For example, the new line of comment isn't starting with `#`. And the line in the command doesn't end with `\` to mean that the next line is a continuation.