### PR TITLE
Priority config missing in front end rule creation

### DIFF
--- a/articles/application-gateway/quick-create-powershell.md
+++ b/articles/application-gateway/quick-create-powershell.md
@@ -129,6 +129,7 @@ $defaultlistener = New-AzApplicationGatewayHttpListener `
 $frontendRule = New-AzApplicationGatewayRequestRoutingRule `
   -Name rule1 `
   -RuleType Basic `
+  -Priority 100 `
   -HttpListener $defaultlistener `
   -BackendAddressPool $backendPool `
   -BackendHttpSettings $poolSettings


### PR DESCRIPTION
When I try the create front end rule as per the doc, 
$frontendRule = New-AzApplicationGatewayRequestRoutingRule `
  -Name rule1 `
  -RuleType Basic `
  -HttpListener $defaultlistener `
  -BackendAddressPool $backendPool `
  -BackendHttpSettings $poolSettings, 

Instead of this: It has to be this, with priority configuration added.
$frontendRule = New-AzApplicationGatewayRequestRoutingRule `
  -Name rule1 `
  -RuleType Basic `
  -Priority 100 `
  -HttpListener $defaultlistener `
  -BackendAddressPool $backendPool `
  -BackendHttpSettings $poolSettings
It says priority is not configured when I try to create an application gateway with the steps. I would like to suggest adding -priority 100 with the creating front end rule step so application gateway creation step passes and deploys app gateway.