### PR TITLE
autovacuum

### DIFF
--- a/articles/postgresql/flexible-server/how-to-autovacuum-tuning.md
+++ b/articles/postgresql/flexible-server/how-to-autovacuum-tuning.md
@@ -115,7 +115,7 @@ Use the following query to list the tables in a database and identify the tables
           'pg_catalog'
           ,'information_schema'
           )
-        AND N.nspname ! ~ '^pg_toast'
+        AND N.nspname !~ '^pg_toast'
       ) AS av
     ORDER BY av_needed DESC ,n_dead_tup DESC;  
 ```


### PR DESCRIPTION
Fix the query that identify the tables that qualify for the autovacuum process (remove extra space):
....
AND N.nspname ! ~ '^pg_toast'

To:
AND N.nspname !~ '^pg_toast'