### PR TITLE
curl.exe is needed to use -D - option

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-windows.md
@@ -274,14 +274,14 @@ The AADLoginForWindows extension must install successfully in order for the VM t
 
 1. Ensure the required endpoints are accessible from the VM using PowerShell:
    
-   - `curl https://login.microsoftonline.com/ -D -`
-   - `curl https://login.microsoftonline.com/<TenantID>/ -D -`
-   - `curl https://enterpriseregistration.windows.net/ -D -`
-   - `curl https://device.login.microsoftonline.com/ -D -`
-   - `curl https://pas.windows.net/ -D -`
+   - `curl.exe https://login.microsoftonline.com/ -D -`
+   - `curl.exe https://login.microsoftonline.com/<TenantID>/ -D -`
+   - `curl.exe https://enterpriseregistration.windows.net/ -D -`
+   - `curl.exe https://device.login.microsoftonline.com/ -D -`
+   - `curl.exe https://pas.windows.net/ -D -`
 
    > [!NOTE]
-   > Replace `<TenantID>` with the Azure AD Tenant ID that is associated with the Azure subscription.<br/> `enterpriseregistration.windows.net` and `pas.windows.net` should return 404 Not Found, which is expected behavior.
+   > Replace `<TenantID>` with the Azure AD Tenant ID that is associated with the Azure subscription.<br/> `login.microsoftonline.com/<TenantID>`,  `enterpriseregistration.windows.net`, and `pas.windows.net` should return 404 Not Found, which is expected behavior.
             
 1. The Device State can be viewed by running `dsregcmd /status`. The goal is for Device State to show as `AzureAdJoined : YES`.
 


### PR DESCRIPTION
On Windows PowerShell, curl is an alias of Invoke-RestMethod commandlet. This Invoke-RestMethod does not support "-D -" option value. On Windows PowerShell, the correct command will be "curl https://login.microsoftonline.com/ -D" (no trailing -) or "curl.exe https://login.microsoftonline.com/ -D -". If you use curl.exe, the training - is supported and no error is shown. So, I suggest we use curl.exe instead of curl. 

I also added login.microsoftonline.com/<TenantID> to Note as it also returns 404 error.