### PR TITLE
Typo "Azure database for PostgreSQL"→"Azure Database for PostgreSQL"

### DIFF
--- a/articles/postgresql/migrate/how-to-migrate-single-to-flexible-cli.md
+++ b/articles/postgresql/migrate/how-to-migrate-single-to-flexible-cli.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrate from Single Server to Flexible Server by using the Azure CLI"
 titleSuffix: Azure Database for PostgreSQL Flexible Server
-description: Learn about migrating your Single Server databases to Azure database for PostgreSQL Flexible Server by using the Azure CLI.
+description: Learn about migrating your Single Server databases to Azure Database for PostgreSQL Flexible Server by using the Azure CLI.
 author: hariramt
 ms.author: hariramt
 ms.service: postgresql


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/postgresql/migrate/how-to-migrate-single-to-flexible-cli
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/postgresql/migrate/how-to-migrate-single-to-flexible-cli.md
#PingMSFTDocs