### PR TITLE
ONNX Compat issues with latest skl2onnx

### DIFF
--- a/articles/azure-sql-edge/deploy-onnx.md
+++ b/articles/azure-sql-edge/deploy-onnx.md
@@ -179,6 +179,9 @@ onnx_model_path = 'boston1.model.onnx'
 onnxmltools.utils.save_model(onnx_model, onnx_model_path)
 ```
 
+> [!NOTE]
+> You may need to set the target_opset parameter for skl2onnx.convert_sklearn function, if there is a mismatch between ONNX runtime version in SQL Edge and skl2onnx packge. See [SQL Edge Release notes](https://docs.microsoft.com/en-us/azure/azure-sql-edge/release-notes) to get the ONNX runtime version corresponding for the release and pick the target_opset for ONNX runtime based on the [ONNX backward compatibility matrix](https://github.com/microsoft/onnxruntime/blob/master/docs/Versioning.md#version-matrix).
+
 ## Test the ONNX model
 
 After converting the model to ONNX format, score the model to show little to no degradation in performance.

--- a/articles/azure-sql-edge/deploy-onnx.md
+++ b/articles/azure-sql-edge/deploy-onnx.md
@@ -180,7 +180,7 @@ onnxmltools.utils.save_model(onnx_model, onnx_model_path)
 ```
 
 > [!NOTE]
-> You may need to set the target_opset parameter for skl2onnx.convert_sklearn function, if there is a mismatch between ONNX runtime version in SQL Edge and skl2onnx packge. See [SQL Edge Release notes](https://docs.microsoft.com/en-us/azure/azure-sql-edge/release-notes) to get the ONNX runtime version corresponding for the release and pick the target_opset for ONNX runtime based on the [ONNX backward compatibility matrix](https://github.com/microsoft/onnxruntime/blob/master/docs/Versioning.md#version-matrix).
+> You may need to set the `target_opset` parameter for the skl2onnx.convert_sklearn function if there is a mismatch between ONNX runtime version in SQL Edge and skl2onnx packge. For more information, see the [SQL Edge Release notes](release-notes.md) to get the ONNX runtime version corresponding for the release, and pick the `target_opset` for the ONNX runtime based on the [ONNX backward compatibility matrix](https://github.com/microsoft/onnxruntime/blob/master/docs/Versioning.md#version-matrix).
 
 ## Test the ONNX model
 


### PR DESCRIPTION
In order for models to work against SQL Edge the target_opset parameter needs to be set

See ICM https://portal.microsofticm.com/imp/v3/incidents/details/314922421/home for customer issue report details