### PR TITLE
fixed spelling error

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-gitops-flux2-ci-cd.md
+++ b/articles/azure-arc/kubernetes/tutorial-gitops-flux2-ci-cd.md
@@ -197,7 +197,7 @@ CD pipeline manipulates PRs in the GitOps repository. It needs a Service Connect
       --set orchestratorPAT=<Azure Repos PAT token>
 ```
 > [!NOTE]
-> `Azure Repos PAT token` should have `Build: Read & executee` and `Code: Read` permissions.
+> `Azure Repos PAT token` should have `Build: Read & execute` and `Code: Read` permissions.
 
 3. Configure Flux to send notifications to GitOps connector:
 ```console


### PR DESCRIPTION
executee should be execute
This was also submitted via issue #99472 -- that may be closed now.