### PR TITLE
Add Replication option to transfer costs

### DIFF
--- a/articles/storage/blobs/access-tiers-overview.md
+++ b/articles/storage/blobs/access-tiers-overview.md
@@ -169,7 +169,7 @@ A per-transaction charge applies to all tiers and increases as the tier gets coo
 
 ### Geo-replication data transfer costs
 
-This charge only applies to accounts with geo-replication configured, including GRS and RA-GRS. Geo-replication data transfer incurs a per-gigabyte charge.
+This charge only applies to accounts with geo-replication configured, including GRS, RA-GRS and GZRS. Geo-replication data transfer incurs a per-gigabyte charge.
 
 ### Outbound data transfer costs
 


### PR DESCRIPTION
Geo-replication data transfer costs should also include GZRS since the data is replicated into a secondary region with this option as well.