### PR TITLE
Update to reflect ability to pull NPSP data schema

### DIFF
--- a/articles/data-factory/connector-salesforce.md
+++ b/articles/data-factory/connector-salesforce.md
@@ -35,6 +35,9 @@ Specifically, this Salesforce connector supports:
 - Salesforce Developer, Professional, Enterprise, or Unlimited editions.
 - Copying data from and to Salesforce production, sandbox, and custom domain.
 
+>[!NOTE]
+>This function supports copy of any schema from the above mentioned Salesforce environments, including the [Nonprofit Success Pack](https://www.salesforce.org/products/nonprofit-success-pack/) (NPSP). This allows you to bring your Salesforce nonprofit data into Azure, work with it in Azure data services, unify it with other data sets, and visualize it in Power BI for rapid insights.
+
 The Salesforce connector is built on top of the Salesforce REST/Bulk API. When copying data from Salesforce, the connector automatically chooses between REST and Bulk APIs based on the data size – when the result set is large, Bulk API is used for better performance; You can explicitly set the API version used to read/write data via [`apiVersion` property](#linked-service-properties) in linked service.
 
 >[!NOTE]


### PR DESCRIPTION
The purpose of this change is to call out the ability of this connector to pull many different data schemas in Salesforce, specifically the nonprofit success pack.  We have worked with both Salesforce and the Azure Data Factory team to validate this data pull success for this schema.  Calling out this ability is critical for the MS Tech for Social Impact Sales team.