### PR TITLE
Add a note to check maven java version

### DIFF
--- a/articles/spring-apps/quickstart.md
+++ b/articles/spring-apps/quickstart.md
@@ -119,6 +119,8 @@ Use the following steps to clone the Spring Boot sample project.
    ```azurecli-interactive
    mvn clean package -DskipTests
    ```
+> [!NOTE]
+> Verify your system's java version is compatible with the version specified in the 'java.version' in the pom.xml file. You can update the java version by following the instructions [here](https://learn.microsoft.com/en-us/java/openjdk/install#zip-and-targz-packages)
 
 ## Deploy the local app to Azure Spring Apps
 


### PR DESCRIPTION
Out of the box, this project fails mvn build step, due to invalid java version. Azure cloud shell at the moment uses Java 11, and this project is set to 17.  I added a note to verify the systems java version to the appropriate java version.