### PR TITLE
Fix incorrect link in rendered docs (`aks/use-node-public-ips`)

### DIFF
--- a/articles/aks/use-node-public-ips.md
+++ b/articles/aks/use-node-public-ips.md
@@ -73,7 +73,7 @@ az vmss list-instance-public-ips -g MC_MyResourceGroup2_MyManagedCluster_eastus 
 
 ## Use public IP tags on node public IPs (PREVIEW)
 
-Public IP tags can be utilized on node public IPs to utilize the [Azure Routing Preference](/azure/virtual-network/ip-services/routing-preference-overview.md) feature.
+Public IP tags can be utilized on node public IPs to utilize the [Azure Routing Preference](/azure/virtual-network/ip-services/routing-preference-overview) feature.
 
 [!INCLUDE [preview features callout](includes/preview/preview-callout.md)]
 


### PR DESCRIPTION
The link contains a `.md` extension, producing an invalid hyperlink on the rendered page ([here](https://learn.microsoft.com/en-us/azure/aks/use-node-public-ips#use-public-ip-tags-on-node-public-ips-preview)).

Have only fixed the initial instance I saw, but may be worth scanning the repo/running a markdown linter to catch other instances.