### PR TITLE
Add hint on how to handle processing dead letters

### DIFF
--- a/articles/event-grid/manage-event-delivery.md
+++ b/articles/event-grid/manage-event-delivery.md
@@ -23,6 +23,7 @@ To set a dead letter location, you need a storage account for holding events tha
 > [!NOTE]
 > - Create a storage account and a blob container in the storage before running commands in this article.
 > - The Event Grid service creates blobs in this container. The names of blobs will have the name of the Event Grid subscription with all the letters in upper case. For example, if the name of the subscription is My-Blob-Subscription, names of the dead letter blobs will have MY-BLOB-SUBSCRIPTION (myblobcontainer/MY-BLOB-SUBSCRIPTION/2019/8/8/5/111111111-1111-1111-1111-111111111111.json). This behavior is to protect against differences in case handling between Azure services.
+> - The dead letter blobs created will contain one or more events in an array. An important behavior to consider when processing dead letters.
 
 
 ### Azure CLI


### PR DESCRIPTION
The C# SDK contains a `EventGridEvent.Parse(BinaryData ...)` as well as a `EventGridEvent.ParseMany(BinaryData ...)` and it was surprising to learn that `ParseMany` existed only after having Parse fail and error message mentioning `ParseMany`.

Adding this note but I kind of wish `Parse(...)` in the SDK was simply deprecated and later removed. You'd have to know up front how many events are in the BinaryData before calling `Parse` OR you have to try a call with `Parse` catch the error and then try with `ParseMany` when it's actually simpler code to just never use `Parse` and only use `ParseMany` even if only one event is in the dead letter blob.