### PR TITLE
Changed ValidationResponse handling

### DIFF
--- a/articles/event-grid/receive-events.md
+++ b/articles/event-grid/receive-events.md
@@ -69,11 +69,11 @@ namespace Function1
                     {
                         log.LogInformation($"Got SubscriptionValidation event data, validation code: {subscriptionValidationEventData.ValidationCode}, topic: {eventGridEvent.Topic}");
                         // Do any additional validation (as required) and then return back the below response
-
-                        var responseData = new SubscriptionValidationResponse()
+                        var responseData = new
                         {
                             ValidationResponse = subscriptionValidationEventData.ValidationCode
                         };
+
                         return new OkObjectResult(responseData);
                     }
                 }

--- a/articles/event-grid/receive-events.md
+++ b/articles/event-grid/receive-events.md
@@ -171,7 +171,7 @@ namespace Function1
                         log.LogInformation($"Got SubscriptionValidation event data, validation code: {subscriptionValidationEventData.ValidationCode}, topic: {eventGridEvent.Topic}");
                         // Do any additional validation (as required) and then return back the below response
 
-                        var responseData = new SubscriptionValidationResponse()
+                        var responseData = new
                         {
                             ValidationResponse = subscriptionValidationEventData.ValidationCode
                         };
@@ -305,7 +305,7 @@ namespace Function1
                         log.LogInformation($"Got SubscriptionValidation event data, validation code: {subscriptionValidationEventData.ValidationCode}, topic: {eventGridEvent.Topic}");
                         // Do any additional validation (as required) and then return back the below response
 
-                        var responseData = new SubscriptionValidationResponse()
+                        var responseData = new
                         {
                             ValidationResponse = subscriptionValidationEventData.ValidationCode
                         };


### PR DESCRIPTION
Changed ValidationResponse handling because ValidationResponse property in SubscriptionValidationResponse class doesn't support anymore setting value directly when Azure.Messaging.EventGrid library is used.