### PR TITLE
FIX: Exception when calling StateHasChanged

### DIFF
--- a/articles/azure-signalr/signalr-tutorial-build-blazor-server-chat-app.md
+++ b/articles/azure-signalr/signalr-tutorial-build-blazor-server-chat-app.md
@@ -185,7 +185,7 @@ Beginning in Visual Studio 2019 version 16.2.0, Azure SignalR Service is built i
               _messages.Add(new Message(name, message, isMine));
       
               // Inform blazor the UI needs updating
-               InvokeAsync(StateHasChanged);
+              InvokeAsync(StateHasChanged);
           }
       
           private async Task DisconnectAsync()

--- a/articles/azure-signalr/signalr-tutorial-build-blazor-server-chat-app.md
+++ b/articles/azure-signalr/signalr-tutorial-build-blazor-server-chat-app.md
@@ -185,7 +185,7 @@ Beginning in Visual Studio 2019 version 16.2.0, Azure SignalR Service is built i
               _messages.Add(new Message(name, message, isMine));
       
               // Inform blazor the UI needs updating
-              StateHasChanged();
+               InvokeAsync(StateHasChanged);
           }
       
           private async Task DisconnectAsync()


### PR DESCRIPTION
This fixes the bug that will cause the following Exception:

The current thread is not associated with the Dispatcher. Use InvokeAsync() to switch execution to the Dispatcher when triggering rendering or component state.

I did as it said and used InvokeAsync. The project runs correctly right now.