### PR TITLE
Updating built in roles that can access report

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-methods-activity.md
+++ b/articles/active-directory/authentication/howto-authentication-methods-activity.md
@@ -33,6 +33,8 @@ The following roles have the required permissions:
 - Reports Reader
 - Security Reader
 - Global Reader
+- Application Administrator
+- Cloud Application Administrator
 - Security Operator
 - Security Administrator
 - Global Administrator


### PR DESCRIPTION
Added app admin and cloud app admin to the docs to show full list of roles that can access the report