### PR TITLE
Amendment to applicable Windows SKU and wording

### DIFF
--- a/articles/active-directory/authentication/howto-sspr-windows.md
+++ b/articles/active-directory/authentication/howto-sspr-windows.md
@@ -48,7 +48,7 @@ The following limitations apply to using SSPR from the Windows sign-in screen:
 - The combination of the following specific three settings can cause this feature to not work.
     - Interactive logon: Do not require CTRL+ALT+DEL = Disabled
     - *DisableLockScreenAppNotifications* = 1 or Enabled
-    - Windows SKU isn't Home or Professional edition
+    - Windows SKU is Home edition
 
 > [!NOTE]
 > These limitations also apply to Windows Hello for Business PIN reset from the device lock screen.


### PR DESCRIPTION
Customer was quite confused around this wording and upon checking the CSP is seems to be applicable to all BUT Home Edition.
https://docs.microsoft.com/en-us/windows/client-management/mdm/policy-csp-authentication#authentication-allowaadpasswordreset

Amended to clearer wording - "three settings can cause this feature not to work.... . . . Windows SKU is Home edition"