### PR TITLE
Update troubleshoot-managed-grafana.md

### DIFF
--- a/articles/managed-grafana/troubleshoot-managed-grafana.md
+++ b/articles/managed-grafana/troubleshoot-managed-grafana.md
@@ -47,7 +47,7 @@ If you get an error while filling out the form to create the Managed Grafana ins
 Enter a name that:
 
 - Is unique in the entire Azure region. It can't already be used by another user.
-- Is 30 characters long or smaller
+- Is 23 characters long or smaller
 - Begins with a letter. The rest can only be alphanumeric characters or hyphens, and the name must end with an alphanumeric character.
 
 ### Solution 2: review deployment error


### PR DESCRIPTION
The naming limitation is outdated, listing 30 characters while Azure lists 23 characters as the maximum, and indeed this is what the limit is when validating.