### PR TITLE
Updated the ARM template to show a secure CORS sample

### DIFF
--- a/articles/cosmos-db/sql/how-to-configure-cross-origin-resource-sharing.md
+++ b/articles/cosmos-db/sql/how-to-configure-cross-origin-resource-sharing.md
@@ -50,7 +50,7 @@ To enable CORS by using a Resource Manager template, add the “cors” section 
     "databaseAccountOfferType": "Standard",
     "cors": [
       {
-        "allowedOrigins": "*"
+        "allowedOrigins": "https://contoso.com"
       }
     ]
   }


### PR DESCRIPTION
You should never use CORS when origins == '*' because this means any URI, which defeats the purpose of CORS