### PR TITLE
Added context to B2C custom attribute requirements

### DIFF
--- a/articles/active-directory-b2c/user-flow-custom-attributes.md
+++ b/articles/active-directory-b2c/user-flow-custom-attributes.md
@@ -147,7 +147,7 @@ You can create these attributes by using the portal UI before or after you use t
 |`extension_<b2c-extensions-app-guid>_loyaltyId`  | [Microsoft Graph API](microsoft-graph-operations.md#application-extension-directory-extension-properties)|
 
 > [!NOTE] 
-> When using custom attributes in custom policies, the claim type ID must be prefixed with `extension_` to allow the correct data mapping to take place within the Azure AD B2C directory.
+> When using a custom attribute in custom policies, you must prefix the claim type ID with `extension_` to allow the correct data mapping to take place within the Azure AD B2C directory.
 
 The following example demonstrates the use of custom attributes in an Azure AD B2C custom policy claim definition.
 

--- a/articles/active-directory-b2c/user-flow-custom-attributes.md
+++ b/articles/active-directory-b2c/user-flow-custom-attributes.md
@@ -143,8 +143,11 @@ You can create these attributes by using the portal UI before or after you use t
 
 |Name     |Used in |
 |---------|---------|
-|`extension_loyaltyId`  | Custom policy|
+|`extension_loyaltyId` | Custom policy|
 |`extension_<b2c-extensions-app-guid>_loyaltyId`  | [Microsoft Graph API](microsoft-graph-operations.md#application-extension-directory-extension-properties)|
+
+> [!NOTE] 
+> When using custom attributes in custom policies, the claim type ID must be prefixed with `extension_` to allow the correct data mapping to take place within the B2C directory.
 
 The following example demonstrates the use of custom attributes in an Azure AD B2C custom policy claim definition.
 

--- a/articles/active-directory-b2c/user-flow-custom-attributes.md
+++ b/articles/active-directory-b2c/user-flow-custom-attributes.md
@@ -147,7 +147,7 @@ You can create these attributes by using the portal UI before or after you use t
 |`extension_<b2c-extensions-app-guid>_loyaltyId`  | [Microsoft Graph API](microsoft-graph-operations.md#application-extension-directory-extension-properties)|
 
 > [!NOTE] 
-> When using custom attributes in custom policies, the claim type ID must be prefixed with `extension_` to allow the correct data mapping to take place within the B2C directory.
+> When using custom attributes in custom policies, the claim type ID must be prefixed with `extension_` to allow the correct data mapping to take place within the Azure AD B2C directory.
 
 The following example demonstrates the use of custom attributes in an Azure AD B2C custom policy claim definition.
 


### PR DESCRIPTION
ClaimTypes referencing an extension attribute start with `extension_` but the reader is never informed to why that is. Now they will be.