### PR TITLE
Fixed wrong partition key format for ARM and Bicep

### DIFF
--- a/articles/cosmos-db/hierarchical-partition-keys.md
+++ b/articles/cosmos-db/hierarchical-partition-keys.md
@@ -363,9 +363,9 @@ For example, assume we have a hierarchical partition key composed of **TenantId 
 ```bicep
 partitionKey: {
   paths: [
-    'TenantId',
-    'UserId',
-    'SessionId'
+    '/TenantId',
+    '/UserId',
+    '/SessionId'
   ]
   kind: 'MultiHash'
   version: 2
@@ -377,9 +377,9 @@ partitionKey: {
 ```json
 "partitionKey": {
     "paths": [
-        "TenantId",
-        "UserId",
-        "SessionId"
+        "/TenantId",
+        "/UserId",
+        "/SessionId"
     ],
     "kind": "MultiHash",
     "version": 2


### PR DESCRIPTION
Partition key needs to be prefixed with forward slash. Java and .NET examples were correct, but ARM and Bicep ones were missing it.