### PR TITLE
APIM: Fixing "Set status code" docs

### DIFF
--- a/articles/api-management/api-management-advanced-policies.md
+++ b/articles/api-management/api-management-advanced-policies.md
@@ -900,7 +900,7 @@ This example shows how to return a 401 response if the authorization token is in
 
 This policy can be used in the following policy [sections](./api-management-howto-policies.md#sections) and [scopes](./api-management-howto-policies.md#scopes).
 
--   **Policy sections:** outbound, backend, on-error
+-   **Policy sections:** inbound, outbound, backend, on-error
 -   **Policy scopes:** all scopes
 
 ## <a name="set-variable"></a> Set variable


### PR DESCRIPTION
I'm a backend dev on the APIM team and the set-status policy can also be used in the inbound section.
Here's the code that decides what sections are allowed for this policy:
![image](https://user-images.githubusercontent.com/8254243/158881897-98ea49a5-40c8-4cdf-b2d6-394dc21e4584.png)
