### PR TITLE
Tweak wording to avoid use of gender-specific language

### DIFF
--- a/articles/active-directory/manage-apps/grant-consent-single-user.md
+++ b/articles/active-directory/manage-apps/grant-consent-single-user.md
@@ -19,7 +19,7 @@ ms.author: phsignor
 
 In this article, you'll learn how to grant consent on behalf of a single user by using PowerShell.
 
-When a user grants their own consent, the following events occur:
+When a user grants consent for themselves, the following events occur
 
 1. A service principal for the client application is created, if it doesn't already exist. A service principal is the instance of an application or a service in your Azure Active Directory (Azure AD) tenant. Access that's granted to the app or service is associated with this service principal object.
 

--- a/articles/active-directory/manage-apps/grant-consent-single-user.md
+++ b/articles/active-directory/manage-apps/grant-consent-single-user.md
@@ -19,7 +19,7 @@ ms.author: phsignor
 
 In this article, you'll learn how to grant consent on behalf of a single user by using PowerShell.
 
-When a user grants consent on their own behalf, the following events occur:
+When a user grants their own consent, the following events occur:
 
 1. A service principal for the client application is created, if it doesn't already exist. A service principal is the instance of an application or a service in your Azure Active Directory (Azure AD) tenant. Access that's granted to the app or service is associated with this service principal object.
 

--- a/articles/active-directory/manage-apps/grant-consent-single-user.md
+++ b/articles/active-directory/manage-apps/grant-consent-single-user.md
@@ -19,7 +19,7 @@ ms.author: phsignor
 
 In this article, you'll learn how to grant consent on behalf of a single user by using PowerShell.
 
-When a user grants consent on his or her own behalf, the following events occur:
+When a user grants consent on their own behalf, the following events occur:
 
 1. A service principal for the client application is created, if it doesn't already exist. A service principal is the instance of an application or a service in your Azure Active Directory (Azure AD) tenant. Access that's granted to the app or service is associated with this service principal object.
 


### PR DESCRIPTION
Have submitted this PR as it would be good to reflect on the wording so as to align to [Microsoft's Bias-free communication style guide](https://docs.microsoft.com/en-us/style-guide/bias-free-communication), but not sure that substituting 'his or her' with 'their' is correct, based on [this article](http://www.kentlaw.edu/academics/lrw/grinker/LwtaGender_Neutral_Language.htm#:~:text=Do%20not%20use%20%22their%22%20as,for%20any%20pronoun%20at%20all.).

It advises that re-writing the sentence to avoid the need for gender-based pronouns is, instead, the best route to go down.