### PR TITLE
Update certificate-rotation.md

### DIFF
--- a/articles/aks/certificate-rotation.md
+++ b/articles/aks/certificate-rotation.md
@@ -75,7 +75,7 @@ For any AKS clusters created or upgraded after March 2022 Azure Kubernetes Servi
 
 To verify if TLS Bootstrapping is enabled on your cluster browse to the following paths:
 
-* On a Linux node: */var/lib/kubelet/bootstrap-kubeconfig*
+* On a Linux node: */var/lib/kubelet/bootstrap-kubeconfig* or */host/var/lib/kubelet/bootstrap-kubeconfig*
 * On a Windows node: *C:\k\bootstrap-config*
 
 To access agent nodes, see [Connect to Azure Kubernetes Service cluster nodes for maintenance or troubleshooting][aks-node-access] for more information.


### PR DESCRIPTION
To check if TLS Bootstrapping is enabled on your cluster, Current path is now updated to "/host/var/lib/kubelet/bootstrap-kubeconfig"

Have updated the same in line 78

Checked on root@aks-nodepool1-78886619-vmss000005:/# uname -a              Linux aks-nodepool1-78886619-vmss000005 5.4.0-1094-azure #100~18.04.1-Ubuntu SMP Mon Oct 17 11:44:30 UTC 2022 x86_64 GNU/Linux

Node pool Kubernetes versions
1.24.6