### PR TITLE
Update tasks-agent-pools.md

### DIFF
--- a/articles/container-registry/tasks-agent-pools.md
+++ b/articles/container-registry/tasks-agent-pools.md
@@ -113,6 +113,7 @@ subnetId=$(az network vnet subnet show \
 
 az acr agentpool create \
     --name myagentpool \
+    --registry MyRegistry \
     --tier S2 \
     --subnet-id $subnetId
 ```


### PR DESCRIPTION
The registry name is required parameter in "az acr agentpool create"  command as mentioned here:
https://docs.microsoft.com/en-us/cli/azure/acr/agentpool?view=azure-cli-latest#az-acr-agentpool-create