### PR TITLE
fix typo OSCP to OCSP

### DIFF
--- a/articles/frontdoor/concept-end-to-end-tls.md
+++ b/articles/frontdoor/concept-end-to-end-tls.md
@@ -38,7 +38,7 @@ Certificates from internal CAs or self-signed certificates aren't allowed.
 
 ## Online Certificate Status Protocol (OCSP) stapling
 
-OSCP stapling is supported by default in Azure Front Door and no configuration is required.
+OCSP stapling is supported by default in Azure Front Door and no configuration is required.
 
 ## Backend TLS connection (Azure Front Door to backend)
 


### PR DESCRIPTION
Correct word is OCSP (as shown in the title just above).