### PR TITLE
fix: Use correct Prometheus metric names in "Configure local metrics and logs for Azure API Management self-hosted gateway" 

### DIFF
--- a/articles/api-management/how-to-configure-local-metrics-logs.md
+++ b/articles/api-management/how-to-configure-local-metrics-logs.md
@@ -194,7 +194,7 @@ Make some API calls through the self-hosted gateway, if everything is configured
 | ------------- | ------------- |
 | requests_total  | Number of API requests in the period |
 | request_duration_seconds | Number of milliseconds from the moment gateway received request until the moment response sent in full |
-| request_backend_duration_seconds_count | Number of milliseconds spent on overall backend IO (connecting, sending and receiving bytes)  |
+| request_backend_duration_seconds | Number of milliseconds spent on overall backend IO (connecting, sending and receiving bytes)  |
 | request_client_duration_seconds | Number of milliseconds spent on overall client IO (connecting, sending and receiving bytes)  |
 
 ## Logs

--- a/articles/api-management/how-to-configure-local-metrics-logs.md
+++ b/articles/api-management/how-to-configure-local-metrics-logs.md
@@ -190,12 +190,12 @@ Now we have everything deployed and configured, the self-hosted gateway should r
 
 Make some API calls through the self-hosted gateway, if everything is configured correctly, you should be able to view below metrics:
 
-| Metric  | Description |
+| Metric        | Description |
 | ------------- | ------------- |
-| Requests  | Number of API requests in the period |
-| DurationInMS | Number of milliseconds from the moment gateway received request until the moment response sent in full |
-| BackendDurationInMS | Number of milliseconds spent on overall backend IO (connecting, sending and receiving bytes)  |
-| ClientDurationInMS | Number of milliseconds spent on overall client IO (connecting, sending and receiving bytes)  |
+| requests_total  | Number of API requests in the period |
+| request_duration_seconds | Number of milliseconds from the moment gateway received request until the moment response sent in full |
+| request_backend_duration_seconds_count | Number of milliseconds spent on overall backend IO (connecting, sending and receiving bytes)  |
+| request_client_duration_seconds | Number of milliseconds spent on overall client IO (connecting, sending and receiving bytes)  |
 
 ## Logs
 


### PR DESCRIPTION
Use correct Prometheus metric names in "Configure local metrics and logs for Azure API Management self-hosted gateway" which are available in the Prometheus output.

```
# HELP request_backend_duration_seconds Metric autogenerated by statsd_exporter.
# TYPE request_backend_duration_seconds summary
request_backend_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.5"} NaN
request_backend_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.9"} NaN
request_backend_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.99"} NaN
request_backend_duration_seconds_sum{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 0
request_backend_duration_seconds_count{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 1
request_backend_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.5"} NaN
request_backend_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.9"} NaN
request_backend_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.99"} NaN
request_backend_duration_seconds_sum{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 2.891
request_backend_duration_seconds_count{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 9
# HELP request_client_duration_seconds Metric autogenerated by statsd_exporter.
# TYPE request_client_duration_seconds summary
request_client_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.5"} NaN
request_client_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.9"} NaN
request_client_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.99"} NaN
request_client_duration_seconds_sum{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 0
request_client_duration_seconds_count{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 1
request_client_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.5"} NaN
request_client_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.9"} NaN
request_client_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.99"} NaN
request_client_duration_seconds_sum{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 0.001
request_client_duration_seconds_count{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 9
# HELP request_duration_seconds Metric autogenerated by statsd_exporter.
# TYPE request_duration_seconds summary
request_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.5"} NaN
request_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.9"} NaN
request_duration_seconds{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized",quantile="0.99"} NaN
request_duration_seconds_sum{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 0.187
request_duration_seconds_count{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 1
request_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.5"} NaN
request_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.9"} NaN
request_duration_seconds{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful",quantile="0.99"} NaN
request_duration_seconds_sum{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 2.957
request_duration_seconds_count{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 9
# HELP requests_total Metric autogenerated by statsd_exporter.
# TYPE requests_total counter
requests_total{BackendResponseCode="0",BackendResponseCodeCategory="None",Cache="None",Hostname="localhost",LastErrorReason="SubscriptionKeyNotFound",Location="sandbox",ResponseCode="401",ResponseCodeCategory="4xx",Status="Unauthorized"} 1
requests_total{BackendResponseCode="200",BackendResponseCodeCategory="2xx",Cache="None",Hostname="localhost",LastErrorReason="None",Location="sandbox",ResponseCode="200",ResponseCodeCategory="2xx",Status="Successful"} 9
```
