### PR TITLE
Typo "Azure Monitor Application insights"→"Azure Monitor Application Insights"

### DIFF
--- a/articles/azure-monitor/app/statsbeat.md
+++ b/articles/azure-monitor/app/statsbeat.md
@@ -9,7 +9,7 @@ ms.reviwer: heya
 
 # Statsbeat in Azure Application Insights
 
-Statsbeat collects essential and non-essential [custom metric](../essentials/metrics-custom-overview.md) about Application Insights SDKs and auto-instrumentation. Statsbeat serves three benefits for Azure Monitor Application insights customers:
+Statsbeat collects essential and non-essential [custom metric](../essentials/metrics-custom-overview.md) about Application Insights SDKs and auto-instrumentation. Statsbeat serves three benefits for Azure Monitor Application Insights customers:
 -	Service Health and Reliability (outside-in monitoring of connectivity to ingestion endpoint)
 -	Support Diagnostics (self-help insights and CSS insights)
 -	Product Improvement (insights for design optimizations)


### PR DESCRIPTION
…plication Insights SDKs and auto-instrumentation. Statsbeat serves three benefits for Azure Monitor Application insights customers:

https://learn.microsoft.com/en-us/azure/azure-monitor/app/statsbeat?tabs=eu-java%2Cjava 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-monitor/app/statsbeat.md 
#PingMSFTDocs