### PR TITLE
azure/aks/integrations: fix incorrect az aks command

### DIFF
--- a/articles/aks/integrations.md
+++ b/articles/aks/integrations.md
@@ -13,7 +13,7 @@ Azure Kubernetes Service (AKS) provides additional, supported functionality for 
 
 ## Add-ons
 
-Add-ons are a fully supported way to provide extra capabilities for your AKS cluster. Add-ons' installation, configuration, and lifecycle is managed by AKS. Use `az aks addon` to install an add-on or manage the add-ons for your cluster.
+Add-ons are a fully supported way to provide extra capabilities for your AKS cluster. Add-ons' installation, configuration, and lifecycle is managed by AKS. Use `az aks enable-addons` to install an add-on or manage the add-ons for your cluster.
 
 The following rules are used by AKS for applying updates to installed add-ons:
 


### PR DESCRIPTION
[Add-ons, extensions, and other integrations with Azure Kubernetes Service](https://learn.microsoft.com/en-us/azure/aks/integrations) mentions a non-existing (or possibly outdated) command `az aks addon`. Fixing this to use the correct command `az aks enable-addons`.


UPDATE - actually looks like `az aks addon` [exists](https://learn.microsoft.com/en-us/cli/azure/aks/addon)?
My CLI (3.10.8) doesn't appear to know it though: 

```
$ az aks addon
'addon' is misspelled or not recognized by the system.
```

Reverting PR to draft for now.