### PR TITLE
Update data-lake-storage-use-databricks-spark.md

### DIFF
--- a/articles/storage/blobs/data-lake-storage-use-databricks-spark.md
+++ b/articles/storage/blobs/data-lake-storage-use-databricks-spark.md
@@ -35,16 +35,10 @@ If you don't have an Azure subscription, create a [free account](https://azure.m
 
 - Install AzCopy v10. See [Transfer data with AzCopy v10](../common/storage-use-azcopy-v10.md?toc=/azure/storage/blobs/toc.json)
 
-- Create a service principal. See [How to: Use the portal to create an Azure AD application and service principal that can access resources](../../active-directory/develop/howto-create-service-principal-portal.md).
+- Follow Step 1 to Step 3 from 
+[Connect to Azure Data Lake Storage Gen2 using OAuth 2.0 with an Azure service principal](https://learn.microsoft.com/azure/databricks/getting-started/connect-to-azure-storage) to connect to ADL Stroage Gen 2 using Secret directly or  Step 1  to Step 5 to connect to ADL Gen2 Storage using Keyvault back Secrets.
 
-  There's a couple of specific things that you'll have to do as you perform the steps in that article.
-
-  :heavy_check_mark: When performing the steps in the [Assign the application to a role](../../active-directory/develop/howto-create-service-principal-portal.md#assign-a-role-to-the-application) section of the article, make sure to assign the **Storage Blob Data Contributor** role to the service principal.
-
-  > [!IMPORTANT]
-  > Make sure to assign the role in the scope of the Data Lake Storage Gen2 storage account. You can assign a role to the parent resource group or subscription, but you'll receive permissions-related errors until those role assignments propagate to the storage account.
-
-  :heavy_check_mark: When performing the steps in the [Get values for signing in](../../active-directory/develop/howto-create-service-principal-portal.md#get-tenant-and-app-id-values-for-signing-in) section of the article, paste the tenant ID, app ID, and client secret values into a text file. You'll need those soon.
+  :heavy_check_mark: When performing the steps in the [Get values for signing in](https://learn.microsoft.com/en-us/azure/databricks/getting-started/connect-to-azure-storage#--step-2-create-a-client-secret-for-your-service-principal) section of the article, paste the tenant ID, app ID, and client secret values into a text file. You'll need those soon.
 
 ### Download the flight data
 

--- a/articles/storage/blobs/data-lake-storage-use-databricks-spark.md
+++ b/articles/storage/blobs/data-lake-storage-use-databricks-spark.md
@@ -36,9 +36,9 @@ If you don't have an Azure subscription, create a [free account](https://azure.m
 - Install AzCopy v10. See [Transfer data with AzCopy v10](../common/storage-use-azcopy-v10.md?toc=/azure/storage/blobs/toc.json)
 
 - Follow Step 1 to Step 3 from 
-[Connect to Azure Data Lake Storage Gen2 using OAuth 2.0 with an Azure service principal](https://learn.microsoft.com/azure/databricks/getting-started/connect-to-azure-storage) to connect to ADL Stroage Gen 2 using Secret directly or  Step 1  to Step 5 to connect to ADL Gen2 Storage using Keyvault back Secrets.
+[Connect to Azure Data Lake Storage Gen2 using OAuth 2.0 with an Azure service principal](../../databricks/getting-started/connect-to-azure-storage) to connect to ADL Stroage Gen 2 using Secret directly or  Step 1  to Step 5 to connect to ADL Gen2 Storage using Keyvault back Secrets.
 
-  :heavy_check_mark: When performing the steps in the [Get values for signing in](https://learn.microsoft.com/en-us/azure/databricks/getting-started/connect-to-azure-storage#--step-2-create-a-client-secret-for-your-service-principal) section of the article, paste the tenant ID, app ID, and client secret values into a text file. You'll need those soon.
+  :heavy_check_mark: When performing the steps in the [Get values for signing in](../../databricks/getting-started/connect-to-azure-storage#--step-2-create-a-client-secret-for-your-service-principal) section of the article, paste the tenant ID, app ID, and client secret values into a text file. You'll need those soon.
 
 ### Download the flight data
 


### PR DESCRIPTION
Replace following section

Create a service principal. See How to: Use the portal to create an Azure AD application and service principal that can access resources.

There's a couple of specific things that you'll have to do as you perform the steps in that article.

✔️ When performing the steps in the Assign the application to a role section of the article, make sure to assign the Storage Blob Data Contributor role to the service principal.

[!IMPORTANT] Make sure to assign the role in the scope of the Data Lake Storage Gen2 storage account. You can assign a role to the parent resource group or subscription, but you'll receive permissions-related errors until those role assignments propagate to the storage account.

✔️ When performing the steps in the Get values for signing in section of the article, paste the tenant ID, app ID, and client secret values into a text file. You'll need those soon.

With  following

- Follow Step 1 to Step 3 from  [Connect to Azure Data Lake Storage Gen2 using OAuth 2.0 with an Azure service principal](https://learn.microsoft.com/azure/databricks/getting-started/connect-to-azure-storage) to connect to ADL Stroage Gen 2 using Secret directly or  Step 1  to Step 5 to connect to ADL Gen2 Storage using Keyvault back Secrets.

  :heavy_check_mark: When performing the steps in the [Get values for signing in](https://learn.microsoft.com/en-us/azure/databricks/getting-started/connect-to-azure-storage#--step-2-create-a-client-secret-for-your-service-principal) section of the article, paste the tenant ID, app ID, and client secret values into a text file. You'll need those soon.