### PR TITLE
Update logs-ingestion-api-overview.md

### DIFF
--- a/articles/azure-monitor/logs/logs-ingestion-api-overview.md
+++ b/articles/azure-monitor/logs/logs-ingestion-api-overview.md
@@ -36,14 +36,15 @@ The Logs Ingestion API can send data to any custom table that you create and to 
 
 ### Built-in tables
 
-The Logs Ingestion API can send data to the following built-in tables. Other tables may be added to this list as support for them is implemented. Columns extended on top of built-in tables must have the suffix `_CF`. Columns in a custom table don't need this suffix. Column names can consist of alphanumeric characters and the characters `_` and `-`, and they must start with a letter. 
+The Logs Ingestion API can send data to the following built-in tables. Other tables may be added to this list as support for them is implemented. Columns extended on top of built-in tables must have the suffix `_CF`. Columns in a custom table don't need this suffix.
 
 - [CommonSecurityLog](/azure/azure-monitor/reference/tables/commonsecuritylog)
 - [SecurityEvents](/azure/azure-monitor/reference/tables/securityevent)
 - [Syslog](/azure/azure-monitor/reference/tables/syslog)
 - [WindowsEvents](/azure/azure-monitor/reference/tables/windowsevent)
 
-
+> [!NOTE]
+> Column names can consist of alphanumeric characters and the characters `_` and `-`, and they must start with a letter. 
 
 ## Authentication
 


### PR DESCRIPTION
We need to make it more explicit that the naming convention (alphanumeric characters and the characters `_` and `-`, and they must start with a letter) also applies to column names of custom tables