### PR TITLE
Add note about Office Add-ins browser usage to clarify CA support

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
@@ -110,6 +110,9 @@ The following key applications are included in the Office 365 client app:
 
 A complete list of all services included can be found in the article [Apps included in Conditional Access Office 365 app suite](reference-office-365-application-contents.md).
 
+> [!IMPORTANT] 
+> Conditional Access is not supported for Office Add-ins on iOS. Those add-ins use [embedded Safari](/office/dev/add-ins/concepts/browsers-used-by-office-web-add-ins), not Edge.
+
 ### Microsoft Azure Management
 
 The Microsoft Azure Management application includes multiple services. 


### PR DESCRIPTION
We recently had a customer issue wherein they were trying to use Conditional Access with iOS-based Add-ins. Because the [browser control is dictated by the platform](https://docs.microsoft.com/en-us/office/dev/add-ins/concepts/browsers-used-by-office-web-add-ins), there is no way to change the browser in iOS to Edge for use with CA.

A question to the reviewers: should this information also be added to the [FAQ](https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/faqs)?