### PR TITLE
Update how-to-gmsa-cmdlets.md

### DIFF
--- a/articles/active-directory/cloud-sync/how-to-gmsa-cmdlets.md
+++ b/articles/active-directory/cloud-sync/how-to-gmsa-cmdlets.md
@@ -7,7 +7,7 @@ manager: karenhoran
 ms.service: active-directory
 ms.workload: identity
 ms.topic: how-to
-ms.date: 11/16/2020
+ms.date: 2022-07-01
 ms.subservice: hybrid
 ms.author: billmath
 ms.collection: M365-identity-device-management
@@ -15,13 +15,13 @@ ms.collection: M365-identity-device-management
 
 # Azure AD Connect cloud provisioning agent gMSA PowerShell cmdlets
 
-The purpose of this document is to describe the Azure AD Connect cloud provisioning agent gMSA PowerShell cmdlets. These cmdlets allow you to have more granularity on the permissions that are applied on the service account (gMSA). By default, Azure AD Connect cloud sync applies all permissions similar to Azure AD Connect on the default gMSA or a custom gMSA.
+The purpose of this document is to describe the Azure AD Connect cloud provisioning agent gMSA PowerShell cmdlets. These cmdlets allow you to have more granularity on the permissions that are applied on the service account (gMSA). By default, Azure AD Connect cloud sync applies all permissions similar to Azure AD Connect on the default gMSA or a custom gMSA, during cloud provisioning agent install.
 
 This document will cover the following cmdlets:
 
-`Set-AADCloudSyncRestrictedPermissions`
-
 `Set-AADCloudSyncPermissions`
+
+`Set-AADCloudSyncRestrictedPermissions`
 
 ## How to use the cmdlets:
 
@@ -32,34 +32,26 @@ The following prerequisites are required to use these cmdlets.
 2. Import Provisioning Agent PS module into a PowerShell session.
 
    ```powershell
-   Import-Module "C:\Program Files\Microsoft Azure AD Connect Provisioning Agent\Microsoft.CloudSync.Powershell.dll"  
+   Import-Module "C:\Program Files\Microsoft Azure AD Connect Provisioning Agent\Microsoft.CloudSync.Powershell.dll"
    ```
 
-3. Remove existing permissions.  To remove all existing permissions on the service account, except SELF use: `Set-AADCloudSyncRestrictedPermission`.
+3. These cmdlets require a parameter called `Credential` which can be passed, or will prompt the user if not provided in the command line. Depending on the cmdlet syntax used, these credentials must be an enterprise admin account or, at a minimum, a domain administrator of the target domain where you're setting the permissions. 
 
-   This cmdlet requires a parameter called `Credential` which can be passed, or it will prompt if called without it.
-
-   To create a variable, use:
+4. To create a variable for credentials, use:
 
    `$credential = Get-Credential`
+   
+5. To set Active Directory permissions for cloud provisioning agent, you can use the following cmdlet. This will grant permissions in the root of the domain allowing the service account to manage on-premises Active Directory objects. See [Using Set-AADCloudSyncPermissions](#using-set-aadcloudsyncpermissions) below for examples on setting the permissions.
 
-   This will prompt the user to enter username and password. The credentials must be at a minimum domain administrator(of the domain where agent is installed), could be enterprise admin as well.
+   `Set-AADCloudSyncPermissions -EACredential $credential`
 
-4. Then you can call the cmdlet to remove extra permissions:
+6. To restrict Active Directory permissions set by default on the cloud provisioning agent account, you can use the following cmdlet. This will increase the security of the service account by disabling permission inheritance and removing all existing permissions, except SELF and Full Control for administrators. See [Using Set-AADCloudSyncRestrictedPermission](#using-set-aadcloudsyncrestrictedpermission) below for examples on restricting the permissions.
 
-   ```powershell
-   Set-AADCloudSyncRestrictedPermissions -Credential $credential 
-   ```
-
-5. Or you can simply call:
-
-   `Set-AADCloudSyncRestrictedPermissions` which will prompt for credentials.
-
-6. Add specific permission type. Permissions added are same as Azure AD Connect. See [Using Set-AADCloudSyncPermissions](#using-set-aadcloudsyncpermissions) below for examples on setting the permissions.
+   `Set-AADCloudSyncRestrictedPermission -Credential $credential`
 
 ## Using Set-AADCloudSyncPermissions
 
-`Set-AADCloudSyncPermissions` supports the following permission types which are identical to the permissions used by Azure AD Connect. The following permission types are supported:
+`Set-AADCloudSyncPermissions` supports the following permission types which are identical to the permissions used by Azure AD Connect Classic Sync (ADSync). The following permission types are supported:
 
 |Permission type|Description|
 |-----|-----|
@@ -69,28 +61,43 @@ The following prerequisites are required to use these cmdlets.
 |HybridExchangePermissions|See [HybridExchangePermissions](../../active-directory/hybrid/how-to-connect-configure-ad-ds-connector-account.md#permissions-for-exchange-hybrid-deployment) permissions for Azure AD Connect|
 |ExchangeMailPublicFolderPermissions| See [ExchangeMailPublicFolderPermissions](../../active-directory/hybrid/how-to-connect-configure-ad-ds-connector-account.md#permissions-for-exchange-mail-public-folders) permissions for Azure AD Connect|
 |CloudHR| Applies 'Create/delete User objects' on 'This object and all descendant objects'|
-|All|adds all the above permissions.|
+|All| Applies all the above permissions|
 
 You can use AADCloudSyncPermissions in one of two ways:
-- [Grant a certain permission to all configured domains](#grant-a-certain-permission-to-all-configured-domains)
-- [Grant a certain permission to a specific domain](#grant-a-certain-permission-to-a-specific-domain)
+- [Grant permissions to all configured domains](#grant-permissions-to-all-configured-domains)
+- [Grant permissions to a specific domain](#grant-permissions-to-a-specific-domain)
 
-## Grant a certain permission to all configured domains
+## Grant permissions to all configured domains
 
 Granting certain permissions to all configured domains will require the use of an enterprise admin account.
 
 ```powershell
-Set-AADCloudSyncPermissions -PermissionType "Any mentioned above" -EACredential $credential (prepopulated same as above [$credential = Get-Credential]) 
+$credential = Get-Credential
+Set-AADCloudSyncPermissions -PermissionType "Any mentioned above" -EACredential $credential 
 ```
 
-## Grant a certain permission to a specific domain
+## Grant permissions to a specific domain
 
-Granting certain permissions to a specific domain will require the use of, at minimum a domain admin account of the domain you are attempting to add.
+Granting certain permissions to a specific domain will require the use of a TargetDomainCredential that is enterprise admin or, domain admin of the target domain. The TargetDomain has to be already configured through wizard.
 
 ```powershell
-Set-AADCloudSyncPermissions -PermissionType "Any mentioned above" -TargetDomain "FQDN of domain" (has to be already configured through wizard) -TargetDomainCredential $credential(same as above) 
+$credential = Get-Credential
+Set-AADCloudSyncPermissions -PermissionType "Any mentioned above" -TargetDomain "FQDN of domain" -TargetDomainCredential $credential
 ```
 
-Note: for 1. The credentials must be at a minimum Enterprise admin.
+## Using Set-AADCloudSyncRestrictedPermissions
+For increased security, `Set-AADCloudSyncRestrictedPermissions` will tighten the permissions set on the cloud provisioning agent account itself. Hardening permissions on the cloud provisioning agent account involves the following changes: 
 
-For 2. The Credentials can be either Domain admin or enterprise admin.
+- Disable inheritance
+- Remove all default permissions, except ACEs specific to SELF.
+- Set Full Control permissions for SYSTEM, Administrators, Domain Admins, and Enterprise Admins.
+- Set Read permissions for Authenticated Users and Enterprise Domain Controllers.
+ 
+  The -Credential parameter is necessary to specify the Administrator account that has the necessary privileges to restrict Active Directory permissions on the cloud provisioning agent account. This is typically the domain or enterprise administrator.  
+ 
+For Example: 
+
+``` powershell
+$credential = Get-Credential 
+Set-AADCloudSyncRestrictedPermissions -Credential $credential  
+```


### PR DESCRIPTION
- The article was misleading an admin to remove permissions with Set-AADCloudSyncRestrictedPermissions and then add the permissions Set-AADCloudSyncPermissions when that's not the designed purpose of these cmdlets. These cmdlets have different purposes and are used independently so I gave Set-AADCloudSyncRestrictedPermissions its own section and provided more details.
- For consistency, adapted some of the text already present in AADConnect documentation (https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-configure-ad-ds-connector-account#restrict-permissions-on-the-ad-ds-connector-account).
- Made other small plain English updates for better readability.