### PR TITLE
Warning on permissions needed for firewall for AML

### DIFF
--- a/articles/machine-learning/how-to-configure-auto-train.md
+++ b/articles/machine-learning/how-to-configure-auto-train.md
@@ -339,8 +339,11 @@ No&nbsp;criteria | If you do not define any exit parameters the experiment conti
 `max_concurrent_trials`| Represents the maximum number of trials (children jobs) that would be executed in parallel. It's a good practice to match this number with the number of nodes your cluster
 
 ## Run experiment
-> [!WARNING]
+> [!NOTE]
 > If you run an experiment with the same configuration settings and primary metric multiple times, you'll likely see variation in each experiments final metrics score and generated models. The algorithms automated ML employs have inherent randomness that can cause slight variation in the models output by the experiment and the recommended model's final metrics score, like accuracy. You'll likely also see results with the same model name, but different hyperparameters used. 
+
+> [!WARNING]
+> If you have set rules in firewall and/or Network Security Group over your workspace, verify that required permissions are given to inbound and outbound network traffic as defined in [Configure inbound and outbound network traffic](how-to-access-azureml-behind-firewall.md).
 
 Submit the experiment to run and generate a model. With the MLClient created in the prerequisites,you can run the following command in the workspace.
 


### PR DESCRIPTION
Added a warning message to highlight that in case firewall or NSG is set, certain set of network traffic has to be allowed for AML to function.