### PR TITLE
Added example of number as a string

### DIFF
--- a/articles/cosmos-db/sql/sql-query-is-number.md
+++ b/articles/cosmos-db/sql/sql-query-is-number.md
@@ -37,17 +37,18 @@ IS_NUMBER(<expr>)
 SELECT   
     IS_NUMBER(true) AS isNum1,   
     IS_NUMBER(1) AS isNum2,  
-    IS_NUMBER("value") AS isNum3,   
-    IS_NUMBER(null) AS isNum4,  
-    IS_NUMBER({prop: "value"}) AS isNum5,   
-    IS_NUMBER([1, 2, 3]) AS isNum6,  
-    IS_NUMBER({prop: "value"}.prop2) AS isNum7  
+    IS_NUMBER("value") AS isNum3, 
+    IS_NUMBER("12") AS isNum4,
+    IS_NUMBER(null) AS isNum5,  
+    IS_NUMBER({prop: "value"}) AS isNum6,   
+    IS_NUMBER([1, 2, 3]) AS isNum7,  
+    IS_NUMBER({prop: "value"}.prop2) AS isNum8  
 ```  
   
  Here is the result set.  
   
 ```json
-[{"isNum1":false,"isNum2":true,"isNum3":false,"isNum4":false,"isNum5":false,"isNum6":false,"isNum7":false}]  
+[{"isNum1":false,"isNum2":true,"isNum3":false,"isNum4":false,"isNum5":false,"isNum6":false,"isNum7":false,"isNum8":false}]  
 ```  
 
 ## Remarks

--- a/articles/cosmos-db/sql/sql-query-is-number.md
+++ b/articles/cosmos-db/sql/sql-query-is-number.md
@@ -37,12 +37,13 @@ IS_NUMBER(<expr>)
 SELECT   
     IS_NUMBER(true) AS isBooleanANumber,   
     IS_NUMBER(1) AS isNumberANumber, 
-    IS_NUMBER("value") AS isNum3, 
-    IS_NUMBER("12") AS isNum4,
-    IS_NUMBER(null) AS isNum5,  
-    IS_NUMBER({prop: "value"}) AS isNum6,   
-    IS_NUMBER([1, 2, 3]) AS isNum7,  
-    IS_NUMBER({prop: "value"}.prop2) AS isNum8  
+    IS_NUMBER("value") AS isTextStringANumber, 
+    IS_NUMBER("1") AS isNumberStringANumber,
+    IS_NUMBER(null) AS isNullANumber,  
+    IS_NUMBER({prop: "value"}) AS isObjectANumber,   
+    IS_NUMBER([1, 2, 3]) AS isArrayANumber,  
+    IS_NUMBER({stringProp: "value"}.stringProp) AS isObjectStringPropertyANumber, 
+    IS_NUMBER({numberProp: 1}.numberProp) AS isObjectNumberPropertyANumber  
 ```  
   
  Here is the result set.  

--- a/articles/cosmos-db/sql/sql-query-is-number.md
+++ b/articles/cosmos-db/sql/sql-query-is-number.md
@@ -35,8 +35,8 @@ IS_NUMBER(<expr>)
   
 ```sql
 SELECT   
-    IS_NUMBER(true) AS isNum1,   
-    IS_NUMBER(1) AS isNum2,  
+    IS_NUMBER(true) AS isBooleanANumber,   
+    IS_NUMBER(1) AS isNumberANumber, 
     IS_NUMBER("value") AS isNum3, 
     IS_NUMBER("12") AS isNum4,
     IS_NUMBER(null) AS isNum5,  

--- a/articles/cosmos-db/sql/sql-query-is-number.md
+++ b/articles/cosmos-db/sql/sql-query-is-number.md
@@ -49,7 +49,19 @@ SELECT
  Here is the result set.  
   
 ```json
-[{"isNum1":false,"isNum2":true,"isNum3":false,"isNum4":false,"isNum5":false,"isNum6":false,"isNum7":false,"isNum8":false}]  
+[
+    {
+        "isBooleanANumber": false,
+        "isNumberANumber": true,
+        "isTextStringANumber": false,
+        "isNumberStringANumber": false,
+        "isNullANumber": false,
+        "isObjectANumber": false,
+        "isArrayANumber": false,
+        "isObjectStringPropertyANumber": false,
+        "isObjectNumberPropertyANumber": true
+    }
+]
 ```  
 
 ## Remarks


### PR DESCRIPTION
This article shows "value" as a string, but the really confusing option is where a number is sent as a string e.g. "12". I have added that value for clarity.