### PR TITLE
Removed         "use-protectedsettings-for-commandtoexecute-secrets":

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -92,9 +92,6 @@ The following example shows the rules that are available for configuration.
         "use-parent-property": {
           "level": "warning"
         },
-        "use-protectedsettings-for-commandtoexecute-secrets": {
-          "level": "warning"
-        },
         "use-recent-api-versions": {
           "level": "warning"
         },


### PR DESCRIPTION
The linter is giving me errors for the property: use-protectedsettings-for-commandtoexecute-secrets , probably it does not exist anymore and documentation needs to be updated.