### PR TITLE
Typo - modify 'you' to 'your'

### DIFF
--- a/articles/synapse-analytics/security/connectivity-settings.md
+++ b/articles/synapse-analytics/security/connectivity-settings.md
@@ -16,7 +16,7 @@ This article will explain connectivity settings in Azure Synapse Analytics and h
 
 ## Public network access 
 
-You can use the public network access feature to allow incoming public network connectivity to you Azure Synapse workspace. 
+You can use the public network access feature to allow incoming public network connectivity to your Azure Synapse workspace. 
 
 - When public network access is **disabled**, you can connect to your workspace only using [private endpoints](synapse-workspace-managed-private-endpoints.md). 
 - When public network access is **enabled**, you can connect to your workspace also from public networks. You can manage this feature both during and after your workspace creation. 


### PR DESCRIPTION
Typo in 'You can use the public network access feature to allow incoming public network connectivity to you Azure Synapse workspace.' It should be your Azure Synapse workspace.