### PR TITLE
Adding note that CAE is not yet enabled in GCCH

### DIFF
--- a/articles/active-directory/conditional-access/concept-continuous-access-evaluation.md
+++ b/articles/active-directory/conditional-access/concept-continuous-access-evaluation.md
@@ -160,6 +160,9 @@ More information about continuous access evaluation as a session control can be 
 
 ## Limitations
 
+> [!NOTE] 
+> Continuous Access Evaluation (CAE) is not yet enabled for GCC High tenants.
+
 ### Group membership and Policy update effective time
 
 Changes made to Conditional Access policies and group membership made by administrators could take up to one day to be effective. The delay is from replication between Azure AD and resource providers like Exchange Online and SharePoint Online. Some optimization has been done for policy updates, which reduce the delay to two hours. However, it doesn't cover all the scenarios yet.  


### PR DESCRIPTION
Adding note that CAE is not yet enabled in GCC high. 
This is confirmed by the following ICM: 
https://portal.microsofticm.com/imp/v3/incidents/details/284126506/home