### PR TITLE
Update property authHeader to authHeaders

### DIFF
--- a/articles/data-factory/connector-rest.md
+++ b/articles/data-factory/connector-rest.md
@@ -88,7 +88,7 @@ The following properties are supported for the REST linked service:
 | type | The **type** property must be set to **RestService**. | Yes |
 | url | The base URL of the REST service. | Yes |
 | enableServerCertificateValidation | Whether to validate server-side TLS/SSL certificate when connecting to the endpoint. | No<br /> (the default is **true**) |
-| authenticationType | Type of authentication used to connect to the REST service. Allowed values are **Anonymous**, **Basic**, **AadServicePrincipal**, **OAuth2ClientCredential**, and **ManagedServiceIdentity**. You can additionally configure authentication headers in `authHeader` property. Refer to corresponding sections below on more properties and examples respectively.| Yes |
+| authenticationType | Type of authentication used to connect to the REST service. Allowed values are **Anonymous**, **Basic**, **AadServicePrincipal**, **OAuth2ClientCredential**, and **ManagedServiceIdentity**. You can additionally configure authentication headers in `authHeaders` property. Refer to corresponding sections below on more properties and examples respectively.| Yes |
 | authHeaders | Additional HTTP request headers for authentication.<br/> For example, to use API key authentication, you can select authentication type as “Anonymous” and specify API key in the header. | No |
 | connectVia | The [Integration Runtime](concepts-integration-runtime.md) to use to connect to the data store. Learn more from [Prerequisites](#prerequisites) section. If not specified, this property uses the default Azure Integration Runtime. |No |
 
@@ -282,7 +282,7 @@ In addition, you can configure request headers for authentication along with the
         "typeProperties": {
             "url": "<REST endpoint>",
             "authenticationType": "Anonymous",
-            "authHeader": {
+            "authHeaders": {
                 "x-api-key": {
                     "type": "SecureString",
                     "value": "<API key>"


### PR DESCRIPTION
authHeader didn't work in datafactory, but authHeaders worked like a charm when using tokens.