### PR TITLE
azure-functions: use latest stable Node.js version

### DIFF
--- a/articles/azure-functions/functions-how-to-github-actions.md
+++ b/articles/azure-functions/functions-how-to-github-actions.md
@@ -95,7 +95,7 @@ The following example shows the part of the workflow that sets up the environmen
 
 ```yaml
 
-    - name: Setup Node 12.x Environment
+    - name: Setup Node 14.x Environment
       uses: actions/setup-node@v2
       with:
         node-version: 14.x
@@ -373,7 +373,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: your-app-name    # set this to your application's name
   AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: '12.x'                     # set this to the node version to use (supports 8.x, 10.x, 12.x)
+  NODE_VERSION: '14.x'                     # set this to the node version to use (supports 8.x, 10.x, 12.x, 14.x)
 
 jobs:
   build-and-deploy:
@@ -415,7 +415,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: your-app-name    # set this to your application's name
   AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'      # set this to the path to your web app project, defaults to the repository root
-  NODE_VERSION: '10.x'                     # set this to the node version to use (supports 8.x, 10.x, 12.x)
+  NODE_VERSION: '14.x'                     # set this to the node version to use (supports 8.x, 10.x, 12.x, 14.x)
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
- Remove misalignment between `12.x` in step name and `14.x` in passed option
- Use latest stable Node.js version supported by Azure Functions, that is `14.x`
- Mention `14.x` in supported versions comments