### PR TITLE
Update to the "essentials" example payload.

### DIFF
--- a/articles/azure-monitor/alerts/alerts-common-schema-definitions.md
+++ b/articles/azure-monitor/alerts/alerts-common-schema-definitions.md
@@ -102,6 +102,9 @@ Any alert instance describes the resource that was affected and the cause of the
     "alertTargetIDs": [
       "/subscriptions/<subscription ID>/resourceGroups/aimon-rg/providers/Microsoft.Insights/components/ai-orion-int-fe"
     ],
+    "configurationItems": [
+      "ai-orion-int-fe"
+    ],
     "originAlertId": "74ff8faa0c79db6084969cf7c72b0710e51aec70b4f332c719ab5307227a984f",
     "firedDateTime": "2019-03-26T05:25:50.4994863Z",
     "description": "Test Metric alert",


### PR DESCRIPTION
Above this is a table of "essentials".  Guaranteed data that will come from an alert trigger.    Although Configuration items is listed in that table,  it is excluded from the payload example.   

Extremely valuable data for those using this for logic app creation and want the ConfigurationItems data.  

Additionally, this page conflicts with the Example payload found here:  https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-common-schema where the configurationItems is clearly in place.