### PR TITLE
rephrasing statement to avoid confusion

### DIFF
--- a/articles/logic-apps/set-up-devops-deployment-single-tenant-azure-logic-apps.md
+++ b/articles/logic-apps/set-up-devops-deployment-single-tenant-azure-logic-apps.md
@@ -66,7 +66,7 @@ The following diagram shows the dependencies between your logic app project and 
 
 ## Deploy logic app resources (zip deploy)
 
-After you push your logic app project to your source repository, you can set up build and release pipelines that deploy logic apps to infrastructure either inside or outside Azure.
+After you push your logic app project to your source repository, you can set up build and release pipelines either inside or outside Azure that deploy logic apps to infrastructure.
 
 ### Build your project
 


### PR DESCRIPTION
"you can set up build and release pipelines that `deploy logic apps to infrastructure either inside or outside Azure`" sounds like we can deploy logic app to infrastructure outside Azure which is not the case. Rephrased sentence avoids misleading here.