### PR TITLE
Adding "Gated" description for Read OCR Container

### DIFF
--- a/articles/cognitive-services/cognitive-services-container-support.md
+++ b/articles/cognitive-services/cognitive-services-container-support.md
@@ -72,7 +72,7 @@ Azure Cognitive Services containers provide the following set of Docker containe
 
 | Service |  Container | Description | Availability |
 |--|--|--|--|
-| [Computer Vision][cv-containers] | **Read OCR** ([image](https://hub.docker.com/_/microsoft-azure-cognitive-services-vision-read)) | The Read OCR container allows you to extract printed and handwritten text from images and documents with support for JPEG, PNG, BMP, PDF, and TIFF file formats. For more information, see the [Read API documentation](./computer-vision/overview-ocr.md). | Generally Available. This container can also [run in disconnected environments](containers/disconnected-containers.md). |
+| [Computer Vision][cv-containers] | **Read OCR** ([image](https://hub.docker.com/_/microsoft-azure-cognitive-services-vision-read)) | The Read OCR container allows you to extract printed and handwritten text from images and documents with support for JPEG, PNG, BMP, PDF, and TIFF file formats. For more information, see the [Read API documentation](./computer-vision/overview-ocr.md). | Generally Available. Gated - [request access](https://aka.ms/csgate). <br>This container can also [run in disconnected environments](containers/disconnected-containers.md). |
 | [Spatial Analysis][spa-containers] | **Spatial analysis** ([image](https://hub.docker.com/_/microsoft-azure-cognitive-services-vision-spatial-analysis)) | Analyzes real-time streaming video to understand spatial relationships between people, their movement, and interactions with objects in physical environments. | Preview |
 
 <!--


### PR DESCRIPTION
Adding the description that Read OCR Container needs registration to use.  Currently, there is no explanation of this in the overall containers list, and users are confused by the differences between the following OCR container stand-alone documents.

- Computer Vision 3.2 GA Read OCR container - Azure Cognitive Services | Microsoft Learn https://learn.microsoft.com/en-us/azure/cognitive-services/computer-vision/computer-vision-how-to-install-containers#request-approval-to-run-the-container 

> Install Computer Vision 3.2 GA Read OCR container
> Fill out and submit the [request form](https://aka.ms/csgate) to request approval to run the container. 
