### PR TITLE
Update functions-add-output-binding-cosmos-db-vs-code.md

### DIFF
--- a/articles/azure-functions/functions-add-output-binding-cosmos-db-vs-code.md
+++ b/articles/azure-functions/functions-add-output-binding-cosmos-db-vs-code.md
@@ -106,7 +106,6 @@ dotnet add package Microsoft.Azure.WebJobs.Extensions.CosmosDB
 dotnet add package Microsoft.Azure.Functions.Worker.Extensions.CosmosDB
 ```
 ---
-Now, you can add the storage output binding to your project.  
 ::: zone-end
 
 ::: zone pivot="programming-language-javascript"


### PR DESCRIPTION
Remove following which looks like it is copied from the [storage example](https://docs.microsoft.com/en-us/azure/azure-functions/functions-add-output-binding-storage-queue-vs-code?tabs=in-process&pivots=programming-language-powershell)

```
Now, you can add the storage output binding to your project.  
```