### PR TITLE
Adding pcmk_delay_max=15 for  fence_azure_arm on Update high-availability-guide-suse-pacemaker.md

### DIFF
--- a/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
+++ b/articles/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker.md
@@ -830,7 +830,7 @@ Make sure to assign the custom role to the service principal at all VM (cluster 
    
    sudo crm configure primitive rsc_st_azure stonith:fence_azure_arm \
    params subscriptionId="<b>subscription ID</b>" resourceGroup="<b>resource group</b>" tenantId="<b>tenant ID</b>" login="<b>application ID</b>" passwd="<b>password</b>" \
-   pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 <b>pcmk_host_map="prod-cl1-0:prod-cl1-0-vm-name;prod-cl1-1:prod-cl1-1-vm-name"</b> \
+   pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 pcmk_delay_max=15 <b>pcmk_host_map="prod-cl1-0:prod-cl1-0-vm-name;prod-cl1-1:prod-cl1-1-vm-name"</b> \
    op monitor interval=3600 timeout=120
    
    sudo crm configure property stonith-timeout=900


### PR DESCRIPTION
The parameter pcmk_delay_max=15 which could avoid the fence of both nodes at the same time is missing as for fence_azure_arm resource. It would be great to have it on the documentation, as there have been already cases of having both nodes fenced at the same time because if absence of this parameter. 