### PR TITLE
Request to add CSP info.

### DIFF
--- a/articles/cost-management-billing/reservations/prepay-databricks-reserved-capacity.md
+++ b/articles/cost-management-billing/reservations/prepay-databricks-reserved-capacity.md
@@ -38,7 +38,7 @@ You can buy Databricks plans in the [Azure portal](https://portal.azure.com/#bla
 
 - You must be in an Owner role for at least one Enterprise Agreement (offer numbers: MS-AZR-0017P or MS-AZR-0148P) or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates (offer numbers: MS-AZR-0003P or MS-AZR-0023P).
 - For Enterprise subscriptions, **Add Reserved Instances** must be enabled in the [EA portal](https://ea.azure.com/). Or, if that setting is disabled, you must be an EA Admin of the subscription to enable it. Direct EA customers can now update **Reserved Instance** setting on [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_GTM/ModernBillingMenuBlade/AllBillingScopes). Navigate to the Policies menu to change settings.
-- For CSP subscriptions, follow the steps in [https://learn.microsoft.com/partner-center/azure-ri-server-subscriptions](/partner-center/azure-ri-server-subscriptions).
+- For CSP subscriptions, follow the steps in [Acquire, provision, and manage Azure reserved VM instances (RI) + server subscriptions for customers](/partner-center/azure-ri-server-subscriptions).
 
 
 **To Purchase:**

--- a/articles/cost-management-billing/reservations/prepay-databricks-reserved-capacity.md
+++ b/articles/cost-management-billing/reservations/prepay-databricks-reserved-capacity.md
@@ -34,10 +34,11 @@ Before you buy, calculate the total DBU quantity consumed for different workload
 
 ## Purchase Databricks commit units
 
-You can buy Databricks plans in the [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_Reservations/CreateBlade/referrer/documentation/filters/%7B%22reservedResourceType%22%3A%22Databricks%22%7D). To buy reserved capacity, you must have the owner role for at least one enterprise subscription.
+You can buy Databricks plans in the [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_Reservations/CreateBlade/referrer/documentation/filters/%7B%22reservedResourceType%22%3A%22Databricks%22%7D). To buy reserved capacity, you must have the owner role for at least one enterprise or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates subscription, or the required role for CSP subscriptions.
 
 - You must be in an Owner role for at least one Enterprise Agreement (offer numbers: MS-AZR-0017P or MS-AZR-0148P) or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates (offer numbers: MS-AZR-0003P or MS-AZR-0023P).
 - For Enterprise subscriptions, **Add Reserved Instances** must be enabled in the [EA portal](https://ea.azure.com/). Or, if that setting is disabled, you must be an EA Admin of the subscription to enable it. Direct EA customers can now update **Reserved Instance** setting on [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_GTM/ModernBillingMenuBlade/AllBillingScopes). Navigate to the Policies menu to change settings.
+- For CSP subscriptions, follow the steps in https://learn.microsoft.com/en-us/partner-center/azure-ri-server-subscriptions.
 
 
 **To Purchase:**

--- a/articles/cost-management-billing/reservations/prepay-databricks-reserved-capacity.md
+++ b/articles/cost-management-billing/reservations/prepay-databricks-reserved-capacity.md
@@ -38,7 +38,7 @@ You can buy Databricks plans in the [Azure portal](https://portal.azure.com/#bla
 
 - You must be in an Owner role for at least one Enterprise Agreement (offer numbers: MS-AZR-0017P or MS-AZR-0148P) or Microsoft Customer Agreement or an individual subscription with pay-as-you-go rates (offer numbers: MS-AZR-0003P or MS-AZR-0023P).
 - For Enterprise subscriptions, **Add Reserved Instances** must be enabled in the [EA portal](https://ea.azure.com/). Or, if that setting is disabled, you must be an EA Admin of the subscription to enable it. Direct EA customers can now update **Reserved Instance** setting on [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_GTM/ModernBillingMenuBlade/AllBillingScopes). Navigate to the Policies menu to change settings.
-- For CSP subscriptions, follow the steps in https://learn.microsoft.com/en-us/partner-center/azure-ri-server-subscriptions.
+- For CSP subscriptions, follow the steps in [https://learn.microsoft.com/partner-center/azure-ri-server-subscriptions](/partner-center/azure-ri-server-subscriptions).
 
 
 **To Purchase:**


### PR DESCRIPTION
Kindly add Azure Databricks costs with a pre-purchase are offered to CSP subscriptions too. FYI: We have verified both Azure portal and CSP price list shows the products to be purchased with our test CSP account and subscription. (Kindly let us know if you need the screenshot and pricing info. as a proof.) https://learn.microsoft.com/en-us/partner-center/azure-ri-server-subscriptions
 You can buy Azure reservations on behalf of a customer, or you can allow the customer to buy their own reservations from a prior Azure subscription the partner has purchased for them.
See Purchase Reservations on the Azure portal.
See the Azure RI CSP Commercial Price