### PR TITLE
Update nat-gateway-integration.md

### DIFF
--- a/articles/app-service/networking/nat-gateway-integration.md
+++ b/articles/app-service/networking/nat-gateway-integration.md
@@ -26,6 +26,8 @@ For more information and pricing. Go to the [NAT gateway overview](../../virtual
 
 > [!Note] 
 > Using NAT gateway with App Service is dependent on regional VNet Integration, and therefore **Standard**, **Premium**, **PremiumV2** or **PremiumV3** App Service plan is required.
+>
+> If you plan to use, or already use, [Service Endpoints with App Service regional VNet Integration](../app-service/overview-vnet-integration.md#service-endpoints) they will continue to work as expected with the addition of a NAT gateway to the subnet. The Service Endpoint adds a more specific route, so traffic to the service it represents will not egress via the NAT gateway. For more information see [Virtual Network Service Endpoints](../../virtual-network/virtual-network-service-endpoints-overview.md).
 
 ## Configuring NAT gateway integration
 


### PR DESCRIPTION
The point about using NAT GW with a subnet that has Service Endpoints is not addressed (as far as I can see) anywhere else in the docs. Fast Track for Azure Customer recently queried this as they wish to utilise both with App Service + Regional VNet integration.

The NAT Gateway will be leveraged for traffic hitting the 0.0.0.0/0 route injected by the service. Since service endpoints inject a more specific route, traffic to the service endpoint will not hit the 0.0.0.0/0 and hence bypass the NAT GW