### PR TITLE
missing "properties" in bash/PS1 query examples

### DIFF
--- a/articles/container-apps/vnet-custom-internal.md
+++ b/articles/container-apps/vnet-custom-internal.md
@@ -195,11 +195,11 @@ First, extract identifiable information from the environment.
 # [Bash](#tab/bash)
 
 ```bash
-ENVIRONMENT_DEFAULT_DOMAIN=`az containerapp env show --name ${CONTAINERAPPS_ENVIRONMENT} --resource-group ${RESOURCE_GROUP} --query defaultDomain --out json | tr -d '"'`
+ENVIRONMENT_DEFAULT_DOMAIN=`az containerapp env show --name ${CONTAINERAPPS_ENVIRONMENT} --resource-group ${RESOURCE_GROUP} --query properties.defaultDomain --out json | tr -d '"'`
 ```
 
 ```bash
-ENVIRONMENT_STATIC_IP=`az containerapp env show --name ${CONTAINERAPPS_ENVIRONMENT} --resource-group ${RESOURCE_GROUP} --query staticIp --out json | tr -d '"'`
+ENVIRONMENT_STATIC_IP=`az containerapp env show --name ${CONTAINERAPPS_ENVIRONMENT} --resource-group ${RESOURCE_GROUP} --query properties.staticIp --out json | tr -d '"'`
 ```
 
 ```bash
@@ -209,11 +209,11 @@ VNET_ID=`az network vnet show --resource-group ${RESOURCE_GROUP} --name ${VNET_N
 # [PowerShell](#tab/powershell)
 
 ```powershell
-$ENVIRONMENT_DEFAULT_DOMAIN=(az containerapp env show --name $CONTAINERAPPS_ENVIRONMENT --resource-group $RESOURCE_GROUP --query defaultDomain -o tsv)
+$ENVIRONMENT_DEFAULT_DOMAIN=(az containerapp env show --name $CONTAINERAPPS_ENVIRONMENT --resource-group $RESOURCE_GROUP --query properties.defaultDomain -o tsv)
 ```
 
 ```powershell
-$ENVIRONMENT_STATIC_IP=(az containerapp env show --name $CONTAINERAPPS_ENVIRONMENT --resource-group $RESOURCE_GROUP --query staticIp -o tsv)
+$ENVIRONMENT_STATIC_IP=(az containerapp env show --name $CONTAINERAPPS_ENVIRONMENT --resource-group $RESOURCE_GROUP --query properties.staticIp -o tsv)
 ```
 
 ```powershell


### PR DESCRIPTION
the json object returned has staticIp and defaultDomain under the properties element

E.g.

{
  "id": "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.App/managedEnvironments/begim-ca-env2",
  "location": "uksouth",
  "name": "begim-ca-env2",
  "properties": {
    "appLogsConfiguration": {
      "destination": "log-analytics",
      "logAnalyticsConfiguration": {
        ...
      }
    },
    "defaultDomain": "wonderfulbeach-088cf62d.uksouth.azurecontainerapps.io",
    "provisioningState": "Succeeded",
    "staticIp": "10.2.0.248",
    "vnetConfiguration": {
      ...
    },
    "zoneRedundant": false
  },
  "resourceGroup": "aks-rg",
  "systemData": {
      ...
  },
  "type": "Microsoft.App/managedEnvironments"
}