### PR TITLE
Fixed a wrong parameter in the command

### DIFF
--- a/articles/deployment-environments/quickstart-create-access-environments.md
+++ b/articles/deployment-environments/quickstart-create-access-environments.md
@@ -88,12 +88,12 @@ Run the following steps in Azure CLI to create an Environment and configure reso
         --catalog-item-name <catalog-item-name> ---catalog-name <catalog-name> 
     ```
 
-    If the specific *catalog-item* requires any parameters use `--deployment-parameters` and provide the parameters as a json-string or json-file, for example:  
+    If the specific *catalog-item* requires any parameters use `--parameters` and provide the parameters as a json-string or json-file, for example:  
     ```json
     $params = "{ 'name': 'firstMsi', 'location': 'northeurope' }"
     az devcenter dev environment create --dev-center-name <devcenter-name> 
         --project-name <project-name> -n <name> --environment-type <environment-type-name> 
-        --catalog-item-name <catalog-item-name> ---catalog-name <catalog-name> 
+        --catalog-item-name <catalog-item-name> --catalog-name <catalog-name> 
         --parameters $params
     ```
 


### PR DESCRIPTION
`---catalog-name` and `--deployment-parameters` were not present and have been corrected to be normal, respectively.

Command Help:
```
$ az devcenter dev environment create --help
This command is from the following extension: devcenter

Command
    az devcenter dev environment create : Create an environment.
        Command group 'devcenter' is experimental and under development. Reference and support
        levels: https://aka.ms/CLI_refstatus
Arguments
    --catalog-item-name               [Required] : Name of the catalog item.
    --catalog-name                    [Required] : Name of the catalog.
    --dev-center --dev-center-name -d [Required] : The DevCenter to operate on.
    --environment-name --name -n      [Required] : The name of the environment.
    --environment-type                [Required] : Environment type.
    --project --project-name          [Required] : The DevCenter Project upon which to execute
                                                   operations.
    --description                                : Description of the Environment.
    --no-wait                                    : Do not wait for the long-running operation to
                                                   finish.
    --owner                                      : Identifier of the owner of this Environment.
    --parameters                                 : Parameters object for the deploy action Expected
                                                   value: json-string/json-file/@json-file.
    --scheduled-tasks                            : Set of supported scheduled tasks to help manage
                                                   cost. Expected value: json-string/json-
                                                   file/@json-file.
    --tags                                       : Space-separated tags: key[=value] [key[=value]
                                                   ...]. Use "" to clear existing tags.
    --user-id                                    : The id of the user. If value is 'me', the
                                                   identity is taken from the authentication
                                                   context.  Default: me.
```
