### PR TITLE
{AzureContainerApps} fixes Azure/azure-cli-extensions#5365

### DIFF
--- a/articles/container-apps/azure-resource-manager-api-spec.md
+++ b/articles/container-apps/azure-resource-manager-api-spec.md
@@ -121,7 +121,7 @@ The following example ARM template deploys a Container Apps environment.
 
 # [YAML](#tab/yaml)
 
-YAML input isn't currently used by Azure CLI commands to specify a Container Apps environment.
+YAML input is currently used by Azure CLI commands to specify a Container Apps environment. See [this](https://learn.microsoft.com/azure/container-apps/azure-resource-manager-api-spec?tabs=yaml#container-app-examples) example for more details.
 
 ---
 


### PR DESCRIPTION
fixes Azure/azure-cli-extensions#5365

The CLI help for containerapp create mentions using --yaml, but in this docs its mentioned in the argument help saying YAML isn't currently used. This is incorrect. This PR fixes this issue.