### PR TITLE
Update howto-password-smart-lockout.md

### DIFF
--- a/articles/active-directory/authentication/howto-password-smart-lockout.md
+++ b/articles/active-directory/authentication/howto-password-smart-lockout.md
@@ -35,7 +35,7 @@ Smart lockout is always on, for all Azure AD customers, with these default setti
 Using smart lockout doesn't guarantee that a genuine user is never locked out. When smart lockout locks a user account, we try our best to not lock out the genuine user. The lockout service attempts to ensure that bad actors can't gain access to a genuine user account. The following considerations apply:
 
 * Each Azure AD data center tracks lockout independently. A user has (*threshold_limit * datacenter_count*) number of attempts, if the user hits each data center.
-* Smart Lockout uses familiar location vs unfamiliar location to differentiate between a bad actor and the genuine user. Unfamiliar and familiar locations both have separate lockout counters.
+
 
 Smart lockout can be integrated with hybrid deployments that use password hash sync or pass-through authentication to protect on-premises Active Directory Domain Services (AD DS) accounts from being locked out by attackers. By setting smart lockout policies in Azure AD appropriately, attacks can be filtered out before they reach on-premises AD DS.
 


### PR DESCRIPTION
Can you confirm if this statement is accurate? 
Smart Lockout uses familiar location vs unfamiliar location to differentiate between a bad actor and the genuine user. Unfamiliar and familiar locations both have separate lockout counters.

I'm aware of the concept for AD FS but on AAD side not sure how we differentiate familiar from un-familiar locations