### PR TITLE
Added a description about disconnect notification during listening

### DIFF
--- a/articles/iot-hub/iot-hub-node-node-file-upload.md
+++ b/articles/iot-hub/iot-hub-node-node-file-upload.md
@@ -242,7 +242,7 @@ In this section, you create a Node.js console app that receives file upload noti
     });
     ```
     > [!NOTE]
-    > If you want to receive disconnet notification while you are listening file upload notification, you need to register `'error'` by using `receiver.on`. In order to continue receive file upload notification, you need to reconect IoT Hub by using `serviceClient.open` method.
+    > If you want to receive disconnect notifications while you are listening to file upload notifications, you need to register `'error'` by using `receiver.on`. To continue to receive file upload notifications, you need to reconect to IoT Hub by using the `serviceClient.open` method.
 
 1. Save and close the **FileUploadNotification.js** file.
 

--- a/articles/iot-hub/iot-hub-node-node-file-upload.md
+++ b/articles/iot-hub/iot-hub-node-node-file-upload.md
@@ -241,8 +241,8 @@ In this section, you create a Node.js console app that receives file upload noti
       }
     });
     ```
-> [!NOTE]
-> If you want to receive disconnet notification while you are listening file upload notification, you need to register `'error'` by using `receiver.on`. In order to continue receive file upload notification, you need to reconect IoT Hub by using `serviceClient.open` method.
+    > [!NOTE]
+    > If you want to receive disconnet notification while you are listening file upload notification, you need to register `'error'` by using `receiver.on`. In order to continue receive file upload notification, you need to reconect IoT Hub by using `serviceClient.open` method.
 
 1. Save and close the **FileUploadNotification.js** file.
 

--- a/articles/iot-hub/iot-hub-node-node-file-upload.md
+++ b/articles/iot-hub/iot-hub-node-node-file-upload.md
@@ -241,6 +241,8 @@ In this section, you create a Node.js console app that receives file upload noti
       }
     });
     ```
+> [!NOTE]
+> If you want to receive disconnet notification while you are listening file upload notification, you need to register `'error'` by using `receiver.on`. In order to continue receive file upload notification, you need to reconect IoT Hub by using `serviceClient.open` method.
 
 1. Save and close the **FileUploadNotification.js** file.
 


### PR DESCRIPTION
If user get disconnected during listening by any network issue, file notification might be stopped. In this scenario, user need to get reconnect. To reconnect to IoT Hub, user need to get disconnect notification. I added about this since it seems there is no discription about this matter. Please see a reference the issue below.
https://github.com/Azure/azure-iot-sdk-node/issues/919#issuecomment-765650015