### PR TITLE
Fix the Synapse SQL Pool

### DIFF
--- a/articles/azure-resource-manager/management/resource-name-rules.md
+++ b/articles/azure-resource-manager/management/resource-name-rules.md
@@ -747,7 +747,7 @@ In the following tables, the term alphanumeric refers to:
 > | --- | --- | --- | --- |
 > | workspaces | global | 1-50 | Lowercase letters, hyphens, and numbers.<br><br>Start and end with letter or number.<br><br>Can't contain `-ondemand` |
 > | workspaces / bigDataPools | workspace | 1-15 | Letters and numbers.<br><br>Start with letter. End with letter or number.<br><br>Can't contain [reserved word](../troubleshooting/error-reserved-resource-name.md). |
-> | workspaces / sqlPools | workspace | 1-15  |  Can contain only letters, numbers or underscore.<br><br>Can't contain [reserved word](../troubleshooting/error-reserved-resource-name.md). |
+> | workspaces / sqlPools | workspace | 1-15  |  Can contain only letters, numbers, or underscore.<br><br>Can't contain [reserved word](../troubleshooting/error-reserved-resource-name.md). |
 
 ## Microsoft.TimeSeriesInsights
 

--- a/articles/azure-resource-manager/management/resource-name-rules.md
+++ b/articles/azure-resource-manager/management/resource-name-rules.md
@@ -747,7 +747,7 @@ In the following tables, the term alphanumeric refers to:
 > | --- | --- | --- | --- |
 > | workspaces | global | 1-50 | Lowercase letters, hyphens, and numbers.<br><br>Start and end with letter or number.<br><br>Can't contain `-ondemand` |
 > | workspaces / bigDataPools | workspace | 1-15 | Letters and numbers.<br><br>Start with letter. End with letter or number.<br><br>Can't contain [reserved word](../troubleshooting/error-reserved-resource-name.md). |
-> | workspaces / sqlPools | workspace | 1-60 | Can't contain `<>*%&:\/?@-` or control characters.<br><br>Can't end with `.` or space.<br><br>Can't contain [reserved word](../troubleshooting/error-reserved-resource-name.md). |
+> | workspaces / sqlPools | workspace | 1-15  |  Can contain only letters, numbers or underscore.<br><br>Can't contain [reserved word](../troubleshooting/error-reserved-resource-name.md). |
 
 ## Microsoft.TimeSeriesInsights
 


### PR DESCRIPTION
Error: name can contain only letters, numbers or underscore, The value must be between 1 and 15 characters long with module.example.module.synapse_sql_pool