### PR TITLE
Specified gremlinpython library version 3.4.13

### DIFF
--- a/articles/cosmos-db/graph/create-graph-python.md
+++ b/articles/cosmos-db/graph/create-graph-python.md
@@ -32,13 +32,16 @@ In this quickstart, you create and manage an Azure Cosmos DB Gremlin (graph) API
   You can also install the Python driver for Gremlin by using the `pip` command line:
 
    ```bash
-   pip install gremlinpython
+   pip install gremlinpython==3.4.13
    ```
 
 - [Git](https://git-scm.com/downloads).
 
 > [!NOTE]
 > This quickstart requires a graph database account created after December 20, 2017. Existing accounts will support Python once they’re migrated to general availability.
+
+> [!NOTE]
+> We currently recommend using gremlinpython==3.4.13 with Gremlin (Graph) API as we haven't fully tested all language-specific libraries of version 3.5.* for use with the service.
 
 ## Create a database account
 


### PR DESCRIPTION
Specified that we recommend the use of gremlinpython==3.4.13 with the Gremlin (Graph) API for the time being.

The previous instructions would result in pip defaulting to version 3.5.2, which was not working correctly when I attempted to run the sample.