### PR TITLE
changed link to Azure portal integrated AVD templates

### DIFF
--- a/articles/virtual-desktop/TOC.yml
+++ b/articles/virtual-desktop/TOC.yml
@@ -378,6 +378,6 @@
   - name: Azure Virtual Desktop roadmap
     href: https://aka.ms/avdroadmap
   - name: Azure Resource Manager templates
-    href: https://github.com/Azure/RDS-Templates/tree/master/wvd-templates
+    href: https://github.com/Azure/RDS-Templates/tree/master/ARM-wvd-templates
   - name: Azure compliance offerings
     href: https://azure.microsoft.com/resources/microsoft-azure-compliance-offerings/


### PR DESCRIPTION
I changed link to Azure portal integrated AVD ARM templates, the current link was pointing to the (old) classic ARM Templates