### PR TITLE
Update the line about latest driver support

### DIFF
--- a/includes/virtual-machines-n-series-linux-support.md
+++ b/includes/virtual-machines-n-series-linux-support.md
@@ -17,7 +17,7 @@
 For the latest CUDA drivers and supported operating systems, visit the [NVIDIA](https://developer.nvidia.com/cuda-zone) website. Ensure that you install or upgrade to the latest supported CUDA drivers for your distribution. 
 
 > [!NOTE]
-> The latest supported CUDA drivers for NC-series VMs is currently 470.82.01. Later driver versions are not supported on the K80 cards in NC.
+> The latest supported CUDA drivers for original NC-series SKU VMs is currently 470.82.01. Later driver versions are not supported on the K80 cards in NC.
 > 
 
 > [!TIP]


### PR DESCRIPTION
The line "The latest supported CUDA drivers for original NC-series SKU VMs is currently 470.82.01." is confusing customers.  Adding the word original defines the NC-Series as a specific SKU versus the family of NC-Series (v1,v2, v3, A100 v4, T4, etc.)