### PR TITLE
Fixed FastAPI sample code memory leak

### DIFF
--- a/articles/azure-monitor/app/opencensus-python-request.md
+++ b/articles/azure-monitor/app/opencensus-python-request.md
@@ -124,6 +124,7 @@ OpenCensus doesn't have an extension for FastAPI. To write your own FastAPI midd
 1. The following dependencies are required: 
     - [fastapi](https://pypi.org/project/fastapi/)
     - [uvicorn](https://pypi.org/project/uvicorn/)
+      - Deploying [uvicorn with gunicorn](https://www.uvicorn.org/deployment/#gunicorn) for production grade setting is recommended.
 
 2. Add [FastAPI middleware](https://fastapi.tiangolo.com/tutorial/middleware/). Make sure that you set the span kind server: `span.span_kind = SpanKind.SERVER`.
 

--- a/articles/azure-monitor/app/opencensus-python-request.md
+++ b/articles/azure-monitor/app/opencensus-python-request.md
@@ -124,7 +124,8 @@ OpenCensus doesn't have an extension for FastAPI. To write your own FastAPI midd
 1. The following dependencies are required: 
     - [fastapi](https://pypi.org/project/fastapi/)
     - [uvicorn](https://pypi.org/project/uvicorn/)
-      - Deploying [uvicorn with gunicorn](https://www.uvicorn.org/deployment/#gunicorn) for production grade setting is recommended.
+      
+      In a production setting, we recommend that you deploy [uvicorn with gunicorn](https://www.uvicorn.org/deployment/#gunicorn).
 
 2. Add [FastAPI middleware](https://fastapi.tiangolo.com/tutorial/middleware/). Make sure that you set the span kind server: `span.span_kind = SpanKind.SERVER`.
 

--- a/articles/azure-monitor/app/opencensus-python-request.md
+++ b/articles/azure-monitor/app/opencensus-python-request.md
@@ -145,11 +145,12 @@ OpenCensus doesn't have an extension for FastAPI. To write your own FastAPI midd
 
     HTTP_URL = COMMON_ATTRIBUTES['HTTP_URL']
     HTTP_STATUS_CODE = COMMON_ATTRIBUTES['HTTP_STATUS_CODE']
+    
+    tracer = Tracer(exporter=AzureExporter(connection_string=f'InstrumentationKey={APPINSIGHTS_INSTRUMENTATIONKEY}'),sampler=ProbabilitySampler(1.0))
 
     # fastapi middleware for opencensus
     @app.middleware("http")
-    async def middlewareOpencensus(request: Request, call_next):
-        tracer = Tracer(exporter=AzureExporter(connection_string=f'InstrumentationKey={APPINSIGHTS_INSTRUMENTATIONKEY}'),sampler=ProbabilitySampler(1.0))
+    async def middlewareOpencensus(request: Request, call_next):        
         with tracer.span("main") as span:
             span.span_kind = SpanKind.SERVER
 


### PR DESCRIPTION
There is a memory leak in the FastAPI / Tracer sample code. In the code, the Tracer is created on every request, and that leaks hundreds of KB of memory for each request. Each AzureExporer instantiation will spin up worker threads and will remain allocated even after the request is over.

We should only instantiate the Tracer once outside of the middleware function.

This is an example of the memory leak with the current code.
![image](https://user-images.githubusercontent.com/3258724/152652184-99f1c197-4680-44d2-b14d-f0a14141c365.png)


This bug was found separately in the opencensus repo.
https://github.com/census-instrumentation/opencensus-python/issues/1020#issuecomment-1022549110