### PR TITLE
Update Azure AD Role for deleting a device

### DIFF
--- a/articles/active-directory/devices/device-management-azure-portal.md
+++ b/articles/active-directory/devices/device-management-azure-portal.md
@@ -77,7 +77,7 @@ There are two ways to delete a device:
 - The toolbar, after you drill down for a specific device.
 
 > [!IMPORTANT]
-> - You must be a Cloud Device Administrator, Intune Administrator, or Global Administrator in Azure AD to delete a device.
+> - You must be a Cloud Device Administrator, Intune Administrator, Windows 365 Administrator or Global Administrator in Azure AD to delete a device.
 > - Printers and Windows Autopilot devices can't be deleted in Azure AD.
 > - Deleting a device:
 >    - Prevents it from accessing your Azure AD resources.


### PR DESCRIPTION
As per below document, Windows 365 Administrator can delete a device. As this is not documented in this article, raising request for the same. 
https://docs.microsoft.com/en-us/azure/active-directory/roles/permissions-reference#windows-365-administrator