### PR TITLE
Update IPsec/IKE Policy Guides

### DIFF
--- a/articles/vpn-gateway/ipsec-ike-policy-howto.md
+++ b/articles/vpn-gateway/ipsec-ike-policy-howto.md
@@ -7,7 +7,7 @@ author: cherylmc
 
 ms.service: vpn-gateway
 ms.topic: how-to
-ms.date: 04/28/2021
+ms.date: 12/02/2022
 ms.author: cherylmc
 
 ---
@@ -24,8 +24,8 @@ This article provides instructions to create and configure an IPsec/IKE policy, 
 ### Considerations
 
 * IPsec/IKE policy only works on the following gateway SKUs:
-  * ***VpnGw1~5 and VpnGw1AZ~5AZ***
-  * ***Standard*** and ***HighPerformance***
+  * **VpnGw1~5**
+  * **VpnGw1AZ~5AZ**
 * You can only specify ***one*** policy combination for a given connection.
 * You must specify all algorithms and parameters for both IKE (Main Mode) and IPsec (Quick Mode). Partial policy specification is not allowed.
 * Consult with your VPN device vendor specifications to ensure the policy is supported on your on-premises VPN devices. S2S or VNet-to-VNet connections cannot establish if the policies are incompatible.
@@ -45,68 +45,7 @@ The instructions in this article help you set up and configure IPsec/IKE policie
 
 ## <a name ="params"></a>Supported cryptographic algorithms & key strengths
 
-### <a name ="table1"></a>Algorithms and keys
-
-The following table lists the supported cryptographic algorithms and key strengths configurable by the customers:
-
-| **IPsec/IKE**    | **Options**    |
-| ---              | ---            |
-| IKE Encryption   | AES256, AES192, AES128, DES3, DES                  |
-| IKE Integrity    | SHA384, SHA256, SHA1, MD5                          |
-| DH Group         | DHGroup24, ECP384, ECP256, DHGroup14, DHGroup2048, DHGroup2, DHGroup1, None |
-| IPsec Encryption | GCMAES256, GCMAES192, GCMAES128, AES256, AES192, AES128, DES3, DES, None    |
-| IPsec Integrity  | GCMASE256, GCMAES192, GCMAES128, SHA256, SHA1, MD5 |
-| PFS Group        | PFS24, ECP384, ECP256, PFS2048, PFS2, PFS1, None   |
-| QM SA Lifetime   | (**Optional**: default values are used if not specified)<br>Seconds (integer; **min. 300**/default 27000 seconds)<br>KBytes (integer; **min. 1024**/default 102400000 KBytes)    |
-| Traffic Selector | UsePolicyBasedTrafficSelectors** ($True/$False; **Optional**, default $False if not specified)    |
-| DPD timeout      | Seconds (integer: min. 9/max. 3600; default 45 seconds) |
-|  |  |
-
-#### Important requirements
-
-* Your on-premises VPN device configuration must match or contain the following algorithms and parameters that you specify on the Azure IPsec/IKE policy:
-  * IKE encryption algorithm (Main Mode / Phase 1)
-  * IKE integrity algorithm (Main Mode / Phase 1)
-  * DH Group (Main Mode / Phase 1)
-  * IPsec encryption algorithm (Quick Mode / Phase 2)
-  * IPsec integrity algorithm (Quick Mode / Phase 2)
-  * PFS Group (Quick Mode / Phase 2)>    * Traffic Selector (if UsePolicyBasedTrafficSelectors is used)
-  * The SA lifetimes are local specifications only, do not need to match.
-
-* If GCMAES is used as for IPsec Encryption algorithm, you must select the same GCMAES algorithm and key length for IPsec Integrity; for example, using GCMAES128 for both.
-
-* In the [algorithms and keys table](#table1) above:
-  * IKE corresponds to Main Mode or Phase 1
-  * IPsec corresponds to Quick Mode or Phase 2
-  * DH Group specifies the Diffie-Hellmen Group used in Main Mode or Phase 1
-  * PFS Group specified the Diffie-Hellmen Group used in Quick Mode or Phase 2
-
-* IKE Main Mode SA lifetime is fixed at 28,800 seconds on the Azure VPN gateways.
-
-* If you set **UsePolicyBasedTrafficSelectors** to $True on a connection, it will configure the Azure VPN gateway to connect to policy-based VPN firewall on premises. If you enable PolicyBasedTrafficSelectors, you need to ensure your VPN device has the matching traffic selectors defined with all combinations of your on-premises network (local network gateway) prefixes to/from the Azure virtual network prefixes, instead of any-to-any. For example, if your on-premises network prefixes are 10.1.0.0/16 and 10.2.0.0/16, and your virtual network prefixes are 192.168.0.0/16 and 172.16.0.0/16, you need to specify the following traffic selectors:
-  * 10.1.0.0/16 <====> 192.168.0.0/16
-  * 10.1.0.0/16 <====> 172.16.0.0/16
-  * 10.2.0.0/16 <====> 192.168.0.0/16
-  * 10.2.0.0/16 <====> 172.16.0.0/16
-
-   For more information regarding policy-based traffic selectors, see [Connect multiple on-premises policy-based VPN devices](vpn-gateway-connect-multiple-policybased-rm-ps.md).
-
-* DPD timeout - The default value is 45 seconds on Azure VPN gateways. Setting the timeout to shorter periods will cause IKE to rekey more aggressively, causing the connection to appear to be disconnected in some instances. This may not be desirable if your on-premises locations are farther away from the Azure region where the VPN gateway resides, or the physical link condition could incur packet loss. The general recommendation is to set the timeout between **30 to 45** seconds.
-
-### Diffie-Hellman Groups
-
-The following table lists the corresponding Diffie-Hellman Groups supported by the custom policy:
-
-| **Diffie-Hellman Group**  | **DHGroup**              | **PFSGroup** | **Key length** |
-| --- | --- | --- | --- |
-| 1                         | DHGroup1                 | PFS1         | 768-bit MODP   |
-| 2                         | DHGroup2                 | PFS2         | 1024-bit MODP  |
-| 14                        | DHGroup14<br>DHGroup2048 | PFS2048      | 2048-bit MODP  |
-| 19                        | ECP256                   | ECP256       | 256-bit ECP    |
-| 20                        | ECP384                   | ECP384       | 384-bit ECP    |
-| 24                        | DHGroup24                | PFS24        | 2048-bit MODP  |
-
-Refer to [RFC3526](https://tools.ietf.org/html/rfc3526) and [RFC5114](https://tools.ietf.org/html/rfc5114) for more details.
+Refer to the [IPsec/IKE parameters table](#ipsecikeparams) later in this guide for the list of encryption algorithms, authentication algorithms, and key strengths available for use in a custom policy.
 
 ## <a name ="S2S"></a>S2S VPN with IPsec/IKE policy
 
@@ -205,6 +144,10 @@ The steps to create a VNet-to-VNet connection with an IPsec/IKE policy are simil
    :::image type="content" source="./media/ipsec-ike-policy-howto/delete-policy.png" alt-text="Delete policy":::
 
 3. Select **Save** to remove the custom policy and restore the default IPsec/IKE settings on the connection.
+
+## IPsec/IKE policy FAQ
+
+[!INCLUDE [vpn-gateway-ipsecikepolicy-faq-include](../../includes/vpn-gateway-faq-ipsecikepolicy-include.md)]
 
 ## Next steps
 

--- a/articles/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell.md
+++ b/articles/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell.md
@@ -362,6 +362,10 @@ Set-AzVirtualNetworkGatewayConnection -VirtualNetworkGatewayConnection $connecti
 
 You can use the same script to check if the policy has been removed from the connection.
 
+## IPsec/IKE policy FAQ
+
+[!INCLUDE [vpn-gateway-ipsecikepolicy-faq-include](../../includes/vpn-gateway-faq-ipsecikepolicy-include.md)]
+
 ## Next steps
 
 See [Connect multiple on-premises policy-based VPN devices](vpn-gateway-connect-multiple-policybased-rm-ps.md) for more details regarding policy-based traffic selectors.

--- a/articles/vpn-gateway/vpn-gateway-vpn-faq.md
+++ b/articles/vpn-gateway/vpn-gateway-vpn-faq.md
@@ -6,7 +6,7 @@ author: cherylmc
 
 ms.service: vpn-gateway
 ms.topic: conceptual
-ms.date: 06/10/2022
+ms.date: 12/02/2022
 ms.author: cherylmc
 ---
 
@@ -247,6 +247,12 @@ Yes, this is supported. For more information, see [Configure ExpressRoute and si
 ## <a name="ipsecike"></a>IPsec/IKE policy
 
 [!INCLUDE [vpn-gateway-ipsecikepolicy-faq-include](../../includes/vpn-gateway-faq-ipsecikepolicy-include.md)]
+
+### Where can I find more configuration guidance for IPsec policies?
+
+See the following articles:
+* [Azure portal](ipsec-ike-policy-howto.md)
+* [Azure PowerShell](vpn-gateway-ipsecikepolicy-rm-powershell.md)
 
 ## <a name="bgp"></a>BGP and routing
 

--- a/includes/vpn-gateway-faq-ipsecikepolicy-include.md
+++ b/includes/vpn-gateway-faq-ipsecikepolicy-include.md
@@ -2,7 +2,7 @@
  title: include file
  author: cherylmc
  ms.service: vpn-gateway
- ms.date: 05/25/2022
+ ms.date: 12/02/2022
  ms.author: cherylmc
 ---
 ### Is Custom IPsec/IKE policy supported on all Azure VPN Gateway SKUs?
@@ -17,28 +17,27 @@ You can only specify ***one*** policy combination for a given connection.
 
 No, you must specify all algorithms and parameters for both IKE (Main Mode) and IPsec (Quick Mode). Partial policy specification isn't allowed.
 
-### What are the algorithms and key strengths supported in the custom policy?
+### <a name="ipsecikeparams"></a>What are the algorithms and key strengths supported in the custom policy?
 
 The following table lists the supported cryptographic algorithms and key strengths configurable by the customers. You must select one option for every field.
 
-| **IPsec/IKEv2**  | **Options**                                                                   |
-| ---              | ---                                                                           |
-| IKEv2 Encryption | GCMAES256, GCMAES128, AES256, AES192, AES128, DES3, DES                                             |
-| IKEv2 Integrity  | GCMAES256, GCMAES128, SHA384, SHA256, SHA1, MD5                                                     |
-| DH Group         | DHGroup24, ECP384, ECP256, DHGroup14 (DHGroup2048), DHGroup2, DHGroup1, None  |
-| IPsec Encryption | GCMAES256, GCMAES192, GCMAES128, AES256, AES192, AES128, DES3, DES, None      |
-| IPsec Integrity  | GCMAES256, GCMAES192, GCMAES128, SHA256, SHA1, MD5                            |
-| PFS Group        | PFS24, ECP384, ECP256, PFS2048, PFS2, PFS1, None                              |
-| QM SA Lifetime   | Seconds (integer; **min. 300**/default 27000 seconds)<br>KBytes (integer; **min. 1024**/default 102400000 KBytes)           |
-| Traffic Selector | UsePolicyBasedTrafficSelectors ($True/$False; default $False)                 |
-|                  |                                                                               |
+| **IPsec/IKE**    | **Options**                                                                                                       |
+|-------------------|--------------------------------------------------------------------------------------------------------------------|
+| IKE Encryption   | GCMAES256, GCMAES128, AES256, AES192, AES128, DES3, DES                                                           |
+| IKE Integrity    | GCMAES256, GCMAES128, SHA384, SHA256, SHA1, MD5                                                                   |
+| DH Group         | DHGroup24, ECP384, ECP256, DHGroup14 (DHGroup2048), DHGroup2, DHGroup1, None                                      |
+| IPsec Encryption | GCMAES256, GCMAES192, GCMAES128, AES256, AES192, AES128, DES3, DES, None                                          |
+| IPsec Integrity  | GCMAES256, GCMAES192, GCMAES128, SHA256, SHA1, MD5                                                                |
+| PFS Group        | PFS24, ECP384, ECP256, PFS2048, PFS2, PFS1, None                                                                  |
+| QM SA Lifetime   | Seconds (integer; **min. 300**/default 27000 seconds)<br>KBytes (integer; **min. 1024**/default 102400000 KBytes) |
+| Traffic Selector | UsePolicyBasedTrafficSelectors ($True/$False; default $False)                                                     |
 
 > [!IMPORTANT]
 > * DHGroup2048 & PFS2048 are the same as Diffie-Hellman Group **14** in IKE and IPsec PFS. See [Diffie-Hellman Groups](#DH) for the complete mappings.
 > * For GCMAES algorithms, you must specify the same GCMAES algorithm and key length for both IPsec Encryption and Integrity.
-> * IKEv2 Main Mode SA lifetime is fixed at 28,800 seconds on the Azure VPN gateways.
+> * IKE Main Mode SA lifetime is fixed at 28,800 seconds on the Azure VPN gateways.
 > * QM SA Lifetimes are optional parameters. If none was specified, default values of 27,000 seconds (7.5 hrs) and 102400000 KBytes (102GB) are used.
-> * UsePolicyBasedTrafficSelector is an option parameter on the connection. See the next FAQ item for "UsePolicyBasedTrafficSelectors".
+> * UsePolicyBasedTrafficSelector is an optional parameter on the connection. See the next item for more details.
 
 ### Does everything need to match between the Azure VPN gateway policy and my on-premises VPN device configurations?
 
@@ -52,7 +51,7 @@ Your on-premises VPN device configuration must match or contain the following al
 * PFS Group
 * Traffic Selector (*)
 
-The SA lifetimes are local specifications only, don't need to match.
+The SA lifetimes are local specifications only. They don't need to match.
 
 If you enable **UsePolicyBasedTrafficSelectors**, you need to ensure your VPN device has the matching traffic selectors defined with all combinations of your on-premises network (local network gateway) prefixes to/from the Azure virtual network prefixes, instead of any-to-any. For example, if your on-premises network prefixes are 10.1.0.0/16 and 10.2.0.0/16, and your virtual network prefixes are 192.168.0.0/16 and 172.16.0.0/16, you need to specify the following traffic selectors:
 * 10.1.0.0/16 <====> 192.168.0.0/16
@@ -74,7 +73,6 @@ The table below lists the supported Diffie-Hellman Groups for IKE (DHGroup) and 
 | 19                        | ECP256                   | ECP256       | 256-bit ECP    |
 | 20                        | ECP384                   | ECP384       | 384-bit ECP    |
 | 24                        | DHGroup24                | PFS24        | 2048-bit MODP  |
-|                           |                          |              |                |
 
 For more information, see [RFC3526](https://tools.ietf.org/html/rfc3526) and [RFC5114](https://tools.ietf.org/html/rfc5114).
 
@@ -84,7 +82,7 @@ Yes, once a custom policy is specified on a connection, Azure VPN gateway will o
 
 ### If I remove a custom IPsec/IKE policy, does the connection become unprotected?
 
-No, the connection will still be protected by IPsec/IKE. Once you remove the custom policy from a connection, the Azure VPN gateway reverts back to the [default list of IPsec/IKE proposals](../articles/vpn-gateway/vpn-gateway-about-vpn-devices.md) and restart the IKE handshake again with your on-premises VPN device.
+No, the connection will still be protected by IPsec/IKE. Once you remove the custom policy from a connection, the Azure VPN gateway reverts back to the [default list of IPsec/IKE proposals](../articles/vpn-gateway/vpn-gateway-about-vpn-devices.md#RouteBasedOffers) and restart the IKE handshake again with your on-premises VPN device.
 
 ### Would adding or updating an IPsec/IKE policy disrupt my VPN connection?
 
@@ -104,7 +102,10 @@ Yes. A VNet-to-VNet tunnel consists of two connection resources in Azure, one fo
 
 ### What is the default DPD timeout value? Can I specify a different DPD timeout?
 
-The default DPD timeout is 45 seconds. You can specify a different DPD timeout value on each IPsec or VNet-to-VNet connection between 9 seconds to 3600 seconds.
+The default DPD timeout is 45 seconds. You can specify a different DPD timeout value on each IPsec or VNet-to-VNet connection, from 9 seconds to 3600 seconds.
+
+> [!IMPORTANT]
+> The default value is 45 seconds on Azure VPN gateways. Setting the timeout to shorter periods will cause IKE to rekey more aggressively, causing the connection to appear to be disconnected in some instances. This may not be desirable if your on-premises locations are farther away from the Azure region where the VPN gateway resides, or when the physical link condition could incur packet loss. The general recommendation is to set the timeout between **30 and 45** seconds.
 
 ### Does custom IPsec/IKE policy work on ExpressRoute connection?
 
@@ -130,7 +131,3 @@ No. Once the connection is created, IKEv1/IKEv2 protocols can't be changed. You 
 If your static routing or route based IKEv1 connection is disconnecting at routine intervals, it's likely due to VPN gateways not supporting in-place rekeys. When Main mode is getting rekeyed, your IKEv1 tunnels will disconnect and take up to 5 seconds to reconnect. Your Main mode negotiation time out value will determine the frequency of rekeys. To prevent these reconnects, you can switch to using IKEv2, which supports in-place rekeys.
 
 If your connection is reconnecting at random times, follow our [troubleshooting guide](../articles/vpn-gateway/vpn-gateway-troubleshoot-site-to-site-disconnected-intermittently.md).
-
-### Where can I find more configuration information for IPsec?
-
-See [Configure IPsec/IKE policy for S2S or VNet-to-VNet connections](../articles/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell.md).


### PR DESCRIPTION
This is a revised submission of changes from PR #99648.

* Changed VPN FAQ's include Markdown file for IPsec/IKE policies so it could be re-used in other VPN articles.
* Updated Azure Portal and PowerShell guides for IPsec/IKE policies to make use of the updated include file. This avoids 3 copies of the tables for encryption algorithms, integrity, DH groups, and related guidance/comments from needing to be maintained.
