### PR TITLE
Clarification on provider name and 2 notes with typical issues

### DIFF
--- a/articles/app-service/configure-authentication-provider-openid-connect.md
+++ b/articles/app-service/configure-authentication-provider-openid-connect.md
@@ -49,11 +49,10 @@ If you are unable to use a configuration metadata document, you will need to gat
 1. Press the **Add** button to finish setting up the identity provider. 
 
 > [!NOTE]
-> The OpenID provider name cannot contain symbols like "-" because an appsetting will be created based this and it does not support it. Use "_" instead.  
+> The OpenID provider name can't contain symbols like "-" because an appsetting will be created based on this and it doesn't support it. Use "_" instead.  
 
 > [!NOTE]
-> Azure requires “openid”, “profile” and “email” scopes, make sure you have configured your App Registration in your ID Provider with at least these scopes.  
->
+> Azure requires "openid," "profile," and "email" scopes. Make sure you've configured your App Registration in your ID Provider with at least these scopes.  
 
 ## <a name="related-content"> </a>Next steps
 

--- a/articles/app-service/configure-authentication-provider-openid-connect.md
+++ b/articles/app-service/configure-authentication-provider-openid-connect.md
@@ -16,7 +16,7 @@ You can configure your app to use one or more OIDC providers. Each must be given
 
 ## <a name="register"> </a>Register your application with the identity provider
 
-Your provider will require you to register the details of your application with it. One of these steps involves specifying a redirect URI. This redirect URI will be of the form `<app-url>/.auth/login/<provider-name>/callback`. Each identity provider should provide more instructions on how to complete these steps.
+Your provider will require you to register the details of your application with it. One of these steps involves specifying a redirect URI. This redirect URI will be of the form `<app-url>/.auth/login/<provider-name>/callback`. Each identity provider should provide more instructions on how to complete these steps. `<provider-name>` will refer to the friendly name you give to the OpenID provider name in Azure.
 
 > [!NOTE]
 > Some providers may require additional steps for their configuration and how to use the values they provide. For example, Apple provides a private key which is not itself used as the OIDC client secret, and you instead must use it craft a JWT which is treated as the secret you provide in your app config (see the "Creating the Client Secret" section of the [Sign in with Apple documentation](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens))
@@ -47,6 +47,13 @@ If you are unable to use a configuration metadata document, you will need to gat
 1. Provide the earlier collected **Client ID** and **Client Secret** in the appropriate fields.
 1. Specify an application setting name for your client secret. Your client secret will be stored as an app setting to ensure secrets are stored in a secure fashion. You can update that setting later to use [Key Vault references](./app-service-key-vault-references.md) if you wish to manage the secret in Azure Key Vault.
 1. Press the **Add** button to finish setting up the identity provider. 
+
+> [!NOTE]
+> The OpenID provider name cannot contain symbols like "-" because an appsetting will be created based this and it does not support it. Use "_" instead.  
+
+> [!NOTE]
+> Azure requires “openid”, “profile” and “email” scopes, make sure you have configured your App Registration in your ID Provider with at least these scopes.  
+>
 
 ## <a name="related-content"> </a>Next steps
 


### PR DESCRIPTION
I added clarification that provider-name will refer to the friendly name you give to the OpenID provider name in Azure.

I also added 2 Notes regarding typical issues that I see when working in Support Cases.  
[!NOTE] The OpenID provider name cannot contain symbols like "-" because an appsetting will be created based on the provider name suggested and it does not support it. Use "_" instead.

[!NOTE] Azure requires “openid”, “profile” and “email” scopes, make sure you have configured your App Registration in your ID Provider with at least thses scopes.