### PR TITLE
Fix code example errors

### DIFF
--- a/articles/azure-maps/how-to-use-ios-map-control-library.md
+++ b/articles/azure-maps/how-to-use-ios-map-control-library.md
@@ -41,8 +41,8 @@ The Azure Maps iOS SDK provides three ways of setting the language and regional 
 
     ```swift
     MapControl(options: [
-        StyleOptions.language("fr-FR"),
-        StyleOptions.view("Auto")
+        StyleOption.language("fr-FR"),
+        StyleOption.view("Auto")
     ])
     ```
 
@@ -50,9 +50,9 @@ The Azure Maps iOS SDK provides three ways of setting the language and regional 
 
     ```swift
     mapControl.getMapAsync { map in
-        map.setStyle([
-            StyleOptions.language("fr-FR"),
-            StyleOptions.view("Auto")
+        map.setStyleOptions([
+            StyleOption.language("fr-FR"),
+            StyleOption.view("Auto")
         ])
     }
     ```


### PR DESCRIPTION
Some of the code samples on this page are incorrect; they may be out of date. The changes here work with the latest version 1.0.0-pre.3 of the SDK.