### PR TITLE
Fixed incorrect 'Certificates Officer' role name

### DIFF
--- a/articles/key-vault/general/rbac-migration.md
+++ b/articles/key-vault/general/rbac-migration.md
@@ -35,7 +35,7 @@ Azure RBAC has several Azure built-in roles that you can assign to users, groups
 Key Vault built-in roles for keys, certificates, and secrets access management:
 - Key Vault Administrator
 - Key Vault Reader
-- Key Vault Certificate Officer
+- Key Vault Certificates Officer
 - Key Vault Crypto Officer
 - Key Vault Crypto User
 - Key Vault Crypto Service Encryption User


### PR DESCRIPTION
The role 'Key Vault Certificates Officer' was lacking an 's' which will cause issues if somebody copy-pastes this line into their Terraform code. Trust me.