### PR TITLE
Include password reset scenario

### DIFF
--- a/articles/active-directory/authentication/concept-sspr-writeback.md
+++ b/articles/active-directory/authentication/concept-sspr-writeback.md
@@ -157,7 +157,7 @@ Passwords aren't written back in any of the following situations:
 > Use of the checkbox "User must change password at next logon" in on-premises AD DS administrative tools like Active Directory Users and Computers or the Active Directory Administrative Center is supported as a preview feature of Azure AD Connect. For more information, see [Implement password hash synchronization with Azure AD Connect sync](../hybrid/how-to-connect-password-hash-synchronization.md).
 
 > [!NOTE]
-> If a user has the option "Password never expires" set in Active Directory (AD), the force password change flag will not be set in Active Directory (AD), so the user will not be prompted to change the password during the next sign-in even if the option to force the user to change their password on next logon option is checked during an administrator-initiated end-user password reset.
+> If a user has the option "Password never expires" set in Active Directory (AD), the force password change flag will not be set in Active Directory (AD), so the user will not be prompted to change the password during the next sign-in even if the option to force the user to change their password on next logon option is selected during an administrator-initiated end-user password reset.
 
 ## Next steps
 

--- a/articles/active-directory/authentication/concept-sspr-writeback.md
+++ b/articles/active-directory/authentication/concept-sspr-writeback.md
@@ -156,6 +156,9 @@ Passwords aren't written back in any of the following situations:
 > [!WARNING]
 > Use of the checkbox "User must change password at next logon" in on-premises AD DS administrative tools like Active Directory Users and Computers or the Active Directory Administrative Center is supported as a preview feature of Azure AD Connect. For more information, see [Implement password hash synchronization with Azure AD Connect sync](../hybrid/how-to-connect-password-hash-synchronization.md).
 
+> [!NOTE]
+> If a user has the option "Password never expires" set in Active Directory (AD), the force password change flag will not be set in Active Directory (AD), so the user will not be prompted to change the password during the next sign-in even if the option to force the user to change their password on next logon option is checked during an administrator-initiated end-user password reset.
+
 ## Next steps
 
 To get started with SSPR writeback, complete the following tutorial:


### PR DESCRIPTION
Include note about scenario where user has the option "Password never expires" set in Active Directory. 
In this case, a password reset with the option to force user to change their password on next logon checked, will not prompt the user to change the password during the next sign-in.
This happens because, by design, Active Directory (AD) does not allow both options to be checked, so the "force password change" flag is never set in AD.