### PR TITLE
VSCode Bicep Extension does not install Bicep CLI

### DIFF
--- a/articles/azure-resource-manager/bicep/install.md
+++ b/articles/azure-resource-manager/bicep/install.md
@@ -16,7 +16,7 @@ Let's make sure your environment is set up for working with Bicep files. To auth
 |  | [Visual Studio and Bicep extension](#visual-studio-and-bicep-extension) | automatic |
 | Deploy | [Azure CLI](#azure-cli) | automatic |
 |  | [Azure PowerShell](#azure-powershell) | [manual](#install-manually) |
-|  | [VS Code and Bicep extension](#vs-code-and-bicep-extension) | automatic |
+|  | [VS Code and Bicep extension](#vs-code-and-bicep-extension) | [manual](#install-manually) |
 |  | [Air-gapped cloud](#install-on-air-gapped-cloud) | download |
 
 ## VS Code and Bicep extension


### PR DESCRIPTION
I have just tested this. Installing the VSCode Bicep Extension installs the Language Server which is for authoring bicep files, it does not install the Bicep CLI as stated in the table at the top.