### PR TITLE
Android 12 Activity must specify android:exported

### DIFF
--- a/articles/active-directory/develop/msal-net-xamarin-android-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-android-considerations.md
@@ -96,7 +96,7 @@ Alternatively, [create the activity in code](/xamarin/android/platform/android-m
 Here's an example of a class that represents the values of the XML file:
 
 ```csharp
-  [Activity]
+  [Activity(Exported = true)]
   [IntentFilter(new[] { Intent.ActionView },
         Categories = new[] { Intent.CategoryBrowsable, Intent.CategoryDefault },
         DataHost = "auth",

--- a/articles/active-directory/develop/msal-net-xamarin-android-considerations.md
+++ b/articles/active-directory/develop/msal-net-xamarin-android-considerations.md
@@ -75,7 +75,7 @@ protected override void OnActivityResult(int requestCode,
 To support System WebView, the *AndroidManifest.xml* file should contain the following values:
 
 ```xml
-<activity android:name="microsoft.identity.client.BrowserTabActivity" android:configChanges="orientation|screenSize">
+<activity android:name="microsoft.identity.client.BrowserTabActivity" android:configChanges="orientation|screenSize" android:exported="true">
   <intent-filter>
     <action android:name="android.intent.action.VIEW" />
     <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
android:exported needs to be explicitly specified for element <activity#xxxxxxxxxxxxx.MsalActivity>. 

Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` 
when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.

Regards,