### PR TITLE
Update storage-how-to-mount-container-linux.md

### DIFF
--- a/articles/storage/blobs/storage-how-to-mount-container-linux.md
+++ b/articles/storage/blobs/storage-how-to-mount-container-linux.md
@@ -120,7 +120,7 @@ containerName mycontainer
 authType Key
 ```
 
-The `accountName` is the name of your storage account, and not the full URL.
+The `accountName` is the name of your storage account, and not the full URL. You need to update `myaccount`, `storageaccesskey`, and `mycontainer` with your storage information. 
 
 Create this file using:
 

--- a/articles/storage/blobs/storage-how-to-mount-container-linux.md
+++ b/articles/storage/blobs/storage-how-to-mount-container-linux.md
@@ -117,6 +117,7 @@ For example, suppose you are authorizing with the account access keys and storin
 accountName myaccount
 accountKey storageaccesskey
 containerName mycontainer
+authType Key
 ```
 
 The `accountName` is the name of your storage account, and not the full URL.


### PR DESCRIPTION
Add "authType Key" to the example of config file. If this line is missing, blobfuse will reports the following error, 

```
Unable to start blobfuse due to a lack of credentials. Please check the readme for valid auth setups.
Unmounting blobfuse.
Unmounted blobfuse successfully.
```
