### PR TITLE
Use secureString for secret ARM template parameter values

### DIFF
--- a/articles/container-apps/background-processing.md
+++ b/articles/container-apps/background-processing.md
@@ -163,12 +163,10 @@ Create a file named *queue.json* and paste the following configuration code into
             "type": "String"
         },
         "environment_name": {
-            "defaultValue": "",
             "type": "String"
         },
         "queueconnection": {
-            "defaultValue": "",
-            "type": "String"
+            "type": "secureString"
         }
     },
     "variables": {},


### PR DESCRIPTION
Noticed this while going through the docs -- I have also removed unnecessary default parameter values which will only cause confusion if you mistakenly do not pass the right parameter from the command line.