### PR TITLE
Added missing session manager to embedded password reset

### DIFF
--- a/articles/active-directory-b2c/add-password-reset-policy.md
+++ b/articles/active-directory-b2c/add-password-reset-policy.md
@@ -130,6 +130,7 @@ Declare your claims in the [claims schema](claimsschema.md). Open the extensions
     </BuildingBlocks> -->
     ```
 
+### Add the Technical Profiles
 A claims transformation technical profile initiates the **isForgotPassword** claim. The technical profile is referenced later. When invoked, it sets the value of the **isForgotPassword** claim to `true`. Find the **ClaimsProviders** element. If the element doesn't exist, add it. Then add the following claims provider:  
 
 ```xml
@@ -151,6 +152,9 @@ A claims transformation technical profile initiates the **isForgotPassword** cla
           <Item Key="setting.forgotPasswordLinkOverride">ForgotPasswordExchange</Item>
         </Metadata>
       </TechnicalProfile>
+      <TechnicalProfile Id="LocalAccountWritePasswordUsingObjectId">
+        <UseTechnicalProfileForSessionManagement ReferenceId="SM-AAD" />
+      </TechnicalProfile>
     </TechnicalProfiles>
   </ClaimsProvider>
 <!-- 
@@ -158,6 +162,8 @@ A claims transformation technical profile initiates the **isForgotPassword** cla
 ```
 
 The **SelfAsserted-LocalAccountSignin-Email** technical profile **setting.forgotPasswordLinkOverride** defines the password reset claims exchange that executes in your user journey.
+
+The **LocalAccountWritePasswordUsingObjectId** technical profile **UseTechnicalProfileForSessionManagement** AAD session manager is required for sessions to persist correctly for SSO.
 
 ### Add the password reset sub journey
 

--- a/articles/active-directory-b2c/add-password-reset-policy.md
+++ b/articles/active-directory-b2c/add-password-reset-policy.md
@@ -130,8 +130,8 @@ Declare your claims in the [claims schema](claimsschema.md). Open the extensions
     </BuildingBlocks> -->
     ```
 
-### Add the Technical Profiles
-A claims transformation technical profile accesses the `isForgotPassword` claim. The technical profile is referenced later. When it's invoked, it sets the value of the `isForgotPassword` claim to `true`. Find the **ClaimsProviders** element (if the element doesn't exist, create it), then add the following claims provider:
+### Add the technical profiles
+A claims transformation technical profile accesses the `isForgotPassword` claim. The technical profile is referenced later. When it's invoked, it sets the value of the `isForgotPassword` claim to `true`. Find the **ClaimsProviders** element (if the element doesn't exist, create it), and then add the following claims provider:
 
 ```xml
 <!-- 

--- a/articles/active-directory-b2c/add-password-reset-policy.md
+++ b/articles/active-directory-b2c/add-password-reset-policy.md
@@ -131,7 +131,7 @@ Declare your claims in the [claims schema](claimsschema.md). Open the extensions
     ```
 
 ### Add the Technical Profiles
-A claims transformation technical profile initiates the **isForgotPassword** claim. The technical profile is referenced later. When invoked, it sets the value of the **isForgotPassword** claim to `true`. Find the **ClaimsProviders** element. If the element doesn't exist, add it. Then add the following claims provider:  
+A claims transformation technical profile accesses the `isForgotPassword` claim. The technical profile is referenced later. When it's invoked, it sets the value of the `isForgotPassword` claim to `true`. Find the **ClaimsProviders** element (if the element doesn't exist, create it), then add the following claims provider:
 
 ```xml
 <!-- 

--- a/articles/active-directory-b2c/add-password-reset-policy.md
+++ b/articles/active-directory-b2c/add-password-reset-policy.md
@@ -163,7 +163,7 @@ A claims transformation technical profile accesses the `isForgotPassword` claim.
 
 The **SelfAsserted-LocalAccountSignin-Email** technical profile **setting.forgotPasswordLinkOverride** defines the password reset claims exchange that executes in your user journey.
 
-The **LocalAccountWritePasswordUsingObjectId** technical profile **UseTechnicalProfileForSessionManagement** AAD session manager is required for sessions to persist correctly for SSO.
+The **LocalAccountWritePasswordUsingObjectId** technical profile **UseTechnicalProfileForSessionManagement** `SM-AAD` session manager is required for the user to preform subsequent logins successfully under [SSO](./custom-policy-reference-sso.md) conditions.
 
 ### Add the password reset sub journey
 


### PR DESCRIPTION
Without this session manager the user journey can fall into the password reset flow unwillingly when using SSO.