### PR TITLE
Update closing quote - omsagent example

### DIFF
--- a/articles/sentinel/connect-syslog.md
+++ b/articles/sentinel/connect-syslog.md
@@ -73,7 +73,7 @@ Having already set up [data collection from your CEF sources](connect-common-eve
 1. You must run the following command on those machines to disable the synchronization of the agent with the Syslog configuration in Microsoft Sentinel. This ensures that the configuration change you made in the previous step does not get overwritten.
 
     ```c
-    sudo su omsagent -c 'python /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py --disable
+    sudo su omsagent -c 'python /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py --disable'
     ```
 
 ## Configure your device's logging settings


### PR DESCRIPTION
Missing closing quote in the example code snippet in the "Configure your Linux machine or appliance" Section, Sub-Section 2 of "Using the same machine to forward both plain Syslog and CEF messages" (omsagent execution).