### PR TITLE
key and value of DeploymentManifest.json are incorrectly described

### DIFF
--- a/articles/cognitive-services/Computer-vision/spatial-analysis-web-app.md
+++ b/articles/cognitive-services/Computer-vision/spatial-analysis-web-app.md
@@ -74,10 +74,10 @@ Most of the **Environment Variables** for the IoT Edge Module are already set in
     "value": "accept"
 },
 "BILLING":{ 
-    "value": "<Use a key from your Computer Vision resource>"
+    "value": "<Use the endpoint from your Computer Vision resource>"
 },
 "APIKEY":{
-    "value": "<Use the endpoint from your Computer Vision resource>"
+    "value": "<Use a key from your Computer Vision resource>"
 }
 ```
 


### PR DESCRIPTION
key is indicated where endpoint should be, and endpoint is indicated where key should be.
<img width="283" alt="image" src="https://user-images.githubusercontent.com/65746722/167749826-4b816150-6669-44e4-ac51-cadb1692ce4e.png">

FYI: The sample json on Github describes these correctly.
https://github.com/Azure-Samples/cognitive-services-spatial-analysis/blob/ee606441cadbb6556fb763623f1e14a0aea3dbc5/deployment.json#L34
<img width="532" alt="image" src="https://user-images.githubusercontent.com/65746722/167749859-312635e1-5d84-4d8a-ba07-14f590c55d19.png">
