### PR TITLE
articles/openshift/support-lifecycle: "outside of the support", etc.

### DIFF
--- a/articles/openshift/support-lifecycle.md
+++ b/articles/openshift/support-lifecycle.md
@@ -113,7 +113,7 @@ Reverting your cluster to a previous version, or a rollback, isn't supported. On
 **What does "Outside of Support" mean?**
 
 If your ARO cluster is running an OpenShift version that is not on the supported versions list or is using an [unsupported cluster configuration](./support-policies-v4.md), your cluster is "outside of support". As a result:
-- When opening a support ticket for your cluster, you will be asked to upgrade the cluster to a supported version. before receiving support, unless you are within the 30-day grace period after version support ends. 
-- Any runtime or SLA guarantees for clusters outside of the support are voided.
+- When opening a support ticket for your cluster, you will be asked to upgrade the cluster to a supported version, before receiving support, unless you are within the 30-day grace period after version support ends. 
+- Any runtime or SLA guarantees are voided for clusters outside of support.
 - Clusters outside of support will be patched only on a best effort basis.
 - Clusters outside of support will not be monitored.


### PR DESCRIPTION
Surrounding text use "outside of support", so adjust for consistency.  Also shift "are voided" to get "guarantees are voided" close together, without having the "for clusters ..." qualifier in the middle of the effect description.

Also fix the `.` -> `,` typo for "'before receiving support".