### PR TITLE
Enable autoscaling profiles in examples

### DIFF
--- a/articles/machine-learning/how-to-autoscale-endpoints.md
+++ b/articles/machine-learning/how-to-autoscale-endpoints.md
@@ -109,6 +109,7 @@ mon_client.autoscale_settings.create_or_update(
     resource_group, 
     autoscale_settings_name, 
     parameters = {
+        "enabled" : True,
         "location" : endpoint.location,
         "target_resource_uri" : deployment.id,
         "profiles" : [
@@ -197,6 +198,7 @@ mon_client.autoscale_settings.create_or_update(
     resource_group, 
     autoscale_settings_name, 
     parameters = {
+        "enabled" : True,
         "location" : endpoint.location,
         "target_resource_uri" : deployment.id,
         "profiles" : [
@@ -274,6 +276,7 @@ mon_client.autoscale_settings.create_or_update(
     resource_group, 
     autoscale_settings_name, 
     parameters = {
+        "enabled" : True,
         "location" : endpoint.location,
         "target_resource_uri" : deployment.id,
         "profiles" : [
@@ -359,6 +362,7 @@ mon_client.autoscale_settings.create_or_update(
     resource_group, 
     autoscale_settings_name, 
     parameters = {
+        "enabled" : True,
         "location" : endpoint.location,
         "target_resource_uri" : deployment.id,
         "profiles" : [
@@ -416,6 +420,7 @@ mon_client.autoscale_settings.create_or_update(
     resource_group, 
     autoscale_settings_name, 
     parameters = {
+        "enabled" : True,
         "location" : endpoint.location,
         "target_resource_uri" : deployment.id,
         "profiles" : [


### PR DESCRIPTION
It took me some time to find why the autoscale setting python SDK was not working. Turns out you also need to enable it.

[`AutoscaleSettingsOperations`](https://learn.microsoft.com/en-us/python/api/azure-mgmt-monitor/azure.mgmt.monitor.v2015_04_01.operations.autoscalesettingsoperations?view=azure-python) has a `parameters` argument which takes an [`AutoscaleSettingResource`](https://learn.microsoft.com/en-us/python/api/azure-mgmt-monitor/azure.mgmt.monitor.v2015_04_01.models.autoscalesettingresource?view=azure-python), which has a `default` argument that is set to `False` by default. 

The entire article (Docs: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-autoscale-endpoints?tabs=azure-cli) does not mention how to enable it at all, which seems like an oversight. Probably best to explicitly enabled it, which is what this PR is for
