### PR TITLE
Correct go get command for SDK

### DIFF
--- a/articles/cognitive-services/Computer-vision/includes/quickstarts-sdk/go-sdk.md
+++ b/articles/cognitive-services/Computer-vision/includes/quickstarts-sdk/go-sdk.md
@@ -16,7 +16,7 @@ ms.author: pafarley
 
 Use the OCR client library to read printed and handwritten text from images.
 
-[Reference documentation](https://godoc.org/github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v2.1/computervision) | [Library source code](https://github.com/Azure/azure-sdk-for-go/tree/master/services/cognitiveservices/v2.1/computervision) | [Package](https://github.com/Azure/azure-sdk-for-go)
+[Reference documentation](https://godoc.org/github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v2.1/computervision) | [Library source code](github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v2.1/computervision) | [Package](https://github.com/Azure/azure-sdk-for-go)
 
 ## Prerequisites
 


### PR DESCRIPTION
The link was taken from the URL of a browser and includes the schema and github branch data. 
The correct link should be the github module

`go get -u github.com/Azure/azure-sdk-for-go/services/cognitiveservices/v2.1/computervision`