### PR TITLE
Fix Azure function EOL date for .NET 5.0 runtime to be May 2022 and not February 2022

### DIFF
--- a/articles/azure-functions/language-support-policy.md
+++ b/articles/azure-functions/language-support-policy.md
@@ -34,7 +34,7 @@ There are few exceptions to the retirement policy outlined above. Here is a list
 
 |Language Versions                        |EOL Date         |Retirement Date|
 |-----------------------------------------|-----------------|----------------|
-|.NET 5|February 2022|TBA|
+|.NET 5|May 2022|TBA|
 |Node 6|30 April 2019|28 February 2022| 
 |Node 8|31 December 2019|28 February 2022| 
 |Node 10|30 April 2021|30 September 2022| 


### PR DESCRIPTION
As discussed here: https://twitter.com/nthonyChu/status/1487148837542109184
cc @anthonychu 

It seems though the internal fork already has this change so happy for you to close this PR but leave it open for now just in case https://twitter.com/nthonyChu/status/1487179232023236610