### PR TITLE
Corrected Step2 CLI command

### DIFF
--- a/articles/azure-resource-manager/bicep/key-vault-parameter.md
+++ b/articles/azure-resource-manager/bicep/key-vault-parameter.md
@@ -131,10 +131,9 @@ The following procedure shows how to create a role with the minimum permission, 
     ```azurecli-interactive
     az role definition create --role-definition "<path-to-role-file>"
     az role assignment create \
-      --role "Key Vault resource manager template deployment operator" \
+      --role "Key Vault Bicep deployment operator" \
       --scope /subscriptions/<Subscription-id>/resourceGroups/<resource-group-name> \
-      --assignee <user-principal-name> \
-      --resource-group ExampleGroup
+      --assignee <user-principal-name>
     ```
 
     # [PowerShell](#tab/azure-powershell)


### PR DESCRIPTION
In step 2. "Create the new role using the JSON file", the role name does not match the role name of the previous step. 
Also, the CLI throws error using the--resource-group parameter stating "Resource group <resource group name> is redundant because scope is supplied.