### PR TITLE
Updating link to ARO docs instead of AKS

### DIFF
--- a/articles/openshift/howto-secure-openshift-with-front-door.md
+++ b/articles/openshift/howto-secure-openshift-with-front-door.md
@@ -18,7 +18,7 @@ This article explains how to use Azure Front Door Premium to secure access to Az
 
 The following prerequisites are required: 
 
-- You have an existing Azure Red Hat OpenShift cluster. For information on creating an Azure Red Hat OpenShift Cluster, learn how to [create-an-aks-cluster](../aks/kubernetes-walkthrough-portal.md#create-an-aks-cluster).
+- You have an existing Azure Red Hat OpenShift cluster. Follow this guide to to [create a private Azure Red Hat OpenShift cluster](../openshift/howto-create-private-cluster-4x.md).
 
 - The cluster is configured with private ingress visibility.
 

--- a/articles/openshift/howto-secure-openshift-with-front-door.md
+++ b/articles/openshift/howto-secure-openshift-with-front-door.md
@@ -18,7 +18,7 @@ This article explains how to use Azure Front Door Premium to secure access to Az
 
 The following prerequisites are required: 
 
-- You have an existing Azure Red Hat OpenShift cluster. Follow this guide to to [create a private Azure Red Hat OpenShift cluster](../openshift/howto-create-private-cluster-4x.md).
+- You have an existing Azure Red Hat OpenShift cluster. Follow this guide to to [create a private Azure Red Hat OpenShift cluster](./howto-create-private-cluster-4x.md).
 
 - The cluster is configured with private ingress visibility.
 

--- a/articles/openshift/howto-secure-openshift-with-front-door.md
+++ b/articles/openshift/howto-secure-openshift-with-front-door.md
@@ -18,7 +18,7 @@ This article explains how to use Azure Front Door Premium to secure access to Az
 
 The following prerequisites are required: 
 
-- You have an existing Azure Red Hat OpenShift cluster. Follow this guide to to [create a private Azure Red Hat OpenShift cluster](./howto-create-private-cluster-4x.md).
+- You have an existing Azure Red Hat OpenShift cluster. Follow this guide to to [create a private Azure Red Hat OpenShift cluster](howto-create-private-cluster-4x.md).
 
 - The cluster is configured with private ingress visibility.
 


### PR DESCRIPTION
This documentation is for ARO with Azure Front Door, it shouldn't reference AKS documentation. This change points to the documentation on how to create a private ARO cluster instead. 