### PR TITLE
Fix az ml workspace show command in how-to-secure-workspace-vnet.md

### DIFF
--- a/articles/machine-learning/how-to-secure-workspace-vnet.md
+++ b/articles/machine-learning/how-to-secure-workspace-vnet.md
@@ -219,7 +219,7 @@ Azure Container Registry can be configured to use a private endpoint. Use the fo
     If you've [installed the Machine Learning extension v2 for Azure CLI](how-to-configure-cli.md), you can use the `az ml workspace show` command to show the workspace information. The v1 extension does not return this information.
 
     ```azurecli-interactive
-    az ml workspace show -w yourworkspacename -g resourcegroupname --query 'container_registry'
+    az ml workspace show -n yourworkspacename -g resourcegroupname --query 'container_registry'
     ```
 
     This command returns a value similar to `"/subscriptions/{GUID}/resourceGroups/{resourcegroupname}/providers/Microsoft.ContainerRegistry/registries/{ACRname}"`. The last part of the string is the name of the Azure Container Registry for the workspace.


### PR DESCRIPTION
Change the argument name from `-w` to `-n`.

```
> az ml workspace show --help
This command is from the following extension: ml

Command
    az ml workspace show : Show details for a workspace.

Arguments
    --name -n           : Name of the Azure ML workspace. You can configure the default group using
                          `az configure --defaults workspace=<name>`.
    --resource-group -g : Name of resource group. You can configure the default group using `az
                          configure --defaults group=<name>`. 
```