### PR TITLE
Update control-flow-expression-language-functions.md

### DIFF
--- a/articles/data-factory/control-flow-expression-language-functions.md
+++ b/articles/data-factory/control-flow-expression-language-functions.md
@@ -3042,7 +3042,7 @@ ticks('<timestamp>')
 
 | Return value | Type | Description |
 | ------------ | ---- | ----------- |
-| <*ticks-number*> | Integer | The number of ticks since the specified timestamp |
+| <*ticks-number*> | Integer | The number of ticks that have elapsed since 12:00:00 midnight, January 1, 0001 in the Gregorian calendar since the input timestamp |
 ||||
 
 <a name="toLower"></a>


### PR DESCRIPTION
the current version reads as the number to ticks since the timestamp. this would be zero. the ticks property is the number of ticks elasped from the 12:00:00 midnight, January 1, 0001 in the Gregorian calendar (anchor or epoch time) until the timestamp. 

ref: https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks?view=net-6.0