### PR TITLE
Group optional claims for service principals

### DIFF
--- a/articles/active-directory/develop/active-directory-optional-claims.md
+++ b/articles/active-directory/develop/active-directory-optional-claims.md
@@ -239,6 +239,9 @@ This section covers the configuration options under optional claims for changing
 > [!IMPORTANT]
 > Azure AD limits the number of groups emitted in a token to 150 for SAML assertions and 200 for JWT, including nested groups.  For more information on group limits and important caveats for group claims from on-premises attributes, see [Configure group claims for applications with Azure AD](../hybrid/how-to-connect-fed-group-claims.md).
 
+> [!IMPORTANT]
+> Group optional claims are only emitted in the JWT for user principals. Service principals will not have group optional claims emitted in the JWT.
+
 **Configuring groups optional claims through the UI:**
 
 1. Sign in to the <a href="https://portal.azure.com/" target="_blank">Azure portal</a>.

--- a/articles/active-directory/develop/active-directory-optional-claims.md
+++ b/articles/active-directory/develop/active-directory-optional-claims.md
@@ -234,13 +234,10 @@ Within the SAML tokens, these claims will be emitted with the following URI form
 
 ## Configuring groups optional claims
 
-This section covers the configuration options under optional claims for changing the group attributes used in group claims from the default group objectID to attributes synced from on-premises Windows Active Directory. You can configure groups optional claims for your application through the UI or application manifest.
+This section covers the configuration options under optional claims for changing the group attributes used in group claims from the default group objectID to attributes synced from on-premises Windows Active Directory. You can configure groups optional claims for your application through the UI or application manifest. Group optional claims are only emitted in the JWT for **user principals**. **Service principals** _will not_ have group optional claims emitted in the JWT.
 
 > [!IMPORTANT]
 > Azure AD limits the number of groups emitted in a token to 150 for SAML assertions and 200 for JWT, including nested groups.  For more information on group limits and important caveats for group claims from on-premises attributes, see [Configure group claims for applications with Azure AD](../hybrid/how-to-connect-fed-group-claims.md).
-
-> [!IMPORTANT]
-> Group optional claims are only emitted in the JWT for user principals. Service principals will not have group optional claims emitted in the JWT.
 
 **Configuring groups optional claims through the UI:**
 


### PR DESCRIPTION
Added note that service principals will not have groups claims emitted in JWT.