### PR TITLE
Add missing vnet flag for Create a PostgreSQL Flexible Server in a new virtual network

### DIFF
--- a/articles/postgresql/flexible-server/tutorial-django-app-service-postgres.md
+++ b/articles/postgresql/flexible-server/tutorial-django-app-service-postgres.md
@@ -74,7 +74,7 @@ Create a private flexible server and a database inside a virtual network (VNET) 
 ```azurecli
 # Create Flexible server in a VNET
 
-az postgres flexible-server create --resource-group myresourcegroup --location westus2
+az postgres flexible-server create --resource-group myresourcegroup --location westus2 --vnet VNETName
 
 ```
 


### PR DESCRIPTION
The discription mentions that the command will create a vnet as well. which is not the case. By adding this, it will.