### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#93692

### DIFF
--- a/articles/container-apps/revisions-manage.md
+++ b/articles/container-apps/revisions-manage.md
@@ -120,7 +120,7 @@ As you interact with this example, replace the placeholders surrounded by `<>` w
 
 ## Deactivate
 
-Deactivate revisions that are no longer in use with `az container app revision deactivate`. Deactivation stops all running replicas of a revision.
+Deactivate revisions that are no longer in use with `az containerapp revision deactivate`. Deactivation stops all running replicas of a revision.
 
 # [Bash](#tab/bash)
 


### PR DESCRIPTION
In the Deactivate section there's a small error on the command to execute, page says:
Deactivate revisions that are no longer in use with az container app revision deactivate.

but it should be instead:
Deactivate revisions that are no longer in use with az containerapp revision deactivate.