### PR TITLE
Update register-application-cli-rest.md

### DIFF
--- a/articles/healthcare-apis/register-application-cli-rest.md
+++ b/articles/healthcare-apis/register-application-cli-rest.md
@@ -89,7 +89,7 @@ Choose a name for the secret and specify the expiration duration. The default is
 ###Add client secret with expiration. The default is one year.
 clientsecretname=mycert2
 clientsecretduration=2
-clientsecret=$(az ad app credential reset --id $clientid --append --credential-description $clientsecretname --years $clientsecretduration --query password --output tsv)
+clientsecret=$(az ad app credential reset --id $clientid --append --display-name $clientsecretname --years $clientsecretduration --query password --output tsv)
 echo $clientsecret
 ```
 


### PR DESCRIPTION
This updates the command for adding a secret to use the `--display-name` parameter instead of  `--credential-description` for the secret name.  Using `--credential-description` results in the following error:

```
ERROR: unrecognized arguments: --credential-description
```
Tested on Azure CLI v2.39.