### PR TITLE
Update cassandra-support.md

### DIFF
--- a/articles/cosmos-db/cassandra/cassandra-support.md
+++ b/articles/cosmos-db/cassandra/cassandra-support.md
@@ -262,7 +262,7 @@ curl https://cacert.omniroot.com/bc2025.crt > bc2025.crt
 keytool -importcert -alias bc2025ca -file bc2025.crt
 
 # Install the Cassandra libraries in order to get CQLSH:
-echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+echo "deb https://downloads.apache.org/cassandra/debian 311x main" | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
 curl https://downloads.apache.org/cassandra/KEYS | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install cassandra


### PR DESCRIPTION
For now, the repo address "http://www.apache.org/dist/cassandra/debian" doesn't work and will hit some SSL related issue, use the underlying address "https://downloads.apache.org/cassandra/debian" instead. 
The official guide in https://cassandra.apache.org/_/download.html also starts to use the new address "http://www.apache.org/dist/cassandra/debian".