### PR TITLE
Example of FQDN is unclear

### DIFF
--- a/articles/bastion/bastion-faq.md
+++ b/articles/bastion/bastion-faq.md
@@ -37,7 +37,7 @@ Azure Bastion needs to be able to communicate with certain internal endpoints to
 * vault.azure.com
 * azure.com
 
-You may use a private DNS zone ending with one of the names listed above (ex: dummy.blob.core.windows.net).
+You may use a private DNS zone ending with one of the names listed above (ex: privatelink.blob.core.windows.net).
 
 The use of Azure Bastion is also not supported with Azure Private DNS Zones in national clouds.
 


### PR DESCRIPTION
Many user use Private DNS with Private link. I think privatelink.xx is better than dummy.xx as the example. Could you fix it ?