### PR TITLE
Power Automate Service Dependency on Power Apps.

### DIFF
--- a/articles/active-directory/conditional-access/service-dependencies.md
+++ b/articles/active-directory/conditional-access/service-dependencies.md
@@ -61,6 +61,7 @@ The below table lists some more service dependencies, where the client apps must
 |                     | Windows Azure Active Directory              | Early-bound |
 |                     | SharePoint                                  | Early-bound |
 |                     | Exchange                                    | Early-bound |
+| Power Automate      | Power Apps                                  | Early-bound |
 | Project             | Dynamics CRM                                | Early-bound |
 | Skype for Business  | Exchange                                    | Early-bound |
 | Visual Studio       | Microsoft Azure Management (portal and API) | Early-bound |


### PR DESCRIPTION
Power Automate has a service dependency on Power Apps which is documented here (https://docs.microsoft.com/en-us/power-automate/ip-address-configuration#required-services). If a customer is blocking Power Apps, Power Automate will be blocked as well. It's important to add this in the documentation because this did not cause a block to Power Automate until the recent changes to the Power Automate portal (https://powerautomate.microsoft.com/en-us/blog/flow-microsoft-com-is-moving-to-make-powerautomate-com/)