### PR TITLE
Update concept-registration-mfa-sspr-combined.md

### DIFF
--- a/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
+++ b/articles/active-directory/authentication/concept-registration-mfa-sspr-combined.md
@@ -93,7 +93,7 @@ For both modes, users who have previously registered a method that can be used f
 
 ### Interrupt mode
 
-Combined registration adheres to both Multi-Factor Authentication and SSPR policies, if both are enabled for your tenant. These policies control whether a user is interrupted for registration during sign-in and which methods are available for registration. If only an SSPR policy is enabled, then users will be able to skip the registration interruption and complete it at a later time.
+Combined registration adheres to both Multi-Factor Authentication and SSPR policies, if both are enabled for your tenant. These policies control whether a user is interrupted for registration during sign-in and which methods are available for registration. If only an SSPR policy is enabled, then users will be able to skip(indefinitely) the registration interruption and complete it at a later time.
 
 The following are sample scenarios where users might be prompted to register or refresh their security info:
 


### PR DESCRIPTION
If users are enforced to register when sign-in through SSPR then they can skip the registration indefinitely. Added the same in documentation to provide clarity to the customers looking out for an answer on 'for how long the users can skip it'. 