### PR TITLE
Amend the Sign-on URL pattern

### DIFF
--- a/articles/active-directory/saas-apps/cch-tagetik-tutorial.md
+++ b/articles/active-directory/saas-apps/cch-tagetik-tutorial.md
@@ -82,7 +82,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 1. Click **Set additional URLs** and perform the following step if you wish to configure the application in **SP** initiated mode:
 
     In the **Sign-on URL** text box, type a URL using the following pattern:
-    `https://<CUSTOMER_NAME>.saastagetik.com/prod/5/`
+    `https://<CUSTOMER_NAME>.saastagetik.com/prod/`
 
 	> [!NOTE]
 	> These values are not real. Update these values with the actual Identifier, Reply URL and Sign-on URL. Contact [CCH Tagetik Client support team](mailto:tgk-dl-supportmembers@wolterskluwer.com) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.


### PR DESCRIPTION
The Sign-on URL pattern was not correct: unlike the Identifier URL and Reply URL, it must not have the trailing `5/` otherwise the SSO authentication will succeed but the user won't be logged-in Tagetik and an error page will be shown stating that "Message is not a valid SAML message".