### PR TITLE
Update apiVersion for Sample App: extensions/v1beta1 -> networking.k8s.io/v1

### DIFF
--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -316,7 +316,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aspnetapp
@@ -328,8 +328,11 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: aspnetapp
-          servicePort: 80
+          service:
+            name: aspnetapp
+            port:
+              number: 80
+        pathType: Exact
 EOF
 ```
 


### PR DESCRIPTION
Ingress in the extensions/v1beta1 API version no longer be served.

```console
error: unable to recognize "STDIN": no matches for kind "Ingress" in version "extensions/v1beta1"
```

ref https://github.com/MicrosoftDocs/azure-docs/issues/79323