### PR TITLE
Fix Key Vault RBAC Role Typo

### DIFF
--- a/articles/key-vault/general/rbac-migration.md
+++ b/articles/key-vault/general/rbac-migration.md
@@ -36,7 +36,7 @@ Azure RBAC has several Azure built-in roles that you can assign to users, groups
 Key Vault built-in roles for keys, certificates, and secrets access management:
 - Key Vault Administrator
 - Key Vault Reader
-- Key Vault Certificate Officer
+- Key Vault Certificates Officer
 - Key Vault Crypto Officer
 - Key Vault Crypto User
 - Key Vault Crypto Service Encryption User


### PR DESCRIPTION
Fix typo with Key Vault Certificates Offer RBAC Role name in migration docs.

`Key Vault Certificate Officer` -> `Key Vault Certificates Officer`