### PR TITLE
Give evidence to users group not used

### DIFF
--- a/articles/active-directory/identity-protection/howto-identity-protection-configure-notifications.md
+++ b/articles/active-directory/identity-protection/howto-identity-protection-configure-notifications.md
@@ -24,7 +24,8 @@ Azure AD Identity Protection sends two types of automated notification emails to
 
 This article provides you with an overview of both notification emails.
 
-We don't support sending emails to users in group-assigned roles.
+   > [!Note]
+   > **We don't support sending emails to users in group-assigned roles.**
 
 ## Users at risk detected email
 


### PR DESCRIPTION
Due to being referenced on community forums several times (usage of user group for IDP mail notifications), it should highlighted for future reference