### PR TITLE
{AzureLogAnalytics} fixes Azure/azure-rest-api-specs#21506 Include Saved search to add the tag limit of 15

### DIFF
--- a/articles/azure-resource-manager/management/tag-resources.md
+++ b/articles/azure-resource-manager/management/tag-resources.md
@@ -868,6 +868,7 @@ The following limitations apply to tags:
    >     * Azure Automation
    >     * Azure Content Delivery Network (CDN)
    >     * Azure DNS (Zone and A records)
+   >     * Azure Log Analytics Saved Search
 
 ## Next steps
 


### PR DESCRIPTION
Include Saved search to add the tag limit of 15

fixes Azure/azure-rest-api-specs#21506 

When we are trying to create Saved Searches via terraform we get bad request. It turned out that we are using 16 tags for this resource.

I managed to run REST Api calls via curl and it was also failing with Bad request [The element 'Tags' has invalid child element 'Tag'.]

If I use 15 tags or less the request is success and the resource is created.

I have found this max 15 tags limitation in the Tagging docs, but it does not mention Saved Searches.

API: https://learn.microsoft.com/en-us/rest/api/loganalytics/saved-searches/create-or-update?tabs=HTTP
api-version: 2020-08-01