### PR TITLE
Update concept-best-practices-network.md

### DIFF
--- a/articles/purview/concept-best-practices-network.md
+++ b/articles/purview/concept-best-practices-network.md
@@ -85,7 +85,7 @@ Here are some best practices:
 
 When you're scanning a data source in Microsoft Purview, you need to provide a credential. Microsoft Purview can then read the metadata of the assets by using the Azure integration runtime in the destination data source. When you're using a public network, authentication options and requirements vary based on the following factors: 
 
-- **Data source type**. For example, if the data source is Azure SQL Database, you need to use SQL authentication with db_datareader access to each database. This can be a user-managed identity or a Microsoft Purview managed identity. Or it can be a service principal in Azure Active Directory added to SQL Database as db_datareader. 
+- **Data source type**. For example, if the data source is Azure SQL Database, you need to use a login with db_datareader access to each database. This can be a user-managed identity or a Microsoft Purview managed identity. Or it can be a service principal in Azure Active Directory added to SQL Database as db_datareader. 
 
   If the data source is Azure Blob Storage, you can use a Microsoft Purview managed identity, or a service principal in Azure Active Directory added as a Blob Storage Data Reader role on the Azure storage account. Or use the storage account's key.  
 


### PR DESCRIPTION
Clarified wording in example - the usage of the phrase "SQL authentication" is incorrect in this context and is contradicted by the sentences which follow it.  The requirement is to have a database login with the db_datareader role.