### PR TITLE
Update nullable variable invocation in ADF

### DIFF
--- a/articles/data-factory/control-flow-system-variables.md
+++ b/articles/data-factory/control-flow-system-variables.md
@@ -32,8 +32,8 @@ These system variables can be referenced anywhere in the pipeline JSON.
 | @pipeline().TriggerName|Name of the trigger that invoked the pipeline |
 | @pipeline().TriggerTime|Time of the trigger run that invoked the pipeline. This is the time at which the trigger **actually** fired to invoke the pipeline run, and it may differ slightly from the trigger's scheduled time.  |
 | @pipeline().GroupId | ID of the group to which pipeline run belongs. |
-| @pipeline()?TriggeredByPipelineName | Name of the pipeline that triggers the pipeline run. Applicable when the pipeline run is triggered by an ExecutePipeline activity. Evaluate to _Null_ when used in other circumstances. Note the question mark after @pipeline() |
-| @pipeline()?TriggeredByPipelineRunId | Run ID of the pipeline that triggers the pipeline run. Applicable when the pipeline run is triggered by an ExecutePipeline activity. Evaluate to _Null_ when used in other circumstances. Note the question mark after @pipeline() |
+| @pipeline()?.TriggeredByPipelineName | Name of the pipeline that triggers the pipeline run. Applicable when the pipeline run is triggered by an ExecutePipeline activity. Evaluate to _Null_ when used in other circumstances. Note the question mark after @pipeline() |
+| @pipeline()?.TriggeredByPipelineRunId | Run ID of the pipeline that triggers the pipeline run. Applicable when the pipeline run is triggered by an ExecutePipeline activity. Evaluate to _Null_ when used in other circumstances. Note the question mark after @pipeline() |
 
 >[!NOTE]
 >Trigger-related date/time system variables (in both pipeline and trigger scopes) return UTC dates in ISO 8601 format, for example, `2017-06-01T22:20:00.4061448Z`.


### PR DESCRIPTION
In the current documentation the nullable variables from the pipelines are invoked using _@pipeline()?VariableName_. In fact, the variables need to be invoked using _@pipeline()?.TriggeredByPipelineName_.

![image](https://user-images.githubusercontent.com/24252078/183380727-d033f25a-f2b4-4644-9e7c-b0011a3960c9.png)
![image](https://user-images.githubusercontent.com/24252078/183380741-6284eb7d-f079-4dcc-9bbf-666848b9381a.png)
