### PR TITLE
Add another example to display another possible case of one-to-many document keys

### DIFF
--- a/articles/search/search-howto-index-one-to-many-blobs.md
+++ b/articles/search/search-howto-index-one-to-many-blobs.md
@@ -132,7 +132,7 @@ id, temperature, pressure, timestamp
 2, 120, 3,"2013-05-11T00:00:00Z" 
 ```
 
-Notice that each document contains the id field, which is defined as the 'key' field in the index. In such a case, even though a document-unique AzureSearch_DocumentKey will be generated, it won't be used as the 'key' for the document. Rather, the value of the id field will be mapped to the 'key' field
+Notice that each document contains the `id` field, which is defined as the 'key' field in the index. In such a case, even though a document-unique `AzureSearch_DocumentKey` will be generated, it won't be used as the 'key' for the document. Rather, the value of the `id` field will be mapped to the 'key' field
 
 Similar to the example above, this mapping will _not_ result in 4 documents showing up in the index, because the `id` field is not unique _across blobs_. When this is the case, any json entry that specifies an `id` will result in a merge on the existing document instead of an upload of a new document, and the state of the index will reflect the latest read entry with the specified `id`.
 

--- a/articles/search/search-howto-index-one-to-many-blobs.md
+++ b/articles/search/search-howto-index-one-to-many-blobs.md
@@ -132,7 +132,7 @@ id, temperature, pressure, timestamp
 2, 120, 3,"2013-05-11T00:00:00Z" 
 ```
 
-Notice that `id` is set as the target field with the source `AzureSearch_DocumentKey` but the field is also present in the structure of the blobs. In this case, the key taken from each json line will be used as the document key instead of the unique identifier that would be generated for `AzureSearch_DocumentKey`.
+Notice that each document contains the id field, which is defined as the 'key' field in the index. In such a case, even though a document-unique AzureSearch_DocumentKey will be generated, it won't be used as the 'key' for the document. Rather, the value of the id field will be mapped to the 'key' field
 
 Similar to the example above, this mapping will _not_ result in 4 documents showing up in the index, because the `id` field is not unique _across blobs_. When this is the case, any json entry that specifies an `id` will result in a merge on the existing document instead of an upload of a new document, and the state of the index will reflect the latest read entry with the specified `id`.
 

--- a/articles/search/search-howto-index-one-to-many-blobs.md
+++ b/articles/search/search-howto-index-one-to-many-blobs.md
@@ -132,7 +132,7 @@ id, temperature, pressure, timestamp
 2, 120, 3,"2013-05-11T00:00:00Z" 
 ```
 
-Notice that each document contains the `id` field, which is defined as the "key" field in the index. In such a case, even though a document-unique `AzureSearch_DocumentKey` will be generated, it won't be used as the "key" for the document. Rather, the value of the `id` field will be mapped to the "key" field
+Notice that each document contains the `id` field, which is defined as the `key` field in the index. In such a case, even though a document-unique `AzureSearch_DocumentKey` will be generated, it won't be used as the "key" for the document. Rather, the value of the `id` field will be mapped to the `key` field
 
 Similar to the example above, this mapping will _not_ result in four documents showing up in the index, because the `id` field is not unique _across blobs_. When this is the case, any json entry that specifies an `id` will result in a merge on the existing document instead of an upload of a new document, and the state of the index will reflect the latest read entry with the specified `id`.
 

--- a/articles/search/search-howto-index-one-to-many-blobs.md
+++ b/articles/search/search-howto-index-one-to-many-blobs.md
@@ -132,9 +132,9 @@ id, temperature, pressure, timestamp
 2, 120, 3,"2013-05-11T00:00:00Z" 
 ```
 
-Notice that each document contains the `id` field, which is defined as the 'key' field in the index. In such a case, even though a document-unique `AzureSearch_DocumentKey` will be generated, it won't be used as the 'key' for the document. Rather, the value of the `id` field will be mapped to the 'key' field
+Notice that each document contains the `id` field, which is defined as the "key" field in the index. In such a case, even though a document-unique `AzureSearch_DocumentKey` will be generated, it won't be used as the "key" for the document. Rather, the value of the `id` field will be mapped to the "key" field
 
-Similar to the example above, this mapping will _not_ result in 4 documents showing up in the index, because the `id` field is not unique _across blobs_. When this is the case, any json entry that specifies an `id` will result in a merge on the existing document instead of an upload of a new document, and the state of the index will reflect the latest read entry with the specified `id`.
+Similar to the example above, this mapping will _not_ result in four documents showing up in the index, because the `id` field is not unique _across blobs_. When this is the case, any json entry that specifies an `id` will result in a merge on the existing document instead of an upload of a new document, and the state of the index will reflect the latest read entry with the specified `id`.
 
 ## Next steps
 

--- a/articles/search/search-howto-index-one-to-many-blobs.md
+++ b/articles/search/search-howto-index-one-to-many-blobs.md
@@ -112,6 +112,30 @@ If you do want to set up an explicit field mapping, make sure that the _sourceFi
 > [!NOTE]
 > The approach used by `AzureSearch_DocumentKey` of ensuring uniqueness per extracted entity is subject to change and therefore you should not rely on it's value for your application's needs.
 
+## Specifiying the index key field in your data
+
+Assuming the same index definition as the previous example and **parsingMode** is set to `jsonLines` without specifying any explicit field mappings so the mappings look like in the first example, suppose your blob container has blobs with the following structure:
+
+_Blob1.json_
+
+```json
+id, temperature, pressure, timestamp
+1, 100, 100,"2019-02-13T00:00:00Z" 
+2, 33, 30,"2019-02-14T00:00:00Z"
+```
+
+_Blob2.json_
+
+```json
+id, temperature, pressure, timestamp
+1, 1, 1,"2018-01-12T00:00:00Z" 
+2, 120, 3,"2013-05-11T00:00:00Z" 
+```
+
+Notice that `id` is set as the target field with the source `AzureSearch_DocumentKey` but the field is also present in the structure of the blobs. In this case, the key taken from each json line will be used as the document key instead of the unique identifier that would be generated for `AzureSearch_DocumentKey`.
+
+Similar to the example above, this mapping will _not_ result in 4 documents showing up in the index, because the `id` field is not unique _across blobs_. When this is the case, any json entry that specifies an `id` will result in a merge on the existing document instead of an upload of a new document, and the state of the index will reflect the latest read entry with the specified `id`.
+
 ## Next steps
 
 If you aren't already familiar with the basic structure and workflow of blob indexing, you should review [Indexing Azure Blob Storage with Azure Cognitive Search](search-howto-index-json-blobs.md) first. For more information about parsing modes for different blob content types, review the following articles.


### PR DESCRIPTION
The case outlined in this example is unclear from the existing documentation. This should help users better understand a potentially misleading configuration.