### PR TITLE
Update network-watcher-nsg-flow-logging-overview.md

### DIFF
--- a/articles/network-watcher/network-watcher-nsg-flow-logging-overview.md
+++ b/articles/network-watcher/network-watcher-nsg-flow-logging-overview.md
@@ -389,7 +389,7 @@ $virtualNetwork |  Set-AzVirtualNetwork
 - [Azure Functions](https://azure.microsoft.com/services/functions/)
 
 > [!NOTE]
-> App services deployed under App Service Plan do not support NSG Flow Logs. Please refer [this documentaion](../app-service/overview-vnet-integration.md#how-regional-virtual-network-integration-works) for additional details.
+> App services deployed under App Service Plan do not support NSG Flow Logs. Please refer [this documentation](../app-service/overview-vnet-integration.md#how-regional-virtual-network-integration-works) for additional details.
 
 ## Best practices
 


### PR DESCRIPTION
App services deployed under App Service Plan do not support NSG Flow Logs. Please refer [this documentation](../app-service/overview-vnet-integration.md#how-regional-virtual-network-integration-works) for additional details. - in this line, corrected typo documentaion to documentation