### PR TITLE
Update HC Series to reflect Constrained Cores

### DIFF
--- a/articles/virtual-machines/hc-series.md
+++ b/articles/virtual-machines/hc-series.md
@@ -30,6 +30,9 @@ HC-series VMs feature 100 Gb/sec Mellanox EDR InfiniBand. These VMs are connecte
 | Size | vCPU | Processor | Memory (GiB) | Memory bandwidth GB/s | Base CPU frequency (GHz) | All-cores frequency (GHz, peak) | Single-core frequency (GHz, peak) | RDMA performance (Gb/s) | MPI support | Temp storage (GiB) | Max data disks | Max Ethernet vNICs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Standard_HC44rs | 44 | Intel Xeon Platinum 8168 | 352 | 191 | 2.7 | 3.4 | 3.7 | 100 | All | 700 | 4 | 8 |
+| Standard_HC44-16rs | 16 | Intel Xeon Platinum 8168 | 352 | 191 | 2.7 | 3.4 | 3.7 | 100 | All | 700 | 4 | 8 |
+| Standard_HC44-32rs | 32 | Intel Xeon Platinum 8168 | 352 | 191 | 2.7 | 3.4 | 3.7 | 100 | All | 700 | 4 | 8 |
+
 
 Learn more about the:
 - [Architecture and VM topology](./workloads/hpc/hc-series-overview.md)


### PR DESCRIPTION
HC Constrained Cores were implemented in August. Documentation is out of date.