### PR TITLE
Update TXT record specification for accuracy

### DIFF
--- a/articles/dns/dns-zones-records.md
+++ b/articles/dns/dns-zones-records.md
@@ -94,9 +94,9 @@ The zone serial number in the SOA record isn't updated automatically when change
 
 TXT records are used to map domain names to arbitrary text strings. They're used in multiple applications, in particular related to email configuration, such as the [Sender Policy Framework (SPF)](https://en.wikipedia.org/wiki/Sender_Policy_Framework) and [DomainKeys Identified Mail (DKIM)](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail).
 
-The DNS standards permit a single TXT record to contain multiple strings, each of which may be up to 254 characters in length. Where multiple strings are used, they are concatenated by clients and treated as a single string.
+The DNS standards permit a single TXT record to contain multiple strings, each of which may be up to 255 characters in length. Where multiple strings are used, they are concatenated by clients and treated as a single string.
 
-When calling the Azure DNS REST API, you need to specify each TXT string separately.  When using the Azure portal, PowerShell or CLI interfaces you should specify a single string per record, which is automatically divided into 254-character segments if necessary.
+When calling the Azure DNS REST API, you need to specify each TXT string separately.  When using the Azure portal, PowerShell or CLI interfaces you should specify a single string per record, which is automatically divided into 255-character segments if necessary.
 
 The multiple strings in a DNS record shouldn't be confused with the multiple TXT records in a TXT record set.  A TXT record set can contain multiple records, *each of which* can contain multiple strings.  Azure DNS supports a total string length of up to 1024 characters in each TXT record set (across all records combined).
 


### PR DESCRIPTION
- The [DNS Standards](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4) referenced support 255 octets (bytes), where one char equals one byte.
- AzureDNS APIs support TXT record length of 255.
- Verified using Azure Portal and calling AzureDNS APIs that 255 chars are supported for TXT record type, not 254 char limitation published in Docs. 
- Changing here to fix the documentation.