### PR TITLE
Updated Synapse Analytics Apache Spark Azure ML Tutorial

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-azure-machine-learning-tutorial.md
+++ b/articles/synapse-analytics/spark/apache-spark-azure-machine-learning-tutorial.md
@@ -126,16 +126,14 @@ In Azure Machine Learning, a workspace is a class that accepts your Azure subscr
 ```python
 from azureml.core import Workspace
 
-# Enter your workspace subscription, resource group, name, and region.
+# Enter your subscription id, resource group, and workspace name.
 subscription_id = "<enter your subscription ID>" #you should be owner or contributor
 resource_group = "<enter your resource group>" #you should be owner or contributor
 workspace_name = "<enter your workspace name>" #your workspace name
-workspace_region = "<enter workspace region>" #your region
 
 ws = Workspace(workspace_name = workspace_name,
                subscription_id = subscription_id,
                resource_group = resource_group)
-
 ```
 
 ## Convert a DataFrame to an Azure Machine Learning dataset
@@ -321,11 +319,11 @@ After you've validated your best model, you can register it to Azure Machine Lea
 ```python
 description = 'My automated ML model'
 model_path='outputs/model.pkl'
-model = best_run.register_model(model_name = 'NYCGreenTaxiModel', model_path = model_path, description = description)
+model = best_run.register_model(model_name = 'NYCYellowTaxiModel', model_path = model_path, description = description)
 print(model.name, model.version)
 ```
 ```Output
-NYCGreenTaxiModel 1
+NYCYellowTaxiModel 1
 ```
 ## View results in Azure Machine Learning
 You can also access the results of the iterations by going to the experiment in your Azure Machine Learning workspace. Here, you can get additional details on the status of your run, attempted models, and other model metrics. 


### PR DESCRIPTION
Removed the region part, as it is not needed or used anywhere.
Also renamed the model registration from NYCGreenTaxiModel to NYCYellowTaxiModel as it is the Yellow Taxi dataset used in this tutorial.