### PR TITLE
Add details when using Azurite locally

### DIFF
--- a/articles/azure-functions/create-first-function-cli-python.md
+++ b/articles/azure-functions/create-first-function-cli-python.md
@@ -211,7 +211,7 @@ For more information, see [Azure Functions HTTP triggers and bindings](./functio
 
 ## Start the storage emulator
 
-Before running the function locally, you must start the local Azurite storage emulator. You can skip this step if the `AzureWebJobsStorage` setting in the local.settings.json file is set to the connection string for an Azure Storage account.   
+Before running the function locally, you must start the local Azurite storage emulator. You can skip this step if the `AzureWebJobsStorage` setting in the local.settings.json file is set to the connection string for an Azure Storage account.   Otherwise, for local development using Azurite, set `"AzureWebJobsStorage": "UseDevelopmentStorage=true"`
 
 Use the following command to start the Azurite storage emulator:
 


### PR DESCRIPTION
Granted there is the "more information on how to run azurite, but the portion to use ie `"AzureWebJobsStorage": "UseDevelopmentStorage=true"` is buried half way down the page.  I ended up googling to find the answer on StackOverflow.