### PR TITLE
Update notification-hubs-python-push-notification-tutorial.md

### DIFF
--- a/articles/notification-hubs/notification-hubs-python-push-notification-tutorial.md
+++ b/articles/notification-hubs/notification-hubs-python-push-notification-tutorial.md
@@ -89,7 +89,7 @@ class NotificationHub:
 
         for part in parts:
             if part.startswith('Endpoint'):
-                self.Endpoint = 'https' + part[11:]
+                self.Endpoint = 'https' + part[11:].lower()
             if part.startswith('SharedAccessKeyName'):
                 self.SasKeyName = part[20:]
             if part.startswith('SharedAccessKey'):


### PR DESCRIPTION
If the HubNamespace is created with Uppercase Letters (for eg: TestNamespace), the resulting connection string will not work directly, as the API throws 400 Code. the Endpoint string has to be in lowercase.