### PR TITLE
Updated GitHub sample to use .NET Core 3.1

### DIFF
--- a/articles/defender-for-cloud/github-action.md
+++ b/articles/defender-for-cloud/github-action.md
@@ -75,8 +75,9 @@ Security DevOps uses the following Open Source tools:
         - uses: actions/setup-dotnet@v1
           with:
             dotnet-version: |
+              3.1.x
               5.0.x
-              6.0.x
+              6.0.x              
 
         # Run analyzers
         - name: Run Microsoft Security DevOps Analysis


### PR DESCRIPTION
As the Microsoft Security DevOps CLI have a dependency on the .NET Core 3.1.402 a use for .NET Core 3.1 is needed