### PR TITLE
Fixed a little text format on concept of SIgnalR upstream page

### DIFF
--- a/articles/azure-signalr/concept-upstream.md
+++ b/articles/azure-signalr/concept-upstream.md
@@ -150,7 +150,7 @@ POST
 
 #### Connected
 
-Content-Type: application/json
+Content-Type: `application/json`
 
 #### Disconnected
 


### PR DESCRIPTION
I found a unmatched text format on [this page](https://docs.microsoft.com/en-us/azure/azure-signalr/concept-upstream#connected).

![image](https://user-images.githubusercontent.com/11372210/154066168-364fb4c0-7af6-486b-b993-2a1b1ac7015f.png)
