### PR TITLE
Updating the Github action yaml file

### DIFF
--- a/articles/defender-for-cloud/github-action.md
+++ b/articles/defender-for-cloud/github-action.md
@@ -57,39 +57,47 @@ Security DevOps uses the following Open Source tools:
 
     ```yml
     name: MSDO windows-latest
-    on:
-      push:
-        branches: [ main ]
-      pull_request:
-        branches: [ main ]
-      workflow_dispatch:
+on:
+  push:
+    branches:
+      - main
 
-    jobs:
-      sample:
+jobs:
+  sample:
+    name: Microsoft Security DevOps Analysis
 
-        # MSDO runs on windows-latest and ubuntu-latest.
-        # macos-latest supporting coming soon
-        runs-on: windows-latest
+    # MSDO runs on windows-latest.
+    # ubuntu-latest and macos-latest supporting coming soon
+    runs-on: windows-latest
 
-        steps:
-        - uses: actions/checkout@v2
+    steps:
 
-        - uses: actions/setup-dotnet@v1
-          with:
-            dotnet-version: |
-              5.0.x
-              6.0.x
+      # Checkout your code repository to scan
+    - uses: actions/checkout@v3
 
-        # Run analyzers
-        - name: Run Microsoft Security DevOps Analysis
-          uses: microsoft/security-devops-action@preview
-          id: msdo
+      # Install dotnet, used by MSDO
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          5.0.x
+          6.0.x
+      # Run analyzers
+    - name: Run Microsoft Security DevOps Analysis
+      uses: microsoft/security-devops-action@preview
+      id: msdo
 
-        # Upload alerts to the Security tab
-        - name: Upload alerts to Security tab
-          uses: github/codeql-action/upload-sarif@v1
-          with:
-            sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+      # Upload alerts to the Security tab
+    - name: Upload alerts to Security tab
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: ${{ steps.msdo.outputs.sarifFile }}
+
+      # Upload alerts file as a workflow artifact
+    - name: Upload alerts file as a workflow artifact
+      uses: actions/upload-artifact@v3
+      with:  
+        name: alerts
+        path: ${{ steps.msdo.outputs.sarifFile }}
     ```
         
     For details on various input options, see [action.yml](https://github.com/microsoft/security-devops-action/blob/main/action.yml)                


### PR DESCRIPTION
The yaml code in our doc should be the same as the yaml file found at https://github.com/microsoft/security-devops-action/blob/main/.github/workflows/sample-workflow-windows-latest.yml .

Currently the yaml is using old versions: 

uses: actions/checkout@v2

    - uses: actions/setup-dotnet@v1

The Github action does not work with the versions 1 and 2. Instead both of these should be version 3 , as per https://github.com/microsoft/security-devops-action/blob/main/.github/workflows/sample-workflow-windows-latest.yml . What I included in to the pull request in the yaml code is a direct copy paste from https://github.com/microsoft/security-devops-action/blob/main/.github/workflows/sample-workflow-windows-latest.yml , which contains the version 3. Can you please ensure that these versions and other yaml code is up-to-date on this page, or that it's the same as in that other link https://github.com/microsoft/security-devops-action/blob/main/.github/workflows/sample-workflow-windows-latest.yml?

Thanks so much,
Liana