### PR TITLE
Add missing permission requirement to Azure Arc Cluster Connect

### DIFF
--- a/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
+++ b/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
@@ -63,7 +63,7 @@ For a conceptual look at connecting clusters to Azure Arc, see [Azure Arc-enable
     ```
 
 * [Log in to Azure PowerShell](/powershell/azure/authenticate-azureps) using the identity (user or service principal) that you want to use for connecting your cluster to Azure Arc.
-  * The identity used needs to at least have 'Read' and 'Write' permissions on the Azure Arc-enabled Kubernetes resource type (`Microsoft.Kubernetes/connectedClusters`).
+  * The identity used needs to at least have 'Read' and 'Write' permissions on the Azure Arc-enabled Kubernetes resource type (`Microsoft.Kubernetes/connectedClusters`) and 'Read' permission on the resource group the Azure Arc Cluster is targeting.
   * The [Kubernetes Cluster - Azure Arc Onboarding built-in role](../../role-based-access-control/built-in-roles.md#kubernetes-cluster---azure-arc-onboarding) is useful for at-scale onboarding as it has the granular permissions required to only connect clusters to Azure Arc. This role doesn't have the permissions to update, delete, or modify any other clusters or other Azure resources.
 
 * An up-and-running Kubernetes cluster. If you don't have one, you can create a cluster using one of these options:


### PR DESCRIPTION
When using a SP to connect your existing cluster to Azure Arc, the SP also needs a permission to read the resource group that the Azure Arc Cluster will be created it. I believe under the hood it's querying the resource group to see if the Arc Cluster already exists with that name, but that's a guess. 

You can test this out by creating a SP with no permissions and adding just the `Microsoft.Kubernetes/connectedClusters/write` and `Microsoft.Kubernetes/connectedClusters/read` permissions to it and logging into the Azure CLI with the SP. This will result in a permission denied error when running the `az connectedk8s connect --name AzureArcTest1 --resource-group AzureArcTest` command, given a otherwise working cluster.