### PR TITLE
Added command for installing libtool

### DIFF
--- a/articles/virtual-network/virtual-network-test-latency.md
+++ b/articles/virtual-network/virtual-network-test-latency.md
@@ -148,6 +148,7 @@ Run the following commands:
     sudo apt-get install -y autotools-dev
     sudo apt-get install -y automake
     sudo apt-get install -y autoconf
+    sudo apt-get install -y libtool
 ```
 
 #### For all distros


### PR DESCRIPTION
When running ./autogen.sh the following error will be output: `configure.ac:70: error: possibly undefined macro: AC_PROG_LIBTOOL` unless libtool is already installed. To relieve the users from the troubleshooting it should be added to the walkthrough.