### PR TITLE
private plan tenantid removed scenario update

### DIFF
--- a/articles/marketplace/azure-private-plan-troubleshooting.md
+++ b/articles/marketplace/azure-private-plan-troubleshooting.md
@@ -65,7 +65,7 @@ While troubleshooting the Azure Subscription Hierarchy, keep these things in min
 
 - ISV to ensure the SaaS private plan is using the correct tenant ID for the customer - [How to find your Azure Active Directory tenant ID](../active-directory/fundamentals/active-directory-how-to-find-tenant.md). For VMs use the [Azure Subscription ID.](../azure-portal/get-subscription-tenant-id.md)
 - ISV to ensure that the Customer is not buying through a CSP. Private Plans are not available on a CSP-managed subscription.
-- ISV to ensure the purchaser tenant Id is always present in the private audience list and is not removed untill the customer saas subscription is unsubscribed as this could have potential consequences of managing or sending meter usage for that customer saas subscription.
+- ISV to ensure the purchaser tenant ID is always present in the private audience list and isn't removed until the customer SaaS subscription is unsubscribed as this could have potential consequences of managing or sending meter usage for that customer SaaS subscription.
 - Customer to ensure customer is logging in with an email ID that is registered under the same tenant ID (use the same user ID they used in step #1 above)
 - ISV to ask the customer to find the Private Plan in Azure Marketplace: [Private plans in Azure Marketplace](/marketplace/private-plans)
 - Customer to ensure marketplace is enabled - [Azure Marketplace](../cost-management-billing/manage/ea-azure-marketplace.md) – if it is not, the user has to contact their Azure Administrator to enable marketplace, for more information regarding Azure Marketplace, see [Azure Marketplace](../cost-management-billing/manage/ea-azure-marketplace.md).

--- a/articles/marketplace/azure-private-plan-troubleshooting.md
+++ b/articles/marketplace/azure-private-plan-troubleshooting.md
@@ -65,6 +65,7 @@ While troubleshooting the Azure Subscription Hierarchy, keep these things in min
 
 - ISV to ensure the SaaS private plan is using the correct tenant ID for the customer - [How to find your Azure Active Directory tenant ID](../active-directory/fundamentals/active-directory-how-to-find-tenant.md). For VMs use the [Azure Subscription ID.](../azure-portal/get-subscription-tenant-id.md)
 - ISV to ensure that the Customer is not buying through a CSP. Private Plans are not available on a CSP-managed subscription.
+- ISV to ensure the purchaser tenant Id is always present in the private audience list and is not removed untill the customer saas subscription is unsubscribed as this could have potential consequences of managing or sending meter usage for that customer saas subscription.
 - Customer to ensure customer is logging in with an email ID that is registered under the same tenant ID (use the same user ID they used in step #1 above)
 - ISV to ask the customer to find the Private Plan in Azure Marketplace: [Private plans in Azure Marketplace](/marketplace/private-plans)
 - Customer to ensure marketplace is enabled - [Azure Marketplace](../cost-management-billing/manage/ea-azure-marketplace.md) – if it is not, the user has to contact their Azure Administrator to enable marketplace, for more information regarding Azure Marketplace, see [Azure Marketplace](../cost-management-billing/manage/ea-azure-marketplace.md).


### PR DESCRIPTION
Added information to not remove the tenantId on an active saas subscription created off a private plan as this could have consequences for ISV not being able to manage that subscription or send meter usage events.