### PR TITLE
The Azure Cosmos DB for NoSQL option is not available

### DIFF
--- a/articles/azure-functions/functions-add-output-binding-cosmos-db-vs-code.md
+++ b/articles/azure-functions/functions-add-output-binding-cosmos-db-vs-code.md
@@ -36,7 +36,7 @@ Before you get started, make sure to install the [Azure Databases extension](htt
 
     |Prompt| Selection|
     |--|--|
-    |**Select an Azure Database Server**| Choose **Azure Cosmos DB for NoSQL** to create a document database that you can query by using a SQL syntax. [Learn more about the Azure Cosmos DB for NoSQL](../cosmos-db/introduction.md). |
+    |**Select an Azure Database Server**| Choose **Core (SQL)** to create a document database that you can query by using a SQL syntax. [Learn more about the Azure Cosmos DB for NoSQL](../cosmos-db/introduction.md). |
     |**Account name**| Enter a unique name to identify your Azure Cosmos DB account. The account name can use only lowercase letters, numbers, and hyphens (-), and must be between 3 and 31 characters long.|
     |**Select a capacity model**| Select **Serverless** to create an account in [serverless](../cosmos-db/serverless.md) mode. 
     |**Select a resource group for new resources**| Choose the resource group where you created your function app in the [previous article](./create-first-function-vs-code-csharp.md). |


### PR DESCRIPTION
I am currently going through this tutorial. In Visual Studio Code, after selecting 'Azure Databse: Create Server...', there is not the option 'Azure Cosmos DB for NoSQL'. But there is the option 'Core (SQL)'. When I select this option, creating a document in Cosmos DB does work.