### PR TITLE
Added clarity around UAA for tenant level

### DIFF
--- a/articles/cost-management-billing/reservations/view-reservations.md
+++ b/articles/cost-management-billing/reservations/view-reservations.md
@@ -133,7 +133,8 @@ When you use the PowerShell script to assign the ownership role and it runs succ
 - Accept pipeline input: False
 - Accept wildcard characters: False
 
-[User Access Administrators](../../role-based-access-control/built-in-roles.md#user-access-administrator) can add the users to Reservation Administrator and Reservation Reader roles.
+# Tenant level access
+[User Access Administrator](../../role-based-access-control/built-in-roles.md#user-access-administrator) rights are required before you can grant users or groups the Reservation Administrator and Reservation Reader roles at the tenant level.
 
 ## Add a Reservation Administrator role at the tenant level
 

--- a/articles/cost-management-billing/reservations/view-reservations.md
+++ b/articles/cost-management-billing/reservations/view-reservations.md
@@ -133,7 +133,7 @@ When you use the PowerShell script to assign the ownership role and it runs succ
 - Accept pipeline input: False
 - Accept wildcard characters: False
 
-# Tenant level access
+## Tenant-level access
 [User Access Administrator](../../role-based-access-control/built-in-roles.md#user-access-administrator) rights are required before you can grant users or groups the Reservation Administrator and Reservation Reader roles at the tenant level.
 
 ## Add a Reservation Administrator role at the tenant level


### PR DESCRIPTION
Added a top level heading to make it clear that you must grant UAA before you can apply tenant level permissions.
Previously it was just a line of text above a sub-heading which makes it appear to apply to the previous section, not the following one