### PR TITLE
Updated wording

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-block-access.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-block-access.md
@@ -63,7 +63,7 @@ The first policy blocks access to all apps except for Microsoft 365 applications
 
 After confirming your settings using [report-only mode](howto-conditional-access-insights-reporting.md), an administrator can move the **Enable policy** toggle from **Report-only** to **On**.
 
-A second policy is created below to require multi-factor authentication or a compliant device for users of Microsoft 365.
+A second policy is created below to require multi-factor authentication and a compliant device for users of Microsoft 365.
 
 1. Select **New policy**.
 1. Give your policy a name. We recommend that organizations create a meaningful standard for the names of their policies.


### PR DESCRIPTION
**From:**
 require multi-factor authentication **or** a compliant device 

**To:**
 require multi-factor authentication **and** a compliant device 

It also states "and" within the documentation:
![image](https://user-images.githubusercontent.com/36619112/153921974-0ded83bc-b624-49b1-b43a-cba9a97aa675.png)


---------
cc: @MicrosoftGuyJFlo 
GitHub Issue: https://github.com/MicrosoftDocs/azure-docs/issues/87980