### PR TITLE
Update use-windows-hpc.md

### DIFF
--- a/articles/aks/use-windows-hpc.md
+++ b/articles/aks/use-windows-hpc.md
@@ -111,7 +111,7 @@ NAME                                  READY   STATUS    RESTARTS   AGE
 privileged-daemonset-12345            1/1     Running   0          2m13s
 ```
 
-Use `kubctl log` to view the logs of the pod and verify the pod has administrator rights:
+Use `kubectl log` to view the logs of the pod and verify the pod has administrator rights:
 
 ```output
 $ kubectl logs privileged-daemonset-12345 --namespace kube-system


### PR DESCRIPTION
In the 114 line, command seems wrong.

Use `kubctl log` to view the logs of the pod and verify the pod has administrator rights:

It should be like this Use `kubectl logs` to view the logs of the pod and verify the pod has administrator rights: