### PR TITLE
update auth configuration for webApi for net6.0

### DIFF
--- a/articles/active-directory-b2c/enable-authentication-web-api.md
+++ b/articles/active-directory-b2c/enable-authentication-web-api.md
@@ -149,9 +149,8 @@ If you're targeting .NET 6.0, you need to perform two additional steps:
 using ConfigurationManager = Microsoft.Extensions.Configuration.ConfigurationManager;
 ```
 1. Just after `WebApplication.CreateBuilder(args)`, add the following line:
-```csharp
-ConfigurationManager Configuration = builder.Configuration;
-```
+  ```csharp
+  ConfigurationManager Configuration = builder.Configuration;
 
 Find the `ConfigureServices(IServiceCollection services)` function. Then, before the `services.AddControllers();` line of code, add the following code snippet:
 

--- a/articles/active-directory-b2c/enable-authentication-web-api.md
+++ b/articles/active-directory-b2c/enable-authentication-web-api.md
@@ -142,7 +142,7 @@ Open *Startup.cs* and then, at the beginning of the class, add the following `us
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
 ```
-if targeting net 6.0, you will also need to peform two additional steps 
+If you're targeting .NET 6.0, you need to perform two additional steps:
 1. add an extra `using` declaration  to access `Configuration` properties 
 
 ```csharp

--- a/articles/active-directory-b2c/enable-authentication-web-api.md
+++ b/articles/active-directory-b2c/enable-authentication-web-api.md
@@ -148,7 +148,7 @@ If you're targeting .NET 6.0, you need to perform two additional steps:
 ```csharp
 using ConfigurationManager = Microsoft.Extensions.Configuration.ConfigurationManager;
 ```
-2.  add the line below after `WebApplication.CreateBuilder(args)`
+1. Just after `WebApplication.CreateBuilder(args)`, add the following line:
 ```csharp
 ConfigurationManager Configuration = builder.Configuration;
 ```

--- a/articles/active-directory-b2c/enable-authentication-web-api.md
+++ b/articles/active-directory-b2c/enable-authentication-web-api.md
@@ -143,7 +143,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
 ```
 If you're targeting .NET 6.0, you need to perform two additional steps:
-1. add an extra `using` declaration  to access `Configuration` properties 
+1. Add an extra `using` declaration to access `Configuration` properties: 
 
 ```csharp
 using ConfigurationManager = Microsoft.Extensions.Configuration.ConfigurationManager;

--- a/articles/active-directory-b2c/enable-authentication-web-api.md
+++ b/articles/active-directory-b2c/enable-authentication-web-api.md
@@ -142,6 +142,16 @@ Open *Startup.cs* and then, at the beginning of the class, add the following `us
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Identity.Web;
 ```
+if targeting net 6.0, you will also need to peform two additional steps 
+1. add an extra `using` declaration  to access `Configuration` properties 
+
+```csharp
+using ConfigurationManager = Microsoft.Extensions.Configuration.ConfigurationManager;
+```
+2.  add the line below after `WebApplication.CreateBuilder(args)`
+```csharp
+ConfigurationManager Configuration = builder.Configuration;
+```
 
 Find the `ConfigureServices(IServiceCollection services)` function. Then, before the `services.AddControllers();` line of code, add the following code snippet:
 


### PR DESCRIPTION
using 6.0 a user will run into errors when trying to configure jwt bearer options.
This is because they will need to access the Configuration manager which is not imported by default. in earlier versions e.g.
netcore 3.1 we could easily access this by DI