### PR TITLE
Updated Zone-Redundant HA availability for Norway East

### DIFF
--- a/articles/postgresql/flexible-server/overview.md
+++ b/articles/postgresql/flexible-server/overview.md
@@ -104,7 +104,7 @@ One advantage of running your workload in Azure is global reach. The flexible se
 | Korea South | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | North Central US | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: |
 | North Europe | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Norway East | :heavy_check_mark: | :x: | :heavy_check_mark: | :x: |
+| Norway East | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: |
 | Qatar Central | :heavy_check_mark: | :x: | :heavy_check_mark: | :x: |
 | South Africa North | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: |
 | South Central US | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |


### PR DESCRIPTION
Provisioning Zone-Redundant Azure Database for PostgreSQL flexible servers in the Norway East region is possible today, hence the documentation should be updated to reflect this

![image](https://user-images.githubusercontent.com/2039662/211792542-31510b2d-5f89-467f-a1d9-0062e1410b25.png)
