### PR TITLE
Remove experimental state of Helm 3 OCI support

### DIFF
--- a/articles/container-registry/container-registry-helm-repos.md
+++ b/articles/container-registry/container-registry-helm-repos.md
@@ -65,7 +65,7 @@ The following resources are needed for the scenario in this article:
 - **A Kubernetes cluster** where you will install a Helm chart. If needed, create an AKS cluster [using the Azure CLI][./learn/quick-kubernetes-deploy-cli], [using Azure PowerShell][./learn/quick-kubernetes-deploy-powershell], or [using the Azure portal][./learn/quick-kubernetes-deploy-portal].
 - **Azure CLI version 2.0.71 or later** - Run `az --version` to find the version. If you need to install or upgrade, see [Install Azure CLI][azure-cli-install].
 
-## Enable OCI support
+## Set up Helm client
 
 Use the `helm version` command to verify that you have installed Helm 3:
 
@@ -73,11 +73,8 @@ Use the `helm version` command to verify that you have installed Helm 3:
 helm version
 ```
 
-Set the following environment variable to enable OCI support in the Helm 3 client. Currently, this support is experimental and subject to change. 
-
-```console
-export HELM_EXPERIMENTAL_OCI=1
-```
+> [!NOTE]
+> The version indicated must be at least 3.8.0 as OCI support in earlier versions was experimental.
 
 Set the following environment variables for the target registry. The ACR_NAME is the registry resource name. If the ACR registry url is myregistry.azurecr.io, set the ACR_NAME to myregistry
 

--- a/articles/container-registry/container-registry-helm-repos.md
+++ b/articles/container-registry/container-registry-helm-repos.md
@@ -74,7 +74,7 @@ helm version
 ```
 
 > [!NOTE]
-> The version indicated must be at least 3.8.0 as OCI support in earlier versions was experimental.
+> The version indicated must be at least 3.8.0, as OCI support in earlier versions was experimental.
 
 Set the following environment variables for the target registry. The ACR_NAME is the registry resource name. If the ACR registry url is myregistry.azurecr.io, set the ACR_NAME to myregistry
 


### PR DESCRIPTION
As support for OCI was moved out of the experimental state with v3.8.0, this step in the guideline is no longer needed and confusing.
(see https://github.com/helm/helm/releases/tag/v3.8.0)

To avoid confusion of users using Helm <3.8.0, a note was added indicating the experimental state of OCI in Helm versions below 3.8.0.