### PR TITLE
adding a determiner for the syntax: "The W10/11 Enterprise ..... and …RDSH role on WS"

### DIFF
--- a/articles/virtual-desktop/overview.md
+++ b/articles/virtual-desktop/overview.md
@@ -35,7 +35,7 @@ With Azure Virtual Desktop, you can set up a scalable and flexible environment:
 - Create a full desktop virtualization environment in your Azure subscription without running any gateway servers.
 - Publish host pools as you need to accommodate your diverse workloads.
 - Bring your own image for production workloads or test from the Azure Gallery.
-- Reduce costs with pooled, multi-session resources. With the new Windows 11 and Windows 10 Enterprise multi-session capability, exclusive to Azure Virtual Desktop and Remote Desktop Session Host (RDSH) role on Windows Server, you can greatly reduce the number of virtual machines and operating system overhead while still providing the same resources to your users.
+- Reduce costs with pooled, multi-session resources. With the new Windows 11 and Windows 10 Enterprise multi-session capability, exclusive to Azure Virtual Desktop and the Remote Desktop Session Host (RDSH) role on Windows Server, you can greatly reduce the number of virtual machines and operating system overhead while still providing the same resources to your users.
 - Provide individual ownership through personal (persistent) desktops.
 - Use autoscale to automatically increase or decrease capacity based on time of day, specific days of the week, or as demand changes, helping to manage cost.
 


### PR DESCRIPTION
Hello, 

Was going through our docs and found the following phrase:

"- Reduce costs with pooled, multi-session resources. With **the new Windows 11 and Windows 10 Enterprise** multi-session capability, exclusive to Azure Virtual Desktop **and Remote Desktop Session Host (RDSH) role** on Windows Server......"

^---- we are referring to the subject: "the new Windows 11 and Windows 10 Enterprise" and then we introduce a new subject - "Remote Desktop Session Host (RDSH) role" ..... but this subject in my opinion does not have a good highlight, since it is missing the determiner "<code>the</code> Remote Desktop Session Host (RDSH ) role"

What is your opinion on this?

Feel free to also reach out to me on Teams (aolariu) if you have any questions about this PR.
Wish you a good day! :)