### PR TITLE
Improve python scripts for parquet to delta conversion

### DIFF
--- a/articles/synapse-analytics/sql/query-delta-lake-format.md
+++ b/articles/synapse-analytics/sql/query-delta-lake-format.md
@@ -49,7 +49,7 @@ If you don't have this subfolder, you are not using Delta Lake format. You can c
 
 ```python
 %%pyspark
-from delta.tables import *
+from delta.tables import DeltaTable
 deltaTable = DeltaTable.convertToDelta(spark, "parquet.`abfss://delta-lake@sqlondemandstorage.dfs.core.windows.net/covid`")
 ```
 
@@ -168,7 +168,7 @@ If you don't have this subfolder, you are not using Delta Lake format. You can c
 
 ```python
 %%pyspark
-from delta.tables import *
+from delta.tables import DeltaTable
 deltaTable = DeltaTable.convertToDelta(spark, "parquet.`abfss://delta-lake@sqlondemandstorage.dfs.core.windows.net/yellow`", "year INT, month INT")
 ```
 


### PR DESCRIPTION
Change import statement `from delta.tables import *` to `from delta.tables import DeltaTable`.

`from package_name import *` is considered an [improvable coding practice](https://docs.python.org/3/tutorial/modules.html#more-on-modules) in python, because it may import unneeded classes and obstructs static code analysis.