### PR TITLE
Fix formating of code block

### DIFF
--- a/articles/iot-edge/how-to-vs-code-develop-module.md
+++ b/articles/iot-edge/how-to-vs-code-develop-module.md
@@ -758,8 +758,7 @@ The Docker and Moby engines support SSH connections to containers allowing you t
           "-i",
           "filtermodule",
           "sh",
-         
- "-c"
+          "-c"
         ],
         "debuggerPath": "~/vsdbg/vsdbg",
         "pipeCwd": "${workspaceFolder}",


### PR DESCRIPTION
There was a blank line that broke the code block.
When using the "Copy" function, only the part up to this blank line was copied.