### PR TITLE
Update number of replica sets that can be deployed

### DIFF
--- a/articles/active-directory-domain-services/tutorial-create-replica-set.md
+++ b/articles/active-directory-domain-services/tutorial-create-replica-set.md
@@ -100,7 +100,7 @@ The replica set reports as *Provisioning* as deployment continues, as shown in t
 
 ## Delete a replica set
 
-A managed domain is currently limited to four replicas - the initial replica set, and three additional replica sets. If you don't need a replica set anymore, or if you want to create a replica set in another region, you can delete unneeded replica sets.
+A managed domain is currently limited to five replicas - the initial replica set, and four additional replica sets. If you don't need a replica set anymore, or if you want to create a replica set in another region, you can delete unneeded replica sets.
 
 > [!IMPORTANT]
 > You can't delete either the last replica set or the initial replica set in a managed domain.


### PR DESCRIPTION
This is merely a doc issue in which the public articles available do not reflect the same data (this one being outdated as AADDS can have up to five replicate sets and not four).  The proper data can be also found in this doc https://learn.microsoft.com/en-us/azure/active-directory-domain-services/concepts-replica-sets#deployment-considerations