### PR TITLE
Update redemption-experience.md

### DIFF
--- a/articles/active-directory/external-identities/redemption-experience.md
+++ b/articles/active-directory/external-identities/redemption-experience.md
@@ -81,7 +81,7 @@ When a user clicks the **Accept invitation** link in an [invitation email](invit
 
 ![Screenshot showing the redemption flow diagram](media/redemption-experience/invitation-redemption-flow.png)
 
-**If the user’s User Principal Name (UPN) matches with both an existing Azure AD and personal MSA account, the user will be prompted to choose which account they want to redeem with.*
+**If the user’s User Principal Name (UPN) matches with both an existing Azure AD and personal MSA account, the user will be prompted to choose which account they want to redeem with. If Email OTP is enabled, existing unmanaged "viral" Azure AD accounts will be ignored (See step #9).*
 
 1. Azure AD performs user-based discovery to determine if the user exists in an [existing Azure AD tenant](./what-is-b2b.md#easily-invite-guest-users-from-the-azure-ad-portal).
 


### PR DESCRIPTION
Updating doc to let people know that we've tweaked the logic in step #1. If Email OTP is enabled, we will ignore viral accounts that may have been previously created in step 9.