### PR TITLE
Add link to package feed and API docs

### DIFF
--- a/articles/azure-fluid-relay/how-tos/test-automation.md
+++ b/articles/azure-fluid-relay/how-tos/test-automation.md
@@ -17,7 +17,7 @@ fluid.url: https://fluidframework.com/docs/testing/testing/
 
 Testing and automation are crucial to maintaining the quality and longevity of your code. Internally, Fluid uses a range of unit and integration tests powered by [Mocha](https://mochajs.org/), [Jest](https://jestjs.io/), [Puppeteer](https://github.com/puppeteer/puppeteer), and [Webpack](https://webpack.js.org/).
 
-You can run tests using the local **@fluidframework/azure-local-service** or using a test tenant in Azure Fluid Relay service. **AzureClient** can be configured to connect to both a remote service and a local service, which enables you to use a single client type between tests against live and local service instances. The only difference is the configuration used to create the client.
+You can run tests using the local [@fluidframework/azure-local-service](https://www.npmjs.com/package/@fluidframework/azure-local-service) or using a test tenant in Azure Fluid Relay service. [AzureClient](https://fluidframework.com/docs/apis/azure-client/azureclient) can be configured to connect to both a remote service and a local service, which enables you to use a single client type between tests against live and local service instances. The only difference is the configuration used to create the client.
 
 ## Automation against Azure Fluid Relay
 


### PR DESCRIPTION
Link to `@fluidframework/azure-local-service` npm package feed (https://www.npmjs.com/package/@fluidframework/azure-local-service), and to `AzureClient` API docs (https://fluidframework.com/docs/apis/azure-client/azureclient)