### PR TITLE
Correct incorrect column names in SELECT

### DIFF
--- a/articles/synapse-analytics/sql/create-external-table-as-select.md
+++ b/articles/synapse-analytics/sql/create-external-table-as-select.md
@@ -83,12 +83,12 @@ USE [mydbname];
 GO
 
 SELECT
-    country_name, population
+    CountryName, PopulationCount
 FROM PopulationCETAS
 WHERE
-    [year] = 2019
+    [Year] = 2019
 ORDER BY
-    [population] DESC;
+    [PopulationCount] DESC;
 ```
 
 ## Remarks


### PR DESCRIPTION
In the SELECT query using the CETAS created table, the column names do not match what was created