### PR TITLE
Update PowerShell Command for Function App Creation

### DIFF
--- a/articles/azure-functions/create-first-function-cli-powershell.md
+++ b/articles/azure-functions/create-first-function-cli-powershell.md
@@ -118,7 +118,7 @@ Each binding requires a direction, a type, and a unique name. The HTTP trigger h
     # [Azure PowerShell](#tab/azure-powershell)
 
     ```azurepowershell
-    New-AzFunctionApp -Name <APP_NAME> -ResourceGroupName AzureFunctionsQuickstart-rg -StorageAccount <STORAGE_NAME> -Runtime PowerShell -FunctionsVersion 3 -Location '<REGION>'
+    New-AzFunctionApp -Name <APP_NAME> -ResourceGroupName AzureFunctionsQuickstart-rg -StorageAccount <STORAGE_NAME> -Runtime PowerShell -FunctionsVersion 4 -Location '<REGION>'
     ```
 
     The [New-AzFunctionApp](/powershell/module/az.functions/new-azfunctionapp) cmdlet creates the function app in Azure.


### PR DESCRIPTION
Original Call used Version 3 of Functions, but the document points towards the use of version 4, this change prevents an error of version mismatch