### PR TITLE
Added SignalR trigger as a supported bindings

### DIFF
--- a/includes/functions-bindings.md
+++ b/includes/functions-bindings.md
@@ -26,7 +26,7 @@ This table shows the bindings that are supported in the major versions of the Az
 | [RabbitMQ](../articles/azure-functions/functions-bindings-rabbitmq.md)<sup>2</sup>             | |✔|✔| |✔|
 | [SendGrid](../articles/azure-functions/functions-bindings-sendgrid.md)                   |✔|✔| | |✔|
 | [Service Bus](../articles/azure-functions/functions-bindings-service-bus.md)             |✔|✔|✔| |✔|
-| [SignalR](../articles/azure-functions/functions-bindings-signalr-service.md)             | |✔| |✔|✔|
+| [SignalR](../articles/azure-functions/functions-bindings-signalr-service.md)             | |✔|✔|✔|✔|
 | [Table storage](../articles/azure-functions/functions-bindings-storage-table.md)         |✔|✔| |✔|✔|
 | [Timer](../articles/azure-functions/functions-bindings-timer.md)                         |✔|✔|✔| | |
 | [Twilio](../articles/azure-functions/functions-bindings-twilio.md)                       |✔|✔| | |✔|


### PR DESCRIPTION
At the moment, the documentation contains outdated information, because _SignalR_ already has a trigger for a long time and there is a separate article about it.
https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-trigger