### PR TITLE
Update reply-url.md

### DIFF
--- a/articles/active-directory/develop/reply-url.md
+++ b/articles/active-directory/develop/reply-url.md
@@ -45,6 +45,8 @@ This table shows the maximum number of redirect URIs you can add to an app regis
 | Microsoft work or school accounts in any organization's Azure Active Directory (Azure AD) tenant | 256 | `signInAudience` field in the application manifest is set to either *AzureADMyOrg* or *AzureADMultipleOrgs* |
 | Personal Microsoft accounts and work and school accounts | 100 | `signInAudience` field in the application manifest is set to *AzureADandPersonalMicrosoftAccount* |
 
+The maximan number of redirect URIS can not be raised for [security reasons](#restrictions-on-wildcards-in-redirect-uris). If your scenario requires more redirect URIs than the maximum limit allowed, consider the following [state parameter approach](#use-a-state-parameter) as the solution.
+
 ## Maximum URI length
 
 You can use a maximum of 256 characters for each redirect URI you add to an app registration.

--- a/articles/active-directory/develop/reply-url.md
+++ b/articles/active-directory/develop/reply-url.md
@@ -45,7 +45,7 @@ This table shows the maximum number of redirect URIs you can add to an app regis
 | Microsoft work or school accounts in any organization's Azure Active Directory (Azure AD) tenant | 256 | `signInAudience` field in the application manifest is set to either *AzureADMyOrg* or *AzureADMultipleOrgs* |
 | Personal Microsoft accounts and work and school accounts | 100 | `signInAudience` field in the application manifest is set to *AzureADandPersonalMicrosoftAccount* |
 
-The maximan number of redirect URIS can not be raised for [security reasons](#restrictions-on-wildcards-in-redirect-uris). If your scenario requires more redirect URIs than the maximum limit allowed, consider the following [state parameter approach](#use-a-state-parameter) as the solution.
+The maximum number of redirect URIS can't be raised for [security reasons](#restrictions-on-wildcards-in-redirect-uris). If your scenario requires more redirect URIs than the maximum limit allowed, consider the following [state parameter approach](#use-a-state-parameter) as the solution.
 
 ## Maximum URI length
 


### PR DESCRIPTION
https://onesupport.crm.dynamics.com//main.aspx?appname=msdyn_CustomerServiceWorkspace&pagetype=entityrecord&etn=incident&id=d9036453-6fd0-ec11-a7b5-0022482e0a25

This customer raised a support case to raise redirect URI limit. I think it could be helpful to clarify in our docs that this limit can't be raised and what is the solution.