### PR TITLE
fix latest release version to 2.14.11

### DIFF
--- a/articles/cosmos-db/local-emulator-release-notes.md
+++ b/articles/cosmos-db/local-emulator-release-notes.md
@@ -27,7 +27,7 @@ This article shows the Azure Cosmos DB Emulator released versions and it details
 
 ## Release notes
 
-### `2.14.1` (January 27, 2023)
+### `2.14.11` (January 27, 2023)
 
 - This release updates the Azure Cosmos DB Emulator background services to match the latest online functionality of the Azure Cosmos DB.
 


### PR DESCRIPTION
There is a minor typo in latest release number. Actual release version is 2.14.11 but typed as 2.14.1.

As part of this PR, fixing it.