### PR TITLE
Fix typo in concept-conditional-access-users-groups.md

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-users-groups.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-users-groups.md
@@ -74,7 +74,7 @@ By default the policy will provide an option to exclude the current user from th
 
 ![Warning, don't lock yourself out!](./media/concept-conditional-access-users-groups/conditional-access-users-and-groups-lockout-warning.png)
 
-If you do find yourself locked out[What to do if you are locked out of the Azure portal?](troubleshoot-conditional-access.md#what-to-do-if-youre-locked-out-of-the-azure-portal)
+If you do find yourself locked out [What to do if you are locked out of the Azure portal?](troubleshoot-conditional-access.md#what-to-do-if-youre-locked-out-of-the-azure-portal)
 
 ## Next steps
 

--- a/articles/active-directory/conditional-access/concept-conditional-access-users-groups.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-users-groups.md
@@ -74,7 +74,7 @@ By default the policy will provide an option to exclude the current user from th
 
 ![Warning, don't lock yourself out!](./media/concept-conditional-access-users-groups/conditional-access-users-and-groups-lockout-warning.png)
 
-If you do find yourself locked out [What to do if you are locked out of the Azure portal?](troubleshoot-conditional-access.md#what-to-do-if-youre-locked-out-of-the-azure-portal)
+If you do find yourself locked out, see [What to do if you are locked out of the Azure portal?](troubleshoot-conditional-access.md#what-to-do-if-youre-locked-out-of-the-azure-portal)
 
 ## Next steps
 


### PR DESCRIPTION
There was no space between the end of this sentence and a hyperlink. Fixed.