### PR TITLE
HRD policy defined through Powershell is incorrect

### DIFF
--- a/articles/active-directory/manage-apps/prevent-domain-hints-with-home-realm-discovery.md
+++ b/articles/active-directory/manage-apps/prevent-domain-hints-with-home-realm-discovery.md
@@ -76,7 +76,7 @@ Admins of federated domains should set up this section of the HRD policy in a fo
 ::: zone pivot="powershell-hrd"
 
 ```powershell 
-New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"testDomain.com`" ], `"RespectDomainHintForDomains`": [], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": [] } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
+New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"testDomain.com`" ], `"RespectDomainHintForDomains`": [], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": [] } } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
 ```
 ::: zone-end
 
@@ -97,7 +97,7 @@ New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForD
 ::: zone pivot="powershell-hrd"
 
 ```powershell
-New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"testDomain.com`" ], `"RespectDomainHintForDomains`": [], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": ["app1-clientID-Guid", "app2-clientID-Guid] } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
+New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"testDomain.com`" ], `"RespectDomainHintForDomains`": [], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": ["app1-clientID-Guid", "app2-clientID-Guid] } } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
 ```
 ::: zone-end
 
@@ -118,7 +118,7 @@ New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForD
 ::: zone pivot="powershell-hrd"
 
 ```powershell
-New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"testDomain.com`", "otherDomain.com", "anotherDomain.com"], `"RespectDomainHintForDomains`": [], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": ["app1-clientID-Guid", "app2-clientID-Guid] } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
+New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"testDomain.com`", "otherDomain.com", "anotherDomain.com"], `"RespectDomainHintForDomains`": [], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": ["app1-clientID-Guid", "app2-clientID-Guid] } } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
 ```
 
 ::: zone-end
@@ -141,7 +141,7 @@ New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForD
 ::: zone pivot="powershell-hrd"
 
 ```powershell
-New-AzureADPolicy -Definition @("{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"*`" ], `"RespectDomainHintForDomains`": [guestHandlingDomain.com], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": ["app1-clientID-Guid", "app2-clientID-Guid] } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
+New-AzureADPolicy -Definition @("{`"HomeRealmDiscoveryPolicy`":{`"DomainHintPolicy`": { `"IgnoreDomainHintForDomains`": [ `"*`" ], `"RespectDomainHintForDomains`": [guestHandlingDomain.com], `"IgnoreDomainHintForApps`": [], `"RespectDomainHintForApps`": ["app1-clientID-Guid", "app2-clientID-Guid] } } }") -DisplayName BasicBlockAccelerationPolicy -Type HomeRealmDiscoveryPolicy
 ```
 
 ::: zone-end


### PR DESCRIPTION
The HRD policy defined through Powershell is missing the important HomeRealmDiscoveryPolicy JSON portion, which is not recognized and loaded by AAD backend runtime. The Graph part has the correct format of the HRD policy, however. We have the internal product feedback work item here: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2194824/