### PR TITLE
SAML Certificate and Key File Clarification

### DIFF
--- a/articles/active-directory/saas-apps/tableauserver-tutorial.md
+++ b/articles/active-directory/saas-apps/tableauserver-tutorial.md
@@ -147,6 +147,9 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 	> [!NOTE]
 	> Customer have to upload A PEM-encoded x509 Certificate file with a .crt extension and a RSA or DSA private key file that has the .key extension, as a Certificate Key file. For more information on Certificate file and Certificate Key file, please refer to [this](https://help.tableau.com/current/server/en-us/saml_requ.htm) document. If you need help configuring SAML on Tableau Server then please refer to this article [Configure Server Wide SAML](https://help.tableau.com/current/server/en-us/config_saml.htm).
+	
+	> [!NOTE]
+	> The SAML Certificate and SAML Key files are generated separately and uploaded to the Tableau Server Manager. For example, in the linux shell, use openssl to generate the cert and key like so: `openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout private.key -out saml.crt` then upload the `saml.crt` and `private.key` files via the TSM Configruation GUI (As shown in the screenshot at the start of this step) or via the [command line according to the tableau docs](https://help.tableau.com/current/server-linux/en-us/config_saml.htm). If you are in a production environment, you may want to find a more secure way to handle SAML certs and keys.
 
 ### Create Tableau Server test user
 


### PR DESCRIPTION
Explains where the SAML Certificate and Key Files come from. Users unfamiliar with Public/Key encryption may *incorrectly* assume that the SAML Certificate is the Microsoft SAML Signing Certificate which is to be uploaded to the Tableau Server Manger (TSM) while also missing a .key file.

SAML tickets are suppose to be individually generated and uploaded to TSM.

Close #100651