### PR TITLE
Update connect-log-forwarder.md

### DIFF
--- a/articles/sentinel/connect-log-forwarder.md
+++ b/articles/sentinel/connect-log-forwarder.md
@@ -214,7 +214,7 @@ Choose a syslog daemon to see the appropriate description.
         Contents of the `security-config-omsagent.conf` file:
 
         ```bash
-        filter f_oms_filter {match(\"CEF\|ASA\" ) ;};destination oms_destination {tcp(\"127.0.0.1\" port(25226));};
+        filter f_oms_filter {match("CEF\|ASA" ) ;};destination oms_destination {tcp("127.0.0.1" port(25226));};
         log {source(s_src);filter(f_oms_filter);destination(oms_destination);};
         ```
 


### PR DESCRIPTION
Removed backslashes from file contents ('security-config-omsagent.conf') which cause syntax errors.