### PR TITLE
Update link for REST integration documentation

### DIFF
--- a/articles/service-bus-messaging/includes/service-bus-selector-queues.md
+++ b/articles/service-bus-messaging/includes/service-bus-selector-queues.md
@@ -12,6 +12,6 @@ ms.author: spelluru
 > * [PHP](../service-bus-php-how-to-use-queues.md)
 > * [Python](../service-bus-python-how-to-use-queues.md)
 > * [Ruby](https://github.com/Azure/azure-sdk-for-ruby)
-> * [REST](https://docs.microsoft.com/en-us/rest/api/azure/)
+> * [REST](https://docs.microsoft.com/rest/api/azure/)
 > 
 >

--- a/articles/service-bus-messaging/includes/service-bus-selector-queues.md
+++ b/articles/service-bus-messaging/includes/service-bus-selector-queues.md
@@ -12,6 +12,6 @@ ms.author: spelluru
 > * [PHP](../service-bus-php-how-to-use-queues.md)
 > * [Python](../service-bus-python-how-to-use-queues.md)
 > * [Ruby](https://github.com/Azure/azure-sdk-for-ruby)
-> * [REST](../service-bus-dotnet-get-started-with-queues.md)
+> * [REST](https://docs.microsoft.com/en-us/rest/api/azure/)
 > 
 >


### PR DESCRIPTION
The linked page said nothing about REST.

The link for REST was wrong, it redirecting to the page where you learn how to integrate the Azure Service Bus with a .NET SDK (or Java, Python, JavaScript).