### PR TITLE
OPC Publisher Documentation: update link to main branch of the Azure/Industrial-IoT repository

### DIFF
--- a/articles/industrial-iot/tutorial-publisher-configure-opc-publisher.md
+++ b/articles/industrial-iot/tutorial-publisher-configure-opc-publisher.md
@@ -115,7 +115,7 @@ We have provided a [sample configuration application](https://github.com/Azure-S
 >[!NOTE] 
 > This feature is only available in version 2.6 and above of OPC Publisher.
 
-A cloud-based, companion microservice with a REST interface is described and available [here](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/publisher.md). It can be used to configure OPC Publisher via an OpenAPI-compatible interface, for example through Swagger.
+A cloud-based, companion microservice with a REST interface is described and available [here](https://github.com/Azure/Industrial-IoT/blob/main/docs/services/publisher.md). It can be used to configure OPC Publisher via an OpenAPI-compatible interface, for example through Swagger.
 
 ## Configuration of the simple JSON telemetry format via Separate Configuration File
 


### PR DESCRIPTION
The current link points to the old `master` branch. I changed the link so that it points to the `main` branch that is actively maintained.