### PR TITLE
error getting resourceID USING --output tsv

### DIFF
--- a/articles/container-instances/container-instances-managed-identity.md
+++ b/articles/container-instances/container-instances-managed-identity.md
@@ -102,7 +102,7 @@ spID=$(az identity show \
 resourceID=$(az identity show \
   --resource-group myResourceGroup \
   --name myACIId \
-  --query id --output tsv)
+  --query id --output none)
 ```
 
 ### Grant user-assigned identity access to the key vault


### PR DESCRIPTION
error getting resourceID using --output tsv. This includes at the end of the resource "\r" causing bad request when yo create the container with the command:
az container create \
  --resource-group myResourceGroup \
  --name mycontainer \
  --image mcr.microsoft.com/azure-cli \
  --assign-identity $resourceID \
  --command-line "tail -f /dev/null"

If I use --output none it works.