### PR TITLE
Update sql-data-warehouse-tables-overview.md

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview.md
+++ b/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview.md
@@ -232,6 +232,7 @@ INNER JOIN sys.dm_pdw_nodes_db_partition_stats nps
     ON nt.[object_id] = nps.[object_id]
     AND nt.[pdw_node_id] = nps.[pdw_node_id]
     AND nt.[distribution_id] = nps.[distribution_id]
+    AND i.[index_id] = nps.[index_id]
 LEFT OUTER JOIN (select * from sys.pdw_column_distribution_properties where distribution_ordinal = 1) cdp
     ON t.[object_id] = cdp.[object_id]
 LEFT OUTER JOIN sys.columns c

--- a/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview.md
+++ b/articles/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview.md
@@ -5,7 +5,7 @@ manager: craigg
 ms.service: synapse-analytics
 ms.topic: conceptual
 ms.subservice: sql-dw 
-ms.date: 11/02/2021
+ms.date: 06/10/2022
 author: WilliamDAssafMSFT
 ms.author: wiassaf
 ms.reviewer: 


### PR DESCRIPTION
Added a new join criteria to the dm_pdw_nodes_db_partition_stats table in the vTableSizes view definition (AND i.[index_id] = nps.[index_id]). Without this records counts are inflated because the query is multiplying the number of records by the number of secondary indexes on the table. This change ensures only the primary index/storage is considered for counting.