### PR TITLE
Changing "Azure AD DS" to AD DS because this document pertains to AD DS

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-install-custom.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-custom.md
@@ -88,7 +88,7 @@ If you see an error or have problems with connectivity, then see [Troubleshoot c
 The following sections describe the pages in the **Sync** section.
 
 ### Connect your directories
-To connect to Active Directory Domain Services (Azure AD DS), Azure AD Connect needs the forest name and credentials of an account that has sufficient permissions.
+To connect to Active Directory Domain Services (AD DS), Azure AD Connect needs the forest name and credentials of an account that has sufficient permissions.
 
 ![Screenshot that shows the "Connect your directories" page.](./media/how-to-connect-install-custom/connectdir01.png)
 
@@ -96,17 +96,17 @@ After you enter the forest name and select  **Add Directory**, a window appears.
 
 | Option | Description |
 | --- | --- |
-| Create new account | Create the Azure AD DS account that Azure AD Connect needs to connect to the Active Directory forest during directory synchronization. After you select this option, enter the username and password for an enterprise admin account.  Azure AD Connect uses the provided enterprise admin account to create the required Azure AD DS account. You can enter the domain part in either NetBIOS format or FQDN format. That is, enter *FABRIKAM\administrator* or *fabrikam.com\administrator*. |
-| Use existing account | Provide an existing Azure AD DS account that Azure AD Connect can use to connect to the Active Directory forest during directory synchronization. You can enter the domain part in either NetBIOS format or FQDN format. That is, enter *FABRIKAM\syncuser* or *fabrikam.com\syncuser*. This account can be a regular user account because it needs only the default read permissions. But depending on your scenario, you might need more permissions. For more information, see [Azure AD Connect accounts and permissions](reference-connect-accounts-permissions.md#create-the-ad-ds-connector-account). |
+| Create new account | Create the AD DS account that Azure AD Connect needs to connect to the Active Directory forest during directory synchronization. After you select this option, enter the username and password for an enterprise admin account.  Azure AD Connect uses the provided enterprise admin account to create the required AD DS account. You can enter the domain part in either NetBIOS format or FQDN format. That is, enter *FABRIKAM\administrator* or *fabrikam.com\administrator*. |
+| Use existing account | Provide an existing AD DS account that Azure AD Connect can use to connect to the Active Directory forest during directory synchronization. You can enter the domain part in either NetBIOS format or FQDN format. That is, enter *FABRIKAM\syncuser* or *fabrikam.com\syncuser*. This account can be a regular user account because it needs only the default read permissions. But depending on your scenario, you might need more permissions. For more information, see [Azure AD Connect accounts and permissions](reference-connect-accounts-permissions.md#create-the-ad-ds-connector-account). |
 
 ![Screenshot showing the "Connect Directory" page and the A D forest account window, where you can choose to create a new account or use an existing account.](./media/how-to-connect-install-custom/connectdir02.png)
 
 >[!NOTE]
-> As of build 1.4.18.0, you can't use an enterprise admin or domain admin account as the Azure AD DS connector account. When you select **Use existing account**, if you try to enter an enterprise admin account or a domain admin account, you see the following error: "Using  an Enterprise or Domain administrator account for your AD forest account is not allowed. Let Azure AD Connect create the account for you or specify a synchronization account with the correct permissions."
+> As of build 1.4.18.0, you can't use an enterprise admin or domain admin account as the AD DS connector account. When you select **Use existing account**, if you try to enter an enterprise admin account or a domain admin account, you see the following error: "Using  an Enterprise or Domain administrator account for your AD forest account is not allowed. Let Azure AD Connect create the account for you or specify a synchronization account with the correct permissions."
 >
 
 ### Azure AD sign-in configuration
-On the **Azure AD sign-in configuration** page, review the user principal name (UPN) domains in on-premises Azure AD DS. These UPN domains have been verified in Azure AD. On this page, you configure the attribute to use for the userPrincipalName.
+On the **Azure AD sign-in configuration** page, review the user principal name (UPN) domains in on-premises AD DS. These UPN domains have been verified in Azure AD. On this page, you configure the attribute to use for the userPrincipalName.
 
 ![Screenshot showing unverified domains on the "Azure A D sign-in configuration" page.](./media/how-to-connect-install-custom/aadsigninconfig2.png)  
 
@@ -147,7 +147,7 @@ If you see this warning, make sure that these domains are indeed unreachable and
 On the **Identifying users** page, choose how to identify users in your on-premises directories and how to identify them by using the sourceAnchor attribute.
 
 #### Select how users should be identified in your on-premises directories
-By using the *Matching across forests* feature, you can define how users from your Azure AD DS forests are represented in Azure AD. A user might be represented only once across all forests or might have a combination of enabled and disabled accounts. The user might also be represented as a contact in some forests.
+By using the *Matching across forests* feature, you can define how users from your AD DS forests are represented in Azure AD. A user might be represented only once across all forests or might have a combination of enabled and disabled accounts. The user might also be represented as a contact in some forests.
 
 ![Screenshot showing the page where you can uniquely identify your users.](./media/how-to-connect-install-custom/unique2.png)
 
@@ -329,7 +329,7 @@ The AD FS service requires a domain service account to authenticate users and to
 If you selected **Create a group Managed Service Account** and this feature has never been used in Active Directory, then enter your enterprise admin credentials. These credentials are used to initiate the key store and enable the feature in Active Directory.
 
 > [!NOTE]
-> Azure AD Connect checks whether the AD FS service is already registered as a service principal name (SPN) in the domain.  Azure AD DS doesn't allow duplicate SPNs to be registered at the same time.  If a duplicate SPN is found, you can't proceed further until the SPN is removed.
+> Azure AD Connect checks whether the AD FS service is already registered as a service principal name (SPN) in the domain.  AD DS doesn't allow duplicate SPNs to be registered at the same time.  If a duplicate SPN is found, you can't proceed further until the SPN is removed.
 
 ![Screenshot showing the "A D F S service account" page.](./media/how-to-connect-install-custom/adfs5.png)
 
@@ -424,7 +424,7 @@ Azure AD Connect verifies the DNS settings when you select the **Verify** button
 To validate end-to-end authentication, manually perform one or more of the following tests:
 
 * When synchronization finishes, in Azure AD Connect, use the **Verify federated login** additional task to verify authentication for an on-premises user account that you choose.
-* From a domain-joined machine on the intranet, ensure that you can sign in from a browser. Connect to https://myapps.microsoft.com. Then use your logged-on account to verify the sign-in. The built-in Azure AD DS administrator account isn't synchronized, and you can't use it for verification.
+* From a domain-joined machine on the intranet, ensure that you can sign in from a browser. Connect to https://myapps.microsoft.com. Then use your logged-on account to verify the sign-in. The built-in AD DS administrator account isn't synchronized, and you can't use it for verification.
 * Ensure that you can sign in from a device on the extranet. On a home machine or a mobile device, connect to https://myapps.microsoft.com. Then provide your credentials.
 * Validate rich client sign-in. Connect to https://testconnectivity.microsoft.com. Then select **Office 365** > **Office 365 Single Sign-On Test**.
 


### PR DESCRIPTION
Currently, the document states “install Azure AD Connect Health on Azure AD DS.”

However, Azure AD Connect (AADC) Health is used to monitor the on-premises infrastructure, which is usually (if not always) used with Azure AD Connect, which in turn is used in the environment with on-premises AD DS but not in Azure AD DS. AADC synchronizes on-premises AD objects to AAD,  but it is not needed for synchronization from AAD to Azure AD DS. AADC Health is not needed in the context of Azure AD DS. 
 
In addition, the screenshots of the installation agent clearly state that “Microsoft Azure AD Connect Health agent for AD DS,” not for “Azure AD DS.”
For the reasons above, I believe the AADC Health installation is intended for AD DS, not Azure AD DS.
Please consider changing all the instances of “Azure AD DS” in the document to “AD DS.”