### PR TITLE
Update deploy-staging-slots.md

### DIFF
--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -49,7 +49,7 @@ The app must be running in the **Standard**, **Premium**, or **Isolated** tier i
     You can clone a configuration from any existing slot. Settings that can be cloned include app settings, connection strings, language framework versions, web sockets, HTTP version, and platform bitness.
     
   > [!NOTE]
-  > Currently, the Private Endpoint are not cloned across slots.
+  > Currently, a Private Endpoint isn't cloned across slots.
   > 
 
 4. After the slot is added, select **Close** to close the dialog box. The new slot is now shown on the **Deployment slots** page. By default, **Traffic %** is set to 0 for the new slot, with all customer traffic routed to the production slot.

--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -49,7 +49,7 @@ The app must be running in the **Standard**, **Premium**, or **Isolated** tier i
     You can clone a configuration from any existing slot. Settings that can be cloned include app settings, connection strings, language framework versions, web sockets, HTTP version, and platform bitness.
     
   > [!NOTE]
-  > Currently, VNET and the Private Endpoint are not cloned across slots.
+  > Currently, the Private Endpoint are not cloned across slots.
   > 
 
 4. After the slot is added, select **Close** to close the dialog box. The new slot is now shown on the **Deployment slots** page. By default, **Traffic %** is set to 0 for the new slot, with all customer traffic routed to the production slot.


### PR DESCRIPTION
VNET is cloned among slots. When adding a slot from Deployment Slots menu, for "clone settings from" I chose the production app that VNET integration is enabled, I could confirm the vnet is cloned to the slot web app. The customer also confirmed this behavior similar to my test run. So I think currently VNET is cloned among slots.