### PR TITLE
Note on Swap With Preview

### DIFF
--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -147,7 +147,7 @@ When you perform a swap with preview, App Service performs the same [swap operat
 If you cancel the swap, App Service reapplies configuration elements to the source slot.
 
 > [!NOTE]
-> Swap with preview cannot be used when one of the slots has site authentication enabled.
+> Swap with preview can't be used when one of the slots has site authentication enabled.
 > 
 
 To swap with preview:

--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -146,6 +146,10 @@ When you perform a swap with preview, App Service performs the same [swap operat
 
 If you cancel the swap, App Service reapplies configuration elements to the source slot.
 
+> [!NOTE]
+> Swap with preview cannot be used when one of the slots has site authentication enabled.
+> 
+
 To swap with preview:
 
 1. Follow the steps in [Swap deployment slots](#Swap) but select **Perform swap with preview**.


### PR DESCRIPTION
Added a note to the "Swap with preview" section to mention that the feature is not available if authentication is enabled on one of the slots. There is an error being thrown if a user attempts to start a start with preview (from the UI or Azure DevOps pipeline) that reads: "Conflict - Swap with Preview cannot be used when one of the slots has site authentication enabled. (CODE: 409)". This fact was not documented anywhere and I lost some time re-working my pipeline to start using "swap with preview" and then back to not use it when it turned out it's not possible in our case.