### PR TITLE
Update instruction on distributed GPU training with PyTorch Lightning

### DIFF
--- a/articles/machine-learning/how-to-train-distributed-gpu.md
+++ b/articles/machine-learning/how-to-train-distributed-gpu.md
@@ -267,6 +267,7 @@ To run an experiment using multiple nodes with multiple GPUs, there are 2 option
       - MASTER_ADDR
       - MASTER_PORT
       - NODE_RANK
+      - LOCAL_RANK
       
       Manually set these environment variables that Lightning requires in the main training scripts:
 
@@ -296,7 +297,7 @@ To run an experiment using multiple nodes with multiple GPUs, there are 2 option
        parser.add_argument("--num_nodes", type=int, required=True)
        parser.add_argument("--gpus_per_node", type=int, required=True)
        args = parser.parse_args()
-       set_environment_variables_for_nccl_backend(args.num_nodes, args.gpus_per_node)
+       set_environment_variables_for_mpi(args.num_nodes, args.gpus_per_node)
        
        trainer = Trainer(
         num_nodes=args.num_nodes,

--- a/articles/machine-learning/how-to-train-distributed-gpu.md
+++ b/articles/machine-learning/how-to-train-distributed-gpu.md
@@ -291,8 +291,8 @@ To run an experiment using multiple nodes with multiple GPUs:
            
    if __name__ == "__main__":
        parser = ArgumentParser()
-       parser.add_argument("--num_nodes", required=True)
-       parser.add_argument("--gpus", required=True)
+       parser.add_argument("--num_nodes", type=int, required=True)
+       parser.add_argument("--gpus", type=int, required=True)
        args = parser.parse_args()
        set_environment_variables_for_nccl_backend(args.num_nodes, args.gpus)
    ```

--- a/articles/machine-learning/how-to-train-distributed-gpu.md
+++ b/articles/machine-learning/how-to-train-distributed-gpu.md
@@ -258,7 +258,7 @@ run = Experiment(ws, 'experiment_name').submit(run_config)
 For single-node training (including single-node multi-GPU), you can run your code on Azure ML without needing to specify a `distributed_job_config`. 
 To run an experiment using multiple nodes with multiple GPUs, there are 2 options:
 
-- Using PyTorch configuration (recommended): Define `PyTorchConfiguration` and specify `communication_backend="Nccl"`, `node_count`, and `process_count` (note that this is the total number of processes, ie, `num_nodes * process_count_per_node`). In Lightning Trainer module, specify both `num_nodes` and `gpus` to be consistent with `PyTorchConfiguration`, ie, `num_nodes = node_count` and `gpus = process_count_per_node`.
+- Using PyTorch configuration (recommended): Define `PyTorchConfiguration` and specify `communication_backend="Nccl"`, `node_count`, and `process_count` (note that this is the total number of processes, ie, `num_nodes * process_count_per_node`). In Lightning Trainer module, specify both `num_nodes` and `gpus` to be consistent with `PyTorchConfiguration`. For example, `num_nodes = node_count` and `gpus = process_count_per_node`.
 
 - Using MPI Configuration: 
 

--- a/articles/machine-learning/how-to-train-distributed-gpu.md
+++ b/articles/machine-learning/how-to-train-distributed-gpu.md
@@ -258,7 +258,7 @@ run = Experiment(ws, 'experiment_name').submit(run_config)
 For single-node training (including single-node multi-GPU), you can run your code on Azure ML without needing to specify a `distributed_job_config`. 
 To run an experiment using multiple nodes with multiple GPUs, there are 2 options:
 
-- Using PyTorch configuration (recommneded): Define `PyTorchConfiguration` and specify `communication_backend="Nccl"`, `node_count`, and `process_count` (note that this is the total number of processes, ie, `num_nodes * process_count_per_node`). In Lightning Trainer module, specify both `num_nodes` and `gpus` to be consistent with `PyTorchConfiguration`, ie, `num_nodes = node_count` and `gpus = process_count_per_node`.
+- Using PyTorch configuration (recommended): Define `PyTorchConfiguration` and specify `communication_backend="Nccl"`, `node_count`, and `process_count` (note that this is the total number of processes, ie, `num_nodes * process_count_per_node`). In Lightning Trainer module, specify both `num_nodes` and `gpus` to be consistent with `PyTorchConfiguration`, ie, `num_nodes = node_count` and `gpus = process_count_per_node`.
 
 - Using MPI Configuration: 
 


### PR DESCRIPTION
The existing instructions for distributed GPU training with PyTorch Lightning is wrong and confusing. Particularly, this line

```
os.environ["NODE_RANK"] = os.environ["OMPI_COMM_WORLD_RANK"]
```
will hang the process when training on multiple nodes, each nodes containing multiple GPUs. Unlike the OpenMPI definition for `OMPI_COMM_WORLD_NODE_RANK`, PyTorch Lightning interprets `NODE_RANK` as the rank of the node within the cluster. For example, if `num_nodes = 2` and `gpus_per_node = 2`, PyTorch Lightning requires:

- `NODE_RANK = 0` for `OMPI_COMM_WORLD_RANK = 0, 1`
- `NODE_RANK = 1` for `OMPI_COMM_WORLD_RANK = 2, 3`

This pull request changes `NODE_RANK` based on number of GPUs per node:
```python
os.environ["NODE_RANK"] = str(int(os.environ.get("OMPI_COMM_WORLD_RANK")) // gpus_per_node)
```

I removed 
```python
os.environ["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
```
since by default, [NVIDIA already excludes those values](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-socket-ifname).
 
Additionally, the document contains outdated information, such as only allowing per-node launch with MPI for distributed training with Lightning, which requires this environment variable hack. 

Nowadays it's possible to do per-process launch with PyTorch configuration, which is much more convenient, with a dedicated driver log for each process, and does not require manually setting the environment variables. Therefore, I removed per-node launch instruction (which requires not setting `process_count_per_node` in `MpiConfiguration`), and leave per-process launch with MPI as an additional option while recommending PyTorch configuration as the preferred method. 