### PR TITLE
Update Restrictions for role-assignable groups

### DIFF
--- a/articles/active-directory/roles/groups-concept.md
+++ b/articles/active-directory/roles/groups-concept.md
@@ -38,6 +38,7 @@ Role-assignable groups have the following restrictions:
 - The `isAssignableToRole` property is **immutable**. Once a group is created with this property set, it can't be changed.
 - You can't make an existing group a role-assignable group.
 - A maximum of 500 role-assignable groups can be created in a single Azure AD organization (tenant).
+- You can't assign licenses to a role-assignable group.
 
 ## How are role-assignable groups protected?
 


### PR DESCRIPTION
In Azure AD portal, you cannot assign licenses to a role-assignable groups. If you try to choose a role-assignable group from the group picker, it says "Role assignable groups are not allowed." Also, in Azure portal, [Licenses] blade is now not shown in role-assignable groups.