### PR TITLE
Fixing call to get AppConfig connection string

### DIFF
--- a/articles/azure-app-configuration/quickstart-aspnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-aspnet-core-app.md
@@ -79,7 +79,7 @@ dotnet new mvc --no-https --output TestAppConfig
     ```csharp
     var builder = WebApplication.CreateBuilder(args);
     //Retrieve the Connection String from the secrets manager 
-    var connectionString = builder.Configuration["AppConfig"];
+    var connectionString = builder.Configuration.GetConnectionString("AppConfig");
     
     builder.Host.ConfigureAppConfiguration(builder =>
                     {


### PR DESCRIPTION
The original code was trying to load an app setting but the walkthrough created the secret as a connection string. This makes it so the walkthrough works for .NET 6