### PR TITLE
Deprecated Google guide replaced with a new one

### DIFF
--- a/articles/app-service/configure-authentication-provider-google.md
+++ b/articles/app-service/configure-authentication-provider-google.md
@@ -18,7 +18,7 @@ To complete the procedure in this topic, you must have a Google account that has
 
 ## <a name="register"> </a>Register your application with Google
 
-1. Follow the Google documentation at [Google Sign-In for server-side apps](https://developers.google.com/identity/sign-in/web/server-side-flow) to create a client ID and client secret. There's no need to make any code changes. Just use the following information:
+1. Follow the Google documentation at [Sign In with Google for Web - Setup](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid) to create a client ID and client secret. There's no need to make any code changes. Just use the following information:
     - For **Authorized JavaScript Origins**, use `https://<app-name>.azurewebsites.net` with the name of your app in *\<app-name>*.
     - For **Authorized Redirect URI**, use `https://<app-name>.azurewebsites.net/.auth/login/google/callback`.
 1. Copy the App ID and the App secret values.


### PR DESCRIPTION
This old guide [Google Sign-In for server-side apps](https://developers.google.com/identity/sign-in/web/server-side-flow) should be replaced by new guide [Sign In with Google for Web - Setup](https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid).

> Warning: The Google Sign-In JavaScript platform library for Web is deprecated, and unavailable for download after March 31, 2023. The solutions in this guide are based on this library and therefore also deprecated.
> 
> Use instead the new Google Identity Services for Web solution to quickly and easily sign users into your app using their Google accounts.
> 
> By default, new client IDs are now blocked from using the older platform library; existing client IDs are unaffected. New client IDs created before July 29th, 2022 may set the plugin_name to enable use of the legacy Google platform library.