### PR TITLE
Fix the typo in query filter - Configure custom partitioning doc

### DIFF
--- a/articles/cosmos-db/configure-custom-partitioning.md
+++ b/articles/cosmos-db/configure-custom-partitioning.md
@@ -115,7 +115,7 @@ val df = spark.read.
             option("spark.cosmos.asns.partition.keys", "readDate String").
             option("spark.cosmos.asns.basePath", "/mnt/CosmosDBPartitionedStore/").
             load()
-val df_filtered = df.filter("readDate='2020-11-27 00:00:00.000'")
+val df_filtered = df.filter("readDate='2020-11-01 00:00:00.000'")
 display(df_filtered.limit(10))
 ```
 ---


### PR DESCRIPTION
Fix the typo in query filter for Configure custom partitioning doc - https://github.com/MicrosoftDocs/azure-docs/issues/92871