### PR TITLE
Fix typo on apt-get update command

### DIFF
--- a/articles/postgresql/flexible-server/quickstart-create-connect-server-vnet.md
+++ b/articles/postgresql/flexible-server/quickstart-create-connect-server-vnet.md
@@ -129,7 +129,7 @@ ssh -i .\Downloads\myKey1.pem azureuser@10.111.12.123
 You need to install the postgresql-client tool to be able to connect to the server.
 
 ```bash
-sudo apt-getupdate
+sudo apt-get update
 sudo apt-get install postgresql-client
 ```
 


### PR DESCRIPTION
This PR fixes a typo on the `apt-get update` command under the [Install PostgreSQL client tools](https://docs.microsoft.com/en-us/azure/postgresql/flexible-server/quickstart-create-connect-server-vnet#install-postgresql-client-tools) section. 

If the command is copy and pasted as is into a terminal it results into a `sudo: apt-getupdate: command not found` terminal response.

## What has changed?

The package copy and paste packages update command.

## How can success be measured?

Copying and pasting the update command as is should update packages information on the host machine.