### PR TITLE
Update speech-container-howto.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/speech-container-howto.md
+++ b/articles/cognitive-services/Speech-Service/speech-container-howto.md
@@ -217,10 +217,6 @@ After the container is on the [host computer](#host-computer-requirements-and-re
 
 Use the [docker run](https://docs.docker.com/engine/reference/commandline/run/) command to run the container. For more information on how to get the `{Endpoint_URI}` and `{API_Key}` values, see [Gather required parameters](#gather-required-parameters). More [examples](speech-container-configuration.md#example-docker-run-commands) of the `docker run` command are also available.
 
-## Run the container in disconnected environments
-
-You must request access to use containers disconnected from the internet. For more information, see [Request access to use containers in disconnected environments](../containers/disconnected-containers.md#request-access-to-use-containers-in-disconnected-environments).
-
 > [!NOTE]
 > For general container requirements, see [Container requirements and recommendations](#container-requirements-and-recommendations).
 
@@ -508,6 +504,10 @@ Increasing the number of concurrent calls can affect reliability and latency. Fo
 
 > [!IMPORTANT]
 > The `Eula`, `Billing`, and `ApiKey` options must be specified to run the container. Otherwise, the container won't start. For more information, see [Billing](#billing).
+
+## Run the container in disconnected environments
+
+You must request access to use containers disconnected from the internet. For more information, see [Request access to use containers in disconnected environments](../containers/disconnected-containers.md#request-access-to-use-containers-in-disconnected-environments).
 
 ## Query the container's prediction endpoint
 


### PR DESCRIPTION
Moving the "Run the container in disconnected environments" outside of the "Run containers with docker run" section as the chapters were mixed up and created confusion.