### PR TITLE
[Azure App Service] Enable SSH Section Refactor

### DIFF
--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -363,7 +363,7 @@ Group Managed Service Accounts (gMSAs) are currently not supported in Windows co
 
 ## Enable SSH
 
-Secure Shell (SSH) is commonly used to execute administrative commands remotely from a command-line terminal. In order to enable the Azure Portal SSH console feature with custom containers, the following steps are required:
+Secure Shell (SSH) is commonly used to execute administrative commands remotely from a command-line terminal. In order to enable the Azure portal SSH console feature with custom containers, the following steps are required:
 
 1. Create a standard [sshd_config](https://man.openbsd.org/sshd_config) file with the following example contents and place it on the application project root directory:
     
@@ -383,12 +383,12 @@ Secure Shell (SSH) is commonly used to execute administrative commands remotely 
     ```
     
     > [!NOTE]
-    > This file configures OpenSSH and must include the following items in order to comply with the Azure Portal SSH feature:
+    > This file configures OpenSSH and must include the following items in order to comply with the Azure portal SSH feature:
     > - `Port` must be set to 2222.
     > - `Ciphers` must include at least one item in this list: `aes128-cbc,3des-cbc,aes256-cbc`.
     > - `MACs` must include at least one item in this list: `hmac-sha1,hmac-sha1-96`.
     
-2. Create an entrypoint script with the name `entrypoint.sh` (or change any existing entrypoint file) and add the command to start the SSH service, along with the application startup command. The below example demonstrates starting a Python application, please replace the last command according to the project language/stack:
+2. Create an entrypoint script with the name `entrypoint.sh` (or change any existing entrypoint file) and add the command to start the SSH service, along with the application startup command. The following example demonstrates starting a Python application. Please replace the last command according to the project language/stack:
     
     ### [Debian](#tab/debian)
     
@@ -451,7 +451,7 @@ Secure Shell (SSH) is commonly used to execute administrative commands remotely 
     > [!NOTE] 
     > The root password must be exactly `Docker!` as it is used by App Service to let you access the SSH session with the container. This configuration doesn't allow external connections to the container. Port 2222 of the container is accessible only within the bridge network of a private virtual network and is not accessible to an attacker on the internet.
 
-4. Rebuild and push the Docker image to the registry, then test the Web App SSH feature on Azure Portal.
+4. Rebuild and push the Docker image to the registry, and then test the Web App SSH feature on Azure portal.
 
 For further troubleshooting additional information is available at the Azure App Service OSS blog: [Enabling SSH on Linux Web App for Containers](https://azureossd.github.io/2022/04/27/2022-Enabling-SSH-on-Linux-Web-App-for-Containers/index.html#troubleshooting)
 

--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -3,7 +3,7 @@ title: Configure a custom container
 description: Learn how to configure a custom container in Azure App Service. This article shows the most common configuration tasks. 
 
 ms.topic: how-to
-ms.date: 10/22/2021
+ms.date: 01/04/2023
 ms.custom: devx-track-azurepowershell, devx-track-azurecli
 zone_pivot_groups: app-service-containers-windows-linux
 ---
@@ -363,12 +363,9 @@ Group Managed Service Accounts (gMSAs) are currently not supported in Windows co
 
 ## Enable SSH
 
-SSH enables secure communication between a container and a client. In order for a custom container to support SSH, you must add it into your Docker image itself.
+Secure Shell (SSH) is commonly used to execute administrative commands remotely from a command-line terminal. In order to enable the Azure Portal SSH console feature with custom containers, the following steps are required:
 
-> [!TIP]
-> All built-in Linux containers in App Service have added the SSH instructions in their image repositories. You can go through the following instructions with the [Node.js 10.14 repository](https://github.com/Azure-App-Service/node/blob/master/10.14) to see how it's enabled there. The configuration in the Node.js built-in image is slightly different, but the same in principle.
-
-- Add [an sshd_config file](https://man.openbsd.org/sshd_config) to your repository, like the following example.
+1. Create a standard [sshd_config](https://man.openbsd.org/sshd_config) file with the following example contents and place it on the application project root directory:
 
     ```
     Port 			2222
@@ -386,52 +383,75 @@ SSH enables secure communication between a container and a client. In order for 
     ```
 
     > [!NOTE]
-    > This file configures OpenSSH and must include the following items:
+    > This file configures OpenSSH and must include the following items in order to comply with the Azure Portal SSH feature:
     > - `Port` must be set to 2222.
     > - `Ciphers` must include at least one item in this list: `aes128-cbc,3des-cbc,aes256-cbc`.
     > - `MACs` must include at least one item in this list: `hmac-sha1,hmac-sha1-96`.
 
-- Add an ssh_setup script file to create the SSH keys [using ssh-keygen](https://man.openbsd.org/ssh-keygen.1) to your repository.
+2. Create an entrypoint script with the name `entrypoint.sh` (or change any existing entrypoint file) and add the command to start the SSH service, along with the application startup command. The below example demonstrates starting a Python application, please replace the last command according to the project language/stack:
 
-    ```
+    ### [Debian](#tab/debian)
+
+    ```Bash
     #!/bin/sh
-
-    ssh-keygen -A
-
-    #prepare run dir
-    if [ ! -d "/var/run/sshd" ]; then
-        mkdir -p /var/run/sshd
-    fi
+    set -e
+    service ssh start
+    exec gunicorn -w 4 -b 0.0.0.0:8000 app:app
     ```
 
-- In your Dockerfile, add the following commands:
+    ### [Alpine](#tab/alpine)
+    
+    ```Bash
+    #!/bin/sh
+    set -e
+    /usr/sbin/sshd
+    exec gunicorn -w 4 -b 0.0.0.0:8000 app:app
+    ```
+
+3. Add to the Dockerfile the following instructions according to the base image distribution. The same will copy the new files, install OpenSSH server, set proper permissions and configure the custom entrypoint, and expose the ports required by the application and SSH server, respectively:
+
+    ### [Debian](#tab/debian)
 
     ```Dockerfile
-    # Install OpenSSH and set the password for root to "Docker!". In this example, "apk add" is the install instruction for an Alpine Linux-based image.
-    RUN apk add openssh \
-         && echo "root:Docker!" | chpasswd 
-
-    # Copy the sshd_config file to the /etc/ssh/ directory
     COPY sshd_config /etc/ssh/
+    COPY entrypoint.sh ./
 
-    # Copy and configure the ssh_setup file
-    RUN mkdir -p /tmp
-    COPY ssh_setup.sh /tmp
-    RUN chmod +x /tmp/ssh_setup.sh \
-        && (sleep 1;/tmp/ssh_setup.sh 2>&1 > /dev/null)
+    # Start and enable SSH
+    RUN apt-get update \
+        && apt-get install -y --no-install-recommends dialog \
+        && apt-get install -y --no-install-recommends openssh-server \
+        && echo "root:Docker!" | chpasswd \
+        && chmod u+x ./entrypoint.sh
 
-    # Open port 2222 for SSH access
-    EXPOSE 80 2222
+    EXPOSE 8000 2222
+
+    ENTRYPOINT [ "./entrypoint.sh" ] 
+    ```
+
+    ### [Alpine](#tab/alpine)
+
+    ```Dockerfile
+    COPY sshd_config /etc/ssh/
+    COPY entrypoint.sh ./
+
+    # Start and enable SSH
+    RUN apk add openssh \
+        && echo "root:Docker!" | chpasswd \
+        && chmod +x ./entrypoint.sh \
+        && cd /etc/ssh/ \
+        && ssh-keygen -A
+
+    EXPOSE 8000 2222
+
+    ENTRYPOINT [ "./entrypoint.sh" ]
     ```
 
     > [!NOTE] 
     > The root password must be exactly `Docker!` as it is used by App Service to let you access the SSH session with the container. This configuration doesn't allow external connections to the container. Port 2222 of the container is accessible only within the bridge network of a private virtual network and is not accessible to an attacker on the internet.
 
-- In the start-up script for your container, start the SSH server.
+4. Rebuild and push the Docker image to the registry, then test the Web App SSH feature on Azure Portal.
 
-    ```bash
-    /usr/sbin/sshd
-    ```
+For further troubleshooting additional information is available at the Azure App Service OSS blog: [Enabling SSH on Linux Web App for Containers](https://azureossd.github.io/2022/04/27/2022-Enabling-SSH-on-Linux-Web-App-for-Containers/index.html#troubleshooting)
 
 ## Access diagnostic logs
 

--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -407,6 +407,7 @@ Secure Shell (SSH) is commonly used to execute administrative commands remotely 
     /usr/sbin/sshd
     exec gunicorn -w 4 -b 0.0.0.0:8000 app:app
     ```
+    ---
 
 3. Add to the Dockerfile the following instructions according to the base image distribution. The same will copy the new files, install OpenSSH server, set proper permissions and configure the custom entrypoint, and expose the ports required by the application and SSH server, respectively:
 
@@ -445,6 +446,7 @@ Secure Shell (SSH) is commonly used to execute administrative commands remotely 
 
     ENTRYPOINT [ "./entrypoint.sh" ]
     ```
+    ---
 
     > [!NOTE] 
     > The root password must be exactly `Docker!` as it is used by App Service to let you access the SSH session with the container. This configuration doesn't allow external connections to the container. Port 2222 of the container is accessible only within the bridge network of a private virtual network and is not accessible to an attacker on the internet.


### PR DESCRIPTION
Refactoring SSH Setup for custom containers section for additional clarity and compliance to most recent instructions from the Azure App Service OSS Blog (https://azureossd.github.io/2022/04/27/2022-Enabling-SSH-on-Linux-Web-App-for-Containers/index.html)