### PR TITLE
Update link to new Ping Identity docs delivery system

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-install-custom.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-custom.md
@@ -347,7 +347,7 @@ When you select the domain that you want to federate, Azure AD Connect provides 
 
 ## Configuring federation with PingFederate
 You can configure PingFederate with Azure AD Connect in just a few clicks. The following prerequisites are required:
-- PingFederate 8.4 or later.  For more information, see [PingFederate integration with Azure Active Directory and Microsoft 365](https://docs.pingidentity.com/bundle/pingfederate-azuread-office365-integration/).
+- PingFederate 8.4 or later.  For more information, see [PingFederate integration with Azure Active Directory and Microsoft 365](https://docs.pingidentity.com/access/sources/dita/topic?category=Integration&resourceid=pingfederate_azuread_office365_integration).
 - A TLS/SSL certificate for the federation service name that you intend to use (for example, sts.contoso.com).
 
 ### Verify the domain


### PR DESCRIPTION
Ping Identity docs migrated to a new system on Dec 18. Submitting this update, which should remain for a long time.