### PR TITLE
Add missing code snippet in the Azure ML Documentation

### DIFF
--- a/articles/machine-learning/tutorial-pipeline-python-sdk.md
+++ b/articles/machine-learning/tutorial-pipeline-python-sdk.md
@@ -202,6 +202,7 @@ The second component that you'll create will consume the training and test data,
 
 You used the `CommandComponent` class to create your first component. This time you'll use the yaml definition to define the second component. Each method has its own advantages. A yaml definition can actually be checked-in along the code, and would provide a readable history tracking. The programmatic method using `CommandComponent` can be easier with built-in class documentation and code completion.
 
+
 Create the directory for this component:
 
 [!Notebook-python[] (~/azureml-examples-main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb?name=train_src_dir)]

--- a/articles/machine-learning/tutorial-pipeline-python-sdk.md
+++ b/articles/machine-learning/tutorial-pipeline-python-sdk.md
@@ -207,8 +207,11 @@ Create the directory for this component:
 
 [!Notebook-python[] (~/azureml-examples-main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb?name=train_src_dir)]
 
-As you can see in this training script, once the model is trained, the model file is saved and registered to the workspace. Now you can use the registered model in inferencing endpoints.
+Create the training script in the directory:
 
+[!Notebook-python[] (~/azureml-examples-main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb?name=train.py)]
+
+As you can see in this training script, once the model is trained, the model file is saved and registered to the workspace. Now you can use the registered model in inferencing endpoints.
 
 For the environment of this step, you'll use one of the built-in (curated) Azure ML environments. The tag `azureml`, tells the system to use look for the name in curated environments.
 

--- a/articles/machine-learning/tutorial-pipeline-python-sdk.md
+++ b/articles/machine-learning/tutorial-pipeline-python-sdk.md
@@ -202,7 +202,6 @@ The second component that you'll create will consume the training and test data,
 
 You used the `CommandComponent` class to create your first component. This time you'll use the yaml definition to define the second component. Each method has its own advantages. A yaml definition can actually be checked-in along the code, and would provide a readable history tracking. The programmatic method using `CommandComponent` can be easier with built-in class documentation and code completion.
 
-
 Create the directory for this component:
 
 [!Notebook-python[] (~/azureml-examples-main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb?name=train_src_dir)]


### PR DESCRIPTION
As described in #99635, a code snippet is missing from the [create production pipeline](https://learn.microsoft.com/en-us/azure/machine-learning/tutorial-pipeline-python-sdk) tutorial. 

The required code snippet was found [here](https://github.com/Azure/azureml-examples/blob/main/tutorials/e2e-ds-experience/e2e-ml-workflow.ipynb) and referenced in the PR.