### PR TITLE
Fix #95423 : adjusting file name in sample data

### DIFF
--- a/articles/storage/blobs/blob-inventory.md
+++ b/articles/storage/blobs/blob-inventory.md
@@ -269,7 +269,7 @@ The `BlobInventoryPolicyCompleted` event is generated when the inventory run com
     "policyRunStatus": "Succeeded",
     "policyRunStatusMessage": "Inventory run succeeded, refer manifest file for inventory details.",
     "policyRunId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "manifestBlobUrl": "https://testaccount.blob.core.windows.net/inventory-destination-container/2021/05/26/13-25-36/Rule_1/Rule_1.csv"
+    "manifestBlobUrl": "https://testaccount.blob.core.windows.net/inventory-destination-container/2021/05/26/13-25-36/Rule_1/Rule_1-manifest.json"
   },
   "dataVersion": "1.0",
   "metadataVersion": "1",


### PR DESCRIPTION
#95423
Although the description of the attributes for the "Inventory completed event" is correct, the sample data for attribute manifestBlobUrl is misleading.
We should expect a file named Rule_1-manifest.json instead of currently Rule_1.csv