### PR TITLE
Fix typo in link to GitHub Actions for Azure docs

### DIFF
--- a/articles/aks/integrations.md
+++ b/articles/aks/integrations.md
@@ -53,7 +53,7 @@ Both extensions and add-ons are supported ways to add functionality to your AKS 
 
 ## GitHub Actions
 
-GitHub Actions helps you automate your software development workflows from within GitHub. For more details on using GitHub Actions with Azure, see [What is GitHub Actions for Azures][github-actions]. For an example of using GitHub Actions with an AKS cluster, see [Build, test, and deploy containers to Azure Kubernetes Service using GitHub Actions][github-actions-aks].
+GitHub Actions helps you automate your software development workflows from within GitHub. For more details on using GitHub Actions with Azure, see [What is GitHub Actions for Azure][github-actions]. For an example of using GitHub Actions with an AKS cluster, see [Build, test, and deploy containers to Azure Kubernetes Service using GitHub Actions][github-actions-aks].
 
 ## Open source and third-party integrations
 


### PR DESCRIPTION
Removed extraneous `s` in the text for the GitHub Actions for Azure docs link