### PR TITLE
Updated parameter 'storageCount' default value

### DIFF
--- a/articles/azure-resource-manager/templates/copy-resources.md
+++ b/articles/azure-resource-manager/templates/copy-resources.md
@@ -56,7 +56,7 @@ The following example creates the number of storage accounts specified in the `s
   "parameters": {
     "storageCount": {
       "type": "int",
-      "defaultValue": 2
+      "defaultValue": 3
     }
   },
   "resources": [


### PR DESCRIPTION
With this change, updated the default value of 'storageCount' parameter to 3. 

At line number 88 & 100, the documentation mentions 3 storage accounts get created, but in the original documentation, storageCount is mentioned as 2 (line number 59) which is incorrect.