### PR TITLE
Update cache-how-to-premium-persistence.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -210,7 +210,7 @@ When clustering is enabled, each shard in the cache has its own set of page blob
 After a rewrite, two sets of AOF files exist in storage. Rewrites occur in the background and append to the first set of files. Set operations, sent to the cache during the rewrite, append to the second set. A backup is temporarily stored during rewrites if there's a failure. The backup is promptly deleted after a rewrite finishes. If soft delete is turned on for your storage account, the soft delete setting applies and existing backups continue to stay in the soft delete state.
 
 ### Will having firewall exceptions on the storage account affect persistence
-Using managed identity will conveniently add the cache instance to the [trusted services list](../storage/common/storage-network-security.md?tabs=azure-portal), making firewall exceptions easier to implement. If not using managed identity and authorizing to storage account via key, then having firewall exceptions on the storage account shall tend to break the persistence process.
+Using managed identity adds the cache instance to the [trusted services list](../storage/common/storage-network-security.md?tabs=azure-portal), making firewall exceptions easier to carry out. If you are not using managed identity and instead authorizing to storage account using a key, then having firewall exceptions on the storage account tends to break the persistence process.
 
 ## Next steps
 

--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -102,6 +102,7 @@ The following list contains answers to commonly asked questions about Azure Cach
 - [Can I use the same storage account for persistence across two different caches?](#can-i-use-the-same-storage-account-for-persistence-across-two-different-caches)
 - [Will I be charged for the storage being used in Data Persistence](#will-i-be-charged-for-the-storage-being-used-in-data-persistence)
 - [How frequently does RDB and AOF persistence write to my blobs, and should I enable soft delete?](#how-frequently-does-rdb-and-aof-persistence-write-to-my-blobs-and-should-i-enable-soft-delete)
+- [Will having firewall exceptions on the storage account affect persistence](#Will having firewall exceptions on the storage account affect persistence)
 
 ### RDB persistence
 
@@ -207,6 +208,9 @@ Data stored in AOF files is divided into multiple page blobs per node to increas
 When clustering is enabled, each shard in the cache has its own set of page blobs, as indicated in the previous table. For example, a P2 cache with three shards distributes its AOF file across 24 page blobs (eight blobs per shard, with three shards).
 
 After a rewrite, two sets of AOF files exist in storage. Rewrites occur in the background and append to the first set of files. Set operations, sent to the cache during the rewrite, append to the second set. A backup is temporarily stored during rewrites if there's a failure. The backup is promptly deleted after a rewrite finishes. If soft delete is turned on for your storage account, the soft delete setting applies and existing backups continue to stay in the soft delete state.
+
+### Will having firewall exceptions on the storage account affect persistence
+Using managed identity will conveniently add the cache instance to the [trusted services list](../storage/common/storage-network-security.md?tabs=azure-portal), making firewall exceptions easier to implement. If not using managed identity and authorizing to storage account via key, then having firewall exceptions on the storage account shall tend to break the persistence process.
 
 ## Next steps
 


### PR DESCRIPTION
Firewall Exception on the storage account will affect the persistence process. 
If using Managed Identity in order to authenticate the storage account, this shall help manage firewall exceptions and if not and key being used then the process may tend to break. This seem to have been there previously but not now and hence proposing to have this as an FAQ. Please review