### PR TITLE
Update service-fabric-reliable-actors-enumerate.md

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-actors-enumerate.md
+++ b/articles/service-fabric/service-fabric-reliable-actors-enumerate.md
@@ -6,7 +6,7 @@ ms.date: 03/19/2018
 ms.custom: devx-track-csharp
 ---
 # Enumerate Service Fabric Reliable Actors
-The Reliable Actors service allows a client to enumerate metadata about the actors that the service is hosting. Because the actor service is a partitioned stateful service, enumeration is performed per partition. Because each partition might contain many actors, the enumeration is returned as a set of paged results. The pages are looped over until all pages are read. The following example shows how to create a list of all active actors in one partition of an actor service:
+The Reliable Actors service allows a client to enumerate metadata about the actors that the service is hosting. Because the actor service is a partitioned stateful service, enumeration is performed per partition. Because each partition might contain many actors, the enumeration is returned as a set of paged results. The pages are looped over until all pages are read. The following example shows how to create a list of all [active](service-fabric-reliable-actors-lifecycle.md) actors in one partition of an actor service:
 
 ```csharp
 IActorService actorServiceProxy = ActorServiceProxy.Create(


### PR DESCRIPTION
While the lifecycle documentation is referenced in the next steps, it wasn't immediately clear what "active" meant in the context it was used in, so drawing better attention to precisely what an active or inactive actor is up top.