### PR TITLE
Correcting invalid CompleteAsync() on TransactionScope

### DIFF
--- a/articles/service-bus-messaging/service-bus-partitioning.md
+++ b/articles/service-bus-messaging/service-bus-partitioning.md
@@ -68,7 +68,7 @@ using (TransactionScope ts = new TransactionScope(committableTransaction))
     ServiceBusMessage msg = new ServiceBusMessage("This is a message");
     msg.PartitionKey = "myPartitionKey";
     await sender.SendMessageAsync(msg); 
-    await ts.CompleteAsync();
+    await ts.Complete();
 }
 committableTransaction.Commit();
 ```
@@ -88,7 +88,7 @@ using (TransactionScope ts = new TransactionScope(committableTransaction))
     ServiceBusMessage msg = new ServiceBusMessage("This is a message");
     msg.SessionId = "mySession";
     await sender.SendMessageAsync(msg); 
-    await ts.CompleteAsync();
+    await ts.Complete();
 }
 committableTransaction.Commit();
 ```

--- a/articles/service-bus-messaging/service-bus-partitioning.md
+++ b/articles/service-bus-messaging/service-bus-partitioning.md
@@ -68,7 +68,7 @@ using (TransactionScope ts = new TransactionScope(committableTransaction))
     ServiceBusMessage msg = new ServiceBusMessage("This is a message");
     msg.PartitionKey = "myPartitionKey";
     await sender.SendMessageAsync(msg); 
-    await ts.Complete();
+    ts.Complete();
 }
 committableTransaction.Commit();
 ```
@@ -88,7 +88,7 @@ using (TransactionScope ts = new TransactionScope(committableTransaction))
     ServiceBusMessage msg = new ServiceBusMessage("This is a message");
     msg.SessionId = "mySession";
     await sender.SendMessageAsync(msg); 
-    await ts.Complete();
+    ts.Complete();
 }
 committableTransaction.Commit();
 ```


### PR DESCRIPTION
TransactionScope does not have an async version of Complete(). Changing code samples referencing CompleteAsync() to Complete().
Refer, https://docs.microsoft.com/en-us/dotnet/api/system.transactions.transactionscope?view=net-6.0