### PR TITLE
Update logins-create-manage.md

### DIFF
--- a/articles/azure-sql/database/logins-create-manage.md
+++ b/articles/azure-sql/database/logins-create-manage.md
@@ -112,7 +112,7 @@ You can create accounts for non-administrative users using one of two methods:
   With this approach, the user authentication information is stored in each database, and replicated to geo-replicated databases automatically. However, if the same account exists in multiple databases and you are using Azure SQL Authentication, you must keep the passwords synchronized manually. Additionally, if a user has an account in different databases with different passwords, remembering those passwords can become a problem.
 
 > [!IMPORTANT]
-> To create contained users mapped to Azure AD identities, you must be logged in using an Azure AD account that is an administrator in the database in Azure SQL Database. In SQL Managed Instance, a SQL login with `sysadmin` permissions can also create an Azure AD login or user.
+> To create contained users mapped to Azure AD identities, you must be logged in using an Azure AD account that is an administrator (or member of db_owner role) in the database in Azure SQL Database. In SQL Managed Instance, a SQL login with `sysadmin` permissions can also create an Azure AD login or user.
 
 For examples showing how to create logins and users, see:
 

--- a/articles/azure-sql/database/logins-create-manage.md
+++ b/articles/azure-sql/database/logins-create-manage.md
@@ -112,7 +112,7 @@ You can create accounts for non-administrative users using one of two methods:
   With this approach, the user authentication information is stored in each database, and replicated to geo-replicated databases automatically. However, if the same account exists in multiple databases and you are using Azure SQL Authentication, you must keep the passwords synchronized manually. Additionally, if a user has an account in different databases with different passwords, remembering those passwords can become a problem.
 
 > [!IMPORTANT]
-> To create contained users mapped to Azure AD identities, you must be logged in using an Azure AD account that is an administrator (or member of db_owner role) in the database in Azure SQL Database. In SQL Managed Instance, a SQL login with `sysadmin` permissions can also create an Azure AD login or user.
+> To create contained users mapped to Azure AD identities, you must be logged in using an Azure AD account in the database in Azure SQL Database. In SQL Managed Instance, a SQL login with `sysadmin` permissions can also create an Azure AD login or user.
 
 For examples showing how to create logins and users, see:
 


### PR DESCRIPTION
Wording of
To create contained users mapped to Azure AD identities, you must be logged in using an Azure AD account that is an administrator in the database in Azure SQL Database. In SQL Managed Instance, a SQL login with `sysadmin` permissions can also create an Azure AD login or user.

Is very poor. That kinda suggest that only someone set as AD server admin can do such action which is incorrect. "Administrator" word should be used with caution