### PR TITLE
Update nested groups unsupported scenarios

### DIFF
--- a/articles/active-directory/fundamentals/active-directory-groups-membership-azure-portal.md
+++ b/articles/active-directory/fundamentals/active-directory-groups-membership-azure-portal.md
@@ -26,7 +26,7 @@ This article helps you to add and remove a group from another group using Azure 
 You can add an existing Security group to another existing Security group (also known as nested groups), creating a member group (subgroup) and a parent group. The member group inherits the attributes and properties of the parent group, saving you configuration time.
 
 >[!Important]
->We don't currently support:<ul><li>Adding groups to a group synced with on-premises Active Directory.</li><li>Adding Security groups to Microsoft 365 groups.</li><li>Adding Microsoft 365 groups to Security groups or other Microsoft 365 groups.</li><li>Assigning apps to nested groups.</li><li>Applying licenses to nested groups.</li><li>Adding distribution groups in nesting scenarios.</li><li> Adding security groups as members of mail-enabled security groups</li></ul>
+>We don't currently support:<ul><li>Adding groups to a group synced with on-premises Active Directory.</li><li>Adding Security groups to Microsoft 365 groups.</li><li>Adding Microsoft 365 groups to Security groups or other Microsoft 365 groups.</li><li>Assigning apps to nested groups.</li><li>Applying licenses to nested groups.</li><li>Adding distribution groups in nesting scenarios.</li><li>Adding security groups as members of mail-enabled security groups</li><li> Adding groups as members of a role-assignable group.</li></ul>
 
 ### To add a group as a member of another group
 


### PR DESCRIPTION
Add another unsupported scenario to https://github.com/MicrosoftDocs/azure-docs/edit/main/articles/active-directory/fundamentals/active-directory-groups-membership-azure-portal.md.

Where groups can't be added to role-assignable groups. 
Which is mentioned in documentation at: https://docs.microsoft.com/en-us/azure/active-directory/roles/groups-concept#how-are-role-assignable-groups-protected