### PR TITLE
Update firewall-integration.md

### DIFF
--- a/articles/container-apps/firewall-integration.md
+++ b/articles/container-apps/firewall-integration.md
@@ -26,8 +26,7 @@ The following tables describe how to configure a collection of NSG allow rules.
 
 | Protocol | Port | ServiceTag | Description |
 |--|--|--|--|
-| Any | \* | Control plane subnet address space | Allow communication between IPs in the control plane subnet. This address is passed to as a parameter when you create an environment. For example, `10.0.0.0/21`. |
-| Any | \* | App subnet address space | Allow communication between nodes in the app subnet. This address is passed as a parameter when you create an environment. For example, `10.0.8.0/21`. |
+| Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed to as a parameter when you create an environment. For example, `10.0.0.0/21`. |
 
 ### Outbound with ServiceTags
 
@@ -45,8 +44,7 @@ As the following rules require allowing all IPs, use a Firewall solution to lock
 |--|--|--|--|
 | TCP | `443` | \* | Allow all outbound on port `443` provides a way to allow all FQDN based outbound dependencies that don't have a static IP. |
 | UDP | `123` | \* | NTP server. If using firewall, allowlist `ntp.ubuntu.com:123`. |
-| Any | \* | Control plane subnet address space | Allow communication between IPs in the control plane subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/21`. |
-| Any | \* | App subnet address space | Allow communication between nodes in the App subnet. This address is passed as a parameter when you create an environment. For example, `10.0.8.0/21`. |
+| Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/21`. |
 
 ## Firewall configuration
 

--- a/articles/container-apps/firewall-integration.md
+++ b/articles/container-apps/firewall-integration.md
@@ -11,12 +11,11 @@ ms.author: jennylaw
 
 # Securing a custom VNET in Azure Container Apps
 
-Firewall settings Network Security Groups (NSGs) needed to configure virtual networks closely resemble the settings required by Kubernetes.
+Network Security Groups (NSGs) needed to configure virtual networks closely resemble the settings required by Kubernetes.
 
-Some outbound dependencies of Azure Kubernetes Service (AKS) clusters rely exclusively on fully qualified domain names (FQDN), therefore securing an AKS cluster purely with NSGs isn't possible. Refer to [Control egress traffic for cluster nodes in Azure Kubernetes Service](/azure/aks/limit-egress-traffic) for details.
+You can lock down a network via NSGs with more restrictive rules than the default NSG rules to control all inbound and outbound traffic for the Container App Environment.
 
-* You can lock down a network via NSGs with more restrictive rules than the default NSG rules.
-* To fully secure a cluster, use a combination of NSGs and a firewall.
+Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. Therefore, securing a Container App Environment with a firewall is not yet supported.
 
 ## NSG allow rules
 
@@ -26,7 +25,8 @@ The following tables describe how to configure a collection of NSG allow rules.
 
 | Protocol | Port | ServiceTag | Description |
 |--|--|--|--|
-| Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed to as a parameter when you create an environment. For example, `10.0.0.0/21`. |
+| Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/23`. |
+| Any | \* | AzureLoadBalancer | Allow the Azure infrastructure load balancer to communicate with your environment. |
 
 ### Outbound with ServiceTags
 
@@ -38,14 +38,8 @@ The following tables describe how to configure a collection of NSG allow rules.
 
 ### Outbound with wild card IP rules
 
-As the following rules require allowing all IPs, use a Firewall solution to lock down to specific FQDNs.
-
 | Protocol | Port | IP | Description |
 |--|--|--|--|
-| TCP | `443` | \* | Allow all outbound on port `443` provides a way to allow all FQDN based outbound dependencies that don't have a static IP. |
-| UDP | `123` | \* | NTP server. If using firewall, allowlist `ntp.ubuntu.com:123`. |
-| Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/21`. |
-
-## Firewall configuration
-
-Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. 
+| TCP | `443` | \* | Allowing all outbound on port `443` provides a way to allow all FQDN based outbound dependencies that don't have a static IP. |
+| UDP | `123` | \* | NTP server. |
+| Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/23`. |

--- a/articles/container-apps/firewall-integration.md
+++ b/articles/container-apps/firewall-integration.md
@@ -47,19 +47,4 @@ As the following rules require allowing all IPs, use a Firewall solution to lock
 | Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/21`. |
 
 ## Firewall configuration
-
-### Outbound FQDN dependencies
-
-| FQDN | Protocol | Port | Description |
-|--|--|--|--|
-| `*.hcp.<REGION>.azmk8s.io` | HTTPS | `443` | Required for internal AKS secure connection between nodes and control plane. |
-| `mcr.microsoft.com` | HTTPS | `443` | Required to access images in Microsoft Container Registry (MCR). This registry contains first-party images and charts (for example, coreDNS). These images are required for the correct creation and functioning of the cluster, including scale and upgrade operations. |
-| `*.data.mcr.microsoft.com` | HTTPS | `443` | Required for MCR storage backed by the Azure content delivery network (CDN). |
-| `management.azure.com` | HTTPS | `443` | Required for Kubernetes operations against the Azure API. |
-| `login.microsoftonline.com` | HTTPS | `443` | Required for Azure Active Directory authentication. |
-| `packages.microsoft.com` | HTTPS | `443` | This address is the Microsoft packages repository used for cached apt-get operations. Example packages include Moby, PowerShell, and Azure CLI. |
-| `acs-mirror.azureedge.net` | HTTPS | `443` | This address is for the repository required to download and install required binaries like `kubenet` and Azure Container Networking Interface. |
-| `dc.services.visualstudio.com` | HTTPS | `443` | This endpoint is used for metrics and monitoring using Azure Monitor. |
-| `*.ods.opinsights.azure.com` | HTTPS | `443` | This endpoint is used by Azure Monitor for ingesting log analytics data. |
-| `*.oms.opinsights.azure.com` | HTTPS | `443` | This endpoint is used by `omsagent`, which is used to authenticate the log analytics service. |
-| `*.monitoring.azure.com` | HTTPS | `443` | This endpoint is used to send metrics data to Azure Monitor. |
+Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. 

--- a/articles/container-apps/firewall-integration.md
+++ b/articles/container-apps/firewall-integration.md
@@ -47,4 +47,5 @@ As the following rules require allowing all IPs, use a Firewall solution to lock
 | Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/21`. |
 
 ## Firewall configuration
+
 Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. 


### PR DESCRIPTION
Propose changing "control plane" to "infrastructure" subnet and removing the reference to the application subnet in the "Inbound" and "Outbound with ServiceTags" NSG rules, since we now just have the infrastructure subnet instead of separate control plane and application subnets.