### PR TITLE
Update howto-conditional-access-policy-compliant-device.md

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
@@ -63,7 +63,7 @@ On Windows 7, iOS, Android, macOS, and some third-party web browsers, Azure AD i
 
 #### Subscription activation
 
-Organizations that use the [Subscription Activation](/windows/deployment/windows-10-subscription-activation) feature to enable users to “step-up” from one version of Windows to another, may want to exclude the Universal Store Service APIs and Web Application, AppID 45a330b1-b1ec-4cc1-9161-9f03992aa49f from their device compliance policy.
+Organizations that use the [Subscription Activation](/windows/deployment/windows-10-subscription-activation) feature to enable users to “step-up” from one version of Windows to another, may want to exclude the Universal Store Service APIs and Web Application, AppID 45a330b1-b1ec-4cc1-9161-9f03992aa49f from existing MFA Conditional Access policies.
 
 ## Next steps
 


### PR DESCRIPTION
On Subscription activation it is written "Organizations that use the Subscription Activation feature to enable users to “step-up” from one version of Windows to another, may want to exclude the Universal Store Service APIs and Web Application, AppID 45a330b1-b1ec-4cc1-9161-9f03992aa49f from their device compliance policy."

Where device compliance policy is written should be Conditional Access policy.