### PR TITLE
graph.windows.net is duplicated

### DIFF
--- a/articles/machine-learning/how-to-access-azureml-behind-firewall.md
+++ b/articles/machine-learning/how-to-access-azureml-behind-firewall.md
@@ -94,7 +94,6 @@ These rule collections are described in more detail in [What are some Azure Fire
 
     | **Host name** | **Purpose** |
     | ---- | ---- |
-    | **graph.windows.net** | Used by Azure Machine Learning compute instance/cluster. |
     | **anaconda.com**</br>**\*.anaconda.com** | Used to install default packages. |
     | **\*.anaconda.org** | Used to get repo data. |
     | **pypi.org** | Used to list dependencies from the default index, if any, and the index isn't overwritten by user settings. If the index is overwritten, you must also allow **\*.pythonhosted.org**. |


### PR DESCRIPTION
Azure Active Directory service tag includes "graph.windows.net". So it is duplicated to list "graph.windows.net" in Azure Firewall - Outbound configuration section.