### PR TITLE
add resource requests and limits for added stability

### DIFF
--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -168,9 +168,16 @@ spec:
     spec:
       runtimeClassName: wasmtime-slight-v1
       containers:
-        - name: testwasm
+        - name: hello-slight
           image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:latest
           command: ["/"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This change adds resource requests and limits to the slight workload to resolve an issue where the workload would restart in some scenarios on AKS.

I've also change the name of the container from `testwasm` to `hello-slight` which seems a little more informative. The name change to the container does not affect the behavior of the example or subsequent documentation.