### PR TITLE
Updating Agent-based VMware permissions table.

### DIFF
--- a/articles/migrate/migrate-support-matrix-vmware-migration.md
+++ b/articles/migrate/migrate-support-matrix-vmware-migration.md
@@ -121,7 +121,7 @@ This table summarizes assessment support and limitations for VMware vSphere virt
 --- | ---
 **VMware vCenter Server** | Version 5.5, 6.0, 6.5, or 6.7.
 **VMware vSphere ESXi host** | Version 5.5, 6.0, 6.5, 6.7 or 7.0.
-**vCenter Server permissions** | A read-only account for vCenter Server.
+**vCenter Server permissions** | **VM discovery**: At least a read-only user<br/><br/> Data Center object –> Propagate to Child Object, role=Read-only.<br/><br/> **Replication**: Create a role (Azure Site Recovery) with the required permissions, and then assign the role to a VMware vSphere user or group<br/><br/> Data Center object –> Propagate to Child Object, role=Azure Site Recovery<br/><br/> Datastore -> Allocate space, browse datastore, low-level file operations, remove file, update virtual machine files<br/><br/> Network -> Network assign<br/><br/> Resource -> Assign VM to resource pool, migrate powered off VM, migrate powered on VM<br/><br/> Tasks -> Create task, update task<br/><br/> Virtual machine -> Configuration<br/><br/> Virtual machine -> Interact -> answer question, device connection, configure CD media, configure floppy media, power off, power on, VMware tools install<br/><br/> Virtual machine -> Inventory -> Create, register, unregister<br/><br/> Virtual machine -> Provisioning -> Allow virtual machine download, allow virtual machine files upload<br/><br/> Virtual machine -> Snapshots -> Remove snapshots.<br/><br/><br/>**Note**:<br/>User assigned at datacenter level, and has access to all the objects in the datacenter.<br/><br/> To restrict access, assign the **No access** role with the **Propagate to child** object, to the child objects (vSphere hosts, datastores, VMs, and networks).
 
 ### VM requirements (agent-based)
 


### PR DESCRIPTION
Requesting PG to add the agent-based permissions table to this page where agent-less is there but agent- based section only mentions a "read only" permission (missing other required permissions). Those permissions requirement table is available on another page (https://learn.microsoft.com/en-us/azure/migrate/tutorial-migrate-vmware-agent#vmware-account-permissions)  but having it here will help with doc consistency.