### PR TITLE
Azure CXP Doc Edit | Update reference-claims-mapping-policy-type.md

### DIFF
--- a/articles/active-directory/develop/reference-claims-mapping-policy-type.md
+++ b/articles/active-directory/develop/reference-claims-mapping-policy-type.md
@@ -337,6 +337,7 @@ The ID element identifies which property on the source provides the value for th
 | User | preferreddatalocation | Preffered Data Location |
 | User | proxyaddresses | Proxy Addresses |
 | User | usertype | User Type |
+| User | telephonenumber| Business Phones / Office Phones |
 | application, resource, audience | displayname | Display Name |
 | application, resource, audience | objectid | ObjectID |
 | application, resource, audience | tags | Service Principal Tag |
@@ -428,6 +429,7 @@ Based on the method chosen, a set of inputs and outputs is expected. Define the 
 | User | userprincipalname|User Principal Name|
 | User | onpremisessamaccountname|On Premises Sam Account Name|
 | User | employeeid|Employee ID|
+| User | telephonenumber| Business Phones / Office Phones |
 | User | extensionattribute1 | Extension Attribute 1 |
 | User | extensionattribute2 | Extension Attribute 2 |
 | User | extensionattribute3 | Extension Attribute 3 |


### PR DESCRIPTION
user's telephonenumber attribute is supported as valid ID and SAML token, even was able to confirm this in my lab. Therefore, added in supported list in our Doc in line number 340 & 431.

MicrosoftDocs/azure-docs/issues/92218