### PR TITLE
Update gateway.md to clarify no support for runbooks or DSC

### DIFF
--- a/articles/azure-monitor/agents/gateway.md
+++ b/articles/azure-monitor/agents/gateway.md
@@ -12,7 +12,7 @@ ms.date: 12/24/2019
 
 This article describes how to configure communication with Azure Automation and Azure Monitor by using the Log Analytics gateway when computers that are directly connected or that are monitored by Operations Manager have no internet access. 
 
-The Log Analytics gateway is an HTTP forward proxy that supports HTTP tunneling using the HTTP CONNECT command. This gateway sends data to Azure Automation and a Log Analytics workspace in Azure Monitor on behalf of the computers that cannot directly connect to the internet. 
+The Log Analytics gateway is an HTTP forward proxy that supports HTTP tunneling using the HTTP CONNECT command. This gateway sends data to Azure Automation and a Log Analytics workspace in Azure Monitor on behalf of the computers that cannot directly connect to the internet. The gateway is only for log agent related connectivity and does not support Azure Automation features like runbook, DSC, and others.
 
 The Log Analytics gateway supports:
 


### PR DESCRIPTION
Added text to clarify that the gateway does not support Azure Automation runbook or DSC. The diagram in this doc is a little misleading because it shows a green connectivity line to Runbooks, but those are not supported. The gateway only supports log agent related calls.