### PR TITLE
Fix typo in nodepool snapshot creation

### DIFF
--- a/articles/aks/node-pool-snapshot.md
+++ b/articles/aks/node-pool-snapshot.md
@@ -41,7 +41,7 @@ NODEPOOL_ID=$(az aks nodepool show --name nodepool1 --cluster-name myAKSCluster 
 Now, to take a snapshot from the previous node pool you'll use the `az aks snapshot` CLI command.
 
 ```azurecli-interactive
-az aks snapshot create --name MySnapshot --resource-group MyResourceGroup --nodepool-id $NODEPOOL_ID --location eastus
+az aks nodepool snapshot create --name MySnapshot --resource-group MyResourceGroup --nodepool-id $NODEPOOL_ID --location eastus
 ```
 
 ## Create a node pool from a snapshot


### PR DESCRIPTION
This is a simple PR to fix the creation of a nodepool snapshot command line.

If we use `az aks snapshot create` as documented previously, the cli actually tries to create a full snapshot of the cluster, instead of just the nodepool. Also, the command line fails with message: `the following arguments are required: --cluster-id`.

The fix is simple, we just need to use `az aks nodepool snapshot create` instead.