### PR TITLE
Update prometheus-remote-write-managed-identity.md

### DIFF
--- a/articles/azure-monitor/essentials/prometheus-remote-write-managed-identity.md
+++ b/articles/azure-monitor/essentials/prometheus-remote-write-managed-identity.md
@@ -150,7 +150,7 @@ This step isn't required if you're using an AKS identity since it will already h
     az aks get-credentials -g <aks-rg-name> -n <aks-cluster-name> 
  
     # use helm to update your remote write config 
-    helm upgrade -f <YAML-FILENAME>.yml prometheus prometheus-community/kube-prometheus-stack -namespace <namespace where Prometheus pod resides> 
+    helm upgrade -f <YAML-FILENAME>.yml prometheus prometheus-community/kube-prometheus-stack --namespace <namespace where Prometheus pod resides> 
     ```
 
 ## Verification and troubleshooting


### PR DESCRIPTION
Corrected helm upgrade command in documentation. When specifying namespace we should use either `-n` or `--namespace`, rather than `-namespace`. Including a screenshot of output from `Helm -h` for reference.

<img width="464" alt="image" src="https://user-images.githubusercontent.com/21350853/207413988-d80d7926-1d17-4967-a17a-55f9c39c4185.png">
