### PR TITLE
Grammatical correction under Note

### DIFF
--- a/articles/logic-apps/create-integration-service-environment-rest-api.md
+++ b/articles/logic-apps/create-integration-service-environment-rest-api.md
@@ -47,7 +47,7 @@ Deployment usually takes within two hours to finish. Occasionally, deployment mi
 
 > [!NOTE]
 > If deployment fails or you delete your ISE, Azure might take up to an hour before releasing your subnets. 
-> This delay means means you might have to wait before reusing those subnets in another ISE.
+> This delay means you might have to wait before reusing those subnets in another ISE.
 >
 > If you delete your virtual network, Azure generally takes up to two hours 
 > before releasing up your subnets, but this operation might take longer. 


### PR DESCRIPTION
Under Note

If deployment fails or you delete your ISE, Azure might take up to an hour before releasing your subnets. This delay "means means" you might have to wait before reusing those subnets in another ISE.

means is repeated twice and needs to be removed once.

Doc link - Link - https://learn.microsoft.com/en-us/azure/logic-apps/create-integration-service-environment-rest-api?source=recommendations#create-the-ise

Note - section