### PR TITLE
Update storage-quickstart-blobs-cli.md

### DIFF
--- a/articles/storage/blobs/storage-quickstart-blobs-cli.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-cli.md
@@ -115,6 +115,8 @@ az storage blob upload \
 
 This operation creates the blob if it doesn't already exist, and overwrites it if it does. Upload as many files as you like before continuing.
 
+++When you upload a blob using AZ CLI, AZ CLI issues respective REST API calls: https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api via http and https protocols. 
+
 To upload multiple files at the same time, you can use the [az storage blob upload-batch](/cli/azure/storage/blob) command.
 
 ## List the blobs in a container

--- a/articles/storage/blobs/storage-quickstart-blobs-cli.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-cli.md
@@ -115,7 +115,7 @@ az storage blob upload \
 
 This operation creates the blob if it doesn't already exist, and overwrites it if it does. Upload as many files as you like before continuing.
 
-++When you upload a blob using AZ CLI, AZ CLI issues respective REST API calls: https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api via http and https protocols. 
+When you upload a blob using the Azure CLI, it issues respective [REST API calls](/rest/api/storageservices/blob-service-rest-api) via http and https protocols. 
 
 To upload multiple files at the same time, you can use the [az storage blob upload-batch](/cli/azure/storage/blob) command.
 


### PR DESCRIPTION
Update the content in the document to include the protocols used for uploading the blob to Storage account through AZ CLI 

Added the line 118 When you upload a blob using AZ CLI, AZ CLI issues respective REST API calls: https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-rest-api via http and https protocols.