### PR TITLE
hareplica

### DIFF
--- a/articles/postgresql/flexible-server/concepts-high-availability.md
+++ b/articles/postgresql/flexible-server/concepts-high-availability.md
@@ -229,7 +229,7 @@ Flexible servers that are configured with high availability, log data is replica
 
 * Restarting the primary database server also restarts standby replica. 
 
-* Configuring additional read replicas are not supported.
+* Configuring additional standby replicas are not supported.
 
 * Configuring customer initiated management tasks cannot be scheduled during managed maintenance window.
 


### PR DESCRIPTION
we mentioned in this documentation "Configuring additional read replicas are not supported."  I believe we are referring about standby replicas in HA enabled, and not the read replica feature we have currently in preview, If this is the case, it would be better if we made the difference explicitly to avoid any misunderstanding.