### PR TITLE
[fix] Wrong samples operator managementState JSON path

### DIFF
--- a/articles/openshift/howto-add-update-pull-secret.md
+++ b/articles/openshift/howto-add-update-pull-secret.md
@@ -131,7 +131,7 @@ This section walks through updating that pull secret with additional values from
 Run the following command to update your pull secret.
 
 > [!NOTE]
-> Running this command will cause your cluster nodes to restart one by one as they're updated. 
+> Running this command will cause your cluster nodes to restart one by one as they're updated.
 
 ```console
 oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=./pull-secret.json
@@ -149,7 +149,7 @@ First, modify the Samples Operator configuration file. Then, you can run the fol
 oc edit configs.samples.operator.openshift.io/cluster -o yaml
 ```
 
-Change the `spec.architectures.managementState` value from `Removed` to `Managed`. 
+Change the `spec.managementState` value from `Removed` to `Managed`.
 
 The following YAML snippet shows only the relevant sections of the edited YAML file:
 
@@ -166,7 +166,7 @@ spec:
   managementState: Managed
 ```
 
-Second, run the following command to edit the Operator Hub configuration file:  
+Second, run the following command to edit the Operator Hub configuration file:
 
 ```console
 oc edit operatorhub cluster -o yaml


### PR DESCRIPTION
The reference to  spec.architectures.managementState is wrong. It should read spec.managementState instead.