### PR TITLE
Update groups-assign-sensitivity-labels.md

### DIFF
--- a/articles/active-directory/enterprise-users/groups-assign-sensitivity-labels.md
+++ b/articles/active-directory/enterprise-users/groups-assign-sensitivity-labels.md
@@ -33,7 +33,7 @@ To apply published labels to groups, you must first enable the feature. These st
     ```powershell
     Install-Module AzureADPreview
     Import-Module AzureADPreview
-    Connect-AzureAD
+    AzureADPreview\Connect-AzureAD
     ```
 
     In the **Sign in to your account** page, enter your admin account and password to connect you to your service, and select **Sign in**.


### PR DESCRIPTION
Can not connect to AzureAD with "Connect-AzureAD" command. "AzureADPreview" needs to be specified if the user already has "Connect-AzureAD" installed. Which most do.