### PR TITLE
Fixing SAS Token variable for Azure Databricks Example

### DIFF
--- a/articles/open-datasets/dataset-taxi-yellow.md
+++ b/articles/open-datasets/dataset-taxi-yellow.md
@@ -187,7 +187,7 @@ Sample not available for this platform/package combination.
 blob_account_name = "azureopendatastorage"
 blob_container_name = "nyctlc"
 blob_relative_path = "yellow"
-blob_sas_token = r"
+blob_sas_token = "r"
 
 # Allow SPARK to read from Blob remotely
 wasbs_path = 'wasbs://%s@%s.blob.core.windows.net/%s' % (blob_container_name, blob_account_name, blob_relative_path)


### PR DESCRIPTION
The Read token is incorrect and fails if you try to use the code example as it misses a quote "

Fails with Syntax error 
![image](https://user-images.githubusercontent.com/315909/175042551-f0cb6b2d-f11b-4d26-a5f9-58dacd595977.png)
