### PR TITLE
Update howto-service-principal-credential-rotation.md

### DIFF
--- a/articles/openshift/howto-service-principal-credential-rotation.md
+++ b/articles/openshift/howto-service-principal-credential-rotation.md
@@ -88,7 +88,7 @@ To check the expiration date of service principal credentials run the following:
 # Service principal expiry in ISO 8601 UTC format
 SP_ID=$(az aro show --name MyManagedCluster --resource-group MyResourceGroup \
     --query servicePrincipalProfile.clientId -o tsv)
-az ad sp credential list --id $SP_ID --query "[].endDate" -o tsv
+az ad app credential list --id $SP_ID --query "[].endDate" -o tsv
 ```
 If the service principal credentials are expired please update using one of the two credential rotation methods.
 


### PR DESCRIPTION
With the recent updates on the Az module (https://docs.microsoft.com/en-us/cli/azure/microsoft-graph-migration), running "az ad sp credential list" now queries the Service Principal Object and returns no results if customers follow the document. "az ad app credential list" should be used instead to keep querying the Application Object where the Key Credentials reside.