### PR TITLE
code sample in dynamic dictionary example.

### DIFF
--- a/articles/cognitive-services/Translator/dynamic-dictionary.md
+++ b/articles/cognitive-services/Translator/dynamic-dictionary.md
@@ -27,7 +27,7 @@ If you already know the translation you want to apply to a word or a phrase, you
 
 **Example: en-de:**
 
-Source input: `The word <mstrans:dictionary translation=\"wordomatic\">word or phrase</mstrans:dictionary> is a dictionary entry.`
+Source input: `The word <mstrans:dictionary translation=\"wordomatic\">wordomatic</mstrans:dictionary> is a dictionary entry.`
 
 Target output: `Das Wort "wordomatic" ist ein Wörterbucheintrag.`
 


### PR DESCRIPTION
corrected the code sample in dynamic dictionary example.
curl -X POST "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=en&to=de" -H "Ocp-Apim-Subscription-Key: " -H "Content-Type: application/json; charset=UTF-8" -d "[{'Text':'The word <mstrans:dictionary translation="wordomatic">wordomatic</mstrans:dictionary> is a dictionary entry.'}]"