### PR TITLE
Add link / info container registry anonymous pull access tiers

### DIFF
--- a/includes/container-registry-limits.md
+++ b/includes/container-registry-limits.md
@@ -34,6 +34,7 @@ ms.custom: include file
 | &bull; Tokens | N/A | N/A | 20,000 |
 | &bull; Scope maps | N/A | N/A | 20,000 |
 | &bull; Repositories per scope map<sup>5</sup> | N/A | N/A | 500 |
+| Anonymous pull access | N/A | [Preview][anonymous-pull-access] | [Preview][anonymous-pull-access] |
 
 
 <sup>1</sup> Storage included in the daily rate for each tier. Additional storage may be used, up to the registry storage limit, at an additional daily rate per GiB. For rate information, see [Azure Container Registry pricing][pricing]. If you need storage beyond the registry storage limit, please contact Azure Support.
@@ -57,3 +58,4 @@ ms.custom: include file
 [cmk]: ../articles/container-registry/tutorial-enable-customer-managed-keys.md
 [token]: ../articles/container-registry/container-registry-repository-scoped-permissions.md
 [zones]: ../articles/container-registry/zone-redundancy.md
+[anonymous-pull-access]: ../articles/container-registry/anonymous-pull-access.md


### PR DESCRIPTION
This PR Clarifies which container registry tiers support anonymous pull access.

At the moment when deploying with `Basic` SKU and  `anonymousPullEnabled` set to `true` ARM provider reports

> Anonymous pull is not supported for SKU Managed_Basic. For more information on SKU tiers, please visit https://aka.ms/acr/tiers .

Going to [aka.ms/acr/tiers](https://aka.ms/acr/tiers) gives no info about anonymous pull access.

