### PR TITLE
Fixing the rule to update the UPN to a new extension

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-sync-change-the-configuration.md
+++ b/articles/active-directory/hybrid/how-to-connect-sync-change-the-configuration.md
@@ -137,7 +137,7 @@ String attributes are indexable by default, and the maximum length is 448 charac
 The userPrincipalName attribute in Active Directory is not always known by the users and might not be suitable as the sign-in ID. With the Azure AD Connect sync installation wizard, you can choose a different attribute--for example, *mail*. But in some cases, the attribute must be calculated.
 
 For example, the company Contoso has two Azure AD directories, one for production and one for testing. They want the users in their test tenant to use another suffix in the sign-in ID:  
-`userPrincipalName` <- `Word([userPrincipalName],1,"@") & "@contosotest.com"`.
+`Word([userPrincipalName],1,"@") & "@contosotest.com"`.
 
 In this expression, take everything left of the first @-sign (Word) and concatenate with a fixed string.
 


### PR DESCRIPTION
The originally provided rule did not work. This one does.