### PR TITLE
Fix ambiguous text

### DIFF
--- a/articles/search/search-lucene-query-architecture.md
+++ b/articles/search/search-lucene-query-architecture.md
@@ -60,7 +60,7 @@ POST /indexes/hotels/docs/search?api-version=2020-06-30
 
 For this request, the search engine does the following operations:
 
-1. Filters out documents where the price is at least $60 and less than $300.
+1. Finds documents where the price is at least $60 and less than $300.
 
 2. Executes the query. In this example, the search query consists of phrases and terms: `"Spacious, air-condition* +\"Ocean view\""` (users typically don't enter punctuation, but including it in the example allows us to explain how analyzers handle it). 
 


### PR DESCRIPTION
To "filter something out" is commonly understood to mean "remove something that you do not want" therefore this sentence could be ambiguous as to whether a $100 hotel will be returned from the index or not.