### PR TITLE
Update dominant-speaker-web.md to use the new feature function rather than api old function

### DIFF
--- a/articles/communication-services/how-tos/calling-sdk/includes/dominant-speaker/dominant-speaker-web.md
+++ b/articles/communication-services/how-tos/calling-sdk/includes/dominant-speaker/dominant-speaker-web.md
@@ -33,7 +33,7 @@ const dominantSpeakersChangedHandler = () => {
     // Get the most up to date list of dominant speakers
     let dominantSpeakers = callDominantSpeakersApi.dominantSpeakers;
 };
-callDominantSpeakersApi.api(Features.CallDominantSpeakers).on('dominantSpeakersChanged', dominantSpeakersChangedHandler);
+callDominantSpeakersApi.on('dominantSpeakersChanged', dominantSpeakersChangedHandler);
 ``` 
 #### Handle the Dominant Speaker's video streams
 


### PR DESCRIPTION
The code was still using the old api function which has been renamed to feature. Also, we already have the CallDominantSpeakers feature object, so we can use it directly without get the feature again