### PR TITLE
Add AZURE_WEBAPP_PACKAGE_PATH variable for JavaScript CI example for avoiding error

### DIFF
--- a/articles/app-service/deploy-github-actions.md
+++ b/articles/app-service/deploy-github-actions.md
@@ -715,6 +715,7 @@ name: Node.js
 
 env:
   AZURE_WEBAPP_NAME: my-app   # set this to your application's name
+  AZURE_WEBAPP_PACKAGE_PATH: 'my-app-path'      # set this to the path to your web app project, defaults to the repository root
   NODE_VERSION: '14.x'                # set this to the node version to use
 
 jobs:
@@ -974,6 +975,7 @@ name: Node.js
 
 env:
   AZURE_WEBAPP_NAME: my-app   # set this to your application's name
+  AZURE_WEBAPP_PACKAGE_PATH: 'my-app-path'      # set this to the path to your web app project, defaults to the repository root
   NODE_VERSION: '14.x'                # set this to the node version to use
 
 jobs:


### PR DESCRIPTION
# Background
- There are 3 `JavaScript CI` examples in [Deploy to App Service using GitHub Actions](https://learn.microsoft.com/en-us/azure/app-service/deploy-github-actions) page (These 3 examples corresponds to each of `Public profile`, `Service principal` and `OpenID Connect`).
- All 3 examples refer to `AZURE_WEBAPP_PACKAGE_PATH` environment variable in the GitHub Actions workflow, but only `Public profile` example defines the variable before using it.
- Therefore, if we just apply `Service principal` and `OpenID Connect` examples, it results in the following error.

> Deployment Failed with Error: Error: No package found with specified pattern:


<img width="500" alt="image" src="https://user-images.githubusercontent.com/1172471/203022217-99777ba3-eb90-4ceb-8570-2970827eb5a6.png">

# Changes
This pull request intends to define `AZURE_WEBAPP_PACKAGE_PATH` in the `env` section of the workflow for `Service principal` and `OpenID Connect`. The description is based on the existing `Public profile` one.
  - https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/app-service/deploy-github-actions.md?plain=1#L496

## Before
<img width="629" alt="image" src="https://user-images.githubusercontent.com/1172471/203022536-8aa976c0-5d27-4fbe-9439-55f1ab0bff8b.png">

## After
<img width="674" alt="image" src="https://user-images.githubusercontent.com/1172471/203022633-3e877b02-aee0-4f6a-a812-3d3356db8e76.png">


