### PR TITLE
Corrected `walinuxagent` sed search string

### DIFF
--- a/articles/virtual-machines/extensions/update-linux-agent.md
+++ b/articles/virtual-machines/extensions/update-linux-agent.md
@@ -61,7 +61,7 @@ AutoUpdate.Enabled=y
 To enable run:
 
 ```bash
-sudo sed -i 's/# AutoUpdate.Enabled=n/AutoUpdate.Enabled=y/g' /etc/waagent.conf
+sudo sed -i 's/# AutoUpdate.Enabled=y/AutoUpdate.Enabled=y/g' /etc/waagent.conf
 ```
 
 Restart waagengt service for 14.04


### PR DESCRIPTION
Corrected instructions issue where sed was looking for `# AutoUpdate.Enabled=n` when it should have been looking for `# AutoUpdate.Enabled=y`, and so AutoUpdate was never enabled.