### PR TITLE
Commands are outdated & not working

### DIFF
--- a/articles/aks/update-credentials.md
+++ b/articles/aks/update-credentials.md
@@ -37,7 +37,7 @@ To check the expiration date of your service principal, use the [az ad sp creden
 ```azurecli
 SP_ID=$(az aks show --resource-group myResourceGroup --name myAKSCluster \
     --query servicePrincipalProfile.clientId -o tsv)
-az ad sp credential list --id "$SP_ID" --query "[].endDateTime" -o tsv
+az ad app credential list --id "$SP_ID" --query "[].endDateTime" -o tsv
 ```
 
 ### Reset the existing service principal credential
@@ -55,7 +55,7 @@ SP_ID=$(az aks show --resource-group myResourceGroup --name myAKSCluster \
 With a variable set that contains the service principal ID, now reset the credentials using [az ad sp credential reset][az-ad-sp-credential-reset]. The following example lets the Azure platform generate a new secure secret for the service principal. This new secure secret is also stored as a variable.
 
 ```azurecli-interactive
-SP_SECRET=$(az ad sp credential reset --id "$SP_ID" --query password -o tsv)
+SP_SECRET=$(az ad app credential reset --id "$SP_ID" --query password -o tsv)
 ```
 
 Now continue on to [update AKS cluster with new service principal credentials](#update-aks-cluster-with-new-service-principal-credentials). This step is necessary for the Service Principal changes to reflect on the AKS cluster.


### PR DESCRIPTION
az ad sp credential list --id $spid is not working any more Updated command should be
az ad app credential list --id $spid
//////////////////////////
az ad sp credential reset --id $spid  is not working any more Updated command should be:
az ad app credential reset --id $spid 

(I have tested locally and have the screen shots ready to justify the above statements, customers are facing issues with those stale commands) Please approve the changes