### PR TITLE
Corrected Log Analytics AppMetrics Table Schema

### DIFF
--- a/articles/azure-monitor/app/apm-tables.md
+++ b/articles/azure-monitor/app/apm-tables.md
@@ -241,7 +241,7 @@ Legacy table: customMetrics
 |valueCount|int|ValueCount|int|
 |valueMax|real|ValueMax|real|
 |valueMin|real|ValueMin|real|
-|valueStdDev|real|ValueStdDev|real|
+|valueStdDev|real|(removed)||
 |valueSum|real|ValueSum|real|
 
 ### AppPageViews


### PR DESCRIPTION
Hey team, the ValueStdDev field from Application Insights did not make it into the Log Analytics AppMetrics table schema. We need the content to reflect this fact, so adjusting the AppMetrics table on this page.