### PR TITLE
update quota to reflect accurate limitations

### DIFF
--- a/articles/container-apps/quotas.md
+++ b/articles/container-apps/quotas.md
@@ -16,7 +16,7 @@ The following quotas exist per subscription for Azure Container Apps Preview.
 
 | Feature | Quantity |
 |---|---|
-| Environments | 2 |
+| Environments per region | 2 |
 | Container apps per environment | 20 |
 | Replicas per container app | 25 |
 | Cores per replica | 2 |


### PR DESCRIPTION
current description can be misinterpreted that a user can only deploy 2 container app environments per subscription. They can deploy a max of 2 per region.
Ex: Deploying in East US, North Europe & Canada Cental would allow a max of 6 container app environments at the subscription level.