### PR TITLE
Update instructions to set service port to 8080

### DIFF
--- a/articles/aks/devops-pipeline.md
+++ b/articles/aks/devops-pipeline.md
@@ -88,7 +88,9 @@ Within your selected organization, create a _project_. If you don't have any pro
 
 1. Select the name of your container registry.
 
-1. You can leave the image name and the service port set to the defaults.
+1. You can leave the image name set to the default.
+
+1. Set the service port to 8080.
 
 1. Set the **Enable Review App for Pull Requests** checkbox for [review app](/azure/devops/pipelines/process/environments-kubernetes) related configuration to be included in the pipeline YAML auto-generated in subsequent steps.
 


### PR DESCRIPTION
Current instructions leave the service port as default of 80 which means the application cannot be accessed when testing.

Resolves #91898 