### PR TITLE
Linked Service usage with multiple storage accounts

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -84,11 +84,14 @@ Synapse provides an integrated linked services experience when connecting to Azu
 
 When the linked service authentication method is set to **Account Key**, the linked service will authenticate using the provided storage account key, request a SAS key, and automatically apply it to the storage request using the **LinkedServiceBasedSASProvider**.
 
+Synapse allows users to set the linked service for a particular storage account. This makes it possible to read/write data from **multiple storage accounts** in a single spark application/query. Once we set **spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName** for each storage account that will be used, spark figures out which linked service to use for a particular read/write operation.However if our spark job only deals with a single storage account, we can simply omit the storage account name and use **spark.storage.synapse.linkedServiceName**
+
 ::: zone pivot = "programming-language-scala"
 
 ```scala
 val sc = spark.sparkContext
-spark.conf.set("spark.storage.synapse.linkedServiceName", "<LINKED SERVICE NAME>")
+val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
+spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
 spark.conf.set("fs.azure.account.auth.type", "SAS")
 spark.conf.set("fs.azure.sas.token.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
 
@@ -104,7 +107,8 @@ display(df.limit(10))
 ```python
 %%pyspark
 # Python code
-spark.conf.set("spark.storage.synapse.linkedServiceName", "<lINKED SERVICE NAME>")
+val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
+spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<lINKED SERVICE NAME>")
 spark.conf.set("fs.azure.account.auth.type", "SAS")
 spark.conf.set("fs.azure.sas.token.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
 
@@ -122,7 +126,8 @@ When the linked service authentication method is set to **Managed Identity** or 
 
 ```scala
 val sc = spark.sparkContext
-spark.conf.set("spark.storage.synapse.linkedServiceName", "<LINKED SERVICE NAME>")
+val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
+spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
 spark.conf.set("fs.azure.account.oauth.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider") 
 val df = spark.read.csv("abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<FILE PATH>")
 
@@ -136,7 +141,8 @@ display(df.limit(10))
 ```python
 %%pyspark
 # Python code
-spark.conf.set("spark.storage.synapse.linkedServiceName", "<lINKED SERVICE NAME>")
+val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
+spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
 spark.conf.set("fs.azure.account.oauth.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider")
 
 df = spark.read.csv('abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<DIRECTORY PATH>')

--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -84,7 +84,7 @@ Synapse provides an integrated linked services experience when connecting to Azu
 
 When the linked service authentication method is set to **Account Key**, the linked service will authenticate using the provided storage account key, request a SAS key, and automatically apply it to the storage request using the **LinkedServiceBasedSASProvider**.
 
-Synapse allows users to set the linked service for a particular storage account. This makes it possible to read/write data from **multiple storage accounts** in a single spark application/query. Once we set **spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName** for each storage account that will be used, spark figures out which linked service to use for a particular read/write operation.However if our spark job only deals with a single storage account, we can simply omit the storage account name and use **spark.storage.synapse.linkedServiceName**
+Synapse allows users to set the linked service for a particular storage account. This makes it possible to read/write data from **multiple storage accounts** in a single spark application/query. Once we set **spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName** for each storage account that will be used, Synapse figures out which linked service to use for a particular read/write operation. However if our spark job only deals with a single storage account, we can simply omit the storage account name and use **spark.storage.synapse.linkedServiceName**
 
 ::: zone pivot = "programming-language-scala"
 

--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -92,8 +92,8 @@ Synapse allows users to set the linked service for a particular storage account.
 val sc = spark.sparkContext
 val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
 spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
-spark.conf.set("fs.azure.account.auth.type", "SAS")
-spark.conf.set("fs.azure.sas.token.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
+spark.conf.set(f"fs.azure.account.auth.type.{source_full_storage_account_name}", "SAS")
+spark.conf.set(f"fs.azure.sas.token.provider.type.{source_full_storage_account_name}", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
 
 val df = spark.read.csv("abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<FILE PATH>")
 
@@ -109,8 +109,8 @@ display(df.limit(10))
 # Python code
 val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
 spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<lINKED SERVICE NAME>")
-spark.conf.set("fs.azure.account.auth.type", "SAS")
-spark.conf.set("fs.azure.sas.token.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
+spark.conf.set(f"fs.azure.account.auth.type.{source_full_storage_account_name}", "SAS")
+spark.conf.set(f"fs.azure.sas.token.provider.type.{source_full_storage_account_name}", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
 
 df = spark.read.csv('abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<DIRECTORY PATH>')
 
@@ -128,7 +128,7 @@ When the linked service authentication method is set to **Managed Identity** or 
 val sc = spark.sparkContext
 val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
 spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
-spark.conf.set("fs.azure.account.oauth.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider") 
+spark.conf.set(f"fs.azure.account.oauth.provider.type.{source_full_storage_account_name}", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider") 
 val df = spark.read.csv("abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<FILE PATH>")
 
 display(df.limit(10))

--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -143,7 +143,7 @@ display(df.limit(10))
 # Python code
 val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
 spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
-spark.conf.set("fs.azure.account.oauth.provider.type", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider")
+spark.conf.set(f"fs.azure.account.oauth.provider.type.{source_full_storage_account_name}", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider")
 
 df = spark.read.csv('abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<DIRECTORY PATH>')
 


### PR DESCRIPTION
One of the common scenario's for our customers is to read/write data from multiple storage accounts. Unfortunately our documentation does not explain how to accomplish that. This change makes is self-explanatory for the user as to how they can use token library in such scenarios