### PR TITLE
Updating link to rewrite-http-headers-portal.md

### DIFF
--- a/articles/application-gateway/rewrite-http-headers-url.md
+++ b/articles/application-gateway/rewrite-http-headers-url.md
@@ -23,7 +23,7 @@ HTTP headers allow a client and server to pass additional information with a req
 
 Application Gateway allows you to add, remove, or update HTTP request and response headers while the request and response packets move between the client and back-end pools.
 
-To learn how to rewrite request and response headers with Application Gateway using Azure portal, see [here](rewrite-url-portal.md).
+To learn how to rewrite request and response headers with Application Gateway using Azure portal, see [here](rewrite-http-headers-portal.md).
 
 ![img](./media/rewrite-http-headers-url/header-rewrite-overview.png)
 


### PR DESCRIPTION
In rewrite-http-headers-url.md, there should be a link to rewrite-http-headers-portal.md in the header sections instead of link to rewrite-url-portal.md.