### PR TITLE
Fixed link in Next Steps

### DIFF
--- a/articles/machine-learning/overview-what-is-azure-machine-learning.md
+++ b/articles/machine-learning/overview-what-is-azure-machine-learning.md
@@ -209,4 +209,4 @@ Also, Azure Machine Learning includes features for monitoring and auditing:
 Start using Azure Machine Learning:
 - [Set up an Azure Machine Learning workspace](quickstart-create-resources.md)
 - [Tutorial: Build a first machine learning project](tutorial-1st-experiment-hello-world.md)
-- [How to run training jobs(how-to-train-model.md)
+- [How to run training jobs](how-to-train-model.md)


### PR DESCRIPTION
The "How to run training jobs like was missing a closing square bracket so it was not actually a link. I fixed it.