### PR TITLE
fix incorrect sample for isolated timer

### DIFF
--- a/articles/azure-functions/functions-bindings-timer.md
+++ b/articles/azure-functions/functions-bindings-timer.md
@@ -45,7 +45,7 @@ public static void Run([TimerTrigger("0 */5 * * * *")]TimerInfo myTimer, ILogger
 
 # [Isolated process](#tab/isolated-process)
 
-:::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/Timer/TimerFunction.cs" range="12-18":::
+:::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/Timer/TimerFunction.cs" range="11-17":::
 
 
 # [C# Script](#tab/csharp-script)


### PR DESCRIPTION
reference: https://github.com/Azure/azure-functions-dotnet-worker/blob/main/samples/Extensions/Timer/TimerFunction.cs

fixes:

![image](https://user-images.githubusercontent.com/14079228/199359917-48af296f-a358-4316-9eb2-8622531a8c71.png)

pretty sure the goal was to have this snippet:

![image](https://user-images.githubusercontent.com/14079228/199359966-42edb4dd-7749-40c9-8d05-a52e42cf6a17.png)
