### PR TITLE
Update tutorial-ingress-controller-add-on-new.md

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-new.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-new.md
@@ -49,11 +49,12 @@ You'll now deploy a new AKS cluster with the AGIC add-on enabled. If you don't p
 
 In the following example, you'll deploy a new AKS cluster named *myCluster* by using [Azure CNI](../aks/concepts-network.md#azure-cni-advanced-networking) and [managed identities](../aks/use-managed-identity.md). The AGIC add-on will be enabled in the resource group that you created, *myResourceGroup*. 
 
-Deploying a new AKS cluster with the AGIC add-on enabled without specifying an existing Application Gateway instance will mean an automatic creation of a Standard_v2 SKU Application Gateway instance. So, you'll also specify the name and subnet address space of the Application Gateway instance. The name of the Application Gateway instance will be *myApplicationGateway*, and the subnet address space we're using is 10.2.0.0/16.
+Deploying a new AKS cluster with the AGIC add-on enabled without specifying an existing Application Gateway instance will mean an automatic creation of a Standard_v2 SKU Application Gateway instance. So, you'll also specify the name and subnet address space of the Application Gateway instance. The name of the Application Gateway instance will be *myApplicationGateway*, and the subnet address space we're using is 10.225.0.0/16.
 
 ```azurecli-interactive
-az aks create -n myCluster -g myResourceGroup --network-plugin azure --enable-managed-identity -a ingress-appgw --appgw-name myApplicationGateway --appgw-subnet-cidr "10.2.0.0/16" --generate-ssh-keys
+az aks create -n myCluster -g myResourceGroup --network-plugin azure --enable-managed-identity -a ingress-appgw --appgw-name myApplicationGateway --appgw-subnet-cidr "10.225.0.0/16" --generate-ssh-keys
 ```
+The default VNET address for managed VNETs is 10.224.0.0/12 and the default node subnet address is 10.224.0.0/16. New clusters will be required to have service and pod CIDR ranges that do not overlap with these new VNET ranges. These requirements were introduced in [2022-02-24 release](https://github.com/Azure/AKS/releases/tag/2022-02-24) changes.
 
 To configure additional parameters for the `az aks create` command, see [these references](/cli/azure/aks#az-aks-create). 
 


### PR DESCRIPTION
Release [2022-02-24](https://github.com/Azure/AKS/releases/tag/2022-02-24) changed the default VNET configuration:

> The default VNET address for managed VNETs will change from 10.0.0.0/8 to 10.224.0.0/12 and the default node subnet address will change from 10.240.0.0/16 to 10.224.0.0/16. New clusters will be required to have service and pod CIDR ranges that do not overlap with these new VNET ranges.

Running the the suggested command will output the following error:

```
$ az aks create -n myCluster -g myResourceGroup --network-plugin azure --enable-managed-identity -a ingress-appgw --appgw-name myApplicationGateway --appgw-subnet-cidr "10.2.0.0/16" --generate-ssh-keys

(IngressAppGwAddonConfigInvalidSubnetCIDRNotContainedWithinVirtualNetwork) Subnet Prefix '10.2.0.0/16' specified for IngressApplicationGateway addon is not contained within the AKS Agent Pool's Virtual Network address prefixes '[10.224.0.0/12]'.
Code: IngressAppGwAddonConfigInvalidSubnetCIDRNotContainedWithinVirtualNetwork
Message: Subnet Prefix '10.2.0.0/16' specified for IngressApplicationGateway addon is not contained within the AKS Agent Pool's Virtual Network address prefixes '[10.224.0.0/12]'.
Target: AddonProfiles.IngressApplicationGateway
```

I'm suggesting the following changes in this article:
- Ingress AGW IP example range: `10.225.0.0/16`
- Add info and reference to the the newly introduced requirements.