### PR TITLE
[D365BC] Add note about the preview audience limited capabilities

### DIFF
--- a/articles/marketplace/dynamics-365-business-central-availability.md
+++ b/articles/marketplace/dynamics-365-business-central-availability.md
@@ -33,7 +33,7 @@ Then, when you're ready to make your offer available and remove the preview rest
 Select **Save draft** before continuing to the next tab in the left-nav menu, **Technical configuration**.
 
 > [!IMPORTANT]
-> Only the offer listing in the marketplace will be available in Preview. You will not be able to install the app in Business Central environment until you have completed the publishing process in Partner Center.
+> Only the offer listing information will be available in the marketplace preview. You won't be able to install the app in the Business Central environment until you've completed the publishing process in Partner Center.
 
 ## Next steps
 

--- a/articles/marketplace/dynamics-365-business-central-availability.md
+++ b/articles/marketplace/dynamics-365-business-central-availability.md
@@ -32,6 +32,9 @@ Then, when you're ready to make your offer available and remove the preview rest
 
 Select **Save draft** before continuing to the next tab in the left-nav menu, **Technical configuration**.
 
+> [!IMPORTANT]
+> Only the offer listing in the marketplace will be available in Preview. You will not be able to install the app in Business Central environment until you have completed the publishing process in Partner Center.
+
 ## Next steps
 
 - [Set offer technical configuration](dynamics-365-business-central-technical-configuration.md)


### PR DESCRIPTION
Business Central doesn't support installing preview apps in customer environments. At the preview stage, only the offer listing in the marketplace can be done. This behavior is documented in Business Central docs: https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-checklist-submission-faq#when-are-my-apps-ready-to-be-installed-in-my-business-central-environment

For visibility, it should be mentioned here too.