### PR TITLE
Fixing broken link and typo

### DIFF
--- a/articles/sentinel/normalization.md
+++ b/articles/sentinel/normalization.md
@@ -91,7 +91,7 @@ On the other hand, while ASIM parsers are optimized, query time parsing can slow
 
 Currently, ASIM supports the following normalized tables as a destination for ingest time normalization:
 - [**ASimDnsActivityLogs**](/azure/azure-monitor/reference/tables/asimdnsactivitylogs) for the [DNS](normalization-schema-dns.md) schema.
-- [**ASimNetworkSessionLogs**](/azire/azure-monitor/reference/tables/asimnetworksessionlogs) for the [NetworkS Session](network-normalization-schema.md) schema 
+- [**ASimNetworkSessionLogs**](/azure/azure-monitor/reference/tables/asimnetworksessionlogs) for the [Network Session](network-normalization-schema.md) schema 
  
 For more information, see [Ingest Time Normalization](normalization-ingest-time.md).
 


### PR DESCRIPTION
Link went to /azire/ instead of /azure/