### PR TITLE
Correct statement about when `location` is present

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-functions-deployment.md
+++ b/articles/azure-resource-manager/bicep/bicep-functions-deployment.md
@@ -26,7 +26,7 @@ This function returns the object that is passed during deployment. The propertie
 * deploying a local Bicep file.
 * deploying to a resource group or deploying to one of the other scopes ([Azure subscription](deploy-to-subscription.md), [management group](deploy-to-management-group.md), or [tenant](deploy-to-tenant.md)).
 
-When deploying a local Bicep file to a resource group: the function returns the following format:
+When deploying a local Bicep file to a resource group, the function returns the following format:
 
 ```json
 {
@@ -48,7 +48,7 @@ When deploying a local Bicep file to a resource group: the function returns the 
 }
 ```
 
-When you deploy to an Azure subscription, management group, or tenant, the return object includes a `location` property. The location property is included when deploying a local Bicep file. The format is:
+When you deploy to an Azure subscription, management group, or tenant, the return object includes a `location` property. The `location` property is not included when deploying a local Bicep file. The format is:
 
 ```json
 {


### PR DESCRIPTION
And format the property name. And change a `:` to a `,` for grammar/legibility.