### PR TITLE
Updated client log path for the Guest Configuration Windows agent

### DIFF
--- a/articles/governance/policy/concepts/guest-configuration.md
+++ b/articles/governance/policy/concepts/guest-configuration.md
@@ -282,8 +282,8 @@ The guest configuration extension writes log files to the following locations:
 
 Windows
 
-Azure VM: C:\ProgramData\GuestConfig\gc_agent_logs\gc_agent.log
-Arc-enabled server: C:\ProgramData\GuestConfig\arc_policy_logs\gc_agent.log
+- Azure VM: `C:\ProgramData\GuestConfig\gc_agent_logs\gc_agent.log`
+- Arc-enabled server: `C:\ProgramData\GuestConfig\arc_policy_logs\gc_agent.log`
 
 Linux
 

--- a/articles/governance/policy/concepts/guest-configuration.md
+++ b/articles/governance/policy/concepts/guest-configuration.md
@@ -280,7 +280,10 @@ Management Groups.
 
 The guest configuration extension writes log files to the following locations:
 
-Windows: `C:\ProgramData\GuestConfig\gc_agent_logs\gc_agent.log`
+Windows
+
+Azure VM: C:\ProgramData\GuestConfig\gc_agent_logs\gc_agent.log
+Arc-enabled server: C:\ProgramData\GuestConfig\arc_policy_logs\gc_agent.log
 
 Linux
 


### PR DESCRIPTION
The client log path for the Azure Guest Configuration Windows agent is different for Azure VMs and Azure-enabled servers, like the Linux agent.

This might have been the same in the past, but testing on new deployments shows that it is now different.