### PR TITLE
Update overview.md

### DIFF
--- a/articles/postgresql/flexible-server/overview.md
+++ b/articles/postgresql/flexible-server/overview.md
@@ -37,7 +37,7 @@ Flexible servers are best suited for
   
 ## High availability
 
-The flexible server deployment model is designed to support high availability within single availability zone and across multiple availability zones. The architecture separates compute and storage. The database engine runs on a container inside a Linux virtual machine, while data files reside on Azure storage. The storage maintains three locally redundant synchronous copies of the database files ensuring data durability.
+The flexible server deployment model is designed to support high availability within a single availability zone and across multiple availability zones. The architecture separates compute and storage. The database engine runs on a container inside a Linux virtual machine, while data files reside on Azure storage. The storage maintains three locally redundant synchronous copies of the database files ensuring data durability.
 
 During planned or unplanned failover events, if the server goes down, the service maintains high availability of the servers using following automated procedure:
 


### PR DESCRIPTION
Grammatical fix for L40, replaced `high availability within single availability zone` to `high availability within a single availability zone`