### PR TITLE
adds details and samples to current ACA limitations

### DIFF
--- a/articles/container-apps/firewall-integration.md
+++ b/articles/container-apps/firewall-integration.md
@@ -16,7 +16,7 @@ Network Security Groups (NSGs) needed to configure virtual networks closely rese
 
 You can lock down a network via NSGs with more restrictive rules than the default NSG rules to control all inbound and outbound traffic for the Container App Environment.
 
-Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. Therefore, securing a Container App Environment with a firewall is not yet supported.
+Using custom user-defined routes (UDRs) or ExpressRoutes, other than with UDRs of selected destinations that you own, are not yet supported for Container App Environments with VNETs. Therefore, securing a Container App Environment with a firewall, ExpressRoute "Forced Tunneling" or UDRs routing 0.0.0.0/0 is not yet supported.
 
 ## NSG allow rules
 


### PR DESCRIPTION
I added some details about when ExpressRoutes and UDRs are supported by ACA and when they are not. There were a few details/examples missing in the current explanation. 