### PR TITLE
Update how-to-connect-health-agent-install.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-health-agent-install.md
+++ b/articles/active-directory/hybrid/how-to-connect-health-agent-install.md
@@ -319,7 +319,7 @@ To configure the Azure AD Connect Health agent to use an HTTP proxy, you can:
 > [!NOTE]
 > To update the proxy settings, you must restart all Azure AD Connect Health agent services. Run the following command:
 >
-> `Restart-Service AzureADConnectHealth*`
+> `Restart-Service AdHealthAdfs*`
 
 #### Import existing proxy settings
 


### PR DESCRIPTION
Restart-Service AzureADConnectHealth* seems to be for old version of agent, the services are now named AdHealthAdfs*