### PR TITLE
stratum 2 option described in refclock is invalid

### DIFF
--- a/articles/virtual-machines/linux/time-sync.md
+++ b/articles/virtual-machines/linux/time-sync.md
@@ -107,7 +107,8 @@ In Linux VMs with Accelerated Networking enabled, you may see multiple PTP devic
 On Ubuntu 19.10 and later versions, Red Hat Enterprise Linux, and CentOS 8.x, [chrony](https://chrony.tuxfamily.org/) is configured to use a PTP source clock. Instead of chrony, older Linux releases use the Network Time Protocol daemon (ntpd), which doesn't support PTP sources. To enable PTP in those releases, chrony must be manually installed and configured (in chrony.conf) by using the following statement:
 
 ```bash
-refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0 stratum 2
+local stratum 2
+refclock PHC /dev/ptp_hyperv poll 3 dpoll -2 offset 0
 ```
 
 If the /dev/ptp_hyperv symlink is available, use it instead of /dev/ptp0 to avoid any confusion with the /dev/ptp device created by the Mellanox mlx5 driver.


### PR DESCRIPTION
If you have that option, chronyd won't start properly.

We could simply add to the configuration file the line: local stratum 2