### PR TITLE
Attempt to remove confusion for abbreviation

### DIFF
--- a/articles/virtual-desktop/create-profile-container-azure-ad.md
+++ b/articles/virtual-desktop/create-profile-container-azure-ad.md
@@ -13,11 +13,11 @@ ms.author: helohr
 # Create a profile container with Azure Files and Azure Active Directory (preview)
 
 > [!IMPORTANT]
-> Storing FSLogix profiles on Azure Files for Azure Active Directory (AD)-joined VMs is currently in public preview.
+> Storing FSLogix profiles on Azure Files for Azure Active Directory-joined VMs is currently in public preview.
 > This preview version is provided without a service level agreement, and is not recommended for production workloads. Certain features might not be supported or might have constrained capabilities.
 > For more information, see [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
 
-In this article, you'll learn how to create an Azure Files share to store FSLogix profiles that can be accessed by hybrid user identities authenticated with Azure Active Directory (AD). Azure AD users can now access an Azure file share using Kerberos authentication. This configuration uses Azure AD to issue the necessary Kerberos tickets to access the file share with the industry-standard SMB protocol. Your end-users can access Azure file shares over the internet without requiring a line-of-sight to domain controllers from Hybrid Azure AD-joined and Azure AD-joined VMs.
+In this article, you'll learn how to create an Azure Files share to store FSLogix profiles that can be accessed by hybrid user identities authenticated with Azure Active Directory (Azure AD). Azure AD users can now access an Azure file share using Kerberos authentication. This configuration uses Azure AD to issue the necessary Kerberos tickets to access the file share with the industry-standard SMB protocol. Your end-users can access Azure file shares over the internet without requiring a line-of-sight to domain controllers from Hybrid Azure AD-joined and Azure AD-joined VMs.
 
 In this article, you'll learn how to:
 


### PR DESCRIPTION
Using `Azure Active Directory (AD)-joined` is potentially quite confusing. I understand the meaning was to indicate that "AD" only abbreviates "Active Directory," but with the "-joined" right behind it, it reads as AD-joined as opposed to Azure AD-joined (or AAD-joined), which is not what's intended.