### PR TITLE
Update quick-create-cli.md

### DIFF
--- a/articles/key-vault/managed-hsm/quick-create-cli.md
+++ b/articles/key-vault/managed-hsm/quick-create-cli.md
@@ -61,7 +61,7 @@ You need to provide following inputs to create a Managed HSM resource:
 The following example creates an HSM named **ContosoMHSM**, in the resource group  **ContosoResourceGroup**, residing in the **West US 3** location, with **the current signed in user** as the only administrator, with **7 days retention period** for soft-delete. Read more about [Managed HSM soft-delete](soft-delete-overview.md)
 
 ```azurecli-interactive
-oid=$(az ad signed-in-user show --query objectId -o tsv)
+oid=$(az ad signed-in-user show --query id -o tsv)
 az keyvault create --hsm-name "ContosoMHSM" --resource-group "ContosoResourceGroup" --location "westus3" --administrators $oid --retention-days 7
 ```
 


### PR DESCRIPTION
There is an error on the documentation:

oid=$(az ad signed-in-user show --query objectId -o tsv)
az keyvault create --hsm-name "ContosoMHSM" --resource-group "ContosoResourceGroup" --location "westus3" --administrators $oid --retention-days 7

should be

oid=$(az ad signed-in-user show --query id -o tsv)
az keyvault create --hsm-name "ContosoMHSM" --resource-group "ContosoResourceGroup" --location "westus3" --administrators $oid --retention-days 7