### PR TITLE
Please remove Office.com from the list of applications included in Of…

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
@@ -97,7 +97,6 @@ The following key applications are included in the Office 365 client app:
 - Microsoft Whiteboard Services
 - Office Delve
 - Office Online
-- Office.com
 - OneDrive
 - Power Apps
 - Power Automate


### PR DESCRIPTION
…fice 365 Client App

Please remove Office.com from the list of applications included in the Office 365 Client App as we already have included Office Online in the list of included Apps. Office.com is the landing page for Office Online as is Outlook.com the landing page for Exchange Online.