### PR TITLE
Update develop-tables-cetas.md

### DIFF
--- a/articles/synapse-analytics/sql/develop-tables-cetas.md
+++ b/articles/synapse-analytics/sql/develop-tables-cetas.md
@@ -101,7 +101,7 @@ WITH (
 AS
 SELECT decennialTime, stateName, SUM(population) AS population
 FROM
-    OPENROWSET(BULK 'https://azureopendatastorage.blob.core.windows.net/censusdatacontainer/release/us_population_county/year=*/*.parquet',
+    OPENROWSET(BULK 'https://azureopendatastorage.dfs.core.windows.net/censusdatacontainer/release/us_population_county/year=*/*.parquet',
     FORMAT='PARQUET') AS [r]
 GROUP BY decennialTime, stateName
 GO


### PR DESCRIPTION
Gen2 Storage Account, which is a Synapse prerequesite -> https://docs.microsoft.com/en-us/sql/t-sql/statements/create-external-data-source-transact-sql?view=azure-sqldw-latest&tabs=dedicated
The doc should be pointing to .dfs. endpoint instead of blob. I was trying to demo with this example and it was failing. Please note this is also documented here: https://docs.microsoft.com/en-us/answers/questions/825946/external-table-location-path-is-not-valid-location.html