### PR TITLE
Explicitly call out access requirements

### DIFF
--- a/articles/virtual-desktop/azure-monitor.md
+++ b/articles/virtual-desktop/azure-monitor.md
@@ -28,7 +28,7 @@ Anyone monitoring Azure Monitor for Azure Virtual Desktop for your environment w
 
 - Read-access to the Azure resource groups that hold your Azure Virtual Desktop resources
 - Read-access to the subscription's resource groups that hold your Azure Virtual Desktop session hosts
-- Read access to the Log Analytics workspace or workspaces
+- Read access to the Log Analytics workspace (or *all* Log Analytics workspaces, if more than one) configured in the diagnostics settings of the resources
 
 >[!NOTE]
 > Read access only lets admins view data. They'll need different permissions to manage resources in the Azure Virtual Desktop portal.

--- a/articles/virtual-desktop/azure-monitor.md
+++ b/articles/virtual-desktop/azure-monitor.md
@@ -28,7 +28,7 @@ Anyone monitoring Azure Monitor for Azure Virtual Desktop for your environment w
 
 - Read-access to the Azure resource groups that hold your Azure Virtual Desktop resources
 - Read-access to the subscription's resource groups that hold your Azure Virtual Desktop session hosts
-- Read-access to the Log Analytics workspace (or *all* Log Analytics workspaces, if more than one) configured in the diagnostics settings of the resources
+- Read-access to the Log Analytics workspace (or, if multiple workspaces are in use, *all* related Log Analytics workspaces) configured in the diagnostics settings of the resources
 
 >[!NOTE]
 > Read access only lets admins view data. They'll need different permissions to manage resources in the Azure Virtual Desktop portal.

--- a/articles/virtual-desktop/azure-monitor.md
+++ b/articles/virtual-desktop/azure-monitor.md
@@ -28,7 +28,7 @@ Anyone monitoring Azure Monitor for Azure Virtual Desktop for your environment w
 
 - Read-access to the Azure resource groups that hold your Azure Virtual Desktop resources
 - Read-access to the subscription's resource groups that hold your Azure Virtual Desktop session hosts
-- Read access to the Log Analytics workspace (or *all* Log Analytics workspaces, if more than one) configured in the diagnostics settings of the resources
+- Read-access to the Log Analytics workspace (or *all* Log Analytics workspaces, if more than one) configured in the diagnostics settings of the resources
 
 >[!NOTE]
 > Read access only lets admins view data. They'll need different permissions to manage resources in the Azure Virtual Desktop portal.


### PR DESCRIPTION
While the docs *hinted* at the fact that read access to all configured Log Analytics workspaces was required, it wasn't explicitly stated. This change prevents confusion for users by being more descriptive.