### PR TITLE
Removal of repeated info

### DIFF
--- a/articles/active-directory/authentication/certificate-based-authentication-faq.yml
+++ b/articles/active-directory/authentication/certificate-based-authentication-faq.yml
@@ -125,11 +125,6 @@ sections:
           There's no support for a second factor when the first factor is a single-factor certificate. We're working to add support for second factors.
           
       - question: |
-          Will the changes to the Authentication methods policy take effect immediately?
-        answer: |
-          The policy is cached. After a policy update, it may take up to an hour for the changes to take effect.
-          
-      - question: |
           CertificateUserIds update fails with value already there. How can an admin query all the user objects with the same value?
         answer: |
           Tenant admins can run MS Graph queries to find all the users with a given certificateUserId value. More information can be found at [CertificateUserIds graph queries](concept-certificate-based-authentication-certificateuserids.md#look-up-certificateuserids-using-microsoft-graph-queries)


### PR DESCRIPTION
There were 2 statements for the same subject "Will the changes to the Authentication methods policy take effect immediately?" and it was removed the last one