### PR TITLE
Fixes description for HyperScale Citus overview

### DIFF
--- a/articles/postgresql/hyperscale/index.yml
+++ b/articles/postgresql/hyperscale/index.yml
@@ -2,7 +2,7 @@
 title: Hyperscale (Citus) documentation
 summary: "Hyperscale (Citus) is PostgreSQL extended with the superpower of distributed tables. It's a fully managed service designed to build highly scalable relational apps."
 metadata:
-  description: "Azure Database for PostgreSQL is a relational database service in the Microsoft cloud that is built for developers based on the open-source PostgreSQL database engine."
+  description: "Hyperscale (Citus) is PostgreSQL extended with the superpower of distributed tables. It's a fully managed service designed to build highly scalable relational apps."
   author: jonels-msft
   ms.author: jonels
   ms.date: 04/28/2022


### PR DESCRIPTION
When sharing a link to HyperScale(citus) in Slack, I realized that the preview contained some information that appeared to be copy pasted from another managed service.

Feel free to update the description, and take ownership of this PR.

![image](https://user-images.githubusercontent.com/6772247/175933170-4c49603c-fad5-4931-a973-126bd96d3af2.png)
