### PR TITLE
Add note to semantic type example

### DIFF
--- a/articles/digital-twins/concepts-models.md
+++ b/articles/digital-twins/concepts-models.md
@@ -156,7 +156,7 @@ The following example shows a Sensor model with a semantic-type telemetry for Te
 :::code language="json" source="~/digital-twins-docs-samples-getting-started/models/advanced-home-example/ISensor.json" highlight="7-18":::
 
 > [!NOTE]
-> Currently, "Property" or "Telemetry" type must be the first element of the array followed by the semantic type. Otherwise, the field may not be visible in the Azure Digital Twins Explorer.
+> Currently, "Property" or "Telemetry" type must be the first element of the array, followed by the semantic type. Otherwise, the field may not be visible in the Azure Digital Twins Explorer.
 
 ## Relationships
 

--- a/articles/digital-twins/concepts-models.md
+++ b/articles/digital-twins/concepts-models.md
@@ -151,9 +151,12 @@ The following example shows another version of the Home model, with a property f
 
 Semantic types make it possible to express a value with a unit. Properties and telemetry can be represented with any of the semantic types that are supported by DTDL. For more information on semantic types in DTDL and what values are supported, see [Semantic types in the DTDL v2 spec](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v2/dtdlv2.md#semantic-types).
 
-The following example shows a Sensor model with a semantic-type telemetry for Temperature, and a semantic-type property for Humidity.
+The following example shows a Sensor model with a semantic-type telemetry for Temperature, and a semantic-type property for Humidity. 
 
 :::code language="json" source="~/digital-twins-docs-samples-getting-started/models/advanced-home-example/ISensor.json" highlight="7-18":::
+
+> [!NOTE]
+> Currently, "Property" or "Telemetry" type must be the first element of the array followed by the semantic type. Otherwise, the field may not be visible in the Azure Digital Twins Explorer.
 
 ## Relationships
 


### PR DESCRIPTION
It was reported by ADT Explorer users that a semantic property defined in one of their models was missing on the twin-level properties window. This was caused because they were not following the sequential order shown in the example. In the proposed change request, a note was added to the Semantic type example section highlighting the fact that the order of the elements in the array is relevant.