### PR TITLE
Adding explicit scopes excluded in All cloud apps

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-cloud-apps.md
@@ -167,10 +167,10 @@ In some cases, an **All cloud apps** policy could inadvertently block user acces
 
 - Calls to Azure AD Graph and MS Graph, to access user profile, group membership and relationship information that is commonly used by applications excluded from policy. The excluded scopes are listed below. Consent is still required for apps to use these permissions. 
    - For native clients:
-      - Azure AD Graph: User.read
+      - Azure AD Graph: email, offline_access, openid, profile, User.read
       - MS Graph: User.read, People.read, and UserProfile.read 
    - For confidential / authenticated clients:
-      - Azure AD Graph: User.read, User.read.all, and User.readbasic.all
+      - Azure AD Graph: email, offline_access, openid, profile, User.read, User.read.all, and User.readbasic.all
       - MS Graph: User.read,User.read.all, User.read.All People.read, People.read.all, GroupMember.Read.All, Member.Read.Hidden, and UserProfile.read 
 
 ## User actions


### PR DESCRIPTION
Customers tend to get confused on when we include Graph while applying the CA policy. Calling out the basic scopes explicitly should help to avoid such confusions.