### PR TITLE
Update Sample YAML in prometheus-remote-write-managed-identity.md

### DIFF
--- a/articles/azure-monitor/essentials/prometheus-remote-write-managed-identity.md
+++ b/articles/azure-monitor/essentials/prometheus-remote-write-managed-identity.md
@@ -105,14 +105,14 @@ This step isn't required if you're using an AKS identity since it will already h
               httpGet:
                 path: /health
                 port: rw-port
-                initialDelaySeconds: 10
-                timeoutSeconds: 10
+              initialDelaySeconds: 10
+              timeoutSeconds: 10
             readinessProbe:
               httpGet:
                 path: /ready
                 port: rw-port
-                initialDelaySeconds: 10
-                timeoutSeconds: 10
+              initialDelaySeconds: 10
+              timeoutSeconds: 10
             env:
               - name: INGESTION_URL
                 value: <INGESTION_URL>


### PR DESCRIPTION
The sample YAML in the `Deploy Side car and configure remote write on the Prometheus server` section appears to be wrong. `livenessProbe` should contain `httpGet`, `initialDelaySeconds`, and `timeoutSeconds`. Presently, the latter two are values under `httpGet`, which makes this YAML invalid. This exact same issue occurs in the `readinessProbe` value below, too. The Prometheus spec used in this step of the guide can be seen here, laying out what I am claiming here: 

https://docs.okd.io/latest/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.html#spec-containers-livenessprobe https://docs.okd.io/latest/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.html#spec-containers-readinessprobe