### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#100986

### DIFF
--- a/includes/api-management-recommended-nsg-rules.md
+++ b/includes/api-management-recommended-nsg-rules.md
@@ -20,7 +20,7 @@ Configure custom network rules in the API Management subnet to filter traffic to
 |------------------------------|--------------------|--------------------|---------------------------------------|-------------------------------------------------------------|----------------------|
 | * / [80], 443                  | Inbound            | TCP                | Internet / VirtualNetwork            | Client communication to API Management                   | External only          |
 | * / 3443                     | Inbound            | TCP                | ApiManagement / VirtualNetwork       | Management endpoint for Azure portal and PowerShell        | External & Internal  |
-| * / 6390                       | Inbound            | TCP                | AzureLoadBalancer / VirtualNetwork | Azure Infrastructure Load Balancer (required for Premium service tier)                        | External & Internal  |
+| * / 6390                       | Inbound            | TCP                | AzureLoadBalancer / VirtualNetwork | Azure Infrastructure Load Balancer                        | External & Internal  |
 | * / 443                  | Outbound           | TCP                | VirtualNetwork / Storage             | Dependency on Azure Storage                             | External & Internal  |
 | * / 1433                     | Outbound           | TCP                | VirtualNetwork / SQL                 | Access to Azure SQL endpoints                           | External & Internal  |
 | * / 443                     | Outbound           | TCP                | VirtualNetwork / AzureKeyVault                | Access to Azure Key Vault                         | External & Internal  |


### PR DESCRIPTION
LoadBalancer port is required to be added in NSG for both developer and premium sku in Stv2, removed the section (required for Premium service tier)