### PR TITLE
Update concepts-storage.md

### DIFF
--- a/articles/aks/concepts-storage.md
+++ b/articles/aks/concepts-storage.md
@@ -41,7 +41,7 @@ Use *Azure Disks* to create a Kubernetes *DataDisk* resource. Disks can use:
 > [!TIP]
 >For most production and development workloads, use Premium storage. 
 
-Since Azure Disks are mounted as *ReadWriteOnce*, they're only available to a single pod. For storage volumes that can be accessed by multiple pods simultaneously, use Azure Files.
+Since Azure Disks are mounted as *ReadWriteOnce*, they're only available to a single or multiple pods running on the same node. For storage volumes that can be accessed by multiple pods simultaneously, use Azure Files.
 
 ### Azure Files
 Use *Azure Files* to mount an SMB 3.0 share backed by an Azure Storage account to pods. Files let you share data across multiple nodes and pods and can use:


### PR DESCRIPTION
corrected read write once mode for persistent storage. In the documentation it is given that a single pod in the node can access storage which is not fully correct.
Multiple pods running on the same node can also access storage medium mounted with read write once mode.More info here https://kubernetes.io/docs/concepts/storage/persistent-volumes/