### PR TITLE
Clarify that you should not use App Registrations Object ID

### DIFF
--- a/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
+++ b/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
@@ -207,6 +207,11 @@ Now you can use the SPN to automatically access EA APIs. The SPN has the Subscri
 
 You must identify and use the Enterprise application object ID where you granted the EA role. If you use the Object ID from some other application, API calls will fail. Verify that you’re using the correct Enterprise application object ID.
 
+If you receive the error below when making your API call, then you may be incorrectly using the SPN object ID value located in App Registrations. To resolve this error, ensure you are using the SPN object ID from Enterprise Applications, not App Registrations.
+
+`The provided principal Tenant Id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx and principal Object Id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx are not valid`
+
+
 ## Next steps
 
 Learn more about [Azure EA portal administration](ea-portal-administration.md).

--- a/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
+++ b/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
@@ -207,7 +207,7 @@ Now you can use the SPN to automatically access EA APIs. The SPN has the Subscri
 
 You must identify and use the Enterprise application object ID where you granted the EA role. If you use the Object ID from some other application, API calls will fail. Verify that you’re using the correct Enterprise application object ID.
 
-If you receive the error below when making your API call, then you may be incorrectly using the SPN object ID value located in App Registrations. To resolve this error, ensure you are using the SPN object ID from Enterprise Applications, not App Registrations.
+If you receive the following error when making your API call, then you may be incorrectly using the SPN object ID value located in App Registrations. To resolve this error, ensure you're using the SPN object ID from Enterprise Applications, not App Registrations.
 
 `The provided principal Tenant Id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx and principal Object Id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx are not valid`
 


### PR DESCRIPTION
Clarify that the SPN Object ID from app registrations cannot be used and include example error message that API call will return