### PR TITLE
docs(static-web-apps): build-configuration.md 

### DIFF
--- a/articles/static-web-apps/build-configuration.md
+++ b/articles/static-web-apps/build-configuration.md
@@ -147,6 +147,7 @@ For Node.js applications, you can take fine-grained control over what commands r
 
 > [!NOTE]
 > Currently, you can only define `app_build_command` and `api_build_command` for Node.js builds.
+> To specify the Node.js version, use the [`engines`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines) field in the `package.json` file.
 
 # [GitHub Actions](#tab/github-actions)
 


### PR DESCRIPTION
I encountered a problem while I was trying to build and deploy my Azure Static Web App.
After a while, I found that the default build uses Node.js v14, and that I required v16.

A search on the internet, pointed me to [this Stack Overflow answer](https://stackoverflow.com/a/71947697/10112124), which provided the solution to my issue. 

I think it would be useful if the docs mentioned something about how to specify the Node.js version.