### PR TITLE
Replace usage of "expr length $var" with ${#var} for string length

### DIFF
--- a/articles/storage/files/storage-how-to-use-files-linux.md
+++ b/articles/storage/files/storage-how-to-use-files-linux.md
@@ -84,7 +84,7 @@ uname -r
         --resource-group $resourceGroupName \
         --name $storageAccountName \
         --query "primaryEndpoints.file" --output tsv | tr -d '"')
-    smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))
+    smbPath=$(echo $httpEndpoint | cut -c7-${#httpEndpoint})
     fileHost=$(echo $smbPath | tr -d "/")
 
     nc -zvw3 $fileHost 445
@@ -126,7 +126,7 @@ httpEndpoint=$(az storage account show \
     --resource-group $resourceGroupName \
     --name $storageAccountName \
     --query "primaryEndpoints.file" --output tsv | tr -d '"')
-smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))$fileShareName
+smbPath=$(echo $httpEndpoint | cut -c7-${#httpEndpoint})$fileShareName
 
 storageAccountKey=$(az storage account keys list \
     --resource-group $resourceGroupName \
@@ -143,7 +143,7 @@ httpEndpoint=$(az storage account show \
     --resource-group $resourceGroupName \
     --name $storageAccountName \
     --query "primaryEndpoints.file" --output tsv | tr -d '"')
-smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))$fileShareName
+smbPath=$(echo $httpEndpoint | cut -c7-${#httpEndpoint})$fileShareName
 
 storageAccountKey=$(az storage account keys list \
     --resource-group $resourceGroupName \
@@ -160,7 +160,7 @@ httpEndpoint=$(az storage account show \
     --resource-group $resourceGroupName \
     --name $storageAccountName \
     --query "primaryEndpoints.file" --output tsv | tr -d '"')
-smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))$fileShareName
+smbPath=$(echo $httpEndpoint | cut -c7-${#httpEndpoint})$fileShareName
 
 storageAccountKey=$(az storage account keys list \
     --resource-group $resourceGroupName \
@@ -237,7 +237,7 @@ httpEndpoint=$(az storage account show \
     --resource-group $resourceGroupName \
     --name $storageAccountName \
     --query "primaryEndpoints.file" --output tsv | tr -d '"')
-smbPath=$(echo $httpEndpoint | cut -c7-$(expr length $httpEndpoint))$fileShareName
+smbPath=$(echo $httpEndpoint | cut -c7-${#httpEndpoint})$fileShareName
 
 if [ -z "$(grep $smbPath\ $mntPath /etc/fstab)" ]; then
     echo "$smbPath $mntPath cifs nofail,credentials=$smbCredentialFile,serverino,nosharesock,actimeo=30" | sudo tee -a /etc/fstab > /dev/null


### PR DESCRIPTION
Hi team,

`expr` is actually not part of Bash, but a very old tool that was used back when ancient Bash versions couldn't perform simple calculations without external programs.  The most efficient and portable way to get the length of string variable `$FOO` today is with the `${#FOO}` syntax.  As a bonus, it also works on other shells like MacOS bash, while `expr length $FOO` won't work on some shells.  The `${#FOO}` syntax is a surefire for all systems.


```bash
bash-3.2$ echo $BASH_VERSION
3.2.57(1)-release
bash-3.2$ foo=bar
bash-3.2$ echo $(expr length $foo)
expr: syntax error

bash-3.2$ echo ${#foo}
3
bash-3.2$
```

Also, the following is taken from the `man expr` output:

```
     The following examples output the number of characters in variable a.  Again, if a might 
     begin with a hyphen, it is necessary to prevent it from being interpreted as an option 
     to expr, and a might be interpreted as an operator.

     •   To deal with all of this, a complicated command is required:
               expr \( "X$a" : ".*" \) - 1

     •   With modern sh(1) syntax, this can be done much more easily:
               ${#a}
         expands to the required number.
```