### PR TITLE
Fix command in OpenShift BYOK article

### DIFF
--- a/articles/openshift/howto-byok.md
+++ b/articles/openshift/howto-byok.md
@@ -53,8 +53,7 @@ You must use an Azure Key Vault instance to store your keys. Create a new Key Va
     az keyvault create -n $KEYVAULT_NAME \
                    -g $RESOURCEGROUP \
                    -l $LOCATION \
-                   --enable-purge-protection true \
-                   --enable-soft-delete true
+                   --enable-purge-protection true
 
     az keyvault key create --vault-name $KEYVAULT_NAME \
                            -n $KEYVAULT_KEY_NAME \


### PR DESCRIPTION
Specifying this argument leads to the following error:

```
az keyvault create -n $KEYVAULT_NAME \
                   -g $RESOURCEGROUP \
                   -l $LOCATION \
                   --enable-purge-protection true \
                   --enable-soft-delete true
unrecognized arguments: --enable-soft-delete true
```

I'm not sure if there's another argument that should be specified instead, or if there are other occurrences here that should also be changed.