### PR TITLE
slack-tutorial: remove redundant paragraph

### DIFF
--- a/articles/active-directory/saas-apps/slack-tutorial.md
+++ b/articles/active-directory/saas-apps/slack-tutorial.md
@@ -38,7 +38,7 @@ To get started, you need the following items:
 
 In this tutorial, you configure and test Azure AD SSO in a test environment.
 
-* Slack supports **SP** initiated SSO.
+* Slack supports **SP** (service provider) initiated SSO.
 * Slack supports **Just In Time** user provisioning.
 * Slack supports [**Automated** user provisioning](./slack-provisioning-tutorial.md).
 
@@ -55,8 +55,6 @@ To configure the integration of Slack into Azure AD, you need to add Slack from 
 1. To add new application, select **New application**.
 1. In the **Add from the gallery** section, type **Slack** in the search box.
 1. Select **Slack** from results panel and then add the app. Wait a few seconds while the app is added to your tenant.
-
- Alternatively, you can also use the [Enterprise App Configuration Wizard](https://portal.office.com/AdminPortal/home?Q=Docs#/azureadappintegration). In this wizard, you can add an application to your tenant, add users/groups to the app, assign roles, as well as walk through the SSO configuration as well. [Learn more about Microsoft 365 wizards.](/microsoft-365/admin/misc/azure-ad-setup-guides)
 
 Alternatively, you can also use the [Enterprise App Configuration Wizard](https://portal.office.com/AdminPortal/home?Q=Docs#/azureadappintegration). In this wizard, you can add an application to your tenant, add users/groups to the app, assign roles, as well as walk through the SSO configuration as well. You can learn more about O365 wizards [here](/microsoft-365/admin/misc/azure-ad-setup-guides?view=o365-worldwide&preserve-view=true).
 


### PR DESCRIPTION
The same information is present in the next paragraph.

Also add clarification of SP (service provider)