### PR TITLE
Update expressroute-routing.md

### DIFF
--- a/articles/expressroute/expressroute-routing.md
+++ b/articles/expressroute/expressroute-routing.md
@@ -265,6 +265,7 @@ In addition to the above, Microsoft will also tag prefixes based on the service 
 | China East | 12076:51302 |
 | China East 2| 12076:51303 |
 | China North 2 | 12076:51304 |
+| China North 3 | 12076:51305 |
 
 | **Service in National Clouds** | **BGP community value** |
 | --- | --- |


### PR DESCRIPTION
when configure the Manage rule in Router filter from the Azure portal, we already can see the latest BGP community for China North3 as 12076:51305, want to update this entry on this document.

![image](https://user-images.githubusercontent.com/36225214/198185916-7cdbc9db-fd86-49ac-b335-94e7373e42a3.png)
