### PR TITLE
Got an error when updating the app

### DIFF
--- a/articles/app-service/quickstart-nodejs.md
+++ b/articles/app-service/quickstart-nodejs.md
@@ -305,7 +305,7 @@ You can deploy changes to this app by making edits in Visual Studio Code, saving
 
 :::zone target="docs" pivot="development-environment-cli"
 
-2. Save your changes, then redeploy the app using the [az webapp up](/cli/azure/webapp#az-webapp-up) command again with no arguments:
+2. Save your changes, then redeploy the app using the [az webapp up](/cli/azure/webapp#az-webapp-up) command again with no arguments for Linux. Add `--os-type Windows` for Windows:
 
     ```azurecli
     az webapp up


### PR DESCRIPTION
Got this error when updating the app using Windows:

`The webapp 'APPNAME' is a Windows app. The code detected at 'C:\myExpressApp' will default to 'Linux'. Please create a new app to continue this operation. For more information on default behaviors, see https://docs.microsoft.com/cli/azure/webapp?view=azure-cli-latest#az_webapp_up.`

Had to run `az webapp up --os-type Windows`