### PR TITLE
For Linux:  useManagedDataDisk:true** and **dataPath: '/mnt/sfroot'

### DIFF
--- a/articles/service-fabric/service-fabric-managed-disk.md
+++ b/articles/service-fabric/service-fabric-managed-disk.md
@@ -27,7 +27,7 @@ To use managed data disks on a node type, configure the underlying virtual machi
 * Add a managed disk in data disks section of the template for the virtual machine scale set. 
 * Update the Service Fabric extension for the virtual machine scale set with following settings: 
     * For Windows: **useManagedDataDisk: true** and **dataPath: 'K:\\\\SvcFab'**. Note that drive K is just a representation. You can use any drive letter lexicographically greater than all the drive letters present in the virtual machine scale set SKU.
-    * For Linux: **useManagedDataDisk:true** and **dataPath: '\mnt\sfdataroot'**.
+    * For Linux: **useManagedDataDisk:true** and **dataPath: '/mnt/sfroot'**.
 
 Here's an Azure Resource Manager template for a Service Fabric extension:
 


### PR DESCRIPTION
Upon trying as much as the article instructed and created a new cluster from scratch with an intention to Deploy an Azure Service Fabric cluster node type with managed data disks, one thing that we need to change is that instead of using "\mnt\sfdataroot" for linux datapath as written in there, we must put "/mnt/sfroot" because when we tried with "\mnt\sfdataroot" (the first), nothing works at all.