### PR TITLE
Change order of steps to avoid error

### DIFF
--- a/articles/azure-arc/servers/onboard-group-policy-service-principal-encryption.md
+++ b/articles/azure-arc/servers/onboard-group-policy-service-principal-encryption.md
@@ -29,13 +29,13 @@ The Group Policy Object, which is used to onboard Azure Arc-enabled servers, req
 
 1. Download and unzip the folder **ArcEnabledServersGroupPolicy_v1.0.1** from [https://aka.ms/gp-onboard](https://aka.ms/gp-onboard). This folder contains the ArcGPO project structure with the scripts `EnableAzureArc.ps1`, `DeployGPO.ps1`, and `AzureArcDeployment.psm1`. These assets will be used for onboarding the machine to Azure Arc-enabled servers.
 
+1. Download the latest version of the [Azure Connected Machine agent Windows Installer package](https://aka.ms/AzureConnectedMachineAgent) from the Microsoft Download Center and save it to the remote share.
+
 1. Execute the deployment script `DeployGPO.ps1`, modifying the run parameters for the DomainFQDN, ReportServerFQDN, ArcRemoteShare, Service Principal secret, Service Principal Client Id, Subscription Id, Resource Group, Region, Tenant, and AgentProxy (if applicable):
 
    ```
    .\DeployGPO.ps1 -DomainFQDN contoso.com -ReportServerFQDN Server.contoso.com -ArcRemoteShare AzureArcOnBoard -ServicePrincipalSecret $ServicePrincipalSecret -ServicePrincipalClientId $ServicePrincipalClientId -SubscriptionId $SubscriptionId --ResourceGroup $ResourceGroup -Location $Location -TenantId $TenantId [-AgentProxy $AgentProxy]
     ```
-
-1. Download the latest version of the [Azure Connected Machine agent Windows Installer package](https://aka.ms/AzureConnectedMachineAgent) from the Microsoft Download Center and save it to the remote share.
 
 ## Apply the Group Policy Object
 


### PR DESCRIPTION
If the msi is not already in the Remote Share the DeployGPO will fail with the following error message 
```
Onboarding script could not be copied:
Cannot find path '\\aadc01.int.c4a8korriban.com\AzureArcOnBoard\AzureConnectedMachineAgent.msi' because it does not exist.
```