### PR TITLE
Update CmdLet to latest Azure PowerShell module version

### DIFF
--- a/articles/active-directory-domain-services/powershell-create-instance.md
+++ b/articles/active-directory-domain-services/powershell-create-instance.md
@@ -209,7 +209,7 @@ $replicaSetParams = @{
   Location = $AzureLocation
   SubnetId = "/subscriptions/$AzureSubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.Network/virtualNetworks/$VnetName/subnets/DomainServices"
 }
-$replicaSet = New-AzADDomainServiceReplicaSet @replicaSetParams
+$replicaSet = New-AzADDomainServiceReplicaSetObject @replicaSetParams
 
 $domainServiceParams = @{
   Name = $ManagedDomainName


### PR DESCRIPTION
Since version 8 of Azure PowerShell module `New-AzADDomainServiceReplicaSet` has been renamed to `New-AzADDomainServiceReplicaSetObject`.