### PR TITLE
Delete information about WAM

### DIFF
--- a/articles/active-directory/devices/concept-primary-refresh-token.md
+++ b/articles/active-directory/devices/concept-primary-refresh-token.md
@@ -25,7 +25,7 @@ This article assumes that you already understand the different device states ava
 The following Windows components play a key role in requesting and using a PRT:
 
 * **Cloud Authentication Provider** (CloudAP): CloudAP is the modern authentication provider for Windows sign in, that verifies users logging to a Windows 10 or newer device. CloudAP provides a plugin framework that identity providers can build on to enable authentication to Windows using that identity provider’s credentials.
-* **Web Account Manager** (WAM): WAM is the default token broker on Windows 10 or newer devices. WAM also provides a plugin framework that identity providers can build on and enable SSO to their applications relying on that identity provider. (Not included in Windows Server 2016 LTSC builds)
+* **Web Account Manager** (WAM): WAM is the default token broker on Windows 10 or newer devices. WAM also provides a plugin framework that identity providers can build on and enable SSO to their applications relying on that identity provider. 
 * **Azure AD CloudAP plugin**: An Azure AD specific plugin built on the CloudAP framework, that verifies user credentials with Azure AD during Windows sign in.
 * **Azure AD WAM plugin**: An Azure AD specific plugin built on the WAM framework, that enables SSO to applications that rely on Azure AD for authentication.
 * **Dsreg**: An Azure AD specific component on Windows 10 or newer, that handles the device registration process for all device states.


### PR DESCRIPTION
I checked with product group that LTSB or LTSC includes WAM module. So, we should delete "(Not included in Windows Server 2016 LTSC builds)" from following sentence.

-----------------------------------------
* **Web Account Manager** (WAM): WAM is the default token broker on Windows 10 or newer devices. WAM also provides a plugin framework that identity providers can build on and enable SSO to their applications relying on that identity provider. (Not included in Windows Server 2016 LTSC builds)
-----------------------------------------