### PR TITLE
Document login_hint alternative to SAML request subject

### DIFF
--- a/articles/active-directory/develop/single-sign-on-saml-protocol.md
+++ b/articles/active-directory/develop/single-sign-on-saml-protocol.md
@@ -101,7 +101,9 @@ A `Signature` element in `AuthnRequest` elements is optional. Azure AD can be co
 
 ### Subject
 
-Don't include a `Subject` element. Azure AD doesn't support specifying a subject for a request and will return an error if one is provided.
+Don't include a `Subject` element. Azure AD doesn't support specifying a subject in `AuthnRequest` and will return an error if one is provided.
+
+A subject can instead be provided by adding a `login_hint` parameter to the HTTP request to the single sign-on URL, with the subject's NameID as the parameter value.
 
 ## Response
 


### PR DESCRIPTION
While it is accurate that Azure's SAML implementation will throw an error if there's a Subject in the AuthnRequest, subject-like behavior is possible by including a login_hint parameter on the URL. It would be helpful to document that alternative here.

As this isn't a part of the SAML standard I'm not sure if the change here fully and accurately describe how the login_hint parameter works with Azure's SAML implementation -- my own test case was including it on the query string of a GET request, and I kept the wording here general enough to cover POST as well if that's supported.