### PR TITLE
Fix Identity provider name

### DIFF
--- a/articles/container-apps/authentication.md
+++ b/articles/container-apps/authentication.md
@@ -40,7 +40,7 @@ Container Apps uses [federated identity](https://en.wikipedia.org/wiki/Federated
 | - | - | - |
 | [Microsoft Identity Platform](../active-directory/fundamentals/active-directory-whatis.md) | `/.auth/login/aad` | [Microsoft Identity Platform](authentication-azure-active-directory.md) |
 | [Facebook](https://developers.facebook.com/docs/facebook-login) | `/.auth/login/facebook` | [Facebook](authentication-facebook.md) |
-| [GitHub](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps) | `/.auth/login/github` | [Google](authentication-github.md) |
+| [GitHub](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps) | `/.auth/login/github` | [GitHub](authentication-github.md) |
 | [Google](https://developers.google.com/identity/choose-auth) | `/.auth/login/google` | [Google](authentication-google.md) |
 | [Twitter](https://developer.twitter.com/en/docs/basics/authentication) | `/.auth/login/twitter` | [Twitter](authentication-twitter.md) |
 | Any [OpenID Connect](https://openid.net/connect/) provider | `/.auth/login/<providerName>` | [OpenID Connect](authentication-openid.md) |


### PR DESCRIPTION
This should be "GitHub".
![image](https://user-images.githubusercontent.com/17608272/166134482-b66f4070-8147-4a09-9917-1c3ba874301a.png)
