### PR TITLE
Fixed invalid json

### DIFF
--- a/articles/active-directory-b2c/add-api-connector.md
+++ b/articles/active-directory-b2c/add-api-connector.md
@@ -72,7 +72,7 @@ Content-type: application/json
      }
  ],
  "displayName": "John Smith",
- "objectId": "11111111-0000-0000-0000-000000000000"
+ "objectId": "11111111-0000-0000-0000-000000000000",
  "givenName":"John",
  "surname":"Smith",
  "jobTitle":"Supplier",


### PR DESCRIPTION
Documentation page for adding an API connector to a sign-up user flow in B2C has invalid JSON due to missing comma.

Added comma to example.