### PR TITLE
Removing duplicate links

### DIFF
--- a/articles/confidential-ledger/overview.md
+++ b/articles/confidential-ledger/overview.md
@@ -62,6 +62,5 @@ The Functional APIs allow direct interaction with your instantiated confidential
 ## Next steps
 
 - [Microsoft Azure confidential ledger architecture](architecture.md)
-- [Quickstart: Azure portal](quickstart-portal.md)
 - [Quickstart: Python](quickstart-python.md)
 - [Quickstart: Azure Resource Manager (ARM) template](quickstart-portal.md)


### PR DESCRIPTION
In the list for next step two of the links are the same. I removed the first one as the text is better in the second one. Both linked to (quickstart-portal.md)