### PR TITLE
Update azure-resource-manager-api-spec.md

### DIFF
--- a/articles/container-apps/azure-resource-manager-api-spec.md
+++ b/articles/container-apps/azure-resource-manager-api-spec.md
@@ -217,9 +217,6 @@ The following example ARM template deploys a container app.
     },
     "registry_password": {
       "type": "SecureString"
-    },
-    "storage_share_name": {
-      "type": "String"
     }
   },
   "variables": {},


### PR DESCRIPTION
Remove storage_share_name from container app template.  It is used in container app environment template but should not be in the container app.