### PR TITLE
  (AzureCXP) fixes MicrosoftDocs/azure-docs#100655

### DIFF
--- a/articles/data-factory/continuous-integration-delivery-improvements.md
+++ b/articles/data-factory/continuous-integration-delivery-improvements.md
@@ -119,7 +119,7 @@ Follow these steps to get started:
    ```json
    {
        "scripts":{
-           "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index",
+           "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index"
        },
        "dependencies":{
            "@microsoft/azure-data-factory-utilities":"^1.0.0"


### PR DESCRIPTION
We have done changes in the line no:122

Extra comma in build element causes JSON to be invalid. Proposed change: { "scripts":{ "build":"node node_modules/@microsoft/azure-data-factory-utilities/lib/index" }, "dependencies":{ "@microsoft/azure-data-factory-utilities":"^1.0.0" } }