### PR TITLE
Update network-requirements.md

### DIFF
--- a/articles/azure-arc/servers/network-requirements.md
+++ b/articles/azure-arc/servers/network-requirements.md
@@ -13,7 +13,7 @@ This topic describes the networking requirements for using the Connected Machine
 
 The Azure Connected Machine agent for Linux and Windows communicates outbound securely to Azure Arc over TCP port 443. By default, the agent uses the default route to the internet to reach Azure services. You can optionally [configure the agent to use a proxy server](manage-agent.md#update-or-remove-proxy-settings) if your network requires it. Proxy servers don't make the Connected Machine agent more secure because the traffic is already encrypted.
 
-To further secure your network connectivity to Azure Arc, instead of using public networks and proxy servers, you can implement an [Azure Arc Private Link Scope](private-link-security.md) (preview).
+To further secure your network connectivity to Azure Arc, instead of using public networks and proxy servers, you can implement an [Azure Arc Private Link Scope](private-link-security.md) .
 
 > [!NOTE]
 > Azure Arc-enabled servers does not support using a [Log Analytics gateway](../../azure-monitor/agents/gateway.md) as a proxy for the Connected Machine agent.


### PR DESCRIPTION
Private link for Azure-Arc-enabled servers isn't preview anymore, that's GA now.