### PR TITLE
OCI console URL will be change.

### DIFF
--- a/articles/active-directory/saas-apps/oracle-cloud-tutorial.md
+++ b/articles/active-directory/saas-apps/oracle-cloud-tutorial.md
@@ -87,7 +87,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
       > If the **Identifier** and **Reply URL** values do not get auto populated, then fill in the values manually according to your requirement.
 
       In the **Sign-on URL** text box, type a URL using the following pattern:
-      `https://console.<REGIONNAME>.oraclecloud.com/`
+      `https://cloud.oracle.com/?region=<REGIONNAME>`
 
       > [!NOTE]
       > The value is not real. Update the value with the actual Sign-On URL. Contact [Oracle Cloud Infrastructure Console Client support team](https://www.oracle.com/support/advanced-customer-services/cloud/) to get the value. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.


### PR DESCRIPTION
Oracle announced integrate to new OCI console URL (https://cloud.oracle.com/), and will retire old URL (https://console.\<REGIONNAME\>.oraclecloud.com/) .
https://docs.oracle.com/en-us/iaas/Content/GSG/Reference/faq.htm#one-url