### PR TITLE
clarify staging routing lifecycle

### DIFF
--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -246,7 +246,7 @@ To route production traffic automatically:
 
 After the setting is saved, the specified percentage of clients is randomly routed to the non-production slot. 
 
-After a client is automatically routed to a specific slot, it's "pinned" to that slot for the life of that client session. On the client browser, you can see which slot your session is pinned to by looking at the `x-ms-routing-name` cookie in your HTTP headers. A request that's routed to the "staging" slot has the cookie `x-ms-routing-name=staging`. A request that's routed to the production slot has the cookie `x-ms-routing-name=self`.
+After a client is automatically routed to a specific slot, it's "pinned" to that slot for one hour or until the cookies are deleted. On the client browser, you can see which slot your session is pinned to by looking at the `x-ms-routing-name` cookie in your HTTP headers. A request that's routed to the "staging" slot has the cookie `x-ms-routing-name=staging`. A request that's routed to the production slot has the cookie `x-ms-routing-name=self`.
 
    > [!NOTE]
    > You can also use the [`az webapp traffic-routing set`](/cli/azure/webapp/traffic-routing#az-webapp-traffic-routing-set) command in the Azure CLI to set the routing percentages from CI/CD tools like GitHub Actions, DevOps pipelines, or other automation systems.


### PR DESCRIPTION
The current documentation of the "pinning" status of the routing is incorrect, as the cookie is set with a MAX-AGE = 3600