### PR TITLE
typo: Change TimeSpan.Max to TimeSpan.MaxValue.

### DIFF
--- a/articles/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted.md
+++ b/articles/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted.md
@@ -124,7 +124,7 @@ This section compares Storage queues and Service Bus queues from the perspective
 | --- | --- | --- |
 | Maximum queue size |500 TB<br/><br/>(limited to a [single storage account capacity](../storage/common/storage-introduction.md#queue-storage)) |1 GB to 80 GB<br/><br/>(defined upon creation of a queue and [enabling partitioning](service-bus-partitioning.md) – see the “Additional Information” section) |
 | Maximum message size |64 KB<br/><br/>(48 KB when using Base64 encoding)<br/><br/>Azure supports large messages by combining queues and blobs – at which point you can enqueue up to 200 GB for a single item. |256 KB or 100 MB<br/><br/>(including both header and body, maximum header size: 64 KB).<br/><br/>Depends on the [service tier](service-bus-premium-messaging.md). |
-| Maximum message TTL |Infinite (api-version 2017-07-27 or later) |TimeSpan.Max |
+| Maximum message TTL |Infinite (api-version 2017-07-27 or later) |TimeSpan.MaxValue |
 | Maximum number of queues |Unlimited |10,000<br/><br/>(per service namespace) |
 | Maximum number of concurrent clients |Unlimited |5,000 |
 


### PR DESCRIPTION
# Summary

I noticed the documentation for the maximum message TTL used `TimeSpan.Max` instead of `TimeSpan.MaxValue`. Assuming it means the .NET type constant, then it should be corrected to `TimeSpan.MaxValue`.