### PR TITLE
Target Azure Sentinel to avoid 400 Error

### DIFF
--- a/articles/sentinel/connect-threat-intelligence-tip.md
+++ b/articles/sentinel/connect-threat-intelligence-tip.md
@@ -110,7 +110,7 @@ You now have all three pieces of information you need to configure your TIP or c
 
 1. Enter these values in the configuration of your integrated TIP or custom solution where required.
 
-1. For the target product, specify **Microsoft Sentinel**.
+1. For the target product, specify **Azure Sentinel**.
 
 1. For the action, specify **alert**.
 


### PR DESCRIPTION
Line 113 of the Connect Threat Intel Platform Sentinel docs page specifies **Microsoft Sentinel** as the target product, however if this is sent to the Graph API endpoint a 400 error will be returned. Using **Azure Sentinel** resolves the issue. Per the API [docs](https://docs.microsoft.com/en-us/graph/api/tiindicators-post?view=graph-rest-beta&tabs=http#request)