### PR TITLE
Update admin consent sequence

### DIFF
--- a/articles/active-directory/manage-apps/configure-admin-consent-workflow.md
+++ b/articles/active-directory/manage-apps/configure-admin-consent-workflow.md
@@ -36,21 +36,23 @@ To configure the admin consent workflow, you need:
 To enable the admin consent workflow and choose reviewers:
 
 1. Sign-in to the [Azure portal](https://portal.azure.com)  with one of the roles listed in the prerequisites.
-1. Search for and select **Azure Active Directory**.
-1. Select **Enterprise applications**.
-1. Under **Manage**, select **User settings**.
+2. Search for and select **Azure Active Directory**.
+3. Select **Enterprise applications**.
+4. Under **Security**, select **Consent and permissions**.
 Under **Admin consent requests**,  select **Yes** for **Users can request admin consent to apps they are unable to consent to** .
-   :::image type="content" source="media/configure-admin-consent-workflow/enable-admin-consent-workflow.png" alt-text="Configure admin consent workflow settings":::
-1. Configure the following settings:
+   ![Configure admin consent workflow settings](./media/configure-admin-consent-workflow/enable-admin-consent-workflow.png)
+   
+5. Configure the following settings:
 
    - **Select users, groups, or roles that will be designated as reviewers for admin consent requests** - Reviewers can view, block, or deny admin consent requests, but only global administrators can approve admin consent requests. People designated as reviewers can view incoming requests in the **My Pending** tab after they have been set as reviewers. Any new reviewers won't be able to act on existing or expired admin consent requests.
    - **Selected users will receive email notifications for requests** - Enable or disable email notifications to the reviewers when a request is made.  
-   - **Selected users will receive request expiration reminders** - Enable or disable reminder email notifications to the reviewers when a request is about to expire.  
+   - **Selected users will receive request expiration reminders** - Enable or disable reminder email notifications to the reviewers when a request is about to expire.
    - **Consent request expires after (days)** - Specify how long requests stay valid.
-1. Select **Save**. It can take up to an hour for the workflow to become enabled.
 
-> [!NOTE]
-> You can add or remove reviewers for this workflow by modifying the **Select admin consent requests reviewers** list. A current limitation of this feature is that a reviewer can retain the ability to review requests that were made while they were designated as a reviewer.
+6. Select **Save**. It can take up to an hour for the workflow to become enabled.
+
+ > [!NOTE]
+ > You can add or remove reviewers for this workflow by modifying the **Select admin consent requests reviewers** list. A current limitation of this feature is that a reviewer can retain the ability to review requests that were made while they were designated as a reviewer.
 
 ## Configure the admin consent workflow using Microsoft Graph
 

--- a/articles/active-directory/manage-apps/configure-admin-consent-workflow.md
+++ b/articles/active-directory/manage-apps/configure-admin-consent-workflow.md
@@ -36,20 +36,22 @@ To configure the admin consent workflow, you need:
 To enable the admin consent workflow and choose reviewers:
 
 1. Sign-in to the [Azure portal](https://portal.azure.com)  with one of the roles listed in the prerequisites.
-2. Search for and select **Azure Active Directory**.
-3. Select **Enterprise applications**.
-4. Under **Security**, select **Consent and permissions**.
+1. Search for and select **Azure Active Directory**.
+1. Select **Enterprise applications**.
+1. Under **Security**, select **Consent and permissions**.
+1. Under **Manage**, select **Admin consent settings**.
 Under **Admin consent requests**,  select **Yes** for **Users can request admin consent to apps they are unable to consent to** .
-   ![Configure admin consent workflow settings](./media/configure-admin-consent-workflow/enable-admin-consent-workflow.png)
+
+   ![Screenshot of configure admin consent workflow settings.](./media/configure-admin-consent-workflow/enable-admin-consent-workflow.png)
    
-5. Configure the following settings:
+1. Configure the following settings:
 
    - **Select users, groups, or roles that will be designated as reviewers for admin consent requests** - Reviewers can view, block, or deny admin consent requests, but only global administrators can approve admin consent requests. People designated as reviewers can view incoming requests in the **My Pending** tab after they have been set as reviewers. Any new reviewers won't be able to act on existing or expired admin consent requests.
    - **Selected users will receive email notifications for requests** - Enable or disable email notifications to the reviewers when a request is made.  
    - **Selected users will receive request expiration reminders** - Enable or disable reminder email notifications to the reviewers when a request is about to expire.
    - **Consent request expires after (days)** - Specify how long requests stay valid.
 
-6. Select **Save**. It can take up to an hour for the workflow to become enabled.
+1. Select **Save**. It can take up to an hour for the workflow to become enabled.
 
  > [!NOTE]
  > You can add or remove reviewers for this workflow by modifying the **Select admin consent requests reviewers** list. A current limitation of this feature is that a reviewer can retain the ability to review requests that were made while they were designated as a reviewer.


### PR DESCRIPTION
Admin and user consents have changed place, going to a new blade on Security section. Updated tag for image in the right "gitHub" format. NOTE is not displaying with pink background and I don't know why, when doing PREVIEW mode of current doc. It happens also with IMPORTANT areas in blue !!!