### PR TITLE
Correct mail regex for pattern example

### DIFF
--- a/articles/active-directory-b2c/claimsschema.md
+++ b/articles/active-directory-b2c/claimsschema.md
@@ -224,7 +224,7 @@ The following example configures an **email** claim with regular expression inpu
   <UserHelpText>Email address that can be used to contact you.</UserHelpText>
   <UserInputType>TextBox</UserInputType>
   <Restriction>
-    <Pattern RegularExpression="^[a-zA-Z0-9.+!#$%&amp;'^_`{}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$" HelpText="Please enter a valid email address." />
+    <Pattern RegularExpression="^[a-zA-Z0-9.+!#$%&amp;'+^_`{}~-]+(?:\.[a-zA-Z0-9!#$%&amp;'+^_`{}~-]+)*@(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$" HelpText="Please enter a valid email address." />
   </Restriction>
 </ClaimType>
 ```


### PR DESCRIPTION
The regex example for mails to demonstrate the pattern matching is not correct. The current regex does not match values after "@". If you use this example in your claims you got wrong email validation. The regex is replaced with the correct one from the "EmailBox" example.