### PR TITLE
Update environment-variables.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/includes/common/environment-variables.md
+++ b/articles/cognitive-services/Speech-Service/includes/common/environment-variables.md
@@ -18,6 +18,7 @@ To set the environment variable for your Speech resource key, open a console win
 
 ```console
 setx SPEECH_KEY your-key
+setx SPEECH_REGION your-chosen-region
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Refactors to add `setx` syntax for SPEECH_REGION as well. 

https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-speech-to-text?tabs=windows%2Cterminal&pivots=programming-language-csharp

**I am following this tutorial and it references the SPEECH_REGION environment variable we should have set. Unless I'm missing it, we are missing the step to actually set the SPEECH_REGION environment variable there and then subsequently telling people to rely on it. That's causing my code to fail with a somewhat obscure error.**

**Please make sure to go and update the website I've linked to also include instructions to better understand the SPEECH_REGION variable and what the expectation is there.**