### PR TITLE
Fix stale link in aks MSI documentation

### DIFF
--- a/articles/aks/use-managed-identity.md
+++ b/articles/aks/use-managed-identity.md
@@ -57,7 +57,7 @@ AKS uses several managed identities for built-in services and add-ons.
 | Add-on | Ingress application gateway | Manages required network resources| Contributor role for node resource group | No
 | Add-on | omsagent | Used to send AKS metrics to Azure Monitor | Monitoring Metrics Publisher role | No
 | Add-on | Virtual-Node (ACIConnector) | Manages required network resources for Azure Container Instances (ACI) | Contributor role for node resource group | No
-| OSS project | aad-pod-identity | Enables applications to access cloud resources securely with Microsoft Azure Active Directory (Azure AD) | NA | Steps to grant permission at https://github.com/Azure/aad-pod-identity#role-assignment.
+| OSS project | aad-pod-identity | Enables applications to access cloud resources securely with Microsoft Azure Active Directory (Azure AD) | NA | Steps to grant permission at https://azure.github.io/aad-pod-identity/docs/getting-started/role-assignment/.
 
 ## Create an AKS cluster using a managed identity
 


### PR DESCRIPTION
Fix a stale link in the AKS MSI documentation to point to the correct resource.