### PR TITLE
Add missing path separator

### DIFF
--- a/articles/virtual-machines/extensions/key-vault-windows.md
+++ b/articles/virtual-machines/extensions/key-vault-windows.md
@@ -294,9 +294,9 @@ The Key Vault VM extension logs only exist locally on the VM and are most inform
 |Location|Description|
 |--|--|
 | C:\WindowsAzure\Logs\WaAppAgent.log | Shows when an update to the extension occurred. |
-| C:\WindowsAzure\Logs\Plugins\Microsoft.Azure.KeyVault.KeyVaultForWindows\<most recent version\>\ | Shows the status of certificate download. The download location will always be the Windows computer's MY store (certlm.msc). |
-| C:\Packages\Plugins\Microsoft.Azure.KeyVault.KeyVaultForWindows\<most recent version\>\RuntimeSettings\ |	The Key Vault VM Extension service logs show the status of the akvvm_service service. |
-| C:\Packages\Plugins\Microsoft.Azure.KeyVault.KeyVaultForWindows\<most recent version\>\Status\	| The configuration and binaries for Key Vault VM Extension service. |
+| C:\WindowsAzure\Logs\Plugins\Microsoft.Azure.KeyVault.KeyVaultForWindows\\\<most recent version\>\ | Shows the status of certificate download. The download location will always be the Windows computer's MY store (certlm.msc). |
+| C:\Packages\Plugins\Microsoft.Azure.KeyVault.KeyVaultForWindows\\\<most recent version\>\RuntimeSettings\ |	The Key Vault VM Extension service logs show the status of the akvvm_service service. |
+| C:\Packages\Plugins\Microsoft.Azure.KeyVault.KeyVaultForWindows\\\<most recent version\>\Status\	| The configuration and binaries for Key Vault VM Extension service. |
 |||  
 
 


### PR DESCRIPTION
The current backslash is being used as an escape character to the <, making it look like the folder has the version postfixed, but it's actually a subfolder.