### PR TITLE
Fix Small Typo

### DIFF
--- a/articles/azure-functions/durable/durable-functions-overview.md
+++ b/articles/azure-functions/durable/durable-functions-overview.md
@@ -244,7 +244,7 @@ $Total = ($Outputs | Measure-Object -Sum).Sum
 Invoke-DurableActivity -FunctionName 'F3' -Input $Total
 ```
 
-The fan-out work is distributed to multiple instances of the `F2` function. Please note the usage of the `NoWait` switch on the `F2` function invocation: this switch allows the orchestrator to proceed invoking `F2` without for activity completion. The work is tracked by using a dynamic list of tasks. The `Wait-ActivityFunction` command is called to wait for all the called functions to finish. Then, the `F2` function outputs are aggregated from the dynamic task list and passed to the `F3` function.
+The fan-out work is distributed to multiple instances of the `F2` function. Please note the usage of the `NoWait` switch on the `F2` function invocation: this switch allows the orchestrator to proceed invoking `F2` without waiting for activity completion. The work is tracked by using a dynamic list of tasks. The `Wait-ActivityFunction` command is called to wait for all the called functions to finish. Then, the `F2` function outputs are aggregated from the dynamic task list and passed to the `F3` function.
 
 The automatic checkpointing that happens at the `Wait-ActivityFunction` call ensures that a potential midway crash or reboot doesn't require restarting an already completed task.
 


### PR DESCRIPTION
From 

> to proceed invoking F2 without for activity completion.

to 

> to proceed invoking F2 without **waiting** for activity completion.

