### PR TITLE
Fixed documentation MLTable examples

### DIFF
--- a/articles/machine-learning/how-to-create-data-assets.md
+++ b/articles/machine-learning/how-to-create-data-assets.md
@@ -242,7 +242,7 @@ paths:
   - pattern: ./*.txt
 transformations:
   - read_delimited:
-      delimiter: ,
+      delimiter: ','
       encoding: ascii
       header: all_files_same_headers
 ```

--- a/articles/machine-learning/reference-yaml-mltable.md
+++ b/articles/machine-learning/reference-yaml-mltable.md
@@ -65,7 +65,7 @@ paths:
   - pattern: ./*.txt
 transformations:
   - read_delimited:
-      delimiter: ,
+      delimiter: ','
       encoding: ascii
       header: all_files_same_headers
   - columns: [Trip_Pickup_DateTime, Trip_Dropoff_DateTime]


### PR DESCRIPTION
Fixed MLTable documentation examples which had incorrect syntax