### PR TITLE
More clarification over Subscription level system topic 

### DIFF
--- a/articles/event-grid/system-topics.md
+++ b/articles/event-grid/system-topics.md
@@ -26,7 +26,9 @@ In the past, a system topic was implicit and wasn't exposed for simplicity. Syst
 - Set up alerts on publish and delivery failures 
 
 > [!NOTE]
-> Azure Event Grid creates a system topic resource in the same Azure subscription that has the event source. For example, if you create a system topic for a storage account *ContosoStorage* in an Azure subscription *ContosoSubscription*, Event Grid creates the system topic in the *ContosoSubscription*. It's not possible to create a system topic in an Azure subscription that's different from the event source's Azure subscription.
+> - Only one Azure Event Grid system topic is allowed per source (like Subscription, Resource Group, etc.).
+> - Resource Group is required for Subscription level Event Grid system topic and cannot be changed until deleted/moved to another subscription.  
+> - Azure Event Grid creates a system topic resource in the same Azure subscription that has the event source. For example, if you create a system topic for a storage account *ContosoStorage* in an Azure subscription *ContosoSubscription*, Event Grid creates the system topic in the *ContosoSubscription*. It's not possible to create a system topic in an Azure subscription that's different from the event source's Azure subscription.
 
 ## Lifecycle of system topics
 You can create a system topic in two ways: 


### PR DESCRIPTION
Faced below conflict error while updating subscription level EG system topic when choose the different RG and it's not documentation that user can create only one system topic per source.

{
  "error": {
    "code": "InvalidRequest",
    "message": "There is an existing tracked system topic for the given source /subscriptions/b86ccb78-d0cc-4c55-ba7d-80fee998dd7f. Only one system topic is allowed per source."
  }
}