### PR TITLE
Updated some lines

### DIFF
--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -243,7 +243,7 @@ Make sure the following settings are configured correctly for remote access:
    ```
    
 > [!NOTE]
-> By running this command; it will enable the appropiate firewall rules automatically
+> When this command runs, it enables the appropriate firewall rules automatically.
 
 1. Enable the following firewall rules to allow the RDP traffic:
 
@@ -266,8 +266,7 @@ Make sure the following settings are configured correctly for remote access:
    ```
   
  > [!IMPORTANT]
- > 168.63.129.16 is a special public IP address that is owned by Microsoft for Azure Platform
- > ([what-is-ip-address-168-63-129-16](../../virtual-network/what-is-ip-address-168-63-129-16.md))
+ > 168.63.129.16 is a special public IP address that is owned by Microsoft for Azure. For more information, see [What is IP address 168.63.129.16](../../virtual-network/what-is-ip-address-168-63-129-16.md).
 
 1. If the VM is part of a domain, check the following Azure AD policies to make sure the previous
    settings aren't reverted.

--- a/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
+++ b/articles/virtual-machines/windows/prepare-for-upload-vhd-image.md
@@ -240,13 +240,15 @@ Make sure the following settings are configured correctly for remote access:
 
    ```powershell
    Enable-PSRemoting -Force
-   Set-NetFirewallRule -Name WINRM-HTTP-In-TCP, WINRM-HTTP-In-TCP-PUBLIC -Enabled True
    ```
+   
+> [!NOTE]
+> By running this command; it will enable the appropiate firewall rules automatically
 
 1. Enable the following firewall rules to allow the RDP traffic:
 
    ```powershell
-   Set-NetFirewallRule -Group '@FirewallAPI.dll,-28752' -Enabled True
+   Get-NetFirewallRule -DisplayGroup 'Remote Desktop' | Set-NetFirewallRule -Enabled True
    ```
 
 1. Enable the rule for file and printer sharing so the VM can respond to ping requests inside the
@@ -262,6 +264,10 @@ Make sure the following settings are configured correctly for remote access:
    New-NetFirewallRule -DisplayName AzurePlatform -Direction Inbound -RemoteAddress 168.63.129.16 -Profile Any -Action Allow -EdgeTraversalPolicy Allow
    New-NetFirewallRule -DisplayName AzurePlatform -Direction Outbound -RemoteAddress 168.63.129.16 -Profile Any -Action Allow
    ```
+  
+ > [!IMPORTANT]
+ > 168.63.129.16 is a special public IP address that is owned by Microsoft for Azure Platform
+ > ([what-is-ip-address-168-63-129-16](../../virtual-network/what-is-ip-address-168-63-129-16.md))
 
 1. If the VM is part of a domain, check the following Azure AD policies to make sure the previous
    settings aren't reverted.


### PR DESCRIPTION
There were some areas that were confusing for customers. Changing @FirewallAPI.dll,-28752 to Remote Desktop makes more sense. Also by running the Enable-PSRemoting command; in testing this enables this firewall rule as well (the Also WINRM-HTTP-In-TCP-PUBLIC does not exist). I also added the Azure platform message to further clarify WHY customers are hardcoding an IP address.