### PR TITLE
Update export-api-power-platform.md

### DIFF
--- a/articles/api-management/export-api-power-platform.md
+++ b/articles/api-management/export-api-power-platform.md
@@ -42,6 +42,7 @@ Once the connector is created, navigate to your [Power Apps](https://make.powera
 
 > [!NOTE]
 > To call the API from the Power Apps test console, you need to add the "https://flow.microsoft.com" URL as an origin to the [CORS policy](api-management-cross-domain-policies.md#CORS) in your API Management instance.
+> To call the API from the Power Apps, you need to add the origin "https://authoring.*.powerapps.com" URL (this URL can be retrieved from the network tab of the browser when requested for the API call)  as an origin to the [CORS policy](api-management-cross-domain-policies.md#CORS) in your API Management instance.
 
 ## Next steps
 

--- a/articles/api-management/export-api-power-platform.md
+++ b/articles/api-management/export-api-power-platform.md
@@ -41,8 +41,8 @@ Once the connector is created, navigate to your [Power Apps](https://make.powera
 :::image type="content" source="media/export-api-power-platform/custom-connector-power-app.png" alt-text="Custom connector in Power Platform":::
 
 > [!NOTE]
-> To call the API from the Power Apps test console, you need to add the "https://flow.microsoft.com" URL as an origin to the [CORS policy](api-management-cross-domain-policies.md#CORS) in your API Management instance.
-> To call the API from the Power Apps, you need to add the origin "https://authoring.*.powerapps.com" URL (this URL can be retrieved from the network tab of the browser when requested for the API call)  as an origin to the [CORS policy](api-management-cross-domain-policies.md#CORS) in your API Management instance.
+> To call the API from the Power Apps test console, you need to add the `https://flow.microsoft.com` URL as an origin to the [CORS policy](api-management-cross-domain-policies.md#CORS) in your API Management instance.
+> To call the API from the Power Apps, you need to add the origin `https://authoring.*.powerapps.com` URL (this URL can be retrieved from the network tab of the browser when requested for the API call)  as an origin to the [CORS policy](api-management-cross-domain-policies.md#CORS) in your API Management instance.
 
 ## Next steps
 


### PR DESCRIPTION
While testing out .net core web APIS from the PowerApps through custom connectors, it is required to add "https://flow.microsoft.com" and also there is one more origin of the PowerApps which needs to be added which starts with "https://authoring..." and every custom connector is hosted on different APIM internally which has different authoring URL. This also need to be added and proposing these changes