### PR TITLE
fix: replace deprecated usages of iotedgedev init

### DIFF
--- a/articles/iot-edge/how-to-vs-code-develop-module.md
+++ b/articles/iot-edge/how-to-vs-code-develop-module.md
@@ -167,7 +167,7 @@ The [IoT Edge Dev Tool](https://github.com/Azure/iotedgedev) simplifies Azure Io
 
     ---
 
-The *iotedgedev init* script prompts you to complete several steps including:
+The *iotedgedev solution init* script prompts you to complete several steps including:
 
 * Authenticate to Azure
 * Choose an Azure subscription

--- a/articles/iot-edge/how-to-vs-code-develop-module.md
+++ b/articles/iot-edge/how-to-vs-code-develop-module.md
@@ -125,18 +125,18 @@ The [IoT Edge Dev Tool](https://github.com/Azure/iotedgedev) simplifies Azure Io
     mkdir c:\dev\iotedgesolution
     ```
 
-1. Use the **iotedgedev init** command to create a solution and set up your Azure IoT Hub. Use the following command to create an IoT Edge solution for a specified development language.
+1. Use the **iotedgedev solution init** command to create a solution and set up your Azure IoT Hub. Use the following command to create an IoT Edge solution for a specified development language.
 
     # [C](#tab/c)
     
     ```bash
-    iotedgedev init --template c
+    iotedgedev solution init --template c
     ```
     
     # [C\#](#tab/csharp)
     
     ```bash
-    iotedgedev init --template csharp
+    iotedgedev solution init --template csharp
     ```
     
     The solution includes a default C# module named *filtermodule*.
@@ -144,25 +144,25 @@ The [IoT Edge Dev Tool](https://github.com/Azure/iotedgedev) simplifies Azure Io
     # [Azure Functions](#tab/azfunctions)
     
     ```bash
-    iotedgedev init --template csharpfunction
+    iotedgedev solution init --template csharpfunction
     ```
     
     # [Java](#tab/java)
     
     ```bash
-    iotedgedev init --template java
+    iotedgedev solution init --template java
     ```
 
     # [Node.js](#tab/node)
 
     ```bash
-    iotedgedev init --template nodejs
+    iotedgedev solution init --template nodejs
     ```
 
     # [Python](#tab/python)
 
     ```bash
-    iotedgedev init --template python
+    iotedgedev solution init --template python
     ```
 
     ---


### PR DESCRIPTION
Relevant page: https://learn.microsoft.com/en-us/azure/iot-edge/how-to-vs-code-develop-module?view=iotedge-1.4&branch=pr-en-us-203829&tabs=csharp&pivots=iotedge-dev-cli#create-iot-edge-module

The command `iotedgedev init` is listed as deprecated in the iotedgedev tool. The recommend usage is `iotedgedev solution init`. See https://github.com/Azure/iotedgedev/blob/main/iotedgedev/cli.py#L135 

This PR replaces occurrences of `iotedgedev init` with `iotedgedev solution init` for this page.