### PR TITLE
Add link to Version 4.2 to Overview page

### DIFF
--- a/articles/cosmos-db/mongodb/mongodb-introduction.md
+++ b/articles/cosmos-db/mongodb/mongodb-introduction.md
@@ -38,6 +38,7 @@ Azure Cosmos DB API for MongoDB implements the wire protocol for MongoDB. This i
 MongoDB feature compatibility:
 
 Azure Cosmos DB API for MongoDB is compatible with the following MongoDB server versions:
+- [Version 4.2](feature-support-42.md)
 - [Version 4.0](feature-support-40.md)
 - [Version 3.6](feature-support-36.md)
 - [Version 3.2](feature-support-32.md)


### PR DESCRIPTION
There is no mention of API version 4.2 on the Overview page, yet I see a document link to 4.2 on the Concepts page. Request to add API version 4.2 to the Overview page for the Cosmos DB MongoDB API page