### PR TITLE
Correct Basic SAML Configuration URLs

### DIFF
--- a/articles/active-directory/saas-apps/appdynamics-tutorial.md
+++ b/articles/active-directory/saas-apps/appdynamics-tutorial.md
@@ -73,14 +73,17 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 
 4. On the **Basic SAML Configuration** section, perform the following steps:
 
-    a. In the **Sign on URL** text box, type a URL using the following pattern:
-    `https://<companyname>.saas.appdynamics.com?accountName=<companyname>`
-
-    b. In the **Identifier (Entity ID)** text box, type a URL using the following pattern:
+    a. In the **Identifier (Entity ID)** text box, type a URL using the following pattern:
     `https://<companyname>.saas.appdynamics.com/controller`
 
+    b. In the **Reply URL (Assertion Consumer Service URL)** text box, type a URL using the following pattern:
+    `https://<companyname>.saas.appdynamics.com/controller/saml-auth?accountName=<companyname>`
+
+    c. In the **Sign on URL** text box, type a URL using the following pattern:
+    `https://<companyname>.saas.appdynamics.com/?accountName=<companyname>`
+
     > [!NOTE]
-    > These values are not real. Update these values with the actual Sign on URL and Identifier. Contact [AppDynamics Client support team](https://www.appdynamics.com/support/) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+    > These values are not real. Update these values with the actual Identifier, Reply URL and Sign on URL. Contact [AppDynamics Client support team](https://www.appdynamics.com/support/) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
 4. On the **Set up Single Sign-On with SAML** page, in the **SAML Signing Certificate** section, click **Download** to download the **Certificate (Base64)** from the given options as per your requirement and save it on your computer.
 


### PR DESCRIPTION
The Sign on URL was missing a '/' and the Reply URL was missing from the document altogether. I've amended the document based on practical findings based several implementations done in the past few months.