### PR TITLE
Update plan-connect-design-concepts.md

### DIFF
--- a/articles/active-directory/hybrid/plan-connect-design-concepts.md
+++ b/articles/active-directory/hybrid/plan-connect-design-concepts.md
@@ -181,7 +181,7 @@ When you are selecting the attribute for providing the value of UPN to be used i
 In express settings, the assumed choice for the attribute is userPrincipalName. If the userPrincipalName attribute does not contain the value you want your users to sign in to Azure, then you must choose **Custom Installation**.
 
 >[!NOTE]
->It is recommended as best practice that UPN prefix contains more than one character.
+>It's recommended as a best practice that the UPN prefix contains more than one character.
 
 ### Custom domain state and UPN
 It is important to ensure that there is a verified domain for the UPN suffix.

--- a/articles/active-directory/hybrid/plan-connect-design-concepts.md
+++ b/articles/active-directory/hybrid/plan-connect-design-concepts.md
@@ -180,6 +180,9 @@ When you are selecting the attribute for providing the value of UPN to be used i
 
 In express settings, the assumed choice for the attribute is userPrincipalName. If the userPrincipalName attribute does not contain the value you want your users to sign in to Azure, then you must choose **Custom Installation**.
 
+>[!NOTE]
+>It is recommended as best practice that UPN prefix contains more than one character.
+
 ### Custom domain state and UPN
 It is important to ensure that there is a verified domain for the UPN suffix.
 


### PR DESCRIPTION
I'm proposing the following addition to the documentation due to a conditions where the use of a single character prefix at the UPN can culminate to failure to validate the value since during the user object creation process a random password is created prior to the assignment of the on-prem object password. This increases the chance the the prefix is contained at the random password, hence the suggestion.

>[!NOTE]
>It is recommended as best practice that UPN prefix contains more than one character.