### PR TITLE
Added helm chart release train

### DIFF
--- a/articles/azure-arc/data/includes/azure-arc-data-preview-release.md
+++ b/articles/azure-arc/data/includes/azure-arc-data-preview-release.md
@@ -15,7 +15,7 @@ The current preview released on July 05, 2022.
 |CRD names and version|`datacontrollers.arcdata.microsoft.com`: v1beta1, v1 through v6<br/>`exporttasks.tasks.arcdata.microsoft.com`: v1beta1, v1, v2<br/>`kafkas.arcdata.microsoft.com`: v1beta1<br/>`monitors.arcdata.microsoft.com`: v1beta1, v1, v2<br/>`sqlmanagedinstances.sql.arcdata.microsoft.com`: v1beta1, v1 through v6<br/>`postgresqls.arcdata.microsoft.com`: v1beta1, v1beta2<br/>`sqlmanagedinstancerestoretasks.tasks.sql.arcdata.microsoft.com`: v1beta1, v1<br/>`failovergroups.sql.arcdata.microsoft.com`: v1beta1, v1beta2, v1<br/>`activedirectoryconnectors.arcdata.microsoft.com`: v1beta1, v1beta2<br/>|
 |Azure Resource Manager (ARM) API version|2022-03-01-preview (No change)|
 |`arcdata` Azure CLI extension version|1.4.3 ([Download](https://aka.ms/az-cli-arcdata-ext))|
-|Arc enabled Kubernetes helm chart extension version|1.2.20031002|
+|Arc enabled Kubernetes helm chart extension version|1.2.20031002 (release train: **preview**)|
 |Arc Data extension for Azure Data Studio<br/>`arc`<br/>`azcli`|<br/>1.3.0 ([Download](https://azuredatastudioarcext.blob.core.windows.net/stage/arc-1.3.0.vsix))</br>1.3.0 ([Download](https://azuredatastudioarcext.blob.core.windows.net/stage/azcli-1.3.0.vsix))|
 
 New for this release:


### PR DESCRIPTION
**Change 1:** The default prompt for `stable` right before the Data Controller deploy needs to be changed to `preview`
**Change 2:** Github seems to be truncating extra whitespace in the last sentence (I can't seem to stop it from doing that)