### PR TITLE
Option --remove-vnet-id has been removed in current API

### DIFF
--- a/articles/virtual-network/create-peering-different-deployment-models-subscriptions.md
+++ b/articles/virtual-network/create-peering-different-deployment-models-subscriptions.md
@@ -153,7 +153,7 @@ This tutorial uses different accounts for each subscription. If you're using an 
       --name myVnetAToMyVnetB \
       --resource-group $rgName \
       --vnet-name myVnetA \
-      --remote-vnet-id  /subscriptions/<SubscriptionB-id>/resourceGroups/Default-Networking/providers/Microsoft.ClassicNetwork/virtualNetworks/myVnetB \
+      --remote-vnet  /subscriptions/<SubscriptionB-id>/resourceGroups/Default-Networking/providers/Microsoft.ClassicNetwork/virtualNetworks/myVnetB \
       --allow-vnet-access
     ```
 


### PR DESCRIPTION
In the current API for the CLI, `--remote-vnet-id` when creating a vnet peering is no longer supported.

I get the error `the following arguments are required: --remote-vnet` if I use `--remote-vnet-id`