### PR TITLE
Fix typo: use app 2 in endpoint creation

### DIFF
--- a/articles/traffic-manager/quickstart-create-traffic-manager-profile-cli.md
+++ b/articles/traffic-manager/quickstart-create-traffic-manager-profile-cli.md
@@ -156,7 +156,7 @@ Make note of ID displayed in output and use in the following command to add the 
 ```azurecli-interactive
 
 az network traffic-manager endpoint create \
-    --name <app1name_westeurope> \
+    --name <app2name_westeurope> \
     --resource-group myResourceGroup \
     --profile-name <profile_name> \
     --type azureEndpoints \


### PR DESCRIPTION
Fix typo, for consistency we should have `app2name_westeurope`