### PR TITLE
fix: MSAL net Client Assertions code fixed

### DIFF
--- a/articles/active-directory/develop/msal-net-client-assertions.md
+++ b/articles/active-directory/develop/msal-net-client-assertions.md
@@ -71,9 +71,9 @@ jti | (a Guid) | The "jti" (JWT ID) claim provides a unique identifier for the J
 nbf | 1601519114 | The "nbf" (not before) claim identifies the time before which the JWT MUST NOT be accepted for processing. [RFC 7519, Section 4.1.5](https://tools.ietf.org/html/rfc7519#section-4.1.5).  Using the current time is appropriate. 
 sub | {ClientID} | The "sub" (subject) claim identifies the subject of the JWT, in this case also your application. Use the same value as `iss`. 
 
-Using a certificate as a client secret, requires you to keep a certificate save. We recommend to store it a secure spot supported by the platform. Like the certificate store on Windows.
+If you use a certificate as a client secret, the certificate must be deployed safely. We recommend that you store the certificate in a secure spot supported by the platform, such as in the certificate store on Windows or by using Azure Key Vault.
 
-Here is an example of how to craft these claims:
+Here's an example of how to craft these claims:
 
 ```csharp
 using System.Collections.Generic;
@@ -99,7 +99,7 @@ private static IDictionary<string, object> GetClaims(string tenantId, string cli
 }
 ```
 
-Here is how to craft a signed client assertion:
+Here's how to craft a signed client assertion:
 
 ```csharp
 using System.Collections.Generic;

--- a/articles/active-directory/develop/msal-net-client-assertions.md
+++ b/articles/active-directory/develop/msal-net-client-assertions.md
@@ -130,11 +130,12 @@ static string GetSignedClientAssertion(X509Certificate2 certificate, string tena
     var rsa = certificate.GetRSAPrivateKey();
 
     //alg represents the desired signing algorithm, which is SHA-256 in this case
-    //kid represents the certificate thumbprint
+    //x5t represents the certificate thumbprint base64 url encoded
     var header = new Dictionary<string, string>()
     {
         { "alg", "RS256"},
-        { "kid", Encode(certificate.GetCertHash()) }
+        { "typ", "JWT" },
+        { "x5t", Base64UrlEncode(certificate.GetCertHash()) }
     };
 
     //Please see the previous code snippet on how to craft claims for the GetClaims() method
@@ -155,7 +156,7 @@ static string GetSignedClientAssertion(X509Certificate2 certificate, string tena
 You also have the option of using [Microsoft.IdentityModel.JsonWebTokens](https://www.nuget.org/packages/Microsoft.IdentityModel.JsonWebTokens/) to create the assertion for you. The code will be a more elegant as shown in the example below:
 
 ```csharp
-        string GetSignedClientAssertion(X509Certificate2 certificate)
+        string GetSignedClientAssertionAlt(X509Certificate2 certificate)
         {
             //aud = https://login.microsoftonline.com/ + Tenant ID + /v2.0
             string aud = $"https://login.microsoftonline.com/{tenantID}/v2.0";
@@ -187,9 +188,9 @@ Once you have your signed client assertion, you can use it with the MSAL apis as
 
 ```csharp
             X509Certificate2 certificate = ReadCertificate(config.CertificateName);
-            string signedClientAssertion = GetSignedClientAssertion(certificate);
+            string signedClientAssertion = GetSignedClientAssertion(certificate, tenantId, ConfidentialClientID)
             // OR
-            //string signedClientAssertion = GetSignedClientAssertion(certificate, tenantId, ConfidentialClientID);
+            //string signedClientAssertion = GetSignedClientAssertionAlt(certificate);
 
             var confidentialApp = ConfidentialClientApplicationBuilder
                 .Create(ConfidentialClientID)


### PR DESCRIPTION
The previous version of the code had several flaws:

- The claims in the token where incorrect. `exp` and `nbf` should be numbers not strings
- It manually created the `RSACryptoServiceProvider`, which is superseded by `certificate.GetRSAPrivateKey();`
- This new code Serializes the header and the token directly to bytes
- Using **System.Text.Json** instead of an **Newtonsoft.Json**

Fixed: #86635