### PR TITLE
[service-connector] Streamline display of next steps links

### DIFF
--- a/articles/service-connector/overview.md
+++ b/articles/service-connector/overview.md
@@ -72,8 +72,16 @@ There are two major ways to use Service Connector for your Azure application:
 Follow the tutorials listed below to start building your own application with Service Connector.
 
 > [!div class="nextstepaction"]
-> - [Quickstart: Service Connector in App Service using Azure CLI](./quickstart-cli-app-service-connection.md)
-> - [Quickstart: Service Connector in App Service using Azure portal](./quickstart-portal-app-service-connection.md)
-> - [Quickstart: Service Connector in Spring Cloud Service using Azure CLI](./quickstart-cli-spring-cloud-connection.md)
-> - [Quickstart: Service Connector in Spring Cloud using Azure portal](./quickstart-portal-spring-cloud-connection.md)
-> - [Learn about Service Connector concepts](./concept-service-connector-internals.md)
+> [Quickstart: Service Connector in App Service using Azure CLI](./quickstart-cli-app-service-connection.md)
+
+> [!div class="nextstepaction"]
+> [Quickstart: Service Connector in App Service using Azure portal](./quickstart-portal-app-service-connection.md)
+
+> [!div class="nextstepaction"]
+> [Quickstart: Service Connector in Spring Cloud Service using Azure CLI](./quickstart-cli-spring-cloud-connection.md)
+
+> [!div class="nextstepaction"]
+> [Quickstart: Service Connector in Spring Cloud using Azure portal](./quickstart-portal-spring-cloud-connection.md)
+
+> [!div class="nextstepaction"]
+> [Learn about Service Connector concepts](./concept-service-connector-internals.md)

--- a/articles/service-connector/quickstart-cli-app-service-connection.md
+++ b/articles/service-connector/quickstart-cli-app-service-connection.md
@@ -86,5 +86,7 @@ az webapp connection list -g "<your-app-service-resource-group>" -n "<your-app-s
 Follow the tutorials listed below to start building your own application with Service Connector.
 
 > [!div class="nextstepaction"]
-> - [Tutorial: WebApp + Storage with Azure CLI](./tutorial-csharp-webapp-storage-cli.md)
-> - [Tutorial: WebApp + PostgreSQL with Azure CLI](./tutorial-django-webapp-postgres-cli.md)
+> [Tutorial: WebApp + Storage with Azure CLI](./tutorial-csharp-webapp-storage-cli.md)
+
+> [!div class="nextstepaction"]
+> [Tutorial: WebApp + PostgreSQL with Azure CLI](./tutorial-django-webapp-postgres-cli.md)

--- a/articles/service-connector/quickstart-cli-spring-cloud-connection.md
+++ b/articles/service-connector/quickstart-cli-spring-cloud-connection.md
@@ -86,4 +86,6 @@ Follow the tutorials listed below to start building your own application with Se
 
 > [!div class="nextstepaction"]
 > [Tutorial: Spring Cloud + MySQL](./tutorial-java-spring-mysql.md)
+
+> [!div class="nextstepaction"]
 > [Tutorial: Spring Cloud + Apache Kafka on Confluent Cloud](./tutorial-java-spring-confluent-kafka.md)

--- a/articles/service-connector/quickstart-portal-spring-cloud-connection.md
+++ b/articles/service-connector/quickstart-portal-spring-cloud-connection.md
@@ -55,5 +55,7 @@ Sign in to the Azure portal at [https://portal.azure.com/](https://portal.azure.
 Follow the tutorials listed below to start building your own application with Service Connector.
 
 > [!div class="nextstepaction"]
-> - [Tutorial: Spring Cloud + MySQL](./tutorial-java-spring-mysql.md)
-> - [Tutorial: Spring Cloud + Apache Kafka on Confluent Cloud](./tutorial-java-spring-confluent-kafka.md)
+> [Tutorial: Spring Cloud + MySQL](./tutorial-java-spring-mysql.md)
+
+> [!div class="nextstepaction"]
+> [Tutorial: Spring Cloud + Apache Kafka on Confluent Cloud](./tutorial-java-spring-confluent-kafka.md)


### PR DESCRIPTION
Multiple links in the `Next steps` section look a bit off.

<img width="682" alt="quickstart-cli-app-service-connection" src="https://user-images.githubusercontent.com/10836210/184312395-5151a4cb-ce9c-48da-90b8-9c4358276331.png">

This PR streamlines the display of `Next steps` section for the service-connector documentation
