### PR TITLE
Update developer-portal-implement-widgets.md

### DIFF
--- a/articles/api-management/developer-portal-implement-widgets.md
+++ b/articles/api-management/developer-portal-implement-widgets.md
@@ -190,7 +190,7 @@ From the design-time perspective, any runtime component is just an HTML tag with
     ```typescript
     ...
     createModel: async () => {
-        var model = new ConferenceSessionModel();
+        var model = new WidgetModel();
         model.sessionNumber = "107";
             return model;
         }


### PR DESCRIPTION
It's not mentioned to rename the `WidgetModel` to `ConferenceSessionModel`, so such class does not exist.