### PR TITLE
Fix broken numbered list interrupted by Note

### DIFF
--- a/articles/storage/file-sync/file-sync-planning.md
+++ b/articles/storage/file-sync/file-sync-planning.md
@@ -194,11 +194,11 @@ With Azure File Sync, you will need to account for the following taking up space
 We'll use an example to illustrate how to estimate the amount of free space would need on your local disk. Let's say you installed your Azure File Sync agent on your Azure Windows VM, and plan to create a server endpoint on disk F. You have 1 million files and would like to tier all of them, 100,000 directories, and a disk cluster size of 4 KiB. The disk size is 1000 GiB. You want to enable cloud tiering and set your volume free space policy to 20%. 
 
 1. NTFS allocates a cluster size for each of the tiered files. 1 million files * 4 KiB cluster size = 4,000,000 KiB (4 GiB)
-> [!Note]  
-> The space occupied by tiered files is allocated by NTFS. Therefore, it will not show up in any UI.
-3. Sync metadata occupies a cluster size per item. (1 million files + 100,000 directories) * 4 KB cluster size = 4,400,000 KiB (4.4 GiB)
-4. Azure File Sync heatstore occupies 1.1 KiB per file. 1 million files * 1.1 KiB = 1,100,000 KiB (1.1 GiB)
-5. Volume free space policy is 20%. 1000 GiB * 0.2 = 200 GiB
+   > [!Note]  
+   > The space occupied by tiered files is allocated by NTFS. Therefore, it will not show up in any UI.
+1. Sync metadata occupies a cluster size per item. (1 million files + 100,000 directories) * 4 KB cluster size = 4,400,000 KiB (4.4 GiB)
+1. Azure File Sync heatstore occupies 1.1 KiB per file. 1 million files * 1.1 KiB = 1,100,000 KiB (1.1 GiB)
+1. Volume free space policy is 20%. 1000 GiB * 0.2 = 200 GiB
 
 In this case, Azure File Sync would need about 209,500,000 KiB (209.5 GiB) of space for this namespace. Add this amount to any additional free space that is desired in order to figure out how much free space is required for this disk.
 


### PR DESCRIPTION
Fixed the broken list in the 'Consider how much free space you need on your local disk' section due to a !Note breaking the list. Updated numbering format.