### PR TITLE
Fix a request example using user-assigned identity

### DIFF
--- a/articles/container-instances/container-instances-managed-identity.md
+++ b/articles/container-instances/container-instances-managed-identity.md
@@ -168,7 +168,8 @@ az container exec \
 Run the following commands in the bash shell in the container. To get an access token to use Azure Active Directory to authenticate to key vault, run the following command:
 
 ```bash
-curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net' -H Metadata:true -s
+client_id="CLIENT ID (xxxxxxxx-5523-45fc-9f49-xxxxxxxxxxxx)"
+curl "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net&client_id=$client_id" -H Metadata:true -s
 ```
 
 Output:


### PR DESCRIPTION
The request using user-assigned identity need the client_id.
It is not witten in the doc. 