### PR TITLE
Update container-registry-tutorial-sign-build-push.md to use the latest version of Notation-Azure-KV plugin

### DIFF
--- a/articles/container-registry/container-registry-tutorial-sign-build-push.md
+++ b/articles/container-registry/container-registry-tutorial-sign-build-push.md
@@ -56,7 +56,7 @@ In this tutorial:
     
     # Download the plugin
     curl -Lo notation-azure-kv.tar.gz \
-        https://github.com/Azure/notation-azure-kv/releases/download/v0.3.0-alpha.1/notation-azure-kv_0.3.0-alpha.1_Linux_amd64.tar.gz
+        https://github.com/Azure/notation-azure-kv/releases/download/v0.3.1-alpha.1/notation-azure-kv_0.3.1-alpha.1_Linux_amd64.tar.gz
     
     # Extract to the plugin directory
     tar xvzf notation-azure-kv.tar.gz -C ~/.config/notation/plugins/azure-kv notation-azure-kv


### PR DESCRIPTION
We released a patch for the [Notation-Azure-KV plugin](https://github.com/Azure/notation-azure-kv/releases/tag/v0.3.1-alpha.1) yesterday. So we need to upgrade the Notation-Azure-KV plugin version from `v0.3.0-alpha.1` to `v0.3.1-alpha.1` in Azure Documentation.