### PR TITLE
SynapseBuiltinSqlReqsEnded update

### DIFF
--- a/articles/synapse-analytics/monitoring/how-to-monitor-using-azure-monitor.md
+++ b/articles/synapse-analytics/monitoring/how-to-monitor-using-azure-monitor.md
@@ -106,6 +106,10 @@ Here are the logs emitted by Azure Synapse Analytics workspaces:
 | SynapseIntegrationActivityRuns | IntegrationActivityRuns | Azure Synapse integration activity runs. |
 | SynapseIntegrationTriggerRuns | IntegrationTriggerRuns | Azure Synapse integration trigger runs. |
 
+   > [!NOTE]  
+   > The event **SynapseBuiltinSqlReqsEnded** is only emitted for queries that read data from storage, it will not be emitted for queries that only process metadata.
+
+
 ### Dedicated SQL pool logs
 
 Here are the logs emitted by dedicated SQL pools:

--- a/articles/synapse-analytics/monitoring/how-to-monitor-using-azure-monitor.md
+++ b/articles/synapse-analytics/monitoring/how-to-monitor-using-azure-monitor.md
@@ -107,7 +107,7 @@ Here are the logs emitted by Azure Synapse Analytics workspaces:
 | SynapseIntegrationTriggerRuns | IntegrationTriggerRuns | Azure Synapse integration trigger runs. |
 
    > [!NOTE]  
-   > The event **SynapseBuiltinSqlReqsEnded** is only emitted for queries that read data from storage, it will not be emitted for queries that only process metadata.
+   > The event **SynapseBuiltinSqlReqsEnded** is only emitted for queries that read data from storage. It will not be emitted for queries that only process metadata.
 
 
 ### Dedicated SQL pool logs


### PR DESCRIPTION
Add information that the event SynapseBuiltinSqlReqsEnded is only emitted for queries that read data from storage, it will not be emitted for queries that only process metadata.