### PR TITLE
Offered another identifier for orphaned assignments

### DIFF
--- a/articles/role-based-access-control/troubleshooting.md
+++ b/articles/role-based-access-control/troubleshooting.md
@@ -126,7 +126,7 @@ If you recently invited a user when creating a role assignment, this security pr
 
 However, if this security principal is not a recently invited user, it might be a deleted security principal. If you assign a role to a security principal and then you later delete that security principal without first removing the role assignment, the security principal will be listed as **Identity not found** and an **Unknown** type.
 
-If you list this role assignment using Azure PowerShell, you might see an empty `DisplayName` and `SignInName`. For example, [Get-AzRoleAssignment](/powershell/module/az.resources/get-azroleassignment) returns a role assignment that is similar to the following output:
+If you list this role assignment using Azure PowerShell, you might see an empty `DisplayName` and `SignInName`, or a value for `ObjectType` of `Unknown`. For example, [Get-AzRoleAssignment](/powershell/module/az.resources/get-azroleassignment) returns a role assignment that is similar to the following output:
 
 ```
 RoleAssignmentId   : /subscriptions/11111111-1111-1111-1111-111111111111/providers/Microsoft.Authorization/roleAssignments/22222222-2222-2222-2222-222222222222


### PR DESCRIPTION
Clarified that `ObjectType` reflects an unknown value for orphaned role assignments in PowerShell #atcp