### PR TITLE
Added priority argument to create gateway command

### DIFF
--- a/articles/application-gateway/quick-create-cli.md
+++ b/articles/application-gateway/quick-create-cli.md
@@ -153,7 +153,8 @@ az network application-gateway create \
   --public-ip-address myAGPublicIPAddress \
   --vnet-name myVNet \
   --subnet myAGSubnet \
-  --servers "$address1" "$address2"
+  --servers "$address1" "$address2" \
+  --priority 100
 ```
 
 It can take up to 30 minutes for Azure to create the application gateway. After it's created, you can view the following settings in the **Settings** section of the **Application gateway** page:


### PR DESCRIPTION
An error was occurring when trying to run the az network application-gateway create command as shown. I needed to add the --priority 100 argument to allow it to work.