### PR TITLE
AKV Secrets Provider Add System Assigned Identity to ARM template - fixes #96592

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-akv-secrets-provider.md
+++ b/articles/azure-arc/kubernetes/tutorial-akv-secrets-provider.md
@@ -163,6 +163,9 @@ You should see output similar to the example below. Note that it may take severa
                "type": "Microsoft.KubernetesConfiguration/extensions",
                "apiVersion": "2021-09-01",
                "name": "[parameters('ExtensionInstanceName')]",
+               "identity": {
+                "type": "SystemAssigned"
+               },
                "properties": {
                    "extensionType": "[parameters('ExtensionType')]",
                    "releaseTrain": "[parameters('ReleaseTrain')]",


### PR DESCRIPTION
Hi all,

see [issue on AKV Secrets Provider repo](https://github.com/Azure/secrets-store-csi-driver-provider-azure/issues/948). Fixes #96592 