### PR TITLE
Correct details of PowerShell version for Windows

### DIFF
--- a/articles/governance/policy/concepts/guest-configuration-custom.md
+++ b/articles/governance/policy/concepts/guest-configuration-custom.md
@@ -29,7 +29,7 @@ previous implementation of
 [DSC for Linux](https://github.com/Microsoft/PowerShell-DSC-for-Linux)
 or the "nx" providers included in that repository.
 
-Guest configuration operates in PowerShell 7.1.3 for Windows and PowerShell 7.2
+As of version 1.29.33, guest configuration operates in PowerShell 7.1.2 for Windows and PowerShell 7.2
 preview 6 for Linux. Starting with version 7.2, the `PSDesiredStateConfiguration`
 module moved from being part of the PowerShell installation and is instead
 installed as a


### PR DESCRIPTION
I'm not sure how this doc is wrong, but if you deploy a VM with guest configuration right now, it's 7.1.2

You can check it from PowerShell. E.g. on Windows:

```PowerShell
ls C:\Packages\Plugins\Microsoft.GuestConfiguration.ConfigurationforWindows\*\dsc\GC\pwsh.exe | 
ft @{Name = "GC Version"; Expr = { $_.Directory.Parent.Parent.Name } }, 
   @{Name = "PS Version"; Expr = { $_.VersionInfo.ProductVersion } }
```