### PR TITLE
Update iot-edge-install-linux.md

### DIFF
--- a/includes/iot-edge-install-linux.md
+++ b/includes/iot-edge-install-linux.md
@@ -14,7 +14,7 @@ In this section, you prepare your Linux VM or physical device for IoT Edge. Then
 Run the following commands to add the package repository and then add the Microsoft package signing key to your list of trusted keys.
 
 > [!IMPORTANT]
-> By June 30, 2022 we will retire Raspberry Pi OS Stretch from the Tier 1 OS support list. To avoid potential security vulnerabilities update your host OS to Bullseye.
+> On June 30, 2022, Raspberry Pi OS Stretch was retired from the Tier 1 OS support list. To avoid potential security vulnerabilities, update your host OS to Bullseye.
 
 # [Ubuntu](#tab/ubuntu)
 

--- a/includes/iot-edge-install-linux.md
+++ b/includes/iot-edge-install-linux.md
@@ -13,6 +13,9 @@ In this section, you prepare your Linux VM or physical device for IoT Edge. Then
 
 Run the following commands to add the package repository and then add the Microsoft package signing key to your list of trusted keys.
 
+> [!IMPORTANT]
+> By June 30, 2022 we will retire Raspberry Pi OS Stretch from the Tier 1 OS support list. To avoid potential security vulnerabilities update your host OS to Bullseye.
+
 # [Ubuntu](#tab/ubuntu)
 
 Installing can be done with a few commands.  Open a terminal and run the following commands:
@@ -47,19 +50,6 @@ Installing with APT can be done with a few commands.  Open a terminal and run th
 > [!TIP]
 > If you gave the "root" account a password during the OS install, you will not need 'sudo' and can run the above command by starting with 'apt'.
 
-# [Raspberry Pi OS](#tab/rpios)
-
-> [!IMPORTANT]
-> By June 30, 2022 we will retire Raspberry Pi OS Stretch from the Tier 1 OS support list. To avoid potential security vulnerabilities update your host OS to Bullseye.
-
-Installing can be done with a few commands.  Open a terminal and run the following commands:
-
-* **Latest**:
-
-    ```bash
-    curl https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb > ./packages-microsoft-prod.deb
-    sudo apt install ./packages-microsoft-prod.deb
-    ```
 
 # [Red Hat Enterprise Linux](#tab/rhel)
 
@@ -100,17 +90,6 @@ Install the Moby engine.
      sudo apt-get install moby-engine
    ```
 
-# [Raspberry Pi OS](#tab/rpios)
-
-> [!IMPORTANT]
-> By June 30, 2022 we will retire Raspberry Pi OS Stretch from the Tier 1 OS support list. To avoid potential security vulnerabilities update your host OS to Bullseye.
-
-Install the Moby engine.
-
-   ```bash
-   sudo apt-get update; \
-     sudo apt-get install moby-engine
-   ```
 
 # [Red Hat Enterprise Linux](#tab/rhel)
 
@@ -173,15 +152,6 @@ Install IoT Edge version 1.1.* along with the **libiothsm-std** package:
      sudo apt-get install iotedge
    ```
 
-# [Raspberry Pi OS](#tab/rpios)
-
-> [!IMPORTANT]
-> By June 30, 2022 we will retire Raspberry Pi OS Stretch from the Tier 1 OS support list. To avoid potential security vulnerabilities update your host OS to Bullseye.
-
-   ```bash
-   sudo apt-get update; \
-     sudo apt-get install iotedge
-   ```
 
 # [Red Hat Enterprise Linux](#tab/rhel)
 
@@ -232,17 +202,6 @@ Install the latest version of IoT Edge and the IoT identity service package:
 The defender-iot-micro-agent-edge package includes the Microsoft Defender for IoT security micro-agent that provides endpoint visibility into security posture management, vulnerabilities, threat detection, fleet management and more to help you secure your IoT Edge devices. It's recommended to install the micro agent with the Edge agent to enable security monitoring and hardening of your Edge devices. To learn more about Microsoft Defender for IoT, see [What is Microsoft Defender for IoT for device builders](../articles/defender-for-iot/device-builders/overview.md).
 
 
-# [Raspberry Pi OS](#tab/rpios)
-
-> [!IMPORTANT]
-> By June 30, 2022 we will retire Raspberry Pi OS Stretch from the Tier 1 OS support list. To avoid potential security vulnerabilities update your host OS to Bullseye.
-
-Install the latest version of IoT Edge and the IoT identity service package:
-
-   ```bash
-   sudo apt-get update; \
-     sudo apt-get install aziot-edge
-   ```
 
 # [Red Hat Enterprise Linux](#tab/rhel)
 


### PR DESCRIPTION
As we are no longer supporting Raspbian OS as of June 30th, there is no reason to have individual tab for Raspbian OS. In addition, now it's Bullseye (same step as Debian 11), the same steps apply for Bullseye and Debian 11.