### PR TITLE
Update groups-concept.md

### DIFF
--- a/articles/active-directory/roles/groups-concept.md
+++ b/articles/active-directory/roles/groups-concept.md
@@ -72,7 +72,7 @@ The following scenarios are not supported:
 The following are known issues with role-assignable groups:
 
 - *Azure AD P2 licensed customers only*: Even after deleting the group, it is still shown an eligible member of the role in PIM UI. Functionally there's no problem; it's just a cache issue in the Azure portal.  
-- Use the new [Exchange admin center](/exchange/exchange-admin-center) for role assignments via group membership. The old Exchange admin center doesn't support this feature yet. Exchange PowerShell cmdlets will work as expected.
+- Use the new [Exchange admin center](/exchange/exchange-admin-center) for role assignments via group membership. The old Exchange admin center doesn't support this feature. If accessing the old Exchange admin center is required, assign the eligible role directly to the user (not via role-assignable groups). Exchange PowerShell cmdlets will work as expected.
 - If an administrator role is assigned to a role-assignable group instead of individual users, members of the group will not be able to access Rules, Organization, or Public Folders in the new [Exchange admin center](/exchange/exchange-admin-center). The workaround is to assign the role directly to users instead of the group.
 - Azure Information Protection Portal (the classic portal) doesn't recognize role membership via group yet. You can [migrate to the unified sensitivity labeling platform](/azure/information-protection/configure-policy-migrate-labels) and then use the Office 365 Security & Compliance center to use group assignments to manage roles.
 - [Apps admin center](https://config.office.com/) doesn't support this feature yet. Assign the Office Apps Administrator role directly to users.


### PR DESCRIPTION
Hello, I'm making this change to clarify customer that the old Exchange admin center doesn't support the feature of role-assignable groups. If customer would like to use the old Exchange admin center, customers need to assign eligible roles directly to users instead of using role-assignable groups. 

Hope this makes sense and please reach out to veraviriya@microsoft.com if you have any doubt with this change.