### PR TITLE
[D365BC] Update docs about unused partner center fields

### DIFF
--- a/articles/marketplace/dynamics-365-business-central-supplemental-content.md
+++ b/articles/marketplace/dynamics-365-business-central-supplemental-content.md
@@ -18,7 +18,7 @@ This page lets you provide additional information to help us validate your offer
 Indicate which release of Microsoft Dynamics 365 Business Central your solution targets: **Current**, **Next Major**, or **Next Minor**. This information lets us test your solution appropriately.
 
 > [!NOTE]
-> The target release isn't used anymore during the validation of Business Central solutions and we are working on removing this field from Partner Center. For more information about the release computation during the validation, see [Technical Validation Checklist](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission).
+> The target release isn't used anymore during the validation of Business Central solutions and this field is being removed from Partner Center soon. For more information about the release computation during the validation, see [Technical Validation Checklist](/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission).
 
 ## Supported editions
 
@@ -29,7 +29,7 @@ If your offer requires the Premium edition of Microsoft Dynamics 365 Business Ce
 Upload a PDF file that lists your offer's key usage scenarios. All scenarios listed here may be verified by our validation team before we approve your offer for the marketplace.
 
 > [!NOTE]
-> The key usage scenario PDF isn't used anymore during the validation of Business Central solutions and we are working on removing this field from Partner Center. For more information, see [Technical Validation FAQ](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq).
+> The key usage scenario PDF isn't used anymore during the validation of Business Central solutions and we are working on removing this field from Partner Center. For more information, see [Technical Validation FAQ](/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq).
 
 ## Test accounts
 
@@ -42,7 +42,7 @@ If your offer is an Add-on app, you must upload an **App tests automation** file
 Select **Save draft**, then continue with review and publish in **Next steps** below.
 
 > [!NOTE]
-> The test app isn't used anymore during the validation of Business Central solutions and we are currently working on removing this field from Partner Center. For more information, see [Technical Validation FAQ](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq).
+> The test app isn't used anymore during the validation of Business Central solutions and we are currently working on removing this field from Partner Center. For more information, see [Technical Validation FAQ](/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq).
 
 ## Next steps
 

--- a/articles/marketplace/dynamics-365-business-central-supplemental-content.md
+++ b/articles/marketplace/dynamics-365-business-central-supplemental-content.md
@@ -17,6 +17,9 @@ This page lets you provide additional information to help us validate your offer
 
 Indicate which release of Microsoft Dynamics 365 Business Central your solution targets: **Current**, **Next Major**, or **Next Minor**. This information lets us test your solution appropriately.
 
+> [!NOTE]
+> The target release isn't used anymore during the validation of Business Central solutions and we are working on removing this field from Partner Center. For more information about the release computation during the validation, see [Technical Validation Checklist](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission).
+
 ## Supported editions
 
 If your offer requires the Premium edition of Microsoft Dynamics 365 Business Central, select **Premium** only. Otherwise, select both **Essentials** and **Premium**.
@@ -24,6 +27,9 @@ If your offer requires the Premium edition of Microsoft Dynamics 365 Business Ce
 ## Key usage scenario
 
 Upload a PDF file that lists your offer's key usage scenarios. All scenarios listed here may be verified by our validation team before we approve your offer for the marketplace.
+
+> [!NOTE]
+> The key usage scenario PDF isn't used anymore during the validation of Business Central solutions and we are working on removing this field from Partner Center. For more information, see [Technical Validation FAQ](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq).
 
 ## Test accounts
 
@@ -34,6 +40,9 @@ If a test account is needed in order for our certification team to properly revi
 If your offer is an Add-on app, you must upload an **App tests automation** file (.app). This file is not applicable to Connect apps.
 
 Select **Save draft**, then continue with review and publish in **Next steps** below.
+
+> [!NOTE]
+> The test app isn't used anymore during the validation of Business Central solutions and we are currently working on removing this field from Partner Center. For more information, see [Technical Validation FAQ](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq).
 
 ## Next steps
 


### PR DESCRIPTION
Some fields aren't used anymore during the validation of Business Central apps and are planned for removal from Partner Center.