### PR TITLE
Update rule name to match schema in Azure/bicep repository

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -51,7 +51,7 @@ The following example shows the rules that are available for configuration.
         "simplify-interpolation": {
           "level": "warning"
         },
-        "use-protectedsettings-for-commandtoexecute-secrets": {
+        "protect-commandtoexecute-secrets": {
           "level": "warning"
         },
         "use-stable-vm-image": {


### PR DESCRIPTION
Rule name in document does not match current schema for bicepconfig in Azure/bicep repository

Azure/bicep@c7ce978/src/vscode-bicep/schemas/bicepconfig.schema.json

If using the name in the current docs you get a warning / error in VS Code when trying to use it