### PR TITLE
Add Cosmos DB domains

### DIFF
--- a/articles/security/fundamentals/azure-domains.md
+++ b/articles/security/fundamentals/azure-domains.md
@@ -33,6 +33,8 @@ This page is a partial list of the Azure domains in use. Some of them are REST A
 |[Azure Container Registry](https://azure.microsoft.com/services/container-registry/)|*.azurecr.io|
 |Azure Container Service (ACS) (deprecated)|*.azurecontainer.io|
 |[Azure Content Delivery Network (CDN)](https://azure.microsoft.com/services/cdn/)|*.vo.msecnd.net|
+|[Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/)|*.cosmos.azure.com|
+|[Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/)|*.documents.azure.com|
 |[Azure Files](../../storage/files/storage-files-introduction.md)|*.file.core.windows.net|
 |[Azure Front Door](https://azure.microsoft.com/services/frontdoor/)|*.azurefd.net|
 |Azure Management Services|*.management.core.windows.net|

--- a/articles/security/fundamentals/azure-domains.md
+++ b/articles/security/fundamentals/azure-domains.md
@@ -33,8 +33,8 @@ This page is a partial list of the Azure domains in use. Some of them are REST A
 |[Azure Container Registry](https://azure.microsoft.com/services/container-registry/)|*.azurecr.io|
 |Azure Container Service (ACS) (deprecated)|*.azurecontainer.io|
 |[Azure Content Delivery Network (CDN)](https://azure.microsoft.com/services/cdn/)|*.vo.msecnd.net|
-|[Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/)|*.cosmos.azure.com|
-|[Azure Cosmos DB](https://docs.microsoft.com/en-us/azure/cosmos-db/)|*.documents.azure.com|
+|[Azure Cosmos DB](/azure/cosmos-db/)|*.cosmos.azure.com|
+|[Azure Cosmos DB](/azure/cosmos-db/)|*.documents.azure.com|
 |[Azure Files](../../storage/files/storage-files-introduction.md)|*.file.core.windows.net|
 |[Azure Front Door](https://azure.microsoft.com/services/frontdoor/)|*.azurefd.net|
 |Azure Management Services|*.management.core.windows.net|


### PR DESCRIPTION
`*.documents.azure.com` is the most common, but the [Private Link documentation](https://docs.microsoft.com/en-us/azure/cosmos-db/how-to-configure-private-endpoints#private-zone-name-mapping) has a nice table showing a more comprehensive mapping of API to domain, which adds `*.cosmos.azure.com`.