### PR TITLE
Update IoT Central application limit

### DIFF
--- a/articles/iot-central/core/howto-faq.yml
+++ b/articles/iot-central/core/howto-faq.yml
@@ -39,7 +39,7 @@ sections:
       - question: |
           How many IoT Central applications can I deploy in my subscription?
         answer: |
-          Each Azure subscription has default quotas that could impact the scope of your IoT solution. Currently, IoT Central limits the number of applications you can deploy in a subscription to 10. If you need to increase this limit, contact [Microsoft support](https://azure.microsoft.com/support/options/).
+          Each Azure subscription has default quotas that could impact the scope of your IoT solution. Currently, IoT Central limits the number of applications you can deploy in a subscription to 100. If you need to increase this limit, contact [Microsoft support](https://azure.microsoft.com/support/options/).
                     
       - question: |
           How do I file a ticket with customer support?


### PR DESCRIPTION
IoT Central allows users to create 100 applications per subscription by default. 

This change updates the documentation where the older limit of 10 was referenced.