### PR TITLE
Update Azure Arc Network Requirements

### DIFF
--- a/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
+++ b/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
@@ -155,6 +155,9 @@ For a conceptual look at connecting clusters to Azure Arc, see [Azure Arc-enable
 > [!NOTE]
 > To translate the `*.servicebus.windows.net` wildcard into specific endpoints, use the command `\GET https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=<location>`. Within this command, the region must be specified for the `<location>` placeholder.
 
+> [!IMPORTANT]
+> Accessing the connected Kubernetes cluster from the Azure Arc resource through the Azure Portal requires `https://*.arc.azure.net`.
+
 ## Create a resource group
 
 Run the following command:

--- a/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
+++ b/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
@@ -156,7 +156,7 @@ For a conceptual look at connecting clusters to Azure Arc, see [Azure Arc-enable
 > To translate the `*.servicebus.windows.net` wildcard into specific endpoints, use the command `\GET https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=<location>`. Within this command, the region must be specified for the `<location>` placeholder.
 
 > [!IMPORTANT]
-> Accessing the connected Kubernetes cluster from the Azure Arc resource through the Azure Portal requires `https://*.arc.azure.net`.
+> To view and manage connected clusters in the Azure portal, be sure that your network allows traffic to `*.arc.azure.net`.
 
 ## Create a resource group
 


### PR DESCRIPTION
The Azure Arc resource from the portal requires access to the `*.arc.azure.net` domain for its RESTful API that it uses to query for the cluster resources. Adding a mention of it to this documentation so access can be considered when collecting network requirements.