### PR TITLE
Update disks-enable-host-based-encryption-portal.md

### DIFF
--- a/articles/virtual-machines/disks-enable-host-based-encryption-portal.md
+++ b/articles/virtual-machines/disks-enable-host-based-encryption-portal.md
@@ -65,6 +65,9 @@ You must enable the feature for your subscription before you use the EncryptionA
     az feature show --name EncryptionAtHost --namespace Microsoft.Compute
     ```
     ---
+    
+> [!NOTE]
+> In Azure Government you must enable the necessary feature flag by browsing to https://portal.azure.us/?feature.enabledoubleencryption=true&feature.enablehostbasedencryption=true#home to display the options shown below.
 
 ## Deploy a VM with platform-managed keys
 


### PR DESCRIPTION
Discovered that even after registering the resource providers these elements don't appear by default in the Azure Government portal unless added via a feature flag in the URL. Added a small blurb calling this out.