### PR TITLE
Update quick-windows-container-deploy-cli.md

### DIFF
--- a/articles/aks/learn/quick-windows-container-deploy-cli.md
+++ b/articles/aks/learn/quick-windows-container-deploy-cli.md
@@ -162,6 +162,8 @@ When ready, refresh the registration of the *Microsoft.ContainerService* resourc
 ```azurecli-interactive
 az provider register --namespace Microsoft.ContainerService
 ```
+> [!NOTE]
+> Windows Server 2022 requires Kubernetes version "1.23.0" or higher.
 
 Use `az aks nodepool add` command to add a Windows Server 2022 node pool:
 


### PR DESCRIPTION
This change adds a note on the required Kubernetes version for Windows Server 2022. This avoids customers trying to add a new node pool for Windows Server 2022 on earlier Kubernetes versions.