### PR TITLE
Iotedge: Production guidance for twin limits

### DIFF
--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -137,12 +137,12 @@ When moving from test scenarios to production scenarios, remember to remove debu
 
 ### Be mindful of twin size limits when using custom modules
 
-The deployment manifest containing custom modules is part of the EdgeAgent twin. The size limitation on properties of this twin are [described here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-module-twins#module-twin-size).
+The deployment manifest that contains custom modules is part of the EdgeAgent twin. Review the [limitation on module twin size](../iot-hub/iot-hub-devguide-module-twins.md#module-twin-size).
 
-When deploying many modules it is possible to exhaust this twin size limit. There are a few common mitigations to this hard limit:
-1. Store any configuration in the custom module twin, which has its own limit
-2. Store some configuration that points to a non-space-limited location (i.e. blob store)
+If you deploy a large number of modules, you might exhaust this twin size limit. Consider some common mitigations to this hard limit:
 
+- Store any configuration in the custom module twin, which has its own limit.
+- Store some configuration that points to a non-space-limited location (that is, to a blob store).
 
 ## Container management
 

--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -137,7 +137,7 @@ When moving from test scenarios to production scenarios, remember to remove debu
 
 ### Be mindful of twin size limits when using custom modules
 
-The deployment manifest containing custom modules is part of the EdgeAgent twin. The size limitation on properties of this twin are [described here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins#device-twin-size).
+The deployment manifest containing custom modules is part of the EdgeAgent twin. The size limitation on properties of this twin are [described here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-module-twins#module-twin-size).
 
 When deploying many modules it is possible to exhaust this twin size limit. There are a few common mitigations to this hard limit:
 1. Store any configuration in the custom module twin, which has its own limit

--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -135,7 +135,7 @@ The default value of the timeToLiveSecs parameter is 7200 seconds, which is two 
 
 When moving from test scenarios to production scenarios, remember to remove debug configurations from deployment manifests. Check that none of the module images in the deployment manifests have the **\.debug** suffix. If you added create options to expose ports in the modules for debugging, remove those create options as well.
 
-#### Be mindful of twin size limits when using custom modules
+### Be mindful of twin size limits when using custom modules
 
 The deployment manifest containing custom modules is part of the EdgeAgent twin. The size limitation on properties of this twin are [described here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins#device-twin-size).
 

--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -140,7 +140,7 @@ When moving from test scenarios to production scenarios, remember to remove debu
 The deployment manifest containing custom modules is part of the EdgeAgent twin. The size limitation on properties of this twin are [described here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins#device-twin-size).
 
 When deploying many modules it is possible to exhaust this twin size limit. There are a few common mitigations to this hard limit:
-1. Store any configuration in the custom module twin, which has its own limit.
+1. Store any configuration in the custom module twin, which has its own limit
 2. Store some configuration that points to a non-space-limited location (i.e. blob store)
 
 

--- a/articles/iot-edge/production-checklist.md
+++ b/articles/iot-edge/production-checklist.md
@@ -85,6 +85,7 @@ Once your IoT Edge device connects, be sure to continue configuring the Upstream
   * Set up host storage for system modules
   * Reduce memory space used by the IoT Edge hub
   * Do not use debug versions of module images
+  * Be mindful of twin size limits when using custom modules
 
 ### Be consistent with upstream protocol
 
@@ -133,6 +134,15 @@ The default value of the timeToLiveSecs parameter is 7200 seconds, which is two 
 ### Do not use debug versions of module images
 
 When moving from test scenarios to production scenarios, remember to remove debug configurations from deployment manifests. Check that none of the module images in the deployment manifests have the **\.debug** suffix. If you added create options to expose ports in the modules for debugging, remove those create options as well.
+
+#### Be mindful of twin size limits when using custom modules
+
+The deployment manifest containing custom modules is part of the EdgeAgent twin. The size limitation on properties of this twin are [described here](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-device-twins#device-twin-size).
+
+When deploying many modules it is possible to exhaust this twin size limit. There are a few common mitigations to this hard limit:
+1. Store any configuration in the custom module twin, which has its own limit.
+2. Store some configuration that points to a non-space-limited location (i.e. blob store)
+
 
 ## Container management
 


### PR DESCRIPTION
This documentation update is prompted by a customer who added many custom modules with some env vars, and exhausted the available space in the edge agent twin. Described workarounds for this hard-limit.