### PR TITLE
Update rule-processing.md

### DIFF
--- a/articles/firewall/rule-processing.md
+++ b/articles/firewall/rule-processing.md
@@ -37,13 +37,13 @@ Here's an example policy:
 |BaseRCG1      |Rule collection group           |200         |8         |Parent policy|
 |DNATRC1     |DNAT rule collection         |  600       |   7      |Parent policy|
 |DNATRC3|DNAT rule collection|610|3|Parent policy|
-|NetworkRc1     |Network rule collection  | 800        |    1     |Parent policy|
+|NetworkRC1     |Network rule collection  | 800        |    1     |Parent policy|
 |BaseRCG2  |Rule collection group         |300         | 3        |Parent policy|
-|AppRCG2     |Application rule collection | 1200        |2         |Parent policy
+|AppRC2     |Application rule collection | 1200        |2         |Parent policy
 |NetworkRC2     |Network rule collection         |1300         |    1     |Parent policy|
 |ChildRCG1  | Rule collection group        | 300        |5         |-|
-|ChAppRC1     |Application rule collection         |  700       | 3        |-|
-|ChNetRC1       |   Network rule collection      |    900     |    2     |-|
+|ChNetRC1     |Network rule collection         |  700       | 3        |-|
+|ChAppRC1       |   Application rule collection      |    900     |    2     |-|
 |ChildRCG2      |Rule collection group         | 650        |    9     |-|
 |ChNetRC2      |Network rule collection         |    1100     |  2       |-|
 |ChAppRC2      |     Application rule collection    |2000         |7         |-|


### PR DESCRIPTION
In ChildRCG1, Network rule should have a higher priority (smaller priority field value) than Application rules. Corrected Capitalization on NetworkRc1.
Corrected AppRCG2 to AppRC2 as it is a collection, not a group.