### PR TITLE
Update application-proxy-configure-complex-application.md

### DIFF
--- a/articles/active-directory/app-proxy/application-proxy-configure-complex-application.md
+++ b/articles/active-directory/app-proxy/application-proxy-configure-complex-application.md
@@ -69,7 +69,7 @@ Here is an example of the request.
 
 
 ```http
-PATCH https://graph.microsoft.com/beta/applications/{<object-id-of--the-complex-app}
+PATCH https://graph.microsoft.com/beta/applications/{<object-id-of--the-complex-app-under-App-Registration}
 Content-type: application/json
 
 {


### PR DESCRIPTION
if you agree with me this needs to be identified and be clear, as the customer will understand the object ID under the enterprise APP blade not the Object ID under the APP registration blade.
old :{<object-id-of--the-complex-app}
suggestion : {<object-id-of--the-complex-app-under-App-Registration}