### PR TITLE
Update functions-bindings-cosmosdb-v2.md

### DIFF
--- a/articles/azure-functions/functions-bindings-cosmosdb-v2.md
+++ b/articles/azure-functions/functions-bindings-cosmosdb-v2.md
@@ -53,7 +53,7 @@ The process for installing the extension varies depending on the extension versi
 
 # [Functions 2.x+](#tab/functionsv2/in-process)
 
-Working with the trigger and bindings requires that you reference the appropriate NuGet package. Install the [NuGet package](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.CosmosDB), version 3.x.
+Working with the trigger and bindings requires that you reference the appropriate NuGet package. Install the [NuGet package](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.10), version 3.x.
 
 # [Extension 4.x+ (preview)](#tab/extensionv4/in-process)
 


### PR DESCRIPTION
The current GA version of the extension is 4.0, but the docs are geared towards 3.x and mostly incompatible with 4.0. Updated the Nuget link to avoid having users taken to the (now default) 4.0 version of the package.