### PR TITLE
Typo "Azure Storage library"→"Azure Storage Library"

### DIFF
--- a/articles/storage/blobs/storage-quickstart-blobs-ruby.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-ruby.md
@@ -22,7 +22,7 @@ Learn how to use Ruby to create, download, and list blobs in a container in Micr
 Make sure you have the following additional prerequisites installed:
 
 - [Ruby](https://www.ruby-lang.org/en/downloads/)
-- [Azure Storage library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
+- [Azure Storage Library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
 
     ```console
     gem install azure-storage-blob

--- a/articles/storage/blobs/storage-quickstart-blobs-ruby.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-ruby.md
@@ -22,7 +22,7 @@ Learn how to use Ruby to create, download, and list blobs in a container in Micr
 Make sure you have the following additional prerequisites installed:
 
 - [Ruby](https://www.ruby-lang.org/en/downloads/)
-- [Azure Storage Library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
+- [Azure Storage Client Library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
 
     ```console
     gem install azure-storage-blob

--- a/articles/storage/blobs/storage-quickstart-blobs-ruby.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-ruby.md
@@ -22,7 +22,7 @@ Learn how to use Ruby to create, download, and list blobs in a container in Micr
 Make sure you have the following additional prerequisites installed:
 
 - [Ruby](https://www.ruby-lang.org/en/downloads/)
-- [Azure Storage client Library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
+- [Azure Storage client library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
 
     ```console
     gem install azure-storage-blob

--- a/articles/storage/blobs/storage-quickstart-blobs-ruby.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-ruby.md
@@ -22,7 +22,7 @@ Learn how to use Ruby to create, download, and list blobs in a container in Micr
 Make sure you have the following additional prerequisites installed:
 
 - [Ruby](https://www.ruby-lang.org/en/downloads/)
-- [Azure Storage Client Library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
+- [Azure Storage client Library for Ruby](https://github.com/azure/azure-storage-ruby), using the [RubyGem package](https://rubygems.org/gems/azure-storage-blob):
 
     ```console
     gem install azure-storage-blob


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-ruby
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/storage/blobs/storage-quickstart-blobs-ruby.md
#PingMSFTDocs