### PR TITLE
Update iot-edge-prerequisites-register-device.md

### DIFF
--- a/includes/iot-edge-prerequisites-register-device.md
+++ b/includes/iot-edge-prerequisites-register-device.md
@@ -19,7 +19,8 @@ A free or standard [IoT hub](../articles/iot-hub/iot-hub-create-through-portal.m
 
 * A free or standard [IoT hub](../articles/iot-hub/iot-hub-create-through-portal.md) in your Azure subscription
 * [Visual Studio Code](https://code.visualstudio.com/)
-* [Azure IoT Edge extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-edge) for Visual Studio Code
+* [Azure IoT Tools](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools) for Visual Studio Code
+* [Azure IoT Edge](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-edge) for Visual Studio Code
 
 # [Azure CLI](#tab/azure-cli)
 

--- a/includes/iot-edge-prerequisites-register-device.md
+++ b/includes/iot-edge-prerequisites-register-device.md
@@ -19,7 +19,7 @@ A free or standard [IoT hub](../articles/iot-hub/iot-hub-create-through-portal.m
 
 * A free or standard [IoT hub](../articles/iot-hub/iot-hub-create-through-portal.md) in your Azure subscription
 * [Visual Studio Code](https://code.visualstudio.com/)
-* [Azure IoT Tools](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-tools) for Visual Studio Code
+* [Azure IoT Edge extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-edge) for Visual Studio Code
 
 # [Azure CLI](#tab/azure-cli)
 


### PR DESCRIPTION
Azure IoT tools no longer includes IoT Edge extension (change is slated to be merged in early December). Changing to point directly to IoT Edge