### PR TITLE
Fix blobfuse2 installation command

### DIFF
--- a/articles/storage/blobs/blobfuse2-how-to-deploy.md
+++ b/articles/storage/blobs/blobfuse2-how-to-deploy.md
@@ -66,7 +66,7 @@ To install BlobFuse2:
 
     ```bash
     sudo apt-get install libfuse3-dev fuse3 
-    sudo apt install blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb
+    sudo apt install ./blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb
     ```
     
 ### Option 2: Build from source


### PR DESCRIPTION
If you follow the instructions as they're written today on an Ubuntu machine, you'll get an error when you run the following command:

```shell
sudo apt install blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb
```

Output:

```
Reading package lists... Done
Building dependency tree
Reading state information... Done
E: Unable to locate package blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb
E: Couldn't find any package by glob 'blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb'
```

This will happen regardless of whether the file `blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb` exists in the present working directory, because `apt` (and `apt-get`) looks for a remote package unless it detects a glob pattern of a file system path.

Any of the following alternatives would work:

```shell
# If the deb package is in the current directory:
sudo apt install ./blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb

# If the deb package is in the current directory and you prefer expanding the full path:
sudo apt install $(pwd)/blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb

# If the deb package is in another directory:
sudo apt install /path/to/blobfuse2-2.0.0-preview.2-ubuntu-20.04-x86-64.deb
```

This PR suggests the first one, as a previous step saves the file in the present directory.


This has been tested on:

```shell
~ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.4 LTS
Release:	20.04
Codename:	focal

~ apt --version 
apt 2.0.9 (amd64)
```