### PR TITLE
"Run the app" section will not work as intended

### DIFF
--- a/articles/app-service/app-service-web-tutorial-dotnet-sqldatabase.md
+++ b/articles/app-service/app-service-web-tutorial-dotnet-sqldatabase.md
@@ -48,8 +48,8 @@ The sample project contains a basic [ASP.NET MVC](https://www.asp.net/mvc) creat
 
 1. Type `F5` to run the app. The app is displayed in your default browser.
 
-> [!NOTE] 
-> If you just installed Visual Studio and follow the prerequisites, you may have to [install missing packages via NuGet](/nuget/consume-packages/install-use-packages-visual-studio).
+   > [!NOTE] 
+   > If you only installed Visual Studio and the prerequisites, you may have to [install missing packages via NuGet](/nuget/consume-packages/install-use-packages-visual-studio).
 
 1. Select the **Create New** link and create a couple *to-do* items.
 

--- a/articles/app-service/app-service-web-tutorial-dotnet-sqldatabase.md
+++ b/articles/app-service/app-service-web-tutorial-dotnet-sqldatabase.md
@@ -46,7 +46,10 @@ The sample project contains a basic [ASP.NET MVC](https://www.asp.net/mvc) creat
 
 1. Open the *dotnet-sqldb-tutorial-master/DotNetAppSqlDb.sln* file in Visual Studio.
 
-1. Type `Ctrl+F5` to run the app without debugging. The app is displayed in your default browser.
+1. Type `F5` to run the app. The app is displayed in your default browser.
+
+> [!NOTE] 
+> If you just installed Visual Studio and follow the prerequisites, you may have to [install missing packages via NuGet](/nuget/consume-packages/install-use-packages-visual-studio).
 
 1. Select the **Create New** link and create a couple *to-do* items.
 


### PR DESCRIPTION
Unless you have all the packages for NuGet installed. I think this wouldn't be a great assumption to make. Or add this to the Prerequisites.

Instead of `Ctrl+F5`, the User should be encouraged to run debugging as this will throw an error if you're missing the package. Also added a note for the users who started from 0 and did the prereqs and downloaded the sample as stated only in this doc.