### PR TITLE
Add Note for using jsonarray in GenerateJson

### DIFF
--- a/articles/active-directory-b2c/json-transformations.md
+++ b/articles/active-directory-b2c/json-transformations.md
@@ -250,8 +250,9 @@ The following claims transformation outputs a JSON string claim that will be the
        }
     }
     ```
-> [!NOTE]
-> The GenerateJson claims transformation accepts plain strings. If an input claim contains a JSON string, that string will be escaped. In the following example, if you use email output from CreateJsonArray above that is ["someone@contoso.com"] and used it as input parameter in the GenerateJson example, the email will look like the following JSON:
+
+The **GenerateJson** claims transformation accepts plain strings. If an input claim contains a JSON string, that string will be escaped. In the following example, if you use email output from [CreateJsonArray above](json-transformations.md#example-of-createjsonarray), that is ["someone@contoso.com"], as an input parameter, the email will look like as shown in the following JSON claim:
+
 - Output claim:
   - **requestBody**:
 

--- a/articles/active-directory-b2c/json-transformations.md
+++ b/articles/active-directory-b2c/json-transformations.md
@@ -251,8 +251,7 @@ The following claims transformation outputs a JSON string claim that will be the
     }
     ```
 > [!NOTE]
-> The GenerateJson claims transformation accepts plain strings. If an input claim contains a JSON string, that string will be escaped. The
-> backspace to be replaced with `\b`, and double quote to be replaced with `\"`. In the following example, if you use email output from CreateJsonArray above i.e ["someone@contoso.com"] and used it as input parameter in the GenerateJson example, the email will look like the following JSON:
+> The GenerateJson claims transformation accepts plain strings. If an input claim contains a JSON string, that string will be escaped. In the following example, if you use email output from CreateJsonArray above that is ["someone@contoso.com"] and used it as input parameter in the GenerateJson example, the email will look like the following JSON:
 - Output claim:
   - **requestBody**:
 

--- a/articles/active-directory-b2c/json-transformations.md
+++ b/articles/active-directory-b2c/json-transformations.md
@@ -9,7 +9,7 @@ manager: CelesteDG
 ms.service: active-directory
 ms.workload: identity
 ms.topic: reference
-ms.date: 08/10/2022
+ms.date: 09/07/2022
 ms.author: kengaderdus
 ms.subservice: B2C
 ---

--- a/articles/active-directory-b2c/json-transformations.md
+++ b/articles/active-directory-b2c/json-transformations.md
@@ -250,6 +250,26 @@ The following claims transformation outputs a JSON string claim that will be the
        }
     }
     ```
+> [!NOTE]
+> The GenerateJson claims transformation accepts plain strings. If an input claim contains a JSON string, that string will be escaped. The
+> backspace to be replaced with `\b`, and double quote to be replaced with `\"`. In the following example, if you use email output from CreateJsonArray above i.e ["someone@contoso.com"] and used it as input parameter in the GenerateJson example, the email will look like the following JSON:
+- Output claim:
+  - **requestBody**:
+
+    ```json
+    {
+       "customerEntity":{
+          "email":"[\"someone@contoso.com\"]",
+          "userObjectId":"01234567-89ab-cdef-0123-456789abcdef",
+          "firstName":"John",
+          "lastName":"Smith",
+          "role":{
+             "name":"Administrator",
+             "id": 1
+          }
+       }
+    }
+    ```
 
 ## GetClaimFromJson
 


### PR DESCRIPTION
Got an email before where the customer is using a json array as input parameter to GenerateJson and was wondering why the output was escaped.