### PR TITLE
Include cm-resource-parent in guidance

### DIFF
--- a/articles/virtual-desktop/tag-virtual-desktop-resources.md
+++ b/articles/virtual-desktop/tag-virtual-desktop-resources.md
@@ -76,7 +76,8 @@ Like with the [general suggestions](#suggested-tags-for-azure-virtual-desktop), 
 
 - If you build your tagging system around your host pools, make sure to use key-value pairs that make sense to add to other Azure services later.
 
-### Using cm-resource-parent to automatically group costs by host pool in Microsoft Cost Management
+### Use the cm-resource-parent tag to automatically group costs by host pool
+
 In addition to any existing tags you've applied to your host pool resources, you can also leverage the cm-resource-parent tag to group costs by your host pool. This tag will not impact billing, but it will allow you to review these costs without filtering in Microsoft Cost Management. The key of this tag is "cm-resource-parent" and the value is the ResourceID of the Azure resource you want to group costs by, like each host pool you want to deploy. To learn more about how to use cm-resource-parent, review [Group related resources in the cost analysis preview](../cost-management-billing/costs/enable-preview-features-cost-management-labs#group-related-resources-in-the-cost-analysis-preview).
 
 ## Suggested tags for other Azure Virtual Desktop resources

--- a/articles/virtual-desktop/tag-virtual-desktop-resources.md
+++ b/articles/virtual-desktop/tag-virtual-desktop-resources.md
@@ -76,6 +76,9 @@ Like with the [general suggestions](#suggested-tags-for-azure-virtual-desktop), 
 
 - If you build your tagging system around your host pools, make sure to use key-value pairs that make sense to add to other Azure services later.
 
+### Using cm-resource-parent to automatically group costs by host pool in Microsoft Cost Management
+In addition to any existing tags you've applied to your host pool resources, you can also leverage the cm-resource-parent tag to group costs by your host pool. This tag will not impact billing, but it will allow you to review these costs without filtering in Microsoft Cost Management. The key of this tag is "cm-resource-parent" and the value is the ResourceID of the Azure resource you want to group costs by, like each host pool you want to deploy. To learn more about how to use cm-resource-parent, review [Group related resources in the cost analysis preview](../cost-management-billing/costs/enable-preview-features-cost-management-labs#group-related-resources-in-the-cost-analysis-preview).
+
 ## Suggested tags for other Azure Virtual Desktop resources
 
 Most Azure Virtual Desktop customers deploy other Azure services to support their deployments. If you want to include the cost of these extra services in your cost report, you should consider the following suggestions:

--- a/articles/virtual-desktop/tag-virtual-desktop-resources.md
+++ b/articles/virtual-desktop/tag-virtual-desktop-resources.md
@@ -78,7 +78,7 @@ Like with the [general suggestions](#suggested-tags-for-azure-virtual-desktop), 
 
 ### Use the cm-resource-parent tag to automatically group costs by host pool
 
-In addition to any existing tags you've applied to your host pool resources, you can also leverage the cm-resource-parent tag to group costs by your host pool. This tag will not impact billing, but it will allow you to review these costs without filtering in Microsoft Cost Management. The key of this tag is "cm-resource-parent" and the value is the ResourceID of the Azure resource you want to group costs by, like each host pool you want to deploy. To learn more about how to use cm-resource-parent, review [Group related resources in the cost analysis preview](../cost-management-billing/costs/enable-preview-features-cost-management-labs#group-related-resources-in-the-cost-analysis-preview).
+You can group costs by host pool by using the cm-resource-parent tag. This tag won't impact billing but will let you review tagged costs in Microsoft Cost Management without having to use filters. The key for this tag is **cm-resource-parent** and its value is the resource ID of the Azure resource you want to group costs by. For example, you can group costs by host pool by entering the host pool resource ID as the value. To learn more about how to use this tag, see [Group related resources in the cost analysis (preview)](../cost-management-billing/costs/enable-preview-features-cost-management-labs#group-related-resources-in-the-cost-analysis-preview).
 
 ## Suggested tags for other Azure Virtual Desktop resources
 


### PR DESCRIPTION
We should update AVD's tagging guidance to leverage a new preview feature in Microsoft Cost Management: https://docs.microsoft.com/en-us/azure/cost-management-billing/costs/enable-preview-features-cost-management-labs#group-related-resources-in-the-cost-analysis-preview

cm-resource-parent can be used to group costs by any taggable Azure resource. Since we suspect many AVD customers would be interested in viewing costs by host pool, I added this guidance under the "Suggested tags for Azure Virtual Desktop host pools" section, in its own subsection at the bottom. Open to changing this addition's location if it makes more sense to be less prescriptive on how we recommend customers use this unique tag or if there's a better way to make this information more discoverable.