### PR TITLE
Emphasize vision dataset cannot be created using UI [v2 doc]

### DIFF
--- a/articles/machine-learning/how-to-auto-train-image-models.md
+++ b/articles/machine-learning/how-to-auto-train-image-models.md
@@ -110,7 +110,7 @@ If your training data is in a different format (like, pascal VOC or COCO), you c
 > The training data needs to have at least 10 images in order to be able to submit an AutoML run. 
 
 > [!Warning]
-> Creation of `MLTable` from data in JSONL format is supported using the SDK and CLI only, for this capability. Creating the `MLTable` via UI is not supported at this time. As of now UI doesn't recognize StreamInfo datatype, which is the datatype used for image urls in JSONL format.  
+> Creation of `MLTable` from data in JSONL format is supported using the SDK and CLI only, for this capability. Creating the `MLTable` via UI is not supported at this time. As of now, the UI doesn't recognize the StreamInfo datatype, which is the datatype used for image URLs in JSONL format.  
 
 
 ### JSONL schema samples

--- a/articles/machine-learning/how-to-auto-train-image-models.md
+++ b/articles/machine-learning/how-to-auto-train-image-models.md
@@ -110,7 +110,7 @@ If your training data is in a different format (like, pascal VOC or COCO), you c
 > The training data needs to have at least 10 images in order to be able to submit an AutoML run. 
 
 > [!Warning]
-> Creation of `MLTable` from data in JSONL format is supported only using the SDK and CLI. Creating the `MLTable` via UI is not supported at this time. As of now UI doesn't recognize StreamInfo datatype, which is the datatype used for image urls in JSONL format.  
+> Creation of `MLTable` from data in JSONL format is supported using the SDK and CLI only, for this capability. Creating the `MLTable` via UI is not supported at this time. As of now UI doesn't recognize StreamInfo datatype, which is the datatype used for image urls in JSONL format.  
 
 
 ### JSONL schema samples

--- a/articles/machine-learning/how-to-auto-train-image-models.md
+++ b/articles/machine-learning/how-to-auto-train-image-models.md
@@ -110,7 +110,7 @@ If your training data is in a different format (like, pascal VOC or COCO), you c
 > The training data needs to have at least 10 images in order to be able to submit an AutoML run. 
 
 > [!Warning]
-> Creation of `MLTable` is only supported using the SDK and CLI to create from data in JSONL format for this capability. Creating the `MLTable` via UI is not supported at this time.
+> Creation of `MLTable` from data in JSONL format is supported only using the SDK and CLI. Creating the `MLTable` via UI is not supported at this time. As of now UI doesn't recognize StreamInfo datatype, which is the datatype used for image urls in JSONL format.  
 
 
 ### JSONL schema samples


### PR DESCRIPTION
Updated warning:
1) Rephrased to warning to emphasize JSONL format cannot be read using UI for vison jobs 2) Provided more details, highlight that StreamInfo object used for representing image urls in JSONL format is not recognized by UI