### PR TITLE
(AzureCXP) https://github.com/MicrosoftDocs/azure-docs/issues/99327

### DIFF
--- a/articles/app-service/configure-language-nodejs.md
+++ b/articles/app-service/configure-language-nodejs.md
@@ -86,7 +86,7 @@ This setting specifies the Node.js version to use, both at runtime and during au
 
 ## Get port number
 
-You Node.js app needs to listen to the right port to receive incoming requests.
+Your Node.js app needs to listen to the right port to receive incoming requests.
 
 ::: zone pivot="platform-windows"  
 


### PR DESCRIPTION
Based on the feedback, updated the doc.

Under the Get Port Number section:

It states "You Node.js app needs to listen to the right port to receive incoming requests." you should be "your"