### PR TITLE
Replace Invoke-ActivityFunction with Invoke-DurableActivity

### DIFF
--- a/articles/azure-functions/durable/quickstart-powershell-vscode.md
+++ b/articles/azure-functions/durable/quickstart-powershell-vscode.md
@@ -121,7 +121,7 @@ Finally, you'll add an HTTP triggered function that starts the orchestration.
     | Provide a function name | HttpStart | Name of your activity function |
     | Authorization level | Anonymous | For demo purposes, allow the function to be called without authentication |
 
-You've added an HTTP triggered function that starts an orchestration. Open *HttpStart/run.ps1* to see that it uses the `Start-NewOrchestration` cmdlet to start a new orchestration. Then it uses the `New-OrchestrationCheckStatusResponse` cmdlet to return an HTTP response containing URLs that can be used to monitor and manage the new orchestration.
+You've added an HTTP triggered function that starts an orchestration. Open *HttpStart/run.ps1* to see that it uses the `Start-DurableOrchestration` cmdlet to start a new orchestration. Then it uses the `New-OrchestrationCheckStatusResponse` cmdlet to return an HTTP response containing URLs that can be used to monitor and manage the new orchestration.
 
 You now have a Durable Functions app that can be run locally and deployed to Azure.
 

--- a/articles/azure-functions/durable/quickstart-powershell-vscode.md
+++ b/articles/azure-functions/durable/quickstart-powershell-vscode.md
@@ -90,7 +90,7 @@ You use a template to create the durable function code in your project.
     | Select a template for your function | Durable Functions orchestrator | Create a Durable Functions orchestration |
     | Provide a function name | HelloOrchestrator | Name of your durable function |
 
-You've added an orchestrator to coordinate activity functions. Open *HelloOrchestrator/run.ps1* to see the orchestrator function. Each call to the `Invoke-ActivityFunction` cmdlet invokes an activity function named `Hello`.
+You've added an orchestrator to coordinate activity functions. Open *HelloOrchestrator/run.ps1* to see the orchestrator function. Each call to the `Invoke-DurableActivity` cmdlet invokes an activity function named `Hello`.
 
 Next, you'll add the referenced `Hello` activity function.
 

--- a/articles/azure-functions/durable/quickstart-powershell-vscode.md
+++ b/articles/azure-functions/durable/quickstart-powershell-vscode.md
@@ -121,7 +121,7 @@ Finally, you'll add an HTTP triggered function that starts the orchestration.
     | Provide a function name | HttpStart | Name of your activity function |
     | Authorization level | Anonymous | For demo purposes, allow the function to be called without authentication |
 
-You've added an HTTP triggered function that starts an orchestration. Open *HttpStart/run.ps1* to see that it uses the `Start-DurableOrchestration` cmdlet to start a new orchestration. Then it uses the `New-OrchestrationCheckStatusResponse` cmdlet to return an HTTP response containing URLs that can be used to monitor and manage the new orchestration.
+You've added an HTTP triggered function that starts an orchestration. Open *HttpStart/run.ps1* to see that it uses the `Start-DurableOrchestration` cmdlet to start a new orchestration. Then it uses the `New-DurableOrchestrationCheckStatusResponse` cmdlet to return an HTTP response containing URLs that can be used to monitor and manage the new orchestration.
 
 You now have a Durable Functions app that can be run locally and deployed to Azure.
 


### PR DESCRIPTION
`Invoke-ActivityFunction` has been renamed to `Invoke-DurableActivity`. The old name still works because of a backward-compatibility alias, but mentioning the old name in the docs creates confuses customers.