### PR TITLE
Updated doc to include KeyVault permissions

### DIFF
--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -220,7 +220,10 @@ If you use Azure Key Vault to manage your certificates, you can import a PKCS12 
 ### Authorize App Service to read from the vault
 By default, the App Service resource provider doesn’t have access to the Key Vault. In order to use a Key Vault for a certificate deployment, you need to [authorize the resource provider read access to the KeyVault](../key-vault/general/assign-access-policy-cli.md). 
 
-`abfa0a7c-a6b6-4736-8310-5855508787cd`  is the resource provider service principal name for App Service, and it's the same for all Azure subscriptions. For Azure Government cloud environment, use `6a02c803-dafd-4136-b4c3-5a6f318b4714` instead as the resource provider service principal name.
+| Resource Provider | Service Principal AppId | KeyVault secret permissions | KeyVault certificate permissions |
+|--|--|--|--|
+| `Microsoft Azure App Service` or `Microsoft.Azure.WebSites` | `abfa0a7c-a6b6-4736-8310-5855508787cd` (It's the same for all Azure subscriptions)<br/><br/>For Azure Government cloud environment, use `6a02c803-dafd-4136-b4c3-5a6f318b4714`. | Get | Get |
+| Microsoft.Azure.CertificateRegistration |  | Get<br/>List<br/>Set<br/>Delete | Get<br/>List |
 
 > [!NOTE]
 > Currently, Key Vault Certificate only supports Key Vault access policy but not RBAC model.


### PR DESCRIPTION
Updated doc to include KeyVault permissions required for App Service certificate to import certificate object from KeyVault secret.