### PR TITLE
Adding the explanation about Redis nodes by default

### DIFF
--- a/articles/azure-cache-for-redis/cache-reserved-pricing.md
+++ b/articles/azure-cache-for-redis/cache-reserved-pricing.md
@@ -29,7 +29,7 @@ The size of reservation should be based on the total amount of memory size that 
 
 For example, let's suppose that you're running two caches - one at 13 GB and the other at 26 GB. You'll need both for at least one year. Further, let's suppose that you plan to scale the existing 13-GB caches to 26 GB for a month to meet your seasonal demand, and then scale back. In this case, you can purchase either one P2-cache and one P3-cache or three P2-caches on a one-year reservation to maximize savings. You'll receive discount on the total amount of cache memory you reserve, independent of how that amount is allocated across your caches.
 
-Reserved capacity is sold in increments of nodes. Each shard contains 2 nodes by default, so to buy reserved capacity for a shard buy 2 reserved capacity. For the number of nodes calculation, see "View Cost Calculation" on [Pricing calculator](https://azure.microsoft.com/en-us/pricing/calculator/).
+Reserved capacity is sold in increments of nodes. Each shard contains 2 nodes by default. To buy reserved capacity for a shard, you buy 2 reserved capacity. For the number of nodes calculation, see "View Cost Calculation" on [Pricing calculator](https://azure.microsoft.com/pricing/calculator/). For an explanation of the architecture of a cache, see [A quick summary of cache architecture](cache-failover.md#a-quick-summary-of-cache-architecture).
 
 ## Buy Azure Cache for Redis reserved capacity
 

--- a/articles/azure-cache-for-redis/cache-reserved-pricing.md
+++ b/articles/azure-cache-for-redis/cache-reserved-pricing.md
@@ -29,6 +29,8 @@ The size of reservation should be based on the total amount of memory size that 
 
 For example, let's suppose that you're running two caches - one at 13 GB and the other at 26 GB. You'll need both for at least one year. Further, let's suppose that you plan to scale the existing 13-GB caches to 26 GB for a month to meet your seasonal demand, and then scale back. In this case, you can purchase either one P2-cache and one P3-cache or three P2-caches on a one-year reservation to maximize savings. You'll receive discount on the total amount of cache memory you reserve, independent of how that amount is allocated across your caches.
 
+Reserved capacity is sold in increments of nodes. Each shard contains 2 nodes by default, so to buy reserved capacity for a shard buy 2 reserved capacity. For the number of nodes calculation, see "View Cost Calculation" on [Pricing calculator](https://azure.microsoft.com/en-us/pricing/calculator/).
+
 ## Buy Azure Cache for Redis reserved capacity
 
 You can buy a reserved VM instance in the [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_Reservations/CreateBlade/). Pay for the reservation [up front or with monthly payments](../cost-management-billing/reservations/prepare-buy-reservation.md).


### PR DESCRIPTION
This explanation "Reserved capacity is sold in increments of nodes. Each shard contains 2 nodes by default, so to buy reserved capacity for a shard buy 2 reserved capacity." is referred on the reservation purchasing page of Azure Portal. 

This request is because it is difficult for new users to know the number of nodes (2 nodes) by default.