### PR TITLE
Fix azure functions service bus binding maxAutoRenewDuration

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus-trigger.md
+++ b/articles/azure-functions/functions-bindings-service-bus-trigger.md
@@ -434,7 +434,7 @@ Poison message handling can't be controlled or configured in Azure Functions. Se
 
 The Functions runtime receives a message in [PeekLock mode](../service-bus-messaging/service-bus-performance-improvements.md#receive-mode). It calls `Complete` on the message if the function finishes successfully, or calls `Abandon` if the function fails. If the function runs longer than the `PeekLock` timeout, the lock is automatically renewed as long as the function is running.
 
-The `maxAutoRenewDuration` is configurable in *host.json*, which maps to [OnMessageOptions.MaxAutoRenewDuration](/dotnet/api/microsoft.azure.servicebus.messagehandleroptions.maxautorenewduration). The maximum allowed for this setting is 5 minutes according to the Service Bus documentation, whereas you can increase the Functions time limit from the default of 5 minutes to 10 minutes. For Service Bus functions you wouldn’t want to do that then, because you’d exceed the Service Bus renewal limit.
+The `maxAutoRenewDuration` is configurable in *host.json*, which maps to [OnMessageOptions.MaxAutoRenewDuration](/dotnet/api/microsoft.azure.servicebus.messagehandleroptions.maxautorenewduration). The default value of this setting is 5 minutes.
 
 ::: zone pivot="programming-language-csharp" 
 ## Message metadata


### PR DESCRIPTION
Fixes #98589 #78261 #62110 

Documentation incorrectly states that there's a maximum value for `maxAutoRenewDuration` on the Service Bus side