### PR TITLE
Fix for failing docker build task

### DIFF
--- a/articles/container-apps/communicate-between-microservices.md
+++ b/articles/container-apps/communicate-between-microservices.md
@@ -129,13 +129,13 @@ Output from the `az acr build` command shows the upload progress of the source c
     # [Bash](#tab/bash)
 
     ```azurecli
-    docker build --tag $ACR_NAME.azurecr.io/albumapp-ui . 
+    docker build --tag "$ACR_NAME.azurecr.io/albumapp-ui" . 
     ```
 
     # [PowerShell](#tab/powershell)
 
     ```powershell
-    docker build --tag $ACR_NAME.azurecr.io/albumapp-ui . 
+    docker build --tag "$ACR_NAME.azurecr.io/albumapp-ui" . 
     ```
 
     ---


### PR DESCRIPTION
The docker build task docker build --tag $ACR_NAME.azurecr.io/albumapp-ui . is failing because of missing quotes. 
```
invalid argument "/albumapp-ui" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
```

Proposing a change to include the quotes:
docker build --tag "$ACR_NAME.azurecr.io/albumapp-ui" .