### PR TITLE
Fix link to Kudu service overview

### DIFF
--- a/articles/app-service/environment/using.md
+++ b/articles/app-service/environment/using.md
@@ -210,7 +210,7 @@ To delete:
 [Pricing]: https://azure.microsoft.com/pricing/details/app-service/
 [ARMOverview]: ../../azure-resource-manager/management/overview.md
 [ConfigureSSL]: ../configure-ssl-certificate.md
-[Kudu]: https://azure.microsoft.com/resources/videos/super-secret-kudu-debug-console-for-azure-web-sites/
+[Kudu]: ../resources-kudu.md
 [AppDeploy]: ../deploy-local-git.md
 [ASEWAF]: ./integrate-with-application-gateway.md
 [AppGW]: ../../web-application-firewall/ag/ag-overview.md


### PR DESCRIPTION
Current doc link points to an Azure Fridays video that is no longer available from Azure Videos. Proposing update to point to docs describing Kudu console. Alternatively, video resource is still available on Scott Hanselman's YouTube channel.