### PR TITLE
Windows Provisoning agent minimum OS required

### DIFF
--- a/articles/virtual-machines/extensions/agent-windows.md
+++ b/articles/virtual-machines/extensions/agent-windows.md
@@ -66,7 +66,7 @@ $vm | Update-AzVM
 
 ### Prerequisites
 
-- The Windows VM Agent needs at least Windows Server 2008 SP2 (64-bit) to run, with the .NET Framework 4.0. See [Minimum version support for virtual machine agents in Azure](https://support.microsoft.com/help/4049215/extensions-and-virtual-machine-agent-minimum-version-support).
+- The Windows VM Agent needs at least Windows Server 2008 R2 (64-bit) to run, with the .NET Framework 4.0. See [Minimum version support for virtual machine agents in Azure](https://support.microsoft.com/help/4049215/extensions-and-virtual-machine-agent-minimum-version-support).
 
 - Ensure your VM has access to IP address 168.63.129.16. For more information, see [What is IP address 168.63.129.16](../../virtual-network/what-is-ip-address-168-63-129-16.md).
 


### PR DESCRIPTION
The documentation currently says that the Windows VM Agent needs at least Windows Server 2008 SP2 but Windows Provisioning agent doesn't support lower than Windows Server 2008 R2. Proposing a change to make this accurate.

We have had customers file ICMs against this quoting this documentation.