### PR TITLE
Update assign-roles-azure-service-principals.md

### DIFF
--- a/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
+++ b/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
@@ -16,6 +16,8 @@ ms.author: banders
 You can manage your Enterprise Agreement (EA) enrollment in the [Azure Enterprise portal](https://ea.azure.com/). Direct Enterprise customer can now manage Enterprise Agreement(EA) enrollment in [Azure portal](https://portal.azure.com/).
 You can create different roles to manage your organization, view costs, and create subscriptions. This article helps you automate some of those tasks by using Azure PowerShell and REST APIs with Azure service principal names (SPNs).
 
+**Note:** If you have multiple EA billing accounts in your organization, you will need to grant the EA roles to Azure service principal names (SPNs) individually in each EA billing account.
+
 Before you begin, ensure that you're familiar with the following articles:
 
 - [Enterprise agreement roles](understand-ea-roles.md)
@@ -37,7 +39,14 @@ Here's an example of the application registration page.
 
 ### Find your SPN and tenant ID
 
-You also need the object ID of the SPN and the tenant ID of the app. You need this information for permission assignment operations later in this article.
+You also need the object ID of the SPN and the tenant ID of the app. You need this information for permission assignment operations later in this article. All applications that get registered in AAD, in the tenant, two types of objects get created once the app registration is done:
+
+-Application Object     
+-Service Principal Object
+
+The Application Object ID is what you see under App Registrations in AAD and this object ID should **not** be used to grant any EA Roles.
+
+The Service Principal Object is what you see under the Enterprise Registration blade in AAD. This Object ID should be used while granting any EA Roles to the SPN.
 
 1. Open Azure Active Directory, and then select **Enterprise applications**.
 1. Find your app in the list.
@@ -67,9 +76,11 @@ Later in this article, you'll give permission to the Azure AD app to act by usin
 | SubscriptionCreator | Create new subscriptions in the given scope of Account. | a0bcee42-bf30-4d1b-926a-48d21664ef71 |
 
 - An EnrollmentReader role can be assigned to an SPN only by a user who has an enrollment writer role.
+- An EnrollmentReader role assigned to an SPN isn't shown in the EA portal. It's created by programmatic means and is only for programmatic use.
 - A DepartmentReader role can be assigned to an SPN only by a user who has an enrollment writer or department writer role.
 - A SubscriptionCreator role can be assigned to an SPN only by a user who is the owner of the enrollment account (EA administrator). The role isn't shown in the EA portal. It's created by programmatic means and is only for programmatic use.
 - The EA purchaser role isn't shown in the EA portal. It's created by programmatic means and is only for programmatic use.
+- While granting any EA Roles to the SPN, it required this property billingRoleAssignmentName. This parameter is a unique GUID that you need to provide. You can generate a GUID using the New-Guid PowerShell command. You can also use the [Online GUID / UUID Generator](https://guidgenerator.com/) website to generate a unique GUID.
 
 An SPN can have only one role.
 

--- a/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
+++ b/articles/cost-management-billing/manage/assign-roles-azure-service-principals.md
@@ -16,7 +16,8 @@ ms.author: banders
 You can manage your Enterprise Agreement (EA) enrollment in the [Azure Enterprise portal](https://ea.azure.com/). Direct Enterprise customer can now manage Enterprise Agreement(EA) enrollment in [Azure portal](https://portal.azure.com/).
 You can create different roles to manage your organization, view costs, and create subscriptions. This article helps you automate some of those tasks by using Azure PowerShell and REST APIs with Azure service principal names (SPNs).
 
-**Note:** If you have multiple EA billing accounts in your organization, you will need to grant the EA roles to Azure service principal names (SPNs) individually in each EA billing account.
+[!NOTE]
+If you have multiple EA billing accounts in your organization, you will need to grant the EA roles to Azure service principal names (SPNs) individually in each EA billing account.
 
 Before you begin, ensure that you're familiar with the following articles:
 
@@ -39,14 +40,14 @@ Here's an example of the application registration page.
 
 ### Find your SPN and tenant ID
 
-You also need the object ID of the SPN and the tenant ID of the app. You need this information for permission assignment operations later in this article. All applications that get registered in AAD, in the tenant, two types of objects get created once the app registration is done:
+You also need the object ID of the SPN and the tenant ID of the app. You need this information for permission assignment operations later in this article. All applications that get registered in Azure Active Directory, in the tenant, two types of objects get created once the app registration is done:
 
 -Application Object     
 -Service Principal Object
 
-The Application Object ID is what you see under App Registrations in AAD and this object ID should **not** be used to grant any EA Roles.
+The Application Object ID is what you see under App Registrations in Azure Active Directory and this object ID should **not** be used to grant any EA Roles.
 
-The Service Principal Object is what you see under the Enterprise Registration blade in AAD. This Object ID should be used while granting any EA Roles to the SPN.
+The Service Principal Object is what you see under the Enterprise Registration blade in Azure Active Directory. This Object ID should be used while granting any EA Roles to the SPN.
 
 1. Open Azure Active Directory, and then select **Enterprise applications**.
 1. Find your app in the list.
@@ -80,7 +81,7 @@ Later in this article, you'll give permission to the Azure AD app to act by usin
 - A DepartmentReader role can be assigned to an SPN only by a user who has an enrollment writer or department writer role.
 - A SubscriptionCreator role can be assigned to an SPN only by a user who is the owner of the enrollment account (EA administrator). The role isn't shown in the EA portal. It's created by programmatic means and is only for programmatic use.
 - The EA purchaser role isn't shown in the EA portal. It's created by programmatic means and is only for programmatic use.
-- While granting any EA Roles to the SPN, it required this property billingRoleAssignmentName. This parameter is a unique GUID that you need to provide. You can generate a GUID using the New-Guid PowerShell command. You can also use the [Online GUID / UUID Generator](https://guidgenerator.com/) website to generate a unique GUID.
+- While granting any EA roles to the SPN, you must use the billingRoleAssignmentName required property. The parameter is a unique GUID that you must provide. You can generate a GUID using the [New-Guid](https://github.com/en-us/powershell/module/microsoft.powershell.utility/new-guid) PowerShell command. You can also use the [Online GUID / UUID Generator](https://guidgenerator.com/) website to generate a unique GUID.
 
 An SPN can have only one role.
 


### PR DESCRIPTION
1. If customers have multiple EA Billing Accounts and they want to at the EnrollmentReader or EA Purchaser role at EA billing account scope, they need to grant the SPN the specific role for each EA billing accounts separately. The SPN role assignment at EA Billing Account will not inherit to all the EA billing accounts which customer is not aware of and its not mentioned in this document. 

2. The document does not say anything about currently granting SPN EnrollmentReader roles is all under the hood and its not visible/possible on the UX to check or grant any EnrollmentReader to the SPN.

3. Regarding the SPN enterprise object ID, the document does not have any reference to help customer find the right SPN object ID. When an Application Registration is created in Azure AD, it will have its own object ID which customer should not be using. Instead when the Application Registrations is created, it will create it's own Enterprise App (SPN). The customer should navigate to the App Registration's Enterprise App and use that Object ID while granting the EA roles to the SPN.

4. Customers are getting confused on they need to generate a unique GUID for each billingRoleAssignmentName. Hence, it would be good to add a note about the same at the beginning.