### PR TITLE
Adding autoremove command after Moby uninstall

### DIFF
--- a/articles/iot-edge/how-to-provision-single-device-linux-symmetric.md
+++ b/articles/iot-edge/how-to-provision-single-device-linux-symmetric.md
@@ -298,6 +298,7 @@ Finally, remove the container runtime from your device.
 ```bash
 sudo apt-get remove --purge moby-cli
 sudo apt-get remove --purge moby-engine
+sudo apt autoremove
 ```
 
 ## Next steps


### PR DESCRIPTION
Added "sudo apt autoremove" command after uninstalling moby-engine.
Without executing this command, a fresh installation of moby runtime could fail.