### PR TITLE
Update tutorial-multiple-sites-cli.md

### DIFF
--- a/articles/application-gateway/tutorial-multiple-sites-cli.md
+++ b/articles/application-gateway/tutorial-multiple-sites-cli.md
@@ -153,7 +153,8 @@ az network application-gateway rule create \
   --resource-group myResourceGroupAG \
   --http-listener contosoListener \
   --rule-type Basic \
-  --address-pool contosoPool
+  --address-pool contosoPool \
+  --priority 200
 
 az network application-gateway rule create \
   --gateway-name myAppGateway \
@@ -161,7 +162,8 @@ az network application-gateway rule create \
   --resource-group myResourceGroupAG \
   --http-listener fabrikamListener \
   --rule-type Basic \
-  --address-pool fabrikamPool
+  --address-pool fabrikamPool \
+  --priority 100
 
 az network application-gateway rule delete \
   --gateway-name myAppGateway \


### PR DESCRIPTION
 --priority  is required option to run the command for add rule for application gateway

Below errors are produced if rules are run without  --priority flag

```
root@jumpbox:~# az network application-gateway rule create \
>   --gateway-name myAppGateway \
>   --name contosoRule \
>   --resource-group myResourceGroupAG \
>   --http-listener contosoListener \
>   --rule-type Basic \
>   --address-pool contosoPool
(ApplicationGatewayRequestRoutingRulePriorityCannotBeEmpty) Priority for the request routing rule /subscriptions/4ff5187b-445f-4080-a09f-5565e458d856/resourceGroups/myResourceGroupAG/providers/Microsoft.Network/applicationGateways/myAppGateway/requestRoutingRules/contosoRule cannot be empty. All request routing rules should have a priority defined starting from api-version 2021-08-01
Code: ApplicationGatewayRequestRoutingRulePriorityCannotBeEmpty
Message: Priority for the request routing rule /subscriptions/4ff5187b-445f-4080-a09f-5565e458d856/resourceGroups/myResourceGroupAG/providers/Microsoft.Network/applicationGateways/myAppGateway/requestRoutingRules/contosoRule cannot be empty. All request routing rules should have a priority defined starting from api-version 2021-08-01
root@jumpbox:~#
root@jumpbox:~# az network application-gateway rule create \
>   --gateway-name myAppGateway \
>   --name fabrikamRule \
>   --resource-group myResourceGroupAG \
>   --http-listener fabrikamListener \
>   --rule-type Basic \
>   --address-pool fabrikamPool
(ApplicationGatewayRequestRoutingRulePriorityCannotBeEmpty) Priority for the request routing rule /subscriptions/4ff5187b-445f-4080-a09f-5565e458d856/resourceGroups/myResourceGroupAG/providers/Microsoft.Network/applicationGateways/myAppGateway/requestRoutingRules/fabrikamRule cannot be empty. All request routing rules should have a priority defined starting from api-version 2021-08-01
Code: ApplicationGatewayRequestRoutingRulePriorityCannotBeEmpty
Message: Priority for the request routing rule /subscriptions/4ff5187b-445f-4080-a09f-5565e458d856/resourceGroups/myResourceGroupAG/providers/Microsoft.Network/applicationGateways/myAppGateway/requestRoutingRules/fabrikamRule cannot be empty. All request routing rules should have a priority defined starting from api-version 2021-08-01

```

Updated line 157 & 166 with --priority flag to make command successful on the run