### PR TITLE
Update Publish Hugo documentation for those using Git Info module

### DIFF
--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -169,9 +169,9 @@ jobs:
           HUGO_VERSION: 0.58.0
 ```
 
-#### Using the Git Info feature in your Hugo application
+#### Use the Git Info feature in your Hugo application
 
-If your Hugo application makes use of the [Git Info feature](https://gohugo.io/variables/git/), the default [workflow file](./build-configuration.md) created for the Static Web App uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a _single commit_, so they will share the same author, last modification timestamp and other `.GitInfo` variables.
+If your Hugo application uses the [Git Info feature](https://gohugo.io/variables/git/), the default [workflow file](./build-configuration.md) created for the Static Web App uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. In this scenario, Hugo sees all your content files as coming from a _single commit_, so they have the same author, last modification timestamp, and other `.GitInfo` variables.
 
 Update your workflow file to [fetch your full Git history](https://github.com/actions/checkout/blob/main/README.md#fetch-all-history-for-all-tags-and-branches) by adding a new parameter under the `actions/checkout` step to set the `fetch-depth` to `0` (no limit):
 
@@ -182,7 +182,7 @@ Update your workflow file to [fetch your full Git history](https://github.com/ac
           fetch-depth: 0
 ```
 
-Fetching the full history will increase the build time of your GitHub Actions workflow, but your `.Lastmod` and `.GitInfo` variables will now be accurate and available to each of your content files.
+Fetching the full history increases the build time of your GitHub Actions workflow, but your `.Lastmod` and `.GitInfo` variables will be accurate and available for each of your content files.
 
 ## Clean up resources
 

--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -171,23 +171,20 @@ jobs:
 
 #### Using the Git Info feature in your Hugo templates
 
-Hugo's (Git Info feature)[https://gohugo.io/variables/git/] gives you access to your content's Git revision information, including automatically setting the last modification date variable  (.Lastmod).
+Hugo's [Git Info feature](https://gohugo.io/variables/git/) gives you access to your content's Git revision information, including automatically setting the last modification date variable `.Lastmod`.
 
-When you generate a Static Web App, the default workflow file checks out a shallow version of your Git repository, to a depth of 1. Hugo will see all of your content files as coming from a single commit, so they will share the same author and last modification date and time.
+When you generate a Static Web App, the default workflow file uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a single commit, so they will share the same author and last modification date and time.
 
-You can update the default workflow to check out your full history by setting the fetch depth to 0 (no limit):
+To update your workflow flow to fetch your full Git history, add a new parameter to set the `fetch-depth` to `0` (no limit) under the `actions/checkout` step:
 
 ```yaml
-jobs:
-  build_and_deploy_job:
-    name: Build and Deploy Job
-    steps:
       - uses: actions/checkout@v2
         with:
-          depth: 0
+          submodules: true
+          fetch-depth: 0
 ```
 
-Fetching the full history of your branch will increase the build time of your GitHub Actions workflow, but your GitInfo properties and Lastmod property will now be accurate and available to each of your content pages.
+Fetching the full history of your branch will increase the build time of your GitHub Actions workflow, but your `.Lastmod` and `.GitInfo` page variables will now be accurate and available to each of your content pages.
 
 ## Clean up resources
 

--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -171,11 +171,9 @@ jobs:
 
 #### Using the Git Info feature in your Hugo templates
 
-Hugo's [Git Info feature](https://gohugo.io/variables/git/) gives you access to your content's Git revision information, including automatically setting the last modification date variable `.Lastmod`.
+If your Hugo application makes use of Hugo's [Git Info feature](https://gohugo.io/variables/git/), the default workflow file created for the Static Web App uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a _single commit_, so they will share the same author, last modification date and time etc.
 
-When you generate a Static Web App, the default workflow file uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a single commit, so they will share the same author and last modification date and time.
-
-To update your workflow file to fetch your full Git history, add a new parameter to set the `fetch-depth` to `0` (no limit) under the `actions/checkout` step:
+Update your workflow file to fetch your full Git history by adding a new parameter to set the `fetch-depth` to `0` (no limit) under the `actions/checkout` step:
 
 ```yaml
       - uses: actions/checkout@v2

--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -169,6 +169,26 @@ jobs:
           HUGO_VERSION: 0.58.0
 ```
 
+#### Using the Git Info feature in your Hugo templates
+
+Hugo's (Git Info feature)[https://gohugo.io/variables/git/] gives you access to your content's Git revision information, including automatically setting the last modification date variable  (.Lastmod).
+
+When you generate a Static Web App, the default workflow file checks out a shallow version of your Git repository, to a depth of 1. Hugo will see all of your content files as coming from a single commit, so they will share the same author and last modification date and time.
+
+You can update the default workflow to check out your full history by setting the fetch depth to 0 (no limit):
+
+```yaml
+jobs:
+  build_and_deploy_job:
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          depth: 0
+```
+
+Fetching the full history of your branch will increase the build time of your GitHub Actions workflow, but your GitInfo properties and Lastmod property will now be accurate and available to each of your content pages.
+
 ## Clean up resources
 
 [!INCLUDE [cleanup-resource](../../includes/static-web-apps-cleanup-resource.md)]

--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -169,11 +169,11 @@ jobs:
           HUGO_VERSION: 0.58.0
 ```
 
-#### Using the Git Info feature in your Hugo templates
+#### Using the Git Info feature in your Hugo application
 
-If your Hugo application makes use of Hugo's [Git Info feature](https://gohugo.io/variables/git/), the default workflow file created for the Static Web App uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a _single commit_, so they will share the same author, last modification date and time etc.
+If your Hugo application makes use of the [Git Info feature](https://gohugo.io/variables/git/), the default [workflow file](./build-configuration.md) created for the Static Web App uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a _single commit_, so they will share the same author, last modification timestamp and other `.GitInfo` variables.
 
-Update your workflow file to fetch your full Git history by adding a new parameter under the `actions/checkout` step to set the `fetch-depth` to `0` (no limit) :
+Update your workflow file to [fetch your full Git history](https://github.com/actions/checkout/blob/main/README.md#fetch-all-history-for-all-tags-and-branches) by adding a new parameter under the `actions/checkout` step to set the `fetch-depth` to `0` (no limit):
 
 ```yaml
       - uses: actions/checkout@v2
@@ -182,7 +182,7 @@ Update your workflow file to fetch your full Git history by adding a new paramet
           fetch-depth: 0
 ```
 
-Fetching the full history of your branch will increase the build time of your GitHub Actions workflow, but your `.Lastmod` and `.GitInfo` page variables will now be accurate and available to each of your content pages.
+Fetching the full history will increase the build time of your GitHub Actions workflow, but your `.Lastmod` and `.GitInfo` variables will now be accurate and available to each of your content files.
 
 ## Clean up resources
 

--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -140,7 +140,7 @@ The following steps show you how to create a new static site app and deploy it t
 
 #### Custom Hugo version
 
-When you generate a Static Web App, a [workflow file](./build-configuration.md) is generated which contains the publishing configuration settings for the application. You can designate a specific Hugo version in the workflow file by providing a value for `HUGO_VERSION` in the `env` section. The following example configuration demonstrates how to set set Hugo to a specific version.
+When you generate a Static Web App, a [workflow file](./build-configuration.md) is generated which contains the publishing configuration settings for the application. You can designate a specific Hugo version in the workflow file by providing a value for `HUGO_VERSION` in the `env` section. The following example configuration demonstrates how to set Hugo to a specific version.
 
 ```yaml
 jobs:
@@ -173,7 +173,7 @@ jobs:
 
 If your Hugo application makes use of Hugo's [Git Info feature](https://gohugo.io/variables/git/), the default workflow file created for the Static Web App uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a _single commit_, so they will share the same author, last modification date and time etc.
 
-Update your workflow file to fetch your full Git history by adding a new parameter to set the `fetch-depth` to `0` (no limit) under the `actions/checkout` step:
+Update your workflow file to fetch your full Git history by adding a new parameter under the `actions/checkout` step to set the `fetch-depth` to `0` (no limit) :
 
 ```yaml
       - uses: actions/checkout@v2

--- a/articles/static-web-apps/publish-hugo.md
+++ b/articles/static-web-apps/publish-hugo.md
@@ -175,7 +175,7 @@ Hugo's [Git Info feature](https://gohugo.io/variables/git/) gives you access to 
 
 When you generate a Static Web App, the default workflow file uses the [checkout GitHub Action](https://github.com/actions/checkout) to fetch a _shallow_ version of your Git repository, with a default depth of **1**. Hugo will see all of your content files as coming from a single commit, so they will share the same author and last modification date and time.
 
-To update your workflow flow to fetch your full Git history, add a new parameter to set the `fetch-depth` to `0` (no limit) under the `actions/checkout` step:
+To update your workflow file to fetch your full Git history, add a new parameter to set the `fetch-depth` to `0` (no limit) under the `actions/checkout` step:
 
 ```yaml
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Overview

This Pull Request adds a section to the `Publish a Hugo site to Azure Static Web Apps` tutorial with the steps needed to update the default workflow when the application makes use of Hugo's Git Info feature.

## Details

Hugo has a [Git Info feature](https://gohugo.io/variables/git/) that exposes Git commit information for each individual content file. This includes the author, and last modification date and time.

> The Hugo documentation itself uses Git Info; near the bottom of each documentation page is an "Improve this page" section which uses Git variables including the automatic last updated timestamp.

Notably when publishing to Azure Static Web Apps for Hugo, the default workflow file uses the `checkout` GitHub Action, which uses a default fetch depth of 1.

This means Hugo's Git Info feature sees every file as coming from a single commit (same author, hash, date / time modification etc). This will break anything making use of this feature e.g. all pages will appear to have been modified at the same moment in time.

## Solution

I have added a new section to the tutorial with instructions on how to update the workflow file to ensure the Git Info feature works as intended.

## Alternatives

Should the default workflow file generated using the Hugo Build Preset in the Azure portal be updated to set the `fetch-depth` to 0, so that Git Info "just works" right from the start?