### PR TITLE
Libtool as dependency for autogen.sh

### DIFF
--- a/articles/virtual-network/virtual-network-test-latency.md
+++ b/articles/virtual-network/virtual-network-test-latency.md
@@ -148,6 +148,7 @@ Run the following commands:
     sudo apt-get install -y autotools-dev
     sudo apt-get install -y automake
     sudo apt-get install -y autoconf
+    sudo apt-get install -y libtool
 ```
 
 #### For all distros


### PR DESCRIPTION
autoconf.sh will fail on Ubuntu 18.04 w/o having libtool package installed. 