### PR TITLE
Update the version of csi driver

### DIFF
--- a/articles/openshift/howto-use-key-vault-secrets.md
+++ b/articles/openshift/howto-use-key-vault-secrets.md
@@ -1,5 +1,5 @@
 ---
-title: Use Azure Key Vault Provider for Secrets Store CSI Driver on Azure Red Hat OpenShift a
+title: Use Azure Key Vault Provider for Secrets Store CSI Driver on Azure Red Hat OpenShift
 description: This article explains how to use Azure Key Vault Provider for Secrets Store CSI Driver on Azure Red Hat OpenShift.
 author: johnmarco
 ms.author: johnmarc

--- a/articles/openshift/howto-use-key-vault-secrets.md
+++ b/articles/openshift/howto-use-key-vault-secrets.md
@@ -1,5 +1,5 @@
 ---
-title: Use Azure Key Vault Provider for Secrets Store CSI Driver on Azure Red Hat OpenShift 
+title: Use Azure Key Vault Provider for Secrets Store CSI Driver on Azure Red Hat OpenShift a
 description: This article explains how to use Azure Key Vault Provider for Secrets Store CSI Driver on Azure Red Hat OpenShift.
 author: johnmarco
 ms.author: johnmarc
@@ -68,7 +68,7 @@ export AZ_TENANT_ID=$(az account show -o tsv --query tenantId)
     ```
     helm install -n k8s-secrets-store-csi csi-secrets-store \
        secrets-store-csi-driver/secrets-store-csi-driver \
-       --version v1.0.1 \
+       --version v1.3.1 \
        --set "linux.providersDir=/var/run/secrets-store-csi-providers"
     ```
     Optionally, you can enable autorotation of secrets by adding the following parameters to the command above:
@@ -111,7 +111,7 @@ export AZ_TENANT_ID=$(az account show -o tsv --query tenantId)
        csi-secrets-store-provider-azure/csi-secrets-store-provider-azure \
        --set linux.privileged=true --set secrets-store-csi-driver.install=false \
        --set "linux.providersDir=/var/run/secrets-store-csi-providers" \
-       --version=v1.0.1
+       --version=v1.4.1
     ```
 
 1. Set SecurityContextConstraints to allow the CSI driver to run:
@@ -295,6 +295,7 @@ Uninstall the Key Vault Provider and the CSI Driver.
 
     ```
     helm uninstall -n k8s-secrets-store-csi csi-secrets-store
+    oc delete project k8s-secrets-store-csi
     ```
 
 1. Delete the SecurityContextConstraints:


### PR DESCRIPTION
I tested the latest version of both helm charts and it is working with the latest version.

 https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v1.3.1/charts/secrets-store-csi-driver/Chart.yaml
  ```
helm upgrade -n k8s-secrets-store-csi csi-secrets-store \
     secrets-store-csi-driver/secrets-store-csi-driver \
     --version v1.3.1 \
     --set "linux.providersDir=/var/run/secrets-store-csi-providers" --set "syncSecret.enabled=true" --set "enableSecretRotation=true"

```
https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/v1.4.0/charts/csi-secrets-store-provider-azure/README.md
```
helm upgrade -n k8s-secrets-store-csi azure-csi-provider \
   csi-secrets-store-provider-azure/csi-secrets-store-provider-azure \
   --set linux.privileged=true --set secrets-store-csi-driver.install=false \
   --set "linux.providersDir=/var/run/secrets-store-csi-providers" \
   --version=v1.4.0
```

also i added to remove the namespace used for the csi driver.