### PR TITLE
Remove semicolon from SQL instance name

### DIFF
--- a/articles/backup/backup-azure-sql-backup-cli.md
+++ b/articles/backup/backup-azure-sql-backup-cli.md
@@ -156,7 +156,7 @@ As the instruction is to back up all future databases, the operation is done at 
 az backup protection auto-enable-for-azurewl --resource-group SQLResourceGroup \
     --vault-name SQLVault \
     --policy-name SQLPolicy \
-    --protectable-item-name "sqlinstance;mssqlserver;"  \
+    --protectable-item-name "sqlinstance;mssqlserver"  \
     --protectable-item-type SQLInstance \
     --server-name testSQLVM \
     --workload-type MSSQL\


### PR DESCRIPTION
When running the command for enabling auto-protection of all future databases in an instance, the parameter "--protectable-item-name" can't have the final semicolon, or it will fail with the error: "Protectable item not found. Please provide a valid protectable_item_name."