### PR TITLE
Fix typo in functions-app-setttings.md

### DIFF
--- a/articles/azure-functions/functions-app-settings.md
+++ b/articles/azure-functions/functions-app-settings.md
@@ -175,7 +175,7 @@ The tenant ID of the app registration used to access the vault where keys are st
 
 The URI of a key vault instance used to store keys. Supported in version 4.x and later versions of the Functions runtime. This is the recommended setting for using a key vault instance for key storage. Requires that `AzureWebJobsSecretStorageType` be set to `keyvault`.
 
-The `AzureWebJobsSecretStorageKeyVaultTenantId` value should be the full value of **Vault URI** displayed in the **Key Vault overview** tab, including `https://`.
+The `AzureWebJobsSecretStorageKeyVaultUri` value should be the full value of **Vault URI** displayed in the **Key Vault overview** tab, including `https://`.
 
 The vault must have an access policy corresponding to the system-assigned managed identity of the hosting resource. The access policy should grant the identity the following secret permissions: `Get`,`Set`, `List`, and `Delete`. <br/>When running locally, the developer identity is used, and settings must be in the [local.settings.json file](functions-develop-local.md#local-settings-file). 
 


### PR DESCRIPTION
I am pretty sure documenation is talking about `AzureWebJobsSecretStorageKeyVaultUri` and not `AzureWebJobsSecretStorageKeyVaultTenantId`.