### PR TITLE
Correct command

### DIFF
--- a/articles/virtual-desktop/create-profile-container-azure-ad.md
+++ b/articles/virtual-desktop/create-profile-container-azure-ad.md
@@ -271,7 +271,7 @@ To configure your storage account:
     ```powershell
     Connect-AzAccount -Tenant $tenantId -SubscriptionId $subscriptionId
 
-    $AdModule = Get-Module ActiveDirectory;
+    $AdModule = Get-Module ActiveDirectory -ListAvailable;
 	if ($null -eq $AdModule) {
         Write-Error "Please install and/or import the ActiveDirectory PowerShell module." -ErrorAction Stop;
     }


### PR DESCRIPTION
Tested on Windows 10 21H1. It has the AD RSAT tools installed. Without `-ListAvailable`, the `Get-Module` cmdlet doesn't return the module.