### PR TITLE
Update image-builder-powershell.md

### DIFF
--- a/articles/virtual-machines/windows/image-builder-powershell.md
+++ b/articles/virtual-machines/windows/image-builder-powershell.md
@@ -26,7 +26,7 @@ If you don't have an Azure subscription, [create a free account](https://azure.m
 If you choose to use PowerShell locally, this article requires that you install the Azure PowerShell
 module and connect to your Azure account by using the [Connect-AzAccount](/powershell/module/az.accounts/connect-azaccount) cmdlet. For more information, see [Install Azure PowerShell](/powershell/azure/install-az-ps).
 
-Note that some of the steps require cmdlets from the [Az.ImageBuilder](https://www.powershellgallery.com/packages/Az.ImageBuilder) module, which needs to be installed separately by
+Some of the steps require cmdlets from the [Az.ImageBuilder](https://www.powershellgallery.com/packages/Az.ImageBuilder) module. Install separately by using the following command.
 
 ```azurepowershell-interactive
 Install-Module -Name Az.ImageBuilder

--- a/articles/virtual-machines/windows/image-builder-powershell.md
+++ b/articles/virtual-machines/windows/image-builder-powershell.md
@@ -26,6 +26,12 @@ If you don't have an Azure subscription, [create a free account](https://azure.m
 If you choose to use PowerShell locally, this article requires that you install the Azure PowerShell
 module and connect to your Azure account by using the [Connect-AzAccount](/powershell/module/az.accounts/connect-azaccount) cmdlet. For more information, see [Install Azure PowerShell](/powershell/azure/install-az-ps).
 
+Note that some of the steps require cmdlets from the [Az.ImageBuilder](https://www.powershellgallery.com/packages/Az.ImageBuilder) module, which needs to be installed separately by
+
+```azurepowershell-interactive
+Install-Module -Name Az.ImageBuilder
+```
+
 [!INCLUDE [cloud-shell-try-it](../../../includes/cloud-shell-try-it.md)]
 
 If you have multiple Azure subscriptions, choose the appropriate subscription in which the resources


### PR DESCRIPTION
Customer of Azure PowerShell reported that they could not follow the steps in this document because the required cmdlet could not be found. Root cause is that the `Az.ImageBuilder` PowerShell module is not included in the `Az` rollup module so it needs to be installed separately.

This PR adds a note in the "Prerequsites" section to state how to do that.

Link to the doc: https://learn.microsoft.com/en-us/azure/virtual-machines/windows/image-builder-powershell#create-an-image
Link to customer reported issue: https://github.com/Azure/azure-powershell/issues/20923