### PR TITLE
Update PowerShell show command

### DIFF
--- a/articles/container-apps/revisions-manage.md
+++ b/articles/container-apps/revisions-manage.md
@@ -57,8 +57,8 @@ az containerapp revision show \
 
 ```azurecli
 az containerapp revision show `
-  --name <REVISION_NAME> `
-  --app <CONTAINER_APP_NAME> `
+  --revision <REVISION_NAME> `
+  --name <CONTAINER_APP_NAME> `
   --resource-group <RESOURCE_GROUP_NAME>
 ```
 


### PR DESCRIPTION
Revision name should be under required parameter "--revision" and there is no parameter "--app" (optional app name is passed in with "--name") according to documentation (https://docs.microsoft.com/en-us/cli/azure/containerapp/revision?view=azure-cli-latest#az-containerapp-revision-show); current commands throw "ERROR: the following arguments are required: --revision"