### PR TITLE
[ACR] Update IoT Edge install instructions to use 0.8.0 tag

### DIFF
--- a/articles/container-registry/tutorial-deploy-connected-registry-nested-iot-edge-cli.md
+++ b/articles/container-registry/tutorial-deploy-connected-registry-nested-iot-edge-cli.md
@@ -92,7 +92,7 @@ Overall, the lower layer deployment file is similar to the top layer deployment 
                 "modules": {
                     "connected-registry": {
                         "settings": {
-                            "image": "$upstream:8000/acr/connected-registry:0.7.0",
+                            "image": "$upstream:8000/acr/connected-registry:0.8.0",
                             "createOptions": "{\"HostConfig\":{\"Binds\":[\"/home/azureuser/connected-registry:/var/acr/data\"]}}"
                         },
                         "type": "docker",

--- a/includes/container-registry-connected-iot-edge-manifest.md
+++ b/includes/container-registry-connected-iot-edge-manifest.md
@@ -36,7 +36,7 @@ ms.author: danlep
                 "modules": {
                     "connected-registry": {
                         "settings": {
-                            "image": "<REPLACE_WITH_CLOUD_REGISTRY_NAME>.azurecr.io/acr/connected-registry:0.7.0",
+                            "image": "<REPLACE_WITH_CLOUD_REGISTRY_NAME>.azurecr.io/acr/connected-registry:0.8.0",
                             "createOptions": "{\"HostConfig\":{\"Binds\":[\"/home/azureuser/connected-registry:/var/acr/data\"]}}"
                         },
                         "type": "docker",


### PR DESCRIPTION
Update the IoT Edge manifests to use the latest connected registry 0.8.0 tag, which is compatible to the `az acr import` command earlier in the docs. 