### PR TITLE
Fixing FOTT link to reference release page

### DIFF
--- a/articles/applied-ai-services/form-recognizer/containers/form-recognizer-container-install-run.md
+++ b/articles/applied-ai-services/form-recognizer/containers/form-recognizer-container-install-run.md
@@ -420,7 +420,7 @@ http {
 
 * Gather a set of at least six forms of the same type. You'll use this data to train the model and test a form. You can use a [sample data set](https://go.microsoft.com/fwlink/?linkid=2090451) (download and extract *sample_data.zip*). Download the training files to the **shared** folder you created above.
 
-* If you want to label your data, download the [Form Recognizer Sample Labeling tool for Windows](https://github.com/microsoft/OCR-Form-Tools/releases/tag/v2.1-ga). The download will import the labeling tool .exe file that you'll use to label the data present on your local file system. You can ignore any warnings that occur during the download process.
+* If you want to label your data, download the [Form Recognizer Sample Labeling tool for Windows](https://github.com/microsoft/OCR-Form-Tools/releases). The download will import the labeling tool .exe file that you'll use to label the data present on your local file system. You can ignore any warnings that occur during the download process.
 
 #### Create a new Sample Labeling tool project
 


### PR DESCRIPTION
At the moment the link to "Recognizer Sample Labeling tool for Windows" is referring to the `v2.1-ga` version. However, there is a newer `v2.1-ga-hotfix` version, so the document is prone to introducing outdated versions. 

Referencing the `latest` version is one option, but the approach can unintendedly introduce use of beta/preview versions. As such the proposal is to let the link point to the general releases page instead so the customer can see which version is the de-facto "latest" one.