### PR TITLE
Update export-data.md

### DIFF
--- a/articles/healthcare-apis/fhir/export-data.md
+++ b/articles/healthcare-apis/fhir/export-data.md
@@ -39,7 +39,7 @@ The FHIR service supports `$export` at the following levels:
 * [Patient](https://hl7.org/Fhir/uv/bulkdata/export/index.html#endpoint---all-patients): `GET {{fhirurl}}/Patient/$export`
 * [Group of patients*](https://hl7.org/Fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients) – *The FHIR service exports all referenced resources but doesn't export the characteristics of the group resource itself: `GET {{fhirurl}}/Group/[ID]/$export`
 
-When data is exported, a separate file is created for each resource type. No individual file will exceeds 100,000 resources. The result is that you may get multiple files for a resource type, which will be enumerated (e.g., Patient-1.ndjson, Patient-2.ndjson). Every file not necessarily will have 100,000 resource records listed.
+When data is exported, a separate file is created for each resource type. No individual file will exceed 1 Million resource records. The result is that you may get multiple files for a resource type, which will be enumerated (e.g., Patient-1.ndjson, Patient-2.ndjson). Every file not necessarily will have 1 Million resource records listed.
 
 > [!Note] 
 > `Patient/$export` and `Group/[ID]/$export` may export duplicate resources if a resource is in multiple groups or in a compartment of more than one resource.

--- a/articles/healthcare-apis/fhir/export-data.md
+++ b/articles/healthcare-apis/fhir/export-data.md
@@ -39,7 +39,7 @@ The FHIR service supports `$export` at the following levels:
 * [Patient](https://hl7.org/Fhir/uv/bulkdata/export/index.html#endpoint---all-patients): `GET {{fhirurl}}/Patient/$export`
 * [Group of patients*](https://hl7.org/Fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients) – *The FHIR service exports all referenced resources but doesn't export the characteristics of the group resource itself: `GET {{fhirurl}}/Group/[ID]/$export`
 
-When data is exported, a separate file is created for each resource type. The FHIR service will create a new file when the size of a single exported file exceeds 64 MB. The result is that you may get multiple files for a resource type, which will be enumerated (e.g., `Patient-1.ndjson`, `Patient-2.ndjson`). 
+When data is exported, a separate file is created for each resource type. No individual file will exceeds 100,000 resources. The result is that you may get multiple files for a resource type, which will be enumerated (e.g., Patient-1.ndjson, Patient-2.ndjson). Every file not necessarily will have 100,000 resource records listed.
 
 > [!Note] 
 > `Patient/$export` and `Group/[ID]/$export` may export duplicate resources if a resource is in multiple groups or in a compartment of more than one resource.


### PR DESCRIPTION
Updated export documentation to mention recent changes to export functionality. Instead of producing export file with size of 64MB, the change is to have files with size of 100,000 resource records.