### PR TITLE
Update v3-java-sdk.md: fix wrong class name ("DocumentOperationResult" -> "OperationResult") + 1

### DIFF
--- a/articles/applied-ai-services/form-recognizer/quickstarts/includes/v3-java-sdk.md
+++ b/articles/applied-ai-services/form-recognizer/quickstarts/includes/v3-java-sdk.md
@@ -463,9 +463,9 @@ public class FormRecognizer {
     String modelId = "prebuilt-invoice";
     String invoiceUrl = "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/sample-invoice.pdf";
 
-    SyncPoller < DocumentOperationResult, AnalyzeResult > analyzeInvoicePoller = client.beginAnalyzeDocumentFromUrl(modelId, invoiceUrl);
+    SyncPoller < OperationResult, AnalyzeResult > analyzeInvoicePoller = client.beginAnalyzeDocumentFromUrl(modelId, invoiceUrl);
 
-    AnalyzeResult analyzeInvoiceResult = analyzeInvoicesPoller.getFinalResult();
+    AnalyzeResult analyzeInvoiceResult = analyzeInvoicePoller.getFinalResult();
 
     for (int i = 0; i < analyzeInvoiceResult.getDocuments().size(); i++) {
       AnalyzedDocument analyzedInvoice = analyzeInvoiceResult.getDocuments().get(i);


### PR DESCRIPTION
Consists of two fixes:
1. fix wrong class name (`DocumentOperationResult` -> `OperationResult`) 
2. fix variable name inconsistency (`analyzeInvoicesPoller` -> `analyzeInvoicePoller`)

without this fix, compilation errors will occur in sample codes.

NOTE:
- It seems `DocumentOperationResult` is no longer existing (only the `OperationResult` is present)
https://azuresdkdocs.blob.core.windows.net/$web/java/azure-ai-formrecognizer/4.0.1/com/azure/ai/formrecognizer/documentanalysis/models/package-summary.html