### PR TITLE
### Can I have AOF persistence enabled if I have more than 1 replica?…

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -227,6 +227,11 @@ After a rewrite, two sets of AOF files exist in storage. Rewrites occur in the b
 
 Using managed identity adds the cache instance to the [trusted services list](../storage/common/storage-network-security.md?tabs=azure-portal), making firewall exceptions easier to carry out. If you aren't using managed identity and instead authorizing to a storage account using a key, then having firewall exceptions on the storage account tends to break the persistence process.
 
+
+### Can I have AOF persistence enabled if I have more than 1 replica?
+
+No, AOF persistence cannot be enabled with replicas (i.e replica count >= 2).
+
 ## Next steps
 
 Learn more about Azure Cache for Redis features.

--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -228,7 +228,7 @@ After a rewrite, two sets of AOF files exist in storage. Rewrites occur in the b
 Using managed identity adds the cache instance to the [trusted services list](../storage/common/storage-network-security.md?tabs=azure-portal), making firewall exceptions easier to carry out. If you aren't using managed identity and instead authorizing to a storage account using a key, then having firewall exceptions on the storage account tends to break the persistence process.
 
 
-### Can I have AOF persistence enabled if I have more than 1 replica?
+### Can I have AOF persistence enabled if I have more than one replica?
 
 No, AOF persistence cannot be enabled with replicas (i.e replica count >= 2).
 


### PR DESCRIPTION

![Screenshot 2023-01-03 170107](https://user-images.githubusercontent.com/96826042/210349105-744e12c1-7459-4db9-bafa-70ae825af3bd.jpg)
…  No, AOF persistence cannot be enabled with replicas (i.e replica count >= 2).

### Can I have AOF persistence enabled if I have more than 1 replica?

No, AOF persistence cannot be enabled with replicas (i.e replica count >= 2).

-->It is indicative in portal when we try to create a redis cache with more than 1 replica, it doesn't allow us to enable AOF persistence.