### PR TITLE
Proposed clarifications regarding replyUrls

### DIFF
--- a/articles/active-directory-b2c/tutorial-register-applications.md
+++ b/articles/active-directory-b2c/tutorial-register-applications.md
@@ -50,8 +50,9 @@ To register a web application in your Azure AD B2C tenant, you can use our new u
 
     The following restrictions apply to redirect URIs:
 
-    * The reply URL must begin with the scheme `https`.
+    * The reply URL must begin with the scheme `https`, unless using localhost.
     * The reply URL is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the reply URL. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
+    * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` may be treated as non matching URLs in your application.
 
 1. Under **Permissions**, select the *Grant admin consent to openid and offline_access permissions* check box.
 1. Select **Register**.
@@ -71,6 +72,7 @@ To register a web application in your Azure AD B2C tenant, you can use our new u
 
     * The reply URL must begin with the scheme `https`, unless using `localhost`.
     * The reply URL is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the reply URL. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
+    * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` may be treated as non matching URLs in your application.
 
 1. Select **Create** to complete the application registration.
 

--- a/articles/active-directory-b2c/tutorial-register-applications.md
+++ b/articles/active-directory-b2c/tutorial-register-applications.md
@@ -52,7 +52,7 @@ To register a web application in your Azure AD B2C tenant, you can use our new u
 
     * The reply URL must begin with the scheme `https`, unless you use a localhost redirect URL.
     * The reply URL is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the reply URL. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
-    * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` may be treated as non matching URLs in your application.
+    * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` might be treated as nonmatching URLs in your application.
 
 1. Under **Permissions**, select the *Grant admin consent to openid and offline_access permissions* check box.
 1. Select **Register**.
@@ -72,7 +72,7 @@ To register a web application in your Azure AD B2C tenant, you can use our new u
 
     * The reply URL must begin with the scheme `https`, unless using `localhost`.
     * The reply URL is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the reply URL. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
-    * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` may be treated as non matching URLs in your application.
+    * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` might be treated as nonmatching URLs in your application.
 
 1. Select **Create** to complete the application registration.
 

--- a/articles/active-directory-b2c/tutorial-register-applications.md
+++ b/articles/active-directory-b2c/tutorial-register-applications.md
@@ -50,7 +50,7 @@ To register a web application in your Azure AD B2C tenant, you can use our new u
 
     The following restrictions apply to redirect URIs:
 
-    * The reply URL must begin with the scheme `https`, unless using localhost.
+    * The reply URL must begin with the scheme `https`, unless you use a localhost redirect URL.
     * The reply URL is case-sensitive. Its case must match the case of the URL path of your running application. For example, if your application includes as part of its path `.../abc/response-oidc`,  do not specify `.../ABC/response-oidc` in the reply URL. Because the web browser treats paths as case-sensitive, cookies associated with `.../abc/response-oidc` may be excluded if redirected to the case-mismatched `.../ABC/response-oidc` URL.
     * The reply URL should include or exclude the trailing forward slash as your application expects it. For example, `https://contoso.com/auth-response` and `https://contoso.com/auth-response/` may be treated as non matching URLs in your application.
 


### PR DESCRIPTION
* Http for localhost applies also the the new app registration experience
* Added a bullet point reminding users to consider the usage of a trailing forward slash at the end of the url