### PR TITLE
Trailing slash on issuer URL causes issues

### DIFF
--- a/articles/active-directory/develop/workload-identity-federation-create-trust.md
+++ b/articles/active-directory/develop/workload-identity-federation-create-trust.md
@@ -209,7 +209,7 @@ az ad app federated-credential create --id f6475511-fd81-4965-a00e-41e7792b7b9c 
 ("credential.json" contains the following content)
 {
     "name": "Testing",
-    "issuer": "https://token.actions.githubusercontent.com/",
+    "issuer": "https://token.actions.githubusercontent.com",
     "subject": "repo:octo-org/octo-repo:environment:Production",
     "description": "Testing",
     "audiences": [


### PR DESCRIPTION
The trailing slash on the issuer URL in the code sample will cause the federated credential to not work when leveraging the azure/login action in a pipeline. The error it throws is "AADSTS70021: No matching federated identity record found for presented assertion".

Removing the trailing slash fixes it and works as expected.

**Description**
Documentation update when using `az ad app federated-credential create` to create a federated credential.

The official GitHub documents also call this out as not having a trailing slash https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#:~:text=(Issuer)%20The%20issuer%20of%20the%20OIDC%20token%3A%20https%3A//token.actions.githubusercontent.com