### PR TITLE
Update data-lake-storage-migrate-gen1-to-gen2-azure-portal.md

### DIFF
--- a/articles/storage/blobs/data-lake-storage-migrate-gen1-to-gen2-azure-portal.md
+++ b/articles/storage/blobs/data-lake-storage-migrate-gen1-to-gen2-azure-portal.md
@@ -221,6 +221,10 @@ When we copy the data over to your Gen2-enabled account, we automatically create
 
 When you copy the data over to your Gen2-enabled account, two factors that can affect performance are the number of files and the amount of metadata you have. For example, many small files can affect the performance of the migration.
 
+#### Will WebHDFS File System API's supported on Gen2 account post migraiton?
+
+WebHDFS File System API's of Gen1 will be supported on Gen2 but with certain deviation and only limited functionality is supported via compatibilty layer. Customers should plan for levaraging ADLS Gen2 specific API's for better performance and features.
+
 ## Next steps
 
 - Learn about migration in general. For more information, see [Migrate Azure Data Lake Storage from Gen1 to Gen2](data-lake-storage-migrate-gen1-to-gen2.md).

--- a/articles/storage/blobs/data-lake-storage-migrate-gen1-to-gen2-azure-portal.md
+++ b/articles/storage/blobs/data-lake-storage-migrate-gen1-to-gen2-azure-portal.md
@@ -223,7 +223,7 @@ When you copy the data over to your Gen2-enabled account, two factors that can a
 
 #### Will WebHDFS File System API's supported on Gen2 account post migraiton?
 
-WebHDFS File System API's of Gen1 will be supported on Gen2 but with certain deviation and only limited functionality is supported via compatibilty layer. Customers should plan for levaraging ADLS Gen2 specific API's for better performance and features.
+WebHDFS File System APIs of Gen1 will be supported on Gen2 but with certain deviations, and only limited functionality is supported via the compatibilty layer. Customers should plan to levarage ADLS Gen2-specific APIs for better performance and features.
 
 ## Next steps
 


### PR DESCRIPTION
The WebHDFS File system API are supported on Gen2 account post migration from Gen1 but with limited functionality. Added this to FAQ documentation as well for the customers based on recent feedback on one of case