### PR TITLE
Update create-complete-managed-instance-directly-connected.md

### DIFF
--- a/articles/azure-arc/data/create-complete-managed-instance-directly-connected.md
+++ b/articles/azure-arc/data/create-complete-managed-instance-directly-connected.md
@@ -181,7 +181,7 @@ NAME          STATE
 <namespace>   Ready
 ```
 
-## Create an Azure Arc-enabled SQL Managed Instance 
+## Create an instance of Azure Arc-enabled SQL Managed Instance 
 
 1. In the portal, locate the resource group.
 1. In the resource group, select **Create**.


### PR DESCRIPTION
to keep this consistent with create-complete-managed-instance-indirectly-connected.md / not have just "an" in from of managed instance (see feedback on PR #92217 for consistency)