### PR TITLE
Removed URL for IDP-initiated

### DIFF
--- a/articles/active-directory/saas-apps/cloudtamer-io-tutorial.md
+++ b/articles/active-directory/saas-apps/cloudtamer-io-tutorial.md
@@ -91,10 +91,6 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
     b. In the **Reply URL** text box, paste the **SERVICE PROVIDER ACS URL** from Kion into this box.
 
-1. Click **Set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
-
-    In the **Sign-on URL** text box, paste the **SERVICE PROVIDER ACS URL** from Kion into this box.
-
 1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Federation Metadata XML** and select **Download** to download the certificate and save it on your computer.
 
 	![The Certificate download link](common/metadataxml.png)


### PR DESCRIPTION
Removed the instructions for assigning a URL. These were incorrect and actually broke IDP-initiated. Omitting this causes it to work out-of-the-box without additional configuration.