### PR TITLE
Update hubble-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/hubble-tutorial.md
+++ b/articles/active-directory/saas-apps/hubble-tutorial.md
@@ -20,7 +20,6 @@ In this tutorial, you'll learn how to integrate Hubble with Azure Active Directo
 
 * Control in Azure AD who has access to Hubble.
 * Enable your users to be automatically signed-in to Hubble with their Azure AD accounts.
-* Manage your accounts in one central location - the Azure portal.
 
 ## Prerequisites
 
@@ -87,10 +86,6 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
 	![The Certificate download link](common/metadataxml.png)
 
-1. On the **Set up Hubble** section, copy the appropriate URL(s) based on your requirement.
-
-	![Copy configuration URLs](common/copy-configuration-urls.png)
-
 ### Create an Azure AD test user
 
 In this section, you'll create a test user in the Azure portal called B.Simon.
@@ -117,7 +112,7 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 ## Configure Hubble SSO
 
-To configure single sign-on on **Hubble** side, you need to send the downloaded **Federation Metadata XML** and appropriate copied URLs from Azure portal to [Hubble support team](mailto:cs@hubble-inc.jp). They set this setting to have the SAML SSO connection set properly on both sides.
+To configure single sign-on on **Hubble** side, you need to upload the downloaded **Federation Metadata XML** to the configuration page on Hubble.
 
 ### Create Hubble test user
 


### PR DESCRIPTION
- Hubble does not support user-provisioning, so users cannot `manage their accounts in one central location - the Azure portal.`
- Users does not need `copy the appropriate URL(s) based on your requirement`. (`Configure Azure AD SSO` section)
- Users need upload the Federation Metadata XML on their own, instead of Hubble support team doing.