### PR TITLE
[CommunicationServices] Single View App template does not exist on Xcode 13

### DIFF
--- a/articles/communication-services/quickstarts/voice-video-calling/includes/get-started/get-started-ios.md
+++ b/articles/communication-services/quickstarts/voice-video-calling/includes/get-started/get-started-ios.md
@@ -33,7 +33,7 @@ To complete this tutorial, you’ll need the following prerequisites:
 
 ### Creating the Xcode project
 
-In Xcode, create a new iOS project and select the **Single View App** template. This tutorial uses the [SwiftUI framework](https://developer.apple.com/xcode/swiftui/), so you should set the **Language** to **Swift** and the **User Interface** to **SwiftUI**. You're not going to create tests during this quick start. Feel free to uncheck **Include Tests**.
+In Xcode, create a new iOS project and select the **App** template. This tutorial uses the [SwiftUI framework](https://developer.apple.com/xcode/swiftui/), so you should set the **Language** to **Swift** and the **User Interface** to **SwiftUI**. You're not going to create tests during this quick start. Feel free to uncheck **Include Tests**.
 
 :::image type="content" source="../../media/ios/xcode-new-ios-project.png" alt-text="Screenshot showing the New Project window within Xcode.":::
 


### PR DESCRIPTION
**Single View App** template was renamed to **App** in Xcode 13

<img width="802" alt="Screen Shot 2022-09-05 at 17 42 24" src="https://user-images.githubusercontent.com/100867762/188510804-f11e1b06-09c4-44c2-a6a4-16289b564eaf.png">
