### PR TITLE
Fix a link to "az group delete"

### DIFF
--- a/includes/cli-clean-up-resources.md
+++ b/includes/cli-clean-up-resources.md
@@ -7,4 +7,4 @@ manager: barbkess
 ms.custom: devx-track-azurecli
 ---
 
-Use the following command to remove the resource group and all resources associated with it using the [az group delete](/cli/azure/vm/extension#az-vm-extension-set) command - unless you have an ongoing need for these resources. Some of these resources may take a while to create, as well as to delete.
+Use the following command to remove the resource group and all resources associated with it using the [az group delete](/azure-resource-manager/management/delete-resource-group?tabs=azure-cli#tabpanel_1_azure-cli) command - unless you have an ongoing need for these resources. Some of these resources may take a while to create, as well as to delete.


### PR DESCRIPTION
I've replaced it with the conceptual article, but maybe "/cli/azure/group#az-group-delete" link is suitable too.