### PR TITLE
Add missing '\' in multi-line command

### DIFF
--- a/articles/spring-cloud/quickstart-deploy-apps-enterprise.md
+++ b/articles/spring-cloud/quickstart-deploy-apps-enterprise.md
@@ -171,7 +171,7 @@ Use the following steps to provision an Azure Spring Apps service instance.
 
    az spring app create \
        --resource-group <resource-group-name> \
-       --name catalog-service
+       --name catalog-service \
        --service <Azure-Spring-Apps-service-instance-name>
 
    az spring app create \


### PR DESCRIPTION
Working through the quick start guide I was tripped up by the missing line separation character. This fix appears to work in my testing but I'm happy to make / test further changes if required.