### PR TITLE
Add total number of incidents per 24 hour period

### DIFF
--- a/includes/sentinel-limits-incidents.md
+++ b/includes/sentinel-limits-incidents.md
@@ -14,6 +14,7 @@ The following limits apply to incidents in Microsoft Sentinel.
 
 |Description  |Limit  |Dependency|
 |---------|---------|-------|
+|Number of incidents  | 3000 per 24 hour period | None |
 |Investigation experience availability     | 90 days from the incident last update time       |None|
 |Number of automation rules     | 512  rules      |None|
 |Number of automation rule actions    | 20  actions    |None|


### PR DESCRIPTION
Hit this recently on corp account, erroneous rules from MCAS/Defender flooded our Sentinel instance. Submitted a ticket figuring this was some soft/hard limit and not in the docs.

case# 2211220040008883