### PR TITLE
Update redis chart version no in quickstart-helm.md

### DIFF
--- a/articles/aks/quickstart-helm.md
+++ b/articles/aks/quickstart-helm.md
@@ -170,7 +170,7 @@ description: A Helm chart for Kubernetes
 
 dependencies:
   - name: redis
-    version: 14.7.1
+    version: 17.3.17
     repository: https://charts.bitnami.com/bitnami
 
 ...


### PR DESCRIPTION
redis chart 14.7.1 is no longer available. Updating to latest version. I tested this and it works.