### PR TITLE
VNET is now supported for Azure Image Builder DevOps task

### DIFF
--- a/articles/virtual-machines/linux/image-builder-devops-task.md
+++ b/articles/virtual-machines/linux/image-builder-devops-task.md
@@ -81,7 +81,12 @@ Image Builder requires a Managed Identity, which it uses to read source custom i
 
 ### VNET Support
 
-Currently the DevOps task does not support specifying an existing Subnet, this is on the roadmap, but if you want to utilize an existing VNET, you can use an ARM template, with an Image Builder template nested inside, please see the Windows Image Builder template examples on how this is achieved, or alternatively use [AZ AIB PowerShell](../windows/image-builder-powershell.md).
+The VM that is created can be configured to be in a specific VNET.
+Provide the resource id of a pre-existing subnet in the 'VNet Configuration (Optional)' input field when configuring the task.
+Omit if no specific virtual network needs to be used. Review https://docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-networking for more information.
+
+
+does not support specifying an existing Subnet, this is on the roadmap, but if you want to utilize an existing VNET, you can use an ARM template, with an Image Builder template nested inside, please see the Windows Image Builder template examples on how this is achieved, or alternatively use [AZ AIB PowerShell](../windows/image-builder-powershell.md).
 
 ### Source
 

--- a/articles/virtual-machines/linux/image-builder-devops-task.md
+++ b/articles/virtual-machines/linux/image-builder-devops-task.md
@@ -85,9 +85,6 @@ The VM that is created can be configured to be in a specific VNET.
 Provide the resource id of a pre-existing subnet in the 'VNet Configuration (Optional)' input field when configuring the task.
 Omit if no specific virtual network needs to be used. Review https://docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-networking for more information.
 
-
-does not support specifying an existing Subnet, this is on the roadmap, but if you want to utilize an existing VNET, you can use an ARM template, with an Image Builder template nested inside, please see the Windows Image Builder template examples on how this is achieved, or alternatively use [AZ AIB PowerShell](../windows/image-builder-powershell.md).
-
 ### Source
 
 The source images must be of the supported Image Builder OSs. You can choose existing custom images in the same region as Image Builder is running from:

--- a/articles/virtual-machines/linux/image-builder-devops-task.md
+++ b/articles/virtual-machines/linux/image-builder-devops-task.md
@@ -83,7 +83,7 @@ Image Builder requires a Managed Identity, which it uses to read source custom i
 
 The VM that is created can be configured to be in a specific VNET.
 Provide the resource id of a pre-existing subnet in the 'VNet Configuration (Optional)' input field when configuring the task.
-Omit if no specific virtual network needs to be used. Review https://docs.microsoft.com/en-us/azure/virtual-machines/linux/image-builder-networking for more information.
+Omit if no specific virtual network needs to be used. Review https://docs.microsoft.com/azure/virtual-machines/linux/image-builder-networking for more information.
 
 ### Source
 


### PR DESCRIPTION
There is a VNET option that works when configuring the Azure Image Builder DevOps Task.
![Screen Shot 2022-04-19 at 9 53 19 AM](https://user-images.githubusercontent.com/6897215/164055556-926b733f-815a-477a-9926-05517bcc005c.png)
