### PR TITLE
pgflexmoveresource

### DIFF
--- a/articles/postgresql/flexible-server/concepts-limits.md
+++ b/articles/postgresql/flexible-server/concepts-limits.md
@@ -116,7 +116,6 @@ A PostgreSQL connection, even idle, can occupy about 10 MB of memory. Also, crea
 
 * Azure AD authentication isn't yet supported. We recommend using the [Single Server](../overview-single-server.md) option if you require Azure AD authentication.
 * Read replicas aren't yet supported. We recommend using the [Single Server](../overview-single-server.md) option if you require read replicas.
-* Moving resources to another subscription isn't supported. 
 
 
 ## Next steps


### PR DESCRIPTION
Remove the limitation from our document "Moving resources to another subscription isn't supported." as it is now supported.