### PR TITLE
Standard AVD network connectivity uses TCP-only on Port 443.

### DIFF
--- a/articles/virtual-desktop/prerequisites.md
+++ b/articles/virtual-desktop/prerequisites.md
@@ -130,7 +130,7 @@ There are different automation and deployment options available depending on whi
 
 There are several network requirements you'll need to meet to successfully deploy Azure Virtual Desktop. This lets users connect to their virtual desktops and remote apps while also giving them the best possible user experience.
 
-Users connecting to Azure Virtual Desktop use Transmission Control Protocol (TCP) or User Datagram Protocol (UDP) on port 443, which securely establishes a reverse connection to the service. This means you don't need to open any inbound ports.
+Users connecting to Azure Virtual Desktop use Transmission Control Protocol (TCP) on port 443, which securely establishes a reverse connection to the service. This means you don't need to open any inbound ports.
 
 To successfully deploy Azure Virtual Desktop, you'll need to meet the following network requirements:
 


### PR DESCRIPTION
Hey, was just reading through our docs and I came upon this statement:

"Users connecting to Azure Virtual Desktop useTransmission Control Protocol (TCP) or User Datagram Protocol
(UDP) on port 443"

This is not true, in my opinion.
Yes, we can leverage the use of UDP connectionless transfer layer protocol, if we implement `RDP ShortPath for Public Networks / Managed Networks`, but in the standard AVD deployment, the connection is leveraging the use of TCP, and indeed, port 443 (HTTPS).

Please let me know what was meant by the above statement and if there is any issues with this PR.
You can also reach out to me on Teams (aolariu).

Thanks! :)