### PR TITLE
Making all "Yes" cells bold so they can be visually scanned.

### DIFF
--- a/articles/azure-resource-manager/management/move-support-resources.md
+++ b/articles/azure-resource-manager/management/move-support-resources.md
@@ -217,8 +217,8 @@ Jump to a resource provider namespace:
 > | ------------- | ----------- | ---------- | ----------- |
 > | diagnosticsettings | No | No | No |
 > | diagnosticsettingscategories | No | No | No |
-> | privatelinkforazuread | Yes | Yes | No |
-> | tenants | Yes | Yes | No |
+> | privatelinkforazuread | **Yes** | **Yes** | No |
+> | tenants | **Yes** | **Yes** | No |
 
 ## Microsoft.Addons
 
@@ -258,13 +258,13 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | actionrules | Yes | Yes | No |
+> | actionrules | **Yes** | **Yes** | No |
 > | alerts | No | No | No |
 > | alertslist | No | No | No |
 > | alertsmetadata | No | No | No |
 > | alertssummary | No | No | No |
 > | alertssummarylist | No | No | No |
-> | smartdetectoralertrules | Yes | Yes | No |
+> | smartdetectoralertrules | **Yes** | **Yes** | No |
 > | smartgroups | No | No | No |
 
 ## Microsoft.AnalysisServices
@@ -272,7 +272,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | servers | Yes | Yes | No |
+> | servers | **Yes** | **Yes** | No |
 
 ## Microsoft.ApiManagement
 
@@ -283,21 +283,21 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | reportfeedback | No | No | No |
-> | service | Yes | Yes | Yes (using template) <br/><br/> [Move API Management across regions](../../api-management/api-management-howto-migrate.md). |
+> | service | **Yes** | **Yes** | **Yes** (using template) <br/><br/> [Move API Management across regions](../../api-management/api-management-howto-migrate.md). |
 
 ## Microsoft.App
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | managedenvironments | Yes | Yes | No |
+> | managedenvironments | **Yes** | **Yes** | No |
 
 ## Microsoft.AppConfiguration
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | configurationstores | Yes | Yes | No |
+> | configurationstores | **Yes** | **Yes** | No |
 > | configurationstores / eventgridfilters | No | No | No |
 
 ## Microsoft.AppPlatform
@@ -305,7 +305,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | spring | Yes | Yes | No |
+> | spring | **Yes** | **Yes** | No |
 
 ## Microsoft.AppService
 
@@ -315,7 +315,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | apiapps | No | No | Yes (using template)<br/><br/> [Move an App Service app to another region](../../app-service/manage-move-across-regions.md) |
+> | apiapps | No | No | **Yes** (using template)<br/><br/> [Move an App Service app to another region](../../app-service/manage-move-across-regions.md) |
 > | appidentities | No | No | No |
 > | gateways | No | No | No |
 
@@ -324,7 +324,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | attestationproviders | Yes | Yes | No |
+> | attestationproviders | **Yes** | **Yes** | No |
 
 ## Microsoft.Authorization
 
@@ -357,23 +357,23 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | automationaccounts | Yes | Yes | Yes (using template) <br/><br/> [Using geo-replication](../../automation/automation-managing-data.md#geo-replication-in-azure-automation) |
-> | automationaccounts / configurations | Yes | Yes | No |
-> | automationaccounts / runbooks | Yes | Yes | No |
+> | automationaccounts | **Yes** | **Yes** | **Yes** (using template) <br/><br/> [Using geo-replication](../../automation/automation-managing-data.md#geo-replication-in-azure-automation) |
+> | automationaccounts / configurations | **Yes** | **Yes** | No |
+> | automationaccounts / runbooks | **Yes** | **Yes** | No |
 
 ## Microsoft.AVS
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | privateclouds | Yes | Yes | No |
+> | privateclouds | **Yes** | **Yes** | No |
 
 ## Microsoft.AzureActiveDirectory
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | b2cdirectories | Yes | Yes | No |
+> | b2cdirectories | **Yes** | **Yes** | No |
 > | b2ctenants | No | No | No |
 
 ## Microsoft.AzureData
@@ -387,7 +387,7 @@ Jump to a resource provider namespace:
 > | sqlinstances | No | No | No |
 > | sqlmanagedinstances | No | No | No |
 > | sqlserverinstances | No | No | No |
-> | sqlserverregistrations | Yes | Yes | No |
+> | sqlserverregistrations | **Yes** | **Yes** | No |
 
 ## Microsoft.AzureStack
 
@@ -395,7 +395,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | cloudmanifestfiles | No | No | No |
-> | registrations | Yes | Yes | No |
+> | registrations | **Yes** | **Yes** | No |
 
 ## Microsoft.AzureStackHCI
 
@@ -409,7 +409,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | batchaccounts | Yes | Yes | Batch accounts can't be moved directly from one region to another, but you can use a template to export a template, modify it, and deploy the template to the new region. <br/><br/> Learn about [moving a Batch account across regions](../../batch/account-move.md) |
+> | batchaccounts | **Yes** | **Yes** | Batch accounts can't be moved directly from one region to another, but you can use a template to export a template, modify it, and deploy the template to the new region. <br/><br/> Learn about [moving a Batch account across regions](../../batch/account-move.md) |
 
 ## Microsoft.Billing
 
@@ -470,7 +470,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | botservices | Yes | Yes | No |
+> | botservices | **Yes** | **Yes** | No |
 
 ## Microsoft.Cache
 
@@ -480,7 +480,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | redis | Yes | Yes | No |
+> | redis | **Yes** | **Yes** | No |
 > | redisenterprise | No | No | No |
 
 ## Microsoft.Capacity
@@ -506,10 +506,10 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | cdnwebapplicationfirewallmanagedrulesets | No | No | No |
-> | cdnwebapplicationfirewallpolicies | Yes | Yes | No |
+> | cdnwebapplicationfirewallpolicies | **Yes** | **Yes** | No |
 > | edgenodes | No | No | No |
-> | profiles | Yes | Yes | No |
-> | profiles / endpoints | Yes | Yes | No |
+> | profiles | **Yes** | **Yes** | No |
+> | profiles / endpoints | **Yes** | **Yes** | No |
 
 ## Microsoft.CertificateRegistration
 
@@ -519,7 +519,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | certificateorders | Yes | Yes | No |
+> | certificateorders | **Yes** | **Yes** | No |
 
 ## Microsoft.ClassicCompute
 
@@ -530,11 +530,11 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | capabilities | No | No | No |
-> | domainnames | Yes | No | No |
+> | domainnames | **Yes** | No | No |
 > | quotas | No | No | No |
 > | resourcetypes | No | No | No |
 > | validatesubscriptionmoveavailability | No | No | No |
-> | virtualmachines | Yes | Yes | No |
+> | virtualmachines | **Yes** | **Yes** | No |
 
 ## Microsoft.ClassicInfrastructureMigrate
 
@@ -577,7 +577,7 @@ Jump to a resource provider namespace:
 > | osplatformimages | No | No | No |
 > | publicimages | No | No | No |
 > | quotas | No | No | No |
-> | storageaccounts | Yes | No | Yes |
+> | storageaccounts | **Yes** | No | **Yes** |
 > | vmimages | No | No | No |
 
 ## Microsoft.ClassicSubscription
@@ -595,8 +595,8 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | accounts | Yes | Yes | No |
-> | Cognitive Search | Yes | Yes | Supported with manual steps.<br/><br/> Learn about [moving your Azure Cognitive Search service to another region](../../search/search-howto-move-across-regions.md) |
+> | accounts | **Yes** | **Yes** | No |
+> | Cognitive Search | **Yes** | **Yes** | Supported with manual steps.<br/><br/> Learn about [moving your Azure Cognitive Search service to another region](../../search/search-howto-move-across-regions.md) |
 
 ## Microsoft.Commerce
 
@@ -611,7 +611,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | communicationservices | Yes | Yes <br/><br/> Note that resources with attached phone numbers cannot be moved to subscriptions in different data locations, nor subscriptions that do not support having phone numbers. | No |
+> | communicationservices | **Yes** | **Yes** <br/><br/> Note that resources with attached phone numbers cannot be moved to subscriptions in different data locations, nor subscriptions that do not support having phone numbers. | No |
 
 ## Microsoft.Compute
 
@@ -621,27 +621,27 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | availabilitysets | Yes | Yes |  Yes <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move availability sets. |
+> | availabilitysets | **Yes** | **Yes** |  **Yes** <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move availability sets. |
 > | diskaccesses | No | No | No |
 > | diskencryptionsets | No | No | No |
-> | disks | Yes | Yes | Yes <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move Azure VMs and related disks. |
+> | disks | **Yes** | **Yes** | **Yes** <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move Azure VMs and related disks. |
 > | galleries | No | No | No |
 > | galleries / images | No | No | No |
 > | galleries / images / versions | No | No | No |
 > | hostgroups | No | No | No |
 > | hostgroups / hosts | No | No | No |
-> | images | Yes | Yes | No |
-> | proximityplacementgroups | Yes | Yes | No |
+> | images | **Yes** | **Yes** | No |
+> | proximityplacementgroups | **Yes** | **Yes** | No |
 > | restorepointcollections | No | No | No |
 > | restorepointcollections / restorepoints | No | No | No |
 > | sharedvmextensions | No | No | No |
 > | sharedvmimages | No | No | No |
 > | sharedvmimages / versions | No | No | No |
-> | snapshots | Yes - Full <br> No - Incremental | Yes - Full <br> No - Incremental | No - Full <br> No - Incremental |
+> | snapshots | **Yes** - Full <br> No - Incremental | **Yes** - Full <br> No - Incremental | No - Full <br> No - Incremental |
 > | sshpublickeys | No | No | No |
-> | virtualmachines | Yes | Yes | Yes <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move Azure VMs. |
-> | virtualmachines / extensions | Yes | Yes | No |
-> | virtualmachinescalesets | Yes | Yes | No |
+> | virtualmachines | **Yes** | **Yes** | **Yes** <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move Azure VMs. |
+> | virtualmachines / extensions | **Yes** | **Yes** | No |
+> | virtualmachinescalesets | **Yes** | **Yes** | No |
 
 ## Microsoft.Confluent
 
@@ -690,12 +690,12 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | registries | Yes | Yes | No |
-> | registries / agentpools | Yes | Yes | No |
-> | registries / buildtasks | Yes | Yes | No |
-> | registries / replications | Yes | Yes | No |
-> | registries / tasks | Yes | Yes | No |
-> | registries / webhooks | Yes | Yes | No |
+> | registries | **Yes** | **Yes** | No |
+> | registries / agentpools | **Yes** | **Yes** | No |
+> | registries / buildtasks | **Yes** | **Yes** | No |
+> | registries / replications | **Yes** | **Yes** | No |
+> | registries / tasks | **Yes** | **Yes** | No |
+> | registries / webhooks | **Yes** | **Yes** | No |
 
 ## Microsoft.ContainerService
 
@@ -729,7 +729,7 @@ Jump to a resource provider namespace:
 > | billingaccounts | No | No | No |
 > | budgets | No | No | No |
 > | cloudconnectors | No | No | No |
-> | connectors | Yes | Yes | No |
+> | connectors | **Yes** | **Yes** | No |
 > | departments | No | No | No |
 > | dimensions | No | No | No |
 > | enrollmentaccounts | No | No | No |
@@ -764,7 +764,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | associations | No | No | No |
-> | resourceproviders | Yes | Yes | No |
+> | resourceproviders | **Yes** | **Yes** | No |
 
 ## Microsoft.DataBox
 
@@ -793,7 +793,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | catalogs | Yes | Yes | No |
+> | catalogs | **Yes** | **Yes** | No |
 > | datacatalogs | No | No | No |
 
 ## Microsoft.DataConnect
@@ -816,8 +816,8 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | datafactories | Yes | Yes | No |
-> | factories | Yes | Yes | No |
+> | datafactories | **Yes** | **Yes** | No |
+> | factories | **Yes** | **Yes** | No |
 
 ## Microsoft.DataLake
 
@@ -831,14 +831,14 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | accounts | Yes | Yes | No |
+> | accounts | **Yes** | **Yes** | No |
 
 ## Microsoft.DataLakeStore
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | accounts | Yes | Yes | No |
+> | accounts | **Yes** | **Yes** | No |
 
 ## Microsoft.DataMigration
 
@@ -855,60 +855,60 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ---------- |
-> | backupvaults | [Yes](../../backup/backup-vault-overview.md#use-azure-portal-to-move-backup-vault-to-a-different-resource-group) | [Yes](../../backup/backup-vault-overview.md#use-azure-portal-to-move-backup-vault-to-a-different-subscription) | No |
+> | backupvaults | [**Yes**](../../backup/backup-vault-overview.md#use-azure-portal-to-move-backup-vault-to-a-different-resource-group) | [**Yes**](../../backup/backup-vault-overview.md#use-azure-portal-to-move-backup-vault-to-a-different-subscription) | No |
 
 ## Microsoft.DataShare
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | accounts | Yes | Yes | No |
+> | accounts | **Yes** | **Yes** | No |
 
 ## Microsoft.DBforMariaDB
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | servers | Yes | Yes | You can use a cross-region read replica to move an existing server. [Learn more](../../postgresql/howto-move-regions-portal.md).<br/><br/> If the service is provisioned with geo-redundant backup storage, you can use geo-restore to restore in other regions. [Learn more](../../mariadb/concepts-business-continuity.md#recover-from-an-azure-regional-data-center-outage).
+> | servers | **Yes** | **Yes** | You can use a cross-region read replica to move an existing server. [Learn more](../../postgresql/howto-move-regions-portal.md).<br/><br/> If the service is provisioned with geo-redundant backup storage, you can use geo-restore to restore in other regions. [Learn more](../../mariadb/concepts-business-continuity.md#recover-from-an-azure-regional-data-center-outage).
 
 ## Microsoft.DBforMySQL
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | flexibleServers | Yes | Yes | No |
-> | servers | Yes | Yes | You can use a cross-region read replica to move an existing server. [Learn more](../../mysql/howto-move-regions-portal.md).
+> | flexibleServers | **Yes** | **Yes** | No |
+> | servers | **Yes** | **Yes** | You can use a cross-region read replica to move an existing server. [Learn more](../../mysql/howto-move-regions-portal.md).
 
 ## Microsoft.DBforPostgreSQL
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | flexibleServers | Yes | Yes | No |
+> | flexibleServers | **Yes** | **Yes** | No |
 > | servergroups | No | No | No |
-> | servers | Yes | Yes | You can use a cross-region read replica to move an existing server. [Learn more](../../postgresql/howto-move-regions-portal.md).
-> | serversv2 | Yes | Yes | No |
+> | servers | **Yes** | **Yes** | You can use a cross-region read replica to move an existing server. [Learn more](../../postgresql/howto-move-regions-portal.md).
+> | serversv2 | **Yes** | **Yes** | No |
 
 ## Microsoft.DeploymentManager
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | artifactsources | Yes | Yes | No |
-> | rollouts | Yes | Yes | No |
-> | servicetopologies | Yes | Yes | No |
-> | servicetopologies / services | Yes | Yes | No |
-> | servicetopologies / services / serviceunits | Yes | Yes | No |
-> | steps | Yes | Yes | No |
+> | artifactsources | **Yes** | **Yes** | No |
+> | rollouts | **Yes** | **Yes** | No |
+> | servicetopologies | **Yes** | **Yes** | No |
+> | servicetopologies / services | **Yes** | **Yes** | No |
+> | servicetopologies / services / serviceunits | **Yes** | **Yes** | No |
+> | steps | **Yes** | **Yes** | No |
 
 ## Microsoft.DesktopVirtualization
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | applicationgroups | Yes | Yes | No |
-> | hostpools | Yes | Yes | No |
-> | workspaces | Yes | Yes | No |
+> | applicationgroups | **Yes** | **Yes** | No |
+> | hostpools | **Yes** | **Yes** | No |
+> | workspaces | **Yes** | **Yes** | No |
 
 ## Microsoft.Devices
 
@@ -917,15 +917,15 @@ Jump to a resource provider namespace:
 > | ------------- | ----------- | ---------- | ----------- |
 > | elasticpools | No | No | No. Resource isn't exposed. |
 > | elasticpools / iothubtenants | No | No | No. Resource isn't exposed. |
-> | iothubs | Yes | Yes | Yes. [Learn more](../../iot-hub/iot-hub-how-to-clone.md) |
-> | provisioningservices | Yes | Yes | No |
+> | iothubs | **Yes** | **Yes** | **Yes**. [Learn more](../../iot-hub/iot-hub-how-to-clone.md) |
+> | provisioningservices | **Yes** | **Yes** | No |
 
 ## Microsoft.DevOps
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | pipelines | Yes | Yes | No |
+> | pipelines | **Yes** | **Yes** | No |
 > | controllers | **pending** | **pending** | No |
 
 ## Microsoft.DevSpaces
@@ -933,7 +933,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | controllers | Yes | Yes | No |
+> | controllers | **Yes** | **Yes** | No |
 > | AKS cluster | **pending** | **pending** | No<br/><br/> [Learn more](/previous-versions/azure/dev-spaces/) about moving to another region.
 
 ## Microsoft.DevTestLab
@@ -942,18 +942,18 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | labcenters | No | No | No |
-> | labs | Yes | No | No |
-> | labs / environments | Yes | Yes | No |
-> | labs / servicerunners | Yes | Yes | No |
-> | labs / virtualmachines | Yes | No | No |
-> | schedules | Yes | Yes | No |
+> | labs | **Yes** | No | No |
+> | labs / environments | **Yes** | **Yes** | No |
+> | labs / servicerunners | **Yes** | **Yes** | No |
+> | labs / virtualmachines | **Yes** | No | No |
+> | schedules | **Yes** | **Yes** | No |
 
 ## Microsoft.DigitalTwins
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | digitaltwinsinstances | No | No | Yes, by recreating resources in new region. [Learn more](../../digital-twins/how-to-move-regions.md) |
+> | digitaltwinsinstances | No | No | **Yes**, by recreating resources in new region. [Learn more](../../digital-twins/how-to-move-regions.md) |
 
 ## Microsoft.DocumentDB
 
@@ -961,14 +961,14 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | databaseaccountnames | No | No | No |
-> | databaseaccounts | Yes | Yes | No |
+> | databaseaccounts | **Yes** | **Yes** | No |
 
 ## Microsoft.DomainRegistration
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | domains | Yes | Yes | No |
+> | domains | **Yes** | **Yes** | No |
 > | generatessorequest | No | No | No |
 > | topleveldomains | No | No | No |
 > | validatedomainregistrationinformation | No | No | No |
@@ -978,21 +978,21 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | services | Yes | Yes | No |
+> | services | **Yes** | **Yes** | No |
 
 ## Microsoft.EventGrid
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | domains | Yes | Yes | No |
+> | domains | **Yes** | **Yes** | No |
 > | eventsubscriptions | No - can't be moved independently but automatically moved with subscribed resource. | No - can't be moved independently but automatically moved with subscribed resource. | No |
 > | extensiontopics | No | No | No |
-> | partnernamespaces | Yes | Yes | No |
+> | partnernamespaces | **Yes** | **Yes** | No |
 > | partnerregistrations | No | No | No |
-> | partnertopics | Yes | Yes | No |
-> | systemtopics | Yes | Yes | No |
-> | topics | Yes | Yes | No |
+> | partnertopics | **Yes** | **Yes** | No |
+> | systemtopics | **Yes** | **Yes** | No |
+> | topics | **Yes** | **Yes** | No |
 > | topictypes | No | No | No |
 
 ## Microsoft.EventHub
@@ -1000,8 +1000,8 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | clusters | Yes | Yes | No |
-> | namespaces | Yes | Yes | Yes (with template)<br/><br/> [Move an Event Hub namespace to another region](../../event-hubs/move-across-regions.md) |
+> | clusters | **Yes** | **Yes** | No |
+> | namespaces | **Yes** | **Yes** | **Yes** (with template)<br/><br/> [Move an Event Hub namespace to another region](../../event-hubs/move-across-regions.md) |
 > | sku | No | No | No |
 
 ## Microsoft.Experimentation
@@ -1023,7 +1023,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | namespaces | Yes | Yes | No |
+> | namespaces | **Yes** | **Yes** | No |
 
 ## Microsoft.Features
 
@@ -1079,29 +1079,29 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | clusters | Yes | Yes | No |
+> | clusters | **Yes** | **Yes** | No |
 
 ## Microsoft.HealthcareApis
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | services | Yes | Yes | No |
+> | services | **Yes** | **Yes** | No |
 
 ## Microsoft.HybridCompute
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | machines | Yes | Yes | No |
-> | machines / extensions | Yes | Yes | No |
+> | machines | **Yes** | **Yes** | No |
+> | machines / extensions | **Yes** | **Yes** | No |
 
 ## Microsoft.HybridData
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | datamanagers | Yes | Yes | No |
+> | datamanagers | **Yes** | **Yes** | No |
 
 ## Microsoft.HybridNetwork
 
@@ -1124,7 +1124,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | jobs | Yes | Yes | No |
+> | jobs | **Yes** | **Yes** | No |
 
 ## Microsoft.Insights
 
@@ -1137,13 +1137,13 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | accounts | Yes | Yes | No. [Learn more](../../azure-monitor/faq.yml#how-do-i-move-an-application-insights-resource-to-a-new-region-). |
-> | actiongroups | Yes | Yes | No |
+> | accounts | **Yes** | **Yes** | No. [Learn more](../../azure-monitor/faq.yml#how-do-i-move-an-application-insights-resource-to-a-new-region-). |
+> | actiongroups | **Yes** | **Yes** | No |
 > | activitylogalerts | No | No | No |
-> | alertrules | Yes | Yes | No |
-> | autoscalesettings | Yes | Yes | No |
+> | alertrules | **Yes** | **Yes** | No |
+> | autoscalesettings | **Yes** | **Yes** | No |
 > | baseline | No | No | No |
-> | components | Yes | Yes | No |
+> | components | **Yes** | **Yes** | No |
 > | datacollectionrules | No | No | No |
 > | diagnosticsettings | No | No | No |
 > | diagnosticsettingscategories | No | No | No |
@@ -1167,14 +1167,14 @@ Jump to a resource provider namespace:
 > | notificationgroups | No | No | No |
 > | privatelinkscopes | No | No | No |
 > | rollbacktolegacypricingmodel | No | No | No |
-> | scheduledqueryrules | Yes | Yes | No |
+> | scheduledqueryrules | **Yes** | **Yes** | No |
 > | topology | No | No | No |
 > | transactions | No | No | No |
 > | vminsightsonboardingstatuses | No | No | No |
-> | webtests | Yes | Yes | No |
+> | webtests | **Yes** | **Yes** | No |
 > | webtests / gettestresultfile | No | No | No |
-> | workbooks | Yes | Yes | No |
-> | workbooktemplates | Yes | Yes | No |
+> | workbooks | **Yes** | **Yes** | No |
+> | workbooktemplates | **Yes** | **Yes** | No |
 
 ## Microsoft.IoTCentral
 
@@ -1182,21 +1182,21 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | apptemplates | No | No | No |
-> | iotapps | Yes | Yes | No |
+> | iotapps | **Yes** | **Yes** | No |
 
 ## Microsoft.IoTHub
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | iothub | Yes | Yes | Yes (clone hub) <br/><br/> [Clone an IoT hub to another region](../../iot-hub/iot-hub-how-to-clone.md) |
+> | iothub | **Yes** | **Yes** | **Yes** (clone hub) <br/><br/> [Clone an IoT hub to another region](../../iot-hub/iot-hub-how-to-clone.md) |
 
 ## Microsoft.IoTSpaces
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | graph | Yes | Yes | No |
+> | graph | **Yes** | **Yes** | No |
 
 ## Microsoft.KeyVault
 
@@ -1209,7 +1209,7 @@ Jump to a resource provider namespace:
 > | deletedvaults | No | No | No |
 > | hsmpools | No | No | No |
 > | managedhsms | No | No | No |
-> | vaults | Yes | Yes | No |
+> | vaults | **Yes** | **Yes** | No |
 
 ## Microsoft.Kubernetes
 
@@ -1231,7 +1231,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | clusters | Yes | Yes | No |
+> | clusters | **Yes** | **Yes** | No |
 
 ## Microsoft.LabServices
 
@@ -1268,11 +1268,11 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | hostingenvironments | No | No | No |
-> | integrationaccounts | Yes | Yes | No |
-> | integrationserviceenvironments | Yes | No | No |
-> | integrationserviceenvironments / managedapis | Yes | No | No |
+> | integrationaccounts | **Yes** | **Yes** | No |
+> | integrationserviceenvironments | **Yes** | No | No |
+> | integrationserviceenvironments / managedapis | **Yes** | No | No |
 > | isolatedenvironments | No | No | No |
-> | workflows | Yes | Yes | No |
+> | workflows | **Yes** | **Yes** | No |
 
 ## Microsoft.MachineLearning
 
@@ -1280,8 +1280,8 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | commitmentplans | No | No | No |
-> | webservices | Yes | No | No |
-> | workspaces | Yes | Yes | No |
+> | webservices | **Yes** | No | No |
+> | workspaces | **Yes** | **Yes** | No |
 
 ## Microsoft.MachineLearningCompute
 
@@ -1317,8 +1317,8 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | configurationassignments | No | No | Yes. [Learn more](../../virtual-machines/move-region-maintenance-configuration.md) |
-> | maintenanceconfigurations | Yes | Yes | Yes. [Learn more](../../virtual-machines/move-region-maintenance-configuration-resources.md) |
+> | configurationassignments | No | No | **Yes**. [Learn more](../../virtual-machines/move-region-maintenance-configuration.md) |
+> | maintenanceconfigurations | **Yes** | **Yes** | **Yes**. [Learn more](../../virtual-machines/move-region-maintenance-configuration-resources.md) |
 > | updates | No | No | No |
 
 ## Microsoft.ManagedIdentity
@@ -1365,8 +1365,8 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | accounts | Yes | Yes | No, Azure Maps is a geospatial service. |
-> | accounts / privateatlases | Yes | Yes | No |
+> | accounts | **Yes** | **Yes** | No, Azure Maps is a geospatial service. |
+> | accounts / privateatlases | **Yes** | **Yes** | No |
 
 ## Microsoft.Marketplace
 
@@ -1402,9 +1402,9 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | mediaservices | Yes | Yes | No |
-> | mediaservices / liveevents | Yes | Yes | No |
-> | mediaservices / streamingendpoints | Yes | Yes | No |
+> | mediaservices | **Yes** | **Yes** | No |
+> | mediaservices / liveevents | **Yes** | **Yes** | No |
+> | mediaservices / streamingendpoints | **Yes** | **Yes** | No |
 
 ## Microsoft.Microservices4Spring
 
@@ -1429,8 +1429,8 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ---------- |
 > | objectunderstandingaccounts | No | No | No |
-> | remoterenderingaccounts | Yes | Yes | No |
-> | spatialanchorsaccounts | Yes | Yes | No |
+> | remoterenderingaccounts | **Yes** | **Yes** | No |
+> | spatialanchorsaccounts | **Yes** | **Yes** | No |
 
 ## Microsoft.NetApp
 
@@ -1453,55 +1453,55 @@ Jump to a resource provider namespace:
 > | ------------- | ----------- | ---------- | ----------- |
 > | applicationgateways | No | No | No |
 > | applicationgatewaywebapplicationfirewallpolicies | No | No | No |
-> | applicationsecuritygroups | Yes | Yes | No |
+> | applicationsecuritygroups | **Yes** | **Yes** | No |
 > | azurefirewalls | No | No | No |
 > | bastionhosts | No | No | No |
 > | bgpservicecommunities | No | No | No |
-> | connections | Yes | Yes | No |
-> | ddoscustompolicies | Yes | Yes | No |
+> | connections | **Yes** | **Yes** | No |
+> | ddoscustompolicies | **Yes** | **Yes** | No |
 > | ddosprotectionplans | No | No | No |
-> | dnszones | Yes | Yes | No |
+> | dnszones | **Yes** | **Yes** | No |
 > | expressroutecircuits | No | No | No |
 > | expressroutegateways | No | No | No |
 > | expressrouteserviceproviders | No | No | No |
 > | firewallpolicies | No | No | No |
 > | frontdoors | No | No | No |
-> | ipallocations | Yes | Yes | No |
+> | ipallocations | **Yes** | **Yes** | No |
 > | ipgroups | No | No | No |
-> | loadbalancers | Yes - Basic SKU<br> Yes - Standard SKU | Yes - Basic SKU<br>No - Standard SKU | Yes <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move internal and external load balancers. |
-> | localnetworkgateways | Yes | Yes | No |
+> | loadbalancers | **Yes** - Basic SKU<br> **Yes** - Standard SKU | **Yes** - Basic SKU<br>No - Standard SKU | **Yes** <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move internal and external load balancers. |
+> | localnetworkgateways | **Yes** | **Yes** | No |
 > | natgateways | No | No | No |
 > | networkexperimentprofiles | No | No | No |
-> | networkintentpolicies | Yes | Yes | No |
-> | networkinterfaces | Yes | Yes | Yes <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move NICs. |
+> | networkintentpolicies | **Yes** | **Yes** | No |
+> | networkinterfaces | **Yes** | **Yes** | **Yes** <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move NICs. |
 > | networkprofiles | No | No | No |
-> | networksecuritygroups | Yes | Yes | Yes <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move network security groups (NSGs). |
+> | networksecuritygroups | **Yes** | **Yes** | **Yes** <br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move network security groups (NSGs). |
 > | networkwatchers | No | No | No |
-> | networkwatchers / connectionmonitors | Yes | No | No |
-> | networkwatchers / flowlogs | Yes | No | No |
-> | networkwatchers / pingmeshes | Yes | No | No |
+> | networkwatchers / connectionmonitors | **Yes** | No | No |
+> | networkwatchers / flowlogs | **Yes** | No | No |
+> | networkwatchers / pingmeshes | **Yes** | No | No |
 > | p2svpngateways | No | No | No |
-> | privatednszones | Yes | Yes | No |
-> | privatednszones / virtualnetworklinks | Yes | Yes | No |
+> | privatednszones | **Yes** | **Yes** | No |
+> | privatednszones / virtualnetworklinks | **Yes** | **Yes** | No |
 > | privatednszonesinternal | No | No | No |
 > | privateendpointredirectmaps | No | No | No |
-> | privateendpoints | Yes - for [supported private-link resources](./move-limitations/networking-move-limitations.md#private-endpoints)<br>No - for all other private-link resources | Yes - for [supported private-link resources](./move-limitations/networking-move-limitations.md#private-endpoints)<br>No - for all other private-link resources | No |
+> | privateendpoints | **Yes** - for [supported private-link resources](./move-limitations/networking-move-limitations.md#private-endpoints)<br>No - for all other private-link resources | **Yes** - for [supported private-link resources](./move-limitations/networking-move-limitations.md#private-endpoints)<br>No - for all other private-link resources | No |
 > | privatelinkservices | No | No | No |
-> | publicipaddresses | Yes | Yes - see [Networking move guidance](./move-limitations/networking-move-limitations.md) | Yes<br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move public IP address configurations (IP addresses are not retained). |
-> | publicipprefixes | Yes | Yes | No |
+> | publicipaddresses | **Yes** | **Yes** - see [Networking move guidance](./move-limitations/networking-move-limitations.md) | **Yes**<br/><br/> Use [Azure Resource Mover](../../resource-mover/tutorial-move-region-virtual-machines.md) to move public IP address configurations (IP addresses are not retained). |
+> | publicipprefixes | **Yes** | **Yes** | No |
 > | routefilters | No | No | No |
-> | routetables | Yes | Yes | No |
-> | securitypartnerproviders | Yes | Yes | No |
-> | serviceendpointpolicies | Yes | Yes | No |
+> | routetables | **Yes** | **Yes** | No |
+> | securitypartnerproviders | **Yes** | **Yes** | No |
+> | serviceendpointpolicies | **Yes** | **Yes** | No |
 > | trafficmanagergeographichierarchies | No | No | No |
-> | trafficmanagerprofiles | Yes | Yes | No |
+> | trafficmanagerprofiles | **Yes** | **Yes** | No |
 > | trafficmanagerprofiles / heatmaps | No | No | No |
 > | trafficmanagerusermetricskeys | No | No | No |
 > | virtualhubs | No | No | No |
-> | virtualnetworkgateways | Yes | Yes - see [Networking move guidance](./move-limitations/networking-move-limitations.md) | No |
-> | virtualnetworks | Yes | Yes | No |
+> | virtualnetworkgateways | **Yes** | **Yes** - see [Networking move guidance](./move-limitations/networking-move-limitations.md) | No |
+> | virtualnetworks | **Yes** | **Yes** | No |
 > | virtualnetworktaps | No | No | No |
-> | virtualrouters | Yes | Yes | No |
+> | virtualrouters | **Yes** | **Yes** | No |
 > | virtualwans | No | No |
 > | vpngateways (Virtual WAN) | No | No | No |
 > | vpnserverconfigurations | No | No | No |
@@ -1512,15 +1512,15 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | namespaces | Yes | Yes | No |
-> | namespaces / notificationhubs | Yes | Yes | No |
+> | namespaces | **Yes** | **Yes** | No |
+> | namespaces / notificationhubs | **Yes** | **Yes** | No |
 
 ## Microsoft.ObjectStore
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | osnamespaces | Yes | Yes | No |
+> | osnamespaces | **Yes** | **Yes** | No |
 
 ## Microsoft.OffAzure
 
@@ -1547,7 +1547,7 @@ Jump to a resource provider namespace:
 > | deletedworkspaces | No | No | No |
 > | linktargets | No | No | No |
 > | storageinsightconfigs | No | No | No |
-> | workspaces | Yes | Yes | No |
+> | workspaces | **Yes** | **Yes** | No |
 
 ## Microsoft.OperationsManagement
 
@@ -1555,9 +1555,9 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | managementassociations | No | No | No |
-> | managementconfigurations | Yes | Yes | No |
-> | solutions | Yes | Yes | No |
-> | views | Yes | Yes | No |
+> | managementconfigurations | **Yes** | **Yes** | No |
+> | solutions | **Yes** | **Yes** | No |
+> | views | **Yes** | **Yes** | No |
 
 ## Microsoft.Peering
 
@@ -1589,7 +1589,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | consoles | No | No | No |
-> | dashboards | Yes | Yes | No |
+> | dashboards | **Yes** | **Yes** | No |
 > | usersettings | No | No | No |
 
 ## Microsoft.PowerBI
@@ -1597,14 +1597,14 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | workspacecollections | Yes | Yes | No |
+> | workspacecollections | **Yes** | **Yes** | No |
 
 ## Microsoft.PowerBIDedicated
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | capacities | Yes | Yes | No |
+> | capacities | **Yes** | **Yes** | No |
 
 ## Microsoft.ProjectBabylon
 
@@ -1618,7 +1618,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ---------- |
-> | accounts | Yes | Yes | No |
+> | accounts | **Yes** | **Yes** | No |
 
 ## Microsoft.ProviderHub
 
@@ -1646,7 +1646,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | replicationeligibilityresults | No | No | No |
-> | vaults | Yes | Yes | No.<br/><br/> Moving Recovery Services vaults for Azure Backup across Azure regions isn't supported.<br/><br/> In Recovery Services vaults for Azure Site Recovery, you can [disable and recreate the vault](../../site-recovery/move-vaults-across-regions.md) in the target region. |
+> | vaults | **Yes** | **Yes** | No.<br/><br/> Moving Recovery Services vaults for Azure Backup across Azure regions isn't supported.<br/><br/> In Recovery Services vaults for Azure Site Recovery, you can [disable and recreate the vault](../../site-recovery/move-vaults-across-regions.md) in the target region. |
 
 ## Microsoft.RedHatOpenShift
 
@@ -1660,14 +1660,14 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | namespaces | Yes | Yes | No |
+> | namespaces | **Yes** | **Yes** | No |
 
 ## Microsoft.ResourceGraph
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | queries | Yes | Yes | No |
+> | queries | **Yes** | **Yes** | No |
 > | resourcechangedetails | No | No | No |
 > | resourcechanges | No | No | No |
 > | resources | No | No | No |
@@ -1691,7 +1691,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | deployments | No | No | No |
-> | deploymentscripts | No | No | Yes<br/><br/>[Move Microsoft.Resources resources to new region](microsoft-resources-move-regions.md) |
+> | deploymentscripts | No | No | **Yes**<br/><br/>[Move Microsoft.Resources resources to new region](microsoft-resources-move-regions.md) |
 > | deploymentscripts / logs | No | No | No |
 > | links | No | No | No |
 > | providers | No | No | No |
@@ -1699,7 +1699,7 @@ Jump to a resource provider namespace:
 > | resources | No | No | No |
 > | subscriptions | No | No | No |
 > | tags | No | No | No |
-> | templatespecs | No | No | Yes<br/><br/>[Move Microsoft.Resources resources to new region](microsoft-resources-move-regions.md) |
+> | templatespecs | No | No | **Yes**<br/><br/>[Move Microsoft.Resources resources to new region](microsoft-resources-move-regions.md) |
 > | templatespecs / versions | No | No | No |
 > | tenants | No | No | No |
 
@@ -1711,8 +1711,8 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | applications | Yes | No | No |
-> | resources | Yes | Yes | No |
+> | applications | **Yes** | No | No |
+> | resources | **Yes** | **Yes** | No |
 > | saasresources | No | No | No |
 
 ## Microsoft.Search
@@ -1724,7 +1724,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | resourcehealthmetadata | No | No | No |
-> | searchservices | Yes | Yes | No |
+> | searchservices | **Yes** | **Yes** | No |
 
 ## Microsoft.Security
 
@@ -1739,7 +1739,7 @@ Jump to a resource provider namespace:
 > | assessmentmetadata | No | No | No |
 > | assessments | No | No | No |
 > | autodismissalertsrules | No | No | No |
-> | automations | Yes | Yes | No |
+> | automations | **Yes** | **Yes** | No |
 > | autoprovisioningsettings | No | No | No |
 > | complianceresults | No | No | No |
 > | compliances | No | No | No |
@@ -1748,7 +1748,7 @@ Jump to a resource provider namespace:
 > | discoveredsecuritysolutions | No | No | No |
 > | externalsecuritysolutions | No | No | No |
 > | informationprotectionpolicies | No | No | No |
-> | iotsecuritysolutions | Yes | Yes | No |
+> | iotsecuritysolutions | **Yes** | **Yes** | No |
 > | iotsecuritysolutions / analyticsmodels | No | No | No |
 > | iotsecuritysolutions / analyticsmodels / aggregatedalerts | No | No | No |
 > | iotsecuritysolutions / analyticsmodels / aggregatedrecommendations | No | No | No |
@@ -1809,7 +1809,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | namespaces | Yes | Yes | No |
+> | namespaces | **Yes** | **Yes** | No |
 > | premiummessagingregions | No | No | No |
 > | sku | No | No | No |
 
@@ -1819,7 +1819,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | applications | No | No | No |
-> | clusters | Yes | Yes | No |
+> | clusters | **Yes** | **Yes** | No |
 > | containergroups | No | No | No |
 > | containergroupsets | No | No | No |
 > | edgeclusters | No | No | No |
@@ -1833,12 +1833,12 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | applications | Yes | Yes | No |
+> | applications | **Yes** | **Yes** | No |
 > | containergroups | No | No | No |
-> | gateways | Yes | Yes | No |
-> | networks | Yes | Yes | No |
-> | secrets | Yes | Yes | No |
-> | volumes | Yes | Yes | No |
+> | gateways | **Yes** | **Yes** | No |
+> | networks | **Yes** | **Yes** | No |
+> | secrets | **Yes** | **Yes** | No |
+> | volumes | **Yes** | **Yes** | No |
 
 ## Microsoft.Services
 
@@ -1852,7 +1852,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | signalr | Yes | Yes | No |
+> | signalr | **Yes** | **Yes** | No |
 
 ## Microsoft.SoftwarePlan
 
@@ -1879,15 +1879,15 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | instancepools | No | No | No |
-> | locations | Yes | Yes | No |
-> | managedinstances | No | No | Yes <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving managed instances across regions. |
-> | managedinstances / databases | No | No | Yes |
-> | servers | Yes | Yes |Yes |
-> | servers / databases | Yes | Yes | Yes <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving databases across regions.<br/><br/> [Learn more](../../resource-mover/tutorial-move-region-sql.md) about using Azure Resource Mover to move Azure SQL databases.  |
-> | servers / databases / backuplongtermretentionpolicies | Yes | Yes | No |
-> | servers / elasticpools | Yes | Yes | Yes <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving elastic pools across regions.<br/><br/> [Learn more](../../resource-mover/tutorial-move-region-sql.md) about using Azure Resource Mover to move Azure SQL elastic pools.  |
-> | servers / jobaccounts | Yes | Yes | No |
-> | servers / jobagents | Yes | Yes | No |
+> | locations | **Yes** | **Yes** | No |
+> | managedinstances | No | No | **Yes** <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving managed instances across regions. |
+> | managedinstances / databases | No | No | **Yes** |
+> | servers | **Yes** | **Yes** |**Yes** |
+> | servers / databases | **Yes** | **Yes** | **Yes** <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving databases across regions.<br/><br/> [Learn more](../../resource-mover/tutorial-move-region-sql.md) about using Azure Resource Mover to move Azure SQL databases.  |
+> | servers / databases / backuplongtermretentionpolicies | **Yes** | **Yes** | No |
+> | servers / elasticpools | **Yes** | **Yes** | **Yes** <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving elastic pools across regions.<br/><br/> [Learn more](../../resource-mover/tutorial-move-region-sql.md) about using Azure Resource Mover to move Azure SQL elastic pools.  |
+> | servers / jobaccounts | **Yes** | **Yes** | No |
+> | servers / jobagents | **Yes** | **Yes** | No |
 > | virtualclusters | No | No | No |
 
 ## Microsoft.SqlVirtualMachine
@@ -1895,15 +1895,15 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | sqlvirtualmachinegroups | Yes | Yes | No |
-> | sqlvirtualmachines | Yes | Yes | No |
+> | sqlvirtualmachinegroups | **Yes** | **Yes** | No |
+> | sqlvirtualmachines | **Yes** | **Yes** | No |
 
 ## Microsoft.Storage
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | storageaccounts | Yes | Yes | Yes<br/><br/> [Move an Azure Storage account to another region](../../storage/common/storage-account-move.md) |
+> | storageaccounts | **Yes** | **Yes** | **Yes**<br/><br/> [Move an Azure Storage account to another region](../../storage/common/storage-account-move.md) |
 
 ## Microsoft.StorageCache
 
@@ -1917,7 +1917,7 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | storagesyncservices | Yes | Yes | No |
+> | storagesyncservices | **Yes** | **Yes** | No |
 
 ## Microsoft.StorageSyncDev
 
@@ -1949,7 +1949,7 @@ Jump to a resource provider namespace:
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
 > | clusters | No | No | No |
-> | streamingjobs | Yes | Yes | No |
+> | streamingjobs | **Yes** | **Yes** | No |
 
 ## Microsoft.StreamAnalyticsExplorer
 
@@ -1988,16 +1988,16 @@ Jump to a resource provider namespace:
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | environments | Yes | Yes | No |
-> | environments / eventsources | Yes | Yes | No |
-> | environments / referencedatasets | Yes | Yes | No |
+> | environments | **Yes** | **Yes** | No |
+> | environments / eventsources | **Yes** | **Yes** | No |
+> | environments / referencedatasets | **Yes** | **Yes** | No |
 
 ## Microsoft.Token
 
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | stores | Yes | Yes | No |
+> | stores | **Yes** | **Yes** | No |
 
 ## Microsoft.VirtualMachineImages
 
@@ -2066,25 +2066,25 @@ Jump to a resource provider namespace:
 > | ------------- | ----------- | ---------- | ----------- |
 > | availablestacks | No | No | No |
 > | billingmeters | No | No | No |
-> | certificates | No | Yes | No |
+> | certificates | No | **Yes** | No |
 > | certificates (managed) | No | No | No |
-> | connectiongateways | Yes | Yes | No |
-> | connections | Yes | Yes | No |
-> | customapis | Yes | Yes | No |
+> | connectiongateways | **Yes** | **Yes** | No |
+> | connections | **Yes** | **Yes** | No |
+> | customapis | **Yes** | **Yes** | No |
 > | deletedsites | No | No | No |
 > | deploymentlocations | No | No | No |
 > | georegions | No | No | No |
 > | hostingenvironments | No | No | No |
-> | kubeenvironments | Yes | Yes | No |
+> | kubeenvironments | **Yes** | **Yes** | No |
 > | publishingusers | No | No | No |
 > | recommendations | No | No | No |
 > | resourcehealthmetadata | No | No | No |
 > | runtimes | No | No | No |
-> | serverfarms | Yes | Yes | No |
+> | serverfarms | **Yes** | **Yes** | No |
 > | serverfarms / eventgridfilters | No | No | No |
-> | sites | Yes | Yes | No |
-> | sites / premieraddons | Yes | Yes | No |
-> | sites / slots | Yes | Yes | No |
+> | sites | **Yes** | **Yes** | No |
+> | sites / premieraddons | **Yes** | **Yes** | No |
+> | sites / slots | **Yes** | **Yes** | No |
 > | sourcecontrols | No | No | No |
 > | staticsites | No | No | No |
 

--- a/articles/azure-resource-manager/management/move-support-resources.md
+++ b/articles/azure-resource-manager/management/move-support-resources.md
@@ -1882,7 +1882,7 @@ Jump to a resource provider namespace:
 > | locations | **Yes** | **Yes** | No |
 > | managedinstances | No | No | **Yes** <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving managed instances across regions. |
 > | managedinstances / databases | No | No | **Yes** |
-> | servers | **Yes** | **Yes** |**Yes** |
+> | servers | **Yes** | **Yes** | **Yes** |
 > | servers / databases | **Yes** | **Yes** | **Yes** <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving databases across regions.<br/><br/> [Learn more](../../resource-mover/tutorial-move-region-sql.md) about using Azure Resource Mover to move Azure SQL databases.  |
 > | servers / databases / backuplongtermretentionpolicies | **Yes** | **Yes** | No |
 > | servers / elasticpools | **Yes** | **Yes** | **Yes** <br/><br/> [Learn more](/azure/azure-sql/database/move-resources-across-regions) about moving elastic pools across regions.<br/><br/> [Learn more](../../resource-mover/tutorial-move-region-sql.md) about using Azure Resource Mover to move Azure SQL elastic pools.  |


### PR DESCRIPTION
Visually scanning HTML tables containing plaintext for "Yes"/"No" or "True/"False" or even "1"/"0" is mentally taxing because they're visually too similar. This change makes all of the "Yes" cells in this article bold so that they stand-out more and is much easier to scan with ones' eyes _without_ engaging one's brain.
