### PR TITLE
vnet k8s netpols: update NPM metrics and include alert examples

### DIFF
--- a/articles/virtual-network/kubernetes-network-policies.md
+++ b/articles/virtual-network/kubernetes-network-policies.md
@@ -104,8 +104,8 @@ Users previously were only able to learn about their Network Configuration with 
 
 Overall, the metrics provide:
 - counts of policies, ACL rules, ipsets, ipset entries, and entries in any given ipset
-- execution times for individual OS calls and for handling resource events (median, 90th percentile, and 99th percentile)
-- failure info for handling resource events (these will fail when an OS call fails)
+- execution times for individual OS calls and for handling kubernetes resource events (median, 90th percentile, and 99th percentile)
+- failure info for handling kubernetes resource events (these will fail when an OS call fails)
 
 #### Example Metrics Use Cases
 ##### Alerts via a Prometheus AlertManager
@@ -115,7 +115,7 @@ See a [configuration for these alerts](#setup-alerts-for-alertmanager) below.
 
 ##### Visualizations and Debugging via our Grafana Dashboard or Azure Monitor Workbook
 1. See how many iptables rules your policies create (having a massive amount of iptables rules may increase latency slightly).
-2. Correlate the number of NPM ipsets to the time to apply kernel changes for pod and namespace events.
+2. Correlate cluster counts (e.g. ACLs) to execution times.
 3. Get the human-friendly name of an ipset in a given iptables rule (e.g. "azure-npm-487392" represents "podlabel-role:database").
  
 ### All Supported Metrics

--- a/articles/virtual-network/kubernetes-network-policies.md
+++ b/articles/virtual-network/kubernetes-network-policies.md
@@ -105,7 +105,7 @@ Users previously were only able to learn about their Network Configuration with 
 Overall, the metrics provide:
 - counts of policies, ACL rules, ipsets, ipset entries, and entries in any given ipset
 - execution times for individual OS calls and for handling resource events (median, 90th percentile, and 99th percentile)
-- failure info for individual OS calls and for handling resource events
+- failure info for handling resource events (these will fail when an OS call fails)
 
 #### Example Metrics Use Cases
 ##### Alerts via a Prometheus AlertManager
@@ -132,8 +132,8 @@ The following is the list of supported metrics. Any `quantile` label has possibl
 | `npm_ipset_counts` (advanced)        | number of entries within each individual IPSet | GaugeVec | `set_name` & `set_hash`      |
 | `npm_add_policy_exec_time`           | runtime for adding a network policy            | Summary  | `quantile` & `had_error`     |
 | `npm_controller_policy_exec_time`    | runtime for updating/deleting a network policy | Summary  | `quantile` & `had_error` & `operation` (with values `update` or `delete`)            |
-| `npm_controller_namespace_exec_time` | runtime for updating/deleting a namespace      | Summary  | `quantile` & `had_error` & `operation` (with values `create`, `update`, or `delete`) |
-| `npm_controller_pod_exec_time`       | runtime for updating/deleting a pod            | Summary  | `quantile` & `had_error` & `operation` (with values `create`, `update`, or `delete`) |
+| `npm_controller_namespace_exec_time` | runtime for creating/updating/deleting a namespace      | Summary  | `quantile` & `had_error` & `operation` (with values `create`, `update`, or `delete`) |
+| `npm_controller_pod_exec_time`       | runtime for creating/updating/deleting a pod            | Summary  | `quantile` & `had_error` & `operation` (with values `create`, `update`, or `delete`) |
 
 There are also "exec_time_count" and "exec_time_sum" metrics for each "exec_time" Summary metric.
 


### PR DESCRIPTION
- Update the metrics table to include new controller exec time metrics
- Give overt use cases for the metrics
- Give example Prometheus alert config for the alert use cases