### PR TITLE
Update vpn-gateway-howto-aws-bgp.md

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-howto-aws-bgp.md
+++ b/articles/vpn-gateway/vpn-gateway-howto-aws-bgp.md
@@ -241,7 +241,7 @@ Next, you'll connect your AWS tunnels to Azure. For each of the four tunnels, yo
     :::image type="content" source="./media/vpn-gateway-howto-aws-bgp/create-connection.png" alt-text="Modifying connection" :::
 
 9. From the **Connections** page for your VPN gateway, select the connection you created and navigate to the **Configuration** page.
-10. Select **ResponderOnly** for the **Connection Mode** and select **Save**.
+10. Select **InitiatorOnly** for the **Connection Mode** and select **Save**.
     :::image type="content" source="./media/vpn-gateway-howto-aws-bgp/responder-only.png" alt-text="Make connections ResponderOnly" :::
 
 


### PR DESCRIPTION
According to the following AWS documentation, by default, the AWS side is ResponderOnly, so the Azure side should be InitiatorOnly. I can provide a corrected image, if necessary, please feel free to contact me.

Reference:
https://docs.aws.amazon.com/en_us/vpn/latest/s2svpn/initiate-vpn-tunnels.html -- snip --
Startup action: The action to take when establishing the VPN tunnel for a new or modified VPN connection. By default, your customer gateway device initiates the IKE negotiation process to bring the tunnel up. You can specify that AWS must initiate the IKE negotiation process instead.