### PR TITLE
Updated new registration and Operations defaults

### DIFF
--- a/includes/iot-dps-limits.md
+++ b/includes/iot-dps-limits.md
@@ -33,7 +33,7 @@ The Device Provisioning Service has the following rate limits.
 
 | Rate | Per-unit value | Adjustable? |
 | --- | --- | --- |
-| Operations | 200/min/service | Yes |
-| Device registrations | 200/min/service | Yes |
+| Operations | 1,000/min/service | Yes |
+| Device registrations | 1,000/min/service | Yes |
 | Device polling operation | 5/10 sec/device | No |
 


### PR DESCRIPTION
As of January 2022 DPS team has increased the new default of the supported Registrations and operations per minute using DPS from 200 to 1,000 in both cases.