### PR TITLE
GitHub action fed issuer without / at the end.

### DIFF
--- a/articles/active-directory/develop/workload-identity-federation-create-trust.md
+++ b/articles/active-directory/develop/workload-identity-federation-create-trust.md
@@ -175,7 +175,7 @@ The *id* parameter specifies the identifier URI, application ID, or object ID of
 
 The *name* specifies the name of your federated identity credential.
 
-The *issuer* identifies the path to the GitHub OIDC provider: `https://token.actions.githubusercontent.com/`. This issuer will become trusted by your Azure application.  
+The *issuer* identifies the path to the GitHub OIDC provider: `https://token.actions.githubusercontent.com`. This issuer will become trusted by your Azure application.  
 
 *subject* identifies the GitHub organization, repo, and environment for your GitHub Actions workflow.  When the GitHub Actions workflow requests Microsoft identity platform to exchange a GitHub token for an access token, the values in the federated identity credential are checked against the provided GitHub token. Before Azure will grant an access token, the request must match the conditions defined here.
 - For Jobs tied to an environment: `repo:< Organization/Repository >:environment:< Name >`


### PR DESCRIPTION
https://token.actions.githubusercontent.com without a slash at the end.

If you have a slash, then you get this error:

```txt
Error: : AADSTS70021: No matching federated identity record found for presented assertion. Assertion Issuer: 'https://token.actions.githubusercontent.com'. Assertion Subject: 'repo:jongio/ghazoidctest1:ref:refs/heads/main'. Assertion Audience: 'api://AzureADTokenExchange'.
```