### PR TITLE
User should be directed to Linked services

### DIFF
--- a/articles/data-factory/tutorial-managed-virtual-network-on-premise-sql-server.md
+++ b/articles/data-factory/tutorial-managed-virtual-network-on-premise-sql-server.md
@@ -250,7 +250,7 @@ data factory from the resources list.
 
 ## Create a linked service and test the connection
 
-1. Go to the **Manage** tab and then go to the **Managed private endpoints** section.
+1. Go to the **Manage** tab and then go to the **Linked services** section.
 2. Select + **New** under **Linked Service**.
 3. Select the **SQL Server** tile from the list and select **Continue**.    
 


### PR DESCRIPTION
Made changes based on issue https://github.com/MicrosoftDocs/azure-docs/issues/90399

Documentation describes going to Manage Private Endpoints to create a new Linked Service which is incorrect, for Step 1

https://docs.microsoft.com/en-us/azure/data-factory/tutorial-managed-virtual-network-on-premise-sql-server#create-a-linked-service-and-test-the-connection

User should be directed to

Go to the Manage tab and then go to the Linked services section.