### PR TITLE
Update with new service name

### DIFF
--- a/articles/azure-resource-manager/management/azure-subscription-service-limits.md
+++ b/articles/azure-resource-manager/management/azure-subscription-service-limits.md
@@ -495,11 +495,11 @@ The following limits apply when you use Azure Resource Manager and Azure resourc
 
 [!INCLUDE [azure-virtual-machines-limits-azure-resource-manager](../../../includes/azure-virtual-machines-limits-azure-resource-manager.md)]
 
-### Shared Image Gallery limits
+### Compute Gallery limits
 
-There are limits, per subscription, for deploying resources using Shared Image Galleries:
+There are limits, per subscription, for deploying resources using Compute Galleries:
 
-- 100 shared image galleries, per subscription, per region
+- 100 compute galleries, per subscription, per region
 - 1,000 image definitions, per subscription, per region
 - 10,000 image versions, per subscription, per region
 


### PR DESCRIPTION
Azure Shared Image Gallery was renamed to Azure Compute Gallery per other documentation such as: https://docs.microsoft.com/en-us/azure/virtual-machines/create-gallery?tabs=portal%2Ccli2 -- "An Azure Compute Gallery (formerly known as Shared Image Gallery) simplifies sharing resources, like images and application packages, across your organization."