### PR TITLE
Provide Details on Cache Volatility

### DIFF
--- a/articles/api-management/api-management-howto-cache.md
+++ b/articles/api-management/api-management-howto-cache.md
@@ -22,7 +22,7 @@ ms.author: danlep
 APIs and operations in API Management can be configured with response caching. Response caching can significantly reduce latency for API callers and backend load for API providers.
 
 > [!IMPORTANT]
-> Built-in cache is volatile and is shared by all units in the same region in the same API Management service. Regardless of cache type being used (internal or external), if the cache related operations fail to connect to the cache due to the volatility of the cache or any other reason, the API call that uses the cache related operation does not raise an error and the cache operation completes successfully. In the case of a read operation, a null value is returned to the calling policy expression. Your policy code should be designed to ensure that that there is a "fallback" mechanism to retrieve data not found in the cache.
+> Built-in cache is volatile and is shared by all units in the same region in the same API Management service. Regardless of the cache type being used (internal or external), if the cache-related operations fail to connect to the cache due to the volatility of the cache or any other reason, the API call that uses the cache related operation doesn't raise an error, and the cache operation completes successfully. In the case of a read operation, a null value is returned to the calling policy expression. Your policy code should be designed to ensure that that there's a "fallback" mechanism to retrieve data not found in the cache.
 For more detailed information about caching, see [API Management caching policies](api-management-caching-policies.md) and  [Custom caching in Azure API Management](api-management-sample-cache-by-key.md).
 
 ![cache policies](media/api-management-howto-cache/cache-policies.png)

--- a/articles/api-management/api-management-howto-cache.md
+++ b/articles/api-management/api-management-howto-cache.md
@@ -22,8 +22,7 @@ ms.author: danlep
 APIs and operations in API Management can be configured with response caching. Response caching can significantly reduce latency for API callers and backend load for API providers.
 
 > [!IMPORTANT]
-> Built-in cache is volatile and is shared by all units in the same region in the same API Management service.
-
+> Built-in cache is volatile and is shared by all units in the same region in the same API Management service. Regardless of cache type being used (internal or external), if the cache related operations fail to connect to the cache due to the volatility of the cache or any other reason, the API call that uses the cache related operation does not raise an error and the cache operation completes successfully. In the case of a read operation, a null value is returned to the calling policy expression. Your policy code should be designed to ensure that that there is a "fallback" mechanism to retrieve data not found in the cache.
 For more detailed information about caching, see [API Management caching policies](api-management-caching-policies.md) and  [Custom caching in Azure API Management](api-management-sample-cache-by-key.md).
 
 ![cache policies](media/api-management-howto-cache/cache-policies.png)


### PR DESCRIPTION
Some customers design their policy code under the assumption that anything written to cache will be available as long as it doesn't expire. For internal cache, cache becomes unavailable during service maintenance and we have seen some customer backends can't handle the load due to cache being unavailable. The cached data may also get evicted if the cache is under memory pressure. Need to provide this clarification so customers design their applications under correct assumptions.