### PR TITLE
Indexer creation sample not valid

### DIFF
--- a/articles/search/search-howto-index-sharepoint-online.md
+++ b/articles/search/search-howto-index-sharepoint-online.md
@@ -233,9 +233,9 @@ There are a few steps to creating the indexer:
         "maxFailedItems": null,
         "maxFailedItemsPerBatch": null,
         "base64EncodeKeys": null,
-        "configuration:" {
-            "indexedFileNameExtensions" : null,
-            "excludedFileNameExtensions" : null,
+        "configuration": {
+            "indexedFileNameExtensions" : ".pdf, .docx",
+            "excludedFileNameExtensions" : ".png, .jpg",
             "dataToExtract": "contentAndMetadata"
           }
         },


### PR DESCRIPTION
Indexer creation sample fails due to syntax error at configuration property and null values at indexedFileNameExtensions and excludedFileNameExtensions