### PR TITLE
Adding NewGroupWritebackDefaultSetting to the list

### DIFF
--- a/articles/active-directory/enterprise-users/groups-settings-cmdlets.md
+++ b/articles/active-directory/enterprise-users/groups-settings-cmdlets.md
@@ -114,22 +114,23 @@ To update the value for UsageGuideLinesUrl in the setting template, read the cur
    
    Output:
    ```powershell
-    Name                          Value
-    ----                          -----
-    EnableMIPLabels               True
+    Name                            Value
+    ----                            -----
+    EnableMIPLabels                 True
     CustomBlockedWordsList
-    EnableMSStandardBlockedWords  False
+    EnableMSStandardBlockedWords    False
     ClassificationDescriptions
     DefaultClassification
     PrefixSuffixNamingRequirement
-    AllowGuestsToBeGroupOwner     False
-    AllowGuestsToAccessGroups     True
+    AllowGuestsToBeGroupOwner       False
+    AllowGuestsToAccessGroups       True
     GuestUsageGuidelinesUrl
     GroupCreationAllowedGroupId
-    AllowToAddGuests              True
-    UsageGuidelinesUrl            https://guideline.example.com
+    AllowToAddGuests                True
+    UsageGuidelinesUrl              https://guideline.example.com
     ClassificationList
-    EnableGroupCreation           True
+    EnableGroupCreation             True
+    NewUnifiedGroupWritebackDefault True
     ```
 3. To remove the value of UsageGuideLinesUrl, edit the URL to be an empty string:
    
@@ -161,6 +162,7 @@ Here are the settings defined in the Group.Unified SettingsTemplate. Unless othe
 |  <ul><li>AllowToAddGuests<li>Type: Boolean<li>Default: True | A boolean indicating whether or not is allowed to add guests to this directory. <br>This setting may be overridden and become read-only if *EnableMIPLabels* is set to *True* and a guest policy is associated with the sensitivity label assigned to the group.<br>If the AllowToAddGuests setting is set to False at the organization level, any AllowToAddGuests setting at the group level is ignored. If you want to enable guest access for only a few groups, you must set AllowToAddGuests to be true at the organization level, and then selectively disable it for specific groups. |
 |  <ul><li>ClassificationList<li>Type: String<li>Default: "" | A comma-delimited list of valid classification values that can be applied to Microsoft 365 groups. <br>This setting does not apply when EnableMIPLabels == True.|
 |  <ul><li>EnableMIPLabels<li>Type: Boolean<li>Default: "False" |The flag indicating whether sensitivity labels published in Microsoft Purview compliance portal can be applied to Microsoft 365 groups. For more information, see [Assign Sensitivity Labels for Microsoft 365 groups](groups-assign-sensitivity-labels.md). |
+|  <ul><li>NewUnifiedGroupWritebackDefault<li>Type: Boolean<li>Default: "True" |The flag that allows an admin to create new Microsoft 365 groups without setting the groupWritebackConfiguration resource type in the request payload. This setting is applicable when group writeback is configured in Azure AD Connect.  "NewUnifiedGroupWritebackDefault" is a global Microfot 365 group setting. Default value is true. Updating the setting value to false will change the default writeback behavior for newly created Microsoft 365 groups, and will not change isEnabled property value for existing Microsoft 365 groups. Group admin will need to explicitly update the group isEnabled property value to change the writeback state for existing Microsoft 365 groups. For more information, see [groupWritebackConfiguration resource type](groupwritebackconfiguration?view=graph-rest-beta.md). |
 
 ## Example: Configure Guest policy for groups at the directory level
 1. Get all the setting templates:


### PR DESCRIPTION
Added the description for the new M365 global setting that helps admins manage m365 groups being written back to on premises active directory