### PR TITLE
Update Credential and Protocol for Blob datastore

### DIFF
--- a/articles/machine-learning/how-to-datastore.md
+++ b/articles/machine-learning/how-to-datastore.md
@@ -123,18 +123,18 @@ ml_client.create_or_update(store)
 
 ```python
 from azure.ai.ml.entities import AzureBlobDatastore
-from azure.ai.ml.entities._datastore.credentials import AccountKeyCredentials
+from azure.ai.ml.entities import AccountKeyConfiguration
 from azure.ai.ml import MLClient
 
 ml_client = MLClient.from_config()
 
 store = AzureBlobDatastore(
     name="blob_protocol_example",
-    description="Datastore pointing to a blob container using wasbs protocol.",
+    description="Datastore pointing to a blob container using https protocol.",
     account_name="mytestblobstore",
     container_name="data-container",
-    protocol="wasbs",
-    credentials=AccountKeyCredentials(
+    protocol="https",
+    credentials=AccountKeyConfiguration(
         account_key="XXXxxxXXXxXXXXxxXXXXXxXXXXXxXxxXxXXXxXXXxXXxxxXXxxXXXxXxXXXxxXxxXXXXxxxxxXXxxxxxxXXXxXXX"
     ),
 )
@@ -146,7 +146,7 @@ ml_client.create_or_update(store)
 
 ```python
 from azure.ai.ml.entities import AzureBlobDatastore
-from azure.ai.ml.entities._datastore.credentials import SasTokenCredentials
+from azure.ai.ml.entities import SasTokenConfiguration 
 from azure.ai.ml import MLClient
 
 ml_client = MLClient.from_config()
@@ -156,7 +156,7 @@ store = AzureBlobDatastore(
     description="Datastore pointing to a blob container using SAS token.",
     account_name="mytestblobstore",
     container_name="data-container",
-    credentials=SasTokenCredentials(
+    credentials=SasTokenConfiguration(
         sas_token= "?xx=XXXX-XX-XX&xx=xxxx&xxx=xxx&xx=xxxxxxxxxxx&xx=XXXX-XX-XXXXX:XX:XXX&xx=XXXX-XX-XXXXX:XX:XXX&xxx=xxxxx&xxx=XXxXXXxxxxxXXXXXXXxXxxxXXXXXxxXXXXXxXXXXxXXXxXXxXX"
     ),
 )
@@ -301,7 +301,7 @@ az ml datastore create --file my_files_datastore.yml
 
 ```python
 from azure.ai.ml.entities import AzureFileDatastore
-from azure.ai.ml.entities._datastore.credentials import AccountKeyCredentials
+from azure.ai.ml.entities import AccountKeyConfiguration
 from azure.ai.ml import MLClient
 
 ml_client = MLClient.from_config()
@@ -311,7 +311,7 @@ store = AzureFileDatastore(
     description="Datastore pointing to an Azure File Share.",
     account_name="mytestfilestore",
     file_share_name="my-share",
-    credentials=AccountKeyCredentials(
+    credentials=AccountKeyConfiguration(
         account_key= "XXXxxxXXXxXXXXxxXXXXXxXXXXXxXxxXxXXXxXXXxXXxxxXXxxXXXxXxXXXxxXxxXXXXxxxxxXXxxxxxxXXXxXXX"
     ),
 )
@@ -323,7 +323,7 @@ ml_client.create_or_update(store)
 
 ```python
 from azure.ai.ml.entities import AzureFileDatastore
-from azure.ai.ml.entities._datastore.credentials import SasTokenCredentials
+from azure.ai.ml.entities import SasTokenConfiguration
 from azure.ai.ml import MLClient
 
 ml_client = MLClient.from_config()
@@ -333,7 +333,7 @@ store = AzureFileDatastore(
     description="Datastore pointing to an Azure File Share using SAS token.",
     account_name="mytestfilestore",
     file_share_name="my-share",
-    credentials=SasTokenCredentials(
+    credentials=SasTokenConfiguration(
         sas_token="?xx=XXXX-XX-XX&xx=xxxx&xxx=xxx&xx=xxxxxxxxxxx&xx=XXXX-XX-XXXXX:XX:XXX&xx=XXXX-XX-XXXXX:XX:XXX&xxx=xxxxx&xxx=XXxXXXxxxxxXXXXXXXxXxxxXXXXXxxXXXXXxXXXXxXXXxXXxXX"
     ),
 )


### PR DESCRIPTION
The SasTokenCredential and the AccountKeyCredential are no longer used and have been replaced by SasTokenConfiguration and AccountKeyConfiguration.

In addition, wasbs does not appear to be a support protocol and should instead be https

* https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.sastokenconfiguration?view=azure-python
* https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.accountkeyconfiguration?view=azure-python
* https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.azureblobdatastore?view=azure-python - This doc doesn't explicitly state that it must be https but when trying to run this on Azure ML Notebooks with the 3.10 SDK v2 kernel, only https would work.

I believe the reference to ServicePrincipalCredential is also out of date and should be replaced with ServicePrincipalConfiguration but I have not tested that.

* https://learn.microsoft.com/en-us/python/api/azure-ai-ml/azure.ai.ml.entities.serviceprincipalconfiguration?view=azure-python