### PR TITLE
Adding missing phone factor metadata

### DIFF
--- a/articles/active-directory-b2c/phone-factor-technical-profile.md
+++ b/articles/active-directory-b2c/phone-factor-technical-profile.md
@@ -93,7 +93,7 @@ The **CryptographicKeys** element is not used.
 | ManualPhoneNumberEntryAllowed| No | Specify whether or not a user is allowed to manually enter a phone number. Possible values: `true`, or `false` (default).|
 | setting.authenticationMode | No | The method to validate the phone number. Possible values: `sms`, `phone`, or `mixed` (default).|
 | setting.autodial| No| Specify whether the technical profile should auto dial or auto send an SMS. Possible values: `true`, or `false` (default). Auto dial requires the `setting.authenticationMode` metadata be set to `sms`, or `phone`. The input claims collection must have a single phone number. |
-| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Passible values are `true` (default), or `false`. When auto-submit is turned off, the user will have to select a button to progress the journey. |
+| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Possible values are `true` (default), or `false`. When auto-submit is turned off, the user will have to select a button to progress the journey. |
 
 ### UI elements
 

--- a/articles/active-directory-b2c/phone-factor-technical-profile.md
+++ b/articles/active-directory-b2c/phone-factor-technical-profile.md
@@ -93,7 +93,7 @@ The **CryptographicKeys** element is not used.
 | ManualPhoneNumberEntryAllowed| No | Specify whether or not a user is allowed to manually enter a phone number. Possible values: `true`, or `false` (default).|
 | setting.authenticationMode | No | The method to validate the phone number. Possible values: `sms`, `phone`, or `mixed` (default).|
 | setting.autodial| No| Specify whether the technical profile should auto dial or auto send an SMS. Possible values: `true`, or `false` (default). Auto dial requires the `setting.authenticationMode` metadata be set to `sms`, or `phone`. The input claims collection must have a single phone number. |
-| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Passible values: `true` (default), or `false` When auto-submit is turned off, the user will have to click a button to progress the journey. |
+| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Passible values are `true` (default), or `false`. When auto-submit is turned off, the user will have to select a button to progress the journey. |
 
 ### UI elements
 

--- a/articles/active-directory-b2c/phone-factor-technical-profile.md
+++ b/articles/active-directory-b2c/phone-factor-technical-profile.md
@@ -93,6 +93,7 @@ The **CryptographicKeys** element is not used.
 | ManualPhoneNumberEntryAllowed| No | Specify whether or not a user is allowed to manually enter a phone number. Possible values: `true`, or `false` (default).|
 | setting.authenticationMode | No | The method to validate the phone number. Possible values: `sms`, `phone`, or `mixed` (default).|
 | setting.autodial| No| Specify whether the technical profile should auto dial or auto send an SMS. Possible values: `true`, or `false` (default). Auto dial requires the `setting.authenticationMode` metadata be set to `sms`, or `phone`. The input claims collection must have a single phone number. |
+| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Passible values: `true` (default), or `false` When auto-submit is turned off, the user will have to click a button to progress the journey. |
 
 ### UI elements
 

--- a/articles/active-directory-b2c/phone-factor-technical-profile.md
+++ b/articles/active-directory-b2c/phone-factor-technical-profile.md
@@ -93,7 +93,7 @@ The **CryptographicKeys** element is not used.
 | ManualPhoneNumberEntryAllowed| No | Specify whether or not a user is allowed to manually enter a phone number. Possible values: `true`, or `false` (default).|
 | setting.authenticationMode | No | The method to validate the phone number. Possible values: `sms`, `phone`, or `mixed` (default).|
 | setting.autodial| No| Specify whether the technical profile should auto dial or auto send an SMS. Possible values: `true`, or `false` (default). Auto dial requires the `setting.authenticationMode` metadata be set to `sms`, or `phone`. The input claims collection must have a single phone number. |
-| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Possible values are `true` (default), or `false`. When auto-submit is turned off, the user will have to select a button to progress the journey. |
+| setting.autosubmit | No | Specifies whether the technical profile should auto submit the one-time password entry form. Possible values are `true` (default), or `false`. When auto-submit is turned off, the user needs to select a button to progress the journey. |
 
 ### UI elements
 


### PR DESCRIPTION
In executing flows in iOS, if the user clicks the predictive text "from messages {code}" and auto-submit is turned on, the code will not automatically submit. Turning auto-submit off will allow iOS users to click continue and progress as normal.

Still outstanding bug first reported: https://docs.microsoft.com/en-us/answers/questions/34461/azure-ad-b2c-auto-fill-login-form-on-ios-not-worki.html