### PR TITLE
fix command to show public IP address in Oracle quick create

### DIFF
--- a/articles/virtual-machines/workloads/oracle/oracle-database-quick-create.md
+++ b/articles/virtual-machines/workloads/oracle/oracle-database-quick-create.md
@@ -100,7 +100,7 @@ In this task you must configure some external endpoints for the database listene
    az network public-ip show ^
        --resource-group rg-oracle ^
        --name vmoracle19cPublicIP ^
-       --query [ipAddress] ^
+       --query "ipAddress" ^
        --output tsv
    ```
 


### PR DESCRIPTION
The current command using `[` and `]` shows nothing. With `"` it works.