### PR TITLE
Clarified "when to use" heading for Hybrid Azure AD joined devices.

### DIFF
--- a/articles/active-directory/devices/concept-azure-ad-join-hybrid.md
+++ b/articles/active-directory/devices/concept-azure-ad-join-hybrid.md
@@ -48,7 +48,7 @@ Hybrid Azure AD joined devices require network line of sight to your on-premises
 
 Use Azure AD hybrid joined devices if:
 
-- You support down-level devices running 8.1.
+- You support down-level devices running Windows 8.1, Windows Server 2008/R2, 2012/R2, 2016.
 - You want to continue to use [Group Policy](/mem/configmgr/comanage/faq#my-environment-has-too-many-group-policy-objects-and-legacy-authenticated-apps--do-i-have-to-use-hybrid-azure-ad-) to manage device configuration.
 - You want to continue to use existing imaging solutions to deploy and configure devices.
 - You have Win32 apps deployed to these devices that rely on Active Directory machine authentication.


### PR DESCRIPTION
Hybrid Azure AD is the only option for Windows Server 2008/R2, 2012/R2, 2016. Azure AD Joined (no hybrid) is not supported on these OS.