### PR TITLE
Include the details of "Microsoft.Storage.Global"

### DIFF
--- a/articles/storage/common/storage-network-security.md
+++ b/articles/storage/common/storage-network-security.md
@@ -127,7 +127,10 @@ By default, storage accounts accept connections from clients on any network. You
 
 You can configure storage accounts to allow access only from specific subnets. The allowed subnets may belong to a VNet in the same subscription, or those in a different subscription, including subscriptions belonging to a different Azure Active Directory tenant.
 
-You can enable a [Service endpoint](../../virtual-network/virtual-network-service-endpoints-overview.md) for Azure Storage within the VNet. The service endpoint routes traffic from the VNet through an optimal path to the Azure Storage service. The identities of the subnet and the virtual network are also transmitted with each request. Administrators can then configure network rules for the storage account that allow requests to be received from specific subnets in a VNet. Clients granted access via these network rules must continue to meet the authorization requirements of the storage account to access the data.
+You can enable a [Service endpoint](../../virtual-network/virtual-network-service-endpoints-overview.md) for Azure Storage within the VNet. The service endpoint routes traffic from the VNet through an optimal path to the Azure Storage service.The identities of the subnet and the virtual network are also transmitted with each request. Administrators can then configure network rules for the storage account that allow requests to be received from specific subnets in a VNet. Clients granted access via these network rules must continue to meet the authorization requirements of the storage account to access the data.
+++There are two options available to add the storage service endpoint - "Microsoft.Storage" and "Microsoft.Storage.Global"
+By default,the option selected is "Microsoft.Storage" where service endpoint works between virtual networks and service instances in the same Azure region. When using service endpoints with Azure Storage, service endpoints also work between virtual networks and service instances in a paired region.
+Another available option is "Microsoft.Storage.Global" where subnet of a VNet in one region can connect to storage account in another region which are not region pairs.
 
 Each storage account supports up to 200 virtual network rules, which may be combined with [IP network rules](#grant-access-from-an-internet-ip-range).
 


### PR DESCRIPTION
Customer was trying to configure Service endpoint access to blob Storage account. Customer could see two different options to configure -  Microsoft.Storage.Global and Microsoft.Storage. Customer approached us to understand the difference between the two so that you may choose the correct one as per your need. We rereferred the document - https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security?tabs=azure-portal#enabling-access-to-virtual-networks-in-other-regions-preview but description is not very clear. Customer gave feedback - the document is not very clear.