### PR TITLE
Updating 'Validating a new resource' text

### DIFF
--- a/articles/healthcare-apis/fhir/validation-against-profiles.md
+++ b/articles/healthcare-apis/fhir/validation-against-profiles.md
@@ -116,7 +116,8 @@ For example:
 
 `POST https://myworkspace-myfhirserver.fhir.azurehealthcareapis.com/Patient/$validate`
 
-This request will create the new resource you're specifying in the request payload and validate the uploaded resource. Then, it will return an `OperationOutcome` as a result of the validation on the new resource.
+This request will first validate the resource. New resource you're specifying in the request will be created after validation.
+The server will always return an `OperationOutcome` as the result.
 
 ## Validate on resource CREATE or resource UPDATE
 


### PR DESCRIPTION
Being explicit on resource will be persisted only after validation passes. 
Reference to ask : https://teams.microsoft.com/l/message/19:1ebe1db801e242828f6745da65195ad3@thread.skype/1663876299698?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=f1ea5cac-bfa9-4405-9c6d-e9adc115628e&parentMessageId=1663876299698&teamName=Project%20Jupiter&channelName=FHIR%20Server%20Chat&createdTime=1663876299698&allowXTenantAccess=false