### PR TITLE
IoT Edge: enhance docs for layered deployments that use private registries

### DIFF
--- a/articles/iot-edge/how-to-deploy-cli-at-scale.md
+++ b/articles/iot-edge/how-to-deploy-cli-at-scale.md
@@ -177,6 +177,9 @@ The same can also be expressed with:
 >[!NOTE]
 >Currently, all layered deployments must include an `edgeAgent` object to be considered valid. Even if a layered deployment only updates module properties, include an empty object. For example: `"$edgeAgent":{}`. A layered deployment with an empty `edgeAgent` object will be shown as **targeted** in the `edgeAgent` module twin, not **applied**.
 
+>[!NOTE]
+>If the image of a layered deployment resides in a private container registry, the registry credentials need to be provided on the "base" automatic deployment.
+
 In summary, to create a layered deployment:
 
 - Add the `--layered` flag to the Azure CLI create command.


### PR DESCRIPTION
[Relevant docs](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-deploy-cli-at-scale?view=iotedge-1.4#layered-deployment): IoT Edge "how to deploy at scale" and specifically layered deployments.

## Description
In the docs, there is no mention of layered deployments for images that reside on private container registries. This PR adds a note about this. Can be discussed if a note is the right way to go there or should be integrated better with the rest of the text.

## Notes
This is a potential limitation of IoT Edge since at the moment you can not use a different container registry for your layered deployment than the one that was used in the "base" deployment. 