### PR TITLE
Clarification on WPJ removal tool versions support

### DIFF
--- a/articles/active-directory/devices/faq.yml
+++ b/articles/active-directory/devices/faq.yml
@@ -270,7 +270,7 @@ sections:
           - For iOS and Android, you can use the Microsoft Authenticator application **Settings** > **Device Registration** and select **Unregister device**.
           - For macOS, you can use the Microsoft Intune Company Portal application to unenroll the device from management and remove any registration. 
           
-          For Windows 10/11 devices, this process can be automated with the [Workplace Join (WPJ) removal tool](https://download.microsoft.com/download/8/e/f/8ef13ae0-6aa8-48a2-8697-5b1711134730/WPJCleanUp.zip)
+          For Windows 10 version 2004 and older, this process can be automated with the [Workplace Join (WPJ) removal tool](https://download.microsoft.com/download/8/e/f/8ef13ae0-6aa8-48a2-8697-5b1711134730/WPJCleanUp.zip)
           
           > [!NOTE]
           > This tool removes all SSO accounts on the device. After this operation, all applications will lose SSO state, and the device will be unenrolled from management tools (MDM) and unregistered from the cloud. The next time an application tries to sign in, users will be asked to add the account again.


### PR DESCRIPTION
Per discussion with PG (Balaji), the WPJ removal tool was designed to work with Windows 10 version 2004 and older.