### PR TITLE
Fix #57943

### DIFF
--- a/articles/active-directory/manage-apps/application-properties.md
+++ b/articles/active-directory/manage-apps/application-properties.md
@@ -39,7 +39,7 @@ The homepage URL can't be edited within enterprise applications. The homepage UR
 
 This is the application logo that users see on the My Apps portal and the Office 365 application launcher. Administrators also see the logo in the Azure AD gallery.
 
-Custom logos must be exactly 215x215 pixels in size and be in the PNG format. You should use a solid color background with no transparency in your application logo. The central image dimensions should be 94x94 pixels and the logo file size can't be over 100 KB.
+Custom logos must be exactly 215x215 pixels in size and be in the PNG format. You should use a solid color background with no transparency in your application logo. The logo file size can't be over 100 KB.
 
 ## Application ID 
 


### PR DESCRIPTION
As discussed in #57943, people aren't sure what "central image dimensions should be 94x94 pixels" means. This is just confusing.