### PR TITLE
Update safe-url-list.md

### DIFF
--- a/articles/virtual-desktop/safe-url-list.md
+++ b/articles/virtual-desktop/safe-url-list.md
@@ -62,18 +62,12 @@ To use the Required URL Check tool:
     > ![Screenshot of accessible URLs output.](media/access.png)
 
 ## Virtual machines
-
+### Azure Public
 The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure commercial cloud:
 
 |Address|Outbound TCP port|Purpose|Service Tag|
 |---|---|---|---|
 |*.wvd.microsoft.com|443|Service traffic|WindowsVirtualDesktop|
-|gcs.prod.monitoring.core.windows.net|443|Agent traffic|AzureCloud|
-|production.diagnostics.monitoring.core.windows.net|443|Agent traffic|AzureCloud|
-|*xt.blob.core.windows.net|443|Agent traffic|AzureCloud|
-|*eh.servicebus.windows.net|443|Agent traffic|AzureCloud|
-|*xt.table.core.windows.net|443|Agent traffic|AzureCloud|
-|*xt.queue.core.windows.net|443|Agent traffic|AzureCloud|
 |*.prod.warm.ingest.monitor.core.windows.net|443|Agent traffic|AzureMonitor|
 |catalogartifact.azureedge.net|443|Azure Marketplace|AzureFrontDoor.Frontend|
 |kms.core.windows.net|1688|Windows activation|Internet|
@@ -81,29 +75,36 @@ The Azure virtual machines you create for Azure Virtual Desktop must have access
 |wvdportalstorageblob.blob.core.windows.net|443|Azure portal support|AzureCloud|
 | 169.254.169.254 | 80 | [Azure Instance Metadata service endpoint](../virtual-machines/windows/instance-metadata-service.md) | N/A |
 | 168.63.129.16 | 80 | [Session host health monitoring](../virtual-network/network-security-groups-overview.md#azure-platform-considerations) | N/A |
+|gcs.prod.monitoring.core.windows.net|443|Agent traffic (optional)|AzureCloud|
+|production.diagnostics.monitoring.core.windows.net|443|Agent traffic (optional)|AzureCloud|
+|*xt.blob.core.windows.net|443|Agent traffic (optional)|AzureCloud|
+|*eh.servicebus.windows.net|443|Agent traffic (optional)|AzureCloud|
+|*xt.table.core.windows.net|443|Agent traffic (optional)|AzureCloud|
+|*xt.queue.core.windows.net|443|Agent traffic (optional)|AzureCloud|
 
 >[!IMPORTANT]
 >Azure Virtual Desktop supports the FQDN tag. For more information, see [Use Azure Firewall to protect Azure Virtual Desktop deployments](../firewall/protect-azure-virtual-desktop.md).
 >
 >We recommend you use FQDN tags or service tags instead of URLs to prevent service issues. The listed URLs and tags only correspond to Azure Virtual Desktop sites and resources. They don't include URLs for other services like Azure Active Directory.
 
+### Azure Gov
 The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure Government cloud:
 
 |Address|Outbound TCP port|Purpose|Service Tag|
 |---|---|---|---|
 |*.wvd.azure.us|443|Service traffic|WindowsVirtualDesktop|
-|gcs.monitoring.core.usgovcloudapi.net|443|Agent traffic|AzureCloud|
-|monitoring.core.usgovcloudapi.net|443|Agent traffic|AzureCloud|
-|fairfax.warmpath.usgovcloudapi.net|443|Agent traffic|AzureCloud|
-|*xt.blob.core.usgovcloudapi.net|443|Agent traffic|AzureCloud|
-|*.servicebus.usgovcloudapi.net|443|Agent traffic|AzureCloud|
-|*xt.table.core.usgovcloudapi.net|443|Agent traffic|AzureCloud|
 |*.prod.warm.ingest.monitor.core.usgovcloudapi.net|443|Agent traffic|AzureMonitor|
 |Kms.core.usgovcloudapi.net|1688|Windows activation|Internet|
 |mrsglobalstugviffx.blob.core.usgovcloudapi.net|443|Agent and SXS stack updates|AzureCloud|
 |wvdportalstorageblob.blob.core.usgovcloudapi.net|443|Azure portal support|AzureCloud|
 | 169.254.169.254 | 80 | [Azure Instance Metadata service endpoint](../virtual-machines/windows/instance-metadata-service.md) | N/A |
 | 168.63.129.16 | 80 | [Session host health monitoring](../virtual-network/network-security-groups-overview.md#azure-platform-considerations) | N/A |
+|gcs.monitoring.core.usgovcloudapi.net|443|Agent traffic (optional)|AzureCloud|
+|monitoring.core.usgovcloudapi.net|443|Agent traffic (optional)|AzureCloud|
+|fairfax.warmpath.usgovcloudapi.net|443|Agent traffic (optional)|AzureCloud|
+|*xt.blob.core.usgovcloudapi.net|443|Agent traffic (optional)|AzureCloud|
+|*.servicebus.usgovcloudapi.net|443|Agent traffic (optional)|AzureCloud|
+|*xt.table.core.usgovcloudapi.net|443|Agent traffic (optional)|AzureCloud|
 
 The following table lists optional URLs that your Azure virtual machines can have access to:
 

--- a/articles/virtual-desktop/safe-url-list.md
+++ b/articles/virtual-desktop/safe-url-list.md
@@ -90,7 +90,8 @@ The Azure virtual machines you create for Azure Virtual Desktop must have access
 >
 >We recommend you use FQDN tags or service tags instead of URLs to prevent service issues. The listed URLs and tags only correspond to Azure Virtual Desktop sites and resources. They don't include URLs for other services like Azure Active Directory.
 
-### Azure Gov
+### Azure government cloud
+
 The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure Government cloud:
 
 |Address|Outbound TCP port|Purpose|Service Tag|

--- a/articles/virtual-desktop/safe-url-list.md
+++ b/articles/virtual-desktop/safe-url-list.md
@@ -90,7 +90,7 @@ The Azure virtual machines you create for Azure Virtual Desktop must have access
 >
 >We recommend you use FQDN tags or service tags instead of URLs to prevent service issues. The listed URLs and tags only correspond to Azure Virtual Desktop sites and resources. They don't include URLs for other services like Azure Active Directory.
 
-### Azure government cloud
+### Azure Government cloud
 
 The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure Government cloud:
 

--- a/articles/virtual-desktop/safe-url-list.md
+++ b/articles/virtual-desktop/safe-url-list.md
@@ -66,7 +66,7 @@ To use the Required URL Check tool:
 You'll need to make sure that the Azure virtual machines you create for Azure Virtual Desktop have access to the URLs in one of the following sections based on which cloud you're using.
 
 ### Azure public cloud
-The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure commercial cloud:
+The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure public cloud:
 
 |Address|Outbound TCP port|Purpose|Service Tag|
 |---|---|---|---|

--- a/articles/virtual-desktop/safe-url-list.md
+++ b/articles/virtual-desktop/safe-url-list.md
@@ -62,7 +62,10 @@ To use the Required URL Check tool:
     > ![Screenshot of accessible URLs output.](media/access.png)
 
 ## Virtual machines
-### Azure Public
+
+You'll need to make sure that the Azure virtual machines you create for Azure Virtual Desktop have access to the URLs in one of the following sections based on which cloud you're using.
+
+### Azure public cloud
 The Azure virtual machines you create for Azure Virtual Desktop must have access to the following URLs in the Azure commercial cloud:
 
 |Address|Outbound TCP port|Purpose|Service Tag|


### PR DESCRIPTION
Put titles for Azure public and gov for easier linking along with moving the legacy URLs to the bottom of the respective tables (and marking optional) to be in line with their deprecation.