### PR TITLE
Fixes the link to the new topic for registering a DICOM application.

### DIFF
--- a/articles/healthcare-apis/dicom/get-started-with-dicom.md
+++ b/articles/healthcare-apis/dicom/get-started-with-dicom.md
@@ -37,7 +37,7 @@ The DICOM service is secured by Azure Active Directory (Azure AD) that can't be 
 
 ### Register a client application
 
-You can create or register a client application from the [Azure portal](../register-application.md), or using PowerShell and Azure CLI scripts. This client application can be used for one or more DICOM service instances. It can also be used for other services in Azure Health Data Services.
+You can create or register a client application from the [Azure portal](dicom-register-application.md), or using PowerShell and Azure CLI scripts. This client application can be used for one or more DICOM service instances. It can also be used for other services in Azure Health Data Services.
 
 If the client application is created with a certificate or client secret, ensure that you renew the certificate or client secret before expiration and replace the client credentials in your applications.
 

--- a/articles/healthcare-apis/dicom/get-started-with-dicom.md
+++ b/articles/healthcare-apis/dicom/get-started-with-dicom.md
@@ -1,7 +1,7 @@
 ---
 title: Get started with the DICOM service - Azure Health Data Services
 description: This document describes how to get started with the DICOM service in Azure Health Data Services.
-author: aersoy
+author: alexandersoy
 ms.service: healthcare-apis
 ms.subservice: fhir
 ms.topic: quickstart


### PR DESCRIPTION
The link from this getting started topic to the guidance for registering a client application needs to be updated.  The current link references [this generic topic](https://docs.microsoft.com/en-us/azure/healthcare-apis/register-application) that does not contain the DICOM specific configurations.  Instead, [the new topic](https://docs.microsoft.com/en-us/azure/healthcare-apis/dicom/dicom-register-application) should be referenced here.  

cc @mcevoy-building7 @smithago 