### PR TITLE
Update apache-spark-autoscale.md

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-autoscale.md
+++ b/articles/synapse-analytics/spark/apache-spark-autoscale.md
@@ -74,7 +74,12 @@ Apache Spark enables configuration of Dynamic Allocation of Executors through co
 ```
 The defaults specified through the code override the values set through the user interface.
 
-On enabling Dynamic allocation, Executors scale up or down based on the utilization of the Executors. This ensure that the Executors are provisioned in accordance with the needs of the job being run.
+In this example, if your job only requires 2 executors, it will only use 2 executors.  When the job requires more, it will scale up to 6 executors (1 driver, 6 executors).  When the job does not need the executors, then it will decommission the executors and if it does not need the node, it will free up the node.
+
+***Note***:
+The maxExecutors will reserve the number of executors configured. Considering the example, even if you only use 2, it will reserve 6. 
+
+Hence, on enabling Dynamic allocation, Executors scale up or down based on the utilization of the Executors. This ensure that the Executors are provisioned in accordance with the needs of the job being run.
 
 ## Best practices
 

--- a/articles/synapse-analytics/spark/apache-spark-autoscale.md
+++ b/articles/synapse-analytics/spark/apache-spark-autoscale.md
@@ -74,12 +74,12 @@ Apache Spark enables configuration of Dynamic Allocation of Executors through co
 ```
 The defaults specified through the code override the values set through the user interface.
 
-In this example, if your job only requires 2 executors, it will only use 2 executors.  When the job requires more, it will scale up to 6 executors (1 driver, 6 executors).  When the job does not need the executors, then it will decommission the executors and if it does not need the node, it will free up the node.
+In this example, if your job requires only 2 executors, it will use only 2 executors.  When the job requires more, it will scale up to 6 executors (1 driver, 6 executors).  When the job doesn't need the executors, then it will decommission the executors. If it doesn't need the node, it will free up the node.
 
-***Note***:
-The maxExecutors will reserve the number of executors configured. Considering the example, even if you only use 2, it will reserve 6. 
+>[!NOTE]
+>The maxExecutors will reserve the number of executors configured. Considering the example, even if you use only 2, it will reserve 6. 
 
-Hence, on enabling Dynamic allocation, Executors scale up or down based on the utilization of the Executors. This ensure that the Executors are provisioned in accordance with the needs of the job being run.
+Hence, on enabling Dynamic allocation, Executors scale up or down based on the utilization of the Executors. This ensures that the Executors are provisioned in accordance with the needs of the job being run.
 
 ## Best practices
 


### PR DESCRIPTION
Proposed a clarification based on the example of auto-scaling discussed by the Synapse Discussion team( email group).
The example has the purpose to bring clarification to the configuration that sometimes causes doubts in customers. ( email follow to the page owner)
"In this example, if your job only requires 2 executors, it will only use 2 executors. When the job requires more, it will scale up to 6 executors (1 driver, 5 executors). When the job does not need the executors, then it will decommission the executors and if it does not need the node, it will free up the node.