### PR TITLE
Change Password does not require SSPR registration

### DIFF
--- a/articles/active-directory/identity-protection/howto-identity-protection-configure-risk-policies.md
+++ b/articles/active-directory/identity-protection/howto-identity-protection-configure-risk-policies.md
@@ -44,7 +44,7 @@ Organizations can choose to block access when risk is detected. Blocking sometim
    - Azure AD MFA can be triggered, allowing to user to prove it's them by using one of their registered authentication methods, resetting the sign-in risk. 
 
 > [!WARNING]
-> Users must register for Azure AD MFA and SSPR before they face a situation requiring remediation. Users not registered are blocked and require administrator intervention.
+> Users must register for Azure AD MFA before they face a situation requiring remediation. Users not registered are blocked and require administrator intervention.
 > 
 > Password change (I know my password and want to change it to something new) outside of the risky user policy remediation flow does not meet the requirement for secure password reset.
 


### PR DESCRIPTION
An end user subject to an assigned user risk by Identity Protection may remediate their assigned risk by using the Conditional Access flow as defined.

However, the Identity Protection article defines a prerequisite requirement that users are both Azure AD MFA and SSPR enrolled.

This appears to be misleading.

From testing it appears users only require Azure AD MFA as a minimum. Users can have an incomplete SSPR registration or be denied SSPR entirely and still perform the remediation.

Example Scenario
An organisation's policy requires all users to MFA (Authenticator) but has not yet mandated all complete its SSPR registration campaign (requiring 2 methods for a reset). Following the article it implies all of its users first must register for SSPR. 
Those members with MFA Authenticator alone can already remediate their 'high risk' using MFA alone (without complete or available SSPR).
