### PR TITLE
Fix typo in microsoft-defender.md

### DIFF
--- a/includes/resource-graph/samples/bycat/microsoft-defender.md
+++ b/includes/resource-graph/samples/bycat/microsoft-defender.md
@@ -195,7 +195,7 @@ Search-AzGraph -Query "SecurityResources | where type =~ 'microsoft.security/iot
 
 ### List Container Registry vulnerability assessment results
 
-Returns all the all the vulnerabilities found on container images. Microsoft Defender for Containers has to be enabled in order to view these security findings.
+Returns all the vulnerabilities found on container images. Microsoft Defender for Containers has to be enabled in order to view these security findings.
 
 ```kusto
 SecurityResources


### PR DESCRIPTION
remove "all the" repeated words. seems to be a typo. 