### PR TITLE
Reflect network-scripts not installed by default.

### DIFF
--- a/articles/virtual-machines/linux/create-upload-centos.md
+++ b/articles/virtual-machines/linux/create-upload-centos.md
@@ -227,6 +227,12 @@ Preparing a CentOS 7 virtual machine for Azure is very similar to CentOS 6, howe
 * The NetworkManager package no longer conflicts with the Azure Linux agent. This package is installed by default and we recommend that it is not removed.
 * GRUB2 is now used as the default bootloader, so the procedure for editing kernel parameters has changed (see below).
 * XFS is now the default file system. The ext4 file system can still be used if desired.
+* Since CentOS 8 Stream and newer no longer include `network.service` by default, you will need to install it manually:
+
+	```console
+	sudo yum install network-scripts
+	sudo systemctl enable network.service
+	```
 
 **Configuration Steps**
 


### PR DESCRIPTION
Since CentOS 8 Stream and newer no longer include `network.service` provided by the package `network-scripts` by default it must be installed manually, This should be mentioned as it is likely to save people a fair bit of time troubleshooting VMs that deploy successfuly but can't communicate thereafter.