### PR TITLE
Removed Views from non-supported list of T-SQL functionality

### DIFF
--- a/articles/synapse-analytics/sql/on-demand-workspace-overview.md
+++ b/articles/synapse-analytics/sql/on-demand-workspace-overview.md
@@ -60,7 +60,7 @@ Serverless SQL pool offers T-SQL querying surface area, which is slightly enhanc
 - Workload can be organized using familiar concepts:
 - Databases - serverless SQL pool endpoint can have multiple databases.
 - Schemas - Within a database, there can be one or many object ownership groups called schemas.
-- Views, stored procedures, inline table value functions
+- Stored procedures, inline table value functions
 - External resources – data sources, file formats, and tables
 
 Security can be enforced using:


### PR DESCRIPTION
Removed Views from the list of T-SQL functionality not supported. I've made views in Azure Synapse Analytics serverless SQL pools and it Synapse Studio lists views along with External Tables, External Resources, Schemas, and Security when expanding the Workspace SQL databases under the Data hub.