### PR TITLE
Update Redwood.js instructions to only build web

### DIFF
--- a/articles/static-web-apps/front-end-frameworks.md
+++ b/articles/static-web-apps/front-end-frameworks.md
@@ -48,7 +48,7 @@ The intent of the table columns is explained by the following items:
 | [Polymer](https://www.polymer-project.org/) | `build/default` | n/a |
 | [Preact](https://preactjs.com/) | `build` | n/a |
 | [React](https://reactjs.org/) | `build` | n/a |
-| [RedwoodJS](https://redwoodjs.com/) | `web/dist` | `yarn rw build` |
+| [RedwoodJS](https://redwoodjs.com/) | `web/dist` | `yarn rw build web` |
 | [Stencil](https://stenciljs.com/) | `www` | n/a |
 | [Svelte](https://svelte.dev/) | `public` | n/a |
 | [Three.js](https://threejs.org/) | `/` | n/a |


### PR DESCRIPTION
Redwood.js applications have two build processes, one for `web` and the other for `api`.  Using the `yarn rw build` will unnecessarily build the `api` portion of the application prolonging the build process. `yarn rw build web` will only build the web portion and help avoid unnecessary build time.