### PR TITLE
It's master instead of main according to the documentation flow.

### DIFF
--- a/articles/container-registry/container-registry-tutorial-build-task.md
+++ b/articles/container-registry/container-registry-tutorial-build-task.md
@@ -50,7 +50,7 @@ az acr task create \
     --registry $ACR_NAME \
     --name taskhelloworld \
     --image helloworld:{{.Run.ID}} \
-    --context https://github.com/$GIT_USER/acr-build-helloworld-node.git#main \
+    --context https://github.com/$GIT_USER/acr-build-helloworld-node.git#master \
     --file Dockerfile \
     --git-access-token $GIT_PAT
 ```
@@ -80,7 +80,7 @@ Output from a successful [az acr task create][az-acr-task-create] command is sim
   "step": {
     "arguments": [],
     "baseImageDependencies": null,
-    "contextPath": "https://github.com/gituser/acr-build-helloworld-node#main",
+    "contextPath": "https://github.com/gituser/acr-build-helloworld-node#master",
     "dockerFilePath": "Dockerfile",
     "imageNames": [
       "helloworld:{{.Run.ID}}"
@@ -102,7 +102,7 @@ Output from a successful [az acr task create][az-acr-task-create] command is sim
         "name": "defaultSourceTriggerName",
         "sourceRepository": {
           "branch": "main",
-          "repositoryUrl": "https://github.com/gituser/acr-build-helloworld-node#main",
+          "repositoryUrl": "https://github.com/gituser/acr-build-helloworld-node#master",
           "sourceControlAuthProperties": null,
           "sourceControlType": "GitHub"
         },
@@ -192,7 +192,7 @@ Next, execute the following commands to create, commit, and push a new file to y
 echo "Hello World!" > hello.txt
 git add hello.txt
 git commit -m "Testing ACR Tasks"
-git push origin main
+git push origin master
 ```
 
 You may be asked to provide your GitHub credentials when you execute the `git push` command. Provide your GitHub username, and enter the personal access token (PAT) that you created earlier for the password.


### PR DESCRIPTION
I had an error when i was running my task with command below: for example az acr task run --registry $ACRname --name taskhelloworld
because of main written in the url instead of master. According to the documentation flow it is master which must be there in order to have no problems for reader to execute this functionality. Otherwise user would have error ( ERROR: failed to download context. Please check  if the url is incorrect. If it has credentials. Please check if they are expired) even though user would follow instructions as written in the documentation so please update this documentation with this pull request