### PR TITLE
Adding statement about the recommended number being 20

### DIFF
--- a/articles/active-directory/devices/device-management-azure-portal.md
+++ b/articles/active-directory/devices/device-management-azure-portal.md
@@ -166,7 +166,7 @@ This option is a premium edition capability available through products like Azur
    > - We recommend that you use the [Register or join devices user](../conditional-access/concept-conditional-access-cloud-apps.md#user-actions) action in Conditional Access to enforce multifactor authentication for joining or registering a device. 
    > - You must configure this setting to **No** if you're using Conditional Access policy to require multifactor authentication. 
 
-- **Maximum number of devices**: This setting enables you to select the maximum number of Azure AD joined or Azure AD registered devices that a user can have in Azure AD. If users reach this limit, they can't add more devices until one or more of the existing devices are removed. The default value is **50**. You can increase the value up to 100. If you enter a value above 100, Azure AD will set it to 100. You can also use **Unlimited** to enforce no limit other than existing quota limits.
+- **Maximum number of devices**: This setting enables you to select the maximum number of Azure AD joined or Azure AD registered devices that a user can have in Azure AD. If users reach this limit, they can't add more devices until one or more of the existing devices are removed. The default value is **50**, but the recommended is **20**. You can increase the value up to 100. If you enter a value above 100, Azure AD will set it to 100. You can also use **Unlimited** to enforce no limit other than existing quota limits.
 
    > [!NOTE]
    > The **Maximum number of devices** setting applies to devices that are either Azure AD joined or Azure AD registered. This setting doesn't apply to hybrid Azure AD joined devices.


### PR DESCRIPTION
The Azure AD interface shows this recommended value, but this article does not communicate that.

Likely this edit should be amended to include reasoning for this recommendation, and why the default differs from the recommendation. However, Microsoft would need to provide this as I don't seem to be able to find a documented reason.