### PR TITLE
Update use-multiple-node-pools.md

### DIFF
--- a/articles/aks/use-multiple-node-pools.md
+++ b/articles/aks/use-multiple-node-pools.md
@@ -139,20 +139,21 @@ az aks nodepool add \
 
 Mariner is an open-source Linux distribution available as an AKS container host. It provides high reliability, security, and consistency. Mariner only includes the minimal set of packages needed for running container workloads, which improves boot times and overall performance.
 
-You can add a Mariner node pool into your existing cluster using the `az aks nodepool add` command and specifying `--os-sku mariner`.
+You can add a Mariner node pool into your existing cluster using the `az aks nodepool add` command and specifying `--os-sku CBLMariner`.
 
 ```azurecli
 az aks nodepool add \
+    --name marinerpool
     --resource-group myResourceGroup \
     --cluster-name myAKSCluster \
-    --os-sku mariner
+    --os-sku CBLMariner
 ```
 
 ### Migrate Ubuntu nodes to Mariner
 
 Use the following instructions to migrate your Ubuntu nodes to Mariner nodes.
 
-1. Add a Mariner node pool into your existing cluster using the `az aks nodepool add` command and specifying `--os-sku mariner`.
+1. Add a Mariner node pool into your existing cluster using the `az aks nodepool add` command and specifying `--os-sku CBLMariner`.
 
 > [!NOTE]
 > When adding a new Mariner node pool, you need to add at least one as `--mode System`. Otherwise, AKS won't allow you to delete your existing Ubuntu node pool.


### PR DESCRIPTION
when running the original command:

```sh
$ az aks nodepool add -g tylloyd-devbox -n v6 --os-sku mariner
az aks nodepool add: 'mariner' is not a valid value for '--os-sku'. Allowed values: Ubuntu, CBLMariner, Windows2019, Windows2022.
```