### PR TITLE
add missing ``` at the end of  ```azurecli

### DIFF
--- a/articles/aks/use-network-policies.md
+++ b/articles/aks/use-network-policies.md
@@ -77,6 +77,7 @@ You can replace the *RESOURCE_GROUP_NAME* and *CLUSTER_NAME* variables:
 RESOURCE_GROUP_NAME=myResourceGroup-NP
 CLUSTER_NAME=myAKSCluster
 LOCATION=canadaeast
+```
 
 Create the AKS cluster and specify *azure* for the network plugin and network policy.
 


### PR DESCRIPTION
Missing ***```*** caused two azurecli blocks and a line to be combined together which was wrong.

It's visible here:
![image](https://user-images.githubusercontent.com/11361528/180800676-5add0b52-2726-417d-95b1-13f59205990c.png)

on this link:
https://docs.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-for-azure-network-policies