### PR TITLE
Update the Storage Key PowerShell command

### DIFF
--- a/articles/event-grid/storage-upload-process-images.md
+++ b/articles/event-grid/storage-upload-process-images.md
@@ -113,7 +113,7 @@ The *images* container's public access is set to `off`. The *thumbnails* contain
 Get the storage account key by using the [Get-AzStorageAccountKey](/powershell/module/az.storage/get-azstorageaccountkey) command. Then, use this key to create two containers with the [New-AzStorageContainer](/powershell/module/az.storage/new-azstoragecontainer) command.
 
 ```powershell
-$blobStorageAccountKey = (Get-AzStorageAccountKey -ResourceGroupName myResourceGroup -Name $blobStorageAccount).Key1
+$blobStorageAccountKey = ((Get-AzStorageAccountKey -ResourceGroupName myResourceGroup -Name $blobStorageAccount)| Where-Object {$_.KeyName -eq "key1"}).Value
 $blobStorageContext = New-AzStorageContext -StorageAccountName $blobStorageAccount -StorageAccountKey $blobStorageAccountKey
 
 New-AzStorageContainer -Name images -Context $blobStorageContext


### PR DESCRIPTION
As per the documentation for Get-AzStorageAccountKey I have update the command to use Azure PowerShell version 1.4 (or later) versions as this is the default installed on Azure Cloud Shell.