### PR TITLE
Hub Routing Preference is now GA with Hub to Hub Path Preference

### DIFF
--- a/articles/virtual-wan/virtual-wan-faq.md
+++ b/articles/virtual-wan/virtual-wan-faq.md
@@ -334,7 +334,7 @@ The current behavior is to prefer the ExpressRoute circuit path over hub-to-hub 
 
 * Configure multiple ExpressRoute circuits (different providers) to connect to one hub and use the hub-to-hub connectivity provided by Virtual WAN for inter-region traffic flows.
 
-* Contact the product team to take part in the gated public preview. In this preview, traffic between the 2 hubs traverses through the Azure Virtual WAN router in each hub and uses a hub-to-hub path instead of the ExpressRoute path (which traverses through the Microsoft Edge routers/MSEE). To use this feature during preview, email **previewpreferh2h@microsoft.com** with the Virtual WAN IDs, Subscription ID, and the Azure region. Expect a response within 48 business hours (Monday-Friday) with confirmation that the feature is enabled.
+* Configure AS Path as the Hub Routing Preference. Once configured, traffic between the 2 hubs traverses through the Azure Virtual WAN router in each hub and uses a hub-to-hub path instead of the ExpressRoute path (which traverses through the Microsoft Edge routers/MSEE). For steps, see [Configure virtual hub routing preference](howto-virtual-hub-routing-preference.md).
 
 ### When there's an ExpressRoute circuit connected as a bow-tie to a Virtual WAN hub and a non Virtual WAN VNet, what is the path for the non Virtual WAN VNet to reach the Virtual WAN hub? 
 


### PR DESCRIPTION
Hub Routing Preference feature is now GA and this provides support for preferring Virtual WAN Hub to hub path in ER bow-tie scenario instead of traffic going via ER / MSEE path. Configuration requires AS Path to be set at each hub and the FAQ is updated to reflect this.