### PR TITLE
Permission Scope Assignment 

### DIFF
--- a/articles/defender-for-cloud/just-in-time-access-overview.md
+++ b/articles/defender-for-cloud/just-in-time-access-overview.md
@@ -69,9 +69,9 @@ If you are setting up JIT on your Amazon Web Service (AWS) VM, you will need to 
 
 | To enable a user to: | Permissions to set|
 | --- | --- |
-|Configure or edit a JIT policy for a VM | *Assign these actions to the role:*  <ul><li>On the scope of a subscription or resource group that is associated with the VM:<br/> `Microsoft.Security/locations/jitNetworkAccessPolicies/write` </li><li> On the scope of a subscription or resource group of VM: <br/>`Microsoft.Compute/virtualMachines/write`</li></ul> | 
-|Request JIT access to a VM | *Assign these actions to the user:*  <ul><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action` </li><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/*/read` </li><li> `Microsoft.Compute/virtualMachines/read` </li><li> `Microsoft.Network/networkInterfaces/*/read` </li> <li> `Microsoft.Network/publicIPAddresses/read` </li></ul> |
-|Read JIT policies| *Assign these actions to the user:*  <ul><li>`Microsoft.Security/locations/jitNetworkAccessPolicies/read`</li><li>`Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action`</li><li>`Microsoft.Security/policies/read`</li><li>`Microsoft.Security/pricings/read`</li><li>`Microsoft.Compute/virtualMachines/read`</li><li>`Microsoft.Network/*/read`</li>|
+|Configure or edit a JIT policy for a VM | *Assign these actions to the role: On the scope of the subscription that is associated with the VM:* <ul><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/write` </li><li> `Microsoft.Compute/virtualMachines/write`</li></ul> | 
+|Request JIT access to a VM | *Assign these actions to the user:* <ul><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action` </li><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/*/read` </li><li> `Microsoft.Compute/virtualMachines/read` </li><li> `Microsoft.Network/networkInterfaces/*/read` </li><li> `Microsoft.Network/publicIPAddresses/read` </li></ul> |
+|Read JIT policies| *Assign these actions to the user: On the scope of the subscription that is associated with the VM:* <ul><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/read`</li><li> `Microsoft.Security/locations/jitNetworkAccessPolicies/initiate/action`</li><li> `Microsoft.Security/policies/read` </li><li> `Microsoft.Security/pricings/read` </li><li> `Microsoft.Compute/virtualMachines/read`</li><li>`Microsoft.Network/*/read`</li>|
 
 > [!Note]
 > Only the `Microsoft.Security` permissions are relevant for AWS.


### PR DESCRIPTION
The Security permissions need to be assigned on the Subscription and not the resource group for assigning a JIT policy and viewing the policy. Changes:
Line 72: Removed the resource group as the assignment scope - Policies can only be enabled with Subscription permissions 
Line 74: changed the scope to the subscription since the Microsoft.Security/policies/read needs to be on the subscription - Even with owner permissions on the RG the user cannot view the configured policies