### PR TITLE
awk is not always in the same place

### DIFF
--- a/articles/azure-netapp-files/performance-linux-nfs-read-ahead.md
+++ b/articles/azure-netapp-files/performance-linux-nfs-read-ahead.md
@@ -99,8 +99,10 @@ fi
 To persistently set read-ahead for NFS mounts, `udev` rules can be written as follows:    
 
 1. Create and test `/etc/udev/rules.d/99-nfs.rules`:
+    #NOTE: Please replace <absolute path> with the actual path to awk
 
-    `SUBSYSTEM=="bdi", ACTION=="add", PROGRAM="/bin/awk -v bdi=$kernel 'BEGIN{ret=1} {if ($4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes", ATTR{read_ahead_kb}="15380"`
+    `SUBSYSTEM=="bdi", ACTION=="add", PROGRAM="<absolute path>/awk -v bdi=$kernel 'BEGIN{ret=1} {if ($4 == bdi) {ret=0}} END{exit ret}' /proc/fs/nfsfs/volumes", ATTR{read_ahead_kb}="15380"`
+    
 
 2. Apply the `udev` rule:   
 


### PR DESCRIPTION
The udev rule will only work when the correct absolute path is include to awk, previously we listed an absolute path of /bin/awk which is not the location of awk in ubuntu.  Change the code to show <absolute path> and let the reader adjust the path themselves.