### PR TITLE
Clarify Azure Storage Explorer incompatibility with Blob Module

### DIFF
--- a/articles/iot-edge/how-to-store-data-blob.md
+++ b/articles/iot-edge/how-to-store-data-blob.md
@@ -198,6 +198,8 @@ You can use [Azure Storage Explorer](https://azure.microsoft.com/features/storag
 1. Download and install Azure Storage Explorer
 
 1. Connect to Azure Storage using a connection string
+   > [!NOTE]
+   > The latest version of Azure Storage Explorer uses a newer storage API version by default than the blob storage module supports. After Storage Explorer starts, select the Edit menu, and check to see if Target Azure Stack Hub APIs is selected. If it isn't, select Target Azure Stack Hub, and then restart Storage Explorer for the change to take effect. This configuration is required for compatibility with your IoT Edge environment.
 
 1. Provide connection string: `DefaultEndpointsProtocol=http;BlobEndpoint=http://<host device name>:11002/<your local account name>;AccountName=<your local account name>;AccountKey=<your local account key>;`
 

--- a/articles/iot-edge/how-to-store-data-blob.md
+++ b/articles/iot-edge/how-to-store-data-blob.md
@@ -199,7 +199,7 @@ You can use [Azure Storage Explorer](https://azure.microsoft.com/features/storag
 
 1. Connect to Azure Storage using a connection string
    > [!NOTE]
-   > The latest version of Azure Storage Explorer uses a newer storage API version by default than the blob storage module supports. After Storage Explorer starts, select the Edit menu, and check to see if Target Azure Stack Hub APIs is selected. If it isn't, select Target Azure Stack Hub, and then restart Storage Explorer for the change to take effect. This configuration is required for compatibility with your IoT Edge environment.
+1. The latest version of Azure Storage Explorer uses a newer storage API version not supported by the blob storage module. Start Azure Storage Explorer. Select the **Edit** menu. Verify the **Target Azure Stack Hub APIs** is selected. If it isn't, select **Target Azure Stack Hub**. Restart Azure Storage Explorer for the change to take effect. This configuration is required for compatibility with your IoT Edge environment.
 
 1. Provide connection string: `DefaultEndpointsProtocol=http;BlobEndpoint=http://<host device name>:11002/<your local account name>;AccountName=<your local account name>;AccountKey=<your local account key>;`
 

--- a/articles/iot-edge/how-to-store-data-blob.md
+++ b/articles/iot-edge/how-to-store-data-blob.md
@@ -197,9 +197,9 @@ You can use [Azure Storage Explorer](https://azure.microsoft.com/features/storag
 
 1. Download and install Azure Storage Explorer
 
-1. Connect to Azure Storage using a connection string
-   > [!NOTE]
 1. The latest version of Azure Storage Explorer uses a newer storage API version not supported by the blob storage module. Start Azure Storage Explorer. Select the **Edit** menu. Verify the **Target Azure Stack Hub APIs** is selected. If it isn't, select **Target Azure Stack Hub**. Restart Azure Storage Explorer for the change to take effect. This configuration is required for compatibility with your IoT Edge environment.
+
+1. Connect to Azure Storage using a connection string
 
 1. Provide connection string: `DefaultEndpointsProtocol=http;BlobEndpoint=http://<host device name>:11002/<your local account name>;AccountName=<your local account name>;AccountKey=<your local account key>;`
 


### PR DESCRIPTION
Clarify that the latest version of Azure Storage Explorer is incompatible with the latest version of the IoT Edge Blob Storage Module. A configuration change is needed for Azure Storage Explorer to work correctly using an older API version. See [this issue](https://github.com/microsoft/AzureStorageExplorer/issues/6416) for more details.