### PR TITLE
Fix typo in article "Protecting DNS Zones/Records"

### DIFF
--- a/articles/dns/dns-protect-zones-recordsets.md
+++ b/articles/dns/dns-protect-zones-recordsets.md
@@ -177,7 +177,7 @@ It can also be created via the Azure CLI:
 
 ```azurecli-interactive
 # Create new role definition based on input file
-az role defination create --role-definition <file path>
+az role definition create --role-definition <file path>
 ```
 
 The role can then be assigned in the same way as built-in roles, as described earlier in this article.


### PR DESCRIPTION
`definition` was mis-spelled in a code snippet.