### PR TITLE
Wrong audience

### DIFF
--- a/articles/azure-monitor/essentials/metrics-store-custom-rest-api.md
+++ b/articles/azure-monitor/essentials/metrics-store-custom-rest-api.md
@@ -50,7 +50,7 @@ curl -X POST 'https://login.microsoftonline.com/<tennant ID>/oauth2/token' \
 --data-urlencode 'grant_type=client_credentials' \
 --data-urlencode 'client_id=<your apps client ID>' \
 --data-urlencode 'client_secret=<your apps client secret' \
---data-urlencode 'resource=https://management.azure.com'
+--data-urlencode 'resource=https://monitor.azure.com'
 ```
 
 The response body appears as follows:  


### PR DESCRIPTION
When requesting the authorization token - the audience should be 'monitor.azure.com'  instead of 'management.azure.com'
Following the current instructions - get an exception when executing the POST command later in the doc - Error: InvalidAudience changing the audience to 'monitor.azure.com' solve the problem.