### PR TITLE
Update active-directory-passwords-faq.yml

### DIFF
--- a/articles/active-directory/authentication/active-directory-passwords-faq.yml
+++ b/articles/active-directory/authentication/active-directory-passwords-faq.yml
@@ -92,9 +92,10 @@ sections:
         answer: |
             > Yes, there are security features built into password reset to protect it from misuse. 
             >
-            > Users can try only five password reset attempts within a 24 hour period before they're locked out for 24 hours. 
             >
-            > Users can try to validate a phone number, send a SMS, or validate security questions and answers only five times within an hour before they're locked out for 24 hours. 
+            > Users can only attempt to validate their information (phone number etc.) but couldn't prove their identity five times within a 24-hour period before they're locked for 24 hours.
+            >
+            > Users can try to validate a phone number, auth app, send a SMS, or validate security questions and answers only five times within an hour before they're locked out for 24 hours. 
             >
             > Users can send an email a maximum of 10 times within a 10 minute period before they're locked out for 24 hours.
             >

--- a/articles/active-directory/authentication/active-directory-passwords-faq.yml
+++ b/articles/active-directory/authentication/active-directory-passwords-faq.yml
@@ -93,7 +93,7 @@ sections:
             > Yes, there are security features built into password reset to protect it from misuse. 
             >
             >
-            > Users can only attempt to validate their information (phone number etc.) but couldn't prove their identity five times within a 24-hour period before they're locked for 24 hours.
+            > Users can attempt to validate their information (such as their phone number), but if they're unable to prove their identity five times within a 24-hour period, they're locked out for 24 hours.
             >
             > Users can try to validate a phone number, auth app, send a SMS, or validate security questions and answers only five times within an hour before they're locked out for 24 hours. 
             >


### PR DESCRIPTION
Update doc: Self-service password reset FAQ - Azure Active Directory | Microsoft Docs

add authenticator app.
update using the word "Users can only attempt to validate their information (phone number etc.) but couldn't prove their identity five times within a 24-hour period before they're locked for 24 hours."

ICM: Incident 293525996 : [Identity ACE] Self Service Password Reset (SSPR) - Users are not being blocked from SSPR as expected