### PR TITLE
Removing Data Box Disk as a valid Data Box option

### DIFF
--- a/articles/storage/files/storage-files-migration-nas-cloud-databox.md
+++ b/articles/storage/files/storage-files-migration-nas-cloud-databox.md
@@ -65,14 +65,15 @@ Consult your migration plan for the number of storage accounts you have decided 
 
 ### DataBox options
 
-For a standard migration, one or a combination of these three DataBox options should be chosen: 
+For a standard migration, one or a combination of these two DataBox options should be chosen: 
 
-* DataBox Disks
-  Microsoft will send you one and up to five SSD disks with a capacity of 8 TiB each, for a maximum total of 40 TiB. The usable capacity is about 20% less, due to encryption and file system overhead. For more information, see [DataBox Disks documentation](../../databox/data-box-disk-overview.md).
 * DataBox
   This is the most common option. A ruggedized DataBox appliance, that works similar to a NAS, will be shipped to you. It has a usable capacity of 80 TiB. For more information, see [DataBox documentation](../../databox/data-box-overview.md).
 * DataBox Heavy
   This option features a ruggedized DataBox appliance on wheels, that works similar to a NAS, with a capacity of 1 PiB. The usable capacity is about 20% less, due to encryption and file system overhead. For more information, see [DataBox Heavy documentation](../../databox/data-box-heavy-overview.md).
+
+> [!WARNING]
+> Data Box Disks is not recommended for migrations into Azure file shares. Data Box Disks does not preserve file metadata, such as access permissions (ACLs) and other attributes.
 
 ## Phase 4: Provision a temporary Windows Server
 


### PR DESCRIPTION
Data Box Disk does not preserve the metadata of files. That is almost never acceptable for Azure Files customers. I kept it in the article in the past because it was always scheduled to come in during the current semester. Recently, for Zinc, it was cut yet again.