### PR TITLE
ChatQuickstart (iOS): Fix add participant error message logic

### DIFF
--- a/articles/communication-services/quickstarts/chat/includes/chat-swift.md
+++ b/articles/communication-services/quickstarts/chat/includes/chat-swift.md
@@ -345,7 +345,11 @@ let user = ChatParticipant(
 chatThreadClient.add(participants: [user]) { result, _ in
     switch result {
     case let .success(result):
-        (result.invalidParticipants != nil) ? print("Added participant") : print("Error adding participant")
+        if let errors = result.invalidParticipants, !errors.isEmpty {
+            print("Error adding participant")
+        } else {
+            print("Added participant")
+        }
     case .failure:
         print("Failed to add the participant")
     }


### PR DESCRIPTION
Updates to Azure Communication Services Chat Quickstart for iOS:
- Fix logic to print error message when adding participants 