### PR TITLE
Link to actual latest ntttcp release

### DIFF
--- a/articles/virtual-network/virtual-network-bandwidth-testing.md
+++ b/articles/virtual-network/virtual-network-bandwidth-testing.md
@@ -50,9 +50,7 @@ Sender parameters: ntttcp -s10.27.33.7 -t 10 -n 1 -P 1
 #### Get NTTTCP onto the VMs.
 
 Download the latest version:
-https://github.com/microsoft/ntttcp/releases/download/v5.35/NTttcp.exe
-
-Or view the top-level GitHub Page: <https://github.com/microsoft/ntttcp>\
+https://github.com/microsoft/ntttcp/releases/latest
 
 Consider putting NTTTCP in separate folder, like c:\\tools
 


### PR DESCRIPTION
The link to download ntttcp points to what was the latest release at the time, but fixes have been made to ntttcp since then. Use github's special "latest" link so that the link doesn't become stale.

There is also an irrelevant link to the toplevel github page, which I'm sure people will be able to find from the release page if they are interested. I've removed it.