### PR TITLE
Fix permissions for SAS token

### DIFF
--- a/articles/governance/machine-configuration/machine-configuration-create-publish.md
+++ b/articles/governance/machine-configuration/machine-configuration-create-publish.md
@@ -61,7 +61,7 @@ Optionally, you can add a SAS token in the URL, this ensures that the content pa
 ```powershell
 $StartTime = Get-Date
 $EndTime = $startTime.AddYears(3)
-$contenturi = New-AzStorageBlobSASToken -StartTime $StartTime -ExpiryTime $EndTime -Container "guestconfiguration" -Blob "MyConfig.zip" -Permission rwd -Context $Context -FullUri 
+$contenturi = New-AzStorageBlobSASToken -StartTime $StartTime -ExpiryTime $EndTime -Container "guestconfiguration" -Blob "MyConfig.zip" -Permission r -Context $Context -FullUri 
 ```
 
 ## Next steps


### PR DESCRIPTION
> The below example generates a blob SAS token with read access and returns the full blob URI with the shared access signature token.

In the PowerShell sample code, remove write and delete permissions for the SAS token to align with description.

Write and delete permissions are not required for the intended use case and must be removed to comply with the secure design principle of **Least Privilege**.