### PR TITLE
Update reservation-renew.md

### DIFF
--- a/articles/cost-management-billing/reservations/reservation-renew.md
+++ b/articles/cost-management-billing/reservations/reservation-renew.md
@@ -43,7 +43,7 @@ The following conditions are required to renew a reservation:
 
 ## Default renewal settings
 
-By default, the renewal inherits all properties from the expiring reservation. A reservation renewal purchase has the same SKU, region, scope, billing subscription, term, and quantity.
+By default, the renewal inherits all properties except automatic renewal setting from the expiring reservation. A reservation renewal purchase has the same SKU, region, scope, billing subscription, term, and quantity.
 
 However, you can update the renewal reservation purchase quantity to optimize your savings.
 


### PR DESCRIPTION
Hi team, thank you for publishing the doc. One of our valued Premier customers asks you for adding no automatic renewal setting is inherited upon auto renewal. Would you please amend it like as below?
Thanks in advance, hiromin
https://docs.microsoft.com/en-us/azure/cost-management-billing/reservations/reservation-renew#default-renewal-settings
Requested)
Default renewal settings
By default, the renewal inherits all properties except automatic renewal setting from the expiring reservation. 
A reservation renewal purchase has the same SKU, region, scope, billing subscription, term, and quantity.
However, you can update the renewal reservation purchase quantity to optimize your savings.