### PR TITLE
Update private endpoint overview to reflect correct subresource

### DIFF
--- a/articles/private-link/private-endpoint-overview.md
+++ b/articles/private-link/private-endpoint-overview.md
@@ -107,7 +107,7 @@ A private-link resource is the destination target of a specified private endpoin
 | Azure Synapse Analytics | Microsoft.Synapse/workspaces | SQL, SqlOnDemand, Dev | 
 | Azure App Service | Microsoft.Web/hostingEnvironments | hosting environment |
 | Azure App Service | Microsoft.Web/sites | sites |
-| Azure Static Web Apps | Microsoft.Web/staticSites | staticSite |
+| Azure Static Web Apps | Microsoft.Web/staticSites | staticSites |
 
 > [!NOTE]
 > You can create private endpoints only on a General Purpose v2 (GPv2) storage account.


### PR DESCRIPTION
staticSite -> staticSites 

chased this issue for a while to try and understand why I was getting groupID failures when trying to reference the resource staticSite.  Added an "s" and it succeeded