### PR TITLE
fix: removes requirement for iotedgedev tool when using the VS Code extension

### DIFF
--- a/articles/iot-edge/how-to-vs-code-develop-module.md
+++ b/articles/iot-edge/how-to-vs-code-develop-module.md
@@ -67,6 +67,9 @@ To build and deploy your module image, you need Docker to build the module image
     > You can use a local Docker registry for prototype and testing purposes instead of a cloud registry.
 
 - Install the [Azure CLI](/cli/azure/install-azure-cli)
+
+::: zone pivot="iotedge-dev-vscode"
+
 - Install the Python-based [Azure IoT Edge Dev Tool](https://pypi.org/project/iotedgedev/) in order to set up your local development environment to debug, run, and test your IoT Edge solution. If you haven't already done so, install [Python (3.6/3.7/3.8) and Pip3](https://www.python.org/) and then install the IoT Edge Dev Tool (iotedgedev) by running this command in your terminal.
 
     ```cmd
@@ -78,6 +81,8 @@ To build and deploy your module image, you need Docker to build the module image
     > If you have multiple Python including pre-installed Python 2.7 (for example, on Ubuntu or macOS), make sure you are using `pip3` to install *IoT Edge Dev Tool (iotedgedev)*.
     >
     > For more information setting up your development machine, see [iotedgedev development setup](https://github.com/Azure/iotedgedev/blob/main/docs/environment-setup/manual-dev-machine-setup.md).
+
+::: zone-end
 
 Install prerequisites specific to the language you're developing in:
 


### PR DESCRIPTION
## Motivation

Relevant docs: https://learn.microsoft.com/en-us/azure/iot-edge/how-to-vs-code-develop-module?view=iotedge-1.4&branch=pr-en-us-203829&tabs=csharp&pivots=iotedge-dev-vscode

The iotedgedev tool is not required when using the VS Code extensions and therefore users do not need to install it. 

## Description

Docs only change that adds the pivot in the prerequisites section. 