### PR TITLE
Update sample-template-experiment.md

### DIFF
--- a/articles/chaos-studio/sample-template-experiment.md
+++ b/articles/chaos-studio/sample-template-experiment.md
@@ -119,7 +119,7 @@ In this sample, we create a chaos experiment with a single target resource and a
         "value": "eastus"
       },
       "chaosTargetResourceId": {
-        "value": "eastus"
+        "value": "/subscriptions/<subscription-id>/resourceGroups/<rg-name>/providers/Microsoft.DocumentDB/databaseAccounts/<account-name>"
       }
   }
 }


### PR DESCRIPTION
The parameter value for  chaosTargetResourceId is East US, which should be target resource ID not the location. 

"chaosTargetResourceId": {
        "value": "eastus"
      }
	  
	   "chaosTargetResourceId": {
      "type": "string",
      "metadata": {
        "description": "Resource ID of the chaos target. This is the resource ID of the resource being targeted plus the target proxy resource."
      }
    }