### PR TITLE
Update ddos-protection-sku-comparison.md

### DIFF
--- a/articles/ddos-protection/ddos-protection-sku-comparison.md
+++ b/articles/ddos-protection/ddos-protection-sku-comparison.md
@@ -48,6 +48,8 @@ The following table shows features and corresponding SKUs.
 
 | Feature | DDoS IP Protection | DDoS Network Protection |
 |---|---|---|
+| Protects Public IP Standard SKU | Yes | Yes |
+| Protects Public IP Basic SKU | No | No |
 | Active traffic monitoring & always on detection |  Yes| Yes |
 | L3/L4 Automatic attack mitigation  | Yes | Yes |
 | Automatic attack mitigation | Yes | Yes |

--- a/articles/ddos-protection/ddos-protection-sku-comparison.md
+++ b/articles/ddos-protection/ddos-protection-sku-comparison.md
@@ -49,7 +49,7 @@ The following table shows features and corresponding SKUs.
 | Feature | DDoS IP Protection | DDoS Network Protection |
 |---|---|---|
 | Protects Public IP Standard SKU | Yes | Yes |
-| Protects Public IP Basic SKU | No | No |
+| Protects Public IP Basic SKU | No | Yes |
 | Active traffic monitoring & always on detection |  Yes| Yes |
 | L3/L4 Automatic attack mitigation  | Yes | Yes |
 | Automatic attack mitigation | Yes | Yes |


### PR DESCRIPTION
Public IP Standard SKU restriction is explicitly stated for DDoS IP Protection here https://learn.microsoft.com/en-us/azure/ddos-protection/manage-ddos-protection-powershell-ip#enable-ddos-ip-protection-preview-for-a-public-ip-address, but is not mentioned anywhere for DDoS IP Network Protection. I am making the assumption that both plans only work with Public IP Standard SKU.