### PR TITLE
Sweep Doc modifications for defaults and descriptions

### DIFF
--- a/articles/machine-learning/how-to-tune-hyperparameters.md
+++ b/articles/machine-learning/how-to-tune-hyperparameters.md
@@ -330,12 +330,12 @@ sweep_job.early_termination = None
 Control your resource budget by setting limits for your sweep job.
 
 * `max_total_trials`: Maximum number of trial jobs. Must be an integer between 1 and 1000.
-* `max_concurrent_trials`: (optional) Maximum number of trial jobs that can run concurrently. If not specified, all jobs launch in parallel. If specified, must be an integer between 1 and 100.
+* `max_concurrent_trials`: (optional) Maximum number of trial jobs that can run concurrently. If not specified, max_total_trials number of jobs launch in parallel. If specified, must be an integer between 1 and 1000.
 * `timeout`: Maximum time in seconds the entire sweep job is allowed to run. Once this limit is reached the system will cancel the sweep job, including all its trials.
 * `trial_timeout`: Maximum time in seconds each trial job is allowed to run. Once this limit is reached the system will cancel the trial. 
 
 >[!NOTE] 
->If both max_total_trials and max_concurrent_trials are specified, the hyperparameter tuning experiment terminates when the first of these two thresholds is reached.
+>If both max_total_trials and timeout are specified, the hyperparameter tuning experiment terminates when the first of these two thresholds is reached.
 
 >[!NOTE] 
 >The number of concurrent trial jobs is gated on the resources available in the specified compute target. Ensure that the compute target has the available resources for the desired concurrency.

--- a/articles/machine-learning/reference-yaml-job-sweep.md
+++ b/articles/machine-learning/reference-yaml-job-sweep.md
@@ -162,9 +162,9 @@ The source JSON schema can be found at https://azuremlschemas.azureedge.net/late
 
 | Key | Type | Description | Default value |
 | --- | ---- | ----------- | ------------- |
-| `max_total_trials` | integer | The maximum time in seconds the job is allowed to run. Once this limit is reached, the system will cancel the job. | `1000` |
-| `max_concurrent_trials` | integer | | Defaults to `max_total_trials`. |
-| `timeout` | integer | The maximum time in seconds the entire sweep job is allowed to run. Once this limit is reached, the system will cancel the sweep job, including all its trials. | `604800` |
+| `max_total_trials` | integer | The maximum number of trial jobs. | `1000` |
+| `max_concurrent_trials` | integer | The maximum number of trial jobs that can run concurrently. | Defaults to `max_total_trials`. |
+| `timeout` | integer | The maximum time in seconds the entire sweep job is allowed to run. Once this limit is reached, the system will cancel the sweep job, including all its trials. | `5184000` |
 | `trial_timeout` | integer | The maximum time in seconds each trial job is allowed to run. Once this limit is reached, the system will cancel the trial. | |
 
 ### Attributes of the `trial` key


### PR DESCRIPTION
1. Modified the description for max_total_trials, max_concurrent_trials, and default value of timeout to 60days which was previously set as 7days : https://learn.microsoft.com/en-us/azure/machine-learning/reference-yaml-job-sweep
2. Modified the note : https://learn.microsoft.com/en-us/azure/machine-learning/how-to-tune-hyperparameters.