### PR TITLE
Use "request" instead of "since" for payload

### DIFF
--- a/articles/iot-central/core/howto-control-devices-with-rest-api.md
+++ b/articles/iot-central/core/howto-control-devices-with-rest-api.md
@@ -421,7 +421,7 @@ The request body looks like the following example:
 
 ```json
 {
-  "since": "2021-03-24T12:55:20.789Z"
+  "request": "2021-03-24T12:55:20.789Z"
 }
 ```
 


### PR DESCRIPTION
Using "since" will get RequestTImeOut error:

```
Request Timeout({"error":{"code":"RequestTimeout","message":"Request timeout waiting for the device. You can contact support at https://aka.ms/iotcentral-support. Please include the following information.
```
So, the body will work for sending commands like the following example:
```
{
    "request":  "<the value should be sent>"
}

```