### PR TITLE
Add note about not using secure string and objects in outputs

### DIFF
--- a/articles/azure-resource-manager/templates/data-types.md
+++ b/articles/azure-resource-manager/templates/data-types.md
@@ -150,7 +150,8 @@ The following example shows two secure parameters.
   }
 }
 ```
-> [!NOTE] Secure strings and objects are not recommended to be used as an output type as they are not stored in the deployment history.
+> [!NOTE] 
+> Secure strings and objects aren't recommended to be used as an output type because they're not stored in the deployment history.
 
 ## Next steps
 

--- a/articles/azure-resource-manager/templates/data-types.md
+++ b/articles/azure-resource-manager/templates/data-types.md
@@ -150,6 +150,7 @@ The following example shows two secure parameters.
   }
 }
 ```
+> [!NOTE] Secure strings and objects are not recommended to be used as an output type as they are not stored in the deployment history.
 
 ## Next steps
 


### PR DESCRIPTION
I spun my wheels for a bit after not knowing that you shouldn't use secure strings in an output. The documentation only stated that they aren't stored in deployment history of parameters, I assumed this meant you could still use secure strings in an output. 