### PR TITLE
Updated Get-MSOLDevice with Get-MgDevice

### DIFF
--- a/articles/active-directory/enterprise-users/groups-dynamic-membership.md
+++ b/articles/active-directory/enterprise-users/groups-dynamic-membership.md
@@ -379,7 +379,10 @@ You can also create a rule that selects device objects for membership in a group
 > [!NOTE]
 > systemlabels is a read-only attribute that cannot be set with Intune.
 >
-> For Windows 10, the correct format of the deviceOSVersion attribute is as follows: (device.deviceOSVersion -startsWith "10.0.1"). The formatting can be validated with the Get-MsolDevice PowerShell cmdlet.
+> For Windows 10, the correct format of the deviceOSVersion attribute is as follows: (device.deviceOSVersion -startsWith "10.0.1"). The formatting can be validated with the Get-MgDevice PowerShell cmdlet:
+> ```
+>Get-MgDevice -Search "displayName:YourMachineNameHere" -ConsistencyLevel eventual | Select-Object -ExpandProperty 'OperatingSystemVersion'
+>```
 
 The following device attributes can be used.
 

--- a/articles/active-directory/enterprise-users/groups-dynamic-membership.md
+++ b/articles/active-directory/enterprise-users/groups-dynamic-membership.md
@@ -381,8 +381,8 @@ You can also create a rule that selects device objects for membership in a group
 >
 > For Windows 10, the correct format of the deviceOSVersion attribute is as follows: (device.deviceOSVersion -startsWith "10.0.1"). The formatting can be validated with the Get-MgDevice PowerShell cmdlet:
 > ```
->Get-MgDevice -Search "displayName:YourMachineNameHere" -ConsistencyLevel eventual | Select-Object -ExpandProperty 'OperatingSystemVersion'
->```
+> Get-MgDevice -Search "displayName:YourMachineNameHere" -ConsistencyLevel eventual | Select-Object -ExpandProperty 'OperatingSystemVersion'
+> ```
 
 The following device attributes can be used.
 


### PR DESCRIPTION
Following the deprecation of the MSOL and AzureAD modules, commands from those modules have to be updated with their corresponding MgGraph ones wherever possible