### PR TITLE
Unclear description of "ExpressRoute Circuit Owner".

### DIFF
--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -88,6 +88,7 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/write
   >- Microsoft.Network/expressRouteCircuits/authorizations/read
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
+  > 
   > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
 
 ### Circuit owner operations

--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -90,7 +90,6 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
   > 
   > This includes the built-in roles such as Contributor, Owner and Network Contributor. Detailed description for the different [built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
-  > 
 
 ### Circuit owner operations
 

--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -82,6 +82,14 @@ The 'circuit owner' is an authorized Power User of the ExpressRoute circuit reso
 
 The circuit owner has the power to modify and revoke authorizations at any time. Revoking an authorization results in all link connections being deleted from the subscription whose access was revoked.
 
+  > [!NOTE]
+  > Circuit owner is not an built-in RBAC role or defined on the ExpressRoute resource.
+  > The definition of the circuit owner is any role with the following access:
+  >- Microsoft.Network/expressRouteCircuits/authorizations/write
+  >- Microsoft.Network/expressRouteCircuits/authorizations/read
+  >- Microsoft.Network/expressRouteCircuits/authorizations/delete
+  > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
+
 ### Circuit owner operations
 
 **To create an authorization**

--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -89,7 +89,8 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/read
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
   > 
-  > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
+  > This includes the built-in roles such as Contributor, Owner and Network Contributor. Detailed description for the different [built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
+  > 
 
 ### Circuit owner operations
 

--- a/articles/expressroute/expressroute-howto-linkvnet-classic.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-classic.md
@@ -84,7 +84,8 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/read
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
   >
-  > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
+  > This includes the built-in roles such as Contributor, Owner and Network Contributor. Detailed description for the different [built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
+  > 
 
 ### Circuit owner operations
 

--- a/articles/expressroute/expressroute-howto-linkvnet-classic.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-classic.md
@@ -83,6 +83,7 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/write
   >- Microsoft.Network/expressRouteCircuits/authorizations/read
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
+  >
   > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
 
 ### Circuit owner operations

--- a/articles/expressroute/expressroute-howto-linkvnet-classic.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-classic.md
@@ -85,7 +85,6 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
   >
   > This includes the built-in roles such as Contributor, Owner and Network Contributor. Detailed description for the different [built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
-  > 
 
 ### Circuit owner operations
 

--- a/articles/expressroute/expressroute-howto-linkvnet-classic.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-classic.md
@@ -77,6 +77,14 @@ The *circuit owner* is the administrator/coadministrator of the subscription in 
 
 The circuit owner has the power to modify and revoke authorizations at any time. Revoking an authorization will result in all links being deleted from the subscription whose access was revoked.
 
+  > [!NOTE]
+  > Circuit owner is not an built-in RBAC role or defined on the ExpressRoute resource.
+  > The definition of the circuit owner is any role with the following access:
+  >- Microsoft.Network/expressRouteCircuits/authorizations/write
+  >- Microsoft.Network/expressRouteCircuits/authorizations/read
+  >- Microsoft.Network/expressRouteCircuits/authorizations/delete
+  > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
+
 ### Circuit owner operations
 
 **Creating an authorization**

--- a/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
@@ -103,7 +103,7 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/read
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
   >
-  > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
+  > This includes the built-in roles such as Contributor, Owner and Network Contributor. Detailed description for the different [built-in roles](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles).
 
 ### Circuit owner operations
 

--- a/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
@@ -96,6 +96,14 @@ The 'circuit owner' is an authorized Power User of the ExpressRoute circuit reso
 
 The circuit owner has the power to modify and revoke authorizations at any time. Revoking an authorization results in all link connections being deleted from the subscription whose access was revoked.
 
+  > [!NOTE]
+  > Circuit owner is not an built-in RBAC role or defined on the ExpressRoute resource.
+  > The definition of the circuit owner is any role with the following access:
+  >- Microsoft.Network/expressRouteCircuits/authorizations/write
+  >- Microsoft.Network/expressRouteCircuits/authorizations/read
+  >- Microsoft.Network/expressRouteCircuits/authorizations/delete
+  > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
+
 ### Circuit owner operations
 
 **To create a connection authorization**

--- a/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-portal-resource-manager.md
@@ -102,6 +102,7 @@ The circuit owner has the power to modify and revoke authorizations at any time.
   >- Microsoft.Network/expressRouteCircuits/authorizations/write
   >- Microsoft.Network/expressRouteCircuits/authorizations/read
   >- Microsoft.Network/expressRouteCircuits/authorizations/delete
+  >
   > This includes the built-in roles such as [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner) and [Network Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#network-contributor)
 
 ### Circuit owner operations


### PR DESCRIPTION
There are mentions of a "Circuit Owner".
However, there's no such role in Azure or a attribute on the ExpressRoute.

Added a note on each of the documentations that explains the defintion of "Cricuit owner" on each "how to peer an express route cross-subscription".

**Definition of the Circuit Owner:**
Circuit Owner is simply any user(s) with the access:
- Microsoft.Network/expressRouteCircuits/authorizations/write
- Microsoft.Network/expressRouteCircuits/authorizations/read
- Microsoft.Network/expressRouteCircuits/authorizations/delete

This could for instance be any user with Contributor, Owner or Network Contributor role access on the ExpressRoute resource (inherited or directly).