### PR TITLE
Stop trying to escape colon in title metadata

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-arm.md
+++ b/articles/active-directory/managed-identities-azure-resources/tutorial-windows-vm-access-arm.md
@@ -1,5 +1,5 @@
 ---
-title: "Tutorial`:` Use managed identity to access Azure Resource Manager - Windows - Azure AD"
+title: "Tutorial: Use managed identity to access Azure Resource Manager - Windows - Azure AD"
 description: A tutorial that walks you through the process of using a Windows VM system-assigned managed identity to access Azure Resource Manager.
 services: active-directory
 documentationcenter: ''


### PR DESCRIPTION
This isn't needed. Just look at e.g. tutorial-windows-vm-ua-arm.md and notice how it doesn't escape the colon but works just fine. Fixes this:
<img width="121" alt="Bad escape in page title" src="https://user-images.githubusercontent.com/2766036/171961351-8b7fb5c9-d3c9-41c9-93f1-0d5625e64a56.png">

Also, this is a Tutorial in the Quickstarts section of the docs. Shouldn't that be changed?