### PR TITLE
Null instead of exception with null conditional

### DIFF
--- a/articles/iot-dps/how-to-use-custom-allocation-policies.md
+++ b/articles/iot-dps/how-to-use-custom-allocation-policies.md
@@ -208,7 +208,7 @@ In this section, you create an Azure function that implements your custom alloca
         }
         else
         {
-            string[] hubs = data?.linkedHubs.ToObject<string[]>();
+            string[] hubs = data?.linkedHubs?.ToObject<string[]>();
 
             // Must have hubs selected on the enrollment
             if (hubs == null)


### PR DESCRIPTION
The sentense:

    data?.linkedHubs.ToObject<string[]>();

throw an exception if the incoming data has not linkedHubs in the JSON.

The code expects a null in that case so let's assign null.

Just add an extra questionmark and it's ok again.