### PR TITLE
Change the rule group name in the table for consistency. Update list to match waf in portal.

### DIFF
--- a/articles/web-application-firewall/afds/waf-front-door-drs.md
+++ b/articles/web-application-firewall/afds/waf-front-door-drs.md
@@ -111,7 +111,7 @@ DRS 2.0 includes 17 rule groups, as shown in the following table. Each group con
 |**[APPLICATION-ATTACK-RFI](#drs931-10)**|Protection against remote file inclusion attacks|
 |**[APPLICATION-ATTACK-RCE](#drs932-10)**|Protection against remote command execution|
 |**[APPLICATION-ATTACK-PHP](#drs933-10)**|Protect against PHP-injection attacks|
-|**[CROSS-SITE-SCRIPTING](#drs941-10)**|XSS - Cross-site Scripting|
+|**[APPLICATION-ATTACK-XSS](#drs941-10)**|Protect against cross-site scripting attacks|
 |**[APPLICATION-ATTACK-SQLI](#drs942-10)**|Protect against SQL-injection attacks|
 |**[APPLICATION-ATTACK-SESSION-FIXATION](#drs943-10)**|Protect against session-fixation attacks|
 |**[APPLICATION-ATTACK-SESSION-JAVA](#drs944-10)**|Protect against JAVA attacks|

--- a/articles/web-application-firewall/afds/waf-front-door-drs.md
+++ b/articles/web-application-firewall/afds/waf-front-door-drs.md
@@ -238,12 +238,10 @@ Front Door.
 |933110|PHP Injection Attack: PHP Script File Upload Found|
 |933120|PHP Injection Attack: Configuration Directive Found|
 |933130|PHP Injection Attack: Variables Found|
-|933131|PHP Injection Attack: Variables Found|
 |933140|PHP Injection Attack: I/O Stream Found|
 |933150|PHP Injection Attack: High-Risk PHP Function Name Found|
 |933151|PHP Injection Attack: Medium-Risk PHP Function Name Found|
 |933160|PHP Injection Attack: High-Risk PHP Function Call Found|
-|933161|PHP Injection Attack: Low-Value PHP Function Call Found|
 |933170|PHP Injection Attack: Serialized Object Injection|
 |933180|PHP Injection Attack: Variable Function Call Found|
 |933200|PHP Injection Attack: Wrapper scheme detected|
@@ -622,12 +620,10 @@ Front Door.
 |933110|PHP Injection Attack: PHP Script File Upload Found|
 |933120|PHP Injection Attack: Configuration Directive Found|
 |933130|PHP Injection Attack: Variables Found|
-|933131|PHP Injection Attack: Variables Found|
 |933140|PHP Injection Attack: I/O Stream Found|
 |933150|PHP Injection Attack: High-Risk PHP Function Name Found|
 |933151|PHP Injection Attack: Medium-Risk PHP Function Name Found|
 |933160|PHP Injection Attack: High-Risk PHP Function Call Found|
-|933161|PHP Injection Attack: Low-Value PHP Function Call Found|
 |933170|PHP Injection Attack: Serialized Object Injection|
 |933180|PHP Injection Attack: Variable Function Call Found|
 


### PR DESCRIPTION
Change the name of the rule group in the table of DRS 1.0 to avoid confusion when comparing the rule sets.

933131 and 933161 have been removed in the portal for all default rule sets. They were only removed from the 1.1 managed rule set in the documentation.