### PR TITLE
Update outdated az cli option

### DIFF
--- a/articles/service-connector/quickstart-cli-app-service-connection.md
+++ b/articles/service-connector/quickstart-cli-app-service-connection.md
@@ -78,7 +78,7 @@ Use the Azure CLI [az webapp connection](/cli/azure/webapp/connection) command t
 - **App Service name:** the name of your App Service that connects to the target service.
 
 ```azurecli-interactive
-az webapp connection list -g "<your-app-service-resource-group>" --webapp "<your-app-service-name>"
+az webapp connection list -g "<your-app-service-resource-group>" -n "<your-app-service-name>"
 ```
 
 ## Next steps


### PR DESCRIPTION
The option doesn't work in cloud-shell zure-cli 2.37.0. Replace outdated cli option `--webapp ` with `-n` to specify the webapp resource. The output was:
```shell
bryce@Azure:~$ az webapp connection list -g "brycechen-test" --webapp "bcstartertest"
unrecognized arguments: --webapp bcstartertest
```
my environment is
```
bryce@Azure:~$ az version --output table
Azure-cli    Azure-cli-core    Azure-cli-telemetry
-----------  ----------------  ---------------------
2.37.0       2.37.0            1.0.6
```