### PR TITLE
Issue when mounting file share of type NFS (BYOS) to App Service

### DIFF
--- a/articles/app-service/configure-connect-to-azure-storage.md
+++ b/articles/app-service/configure-connect-to-azure-storage.md
@@ -106,7 +106,7 @@ The following features are supported for Linux containers:
 - Mapping `/mounts`, `mounts/foo/bar`, `/`, and `/mounts/foo.bar/` to custom-mounted storage is not supported (you can only use /mounts/pathname for mounting custom storage to your web app.)
 - Storage mounts cannot be used together with clone settings option during [deployment slot](deploy-staging-slots.md) creation.
 - Storage mounts are not backed up when you [back up your app](manage-backup.md). Be sure to follow best practices to back up the Azure Storage accounts. 
-- Only Azure Files [SMB](https://docs.microsoft.com/en-us/azure/storage/files/files-smb-protocol) are supported.  Azure Files [NFS](https://docs.microsoft.com/en-us/azure/storage/files/files-nfs-protocol) is not currently supported for Linux App Services.
+- Only Azure Files [SMB](/azure/storage/files/files-smb-protocol) are supported.  Azure Files [NFS](/azure/storage/files/files-nfs-protocol) is not currently supported for Linux App Services.
 
 ::: zone-end
 

--- a/articles/app-service/configure-connect-to-azure-storage.md
+++ b/articles/app-service/configure-connect-to-azure-storage.md
@@ -106,6 +106,7 @@ The following features are supported for Linux containers:
 - Mapping `/mounts`, `mounts/foo/bar`, `/`, and `/mounts/foo.bar/` to custom-mounted storage is not supported (you can only use /mounts/pathname for mounting custom storage to your web app.)
 - Storage mounts cannot be used together with clone settings option during [deployment slot](deploy-staging-slots.md) creation.
 - Storage mounts are not backed up when you [back up your app](manage-backup.md). Be sure to follow best practices to back up the Azure Storage accounts. 
+- Only Azure Files [SMB](https://docs.microsoft.com/en-us/azure/storage/files/files-smb-protocol) are supported.  Azure Files [NFS](https://docs.microsoft.com/en-us/azure/storage/files/files-nfs-protocol) is not currently supported for Linux App Services.
 
 ::: zone-end
 


### PR DESCRIPTION
An email was sent to the "Azure Web Apps (Antares) discussions" alias requesting this change.  Azure Files are supported for Linux App Service.  I think the nuance here is that we only support (currently) Azure Files SMB, but not Azure Files NFS.  Valid point though to call this out explicitly in our docs and such.