### PR TITLE
Fix typo "form"->"from"

### DIFF
--- a/articles/azure-monitor/containers/container-insights-reports.md
+++ b/articles/azure-monitor/containers/container-insights-reports.md
@@ -39,7 +39,7 @@ To create a custom workbook based on any of these workbooks, select the **View W
 
 - **Subnet IP Usage**: Interactive IP usage charts for each node within a cluster by the following perspectives:
  
-    - IPs allocated form subnet.
+    - IPs allocated from subnet.
     - IPs assigned to a pod.
 
 >[!NOTE]


### PR DESCRIPTION
Fix typo in
* IPs allocated form subnet

should be:
* IPs allocated from subnet

(See also names from the workbook, where it is specified correctly)
![image](https://user-images.githubusercontent.com/1635825/206746332-f53834c7-b4fc-4142-bd51-e32aa4146160.png)
