### PR TITLE
Update "what's new" links to current

### DIFF
--- a/articles/databox-online/index.yml
+++ b/articles/databox-online/index.yml
@@ -39,9 +39,9 @@ landingContent:
             url: ../storage/common/storage-solution-large-dataset-low-network.md#offline-transfer-or-network-transfer
       - linkListType: whats-new
         links:
-          - text: 2103 release notes for Azure Stack Edge Pro GPU
-            url: azure-stack-edge-gpu-2103-release-notes.md
-          - text: 2101 release notes for Azure Stack Edge Pro FPGA
+          - text: Azure Stack Edge 2202 release notes
+            url: azure-stack-edge-gpu-2202-release-notes.md
+          - text: Azure Stack Edge Pro with FPGA 2101 release notes
             url: azure-stack-edge-2101-release-notes.md
 
 


### PR DESCRIPTION
The text for "What's New" didn't match the page titles, and the link for the non-FPGA unit was out of date.

Ideally those links would use the existing aka.ms so that when changes happen this page could be unchanged, but I know using aka.ms in docs is discouraged.