### PR TITLE
Adding request id($rid) formate

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-direct-methods.md
+++ b/articles/iot-hub/iot-hub-devguide-direct-methods.md
@@ -167,7 +167,7 @@ The device sends responses to `$iothub/methods/res/{status}/?$rid={request id}`,
 
 * The `status` property is the device-supplied status of method execution.
 
-* The `$rid` property is the request ID from the method invocation received from IoT Hub and request ID contain value in hexadecimal formate.
+* The `$rid` property is the request ID from the method invocation received from IoT Hub. The request ID is a hexadecimal formatted value.
 
 The body is set by the device and can be any status.
 

--- a/articles/iot-hub/iot-hub-devguide-direct-methods.md
+++ b/articles/iot-hub/iot-hub-devguide-direct-methods.md
@@ -167,7 +167,7 @@ The device sends responses to `$iothub/methods/res/{status}/?$rid={request id}`,
 
 * The `status` property is the device-supplied status of method execution.
 
-* The `$rid` property is the request ID from the method invocation received from IoT Hub.
+* The `$rid` property is the request ID from the method invocation received from IoT Hub and request ID contain value in hexadecimal formate.
 
 The body is set by the device and can be any status.
 


### PR DESCRIPTION
Adding $rid (request id) format which is not mentioned, people are assuming that it's in integer format but actually request id generates in hexadecimal format. when we start adding type check in code this issue will start popping out.