### PR TITLE
Updated contained AG Azure Arc instruction steps for accuracy

### DIFF
--- a/articles/azure-arc/data/managed-instance-high-availability.md
+++ b/articles/azure-arc/data/managed-instance-high-availability.md
@@ -278,7 +278,7 @@ Additional steps are required to restore a database into an availability group. 
     Add the database backup file into the primary instance container.
 
     ```console
-    kubectl cp <source file location> <pod name>:var/opt/mssql/data/<file name> -n <namespace name>
+    kubectl cp <source file location> <pod name>:var/opt/mssql/data/<file name> -c <serviceName> -n <namespaceName>
     ```
 
     Example


### PR DESCRIPTION
Modified the "Add the database backup file into the primary instance container" instruction section to include the "-c <serviceName>" option that is present in the example. Also changed the <namespace name> to <namespaceName> to keep the previous steps consistent with this step in the documentation.