### PR TITLE
Update node-updates-kured.md

### DIFF
--- a/articles/aks/node-updates-kured.md
+++ b/articles/aks/node-updates-kured.md
@@ -67,7 +67,7 @@ helm repo update
 kubectl create namespace kured
 
 # Install kured in that namespace with Helm 3 (only on Linux nodes, kured is not working on Windows nodes)
-helm install my-release kubereboot/kured --namespace kured --set nodeSelector."kubernetes.io/os"=linux
+helm install my-release kubereboot/kured --namespace kured --set nodeSelector."kubernetes\.io/os"=linux
 ```
 
 You can also configure additional parameters for `kured`, such as integration with Prometheus or Slack. For more information about additional configuration parameters, see the [kured Helm chart][kured-install].


### PR DESCRIPTION
line 70 fails in Linux shell: 
the dot in "kubernetes.io/os" needs to be escaped.  Modified command:
helm install my-release kubereboot/kured --namespace kured --set nodeSelector."kubernetes\.io/os"=linux

Tested in Ubuntu 20.04