### PR TITLE
Unable to add apex domains via Azure DNS

### DIFF
--- a/articles/frontdoor/front-door-how-to-onboard-apex-domain.md
+++ b/articles/frontdoor/front-door-how-to-onboard-apex-domain.md
@@ -35,6 +35,9 @@ Mapping your apex or root domain to your Front Door profile basically requires C
 
 You can use the Azure portal to onboard an apex domain on your Front Door and enable HTTPS on it by associating it with a certificate for TLS termination. Apex domains are also referred as root or naked domains.
 
+> [!NOTE]
+> The following steps only work with Azure Front Door (classic) and Azure CDN from Microsoft (classic).
+
 ::: zone pivot="front-door-standard-premium"
 
 ## Onboard the custom domain to your Front Door


### PR DESCRIPTION
The current instructions for adding an Apex domain only work on the older version of Frontdoor and CDN.  Currently, the Azure DNS service does not recognize the newest version of Azure Front Door and CDN Profiles.   This means they won't show up in the dropdown.  For more information please see https://github.com/MicrosoftDocs/azure-docs/issues/90819