### PR TITLE
Update form-recognizer-container-install-run.md

### DIFF
--- a/articles/applied-ai-services/form-recognizer/containers/form-recognizer-container-install-run.md
+++ b/articles/applied-ai-services/form-recognizer/containers/form-recognizer-container-install-run.md
@@ -373,7 +373,9 @@ events { worker_connections 1024; }
 http {
 
     sendfile on;
-
+   
+    client_max_body_size 90M;
+   
     upstream docker-api {
         server azure-cognitive-service-custom-api:5000;
     }


### PR DESCRIPTION
Encountering the 413 error due to the client body size being too large and resolving it by manually assigning it to you.