### PR TITLE
Update configure-custom-domain.md

### DIFF
--- a/articles/api-management/configure-custom-domain.md
+++ b/articles/api-management/configure-custom-domain.md
@@ -58,7 +58,7 @@ There are several API Management endpoints to which you can assign a custom doma
 API Management supports custom TLS certificates or certificates imported from Azure Key Vault. You can also enable a free, managed certificate.
 
 > [!WARNING]
-> If you wish to improve the security of your applications with certificate pinning, you should use a custom domain name and either a custom or Key Vault certificate, not the default certificate or the free, managed certificate. We don't recommend taking a hard dependency on a certificate that you don't manage.
+> If you require certificate pinning, please use a custom domain name and either a custom or Key Vault certificate, not the default certificate or the free, managed certificate. We don't recommend taking a hard dependency on a certificate that you don't manage.
 
 # [Custom](#tab/custom)
 


### PR DESCRIPTION
This warning implies that selecting a Managed Certificate makes users less secure and they might not select this useful feature because it blocks them from using the "more secure" certificate pinning methodology. 

In practice, key pinning is obsolete and shouldn't be suggested as "more secure."
Instead of advocating for certificate pinning as more secure, let's remove that "more secure" inference, and just point out that key pinning isn't compatible with a managed certificate.  

Evidence
Obsolete = https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning#Certificate_pinning
Less secure = https://security.stackexchange.com/questions/29988/what-is-certificate-pinning

Related to the original PR = https://github.com/MicrosoftDocs/azure-docs/pull/91084