### PR TITLE
Line 316 URL is broken - Gives 404

### DIFF
--- a/articles/storage/common/azure-defender-storage-configure.md
+++ b/articles/storage/common/azure-defender-storage-configure.md
@@ -313,7 +313,7 @@ Replace `{subscriptionId}` with your subscription ID.
 
 To disable the plan, set the `-pricingTier` property value to `Free` and remove the `subPlan` parameter.
 
-Learn more about the [updating Defender plans with the REST API](https://learn.microsoft.com/en-us/rest/api/defenderforcloud/pricings) in HTTP, Java, Go and JavaScript.
+Learn more about the [updating Defender plans with the REST API](https://learn.microsoft.com/rest/api/defenderforcloud/pricings) in HTTP, Java, Go and JavaScript.
 
 ### Set up the per-transaction pricing plan for an account
 

--- a/articles/storage/common/azure-defender-storage-configure.md
+++ b/articles/storage/common/azure-defender-storage-configure.md
@@ -313,7 +313,7 @@ Replace `{subscriptionId}` with your subscription ID.
 
 To disable the plan, set the `-pricingTier` property value to `Free` and remove the `subPlan` parameter.
 
-Learn more about the [updating Defender plans with the REST API](/rest/api/defenderforcloud/pricings/update.md) in HTTP, Java, Go and JavaScript.
+Learn more about the [updating Defender plans with the REST API](https://learn.microsoft.com/en-us/rest/api/defenderforcloud/pricings) in HTTP, Java, Go and JavaScript.
 
 ### Set up the per-transaction pricing plan for an account
 


### PR DESCRIPTION
Changed the URL on line 316 with the correct one pointing to our API documentation for pricing plans. The old one was giving a 404 error