### PR TITLE
Update lifecycle-management-policy-configure.md

### DIFF
--- a/articles/storage/blobs/lifecycle-management-policy-configure.md
+++ b/articles/storage/blobs/lifecycle-management-policy-configure.md
@@ -223,6 +223,9 @@ A lifecycle management policy must be read or written in full. Partial updates a
 > [!NOTE]
 > A lifecycle management policy can't change the tier of a blob that uses an encryption scope.
 
+> [Note]
+> There are blobs in this storage account which has soft delete enabled, which means the retention given in the Life cycle management policy with respect to delete blobs will be executed as per the configuration only. However the blobs will be deleted permanently after the soft delete retention expires.
+
 > [!NOTE]
 > The delete action of a lifecycle management policy won't work with any blob in an immutable container. With an immutable policy, objects can be created and read, but not modified or deleted. For more information, see [Store business-critical blob data with immutable storage](./immutable-storage-overview.md).
 


### PR DESCRIPTION
There are a lot of support cases created on this question as customer is not aware of this information and there is no info available on any public documents on the below request as well.

There are blobs in this storage account which has soft delete enabled, which means the retention given in the Life cycle management policy with respect to delete blobs will be executed as per the configuration only. However the blobs will be deleted permanently after the soft delete retention expires.