### PR TITLE
Remove asterisk form Norway East

### DIFF
--- a/articles/availability-zones/migrate-api-mgt.md
+++ b/articles/availability-zones/migrate-api-mgt.md
@@ -33,7 +33,7 @@ In this article, we'll take you through the different options for availability z
     * Japan East
     * Korea Central (*)
     * North Europe
-    * Norway East (*)
+    * Norway East
     * South Africa North (*)
     * South Central US
     * Southeast Asia


### PR DESCRIPTION
Norway East is no longer a restricted region for API Management. Let's remove the star.