### PR TITLE
Adding --SKU to the sample command

### DIFF
--- a/articles/availability-zones/migrate-app-service.md
+++ b/articles/availability-zones/migrate-app-service.md
@@ -85,7 +85,7 @@ You can create an App Service with availability zones using the [Azure CLI](/cli
 To enable availability zones using the Azure CLI, include the `--zone-redundant` parameter when you create your App Service plan. You can also include the `--number-of-workers` parameter to specify capacity. If you don't specify a capacity, the platform defaults to three. Capacity should be set based on the workload requirement, but no less than three. A good rule of thumb to choose capacity is to ensure sufficient instances for the application such that losing one zone of instances leaves sufficient capacity to handle expected load.
 
 ```azurecli
-az appservice plan create --resource-group MyResourceGroup --name MyPlan --zone-redundant --number-of-workers 6
+az appservice plan create --resource-group MyResourceGroup --name MyPlan --sku P1v2 --zone-redundant --number-of-workers 6
 ```
 
 > [!TIP]


### PR DESCRIPTION
Adding the --sku parameters to the creation command, Availability Zone is supported in Premium v2 or Premium v3 running the command as is will produce an error since the default value for --sku is B1 which doesn't support availability zone.
Zone redundancy cannot be enabled for sku B1
![image](https://user-images.githubusercontent.com/5002831/183944212-dea741d9-f18a-4ec4-82c2-55f78a90631e.png)
