### PR TITLE
Update cache-how-to-zone-redundancy.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
+++ b/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
@@ -53,7 +53,7 @@ To create a cache, follow these steps:
 1. Configure your settings for clustering and/or RDB persistence.  
 
     > [!NOTE]
-    > Zone redundancy doesn't support AOF persistence or work with geo-replication currently.
+    > Zone redundancy doesn't support AOF persistence with 2 or more replicas or work with geo-replication currently.
     >
 
 1. Select **Create**.


### PR DESCRIPTION
Changed "Zone redundancy doesn't support AOF persistence or work with geo-replication currently" to "Zone redundancy doesn't support AOF persistence with 2 or more replicas or work with geo-replication currently".

With just 1 replica in place, if we enable zone redundancy, then AOF persistence is supported. You can see this while creating a premium cache with just 2 availability zones.