### PR TITLE
Fix further reading link

### DIFF
--- a/articles/machine-learning/concept-mlflow.md
+++ b/articles/machine-learning/concept-mlflow.md
@@ -46,7 +46,7 @@ With MLflow Tracking you can connect Azure Machine Learning as the backend of yo
 
 * [Track ML experiments and models running locally or in the cloud](how-to-use-mlflow-cli-runs.md) with MLflow in Azure Machine Learning.
 * [Track Azure Databricks ML experiments](how-to-use-mlflow-azure-databricks.md) with MLflow in Azure Machine Learning.
-* [Track Azure Synapse Analytics ML experiments](how-to-use-mlflow-azure-databricks.md) with MLflow in Azure Machine Learning.
+* [Track Azure Synapse Analytics ML experiments](how-to-use-mlflow-azure-synapse.md) with MLflow in Azure Machine Learning.
 
 > [!IMPORTANT]
 > - MLflow in R support is limited to tracking experiment's metrics, parameters and models on Azure Machine Learning jobs. RStudio or Jupyter Notebooks with R kernels are not supported. Model registries are not supported using the MLflow R SDK. As an alternative, use Azure ML CLI or Azure ML studio for model registration and management. View the following [R example about using the MLflow tracking client with Azure Machine Learning](https://github.com/Azure/azureml-examples/tree/main/cli/jobs/single-step/r).


### PR DESCRIPTION
Fixed the further reading link of Synapse from the (mistaken) ADB to the (correct) Synapse one.