### PR TITLE
Increase visibility of limitations

### DIFF
--- a/articles/container-apps/firewall-integration.md
+++ b/articles/container-apps/firewall-integration.md
@@ -16,8 +16,6 @@ Network Security Groups (NSGs) needed to configure virtual networks closely rese
 
 You can lock down a network via NSGs with more restrictive rules than the default NSG rules to control all inbound and outbound traffic for the Container App Environment.
 
-Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. Therefore, securing a Container App Environment with a firewall is not yet supported.
-
 ## NSG allow rules
 
 The following tables describe how to configure a collection of NSG allow rules.
@@ -46,6 +44,9 @@ The following tables describe how to configure a collection of NSG allow rules.
 | TCP | `5671` | \* | Container Apps control plane. |
 | TCP | `5672` | \* | Container Apps control plane. |
 | Any | \* | Infrastructure subnet address space | Allow communication between IPs in the infrastructure subnet. This address is passed as a parameter when you create an environment. For example, `10.0.0.0/23`. |
+
+#### Limitiations
+- Custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. Therefore, securing a Container App Environment with a firewall is not yet supported.
 
 #### Considerations
 


### PR DESCRIPTION
The limitations should not be included in the introduction, as it is easy to miss. The introduction typically includes a description of the article, and should not contain key information relating to support of the product. 

This edit produces a similar structure to https://docs.microsoft.com/en-us/azure/app-service/overview-vnet-integration#limitations.