### PR TITLE
Fix error in PowerShell script, ObjectId parameter should be Id

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/how-to-assign-app-role-managed-identity-powershell.md
+++ b/articles/active-directory/managed-identities-azure-resources/how-to-assign-app-role-managed-identity-powershell.md
@@ -124,7 +124,7 @@ Connect-MgGraph -TenantId $tenantId -Scopes 'Application.Read.All','Application.
 
 # Look up the details about the server app's service principal and app role.
 $serverServicePrincipal = (Get-MgServicePrincipal -Filter "DisplayName eq '$serverApplicationName'")
-$serverServicePrincipalObjectId = $serverServicePrincipal.ObjectId
+$serverServicePrincipalObjectId = $serverServicePrincipal.Id
 $appRoleId = ($serverServicePrincipal.AppRoles | Where-Object {$_.Value -eq $appRoleName }).Id
 
 # Assign the managed identity access to the app role.


### PR DESCRIPTION
The sample script does not work for me without modifications on the latest version of the PowerShell cmdlet.

Get-MgServicePrincipal - The correct property appears to be 'Id' on the returned object, not 'ObjectId. See https://docs.microsoft.com/en-us/powershell/module/microsoft.graph.applications/get-mgserviceprincipal?view=graph-powershell-beta.

Example:
![image](https://user-images.githubusercontent.com/4426330/170446355-fe4292b1-8ea4-401f-be9e-e2c3645b99dc.png)
