### PR TITLE
Add app restart warning

### DIFF
--- a/articles/app-service/overview-managed-identity.md
+++ b/articles/app-service/overview-managed-identity.md
@@ -144,6 +144,9 @@ First, you'll need to create a user-assigned identity resource.
 1. Search for the identity you created earlier and select it. Click **Add**.
 
     ![Managed identity in App Service](media/app-service-managed-service-identity/user-assigned-managed-identity-in-azure-portal.png)
+    
+> [!IMPORTANT]
+> Clicking **Add** after selecting a user assigned idenity to add will restart your application.
 
 # [Azure CLI](#tab/cli)
 

--- a/articles/app-service/overview-managed-identity.md
+++ b/articles/app-service/overview-managed-identity.md
@@ -146,7 +146,7 @@ First, you'll need to create a user-assigned identity resource.
     ![Managed identity in App Service](media/app-service-managed-service-identity/user-assigned-managed-identity-in-azure-portal.png)
     
 > [!IMPORTANT]
-> Clicking **Add** after selecting a user assigned idenity to add will restart your application.
+> If you select **Add** after you select a user-assigned identity to add, your application will restart.
 
 # [Azure CLI](#tab/cli)
 


### PR DESCRIPTION
After adding a user-assigned identity causes an application to restart with no warning in the Azure portal. We learned this on our team by experiencing un-expected downtime in our application. Adding a warning here will at least document the behavior for customer.