### PR TITLE
fix wrong parameter for node.JS in Azure AD authentication for Application Insights

### DIFF
--- a/articles/azure-monitor/app/azure-ad-authentication.md
+++ b/articles/azure-monitor/app/azure-ad-authentication.md
@@ -107,7 +107,7 @@ import { DefaultAzureCredential } from "@azure/identity";
  
 const credential = new DefaultAzureCredential();
 appInsights.setup("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/").start();
-appInsights.defaultClient.aadTokenCredential = credential;
+appInsights.defaultClient.config.aadTokenCredential = credential;
 
 ```
 
@@ -123,7 +123,7 @@ const credential = new ClientSecretCredential(
     "<YOUR_CLIENT_SECRET>"
   );
 appInsights.setup("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://xxxx.applicationinsights.azure.com/").start();
-appInsights.defaultClient.aadTokenCredential = credential;
+appInsights.defaultClient.config.aadTokenCredential = credential;
 
 ```
 


### PR DESCRIPTION
The documentation for Azure AD authentication for Application Insights is wrong for Node.JS.
The parameter to enable authentication must be added to the config object and not to the client object.