### PR TITLE
VC++ Redist 2015 is not enough

### DIFF
--- a/articles/kinect-dk/body-sdk-setup.md
+++ b/articles/kinect-dk/body-sdk-setup.md
@@ -25,9 +25,9 @@ The Body Tracking SDK requires a NVIDIA GPU installed in the host PC. The recomm
 
 Download and install the latest NVIDIA driver for your graphics card. Older drivers may not be compatible with the CUDA binaries redistributed with the body tracking SDK.
 
-### [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
+### [Visual C++ Redistributable for Visual Studio 2015-2022](https://docs.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 
-Download and install Visual C++ Redistributable for Visual Studio 2015. 
+Download and install Visual C++ Redistributable for Visual Studio 2015-2022 (or latest). 
 
 ## Set up hardware
 


### PR DESCRIPTION
Visual C++ Redistributable for Visual Studio 2015 is not enough for body tracking SDK. having only 2015 (x86 and x64) k4abt_simple_3d_viewer.exe gives the following error:

[2022-04-05 11:28:54.916] [error] [t=4444] [K4ABT] ..\src\TrackerHost\TrackerHost.cpp (184): Create(). Find onnxruntime.dll at C:\Program Files\Azure Kinect Body Tracking SDK\tools\onnxruntime.dll but it doesn't load correctly!
[2022-04-05 11:28:54.917] [error] [t=4444] [K4ABT] ..\src\sdk\k4abt.cpp (39): tracker->Create(sensor_calibration, config) returned failure in k4abt_tracker_create()
Body tracker initialization failed!

Visual C++ Redistributable for Visual Studio 2015-2019 or 2015-2022 should be installed.