### PR TITLE
Add support retry policy for the HTTP Trigger.

### DIFF
--- a/articles/azure-functions/functions-bindings-error-pages.md
+++ b/articles/azure-functions/functions-bindings-error-pages.md
@@ -57,12 +57,13 @@ There are two kinds of retries available for your functions: built-in retry beha
 | RabbitMQ | [Binding extension](functions-bindings-rabbitmq-trigger.md#dead-letter-queues) | [Dead letter queue](https://www.rabbitmq.com/dlx.html) | 
 | Service Bus | [Binding extension](../service-bus-messaging/service-bus-dead-letter-queues.md) | [Dead letter queue](../service-bus-messaging/service-bus-dead-letter-queues.md#maximum-delivery-count) | 
 |Timer | [Retry policies](#retry-policies) | Function-level |
+| HTTP | [Retry policies](#retry-policies) | Function-level |
 
 ### Retry policies
 
-Starting with version 3.x of the Azure Functions runtime, you can define a retry policies for Timer and Event Hubs triggers that are enforced by the Functions runtime. The retry policy tells the runtime to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.   
+Starting with version 3.x of the Azure Functions runtime, you can define a retry policies for Timer,HTTP and Event Hubs triggers that are enforced by the Functions runtime. The retry policy tells the runtime to rerun a failed execution until either successful completion occurs or the maximum number of retries is reached.   
 
-A retry policy is evaluated when a Timer or Event Hubs triggered function raises an uncaught exception. As a best practice, you should catch all exceptions in your code and rethrow any errors that you want to result in a retry. Event Hubs checkpoints won't be written until the retry policy for the execution has completed. Because of this behavior, progress on the specific partition is paused until the current batch has completed.
+A retry policy is evaluated when a Timer, HTTP or Event Hubs triggered function raises an uncaught exception. As a best practice, you should catch all exceptions in your code and rethrow any errors that you want to result in a retry. Event Hubs checkpoints won't be written until the retry policy for the execution has completed. Because of this behavior, progress on the specific partition is paused until the current batch has completed.
 
 #### Retry strategies
 


### PR DESCRIPTION
I tried to retry policy the following environment on HTTP Trigger. Seems to be support event function runtime version 4

## Repro Environment:
* Windows
* .NET6
* inprocess
* Azure Functions runtime v4


## csproj file

```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net6.0</TargetFramework>
    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
    <RootNamespace>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</RootNamespace>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
  </ItemGroup>
  <ItemGroup>
    <None Update="host.json">
      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
    </None>
    <None Update="local.settings.json">
      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
    </None>
  </ItemGroup>
</Project>
```

## host.json

```
{
    "IsEncrypted": false,
    "Values": {
        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
    }
}
```


## application code
I referred retry policy [sample codes](https://qiita.com/okazuki/items/f8f7d9ba6c258d20dbc2) . 
```
    public static class Function1
    {
        private static int _counter = 0;

        [ExponentialBackoffRetry(maxRetryCount: 4, minimumInterval: "00:00:03", maximumInterval: "00:00:15")]
        [FunctionName("Function1")]
        public static async Task<IActionResult> Run(
            [HttpTrigger(AuthorizationLevel.Function, "get", "post", Route = null)] HttpRequest req,
            ILogger log)
        {
            log.LogInformation("実行してるよ！");
            if (++_counter % 5 != 0)
            {
                log.LogInformation($"5回に1回しか成功しません。 {_counter}");
                throw new Exception("エラー！！");
            }

            log.LogInformation("成功！！");
            return new OkResult();
        }
    }
```

## Results
![image](https://user-images.githubusercontent.com/24888431/183230203-483fec8f-a08c-4b8f-a7b4-906f59c61186.png)
