### PR TITLE
Update docs for reading a data asset reference

### DIFF
--- a/articles/machine-learning/how-to-read-write-data-v2.md
+++ b/articles/machine-learning/how-to-read-write-data-v2.md
@@ -40,6 +40,7 @@ When you provide a data input/output to a Job, you'll need to specify a `path` p
 |A path on a public http(s) server    |  `https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/titanic.csv`    |
 |A path on Azure Storage     |   `https://<account_name>.blob.core.windows.net/<container_name>/path` <br> `abfss://<file_system>@<account_name>.dfs.core.windows.net/<path>`    |
 |A path on a Datastore   |   `azureml://datastores/<data_store_name>/paths/<path>`      |
+|A path to a Data Asset  |  `azureml:<my_data>:<version>`  |
 
 ## Supported modes
 


### PR DESCRIPTION
Docs do not explicitly show how to reference a registered data asset. It is alluded to in the comments of the example, but is extremely easy to miss. I think it should be listed here as one of the ways to reference data.