### PR TITLE
Update TOC for CVM

### DIFF
--- a/articles/aks/TOC.yml
+++ b/articles/aks/TOC.yml
@@ -221,7 +221,7 @@
               href: use-multiple-node-pools.md
             - name: Use spot node pools
               href: spot-node-pool.md
-            - name: Use CVM
+            - name: Use Confidential Virtual Machines (preview)
               href: use-cvm.md
             - name: Use system node pools
               href: use-system-pools.md


### PR DESCRIPTION
The TOC in the documentation just has "Use CVM" which is for anyone not aware of what CVM is about a little bit confusing...
I suggest expanding this abbreviation.