### PR TITLE
Update high-availability-guide-suse-pacemaker.md

### DIFF
--- a/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
+++ b/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
@@ -582,6 +582,13 @@ Make sure to assign the custom role to the service principal at all VM (cluster 
    vm.dirty_background_bytes = 314572800
    </code></pre>
 
+   c. Make sure vm.swappiness is set to 10 to avoid [hang issues with backups/compression on NetAPP filesystem] (https://me.sap.com/notes/2080199) as well as to reduce swap usage and favor memory.
+
+   <pre>code> sudo vi /etc/sysctl.conf
+   # Change/set the following setting
+   vm.swappiness = 10
+   </code></pre>
+   
 1. **[A]** Configure *cloud-netconfig-azure* for the high availability cluster.
 
    >[!NOTE]


### PR DESCRIPTION
Adding section about vm.swappiness value, these should be standard in deployments with DB's and they also help avoiding some known issues as well helping with overall system optimization.