### PR TITLE
Add tip on how to add DEPLOYMENT_BRANCH in Portal

### DIFF
--- a/articles/app-service/deploy-local-git.md
+++ b/articles/app-service/deploy-local-git.md
@@ -143,6 +143,9 @@ When you push commits to your App Service repository, App Service deploys the fi
     git push azure main
     ```
 
+    You can also change the `DEPLOYMENT_BRANCH` app setting in the Azure Portal, by selecting **Configuration** under **Settings** and adding a new Application Setting with a name of `DEPLOYMENT_BRANCH` and value of `main`.
+
+
 ## Troubleshoot deployment
 
 You may see the following common error messages when you use Git to publish to an App Service app in Azure:


### PR DESCRIPTION
I'm unable to get the Azure CLI working on my computer so I like when the guides show how to accomplish something in the Portal as another option. This PR adds instructions on how to change DEPLOYMENT_BRANCH in the Portal.
