### PR TITLE
Update uninstall-azure-arc-data-controller.md

### DIFF
--- a/articles/azure-arc/data/uninstall-azure-arc-data-controller.md
+++ b/articles/azure-arc/data/uninstall-azure-arc-data-controller.md
@@ -158,7 +158,9 @@ kubectl delete crd dags.sql.arcdata.microsoft.com
 kubectl delete crd exporttasks.tasks.arcdata.microsoft.com
 kubectl delete crd monitors.arcdata.microsoft.com
 kubectl delete crd activedirectoryconnectors.arcdata.microsoft.com
-
+kubectl delete crd failovergroups.sql.arcdata.microsoft.com
+kubectl delete crd kafkas.arcdata.microsoft.com
+kubectl delete crd otelcollectors.arcdata.microsoft.com
 
 ## Delete Cluster roles and Cluster role bindings
 kubectl delete clusterrole arcdataservices-extension


### PR DESCRIPTION
Add missing custom resource definitions to delete. These three *.arcdata.microsoft.com CRDs had been left after applying the current docs. I had to delete them as well before a fresh install finished successful.