### PR TITLE
Update application-gateway-faq.yml

### DIFF
--- a/articles/application-gateway/application-gateway-faq.yml
+++ b/articles/application-gateway/application-gateway-faq.yml
@@ -129,8 +129,9 @@ sections:
         answer: |
           Yes. The Application Gateway v1 SKU will continue to be supported. However, it is strongly recommended to move to v2 to take advantage of the feature updates in that SKU. For more information on the differences between v1 and v2 features, see [Autoscaling and Zone-redundant Application Gateway v2](application-gateway-autoscaling-zone-redundant.md). You can manually migrate Application Gateway v1 sku deployments to v2 by following our [v1-v2 migration document](migrate-v1-v2.md).
           
-      - question: Does Application Gateway V2 support proxying requests with NTLM authentication?
-        answer: No. Application Gateway V2 doesn't support proxying requests with NTLM authentication.
+      - question: Does Application Gateway V2 support proxying requests with 
+      authentication? Does Application Gateway V2 support Kerberos Authentication?
+        answer: No. Application Gateway V2 doesn't support proxying requests with NTLM authentication. Application Gateway doesn't support Kerberos Authentication.
         
       - question: Why are some header values not present when requests are forwarded to my application?
         answer: Request header names can contain alphanumeric characters and hyphens. Request header names containing other characters will be discarded when a request is sent to the backend target. Response header names can contain any alphanumeric characters and specific symbols as defined in [RFC 7230](https://tools.ietf.org/html/rfc7230#page-27), with the exception of underscores (\_).


### PR DESCRIPTION
Add information that Application Gateway V2 doesn't support Kerberos Authentication as well in this below FAQ. Thanks!
      - question: Does Application Gateway V2 support proxying requests with NTLM authentication?
        answer: No. Application Gateway V2 doesn't support proxying requests with NTLM authentication.