### PR TITLE
Update functions-identity-based-connections-tutorial.md

### DIFF
--- a/articles/azure-functions/functions-identity-based-connections-tutorial.md
+++ b/articles/azure-functions/functions-identity-based-connections-tutorial.md
@@ -307,7 +307,7 @@ Next you will update your function app to use its system-assigned identity when 
     | Option      | Suggested value  | Description |
     | ------------ | ---------------- | ----------- |
     | **Name** |  AzureWebJobsStorage__accountName | Update the name from **AzureWebJobsStorage** to the exact name `AzureWebJobsStorage__accountName`. This setting tells the host to use the identity instead of looking for a stored secret. The new setting uses a double underscore (`__`), which is a special character in application settings.  |
-    | **Value** | Your account name | Update the name from the connection string to just your **StorageAccountName**. |
+    | **Value** | Your account name | Update the name from the connection string to just your **StorageAccountName**. (e.g. `AccountName=mystorageaccount` ) |
 
     This configuration will let the system know that it should use an identity to connect to the resource.
 


### PR DESCRIPTION
The table suggests the value is just the account name. That does not work. It has to be prefixed with `AccountName=`.