### PR TITLE
Update virtual-machine-scale-sets-manage-fault-domains.md

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-manage-fault-domains.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-manage-fault-domains.md
@@ -13,17 +13,51 @@ ms.custom: mimckitt, devx-track-azurecli
 ---
 # Choosing the right number of fault domains for virtual machine scale set
 
-**Applies to:** :heavy_check_mark: Linux VMs :heavy_check_mark: Windows VMs :heavy_check_mark: Uniform scale sets
+**Applies to:** :heavy_check_mark: Linux VMs :heavy_check_mark: Windows VMs :heavy_check_mark: Uniform scale sets :heavy_check_mark: Flexible scale sets
 
-Virtual machine scale sets are created with five fault domains by default in Azure regions with no zones. For the regions that support zonal deployment of virtual machine scale sets and this option is selected, the default value of the fault domain count is 1 for each of the zones. FD=1 in this case implies that the VM instances belonging to the scale set will be spread across many racks on a best effort basis.
+The spreading options available on the scale set depend on the orchestration mode and whether you are deploying a scale set using availability zones. The details of the options are described below. Dependent on the orchestration mode, you can consider using max spreading (platformFaultDomainCount = 1), which implies that the VM instances belonging to the scale set will be spread across as many fault domains as possible on a best effort basis. For a zonal scale set, max spreading implies the scale set spreads your VMs across as many fault domains as possible within each zone, on a best effort bases. This spreading could be across greater or fewer than five fault domains per zone. 
 
-You can also consider aligning the number of scale set fault domains with the number of Managed Disks fault domains. This alignment can help prevent loss of quorum if an entire Managed Disks fault domain goes down. The FD count can be set to less than or equal to the number of Managed Disks fault domains available in each of the regions. Refer to this [document](../virtual-machines/availability.md) to learn about the number of Managed Disks fault domains by region.
+With static fixed spreading, the scale set spreads your VMs across exactly five fault domains per zone / region. If the scale set cannot find five distinct fault domains per zone / region to satisfy the allocation request, the request fails.
 
+You can also consider aligning the number of scale set fault domains with the number of Managed Disks fault domains. This alignment can help prevent loss of quorum if an entire Managed Disks fault domain goes down. The FD count can be set to less than or equal to the number of Managed Disks fault domains available in each of the regions.
+
+**We recommend deploying with max spreading for most workloads**, as this approach provides the best spreading in most cases. If you need replicas to be spread across distinct hardware isolation units, we recommend spreading across Availability Zones and utilize max spreading within each zone.
+
+> [!NOTE]
+> With max spreading, you do not see any fault domains in the scale set VM instance view and in the instance metadata regardless of how many fault domains the VMs are spread across. The spreading within each zone is implicit.
+
+## Uniform orchestration mode
+When you deploy a regional (non-zonal) scale set as of API version *2017-12-01*, you have the following availability options:
+
+- Max spreading (platformFaultDomainCount = 1)
+- Static fixed spreading (platformFaultDomainCount = 5)*
+- Spreading aligned with storage disk fault domains (platformFaultDomainCount = 2 or 3)
+
+When you deploy a zonal scale set, you have the following availability options:
+
+- Max spreading (platformFaultDomainCount = 1)*
+- Static fixed spreading (platformFaultDomainCount = 5)
+
+*default if not specified when using the Azure CLI `az vmss create`.
+
+## Flexible orchestration mode
+When you deploy a regional (non-zonal) scale set as of API version *2020-12-01*, you have the following availability options:
+
+- Max spreading (platformFaultDomainCount = 1)*
+- Spreading aligned with storage disk fault domains (platformFaultDomainCount = 2 or 3)
+
+When you deploy a zonal scale set, you have the following availability options:
+
+- Max spreading (platformFaultDomainCount = 1)*
+
+*default if not specified when using the Azure CLI `az vmss create`
+
+ 
 ## REST API
-You can set the property `properties.platformFaultDomainCount` to 1, 2, or 3 (default of 3 if not specified). Refer to the documentation for REST API [here](/rest/api/compute/virtualmachinescalesets/createorupdate).
+You can set the property `properties.platformFaultDomainCount` to 1, 2, 3 or 5 as explained above. Refer to the documentation for REST API [here](/rest/api/compute/virtualmachinescalesets/createorupdate).
 
 ## Azure CLI
-You can set the parameter `--platform-fault-domain-count` to 1, 2, or 3 (default of 3 if not specified). Refer to the documentation for Azure CLI [here](/cli/azure/vmss#az-vmss-create).
+You can set the parameter `--platform-fault-domain-count` to 1, 2, 3 or 5 as explained above. Refer to the documentation for Azure CLI [here](/cli/azure/vmss#az-vmss-create).
 
 ```azurecli-interactive
 az vmss create \


### PR DESCRIPTION
I have spent 3 days trying to understand what platformFaultDomainCount does in zonal and non-zonal scale sets, and found this article, along with https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-availability-zones have not given enough detail at all. 
Specifically what I couldn't tell before, without asking Azure Engineering  - whether platformFaultDomainCount = 1 means Max Spreading in both a zonal and non-zonal scale set, and whether Max Spreading means "best efforts across maximum number of Fault Domains (racks)" for both zonal and non-zonal.

I am more sure about these new docs for Flexible Scale Sets than Uniform but to the best of my testing, this is the case.  

I'm also slightly unsure about the "default" values - I've only tried these out using the Azure CLI, as with an ARM template it fails in certain cases if you don't supply a platformFaultDomainCount, and the API documentation makes no indication if a value is mandatory or has a default value.  In testing using the Azure CLI, what I have written is correct.

I work for A40 but this is my first docs pull request and I'm not sure I'm using the right credentials.