### PR TITLE
Add AES256 prerequisite for hybrid FIDO setup.

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -48,6 +48,8 @@ You must also meet the following system requirements:
     - [Windows Server 2016](https://support.microsoft.com/help/4534307/windows-10-update-kb4534307)
     - [Windows Server 2019](https://support.microsoft.com/help/4534321/windows-10-update-kb4534321)
 
+- AES256_HMAC_SHA1 must be enabled when **Network security: Configure encryption types allowed for Kerberos** policy is [configured](https://docs.microsoft.com/windows/security/threat-protection/security-policy-settings/network-security-configure-encryption-types-allowed-for-kerberos) on domain controllers.
+
 - Have the credentials required to complete the steps in the scenario:
     - An Active Directory user who is a member of the Domain Admins group for a domain and a member of the Enterprise Admins group for a forest. Referred to as **$domainCred**.
     - An Azure Active Directory user who is a member of the Global Administrators role. Referred to as **$cloudCred**.


### PR DESCRIPTION
AzureADHybridAuthenticationManagement PowerShell module requires AES256 Encryption type to be enabled for Kerberos Server keys.

When **Network security: Configure encryption types allowed for Kerberos** policy is in default state ( Not Defined ) all encryption types are allowed, however when administrators configure allowed encryption type manually they may specifically disable AES256 encryption.

Adding prerequisite for AES 256 to be enabled when manually configured.