### PR TITLE
Update factset-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/factset-tutorial.md
+++ b/articles/active-directory/saas-apps/factset-tutorial.md
@@ -81,11 +81,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
     b. In the **Reply URL** text box, type the URL:
     `https://auth.factset.com/sp/ACS.saml2`
 
-    c. In the **Sign-on URL** text box, type a URL using the following pattern:
-    `https://<SUBDOMAIN>.factset.com/services/saml2/`
 
-    > [!NOTE]
-    > The Sign-on URL value is not real. Update the value with the actual Sign-on URL. Contact the [FactSet Support Team](https://www.factset.com/contact-us) to get the value. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal. 
 
 1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Federation Metadata XML** and select **Download** to download the metadata file and save it on your computer.
 


### PR DESCRIPTION
Removed lines 84 thru 88 as unnecessary to configuration of the Federation. There exists no  `https://<SUBDOMAIN>.factset.com/services/saml2/` path, this is causing confusion to implementers.