### PR TITLE
Update atlassian-cloud-provisioning-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/atlassian-cloud-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/atlassian-cloud-provisioning-tutorial.md
@@ -32,7 +32,7 @@ The scenario outlined in this tutorial assumes that you already have the followi
 
 * [An Azure AD tenant](../develop/quickstart-create-new-tenant.md).
 * A user account in Azure AD with [permission](../roles/permissions-reference.md) to configure provisioning (e.g. Application Administrator, Cloud Application administrator, Application Owner, or Global Administrator).
-* [An Atlassian Cloud tenant](https://www.atlassian.com/licensing/cloud)
+* [An Atlassian Cloud tenant](https://www.atlassian.com/licensing/cloud) with an Atlassian Access subscription.
 * A user account in Atlassian Cloud with Admin permissions.
 
 > [!NOTE]


### PR DESCRIPTION
Denoting that having an Atlassian tenant is not enough to enable functionality, as a subscription to Access is required.