### PR TITLE
Fix broken ARM template link in TOC.yml

### DIFF
--- a/articles/azure-functions/TOC.yml
+++ b/articles/azure-functions/TOC.yml
@@ -572,7 +572,7 @@
     - name: API references
       items:
         - name: ARM template
-          href: /azure/templates/microsoft.web/2018-11-01/sites/functions
+          href: /azure/templates/microsoft.web/2022-03-01/sites/functions
         - name: Azure CLI
           href: /cli/azure/functionapp
         - name: Azure Functions Core Tools 


### PR DESCRIPTION
Updated `/azure/templates/microsoft.web/2018-11-01/sites/functions` to `/azure/templates/microsoft.web/2022-03-01/sites/functions` to fix 404 when clicking on `ARM template` API reference link.