### PR TITLE
Fixing the capitalization of a PowerShell comment

### DIFF
--- a/articles/automation/enable-managed-identity-for-automation.md
+++ b/articles/automation/enable-managed-identity-for-automation.md
@@ -308,7 +308,7 @@ Disable-AzContextAutosave -Scope Process
 # Connect to Azure with system-assigned managed identity
 $AzureContext = (Connect-AzAccount -Identity).context
 
-# set and store context
+# Set and store context
 $AzureContext = Set-AzContext -SubscriptionName $AzureContext.Subscription -DefaultProfile $AzureContext
 ```
 


### PR DESCRIPTION
Something about this single character in the PowerShell comment being lowercase really bugged me. Updated the comment in the "Authenticate access with system-assigned managed identity" section where the PowerShell code lies. Specifically, updated the s to S (capitalized) on line 311 in the comment.