### PR TITLE
Fix missing `endpoint` property name

### DIFF
--- a/articles/cosmos-db/how-to-setup-rbac.md
+++ b/articles/cosmos-db/how-to-setup-rbac.md
@@ -392,7 +392,7 @@ const servicePrincipal = new ClientSecretCredential(
     "<client-application-id>",
     "<client-application-secret>");
 const client = new CosmosClient({
-    "<account-endpoint>",
+    endpoint: "<account-endpoint>",
     aadCredentials: servicePrincipal
 });
 ```


### PR DESCRIPTION
According to the [SDK documentation](https://docs.microsoft.com/en-us/javascript/api/@azure/cosmos/cosmosclientoptions?view=azure-node-latest), the property for setting endpoint is `endpoint`.