### PR TITLE
Update mcr.microsoft.com/dotnet/core/samples:aspnetapp to supported tag

### DIFF
--- a/articles/application-gateway/ingress-controller-add-health-probes.md
+++ b/articles/application-gateway/ingress-controller-add-health-probes.md
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: aspnetapp
-        image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -291,7 +291,7 @@ metadata:
     app: aspnetapp
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80

--- a/articles/application-gateway/ingress-controller-troubleshoot.md
+++ b/articles/application-gateway/ingress-controller-troubleshoot.md
@@ -37,7 +37,7 @@ metadata:
     app: test-agic-app
 spec:
   containers:
-  - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
+  - image: "mcr.microsoft.com/dotnet/samples:aspnetapp"
     name: aspnetapp-image
     ports:
     - containerPort: 80


### PR DESCRIPTION
These files had references to the `mcr.microsoft.com/dotnet/core/samples` tag which is [no longer a supported tag](https://github.com/dotnet/dotnet-docker/blob/9eb203c4890d3d0122d3939614ff25d68fc46d6e/README.samples.md?plain=1#L93), and no longer exists.

This updates it to the supported tag: `mcr.microsoft.com/dotnet/samples:aspnetapp`

Without making these updates, the `aspnetapp` container used in the samples will be stuck in the `Pending` or `Waiting` state with reason `ImagePullBackOff` and an error: `Back-off pulling image "mcr.microsoft.com/dotnet/core/samples:aspnetapp"`

Related:
- AGIC samples: https://github.com/Azure/application-gateway-kubernetes-ingress/pull/1473
- https://github.com/MicrosoftDocs/azure-docs/issues/101548
- https://github.com/MicrosoftDocs/azure-docs/issues/101497
- https://github.com/dotnet/AspNetCore.Docs/pull/27202
- https://github.com/dotnet/dotnet-docker/discussions/3674
- https://github.com/dotnet/AspNetCore.Docs/pull/27728