### PR TITLE
Scope support for Azure Functions module to AMD64

### DIFF
--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -88,7 +88,7 @@ The IoT Edge extension tries to pull your container registry credentials from Az
 
 ### Set target architecture to AMD64
 
-Running Azure Functions modules on IoT Edge is supported only on AMD64 architectures. Although Visual Studio Code can develop C modules for Linux AMD64 and Linux ARM32v7 devices. You need to select which architecture you're targeting with each solution, because the container is built and run differently for each architecture type. The default target architecture is Linux AMD64, but we will set it explicitly to AMD64 here.
+Running Azure Functions modules on IoT Edge is supported only on AMD64 architecture. The default target architecture for Visual Studio Code is Linux AMD64, but we will set it explicitly to AMD64 here.
 
 1. Open the command palette and search for **Azure IoT Edge: Set Default Target Platform for Edge Solution**, or select the shortcut icon in the side bar at the bottom of the window.
 

--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -39,7 +39,7 @@ The Azure Function that you create in this tutorial filters the temperature data
 Before beginning this tutorial, you should have gone through the previous tutorial to set up your development environment for Linux container development: [Develop IoT Edge modules using Linux containers](tutorial-develop-for-linux.md). By completing that tutorial, you should have the following prerequisites in place:
 
 * A free or standard-tier [IoT Hub](../iot-hub/iot-hub-create-through-portal.md) in Azure.
-* A device running Azure IoT Edge with Linux containers. You can use the quickstarts to set up a [Linux device](quickstart-linux.md) or [Windows device](quickstart.md).
+* An AMD64 device running Azure IoT Edge with Linux containers. You can use the quickstarts to set up a [Linux device](quickstart-linux.md) or [Windows device](quickstart.md).
 * A container registry, like [Azure Container Registry](../container-registry/index.yml).
 * [Visual Studio Code](https://code.visualstudio.com/) configured with the [Azure IoT Tools](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools).
 * [Docker CE](https://docs.docker.com/install/) configured to run Linux containers.
@@ -86,13 +86,13 @@ The IoT Edge extension tries to pull your container registry credentials from Az
 >[!NOTE]
 >This tutorial uses admin login credentials for Azure Container Registry, which are convenient for development and test scenarios. When you're ready for production scenarios, we recommend a least-privilege authentication option like service principals. For more information, see [Manage access to your container registry](production-checklist.md#manage-access-to-your-container-registry).
 
-### Select your target architecture
+### Set target architecture to AMD64
 
-Currently, Visual Studio Code can develop C modules for Linux AMD64 and Linux ARM32v7 devices. You need to select which architecture you're targeting with each solution, because the container is built and run differently for each architecture type. The default is Linux AMD64.
+Running Azure Functions modules on IoT Edge is supported only on AMD64 architectures. Although Visual Studio Code can develop C modules for Linux AMD64 and Linux ARM32v7 devices. You need to select which architecture you're targeting with each solution, because the container is built and run differently for each architecture type. The default target architecture is Linux AMD64, but we will set it explicitly to AMD64 here.
 
 1. Open the command palette and search for **Azure IoT Edge: Set Default Target Platform for Edge Solution**, or select the shortcut icon in the side bar at the bottom of the window.
 
-2. In the command palette, select the target architecture from the list of options. For this tutorial, we're using an Ubuntu virtual machine as the IoT Edge device, so will keep the default **amd64**.
+2. In the command palette, select the AMD64 target architecture from the list of options.
 
 ### Update the module with custom code
 

--- a/articles/iot-edge/tutorial-deploy-function.md
+++ b/articles/iot-edge/tutorial-deploy-function.md
@@ -88,7 +88,7 @@ The IoT Edge extension tries to pull your container registry credentials from Az
 
 ### Set target architecture to AMD64
 
-Running Azure Functions modules on IoT Edge is supported only on AMD64 architecture. The default target architecture for Visual Studio Code is Linux AMD64, but we will set it explicitly to AMD64 here.
+Running Azure Functions modules on IoT Edge is supported only on Linux AMD64 based containers. The default target architecture for Visual Studio Code is Linux AMD64, but we will set it explicitly to Linux AMD64 here.
 
 1. Open the command palette and search for **Azure IoT Edge: Set Default Target Platform for Edge Solution**, or select the shortcut icon in the side bar at the bottom of the window.
 


### PR DESCRIPTION
We made a decision to deprecate support for ARM32 Azure Functions modules because of usage metrics / complications maintaining Azure Functions base image for ARM32 support. In this PR I have scoped support for Azure Functions module to AMD64 only.