### PR TITLE
Add a note for Set-AzureADUser command that will not work on federate…

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
+++ b/articles/active-directory/hybrid/how-to-connect-password-hash-synchronization.md
@@ -124,6 +124,9 @@ Caveat: If there are synchronized accounts that need to have non-expiring passwo
 > [!NOTE]
 > The Set-MsolPasswordPolicy PowerShell command will not work on federated domains. 
 
+> [!NOTE]
+> The Set-AzureADUser PowerShell command will not work on federated domains. 
+
 #### Synchronizing temporary passwords and "Force Password Change on Next Logon"
 
 It is typical to force a user to change their password during their first logon, especially after an admin password reset occurs.  It is commonly known as setting a "temporary" password and is completed by checking the "User must change password at next logon" flag on a user object in Active Directory (AD).


### PR DESCRIPTION
…d domains.

Set-AzureADUser -ObjectID <User Object ID> -PasswordPolicies "DisablePasswordExpiration"

There is a misunderstanding for disabling password expiration with the command above. That command does not support setting that property for federated users. 
Related note is added for this case.