### PR TITLE
Remove duplicate Front Door header info

### DIFF
--- a/articles/frontdoor/front-door-http-headers-protocol.md
+++ b/articles/frontdoor/front-door-http-headers-protocol.md
@@ -42,7 +42,6 @@ Front Door includes headers for an incoming request unless they're removed becau
 | X-Forwarded-Host | *X-Forwarded-Host: contoso.azurefd.net* </br> The X-Forwarded-Host HTTP header field is a common method used to identify the original host requested by the client in the Host HTTP request header. This is because the host name from Front Door may differ for the backend server handling the request. Any previous value will be overridden by Front Door. |
 | X-Forwarded-Proto | *X-Forwarded-Proto: http* </br> The X-Forwarded-Proto HTTP header field is often used to identify the originating protocol of an HTTP request. Front Door based on configuration might communicate with the backend by using HTTPS. This is true even if the request to the reverse proxy is HTTP. Any previous value will be overridden by Front Door. |
 | X-FD-HealthProbe | X-FD-HealthProbe HTTP header field is used to identify the health probe from Front Door. If this header is set to 1, the request is from the health probe. It can be used to restrict access from Front Door with a particular value for the X-Forwarded-Host header field. |
-| X-Azure-FDID | *X-Azure-FDID header: 437c82cd-360a-4a54-94c3-5ff707647783* </br> This field contains frontdoorID that can be used to identify which Front Door the incoming request is from. This field is populated by Front Door service. | 
 
 ## Front Door to client
 


### PR DESCRIPTION
Removed duplicate definition for the X-Azure-FDID header.

The description for the other entry was kept intact.