### PR TITLE
Update search-query-lucene-examples.md to correct description of fiel…

### DIFF
--- a/articles/search/search-query-lucene-examples.md
+++ b/articles/search/search-query-lucene-examples.md
@@ -76,7 +76,7 @@ POST /indexes/hotel-samples-index/docs/search?api-version=2020-06-30
 }
 ```
 
-Response for this query should look similar to the following example, filtered on "Resort and Spa", returning hotels that include "hotel" or "motel" in the name.
+Response for this query should look similar to the following example, filtered on "Resort and Spa", returning hotels that include "hotel" in the name, while exlcuding results that include "motel" in the name.
 
 ```json
 "@odata.count": 4,


### PR DESCRIPTION
The description of the example mentions "hotels that include "hotel" or "motel" in the name". This seems incorrect, as results including 'motel' are excluded by the query 'HotelName:(hotel NOT motel)'.