### PR TITLE
fix node tokenRequest object example

### DIFF
--- a/articles/active-directory/develop/scenario-desktop-acquire-token.md
+++ b/articles/active-directory/develop/scenario-desktop-acquire-token.md
@@ -175,7 +175,7 @@ let accounts = await msalTokenCache.getAllAccounts();
 
             const tokenRequest = {
                 code: response["authorization_code"],
-                codeVerifier: verifier // PKCE Code Verifier 
+                codeVerifier: verifier, // PKCE Code Verifier 
                 redirectUri: "your_redirect_uri",
                 scopes: ["User.Read"],
             };


### PR DESCRIPTION
The tokenRequest object is missing a comma after verifier as object key:value needs to be comma seperated this is an error