### PR TITLE
Kusto query for “Logical disk IOPS” is wrong

### DIFF
--- a/articles/azure-monitor/vm/monitor-virtual-machine-alerts.md
+++ b/articles/azure-monitor/vm/monitor-virtual-machine-alerts.md
@@ -177,7 +177,7 @@ InsightsMetrics
 | where Origin == "vm.azm.ms" 
 | where Namespace == "LogicalDisk" and Name == "TransfersPerSecond"
 | extend Disk=tostring(todynamic(Tags)["vm.azm.ms/mountId"])
-| summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m) ), Computer, _ResourceId, Disk 
+| summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m), Computer, _ResourceId, Disk 
 ```
 **Logical disk data rate**
 
@@ -186,7 +186,7 @@ InsightsMetrics
 | where Origin == "vm.azm.ms" 
 | where Namespace == "LogicalDisk" and Name == "BytesPerSecond"
 | extend Disk=tostring(todynamic(Tags)["vm.azm.ms/mountId"])
-| summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m) , Computer, _ResourceId, Disk 
+| summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m), Computer, _ResourceId, Disk 
 ```
 
 ## Network alerts


### PR DESCRIPTION
removed the extra close bracket