### PR TITLE
Adding back DHE ciphers to TLS1.2

### DIFF
--- a/articles/frontdoor/end-to-end-tls.md
+++ b/articles/frontdoor/end-to-end-tls.md
@@ -109,8 +109,8 @@ For TLS1.2 the following cipher suites are supported:
 * TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 * TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
 * TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+* TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 
 * TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-* TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
 
 > [!NOTE]
 > For Windows 10 and later versions, we recommend enabling one or both of the ECDHE_GCM cipher suites for better security. Windows 8.1, 8, and 7 aren't compatible with these ECDHE_GCM cipher suites. The ECDHE_CBC and DHE cipher suites have been provided for compatibility with those operating systems. 

--- a/articles/frontdoor/end-to-end-tls.md
+++ b/articles/frontdoor/end-to-end-tls.md
@@ -109,9 +109,11 @@ For TLS1.2 the following cipher suites are supported:
 * TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 * TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
 * TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+* TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+* TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
 
 > [!NOTE]
-> For Windows 10 and later versions, we recommend enabling one or both of the ECDHE cipher suites for better security. CBC ciphers are enabled to support Windows 8.1, 8, and 7 operating systems.  The DHE cipher suites are disabled. Hence connections coming from clients supporting only DHE ciphers will result in SSL Handshake failure. Workaround is to enable TLS 1.0 for the Hosts/Domains where clients connect with DHE ciphers. 
+> For Windows 10 and later versions, we recommend enabling one or both of the ECDHE_GCM cipher suites for better security. Windows 8.1, 8, and 7 aren't compatible with these ECDHE_GCM cipher suites. The ECDHE_CBC and DHE cipher suites have been provided for compatibility with those operating systems. 
 
 Using custom domains with TLS1.0/1.1 enabled the following cipher suites are supported:
 


### PR DESCRIPTION
We reverted the change to remove DHE cipher support. So updating the documentation because we now support DHE ciphers.