### PR TITLE
Update concepts-audit.md

### DIFF
--- a/articles/postgresql/single-server/concepts-audit.md
+++ b/articles/postgresql/single-server/concepts-audit.md
@@ -45,6 +45,9 @@ To use the [portal](https://portal.azure.com):
    1. Select **PGAUDIT**.
    
       :::image type="content" source="./media/concepts-audit/share-preload-parameter.png" alt-text="Screenshot that shows Azure Database for PostgreSQL enabling shared_preload_libraries for PGAUDIT.":::
+      
+   1. Search for **azure.extensions**.
+   2. Select **PGAUDIT**.
 
    1. Restart the server to apply the change.
    1. Check that `pgaudit` is loaded in `shared_preload_libraries` by executing the following query in psql:


### PR DESCRIPTION
If this new step is missing, (selecting PGAUDIT on the azure.extensions Server Parameter), once you execute the command "CREATE EXTENSION pgaudit" (step 7 in the actual documentation), will get an error message saying the following:
ERROR:  extension "pgaudit" is not allow-listed for "azure_pg_admin" users in Azure Database for PostgreSQL
HINT:  to see the full allow list of extensions, please run: "show azure.extensions;"