### PR TITLE
delimiter should be present with ""

### DIFF
--- a/articles/machine-learning/how-to-create-register-data-assets.md
+++ b/articles/machine-learning/how-to-create-register-data-assets.md
@@ -188,7 +188,7 @@ paths:
   - pattern: ./*.txt
 transformations:
   - read_delimited:
-      delimiter: ,
+      delimiter: ","
       encoding: ascii
       header: all_files_same_headers
 ```


### PR DESCRIPTION
Just the delimiter without the "," fails with an error. 

ParserError: while parsing a block node
expected the node content, but found ','
ValueError: MLTable yaml is invalid: None