### PR TITLE
Update configure-authentication-sample-angular-spa-app.md

### DIFF
--- a/articles/active-directory-b2c/configure-authentication-sample-angular-spa-app.md
+++ b/articles/active-directory-b2c/configure-authentication-sample-angular-spa-app.md
@@ -145,7 +145,7 @@ export const b2cPolicies = {
 export const msalConfig: Configuration = {
      auth: {
          clientId: '<your-MyApp-application-ID>',
-         authority: b2cPolicies.authorities.signUpSignIn,
+         authority: b2cPolicies.authorities.signUpSignIn.authority,
          knownAuthorities: [b2cPolicies.authorityDomain],
          redirectUri: '/', 
      },


### PR DESCRIPTION
auth.authority expects "b2cPolicies.authorities.signUpSignIn.authority" otherwise users get an error 
TS2322: Type '{ authority: string; }' is not assignable to type 'string'.

I have corrected this in the docs