### PR TITLE
Correct typo in web-app-routing.md

### DIFF
--- a/articles/aks/web-app-routing.md
+++ b/articles/aks/web-app-routing.md
@@ -415,7 +415,7 @@ spec:
 The Web Application Routing add-on creates an Ingress class on the cluster called `webapprouting.kubernetes.azure.com `. When you create an ingress object with this class, this will activate the add-on. To obtain the certificate URI to use in the Ingress from Azure Key Vault, run the following command.
 
 ```azurecli-interactive
-az keyvault certificate show --vault-name <KeyVaultName> -n <KeyVaultCertificateName> ---query "id" --output tsv
+az keyvault certificate show --vault-name <KeyVaultName> -n <KeyVaultCertificateName> --query "id" --output tsv
 ```
 
 Create a file named **ingress.yaml** and copy in the following YAML. 


### PR DESCRIPTION
Command: `az keyvault certificate show --vault-name <KeyVaultName> -n <KeyVaultCertificateName> ---query "id" --output tsv` is wrong with an extra hyphen. Will cause error: `unrecognized arguments: ---query id` .