### PR TITLE
remove scops option from Connect-AzureAD cmd

### DIFF
--- a/articles/active-directory/manage-apps/manage-application-permissions.md
+++ b/articles/active-directory/manage-apps/manage-application-permissions.md
@@ -56,7 +56,7 @@ Each option generates PowerShell scripts that enable you to control user access 
 Using the following Azure AD PowerShell script revokes all permissions granted to an application.
 
 ```powershell
-Connect-AzureAD -Scopes "Application.ReadWrite.All", "Directory.ReadWrite.All", "DelegatedPermissionGrant.ReadWrite.All" "AppRoleAssignment.ReadWrite.All", 
+Connect-AzureAD 
 
 # Get Service Principal using objectId
 $sp = Get-AzureADServicePrincipal -ObjectId "<ServicePrincipal objectID>"
@@ -83,7 +83,7 @@ $spApplicationPermissions | ForEach-Object {
 Remove appRoleAssignments for users or groups to the application using the following scripts.
 
 ```powershell
-Connect-AzureAD -Scopes "Application.ReadWrite.All", "Directory.ReadWrite.All", "AppRoleAssignment.ReadWrite.All"
+Connect-AzureAD
 
 # Get Service Principal using objectId
 $sp = Get-AzureADServicePrincipal -ObjectId "<ServicePrincipal objectID>"


### PR DESCRIPTION
Connect-AzureAD command doesn't have -Scopes option.

The document about Connect-AzureAD is below:
https://learn.microsoft.com/en-us/powershell/module/azuread/connect-azuread?view=azureadps-2.0-preview

> Connect-AzureAD
       [-AzureEnvironmentName <EnvironmentName>]
       [-TenantId <String>]
       [-Credential <PSCredential>]
       [-AccountId <String>]
       [-LogLevel <LogLevel>]
       [-LogFilePath <String>]
       [-InformationAction <ActionPreference>]
       [-InformationVariable <String>]
       [-WhatIf]
       [-Confirm]
       [<CommonParameters>]