### PR TITLE
Clarify contents of symmetric key if a URI to a file is given.

### DIFF
--- a/articles/iot-edge/how-to-provision-devices-at-scale-linux-symmetric.md
+++ b/articles/iot-edge/how-to-provision-devices-at-scale-linux-symmetric.md
@@ -132,7 +132,7 @@ Have the following information ready:
 
 1. Update the values of `id_scope`, `registration_id`, and `symmetric_key` with your DPS and device information.
 
-   The symmetric key parameter can accept a value of an inline key, a file URI, or a PKCS#11 URI. Uncomment just one symmetric key line, based on which format you're using. The inline key should be base64-encoded like the example, but if you're using a file URI the file should contain the raw bytes of the key.
+   The symmetric key parameter can accept a value of an inline key, a file URI, or a PKCS#11 URI. Uncomment just one symmetric key line, based on which format you're using. When using an inline key, use a base64-encoded key like the example. When using a file URI, your file should contain the raw bytes of the key.
 
    If you use any PKCS#11 URIs, find the **PKCS#11** section in the config file and provide information about your PKCS#11 configuration.
 

--- a/articles/iot-edge/how-to-provision-devices-at-scale-linux-symmetric.md
+++ b/articles/iot-edge/how-to-provision-devices-at-scale-linux-symmetric.md
@@ -132,7 +132,7 @@ Have the following information ready:
 
 1. Update the values of `id_scope`, `registration_id`, and `symmetric_key` with your DPS and device information.
 
-   The symmetric key parameter can accept a value of an inline key, a file URI, or a PKCS#11 URI. Uncomment just one symmetric key line, based on which format you're using.
+   The symmetric key parameter can accept a value of an inline key, a file URI, or a PKCS#11 URI. Uncomment just one symmetric key line, based on which format you're using. The inline key should be base64-encoded like the example, but if you're using a file URI the file should contain the raw bytes of the key.
 
    If you use any PKCS#11 URIs, find the **PKCS#11** section in the config file and provide information about your PKCS#11 configuration.
 


### PR DESCRIPTION
Putting the base64-encoded derived key generated by the example into a file does not work, and the logged error message is useless. However that's what a user would expect, since they are told to generate a derived key using the Powershell example, and told they can put it in a file.

I clarified that if a file URI is the preferred approach, the key should be stored in binary form.