### PR TITLE
Update tutorial-migrate-physical-virtual-machines.md

### DIFF
--- a/articles/migrate/tutorial-migrate-physical-virtual-machines.md
+++ b/articles/migrate/tutorial-migrate-physical-virtual-machines.md
@@ -181,7 +181,7 @@ On machines you want to migrate, you need to install the Mobility service agent.
 3. Register the agent with the replication appliance:
     ```
     cd C:\Program Files (x86)\Microsoft Azure Site Recovery\agent
-    UnifiedAgentConfigurator.exe  /CSEndPoint <replication appliance IP address> /PassphraseFilePath <Passphrase File Path>
+    UnifiedAgentConfigurator.exe  /CSEndPoint <replication appliance FQDN> /PassphraseFilePath <Passphrase File Path>
     ```
 
 ### Install on Linux


### PR DESCRIPTION
I was getting error #6 in https://docs.microsoft.com/en-us/azure/site-recovery/vmware-azure-troubleshoot-configuration-server#registration-failures (request: (60) - Peer certificate cannot be authenticated with given CA certificates) while following this steps. I could solve it by using the Configuration Server FQDN instead of the Configuration Server IP. Since there is a certificate check, seems that using the IP Address will mismatch the server name in the peer certificate.