### PR TITLE
Update TPS value for S1 tier from 10 to 30

### DIFF
--- a/articles/cognitive-services/Computer-vision/how-to/call-read-api.md
+++ b/articles/cognitive-services/Computer-vision/how-to/call-read-api.md
@@ -100,7 +100,7 @@ It returns a JSON response that contains a **status** field with the following p
 You call this operation iteratively until it returns with the **succeeded** value. Use an interval of 1 to 2 seconds to avoid exceeding the requests per second (RPS) rate.
 
 > [!NOTE]
-> The free tier limits the request rate to 20 calls per minute. The paid tier allows 10 requests per second (RPS) that can be increased upon request. Note your Azure resource identfier and region, and open an Azure support ticket or contact your account team to request a higher request per second (RPS) rate.
+> The free tier limits the request rate to 20 calls per minute. The paid tier allows 30 requests per second (RPS) that can be increased upon request. Note your Azure resource identfier and region, and open an Azure support ticket or contact your account team to request a higher request per second (RPS) rate.
 
 When the **status** field has the `succeeded` value, the JSON response contains the extracted text content from your image or document. The JSON response maintains the original line groupings of recognized words. It includes the extracted text lines and their bounding box coordinates. Each text line includes all extracted words with their coordinates and confidence scores.
 


### PR DESCRIPTION
There is the Docs discrepancy. This doc describes TPS value is 10 RPS, but the following FAQ page says that the value is 30 TPS.

- Frequently asked questions - Computer Vision - Azure Cognitive Services | Microsoft Learn https://learn.microsoft.com/en-us/azure/cognitive-services/Computer-vision/FAQ#how-can-i-increase-the-transactions-per-second--tps--allowed-by-the-service-

> The free (S0) tier only allows 20 transactions per minute. Upgrade to **the S1 tier to get up to 30 transactions per second**. 
