### PR TITLE
Fix typo CDIR -> CIDR

### DIFF
--- a/articles/container-apps/vnet-custom.md
+++ b/articles/container-apps/vnet-custom.md
@@ -24,7 +24,7 @@ The following example shows you how to create a Container Apps environment in an
 [!INCLUDE [container-apps-create-portal-steps.md](../../includes/container-apps-create-portal-steps.md)]
 
 > [!NOTE]
-> Network address prefixes requires a CDIR range of `/23`.
+> Network address prefixes requires a CIDR range of `/23`.
 
 7. Select the **Networking** tab to create a VNET.
 8. Select **Yes** next to *Use your own virtual network*.


### PR DESCRIPTION
Typo CDIR -> CIDR.
Maybe `range` could also be substituted by the word `length` in this case, but i may be exaggerating.