### PR TITLE
articles/openshift/support-lifecycle: Modernize example versions

### DIFF
--- a/articles/openshift/support-lifecycle.md
+++ b/articles/openshift/support-lifecycle.md
@@ -16,11 +16,11 @@ Azure Red Hat OpenShift is built from specific releases of OCP. This article cov
 
 ## Red Hat OpenShift versions
 
-Red Hat OpenShift Container Platform uses semantic versioning. Semantic versioning uses different levels of version numbers to specify different levels of versioning. The following table illustrates the different parts of a semantic version number, in this case using the example version number 4.4.11.
+Red Hat OpenShift Container Platform uses semantic versioning. Semantic versioning uses different levels of version numbers to specify different levels of versioning. The following table illustrates the different parts of a semantic version number, in this case using the example version number 4.9.23.
 
 |Major version (x)|Minor version (y)|Patch (z)|
 |-|-|-|
-|4|4|11|
+|4|9|23|
 
 Each number in the version indicates general compatibility with the previous version:
 
@@ -28,15 +28,15 @@ Each number in the version indicates general compatibility with the previous ver
 * **Minor version**: Released approximately every three months. Minor version upgrades can include feature additions, enhancements, deprecations, removals, bug fixes, security enhancements, and other improvements.
 * **Patches**: Typically released each week, or as needed. Patch version upgrades can include bug fixes, security enhancements, and other improvements.
 
-Customers should aim to run the latest minor release of the major version they're running. For example, if your production cluster is on 4.4, and 4.5 is the latest generally available minor version for the 4 series, you should upgrade to 4.5 as soon as you can. 
+Customers should aim to run the latest minor release of the major version they're running. For example, if your production cluster is on 4.8, and 4.9 is the latest generally available minor version for the 4 series, you should upgrade to 4.9 as soon as you can. 
 
 ### Upgrade channels
 
-Upgrade channels are tied to a minor version of Red Hat OpenShift Container Platform (OCP). For instance, OCP 4.4 upgrade channels will never include an upgrade to a 4.5 release. Upgrade channels control only release selection and don't impact the version of the cluster.
+Upgrade channels are tied to a minor version of Red Hat OpenShift Container Platform (OCP). For instance, OCP 4.8 upgrade channels will never include an upgrade to a 4.9 release. Upgrade channels control only release selection and don't impact the version of the cluster.
 
-Azure Red Hat OpenShift 4 supports stable channels only. For example: stable-4.4.
+Azure Red Hat OpenShift 4 supports stable channels only. For example: stable-4.9.
 
-You can use the stable-4.5 channel to upgrade from a previous minor version of Azure Red Hat OpenShift. Clusters upgraded using fast, prerelease, and candidate channels will not be supported.
+You can use the stable-4.9 channel to upgrade from a previous minor version of Azure Red Hat OpenShift. Clusters upgraded using fast, prerelease, and candidate channels will not be supported.
 
 If you change to a channel that does not include your current release, an alert displays and no updates can be recommended, but you can safely change back to your original channel at any point.
 
@@ -50,15 +50,15 @@ If available in a stable upgrade channel, newer minor releases (N+1, N+2) availa
 
 Critical patch updates are applied to clusters automatically by Azure Red Hat OpenShift Site Reliability Engineers (SRE). Customers that wish to install patch updates in advance are free to do so.
 
-For example, if Azure Red Hat OpenShift introduces 4.5.z today, support is provided for the following versions:
+For example, if Azure Red Hat OpenShift introduces 4.9.z today, support is provided for the following versions:
 
 |New minor version|Supported version list|
 |-|-|
-|4.5.z|4.5.z, 4.4.z|
+|4.9.z|4.9.z, 4.8.z|
 
-".z" is representative of patch versions. If available in a stable upgrade channel, customers may also upgrade to 4.6.z.
+".z" is representative of patch versions. If available in a stable upgrade channel, customers may also upgrade to 4.10.z.
 
-When a new minor version is introduced, the oldest minor version is deprecated and removed. For example, say the current supported version list is 4.5.z and 4.4.z. When Azure Red Hat OpenShift releases 4.6.z, the 4.4.z release will be removed and will be out of support within 30 days.
+When a new minor version is introduced, the oldest minor version is deprecated and removed. For example, say the current supported version list is 4.9.z and 4.8.z. When Azure Red Hat OpenShift releases 4.10.z, the 4.8.z release will be removed and will be out of support within 30 days.
 
 > [!NOTE]
 > Please note that if customers are running an unsupported Red Hat OpenShift version, they may be asked to upgrade when requesting support for the cluster. Clusters running unsupported Red Hat OpenShift releases are not covered by the Azure Red Hat OpenShift SLA.
@@ -84,7 +84,7 @@ Specific patch releases may be skipped, or rollout may be accelerated depending 
 
 ## Azure portal and CLI versions
 
-When you deploy an Azure Red Hat OpenShift cluster in the portal or with the Azure CLI, the cluster is defaulted to the latest (N) minor version and latest critical patch. For example, if Azure Red Hat OpenShift supports 4.5.z and 4.4.z, the default version for new installations is 4.5.z. Customers that wish to use the latest upstream OCP minor version (N+1, N+2) can upgrade their cluster at any time to any release available in the stable upgrade channels.
+When you deploy an Azure Red Hat OpenShift cluster in the portal or with the Azure CLI, the cluster is defaulted to the latest (N) minor version and latest critical patch. For example, if Azure Red Hat OpenShift supports 4.9.z and 4.8.z, the default version for new installations is 4.9.z. Customers that wish to use the latest upstream OCP minor version (N+1, N+2) can upgrade their cluster at any time to any release available in the stable upgrade channels.
 
 ## Azure Red Hat OpenShift release calendar
 
@@ -105,8 +105,8 @@ See the following guide for the [past Red Hat OpenShift Container Platform (upst
 
 If you are on the N-2 version or older, it means you are outside of support and will be asked to upgrade to continue recieving support. When your upgrade from version N-2 to N-1 succeeds, you are back within support. Upgrading from version N-3 version or older to a supported version can be challenging and in some cases not possible. We recommend you keep your cluster on the latest OpenShift version to avoid potential upgrade issues. 
 For example:
-* If the oldest supported Azure Red Hat OpenShift version is 4.4.z and you are on 4.3.z or older, you are outside of support.
-* When the upgrade from 4.3.z to 4.4.z or higher succeeds, you are back within our support policies. 
+* If the oldest supported Azure Red Hat OpenShift version is 4.8.z and you are on 4.7.z or older, you are outside of support.
+* When the upgrade from 4.7.z to 4.8.z or higher succeeds, you are back within our support policies. 
 
 Reverting your cluster to a previous version, or a rollback, isn't supported. Only upgrading to a newer version is supported.
 


### PR DESCRIPTION
Less mental work for folks if they don't have to project themselves back to the distant history of 4.5 when reading the docs.  Converting to something generic like `4.y` and `4.(y-1)` would work too, but that seemed like a bigger shift, so this commit kicks the can a bit further down the road.  Folks can either keep periodically kicking things along, convert to generic placeholders, or give up and let things go stale again, whatever seems to make the most sense.
