### PR TITLE
Update Get-AzSubscription PS Command Example

### DIFF
--- a/articles/virtual-machines/windows/build-image-with-packer.md
+++ b/articles/virtual-machines/windows/build-image-with-packer.md
@@ -56,7 +56,8 @@ $sp.AppId
 To authenticate to Azure, you also need to obtain your Azure tenant and subscription IDs with [Get-AzSubscription](/powershell/module/az.accounts/get-azsubscription):
 
 ```powershell
-Get-AzSubscription
+$subName = "mySubscriptionName"
+$sub = Get-AzSubscription -SubscriptionName $subName
 ```
 
 


### PR DESCRIPTION
The documentation references output from $sub.TenantId and $sub.SubscriptionId in the "Where to Obtain" section of the table under "Define Packer Template", however there are no commands specified that would create/define the $sub variable and its values. Updated the PowerShell example command for Get-AzSubscription to properly store results in variable $sub so that a user can properly retrieve the Tenant and Sub ID values.