### PR TITLE
[fix] pull secret doc shouldn't tell user to update status

### DIFF
--- a/articles/openshift/howto-add-update-pull-secret.md
+++ b/articles/openshift/howto-add-update-pull-secret.md
@@ -149,7 +149,7 @@ First, modify the Samples Operator configuration file. Then, you can run the fol
 oc edit configs.samples.operator.openshift.io/cluster -o yaml
 ```
 
-Change the `spec.architectures.managementState` and `status.architecture.managementState` values from `Removed` to `Managed`. 
+Change the `spec.architectures.managementState` value from `Removed` to `Managed`. 
 
 The following YAML snippet shows only the relevant sections of the edited YAML file:
 
@@ -164,13 +164,6 @@ spec:
   architectures:
   - x86_64
   managementState: Managed
-status:
-  architectures:
-
-  ...
-
-  managementState: Managed
-  version: 4.3.27
 ```
 
 Second, run the following command to edit the Operator Hub configuration file:  
@@ -179,7 +172,7 @@ Second, run the following command to edit the Operator Hub configuration file:
 oc edit operatorhub cluster -o yaml
 ```
 
-Change the `Spec.Sources.Disabled` and `Status.Sources.Disabled` values from `true` to `false` for any sources you want enabled.
+Change the `Spec.Sources.Disabled` value from `true` to `false` for any sources you want enabled.
 
 The following YAML snippet shows only the relevant sections of the edited YAML file:
 
@@ -194,18 +187,6 @@ Spec:
     Name:      certified-operators
     Disabled:  false
     Name:      redhat-operators
-Status:
-  Sources:
-    Disabled:  false
-    Name:      certified-operators
-    Status:    Success
-    Disabled:  false
-    Name:      community-operators
-    Status:    Success
-    Disabled:  false
-    Name:      redhat-operators
-    Status:    Success
-Events:        <none>
 ```
 
 Save the file to apply your edits.


### PR DESCRIPTION
The user should not need to update the status of the kubernetes resources, kubernetes itself will do this after it has made the changes specified in the spec.