### PR TITLE
Changes on the min requirement and explanation on Server sizing

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-install-prerequisites.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-prerequisites.md
@@ -219,10 +219,10 @@ The following table shows the minimum requirements for the Azure AD Connect sync
 
 | Number of objects in Active Directory | CPU | Memory | Hard drive size |
 | --- | --- | --- | --- |
-| Fewer than 10,000 |1.6 GHz |4 GB |70 GB |
-| 10,000–50,000 |1.6 GHz |4 GB |70 GB |
+| Fewer than 10,000 |1.6 GHz |6 GB |70 GB |
+| 10,000–50,000 |1.6 GHz |6 GB |70 GB |
 | 50,000–100,000 |1.6 GHz |16 GB |100 GB |
-| For 100,000 or more objects, the full version of SQL Server is required. For performance reasons, installing locally is preferred. | | | |
+| For 100,000 or more objects, the full version of SQL Server is required. For performance reasons, installing locally is preferred. The following values are valid only for AAD Connect installation. If SQL Server will be installed on the same server further memory, drive and CPU is required. | | | |
 | 100,000–300,000 |1.6 GHz |32 GB |300 GB |
 | 300,000–600,000 |1.6 GHz |32 GB |450 GB |
 | More than 600,000 |1.6 GHz |32 GB |500 GB |

--- a/articles/active-directory/hybrid/how-to-connect-install-prerequisites.md
+++ b/articles/active-directory/hybrid/how-to-connect-install-prerequisites.md
@@ -222,7 +222,7 @@ The following table shows the minimum requirements for the Azure AD Connect sync
 | Fewer than 10,000 |1.6 GHz |6 GB |70 GB |
 | 10,000–50,000 |1.6 GHz |6 GB |70 GB |
 | 50,000–100,000 |1.6 GHz |16 GB |100 GB |
-| For 100,000 or more objects, the full version of SQL Server is required. For performance reasons, installing locally is preferred. The following values are valid only for AAD Connect installation. If SQL Server will be installed on the same server further memory, drive and CPU is required. | | | |
+| For 100,000 or more objects, the full version of SQL Server is required. For performance reasons, installing locally is preferred. The following values are valid only for Azure AD Connect installation. If SQL Server will be installed on the same server, further memory, drive, and CPU is required. | | | |
 | 100,000–300,000 |1.6 GHz |32 GB |300 GB |
 | 300,000–600,000 |1.6 GHz |32 GB |450 GB |
 | More than 600,000 |1.6 GHz |32 GB |500 GB |


### PR DESCRIPTION
Changed the min memory for small aad connect environments to change from 4 GB => 6 GB.  4 GB is really less and we should recommend 6 GB since, the AAD Connect health agent might require up to 10% of physical server memory.

Added a short hint to the table, that for bigger installations the 32GB of RAM is required for AAD Connect without having any additional server on the same windows server.