### PR TITLE
Fix typo in `dcv3-series.md`

### DIFF
--- a/articles/virtual-machines/dcv3-series.md
+++ b/articles/virtual-machines/dcv3-series.md
@@ -18,7 +18,7 @@ The DCsv3 and DCdsv3-series Azure Virtual Machines help protect the confidential
 
 These machines are powered by the latest 3rd Generation Intel&reg; Xeon Scalable processors, and use Intel&reg; Turbo Boost Max Technology 3.0 to reach 3.5 GHz. 
 
-With this generation, CPU Cores have increased 6x (up to a maximum of 48 physical cores). Encrypted Memory (EPC) has increased 1500x to 256 GB. Regular Memory has increased 12x to 384 GB. All these changes substantially improve the performance and unlock new entirely new scenarios. 
+With this generation, CPU Cores have increased 6x (up to a maximum of 48 physical cores). Encrypted Memory (EPC) has increased 1500x to 256 GB. Regular Memory has increased 12x to 384 GB. All these changes substantially improve the performance and unlock entirely new scenarios. 
 
 > [!NOTE]
 > Hyperthreading is disabled for added security posture. Pricing is the same as Dv5 and Dsv5-series per physical core.


### PR DESCRIPTION
Remove typo from the dcv3-series description.