### PR TITLE
Update batch-pool-vm-sizes.md to include NC_A100_v4 support

### DIFF
--- a/articles/batch/batch-pool-vm-sizes.md
+++ b/articles/batch/batch-pool-vm-sizes.md
@@ -59,6 +59,7 @@ For each VM series, the following table also lists whether the VM series and VM 
 | NCv2 | All sizes |
 | NCv3 | All sizes |
 | NCasT4_v3 | All sizes |
+| NC_A100_v4 | All sizes |
 | ND | All sizes |
 | NDv4 | All sizes |
 | NDv2 | None - not yet available |


### PR DESCRIPTION
Batch supports the Standard_NC24ads_A100_v4, Standard_NC48ads_A100_v4, and Standard_NC96ads_A100_v4 SKUs