### PR TITLE
added Azure AD Certificate call out

### DIFF
--- a/articles/active-directory/external-identities/authentication-conditional-access.md
+++ b/articles/active-directory/external-identities/authentication-conditional-access.md
@@ -178,6 +178,7 @@ In external user scenarios, the authentication methods that are acceptable for f
 |Microsoft Authenticator push notification    | &#x2705;        | &#x2705; |
 |Microsoft Authenticator phone sign-in        | &#x2705;        | &#x2705; |
 |OATH software token                          | &#x2705;        | &#x2705; |
+|Azure AD certificate-based authentication    | &#x2705;        |          |
 |OATH hardware token                          | &#x2705;        |          |
 |FIDO2 security key                           | &#x2705;        |          |
 |Windows Hello for Business                   | &#x2705;        |          |


### PR DESCRIPTION
Azure Ad Certificate based MFA is in preview and based on this document, it only works on Home Tenants (if I read this right)

https://learn.microsoft.com/en-us/azure/active-directory/authentication/concept-certificate-based-authentication


Specifically:

"External identity support
An external identity can't perform multifactor authentication (MFA) to the resource tenant with Azure AD CBA. Instead, have the user perform MFA using CBA in the home tenant, and set up cross tenant settings for the resource tenant to trust MFA from the home tenant.

For more information about how to enable Trust multi-factor authentication from Azure AD tenants, see Configure B2B collaboration cross-tenant access." https://learn.microsoft.com/en-us/azure/active-directory/authentication/concept-certificate-based-authentication-technical-deep-dive#external-identity-support