### PR TITLE
Update web-app-routing.md

### DIFF
--- a/articles/aks/web-app-routing.md
+++ b/articles/aks/web-app-routing.md
@@ -222,6 +222,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aks-helloworld  
+  namespace: hello-web-app-routing
 spec:
   replicas: 1
   selector:
@@ -251,6 +252,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: aks-helloworld
+  namespace: hello-web-app-routing
 spec:
   type: ClusterIP
   ports:
@@ -327,9 +329,6 @@ spec:
     tls:
       skipClientCertValidation: false
   sources:
-  - kind: Service
-    name: nginx
-    namespace: app-routing-system
   - kind: AuthenticatedPrincipal
     name: ingress-nginx.ingress.cluster.local
 ```

--- a/articles/aks/web-app-routing.md
+++ b/articles/aks/web-app-routing.md
@@ -329,6 +329,9 @@ spec:
     tls:
       skipClientCertValidation: false
   sources:
+  - kind: Service
+    name: nginx
+    namespace: app-routing-system
   - kind: AuthenticatedPrincipal
     name: ingress-nginx.ingress.cluster.local
 ```


### PR DESCRIPTION
Added namespace to deployment and service yaml files.   Otherwise, they get deployed to default ns unless customers use -n
Removed  kind: Service from sources: in IngressBackend as it's unnecessary for this configuration. This managed add-on adds client certificate to kube-system and kind: AuthenticatedPrincipal is all needed (from OSM: When the backend protocol is https, the source specified must be an AuthenticatedPrincipal kind which defines the Subject Alternative Name (SAN) encoded in the client’s certificate that the backend will authenticate). Also verified without Services and works ok.