### PR TITLE
Correct management domain bind to IP 10.1.0.4

### DIFF
--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -114,7 +114,7 @@ To access these API Management endpoints, you can create a virtual machine in a 
 | 10.1.0.5 | `contosointernalvnet.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.portal.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.developer.azure-api.net` |
-| 10.1.0.5 | `contosointernalvnet.management.azure-api.net` |
+| 10.1.0.4 | `contosointernalvnet.management.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.scm.azure-api.net` |
 
 You can then access all the API Management endpoints from the virtual machine you created.


### PR DESCRIPTION
Current document mention domain `contosointernalvnet.management.azure-api.net` bind to IP `10.1.0.5` is not correct. The correct IP for `contosointernalvnet.management.azure-api.net` should be `10.1.0.4` where can access port 3443.

---
#### Document Details

⚠ *Do not edit this section. It is required for docs.microsoft.com ➟ GitHub issue linking.*

* ID: c0666302-7986-481e-97a0-2515d5c60210
* Version Independent ID: 2d45104c-c3ec-4432-ea6f-117ca53ed8cb
* Content: [Connect to an internal virtual network using Azure API Management](https://docs.microsoft.com/en-us/azure/api-management/api-management-using-with-internal-vnet?tabs=stv2)
* Content Source: [articles/api-management/api-management-using-with-internal-vnet.md](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/api-management/api-management-using-with-internal-vnet.md)
* Service: **api-management**
* GitHub Login: @dlepow
* Microsoft Alias: **danlep**