### PR TITLE
Specify that you can pass a -1

### DIFF
--- a/articles/cosmos-db/sql/how-to-time-to-live.md
+++ b/articles/cosmos-db/sql/how-to-time-to-live.md
@@ -199,7 +199,7 @@ async function createcontainerWithTTL(db: Database, containerDefinition: Contain
 
 In addition to setting a default time to live on a container, you can set a time to live for an item. Setting time to live at the item level will override the default TTL of the item in that container.
 
-* To set the TTL on an item, you need to provide a non-zero positive number, which indicates the period, in seconds, to expire the item after the last modified timestamp of the item `_ts`.
+* To set the TTL on an item, you need to provide a non-zero positive number, which indicates the period, in seconds, to expire the item after the last modified timestamp of the item `_ts`. You can provide a `-1` as well when the item should not expire.
 
 * If the item doesn't have a TTL field, then by default, the TTL set to the container will apply to the item.
 


### PR DESCRIPTION
The docs say...

> you need to provide a non-zero positive number

However, you can pass `-1` too. In this PR, I make this more clear.