### PR TITLE
Added Step Defining AZURE_CLIENT_ID in Azure Functions App Setting For Managed Identity Connection

### DIFF
--- a/articles/azure-functions/functions-identity-based-connections-tutorial-2.md
+++ b/articles/azure-functions/functions-identity-based-connections-tutorial-2.md
@@ -94,6 +94,7 @@ You've granted your function app access to the service bus namespace using manag
     | Name      | Value  | Description |
     | ------------ | ---------------- | ----------- |
     | **ServiceBusConnection__fullyQualifiedNamespace** | <SERVICE_BUS_NAMESPACE>.servicebus.windows.net | This setting connections your function app to the Service Bus use identity-based connections instead of secrets. |
+    | **AZURE_CLIENT_ID** | GUID | This setting has the clientId of the Managed Identity. |
 
 1. After you create the two settings, select **Save** > **Confirm**.
 


### PR DESCRIPTION
To create a managed identity connection from Azure Function to Azure Service Bus, we need one additonal setting AZURE_CLIENT_ID defined in the Azure Function's Application Settings (which is missing in the Doc).