### PR TITLE
Add Azure Kubernetes Service domain

### DIFF
--- a/articles/security/fundamentals/azure-domains.md
+++ b/articles/security/fundamentals/azure-domains.md
@@ -35,6 +35,7 @@ This page is a partial list of the Azure domains in use. Some of them are REST A
 |[Azure Content Delivery Network (CDN)](https://azure.microsoft.com/services/cdn/)|*.vo.msecnd.net|
 |[Azure Files](../../storage/files/storage-files-introduction.md)|*.file.core.windows.net|
 |[Azure Front Door](https://azure.microsoft.com/services/frontdoor/)|*.azurefd.net|
+|[Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/)|*.azmk8s.io|
 |Azure Management Services|*.management.core.windows.net|
 |[Azure Media Services](https://azure.microsoft.com/services/media-services/)|*.origin.mediaservices.windows.net|
 |[Azure Mobile Apps](https://azure.microsoft.com/services/app-service/mobile/)|*.azure-mobile.net|

--- a/articles/security/fundamentals/azure-domains.md
+++ b/articles/security/fundamentals/azure-domains.md
@@ -35,7 +35,7 @@ This page is a partial list of the Azure domains in use. Some of them are REST A
 |[Azure Content Delivery Network (CDN)](https://azure.microsoft.com/services/cdn/)|*.vo.msecnd.net|
 |[Azure Files](../../storage/files/storage-files-introduction.md)|*.file.core.windows.net|
 |[Azure Front Door](https://azure.microsoft.com/services/frontdoor/)|*.azurefd.net|
-|[Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/)|*.azmk8s.io|
+|[Azure Kubernetes Service](/azure/aks/)|*.azmk8s.io|
 |Azure Management Services|*.management.core.windows.net|
 |[Azure Media Services](https://azure.microsoft.com/services/media-services/)|*.origin.mediaservices.windows.net|
 |[Azure Mobile Apps](https://azure.microsoft.com/services/app-service/mobile/)|*.azure-mobile.net|


### PR DESCRIPTION
AKS uses `*.azmk8s.io` as a suffix. While I couldn't find that explicitly documented elsewhere, there [is reference to it on the private link page](https://docs.microsoft.com/en-us/azure/aks/private-clusters). I have both private link and non-private link clusters created, all of them appear to use `*.azmk8s.io`.