### PR TITLE
Update permissions-reference.md

### DIFF
--- a/articles/active-directory/roles/permissions-reference.md
+++ b/articles/active-directory/roles/permissions-reference.md
@@ -2250,7 +2250,7 @@ Users with this role can manage [Teams-certified devices](https://www.microsoft.
 
  ## Tenant Creator
 
-Assign the Teant Creator role to users who need to do the following tasks:
+Assign the Tenant Creator role to users who need to do the following tasks:
 -	Create both Azure Active Directory and Azure Active Directory B2C tenants even if the tenant creation toggle is turned off in the user settings
 > [!NOTE]
 >The tenant creators will be assigned the Global administrator role on the new tenants they create.


### PR DESCRIPTION
Correcting a typo in Tenant creator role description: "Tenant" instead of "teant"