### PR TITLE
Update supporting offer type

### DIFF
--- a/articles/cost-management-billing/manage/consumption-api-overview.md
+++ b/articles/cost-management-billing/manage/consumption-api-overview.md
@@ -12,7 +12,7 @@ ms.author: banders
 
 # Azure consumption API overview
 
-The Azure Consumption APIs give you programmatic access to cost and usage data for your Azure resources. These APIs currently only support Enterprise Enrollments and Web Direct Subscriptions (with a few exceptions). The APIs are continually updated to support other types of Azure subscriptions.
+The Azure Consumption APIs give you programmatic access to cost and usage data for your Azure resources. These APIs currently only support Enterprise Enrollments, Web Direct Subscriptions (with a few exceptions) and CSP Azure plan Subscriptions. The APIs are continually updated to support other types of Azure subscriptions.
 
 Azure Consumption APIs provide access to:
 - Enterprise and Web Direct Customers

--- a/articles/cost-management-billing/manage/consumption-api-overview.md
+++ b/articles/cost-management-billing/manage/consumption-api-overview.md
@@ -12,7 +12,7 @@ ms.author: banders
 
 # Azure consumption API overview
 
-The Azure Consumption APIs give you programmatic access to cost and usage data for your Azure resources. These APIs currently only support Enterprise Enrollments, Web Direct Subscriptions (with a few exceptions) and CSP Azure plan Subscriptions. The APIs are continually updated to support other types of Azure subscriptions.
+The Azure Consumption APIs give you programmatic access to cost and usage data for your Azure resources. These APIs currently only support Enterprise Enrollments, Web Direct Subscriptions (with a few exceptions), and CSP Azure plan subscriptions. The APIs are continually updated to support other types of Azure subscriptions.
 
 Azure Consumption APIs provide access to:
 - Enterprise and Web Direct Customers


### PR DESCRIPTION
Hello, I'm member of ASMS Japan team.
I modified line 15.
I checked ASMS internally and confirmed that CSP Azure plan subscription can also use this API now and customer would like to update this page.

Please also update this page "https://docs.microsoft.com/en-us/rest/api/consumption/" since there is same description.