### PR TITLE
Fix form-recognizer model copy route

### DIFF
--- a/articles/applied-ai-services/form-recognizer/v3-migration-guide.md
+++ b/articles/applied-ai-services/form-recognizer/v3-migration-guide.md
@@ -296,7 +296,7 @@ POST https://{your-form-recognizer-endpoint}/formrecognizer/documentModels:compo
 The call pattern for copy model remains unchanged:
 
 * Authorize the copy operation with the target resource calling ```authorizeCopy```. Now a POST request.
-* Submit the authorization to the source resource to copy the model calling ```copy-to```
+* Submit the authorization to the source resource to copy the model calling ```copyTo```
 * Poll the returned operation to validate the operation completed successfully
 
 The only changes to the copy model function are:
@@ -317,7 +317,7 @@ POST https://{targetHost}/formrecognizer/documentModels:authorizeCopy?api-versio
 Use the response body from the authorize action to construct the request for the copy.
 
 ```json
-POST https://{sourceHost}/formrecognizer/documentModels/{sourceModelId}:copy-to?api-version=2022-08-31
+POST https://{sourceHost}/formrecognizer/documentModels/{sourceModelId}:copyTo?api-version=2022-08-31
 {
   "targetResourceId": "{targetResourceId}",
   "targetResourceRegion": "{targetResourceRegion}",


### PR DESCRIPTION
The model copy url seems to be incorrect, `copy-to` => `copyTo`.