### PR TITLE
Update service-fabric-reliable-services-reliable-collections-guidelines

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
+++ b/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
@@ -16,7 +16,7 @@ The guidelines are organized as simple recommendations prefixed with the terms *
 
 * Do not modify an object of custom type returned by read operations (for example, `TryPeekAsync` or `TryGetValueAsync`). Reliable Collections, just like Concurrent Collections, return a reference to the objects and not a copy.
 * Do deep copy the returned object of a custom type before modifying it. Since structs and built-in types are pass-by-value, you do not need to do a deep copy on them unless they contain reference-typed fields or properties that you intend to modify.
-* Do not use `TimeSpan.MaxValue` for time-outs. Time-outs should be used to detect deadlocks.
+* Do not use `TimeSpan.MaxValue` for timeouts. Timeouts should be used to detect deadlocks.
 * Do not use a transaction after it has been committed, aborted, or disposed.
 * Do not use an enumeration outside of the transaction scope it was created in.
 * Do not create a transaction within another transaction's `using` statement because it can cause deadlocks.
@@ -31,7 +31,7 @@ The guidelines are organized as simple recommendations prefixed with the terms *
 
 Here are some things to keep in mind:
 
-* The default time-out is four seconds for all the Reliable Collection APIs. Most users should use the default time-out.
+* The default timeout is 4 seconds for all the Reliable Collection APIs. Most users should use the default timeout.
 * The default cancellation token is `CancellationToken.None` in all Reliable Collections APIs.
 * The key type parameter (*TKey*) for a Reliable Dictionary must correctly implement `GetHashCode()` and `Equals()`. Keys must be immutable.
 * To achieve high availability for the Reliable Collections, each service should have at least a target and minimum replica set size of 3.


### PR DESCRIPTION
- Replaced `time-out` with `timeout`
- Replaced `four` with `4`