### PR TITLE
Change the type for parameter values for New-AzNetworkSecurityRuleConfig

### DIFF
--- a/articles/virtual-machines/windows/nsg-quickstart-powershell.md
+++ b/articles/virtual-machines/windows/nsg-quickstart-powershell.md
@@ -37,11 +37,11 @@ $httprule = New-AzNetworkSecurityRuleConfig `
     -Access "Allow" `
     -Protocol "Tcp" `
     -Direction "Inbound" `
-    -Priority "100" `
+    -Priority 100 `
     -SourceAddressPrefix "Internet" `
     -SourcePortRange * `
     -DestinationAddressPrefix * `
-    -DestinationPortRange 80
+    -DestinationPortRange "80"
 ```
 
 Next, create your Network Security group with [New-AzNetworkSecurityGroup](/powershell/module/az.network/new-aznetworksecuritygroup) and assign the HTTP rule you just created as follows. The following example creates a Network Security Group named *myNetworkSecurityGroup*:


### PR DESCRIPTION
The `-Priority` parameter expects the integer and `-DestinationPortRange` expects an array of strings. 
PowerShell is forgiving about converting "100" into 100, and 80 into "80", but it's better to be precise. :)