### PR TITLE
Update custom-create.md

### DIFF
--- a/articles/active-directory/roles/custom-create.md
+++ b/articles/active-directory/roles/custom-create.md
@@ -111,7 +111,7 @@ $roleAssignment = New-AzureADMSRoleAssignment -DirectoryScopeId $resourceScope -
     POST
 
     ``` HTTP
-    https://graph.microsoft.com/beta/roleManagement/directory/roleDefinitions
+    https://graph.microsoft.com/v1.0/roleManagement/directory/roleDefinitions
     ```
 
     Body
@@ -143,7 +143,7 @@ $roleAssignment = New-AzureADMSRoleAssignment -DirectoryScopeId $resourceScope -
     POST
 
     ```http
-    https://graph.microsoft.com/beta/roleManagement/directory/roleAssignments
+    https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments
     ```
 
     Body
@@ -152,7 +152,7 @@ $roleAssignment = New-AzureADMSRoleAssignment -DirectoryScopeId $resourceScope -
     {
         "principalId":"<GUID OF USER>",
         "roleDefinitionId":"<GUID OF ROLE DEFINITION>",
-        "resourceScope":"/<GUID OF APPLICATION REGISTRATION>"
+        "directoryScopeId":"/<GUID OF APPLICATION REGISTRATION>"
     }
     ```
 


### PR DESCRIPTION
Per resource documentation at https://docs.microsoft.com/en-us/azure/active-directory/roles/custom-assign-graph, resourceScope is being deprecated and replaced with directoryScopeId. Also, these Graph endpoints are now in v1.0 so no longer have to use beta.