### PR TITLE
CosmosDB: intra container copy - add missing second underscore to database name

### DIFF
--- a/articles/cosmos-db/intra-account-container-copy.md
+++ b/articles/cosmos-db/intra-account-container-copy.md
@@ -89,10 +89,10 @@ The container copy job will run in the write region. If there are accounts confi
 
 The account's write region may change in the rare scenario of a region outage or due to manual failover. In such a scenario, incomplete container copy jobs created within the account would fail. You would need to recreate these failed jobs. Recreated jobs would then run in the new (current) write region.
 
-### Why is a new database *_datatransferstate* created in the account when I run container copy jobs? Am I being charged for this database?
-* *_datatransferstate* is a database that is created while running container copy jobs. This database is used by the platform to store the state and progress of the copy job.
+### Why is a new database *__datatransferstate* created in the account when I run container copy jobs? Am I being charged for this database?
+* *__datatransferstate* is a database that is created while running container copy jobs. This database is used by the platform to store the state and progress of the copy job.
 * The database uses manual provisioned throughput of 800 RUs. You'll be charged for this database.
-* Deleting this database will remove the container copy job history from the account. It can be safely deleted once all the jobs in the account have completed, if you no longer need the job history. The platform will not clean up the *_datatransferstate* database automatically.
+* Deleting this database will remove the container copy job history from the account. It can be safely deleted once all the jobs in the account have completed, if you no longer need the job history. The platform will not clean up the *__datatransferstate* database automatically.
 
 ## Supported regions
 
@@ -129,7 +129,7 @@ Make sure the target container is created before running the job as specified in
 * Error - Shared throughput database creation is not supported for serverless accounts
 
 Job creation on serverless accounts may fail with the error *"Shared throughput database creation is not supported for serverless accounts"*.
-As a work-around, create a database called *_datatransferstate* manually within the account and try creating the container copy job again.
+As a work-around, create a database called *__datatransferstate* manually within the account and try creating the container copy job again.
 
 ```
 ERROR: (BadRequest) Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx; Reason: (Shared throughput database creation is not supported for serverless accounts.


### PR DESCRIPTION
added missing additional underscore to database name to make the proposed workaround functional.