### PR TITLE
Update configure-networking-how-to.md

### DIFF
--- a/articles/azure-functions/configure-networking-how-to.md
+++ b/articles/azure-functions/configure-networking-how-to.md
@@ -12,7 +12,7 @@ This article shows you how to perform tasks related to configuring your function
 
 ## Restrict your storage account to a virtual network 
 
-When you create a function app, you must create or link to a general-purpose Azure Storage account that supports Blob, Queue, and Table storage. You can replace this storage account with one that is secured with service endpoints or private endpoints. 
+When you create a function app, you must create or link to a general-purpose Azure Storage account that supports Blob, Queue, and Table storage. You can replace this storage account with one that is secured with service endpoints or private endpoints. When configuring your storage account with private endpoints, public access to your storage account is not automatically disabled. In order to disable public access to your storage account, configure your storage firewall to allow access from only selected networks.
 
 
 

--- a/articles/azure-functions/configure-networking-how-to.md
+++ b/articles/azure-functions/configure-networking-how-to.md
@@ -12,7 +12,9 @@ This article shows you how to perform tasks related to configuring your function
 
 ## Restrict your storage account to a virtual network 
 
-When you create a function app, you must create or link to a general-purpose Azure Storage account that supports Blob, Queue, and Table storage. You can replace this storage account with one that is secured with service endpoints or private endpoints. When configuring your storage account with private endpoints, public access to your function app will be automatically disabled, and your function app will only be accessible through the virtual network. 
+When you create a function app, you must create or link to a general-purpose Azure Storage account that supports Blob, Queue, and Table storage. You can replace this storage account with one that is secured with service endpoints or private endpoints. 
+
+
 
 > [!NOTE]  
 > This feature currently works for all Windows and Linux virtual network-supported SKUs in the Dedicated (App Service) plan and for Windows Elastic Premium plans. ASEv3 is not supported yet. Consumption tier isn't supported. 


### PR DESCRIPTION
CORRECTION: the line "When configuring your storage account with private endpoints, public access to your function app will be automatically disabled, and your function app will only be accessible through the virtual network." is not correct.

i have created a whole lab of multiple functions and Storage accounts and added the Private endpoint on the Blob and File but that didn't disable the access to the function from public.

i still have the full lab ready and can discuss it further if needed.