### PR TITLE
Update how-to-configure-api-proxy-module.md

### DIFF
--- a/articles/iot-edge/how-to-configure-api-proxy-module.md
+++ b/articles/iot-edge/how-to-configure-api-proxy-module.md
@@ -176,7 +176,7 @@ Configure the following modules at the **top layer**:
 
     | Name | Value |
     | ---- | ----- |
-    | `BLOB_UPLOAD_ROUTE_ADDRESS` | The blob storage module name and open port. For example, `azureblobstorageoniotedge:1102`. |
+    | `BLOB_UPLOAD_ROUTE_ADDRESS` | The blob storage module name and open port. For example, `azureblobstorageoniotedge:11002`. |
     | `NGINX_DEFAULT_PORT` | The port that the nginx proxy listens on for requests from downstream devices. For example, `8000`. |
 
   * Configure the following createOptions:


### PR DESCRIPTION
Changed default port for Azure Blob Storage on IoT Edge.