### PR TITLE
Update to CRS 3.2 to add rule 920300

### DIFF
--- a/articles/web-application-firewall/ag/application-gateway-crs-rulegroups-rules.md
+++ b/articles/web-application-firewall/ag/application-gateway-crs-rulegroups-rules.md
@@ -185,6 +185,7 @@ The following rule groups and rules are available when using Web Application Fir
 |920274|Invalid character in request headers (outside of very strict set)|
 |920280|Request Missing a Host Header|
 |920290|Empty Host Header|
+|920300|Request Missing an Accept Header|
 |920310|Request Has an Empty Accept Header|
 |920311|Request Has an Empty Accept Header|
 |920320|Missing User Agent Header|


### PR DESCRIPTION
Added CRS 920300 in OWASP 3.2 since it's automatically added and enabled either when creating a WAF policy and when upgrading from previous versions.