### PR TITLE
Update reference to non-existing class

### DIFF
--- a/articles/machine-learning/how-to-identity-based-service-authentication.md
+++ b/articles/machine-learning/how-to-identity-based-service-authentication.md
@@ -251,14 +251,14 @@ The following steps outline how to set up data access with user identity for tra
 
 1. Grant data access and create data store as described above for CLI.
 
-1. Submit a training job with identity parameter set to [azure.ai.ml.UserIdentity](/python/api/azure-ai-ml/azure.ai.ml.useridentity). This parameter setting enables the job to access data on behalf of user submitting the job.
+1. Submit a training job with identity parameter set to [azure.ai.ml.UserIdentityConfiguration](/python/api/azure-ai-ml/azure.ai.ml.useridentityconfiguration). This parameter setting enables the job to access data on behalf of user submitting the job.
 
     ```python
     from azure.ai.ml import command
     from azure.ai.ml.entities import Data, UriReference
     from azure.ai.ml import Input
     from azure.ai.ml.constants import AssetTypes
-    from azure.ai.ml import UserIdentity
+    from azure.ai.ml import UserIdentityConfiguration
     
     # Specify the data location
     my_job_inputs = {
@@ -272,7 +272,7 @@ The following steps outline how to set up data access with user identity for tra
         inputs=my_job_inputs,
         environment="AzureML-sklearn-0.24-ubuntu18.04-py37-cpu:9",
         compute="<my-compute-cluster-name>",
-        identity= UserIdentity() 
+        identity= UserIdentityConfiguration() 
     )
     # submit the command
     returned_job = ml_client.jobs.create_or_update(job)


### PR DESCRIPTION
The python example for using a user identity in Azure Machine Learning jobs referred to class UserIdentity. This class does not exist in the latest version of the python SDK. The correct class to use is UserIdentityConfiguration.