### PR TITLE
Fix identity type in command placeholder

### DIFF
--- a/articles/app-service/tutorial-connect-msi-azure-database.md
+++ b/articles/app-service/tutorial-connect-msi-azure-database.md
@@ -237,7 +237,7 @@ Next, you configure your App Service app to connect to SQL Database with a manag
 
     ```sql
     SET aad_validate_oids_in_tenant = off;
-    CREATE ROLE <postgresql-user-name> WITH LOGIN PASSWORD '<application-id-of-system-assigned-identity>' IN ROLE azure_ad_user;
+    CREATE ROLE <postgresql-user-name> WITH LOGIN PASSWORD '<application-id-of-user-assigned-identity>' IN ROLE azure_ad_user;
     ```
 
     Whatever name you choose for *\<postgresql-user-name>*, it's the PostgreSQL user you'll use to connect to the database later from your code in App Service.


### PR DESCRIPTION
This PR fixes a small inconsistency in the command placeholder. Before the change, both commands for the user-assigned as well as the system-assigned identity contain the placeholder _system-identity_.
That was confusing to me while following the tutorial.