### PR TITLE
Fix typos in cache-web-app-howto.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-web-app-howto.md
+++ b/articles/azure-cache-for-redis/cache-web-app-howto.md
@@ -68,7 +68,7 @@ Because the file *CacheSecrets.config* isn't deployed to Azure with your applica
 
      :::image type="content" source="media/cache-web-app-howto/cache-web-config.png" alt-text="Web.config":::
 
-1. In the *web.config* file, you can how to set the `<appSetting>` element for running the application locally.
+1. In the *web.config* file, you can set the `<appSettings>` element for running the application locally.
 
     `<appSettings file="C:\AppSecrets\CacheSecrets.config">`
 


### PR DESCRIPTION
Resolves #[104829](https://github.com/MicrosoftDocs/azure-docs/issues/104829)

Fix typos in [articles/azure-cache-for-redis/cache-web-app-howto.md](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/azure-cache-for-redis/cache-web-app-howto.md)

Typos:
```
"In the web.config file, you can how to set the <appSetting> element for running the application locally."
```

Fix:
```
"In the web.config file, you can set the <appSettings> element for running the application locally."
```