### PR TITLE
Update functions-dotnet-dependency-injection.md

### DIFF
--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -228,7 +228,7 @@ And a `local.settings.json` file that might structure the custom setting as foll
 ```
 
 > [!NOTE]
-> ':' are not allowed for Application setting names in the Azure Portal. Use two underscores '__' instead. For example, _MyOptions:MyCustomSetting_ becomes _MyOptions__MyCustomSetting_.
+> ':' are not allowed for Application setting names in the Azure Portal. Use two underscores '__' instead. For example, _MyOptions:MyCustomSetting_ becomes _MyOptions__MyCustomSetting_ in the portal.
 
 From inside the `Startup.Configure` method, you can extract values from the `IConfiguration` instance into your custom type using the following code:
 

--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -228,7 +228,7 @@ And a `local.settings.json` file that might structure the custom setting as foll
 ```
 
 > [!NOTE]
-> ':' are not allowed for Application setting names in the Azure Portal. Use two underscores '__' instead. For example, _MyOptions:MyCustomSetting_ becomes _MyOptions__MyCustomSetting_ in the portal.
+> ':' are not allowed for Application setting names in the Azure portal. Use two underscores '__' instead. For example, _MyOptions:MyCustomSetting_ becomes _MyOptions__MyCustomSetting_ in the portal.
 
 From inside the `Startup.Configure` method, you can extract values from the `IConfiguration` instance into your custom type using the following code:
 

--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -227,6 +227,9 @@ And a `local.settings.json` file that might structure the custom setting as foll
 }
 ```
 
+> [!NOTE]
+> ':' are not allowed for Application setting names in the Azure Portal. Use two underscores '__' instead. For example, _MyOptions:MyCustomSetting_ becomes _MyOptions__MyCustomSetting_.
+
 From inside the `Startup.Configure` method, you can extract values from the `IConfiguration` instance into your custom type using the following code:
 
 ```csharp


### PR DESCRIPTION
The portal does not allow ':' to be used in the Application settings name.  But if you follow the guidance for using the _Options pattern_, you will need to substitute ':' with '__' for your function to run.

Reference:
#86400
#93022