### PR TITLE
Add a missing arg `--generate-name` to `helm install`.

### DIFF
--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -277,7 +277,7 @@ Kubernetes. We will leverage it to install the `application-gateway-kubernetes-i
 1. Install the Application Gateway ingress controller package:
 
     ```bash
-    helm install -f helm-config.yaml application-gateway-kubernetes-ingress/ingress-azure
+    helm install -f helm-config.yaml --generate-name application-gateway-kubernetes-ingress/ingress-azure
     ```
 
 ## Install a Sample App


### PR DESCRIPTION
The arg `--generate-name` is required by the `helm install` command.
Thus users encounter the following error when they try the snippet.

```console
Error: must either provide a name or specify --generate-name
```