### PR TITLE
HTTPS Only should be enabled if Easy Auth is used

### DIFF
--- a/articles/azure-functions/functions-bindings-warmup.md
+++ b/articles/azure-functions/functions-bindings-warmup.md
@@ -22,6 +22,7 @@ The following considerations apply when using a warmup trigger:
 * There can be only one warmup trigger function per function app, and it can't be invoked after the instance is already running.
 * The warmup trigger is only called during scale-out operations, not during restarts or other non-scale startups. Make sure your logic can load all required dependencies without relying on the warmup trigger. Lazy loading is a good pattern to achieve this goal.
 * Dependencies created by warmup trigger should be shared with other functions in your app. To learn more, see [Static clients](manage-connections.md#static-clients).
+* If the [built-in authentication](../app-service/overview-authentication-authorization.md) (aka Easy Auth) is used, [HTTPS Only](../app-service/configure-ssl-bindings.md#enforce-https) should be enabled for the warmup trigger to get invoked.
 
 ## Example
 


### PR DESCRIPTION
If the built-in authentication (aka Easy Auth) is used, but HTTPS Only is disabled, the requests to "/admin/warmup", which originate from within the instance, would be responded to with 302, and the warmup trigger won't be invoked. This is typically not straightforward to figure out. The proposed change clarifies this.

I tested with Windows and Linux Elastic Premium plans, and the observation applies to both.