### PR TITLE
Update quickstart-create-server-bicep.md

### DIFF
--- a/articles/postgresql/flexible-server/quickstart-create-server-bicep.md
+++ b/articles/postgresql/flexible-server/quickstart-create-server-bicep.md
@@ -58,7 +58,7 @@ resource serverName_resource 'Microsoft.DBforPostgreSQL/flexibleServers@2021-06-
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
     network: {
-      delegatedSubnetResourceId: (empty(virtualNetworkExternalId) ? json('null') : json('${virtualNetworkExternalId}/subnets/${subnetName}'))
+      delegatedSubnetResourceId: (empty(virtualNetworkExternalId) ? json('null') : json('\'${virtualNetworkExternalId}/subnets/${subnetName}\''))
       privateDnsZoneArmResourceId: (empty(virtualNetworkExternalId) ? json('null') : privateDnsZoneArmResourceId)
     }
     highAvailability: {


### PR DESCRIPTION
If a user copies the template exactly and pastes in their VNET ExtID and Subnet Name, during deploy without the proposed change will fire off a template violation