### PR TITLE
Typo "Azure Database for Postgres"→"Azure Database for PostgreSQL"

### DIFF
--- a/articles/azure-arc/data/migrate-postgresql-data-into-postgresql-hyperscale-server-group.md
+++ b/articles/azure-arc/data/migrate-postgresql-data-into-postgresql-hyperscale-server-group.md
@@ -210,6 +210,6 @@ Within your Arc setup you can use `psql` to connect to your Postgres instance, s
     * [Design a multi-tenant database](../../postgresql/hyperscale/tutorial-design-database-multi-tenant.md)*
     * [Design a real-time analytics dashboard](../../postgresql/hyperscale/tutorial-design-database-realtime.md)*
 
-> *In these documents, skip the sections **Sign in to the Azure portal**, and **Create an Azure Database for Postgres - Hyperscale (Citus)**. Implement the remaining steps in your Azure Arc deployment. Those sections are specific to the Azure Database for PostgreSQL Hyperscale (Citus) offered as a PaaS service in the Azure cloud but the other parts of the documents are directly applicable to your Azure Arc-enabled PostgreSQL Hyperscale.
+> *In these documents, skip the sections **Sign in to the Azure portal**, and **Create an Azure Database for PostgreSQL - Hyperscale (Citus)**. Implement the remaining steps in your Azure Arc deployment. Those sections are specific to the Azure Database for PostgreSQL Hyperscale (Citus) offered as a PaaS service in the Azure cloud but the other parts of the documents are directly applicable to your Azure Arc-enabled PostgreSQL Hyperscale.
 
 - [Scale out your Azure Database for PostgreSQL Hyperscale server group](scale-out-in-postgresql-hyperscale-server-group.md)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/azure-arc/data/migrate-postgresql-data-into-postgresql-hyperscale-server-group
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-arc/data/migrate-postgresql-data-into-postgresql-hyperscale-server-group.md
#PingMSFTDocs