### PR TITLE
Change storage account typo to key vault.

### DIFF
--- a/articles/storage/blobs/storage-encrypt-decrypt-blobs-key-vault.md
+++ b/articles/storage/blobs/storage-encrypt-decrypt-blobs-key-vault.md
@@ -53,7 +53,7 @@ The following example shows how to assign the **Key Vault Crypto Officer** role 
 
 1. In the Azure portal, locate your key vault using the main search bar or left navigation.
 
-2. On the storage account overview page, select **Access control (IAM)** from the left-hand menu.
+2. On the key vault overview page, select **Access control (IAM)** from the left-hand menu.
 
 3. On the **Access control (IAM)** page, select the **Role assignments** tab.
 


### PR DESCRIPTION
IAM on the key vault overview page should be selected and not the storage account overview page.
