### PR TITLE
MANIFESTS_FOLDER Azure DevOps Services variable

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-gitops-flux2-ci-cd.md
+++ b/articles/azure-arc/kubernetes/tutorial-gitops-flux2-ci-cd.md
@@ -237,6 +237,7 @@ For the details on installation, refer to the [GitOps Connector](https://github.
 | ENVIRONMENT_NAME | Dev |
 | MANIFESTS_BRANCH | `master` |
 | MANIFESTS_REPO | `arc-cicd-demo-gitops` |
+| MANIFESTS_FOLDER | `arc-cicd-cluster` |
 | ORGANIZATION_NAME | Name of Azure DevOps organization |
 | PROJECT_NAME | Name of GitOps project in Azure DevOps |
 | REPO_URL | Full URL for GitOps repository |


### PR DESCRIPTION
MANIFESTS_FOLDER variable must be added to Azure DevOps variables part. CD pipeline fails because of this. This variable is mentioned on the Github part but missing on the Azure DevOps side. This is also related to issue [MicrosoftDocs#76186](https://github.com/MicrosoftDocs/azure-docs/issues/76186)