### PR TITLE
Update how-to-configure-sign-in-azure-ad-authentication.md

### DIFF
--- a/articles/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication.md
+++ b/articles/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication.md
@@ -62,7 +62,7 @@ ObjectId                             AppId                                Displa
 ```
 
 > [!IMPORTANT]  
-> If you are not a **Global Administrator**, **Tenant Creator**,**Application Owner** you can't proceed past this step.
+> If you are not a **Global Administrator**, **Tenant Creator**, or **Application Owner**, you can't proceed past this step.
 
 ### Create Azure Database for PostgreSQL Flexible Server service principal and grant read access
 

--- a/articles/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication.md
+++ b/articles/postgresql/flexible-server/how-to-configure-sign-in-azure-ad-authentication.md
@@ -62,11 +62,11 @@ ObjectId                             AppId                                Displa
 ```
 
 > [!IMPORTANT]  
-> If you are not a **Global Administrator**, **Privileged Role Administrator**, **Tenant Creator**,**Application Owner** you can't proceed past this step.
+> If you are not a **Global Administrator**, **Tenant Creator**,**Application Owner** you can't proceed past this step.
 
-### Grant read access
+### Create Azure Database for PostgreSQL Flexible Server service principal and grant read access
 
-Grant Azure Database for PostgreSQL - Flexible Server Service Principal read access to a customer tenant to request Graph API tokens for Azure AD validation tasks:
+If the Azure Database for PostgreSQL Flexible Server service principal doesn't exist, the following command creates it and grants it read access to your customer tenant to request Graph API tokens for Azure AD validation tasks:
 
 ```powershell
 New-AzureADServicePrincipal -AppId 5657e26c-cc92-45d9-bc47-9da6cfdb4ed9


### PR DESCRIPTION
The documentation is misleading regarding the read access command. The command really creates/inserts the service principal into the customer tenant. 

Also,  the role **Privileged Role Administrator**  doesn't have the permissions. This was found out in support ticket TrackingID#2301270040005465