### PR TITLE
Update functions-supported-languages.md

### DIFF
--- a/includes/functions-supported-languages.md
+++ b/includes/functions-supported-languages.md
@@ -13,7 +13,7 @@ ms.custom: include file
 |[JavaScript](../articles/azure-functions/functions-reference-node.md#node-version)|GA (Node.js 6)|GA (Node.js 10 & 8)| GA (Node.js 14, 12, & 10) | GA (Node.js 14)<br/>GA (Node.js 16)<br/>Preview (Node.js 18) |
 |[F#](../articles/azure-functions/functions-reference-fsharp.md)|GA (.NET Framework 4.8)|GA (.NET Core 2.1<sup>1</sup>)| GA (.NET Core 3.1) | GA (.NET 6.0) |
 |[Java](../articles/azure-functions/functions-reference-java.md)|N/A|GA (Java 8)| GA (Java 11 & 8)| GA (Java 11 & 8) <br/> Preview (Java 17)|
-|[PowerShell](../articles/azure-functions/functions-reference-powershell.md) |N/A|GA (PowerShell Core 6)| GA (PowerShell 7.0 & Core 6)| GA (PowerShell 7.0, 7.2)|
+|[PowerShell](../articles/azure-functions/functions-reference-powershell.md) |N/A|N/A| GA (PowerShell 7.0)| GA (PowerShell 7.0, 7.2)|
 |[Python](../articles/azure-functions/functions-reference-python.md#python-version)|N/A|GA (Python 3.7 & 3.6)| GA (Python 3.9, 3.8, 3.7, & 3.6)| GA (Python 3.9, 3.8, 3.7)|
 |[TypeScript](../articles/azure-functions/functions-reference-node.md#typescript)<sup>2</sup> |N/A|GA| GA | GA |
 


### PR DESCRIPTION
Removing PowerShell Core 6 since Azure Functions retired this version as of 9/30