### PR TITLE
Update quickstart-devkit-mxchip-az3166-iot-hub.md

### DIFF
--- a/articles/iot-develop/quickstart-devkit-mxchip-az3166-iot-hub.md
+++ b/articles/iot-develop/quickstart-devkit-mxchip-az3166-iot-hub.md
@@ -204,7 +204,7 @@ To connect the MXCHIP DevKit to Azure, you'll modify a configuration file for Wi
     |Constant name|Value|
     |-------------|-----|
     |`IOT_HUB_HOSTNAME` |{*Your Iot hub hostName value*}|
-    |`IOT_DPS_REGISTRATION_ID` |{*Your Device ID value*}|
+    |`IOT_HUB_DEVICE_ID` |{*Your Device ID value*}|
     |`IOT_DEVICE_SAS_KEY` |{*Your Primary key value*}|
 
 1. Save and close the file.


### PR DESCRIPTION
Fixing a doc bug in this quick start. For preparing the device it incorrectly directed the user to set 'IOT_DPS_REGISTRATION_ID' instead of 'IOT_HUB_DEVICE_ID'. The latter is correct because this quick start is for the non-DPS scenario.