### PR TITLE
Update reports-faq.yml

### DIFF
--- a/articles/active-directory/reports-monitoring/reports-faq.yml
+++ b/articles/active-directory/reports-monitoring/reports-faq.yml
@@ -89,6 +89,10 @@ sections:
           I see .XXX in part of the IP address from a user in my sign-in logs. Why is that happening?
         answer: |
           Azure AD may redact part of an IP address in the sign-in logs to protect user privacy when a user may not belong to the tenant viewing the logs. This action happens in two cases: first, during cross tenant sign ins, such as when a CSP technician signs into a tenant that CSP manages. Second, when our service wasn't able to determine the user's identity with sufficient confidence to be sure the user belongs to the tenant viewing the logs.
+      - question: |
+          I see the deviceid / displayname is {PII Removed} in sign in logs for the Guest Users.  Why is that happening?
+        answer: |
+          For guest user sign-ins, the device ID and display Name have been removed from resource tenant due to privacy implications.
 
   - name: Conditional Access
     questions:


### PR DESCRIPTION
      - question: |
          I see the deviceid / displayname is {PII Removed} in sign in logs for the Guest Users.  Why is that happening?
        answer: |
          For guest user sign-ins, the device ID and display Name have been removed from resource tenant due to privacy implications.

We were unable to find any public documentation, we are seeing some queries for the customer .