### PR TITLE
Updated docs for `bicepconfig.json`

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-modules.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-modules.md
@@ -101,27 +101,7 @@ module stgModule  'ts/CoreSpecs:storage:v1' = {
 
 ## Credentials for publishing/restoring modules
 
-To [publish](bicep-cli.md#publish) modules to a private module registry or to [restore](bicep-cli.md#restore) external modules to the local cache, the account must have the correct permissions to access the registry. You can configure the credential precedence for authenticating to the registry. By default, Bicep uses the credentials from the user authenticated in Azure CLI or Azure PowerShell. To customize the credential precedence, add `cloud` and `credentialPrecedence` elements to the config file.
-
-```json
-{
-    "cloud": {
-      "credentialPrecedence": [
-        "AzureCLI",
-        "AzurePowerShell"
-      ]
-    }
-}
-```
-
-The available credentials are:
-
-- AzureCLI
-- AzurePowerShell
-- Environment
-- ManagedIdentity
-- VisualStudio
-- VisualStudioCode
+To [publish](bicep-cli.md#publish) modules to a private module registry or to [restore](bicep-cli.md#restore) external modules to the local cache, the account must have the correct permissions to access the registry. You can configure the credential precedence for authenticating to the registry. By default, Bicep uses the credentials from the user authenticated in Azure CLI or Azure PowerShell. To customize the credential precedence, see [Add credential precedence to Bicep config](bicep-config.md#credential-precedence).
 
 ## Next steps
 

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -9,13 +9,15 @@ ms.date: 11/16/2021
 
 Bicep supports a configuration file named **bicepconfig.json**. Within this file, you can add values that customize your Bicep development experience. If you don't add this file, Bicep uses default values.
 
-To customize values, create this file in the directory where you store Bicep files. You can add bicepconfig.json files in multiple directories. The closest configuration file in the directory hierarchy is used.
+To customize values, create this file in the directory where you store Bicep files. You can add `bicepconfig.json` files in multiple directories. The configuration file closest to the Bicep file in the directory hierarchy is used.
 
 ## Available settings
 
-When working with [modules](modules.md), you can add aliases for module paths. These aliases simplify your Bicep file because you don't have to repeat complicated paths. You can also configure the credential precedence for authenticating to the registry. The credential is used to restore external modules to the local cache. For more information, see [Add module settings to Bicep config](bicep-config-modules.md).
+When working with [modules](modules.md), you can add aliases for module paths. These aliases simplify your Bicep file because you don't have to repeat complicated paths. For more information, see [Add module settings to Bicep config](bicep-config-modules.md).
 
-When working with the [Bicep linter](linter.md), you can override the default settings for the Bicep file validation. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
+The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations, you can override the default settings for the Bicep file validation. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
+
+You can also configure the credential precedence for authenticating to Azure from Bicep CLI and VSCode. The credentials are used to publish modules to registries, restore external modules to the local cache and when using the insert resource function. For more information, see [Add credential precedence settings to Bicep config](bicep-config-credential-precedence.md).
 
 ## Intellisense
 
@@ -27,4 +29,5 @@ The Bicep extension for Visual Studio Code supports intellisense for your **bice
 
 * [Add module settings in Bicep config](bicep-config-modules.md)
 * [Add linter settings to Bicep config](bicep-config-linter.md)
+* [Add credential precedence settings to Bicep config](bicep-config-credential-precedence.md)
 * Learn about the [Bicep linter](linter.md)

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -15,7 +15,7 @@ To customize values, create this file in the directory where you store Bicep fil
 
 When working with [modules](modules.md), you can add aliases for module paths. These aliases simplify your Bicep file because you don't have to repeat complicated paths. For more information, see [Add module settings to Bicep config](bicep-config-modules.md).
 
-The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations, you can override the default settings for the Bicep file validation by modifying `bicepconfig.json`. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
+The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations. You can override the default settings for the Bicep file validation by modifying `bicepconfig.json`. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
 
 You can also configure the credential precedence for authenticating to Azure from Bicep CLI and Visual Studio Code. The credentials are used to publish modules to registries and to restore external modules to the local cache when using the insert resource function. 
 

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -53,5 +53,4 @@ The Bicep extension for Visual Studio Code supports intellisense for your `bicep
 
 * [Add module settings in Bicep config](bicep-config-modules.md)
 * [Add linter settings to Bicep config](bicep-config-linter.md)
-* [Add credential precedence settings to Bicep config](bicep-config-credential-precedence.md)
 * Learn about the [Bicep linter](linter.md)

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -17,7 +17,31 @@ When working with [modules](modules.md), you can add aliases for module paths. T
 
 The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations, you can override the default settings for the Bicep file validation. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
 
-You can also configure the credential precedence for authenticating to Azure from Bicep CLI and VSCode. The credentials are used to publish modules to registries, restore external modules to the local cache and when using the insert resource function. For more information, see [Add credential precedence settings to Bicep config](bicep-config-credential-precedence.md).
+You can also configure the credential precedence for authenticating to Azure from Bicep CLI and VSCode. The credentials are used to publish modules to registries, restore external modules to the local cache and when using the insert resource function. 
+
+## Credential precedence
+
+You can configure the credential precedence for authenticating to the registry. By default, Bicep uses the credentials from the user authenticated in Azure CLI or Azure PowerShell. To customize the credential precedence, add `cloud` and `credentialPrecedence` elements to the config file.
+
+```json
+{
+    "cloud": {
+      "credentialPrecedence": [
+        "AzureCLI",
+        "AzurePowerShell"
+      ]
+    }
+}
+```
+
+The available credential types are:
+
+- AzureCLI
+- AzurePowerShell
+- Environment
+- ManagedIdentity
+- VisualStudio
+- VisualStudioCode
 
 ## Intellisense
 

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -7,7 +7,7 @@ ms.date: 11/16/2021
 
 # Configure your Bicep environment
 
-Bicep supports a configuration file named **bicepconfig.json**. Within this file, you can add values that customize your Bicep development experience. If you don't add this file, Bicep uses default values.
+Bicep supports a configuration file named `bicepconfig.json`. Within this file, you can add values that customize your Bicep development experience. If you don't add this file, Bicep uses default values.
 
 To customize values, create this file in the directory where you store Bicep files. You can add `bicepconfig.json` files in multiple directories. The configuration file closest to the Bicep file in the directory hierarchy is used.
 
@@ -15,7 +15,7 @@ To customize values, create this file in the directory where you store Bicep fil
 
 When working with [modules](modules.md), you can add aliases for module paths. These aliases simplify your Bicep file because you don't have to repeat complicated paths. For more information, see [Add module settings to Bicep config](bicep-config-modules.md).
 
-The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations, you can override the default settings for the Bicep file validation. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
+The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations, you can override the default settings for the Bicep file validation by modifying `bicepconfig.json`. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
 
 You can also configure the credential precedence for authenticating to Azure from Bicep CLI and VSCode. The credentials are used to publish modules to registries, restore external modules to the local cache and when using the insert resource function. 
 
@@ -45,7 +45,7 @@ The available credential types are:
 
 ## Intellisense
 
-The Bicep extension for Visual Studio Code supports intellisense for your **bicepconfig.json** file. Use the intellisense to discover available properties and values.
+The Bicep extension for Visual Studio Code supports intellisense for your `bicepconfig.json` file. Use the intellisense to discover available properties and values.
 
 :::image type="content" source="./media/bicep-config/bicep-linter-configure-intellisense.png" alt-text="The intellisense support in configuring bicepconfig.json.":::
 

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -17,7 +17,7 @@ When working with [modules](modules.md), you can add aliases for module paths. T
 
 The [Bicep linter](linter.md) checks Bicep files for syntax errors and best practice violations, you can override the default settings for the Bicep file validation by modifying `bicepconfig.json`. For more information, see [Add linter settings to Bicep config](bicep-config-linter.md).
 
-You can also configure the credential precedence for authenticating to Azure from Bicep CLI and VSCode. The credentials are used to publish modules to registries, restore external modules to the local cache and when using the insert resource function. 
+You can also configure the credential precedence for authenticating to Azure from Bicep CLI and Visual Studio Code. The credentials are used to publish modules to registries and to restore external modules to the local cache when using the insert resource function. 
 
 ## Credential precedence
 


### PR DESCRIPTION
Fixes [#5752](https://github.com/Azure/bicep/issues/5752)

As reported in https://github.com/Azure/bicep/issues/5752 the docs around `bicepconfig.json` needs improvement. Made the changes requested.

- Moved information about credential precedence from module docs to general article
- Fixed some formatting


