### PR TITLE
Update api-server-authorized-ip-ranges.md

### DIFF
--- a/articles/aks/api-server-authorized-ip-ranges.md
+++ b/articles/aks/api-server-authorized-ip-ranges.md
@@ -25,7 +25,7 @@ This article shows you how to use API server authorized IP address ranges, using
 
 The API server Authorized IP ranges feature has the following limitations:
 
-- On clusters created after API server authorized IP address ranges moved out of preview in October 2019, API server authorized IP address ranges are only supported on the *Standard* SKU load balancer. Existing clusters with the *Basic* SKU load balancer and API server authorized IP address ranges configured will continue work as is, but they cann't be migrated to a *Standard* SKU load balancer. Existing clusters will also continue to work if their Kubernetes version or control plane are upgraded.
+- API server authorized IP address ranges are only supported on the *Standard* SKU load balancer. Existing clusters with the *Basic* SKU load balancer and API server authorized IP address ranges configured will continue work as is, but they cann't be migrated to a *Standard* SKU load balancer. Existing clusters will also continue to work if their Kubernetes version or control plane are upgraded.
 - API server authorized IP address ranges aren't supported with private clusters.
 - When using this feature with clusters that use [Public IP per Node](use-multiple-node-pools.md#assign-a-public-ip-per-node-for-your-node-pools), those node pools with public IP per node enabled must use public IP prefixes, and those prefixes must be added as authorized ranges.
 


### PR DESCRIPTION
Removed old context.
"On clusters created after API server authorized IP address ranges moved out of preview in October 2019"

The feature reached GA a long time ago and is now incorporated in security recommendations etc. 
Keeping this old reference makes the documentation seem out of date.