### PR TITLE
Port 1433 instead of 1443

### DIFF
--- a/articles/synapse-analytics/security/synapse-workspace-ip-firewall.md
+++ b/articles/synapse-analytics/security/synapse-workspace-ip-firewall.md
@@ -38,7 +38,7 @@ You can also add IP firewall rules to a Synapse workspace after the workspace is
 
 You can connect to your Synapse workspace using Synapse Studio. You can also use SQL Server Management Studio (SSMS) to connect to the SQL resources (dedicated SQL pools and serverless SQL pool) in your workspace.
 
-Make sure that the firewall on your network and local computer allows outgoing communication on TCP ports 80, 443 and 1443 for Synapse Studio. 
+Make sure that the firewall on your network and local computer allows outgoing communication on TCP ports 80, 443 and 1433 for Synapse Studio. 
 
 Also, you need to allow outgoing communication on UDP port 53 for Synapse Studio. To connect using tools such as SSMS and Power BI, you must allow outgoing communication on TCP port 1433.
 


### PR DESCRIPTION
For required ports it should be 1433 instead of 1443, since this port is for Synapse SQL pool.