### PR TITLE
Update deploy-disaster-recovery-using-jetstream.md

### DIFF
--- a/articles/azure-vmware/deploy-disaster-recovery-using-jetstream.md
+++ b/articles/azure-vmware/deploy-disaster-recovery-using-jetstream.md
@@ -194,7 +194,7 @@ Azure VMware Solution supports the installation of JetStream using either static
    | **Datastore**  | Name of the datastore where you'll deploy the JetStream MSA.  |
    | **VMName** | Name of JetStream MSA VM, for example, **jetstreamServer**. |
    | **Cluster** | Name of the Azure VMware Solution private cluster where the JetStream MSA is deployed, for example, **Cluster-1**. |
-   | **Netmask** | Netmask of the MSA to be deployed, for example, **22** or **24**. |
+   | **Netmask** | Netmask of the MSA to be deployed, for example, **255.255.255.0**. |
    | **MSIp** | IP address of the JetStream MSA VM.   |
    | **Dns** | DNS IP that the JetStream MSA VM should use.   |
    | **Gateway** | IP address of the network gateway for the JetStream MSA VM.  |


### PR DESCRIPTION
In the install-the-jetstream-dr-msa section, the netmask example was incorrectly shown as 2 digit values, when the cmdlet expects dotted decimal notation. I changed the example to 255.255.255.0.