### PR TITLE
Update factset-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/factset-tutorial.md
+++ b/articles/active-directory/saas-apps/factset-tutorial.md
@@ -115,19 +115,19 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 ## Configure FactSet SSO
 
-To configure single sign-on on **FactSet** side, you need to send the downloaded **Federation Metadata XML** and appropriate copied URLs from Azure portal to FactSet account support representatives or to [FactSet Support Team](https://www.factset.com/contact-us). They set this setting to have the SAML SSO connection set properly on both sides.
+To configure single sign-on on **FactSet** side you will need to visit FactSet's [Control Center](https://controlcenter.factset.com) and configure the **Federation Metadata XML** and appropriate copied URLs from Azure portal under Control Center's Security>Single Sign-On (SSO) page. If you require access to this page, please contact [FactSet Support Team](https://www.factset.com/contact-us) and request FactSet product 8514 (Control Center - Source IPs, Security + Authentication).
 
 ### Create FactSet test user
 
-In this section, you create a user called Britta Simon in FactSet. Work with your FactSet account support representatives or contact [FactSet Support Team](https://www.factset.com/contact-us) to add the users in the FactSet platform. Users must be created and activated before you use single sign-on.
+ Work with your FactSet account support representatives or contact [FactSet Support Team](https://www.factset.com/contact-us) to add the users in the FactSet platform. Users must be created and activated before you use single sign-on.
 
 ## Test SSO 
 
 In this section, you test your Azure AD single sign-on configuration with following options.
 
-* Click on Test this application in Azure portal and you should be automatically signed in to the FactSet for which you set up the SSO.
+* FactSet only supports SP-initiated SAML. You may test SSO by visiting any authenticated FactSet URL such as [Issue Tracker](https://issuetracker.factset.com) or [FactSet-Web](https://my.factset.com), click on "Single Sign-On (SSO)" on the logon portal and supply your email address in the subsequent page. Please see supplied [documentation](https://download.factset.com/documents/web/FactSet_Single_Sign-On.pdf) for additional information and usage.  
 
-* You can use Microsoft My Apps. When you click the FactSet tile in the My Apps, you should be automatically signed in to the FactSet for which you set up the SSO. For more information about the My Apps, see [Introduction to the My Apps](https://support.microsoft.com/account-billing/sign-in-and-start-apps-from-the-my-apps-portal-2f3b1bae-0e5a-4a86-a33e-876fbd2a4510).
+
 
 ## Next steps
 


### PR DESCRIPTION
FactSet has adjusted Federation setup to be self-setup via client's access to our IT facing portal at https://controlcenter.factset.com. Further detailed instructions provided to the client are publicly available here: https://download.factset.com/documents/web/FactSet_Single_Sign-On.pdf as well as being directly supplied in FactSet's Control Center.