### PR TITLE
More concise & clear phrasing - RDP Shortpath

### DIFF
--- a/articles/virtual-desktop/shortpath.md
+++ b/articles/virtual-desktop/shortpath.md
@@ -47,13 +47,13 @@ The following diagram gives a high-level overview of the RDP Shortpath network c
 
 ## Requirements
 
-To support RDP Shortpath, the Azure Virtual Desktop client needs a direct line of sight to the session host. You can get a direct line of sight by using one of these methods:
 
 - Make sure the remote client machines are running Windows 11, Windows 10, or Windows 7 and have the [Windows Desktop client](/windows-server/remote/remote-desktop-services/clients/windowsdesktop) installed. Currently, non-Windows clients aren't supported.
-- Use [ExpressRoute private peering](../expressroute/expressroute-circuit-peerings.md)
-- Use a [Site-to-Site virtual private network (VPN) (IPsec-based)](../vpn-gateway/tutorial-site-to-site-portal.md)
-- Use a [Point-to-Site VPN (IPsec-based)](../vpn-gateway/vpn-gateway-howto-point-to-site-resource-manager-portal.md)
-- Use a [public IP address assignment](../virtual-network/ip-services/virtual-network-public-ip-address.md)
+- To support RDP Shortpath, the Azure Virtual Desktop client needs a direct line of sight to the session host. You can get a direct line of sight by using one of these methods:
+   - Use [ExpressRoute private peering](../expressroute/expressroute-circuit-peerings.md)
+   - Use a [Site-to-Site virtual private network (VPN) (IPsec-based)](../vpn-gateway/tutorial-site-to-site-portal.md)
+   - Use a [Point-to-Site VPN (IPsec-based)](../vpn-gateway/vpn-gateway-howto-point-to-site-resource-manager-portal.md)
+   - Use a [public IP address assignment](../virtual-network/ip-services/virtual-network-public-ip-address.md)
 
 If you're using other VPN types to connect to the Azure portal, we recommend using a User Datagram Protocol (UDP)-based VPN. While most Transmission Control Protocol (TCP)-based VPN solutions support nested UDP, they add inherited overhead of TCP congestion control, which slows down RDP performance.
 


### PR DESCRIPTION
Hello,

I was browsing through our docs and came upon this statement:

"
To support RDP Shortpath, the Azure Virtual Desktop client needs a direct line of sight to the session host. You
can get a direct line of sight by using one of these methods:

1.Make sure the remote client machines are running Windows 11, Windows 10, or Windows 7 and have the
Windows Desktop client installed. Currently, non-Windows clients aren't supported.
2.Use ExpressRoute private peering
3.Use a Site-to-Site virtual private network (VPN) (IPsec-based)
4.Use a Point-to-Site VPN (IPsec-based)
5.Use a public IP address assignment
"

Well, the option no.1 is a requirement, not an "option", i.e. if I am a customer and I implement like the article tells me "one of these methods" - I'll not be able to achieve UDP!
In my opinion, the first bullet point should be separate from the bullet points regarding line-of-sight.

Please let me know if there are any questions regarding this PR.
You can also reach out to me on Teams (aolariu).

Thanks!