### PR TITLE
quickstart-python fails with read-only key

### DIFF
--- a/includes/azure-app-configuration-create.md
+++ b/includes/azure-app-configuration-create.md
@@ -29,4 +29,4 @@ ms.date: 1/31/2020
 
 1. Select **Create**. The deployment might take a few minutes.
 
-1. After the deployment finishes, navigate to the App Configuration resource. Select **Settings** > **Access keys**. Make a note of the primary read-only key connection string. You'll use this connection string later to configure your application to communicate with the App Configuration store that you created.
+1. After the deployment finishes, navigate to the App Configuration resource. Select **Settings** > **Access keys**. Make a note of the primary read-write key connection string. You'll use this connection string later to configure your application to communicate with the App Configuration store that you created.


### PR DESCRIPTION
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-app-configuration/quickstart-python.md fails to work with a read-only key. There may be other examples. It's difficult to adhere to the guideline of using the least privilege possible when re-using the same included instructions in many different contexts.