### PR TITLE
Fix: quickstart-feature-flag-aspnet-core.md .net 3

### DIFF
--- a/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
+++ b/articles/azure-app-configuration/quickstart-feature-flag-aspnet-core.md
@@ -138,15 +138,27 @@ dotnet new mvc --no-https --output TestFeatureFlags
     }
     ```
     #### [.NET Core 3.x](#tab/core3x)
-
+    
+    Add the following code:
     ```csharp    
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddControllersWithViews();
+        services.AddAzureAppConfiguration();
         services.AddFeatureManagement();
     }
     ```
 
+    And then add below:
+
+    ```csharp    
+    public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        // ...
+        app.UseAzureAppConfiguration();
+    }
+    ```
+    
     #### [.NET Core 2.x](#tab/core2x)
 
     ```csharp


### PR DESCRIPTION
Fixing bug reported on Stackoverflow: middleware that refreshes feature flags (and configuration) from Azure App Configuration missing.