### PR TITLE
[minor docs] Fixes incorrect and inconsistent IAM policy indent

### DIFF
--- a/articles/cost-management-billing/costs/aws-integration-set-up-configure.md
+++ b/articles/cost-management-billing/costs/aws-integration-set-up-configure.md
@@ -130,10 +130,10 @@ The policy JSON should resemble the following example. Replace `bucketname` with
             "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
-   	    "organizations:ListAccounts",
-            "iam:ListRoles",
-            "ce:*",
-            "cur:DescribeReportDefinitions"
+                "organizations:ListAccounts",
+                "iam:ListRoles",
+                "ce:*",
+                "cur:DescribeReportDefinitions"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
The IAM policy for AWS billing connection is poorly indented (as seen in the below screencap) - this updates the indentation to be consistent and correct.

![image](https://user-images.githubusercontent.com/1835431/151879589-f05620a7-bf8d-4c8e-a38a-498886f495b7.png)
