### PR TITLE
Highlighting that virtual network setting is optional for classic Clo…

### DIFF
--- a/articles/cloud-services-extended-support/schema-cscfg-networkconfiguration.md
+++ b/articles/cloud-services-extended-support/schema-cscfg-networkconfiguration.md
@@ -12,7 +12,7 @@ ms.custom:
 
 # Azure Cloud Services (extended support) config networkConfiguration schema
 
-The `NetworkConfiguration` element of the service configuration file specifies Virtual Network and DNS values. These settings are optional for Cloud Services.
+The `NetworkConfiguration` element of the service configuration file specifies Virtual Network and DNS values. These settings are optional for Cloud Services  (classic).
 
 You can use the following resource to learn more about Virtual Networks and the associated schemas:
 


### PR DESCRIPTION
…ud Service

Below line is to emphasize that its optional for classic cloud service. But actually gives understanding that for current context (extended CS), virtual network is optional.
"These settings are optional for Cloud Services"

To be accurate, changed as below,
"These settings are optional for Cloud Services (Classic)"