### PR TITLE
Purview Roles are Set in Purview not Azure Portal

### DIFF
--- a/articles/purview/tutorial-using-rest-apis.md
+++ b/articles/purview/tutorial-using-rest-apis.md
@@ -69,7 +69,7 @@ Once the new service principal is created, you need to assign the data plane rol
 
 1. Select the **Role assignments** tab.
 
-1. Assign the following roles to the service principal created previously to access various data planes in Microsoft Purview. For detailed steps, see [Assign Azure roles using the Azure portal](../role-based-access-control/role-assignments-portal.md).
+1. Assign the following roles to the service principal created previously to access various data planes in Microsoft Purview. For detailed steps, see [Assign Azure roles using the Microsoft Purview portal](./how-to-create-and-manage-collections.md#add-role-assignments).
 
     * Data Curator role to access Catalog Data plane.
     * Data Source Administrator role to access Scanning Data plane.


### PR DESCRIPTION
Updated link about setting roles for the Service Principal to point to the deep link on setting the role in the Purview portal.