### PR TITLE
Fix host-header argument for ngrok http command

### DIFF
--- a/includes/functions-event-grid-local-dev.md
+++ b/includes/functions-event-grid-local-dev.md
@@ -16,7 +16,7 @@ To break into a function being debugged on your machine, you must enable a way f
 The [ngrok](https://ngrok.com/) utility provides a way for Azure to call the function running on your machine. Start *ngrok* using the following command:
 
 ```bash
-ngrok http -host-header=localhost 7071
+ngrok http --host-header=localhost 7071
 ```
 As the utility is set up, the command window should look similar to the following screenshot:
 


### PR DESCRIPTION
When running `ngrok http -host-header=localhost 7071` the user will encounter the following error:
`ERROR:  unknown shorthand flag: 'o' in -ost-header=localhost`

Adding an additional dash so that the argument, which says "--host-header" will allow the command to function as expected.