### PR TITLE
Replace jar-path with artifact-path

### DIFF
--- a/articles/spring-apps/quickstart-deploy-apps.md
+++ b/articles/spring-apps/quickstart-deploy-apps.md
@@ -228,11 +228,11 @@ Use the following steps to create and deploys apps on Azure Spring Apps using th
    ```azurecli
    az spring app deploy \
        --name api-gateway \
-       --jar-path spring-petclinic-api-gateway/target/spring-petclinic-api-gateway-2.5.1.jar \
+       --artifact-path spring-petclinic-api-gateway/target/spring-petclinic-api-gateway-2.5.1.jar \
        --jvm-options="-Xms2048m -Xmx2048m"
    az spring app deploy \
        --name customers-service \
-       --jar-path spring-petclinic-customers-service/target/spring-petclinic-customers-service-2.5.1.jar \
+       --artifact-path spring-petclinic-customers-service/target/spring-petclinic-customers-service-2.5.1.jar \
        --jvm-options="-Xms2048m -Xmx2048m"
    ```
 


### PR DESCRIPTION
Since `--jar-path` option is deprecated, we need to update the flag to `--artifact-path` to reflect the polyglot evolution of ASA