### PR TITLE
Fix: removed preview classification from title

### DIFF
--- a/articles/confidential-computing/virtual-machine-solutions-amd.md
+++ b/articles/confidential-computing/virtual-machine-solutions-amd.md
@@ -1,5 +1,5 @@
 ---
-title: Azure Confidential virtual machine options on AMD processors (preview)
+title: Azure Confidential virtual machine options on AMD processors
 description: Azure Confidential Computing offers multiple options for confidential virtual machines that run on AMD processors backed by SEV-SNP technology.
 author: mamccrea
 ms.author: mamccrea


### PR DESCRIPTION
Fix: removed preview classification from title. 

Confidential VMs SKUs, discussed in the article, are [generally available](https://techcommunity.microsoft.com/t5/azure-confidential-computing/latest-innovations-in-azure-confidential-computing/ba-p/3573389). I think the preview classification can be dropped? 

This currently shows up as `Azure Confidential virtual machine options on AMD processors (preview)` when this document is linked via the "Recommended content" section of other documentation pages. 