### PR TITLE
Explicitly state Load Balancer Secondary IP Usage

### DIFF
--- a/includes/virtual-network-multiple-ip-addresses-intro.md
+++ b/includes/virtual-network-multiple-ip-addresses-intro.md
@@ -21,7 +21,9 @@ An Azure Virtual Machine (VM) has one or more network interfaces (NIC) attached 
 
 * Hosting multiple websites or services with different IP addresses and SSL certificates on a single server.
 * Serve as a network virtual appliance, such as a firewall or load balancer.
-* The ability to add any of the private IP addresses for any of the NICs to an Azure Load Balancer back-end pool. In the past, only the primary IP address for the primary NIC could be added to a back-end pool. To learn more about how to load balance multiple IP configurations, read the [Load balancing multiple IP configurations](../articles/load-balancer/load-balancer-multiple-ip.md?toc=%2fazure%2fvirtual-network%2ftoc.json) article.
+* The ability to add any of the private IP addresses for any of the NICs to an Azure Load Balancer back-end pool. In the past, only the primary IP address for the primary NIC could be added to a back-end pool. To learn more about how to load balance inbound multiple IP configurations, read the [Load balancing multiple IP configurations](../articles/load-balancer/load-balancer-multiple-ip.md?toc=%2fazure%2fvirtual-network%2ftoc.json) article.
+> [!NOTE]
+> Secondary IPConfigs are not supported for use in Outbound rules in Public Load Balancers.
 
 Every NIC attached to a VM has one or more IP configurations associated to it. Each configuration is assigned one static or dynamic private IP address. Each configuration may also have one public IP address resource associated to it. A public IP address resource has either a dynamic or static public IP address assigned to it. To learn more about IP addresses in Azure, read the [IP addresses in Azure](../articles/virtual-network/ip-services/public-ip-addresses.md) article.
 

--- a/includes/virtual-network-multiple-ip-addresses-intro.md
+++ b/includes/virtual-network-multiple-ip-addresses-intro.md
@@ -22,6 +22,7 @@ An Azure Virtual Machine (VM) has one or more network interfaces (NIC) attached 
 * Hosting multiple websites or services with different IP addresses and SSL certificates on a single server.
 * Serve as a network virtual appliance, such as a firewall or load balancer.
 * The ability to add any of the private IP addresses for any of the NICs to an Azure Load Balancer back-end pool. In the past, only the primary IP address for the primary NIC could be added to a back-end pool. To learn more about how to load balance inbound multiple IP configurations, read the [Load balancing multiple IP configurations](../articles/load-balancer/load-balancer-multiple-ip.md?toc=%2fazure%2fvirtual-network%2ftoc.json) article.
+
 > [!NOTE]
 > Secondary IPConfigs are not supported for use in Outbound rules in Public Load Balancers.
 


### PR DESCRIPTION
Relatively straight forward, the initial information provided is somewhat misleading. 

Although multiple IPConfigs (NICs with multiple IPs) can be used in backend pools, they can only be used for inbound rules, not outbound rules. 