### PR TITLE
Trivial change: Need to specify local directory

### DIFF
--- a/articles/site-recovery/vmware-physical-manage-mobility-service.md
+++ b/articles/site-recovery/vmware-physical-manage-mobility-service.md
@@ -75,7 +75,7 @@ Uninstall from the UI or from a command prompt.
 2. In a terminal, go to /usr/local/ASR.
 3. Run the following command:
     ```
-    uninstall.sh -Y
+    ./uninstall.sh -Y
    ```
    
 ## Install Site Recovery VSS provider on source machine


### PR DESCRIPTION
When running a command from the local directory a relative path containing ./ needs to be specified in most default Linux configurations (and is a good idea even when not needed, since then you ensure you get the command from /usr/local/ASR and not just what happens to be first in some custom PATH.