### PR TITLE
Update monitor-blob-storage.md

### DIFF
--- a/articles/storage/blobs/monitor-blob-storage.md
+++ b/articles/storage/blobs/monitor-blob-storage.md
@@ -518,7 +518,7 @@ Log entries are created only if there are requests made against the service endp
 Requests made by the Blob storage service itself, such as log creation or deletion, aren't logged. For a full list of the logged data, see [Storage logged operations and status messages](/rest/api/storageservices/storage-analytics-logged-operations-and-status-messages) and [Storage log format](monitor-blob-storage-reference.md).
 
 > [!NOTE]
-> Azure Monitor currently filters all logs for ‘insights-‘ container. Please make use of classic analytical logs to track them.
+> Azure Monitor currently filters out logs that describe activity in the `insights-` container. You can track activities in that container by using storage analytics (classic logs).
 
 ### Log anonymous requests
 

--- a/articles/storage/blobs/monitor-blob-storage.md
+++ b/articles/storage/blobs/monitor-blob-storage.md
@@ -517,6 +517,9 @@ Log entries are created only if there are requests made against the service endp
 
 Requests made by the Blob storage service itself, such as log creation or deletion, aren't logged. For a full list of the logged data, see [Storage logged operations and status messages](/rest/api/storageservices/storage-analytics-logged-operations-and-status-messages) and [Storage log format](monitor-blob-storage-reference.md).
 
+> [!NOTE]
+> Azure Monitor currently filters all logs for ‘insights-‘ container. Please make use of classic analytical logs to track them.
+
 ### Log anonymous requests
 
  The following types of anonymous requests are logged:


### PR DESCRIPTION
Azure Monitor intentionally filters all logs for ‘insights-‘ container, since that will cause infinite loop for log uploads.
 
Delete logs from ‘insights-‘ container 
   Storage generates more logs in Geneva 
      AzMon publishes more logs to ‘insights-‘ container 
         Storage generates more logs in Geneva 
            infinite loop.

PG team will be checking on that however there is no ETA. The only option to track them currently is to check via classical logging. Hence proposing for documentation for now,