### PR TITLE
Update cache-how-to-import-export-data.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-import-export-data.md
+++ b/articles/azure-cache-for-redis/cache-how-to-import-export-data.md
@@ -166,7 +166,7 @@ To resolve this error, start the import or export operation before 15 minutes ha
 
 ### I got an error when exporting my data to Azure Blob Storage. What happened?
 
-Export works only with RDB files stored as page blobs. Other blob types aren't currently supported, including Blob storage accounts with hot and cool tiers. For more information, see [Azure storage account overview](../storage/common/storage-account-overview.md). If you are using access key to authenticate to storage account, having firewall exceptions on the storage account may tend to fail the process.
+Export works only with RDB files stored as page blobs. Other blob types aren't currently supported, including Blob storage accounts with hot and cool tiers. For more information, see [Azure storage account overview](../storage/common/storage-account-overview.md). If you are using an access key to authenticate to storage account, having firewall exceptions on the storage account tends to fail the process.
 
 ## Next steps
 

--- a/articles/azure-cache-for-redis/cache-how-to-import-export-data.md
+++ b/articles/azure-cache-for-redis/cache-how-to-import-export-data.md
@@ -166,7 +166,7 @@ To resolve this error, start the import or export operation before 15 minutes ha
 
 ### I got an error when exporting my data to Azure Blob Storage. What happened?
 
-Export works only with RDB files stored as page blobs. Other blob types aren't currently supported, including Blob storage accounts with hot and cool tiers. For more information, see [Azure storage account overview](../storage/common/storage-account-overview.md).
+Export works only with RDB files stored as page blobs. Other blob types aren't currently supported, including Blob storage accounts with hot and cool tiers. For more information, see [Azure storage account overview](../storage/common/storage-account-overview.md). If you are using access key to authenticate to storage account, having firewall exceptions on the storage account may tend to fail the process.
 
 ## Next steps
 


### PR DESCRIPTION
 If you are using access key to authenticate to storage account, having firewall exceptions on the storage account may tend to fail the process. Hence adding this as a pointer for customers to review as well