### PR TITLE
Add missing custom role

### DIFF
--- a/articles/aks/configure-azure-cni.md
+++ b/articles/aks/configure-azure-cni.md
@@ -22,6 +22,7 @@ This article shows you how to use *Azure CNI* networking to create and use a vir
 * The cluster identity used by the AKS cluster must have at least [Network Contributor](../role-based-access-control/built-in-roles.md#network-contributor) permissions on the subnet within your virtual network. If you wish to define a [custom role](../role-based-access-control/custom-roles.md) instead of using the built-in Network Contributor role, the following permissions are required:
   * `Microsoft.Network/virtualNetworks/subnets/join/action`
   * `Microsoft.Network/virtualNetworks/subnets/read`
+  * `Microsoft.Authorization/roleAssignments/write`
 * The subnet assigned to the AKS node pool cannot be a [delegated subnet](../virtual-network/subnet-delegation-overview.md).
 * AKS doesn't apply Network Security Groups (NSGs) to its subnet and will not modify any of the NSGs associated with that subnet. If you provide your own subnet and add NSGs associated with that subnet, you must ensure the security rules in the NSGs allow traffic within the node CIDR range. For more details, see [Network security groups][aks-network-nsg].
 


### PR DESCRIPTION
In order to do Azure CNI networking you also require the permission Microsoft.Authorization/roleAssignments/write. This is documented in the Azure portal when you attempt to create a cluster with Azure ANI and a new virtual network - if the permission is missing, the portal displays a warning stating it is required.