### PR TITLE
Fix the NIC Names Command

### DIFF
--- a/articles/virtual-machines/linux/tutorial-load-balancer.md
+++ b/articles/virtual-machines/linux/tutorial-load-balancer.md
@@ -284,7 +284,7 @@ az network lb address-pool show \
     --lb-name myLoadBalancer \
     --name myBackEndPool \
     --query backendIpConfigurations \
-    --output tsv | cut -f4
+    --output tsv | cut -f5
 ```
 
 The output is similar to the following example, which shows that the virtual NIC for VM 2 is no longer part of the backend address pool:


### PR DESCRIPTION
The AZ CLI command to fetch the NIC names from the Backend Address Pool is incorrect. the current command generates 'Nones'. The command has been corrected now.