### PR TITLE
Update service-bus-go-how-to-use-queues.md

### DIFF
--- a/articles/service-bus-messaging/service-bus-go-how-to-use-queues.md
+++ b/articles/service-bus-messaging/service-bus-go-how-to-use-queues.md
@@ -148,10 +148,7 @@ func GetMessage(count int, client *azservicebus.Client) {
 	}
 
 	for _, message := range messages {
-		body, err := message.Body()
-		if err != nil {
-			panic(err)
-		}
+		body := message.Body
 		fmt.Printf("%s\n", string(body))
 
 		err = receiver.CompleteMessage(context.TODO(), message, nil)
@@ -317,10 +314,7 @@ func GetMessage(count int, client *azservicebus.Client) {
 	}
 
 	for _, message := range messages {
-		body, err := message.Body()
-		if err != nil {
-			panic(err)
-		}
+		body := message.Body
 		fmt.Printf("%s\n", string(body))
 
 		err = receiver.CompleteMessage(context.TODO(), message, nil)


### PR DESCRIPTION
### Changelog:

- when receiving message from AzureServiceBus, `message.Body` is used to access the response content rather than `message.Body()`.