### PR TITLE
Call out requirement for admin privileges

### DIFF
--- a/articles/cognitive-services/Speech-Service/spx-basics.md
+++ b/articles/cognitive-services/Speech-Service/spx-basics.md
@@ -32,6 +32,8 @@ This article assumes that you have working knowledge of the Command Prompt windo
 
 To get started, you need an Azure subscription key and region identifier (for example, `eastus`, `westus`). Create a Speech resource on the [Azure portal](https://portal.azure.com). For more information, see [Create a new Azure Cognitive Services resource](~/articles/cognitive-services/cognitive-services-apis-create-account.md?tabs=speech#create-a-new-azure-cognitive-services-resource).
 
+Open a command prompt window with administrator privileges.
+
 To configure your subscription key and region identifier, run the following commands:  
 
 ```console
@@ -56,6 +58,8 @@ spx config @region --clear
 # [PowerShell](#tab/powershell)
 
 To get started, you need an Azure subscription key and region identifier (for example, `eastus`, `westus`). Create a Speech resource on the [Azure portal](https://portal.azure.com). For more information, see [Create a new Azure Cognitive Services resource](~/articles/cognitive-services/cognitive-services-apis-create-account.md?tabs=speech#create-a-new-azure-cognitive-services-resource).
+
+Open a PowerShell window with administrator privileges.
 
 To configure your subscription key and region identifier, run the following commands in PowerShell: 
 


### PR DESCRIPTION
The current instructions do not mention the need to have administrator privileges. Without admin privileges, users will encounter the following error message the first time they try to set the key and region parameters: ERROR: Could not find file 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\key'