### PR TITLE
Update validate-jwt policy for RS256 signing algorithms

### DIFF
--- a/articles/api-management/api-management-access-restriction-policies.md
+++ b/articles/api-management/api-management-access-restriction-policies.md
@@ -561,7 +561,7 @@ The `validate-jwt` policy enforces existence and validity of a JSON web token (J
 
 > [!IMPORTANT]
 > The `validate-jwt` policy requires that the `exp` registered claim is included in the JWT token, unless `require-expiration-time` attribute is specified and set to `false`.
-> The `validate-jwt` policy supports HS256 and RS256 signing algorithms. For HS256 the key must be provided inline within the policy in the base64 encoded form. For RS256 the key may be provided either via an Open ID configuration endpoint, or by providing the ID of an uploaded certificate that contains the public key or modulus-exponent pair of the public key but in pfx format.
+> The `validate-jwt` policy supports HS256 and RS256 signing algorithms. For HS256 the key must be provided inline within the policy in the base64 encoded form. For RS256 the key may be provided either via an Open ID configuration endpoint, or by providing the ID of an uploaded certificate that contains the public key or modulus-exponent pair of the public key but in PFX format.
 > The `validate-jwt` policy supports tokens encrypted with symmetric keys using the following encryption algorithms: A128CBC-HS256, A192CBC-HS384, A256CBC-HS512.
 
 [!INCLUDE [api-management-policy-form-alert](../../includes/api-management-policy-form-alert.md)]

--- a/articles/api-management/api-management-access-restriction-policies.md
+++ b/articles/api-management/api-management-access-restriction-policies.md
@@ -561,7 +561,7 @@ The `validate-jwt` policy enforces existence and validity of a JSON web token (J
 
 > [!IMPORTANT]
 > The `validate-jwt` policy requires that the `exp` registered claim is included in the JWT token, unless `require-expiration-time` attribute is specified and set to `false`.
-> The `validate-jwt` policy supports HS256 and RS256 signing algorithms. For HS256 the key must be provided inline within the policy in the base64 encoded form. For RS256 the key may be provided either via an Open ID configuration endpoint, or by providing the ID of an uploaded certificate that contains the public key or modulus-exponent pair of the public key.
+> The `validate-jwt` policy supports HS256 and RS256 signing algorithms. For HS256 the key must be provided inline within the policy in the base64 encoded form. For RS256 the key may be provided either via an Open ID configuration endpoint, or by providing the ID of an uploaded certificate that contains the public key or modulus-exponent pair of the public key but in pfx format.
 > The `validate-jwt` policy supports tokens encrypted with symmetric keys using the following encryption algorithms: A128CBC-HS256, A192CBC-HS384, A256CBC-HS512.
 
 [!INCLUDE [api-management-policy-form-alert](../../includes/api-management-policy-form-alert.md)]


### PR DESCRIPTION
The pfx file in general contains a public key as well as its corresponding private key. In this case of jwt validation for RS256 signing algorithms, we need only the public key of the certificate for validation. But APIM custom client certificate uploads don't support cert format and it supports only pfx format. So we have to create a pfx file only with the public key for custom client certificate upload. So it's better to call out this format explicitly in the document as generally, a pfx format has a private key as well. This clarifies to the user that we use should only pfx file but with only the public key and it also clarifies the security concerns about uploading a pfx file.