### PR TITLE
Update how-to-connect-group-writeback-enable.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-group-writeback-enable.md
+++ b/articles/active-directory/hybrid/how-to-connect-group-writeback-enable.md
@@ -29,6 +29,10 @@ Group writeback requires enabling both the original and new versions of the feat
 >
 >The enhanced group writeback feature is enabled on the tenant and not per Azure AD Connect client instance. Please be sure that all Azure AD Connect client instances are updated to a minimal build version of 1.6.4.0 or later.
 
+> [!NOTE]
+> If you don't want to writeback all existing Microsoft 365 groups to Active Directory, you need to make changes to group writeback default behaviour before performing the steps in this article to enable the feature. See [Modify Azure AD Connect group writeback default behavior](how-to-connect-modify-group-writeback.md).
+> Also the new and original versions of the feature need to be enabled in the order documented. If the original feature is enabled first, all existing Microsoft 365 groups will be written back to Active Directory.
+
 ### Enable group writeback by using PowerShell 
 
 1. On your Azure AD Connect server, open a PowerShell prompt as an administrator. 


### PR DESCRIPTION
There's ambiguity in the documentation and what to expect when enabling group writeback. It is not clearly documented in which order changes to default behavior should be done and which order new and original versions need to be enabled or which is the outcome if these orders are not followed. This ambiguity is generating various support cases created by customers.