### PR TITLE
Remove IPv6 Reverse DNS Limitation

### DIFF
--- a/articles/virtual-network/ip-services/ipv6-overview.md
+++ b/articles/virtual-network/ip-services/ipv6-overview.md
@@ -72,7 +72,6 @@ The current IPv6 for Azure virtual network release has the following limitations
 - The Azure platform (AKS, etc.) does not support IPv6 communication for Containers. 
 - IPv6-only Virtual Machines or Virtual Machines Scale Sets are not supported, each NIC must include at least one IPv4 IP configuration. 
 - When adding IPv6 to existing IPv4 deployments, IPv6 ranges can not be added to a VNET with existing resource navigation links.  
-- Forward DNS for IPv6 is supported for Azure public DNS today but Reverse DNS is not yet supported.
 - While it is possible to create NSG rules for IPv4 and IPv6 within the same NSG, it is not currently possible to combine an IPv4 Subnet with an IPv6 subnet in the same rule when specifying IP prefixes.
 - ICMPv6 is not currently supported in Network Security Groups.
 - Azure Virtual WAN currently supports IPv4 traffic only.


### PR DESCRIPTION
As per https://learn.microsoft.com/en-us/azure/dns/dns-reverse-dns-hosting#ipv6 it is possible to reverse lookup IPv6