### PR TITLE
Clarify pattern matching in AAD OIDC for GitHub

### DIFF
--- a/articles/active-directory/develop/workload-identity-federation-create-trust.md
+++ b/articles/active-directory/develop/workload-identity-federation-create-trust.md
@@ -49,7 +49,7 @@ In the **Federated credential scenario** drop-down box, select **GitHub actions 
 
 Specify the **Organization** and **Repository** for your GitHub Actions workflow.  
 
-For **Entity type**, select **Environment**, **Branch**, **Pull request**, or **Tag** and specify the value. The values must exactly match the configuration in the [GitHub workflow](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#on).  For more info, read the [examples](#entity-type-examples).
+For **Entity type**, select **Environment**, **Branch**, **Pull request**, or **Tag** and specify the value. The values must exactly match the configuration in the [GitHub workflow](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#on). Pattern matching is not supported for branches and tags. Specify an environment if your on-push workflow runs against many branches or tags. For more info, read the [examples](#entity-type-examples).
 
 Add a **Name** for the federated credential.
 


### PR DESCRIPTION
Pattern matching not being supported in AAD Github OIDC credentials is a bit of a foot-gun. For example I can create a workflow that is trigged on any version tag (`v*`) and I'm able to enter a matching rule in the AAD credentials however no pattern matching takes place. When the workflow executes for a tag `v1.0.0` this will result in an authorization error and the workflow fails with `AADSTS70021: No matching federated identity record found for presented assertion. ...`.
I worked around this by using environments. I've explained that pattern matching is not supported and suggest using environment instead of branch or tag.