### PR TITLE
Cluster-1 Storage Policy Modification Updates

### DIFF
--- a/articles/azure-vmware/configure-storage-policy.md
+++ b/articles/azure-vmware/configure-storage-policy.md
@@ -121,10 +121,6 @@ You'll run the `Set-LocationStoragePolicy` cmdlet to Modify vSAN based storage p
 You'll run the `Set-ClusterDefaultStoragePolicy` cmdlet to specify default storage policy for a cluster,
 
 
->[!NOTE]
->Changing the storage policy of the default management cluster (Cluster-1) isn't allowed.
-
-
 1. Select **Run command** > **Packages** > **Set-ClusterDefaultStoragePolicy**.
 
 1. Provide the required values or change the default values, and then select **Run**.


### PR DESCRIPTION
Removed notes stating "Changing the storage policy of the default management cluster (Cluster-1) isn't allowed." This is allowed, supported, and verified as functional.