### PR TITLE
Fix typo in mca-section-invoice.md

### DIFF
--- a/articles/cost-management-billing/manage/mca-section-invoice.md
+++ b/articles/cost-management-billing/manage/mca-section-invoice.md
@@ -194,7 +194,7 @@ The total charges for using 100 TB of data in this scenario is **180.5**
 
 #### You have multiple billing profiles.
 
-Now, let's assume you created another billing profile and used 50 GB through subscriptions that are billed to the first billing profile and 50 GB through subscriptions that are billed to the second billing profile, here's how much you would be charged.
+Now, let's assume you created another billing profile and used 50 TB through subscriptions that are billed to the first billing profile and 50 TB through subscriptions that are billed to the second billing profile, here's how much you would be charged.
 
 `Charges for the first billing profile`
 


### PR DESCRIPTION
Correct typo for 50 GB to be 50 TB in the second example for comparing billing profile set ups.