### PR TITLE
NFS 3.0 and SSH File Transfer Protocol (SFTP) can't be enabled on the same storage account.

### DIFF
--- a/articles/storage/blobs/network-file-system-protocol-known-issues.md
+++ b/articles/storage/blobs/network-file-system-protocol-known-issues.md
@@ -25,7 +25,7 @@ This article describes limitations and known issues of Network File System (NFS)
 
 - GRS, GZRS, and RA-GRS redundancy options aren't supported when you create an NFS 3.0 storage account.
 
-- NFS 3.0 and SFTP can't be enabled on the same storage account.
+- NFS 3.0 and SSH File Transfer Protocol (SFTP) can't be enabled on the same storage account.
 
 ## NFS 3.0 features
 

--- a/articles/storage/blobs/network-file-system-protocol-known-issues.md
+++ b/articles/storage/blobs/network-file-system-protocol-known-issues.md
@@ -25,6 +25,8 @@ This article describes limitations and known issues of Network File System (NFS)
 
 - GRS, GZRS, and RA-GRS redundancy options aren't supported when you create an NFS 3.0 storage account.
 
+- NFS 3.0 and SFTP can't be enabled on the same storage account.
+
 ## NFS 3.0 features
 
 The following NFS 3.0 features aren't yet supported.


### PR DESCRIPTION
NFS 3.0 and SFTP can't be enabled on the same storage account.