### PR TITLE
Fixed command to verify service principal role

### DIFF
--- a/articles/azure-arc/data/upload-metrics-and-logs-to-azure-monitor.md
+++ b/articles/azure-arc/data/upload-metrics-and-logs-to-azure-monitor.md
@@ -160,7 +160,7 @@ Example output:
 ## Verify service principal role
 
 ```azurecli
-az role assignment list -o table
+az role assignment list --scope subscriptions/<SubscriptionID>/resourceGroups/<resourcegroup> -o table
 ```
 
 With the service principal assigned to the appropriate role, you can proceed to upload metrics, or user data. 


### PR DESCRIPTION
when creating the roles we are scoping to the resource group, not the subscription. The original command only got the roles for the subscription, so we would never see the roles we just created. Added the -scope parameter to the command so that we can confirm the roles are created.
az role assignment list --scope subscriptions/<SubscriptionID>/resourceGroups/<resourcegroup> -o table