### PR TITLE
updated iod-edge reported properties docs

### DIFF
--- a/articles/iot-edge/module-edgeagent-edgehub.md
+++ b/articles/iot-edge/module-edgeagent-edgehub.md
@@ -34,19 +34,20 @@ The module twin for the IoT Edge agent is called `$edgeAgent` and coordinates th
 | runtime.type | Has to be "docker" | Yes |
 | runtime.settings.minDockerVersion | Set to the minimum Docker version required by this deployment manifest | Yes |
 | runtime.settings.loggingOptions | A stringified JSON containing the logging options for the IoT Edge agent container. [Docker logging options](https://docs.docker.com/engine/admin/logging/overview/) | No |
-| runtime.settings.registryCredentials<br>.{registryId}.username | The username of the container registry. For Azure Container Registry, the username is usually the registry name.<br><br> Registry credentials are necessary for any private module images. | No |
-| runtime.settings.registryCredentials<br>.{registryId}.password | The password for the container registry. | No |
-| runtime.settings.registryCredentials<br>.{registryId}.address | The address of the container registry. For Azure Container Registry, the address is usually *{registry name}.azurecr.io*. | No |  
+| runtime.settings.registryCredentials.{registryId}.username | The username of the container registry. For Azure Container Registry, the username is usually the registry name.<br><br>Registry credentials are necessary for any private module images. | No |
+| runtime.settings.registryCredentials.{registryId}.password | The password for the container registry. | No |
+| runtime.settings.registryCredentials.{registryId}.address | The address of the container registry. For Azure Container Registry, the address is usually *{registry name}.azurecr.io*. | No |  
 | systemModules.edgeAgent.type | Has to be "docker" | Yes |
+| systemModules.edgeAgent.startupOrder | An integer value for which spot a module has in the startup order. 0 is first and max integer (4294967295) is last. If a value isn't provided, the default is max integer.  | No |
 | systemModules.edgeAgent.settings.image | The URI of the image of the IoT Edge agent. Currently, the IoT Edge agent isn't able to update itself. | Yes |
-| systemModules.edgeAgent.settings<br>.createOptions | A stringified JSON containing the options for the creation of the IoT Edge agent container. [Docker create options](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate) | No |
+| systemModules.edgeAgent.settings.createOptions | A stringified JSON containing the options for the creation of the IoT Edge agent container. [Docker create options](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate) | No |
 | systemModules.edgeAgent.configuration.id | The ID of the deployment that deployed this module. | IoT Hub sets this property when the manifest is applied using a deployment. Not part of a deployment manifest. |
 | systemModules.edgeHub.type | Has to be "docker" | Yes |
 | systemModules.edgeHub.status | Has to be "running" | Yes |
 | systemModules.edgeHub.restartPolicy | Has to be "always" | Yes |
 | systemModules.edgeHub.startupOrder | An integer value for which spot a module has in the startup order. 0 is first and max integer (4294967295) is last. If a value isn't provided, the default is max integer.  | No |
 | systemModules.edgeHub.settings.image | The URI of the image of the IoT Edge hub. | Yes |
-| systemModules.edgeHub.settings<br>.createOptions | A stringified JSON containing the options for the creation of the IoT Edge hub container. [Docker create options](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate) | No |
+| systemModules.edgeHub.settings.createOptions | A stringified JSON containing the options for the creation of the IoT Edge hub container. [Docker create options](https://docs.docker.com/engine/api/v1.32/#operation/ContainerCreate) | No |
 | systemModules.edgeHub.configuration.id | The ID of the deployment that deployed this module. | IoT Hub sets this property when the manifest is applied using a deployment. Not part of a deployment manifest. |
 | modules.{moduleId}.version | A user-defined string representing the version of this module. | Yes |
 | modules.{moduleId}.type | Has to be "docker" | Yes |
@@ -83,17 +84,20 @@ The following table does not include the information that is copied from the des
 | runtime.platform.architecture | Reporting the architecture of the CPU on the device |
 | systemModules.edgeAgent.runtimeStatus | The reported status of IoT Edge agent: {"running" \| "unhealthy"} |
 | systemModules.edgeAgent.statusDescription | Text description of the reported status of the IoT Edge agent. |
+| systemModules.edgeAgent.exitCode | The exit code reported by the IoT Edge agent container if the container exits |
+| systemModules.edgeAgent.lastStartTimeUtc | Time when IoT Edge agent was last started |
+| systemModules.edgeAgent.lastExitTimeUtc | Time when IoT Edge agent last exited |
 | systemModules.edgeHub.runtimeStatus | Status of IoT Edge hub: { "running" \| "stopped" \| "failed" \| "backoff" \| "unhealthy" } |
 | systemModules.edgeHub.statusDescription | Text description of the status of IoT Edge hub if unhealthy. |
 | systemModules.edgeHub.exitCode | The exit code reported by the IoT Edge hub container if the container exits |
-| systemModules.edgeHub.startTimeUtc | Time when IoT Edge hub was last started |
+| systemModules.edgeHub.lastStartTimeUtc | Time when IoT Edge hub was last started |
 | systemModules.edgeHub.lastExitTimeUtc | Time when IoT Edge hub last exited |
 | systemModules.edgeHub.lastRestartTimeUtc | Time when IoT Edge hub was last restarted |
 | systemModules.edgeHub.restartCount | Number of times this module was restarted as part of the restart policy. |
 | modules.{moduleId}.runtimeStatus | Status of the module: { "running" \| "stopped" \| "failed" \| "backoff" \| "unhealthy" } |
 | modules.{moduleId}.statusDescription | Text description of the status of the module if unhealthy. |
 | modules.{moduleId}.exitCode | The exit code reported by the module container if the container exits |
-| modules.{moduleId}.startTimeUtc | Time when the module was last started |
+| modules.{moduleId}.lastStartTimeUtc | Time when the module was last started |
 | modules.{moduleId}.lastExitTimeUtc | Time when the module last exited |
 | modules.{moduleId}.lastRestartTimeUtc | Time when the module was last restarted |
 | modules.{moduleId}.restartCount | Number of times this module was restarted as part of the restart policy. |


### PR DESCRIPTION
The iod-edge reported properties docs seems to be not completely up-to-date. If I query the device twin via Azure Portal > IoT Hub > Queries with a statement like the below one, I see the "real" reported properties:

`SELECT * FROM devices.modules WHERE moduleId in ['$edgeAgent'] and deviceId in ['...']`

I updated everything I think was wrong, but I am not sure if really everything is reflected now. Would be great if somebody could verify this (and extend the changes if needed).

E.g. I see that systemModules.edgeAgent and systemModules.edgeHub also reports the env variables what is not reflected in the docs. Also I see that e.g. the settings part also reports an imageHash property what is neither reflected in the docs ...