### PR TITLE
Remove line and an incomplete sentence.

### DIFF
--- a/articles/cosmos-db/sql/how-to-use-stored-procedures-triggers-udfs.md
+++ b/articles/cosmos-db/sql/how-to-use-stored-procedures-triggers-udfs.md
@@ -17,8 +17,6 @@ ms.custom: devx-track-python, devx-track-js, devx-track-csharp
 
 The SQL API in Azure Cosmos DB supports registering and invoking stored procedures, triggers, and user-defined functions (UDFs) written in JavaScript. Once you've defined one or more stored procedures, triggers, and user-defined functions, you can load and view them in the [Azure portal](https://portal.azure.com/) by using Data Explorer.
 
-SQL API SDKs are available for a wide variety of platforms and programming languages. If you haven't worked 
-
 You can use the SQL API SDK across multiple platforms including [.NET v2 (legacy)](sql-api-sdk-dotnet.md), [.NET v3](sql-api-sdk-dotnet-standard.md), [Java](sql-api-sdk-java.md), [JavaScript](sql-api-sdk-node.md), or [Python](sql-api-sdk-python.md) SDKs to perform these tasks. If you haven't worked with one of these SDKs before, see the *"Quickstart"* article for the appropriate SDK:
 
 | SDK | Getting started |


### PR DESCRIPTION
Line 20  didn't add any value and also included an incomplete sentence:
SQL API SDKs are available for a wide variety of platforms and programming languages. If you haven't worked 

The next line basically states the same thing so there isn't a need to repeat the info.  It also looks like the thought moved to the next paragraph anyway "If you haven't worked with one of these SDKs before, see the *"Quickstart"* article for the appropriate SDK:"