### PR TITLE
fix typo in manifest sample

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-fed-group-claims.md
+++ b/articles/active-directory/hybrid/how-to-connect-fed-group-claims.md
@@ -252,12 +252,12 @@ Emit group names to be returned in `NetbiosDomain\sAMAccountName` format as the 
 "optionalClaims": {
     "saml2Token": [{
         "name": "groups",
-        "additionalProperties": ["netbios_name_and_sam_account_name", "emit_as_roles"]
+        "additionalProperties": ["netbios_domain_and_sam_account_name", "emit_as_roles"]
     }],
 
     "idToken": [{
         "name": "groups",
-        "additionalProperties": ["netbios_name_and_sam_account_name", "emit_as_roles"]
+        "additionalProperties": ["netbios_domain_and_sam_account_name", "emit_as_roles"]
     }]
 }
 ```


### PR DESCRIPTION
current manifest sample at the bottom of the doc uses a non-existent property `netbios_name_and_sam_account_name`. This is a typo, and the real property should be `netbios_domain_and_sam_account_name`