### PR TITLE
Remove previously added sentence about TRIM/UNMAP and managed disks

### DIFF
--- a/articles/virtual-machines/linux/add-disk.md
+++ b/articles/virtual-machines/linux/add-disk.md
@@ -6,7 +6,7 @@ ms.service: storage
 ms.subservice: disks
 ms.collection: linux
 ms.topic: how-to
-ms.date: 12/05/2022
+ms.date: 12/08/2022
 ms.author: rogarana
 ---
 
@@ -154,7 +154,7 @@ In this example, we are using the nano editor, so when you are done editing the 
 
 ### TRIM/UNMAP support for Linux in Azure
 
-Some Linux kernels support TRIM/UNMAP operations to discard unused blocks on the disk. This feature is primarily useful to inform Azure that deleted pages are no longer valid and can be discarded. This feature can save money on disks that are billed based on the amount of consumed storage, such as unmanaged standard disks and disk snapshots. Managed disks are billed based on the size of the disk and hence don't benefit.
+Some Linux kernels support TRIM/UNMAP operations to discard unused blocks on the disk. This feature is primarily useful to inform Azure that deleted pages are no longer valid and can be discarded. This feature can save money on disks that are billed based on the amount of consumed storage, such as unmanaged standard disks and disk snapshots.
 
 There are two ways to enable TRIM support in your Linux VM. As usual, consult your distribution for the recommended approach:
 


### PR DESCRIPTION
The Azure Storage PM team has raised an objection to a sentence I added a few days ago.   They don't want to discourage customers from using TRIM/UNMAP because it helps with the overall efficiency and cost of storage.  I'm OK with removing the sentence because the information is already implied by the previous sentence.