### PR TITLE
Correct loglevel description

### DIFF
--- a/articles/iot-edge/how-to-retrieve-iot-edge-logs.md
+++ b/articles/iot-edge/how-to-retrieve-iot-edge-logs.md
@@ -82,7 +82,7 @@ This method accepts a JSON payload with the following schema:
 | tail | integer | Number of log lines in the past to retrieve starting from the latest. OPTIONAL. |
 | since | string | Only return logs since this time, as a duration (1 d, 90 m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp.  If both `tail` and `since` are specified, the logs are retrieved using the `since` value first. Then, the `tail` value is applied to the result, and the final result is returned. OPTIONAL. |
 | until | string | Only return logs before the specified time, as an rfc3339 timestamp, UNIX timestamp, or duration (1 d, 90 m, 2 days 3 hours 2 minutes). OPTIONAL. |
-| log level | integer | Filter log lines less than or equal to specified log level. Log lines should follow recommended logging format and use [Syslog severity level](https://en.wikipedia.org/wiki/Syslog#Severity_level) standard. OPTIONAL. |
+| loglevel | integer | Filter log lines equal to specified log level. Log lines should follow recommended logging format and use [Syslog severity level](https://en.wikipedia.org/wiki/Syslog#Severity_level) standard. Should you need to filter by multiple log level severity values, then rely on regex matching, provided the module follows some consistent format when logging different severity levels. OPTIONAL. |
 | regex | string | Filter log lines that have content that match the specified regular expression using [.NET Regular Expressions](/dotnet/standard/base-types/regular-expressions) format. OPTIONAL. |
 | encoding | string | Either `gzip` or `none`. Default is `none`. |
 | contentType | string | Either `json` or `text`. Default is `text`. |


### PR DESCRIPTION
The logical operator based on which it filters loglevel is not less than or equal but equal instead.

https://github.com/Azure/iotedge/blob/7c54bebc8716419ffb4545fd8a578347bac18c80/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProcessor.cs#L106

Discussed it with @veyalla and he considered this a documentation bug rather than a functional defect.