### PR TITLE
fix typo in manifest sample

### DIFF
--- a/articles/active-directory/develop/active-directory-optional-claims.md
+++ b/articles/active-directory/develop/active-directory-optional-claims.md
@@ -351,7 +351,7 @@ This section covers the configuration options under optional claims for changing
             {
                 "name": "groups",
                 "additionalProperties": [
-                    "netbios_name_and_sam_account_name",
+                    "netbios_domain_and_sam_account_name",
                     "emit_as_roles"
                 ]
             }
@@ -360,7 +360,7 @@ This section covers the configuration options under optional claims for changing
             {
                 "name": "groups",
                 "additionalProperties": [
-                    "netbios_name_and_sam_account_name",
+                    "netbios_domain_and_sam_account_name",
                     "emit_as_roles"
                 ]
             }


### PR DESCRIPTION
current manifest sample for configuring groups optional claim uses a non-existent property `netbios_name_and_sam_account_name`. This is a typo, and the real property should be `netbios_domain_and_sam_account_name`