### PR TITLE
Remove Windows 7 as it is no longer supported

### DIFF
--- a/articles/active-directory/devices/concept-azure-ad-join-hybrid.md
+++ b/articles/active-directory/devices/concept-azure-ad-join-hybrid.md
@@ -27,12 +27,12 @@ Hybrid Azure AD joined devices require network line of sight to your on-premises
 | **Primary audience** | Suitable for hybrid organizations with existing on-premises AD infrastructure |
 |   | Applicable to all users in an organization |
 | **Device ownership** | Organization |
-| **Operating Systems** | Windows 10 or newer, 8.1 and 7 |
+| **Operating Systems** | Windows 10 or newer, 8.1 |
 |   | Windows Server 2008/R2, 2012/R2, 2016 and 2019 |
 | **Provisioning** | Windows 10 or newer, Windows Server 2016/2019 |
 |   | Domain join by IT and autojoin via Azure AD Connect or ADFS config |
 |   | Domain join by Windows Autopilot and autojoin via Azure AD Connect or ADFS config |
-|   | Windows 8.1, Windows 7, Windows Server 2012 R2, Windows Server 2012, and Windows Server 2008 R2 - Require MSI |
+|   | Windows 8.1, Windows Server 2012 R2, Windows Server 2012, and Windows Server 2008 R2 - Require MSI |
 | **Device sign in options** | Organizational accounts using: |
 |   | Password |
 |   | Windows Hello for Business for Win10 and above |
@@ -48,7 +48,7 @@ Hybrid Azure AD joined devices require network line of sight to your on-premises
 
 Use Azure AD hybrid joined devices if:
 
-- You support down-level devices running Windows 7 and 8.1.
+- You support down-level devices running 8.1.
 - You want to continue to use [Group Policy](/mem/configmgr/comanage/faq#my-environment-has-too-many-group-policy-objects-and-legacy-authenticated-apps--do-i-have-to-use-hybrid-azure-ad-) to manage device configuration.
 - You want to continue to use existing imaging solutions to deploy and configure devices.
 - You have Win32 apps deployed to these devices that rely on Active Directory machine authentication.

--- a/articles/active-directory/devices/concept-azure-ad-join-hybrid.md
+++ b/articles/active-directory/devices/concept-azure-ad-join-hybrid.md
@@ -27,9 +27,9 @@ Hybrid Azure AD joined devices require network line of sight to your on-premises
 | **Primary audience** | Suitable for hybrid organizations with existing on-premises AD infrastructure |
 |   | Applicable to all users in an organization |
 | **Device ownership** | Organization |
-| **Operating Systems** | Windows 10 or newer, 8.1 |
-|   | Windows Server 2008/R2, 2012/R2, 2016 and 2019 |
-| **Provisioning** | Windows 10 or newer, Windows Server 2016/2019 |
+| **Operating Systems** | Windows 11, Windows 10 or 8.1 |
+|   | Windows Server 2008/R2, 2012/R2, 2016, 2019 and 2022 |
+| **Provisioning** | Windows 11, Windows 10, Windows Server 2016/2019/2022 |
 |   | Domain join by IT and autojoin via Azure AD Connect or ADFS config |
 |   | Domain join by Windows Autopilot and autojoin via Azure AD Connect or ADFS config |
 |   | Windows 8.1, Windows Server 2012 R2, Windows Server 2012, and Windows Server 2008 R2 - Require MSI |


### PR DESCRIPTION
Windows 7 is no longer a supported operating system. This is also outlined in the documentation for implementing HAADJ for down level devices. 
https://docs.microsoft.com/en-us/azure/active-directory/devices/howto-hybrid-join-downlevel

If we don't plan to support customers creating tickets for HAADJ issues with Windows 7 then it should no longer list Windows 7 as a supported OS in this documentation. 

Other documentation referencing the end of support day for Windows 7.
https://support.microsoft.com/en-us/windows/windows-7-support-ended-on-january-14-2020-b75d4580-2cc7-895a-2c9c-1466d9a53962
https://www.microsoft.com/en-us/windows/end-of-support