### PR TITLE
Fix typo in `functions-bindings-event-hubs`

### DIFF
--- a/includes/functions-host-json-event-hubs.md
+++ b/includes/functions-host-json-event-hubs.md
@@ -22,7 +22,7 @@ ms.author: glenga
             "initialOffsetOptions" : {
                 "type" : "fromStart",
                 "enqueuedTimeUtc" : ""
-            }
+            },
             "clientRetryOptions":{
                 "mode" : "exponential",
                 "tryTimeout" : "00:01:00",


### PR DESCRIPTION
Fixes a typo
