### PR TITLE
Use VM Resource ID as GUID seed

### DIFF
--- a/articles/automation/extension-based-hybrid-runbook-worker-install.md
+++ b/articles/automation/extension-based-hybrid-runbook-worker-install.md
@@ -339,10 +339,6 @@ You can use an Azure Resource Manager (ARM) template to create a new Azure Windo
       "metadata": {
         "description": "DNS name for the public IP"
       }
-    },
-    "_CurrentDateTimeInTicks": {
-      "type": "string",
-      "defaultValue": "[utcNow('yyyy-MM-dd')]"
     }
   },
   "variables": {
@@ -354,8 +350,7 @@ You can use an Azure Resource Manager (ARM) template to create a new Azure Windo
     "vmName": "[parameters('virtualMachineName')]",
     "virtualNetworkName": "MyVNETt",
     "publicIPAddressName": "myPublicIPt",
-    "networkSecurityGroupName": "default-NSGt",
-    "UniqueStringBasedOnTimeStamp": "[uniqueString(deployment().name, parameters('_CurrentDateTimeInTicks'))]"
+    "networkSecurityGroupName": "default-NSGt"
   },
   "resources": [
     {
@@ -499,7 +494,7 @@ You can use an Azure Resource Manager (ARM) template to create a new Azure Windo
       },
       "resources": [
         {
-          "name": "[concat(parameters('workerGroupName'),'/',guid('AzureAutomationJobName', variables('UniqueStringBasedOnTimeStamp')))]",
+          "name": "[concat(parameters('workerGroupName'),'/',guid(resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))))]",
           "type": "hybridRunbookWorkerGroups/hybridRunbookWorkers",
           "apiVersion": "2021-06-22",
           "dependsOn": [


### PR DESCRIPTION
Using a randomly generated seed generates the error "An active hybrid runbook worker 6ebb6681-7c94-5780-8fde-9af90aefcf1d already exists in hybrid worker group test with same AzureResourceId" if the template is redeployed.  Using the VM resource ID ensures that the template can be redeployed without issue as the same GUID will always be generated / assigned for the same VM resource. This change also eliminates the need for the '_currentDateTimeInTicks parameter and UniqeStringBasedOnTimeStap variable.