### PR TITLE
Precise wording for Virtual WAN

### DIFF
--- a/articles/virtual-wan/virtual-wan-about.md
+++ b/articles/virtual-wan/virtual-wan-about.md
@@ -53,7 +53,7 @@ For available regions and locations, see [Virtual WAN partners, regions, and loc
 
 To configure an end-to-end virtual WAN, you create the following resources:
 
-* **Virtual WAN:** The virtualWAN resource represents a virtual overlay of your Azure network and is a collection of multiple resources. It contains links to all your virtual hubs that you would like to have within the virtual WAN. Virtual WAN resources are isolated from each other and can't contain a common hub. Virtual hubs across Virtual WAN don't communicate with each other.
+* **Virtual WAN:** The Virtual WAN resource represents a virtual overlay of your Azure network and is a collection of multiple resources. It contains links to all your virtual hubs that you would like to have within the Virtual WAN. Virtual WANs are isolated from each other and can't contain a common hub. Virtual hubs in different Virtual WANs don't communicate with each other.
 
 * **Hub:** A virtual hub is a Microsoft-managed virtual network. The hub contains various service endpoints to enable connectivity. From your on-premises network (vpnsite), you can connect to a VPN gateway inside the virtual hub, connect ExpressRoute circuits to a virtual hub, or even connect mobile users to a point-to-site gateway in the virtual hub. The hub is the core of your network in a region. Multiple virtual hubs can be created in the same region.
 


### PR DESCRIPTION
Original wording sounds like Hubs within **one** VWAN can't communicate, which would defy the purpose of VWAN.
Please validate this fact with the PG.
Credit: @erjosito 