### PR TITLE
fix for failing az containerapp create command

### DIFF
--- a/articles/container-apps/communicate-between-microservices.md
+++ b/articles/container-apps/communicate-between-microservices.md
@@ -241,7 +241,7 @@ az containerapp create `
   --name $FRONTEND_NAME `
   --resource-group $RESOURCE_GROUP `
   --environment $ENVIRONMENT `
-  --image $ACR_NAME.azurecr.io/albumapp-ui  `
+  --image "$ACR_NAME.azurecr.io/albumapp-ui"  `
   --env-vars API_BASE_URL=https://$API_BASE_URL `
   --target-port 3000 `
   --ingress 'external' `


### PR DESCRIPTION
in az containerapp create the image needs double quotes, otherwise the exception 
`The following field(s) are either invalid or missing. Invalid value: "/albumapp-ui": GET https:: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:albumapp-ui Type:repository]]: template.containers.album-ui.image.` is thrown.

Propose change: image "$ACR_NAME.azurecr.io/albumapp-ui"