### PR TITLE
The Workable SSO options have changed

### DIFF
--- a/articles/active-directory/saas-apps/workable-tutorial.md
+++ b/articles/active-directory/saas-apps/workable-tutorial.md
@@ -74,12 +74,12 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 4. On the **Basic SAML Configuration** section, If you wish to configure the application in **IDP** initiated mode, perform the following step:
 
 	In the **Reply URL** text box, type a URL using the following pattern:
-    `https://www.workable.com/auth/saml/<SUBDOMAIN>/callback`
+    `https://id.workable.com/auth/saml/ats_server/<SUBDOMAIN>/callback`
 
 5. Click **set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
 
     In the **Sign-on URL** text box, type the URL:
-    `https://www.workable.com/sso/signin`
+    `https://<SUBDOMAIN>.workable.com/signin`
 
 	> [!NOTE]
 	> The Reply URL value is not real. Update Reply URL value with the actual Reply URL. Contact [Workable Client support team](mailto:support@workable.com) to get the value. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.


### PR DESCRIPTION
Via our Workable account manager today (2022-07-06) we've been informed to use the following values for the SSO options. These differ from those advertised in this article, and in the AAD integration catalogue. Recommend that the automated catalogue settings be updated, too.

```
To enable Single Sign-On using your company's Identity Provider, you will need the following information to set up Workable in your system:
•	Workable subdomain: companyname123
•	Single Sign-On (SSO) URL: https://[companyname123].workable.com/signin
•	Issuer (Audience or Entity ID): https://id.workable.com/ats_server/[companyname123]
•	Assertion Consumer Service (ACS) URL: https://id.workable.com/auth/saml/ats_server/[companyname123]/callback
•	URL Validator: This field is the regex of ACS URL
•	Single Log Out (SLO) URL: https://id.workable.com/auth/saml/ats_server/[companyname123]/idp_slo
•	Name identifier format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
•	Custom attributes: first_name, last_name, email, image
•	Relay State: leave empty
•	Recipient: leave empty
```