### PR TITLE
Fixes compile error in code snippet

### DIFF
--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -306,6 +306,10 @@ namespace MyNamespace
                 .AddJsonFile(Path.Combine(context.ApplicationRootPath, $"appsettings.{context.EnvironmentName}.json"), optional: true, reloadOnChange: false)
                 .AddEnvironmentVariables();
         }
+        
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+        }
     }
 }
 ```


### PR DESCRIPTION
Missing override causes the error "Abstract inherited member 'void Microsoft.Azure.Functions.Extensions.DependencyInjection.FunctionsStartup.Configure(IFunctionsHostBuilder)' is not implemented"