### PR TITLE
Fix links to contributor guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contributing to open source is more than just providing updates, it's also about
 
 You've decided to contribute, that's great! To contribute to the documentation, you need a few tools.
 
-Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for [GitHub account setup](/contribute/get-started-setup-github) from our contributor guide.
+Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for [GitHub account setup](https://docs.microsoft.com/en-us/contribute/get-started-setup-github) from our contributor guide.
 
 #### Install
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,11 @@ Contributing to open source is more than just providing updates, it's also about
 
 You've decided to contribute, that's great! To contribute to the documentation, you need a few tools.
 
-Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for the [GitHub account setup](/contribute/get-started-setup-github) from our contributor guide.
-
-#### Download
-
-Install the following tools:
-
-* [Git](https://git-scm.com/download)
-* [Visual Studio Code](https://code.visualstudio.com/Download)
-* [Docs Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack) extension for Visual Studio Code
+Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for [GitHub account setup](/contribute/get-started-setup-github) from our contributor guide.
 
 #### Install
 
-Follow the instructions provided in the [Install content authoring tools](/contribute/get-started-setup-tools) from our contributor guide.
+To install necessary tools, follow the instructions for [Install content authoring tools](https://docs.microsoft.com/en-us/contribute/get-started-setup-tools) from our contributor guide.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Contributing to open source is more than just providing updates, it's also about
 
 You've decided to contribute, that's great! To contribute to the documentation, you need a few tools.
 
+#### Github
+
 Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for [GitHub account setup](https://docs.microsoft.com/en-us/contribute/get-started-setup-github) from our contributor guide.
 
-#### Install
+#### Tools
 
 To install necessary tools, follow the instructions for [Install content authoring tools](https://docs.microsoft.com/en-us/contribute/get-started-setup-tools) from our contributor guide.
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ You've decided to contribute, that's great! To contribute to the documentation, 
 
 #### Github
 
-Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for [GitHub account setup](https://docs.microsoft.com/en-us/contribute/get-started-setup-github) from our contributor guide.
+Contributing to the documentation requires a GitHub account. If you don't have an account, follow the instructions for [GitHub account setup](https://docs.microsoft.com/contribute/get-started-setup-github) from our contributor guide.
 
 #### Tools
 
-To install necessary tools, follow the instructions for [Install content authoring tools](https://docs.microsoft.com/en-us/contribute/get-started-setup-tools) from our contributor guide.
+To install necessary tools, follow the instructions for [Install content authoring tools](https://docs.microsoft.com/contribute/get-started-setup-tools) from our contributor guide.
 
 ## License
 


### PR DESCRIPTION
- Fixed two broken links to the contributor guide
- Removed Download section because it repeats steps from the contributor guide (get-started-setup-tools)