### PR TITLE
Update quick-android-map.md

### DIFF
--- a/articles/azure-maps/quick-android-map.md
+++ b/articles/azure-maps/quick-android-map.md
@@ -391,6 +391,9 @@ Android Studio will take a few seconds to build the application. After the build
 
 :::image type="content" source="media/quick-android-map/quickstart-android-map.png" alt-text="A screenshot showing Azure Maps in an Android application.":::
 
+> [!TIP]
+> By default Android reloads the activity when the orientation changes, or when the keyboard is hidden. This results in the map state being reset (reload the map which  resets the view, and reloads data to initial state). To prevent this from happening add the following to the mainfest: `android:configChanges="orientation|keyboardHidden"`. This will stop the activity from reloading and call onConfigurationChanged() instead when the orientation is changed or the keyboard is hidden.
+
 ## Clean up resources
 
 >[!WARNING]

--- a/articles/azure-maps/quick-android-map.md
+++ b/articles/azure-maps/quick-android-map.md
@@ -392,7 +392,7 @@ Android Studio will take a few seconds to build the application. After the build
 :::image type="content" source="media/quick-android-map/quickstart-android-map.png" alt-text="A screenshot showing Azure Maps in an Android application.":::
 
 > [!TIP]
-> By default Android reloads the activity when the orientation changes, or when the keyboard is hidden. This results in the map state being reset (reload the map which  resets the view, and reloads data to initial state). To prevent this from happening add the following to the mainfest: `android:configChanges="orientation|keyboardHidden"`. This will stop the activity from reloading and call onConfigurationChanged() instead when the orientation is changed or the keyboard is hidden.
+> By default, Android reloads the activity when the orientation changes or the keyboard is hidden. This results in the map state being reset (reload the map which resets the view and reloads data to initial state). To prevent this from happening, add the following to the mainfest: `android:configChanges="orientation|keyboardHidden"`. This will stop the activity from reloading and instead call `onConfigurationChanged()` when the orientation has changed or the keyboard is hidden.
 
 ## Clean up resources
 


### PR DESCRIPTION
Adding a tip that will addresses a common question devs have (when the orientation of phone changes the map resets).