### PR TITLE
Update api-management-howto-aad-b2c.md

### DIFF
--- a/articles/api-management/api-management-howto-aad-b2c.md
+++ b/articles/api-management/api-management-howto-aad-b2c.md
@@ -55,7 +55,7 @@ In this section, you'll create a user flow in your Azure Active Directory B2C te
 1. Return to the browser tab for your Azure Active Directory B2C tenant in the Azure portal. Select **App registrations** >  **+ New registration**.
 1. In the **Register an application** page, enter your application's registration information.
     * In the **Name** section, enter an application name of your choosing.
-    * In the **Supported account types** section, choose the type of accounts that are appropriate for your scenario. To target a wide set of customers, select **Accounts in any identity provider or organizational directory (for authenticating users with user flows)**. For more information, see [Register an application](../active-directory/develop/quickstart-register-app.md#register-an-application).
+    * In the **Supported account types** section select **Accounts in any identity provider or organizational directory (for authenticating users with user flows)**. For more information, see [Register an application](../active-directory/develop/quickstart-register-app.md#register-an-application).
     * In **Redirect URI**, enter the Redirect URL your copied from your API Management instance.
     * In **Permissions**, select **Grant admin consent to openid and offline_access permissions.**
     * Select **Register** to create the application.

--- a/articles/api-management/api-management-howto-aad-b2c.md
+++ b/articles/api-management/api-management-howto-aad-b2c.md
@@ -55,7 +55,7 @@ In this section, you'll create a user flow in your Azure Active Directory B2C te
 1. Return to the browser tab for your Azure Active Directory B2C tenant in the Azure portal. Select **App registrations** >  **+ New registration**.
 1. In the **Register an application** page, enter your application's registration information.
     * In the **Name** section, enter an application name of your choosing.
-    * In the **Supported account types** section select **Accounts in any identity provider or organizational directory (for authenticating users with user flows)**. For more information, see [Register an application](../active-directory/develop/quickstart-register-app.md#register-an-application).
+    * In the **Supported account types** section, select **Accounts in any identity provider or organizational directory (for authenticating users with user flows)**. For more information, see [Register an application](../active-directory/develop/quickstart-register-app.md#register-an-application).
     * In **Redirect URI**, enter the Redirect URL your copied from your API Management instance.
     * In **Permissions**, select **Grant admin consent to openid and offline_access permissions.**
     * Select **Register** to create the application.


### PR DESCRIPTION
As b2c idp config for apim dev portal requires user flows, then the only supported account type option (app registration) that is viable is "Accounts in any identity provider or organizational directory (for authenticating users with user flows)". 
Although the accompanying screen shot is correct, the ambiguity of the current wording could lead to customer picking , for example, "single tenant" option.