### PR TITLE
Global region is not supported for resource groups

### DIFF
--- a/articles/cognitive-services/Translator/how-to-create-translator-resource.md
+++ b/articles/cognitive-services/Translator/how-to-create-translator-resource.md
@@ -37,7 +37,7 @@ The Translator service can be accessed through two different resource types:
 
 1. **Resource Group**. You can create a new resource group or add your resource to a pre-existing resource group that shares the same lifecycle, permissions, and policies.
 
-1. **Resource Region**. Choose **Global** unless your business or application requires a specific region. If you're planning on using the Document Translation feature with managed identity authentication, choose a non-global region.
+1. **Resource Region**. Choose **Global** unless your business or application requires a specific region. If you are going to create a new resource group at the same time or you're planning on using the Document Translation feature with managed identity authentication, choose a non-global region.
 
 1. **Name**. Enter the name you have chosen for your resource. The name you choose must be unique within Azure.
 


### PR DESCRIPTION
If you choose to create a new resource group and choose "global" for resource region, validation will fail because Azure portal tries to create the resource group in the same region as the resource but global is not supported for resource groups. So users who are going to create a new resource group should not choose "global".