### PR TITLE
[Form Request] Update the limit page for Form Recognizer: total dataset size about Custom Model (Template)

### DIFF
--- a/articles/applied-ai-services/form-recognizer/service-limits.md
+++ b/articles/applied-ai-services/form-recognizer/service-limits.md
@@ -80,7 +80,9 @@ This article contains both a quick reference and detailed description of Azure F
 | Adjustable | No | No |
 | **Training dataset size * Neural** | 1 GB <sup>3</sup> | 1 GB (default value) |
 | Adjustable | No | No |
-| **Training dataset size * Template** | 50 MB <sup>4</sup> | 50 MB (default value) |
+| **Training file size * Template** | 50 MB <sup>4</sup> | 50 MB (default value) |
+| Adjustable | No | No |
+| **Total Training dataset size * Template** | 150 MB <sup>4</sup> | 150 MB (default value) |
 | Adjustable | No | No |
 | **Max number of pages (Training) * Template** | 500 | 500 (default value) |
 | Adjustable | No | No |


### PR DESCRIPTION
I think the current explanation about training dataset size for Template model is not sufficient because the limit of total dataset limit is not written in this document. As far as I checked the message of Form Recognizer Portal, the total dataset size is 150 MB so I added the table about total training dataset size for Template model.