### PR TITLE
Update how-to-provision-devices-at-scale-linux-tpm.md

### DIFF
--- a/articles/iot-edge/how-to-provision-devices-at-scale-linux-tpm.md
+++ b/articles/iot-edge/how-to-provision-devices-at-scale-linux-tpm.md
@@ -321,7 +321,7 @@ After the runtime is installed on your device, configure the device with the inf
 <!-- iotedge-1.4 -->
 :::moniker range=">=iotedge-1.4"
 
-7. Optionally, uncomment the `payload` parameter to specify the path to a local JSON file. The contents of the file will be [sent to DPS as additional data](../iot-dps/how-to-send-additional-data.md#iot-edge-support) when the device registers. This is useful for [custom allocation](../iot-dps/how-to-use-custom-allocation-policies.md). For example, if you want to allocate your devices based on an IoT Plug and Play model ID without human intervention.
+Optionally, uncomment the `payload` parameter to specify the path to a local JSON file. The contents of the file will be [sent to DPS as additional data](../iot-dps/how-to-send-additional-data.md#iot-edge-support) when the device registers. This is useful for [custom allocation](../iot-dps/how-to-use-custom-allocation-policies.md). For example, if you want to allocate your devices based on an IoT Plug and Play model ID without human intervention.
 :::moniker-end
 
 <!-- iotedge-2020-11 -->

--- a/articles/iot-edge/how-to-provision-devices-at-scale-linux-tpm.md
+++ b/articles/iot-edge/how-to-provision-devices-at-scale-linux-tpm.md
@@ -327,7 +327,7 @@ Optionally, uncomment the `payload` parameter to specify the path to a local JSO
 <!-- iotedge-2020-11 -->
 :::moniker range=">=iotedge-2020-11"
 
-8. Save and close the file.
+Save and close the file.
 
 :::moniker-end
 <!-- end iotedge-2020-11 -->

--- a/articles/iot-edge/how-to-provision-devices-at-scale-linux-tpm.md
+++ b/articles/iot-edge/how-to-provision-devices-at-scale-linux-tpm.md
@@ -320,12 +320,14 @@ After the runtime is installed on your device, configure the device with the inf
 
 <!-- iotedge-1.4 -->
 :::moniker range=">=iotedge-1.4"
-1. Optionally, uncomment the `payload` parameter to specify the path to a local JSON file. The contents of the file will be [sent to DPS as additional data](../iot-dps/how-to-send-additional-data.md#iot-edge-support) when the device registers. This is useful for [custom allocation](../iot-dps/how-to-use-custom-allocation-policies.md). For example, if you want to allocate your devices based on an IoT Plug and Play model ID without human intervention.
+
+7. Optionally, uncomment the `payload` parameter to specify the path to a local JSON file. The contents of the file will be [sent to DPS as additional data](../iot-dps/how-to-send-additional-data.md#iot-edge-support) when the device registers. This is useful for [custom allocation](../iot-dps/how-to-use-custom-allocation-policies.md). For example, if you want to allocate your devices based on an IoT Plug and Play model ID without human intervention.
 :::moniker-end
 
 <!-- iotedge-2020-11 -->
 :::moniker range=">=iotedge-2020-11"
-1. Save and close the file.
+
+8. Save and close the file.
 
 :::moniker-end
 <!-- end iotedge-2020-11 -->


### PR DESCRIPTION
Changed the numbering for the chapter 'Provision the device with its cloud identity'

![image](https://user-images.githubusercontent.com/453360/211489897-3de6237c-3632-4bfd-8429-6561f90b2ccd.png)
