### PR TITLE
Update entitlement-management-organization.md

### DIFF
--- a/articles/active-directory/governance/entitlement-management-organization.md
+++ b/articles/active-directory/governance/entitlement-management-organization.md
@@ -156,6 +156,9 @@ Only users from configured connected organizations can request access packages t
 
 > [!NOTE]
 > As part of rolling out this new feature, all connected organizations created before 09/09/20 were considered **configured**. If you had an access package that allowed users from any organization to sign up, you should review your list of connected organizations that were created before that date to ensure none are miscategorized as **configured**.  An admin can update the **State** property as appropriate. For guidance, see [Update a connected organization](#update-a-connected-organization).
+> [!NOTE]
+>  In some cases, a user might request an access package using their personal account having the same domain as the connected organization resulting in a new suggested connected organization. In this case, make sure the user is using their organization account instead and the portal will identify this user coming from the configured connected organization Azure AD tenant.
+
 
 ## Next steps
 


### PR DESCRIPTION
Hi,

I have worked on couple of support cases where customers were reporting an issue with users coming from a connected org requesting an access package and it results in a new suggested connected org. This is because the user is using their personal account instead of the organization account. The connected org represents the Azure AD version of the organization so the portal did not identify the user coming from this tenant since they are using their personal account hence attempting to create a suggested connected org. I have added a note box in the doc.