### PR TITLE
Update cognitive-search-skill-entity-recognition-v3.md

### DIFF
--- a/articles/search/cognitive-search-skill-entity-recognition-v3.md
+++ b/articles/search/cognitive-search-skill-entity-recognition-v3.md
@@ -23,7 +23,7 @@ The **Entity Recognition** skill (v3) extracts entities of different types from 
 Microsoft.Skills.Text.V3.EntityRecognitionSkill
 
 ## Data limits
-The maximum size of a record should be 50,000 characters as measured by [`String.Length`](/dotnet/api/system.string.length). If you need to break up your data before sending it to the EntityRecognition skill, consider using the [Text Split skill](cognitive-search-skill-textsplit.md).
+The maximum size of a record should be 50,000 characters as measured by [`String.Length`](/dotnet/api/system.string.length). If you need to break up your data before sending it to the EntityRecognition skill, consider using the [Text Split skill](cognitive-search-skill-textsplit.md). When using a split skill, set the page length to 5000 for the best performance.
 
 ## Skill parameters
 


### PR DESCRIPTION
Added additional clarity that they should be using a page length of 5000 for best performance with the split skill.