### PR TITLE
Update backup-and-restore.md

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/backup-and-restore.md
+++ b/articles/synapse-analytics/sql-data-warehouse/backup-and-restore.md
@@ -42,7 +42,14 @@ order by run_id desc
 This feature enables you to manually trigger snapshots to create restore points of your data warehouse before and after large modifications. This capability ensures that restore points are logically consistent, which provides additional data protection in case of any workload interruptions or user errors for quick recovery time. User-defined restore points are available for seven days and are automatically deleted on your behalf. You cannot change the retention period of user-defined restore points. **42 user-defined restore points** are guaranteed at any point in time so they must be [deleted](/powershell/module/azurerm.sql/remove-azurermsqldatabaserestorepoint) before creating another restore point. You can trigger snapshots to create user-defined restore points through [PowerShell](/powershell/module/az.synapse/new-azsynapsesqlpoolrestorepoint?toc=/azure/synapse-analytics/sql-data-warehouse/toc.json&bc=/azure/synapse-analytics/sql-data-warehouse/breadcrumb/toc.jsont#examples) or the Azure portal.
 
 > [!NOTE]
-> If you require restore points longer than 7 days, please vote for this capability [here](https://feedback.azure.com/d365community/idea/4c446fd9-0b25-ec11-b6e6-000d3a4f07b8). You can also create a user-defined restore point and restore from the newly created restore point to a new data warehouse. Once you have restored, you have the dedicated SQL pool online and can pause it indefinitely to save compute costs. The paused database incurs storage charges at the Azure Synapse storage rate. If you need an active copy of the restored data warehouse, you can resume which should take only a few minutes.
+> If you require restore points longer than 7 days, please vote for this capability [here](https://feedback.azure.com/d365community/idea/4c446fd9-0b25-ec11-b6e6-000d3a4f07b8).
+
+> [!NOTE]> In case you are looking for a Long-Term Backup (LTR) concept
+> 1. Create a new user-defined restore point or you can use one of the automatic generated restore points.
+> 2. Restore from the newly created restore point to a new data warehouse.
+> 3. Once you have restored, you have the dedicated SQL pool online Pause it indefinitely to save compute costs. The paused database incurs storage charges at the Azure Synapse storage rate. 
+> 
+> If you need an active copy of the restored data warehouse, you can resume which should take only a few minutes.
 
 ### Restore point retention
 

--- a/articles/synapse-analytics/sql-data-warehouse/backup-and-restore.md
+++ b/articles/synapse-analytics/sql-data-warehouse/backup-and-restore.md
@@ -44,12 +44,13 @@ This feature enables you to manually trigger snapshots to create restore points 
 > [!NOTE]
 > If you require restore points longer than 7 days, please vote for this capability [here](https://feedback.azure.com/d365community/idea/4c446fd9-0b25-ec11-b6e6-000d3a4f07b8).
 
-> [!NOTE]> In case you are looking for a Long-Term Backup (LTR) concept
-> 1. Create a new user-defined restore point or you can use one of the automatic generated restore points.
+> [!NOTE]
+> In case you're looking for a Long-Term Backup (LTR) concept:
+> 1. Create a new user-defined restore point, or you can use one of the automatically generated restore points.
 > 2. Restore from the newly created restore point to a new data warehouse.
-> 3. Once you have restored, you have the dedicated SQL pool online Pause it indefinitely to save compute costs. The paused database incurs storage charges at the Azure Synapse storage rate. 
+> 3. After you have restored, you have the dedicated SQL pool online. Pause it indefinitely to save compute costs. The paused database incurs storage charges at the Azure Synapse storage rate. 
 > 
-> If you need an active copy of the restored data warehouse, you can resume which should take only a few minutes.
+> If you need an active copy of the restored data warehouse, you can resume, which should take only a few minutes.
 
 ### Restore point retention
 


### PR DESCRIPTION
Based on the latest case reviews, customers asked about long term backup (LTB) concept. in Azure Synapse SQL Pool (LTB) is not supported so we are advising the customers to restore a copy from the Datawarehouse and pause it for long term.

The above information's available in this document, but since the note contains two parts, the first one related to vote for the feature and the second one about the LTR concepts it seems our customers missing that part.

The proposed change is to split the note into two parts and identify the steps which the customer should perform. Thanks