### PR TITLE
Update to Total size of rules within an RCG

### DIFF
--- a/includes/firewall-limits.md
+++ b/includes/firewall-limits.md
@@ -14,7 +14,7 @@
 | --- | --- |
 | Data throughput |30 Gbps|
 |Rule limits|10,000 unique source/destinations in network and application rules <br><br> **Unique source/destinations in network** = sum of (unique source addresses * unique destination addresses for each rule)|
-|Total size of rules within a single Rule Collection Group| 2 MB|
+|Total size of rules within a single Rule Collection Group| ~1.4 MB|
 |Number of Rule Collection Groups in a firewall policy|50|
 |Maximum DNAT rules|298 (for firewalls configured with a single Public IP address)<br><br> The DNAT limitation is due to the underlying platform. The maximum number of DNAT rules is 298. However, any additional public IP addresses reduce the number of the available DNAT rules. For example, two public IP addresses allow for 297 DNAT rules. If a rule's protocol is configured for both TCP and UDP, it counts as two rules.|
 |Minimum AzureFirewallSubnet size |/26|


### PR DESCRIPTION
Issue discussed and approved in https://github.com/MicrosoftDocs/azure-docs/issues/93880.
The real max size is around 1.4MB since the limit of 2MB is the CosmosDB limit in the backend, and the real amount of data that can be commited to the CosmosDB excluding the AzFirewall overhead is less than 2MB (as discussed with PG is around 1.4MB).