### PR TITLE
Updated pre-requisite

### DIFF
--- a/articles/sentinel/connect-azure-active-directory.md
+++ b/articles/sentinel/connect-azure-active-directory.md
@@ -35,6 +35,8 @@ You can use Microsoft Sentinel's built-in connector to collect data from [Azure 
 ## Prerequisites
 
 - An Azure Active Directory P1 or P2 license is required to ingest sign-in logs into Microsoft Sentinel. Any Azure AD license (Free/O365/P1/P2) is sufficient to ingest the other log types. Additional per-gigabyte charges may apply for Azure Monitor (Log Analytics) and Microsoft Sentinel.
+ 
+- [**Send logs to Azure Monitor**] (https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/active-directory/reports-monitoring/howto-integrate-activity-logs-with-log-analytics.md#send-logs-to-azure-monitor)
 
 - Your user must be assigned the [Microsoft Sentinel Contributor](../role-based-access-control/built-in-roles.md#microsoft-sentinel-contributor) role on the workspace.
 


### PR DESCRIPTION
Customers are opening request because the connector isn't working but they need to create a diagnostic setting in AAD to stream AAD events to sentinel. Once this is configured, they can use the connector in sentinel. If this isn't enabled in AAD they won't be able to configure the Azure Active Directory connector in Sentinel.