### PR TITLE
The go programming language has a new domain name: go.dev.

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/TOC.yml
+++ b/articles/active-directory/managed-identities-azure-resources/TOC.yml
@@ -137,7 +137,7 @@
   - name: Python
     href: /python/api/overview/azure/identity-readme
   - name: Go
-    href: https://golang.org/doc/
+    href: https://go.dev/doc/
 - name: Resources
   items:
   - name: Frequently asked questions

--- a/articles/azure-cache-for-redis/cache-go-get-started.md
+++ b/articles/azure-cache-for-redis/cache-go-get-started.md
@@ -22,7 +22,7 @@ If you want to skip straight to the code, see the [Go quickstart](https://github
 ## Prerequisites
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)
-- [Go](https://golang.org/doc/install) (preferably version 1.13 or above)
+- [Go](https://go.dev/doc/install) (preferably version 1.13 or above)
 - [Git](https://git-scm.com/downloads)
 - An HTTP client such [curl](https://curl.se/)
 
@@ -47,7 +47,7 @@ func main() {
 ...
 ```
 
-Then, we establish connection with Azure Cache for Redis. We use [tls.Config](https://golang.org/pkg/crypto/tls/#Config)--Azure Cache for Redis only accepts secure connections with [TLS 1.2 as the minimum required version](cache-remove-tls-10-11.md).
+Then, we establish connection with Azure Cache for Redis. We use [tls.Config](https://go.dev/pkg/crypto/tls/#Config)--Azure Cache for Redis only accepts secure connections with [TLS 1.2 as the minimum required version](cache-remove-tls-10-11.md).
 
 ```go
 ...
@@ -62,7 +62,7 @@ if err != nil {
 ...
 ```
 
-If the connection is successful, [HTTP handlers](https://golang.org/pkg/net/http/#HandleFunc) are configured to handle `POST` and `GET` operations and the HTTP server is started.
+If the connection is successful, [HTTP handlers](https://go.dev/pkg/net/http/#HandleFunc) are configured to handle `POST` and `GET` operations and the HTTP server is started.
 
 > [!NOTE]
 > [gorilla mux library](https://github.com/gorilla/mux) is used for routing (although it's not strictly necessary and we could have gotten away by using the standard library for this sample application).

--- a/articles/azure-functions/create-first-function-vs-code-other.md
+++ b/articles/azure-functions/create-first-function-vs-code-other.md
@@ -31,7 +31,7 @@ Before you get started, make sure you have the following requirements in place:
 
 + The [Azure Functions Core Tools](./functions-run-local.md#v2) version 3.x. Use the `func --version` command to check that it is correctly installed.
 
-+ [Go](https://golang.org/doc/install), latest version recommended. Use the `go version` command to check your version.
++ [Go](https://go.dev/doc/install), latest version recommended. Use the `go version` command to check your version.
 
 # [Rust](#tab/rust)
 

--- a/articles/azure-sql/database/connect-query-go.md
+++ b/articles/azure-sql/database/connect-query-go.md
@@ -16,7 +16,7 @@ ms.date: 04/14/2021
 # Quickstart: Use Golang to query a database in Azure SQL Database or Azure SQL Managed Instance
 [!INCLUDE[appliesto-sqldb-sqlmi](../includes/appliesto-sqldb-sqlmi.md)]
 
-In this quickstart, you'll use the [Golang](https://godoc.org/github.com/denisenkom/go-mssqldb) programming language to connect to a database in Azure SQL Database or Azure SQL Managed Instance. You'll then run Transact-SQL statements to query and modify data. [Golang](https://golang.org/) is an open-source programming language that makes it easy to build simple, reliable, and efficient software.  
+In this quickstart, you'll use the [Golang](https://godoc.org/github.com/denisenkom/go-mssqldb) programming language to connect to a database in Azure SQL Database or Azure SQL Managed Instance. You'll then run Transact-SQL statements to query and modify data. [Golang](https://go.dev/) is an open-source programming language that makes it easy to build simple, reliable, and efficient software.  
 
 ## Prerequisites
 
@@ -107,7 +107,7 @@ Get the connection information you need to connect to the database. You'll need 
 
 1. Create a file named **sample.go** in the **SqlServerSample** folder.
 
-2. In the file, paste this code. Add the values for your server, database, username, and password. This example uses the Golang [context methods](https://golang.org/pkg/context/) to make sure there's an active connection.
+2. In the file, paste this code. Add the values for your server, database, username, and password. This example uses the Golang [context methods](https://go.dev/pkg/context/) to make sure there's an active connection.
 
    ```go
    package main

--- a/articles/cognitive-services/Bing-Autosuggest/includes/quickstarts/autosuggest-client-library-go.md
+++ b/articles/cognitive-services/Bing-Autosuggest/includes/quickstarts/autosuggest-client-library-go.md
@@ -19,7 +19,7 @@ Use the Bing Autosuggest client library for Go to get search suggestions based o
 ## Prerequisites
 
 * An Azure subscription. If you don't already have an Azure subscription, [you can create one for free](https://azure.microsoft.com/free/cognitive-services).
-* The latest version of [Go](https://golang.org/dl/).
+* The latest version of [Go](https://go.dev/dl/).
 
 Begin using the Bing Autosuggest client library by creating an Azure resource. Choose the resource type below that's right for you:
 
@@ -76,7 +76,7 @@ In a console window (cmd, PowerShell, Terminal, Bash), create a new workspace fo
 * **bin**: This directory contains the binary executable files that are created when you run `go install`.
 
 > [!TIP]
-> Learn more about the structure of a [Go workspace](https://golang.org/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
+> Learn more about the structure of a [Go workspace](https://go.dev/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
 
 Let's create a workspace called `my-app` and the required sub directories for `src`, `pkg`, and `bin`:
 

--- a/articles/cognitive-services/Bing-News-Search/go.md
+++ b/articles/cognitive-services/Bing-News-Search/go.md
@@ -21,7 +21,7 @@ ms.custom: mode-api
 This quickstart uses the Go language to call the Bing News Search API. The results include names and URLs of news sources identified by the query string.
 
 ## Prerequisites
-* Install the [Go binaries](https://golang.org/dl/).
+* Install the [Go binaries](https://go.dev/dl/).
 * Install the go-spew library to use a deep pretty printer to display the results. Use this command to install the library: `$ go get -u https://github.com/davecgh/go-spew`.
 
 [!INCLUDE [cognitive-services-bing-news-search-signup-requirements](../../../includes/cognitive-services-bing-news-search-signup-requirements.md)]

--- a/articles/cognitive-services/Bing-Web-Search/quickstarts/go.md
+++ b/articles/cognitive-services/Bing-Web-Search/quickstarts/go.md
@@ -27,7 +27,7 @@ Use this quickstart to make your first call to the Bing Web Search API. This Go 
 ## Prerequisites
 Here are a few things that you'll need before running this quickstart:
 
-* [Go binaries](https://golang.org/dl/)
+* [Go binaries](https://go.dev/dl/)
 * A subscription key
 
 [!INCLUDE [bing-web-search-quickstart-signup](../../../../includes/bing-web-search-quickstart-signup.md)]  

--- a/articles/cognitive-services/Computer-vision/includes/quickstarts-sdk/go-sdk.md
+++ b/articles/cognitive-services/Computer-vision/includes/quickstarts-sdk/go-sdk.md
@@ -21,7 +21,7 @@ Use the OCR client library to read printed and handwritten text from images.
 ## Prerequisites
 
 * An Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services/)
-* The latest version of [Go](https://golang.org/dl/)
+* The latest version of [Go](https://go.dev/dl/)
 * Once you have your Azure subscription, <a href="https://portal.azure.com/#create/Microsoft.CognitiveServicesComputerVision"  title="Create a Computer Vision resource"  target="_blank">create a Computer Vision resource </a> in the Azure portal to get your key and endpoint. After it deploys, click **Go to resource**.
     * You will need the key and endpoint from the resource you create to connect your application to the Computer Vision service. You'll paste your key and endpoint into the code below later in the quickstart.
     * You can use the free pricing tier (`F0`) to try the service, and upgrade later to a paid tier for production.
@@ -44,7 +44,7 @@ Your workspace will contain three folders:
 * **bin** - This directory will contain the binary executable files that are created when you run `go install`.
 
 > [!TIP]
-> To learn more about the structure of a Go workspace, see the [Go language documentation](https://golang.org/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
+> To learn more about the structure of a Go workspace, see the [Go language documentation](https://go.dev/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
 
 ### Install the client library for Go
 

--- a/articles/cognitive-services/Computer-vision/includes/quickstarts-sdk/image-analysis-go-sdk.md
+++ b/articles/cognitive-services/Computer-vision/includes/quickstarts-sdk/image-analysis-go-sdk.md
@@ -21,7 +21,7 @@ Use the Image Analysis client library to analyze an image for tags, text descrip
 ## Prerequisites
 
 * An Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services/)
-* The latest version of [Go](https://golang.org/dl/)
+* The latest version of [Go](https://go.dev/dl/)
 * Once you have your Azure subscription, <a href="https://portal.azure.com/#create/Microsoft.CognitiveServicesComputerVision"  title="Create a Computer Vision resource"  target="_blank">create a Computer Vision resource </a> in the Azure portal to get your key and endpoint. After it deploys, click **Go to resource**.
     * You will need the key and endpoint from the resource you create to connect your application to the Computer Vision service. You'll paste your key and endpoint into the code below later in the quickstart.
     * You can use the free pricing tier (`F0`) to try the service, and upgrade later to a paid tier for production.
@@ -44,7 +44,7 @@ Your workspace will contain three folders:
 * **bin** - This directory will contain the binary executable files that are created when you run `go install`.
 
 > [!TIP]
-> To learn more about the structure of a Go workspace, see the [Go language documentation](https://golang.org/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
+> To learn more about the structure of a Go workspace, see the [Go language documentation](https://go.dev/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
 
 ### Install the client library for Go
 

--- a/articles/cognitive-services/Custom-Vision-Service/includes/quickstarts/go-tutorial-object-detection.md
+++ b/articles/cognitive-services/Custom-Vision-Service/includes/quickstarts/go-tutorial-object-detection.md
@@ -24,7 +24,7 @@ Reference documentation [(training)](https://pkg.go.dev/github.com/Azure/azure-s
 ## Prerequisites
 
 * Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services/)
-* [Go 1.8+](https://golang.org/doc/install)
+* [Go 1.8+](https://go.dev/doc/install)
 * Once you have your Azure subscription, <a href="https://portal.azure.com/?microsoft_azure_marketplace_ItemHideKey=microsoft_azure_cognitiveservices_customvision#create/Microsoft.CognitiveServicesCustomVision"  title="Create a Custom Vision resource"  target="_blank">create a Custom Vision resource <span class="docon docon-navigate-external x-hidden-focus"></span></a> in the Azure portal to create a training and prediction resource and get your keys and endpoint. Wait for it to deploy and click the **Go to resource** button.
     * You will need the key and endpoint from the resources you create to connect your application to Custom Vision. You'll paste your key and endpoint into the code below later in the quickstart.
     * You can use the free pricing tier (`F0`) to try the service, and upgrade later to a paid tier for production.

--- a/articles/cognitive-services/Custom-Vision-Service/includes/quickstarts/go-tutorial.md
+++ b/articles/cognitive-services/Custom-Vision-Service/includes/quickstarts/go-tutorial.md
@@ -24,7 +24,7 @@ Reference documentation [(training)](https://pkg.go.dev/github.com/Azure/azure-s
 ## Prerequisites
 
 * Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services/)
-* [Go 1.8+](https://golang.org/doc/install)
+* [Go 1.8+](https://go.dev/doc/install)
 * Once you have your Azure subscription, <a href="https://portal.azure.com/?microsoft_azure_marketplace_ItemHideKey=microsoft_azure_cognitiveservices_customvision#create/Microsoft.CognitiveServicesCustomVision"  title="Create a Custom Vision resource"  target="_blank">create a Custom Vision resource <span class="docon docon-navigate-external x-hidden-focus"></span></a> in the Azure portal to create a training and prediction resource and get your keys and endpoint. Wait for it to deploy and click the **Go to resource** button.
     * You will need the key and endpoint from the resources you create to connect your application to Custom Vision. You'll paste your key and endpoint into the code below later in the quickstart.
     * You can use the free pricing tier (`F0`) to try the service, and upgrade later to a paid tier for production.

--- a/articles/cognitive-services/Face/includes/quickstarts/go-sdk.md
+++ b/articles/cognitive-services/Face/includes/quickstarts/go-sdk.md
@@ -23,7 +23,7 @@ Use the Face service client library for Go to:
 
 ## Prerequisites
 
-* The latest version of [Go](https://golang.org/dl/)
+* The latest version of [Go](https://go.dev/dl/)
 * Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services/)
 * [!INCLUDE [contributor-requirement](../../../includes/quickstarts/contributor-requirement.md)]
 * Once you have your Azure subscription, <a href="https://portal.azure.com/#create/Microsoft.CognitiveServicesFace"  title="Create a Face resource"  target="_blank">create a Face resource </a> in the Azure portal to get your key and endpoint. After it deploys, click **Go to resource**.
@@ -49,7 +49,7 @@ Your workspace will contain three folders:
 * **bin** - This directory will contain the binary executable files that are created when you run `go install`.
 
 > [!TIP]
-> To learn more about the structure of a Go workspace, see the [Go language documentation](https://golang.org/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
+> To learn more about the structure of a Go workspace, see the [Go language documentation](https://go.dev/doc/code.html#Workspaces). This guide includes information for setting `$GOPATH` and `$GOROOT`.
 
 ### Install the client library for Go
 

--- a/articles/cognitive-services/LUIS/includes/get-started-get-model-rest-go.md
+++ b/articles/cognitive-services/LUIS/includes/get-started-get-model-rest-go.md
@@ -15,7 +15,7 @@ ms.date: 06/03/2020
 
 ## Prerequisites
 
-* [Go](https://golang.org/) programming language
+* [Go](https://go.dev/) programming language
 * [Visual Studio Code](https://code.visualstudio.com/)
 
 ## Example utterances JSON file

--- a/articles/cognitive-services/QnAMaker/includes/quickstart-sdk-go.md
+++ b/articles/cognitive-services/QnAMaker/includes/quickstart-sdk-go.md
@@ -28,7 +28,7 @@ Use the QnA Maker client library for Go to:
 ## Prerequisites
 
 * Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services)
-* [Go](https://golang.org/)
+* [Go](https://go.dev/)
 * Once you have your Azure subscription, create a [QnA Maker resource](https://portal.azure.com/#create/Microsoft.CognitiveServicesQnAMaker) in the Azure portal to get your authoring key and endpoint. After it deploys, select **Go to resource**.
     * You will need the key and endpoint from the resource you create to connect your application to the QnA Maker API. Paste your key and endpoint into the code below later in the quickstart.
     * You can use the free pricing tier (`F0`) to try the service, and upgrade later to a paid tier for production.

--- a/articles/cognitive-services/Speech-Service/includes/quickstarts/platform/go-linux.md
+++ b/articles/cognitive-services/Speech-Service/includes/quickstarts/platform/go-linux.md
@@ -15,7 +15,7 @@ This guide shows how to install the [Speech SDK](~/articles/cognitive-services/s
 Before you install the Speech SDK for Go, you need:
 
 * Linux environment set up as described in the [system requirements and setup instructions](~/articles/cognitive-services/speech-service/speech-sdk.md#get-the-speech-sdk)
-* The [Go binary version 1.13 or later](https://golang.org/dl/) installed
+* The [Go binary version 1.13 or later](https://go.dev/dl/) installed
 
 [!INCLUDE [linux-install-sdk](linux-install-sdk.md)]
 

--- a/articles/cognitive-services/Translator/includes/detect-go.md
+++ b/articles/cognitive-services/Translator/includes/detect-go.md
@@ -79,7 +79,7 @@ Next, let's construct the URL. The URL is built using the `Parse()` and `Query()
 Copy this code into the `detect` function.
 
 ```go
-// Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+// Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
 u, _ := url.Parse(uri)
 q := u.Query()
 u.RawQuery = q.Encode()

--- a/articles/cognitive-services/Translator/includes/dictionary-go.md
+++ b/articles/cognitive-services/Translator/includes/dictionary-go.md
@@ -79,7 +79,7 @@ Next, let's construct the URL. The URL is built using the `Parse()` and `Query()
 Copy this code into the `altTranslations` function.
 
 ```go
-// Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+// Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
 u, _ := url.Parse(uri)
 q := u.Query()
 q.Add("from", "en")

--- a/articles/cognitive-services/Translator/includes/languages-go.md
+++ b/articles/cognitive-services/Translator/includes/languages-go.md
@@ -65,7 +65,7 @@ Next, let's construct the URL. The URL is built using the `Parse()` and `Query()
 Copy this code into the `getLanguages` function.
 
 ```go
-// Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+// Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
 u, _ := url.Parse(uri)
 q := u.Query()
 u.RawQuery = q.Encode()

--- a/articles/cognitive-services/Translator/includes/prerequisites-go.md
+++ b/articles/cognitive-services/Translator/includes/prerequisites-go.md
@@ -11,5 +11,5 @@ ms.author: lajanuar
 
 This quickstart requires:
 
-* [Go](https://golang.org/doc/install)
+* [Go](https://go.dev/doc/install)
 * An Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services)

--- a/articles/cognitive-services/Translator/includes/sentences-go.md
+++ b/articles/cognitive-services/Translator/includes/sentences-go.md
@@ -79,7 +79,7 @@ Next, let's construct the URL. The URL is built using the `Parse()` and `Query()
 Copy this code into the `breakSentence` function.
 
 ```go
-// Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+// Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
 u, _ := url.Parse(uri)
 q := u.Query()
 q.Add("languages", "en")

--- a/articles/cognitive-services/Translator/includes/translate-go.md
+++ b/articles/cognitive-services/Translator/includes/translate-go.md
@@ -79,7 +79,7 @@ Next, let's construct the URL. The URL is built using the `Parse()` and `Query()
 Copy this code into the `translate` function.
 
 ```go
-// Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+// Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
 u, _ := url.Parse(uri)
 q := u.Query()
 q.Add("to", "de")

--- a/articles/cognitive-services/Translator/includes/transliterate-go.md
+++ b/articles/cognitive-services/Translator/includes/transliterate-go.md
@@ -79,7 +79,7 @@ Next, let's construct the URL. The URL is built using the `Parse()` and `Query()
 Copy this code into the `transliterate` function.
 
 ```go
-// Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+// Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
 u, _ := url.Parse(uri)
 q := u.Query()
 q.Add("language", "ja")

--- a/articles/cognitive-services/Translator/quickstart-translator.md
+++ b/articles/cognitive-services/Translator/quickstart-translator.md
@@ -204,7 +204,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/translate?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("from", "en")
@@ -491,7 +491,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/translate?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("to", "de")
@@ -779,7 +779,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/detect?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     u.RawQuery = q.Encode()
@@ -1059,7 +1059,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/translate?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("to", "th")
@@ -1344,7 +1344,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/transliterate?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("language", "th")
@@ -1624,7 +1624,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/translate?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("to", "es")
@@ -1916,7 +1916,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/breaksentence?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     u.RawQuery = q.Encode()
@@ -2186,7 +2186,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/dictionary/lookup?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("from", "en")
@@ -2488,7 +2488,7 @@ func main() {
     endpoint := "https://api.cognitive.microsofttranslator.com/"
     uri := endpoint + "/dictionary/examples?api-version=3.0"
 
-    // Build the request URL. See: https://golang.org/pkg/net/url/#example_URL_Parse
+    // Build the request URL. See: https://go.dev/pkg/net/url/#example_URL_Parse
     u, _ := url.Parse(uri)
     q := u.Query()
     q.Add("from", "en")

--- a/articles/cognitive-services/bing-visual-search/quickstarts/go.md
+++ b/articles/cognitive-services/bing-visual-search/quickstarts/go.md
@@ -22,7 +22,7 @@ Use this quickstart to make your first call to the Bing Visual Search API using 
 
 ## Prerequisites
 
-* Install the [Go binaries](https://golang.org/dl/).
+* Install the [Go binaries](https://go.dev/dl/).
 * Install the go-spew deep pretty printer, which is used to display results. To install go-spew, use the `$ go get -u https://github.com/davecgh/go-spew` command.
 
 [!INCLUDE [cognitive-services-bing-visual-search-signup-requirements](../../../../includes/cognitive-services-bing-visual-search-signup-requirements.md)]

--- a/articles/container-registry/container-registry-auto-purge.md
+++ b/articles/container-registry/container-registry-auto-purge.md
@@ -30,7 +30,7 @@ The `acr purge` container command deletes images by tag in a repository that mat
 At a minimum, specify the following when you run `acr purge`:
 
 * `--filter` - A repository and a *regular expression* to filter tags in the repository. Examples: `--filter "hello-world:.*"` matches all tags in the `hello-world` repository, and `--filter "hello-world:^1.*"` matches tags beginning with `1`. Pass multiple `--filter` parameters to purge multiple repositories.
-* `--ago` - A Go-style [duration string](https://golang.org/pkg/time/) to indicate a duration beyond which images are deleted. The duration consists of a sequence of one or more decimal numbers, each with a unit suffix. Valid time units include "d" for days, "h" for hours, and "m" for minutes. For example, `--ago 2d3h6m` selects all filtered images last modified more than 2 days, 3 hours, and 6 minutes ago, and `--ago 1.5h` selects images last modified more than 1.5 hours ago.
+* `--ago` - A Go-style [duration string](https://go.dev/pkg/time/) to indicate a duration beyond which images are deleted. The duration consists of a sequence of one or more decimal numbers, each with a unit suffix. Valid time units include "d" for days, "h" for hours, and "m" for minutes. For example, `--ago 2d3h6m` selects all filtered images last modified more than 2 days, 3 hours, and 6 minutes ago, and `--ago 1.5h` selects images last modified more than 1.5 hours ago.
 
 `acr purge` supports several optional parameters. The following two are used in examples in this article:
 

--- a/articles/cosmos-db/cassandra/manage-data-go.md
+++ b/articles/cosmos-db/cassandra/manage-data-go.md
@@ -29,7 +29,7 @@ Azure Cosmos DB is a multi-model database service that lets you quickly create a
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create one for free](https://azure.microsoft.com/free/?WT.mc_id=cassandrago-docs-abhishgu). Or [try Azure Cosmos DB for free](https://azure.microsoft.com/try/cosmosdb/?WT.mc_id=cassandrago-docs-abhishgu) without an Azure subscription.
-- [Go](https://golang.org/) installed on your computer, and a working knowledge of Go.
+- [Go](https://go.dev/) installed on your computer, and a working knowledge of Go.
 - [Git](https://git-scm.com/downloads).
 
 ## Create a database account

--- a/articles/cosmos-db/mongodb/create-mongodb-go.md
+++ b/articles/cosmos-db/mongodb/create-mongodb-go.md
@@ -27,7 +27,7 @@ The sample application is a command-line based `todo` management tool written in
 
 ## Prerequisites
 - An Azure account with an active subscription. [Create one for free](https://azure.microsoft.com/free). Or [try Azure Cosmos DB for free](https://azure.microsoft.com/try/cosmosdb/) without an Azure subscription. You can also use the [Azure Cosmos DB Emulator](https://aka.ms/cosmosdb-emulator) with the connection string `.mongodb://localhost:C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==@localhost:10255/admin?ssl=true`.
-- [Go](https://golang.org/) installed on your computer, and a working knowledge of Go.
+- [Go](https://go.dev/) installed on your computer, and a working knowledge of Go.
 - [Git](https://git-scm.com/downloads).
 [!INCLUDE [azure-cli-prepare-your-environment-no-header.md](../../../includes/azure-cli-prepare-your-environment-no-header.md)]
 

--- a/articles/event-hubs/event-hubs-go-get-started-send.md
+++ b/articles/event-hubs/event-hubs-go-get-started-send.md
@@ -19,7 +19,7 @@ This tutorial describes how to write Go applications to send events to or receiv
 
 To complete this tutorial, you need the following prerequisites:
 
-- Go installed locally. Follow [these instructions](https://golang.org/doc/install) if necessary.
+- Go installed locally. Follow [these instructions](https://go.dev/doc/install) if necessary.
 - An active Azure account. If you don't have an Azure subscription, create a [free account][] before you begin.
 - **Create an Event Hubs namespace and an event hub**. Use the [Azure portal](https://portal.azure.com) to create a namespace of type Event Hubs, and obtain the management credentials your application needs to communicate with the event hub. To create a namespace and an event hub, follow the procedure in [this article](event-hubs-create.md).
 

--- a/articles/governance/management-groups/create-management-group-go.md
+++ b/articles/governance/management-groups/create-management-group-go.md
@@ -48,7 +48,7 @@ To enable Go to manage management groups, the package must be added. This packag
 can be used, including [bash on Windows 10](/windows/wsl/install-win10) or locally installed.
 
 1. Check that the latest Go is installed (at least **1.15**). If it isn't yet installed, download it
-   at [Golang.org](https://golang.org/dl/).
+   at [Golang.org](https://go.dev/dl/).
 
 1. Check that the latest Azure CLI is installed (at least **2.5.1**). If it isn't yet installed, see
    [Install the Azure CLI](/cli/azure/install-azure-cli).

--- a/articles/governance/resource-graph/first-query-go.md
+++ b/articles/governance/resource-graph/first-query-go.md
@@ -25,7 +25,7 @@ To enable Go to query Azure Resource Graph, the package must be added. This pack
 Go can be used, including [bash on Windows 10](/windows/wsl/install-win10) or locally installed.
 
 1. Check that the latest Go is installed (at least **1.14**). If it isn't yet installed, download it
-   at [Golang.org](https://golang.org/dl/).
+   at [Golang.org](https://go.dev/dl/).
 
 1. Check that the latest Azure CLI is installed (at least **2.5.1**). If it isn't yet installed, see
    [Install the Azure CLI](/cli/azure/install-azure-cli).

--- a/articles/hdinsight/hdinsight-go-sdk-overview.md
+++ b/articles/hdinsight/hdinsight-go-sdk-overview.md
@@ -21,7 +21,7 @@ If you don’t have an Azure subscription, create a [free account](https://azure
 ## Prerequisites
 
 * A [`go get` tool](https://github.com/golang/go/wiki/GoGetTools).
-* [Go](https://golang.org/dl/).
+* [Go](https://go.dev/dl/).
 
 ## SDK installation
 

--- a/articles/key-vault/certificates/quick-create-go.md
+++ b/articles/key-vault/certificates/quick-create-go.md
@@ -21,7 +21,7 @@ Follow this guide to learn how to use the [azcertificates](https://pkg.go.dev/gi
 ## Prerequisites
 
 - An Azure subscription - [create one for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- **Go installed**: Version 1.16 or [above](https://golang.org/dl/)
+- **Go installed**: Version 1.16 or [above](https://go.dev/dl/)
 - [Azure CLI](/cli/azure/install-azure-cli)
 
 ## Set up your environment

--- a/articles/key-vault/keys/quick-create-go.md
+++ b/articles/key-vault/keys/quick-create-go.md
@@ -21,7 +21,7 @@ Follow this guide to learn how to use the [azkeys](https://pkg.go.dev/github.com
 ## Prerequisites
 
 - An Azure subscription - [create one for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- **Go installed**: Version 1.16 or [above](https://golang.org/dl/)
+- **Go installed**: Version 1.16 or [above](https://go.dev/dl/)
 - [Azure CLI](/cli/azure/install-azure-cli)
 
 

--- a/articles/key-vault/secrets/quick-create-go.md
+++ b/articles/key-vault/secrets/quick-create-go.md
@@ -21,7 +21,7 @@ Get started with the [azsecrets](https://pkg.go.dev/github.com/Azure/azure-sdk-f
 ## Prerequisites
 
 - An Azure subscription. If you don't already have a subscription, you can [create one for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Go version 1.16 or later](https://golang.org/dl/), installed. 
+- [Go version 1.16 or later](https://go.dev/dl/), installed. 
 - [The Azure CLI](/cli/azure/install-azure-cli), installed.
 
 ## Setup

--- a/articles/mysql/connect-go.md
+++ b/articles/mysql/connect-go.md
@@ -14,7 +14,7 @@ ms.date: 5/26/2020
 
 [!INCLUDE[applies-to-mysql-single-server](includes/applies-to-mysql-single-server.md)]
 
-This quickstart demonstrates how to connect to an Azure Database for MySQL from Windows, Ubuntu Linux, and Apple macOS platforms by using code written in the [Go](https://golang.org/) language. It shows how to use SQL statements to query, insert, update, and delete data in the database. This topic assumes that you are familiar with development using Go and that you are new to working with Azure Database for MySQL.
+This quickstart demonstrates how to connect to an Azure Database for MySQL from Windows, Ubuntu Linux, and Apple macOS platforms by using code written in the [Go](https://go.dev/) language. It shows how to use SQL statements to query, insert, update, and delete data in the database. This topic assumes that you are familiar with development using Go and that you are new to working with Azure Database for MySQL.
 
 ## Prerequisites
 This quickstart uses the resources created in either of these guides as a starting point:
@@ -25,10 +25,10 @@ This quickstart uses the resources created in either of these guides as a starti
 > Ensure the IP address you're connecting from has been added the server's firewall rules using the [Azure portal](./howto-manage-firewall-using-portal.md) or [Azure CLI](./howto-manage-firewall-using-cli.md)
 
 ## Install Go and MySQL connector
-Install [Go](https://golang.org/doc/install) and the [go-sql-driver for MySQL](https://github.com/go-sql-driver/mysql#installation) on your own computer. Depending on your platform, follow the steps in the appropriate section:
+Install [Go](https://go.dev/doc/install) and the [go-sql-driver for MySQL](https://github.com/go-sql-driver/mysql#installation) on your own computer. Depending on your platform, follow the steps in the appropriate section:
 
 ### Windows
-1. [Download](https://golang.org/dl/) and install Go for Microsoft Windows according to the [installation instructions](https://golang.org/doc/install).
+1. [Download](https://go.dev/dl/) and install Go for Microsoft Windows according to the [installation instructions](https://go.dev/doc/install).
 2. Launch the command prompt from the start menu.
 3. Make a folder for your project such. `mkdir  %USERPROFILE%\go\src\mysqlgo`.
 4. Change directory into the project folder, such as `cd %USERPROFILE%\go\src\mysqlgo`.
@@ -61,7 +61,7 @@ Install [Go](https://golang.org/doc/install) and the [go-sql-driver for MySQL](h
    ```
 
 ### Apple macOS
-1. Download and install Go according to the [installation instructions](https://golang.org/doc/install) matching your platform. 
+1. Download and install Go according to the [installation instructions](https://go.dev/doc/install) matching your platform. 
 2. Launch the Bash shell.
 3. Make a folder for your project in your home directory, such as `mkdir -p ~/go/src/mysqlgo/`.
 4. Change directory into the folder, such as `cd ~/go/src/mysqlgo/`.
@@ -97,9 +97,9 @@ Get the connection information needed to connect to the Azure Database for MySQL
 ## Connect, create table, and insert data
 Use the following code to connect to the server, create a table, and load the data by using an **INSERT** SQL statement. 
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and it checks the connection by using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://golang.org/pkg/database/sql/#DB.Exec) method several times to run several DDL commands. The code also uses [Prepare()](http://go-database-sql.org/prepared.html) and Exec() to run prepared statements with different parameters to insert three rows. Each time, a custom checkError() method is used to check if an error occurred and panic to exit.
+The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and it checks the connection by using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://go.dev/pkg/database/sql/#DB.Exec) method several times to run several DDL commands. The code also uses [Prepare()](http://go-database-sql.org/prepared.html) and Exec() to run prepared statements with different parameters to insert three rows. Each time, a custom checkError() method is used to check if an error occurred and panic to exit.
 
 Replace the `host`, `database`, `user`, and `password` constants with your own values. 
 
@@ -174,9 +174,9 @@ func main() {
 ## Read data
 Use the following code to connect and read the data by using a **SELECT** SQL statement. 
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Query()](https://golang.org/pkg/database/sql/#DB.Query) method to run the select command. Then it runs [Next()](https://golang.org/pkg/database/sql/#Rows.Next) to iterate through the result set and [Scan()](https://golang.org/pkg/database/sql/#Rows.Scan) to parse the column values, saving the value into variables. Each time a custom checkError() method is used to check if an error occurred and panic to exit.
+The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Query()](https://go.dev/pkg/database/sql/#DB.Query) method to run the select command. Then it runs [Next()](https://go.dev/pkg/database/sql/#Rows.Next) to iterate through the result set and [Scan()](https://go.dev/pkg/database/sql/#Rows.Scan) to parse the column values, saving the value into variables. Each time a custom checkError() method is used to check if an error occurred and panic to exit.
 
 Replace the `host`, `database`, `user`, and `password` constants with your own values. 
 
@@ -243,9 +243,9 @@ func main() {
 ## Update data
 Use the following code to connect and update the data using a **UPDATE** SQL statement. 
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://golang.org/pkg/database/sql/#DB.Exec) method to run the update command. Each time a custom checkError() method is used to check if an error occurred and panic to exit.
+The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://go.dev/pkg/database/sql/#DB.Exec) method to run the update command. Each time a custom checkError() method is used to check if an error occurred and panic to exit.
 
 Replace the `host`, `database`, `user`, and `password` constants with your own values. 
 
@@ -298,9 +298,9 @@ func main() {
 ## Delete data
 Use the following code to connect and remove data using a **DELETE** SQL statement. 
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [go sql driver for mysql](https://github.com/go-sql-driver/mysql#installation) as a driver to communicate with the Azure Database for MySQL, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://golang.org/pkg/database/sql/#DB.Exec) method to run the delete command. Each time a custom checkError() method is used to check if an error occurred and panic to exit.
+The code calls method [sql.Open()](http://go-database-sql.org/accessing.html) to connect to Azure Database for MySQL, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://go.dev/pkg/database/sql/#DB.Exec) method to run the delete command. Each time a custom checkError() method is used to check if an error occurred and panic to exit.
 
 Replace the `host`, `database`, `user`, and `password` constants with your own values. 
 

--- a/articles/postgresql/connect-go.md
+++ b/articles/postgresql/connect-go.md
@@ -13,7 +13,7 @@ ms.date: 5/6/2019
 
 # Quickstart: Use Go language to connect and query data in Azure Database for PostgreSQL - Single Server
 
-This quickstart demonstrates how to connect to an Azure Database for PostgreSQL using code written in the [Go](https://golang.org/) language (golang). It shows how to use SQL statements to query, insert, update, and delete data in the database. This article assumes you are familiar with development using Go, but that you are new to working with Azure Database for PostgreSQL.
+This quickstart demonstrates how to connect to an Azure Database for PostgreSQL using code written in the [Go](https://go.dev/) language (golang). It shows how to use SQL statements to query, insert, update, and delete data in the database. This article assumes you are familiar with development using Go, but that you are new to working with Azure Database for PostgreSQL.
 
 ## Prerequisites
 This quickstart uses the resources created in either of these guides as a starting point:
@@ -21,10 +21,10 @@ This quickstart uses the resources created in either of these guides as a starti
 - [Create DB - Azure CLI](quickstart-create-server-database-azure-cli.md)
 
 ## Install Go and pq connector
-Install [Go](https://golang.org/doc/install) and the [Pure Go Postgres driver (pq)](https://github.com/lib/pq) on your own machine. Depending on your platform, follow the appropriate steps:
+Install [Go](https://go.dev/doc/install) and the [Pure Go Postgres driver (pq)](https://github.com/lib/pq) on your own machine. Depending on your platform, follow the appropriate steps:
 
 ### Windows
-1. [Download](https://golang.org/dl/) and install Go for Microsoft Windows according to the [installation instructions](https://golang.org/doc/install).
+1. [Download](https://go.dev/dl/) and install Go for Microsoft Windows according to the [installation instructions](https://go.dev/doc/install).
 2. Launch the command prompt from the start menu.
 3. Make a folder for your project, such as `mkdir  %USERPROFILE%\go\src\postgresqlgo`.
 4. Change directory into the project folder, such as `cd %USERPROFILE%\go\src\postgresqlgo`.
@@ -57,7 +57,7 @@ Install [Go](https://golang.org/doc/install) and the [Pure Go Postgres driver (p
    ```
 
 ### Apple macOS
-1. Download and install Go according to the [installation instructions](https://golang.org/doc/install)  matching your platform. 
+1. Download and install Go according to the [installation instructions](https://go.dev/doc/install)  matching your platform. 
 2. Launch the Bash shell. 
 3. Make a folder for your project in your home directory, such as `mkdir -p ~/go/src/postgresqlgo/`.
 4. Change directory into the folder, such as `cd ~/go/src/postgresqlgo/`.
@@ -92,9 +92,9 @@ Get the connection information needed to connect to the Azure Database for Postg
 ## Connect and create a table
 Use the following code to connect and create a table using **CREATE TABLE** SQL statement, followed by **INSERT INTO** SQL statements to add rows into the table.
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the PostgreSQL server, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the PostgreSQL server, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://golang.org/pkg/database/sql/#DB.Exec) method several times to run several SQL commands. Each time a custom checkError() method checks if an error occurred and panic to exit if an error does occur.
+The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://go.dev/pkg/database/sql/#DB.Exec) method several times to run several SQL commands. Each time a custom checkError() method checks if an error occurred and panic to exit if an error does occur.
 
 Replace the `HOST`, `DATABASE`, `USER`, and `PASSWORD` parameters with your own values. 
 
@@ -158,10 +158,10 @@ func main() {
 ## Read data
 Use the following code to connect and read the data using a **SELECT** SQL statement. 
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the PostgreSQL server, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the PostgreSQL server, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The select query is run by calling method [db.Query()](https://golang.org/pkg/database/sql/#DB.Query), and the resulting rows are kept in a variable of type 
-[rows](https://golang.org/pkg/database/sql/#Rows). The code reads the column data values in the current row using method [rows.Scan()](https://golang.org/pkg/database/sql/#Rows.Scan) and loops over the rows using the iterator [rows.Next()](https://golang.org/pkg/database/sql/#Rows.Next) until no more rows exist. Each row's column values are printed to the console out. Each time a custom checkError() method is used to check if an error occurred and panic to exit if an error does occur.
+The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The select query is run by calling method [db.Query()](https://go.dev/pkg/database/sql/#DB.Query), and the resulting rows are kept in a variable of type 
+[rows](https://go.dev/pkg/database/sql/#Rows). The code reads the column data values in the current row using method [rows.Scan()](https://go.dev/pkg/database/sql/#Rows.Scan) and loops over the rows using the iterator [rows.Next()](https://go.dev/pkg/database/sql/#Rows.Next) until no more rows exist. Each row's column values are printed to the console out. Each time a custom checkError() method is used to check if an error occurred and panic to exit if an error does occur.
 
 Replace the `HOST`, `DATABASE`, `USER`, and `PASSWORD` parameters with your own values. 
 
@@ -227,9 +227,9 @@ func main() {
 ## Update data
 Use the following code to connect and update the data using an **UPDATE** SQL statement.
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the Postgres server, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the Postgres server, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://golang.org/pkg/database/sql/#DB.Exec) method to run the SQL statement that updates the table. A custom checkError() method is used to check if an error occurred and panic to exit if an error does occur.
+The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://go.dev/pkg/database/sql/#DB.Exec) method to run the SQL statement that updates the table. A custom checkError() method is used to check if an error occurred and panic to exit if an error does occur.
 
 Replace the `HOST`, `DATABASE`, `USER`, and `PASSWORD` parameters with your own values. 
 ```go
@@ -280,9 +280,9 @@ func main() {
 ## Delete data
 Use the following code to connect and delete the data using a **DELETE** SQL statement. 
 
-The code imports three packages: the [sql package](https://golang.org/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the Postgres server, and the [fmt package](https://golang.org/pkg/fmt/) for printed input and output on the command line.
+The code imports three packages: the [sql package](https://go.dev/pkg/database/sql/), the [pq package](https://godoc.org/github.com/lib/pq) as a driver to communicate with the Postgres server, and the [fmt package](https://go.dev/pkg/fmt/) for printed input and output on the command line.
 
-The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://golang.org/pkg/database/sql/#DB.Ping). A [database handle](https://golang.org/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://golang.org/pkg/database/sql/#DB.Exec) method to run the SQL statement that deletes a row from the table. A custom checkError() method is used to check if an error occurred and panic to exit if an error does occur.
+The code calls method [sql.Open()](https://godoc.org/github.com/lib/pq#Open) to connect to Azure Database for PostgreSQL database, and checks the connection using method [db.Ping()](https://go.dev/pkg/database/sql/#DB.Ping). A [database handle](https://go.dev/pkg/database/sql/#DB) is used throughout, holding the connection pool for the database server. The code calls the [Exec()](https://go.dev/pkg/database/sql/#DB.Exec) method to run the SQL statement that deletes a row from the table. A custom checkError() method is used to check if an error occurred and panic to exit if an error does occur.
 
 Replace the `HOST`, `DATABASE`, `USER`, and `PASSWORD` parameters with your own values. 
 ```go

--- a/articles/public-multi-access-edge-compute-mec/tutorial-create-vm-using-go-sdk.md
+++ b/articles/public-multi-access-edge-compute-mec/tutorial-create-vm-using-go-sdk.md
@@ -29,7 +29,7 @@ In this tutorial, you learn how to:
 
 - Add an allowlisted subscription to your Azure account, which allows you to deploy resources in Azure public MEC. If you don't have an active allowed subscription, contact the [Azure public MEC product team](https://aka.ms/azurepublicmec).
 
-- [Install Go](https://golang.org/doc/install)
+- [Install Go](https://go.dev/doc/install)
 
 - [Install the Azure SDK for Go](/azure/developer/go/azure-sdk-install)
 


### PR DESCRIPTION
In all new references, they mention their new domain name, including their github page, here: https://github.com/golang/go
They mentioned explicitly that "we will be merging the golang.org sites into a single coherent web presence, here on go.dev."
(here: https://go.dev/blog/tidy-web#:~:text=we%20will%20be%20merging%20the%20golang.org%20sites%20into%20a%20single%20coherent%20web%20presence,%20here%20on%20go.dev.)
so, it's better to be aligned with the authors and update our links to refer to the new go domain name.