### PR TITLE
Update manage-probes-how-to.md

### DIFF
--- a/articles/load-balancer/manage-probes-how-to.md
+++ b/articles/load-balancer/manage-probes-how-to.md
@@ -60,7 +60,6 @@ In this example, you'll create a TCP health probe to monitor port 80.
     | Protocol | Select **TCP**. |
     | Port | Enter the **TCP** port you wish to monitor. For this example, it's **port 80**. |
     | Interval | Enter an interval between probe checks. For this example, it's the default of **5**. |
-    | Unhealthy threshold | Enter the threshold number for consecutive failures. For this example, it's the default of **2**. |
 
 7. Select **Add**.
 
@@ -113,7 +112,6 @@ In this example, you'll create an HTTP health probe.
     | Port | Enter the **TCP** port you wish to monitor. For this example, it's **port 80**. |
     | Path | Enter a URI used for requesting health status. For this example, it's **/**. |
     | Interval | Enter an interval between probe checks. For this example, it's the default of **5**. |
-    | Unhealthy threshold | Enter the threshold number for consecutive failures. For this example, it's the default of **2**. |
 
 7. Select **Add**.
 
@@ -166,7 +164,6 @@ In this example, you'll create an HTTPS health probe.
     | Port | Enter the **TCP** port you wish to monitor. For this example, it's **port 443**. |
     | Path | Enter a URI used for requesting health status. For this example, it's **/**. |
     | Interval | Enter an interval between probe checks. For this example, it's the default of **5**. |
-    | Unhealthy threshold | Enter the threshold number for consecutive failures. For this example, it's the default of **2**. |
 
 7. Select **Add**.
 


### PR DESCRIPTION
The Load Balancer health probe behavior has changed (we only send 1 probe), hence the option "Unhealthy threshold" was removed from the health probe configuration wizard from the Portal and this guide needs to be updated to reflect this to avoid confusion.

Based on ICM 11263 the behavior was changed and they mention that they updated the public documenation to reflect that, I can see that "Azure Load Balancer health probes" section is updated since it doesn't include "Unhealthy threshold" option as part of the configuration which is correct and is the expected behavior since a while.

https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview 

The following screenshots/files need to be updated to reflect the current status (I am not able to upload the required files since it requires push access which I don't have) and other screenshots can be reused, we will need to create a resource group and load balancer with the same naming, then create the three flavors of health probes with the same configuration and take screenshots and upload them to the directory with the same name to replace the outdated files:
add-tcp-probe.png
add-http-probe.png
add-https-probe.png