### PR TITLE
Update the default value

### DIFF
--- a/articles/event-hubs/apache-kafka-configurations.md
+++ b/articles/event-hubs/apache-kafka-configurations.md
@@ -53,7 +53,7 @@ Property | Recommended Values | Permitted Range | Notes
 
 Property | Recommended Values | Permitted Range | Notes
 ---|---:|-----:|---
-`retries` | > 0 | | Default is 2. We recommend that you keep this value. 
+`retries` | 2 | | Default is 2147483647. 
 `request.timeout.ms` | 30000 .. 60000 | > 20000| Event Hubs will internally default to a minimum of 20,000 ms.  `librdkafka` default value is 5000, which can be problematic. *While requests with lower timeout values are accepted, client behavior isn't guaranteed.*
 `partitioner` | `consistent_random` | See librdkafka documentation | `consistent_random` is default and best.  Empty and null keys are handled ideally for most cases.
 `compression.codec` | `none` || Compression currently not supported.


### PR DESCRIPTION
The librdkafka docs (linked by this document and here: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) note that the default for retries is not `2` but is actually `2147483647`. Updated the docs to change the recommended value based on the document.

![screenshot of default docs linked above](https://user-images.githubusercontent.com/821688/190013185-45af6df5-de09-450b-be67-2b5a5c79df47.png)
