### PR TITLE
Update quickstart-php.md

### DIFF
--- a/articles/app-service/quickstart-php.md
+++ b/articles/app-service/quickstart-php.md
@@ -89,7 +89,7 @@ To complete this quickstart:
     In the following example, replace `<app-name>` with a globally unique app name (valid characters are `a-z`, `0-9`, and `-`). The runtime is set to `PHP|7.4`. To see all supported runtimes, run [`az webapp list-runtimes`](/cli/azure/webapp#az-webapp-list-runtimes).
 
     ```azurecli-interactive
-    az webapp create --resource-group myResourceGroup --plan myAppServicePlan --name <app-name> --runtime 'PHP|7.4' --deployment-local-git
+    az webapp create --resource-group myResourceGroup --plan myAppServicePlan --name <app-name> --runtime 'PHP:8.0' --deployment-local-git
     ```
     
     When the web app has been created, the Azure CLI shows output similar to the following example:


### PR DESCRIPTION
Code syntax change for az webapp create --resource-group myResourceGroup --plan myAppServicePlan --name <app-name> --runtime 'PHP|7.4' --deployment-local-git

No longer uses | it is :