### PR TITLE
Added PS for removing orphaned role assignments

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/managed-identity-best-practice-recommendations.md
+++ b/articles/active-directory/managed-identities-azure-resources/managed-identity-best-practice-recommendations.md
@@ -106,6 +106,12 @@ will be displayed with “Identity not found” when viewed in the portal. [Read
 
 :::image type="content" source="media/managed-identity-best-practice-recommendations/identity-not-found.png" alt-text="Identity not found for role assignment.":::
 
+Role assignments which are no longer associated with a user or service principal will appear with an `ObjectType` value of `Unknown`. In order to remove them, you can pipe several Azure PowerShell commands together to first get all the role assignments, filter to only those with an `ObjectType` value of `Unknown` and then remove those role assignments from Azure.
+
+```azurepowershell
+Get-AzRoleAssignment | Where-Object {$_.ObjectType -eq "Unknown"} | Remove-AzRoleAssignment 
+```
+
 ## Limitation of using managed identities for authorization
 
 Using Azure AD **groups** for granting access to services is a great way to simplify the authorization process. The idea is simple – grant permissions to a group and add identities to the group so that they inherit the same permissions. This is a well-established pattern from various on-premises systems and works well when the identities represent users. Another option to control authorization in Azure AD is by using [App Roles](../develop/howto-add-app-roles-in-azure-ad-apps.md), which allows you to declare **roles** that are specific to an app (rather than groups, which are a global concept in the directory). You can then [assign app roles to managed identities](how-to-assign-app-role-managed-identity-powershell.md) (as well as users or groups).


### PR DESCRIPTION
Provided an Azure PowerShell snippet to remove Azure role assignments that are not assigned to either a user or a service principal, but rather an Unknown type (meaning orphaned, in my experience) #atcp