### PR TITLE
Fixed incorrect rule example

### DIFF
--- a/articles/active-directory/enterprise-users/groups-dynamic-membership.md
+++ b/articles/active-directory/enterprise-users/groups-dynamic-membership.md
@@ -394,7 +394,7 @@ The following device attributes can be used.
  deviceOSVersion | any string value | device.deviceOSVersion -eq "9.1"<br>device.deviceOSVersion -startsWith "10.0.1"
  deviceOwnership | Personal, Company, Unknown | device.deviceOwnership -eq "Company"
  devicePhysicalIds | any string value used by Autopilot, such as all Autopilot devices, OrderID, or PurchaseOrderID  | device.devicePhysicalIDs -any _ -contains "[ZTDId]"<br>(device.devicePhysicalIds -any _ -eq "[OrderID]:179887111881"<br>(device.devicePhysicalIds -any _ -eq "[PurchaseOrderId]:76222342342"
- deviceTrustType | AzureAD, ServerAD, Workplace | device.deviceOwnership -eq "AzureAD"
+ deviceTrustType | AzureAD, ServerAD, Workplace | device.deviceTrustType -eq "AzureAD"
  enrollmentProfileName | Apple Device Enrollment Profile name, Android Enterprise Corporate-owned dedicated device Enrollment Profile name, or Windows Autopilot profile name | device.enrollmentProfileName -eq "DEP iPhones"
  extensionAttribute1 | any string value | device.extensionAttribute1 -eq "some string value"
  extensionAttribute2 | any string value | device.extensionAttribute2 -eq "some string value"


### PR DESCRIPTION
Changed the example for the "deviceTrustType" as it was using the 'deviceOwnership' property and not the 'deviceTrustType' property.