### PR TITLE
Corrected the URL for to show it correctly in Readme

### DIFF
--- a/articles/storage/common/storage-introduction.md
+++ b/articles/storage/common/storage-introduction.md
@@ -154,7 +154,7 @@ You can access resources in a storage account by any language that can make HTTP
 - [Azure Storage REST API](/rest/api/storageservices/)
 - [Azure Storage client library for .NET](/dotnet/api/overview/azure/storage)
 - [Azure Storage client library for Java/Android](/java/api/overview/azure/storage)
-- [Azure Storage client library for Node.js]((/azure/storage/blobs/reference#javascript-client-libraries)
+- [Azure Storage client library for Node.js](/azure/storage/blobs/reference#javascript-client-libraries)
 - [Azure Storage client library for Python](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob)
 - [Azure Storage client library for PHP](https://github.com/Azure/azure-storage-php)
 - [Azure Storage client library for Ruby](https://github.com/Azure/azure-storage-ruby)


### PR DESCRIPTION
- Azure Storage client library for Java/Android is not correctly displayed in doc (as shown in below image)
![image](https://user-images.githubusercontent.com/43902034/158016660-be919cd4-0270-4504-aca2-e52a857ace3a.png)

- Corrected the above Link issue in storage-introduction.md