### PR TITLE
remove pub-sub does not support 4.x

### DIFF
--- a/articles/azure-functions/functions-bindings-register.md
+++ b/articles/azure-functions/functions-bindings-register.md
@@ -43,8 +43,6 @@ The following table lists the currently available versions of the default *Micro
 | 3.x | `[3.3.0, 4.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/4f5934a18989353e36d771d0a964f14e6cd17ac3/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle<sup>1</sup> |
 | 4.x | `[4.0.0, 5.0.0)` | See [extensions.json](https://github.com/Azure/azure-functions-extension-bundles/blob/v4.x/src/Microsoft.Azure.Functions.ExtensionBundle/extensions.json) used to generate the bundle<sup>1</sup> |
 
-<sup>1</sup> Version 4.x of the extension bundle currently doesn't include the [Web PubSub bindings](https://learn.microsoft.com/azure/azure-web-pubsub/reference-functions-bindings?tabs=csharp#add-to-your-functions-app ). If your app requires Web PubSub, you'll need to continue using the 3.x version for now.
-
 
 
 > [!NOTE]


### PR DESCRIPTION
Added pub-sub on extension bundle 4.x

https://github.com/Azure/azure-functions-extension-bundles/commit/229d84384834be62b3643b6bedf8de79b1d78d92