### PR TITLE
Update interactive-query-troubleshoot-migrate-36-to-40.md

### DIFF
--- a/articles/hdinsight/interactive-query/interactive-query-troubleshoot-migrate-36-to-40.md
+++ b/articles/hdinsight/interactive-query/interactive-query-troubleshoot-migrate-36-to-40.md
@@ -105,7 +105,7 @@ Steps to disable ACID on HDInsight 4.0:
     metastore.create.as.acid=false;
     ```
 > [!Note]
-> if hive.strict.managed.tables is set to true \<Default value\>, Creating Managed and non-transcation table will fail with the following error:
+> If hive.strict.managed.tables is set to true \<Default value\>, Creating Managed and non-transaction table will fail with the following error:
 ```
 java.lang.Exception: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. Unable to alter table. Table <Table name> failed strict managed table checks due to the following reason: Table is marked as a managed table but is not transactional.
 ```

--- a/articles/hdinsight/interactive-query/interactive-query-troubleshoot-migrate-36-to-40.md
+++ b/articles/hdinsight/interactive-query/interactive-query-troubleshoot-migrate-36-to-40.md
@@ -104,7 +104,11 @@ Steps to disable ACID on HDInsight 4.0:
     hive.create.as.insert.only=false;
     metastore.create.as.acid=false;
     ```
-
+> [!Note]
+> if hive.strict.managed.tables is set to true <Default value>, Creating Managed and non-transcation table will fail with the following error:
+```
+java.lang.Exception: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. Unable to alter table. Table <Table name> failed strict managed table checks due to the following reason: Table is marked as a managed table but is not transactional.
+```
 2. Restart hive service.
 
 > [!IMPORTANT]

--- a/articles/hdinsight/interactive-query/interactive-query-troubleshoot-migrate-36-to-40.md
+++ b/articles/hdinsight/interactive-query/interactive-query-troubleshoot-migrate-36-to-40.md
@@ -105,7 +105,7 @@ Steps to disable ACID on HDInsight 4.0:
     metastore.create.as.acid=false;
     ```
 > [!Note]
-> if hive.strict.managed.tables is set to true <Default value>, Creating Managed and non-transcation table will fail with the following error:
+> if hive.strict.managed.tables is set to true \<Default value\>, Creating Managed and non-transcation table will fail with the following error:
 ```
 java.lang.Exception: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. Unable to alter table. Table <Table name> failed strict managed table checks due to the following reason: Table is marked as a managed table but is not transactional.
 ```


### PR DESCRIPTION
This is a common error during migration from HDI 3.6 to HDI 4.0 when creating Managed and non-transactional table. Strict managed tables mode in Hive (enabled by default on HDI 4.0) will cause a DDL exception. 