### PR TITLE
Sentences are duplicate

### DIFF
--- a/articles/application-gateway/configuration-infrastructure.md
+++ b/articles/application-gateway/configuration-infrastructure.md
@@ -61,9 +61,8 @@ For this scenario, use NSGs on the Application Gateway subnet. Put the following
 1. Allow incoming traffic from a source IP or IP range with the destination as the entire Application Gateway subnet address range and destination port as your inbound access port, for example, port 80 for HTTP access.
 2. Allow incoming requests from source as **GatewayManager** service tag and destination as **Any** and destination ports as 65503-65534 for the Application Gateway v1 SKU, and ports 65200-65535 for v2 SKU for [back-end health status communication](./application-gateway-diagnostics.md). This port range is required for Azure infrastructure communication. These ports are protected (locked down) by Azure certificates. Without appropriate certificates in place, external entities can't initiate changes on those endpoints.
 3. Allow incoming Azure Load Balancer probes (*AzureLoadBalancer* tag) on the [network security group](../virtual-network/network-security-groups-overview.md).
-4. Allow expected inbound traffic to match your listener configuration (i.e. if you have listeners configured for port 80, you will want an allow inbound rule for port 80)
-5. Block all other incoming traffic by using a deny-all rule.
-6. Allow outbound traffic to the Internet for all destinations.
+4. Block all other incoming traffic by using a deny-all rule.
+5. Allow outbound traffic to the Internet for all destinations.
 
 ## Supported user-defined routes 
 


### PR DESCRIPTION
Both of bellow sentences are same meaning. Could you delate #4 ?

1. Allow incoming traffic from a source IP or IP range with the destination as the entire Application Gateway subnet address range and destination port as your inbound access port, for example, port 80 for HTTP access.

4. Allow expected inbound traffic to match your listener configuration (i.e. if you have listeners configured for port 80, you will want an allow inbound rule for port 80)