### PR TITLE
Update linux instructions to use Linux Emulator Cosmos

### DIFF
--- a/articles/cosmos-db/includes/linux-emulator-instructions.md
+++ b/articles/cosmos-db/includes/linux-emulator-instructions.md
@@ -17,7 +17,7 @@
     ```bash
     docker run \
         --publish 8081:8081 \
-        --publish 10251-10254:10251-10254 \
+        --publish 10251-10255:10251-10255 \
         --memory 3g --cpus=2.0 \
         --name=test-linux-emulator \
         --env AZURE_COSMOS_EMULATOR_PARTITION_COUNT=10 \
@@ -33,7 +33,7 @@
     ```bash
     docker run \
         --publish 8081:8081 \
-        --publish 10251-10254:10251-10254 \
+        --publish 10251-10255:10251-10255 \
         --name=test-linux-emulator-mongo \
         --env AZURE_COSMOS_EMULATOR_PARTITION_COUNT=10 \
         --env AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true \


### PR DESCRIPTION
For use the Cosmos Emulator correctly, the port 10255 need is available too, added in documentation.