### PR TITLE
Update custom-create.md

### DIFF
--- a/articles/active-directory/roles/custom-create.md
+++ b/articles/active-directory/roles/custom-create.md
@@ -152,7 +152,7 @@ $roleAssignment = New-AzureADMSRoleAssignment -DirectoryScopeId $resourceScope -
     {
         "principalId":"<GUID OF USER>",
         "roleDefinitionId":"<GUID OF ROLE DEFINITION>",
-        "resourceScope":"/<GUID OF APPLICATION REGISTRATION>"
+        "directoryScopeId":"/<GUID OF APPLICATION REGISTRATION>"
     }
     ```
 


### PR DESCRIPTION
Per resource documentation at https://docs.microsoft.com/en-us/azure/active-directory/roles/custom-assign-graph, resourceScope is being deprecated and replaced with directoryScopeId.