### PR TITLE
Include Microsoft Intune Web Company Portal as excluded by design for device compliance requirement

### DIFF
--- a/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
+++ b/articles/active-directory/conditional-access/howto-conditional-access-policy-compliant-device.md
@@ -55,7 +55,7 @@ The following steps will help create a Conditional Access policy to require mult
 After confirming your settings using [report-only mode](howto-conditional-access-insights-reporting.md), an administrator can move the **Enable policy** toggle from **Report-only** to **On**.
 
 > [!NOTE]
-> You can enroll your new devices to Intune even if you select **Require device to be marked as compliant** for **All users** and **All cloud apps** using the steps above. **Require device to be marked as compliant** control does not block Intune enrollment. 
+> You can enroll your new devices to Intune even if you select **Require device to be marked as compliant** for **All users** and **All cloud apps** using the steps above. **Require device to be marked as compliant** control does not block Intune enrollment and the access to the Microsoft Intune Web Company Portal application. 
 
 ### Known behavior
 


### PR DESCRIPTION
Feedback submitted by customer. Conditional Access policies are not enforcing device compliance if the user authenticates for ¨Microsoft Intune Web Company Portal¨ application. The customer would like to see this mentioned in the document explicitly.