### PR TITLE
Update kured references

### DIFF
--- a/articles/aks/concepts-security.md
+++ b/articles/aks/concepts-security.md
@@ -168,7 +168,7 @@ For more information on core Kubernetes and AKS concepts, see:
 - [Kubernetes / AKS scale][aks-concepts-scale]
 
 <!-- LINKS - External -->
-[kured]: https://github.com/weaveworks/kured
+[kured]: https://github.com/kubereboot/kured
 [kubernetes-network-policies]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 [secret-risks]: https://kubernetes.io/docs/concepts/configuration/secret/#risks
 [encryption-atrest]: ../security/fundamentals/encryption-atrest.md

--- a/articles/aks/node-updates-kured.md
+++ b/articles/aks/node-updates-kured.md
@@ -60,7 +60,7 @@ To deploy the `kured` DaemonSet, install the following official Kured Helm chart
 
 ```console
 # Add the Kured Helm repository
-helm repo add kured https://weaveworks.github.io/kured
+helm repo add kubereboot https://kubereboot.github.io/charts/
 
 # Update your local Helm chart repository cache
 helm repo update


### PR DESCRIPTION
This PR updates external references to the kured project, which has move GitHub organizations as part of its graduation to the CNCF sandbox of projects.

Was: weaveworks
Now: kubereboot

cc @dholbach @ckotzbauer @evrardjp
cc @palma21 