### PR TITLE
Update signalr-howto-troubleshoot-guide.md

### DIFF
--- a/articles/azure-signalr/signalr-howto-troubleshoot-guide.md
+++ b/articles/azure-signalr/signalr-howto-troubleshoot-guide.md
@@ -389,7 +389,7 @@ public class ThreadPoolStarvationDetector : EventListener
     {
         // See: https://learn.microsoft.com/dotnet/framework/performance/thread-pool-etw-events#threadpoolworkerthreadadjustmentadjustment
         if (eventData.EventId == EventIdForThreadPoolWorkerThreadAdjustmentAdjustment &&
-            eventData.Payload[3] as uint? == ReasonForStarvation)
+            eventData.Payload[2] as uint? == ReasonForStarvation)
         {
             _logger.LogWarning("Thread pool starvation detected!");
         }


### PR DESCRIPTION
Was trying this sample and noticed that it was not working.  Checking the official docs https://learn.microsoft.com/en-us/dotnet/framework/performance/thread-pool-etw-events#threadpoolworkerthreadadjustmentadjustment it appears we are inspecting the wrong index.

Can you confirm if my understanding is correct and the change is good? Tested with a .NET 7 app.