### PR TITLE
Fixed lower case IoT hub reference

### DIFF
--- a/articles/iot-central/core/overview-iot-central-developer.md
+++ b/articles/iot-central/core/overview-iot-central-developer.md
@@ -65,7 +65,7 @@ The connection between a device and your IoT Central application is secured by u
 
 ### Communication protocols
 
-Communication protocols that a device can use to connect to IoT Central include MQTT, AMQP, and HTTPS. Internally, IoT Central uses an IoT hub to enable device connectivity. For more information about the communication protocols that IoT Hub supports for device connectivity, see [Choose a communication protocol](../../iot-hub/iot-hub-devguide-protocols.md).
+Communication protocols that a device can use to connect to IoT Central include MQTT, AMQP, and HTTPS. Internally, IoT Central uses an IoT Hub to enable device connectivity. For more information about the communication protocols that IoT Hub supports for device connectivity, see [Choose a communication protocol](../../iot-hub/iot-hub-devguide-protocols.md).
 
 ## Connectivity patterns
 


### PR DESCRIPTION
Small capitalization fix