### PR TITLE
Fix issues found when setting up cluster connect with SP

### DIFF
--- a/articles/azure-arc/kubernetes/cluster-connect.md
+++ b/articles/azure-arc/kubernetes/cluster-connect.md
@@ -99,7 +99,7 @@ A conceptual overview of this feature is available in [Cluster connect - Azure A
    - For an Azure AD application:
 
      ```azurecli
-     AAD_ENTITY_OBJECT_ID=$(az ad sp show --id <id> --query objectId -o tsv)
+     AAD_ENTITY_OBJECT_ID=$(az ad sp show --id <id> --query id -o tsv)
      ```
 
 1. Authorize the entity with appropriate permissions.
@@ -114,6 +114,7 @@ A conceptual overview of this feature is available in [Cluster connect - Azure A
 
      ```azurecli
      az role assignment create --role "Azure Arc Kubernetes Viewer" --assignee $AAD_ENTITY_OBJECT_ID --scope $ARM_ID_CLUSTER
+     az role assignment create --role "Azure Arc Enabled Kubernetes Cluster User Role" --assignee $AAD_ENTITY_OBJECT_ID --scope $ARM_ID_CLUSTER
      ```
 
 ### [Azure PowerShell](#tab/azure-powershell)


### PR DESCRIPTION
While I was trying to set up cluster connect, I found two issues within the docs:
- The output of `az ad sp show` does not contain `objectId` any more, instead it's replaced by `id`, as seen in the output below:

```sh
$ az ad sp show --id $SP_ID 
{
  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#servicePrincipals/$entity",
  "accountEnabled": true,
  "addIns": [],
  "alternativeNames": [],
  "appDescription": null,
  "appDisplayName": "Azure Arc SP",
  "appId": "xxxxxxx-05c3-4a0e-8d82-9b18d547ecc5",
  "appOwnerOrganizationId": "xxxxxx-41af-91ab-2d7cd011db47",
  "appRoleAssignmentRequired": false,
  "appRoles": [],
  "applicationTemplateId": null,
  "createdDateTime": "2022-08-08T07:26:23Z",
  "deletedDateTime": null,
  "description": null,
  "disabledByMicrosoftStatus": null,
  "displayName": "Azure Arc SP",
  "homepage": null,
  "id": "7137118a-5e35-47ab-85a3-6f66106b33d2",
  "info": {
    "logoUrl": null,
    "marketingUrl": null,
    "privacyStatementUrl": null,
    "supportUrl": null,
    "termsOfServiceUrl": null
  },
  "keyCredentials": [],
  "loginUrl": null,
  "logoutUrl": null,
  "notes": null,
  "notificationEmailAddresses": [],
  "oauth2PermissionScopes": [],
  "passwordCredentials": [],
  "preferredSingleSignOnMode": null,
  "preferredTokenSigningKeyThumbprint": null,
  "replyUrls": [],
  "resourceSpecificApplicationPermissions": [],
  "samlSingleSignOnSettings": null,
  "servicePrincipalNames": [
    "xxxxxxx-05c3-4a0e-8d82-9b18d547ecc5"
  ],
  "servicePrincipalType": "Application",
  "signInAudience": "AzureADandPersonalMicrosoftAccount",
  "tags": [],
  "tokenEncryptionKeyId": null,
  "verifiedPublisher": {
    "addedDateTime": null,
    "displayName": null,
    "verifiedPublisherId": null
  }
}
```

- The SP also requires `Azure Arc Enabled Kubernetes Cluster User Role` to be able to list cluster user credentials, otherwise connecting to arc results in the error below:

```sh
$ az connectedk8s proxy -n $CLUSTER_NAME -g $RESOURCE_GROUP
Http response error occured while making ARM request: (AuthorizationFailed) The client '7137118a-5e35-47ab-85a3-6f66106b33d2' with object id '7137118a-5e35-47ab-85a3-6f66106b33d2' does not have authorization to perform action 'Microsoft.Kubernetes/connectedClusters/listClusterUserCredential/action' over scope '/subscriptions/xxxxxx/resourcegroups/test_resource_group/providers/Microsoft.Kubernetes/connectedClusters/device-1' or the scope is invalid. If access was recently granted, please refresh your credentials.
Code: AuthorizationFailed
Message: The client '7137118a-5e35-47ab-85a3-6f66106b33d2' with object id '7137118a-5e35-47ab-85a3-6f66106b33d2' does not have authorization to perform action 'Microsoft.Kubernetes/connectedClusters/listClusterUserCredential/action' over scope '/subscriptions/xxxxxxx/resourcegroups/test_resource_group/providers/Microsoft.Kubernetes/connectedClusters/device-1' or the scope is invalid. If access was recently granted, please refresh your credentials.
Summary: Unable to list cluster user credentials


```