### PR TITLE
Fixing wrong link to feature coverage for machines

### DIFF
--- a/articles/defender-for-cloud/os-coverage.md
+++ b/articles/defender-for-cloud/os-coverage.md
@@ -34,7 +34,7 @@ Defender for Cloud depends on the [Log Analytics agent](../azure-monitor/agents/
 
 Also ensure your Log Analytics agent is [properly configured to send data to Defender for Cloud](working-with-log-analytics-agent.md#manual-agent)
 
-To learn more about the specific Defender for Cloud features available on Windows and Linux, see [Feature coverage for machines](supported-machines-endpoint-solutions-clouds-containers.md).
+To learn more about the specific Defender for Cloud features available on Windows and Linux, see [Feature coverage for machines](supported-machines-endpoint-solutions-clouds-servers.md).
 
 > [!NOTE]
 > Even though **Microsoft Defender for Servers** is designed to protect servers, most of its features are supported for Windows 10 machines. One feature that isn't currently supported is [Defender for Cloud's integrated EDR solution: Microsoft Defender for Endpoint](integration-defender-for-endpoint.md).


### PR DESCRIPTION
The link was wrongly pointing to Defender for Containers features