### PR TITLE
Removing tag limit on Private DNS Zones

### DIFF
--- a/articles/azure-resource-manager/management/tag-resources.md
+++ b/articles/azure-resource-manager/management/tag-resources.md
@@ -868,7 +868,6 @@ The following limitations apply to tags:
    >     * Azure Automation
    >     * Azure Content Delivery Network (CDN)
    >     * Azure DNS (Zone and A records)
-   >     * Azure Private DNS (Zone, A records, and virtual network link)
 
 ## Next steps
 


### PR DESCRIPTION
We don't limit Private DNS Zones to 15 tags