### PR TITLE
remove the warning of workspace move not being possible

### DIFF
--- a/articles/machine-learning/how-to-manage-workspace.md
+++ b/articles/machine-learning/how-to-manage-workspace.md
@@ -381,11 +381,7 @@ In the [Azure portal](https://portal.azure.com/), select **Delete**  at the top 
 ### Resource provider errors
 
 [!INCLUDE [machine-learning-resource-provider](../../includes/machine-learning-resource-provider.md)]
-
-### Moving the workspace
-
-> [!WARNING]
-> Moving your Azure Machine Learning workspace to a different subscription, or moving the owning subscription to a new tenant, is not supported. Doing so may cause errors.
+ 
 
 ### Deleting the Azure Container Registry
 


### PR DESCRIPTION
The below warning might have to be removed as we have the option now to move workspace https://docs.microsoft.com/en-us/azure/machine-learning/how-to-move-workspace?branch=main
### Moving the workspace

> [!WARNING]
> Moving your Azure Machine Learning workspace to a different subscription, or moving the owning subscription to a new tenant, is not supported. Doing so may cause errors.