### PR TITLE
Updating article for clarity and fixing issue

### DIFF
--- a/articles/active-directory/authentication/how-to-mfa-additional-context.md
+++ b/articles/active-directory/authentication/how-to-mfa-additional-context.md
@@ -34,6 +34,9 @@ The additional context can be combined with [number matching](how-to-mfa-number-
 
 ### Policy schema changes 
 
+>[!NOTE]
+>In Graph Explorer ensure you've consented to the **Policy.Read.All** and **Policy.ReadWrite.AuthenticationMethod** permissions. 
+
 Identify a single target group for the schema configuration. Then use the following API endpoint to change the displayAppInformationRequiredState property to **enabled**:
 
 https://graph.microsoft.com/beta/authenticationMethodsPolicy/authenticationMethodConfigurations/MicrosoftAuthenticator
@@ -96,7 +99,7 @@ You need to PATCH the entire includeTarget to prevent overwriting any previous c
             "id": "all_users",
             "authenticationMode": "any",
             "displayAppInformationRequiredState": "enabled",
-            "numberMatchingRequiredState": "enabled"
+            "numberMatchingRequiredState": "default"
         }
     ]
 }
@@ -111,6 +114,9 @@ GET - https://graph.microsoft.com/beta/authenticationMethodsPolicy/authenticatio
  
 Change the **displayAppInformationRequiredState** value from **default** to **enabled.** 
 Change the **id** from **all_users** to the ObjectID of the group from the Azure AD portal.
+
+>[!NOTE]
+>If your organization is currently targeting **All users** for enablement of passwordless, and you enable additional context for a single group, the targeting will now be scoped only to that group for passwordless. You will want to ensure you have another group or groups appropriately scoped to passwordless enablement.
 
 You need to PATCH the entire includeTarget to prevent overwriting any previous configuration. We recommend that you do a GET first, and then update only the relevant fields and then PATCH. The example below only shows the update to the **displayAppInformationRequiredState**. 
 
@@ -131,7 +137,7 @@ You need to PATCH the entire includeTarget to prevent overwriting any previous c
             "id": "1ca44590-e896-4dbe-98ed-b140b1e7a53a",
             "authenticationMode": "any",
             "displayAppInformationRequiredState": "enabled",
-            "numberMatchingRequiredState": "enabled"
+            "numberMatchingRequiredState": "default"
         }
     ]
 }
@@ -168,7 +174,7 @@ To turn off additional context, you'll need to PATCH remove **displayAppInformat
             "targetType": "group",
             "id": "all_users",
             "authenticationMode": "any",
-            "displayAppInformationRequiredState": "enabled",
+            "displayAppInformationRequiredState": "default",
             "numberMatchingRequiredState": "default"
         }
     ]


### PR DESCRIPTION
Proposing a few changes to the article, which are:
1. Updating the json samples to only include the relevant changes since the article is primarily about additional context; the samples also were enabling number matching, which has it's own article.
2. Adding a note on what the required Graph permissions are for updating the policy, so that an administrator does not inadvertently overconsent to permissions because they are not sure what is needed.
3. Adding a note regarding the single group, and that organizations who are targeting all users, for something like enabling passwordless, will now be restricting that setting as well, and clarifying that they will want to create an additional group that might be out of the scope of the pilot/test they are running for additional context.
4. The json for disabling additional context was setting the wrong property to default
#ATCP