### PR TITLE
Change query to check the expiration date of SPN

### DIFF
--- a/articles/aks/update-credentials.md
+++ b/articles/aks/update-credentials.md
@@ -37,7 +37,7 @@ To check the expiration date of your service principal, use the [az ad sp creden
 ```azurecli
 SP_ID=$(az aks show --resource-group myResourceGroup --name myAKSCluster \
     --query servicePrincipalProfile.clientId -o tsv)
-az ad sp credential list --id "$SP_ID" --query "[].endDate" -o tsv
+az ad sp credential list --id "$SP_ID" --query "[].endDateTime" -o tsv
 ```
 
 ### Reset the existing service principal credential


### PR DESCRIPTION
Hi, during the walkthru of the document I noticed that provided query to check the expiration date does not give me any results, so I checked the information about SPN and I noticed that the property name is different and is `endDateTime` not `endDate`.

```
lukasz_szewczak [ ~ ]$ az ad sp credential list --id "$SP_ID" --query "[].endDate" -o tsv
lukasz_szewczak [ ~ ]$ 
lukasz_szewczak [ ~ ]$ az ad sp credential list --id "$SP_ID" 
[
  {
    "customKeyIdentifier": null,
    "displayName": null,
    "endDateTime": "2023-09-29T07:42:27Z",
    "hint": "L9O",
    "keyId": "",
    "secretText": null,
    "startDateTime": "2022-09-29T07:42:27Z"
  }
]
lukasz_szewczak [ ~ ]$ az ad sp credential list --id "$SP_ID" --query "[].endDateTime" -o tsv
2023-09-29T07:42:27Z
```