### PR TITLE
Details about Debugging permissions 

### DIFF
--- a/articles/synapse-analytics/security/synapse-workspace-understand-what-role-you-need.md
+++ b/articles/synapse-analytics/security/synapse-workspace-understand-what-role-you-need.md
@@ -46,6 +46,10 @@ You can review the status of running notebooks and jobs in Apache Spark pools if
 
 You can review logs and cancel running jobs and pipelines if you're a Synapse Compute Operator at the workspace or for a specific Spark pool or pipeline.  
 
+### Monitor and manage execution
+
+
+
 ### Publish and save your code
 
 You can publish new or updated code artifacts to the service if you're a Synapse Artifact Publisher, Synapse Contributor, or Synapse Administrator. 

--- a/articles/synapse-analytics/security/synapse-workspace-understand-what-role-you-need.md
+++ b/articles/synapse-analytics/security/synapse-workspace-understand-what-role-you-need.md
@@ -46,9 +46,9 @@ You can review the status of running notebooks and jobs in Apache Spark pools if
 
 You can review logs and cancel running jobs and pipelines if you're a Synapse Compute Operator at the workspace or for a specific Spark pool or pipeline.  
 
-### Monitor and manage execution
+### Debug pipelines
 
-
+You can review and make changes in pipelines with Synapse User Role but if you want to be able to debug it you also need Synapse Credential User
 
 ### Publish and save your code
 

--- a/articles/synapse-analytics/security/synapse-workspace-understand-what-role-you-need.md
+++ b/articles/synapse-analytics/security/synapse-workspace-understand-what-role-you-need.md
@@ -48,7 +48,7 @@ You can review logs and cancel running jobs and pipelines if you're a Synapse Co
 
 ### Debug pipelines
 
-You can review and make changes in pipelines with Synapse User Role but if you want to be able to debug it you also need Synapse Credential User
+You can review and make changes in pipelines as a Synapse User, but if you want to be able to debug it you also need to have Synapse Credential User.
 
 ### Publish and save your code
 


### PR DESCRIPTION
Adding details about permissions for debugging a pipeline: I've found some customers that don't have very clear the permissions needed for debugging a pipeline.