### PR TITLE
Remove "sign-in using smartcards or certificates not natively supported"

### DIFF
--- a/articles/active-directory/hybrid/choose-ad-authn.md
+++ b/articles/active-directory/hybrid/choose-ad-authn.md
@@ -66,7 +66,6 @@ Details on decision questions:
 2. Azure AD can hand off user sign-in to a trusted authentication provider such as Microsoft’s AD FS.
 3. If you need to apply, user-level Active Directory security policies such as account expired, disabled account, password expired, account locked out, and sign-in hours on each user sign-in, Azure AD requires some on-premises components.
 4. Sign-in features not natively supported by Azure AD:
-   * Sign-in using smartcards or certificates.
    * Sign-in using on-premises MFA Server.
    * Sign-in using third-party authentication solution.
    * Multi-site on-premises authentication solution.


### PR DESCRIPTION
Currently, the document states that “sign-in using smartcards or certificates” are NOT “natively supported by Azure AD” : 
https://docs.microsoft.com/en-us/azure/active-directory/hybrid/choose-ad-authn#decision-tree

The sign-in using smartcards and certificates are now natively supported in Azure AD as in the following document, so please remove this line. 
https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-certificate-based-authentication