### PR TITLE
Updating the steps to disconnect the old connector

### DIFF
--- a/articles/sentinel/connect-microsoft-purview.md
+++ b/articles/sentinel/connect-microsoft-purview.md
@@ -80,8 +80,8 @@ To disconnect the Azure Information Protection connector:
 1. In the **Data connectors** blade, in the search bar, type *Azure Information Protection*. 
 1. Select **Azure Information Protection**.
 1. Below the connector description, select **Open connector page**.
-1. Under **Configuration**, select **Connect Azure Information Protection logs**
-2. Click the configured workspace and select **Ok**
+1. Under **Configuration**, select **Connect Azure Information Protection logs**.
+1. Select the configured workspace and select **Ok**.
 
 ## Known issues and limitations
 

--- a/articles/sentinel/connect-microsoft-purview.md
+++ b/articles/sentinel/connect-microsoft-purview.md
@@ -80,7 +80,8 @@ To disconnect the Azure Information Protection connector:
 1. In the **Data connectors** blade, in the search bar, type *Azure Information Protection*. 
 1. Select **Azure Information Protection**.
 1. Below the connector description, select **Open connector page**.
-1. Under **Configuration**, select **Disconnect**.
+1. Under **Configuration**, select **Connect Azure Information Protection logs**
+2. Click the configured workspace and select **Ok**
 
 ## Known issues and limitations
 


### PR DESCRIPTION
The steps in our documentation to disconnect the old AIP connector do not correspond to the actual steps. I changed the documentation in line 83-84 and added the correct steps