### PR TITLE
Include note about immutability of CosmosClientOptions properties

### DIFF
--- a/articles/cosmos-db/sql/tutorial-sql-api-dotnet-bulk-import.md
+++ b/articles/cosmos-db/sql/tutorial-sql-api-dotnet-bulk-import.md
@@ -126,7 +126,7 @@ Inside the `Main` method, add the following code to initialize the CosmosClient 
 [!code-csharp[Main](~/cosmos-dotnet-bulk-import/src/Program.cs?name=CreateClient)]
 
 > [!Note]
-> Once bulk execution is specified in the [CosmosClientOptions](https://docs.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions?view=azure-dotnet), they are effectively immutable for the lifetime of the CosmosClient. Changing the values will have no effect.
+> Once bulk execution is specified in the [CosmosClientOptions](/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions), they are effectively immutable for the lifetime of the CosmosClient. Changing the values will have no effect.
 
 After the bulk execution is enabled, the CosmosClient internally groups concurrent operations into single service calls. This way it optimizes the throughput utilization by distributing service calls across partitions, and finally assigning individual results to the original callers.
 

--- a/articles/cosmos-db/sql/tutorial-sql-api-dotnet-bulk-import.md
+++ b/articles/cosmos-db/sql/tutorial-sql-api-dotnet-bulk-import.md
@@ -126,7 +126,7 @@ Inside the `Main` method, add the following code to initialize the CosmosClient 
 [!code-csharp[Main](~/cosmos-dotnet-bulk-import/src/Program.cs?name=CreateClient)]
 
 > [!Note]
-> Once bulk execution is specified in the [CosmosClientOptions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions?view=azure-dotnet), they are effectively immutable for the lifetime of the CosmosClient. Changing the values will have no effect.
+> Once bulk execution is specified in the [CosmosClientOptions](https://docs.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions?view=azure-dotnet), they are effectively immutable for the lifetime of the CosmosClient. Changing the values will have no effect.
 
 After the bulk execution is enabled, the CosmosClient internally groups concurrent operations into single service calls. This way it optimizes the throughput utilization by distributing service calls across partitions, and finally assigning individual results to the original callers.
 

--- a/articles/cosmos-db/sql/tutorial-sql-api-dotnet-bulk-import.md
+++ b/articles/cosmos-db/sql/tutorial-sql-api-dotnet-bulk-import.md
@@ -125,6 +125,9 @@ Inside the `Main` method, add the following code to initialize the CosmosClient 
 
 [!code-csharp[Main](~/cosmos-dotnet-bulk-import/src/Program.cs?name=CreateClient)]
 
+> [!Note]
+> Once bulk execution is specified in the [CosmosClientOptions](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions?view=azure-dotnet), they are effectively immutable for the lifetime of the CosmosClient. Changing the values will have no effect.
+
 After the bulk execution is enabled, the CosmosClient internally groups concurrent operations into single service calls. This way it optimizes the throughput utilization by distributing service calls across partitions, and finally assigning individual results to the original callers.
 
 You can then create a container to store all our items.  Define `/pk` as the partition key, 50000 RU/s as provisioned throughput, and a custom indexing policy that will exclude all fields to optimize the write throughput. Add the following code after the CosmosClient initialization statement:


### PR DESCRIPTION
There is some potentially misleading behavior around the CosmosClientOptions class. Despite having a setter, changes to the properties are not respected and will silently do nothing. This was not mentioned in the documentation anywhere when I was learning about bulk support, and I think it could help someone out in the future.

Related to https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3012 and https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3091