### PR TITLE
Update access-api.md

### DIFF
--- a/articles/azure-monitor/logs/api/access-api.md
+++ b/articles/azure-monitor/logs/api/access-api.md
@@ -118,7 +118,7 @@ Use the `https://api.loganalytics.azure.com` endpoint.
 ##### Client Credentials Token URL (POST request)
 
 ```http
-    POST /<your-tenant-id>/oauth2/v2.0/token
+    POST /<your-tenant-id>/oauth2/token
     Host: https://login.microsoftonline.com
     Content-Type: application/x-www-form-urlencoded
     


### PR DESCRIPTION
The client credentials flow sample provided calls AAD's v2.0 endpoint passing a resource parameter - this is not supported an will lead to an error. A proposed solution is to either call the v1 endpoint or call the v2 endpoint passing a scope parameter instead (whichever is supported by the API):

Solution 1: 

##### Client Credentials Token URL (POST request)

```http
    POST /<your-tenant-id>/oauth2/token
    Host: https://login.microsoftonline.com
    Content-Type: application/x-www-form-urlencoded
    
    grant_type=client_credentials
    &client_id=<app-client-id>
    &resource=https://api.loganalytics.io
    &client_secret=<app-client-secret>
```

Solution 2: 
##### Client Credentials Token URL (POST request)

```http
    POST /<your-tenant-id>/oauth2/v2.0/token
    Host: https://login.microsoftonline.com
    Content-Type: application/x-www-form-urlencoded
    
    grant_type=client_credentials
    &client_id=<app-client-id>
    &scope=https://api.loganalytics.io/.default
    &client_secret=<app-client-secret>
```