### PR TITLE
Correcting aks update script with escape

### DIFF
--- a/articles/aks/update-credentials.md
+++ b/articles/aks/update-credentials.md
@@ -103,8 +103,11 @@ az aks update-credentials \
     --name myAKSCluster \
     --reset-service-principal \
     --service-principal "$SP_ID" \
-    --client-secret "$SP_SECRET"
+    --client-secret "${SP_SECRET:Q}"
 ```
+
+> [!IMPORTANT]
+> When using Azure generated secrets, secrets may contain special characters ("-" or "~"); therefore it may be nessesary to excape the characters that are stored in the value of the secret variable (in this case the variable is "SP_SECRET"). This can be done by keeping the vairable within the quotes and adding brackets with the appropate delimiter (:Q or @Q) depending on the console you are using as shown above, for example: "{VARIABLE_HERE:Q}" or "{VARIABLE_HERE@Q}".
 
 For small and midsize clusters, it takes a few moments for the service principal credentials to be updated in the AKS.
 


### PR DESCRIPTION
When using an Azure auto generated secret for the principal in step 2, the secret often contains a special character for example "-". When using the script previously the variable being used to store the value of the secret was causing an error:
Operation failed with status: 'Bad Request'.
Details: The credentials in ServicePrincipalProfile were invalid. Please see https://aka.ms/aks-sp-help for more details.
(Details: adal: Refresh request failed. Status Code = '401'.
This is happening because the variable is not being read as a literal string therefore the special characters are breaking the value rules.
To properly escape the variables value Bash requires the format "${SP_SECRET@Q}" as per https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#:~:text=The%20expansion%20is%20a%20string%20that%20is%20the%20value%20of%20parameter%20quoted%20in%20a%20format%20that%20can%20be%20reused%20as%20input. 
This will still produce an error in the Azure cloud shell:
@Azure:~$ az aks update-credentials --resource-group jamestest --name jamestest --reset-service-principal --service-principal "$SP_ID" --client-secret "${SP_SECRET@Q}"
(BadRequest) Service principal client secret has invalid characters: ` '
Code: BadRequest
Message: Service principal client secret has invalid characters: ` '
Target: servicePrincipalProfile.secret
This is because in the Azure cloud shell Bash we are interacting with is Z shell. The Z shell equivalent is "${SP_SECRET:Q}".