### PR TITLE
Change Azure FrontDoor SP name to `Microsoft.Azure.Cdn`

### DIFF
--- a/articles/cdn/cdn-custom-ssl.md
+++ b/articles/cdn/cdn-custom-ssl.md
@@ -121,7 +121,7 @@ Register Azure CDN as an app in your Azure Active Directory via PowerShell.
 
      `New-AzADServicePrincipal -ApplicationId "205478c0-bd83-4e1b-a9d6-db63a3e1e1c8" -Role Contributor`
     > [!NOTE]
-    > **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8** is the service principal for **Microsoft.AzureFrontDoor-Cdn**.
+    > **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8** is the service principal for **Microsoft.Azure.Cdn**.
 
     ```bash
     New-AzADServicePrincipal -ApplicationId "205478c0-bd83-4e1b-a9d6-db63a3e1e1c8" -Role Contributor
@@ -131,7 +131,7 @@ Register Azure CDN as an app in your Azure Active Directory via PowerShell.
                                 https://microsoft.onmicrosoft.com/033ce1c9-f832-4658-b024-ef1cbea108b8}
     ApplicationId         : 205478c0-bd83-4e1b-a9d6-db63a3e1e1c8
     ObjectType            : ServicePrincipal
-    DisplayName           : Microsoft.AzureFrontDoor-Cdn
+    DisplayName           : Microsoft.Azure.Cdn
     Id                    : c87be08f-686a-4d9f-8ef8-64707dbd413e
     Type                  :
     ```
@@ -143,9 +143,9 @@ Grant Azure CDN permission to access the certificates (secrets) in your Azure Ke
 
     :::image type="content" source="./media/cdn-custom-ssl/cdn-new-access-policy.png" alt-text="Create keyvault access policy for CDN" border="true":::
 
-2. In the **Add access policy** page, select **None selected** next to **Select principal**. In the **Principal** page, enter **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**. Select **Microsoft.AzureFrontdoor-Cdn**.  Choose **Select**:
+2. In the **Add access policy** page, select **None selected** next to **Select principal**. In the **Principal** page, enter **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**. Select **Microsoft.Azure.Cdn**.  Choose **Select**:
 
-3. In **Select principal**, search for **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, choose **Microsoft.AzureFrontDoor-Cdn**. Choose **Select**.
+3. In **Select principal**, search for **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, choose **Microsoft.Azure.Cdn**. Choose **Select**.
 
     :::image type="content" source="./media/cdn-custom-ssl/cdn-access-policy-settings.png" alt-text="Select service principal of Azure CDN" border="true":::
 

--- a/articles/frontdoor/migrate-tier.md
+++ b/articles/frontdoor/migrate-tier.md
@@ -23,8 +23,8 @@ Azure Front Door Standard and Premium tier bring the latest cloud delivery netwo
 * Ensure your Front Door (classic) profile can be migrated:
     * HTTPS is required for all custom domains. Azure Front Door Standard and Premium enforce HTTPS on all domains. If you don't have your own certificate, you can use an Azure Front Door managed certificate. The certificate is free and managed for you.
     * If you use BYOC (Bring your own certificate) for Azure Front Door (classic), you'll need to grant Key Vault access to your Azure Front Door Standard or Premium profile by completing the following steps:
-        * Register the service principal for **Microsoft.AzureFrontDoor-Cdn** as an app in your Azure Active Directory using Azure PowerShell.
-        * Grant **Microsoft.AzureFrontDoor-Cdn** access to your Key Vault.
+        * Register the service principal for **Microsoft.Azure.Cdn** as an app in your Azure Active Directory using Azure PowerShell.
+        * Grant **Microsoft.Azure.Cdn** access to your Key Vault.
     * Session affinity gets enabled from the origin group settings in the Azure Front Door Standard or Premium profile. In Azure Front Door (classic), session affinity is managed at the domain level. As part of the migration, session affinity is based on the Classic profile's configuration. If you have two domains in the Classic profile that shares the same backend pool (origin group), session affinity has to be consistent across both domains in order for migration to be compatible.
     
 ## Validate compatibility

--- a/articles/frontdoor/standard-premium/how-to-configure-https-custom-domain.md
+++ b/articles/frontdoor/standard-premium/how-to-configure-https-custom-domain.md
@@ -135,7 +135,7 @@ Grant Azure Front Door permission to access the certificates in your Azure Key V
 
 1. In **Certificate permissions**, select **Get** to allow Front Door to retrieve the certificate.
 
-1. In **Select principal**, search for **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, and select **Microsoft.AzureFrontDoor-Cdn**. Select **Next**.
+1. In **Select principal**, search for **205478c0-bd83-4e1b-a9d6-db63a3e1e1c8**, and select **Microsoft.Azure.Cdn**. Select **Next**.
 
 1. In **Application**, select **Next**.
 

--- a/articles/frontdoor/tier-migration.md
+++ b/articles/frontdoor/tier-migration.md
@@ -73,8 +73,8 @@ Diagnostic logs and metrics won't be migrated. Azure Front Door Standard/Premium
 
 * HTTPS is required for all custom domains. All Azure Front Door Standard and Premium tiers enforce HTTPS on every domain. If you don't your own certificate, you can use Azure Front Door managed certificate that is free and managed for you.
 * If you use BYOC for Azure Front Door (classic), you need to grant Key Vault access to your Azure Front Door Standard or Premium profile by completing the following steps:
-    * Register the service principal for **Microsoft.AzureFrontDoor-Cdn** as an app in your Azure Active Directory using Azure PowerShell.
-    * Grant **Microsoft.AzureFrontDoor-Cdn** access to your Key Vault.
+    * Register the service principal for **Microsoft.Azure.Cdn** as an app in your Azure Active Directory using Azure PowerShell.
+    * Grant **Microsoft.Azure.Cdn** access to your Key Vault.
 * Session affinity is enabled from within the origin group in an Azure Front Door Standard and Premium profile. In Azure Front Door (classic), session affinity is controlled at the domain level. As part of the migration, session affinity gets enabled or disabled based on the Classic profile's configuration. If you have two domains in a Classic profile that shares the same origin group, session affinity has to be consistent across both domains in order for migration can pass validation.
 
 > [!IMPORTANT]


### PR DESCRIPTION
Fix wrong SP name from `Microsoft.AzureFrontDoor-Cdn` to `Microsoft.Azure.Cdn` as the old name cannot be found on the Azure AD. 

Other users had the same issue. https://learn.microsoft.com/en-us/answers/questions/435168/how-to-grant-access-to-microsoftazurefrontdoor-cdn.html

<sub>Daniel Schniepp [daniel.schniepp@mercedes-benz.com](mailto:daniel.schniepp@mercedes-benz.com), Mercedes-Benz Mobility AG on behalf of Mercedes-Benz Tech Innovation GmbH.</sub>