### PR TITLE
Fix "Set up working directory" step for windows

### DIFF
--- a/articles/iot-edge/how-to-create-test-certificates.md
+++ b/articles/iot-edge/how-to-create-test-certificates.md
@@ -76,7 +76,7 @@ In this section, you clone the IoT Edge repo and execute the scripts.
    mkdir wrkdir
    cd .\wrkdir\
    cp ..\iotedge\tools\CACertificates\*.cnf .
-   cp ..\iotedge\tools\CACertificates\certGen.sh .
+   cp ..\iotedge\tools\CACertificates\ca-certs.ps1 .
    ```
 
    If you downloaded the repo as a ZIP, then the folder name is `iotedge-master` and the rest of the path is the same.


### PR DESCRIPTION
The code snippet copied the shell script instead of the powershell script.