### PR TITLE
"all_files_same_headers" not "all_files_have_same_headers"

### DIFF
--- a/articles/machine-learning/concept-data.md
+++ b/articles/machine-learning/concept-data.md
@@ -318,7 +318,7 @@ traits:
 transformations:
     - read_delimited:
         encoding: ascii
-        header: all_files_have_same_headers
+        header: all_files_same_headers
         delimiter: " "
     - keep_columns: ["store_location", "zip_code", "date", "amount", "x", "y", "z"]
     - convert_column_types:


### PR DESCRIPTION
As per the latest mltable package "all_files_same_headers" not "all_files_have_same_headers" Error from the package ----> 'all_files_have_same_headers' is not one of ['no_header', 'from_first_file', 'all_files_different_headers', 'all_files_same_headers']