### PR TITLE
Removing Reset Password Option from Step 4

### DIFF
--- a/articles/azure-arc/data/active-directory-prerequisites.md
+++ b/articles/azure-arc/data/active-directory-prerequisites.md
@@ -120,7 +120,6 @@ Whether you have created a new account for the DSA or are using an existing Acti
        - **Write all properties**
        - **Create User objects**
        - **Delete User objects**
-       - **Reset Password for Descendant User objects**
 
     - Select **OK**.
 


### PR DESCRIPTION
The "Reset Password for Descendant User objects" option is not valid in Step 4 and is covered in Step 5.