### PR TITLE
Typo "Azure container instances"→"Azure Container Instances"

### DIFF
--- a/articles/container-instances/container-instances-tutorial-azure-function-trigger.md
+++ b/articles/container-instances/container-instances-tutorial-azure-function-trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorial - Trigger container group by Azure function
-description: Create an HTTP-triggered, serverless PowerShell function to automate creation of Azure container instances
+description: Create an HTTP-triggered, serverless PowerShell function to automate creation of Azure Container Instances
 ms.topic: tutorial
 ms.author: tomcassidy
 author: tomvcassidy


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/container-instances/container-instances-tutorial-azure-function-trigger
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/container-instances/container-instances-tutorial-azure-function-trigger.md
#PingMSFTDocs