### PR TITLE
Improve Key Vault Private Link Considerations

### DIFF
--- a/articles/spring-apps/tutorial-custom-domain.md
+++ b/articles/spring-apps/tutorial-custom-domain.md
@@ -29,9 +29,35 @@ Certificates encrypt web traffic. These TLS/SSL certificates can be stored in Az
 * A private certificate (that is, your self-signed certificate) from a third-party provider. The certificate must match the domain.
 * A deployed instance of [Azure Key Vault](../key-vault/general/overview.md)
 
-## Keyvault Private Link Considerations
+## Key Vault Private Link Considerations
 
-The Azure Spring Apps management IPs are not yet part of the Azure Trusted Microsoft services. Therefore, to allow Azure Spring Apps to load certificates from a Key Vault protected with Private endpoint connections, you must add the following IPs to Azure Key Vault Firewall: `20.99.204.111, 20.201.9.97, 20.74.97.5, 52.235.25.35, 20.194.10.0, 20.59.204.46, 104.214.186.86, 52.153.221.222, 52.160.137.39, 20.39.142.56, 20.199.190.222, 20.79.64.6, 20.211.128.96, 52.149.104.144, 20.197.121.209, 40.119.175.77, 20.108.108.22, 102.133.143.38, 52.226.244.150, 20.84.171.169, 20.93.48.108, 20.75.4.46, 20.78.29.213, 20.106.86.34, 20.193.151.132`
+The Azure Spring Apps management IPs are not yet part of the Azure Trusted Microsoft services. Therefore, to allow Azure Spring Apps to load certificates from a Key Vault protected with Private endpoint connections, you must add the following IPs to Azure Key Vault Firewall:
+
+* 20.99.204.111
+* 20.201.9.97
+* 20.74.97.5
+* 52.235.25.35
+* 20.194.10.0
+* 20.59.204.46
+* 104.214.186.86
+* 52.153.221.222
+* 52.160.137.39
+* 20.39.142.56
+* 20.199.190.222
+* 20.79.64.6
+* 20.211.128.96
+* 52.149.104.144
+* 20.197.121.209
+* 40.119.175.77
+* 20.108.108.22
+* 102.133.143.38
+* 52.226.244.150
+* 20.84.171.169
+* 20.93.48.108
+* 20.75.4.46
+* 20.78.29.213
+* 20.106.86.34
+* 20.193.151.132
 
 ## Import certificate
 


### PR DESCRIPTION
In the "Key Vault Private Link Considerations" section, the list of IP addresses is quite long and difficult to read.  This update improves the legibility of this section.