### PR TITLE
Update data-lake-storage-known-issues.md

### DIFF
--- a/articles/storage/blobs/data-lake-storage-known-issues.md
+++ b/articles/storage/blobs/data-lake-storage-known-issues.md
@@ -105,7 +105,7 @@ If parent directories for soft-deleted files or directories are renamed, the sof
 
 ## Events
 
-If your account has an event subscription, read operations on the secondary endpoint will result in an error. To resolve this issue, remove event subscriptions.
+If your account has an event subscription, read operations on the secondary endpoint will result in an error. To resolve this issue, remove event subscriptions. Using the dfs endpoint (abfss://URI) for non-hierarchical namespace enabled accounts will not generate events, but the blob endpoint (wasb:// URI) will generate events.
 
 > [!TIP]
 > Read access to the secondary endpoint is available only when you enable read-access geo-redundant storage (RA-GRS) or read-access geo-zone-redundant storage (RA-GZRS).


### PR DESCRIPTION
Using the dfs endpoint (abfss://URI) for non-hierarchical namespace enabled accounts will not generate events, but the blob endpoint (wasb:// URI) will generate events. This is expected on the Event Grid documentation page and updating the same on ADLS Gen2 known issue page as well to be in sync https://learn.microsoft.com/en-us/azure/event-grid/event-schema-blob-storage?tabs=event-grid-event-schema