### PR TITLE
Updated to remove provisioning solution dependency

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-staged-rollout.md
+++ b/articles/active-directory/hybrid/how-to-connect-staged-rollout.md
@@ -57,7 +57,7 @@ For an overview of the feature, view this "Azure Active Directory: What is Stage
 
 The following scenarios are supported for Staged Rollout. The feature works only for:
 
-- Users who are provisioned to Azure AD by using Azure AD Connect. It does not apply to cloud-only users.
+- Users that are federated via an external identity provider (IDP) such as AD FS or a similar third party IDP. It does not apply to managed authentication based users.
 
 - User sign-in traffic on browsers and *modern authentication* clients. Applications or cloud services that use [legacy authentication](../conditional-access/block-legacy-authentication.md) will fall back to federated authentication flows. An example of legacy authentication might be Exchange online with modern authentication turned off, or Outlook 2010, which does not support modern authentication.
 


### PR DESCRIPTION
Some customers use Graph API based provisioning solutions and dont use Azure AD Connect or Cloud Sync. These users can be federated with an external IDP such as AD FS or otherwise and dont store a password in the cloud. Given that they are provisioned via Graph API, one may think these are cloud only users but the authentication still happens at a federated IDP. Alluding to a dependency on Azure AD Connect and Cloud Sync is incorrect and is causing confusion. Any customer that has federated users (regardless of how user account is provisioned to Azure AD) can use staged rollout to move away from federation to other methods (such as cloud based CBA). PHS and PTA are not the only options available to customers when considering staged rollout.