### PR TITLE
Fix typos about userIdentities vs alternativeSecurityIds

### DIFF
--- a/articles/active-directory-b2c/social-transformations.md
+++ b/articles/active-directory-b2c/social-transformations.md
@@ -16,10 +16,10 @@ ms.subservice: B2C
 
 # Social accounts claims transformations
 
-In Azure Active Directory B2C (Azure AD B2C), social account identities are stored in a `userIdentities` attribute of a **alternativeSecurityIdCollection** claim type. Each item in the **alternativeSecurityIdCollection** specifies the issuer (identity provider name, such as facebook.com) and the `issuerUserId`, which is a unique user identifier for the issuer.
+In Azure Active Directory B2C (Azure AD B2C), social account identities are stored in a `alternativeSecurityIds` attribute of a **alternativeSecurityIdCollection** claim type. Each item in the **alternativeSecurityIdCollection** specifies the issuer (identity provider name, such as facebook.com) and the `issuerUserId`, which is a unique user identifier for the issuer.
 
 ```json
-"userIdentities": [{
+"alternativeSecurityIds": [{
     "issuer": "google.com",
     "issuerUserId": "MTA4MTQ2MDgyOTI3MDUyNTYzMjcw"
   },


### PR DESCRIPTION
`userIdentities` is not of type `alternativeSecurityIdCollection`, but indeed `alternativeSecurityId` is.
