### PR TITLE
Update develop-tables-statistics.md

### DIFF
--- a/articles/synapse-analytics/sql/develop-tables-statistics.md
+++ b/articles/synapse-analytics/sql/develop-tables-statistics.md
@@ -647,23 +647,18 @@ To create statistics on a column, provide a query that returns the column for wh
 
 By default, if you don't specify otherwise, serverless SQL pool uses 100% of the data provided in the dataset when it creates statistics.
 
-For example, to create statistics with default options (FULLSCAN) for a year column of the dataset based on the us_population.csv file:
+For example, to create statistics with default options (FULLSCAN) for a population column of the dataset based on the us_population.csv file:
 
 ```sql
 
 EXEC sys.sp_create_openrowset_statistics N'SELECT 
-    year
+    population
 FROM OPENROWSET(
     BULK ''Https://azureopendatastorage.blob.core.windows.net/censusdatacontainer/raw_us_population_county/us_population.csv'',
     FORMAT = ''CSV'',
     PARSER_VERSION = ''2.0'',
     HEADER_ROW = TRUE)
-WITH (
-    [country_code] VARCHAR (5) COLLATE Latin1_General_100_BIN2_UTF8 ,
-    [country_name] VARCHAR (100) COLLATE Latin1_General_100_BIN2_UTF8 ,
-    [year] smallint,
-    [population] bigint
-) AS [r]'
+AS [r]'
 
 ```
 

--- a/articles/synapse-analytics/sql/develop-tables-statistics.md
+++ b/articles/synapse-analytics/sql/develop-tables-statistics.md
@@ -647,24 +647,23 @@ To create statistics on a column, provide a query that returns the column for wh
 
 By default, if you don't specify otherwise, serverless SQL pool uses 100% of the data provided in the dataset when it creates statistics.
 
-For example, to create statistics with default options (FULLSCAN) for a year column of the dataset based on the population.csv file:
+For example, to create statistics with default options (FULLSCAN) for a year column of the dataset based on the us_population.csv file:
 
 ```sql
 
 EXEC sys.sp_create_openrowset_statistics N'SELECT 
     year
 FROM OPENROWSET(
-    BULK ''https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/ecdc_cases/latest/ecdc_cases.csv'',
+    BULK ''Https://azureopendatastorage.blob.core.windows.net/censusdatacontainer/raw_us_population_county/us_population.csv'',
     FORMAT = ''CSV'',
     PARSER_VERSION = ''2.0'',
     HEADER_ROW = TRUE)
 WITH (
-    [country_code] VARCHAR (5) COLLATE Latin1_General_BIN2,
-    [country_name] VARCHAR (100) COLLATE Latin1_General_BIN2,
+    [country_code] VARCHAR (5) COLLATE Latin1_General_100_BIN2_UTF8 ,
+    [country_name] VARCHAR (100) COLLATE Latin1_General_100_BIN2_UTF8 ,
     [year] smallint,
     [population] bigint
-) AS [r]
-'
+) AS [r]'
 
 ```
 

--- a/articles/synapse-analytics/sql/develop-tables-statistics.md
+++ b/articles/synapse-analytics/sql/develop-tables-statistics.md
@@ -650,24 +650,14 @@ By default, if you don't specify otherwise, serverless SQL pool uses 100% of the
 For example, to create statistics with default options (FULLSCAN) for a year column of the dataset based on the population.csv file:
 
 ```sql
-/* make sure you have credentials for storage account access created
-IF EXISTS (SELECT * FROM sys.credentials WHERE name = 'https://azureopendatastorage.blob.core.windows.net/censusdatacontainer')
-DROP CREDENTIAL [https://azureopendatastorage.blob.core.windows.net/censusdatacontainer]
-GO
 
-CREATE CREDENTIAL [https://azureopendatastorage.blob.core.windows.net/censusdatacontainer]  
-WITH IDENTITY='SHARED ACCESS SIGNATURE',  
-SECRET = ''
-GO
-*/
-
-EXEC sys.sp_create_openrowset_statistics N'SELECT year
+EXEC sys.sp_create_openrowset_statistics N'SELECT 
+    year
 FROM OPENROWSET(
-        BULK ''https://sqlondemandstorage.blob.core.windows.net/csv/population/population.csv'',
-        FORMAT = ''CSV'',
-        FIELDTERMINATOR ='','',
-        ROWTERMINATOR = ''\n''
-    )
+    BULK ''https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/ecdc_cases/latest/ecdc_cases.csv'',
+    FORMAT = ''CSV'',
+    PARSER_VERSION = ''2.0'',
+    HEADER_ROW = TRUE)
 WITH (
     [country_code] VARCHAR (5) COLLATE Latin1_General_BIN2,
     [country_name] VARCHAR (100) COLLATE Latin1_General_BIN2,
@@ -675,6 +665,7 @@ WITH (
     [population] bigint
 ) AS [r]
 '
+
 ```
 
 #### Create single-column statistics by specifying the sample size


### PR DESCRIPTION
The example proposed fails with the error:

File 'https://sqlondemandstorage.blob.core.windows.net/csv/population/population.csv' cannot be opened because it does not exist or it is used by another process. Visit this article to learn more about this error

Also the code  the credential commented is not used in this example.

/* make sure you have credentials for storage account access created IF EXISTS (SELECT * FROM sys.credentials WHERE name = 'https://azureopendatastorage.blob.core.windows.net/censusdatacontainer') DROP CREDENTIAL [https://azureopendatastorage.blob.core.windows.net/censusdatacontainer] GO

CREATE CREDENTIAL [https://azureopendatastorage.blob.core.windows.net/censusdatacontainer]   WITH IDENTITY='SHARED ACCESS SIGNATURE',  
SECRET = ''
GO
*/

EXEC sys.sp_create_openrowset_statistics N'SELECT year FROM OPENROWSET(
        BULK ''https://sqlondemandstorage.blob.core.windows.net/csv/population/population.csv'',
        FORMAT = ''CSV'',
        FIELDTERMINATOR ='','',
        ROWTERMINATOR = ''\n''
    )
WITH (
    [country_code] VARCHAR (5) COLLATE Latin1_General_BIN2,
    [country_name] VARCHAR (100) COLLATE Latin1_General_BIN2,
    [year] smallint,
    [population] bigint
) AS [r]
'
So I am suggesting the follow based on the docs:


EXEC sys.sp_create_openrowset_statistics N'SELECT 
    year
FROM OPENROWSET(
    BULK ''https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/ecdc_cases/latest/ecdc_cases.csv'',
    FORMAT = ''CSV'',
    PARSER_VERSION = ''2.0'',
    HEADER_ROW = TRUE)
WITH (
    [country_code] VARCHAR (5) COLLATE Latin1_General_BIN2,
    [country_name] VARCHAR (100) COLLATE Latin1_General_BIN2,
    [year] smallint,
    [population] bigint
) AS [r]
'