### PR TITLE
[OSDOCS-3874] Update issuer URL to use v2.0 endpoint

### DIFF
--- a/articles/openshift/configure-azure-ad-ui.md
+++ b/articles/openshift/configure-azure-ad-ui.md
@@ -56,7 +56,7 @@ You can use optional claims to:
 
 We'll configure OpenShift to use the `email` claim and fall back to `upn` to set the Preferred Username by adding the `upn` as part of the ID token returned by Azure Active Directory.
 
-Navigate to **Token configuration (preview)** and click on **Add optional claim**. Select **ID** then check the **email** and **upn** claims.
+Navigate to **Token configuration** and click on **Add optional claim**. Select **ID** then check the **email** and **upn** claims.
 
 ![Screenshot that shows the email and upn claims that were added.](media/aro4-ad-tokens.png)
 
@@ -101,7 +101,7 @@ Navigate to **Administration**, click on **Cluster Settings**, then select the *
 Scroll down to select **Add** under **Identity Providers** and select **OpenID Connect**.
 ![Select OpenID Connect from the Identity Providers dropdown](media/aro4-oauth-idpdrop.png)
 
-Fill in the name as **AAD**, the **Client ID** as the **Application ID** and the **Client Secret**. The **Issuer URL** is formatted as such: `https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace the placeholder with the Tenant ID you retrieved earlier.
+Fill in the name as **AAD**, the **Client ID** as the **Application ID** and the **Client Secret**. The **Issuer URL** is formatted as such: `https://login.microsoftonline.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/v2.0`. Replace the placeholder with the Tenant ID you retrieved earlier.
 
 ![Fill in OAuth details](media/aro4-oauth-idp-1.png)
 


### PR DESCRIPTION
[OSDOCS-3874](https://issues.redhat.com/browse/OSDOCS-3874)

When attempting to use group claims, using the v1.0 AAD endpoint for authentication created a concatenation of groups, instead of the correct number of groups. This is fixed when using the v2.0 endpoint. This also removes the "(Preview)" from the "Token Configuration" blade as it has been prompted out of preview.

Shoutout to @datianshi for figuring out it was the endpoint causing the issue. 

