### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#95632

### DIFF
--- a/articles/active-directory/develop/msal-net-token-cache-serialization.md
+++ b/articles/active-directory/develop/msal-net-token-cache-serialization.md
@@ -102,7 +102,7 @@ services.Configure<MsalDistributedTokenCacheAdapterOptions>(options =>
     options.DisableL1Cache = false;
     
     // Or limit the memory (by default, this is 500 MB)
-    options.L1CacheOptions.SizeLimit = 1024 * 1024 * 1024, // 1 GB
+    options.L1CacheOptions.SizeLimit = 1024 * 1024 * 1024; // 1 GB
 
     // You can choose if you encrypt or not encrypt the cache
     options.Encrypt = false;
@@ -110,7 +110,7 @@ services.Configure<MsalDistributedTokenCacheAdapterOptions>(options =>
     // And you can set eviction policies for the distributed
     // cache.
     options.SlidingExpiration = TimeSpan.FromHours(1);
-  }
+  });
 
 // Then, choose your implementation of distributed cache
 // -----------------------------------------------------


### PR DESCRIPTION
Updated line 105 and 113 with semicolons to end the statement.

(AzureCXP) fixes MicrosoftDocs/azure-docs#95632