### PR TITLE
Add global resource examples to description about execptions in resource group update restrictions

### DIFF
--- a/articles/azure-resource-manager/management/overview.md
+++ b/articles/azure-resource-manager/management/overview.md
@@ -84,7 +84,7 @@ There are some important factors to consider when defining your resource group:
 
   The resource group stores metadata about the resources. When you specify a location for the resource group, you're specifying where that metadata is stored. For compliance reasons, you may need to ensure that your data is stored in a particular region.
   
-  If a resource group's region is temporarily unavailable, you can't update resources in the resource group because the metadata is unavailable. The resources in other regions will still function as expected, but you can't update them. This condition doesn't apply to global resources like Azure Content Delivery Network, Azure DNS, Azure Traffic Manager, and Azure Front Door.
+  If a resource group's region is temporarily unavailable, you can't update resources in the resource group because the metadata is unavailable. The resources in other regions will still function as expected, but you can't update them. This condition doesn't apply to global resources like Azure Content Delivery Network, Azure DNS, Azure DNS Private Zones, Azure Traffic Manager, and Azure Front Door.
    
   For more information about building reliable applications, see [Designing reliable Azure applications](/azure/architecture/checklist/resiliency-per-service).
 


### PR DESCRIPTION
 Added "Azure DNS Private Zones" to the examples of the global resources that do not apply to the restrictions when resource groups's region is temporarily unavailable.

In the docs we can see that there is some differences between Azure DNS and Azure Private DNS.
Like in [this docs](https://learn.microsoft.com/en-us/azure/availability-zones/az-region#an-icon-that-signifies-this-service-is-foundational-foundational-services).

Here, Private DNS Zone is specified as a zone-redundant service,
![image](https://user-images.githubusercontent.com/33891415/192473805-2f0379a0-5820-4068-a299-414118367be9.png)

However, Azure DNS it self is stated as always-available service.
![image](https://user-images.githubusercontent.com/33891415/192482575-9480b021-ccc4-4b68-a7b6-a11fe8bceb45.png)

This could cause confusion to our cutomers, therefore, would like to explicitly add Azure Private DNS to the description.