### PR TITLE
Clarified the hash of the public key, and use of the public key

### DIFF
--- a/articles/attestation/claim-sets.md
+++ b/articles/attestation/claim-sets.md
@@ -38,7 +38,7 @@ Claims to be used by policy authors to define authorization rules in an SGX atte
 
 - **x-ms-sgx-mrsigner**: A string value, which identifies the author of SGX enclave.
 
-  MRSIGNER is the hash of the enclave author’s public key which is used to sign the enclave binary. By validating MRSIGNER via an attestation policy, customers can verify if trusted binaries are running inside an enclave. When the policy claim does not match the enclave author’s MRSIGNER, it implies that the enclave binary is not signed by a trusted source and the attestation fails.
+  MRSIGNER is the hash of the enclave author’s public key which is associated with the private key used to sign the enclave binary. By validating MRSIGNER via an attestation policy, customers can verify if trusted binaries are running inside an enclave. When the policy claim does not match the enclave author’s MRSIGNER, it implies that the enclave binary is not signed by a trusted source and the attestation fails.
   
   When an enclave author prefers to rotate MRSIGNER for security reasons, Azure Attestation policy must be updated to support the new and old MRSIGNER values before the binaries are updated. Otherwise authorization checks will fail resulting in attestation failures.
   


### PR DESCRIPTION
You don't sign with a public key, that's the job of the private key.