### PR TITLE
Update monitor-instances-health-check.md

### DIFF
--- a/articles/app-service/monitor-instances-health-check.md
+++ b/articles/app-service/monitor-instances-health-check.md
@@ -59,7 +59,7 @@ If you're using your own authentication system, the Health check path must allow
 
 ## Monitoring
 
-After providing your application's Health check path, you can monitor the health of your site using Azure Monitor. From the **Health check** blade in the Portal, click the **Metrics** in the top toolbar. This will open a new blade where you can see the site's historical health status and create a new alert rule. For more information on monitoring your sites, [see the guide on Azure Monitor](web-sites-monitor.md).
+After providing your application's Health check path, you can monitor the health of your site using Azure Monitor. From the **Health check** blade in the Portal, click the **Metrics** in the top toolbar. This will open a new blade where you can see the site's historical health status and option to create a new alert rule. Health check metrics will aggregate the successful pings & display failures only when the instance was deemed unhealthy based on the health check configuration. For more information on monitoring your sites, [see the guide on Azure Monitor](web-sites-monitor.md).
 
 ## Limitations
 


### PR DESCRIPTION
Updating to reflect the expected behavior of metrics. Once an instance for an app is deemed "unhealthy" only then the instance will be excluded from organic traffic and be reported to metrics. Failed pings prior will not reflect in Metrics, only once the max pings are met.