### PR TITLE
Removed use of json('null') in Bicep Docs

### DIFF
--- a/articles/azure-resource-manager/bicep/conditional-resource-deployment.md
+++ b/articles/azure-resource-manager/bicep/conditional-resource-deployment.md
@@ -94,10 +94,10 @@ resource vmName_omsOnboarding 'Microsoft.Compute/virtualMachines/extensions@2017
     typeHandlerVersion: '1.0'
     autoUpgradeMinorVersion: true
     settings: {
-      workspaceId: ((!empty(logAnalytics)) ? reference(logAnalytics, '2015-11-01-preview').customerId : json('null'))
+      workspaceId: ((!empty(logAnalytics)) ? reference(logAnalytics, '2015-11-01-preview').customerId : null)
     }
     protectedSettings: {
-      workspaceKey: ((!empty(logAnalytics)) ? listKeys(logAnalytics, '2015-11-01-preview').primarySharedKey : json('null'))
+      workspaceKey: ((!empty(logAnalytics)) ? listKeys(logAnalytics, '2015-11-01-preview').primarySharedKey : null)
     }
   }
 }


### PR DESCRIPTION
Removed the use on `json('null')` in favor for `null` in the example. Although they are equal we should promote using the simpler `null` value.