### PR TITLE
Need to add the warning below

### DIFF
--- a/articles/virtual-machines/capture-image-portal.md
+++ b/articles/virtual-machines/capture-image-portal.md
@@ -32,7 +32,7 @@ For images stored in a Shared Image Gallery, you can use VMs that already have a
 
 1. To create the image in a gallery, select **Yes, share it to a gallery as an image version**.
     
-   To only create a managed image, select **No, capture only a managed image**. The VM must have been generalized to create a managed image. The only other required information is a name for the image.
+   To only create a managed image, select **No, capture only a managed image**. The VM must have been generalized to create a managed image. The only other required information is a name for the image. 
 
 6. If you want to delete the source VM after the image has been created, select **Automatically delete this virtual machine after creating the image**. This is not recommended.
 

--- a/articles/virtual-machines/capture-image-portal.md
+++ b/articles/virtual-machines/capture-image-portal.md
@@ -34,6 +34,12 @@ For images stored in a Shared Image Gallery, you can use VMs that already have a
     
    To only create a managed image, select **No, capture only a managed image**. The VM must have been generalized to create a managed image. The only other required information is a name for the image. 
 
+### Warning: 
+```
+The machine will not be accessible after Capturing image. 
+If you generalize the virtual machine, no further actions on it are allowed. For example, a generalized virtual machine can't be started or modified. You can select this checkbox to have the virtual machine deleted automatically once the image is created. If you do not generalize the virtual machine, you can continue to use it as normal.
+```
+
 6. If you want to delete the source VM after the image has been created, select **Automatically delete this virtual machine after creating the image**. This is not recommended.
 
 1. For **Gallery details**, select the gallery or create a new gallery by selecting **Create new**.


### PR DESCRIPTION
This is a warning I would like to add to the Public document because the VM is not accessible after Generalization.

Warning to be added:
The machine will not be accessible after Capturing image.
If you generalize the virtual machine, no further actions on it are allowed. For example, a generalized virtual machine can't be started or modified. You can select this checkbox to have the virtual machine deleted automatically once the image is created. If you do not generalize the virtual machine, you can continue to use it as normal.