### PR TITLE
Azure Functions Folder Structure - add PowerShell link

### DIFF
--- a/includes/functions-folder-structure.md
+++ b/includes/functions-folder-structure.md
@@ -16,7 +16,7 @@ The code for all the functions in a specific function app is located in a root p
 * [F# script](../articles/azure-functions/functions-reference-fsharp.md#folder-structure)
 * [Java](../articles/azure-functions/functions-reference-java.md#folder-structure)
 * [JavaScript](../articles/azure-functions/functions-reference-node.md#folder-structure)
-* [PowerShell](../articles/azure-functions/functions-reference-powershell?tabs=portal#folder-structure)
+* [PowerShell](../articles/azure-functions/functions-reference-powershell.md#folder-structure)
 * [Python](../articles/azure-functions/functions-reference-python.md#folder-structure)
 
 In version 2.x and higher of the Functions runtime, all functions in the function app must share the same language stack. 

--- a/includes/functions-folder-structure.md
+++ b/includes/functions-folder-structure.md
@@ -16,7 +16,7 @@ The code for all the functions in a specific function app is located in a root p
 * [F# script](../articles/azure-functions/functions-reference-fsharp.md#folder-structure)
 * [Java](../articles/azure-functions/functions-reference-java.md#folder-structure)
 * [JavaScript](../articles/azure-functions/functions-reference-node.md#folder-structure)
-* [PowerShell)(../articles/azure-functions/functions-reference-powershell?tabs=portal#folder-structure)
+* [PowerShell](../articles/azure-functions/functions-reference-powershell?tabs=portal#folder-structure)
 * [Python](../articles/azure-functions/functions-reference-python.md#folder-structure)
 
 In version 2.x and higher of the Functions runtime, all functions in the function app must share the same language stack. 

--- a/includes/functions-folder-structure.md
+++ b/includes/functions-folder-structure.md
@@ -16,6 +16,7 @@ The code for all the functions in a specific function app is located in a root p
 * [F# script](../articles/azure-functions/functions-reference-fsharp.md#folder-structure)
 * [Java](../articles/azure-functions/functions-reference-java.md#folder-structure)
 * [JavaScript](../articles/azure-functions/functions-reference-node.md#folder-structure)
+* [PowerShell)(../articles/azure-functions/functions-reference-powershell?tabs=portal#folder-structure)
 * [Python](../articles/azure-functions/functions-reference-python.md#folder-structure)
 
 In version 2.x and higher of the Functions runtime, all functions in the function app must share the same language stack. 


### PR DESCRIPTION
PowerShell missing from the folder structure list