### PR TITLE
Adding --generate-ssh-keys as default

### DIFF
--- a/articles/openshift/howto-restrict-egress.md
+++ b/articles/openshift/howto-restrict-egress.md
@@ -174,7 +174,7 @@ VMUSERNAME=aroadmin
 
 az vm create --name ubuntu-jump \
              --resource-group $RESOURCEGROUP \
-             --ssh-key-values ~/.ssh/id_rsa.pub \
+             --generate-ssh-keys \
              --admin-username $VMUSERNAME \
              --image UbuntuLTS \
              --subnet $JUMPSUBNET \


### PR DESCRIPTION
The current command will not work without the rsa, so let's add the --generate-ssh-keys as default for that