### PR TITLE
Added error scenario for staging resource group

### DIFF
--- a/articles/virtual-machines/linux/image-builder-troubleshoot.md
+++ b/articles/virtual-machines/linux/image-builder-troubleshoot.md
@@ -105,14 +105,16 @@ Microsoft.VirtualMachineImages/imageTemplates 'helloImageTemplateforSIG01' faile
 ```
 #### Cause
 
-In most cases, the resource deployment failure error occurs because of missing permissions.
+In most cases, the resource deployment failure error occurs because of missing permissions.  This error may also be caused by a conflict with the staging resource group.
 
 #### Solution
 
 Depending on your scenario, VM Image Builder might need permissions to:
 - The source image or Azure Compute Gallery (formerly Shared Image Gallery) resource group.
 - The distribution image or Azure Compute Gallery resource.
-- The storage account, container, or blob that the `File` customizer is accessing. 
+- The storage account, container, or blob that the `File` customizer is accessing.
+
+Also, ensure the staging resource group name is uniquely specified for each image template.
 
 For more information about configuring permissions, see [Configure VM Image Builder permissions by using the Azure CLI](image-builder-permissions-cli.md) or [Configure VM Image Builder permissions by using PowerShell](image-builder-permissions-powershell.md).
 


### PR DESCRIPTION
When the staging resource group is specified with the same name for two different image templates, an "InternalOperationError" error is thrown.