### PR TITLE
Correct redirecting for "Retrieve image data"

### DIFF
--- a/articles/kinect-dk/index.yml
+++ b/articles/kinect-dk/index.yml
@@ -59,7 +59,7 @@ landingContent:
           - text: Find then open device
             url: find-then-open-device.md
           - text: Retrieve image data
-            url: about-sensor-sdk.md
+            url: retrieve-images.md
           - text: Access microphone
             url: access-mics.md
           - text: Record and playback


### PR DESCRIPTION
Changed redirection for hyperlink "Retrieve image data" from "About Azure Kinect Sensor SDK" to "Retrieve Azure Kinect image data" going accord to the hyperlink text displayed