### PR TITLE
Fix typo in control-flow-wait-activity.md

### DIFF
--- a/articles/data-factory/control-flow-wait-activity.md
+++ b/articles/data-factory/control-flow-wait-activity.md
@@ -16,7 +16,7 @@ When you use a Wait activity in a pipeline, the pipeline waits for the specified
 
 [!INCLUDE[appliesto-adf-asa-md](includes/appliesto-adf-asa-md.md)]
 
-## Create a Fail activity with UI
+## Create a Wait activity with UI
 
 To use a Wait activity in a pipeline, complete the following steps:
 


### PR DESCRIPTION
Correct header to refer to the Wait activity the page documents.