### PR TITLE
Update tutorial-pipeline-python-sdk.md

### DIFF
--- a/articles/machine-learning/tutorial-pipeline-python-sdk.md
+++ b/articles/machine-learning/tutorial-pipeline-python-sdk.md
@@ -250,6 +250,10 @@ Create the directory for this component:
 
 [!Notebook-python[] (~/azureml-examples-main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb?name=train_src_dir)]
 
+Create the training script in the directory:
+
+[!Notebook-python[] (~/azureml-examples-main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb?name=train.py)]
+
 As you can see in this training script, once the model is trained, the model file is saved and registered to the workspace. Now you can use the registered model in inferencing endpoints.
 
 


### PR DESCRIPTION
Added missing code to generate train.py file.

Note: I am unsure how to test it to make sure it displays the right code it takes from the jupyter notebook. I followed the same pattern as elsewhere. 