### PR TITLE
FIX: correct FastAPI sample

### DIFF
--- a/articles/azure-monitor/app/opencensus-python-request.md
+++ b/articles/azure-monitor/app/opencensus-python-request.md
@@ -145,11 +145,14 @@ OpenCensus doesn't have an extension for FastAPI. To write your own FastAPI midd
     HTTP_URL = COMMON_ATTRIBUTES['HTTP_URL']
     HTTP_STATUS_CODE = COMMON_ATTRIBUTES['HTTP_STATUS_CODE']
     
-    tracer = Tracer(exporter=AzureExporter(connection_string=f'InstrumentationKey={APPINSIGHTS_INSTRUMENTATIONKEY}'),sampler=ProbabilitySampler(1.0))
+    APPINSIGHTS_CONNECTION_STRING='<your-appinsights_connection-string-here>'
+    exporter=AzureExporter(connection_string=f'{APPINSIGHTS_CONNECTION_STRING}')
+    sampler=ProbabilitySampler(1.0)
 
     # fastapi middleware for opencensus
     @app.middleware("http")
-    async def middlewareOpencensus(request: Request, call_next):        
+    async def middlewareOpencensus(request: Request, call_next):  
+        tracer = Tracer(exporter=exporter, sampler=sampler)       
         with tracer.span("main") as span:
             span.span_kind = SpanKind.SERVER
 


### PR DESCRIPTION
Proposed fix for issue [#91897](https://github.com/MicrosoftDocs/azure-docs/issues/91897).

1. Use separate tracer instance (for every request) to ensure incoming requests have a separate trace/operation/correlation id. Tracer instances share Azure exporter and sampler instance.
1. Updated how to create AzureExporter (connection string). If appinsights connection string doesn't contain a specific endpoint then it might result in the folllowing server error:

`Non-retryable server side error 404: {"itemsReceived":1,"itemsAccepted":0,"errors":[{"index":0,"statusCode":404,"message":"Ingestion is allowed only from stamp specific endpoint - Location: https://westeurope-5.in.applicationinsights.azure.com/v2.1/track","location":"https://westeurope-5.in.applicationinsights.azure.com/v2.1/track","cacheControl":"max-age=604800"}]}`

Better to keep it more generic and let users provide the actual connection string.