### PR TITLE
Fix javascript examples

### DIFF
--- a/articles/azure-monitor/app/azure-ad-authentication.md
+++ b/articles/azure-monitor/app/azure-ad-authentication.md
@@ -106,7 +106,7 @@ Application Insights Node.JS supports the credential classes provided by [Azure 
 #### DefaultAzureCredential
 
 ```javascript
-let appInsights = require("applicationinsights");
+import appInsights from "applicationinsights";
 import { DefaultAzureCredential } from "@azure/identity"; 
  
 const credential = new DefaultAzureCredential();
@@ -118,7 +118,7 @@ appInsights.defaultClient.config.aadTokenCredential = credential;
 #### ClientSecretCredential
 
 ```javascript
-let appInsights = require("applicationinsights");
+import appInsights from "applicationinsights";
 import { ClientSecretCredential } from "@azure/identity"; 
  
 const credential = new ClientSecretCredential(


### PR DESCRIPTION
You should either use `import` or `require`. Mixing them is invalid.