### PR TITLE
Changed objectId to id

### DIFF
--- a/articles/app-service/tutorial-connect-msi-sql-database.md
+++ b/articles/app-service/tutorial-connect-msi-sql-database.md
@@ -63,7 +63,7 @@ First, enable Azure Active Directory authentication to SQL Database by assigning
 1. Find the object ID of the Azure AD user using the [`az ad user list`](/cli/azure/ad/user#az-ad-user-list) and replace *\<user-principal-name>*. The result is saved to a variable.
 
     ```azurecli-interactive
-    azureaduser=$(az ad user list --filter "userPrincipalName eq '<user-principal-name>'" --query [].objectId --output tsv)
+    azureaduser=$(az ad user list --filter "userPrincipalName eq '<user-principal-name>'" --query [].id --output tsv)
     ```
 
     > [!TIP]


### PR DESCRIPTION
The `objectId` attribute doesn't seem to exist when I tried it. According to some documentation the objectId is references by `id`, and using that worked.

https://docs.microsoft.com/en-us/cli/azure/ad/user?view=azure-cli-latest#az-ad-user-show-required-parameters