### PR TITLE
Added clarification on validation technical profile execution v2

### DIFF
--- a/articles/active-directory-b2c/self-asserted-technical-profile.md
+++ b/articles/active-directory-b2c/self-asserted-technical-profile.md
@@ -192,6 +192,9 @@ The validation technical profile can be any technical profile in the policy, suc
 
 You can also call a REST API technical profile with your business logic, overwrite input claims, or enrich user data by further integrating with corporate line-of-business application. For more information, see [Validation technical profile](validation-technical-profile.md)
 
+> [!NOTE]
+> A validation technical profile will only be triggered when there is some input from the user. It is not possible to create an _empty_ self-asserted technical profile that exists to call validation technical profiles only e.g. to take advantage of the **ContinueOnError** attribute of a **ValidationTechnicalProfile** element. These validation technical profiles must be called from a self-asserted technical profile that solicits some input from the user, or called from an orchestration step in a user journey.
+
 ## Metadata
 
 | Attribute | Required | Description |

--- a/articles/active-directory-b2c/self-asserted-technical-profile.md
+++ b/articles/active-directory-b2c/self-asserted-technical-profile.md
@@ -193,7 +193,7 @@ The validation technical profile can be any technical profile in the policy, suc
 You can also call a REST API technical profile with your business logic, overwrite input claims, or enrich user data by further integrating with corporate line-of-business application. For more information, see [Validation technical profile](validation-technical-profile.md)
 
 > [!NOTE]
-> A validation technical profile will only be triggered when there is some input from the user. It is not possible to create an _empty_ self-asserted technical profile that exists to call validation technical profiles only e.g. to take advantage of the **ContinueOnError** attribute of a **ValidationTechnicalProfile** element. These validation technical profiles must be called from a self-asserted technical profile that solicits some input from the user, or called from an orchestration step in a user journey.
+> A validation technical profile is only triggered when there's an input from the user. You can't create an _empty_ self-asserted technical profile to call a validation technical profile just to take advantage of the **ContinueOnError** attribute of a **ValidationTechnicalProfile** element. You can only call a validation technical profile from a self-asserted technical profile that requests an input from the user, or from an orchestration step in a user journey. 
 
 ## Metadata
 


### PR DESCRIPTION
This is a duplicate of PR #93154. The PR was closed as it was awaiting a response from me but I was not available that week.

I have raised another PR to have the update included. A question was asked in the previous PR whether some existing content would cover the same area that this PR does, but it would not. The important message in this PR is that _ValidationTechnicalProfiles_ will _not_ be executed unless there is some input from the user. While this may sound obvious to experienced B2C developers, it may not be immediately apparent to an inexperienced B2C developer.