### PR TITLE
check azure resource type and region is supported

### DIFF
--- a/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
+++ b/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
@@ -26,6 +26,11 @@ If this is your first time using Chaos Studio, you must first register the Chaos
 5. In the list of resource providers that appears, search for **Microsoft.Chaos**.
 6. Click on the Microsoft.Chaos provider, and click the **Register** button.
 
+## Create an Azure resource supported by Chaos Studio
+
+Create an azure resource and ensure this is one of the supported [fault providers](https://docs.microsoft.com/en-us/azure/chaos-studio/chaos-studio-fault-providers). Also validate if this resource is being created in the [region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available.In this experiment we choose an Azure Virtual Machine which is one of the supported fault provider for Chaos Studio.
+
+
 ## Enable Chaos Studio on the Virtual Machine you created
 1. Open the [Azure portal](https://portal.azure.com).
 2. Search for **Chaos Studio (preview)** in the search bar.

--- a/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
+++ b/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
@@ -28,7 +28,7 @@ If this is your first time using Chaos Studio, you must first register the Chaos
 
 ## Create an Azure resource supported by Chaos Studio
 
-Create an azure resource and ensure this is one of the supported [fault providers](https://docs.microsoft.com/en-us/azure/chaos-studio/chaos-studio-fault-providers). Also validate if this resource is being created in the [region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available.In this experiment we choose an Azure Virtual Machine which is one of the supported fault provider for Chaos Studio.
+Create an azure resource and ensure this is one of the supported [fault providers](https://docs.microsoft.com/azure/chaos-studio/chaos-studio-fault-providers). Also validate if this resource is being created in the [region](https://azure.microsoft.com/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available.In this experiment we choose an Azure Virtual Machine which is one of the supported fault provider for Chaos Studio.
 
 
 ## Enable Chaos Studio on the Virtual Machine you created

--- a/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
+++ b/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
@@ -28,7 +28,7 @@ If this is your first time using Chaos Studio, you must first register the Chaos
 
 ## Create an Azure resource supported by Chaos Studio
 
-Create an azure resource and ensure this is one of the supported [fault providers](https://docs.microsoft.com/azure/chaos-studio/chaos-studio-fault-providers). Also validate if this resource is being created in the [region](https://azure.microsoft.com/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available.In this experiment we choose an Azure Virtual Machine which is one of the supported fault provider for Chaos Studio.
+Create an azure resource and ensure this is one of the supported [fault providers](chaos-studio-fault-providers). Also validate if this resource is being created in the [region](https://azure.microsoft.com/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available. In this experiment we choose an Azure Virtual Machine which is one of the supported fault providers for Chaos Studio.
 
 
 ## Enable Chaos Studio on the Virtual Machine you created

--- a/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
+++ b/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
@@ -28,7 +28,7 @@ If this is your first time using Chaos Studio, you must first register the Chaos
 
 ## Create an Azure resource supported by Chaos Studio
 
-Create an azure resource and ensure this is one of the supported [fault providers](chaos-studio-fault-providers). Also validate if this resource is being created in the [region](https://azure.microsoft.com/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available. In this experiment we choose an Azure Virtual Machine which is one of the supported fault providers for Chaos Studio.
+Create an azure resource and ensure this is one of the supported [fault providers](chaos-studio-fault-providers.md). Also validate if this resource is being created in the [region](https://azure.microsoft.com/global-infrastructure/services/?products=chaos-studio) where Chaos Studio is available. In this experiment we choose an Azure Virtual Machine which is one of the supported fault providers for Chaos Studio.
 
 
 ## Enable Chaos Studio on the Virtual Machine you created

--- a/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
+++ b/articles/chaos-studio/chaos-studio-quickstart-azure-portal.md
@@ -2,7 +2,7 @@
 title: Create and run a chaos experiment using Azure Chaos Studio
 description: Understand the steps to create and run a Chaos Studio experiment in 10mins
 services: chaos-studio
-author: prashabora
+author: prasha-microsoft
 ms.topic: quickstart
 ms.date: 11/10/2021
 ms.author: prashabora


### PR DESCRIPTION
added a section "Create an Azure resource supported by Chaos Studio" to validate if azure resource is a supported fault provider and existing in a region supported by chaos studio