### PR TITLE
Fix incorrect CLI args for setting CMK encryption

### DIFF
--- a/articles/batch/batch-customer-managed-key.md
+++ b/articles/batch/batch-customer-managed-key.md
@@ -109,14 +109,14 @@ In the [Azure portal](https://portal.azure.com/), go to the Batch account page. 
 
 ### Azure CLI
 
-After the Batch account is created with system-assigned managed identity and the access to Key Vault is granted, update the Batch account with the `{Key Identifier}` URL under `keyVaultProperties` parameter. Also set **encryption_key_source** as `Microsoft.KeyVault`.
+After the Batch account is created with system-assigned managed identity and the access to Key Vault is granted, update the Batch account with the `{Key Identifier}` URL under `keyVaultProperties` parameter. Also set `--encryption-key-source` as `Microsoft.KeyVault`.
 
 ```azurecli
 az batch account set \
     -n $accountName \
     -g $resourceGroupName \
-    --encryption_key_source Microsoft.KeyVault \
-    --encryption_key_identifier {YourKeyIdentifier} 
+    --encryption-key-source Microsoft.KeyVault \
+    --encryption-key-identifier {YourKeyIdentifier} 
 ```
 
 ## Create a Batch account with user-assigned managed identity and customer-managed keys
@@ -161,7 +161,7 @@ You can also use Azure CLI to update the version.
 az batch account set \
     -n $accountName \
     -g $resourceGroupName \
-    --encryption_key_identifier {YourKeyIdentifierWithNewVersion} 
+    --encryption-key-identifier {YourKeyIdentifierWithNewVersion} 
 ```
 
 ## Use a different key for Batch encryption
@@ -178,7 +178,7 @@ You can also use Azure CLI to use a different key.
 az batch account set \
     -n $accountName \
     -g $resourceGroupName \
-    --encryption_key_identifier {YourNewKeyIdentifier} 
+    --encryption-key-identifier {YourNewKeyIdentifier} 
 ```
 
 ## Frequently asked questions


### PR DESCRIPTION
The docs incorrectly used underscores in the CLI parameters instead of dashes.