### PR TITLE
Fix link to Python env variables anchor

### DIFF
--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -24,7 +24,7 @@ Other language stacks, likewise, get the app settings as environment variables a
 - [ASP.NET Core](configure-language-dotnetcore.md#access-environment-variables)
 - [Node.js](configure-language-nodejs.md#access-environment-variables)
 - [PHP](configure-language-php.md#access-environment-variables)
-- [Python](configure-language-python.md#access-environment-variables)
+- [Python](configure-language-python.md#access-app-settings-as-environment-variables)
 - [Java](configure-language-java.md#configure-data-sources)
 - [Ruby](configure-language-ruby.md#access-environment-variables)
 - [Custom containers](configure-custom-container.md#configure-environment-variables)


### PR DESCRIPTION
The current Python link from https://docs.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal goes to the wrong section. This PR fixes that to point to https://docs.microsoft.com/en-us/azure/app-service/configure-language-python#access-app-settings-as-environment-variables instead.