### PR TITLE
Update sap-hana-scale-out-standby-netapp-files-suse.md

### DIFF
--- a/articles/virtual-machines/workloads/sap/sap-hana-scale-out-standby-netapp-files-suse.md
+++ b/articles/virtual-machines/workloads/sap/sap-hana-scale-out-standby-netapp-files-suse.md
@@ -351,7 +351,7 @@ Configure and prepare your OS by doing the following steps:
 > [!TIP]
 > Avoid setting net.ipv4.ip_local_port_range and net.ipv4.ip_local_reserved_ports explicitly in the sysctl configuration files to allow SAP Host Agent to manage the port ranges. For more details see SAP note [2382421](https://launchpad.support.sap.com/#/notes/2382421).  
 
-4. **[A]** Adjust the sunrpc settings, as recommended in SAP note [3024346 - Linux Kernel Settings for NetApp NFS](https://launchpad.support.sap.com/#/notes/3024346).  
+4. **[A]** Adjust the sunrpc settings for NFSv3 volumes, as recommended in SAP note [3024346 - Linux Kernel Settings for NetApp NFS](https://launchpad.support.sap.com/#/notes/3024346).  
 
     <pre><code>
     vi /etc/modprobe.d/sunrpc.conf


### PR DESCRIPTION
adding into on NFS v3 as options sunrpc tcp_max_slot_table_entries=128 only required for NFSv3, not for NFS v4 and v4.1