### PR TITLE
Proposing to add content on Azure functions integration with Kafka tr…

### DIFF
--- a/articles/partner-solutions/apache-kafka-confluent-cloud/add-connectors.md
+++ b/articles/partner-solutions/apache-kafka-confluent-cloud/add-connectors.md
@@ -19,6 +19,8 @@ To set up your connector, see [Azure Cosmos DB Sink Connector for Confluent Clou
 
 **Azure Cosmos DB Self Managed connector** must be installed manually. First download an uber JAR from the [Cosmos DB Releases page](https://github.com/microsoft/kafka-connect-cosmosdb/releases). Or, you can [build your own uber JAR directly from the source code](https://github.com/microsoft/kafka-connect-cosmosdb/blob/dev/doc/README_Sink.md#install-sink-connector). Complete the installation by following the guidance described in the Confluent documentation for [installing connectors manually](https://docs.confluent.io/home/connect/install.html#install-connector-manually).  
 
+**Azure Functions Kafka Trigger extension** You can use the Apache Kafka trigger in Azure Functions to run your function code in response to messages in Kafka topics. You can also use a Kafka output binding to write from your function to a topic. For information on setup and configuration details, see Apache Kafka bindings for Azure Functions overview.
+
 ## Next steps
 
 For help with troubleshooting, see [Troubleshooting Apache Kafka for Confluent Cloud solutions](troubleshoot.md).


### PR DESCRIPTION
…igger

Azure functions team has announced Kafka trigger integration in GA during Build. We have seen huge adoption of Kafka trigger in Azure functions during preview phase 800+ kafka trigger apps. Good number Confluent Cloud and Azure functions customers among them. Hence adding this link will help customers spin up function app once Kafka broker in Confluent Cloud is setup.
**Azure Functions Kafka Trigger extension** You can use the Apache Kafka trigger in Azure Functions to run your function code in response to messages in Kafka topics. You can also use a Kafka output binding to write from your function to a topic. For information on setup and configuration details, see Apache Kafka bindings for Azure Functions overview.