### PR TITLE
Remove "display password expiry notification in the Office Portal and…

### DIFF
--- a/articles/active-directory/hybrid/whatis-hybrid-identity.md
+++ b/articles/active-directory/hybrid/whatis-hybrid-identity.md
@@ -46,7 +46,6 @@ Here are some common hybrid identity and access management scenarios with recomm
 |Enable cloud-based multi-factor authentication solutions.|![Recommended](./media/whatis-hybrid-identity/ic195031.png)|![Recommended](./media/whatis-hybrid-identity/ic195031.png)|![Recommended](./media/whatis-hybrid-identity/ic195031.png)| 
 |Enable on-premises multi-factor authentication solutions.| | |![Recommended](./media/whatis-hybrid-identity/ic195031.png)| 
 |Support smartcard authentication for my users.<sup>4</sup>| | |![Recommended](./media/whatis-hybrid-identity/ic195031.png)| 
-|Display password expiry notifications in the Office Portal and on the Windows 10 desktop.| | |![Recommended](./media/whatis-hybrid-identity/ic195031.png)| 
 
 > <sup>1</sup> Password hash synchronization with single sign-on. 
 > 


### PR DESCRIPTION
… on the Windows 10 desktop"

Currently, the document states that “with AD FS, password expiry notifications are displayed in Office Portal and on the Windows 10 desktop” when AD FS is used. 
https://docs.microsoft.com/en-us/azure/active-directory/hybrid/whatis-hybrid-identity#common-scenarios-and-recommendations

However, now, “Display password expiry notification in the Office Portal” no longer exists, meaning that the “password expiry notification is no longer displayed in Office Portal.” This is stated in the following document and tested in my lab. 
https://docs.microsoft.com/en-us/microsoft-365/admin/manage/set-password-expiration-policy?view=o365-worldwide
     "Password expiration notifications are no longer supported in Office web apps or the admin center"

In addition, the password expiry notification displayed on the Windows 10 desktop is purely an on-premises function, done through the Group Policy. This can be done if whether it is a hybrid identity or on-premises only environment, the password expiry notification can be displayed on Windows 10 desktop. Therefore, it seems irrelevant to the context of “hybrid Identity” or “AD FS” (the document is about hybrid identity). “
 
Due to the reasons above, please consider removing the row “Display password expiry notifications in the Office Portal and on the Windows 10 desktop.” and AD FS (✔) all together.