### PR TITLE
Changed the permissions on line 30 -31

### DIFF
--- a/articles/defender-for-cloud/permissions.md
+++ b/articles/defender-for-cloud/permissions.md
@@ -27,8 +27,8 @@ The following table displays roles and allowed actions in Defender for Cloud.
 | **Action**   | [Security Reader](../role-based-access-control/built-in-roles.md#security-reader) / <br> [Reader](../role-based-access-control/built-in-roles.md#reader) | [Security Admin](../role-based-access-control/built-in-roles.md#security-admin) | [Contributor](../role-based-access-control/built-in-roles.md#contributor) / [Owner](../role-based-access-control/built-in-roles.md#owner) | [Contributor](../role-based-access-control/built-in-roles.md#contributor) | [Owner](../role-based-access-control/built-in-roles.md#owner) |
 |:-|:-:|:-:|:-:|:-:|:-:|
 |  |  |  | **(Resource group level)** | **(Subscription level)** | **(Subscription level)** |
-| Add/assign initiatives (including) regulatory compliance standards) | - | - | - | - | ✔ |
-| Edit security policy | - | ✔ | - | ✔ | ✔ |
+| Add/assign initiatives (including) regulatory compliance standards) | - | ✔ | - | - | ✔ |
+| Edit security policy | - | ✔ | - | - | ✔ |
 | Enable / disable Microsoft Defender plans | - | ✔ | - | ✔ | ✔ |
 | Dismiss alerts | - | ✔ | - | ✔ | ✔ |
 | Apply security recommendations for a resource</br> (and use [Fix](implement-security-recommendations.md#fix-button)) | - | - | ✔ | ✔ | ✔ |


### PR DESCRIPTION
Correcting the permissions on lines 30 and 31 according to https://learn.microsoft.com/en-us/azure/governance/policy/overview#azure-rbac-permissions-in-azure-policy and internal testing

Contributor Not actions:
Not Action
Microsoft.Authorization/*/Delete

NotAction
Microsoft.Authorization/*/Write

The above means that no policy write operations or delete can be performed by a user with the Contributor role

On the other hand Security admin has the following permissions: Microsoft.Authorization/policyAssignments/* This means that the admin can Edit and also Assign policies

The above change was made to reflect the above facts