### PR TITLE
data instead of date, according to original AMD documentations

### DIFF
--- a/articles/aks/use-cvm.md
+++ b/articles/aks/use-cvm.md
@@ -9,7 +9,7 @@ ms.date: 08/01/2022
 
 # Use Confidential Virtual Machines (CVM) in Azure Kubernetes Service (AKS) cluster (Preview)
 
-You can use the generally available [confidential VM sizes (DCav5/ECav5)][cvm-announce] to add a node pool to your AKS cluster with CVM. Confidential VMs with AMD SEV-SNP support bring a new set of security features to protect date-in-use with full VM memory encryption. These features enable node pools with CVM to target the migration of highly sensitive container workloads to AKS without any code refactoring while benefiting from the features of AKS. The nodes in a node pool created with CVM use a customized Ubuntu 20.04 image specially configured for CVM. For more details on CVM, see [Confidential VM node pools support on AKS with AMD SEV-SNP confidential VMs][cvm].
+You can use the generally available [confidential VM sizes (DCav5/ECav5)][cvm-announce] to add a node pool to your AKS cluster with CVM. Confidential VMs with AMD SEV-SNP support bring a new set of security features to protect data-in-use with full VM memory encryption. These features enable node pools with CVM to target the migration of highly sensitive container workloads to AKS without any code refactoring while benefiting from the features of AKS. The nodes in a node pool created with CVM use a customized Ubuntu 20.04 image specially configured for CVM. For more details on CVM, see [Confidential VM node pools support on AKS with AMD SEV-SNP confidential VMs][cvm].
 
 Adding a node pool with CVM to your AKS cluster is currently in preview.
 


### PR DESCRIPTION
It should be **data-in-use** rather than date-in-use, according to official AMD documentations.
Some of the original AMD documents are here:
https://developer.amd.com/sev/#:~:text=memory%20encryption%20for-,data%2Din%2Duse,-protection.%20Takes%20advantage
and
https://www.amd.com/system/files/TechDocs/SEV-SNP-strengthening-vm-isolation-with-integrity-protection-and-more.pdf 
(page3, paragraph 2, line 3 and page 5, paragraph 1, last line)