### PR TITLE
Updated login hint spelling

### DIFF
--- a/articles/active-directory/develop/msal-js-sso.md
+++ b/articles/active-directory/develop/msal-js-sso.md
@@ -91,7 +91,7 @@ If you don't have SID claim configured or need to bypass the account selection p
 ```javascript
 var request = {
   scopes: ["user.read"],
-  loginHint: preferred_username,
+  login_hint: preferred_username,
   extraQueryParameters: { domain_hint: "organizations" },
 };
 
@@ -100,7 +100,7 @@ var request = {
 
 To get the values for login_hint and domain_hint by reading the claims returned in the ID token for the user.
 
-- **loginHint** should be set to the `preferred_username` claim in the ID token.
+- **login_hint** should be set to the `preferred_username` claim in the ID token.
 
 - **domain_hint** is only required to be passed when using the /common authority. The domain hint is determined by tenant ID(tid). If the `tid` claim in the ID token is `9188040d-6c67-4c5b-b112-36a304b66dad` it's consumers. Otherwise, it's organizations.
 
@@ -121,7 +121,7 @@ Pass the `sid` if available (or `login_hint` and optionally `domain_hint`) as re
 ```javascript
 var request = {
   scopes: ["user.read"],
-  loginHint: preferred_username,
+  login_hint: preferred_username,
   extraQueryParameters: { domain_hint: "organizations" },
 };
 


### PR DESCRIPTION
Updated login hint spelling - Login Hint should be `login_hint`
![image](https://user-images.githubusercontent.com/36619112/159543478-369c4f01-b074-451b-a014-223070af1d7a.png)

**For more info:**
https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code
https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-optional-claims#v10-and-v20-optional-claims-set

----------------
GitHub Issue: https://github.com/MicrosoftDocs/azure-docs/issues/90189
cc: @mmacy 