### PR TITLE
Typo fix - update to registration management article

### DIFF
--- a/articles/notification-hubs/notification-hubs-push-notification-registration-management.md
+++ b/articles/notification-hubs/notification-hubs-push-notification-registration-management.md
@@ -313,7 +313,7 @@ public async Task<HttpResponseMessage> Put(DeviceInstallation deviceUpdate)
 }
 ```
 
-### Example code to register with a notification hub from a device using a registration ID
+### Example code to register with a notification hub from a backend using a registration ID
 
 From your app backend, you can perform basic CRUDS operations on registrations. For example:
 


### PR DESCRIPTION
- Change  (Example code to register with a notification hub from a device using a registration ID) to (... from a backend...).