### PR TITLE
Updating to Microsoft Defender for Containers name

### DIFF
--- a/articles/defender-for-cloud/defender-for-container-registries-cicd.md
+++ b/articles/defender-for-cloud/defender-for-container-registries-cicd.md
@@ -1,6 +1,6 @@
 ---
 title: Defender for Cloud's vulnerability scanner for container images in CI/CD workflows
-description: Learn how to scan container images in CI/CD workflows with Microsoft Defender for container registries 
+description: Learn how to scan container images in CI/CD workflows with Microsoft Defender for Containers
 ms.date: 11/09/2021
 ms.topic: how-to
 ms.author: benmansheim
@@ -13,7 +13,7 @@ author: bmansheim
 
 This page explains how to scan your Azure Container Registry-based container images with the integrated vulnerability scanner when they're built as part of your GitHub workflows.
 
-To set up the scanner, you'll need to enable **Microsoft Defender for container registries** and the CI/CD integration. When your CI/CD workflows push images to your registries, you can view registry scan results and a summary of CI/CD scan results.
+To set up the scanner, you'll need to enable **Microsoft Defender for Containers** and the CI/CD integration. When your CI/CD workflows push images to your registries, you can view registry scan results and a summary of CI/CD scan results.
 
 The findings of the CI/CD scans are an enrichment to the existing registry scan findings by Qualys. Defender for Cloud's CI/CD scanning is powered by [Aqua Trivy](https://github.com/aquasecurity/trivy).
 
@@ -27,13 +27,13 @@ You’ll get traceability information such as the GitHub workflow and the GitHub
 |Aspect|Details|
 |----|:----|
 |Release state:| **This CI/CD integration is in preview.**<br>We recommend that you experiment with it on non-production workflows only.<br>[!INCLUDE [Legalese](../../includes/defender-for-cloud-preview-legal-text.md)]|
-|Pricing:|**Microsoft Defender for container registries** is billed as shown on the [pricing page](https://azure.microsoft.com/pricing/details/defender-for-cloud/)|
+|Pricing:|**Microsoft Defender for Containers** is billed as shown on the [pricing page](https://azure.microsoft.com/pricing/details/defender-for-cloud/)|
 |Clouds:|:::image type="icon" source="./media/icons/yes-icon.png"::: Commercial clouds<br>:::image type="icon" source="./media/icons/no-icon.png"::: National (Azure Government, Azure China 21Vianet)|
 
 
 ## Prerequisites
 
-To scan your images as they're pushed by CI/CD workflows into your registries, you must have **Microsoft Defender for container registries** enabled on the subscription.
+To scan your images as they're pushed by CI/CD workflows into your registries, you must have **Microsoft Defender for Containers** enabled on the subscription.
 
 ## Set up vulnerability scanning of your CI/CD workflows
 


### PR DESCRIPTION
Hello team,
I updated the service name from "Microsoft Defender for container registries" to "Microsoft Defender for Containers" everywhere it appears because I understand the former is deprecated.