### PR TITLE
Change to Absolute Path in Line 112

### DIFF
--- a/articles/active-directory/authentication/howto-mfa-nps-extension-errors.md
+++ b/articles/active-directory/authentication/howto-mfa-nps-extension-errors.md
@@ -109,7 +109,7 @@ To collect debug logs for support diagnostics, use the following steps on the NP
 
    ```
    Mkdir c:\NPS
-   Cd NPS
+   Cd c:\NPS
    netsh trace start Scenario=NetConnection capture=yes tracefile=c:\NPS\nettrace.etl
    logman create trace "NPSExtension" -ow -o c:\NPS\NPSExtension.etl -p {7237ED00-E119-430B-AB0F-C63360C8EE81} 0xffffffffffffffff 0xff -nb 16 16 -bs 1024 -mode Circular -f bincirc -max 4096 -ets
    logman update trace "NPSExtension" -p {EC2E6D3A-C958-4C76-8EA4-0262520886FF} 0xffffffffffffffff 0xff -ets


### PR DESCRIPTION
From following these steps, my command prompt opened in a different location.
Because of this, "cd NPS" in line 112 failed as this directory was created in the root "C:\" and once I ran "Start ." in line 128, the File Explorer opened in a different location.

Changing line 112 so it has the user point to the absolute path and the "Start ." command in line 128 will open the File Explorer where the logs will be generated making the user experience better