### PR TITLE
Update concept-azure-ad-connect-sync-default-configuration.md

### DIFF
--- a/articles/active-directory/hybrid/concept-azure-ad-connect-sync-default-configuration.md
+++ b/articles/active-directory/hybrid/concept-azure-ad-connect-sync-default-configuration.md
@@ -71,6 +71,7 @@ The following attribute rules apply:
 ### Contact out-of-box rules
 A contact object must satisfy the following to be synchronized:
 
+* Must have mail attribute value.
 * The contact must be mail-enabled. It is verified with the following rules:
   * `IsPresent([proxyAddresses]) = True)`. The proxyAddresses attribute must be populated.
   * A primary email address can be found in either the proxyAddresses attribute or the mail attribute. The presence of an \@ is used to verify that the content is an email address. One of these two rules must be evaluated to True.


### PR DESCRIPTION
Updating contact out-of-box rules description adding that contact object must have mail attribute value to satisfy the join rule behavior where when an attribute is selected at join rule, if no matching with any existing object in the metaverse, link type will be used, if provision, new object will be created in the metaverse and for that the attribute (mail) must have a value.