### PR TITLE
[Documentation] Update the sample to use GA version

### DIFF
--- a/articles/communication-services/quickstarts/ui-library/includes/get-started-call/ios.md
+++ b/articles/communication-services/quickstarts/ui-library/includes/get-started-call/ios.md
@@ -43,7 +43,7 @@ platform :ios, '14.0'
 
 target 'UILibraryQuickStart' do
     use_frameworks!
-    pod 'AzureCommunicationUICalling', '1.0.0-beta.2'
+    pod 'AzureCommunicationUICalling', '1.0.0'
 end
 ```
 


### PR DESCRIPTION
Update MSDocs for `AzureCommunicationUICalling` moving to GA