### PR TITLE
Slight typo fix + added RDP Shortpath for public networks UdpUse

### DIFF
--- a/articles/virtual-desktop/shortpath.md
+++ b/articles/virtual-desktop/shortpath.md
@@ -167,7 +167,8 @@ If you're using [Azure Log Analytics](./diagnostics-log-analytics.md), you can m
 The possible values are:
 
 * **0** - user connection isn't using RDP Shortpath.
-- **1** - THe user connection is using RDP Shortpath for managed networks.
+- **1** - user connection is using RDP Shortpath for managed networks.
+- **2** - user connection is using RDP Shortpath for public networks.
   
 The following query list lets you review connection information. You can run this query in the [Log Analytics query editor](../azure-monitor/logs/log-analytics-tutorial.md#write-a-query). For each query, replace `userupn` with the UPN of the user you want to look up.
 


### PR DESCRIPTION
Hey,

Was just browsing through our docs and found the following statement:
"
0 - user connection isn't using RDP Shortpath.
1 -THe user connection is using RDP Shortpath for managed networks.
"

I believe the "THe" word is a typo there, so I've deleted it with this PR.
Furthermore, since this article's last update date, we've also introduced RDP Shortpath for public networks which will have a value for the UdpUse field of "2".
I've added that field in the above statement as well.

Please let me know if there is any problem with this PR or if you have questions.
Feel free to reach out directly to me on Teams (aolariu).

Thanks!