### PR TITLE
Updating Firewall Requirements to Include Outbound

### DIFF
--- a/articles/active-directory/app-provisioning/on-premises-application-provisioning-architecture.md
+++ b/articles/active-directory/app-provisioning/on-premises-application-provisioning-architecture.md
@@ -37,6 +37,8 @@ There are three primary components to provisioning users into an on-premises app
 
 You don't need to open inbound connections to the corporate network. The provisioning agents only use outbound connections to the provisioning service, which means there's no need to open firewall ports for incoming connections. You also don't need a perimeter (DMZ) network because all connections are outbound and take place over a secure channel.
 
+The required outbound endpoints for the provisioning agents are detailed [here](https://learn.microsoft.com/en-us/azure/active-directory/cloud-sync/how-to-prerequisites?tabs=public-cloud#firewall-and-proxy-requirements).
+
 ## ECMA Connector Host architecture
 The ECMA Connector Host has several areas it uses to achieve on-premises provisioning.  The diagram below is a conceptual drawing that presents these individual areas.  The table below describes the areas in more detail.
 

--- a/articles/active-directory/app-provisioning/on-premises-application-provisioning-architecture.md
+++ b/articles/active-directory/app-provisioning/on-premises-application-provisioning-architecture.md
@@ -37,7 +37,7 @@ There are three primary components to provisioning users into an on-premises app
 
 You don't need to open inbound connections to the corporate network. The provisioning agents only use outbound connections to the provisioning service, which means there's no need to open firewall ports for incoming connections. You also don't need a perimeter (DMZ) network because all connections are outbound and take place over a secure channel.
 
-The required outbound endpoints for the provisioning agents are detailed [here](https://learn.microsoft.com/en-us/azure/active-directory/cloud-sync/how-to-prerequisites?tabs=public-cloud#firewall-and-proxy-requirements).
+The required outbound endpoints for the provisioning agents are detailed [here](../cloud-sync/how-to-prerequisites.md#firewall-and-proxy-requirements).
 
 ## ECMA Connector Host architecture
 The ECMA Connector Host has several areas it uses to achieve on-premises provisioning.  The diagram below is a conceptual drawing that presents these individual areas.  The table below describes the areas in more detail.


### PR DESCRIPTION
Based on discussion with Chetan Desai, the outbound endpoints for the On-prem provisioning agent are the same for the Cloud Sync and HR provisioning agent: https://teams.microsoft.com/l/message/19:96cc8135752445e0857b872d60ce0e2a@thread.skype/1668601966388?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e1eb424-0cb7-4665-b384-4fbfd3cd0f83&parentMessageId=1668601966388&teamName=Identity%20PM%20Collaboration&channelName=User%20Provisioning%20(ECMA%2C%20Cloud%20Sync)&createdTime=1668601966388&allowXTenantAccess=false