### PR TITLE
Copy blobs and add index tags needs update

### DIFF
--- a/articles/storage/common/storage-use-azcopy-blobs-copy.md
+++ b/articles/storage/common/storage-use-azcopy-blobs-copy.md
@@ -122,7 +122,7 @@ The copy operation is synchronous so when the command returns, that indicates th
 
 Copy blobs to another storage account and add [blob index tags(preview)](../blobs/storage-manage-find-blobs.md) to the target blob.
 
-If you're using Azure AD authorization, your security principal must be assigned the [Storage Blob Data Owner](../../role-based-access-control/built-in-roles.md#storage-blob-data-owner) role or it must be given permission to the `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write` [Azure resource provider operation](../../role-based-access-control/resource-provider-operations.md#microsoftstorage) via a custom Azure role. If you're using a Shared Access Signature (SAS) token, that token must provide access to the blob's tags via the `t` SAS permission.
+If you're using Azure AD authorization, your security principal must be assigned the [Storage Blob Data Owner](../../role-based-access-control/built-in-roles.md#storage-blob-data-owner) role or it must be given permission to the `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/tags/write` [Azure resource provider operation](../../role-based-access-control/resource-provider-operations.md#microsoftstorage) via a custom Azure role. If you're using a Shared Access Signature (SAS) token, that token must provide access to the blob's tags via the `t` SAS permission. to include the 't' SAS permission generate the Shared Access Signature from Azure Storage Account level.
 
 To add tags, use the `--blob-tags` option along with a URL encoded key-value pair.
 


### PR DESCRIPTION
the 't' SAS permission is only available on Storage Account level. thus, the document needs an update to avoid this confusion. Updated Line # 125.