### PR TITLE
cannot import format from undefined

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/how-to/speech-synthesis/javascript.md
+++ b/articles/cognitive-services/Speech-Service/includes/how-to/speech-synthesis/javascript.md
@@ -299,7 +299,7 @@ function synthesizeSpeech() {
     const speechConfig = SpeechConfig.fromSubscription("<paste-your-speech-key-here>", "<paste-your-speech-location/region-here>");
 
     // Set the output format
-    speechConfig.speechSynthesisOutputFormat = SpeechSynthesisOutputFormat.Riff24Khz16BitMonoPcm;
+    speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff24Khz16BitMonoPcm;
 
     const synthesizer = new sdk.SpeechSynthesizer(speechConfig, null);
     synthesizer.speakTextAsync(


### PR DESCRIPTION
SpeechSynthesisOutputFormat does exist inside the sdk reference, should be mentioned on the docs
I've tried to define the context myself until I've figured this out, kinda misleading