### PR TITLE
the "and" here is redundant

### DIFF
--- a/articles/iot-fundamentals/howto-use-iot-explorer.md
+++ b/articles/iot-fundamentals/howto-use-iot-explorer.md
@@ -14,7 +14,7 @@ ms.custom: contperf-fy21q2
 
 # Install and use Azure IoT explorer
 
-The Azure IoT explorer is a graphical tool for interacting with and devices connected to your IoT hub. This article focuses on using the tool to test your IoT Plug and Play devices. After installing the tool on your local machine, you can use it to connect to a hub. You can use the tool to view the telemetry the devices are sending, work with device properties, and invoke commands.
+The Azure IoT explorer is a graphical tool for interacting with devices connected to your IoT hub. This article focuses on using the tool to test your IoT Plug and Play devices. After installing the tool on your local machine, you can use it to connect to a hub. You can use the tool to view the telemetry the devices are sending, work with device properties, and invoke commands.
 
 This article shows you how to:
 


### PR DESCRIPTION
The "and" is redundant. It should be "The Azure IoT explorer is a graphical tool for interacting with and devices connected to your IoT hub".