### PR TITLE
Use the Powershell API for setting app config

### DIFF
--- a/articles/event-grid/storage-upload-process-images.md
+++ b/articles/event-grid/storage-upload-process-images.md
@@ -246,11 +246,13 @@ az webapp config appsettings set --name $webapp --resource-group myResourceGroup
 ```
 
 ```powershell
-az webapp config appsettings set --name $webapp --resource-group myResourceGroup `
-  --settings AzureStorageConfig__AccountName=$blobStorageAccount `
-    AzureStorageConfig__ImageContainer=images `
-    AzureStorageConfig__ThumbnailContainer=thumbnails `
-    AzureStorageConfig__AccountKey=$blobStorageAccountKey
+New-AzStaticWebAppSetting -ResourceGroupName myResourceGroup -Name $webapp `
+  -AppSetting @{ `
+    AzureStorageConfig__AccountName = $blobStorageAccount `
+    AzureStorageConfig__ImageContainer = images `
+    AzureStorageConfig__ThumbnailContainer = thumbnails `
+    AzureStorageConfig__AccountKey = $blobStorageAccountKey `
+  }
 ```
 
 # [JavaScript v12 SDK](#tab/javascript)


### PR DESCRIPTION
In the Configure web app settings section, the overview suggests using `New-AzStaticWebAppSetting` to set the app's config vars, but the PS code simply calls `az webapp config appsettings` from Azure CLI.

This PR resolves that by using `New-AzStaticWebAppSetting` in the PS code example.