### PR TITLE
Removing preview flag from documentation

### DIFF
--- a/articles/azure-resource-manager/management/create-private-link-access-portal.md
+++ b/articles/azure-resource-manager/management/create-private-link-access-portal.md
@@ -5,7 +5,7 @@ ms.topic: conceptual
 ms.date: 04/26/2022
 ---
 
-# Use portal to create private link for managing Azure resources (preview)
+# Use portal to create private link for managing Azure resources
 
 This article explains how you can use [Azure Private Link](../../private-link/index.yml) to restrict access for managing resources in your subscriptions. It shows using the Azure portal for setting up management of resources through private access.
 


### PR DESCRIPTION
Removing the preview flag from the Private Link for ARM documentation for GA release.
(This page was the last one with the lingering title flag.)