### PR TITLE
Fix WebVVT timestamp format

### DIFF
--- a/articles/cognitive-services/Speech-Service/captioning-concepts.md
+++ b/articles/cognitive-services/Speech-Service/captioning-concepts.md
@@ -53,7 +53,7 @@ The [SRT](https://docs.fileformat.com/video/srt/) (SubRip Text) timespan output 
 Welcome to applied Mathematics course 201.
 ```
 
-The [WebVTT](https://www.w3.org/TR/webvtt1/#introduction) (Web Video Text Tracks) timespan output format is `hh:mm:ss,fff`. 
+The [WebVTT](https://www.w3.org/TR/webvtt1/#introduction) (Web Video Text Tracks) timespan output format is `hh:mm:ss.fff`. 
 
 ```
 WEBVTT


### PR DESCRIPTION
According to WebVVT standard milliseconds are separated by full stop character . https://www.w3.org/TR/webvtt1/#webvtt-timestamp