### PR TITLE
Error in az cli

### DIFF
--- a/articles/postgresql/flexible-server/connect-azure-cli.md
+++ b/articles/postgresql/flexible-server/connect-azure-cli.md
@@ -35,7 +35,7 @@ You can provide additional arguments for this command to customize it. See all a
 You can view all the arguments for this command with ```--help``` argument. 
 
 ```azurecli
-az postgresql flexible-server connect --help
+az postgres flexible-server connect --help
 ```
 
 ## Test database server connection


### PR DESCRIPTION
CLI syntax has a keyword error az postgresql should be az postgres.

There is a separate issue that the connect syntax does not work in the Cloud Shell, but that has been called out seperately.