### PR TITLE
Fix wrong Role assignment name

### DIFF
--- a/articles/spring-apps/how-to-deploy-in-azure-virtual-network.md
+++ b/articles/spring-apps/how-to-deploy-in-azure-virtual-network.md
@@ -149,7 +149,7 @@ Select the virtual network **azure-spring-apps-vnet** you previously created.
 
     ![Screenshot that shows the Access control screen.](./media/spring-cloud-v-net-injection/access-control.png)
 
-1. Assign the *Owner* role to the **Azure Spring Apps Resource Provider**. For detailed steps, see [Assign Azure roles using the Azure portal](../role-based-access-control/role-assignments-portal.md#step-2-open-the-add-role-assignment-page).
+1. Assign the *Owner* role to the **Azure Spring Cloud Resource Provider**. For detailed steps, see [Assign Azure roles using the Azure portal](../role-based-access-control/role-assignments-portal.md#step-2-open-the-add-role-assignment-page).
 
     ![Screenshot that shows owner assignment to resource provider.](./media/spring-cloud-v-net-injection/assign-owner-resource-provider.png)
 


### PR DESCRIPTION
In [Grant service permission to the virtual network](https://learn.microsoft.com/en-us/azure/spring-apps/how-to-deploy-in-azure-virtual-network?tabs=azure-portal#grant-service-permission-to-the-virtual-network) section, we mentioned "Assign the Owner role to the **Azure Spring Apps Resource Provider**." 
Actually we are still using "**Azure Spring Cloud Resource Provider**"