### PR TITLE
Update multiline-secrets.md

### DIFF
--- a/articles/key-vault/secrets/multiline-secrets.md
+++ b/articles/key-vault/secrets/multiline-secrets.md
@@ -45,7 +45,7 @@ The secret will be returned with `\n` in place of newline:
 "This is\nmy multi-line\nsecret"
 ```
 
-The `\n` above is a `\` and `n` character, not the newline character.
+The `\n` above is a `\` and `n` character, not the newline character. Quotes `"` are included in the string.
 
 ## Set the secret using Azure Powershell
 
@@ -74,7 +74,7 @@ The secret will be returned with `\n` in place of newline:
 "This is\nmy multi-line\nsecret"
 ```
 
-The `\n` above is a `\` and `n` character, not the newline character.
+The `\n` above is a `\` and `n` character, not the newline character. Quotes `"` are included in the string.
 
 ## Next steps
 

--- a/articles/key-vault/secrets/multiline-secrets.md
+++ b/articles/key-vault/secrets/multiline-secrets.md
@@ -39,11 +39,13 @@ You can then view the stored secret using the Azure CLI [az keyvault secret show
 az keyvault secret show --name "MultilineSecret" --vault-name "<your-unique-keyvault-name>" --query "value"
 ```
 
-The secret will be returned with newlines embedded:
+The secret will be returned with `\n` in place of newline:
 
 ```bash
 "This is\nmy multi-line\nsecret"
 ```
+
+The `\n` above is a `\` and `n` character, not the newline character.
 
 ## Set the secret using Azure Powershell
 
@@ -66,11 +68,13 @@ You can then view the stored secret using the Azure CLI [az keyvault secret show
 az keyvault secret show --name "MultilineSecret" --vault-name "<your-unique-keyvault-name>" --query "value"
 ```
 
-The secret will be returned with newlines embedded:
+The secret will be returned with `\n` in place of newline:
 
 ```bash
 "This is\nmy multi-line\nsecret"
 ```
+
+The `\n` above is a `\` and `n` character, not the newline character.
 
 ## Next steps
 


### PR DESCRIPTION
The multiline secret is returned as `My\nSecret`, where the `\n` is NOT the newline character, but rather `\` and `n`. This is unexpected, because the documentation says newline, and I as .NET developer where `\n` is commonly used to denote the invisible newline character expected that those are literal newlines.

Similarly the string is surrounded by `"` characters, which is also quite unexpected.