### PR TITLE
Update azure-virtual-machines/md - Unattached Disk

### DIFF
--- a/includes/resource-graph/samples/bycat/azure-virtual-machines.md
+++ b/includes/resource-graph/samples/bycat/azure-virtual-machines.md
@@ -355,6 +355,26 @@ Search-AzGraph -Query "PatchAssessmentResources | where type has 'softwarepatche
 
 ---
 
+### List of unattached disks with details 
+
+Returns the list of disks that have a status of unattached with details. The query also includes the disk name, resource group, and location to enable triaging and mitigation as part of auditing or cost optimization efforts. 
+
+```kusto
+Resources
+| where type == "microsoft.compute/disks"
+| where properties['diskState'] == "Unattached"
+| project name,resourceGroup,id,type,kind,location,subscriptionId,tags,properties['diskState']
+```
+
+# [Portal](#tab/azure-portal)
+
+:::image type="icon" source="../../../../articles/governance/resource-graph/media/resource-graph-small.png"::: Try this query in Azure Resource Graph Explorer:
+
+- Azure portal: <a href="https://portal.azure.com/?feature.customportal=false#blade/HubsExtension/ArgQueryBlade/query/HealthResources%0a%7c%20where%20type%20%3d%7e%20%27microsoft.resourcehealth%2favailabilitystatuses%27%0a%7c%20summarize%20by%20ResourceId%20%3d%20tolower(tostring(properties.targetResourceId))%2c%20AvailabilityState%20%3d%20tostring(properties.availabilityState)" target="_blank">portal.azure.com</a>
+- Azure Government portal: <a href="https://portal.azure.us/?feature.customportal=false#blade/HubsExtension/ArgQueryBlade/query/HealthResources%0a%7c%20where%20type%20%3d%7e%20%27microsoft.resourcehealth%2favailabilitystatuses%27%0a%7c%20summarize%20by%20ResourceId%20%3d%20tolower(tostring(properties.targetResourceId))%2c%20AvailabilityState%20%3d%20tostring(properties.availabilityState)" target="_blank">portal.azure.us</a>
+- Azure China 21Vianet portal: <a href="https://portal.azure.cn/?feature.customportal=false#blade/HubsExtension/ArgQueryBlade/query/HealthResources%0a%7c%20where%20type%20%3d%7e%20%27microsoft.resourcehealth%2favailabilitystatuses%27%0a%7c%20summarize%20by%20ResourceId%20%3d%20tolower(tostring(properties.targetResourceId))%2c%20AvailabilityState%20%3d%20tostring(properties.availabilityState)" target="_blank">portal.azure.cn</a>
+```
+
 ### List of virtual machines and associated availability states by Resource Ids
 
 Returns the latest list of virtual machines (type `Microsoft.Compute/virtualMachines`) aggregated by availability state. The query also provides the associated Resource Id based on `properties.targetResourceId`, for easy debugging and mitigation. Availability states can be one of four values: Available, Unavailable, Degraded and Unknown. For more details on what each of the availability states mean, please see [Azure Resource Health overview](../../../../articles/service-health/resource-health-overview.md#health-status).


### PR DESCRIPTION
Add Unattached Disks query to identify not only the disks but also their name so that they can be easily triaged. This is a common ask in Azure Cost engagements that I deliver with our customers as a CE.

Right now, customers are manually searching for them, using this query will allow that time to be significantly reduced and make this an ongoing process.