### PR TITLE
Added note to StringSplit claims tranformation

### DIFF
--- a/articles/active-directory-b2c/string-transformations.md
+++ b/articles/active-directory-b2c/string-transformations.md
@@ -1178,6 +1178,8 @@ Returns a string array that contains the substrings in this instance that are de
 | InputParameter | delimiter | string | The string to use as a separator, such as comma `,`. |
 | OutputClaim | outputClaim | stringCollection | A string collection whose elements contain the substrings in this string that are delimited by the `delimiter` input parameter. |
 
+> **Note:** Any existing elements in the `OutputClaim` stringCollection will be removed.
+
 ### Example of StringSplit
 
 The following example takes a comma delimiter string of user roles, and converts it to a string collection.

--- a/articles/active-directory-b2c/string-transformations.md
+++ b/articles/active-directory-b2c/string-transformations.md
@@ -1178,7 +1178,8 @@ Returns a string array that contains the substrings in this instance that are de
 | InputParameter | delimiter | string | The string to use as a separator, such as comma `,`. |
 | OutputClaim | outputClaim | stringCollection | A string collection whose elements contain the substrings in this string that are delimited by the `delimiter` input parameter. |
 
-> **Note:** Any existing elements in the `OutputClaim` stringCollection will be removed.
+> [!NOTE]
+> Any existing elements in the `OutputClaim` stringCollection will be removed.
 
 ### Example of StringSplit
 


### PR DESCRIPTION
Added a note to the StringSplit section highlighting that any existing elements of the OutputClaim stringCollection will be removed on execution of the claims transformation.