### PR TITLE
Update selective-disk-backup-restore.md

### DIFF
--- a/articles/backup/selective-disk-backup-restore.md
+++ b/articles/backup/selective-disk-backup-restore.md
@@ -237,23 +237,19 @@ You need to pass the above obtained **$item** object to the **–Item** paramete
 ### Modify protection for already backed up VMs with PowerShell
 
 ```azurepowershell
-Enable-AzRecoveryServicesBackupProtection -Item $item -InclusionDisksList[Strings] -VaultId $targetVault.ID
-```
-
-```azurepowershell
-Enable-AzRecoveryServicesBackupProtection -Item $item -ExclusionDisksList[Strings] -VaultId $targetVault.ID
+Enable-AzRecoveryServicesBackupProtection -Item $item -InclusionDisksList[Strings] -VaultId $targetVault.ID  -Policy $pol
 ```
 
 ### Backup only OS disk during modify protection with PowerShell
 
 ```azurepowershell
-Enable-AzRecoveryServicesBackupProtection -Item $item  -ExcludeAllDataDisks -VaultId $targetVault.ID
+Enable-AzRecoveryServicesBackupProtection -Item $item  -ExcludeAllDataDisks -VaultId $targetVault.ID -Policy $pol
 ```
 
 ### Reset disk exclusion setting with PowerShell
 
 ```azurepowershell
-Enable-AzRecoveryServicesBackupProtection -Item $item -ResetExclusionSettings -VaultId $targetVault.ID
+Enable-AzRecoveryServicesBackupProtection -Item $item -ResetExclusionSettings -VaultId $targetVault.ID -Policy $pol
 ```
 
 > [!NOTE]


### PR DESCRIPTION
A policy parameter is missing for cmdlets to modify selective disks. When trying to exclude or include data disks from an already protected backup item using PowerShell cmdlets, an error without a policy parameter is received. The command succeeded with the policy parameter.

1) Modify protection for already backed up VMs with PowerShell
![image](https://user-images.githubusercontent.com/52278244/210555839-a96f9bec-92f1-4a5f-980c-ba389465ebf0.png)

2) Backup only OS disk during modify protection with PowerShell
![image](https://user-images.githubusercontent.com/52278244/210555948-8ac72448-62ed-4c3e-9661-b96faaf18169.png)

3) Reset disk exclusion setting with PowerShell
![image](https://user-images.githubusercontent.com/52278244/210555983-d289b929-05f8-4a32-b626-dea2945de1e6.png)

**Error message:**
Enable-AzRecoveryServicesBackupProtection : Object reference not set to an instance of an object.
At line:1 char:1
+ Enable-AzRecoveryServicesBackupProtection -Item $item -ResetExclusion ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Enable-AzRecove...ackupProtection], NullReferenceException
    + FullyQualifiedErrorId : Microsoft.Azure.Commands.RecoveryServices.Backup.Cmdlets.EnableAzureRmRecoveryServicesBackupProtection