### PR TITLE
Add auto approval note on consumer side

### DIFF
--- a/articles/private-link/private-endpoint-overview.md
+++ b/articles/private-link/private-endpoint-overview.md
@@ -137,7 +137,7 @@ The private link resource owner can do the following actions over a private endp
 
 An alias is a unique moniker that is generated when the service owner creates the private link service behind a standard load balancer. Service owners can share this alias with their consumers offline. 
 
-Consumers can request a connection to private link service using either the resource URI or the alias. If you want to connect using the alias, you must create a private endpoint using the manual connection approval method. For using manual connection approval method, set manual request parameter to true during private endpoint create flow. For more information, see [New-AzPrivateEndpoint](/powershell/module/az.network/new-azprivateendpoint) and [az network private-endpoint create](/cli/azure/network/private-endpoint#az_network_private_endpoint_create).
+Consumers can request a connection to private link service using either the resource URI or the alias. If you want to connect using the alias, you must create a private endpoint using the manual connection approval method. For using manual connection approval method, set manual request parameter to true during private endpoint create flow. For more information, see [New-AzPrivateEndpoint](/powershell/module/az.network/new-azprivateendpoint) and [az network private-endpoint create](/cli/azure/network/private-endpoint#az_network_private_endpoint_create). Note that this manual request can be auto approved if the consumer subscription is whitelisted on the provider side. To learn more, navigate to [controlling service access](/azure/private-link/private-link-service-overview#control-service-access).
 
 ## DNS configuration
 


### PR DESCRIPTION
Bloomberg wanted clarity around consumer side auto approval on our documentation to help reduce and area of confusion.