### PR TITLE
Update index.yml

### DIFF
--- a/articles/cognitive-services/Anomaly-Detector/index.yml
+++ b/articles/cognitive-services/Anomaly-Detector/index.yml
@@ -129,7 +129,7 @@ landingContent:
         - text: REST API (univariate)
           url: https://westus2.dev.cognitive.microsoft.com/docs/services/AnomalyDetector/operations/post-timeseries-entire-detect
         - text: .NET SDK (univariate)
-          url: https://aka.ms/anomaly-detector-dotnet-ref
+          url: /dotnet/api/azure.ai.anomalydetector
         - text: .Python SDK (univariate)
           url: https://go.microsoft.com/fwlink/?linkid=2090370
         - text: Go SDK (univariate)


### PR DESCRIPTION
.Net SDK (univariate) link point to (probably) an internal resource, not publicly accessible. Changing url copied from the  multivariate SDK version.