### PR TITLE
Add .NET 6 Examples to AZ App Config Dynamic Configuration Tutorial for ASP.NET Core

### DIFF
--- a/articles/azure-app-configuration/quickstart-aspnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-aspnet-core-app.md
@@ -1,8 +1,6 @@
 ---
-title: "Quickstart: Create an ASP.NET Core app with Azure App Configuration"
-description: Create an ASP.NET Core app with Azure App Configuration to
-  centralize storage and management of application settings for an ASP.NET Core
-  application.
+title: Quickstart for Azure App Configuration with ASP.NET Core | Microsoft Docs
+description: Create an ASP.NET Core app with Azure App Configuration to centralize storage and management of application settings for an ASP.NET Core application.
 services: azure-app-configuration
 author: maud-lv
 ms.service: azure-app-configuration
@@ -11,7 +9,7 @@ ms.custom: devx-track-csharp, contperf-fy21q1, mode-other
 ms.topic: quickstart
 ms.date: 1/3/2022
 ms.author: malev
-modified: 2022-08-31T16:38:50.903Z
+#Customer intent: As an ASP.NET Core developer, I want to learn how to manage all my app settings in one place.
 ---
 # Quickstart: Create an ASP.NET Core app with Azure App Configuration
 

--- a/articles/azure-app-configuration/quickstart-aspnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-aspnet-core-app.md
@@ -1,6 +1,8 @@
 ---
-title: Quickstart for Azure App Configuration with ASP.NET Core | Microsoft Docs
-description: Create an ASP.NET Core app with Azure App Configuration to centralize storage and management of application settings for an ASP.NET Core application.
+title: "Quickstart: Create an ASP.NET Core app with Azure App Configuration"
+description: Create an ASP.NET Core app with Azure App Configuration to
+  centralize storage and management of application settings for an ASP.NET Core
+  application.
 services: azure-app-configuration
 author: maud-lv
 ms.service: azure-app-configuration
@@ -9,7 +11,7 @@ ms.custom: devx-track-csharp, contperf-fy21q1, mode-other
 ms.topic: quickstart
 ms.date: 1/3/2022
 ms.author: malev
-#Customer intent: As an ASP.NET Core developer, I want to learn how to manage all my app settings in one place.
+modified: 2022-08-31T16:38:50.903Z
 ---
 # Quickstart: Create an ASP.NET Core app with Azure App Configuration
 


### PR DESCRIPTION
This PR adds .NET 6 code examples to complete the objectives of the tutorial.

This also changes the wording and positioning of certain instructions to make more sense in the context of having .NET 6 examples.