### PR TITLE
Added a note about who can be an approver

### DIFF
--- a/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
+++ b/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
@@ -103,7 +103,7 @@ If setting multiple approvers, approval completes as soon as one of them approve
     ![Select a user or group pane to select approvers](./media/pim-resource-roles-configure-role-settings/resources-role-settings-select-approvers.png)
 
 1. Select at least one user and then click **Select**. Select at least one approver. If no specific approvers are selected, Privileged Role Administrators and Global Administrators become the default approvers.
-NOTE: An approver does not have to have an administrative role themselves. They can be a regular user, such as an IT executive.
+NOTE: An approver does not have to have an Azure AD administrative role themselves. They can be a regular user, such as an IT executive.
 
 1. Select **Update** to save your changes.
 

--- a/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
+++ b/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
@@ -103,7 +103,8 @@ If setting multiple approvers, approval completes as soon as one of them approve
     ![Select a user or group pane to select approvers](./media/pim-resource-roles-configure-role-settings/resources-role-settings-select-approvers.png)
 
 1. Select at least one user and then click **Select**. Select at least one approver. If no specific approvers are selected, Privileged Role Administrators and Global Administrators become the default approvers.
-NOTE: An approver does not have to have an Azure AD administrative role themselves. They can be a regular user, such as an IT executive.
+   > [!Note]
+   > An approver does not have to have an Azure AD administrative role themselves. They can be a regular user, such as an IT executive.
 
 1. Select **Update** to save your changes.
 

--- a/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
+++ b/articles/active-directory/privileged-identity-management/pim-how-to-change-default-settings.md
@@ -103,6 +103,7 @@ If setting multiple approvers, approval completes as soon as one of them approve
     ![Select a user or group pane to select approvers](./media/pim-resource-roles-configure-role-settings/resources-role-settings-select-approvers.png)
 
 1. Select at least one user and then click **Select**. Select at least one approver. If no specific approvers are selected, Privileged Role Administrators and Global Administrators become the default approvers.
+NOTE: An approver does not have to have an administrative role themselves. They can be a regular user, such as an IT executive.
 
 1. Select **Update** to save your changes.
 


### PR DESCRIPTION
The document does not specify if the PIM role activation approver needs to have an administrative role themselves - which they do not.