### PR TITLE
x5t claim is base64-encoded not base64url-encoded

### DIFF
--- a/articles/active-directory/develop/active-directory-certificate-credentials.md
+++ b/articles/active-directory/develop/active-directory-certificate-credentials.md
@@ -33,7 +33,7 @@ To compute the assertion, you can use one of the many JWT libraries in the langu
 | --- | --- |
 | `alg` | Should be **RS256** |
 | `typ` | Should be **JWT** |
-| `x5t` | Base64url-encoded SHA-1 thumbprint of the X.509 certificate thumbprint. For example, given an X.509 certificate hash of `84E05C1D98BCE3A5421D225B140B36E86A3D5534` (Hex), the `x5t` claim would be `hOBcHZi846VCHSJbFAs26Go9VTQ=` (Base64url). |
+| `x5t` | Base64-encoded SHA-1 thumbprint of the X.509 certificate thumbprint. For example, given an X.509 certificate hash of `84E05C1D98BCE3A5421D225B140B36E86A3D5534` (Hex), the `x5t` claim would be `hOBcHZi846VCHSJbFAs26Go9VTQ=` (Base64). |
 
 ### Claims (payload)
 


### PR DESCRIPTION
From a recent case, we found that the x5t claim needs to show the certificate thumbprint is base64 encoding, not base64url encoding.
The claim can contain characters like "+" and "/" so base64url encoding is incorrect