### PR TITLE
Add consent methods to comparison table

### DIFF
--- a/articles/active-directory/develop/permissions-consent-overview.md
+++ b/articles/active-directory/develop/permissions-consent-overview.md
@@ -57,6 +57,7 @@ There are other ways in which applications can be granted authorization for app-
 | Types of apps | Web / Mobile / single-page app (SPA) | Web / Daemon |
 | Access context | Get access on behalf of a user | Get access without a user |
 | Who can consent | - Users can consent for their data <br> - Admins can consent for all users | Only admin can consent |
+| Consent methods | - Static: configured list on app registration <br> - Dynamic: request individual permissions at login | - Static ONLY: configured list on app registration |
 | Other names | - Scopes <br> - OAuth2 permission scopes | - App roles <br> - App-only permissions |
 | Result of consent (specific to Microsoft Graph)  | [oAuth2PermissionGrant](/graph/api/resources/oauth2permissiongrant) | [appRoleAssignment](/graph/api/resources/approleassignment) |
 
@@ -65,7 +66,7 @@ One way that applications are granted permissions is through consent. Consent is
 
 - When previously granted consent is revoked.
 - When the application is coded to specifically prompt for consent during every sign-in.
-- When the application uses incremental or dynamic consent to ask for some permissions upfront and more permission later as needed. 
+- When the application uses dynamic consent to ask for new permissions as needed at run time. 
 
 The key details of a consent prompt are the list of permissions the application requires and the publisher information. For more information about the consent prompt and the consent experience for both admins and end-users, see [application consent experience](application-consent-experience.md).
 


### PR DESCRIPTION
- Added a row to indicate that dynamic consent is not available for app only permissions
- Slight clarification of dynamic consent scenario under Consent heading