### PR TITLE
Add note about MapControllers in ASP.NET Core

### DIFF
--- a/articles/active-directory/develop/scenario-web-app-sign-user-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-app-sign-user-app-configuration.md
@@ -261,7 +261,7 @@ To add authentication with the Microsoft identity platform (formerly Azure AD v2
      }).AddMicrosoftIdentityUI();
     ```
 
-3. In the `Configure` method in *Startup.cs*, enable authentication with a call to `app.UseAuthentication();`
+3. In the `Configure` method in *Startup.cs*, enable authentication with a call to `app.UseAuthentication();` and `app.MapControllers();`.
 
    ```c#
    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -270,6 +270,9 @@ To add authentication with the Microsoft identity platform (formerly Azure AD v2
     // more code here
     app.UseAuthentication();
     app.UseAuthorization();
+    
+    app.MapRazorPages();
+    app.MapControllers();
     // more code here
    }
    ```


### PR DESCRIPTION
`MapControllers` is not called by default when starting with a new ASP.NET Core Web App that uses Razor Pages. However, since the Microsoft Identity UI uses it, forgetting to add it will cause sign-in and sign-out links to stay blank and manually navigating to `/MicrosoftIdentity/Account/SignOut` to result in a 404.

Considering the documentation already mentions `UseAuthentication` and `AddRazorPages` in the samples, I feel like `MapControllers` should be added as well.