### PR TITLE
How to force send-request calls go via HTTP proxy?

### DIFF
--- a/articles/api-management/api-management-advanced-policies.md
+++ b/articles/api-management/api-management-advanced-policies.md
@@ -858,7 +858,7 @@ This policy can be used in the following policy [sections](./api-management-howt
 
 ## <a name="SetHttpProxy"></a> Set HTTP proxy
 
-The `proxy` policy allows you to route requests forwarded to backends via an HTTP proxy. Only HTTP (not HTTPS) is supported between the gateway and the proxy. Basic and NTLM authentication only.
+The `proxy` policy allows you to route requests forwarded to backends via an HTTP proxy. Only HTTP (not HTTPS) is supported between the gateway and the proxy. Basic and NTLM authentication only. To route the send-request via HTTP proxy, you must place the set HTTP proxy policy inside the send-request policy block.
 
 [!INCLUDE [api-management-policy-generic-alert](../../includes/api-management-policy-generic-alert.md)]
 


### PR DESCRIPTION
Setting HTTP proxy in inbound scopes just helps route backend request via proxy.  Currently documentation does not cover how to force send request calls via HTTP proxy.

Sample policy:
        <set-variable name="Backend-URL" value="@{
                return "https://mybackendservice.net/";
        }" />
        <send-request mode="new" response-variable-name="RESP" timeout="60">
            <set-url>@((string)context.Variables["Backend-URL"])</set-url>
            <set-method>GET</set-method>
            <proxy url="http://myproxy.net:8080" />
        </send-request>