### PR TITLE
Fix typo in `azure-functions`

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-blob.md
+++ b/articles/azure-functions/functions-bindings-storage-blob.md
@@ -74,7 +74,7 @@ This section describes the function app configuration settings available for fun
     "version": "2.0",
     "extensions": {
         "blobs": {
-            "maxDegreeOfParallelism": "4"
+            "maxDegreeOfParallelism": 4
         }
     }
 }


### PR DESCRIPTION
Fix typo in `functions-bindings-storage-blob.md`. If this was intended, then a note or warning may be useful because it's quite confusing