### PR TITLE
upate tenant name with domain.

### DIFF
--- a/articles/active-directory-b2c/configure-authentication-sample-react-spa-app.md
+++ b/articles/active-directory-b2c/configure-authentication-sample-react-spa-app.md
@@ -171,7 +171,7 @@ In the sample folder, open the *config.json* file. This file contains informatio
 
 |Section  |Key  |Value  |
 |---------|---------|---------|
-|credentials|tenantName| The first part of your Azure AD B2C [tenant name](tenant-management.md#get-your-tenant-name). For example: `contoso`.|
+|credentials|tenantName| The first part of your Azure AD B2C [tenant name](tenant-management.md#get-your-tenant-name). For example: `contoso.onmicrosoft.com`.|
 |credentials|clientID| The web API application ID from step [2.1](#21-register-the-web-api-application). In the [earlier diagram](#app-registration), it's the application with **App ID: 2**.|
 |credentials| issuer| (Optional) The token issuer `iss` claim value. Azure AD B2C by default returns the token in the following format: `https://<your-tenant-name>.b2clogin.com/<your-tenant-ID>/v2.0/`. Replace `<your-tenant-name>` with the first part of your Azure AD B2C [tenant name](tenant-management.md#get-your-tenant-name). Replace `<your-tenant-ID>` with your [Azure AD B2C tenant ID](tenant-management.md#get-your-tenant-id). |
 |policies|policyName|The user flow or custom policy that you created in [step 1](#step-1-configure-your-user-flow). If your application uses multiple user flows or custom policies, specify only one. For example, use the sign-up or sign-in user flow.|


### PR DESCRIPTION
Users are not able to fetch api results because in the documentation for API (config.json) file it is written as below:
credentials -> tenantName: The first part of your Azure AD B2C tenant name. FOR EXAMPLE CONTOSO. which is wrong,
PLEASE ADD full domain contoso.onmicrosoft.com