### PR TITLE
Azure Defender for IoT, wrong symmetric key path

### DIFF
--- a/articles/iot-edge/how-to-connect-downstream-iot-edge-device.md
+++ b/articles/iot-edge/how-to-connect-downstream-iot-edge-device.md
@@ -576,13 +576,13 @@ Learn more about the [Defender for IoT micro agent](../defender-for-iot/device-b
 
 1. Open a terminal on the leaf device.
 
-1. Use the following command to place the connection string encoded in utf-8 in the Defender for Cloud agent directory into the file `connection_string.txt` in the following path: `/var/defender_iot_micro_agent/connection_string.txt`:
+1. Use the following command to place the connection string encoded in utf-8 in the Defender for Cloud agent directory into the file `connection_string.txt` in the following path: `/etc/defender_iot_micro_agent/connection_string.txt`:
 
     ```bash
-    sudo bash -c 'echo "<connection string>" > /var/defender_iot_micro_agent/connection_string.txt'
+    sudo bash -c 'echo "<connection string>" > /etc/defender_iot_micro_agent/connection_string.txt'
     ```
 
-    The `connection_string.txt` should now be located in the following path location `/var/defender_iot_micro_agent/connection_string.txt`.
+    The `connection_string.txt` should now be located in the following path location `/etc/defender_iot_micro_agent/connection_string.txt`.
 
 1. Restart the service using this command:  
 


### PR DESCRIPTION
in https://docs.microsoft.com/en-us/azure/defender-for-iot/device-builders/tutorial-standalone-agent-binary-installation the path /etc/defender_iot_micro_agent/connection_string.txt is used.
This /etc path works ok.