### PR TITLE
To minimize the effect on read access latency, only the first read of…

### DIFF
--- a/articles/storage/blobs/lifecycle-management-policy-configure.md
+++ b/articles/storage/blobs/lifecycle-management-policy-configure.md
@@ -30,7 +30,7 @@ For a blob snapshot or version, the condition that is checked is the number of d
 
 ## Optionally enable access time tracking
 
-Before you configure a lifecycle management policy, you can choose to enable blob access time tracking. When access time tracking is enabled, a lifecycle management policy can include an action based on the time that the blob was last accessed with a read or write operation.
+Before you configure a lifecycle management policy, you can choose to enable blob access time tracking. When access time tracking is enabled, a lifecycle management policy can include an action based on the time that the blob was last accessed with a read or write operation.To minimize the effect on read access latency, only the first read of the last 24 hours updates the last access time. Subsequent reads in the same 24-hour period don't update the last access time. If a blob is modified between reads, the last access time is the more recent of the two values.
 
 #### [Portal](#tab/azure-portal)
 


### PR DESCRIPTION
… the last 24 hours updates the last access time. Subsequent reads in the same 24-hour period don't update the last access time. If a blob is modified between reads, the last access time is the more recent of the two values.

This added information will give more insights to customers on what to expect !