### PR TITLE
Updating for new features now at parity

### DIFF
--- a/articles/active-directory/authentication/feature-availability.md
+++ b/articles/active-directory/authentication/feature-availability.md
@@ -28,7 +28,7 @@ This following tables list Azure AD feature availability in Azure Government.
 |**Authentication, single sign-on, and MFA**|Cloud authentication (Pass-through authentication, password hash synchronization) | &#x2705; |
 || Federated authentication (Active Directory Federation Services or federation with other identity providers) | &#x2705; |
 || Single sign-on (SSO) unlimited | &#x2705; | 
-|| Multifactor authentication (MFA) <sup>1</sup>| &#x2705; | 
+|| Multifactor authentication (MFA) | &#x2705; | 
 || Passwordless (Windows Hello for Business, Microsoft Authenticator, FIDO2 security key integrations) | &#x2705; | 
 || Service-level agreement | &#x2705; | 
 |**Applications access**|SaaS apps with modern authentication (Azure AD application gallery apps, SAML, and OAUTH 2.0) | &#x2705; | 
@@ -69,7 +69,7 @@ This following tables list Azure AD feature availability in Azure Government.
 || Advanced security and usage reports | &#x2705; |
 || Identity Protection: vulnerabilities and risky accounts | &#x2705; |
 || Identity Protection: risk events investigation, SIEM connectivity | &#x2705; |
-|**Frontline workers**|SMS sign-in | Feature not available. |
+|**Frontline workers**|SMS sign-in | &#x2705; |
 || Shared device sign-out | Enterprise state roaming for Windows 10 devices isn't available. |
 || Delegated user management portal (My Staff) | Feature not available. |
 
@@ -83,8 +83,8 @@ This following tables list Azure AD feature availability in Azure Government.
 |Azure AD threat intelligence | Feature not available. |
 |Anonymous IP address | &#x2705; | 
 |Atypical travel | &#x2705; |
-|Anomalous Token | Feature not available. |
-|Token Issuer Anomaly| Feature not available. |
+|Anomalous Token | &#x2705; |
+|Token Issuer Anomaly| &#x2705; |
 |Malware linked IP address | &#x2705; |
 |Suspicious browser | &#x2705; |
 |Unfamiliar sign-in properties | &#x2705; |
@@ -96,7 +96,6 @@ This following tables list Azure AD feature availability in Azure Government.
 |New country | &#x2705; |
 |Activity from anonymous IP address | &#x2705; |
 |Suspicious inbox forwarding | &#x2705; |
-|Azure AD threat intelligence | Feature not available. |
 |Additional risk detected | &#x2705; |
 
 


### PR DESCRIPTION
Removed duplicated 'Azure AD threat intelligence' row in Identity protection section Updated for new features at parity (see diff)
Removing unreferenced footnote '1' from MFA row 
NOTE: I may add more rows with newly discovered parity gaps, just want to get initial fixes in now.