### PR TITLE
Update deploy-control-plane.md

### DIFF
--- a/articles/sap/automation/deploy-control-plane.md
+++ b/articles/sap/automation/deploy-control-plane.md
@@ -77,8 +77,6 @@ $region_code="WEEU"
 
 $env:TF_VAR_app_registration_app_id = (az ad app create `
     --display-name $region_code-webapp-registration     `
-    --enable-id-token-issuance true                     `
-    --sign-in-audience AzureADMyOrg                     `
     --required-resource-accesses ./manifest.json        `
     --query "appId").Replace('"',"")
 


### PR DESCRIPTION
Applied fix for [Issue](https://github.com/MicrosoftDocs/azure-docs/issues/105178)


> [Enter feedback here] When we try to run the block of code for [Prepare the web App](https://camo.githubusercontent.com/e013e03739bec78cd8c50ed34cd7ae74bcf3639b9994530333399090b9f17a36/68747470733a2f2f6c6561726e2e6d6963726f736f66742e636f6d2f656e2d75732f617a7572652f7361702f6175746f6d6174696f6e2f6465706c6f792d636f6e74726f6c2d706c616e653f746162733d6c696e757823707265706172652d7468652d776562617070)
> 
> ```shell
> echo '[{"resourceAppId":"00000003-0000-0000-c000-000000000000","resourceAccess":[{"id":"e1fe6dd8-ba31-4d61-89e7-88639da4683d","type":"Scope"}]}]' >> manifest.json
> 
> region_code=WEEU
> 
> export TF_VAR_app_registration_app_id=$(az ad app create \
>     --display-name ${region_code}-webapp-registration \
>     --enable-id-token-issuance true \
>     --sign-in-audience AzureADMyOrg \
>     --required-resource-access @manifest.json \
>     --query "appId" | tr -d '"')
> 
> export TF_VAR_webapp_client_secret=$(az ad app credential reset \
>     --id $TF_VAR_app_registration_app_id --append               \
>     --query "password" | tr -d '"')
> 
> export TF_VAR_use_webapp=true
> rm manifest.json
> ```
> 
> We get failures like this:
> 
> ```shell
> az: error: unrecognized arguments: --enable-id-token-issuance true --sign-in-audience AzureADMyOrg
> ```
> 
> OR
> 
> ```shell
> az: error: unrecognized arguments: --sign-in-audience AzureADMyOrg
> ```
> 
> To solve this, the 2 lines should be removed from the code:
> 
> ```shell
>     --enable-id-token-issuance true \
>     --sign-in-audience AzureADMyOrg \
> ```
> 
> #### Document Details
> ⚠ _Do not edit this section. It is required for learn.microsoft.com ➟ GitHub issue linking._
> 
> * ID: c00bf88e-38bf-eaa8-923a-aaa94c635447
> * Version Independent ID: b27a7fbd-decb-8306-ac46-ea18a6d17e96
> * Content: [About Control Plane deployment for the SAP on Azure Deployment Automation Framework](https://learn.microsoft.com/en-us/azure/sap/automation/deploy-control-plane?tabs=linux)
> * Content Source: [articles/sap/automation/deploy-control-plane.md](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/sap/automation/deploy-control-plane.md)
> * Service: **sap-on-azure**
> * Sub-service: **sap-automation**
> * GitHub Login: @KimForss
> * Microsoft Alias: **kimforss**





[Enter feedback here]
When we try to run the block of code for [Prepare the web App](https://learn.microsoft.com/en-us/azure/sap/automation/deploy-control-plane?tabs=linux#prepare-the-webapp)

```bash
echo '[{"resourceAppId":"00000003-0000-0000-c000-000000000000","resourceAccess":[{"id":"e1fe6dd8-ba31-4d61-89e7-88639da4683d","type":"Scope"}]}]' >> manifest.json

region_code=WEEU

export TF_VAR_app_registration_app_id=$(az ad app create \
    --display-name ${region_code}-webapp-registration \
    --enable-id-token-issuance true \
    --sign-in-audience AzureADMyOrg \
    --required-resource-access @manifest.json \
    --query "appId" | tr -d '"')

export TF_VAR_webapp_client_secret=$(az ad app credential reset \
    --id $TF_VAR_app_registration_app_id --append               \
    --query "password" | tr -d '"')

export TF_VAR_use_webapp=true
rm manifest.json
```

We get failures like this:

```bash
az: error: unrecognized arguments: --enable-id-token-issuance true --sign-in-audience AzureADMyOrg
```

OR

```bash
az: error: unrecognized arguments: --sign-in-audience AzureADMyOrg
```


To solve this, the 2 lines should be removed from the code:

```bash
    --enable-id-token-issuance true \
    --sign-in-audience AzureADMyOrg \
```



