### PR TITLE
Resolving dead links to contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,19 @@
 
 Thank you for taking the time to contribute to the Microsoft Azure documentation.
 
-This guide covers some general topics related to contribution and refers to the [contributors guide](https://docs.microsoft.com/contribute) for more detailed explanations when required.
+This guide covers some general topics related to contribution and refers to the [contributor guide](https://docs.microsoft.com/contribute) for more detailed explanations when required.
 
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/), or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## How can I contribute?
 
-There are many ways to contribute to the documentation, review the sections below to find out which one is right for you.
+There are many ways to contribute to the documentation. Review the following sections to find out which one is right for you.
 
-### Reporting Bugs and Suggesting Enhancements
+### Reporting bugs and suggesting enhancements
 
 Please use the Feedback tool at the bottom of any article to submit bugs and suggestions.
 
@@ -21,5 +22,9 @@ Please use the Feedback tool at the bottom of any article to submit bugs and sug
 
 ### Editing in GitHub
 
-For guidance on how to contribute by editing in GitHub and submitting a pull request, refer to [Quick edits to existing documents](https://docs.microsoft.com/en-us/contribute/#quick-edits-to-existing-documents) in our contributors guide.
+Follow the guidance for [Quick edits to existing documents](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) in our contributor guide.
+
+### Pull requests
+
+Review the guidance for [pull requests](https://docs.microsoft.com/contribute/how-to-write-workflows-major#pull-request-processing) and the contribution workflow in our contributor guide.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,5 @@ Please use the Feedback tool at the bottom of any article to submit bugs and sug
 
 ### Editing in GitHub
 
-Follow the guidance for [Quick edits to existing documents](/contribute/#quick-edits-to-existing-documents) in our contributors guide.
+For guidance on how to contribute by editing in GitHub and submitting a pull request, refer to [Quick edits to existing documents](https://docs.microsoft.com/en-us/contribute/#quick-edits-to-existing-documents) in our contributors guide.
 
-### Pull Request
-
-Review the guidance for [Pull Requests](/contribute/how-to-write-workflows-major#pull-request-processing) in our contributors guide.


### PR DESCRIPTION
* The links to the contributors guide is not valid. I have corrected.
* Pull requests are covered in the same 'Quick edits to existing documents' guide, and there appears to be no separate documentation available. I have merged these sections as a result.