### PR TITLE
Update prerequisite for Require password change

### DIFF
--- a/articles/active-directory/conditional-access/concept-conditional-access-grant.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-grant.md
@@ -191,7 +191,7 @@ When user risk is detected, administrators can employ the user risk policy condi
 When a user is prompted to change a password, they'll first be required to complete multifactor authentication. Make sure all users have registered for multifactor authentication, so they're prepared in case risk is detected for their account.  
 
 > [!WARNING]
-> Users must have previously registered for multi-factor authentication before triggering the user risk policy.
+> Users must have previously registered for multifactor authentication before triggering the user risk policy.
 
 The following restrictions apply when you configure a policy by using the password change control:  
 

--- a/articles/active-directory/conditional-access/concept-conditional-access-grant.md
+++ b/articles/active-directory/conditional-access/concept-conditional-access-grant.md
@@ -191,7 +191,7 @@ When user risk is detected, administrators can employ the user risk policy condi
 When a user is prompted to change a password, they'll first be required to complete multifactor authentication. Make sure all users have registered for multifactor authentication, so they're prepared in case risk is detected for their account.  
 
 > [!WARNING]
-> Users must have previously registered for self-service password reset before triggering the user risk policy.
+> Users must have previously registered for multi-factor authentication before triggering the user risk policy.
 
 The following restrictions apply when you configure a policy by using the password change control:  
 


### PR DESCRIPTION
Registering for SSPR is not needed to trigger the password change on CA policy. 

Let's say we have a following configuration:

- There is a user that SSPR is not enabled, and the number of methods required for SSPR is two.
- A user has 1 MFA method (e.g., phone number) 
- The user has high user risk 
- There is a CA policy with "Require password change" control for high-risk user.

In this case, the user is required to pass voice/SMS MFA before changing the password. SSPR is not needed for "Require password change" control.