### PR TITLE
Remove sleep command from deployment file

### DIFF
--- a/articles/aks/csi-secrets-store-identity-access.md
+++ b/articles/aks/csi-secrets-store-identity-access.md
@@ -135,9 +135,6 @@ Azure AD workload identity (preview) is supported on both Windows and Linux clus
       containers:
         - name: busybox
           image: k8s.gcr.io/e2e-test-images/busybox:1.29-1
-          command:
-            - "/bin/sleep"
-            - "10000"
           volumeMounts:
           - name: secrets-store01-inline
             mountPath: "/mnt/secrets-store"


### PR DESCRIPTION
By having sleep command by default causes an issue of pod missing logs as pods aren't in active status due to sleep command.