### PR TITLE
limit of cluster per region

### DIFF
--- a/articles/azure-monitor/logs/customer-managed-keys.md
+++ b/articles/azure-monitor/logs/customer-managed-keys.md
@@ -379,7 +379,7 @@ Customer-Managed key is provided on dedicated cluster and these operations are r
 
 ## Limitations and constraints
 
-- The max number of cluster per region and subscription is two.
+- The max number of cluster per region and subscription is five.
 
 - The maximum number of workspaces that can be linked to a cluster is 1000.
 


### PR DESCRIPTION
The limit of cluster per region per subscription should be 5 and not 2 according to https://docs.microsoft.com/en-us/azure/azure-monitor/logs/logs-dedicated-clusters#limitsandconstraints