### PR TITLE
Clarify in docs that Event Hubs for Kafka does not support SAS token authentication

### DIFF
--- a/articles/event-hubs/apache-kafka-frequently-asked-questions.yml
+++ b/articles/event-hubs/apache-kafka-frequently-asked-questions.yml
@@ -38,6 +38,13 @@ sections:
           - They fully distinct from Event Hubs consumer groups. You **don't** need to use '$Default', nor do you need to worry about Kafka clients interfering with AMQP workloads.
           - They aren't viewable in the Azure portal. Consumer group info is accessible via Kafka APIs.
           
+      - question: |
+          Does Azure Event Hubs for Apache Kafka support shared access signature token authentication?
+        answer: |
+          Authenticating using [OAuth 2.0 and Shared access signature](event-hubs-for-kafka-ecosystem-overview#security-and-authentication) is supported.
+          
+          Shared access signature tokens are [generated](authenticate-shared-access-signature.md#generate-a-shared-access-signature-token) using an authorization rule and one of its signing keys. This is not supported when using the Event Hubs for Apache Kafka endpoint.
+
 additionalContent: |
 
   ## Next steps

--- a/articles/event-hubs/apache-kafka-frequently-asked-questions.yml
+++ b/articles/event-hubs/apache-kafka-frequently-asked-questions.yml
@@ -41,9 +41,9 @@ sections:
       - question: |
           Does Azure Event Hubs for Apache Kafka support shared access signature token authentication?
         answer: |
-          Authenticating using [OAuth 2.0 and Shared access signature](event-hubs-for-kafka-ecosystem-overview#security-and-authentication) is supported.
+          Authenticating by using [OAuth 2.0 and shared access signature](event-hubs-for-kafka-ecosystem-overview.md#security-and-authentication) is supported.
           
-          Shared access signature tokens are [generated](authenticate-shared-access-signature.md#generate-a-shared-access-signature-token) using an authorization rule and one of its signing keys. This is not supported when using the Event Hubs for Apache Kafka endpoint.
+          Shared access signature tokens are [generated](authenticate-shared-access-signature.md#generate-a-shared-access-signature-token) by using an authorization rule and one of its signing keys. This is not supported when using the Event Hubs for Apache Kafka endpoint.
 
 additionalContent: |
 

--- a/articles/event-hubs/event-hubs-for-kafka-ecosystem-overview.md
+++ b/articles/event-hubs/event-hubs-for-kafka-ecosystem-overview.md
@@ -79,6 +79,8 @@ sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule require
 > [!NOTE]
 > When using SAS authentication with Kafka clients, established connections aren't disconnected when the SAS key is regenerated. 
 
+> [!NOTE]
+> [Generated shared access signature tokens](authenticate-shared-access-signature.md#generate-a-shared-access-signature-token) are not supported when using the Event Hubs for Apache Kafka endpoint.
 
 #### Samples 
 For a **tutorial** with step-by-step instructions to create an event hub and access it using SAS or OAuth, see [Quickstart: Data streaming with Event Hubs using the Kafka protocol](event-hubs-quickstart-kafka-enabled-event-hubs.md).


### PR DESCRIPTION
Generated `SharedAccessSignature` **tokens** are not supported at the Event Hubs for Kafka endpoint. 

Generating a SAS token is described [here](https://docs.microsoft.com/en-us/azure/event-hubs/authenticate-shared-access-signature#generating-a-signaturetoken-from-a-policy):

```
private static string createToken(string resourceUri, string keyName, string key)
{
    TimeSpan sinceEpoch = DateTime.UtcNow - new DateTime(1970, 1, 1);
    var week = 60 * 60 * 24 * 7;
    var expiry = Convert.ToString((int)sinceEpoch.TotalSeconds + week);
    string stringToSign = HttpUtility.UrlEncode(resourceUri) + "\n" + expiry;
    using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(key)))
    {
        var signature = Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(stringToSign)));
        var sasToken = String.Format(CultureInfo.InvariantCulture, "SharedAccessSignature sr={0}&sig={1}&se={2}&skn={3}", HttpUtility.UrlEncode(resourceUri), HttpUtility.UrlEncode(signature), expiry, keyName);
        return sasToken;
    }
}
```

The output of which looks like:

`SharedAccessSignature sr=sb%3A%2F%2Fnamespacehere.servicebus.windows.net&sig=SIGNATURE_HERE%3D&se=1643385078&skn=RootManageSharedAccessKey;Endpoint=sb://namespacehere.servicebus.windows.net`


For example, the following code works fine using the .NET Azure.Messaging.ServiceBus SDK against Azure Event Hubs, as it is not using the Kafka endpoint:

```
var sasCred = new AzureSasCredential("SharedAccessSignature sr=sb%3A%2F%2Fnamespacehere.servicebus.windows.net&sig=SIGNATURE_HERE%3D&se=1643385078&skn=RootManageSharedAccessKey");
ServiceBusClient sb = new ServiceBusClient("namespacehere.servicebus.windows.net", sasCred);
var sender = sb.CreateSender("ingest");
await sender.SendMessageAsync(new ServiceBusMessage("test from servicebusclient with SAS"));
```

But when using the following `~/.config/kafkacat.conf` Kafka client configuration:

```
bootstrap.servers=namespacehere.servicebus.windows.net:9093
security.protocol=SASL_SSL
sasl.mechanisms=PLAIN
sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="SharedAccessSignature=SharedAccessSignature sr=sb%3A%2F%2Fnamespacehere.servicebus.windows.net&sig=SIGNATURE_HERE%3D&se=1643385078&skn=RootManageSharedAccessKey;Endpoint=sb://namespacehere.servicebus.windows.net";
```

And attempting to produce a single message using the Kafka endpoint:

```
echo hello | kafkacat -d all -P -t ingest -c 1
```

It appears to authenticate successfully:

```
sasl_ssl://namespacehere.servicebus.windows.net:9093/bootstrap: Received SASL frame from broker (0 bytes)
STATE|rdkafka#producer-1| [thrd:sasl_ssl://namespacehere.servicebus.windows.net:9093/]: sasl_ssl://namespacehere.servicebus.windows.net:9093/bootstrap: Broker changed state AUTH_REQ -> UP
```

But then fails with:

```
METADATA|rdkafka#producer-1| [thrd:main]: sasl_ssl://namespacehere.servicebus.windows.net:9093/bootstrap: Topic #0/1: ingest with 0 partitions: Broker: Leader not available
```

/cc https://github.com/Azure/azure-event-hubs-for-kafka/issues/38
/cc @serkantkaraca 