### PR TITLE
(AzureCXP) MicrosoftDocs/azure-docs#88799

### DIFF
--- a/articles/data-factory/data-factory-private-link.md
+++ b/articles/data-factory/data-factory-private-link.md
@@ -225,9 +225,7 @@ Finally, you must create the private endpoint in your data factory.
     | **Private DNS integration** |  |
     | Integrate with private DNS zone | Leave the default of **Yes**. |
     | Subscription | Select your subscription. |
-    | Private DNS zones | Leave the default of **(New) privatelink.azurewebsites.net**.
-    
-
+    | Private DNS zones | Leave the default value in both Target sub-resources:  1. datafactory: **(New) privatelink.datafactory.azure.net**. 2. portal: **(New) privatelink.adf.azure.com**
 7. Select **Review + create**.
 
 8. Select **Create**.


### PR DESCRIPTION
The default private zone listed in the doc is  '(New) privatelink.azurewebsites.net.' 
However, Data Factory has 2 private endpoints dataFactory and portal.
Each has it default dns zone name
dataFactory - 'privatelink.datafactory.azure.net'
portal - 'privatelink.adf.azure.com'