### PR TITLE
Corrected Registry Key name for OTP Override

### DIFF
--- a/articles/active-directory/authentication/how-to-mfa-number-match.md
+++ b/articles/active-directory/authentication/how-to-mfa-number-match.md
@@ -86,7 +86,7 @@ To create the registry key that overrides push notifications:
    Value = TRUE
 1. Restart the NPS Service. 
 
-If you're using Remote Desktop Gateway and the user is registered for OTP code along with Microsoft Authenticator push notifications, the user won't be able to meet the Azure AD MFA challenge and Remote Desktop Gateway sign-in will fail. In this case, you can set OVERRIDE_NUMBER_MATCHING_WITH_TOP = FALSE to fall back to push notifications with Microsoft Authenticator.
+If you're using Remote Desktop Gateway and the user is registered for OTP code along with Microsoft Authenticator push notifications, the user won't be able to meet the Azure AD MFA challenge and Remote Desktop Gateway sign-in will fail. In this case, you can set OVERRIDE_NUMBER_MATCHING_WITH_OTP = FALSE to fall back to push notifications with Microsoft Authenticator.
 
 ### Apple Watch supported for Microsoft Authenticator
 


### PR DESCRIPTION
Registry Key was referred to as "OVERRIDE_NUMBER_MATCHING_WITH_TOP = FALSE"  when it should be "OVERRIDE_NUMBER_MATCHING_WITH_OTP = FALSE"