### PR TITLE
Rust FaaS example always returns 404 when deployed. create-first-function-vs-code-other.md

### DIFF
--- a/articles/azure-functions/create-first-function-vs-code-other.md
+++ b/articles/azure-functions/create-first-function-vs-code-other.md
@@ -167,7 +167,7 @@ The *function.json* file in the *HttpExample* folder declares an HTTP trigger fu
             Err(_) => 3000,
         };
 
-        warp::serve(example1).run((Ipv4Addr::UNSPECIFIED, port)).await
+        warp::serve(example1).run((Ipv4Addr::LOCALHOST, port)).await
     }
     ```
 


### PR DESCRIPTION
The example code for the Rust Azure function will always return a 404 error code when deployed, despite working locally.
`Ipv4Addr::UNSPECIFIED` will listen on `0.0.0.0` which seems to suffer from the same issue as `localhost` as described in this issue: https://github.com/Azure/azure-functions-host/issues/6905

Changing it to `Ipv4Addr::LOCALHOST` which is equivelant to `127.0.0.1` solves the issue.

EDIT: I suspect it's related to how this feature is implemented: https://github.com/MicrosoftDocs/azure-docs/blob/e4d8af235ac141b6ff4a4b484071cf69a472d724/articles/azure-functions/create-first-function-vs-code-other.md?plain=1#L193

This is a duplicate of #92875 As that was accidentally closed..