### PR TITLE
Clarifying host ID override when using slots

### DIFF
--- a/articles/azure-functions/storage-considerations.md
+++ b/articles/azure-functions/storage-considerations.md
@@ -93,7 +93,7 @@ You can use the following strategies to avoid host ID collisions:
 
 You can explicitly set a specific host ID for your function app in the application settings by using the `AzureFunctionsWebHost__hostid` setting. For more information, see [AzureFunctionsWebHost__hostid](functions-app-settings.md#azurefunctionswebhost__hostid). 
 
-When the collision occurs between slots, you need to mark this setting as a sticky slot setting, for all slots, including production slot. To learn how to create app settings, see [Work with application settings](functions-how-to-use-azure-function-app-settings.md#settings).
+When the collision occurs between slots, you must set a specific host ID for each slot, including the production slot. You must also mark these settings as [deployment settings](functions-deployment-slots.md#create-a-deployment-setting) so they don't get swapped. To learn how to create app settings, see [Work with application settings](functions-how-to-use-azure-function-app-settings.md#settings).
 
 ## Azure Arc-enabled clusters
 

--- a/articles/azure-functions/storage-considerations.md
+++ b/articles/azure-functions/storage-considerations.md
@@ -93,7 +93,7 @@ You can use the following strategies to avoid host ID collisions:
 
 You can explicitly set a specific host ID for your function app in the application settings by using the `AzureFunctionsWebHost__hostid` setting. For more information, see [AzureFunctionsWebHost__hostid](functions-app-settings.md#azurefunctionswebhost__hostid). 
 
-When the collision occurs between slots, you may need to mark this setting as a slot setting. To learn how to create app settings, see [Work with application settings](functions-how-to-use-azure-function-app-settings.md#settings).
+When the collision occurs between slots, you need to mark this setting as a sticky slot setting, for all slots, including production slot. To learn how to create app settings, see [Work with application settings](functions-how-to-use-azure-function-app-settings.md#settings).
 
 ## Azure Arc-enabled clusters
 


### PR DESCRIPTION
The propose change aims to make it more clear/explicit that when slot host id collision is happening the proper way to override the host ID is by setting a different host ID on all slots including (and most important) the production slot. 

If this is not done, when you do a swap operation the same will fail with a generic error saying "Swap failed. Details: Cannot swap site slots for site 'YOU_SITE_NAME' because the 'YOUR_SLOT_NAME' slot did not respond to http ping.".

This behavior was tested on the following environment: 
-> Function on Linux Dedicated Plan
-> Function runtime version 4.14.0.0
-> Language dotnet 6.0 (the code used was the hello world template from the Azure Portal. I created a timer trigger function and an HTTP trigger function )