### PR TITLE
Update AML Private DNS Zone Name (Gov)

### DIFF
--- a/articles/private-link/private-endpoint-dns.md
+++ b/articles/private-link/private-endpoint-dns.md
@@ -145,7 +145,7 @@ For Azure services, use the recommended zone names as described in the following
 | Cognitive Services (Microsoft.CognitiveServices/accounts) / account | privatelink.cognitiveservices.azure.us  | cognitiveservices.azure.us  |
 | Azure Cache for Redis (Microsoft.Cache/Redis) / redisCache | privatelink.redis.cache.usgovcloudapi.net | redis.cache.usgovcloudapi.net |
 | Azure HDInsight (Microsoft.HDInsight) | privatelink.azurehdinsight.us | azurehdinsight.us |
-| Azure Machine Learning (Microsoft.MachineLearningServices/workspaces) / amlworkspace | privatelink.api.azureml.us<br/>privatelink.notebooks.usgovcloudapi.net | api.ml.azure.us<br/>notebooks.usgovcloudapi.net<br/>instances.azureml.us<br/>aznbcontent.net<br/>inference.ml.azure.us |
+| Azure Machine Learning (Microsoft.MachineLearningServices/workspaces) / amlworkspace | privatelink.api.ml.azure.us<br/>privatelink.notebooks.usgovcloudapi.net | api.ml.azure.us<br/>notebooks.usgovcloudapi.net<br/>instances.azureml.us<br/>aznbcontent.net<br/>inference.ml.azure.us |
 
 >[!Note]
 >In the above text, `{region}` refers to the region code (for example, **eus** for East US and **ne** for North Europe). Refer to the following lists for regions codes:


### PR DESCRIPTION
### Description
The Azure Machine Learning private DNS zone name for the US Gov cloud is incorrectly listed as "**privatelink.api.azureml.us**". This DNS zone name results in an AML workspace that cannot be accessed from within a VNET. The correct zone name that worked in our testing is "**privatelink.api.ml.azure.us**". 

### To Reproduce
To reproduce the error, deploy an AML workspace behind a VNET in gov cloud using [this quickstart](https://github.com/Azure/terraform/tree/master/quickstart/201-machine-learning-moderately-secure). The private dns zone names under `network.tf` need to be updated according to the table in this documentation.  The result is an AML workspace that cannot be accessed via the provisioned jumpbox. 

Changing the the private dns zone name to "privatelink.api.ml.azure.us" fixed the networking error and resulted in a correctly provisioned AML workspace behind a VNET in the US Gov cloud. 

### Notes
* There are inconsistencies with the "azureml.xx" and "ml.azure.xx" patterns throughout this documentation. From our testing a deployment to the commercial cloud using "privatelink.api.azureml.ms" is correct. The China cloud is listed as "privatelink.api.ml.azure.cn" - we do not have the ability to verify if this is correct, so **this should be looked at too**.
* The public DNS zone forwarders use both "azureml.xx" and "ml.azure.xx" in various dns names. As we did not use any DNS zone forwarders, we were not able to verify if these were all correct, but **someone should check to ensure these are all correct**.

cc: @jplane @vladmsft @NayanGuptaMicrosoft @erikschlegel