### PR TITLE
Provision-EflowVM: improvement on registrationId parameter

### DIFF
--- a/articles/iot-edge/how-to-provision-devices-at-scale-linux-on-windows-tpm.md
+++ b/articles/iot-edge/how-to-provision-devices-at-scale-linux-on-windows-tpm.md
@@ -139,6 +139,12 @@ Simulated TPM samples:
    ```powershell
    Provision-EflowVM -provisioningType "DpsTpm" -scopeId "SCOPE_ID_HERE"
    ```
+   
+   If you have enrolled the device using a custom **Registration Id**, you must specify that Registration Id as well when provisioning:
+   
+   ```powershell
+   Provision-EflowVM -provisioningType "DpsTpm" -scopeId "SCOPE_ID_HERE" -registrationId "REGISTRATION_ID_HERE"
+   ```
 
 # [Windows Admin Center](#tab/windowsadmincenter)
 
@@ -166,6 +172,12 @@ Simulated TPM samples:
 
    ```powershell
    Provision-EflowVM -provisioningType "DpsTpm" -scopeId "SCOPE_ID_HERE"
+   ```
+   
+   If you have enrolled the device using a custom **Registration Id**, you must specify that Registration Id as well when provisioning:
+   
+   ```powershell
+   Provision-EflowVM -provisioningType "DpsTpm" -scopeId "SCOPE_ID_HERE" -registrationId "REGISTRATION_ID_HERE"
    ```
 
 :::moniker-end

--- a/articles/iot-edge/reference-iot-edge-for-linux-on-windows-functions.md
+++ b/articles/iot-edge/reference-iot-edge-for-linux-on-windows-functions.md
@@ -287,7 +287,7 @@ The **Provision-EflowVm** command adds the provisioning information for your IoT
 | deviceId | The device ID of an existing IoT Edge device | Device ID for provisioning an IoT Edge device (**ManualX509**). |
 | scopeId | The scope ID for an existing DPS instance. | Scope ID for provisioning an IoT Edge device (**DpsTPM**, **DpsX509**, or **DpsSymmetricKey**). |
 | symmKey | The primary key for an existing DPS enrollment or the primary key of an existing IoT Edge device registered using symmetric keys | Symmetric key for provisioning an IoT Edge device (**DpsSymmetricKey**). |
-| registrationId | The registration ID of an existing IoT Edge device | Registration ID for provisioning an IoT Edge device (**DpsSymmetricKey**). |
+| registrationId | The registration ID of an existing IoT Edge device | Registration ID for provisioning an IoT Edge device (**DpsSymmetricKey**, **DpsTPM**). |
 | identityCertPath | Directory path | Absolute destination path of the identity certificate on your Windows host machine (**ManualX509**, **DpsX509**). |
 | identityPrivKeyPath | Directory path | Absolute source path of the identity private key on your Windows host machine (**ManualX509**, **DpsX509**). |
 | globalEndpoint | Device Endpoint URL | URL for Global Endpoint to be used for DPS provisioning. |


### PR DESCRIPTION
Specify that the registrationId parameter on the Provision-EflowVM method can also be used when using DpsTPM provisioning.