### PR TITLE
Change `prev` variable name to `next`

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-functions-lambda.md
+++ b/articles/azure-resource-manager/bicep/bicep-functions-lambda.md
@@ -213,8 +213,8 @@ var dogs = [
   }
 ]
 var ages = map(dogs, dog => dog.age)
-output totalAge int = reduce(ages, 0, (cur, prev) => cur + prev)
-output totalAgeAdd1 int = reduce(ages, 1, (cur, prev) => cur + prev)
+output totalAge int = reduce(ages, 0, (cur, next) => cur + next)
+output totalAgeAdd1 int = reduce(ages, 1, (cur, next) => cur + next)
 ```
 
 The output from the preceding example is:


### PR DESCRIPTION
This is in line with the other examples and technically correct: the value in the second variable is the next element that will be processed by the reduce function.