### PR TITLE
Request to add CSP info.

### DIFF
--- a/articles/cost-management-billing/reservations/synapse-analytics-pre-purchase-plan.md
+++ b/articles/cost-management-billing/reservations/synapse-analytics-pre-purchase-plan.md
@@ -34,10 +34,11 @@ For more information about available SCU tiers and pricing discounts, you'll use
 
 ## Purchase Synapse commit units
 
-You buy Synapse plans in the [Azure portal](https://portal.azure.com). To buy a Pre-Purchase Plan, you must have the owner role for at least one enterprise subscription.
+You buy Synapse plans in the [Azure portal](https://portal.azure.com). To buy a Pre-Purchase Plan, you must have the owner role for at least one enterprise or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates subscription, or the required role for CSP subscriptions.
 
 - You must be in an Owner role for at least one Enterprise Agreement (offer numbers: MS-AZR-0017P or MS-AZR-0148P) or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates (offer numbers: MS-AZR-0003P or MS-AZR-0023P).
 - For Enterprise Agreement (EA) subscriptions, the **Add Reserved Instances** option must be enabled in the [EA portal](https://ea.azure.com/). Or, if that setting is disabled, you must be an EA Admin of the subscription.
+- For CSP subscriptions, follow the steps in https://learn.microsoft.com/en-us/partner-center/azure-ri-server-subscriptions.
 
 ### To Purchase:
 

--- a/articles/cost-management-billing/reservations/synapse-analytics-pre-purchase-plan.md
+++ b/articles/cost-management-billing/reservations/synapse-analytics-pre-purchase-plan.md
@@ -38,7 +38,7 @@ You buy Synapse plans in the [Azure portal](https://portal.azure.com). To buy a 
 
 - You must be in an Owner role for at least one Enterprise Agreement (offer numbers: MS-AZR-0017P or MS-AZR-0148P) or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates (offer numbers: MS-AZR-0003P or MS-AZR-0023P).
 - For Enterprise Agreement (EA) subscriptions, the **Add Reserved Instances** option must be enabled in the [EA portal](https://ea.azure.com/). Or, if that setting is disabled, you must be an EA Admin of the subscription.
-- For CSP subscriptions, follow the steps in https://learn.microsoft.com/en-us/partner-center/azure-ri-server-subscriptions.
+- For CSP subscriptions, follow the steps in [Acquire, provision, and manage Azure reserved VM instances (RI) + server subscriptions for customers](/partner-center/azure-ri-server-subscriptions).
 
 ### To Purchase:
 


### PR DESCRIPTION
Kindly add Azure Synapse Analytics costs with a Pre-Purchase Plans are offered to CSP subscriptions too. FYI: We have verified both Azure portal and CSP price list shows the products to be purchased with our test CSP account and subscription. (Kindly let us know if you need the screenshot and pricing info. as a proof.) https://learn.microsoft.com/en-us/partner-center/azure-ri-server-subscriptions
 You can buy Azure reservations on behalf of a customer, or you can allow the customer to buy their own reservations from a prior Azure subscription the partner has purchased for them.
See Purchase Reservations on the Azure portal.
See the Azure RI CSP Commercial Price