### PR TITLE
Important note on prerequisite to pull images from ACR into ACA 

### DIFF
--- a/articles/container-apps/containers.md
+++ b/articles/container-apps/containers.md
@@ -196,7 +196,7 @@ You can use an Azure managed identity to authenticate with Azure Container Regis
 - Specify the managed identity you want to use for each registry.
 
 > [!NOTE]
-> You will need to [enable an admin user account](../container-registry/container-registry-authentication?tabs=azure-cli#admin-account) in your Azure
+> You will need to [enable an admin user account](../container-registry/container-registry-authentication.md) in your Azure
 > Container Registry even when you use an Azure managed identity.  You will not need to use the ACR admin credentials to pull images into Azure
 > Container Apps, however, it is a prequisite to have the ACR admin user account enabled in the registry Azure Container Apps is pulling from.
 

--- a/articles/container-apps/containers.md
+++ b/articles/container-apps/containers.md
@@ -196,8 +196,9 @@ You can use an Azure managed identity to authenticate with Azure Container Regis
 - Specify the managed identity you want to use for each registry.
 
 > [!NOTE]
-> You will need to [enable an admin user account](../container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
-> in your Azure Container Registry even when you use an Azure managed identity.  You will not need to use the ACR admin credentials to pull images into > Azure Container Apps, however, it is a prequisite to have the ACR admin user account enabled in the registry Azure Container Apps is pulling from. 
+> You will need to [enable an admin user account](../container-registry/container-registry-authentication?tabs=azure-cli#admin-account) in your Azure
+> Container Registry even when you use an Azure managed identity.  You will not need to use the ACR admin credentials to pull images into Azure
+> Container Apps, however, it is a prequisite to have the ACR admin user account enabled in the registry Azure Container Apps is pulling from.
 
 When assigned a managed identity to a registry, use the managed identity resource ID for a user-assigned identity, or "system" for the system-assigned identity. For more information about using managed identities see, [Managed identities in Azure Container Apps Preview](managed-identity.md).
 

--- a/articles/container-apps/containers.md
+++ b/articles/container-apps/containers.md
@@ -195,6 +195,10 @@ You can use an Azure managed identity to authenticate with Azure Container Regis
 - Assign a system-assigned or user-assigned managed identity to your container app.
 - Specify the managed identity you want to use for each registry.
 
+> [!NOTE]
+> You will need to [enable an admin user account](../container-registry/container-registry-authentication?tabs=azure-cli#admin-account)
+> in your Azure Container Registry even when you use an Azure managed identity.  You will not need to use the ACR admin credentials to pull images into > Azure Container Apps, however, it is a prequisite to have the ACR admin user account enabled in the registry Azure Container Apps is pulling from. 
+
 When assigned a managed identity to a registry, use the managed identity resource ID for a user-assigned identity, or "system" for the system-assigned identity. For more information about using managed identities see, [Managed identities in Azure Container Apps Preview](managed-identity.md).
 
 ```json


### PR DESCRIPTION
Hi team,

When creating a new Container from ACR in an Azure Container App, a prerequisite is to enable an admin user account on the particular Azure Container Registry that the Azure Container App will be attempting to pull images from.  It is, therefore, worthwhile mentioning that regardless of how the Azure Container App is authenticating against the Azure Container Registry, the latter will have to be set up with an admin user account enabled, even though the usage of managed identities won't require the actual credentials' values.