### PR TITLE
docs(Azure Static Web Apps): running end-to-end tests on the pre-production environment.

### DIFF
--- a/articles/static-web-apps/review-publish-pull-requests.md
+++ b/articles/static-web-apps/review-publish-pull-requests.md
@@ -15,7 +15,7 @@ This article demonstrates how to use pre-production environments to review chang
 
 A pre-production (staging) environment is a fully-functional staged version of your application that includes changes not available in production.
 
-Azure Static Web Apps generates a GitHub Actions workflow in the repository. When a pull request is created against a branch that the workflow watches, the pre-production environment is built. The pre-production environment stages the app, enables you to perform reviews before pushing to production.
+Azure Static Web Apps generates a GitHub Actions workflow in the repository. When a pull request is created against a branch that the workflow watches, the pre-production environment is built. The pre-production environment stages the app, enables you to perform reviews before pushing them to production.
 
 Multiple pre-production environments can co-exist at the same time when using Azure Static Web Apps. Each time you create a pull request against the watched branch, a staged version with your changes is deployed to a distinct pre-production environment.
 
@@ -62,7 +62,7 @@ Next, create a pull request from this change.
 
 1. Click on the **Compare & pull request** button of your branch.
 
-1. You can optionally fill-in some details about your changes, then click on **Create pull request**.
+1. You can optionally fill in some details about your changes, then click on **Create pull request**.
 
     :::image type="content" source="./media/review-publish-pull-requests/open.png" alt-text="Pull request creation in GitHub":::
 
@@ -85,6 +85,9 @@ If you take a closer look at the URL, you can see that it's composed like this: 
 
 For a given pull request, the URL remains the same even if you push new updates. In addition to the URL staying constant, the same pre-production environment is reused for the life of the pull request.
 
+To automate the review process with end-to-end testing, the [Azure Static Web App Deploy GitHub Action](https://github.com/Azure/static-web-apps-deploy) has the `static_web_app_url` output property.
+This URL can be referenced in the rest of your workflow to run your tests against the pre-production environment.
+
 ## Publish changes
 
 Once changes are approved, you can publish your changes to production by merging the pull request.
@@ -93,7 +96,7 @@ Click on **Merge pull request**:
 
 :::image type="content" source="./media/review-publish-pull-requests/merge.png" alt-text="Merge pull request button in GitHub interface":::
 
-Merging copies your changes to the tracked branch (the "production" branch). Then, the deployment workflow starts on the tracked branch and the changes are live after your application has rebuilt.
+Merging copies your changes to the tracked branch (the "production" branch). Then, the deployment workflow starts on the tracked branch and the changes are live after your application has been rebuilt.
 
 To verify the changes in production,  open your production URL to load the live version of the website.
 
@@ -104,7 +107,7 @@ To verify the changes in production,  open your production URL to load the live 
     > [!WARNING]
     > Be careful when publishing sensitive content to staged versions, as access to pre-production environments are not restricted.
 
-- The number of pre-production environments available for each app deployed with Static Web Apps depends of the [hosting plan](plans.md) you are using. For example, with the Free tier you can have 3 pre-production environments in addition to the production environment.
+- The number of pre-production environments available for each app deployed with Static Web Apps depends on the [hosting plan](plans.md) you are using. For example, with the Free tier you can have 3 pre-production environments in addition to the production environment.
 
 - Pre-production environments are not geo-distributed.
 

--- a/articles/static-web-apps/review-publish-pull-requests.md
+++ b/articles/static-web-apps/review-publish-pull-requests.md
@@ -85,7 +85,7 @@ If you take a closer look at the URL, you can see that it's composed like this: 
 
 For a given pull request, the URL remains the same even if you push new updates. In addition to the URL staying constant, the same pre-production environment is reused for the life of the pull request.
 
-To automate the review process with end-to-end testing, the [Azure Static Web App Deploy GitHub Action](https://github.com/Azure/static-web-apps-deploy) has the `static_web_app_url` output property.
+To automate the review process with end-to-end testing, the [Azure Static Web App Deploy GitHub Action](https://github.com/Azure/static-web-apps-deploy) has the `static_web_app_url` output variable.
 This URL can be referenced in the rest of your workflow to run your tests against the pre-production environment.
 
 ## Publish changes

--- a/articles/static-web-apps/review-publish-pull-requests.md
+++ b/articles/static-web-apps/review-publish-pull-requests.md
@@ -40,7 +40,7 @@ Begin by making a change in your repository. You can do it directly on GitHub as
 
 1. Navigate to your project's repository on GitHub, then click on the **Branch** button to create a new branch.
 
-    :::image type="content" source="./media/review-publish-pull-requests/create-branch.png" alt-text="Create new branch using GitHub interface":::]
+    :::image type="content" source="./media/review-publish-pull-requests/create-branch.png" alt-text="Create new branch using GitHub interface":::
 
     Type a branch name and click on **Create branch**.
 


### PR DESCRIPTION
This PR adds a note on how to automatically run end-to-end tests on the pre-production environment based on the [output](https://github.com/Azure/static-web-apps-deploy/blob/v1/action.yml#L43-L45) of the GitHub Deploy Action.

It also addresses some grammatical issues.