### PR TITLE
Added context about maximum length of filter rule

### DIFF
--- a/articles/active-directory/conditional-access/concept-condition-filters-for-devices.md
+++ b/articles/active-directory/conditional-access/concept-condition-filters-for-devices.md
@@ -129,6 +129,9 @@ The following device attributes can be used with the filter for devices conditio
 | extensionAttribute1-15 | Equals, NotEquals, StartsWith, NotStartsWith, EndsWith, NotEndsWith, Contains, NotContains, In, NotIn | extensionAttributes1-15 are attributes that customers can use for device objects. Customers can update any of the extensionAttributes1 through 15 with custom values and use them in the filter for devices condition in Conditional Access. Any string value can be used. | (device.extensionAttribute1 -eq "SAW") |
 
 > [!NOTE] 
+> When building complex rules or using too many individual identifiers like deviceid for device identities please note that "The maximum length for the filter rule is 3072 characters".
+
+> [!NOTE] 
 > The `Contains` and the `NotContains` operators work differently depending on attribute types. For string attributes such as `operatingSystem` and `model`, the `Contains` operator indicates whether a specified substring occurs within the attribute. For string collection attributes such as `physicalIds` and `systemLabels`, the `Contains` operator indicates whether a specified string matches one of the whole strings in the collection.
 
 ## Policy behavior with filter for devices

--- a/articles/active-directory/conditional-access/concept-condition-filters-for-devices.md
+++ b/articles/active-directory/conditional-access/concept-condition-filters-for-devices.md
@@ -129,7 +129,7 @@ The following device attributes can be used with the filter for devices conditio
 | extensionAttribute1-15 | Equals, NotEquals, StartsWith, NotStartsWith, EndsWith, NotEndsWith, Contains, NotContains, In, NotIn | extensionAttributes1-15 are attributes that customers can use for device objects. Customers can update any of the extensionAttributes1 through 15 with custom values and use them in the filter for devices condition in Conditional Access. Any string value can be used. | (device.extensionAttribute1 -eq "SAW") |
 
 > [!NOTE] 
-> When building complex rules or using too many individual identifiers like deviceid for device identities please note that "The maximum length for the filter rule is 3072 characters".
+> When building complex rules or using too many individual identifiers like deviceid for device identities, keep in mind "The maximum length for the filter rule is 3072 characters".
 
 > [!NOTE] 
 > The `Contains` and the `NotContains` operators work differently depending on attribute types. For string attributes such as `operatingSystem` and `model`, the `Contains` operator indicates whether a specified substring occurs within the attribute. For string collection attributes such as `physicalIds` and `systemLabels`, the `Contains` operator indicates whether a specified string matches one of the whole strings in the collection.


### PR DESCRIPTION
Added additional context about maximum length allowed for device filter rule. When too many rules are added Azure Portal displays an error stating "The maximum length for the filter rule is 3072 characters" added this statement in note section below Supported operators and device properties for filters section on the document.