### PR TITLE
Emphasize vision dataset cannot be created using UI [v1 doc]

### DIFF
--- a/articles/machine-learning/v1/how-to-auto-train-image-models-v1.md
+++ b/articles/machine-learning/v1/how-to-auto-train-image-models-v1.md
@@ -75,7 +75,7 @@ In order to generate computer vision models, you need to bring labeled image dat
 If your training data is in a different format (like, pascal VOC or COCO), you can apply the helper scripts included with the sample notebooks to convert the data to JSONL. Learn more about how to [prepare data for computer vision tasks with automated ML](../how-to-prepare-datasets-for-automl-images.md). 
 
 > [!Warning]
-> Creation of TabularDatasets is only supported using the SDK to create datasets from data in JSONL format for this capability. Creating the dataset via UI is not supported at this time.
+> Creation of TabularDatasets from data in JSONL format is supported using the SDK only, for this capability. Creating the dataset via UI is not supported at this time. As of now UI doesn't recognize StreamInfo datatype, which is the datatype used for image urls in JSONL format.
 
 > [!Note]
 > The training dataset needs to have at least 10 images in order to be able to submit an AutoML run. 

--- a/articles/machine-learning/v1/how-to-auto-train-image-models-v1.md
+++ b/articles/machine-learning/v1/how-to-auto-train-image-models-v1.md
@@ -75,7 +75,7 @@ In order to generate computer vision models, you need to bring labeled image dat
 If your training data is in a different format (like, pascal VOC or COCO), you can apply the helper scripts included with the sample notebooks to convert the data to JSONL. Learn more about how to [prepare data for computer vision tasks with automated ML](../how-to-prepare-datasets-for-automl-images.md). 
 
 > [!Warning]
-> Creation of TabularDatasets from data in JSONL format is supported using the SDK only, for this capability. Creating the dataset via UI is not supported at this time. As of now UI doesn't recognize StreamInfo datatype, which is the datatype used for image urls in JSONL format.
+> Creation of TabularDatasets from data in JSONL format is supported using the SDK only, for this capability. Creating the dataset via UI is not supported at this time. As of now, the UI doesn't recognize the StreamInfo datatype, which is the datatype used for image URLs in JSONL format.
 
 > [!Note]
 > The training dataset needs to have at least 10 images in order to be able to submit an AutoML run. 


### PR DESCRIPTION
Updated warning:
Rephrased to warning to emphasize JSONL format cannot be read using UI for vison jobs 2) Provided more details, highlight that StreamInfo object used for representing image urls in JSONL format is not recognized by UI