### PR TITLE
Update tutorial-enable-sspr-writeback.md

### DIFF
--- a/articles/active-directory/authentication/tutorial-enable-sspr-writeback.md
+++ b/articles/active-directory/authentication/tutorial-enable-sspr-writeback.md
@@ -91,7 +91,7 @@ Password policies in the on-premises AD DS environment may prevent password rese
 If you update the group policy, wait for the updated policy to replicate, or use the `gpupdate /force` command.
 
 > [!Note]
-> For passwords to be changed immediately, *Minimum password age* must be set to 0. However, if users adhere to the on-premises policies, and the *Minimum password age* is set to a value greater than zero, password writeback still works after the on-premises policies are evaluated.
+> If you need to allow users to change or reset passwords more than one time per day, *Minimum password age* must be set to 0. Password writeback will work after on-premises password policies are successfully evaluated.
 
 ## Enable password writeback in Azure AD Connect
 


### PR DESCRIPTION
Previous note regarding on-premises password policies were misleading and incorrect. 

 For passwords to be changed immediately, ???password writeback ???must be set to 0. However, if users adhere to the on-premises policies, and the *Minimum password age* is set to a value greater than zero, password writeback still works after the on-premises policies are evaluated.

PWB still works immediately if minimum password age is set to a value greater than Zero. but its limited by this restriction.

If customers needs to allow users to change password more than one time per day, than the minimum password age at on-premises password policy needs to be set to ZERO.