### PR TITLE
WALinuxAgent (waagent.conf) docs update for `AutoUpdate` and `EnableSwapEncryption`

### DIFF
--- a/articles/virtual-machines/extensions/agent-linux.md
+++ b/articles/virtual-machines/extensions/agent-linux.md
@@ -270,7 +270,7 @@ Specifies disk mount options to be passed to the mount -o command. This is a com
 Type: Boolean  
 Default: n
 ```
-If set, a swap file (/swapfile) is created on the resource disk and added to the system swap space.
+If set, a swap file (/mnt/resource/swapfile) is created on the resource disk and added to the system swap space.
 
 **ResourceDisk.SwapSizeMB:**  
 ```txt
@@ -284,7 +284,7 @@ The size of the swap file in megabytes.
 Type: Boolean
 Default: n
 ```
-If set, the swap file (/swapfile) is mounted as an encrypted filesystem (flag supported only on FreeBSD.)
+If set, the swap is mounted as an encrypted filesystem (flag supported only on FreeBSD).
 
 **Logs.Verbose:**  
 ```txt

--- a/articles/virtual-machines/extensions/agent-linux.md
+++ b/articles/virtual-machines/extensions/agent-linux.md
@@ -279,6 +279,13 @@ Default: 0
 ```
 The size of the swap file in megabytes.
 
+**ResourceDisk.EnableSwapEncryption**
+```txt
+Type: Boolean
+Default: n
+```
+If set, the swap file (/swapfile) is mounted as an encrypted filesystem (flag supported only on FreeBSD.)
+
 **Logs.Verbose:**  
 ```txt
 Type: Boolean  

--- a/articles/virtual-machines/extensions/update-linux-agent.md
+++ b/articles/virtual-machines/extensions/update-linux-agent.md
@@ -61,7 +61,7 @@ AutoUpdate.Enabled=y
 To enable run:
 
 ```bash
-sudo sed -i 's/# AutoUpdate.Enabled=n/AutoUpdate.Enabled=y/g' /etc/waagent.conf
+sudo sed -i 's/# AutoUpdate.Enabled=y/AutoUpdate.Enabled=y/g' /etc/waagent.conf
 ```
 
 Restart waagengt service for 14.04


### PR DESCRIPTION
Corrected walinuxagent sed search string: #93251

ResourceDisk.EnableSwapEncryption (only FreBSD.): https://github.com/Azure/WALinuxAgent/issues/2628