### PR TITLE
Update CORS policy behavior description

### DIFF
--- a/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
+++ b/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
@@ -337,7 +337,7 @@ When you configure the **Allowed origins** list for your function app, the `Acce
 
 ![Configure function app's CORS list](./media/functions-how-to-use-azure-function-app-settings/configure-function-app-cors.png)
 
-The wildcard (*) is ignored if there is another domain entry.
+The wildcard (\*) is ignored if there is another domain entry.
 
 Use the [`az functionapp cors add`](/cli/azure/functionapp/cors#az-functionapp-cors-add) command to add a domain to the allowed origins list. The following example adds the contoso.com domain:
 

--- a/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
+++ b/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
@@ -337,7 +337,7 @@ When you configure the **Allowed origins** list for your function app, the `Acce
 
 ![Configure function app's CORS list](./media/functions-how-to-use-azure-function-app-settings/configure-function-app-cors.png)
 
-When the wildcard (`*`) is used, all other domains are ignored. 
+The wildcard (*) is ignored if there is another domain entry entry.
 
 Use the [`az functionapp cors add`](/cli/azure/functionapp/cors#az-functionapp-cors-add) command to add a domain to the allowed origins list. The following example adds the contoso.com domain:
 

--- a/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
+++ b/articles/azure-functions/functions-how-to-use-azure-function-app-settings.md
@@ -337,7 +337,7 @@ When you configure the **Allowed origins** list for your function app, the `Acce
 
 ![Configure function app's CORS list](./media/functions-how-to-use-azure-function-app-settings/configure-function-app-cors.png)
 
-The wildcard (*) is ignored if there is another domain entry entry.
+The wildcard (*) is ignored if there is another domain entry.
 
 Use the [`az functionapp cors add`](/cli/azure/functionapp/cors#az-functionapp-cors-add) command to add a domain to the allowed origins list. The following example adds the contoso.com domain:
 


### PR DESCRIPTION
This change updates the docs to reflect the actual behavior of Azure. If there is another CORS entry, then the wildcard `*` is ignored.