### PR TITLE
Unsupported workflow is not correct.

### DIFF
--- a/articles/expressroute/expressroute-circuit-peerings.md
+++ b/articles/expressroute/expressroute-circuit-peerings.md
@@ -47,7 +47,7 @@ Default quotas and limits apply for every ExpressRoute circuit. Refer to the [Az
 
 #### Unsupported workflow
 
-* Downgrade from Premium to Standard SKU.
+* Downgrade from Premium/Standard to Local SKU.
 * Changing from *UnlimitedData* to *MeteredData*.
 
 ## <a name="routingdomains"></a>ExpressRoute peering


### PR DESCRIPTION
I think "Downgrade from Premium to Standard SKU" is supported, unsupported workflow is "Downgrade from Premium/Standard to Local SKU".
Ref: https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-circuit-portal-resource-manager#create-a-new-expressroute-circuit