### PR TITLE
Updating the upper limits for telemetry and property based queries

### DIFF
--- a/articles/iot-central/core/howto-query-with-rest-api.md
+++ b/articles/iot-central/core/howto-query-with-rest-api.md
@@ -126,7 +126,7 @@ The following limits apply in the `SELECT` clause:
 - There's no wildcard operator.
 - You can't have more than 15 items in the select list.
 - In a single query, you either select telemetry or properties but not both. A property query can include both reported properties and cloud properties.
-- A property based query will return a maximum of 1,000 records. And a telemetry data based query can return up to 10,000 records.  
+- A property-based query will return a maximum of 1,000 records. A telemetry data-based query can return up to 10,000 records.  
 
 ### Aliases
 
@@ -172,7 +172,7 @@ Use the `TOP` to limit the number of results the query returns. For example, the
 }
 ```
 
-If you don't use `TOP`, the query returns a maximum of 10,000 results for telemetry data based query and 1,000 for property based query.
+If you don't use `TOP`, the query returns a maximum of 10,000 results for a telemetry data-based query and 1,000 for a property-based query.
 
 To sort the results before `TOP` limits the number of results, use [ORDER BY](#order-by-clause).
 
@@ -237,7 +237,7 @@ The following limits apply in the `WHERE` clause:
 - You can use a maximum of 10 operators in a single query.
 - In a telemetry query, the `WHERE` clause can only contain telemetry and device metadata filters.
 - In a property query, the `WHERE` clause can only contain reported properties, cloud properties, and device metadata filters.
-- In a telemetry query, you can retrieve up to 10,000 records. And in property query, you can retrieve up to 1,000 records. 
+- In a telemetry query, you can retrieve up to 10,000 records. In property query, you can retrieve up to 1,000 records. 
 
 ## Aggregations and GROUP BY clause
 
@@ -302,8 +302,8 @@ The current limits for queries are:
 - Queries return a maximum of 10,000 records.
 - The maximum length of a query string is 350 characters.
 - You can't use the wildcard (`*`) in the `SELECT` clause list.
-- Telemetry based query can retrieve up to 10,000 records. 
-- Property based query can retrieve up to 1,000 records. 
+- Telemetry-based query can retrieve up to 10,000 records. 
+- Property-based query can retrieve up to 1,000 records. 
 
 ## Next steps
 

--- a/articles/iot-central/core/howto-query-with-rest-api.md
+++ b/articles/iot-central/core/howto-query-with-rest-api.md
@@ -126,6 +126,7 @@ The following limits apply in the `SELECT` clause:
 - There's no wildcard operator.
 - You can't have more than 15 items in the select list.
 - In a single query, you either select telemetry or properties but not both. A property query can include both reported properties and cloud properties.
+- A property based query will return a maximum of 1,000 records. And a telemetry data based query can return up to 10,000 records.  
 
 ### Aliases
 
@@ -171,7 +172,7 @@ Use the `TOP` to limit the number of results the query returns. For example, the
 }
 ```
 
-If you don't use `TOP`, the query returns a maximum of 10,000 results.
+If you don't use `TOP`, the query returns a maximum of 10,000 results for telemetry data based query and 1,000 for property based query.
 
 To sort the results before `TOP` limits the number of results, use [ORDER BY](#order-by-clause).
 
@@ -236,6 +237,7 @@ The following limits apply in the `WHERE` clause:
 - You can use a maximum of 10 operators in a single query.
 - In a telemetry query, the `WHERE` clause can only contain telemetry and device metadata filters.
 - In a property query, the `WHERE` clause can only contain reported properties, cloud properties, and device metadata filters.
+- In a telemetry query, you can retrieve up to 10,000 records. And in property query, you can retrieve up to 1,000 records. 
 
 ## Aggregations and GROUP BY clause
 
@@ -300,6 +302,8 @@ The current limits for queries are:
 - Queries return a maximum of 10,000 records.
 - The maximum length of a query string is 350 characters.
 - You can't use the wildcard (`*`) in the `SELECT` clause list.
+- Telemetry based query can retrieve up to 10,000 records. 
+- Property based query can retrieve up to 1,000 records. 
 
 ## Next steps
 


### PR DESCRIPTION
Updating the article to highlight the following limits: 
- Telemetry based query can retrieve up to 10,000 records. 
- Property based query can retrieve up to 1,000 records.