### PR TITLE
Update create-self-hosted-integration-runtime.md

### DIFF
--- a/articles/data-factory/create-self-hosted-integration-runtime.md
+++ b/articles/data-factory/create-self-hosted-integration-runtime.md
@@ -75,7 +75,7 @@ Installation of the self-hosted integration runtime on a domain controller isn't
 - Copy-activity runs happen with a specific frequency. Processor and RAM usage on the machine follows the same pattern with peak and idle times. Resource usage also depends heavily on the amount of data that is moved. When multiple copy jobs are in progress, you see resource usage go up during peak times.
 - Tasks might fail during extraction of data in Parquet, ORC, or Avro formats. For more on Parquet, see [Parquet format in Azure Data Factory](./format-parquet.md#using-self-hosted-integration-runtime). File creation runs on the self-hosted integration machine. To work as expected, file creation requires the following prerequisites:
   - [Visual C++ 2010 Redistributable](https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe) Package (x64)
-  - Java Runtime (JRE) version 8 from a JRE provider such as [Adopt OpenJDK](https://adoptopenjdk.net/). Ensure that the JAVA_HOME environment variable is set to the JDK folder (and not just the JRE folder).
+  - Java Runtime (JRE) version 8 from a JRE provider such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=8). Ensure that the JAVA_HOME environment variable is set to the JDK folder (and not just the JRE folder).
   >[!NOTE]
   >It might be necessary to adjust the Java settings if memory errors occur, as described in the [Parquet format](./format-parquet.md#using-self-hosted-integration-runtime) documentation.
   


### PR DESCRIPTION
it looks like the adoptopenjdk has moved to eclipse the new link is here: https://adoptium.net/temurin/releases/?version=8

I would suggest adding a note that the JDK version will not work a JRE Version is required

 I believe it needs to be a version 8 release not a higher release such as 11 (this should be validated with the dev team)

More info here: 
https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/