### PR TITLE
Typo in the New-AzureADPolicy example

### DIFF
--- a/articles/active-directory/develop/active-directory-claims-mapping.md
+++ b/articles/active-directory/develop/active-directory-claims-mapping.md
@@ -123,7 +123,7 @@ In this example, you create a policy that emits a custom claim "JoinedData" to J
    1. To create the policy, run the following command:
 
       ```powershell
-      New-AzureADPolicy -Definition @('{"ClaimsMappingPolicy":{"Version":1,"IncludeBasicClaimSet":"true", "ClaimsSchema":[{"Source":"user","ID":"extensionattribute1"},{"Source":"transformation","ID":"DataJoin","TransformationId":"JoinTheData","JwtClaimType":"JoinedData"}],"ClaimsTransformation":[{"ID":"JoinTheData","TransformationMethod":"Join","InputClaims":[{"ClaimTypeReferenceId":"extensionattribute1","TransformationClaimType":"string1"}], "InputParameters": [{"ID":"string2","Value":"sandbox"},{"ID":"separator","Value":"."}],"OutputClaims":[{"ClaimTypeReferenceId":"DataJoin","TransformationClaimType":"outputClaim"}]}]}}') -DisplayName "TransformClaimsExample" -Type "ClaimsMappingPolicy"
+      -
       ```
 
    2. To see your new policy, and to get the policy ObjectId, run the following command:


### PR DESCRIPTION
Existing example powershell code for creating new AzureADPolicy with transformation contains a typo in the name of the property ClaimsTransformation, it should be ClaimsTransformations (missing "s" at the end)