### PR TITLE
Clarify the object id required for Cosmos RBAC auth

### DIFF
--- a/articles/cosmos-db/how-to-setup-rbac.md
+++ b/articles/cosmos-db/how-to-setup-rbac.md
@@ -317,8 +317,7 @@ Assign a role to an identity:
 $resourceGroupName = "<myResourceGroup>"
 $accountName = "<myCosmosAccount>"
 $readOnlyRoleDefinitionId = "<roleDefinitionId>" # as fetched above
-# Make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
-# the other Object ID does not work for this
+# For Service Principals make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
 $principalId = "<aadPrincipalId>"
 New-AzCosmosDBSqlRoleAssignment -AccountName $accountName `
     -ResourceGroupName $resourceGroupName `
@@ -335,8 +334,7 @@ Assign a role to an identity:
 resourceGroupName='<myResourceGroup>'
 accountName='<myCosmosAccount>'
 readOnlyRoleDefinitionId = '<roleDefinitionId>' # as fetched above
-# Make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
-# the other Object ID does not work for this
+# For Service Principals make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
 principalId = '<aadPrincipalId>'
 az cosmosdb sql role assignment create --account-name $accountName --resource-group $resourceGroupName --scope "/" --principal-id $principalId --role-definition-id $readOnlyRoleDefinitionId
 ```

--- a/articles/cosmos-db/how-to-setup-rbac.md
+++ b/articles/cosmos-db/how-to-setup-rbac.md
@@ -319,7 +319,6 @@ $accountName = "<myCosmosAccount>"
 $readOnlyRoleDefinitionId = "<roleDefinitionId>" # as fetched above
 # Make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
 # the other Object ID does not work for this
-# for managed identities make sure you update the filter in the portal to include them by default it's just 'Enterprise Applications'
 $principalId = "<aadPrincipalId>"
 New-AzCosmosDBSqlRoleAssignment -AccountName $accountName `
     -ResourceGroupName $resourceGroupName `
@@ -338,7 +337,6 @@ accountName='<myCosmosAccount>'
 readOnlyRoleDefinitionId = '<roleDefinitionId>' # as fetched above
 # Make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
 # the other Object ID does not work for this
-# for managed identities make sure you update the filter in the portal to include them by default it's just 'Enterprise Applications'
 principalId = '<aadPrincipalId>'
 az cosmosdb sql role assignment create --account-name $accountName --resource-group $resourceGroupName --scope "/" --principal-id $principalId --role-definition-id $readOnlyRoleDefinitionId
 ```

--- a/articles/cosmos-db/how-to-setup-rbac.md
+++ b/articles/cosmos-db/how-to-setup-rbac.md
@@ -317,6 +317,9 @@ Assign a role to an identity:
 $resourceGroupName = "<myResourceGroup>"
 $accountName = "<myCosmosAccount>"
 $readOnlyRoleDefinitionId = "<roleDefinitionId>" # as fetched above
+# Make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
+# the other Object ID does not work for this
+# for managed identities make sure you update the filter in the portal to include them by default it's just 'Enterprise Applications'
 $principalId = "<aadPrincipalId>"
 New-AzCosmosDBSqlRoleAssignment -AccountName $accountName `
     -ResourceGroupName $resourceGroupName `
@@ -333,6 +336,9 @@ Assign a role to an identity:
 resourceGroupName='<myResourceGroup>'
 accountName='<myCosmosAccount>'
 readOnlyRoleDefinitionId = '<roleDefinitionId>' # as fetched above
+# Make sure to use the Object ID as found in the Enterprise applications section of the Azure Active Directory portal blade.
+# the other Object ID does not work for this
+# for managed identities make sure you update the filter in the portal to include them by default it's just 'Enterprise Applications'
 principalId = '<aadPrincipalId>'
 az cosmosdb sql role assignment create --account-name $accountName --resource-group $resourceGroupName --scope "/" --principal-id $principalId --role-definition-id $readOnlyRoleDefinitionId
 ```


### PR DESCRIPTION
See https://github.com/MicrosoftDocs/azure-docs/issues/92567

The callout is not obvious currently, for Azure CLI users it is 3 paragraphs above the existing command.

Documentation should assume people are looking to copy-paste.

This may not be the best way of doing it but the current way is worse I think.
