### PR TITLE
Add note on required body content.

### DIFF
--- a/articles/azure-functions/functions-manually-run-non-http.md
+++ b/articles/azure-functions/functions-manually-run-non-http.md
@@ -65,8 +65,8 @@ Open Postman and follow these steps:
 
     :::image type="content" source="./media/functions-manually-run-non-http/functions-manually-run-non-http-body.png" alt-text="Postman body settings." border="true":::
 
-> [!NOTE]
-> If you don't want to pass data into the function, you must still pass an empty dictionary `{}` as the body of the POST request.
+   > [!NOTE]
+   > If you don't want to pass data into the function, you must still pass an empty dictionary `{}` as the body of the POST request.
 
 1. Select **Send**.
         

--- a/articles/azure-functions/functions-manually-run-non-http.md
+++ b/articles/azure-functions/functions-manually-run-non-http.md
@@ -65,6 +65,9 @@ Open Postman and follow these steps:
 
     :::image type="content" source="./media/functions-manually-run-non-http/functions-manually-run-non-http-body.png" alt-text="Postman body settings." border="true":::
 
+> [!NOTE]
+> If you don't want to pass data into the function, you must still pass an empty dictionary `{}` as the body of the POST request.
+
 1. Select **Send**.
         
     :::image type="content" source="./media/functions-manually-run-non-http/functions-manually-run-non-http-send.png" alt-text="Send a request with Postman." border="true":::


### PR DESCRIPTION
When manually triggering a function, it appears that a body containing at least `{}` is needed. For example:

Error:
`curl --request POST -H "Content-Type:application/json" http://localhost:7071/admin/functions/Foo`

Ok: 
`curl --request POST -H "Content-Type:application/json" --data '{}' http://localhost:7071/admin/functions/Foo`

I couldn't find a mention of this elsewhere in the docs.