### PR TITLE
Add 4.8 to installed framework for Family 7 OS

### DIFF
--- a/articles/cloud-services/cloud-services-guestos-update-matrix.md
+++ b/articles/cloud-services/cloud-services-guestos-update-matrix.md
@@ -177,6 +177,8 @@ The September Guest OS has released.
 ## Family 7 releases
 **Windows Server 2022**
 
+.NET Framework installed: 4.8
+
 | Configuration string | Release date | Disable date |
 | --- | --- | --- |
 |  WA-GUEST-OS-7.11_202204-01 |  April 30, 2022  |  Post 7.13  |


### PR DESCRIPTION
Don't know which other versions are installed too.

IMO 4.8 is installed, because when creating new Cloud Services (extended support) project in VS, you can choose 4.8 (and this creates `*.cscfg` files with `osFamily="7"`):

![image](https://user-images.githubusercontent.com/905878/169062375-ceba53ca-1436-4747-b5ff-bf45a47465ba.png)

And after switching `osFamily` from 6 to 7, this warning is not showing anymore in `Output` tab for build:

```
warning WAT250: The project 'WebRole' targets '.NET Framework 4.8' which is not supported on the Microsoft Azure virtual machine (OSFamily = 'Windows 2019 Server').  To make sure that the role starts, update the 'osFamily' attribute in the service configuration file 'ServiceConfiguration.Cloud.cscfg'.  See https://go.microsoft.com/fwlink/?LinkId=262840 from more information.
```