### PR TITLE
Missing space in cli command

### DIFF
--- a/articles/aks/uptime-sla.md
+++ b/articles/aks/uptime-sla.md
@@ -81,7 +81,7 @@ Create a new cluster, and don't use Uptime SLA:
 
 ```azurecli-interactive
 # Create a new cluster without uptime SLA
-az aks create --resource-group myResourceGroup --name myAKSCluster--node-count 1
+az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 1
 ```
 
 Use the [`az aks update`][az-aks-update] command to update the existing cluster:


### PR DESCRIPTION
Missing a space:
az aks create --resource-group myResourceGroup --name myAKSCluster--node-count 1

should be:
az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 1