### PR TITLE
Clarification on SSISDB migration

### DIFF
--- a/articles/data-factory/scenario-ssis-migration-ssisdb-mi.md
+++ b/articles/data-factory/scenario-ssis-migration-ssisdb-mi.md
@@ -18,7 +18,7 @@ This article focuses on the migration of SQL Server Integration Service (SSIS) p
 
 ## Migrate packages in SSIS catalog (SSISDB)
 
-DMS can migrate SSIS packages stored in SSISDB, as described in the article:
+Database Migration Service can migrate SSIS packages stored in SSISDB, as described in the article:
 [Migrate SSIS packages to SQL Managed Instance](../dms/how-to-migrate-ssis-packages-managed-instance.md).
 
 ## SSIS jobs to SQL Managed Instance agent

--- a/articles/data-factory/scenario-ssis-migration-ssisdb-mi.md
+++ b/articles/data-factory/scenario-ssis-migration-ssisdb-mi.md
@@ -16,9 +16,9 @@ When migrating database workloads from a SQL Server instance to Azure SQL Manage
 
 This article focuses on the migration of SQL Server Integration Service (SSIS) packages stored in SSIS catalog (SSISDB) and SQL Server Agent jobs that schedule SSIS package executions.
 
-## Migrate SSIS catalog (SSISDB)
+## Migrate packages in SSIS catalog (SSISDB)
 
-SSISDB migration can be done using DMS, as described in the article:
+DMS can migrate SSIS packages stored in SSISDB, as described in the article:
 [Migrate SSIS packages to SQL Managed Instance](../dms/how-to-migrate-ssis-packages-managed-instance.md).
 
 ## SSIS jobs to SQL Managed Instance agent


### PR DESCRIPTION
Wording leads to understand that DMS can migrate SSISDB database, rather than packages contained in it.