### PR TITLE
change Note for webspace

### DIFF
--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -24,7 +24,7 @@ The following table lists the options for you to add certificates in App Service
 | Upload a public certificate | Public certificates are not used to secure custom domains, but you can load them into your code if you need them to access remote resources. |
 
 > [!NOTE]
-> After you upload a certificate to an app, the certificate is stored in a deployment unit that's bound to the App Service plan's resource group, region, and operating system combination, internally called a *webspace*. That way, the certificate is accessible to other apps in the same resource group and region combination. Please Note that certificates uploaded or imported to App Service are shared with App Services in the same deployment unit. 
+> After you upload a certificate to an app, the certificate is stored in a deployment unit that's bound to the App Service plan's resource group, region, and operating system combination, internally called a *webspace*. That way, the certificate is accessible to other apps in the same resource group and region combination. Certificates uploaded or imported to App Service are shared with App Services in the same deployment unit. 
 
 ## Prerequisites
 

--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -24,7 +24,7 @@ The following table lists the options for you to add certificates in App Service
 | Upload a public certificate | Public certificates are not used to secure custom domains, but you can load them into your code if you need them to access remote resources. |
 
 > [!NOTE]
-> After you upload a certificate to an app, the certificate is stored in a deployment unit that's bound to the App Service plan's resource group, region, and operating system combination, internally called a *webspace*. That way, the certificate is accessible to other apps in the same resource group and region combination. 
+> After you upload a certificate to an app, the certificate is stored in a deployment unit that's bound to the App Service plan's resource group, region, and operating system combination, internally called a *webspace*. That way, the certificate is accessible to other apps in the same resource group and region combination. Please Note that certificates uploaded or imported to App Service are shared with App Services in the same deployment unit. 
 
 ## Prerequisites
 


### PR DESCRIPTION
Hi

I  added a new note to prevent unintended deletion of certificates in App Service. Some people misunderstand that is is only used by an App Service and remove it when it is no longer needed in the specific App Service. This can cause service impact.  

If you have a better message, please advise.

Thank you