### PR TITLE
Remove duplicate header in example output table

### DIFF
--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -298,7 +298,6 @@ kubectl get services --namespace ingress-basic -o wide -w ingress-nginx-controll
 When the Kubernetes load balancer service is created for the NGINX ingress controller, an IP address is assigned under *EXTERNAL-IP*, as shown in the following example output:
 
 ```
-NAME                                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE   SELECTOR
 NAME                       TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE   SELECTOR
 ingress-nginx-controller   LoadBalancer   10.0.65.205   EXTERNAL-IP     80:30957/TCP,443:32414/TCP   1m   app.kubernetes.io/component=controller,app.kubernetes.io/instance=ingress-nginx,app.kubernetes.io/name=ingress-nginx
 ```


### PR DESCRIPTION
Removing the duplicate header row on the example table output under "Check the load balancer service"