### PR TITLE
Fix bash snippet in "Configure a GitHub Action to create a container instance" article

### DIFF
--- a/articles/container-instances/container-instances-github-action.md
+++ b/articles/container-instances/container-instances-github-action.md
@@ -156,7 +156,7 @@ Update the Azure service principal credentials to allow push and pull access to 
 Get the resource ID of your container registry. Substitute the name of your registry in the following [az acr show][az-acr-show] command:
 
 ```azurecli
-$registryId=$(az acr show \
+registryId=$(az acr show \
   --name <registry-name> \
   --resource-group <resource-group-name> \
   --query id --output tsv)


### PR DESCRIPTION
The terminal snippet for retrieving the registry id incorrectly uses a `$` when assigning the environment variable, which causes some shells (including zsh) to attempt to execute the variable contents. This PR removes that `$` found here: https://learn.microsoft.com/en-us/azure/container-instances/container-instances-github-action?tabs=userlevel#update-for-registry-authentication