### PR TITLE
support multi-byte characters

### DIFF
--- a/articles/active-directory-b2c/deploy-custom-policies-devops.md
+++ b/articles/active-directory-b2c/deploy-custom-policies-devops.md
@@ -92,7 +92,8 @@ try {
                 Write-Host "Uploading the" $PolicyId "policy..."
     
                 $graphuri = 'https://graph.microsoft.com/beta/trustframework/policies/' + $PolicyId + '/$value'
-                $response = Invoke-RestMethod -Uri $graphuri -Method Put -Body $policycontent -Headers $headers
+                $content = [System.Text.Encoding]::UTF8.GetBytes($policycontent)
+                $response = Invoke-RestMethod -Uri $graphuri -Method Put -Body $content -Headers $headers
     
                 Write-Host "Policy" $PolicyId "uploaded successfully."
             }


### PR DESCRIPTION
Invoke-RestMethod can not send correctly content which include multi-byte chars. Therefore if you upload custom policy include multi-byte charactors, uploaded policy is garbled. So we need convert string to bytes array to prevent it.