### PR TITLE
Change the permissions in line 30

### DIFF
--- a/articles/defender-for-cloud/permissions.md
+++ b/articles/defender-for-cloud/permissions.md
@@ -27,7 +27,7 @@ The following table displays roles and allowed actions in Defender for Cloud.
 | **Action**   | [Security Reader](../role-based-access-control/built-in-roles.md#security-reader) / <br> [Reader](../role-based-access-control/built-in-roles.md#reader) | [Security Admin](../role-based-access-control/built-in-roles.md#security-admin) | [Contributor](../role-based-access-control/built-in-roles.md#contributor) / [Owner](../role-based-access-control/built-in-roles.md#owner) | [Contributor](../role-based-access-control/built-in-roles.md#contributor) | [Owner](../role-based-access-control/built-in-roles.md#owner) |
 |:-|:-:|:-:|:-:|:-:|:-:|
 |  |  |  | **(Resource group level)** | **(Subscription level)** | **(Subscription level)** |
-| Add/assign initiatives (including) regulatory compliance standards) | - | - | - | ✔ | ✔ |
+| Add/assign initiatives (including) regulatory compliance standards) | - | - | - | - | ✔ |
 | Edit security policy | - | ✔ | - | ✔ | ✔ |
 | Enable / disable Microsoft Defender plans | - | ✔ | - | ✔ | ✔ |
 | Dismiss alerts | - | ✔ | - | ✔ | ✔ |


### PR DESCRIPTION
A user can only assign a policy with Owner permissions: https://learn.microsoft.com/en-us/azure/governance/policy/overview#azure-rbac-permissions-in-azure-policy In the current version we say that Contributor can as well which is false