### PR TITLE
Add instructions for pushing to the remote

### DIFF
--- a/articles/app-service/includes/quickstart-python/deploy-local-git.md
+++ b/articles/app-service/includes/quickstart-python/deploy-local-git.md
@@ -15,6 +15,20 @@ You can deploy your application code from a local Git repository to Azure by con
 | [!INCLUDE [Deploy local Git Azure portal 3](<./deploy-local-git-azure-portal-3.md>)] | :::image type="content" source="../../media/quickstart-python/deploy-local-git-azure-portal-3-240px.png" alt-text="A screenshot showing the deployment center after saving and the remote Git URL to use for deployments." lightbox="../../media/quickstart-python/deploy-local-git-azure-portal-3.png"::: |
 | [!INCLUDE [Deploy local Git Azure portal 4](<./deploy-local-git-azure-portal-4.md>)] | :::image type="content" source="../../media/quickstart-python/deploy-local-git-azure-portal-4-240px.png" alt-text="A screenshot showing the location of the deployment credentials in the deployment center in App Service." lightbox="../../media/quickstart-python/deploy-local-git-azure-portal-4.png"::: |
 
+Next, in the root directory of your application, configure a [Git remote](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) that points to Azure using the Git URL of the Azure remote obtained in a previous step.
+
+```bash
+git remote add azure <git-deployment-url>
+```
+
+You can now push code from your local Git repository to Azure using the Git remote you just configured. The default deployment branch for App Service is `master`, but many Git repositories are moving away from `master` to `main`. You can either specify the mapping from local branch name to remote branch name in the push (as shown below), or you can configure your [`DEPLOYMENT_BRANCH` app setting](https://docs.microsoft.com/en-us/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).
+
+```bash
+git push azure main:master
+```
+
+The first time you push code to Azure, Git will prompt you for the Azure deployment credentials you obtained in the previous step. Git will then cache these credentials so you will not have to reenter them on subsequent deployments.
+
 ### [Azure CLI](#tab/deploy-instructions-azcli)
 
 First, configure the deployment source for your web app to be local Git using the `az webapp deployment source` command.  This command will output the URL of the remote Git repository that you will be pushing code to.  Make a copy of this value as you will need it in a later step.
@@ -31,7 +45,7 @@ Next, in the root directory of your application, configure a [Git remote](https:
 git remote add azure <git-deployment-url>
 ```
 
-You can now push code from your local Git repository to Azure using the Git remote you just configured. Master is the default deployment branch for App Service. You must specify the mapping from local branch name to remote branch name in the push.
+You can now push code from your local Git repository to Azure using the Git remote you just configured. The default deployment branch for App Service is `master`, but many Git repositories are moving away from `master` to `main`. You can either specify the mapping from local branch name to remote branch name in the push (as shown below), or you can configure your [`DEPLOYMENT_BRANCH` app setting](https://docs.microsoft.com/en-us/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).
 
 ```bash
 git push azure main:master

--- a/articles/app-service/includes/quickstart-python/deploy-local-git.md
+++ b/articles/app-service/includes/quickstart-python/deploy-local-git.md
@@ -21,7 +21,7 @@ Next, in the root directory of your application, configure a [Git remote](https:
 git remote add azure <git-deployment-url>
 ```
 
-You can now push code from your local Git repository to Azure using the Git remote you just configured. The default deployment branch for App Service is `master`, but many Git repositories are moving away from `master` to `main`. You can either specify the mapping from local branch name to remote branch name in the push (as shown below), or you can configure your [`DEPLOYMENT_BRANCH` app setting](https://docs.microsoft.com/en-us/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).
+You can now push code from your local Git repository to Azure using the Git remote you just configured. The default deployment branch for App Service is `master`, but many Git repositories are moving away from `master` to `main`. You can either specify the mapping from local branch name to remote branch name in the push (as shown below), or you can configure your [`DEPLOYMENT_BRANCH` app setting](/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).
 
 ```bash
 git push azure main:master
@@ -45,7 +45,7 @@ Next, in the root directory of your application, configure a [Git remote](https:
 git remote add azure <git-deployment-url>
 ```
 
-You can now push code from your local Git repository to Azure using the Git remote you just configured. The default deployment branch for App Service is `master`, but many Git repositories are moving away from `master` to `main`. You can either specify the mapping from local branch name to remote branch name in the push (as shown below), or you can configure your [`DEPLOYMENT_BRANCH` app setting](https://docs.microsoft.com/en-us/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).
+You can now push code from your local Git repository to Azure using the Git remote you just configured. The default deployment branch for App Service is `master`, but many Git repositories are moving away from `master` to `main`. You can either specify the mapping from local branch name to remote branch name in the push (as shown below), or you can configure your [`DEPLOYMENT_BRANCH` app setting](/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).
 
 ```bash
 git push azure main:master

--- a/articles/app-service/includes/quickstart-python/deploy-local-git.md
+++ b/articles/app-service/includes/quickstart-python/deploy-local-git.md
@@ -1,6 +1,6 @@
 ---
-author: DavidCBerry13
-ms.author: daberry
+author: cephalin
+ms.author: cephalin
 ms.topic: include
 ms.date: 01/29/2022
 ---


### PR DESCRIPTION
When I went through the Flask quickstart, I followed the Azure portal approach. However, the Azure portal instructions stop short of describing how to push to the remote, which I eventually found in the [Ruby tutorial](https://docs.microsoft.com/en-us/azure/app-service/quickstart-ruby#deploy-your-application). I then got the 'master' error which I found described in the general [Deploy Local Git article](https://docs.microsoft.com/en-us/azure/app-service/deploy-local-git?tabs=cli#change-deployment-branch).

Looking at the source code of the Flask tutorial, I realized that the instructions do exist for the Azure CLI tab, so this PR copies those instructions into the Azure portal tab and adds a link to the helpful "Change deployment branch" section of the Deploy Local Git article as well. 

Since these steps are the same across Portal/CLI, I could also make an include for them, if that is preferred.

