### PR TITLE
maintenance-and-updates.md: fix reasoning for temp disk loss

### DIFF
--- a/articles/virtual-machines/maintenance-and-updates.md
+++ b/articles/virtual-machines/maintenance-and-updates.md
@@ -63,7 +63,7 @@ In the rare case where VMs need to be rebooted for planned maintenance, you'll b
 
 During the *self-service phase*, which typically lasts four weeks, you start the maintenance on your VMs. As part of the self-service, you can query each VM to see its status and the result of your last maintenance request.
 
-When you start self-service maintenance, your VM is redeployed to an already updated node. Because the VM reboots, the temporary disk is lost and dynamic IP addresses associated with the virtual network interface are updated.
+When you start self-service maintenance, your VM is redeployed to an already updated node. Because the VM is redeployed, the temporary disk is lost and dynamic IP addresses associated with the virtual network interface are updated.
 
 If an error arises during self-service maintenance, the operation stops, the VM isn't updated, and you get the option to retry the self-service maintenance. 
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#temporary-disk says:
> Data on the temporary disk may be lost during a maintenance event or when you redeploy a VM. During a successful standard reboot of the VM, data on the temporary disk will persist.

So I think this is a typo (emphasis mine):
> When you start self-service maintenance, your VM is **redeployed** to an already updated node. Because the VM **reboots**, the temporary disk is lost

and the reason for temp disk loss is actually the redeployment