### PR TITLE
Fixed typo in JSON example for Data Factory (CI/CD) 

### DIFF
--- a/articles/data-factory/continuous-integration-delivery-improvements.md
+++ b/articles/data-factory/continuous-integration-delivery-improvements.md
@@ -119,7 +119,7 @@ Follow these steps to get started:
    ```json
    {
        "scripts":{
-           "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index",
+           "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index"
        },
        "dependencies":{
            "@microsoft/azure-data-factory-utilities":"^1.0.0"


### PR DESCRIPTION
Hi,

I discovered a typo in the JSON example for the package.json in the article Automated publishing for continuous integration and delivery

In step 2 of the chapter Create an Azure pipeline, the example JSON code has a comma at the end that should be removed. Using the package.json as is in an Azure Pipeline will result in a NPM error.

Also created an issue: https://github.com/MicrosoftDocs/azure-docs/issues/100633