### PR TITLE
Changes to the reference section of the TOC to create a new section called Creator indoor maps and move creator articles into this new section.

### DIFF
--- a/articles/azure-maps/creator-facility-ontology.md
+++ b/articles/azure-maps/creator-facility-ontology.md
@@ -545,6 +545,13 @@ The `category` class feature defines category names. For example: "room.conferen
 
 :::zone-end
 
+## Next steps
+
+Learn more about Creator for indoor maps by reading:
+
+> [!div class="nextstepaction"]
+> [Creator for indoor maps](creator-indoor-maps.md)
+
 [conversion]: /rest/api/maps/v2/conversion
 [geojsonpoint]: /rest/api/maps/v2/wfs/get-features#geojsonpoint
 [GeoJsonPolygon]: /rest/api/maps/v2/wfs/get-features?tabs=HTTP#geojsonpolygon

--- a/articles/azure-maps/drawing-error-visualizer.md
+++ b/articles/azure-maps/drawing-error-visualizer.md
@@ -85,19 +85,7 @@ Once the _ConversionWarningsAndErrors.json_ file loads, you'll see a list of you
 
 ## Next steps
 
-Once your [Drawing package meets the requirements](drawing-requirements.md), you can use the [Azure Maps Dataset service](/rest/api/maps/v2/conversion) to convert the Drawing package to a dataset. Then, you can use the Indoor Maps web module to develop your application. Learn more by reading the following articles:
-
-> [!div class="nextstepaction"]
-> [Drawing Conversion error codes](drawing-conversion-error-codes.md)
-
-> [!div class="nextstepaction"]
-> [Drawing Package Guide](drawing-package-guide.md)
+Learn more by reading:
 
 > [!div class="nextstepaction"]
 > [Creator for indoor maps](creator-indoor-maps.md)
-
-> [!div class="nextstepaction"]
-> [Use the Indoor Maps module](how-to-use-indoor-module.md)
-
-> [!div class="nextstepaction"]
-> [Implement indoor map dynamic styling](indoor-map-dynamic-styling.md)

--- a/articles/azure-maps/drawing-requirements.md
+++ b/articles/azure-maps/drawing-requirements.md
@@ -417,22 +417,10 @@ Below is the manifest file for the sample Drawing package. Go to the [Sample Dra
 
 ## Next steps
 
-When your Drawing package meets the requirements, you can use the [Azure Maps Conversion service](/rest/api/maps/v2/conversion) to convert the package to a map dataset. Then, you can use the dataset to generate an indoor map by using the indoor maps module.
-
-> [!div class="nextstepaction"]
-> [Creator Facility Ontology](creator-facility-ontology.md)
-
-> [!div class="nextstepaction"]
-> [Creator for indoor maps](creator-indoor-maps.md)
-
-> [!div class="nextstepaction"]
-> [Drawing Package Guide](drawing-package-guide.md)
-
-> [!div class="nextstepaction"]
-> [Creator  for indoor maps](creator-indoor-maps.md)
-
 > [!div class="nextstepaction"]
 > [Tutorial: Creating a Creator indoor map](tutorial-creator-indoor-maps.md)
 
+Learn more by reading:
+
 > [!div class="nextstepaction"]
-> [Indoor maps dynamic styling](indoor-map-dynamic-styling.md)
+> [Creator for indoor maps](creator-indoor-maps.md)

--- a/articles/azure-maps/schema-stateset-stylesobject.md
+++ b/articles/azure-maps/schema-stateset-stylesobject.md
@@ -234,3 +234,10 @@ The following JSON illustrates a `BooleanTypeStyleRule` *state* named `occupied`
     ]
 }
 ```
+
+## Next steps
+
+Learn more about Creator for indoor maps by reading:
+
+> [!div class="nextstepaction"]
+> [Creator for indoor maps](creator-indoor-maps.md)

--- a/articles/azure-maps/toc.yml
+++ b/articles/azure-maps/toc.yml
@@ -252,9 +252,7 @@ items:
       - name: Custom styling for indoor maps
         href: how-to-create-custom-styles.md
       - name: Indoor maps wayfinding service
-        href: how-to-creator-wayfinding.md    
-      - name: Drawing error visualizer
-        href: drawing-error-visualizer.md
+        href: how-to-creator-wayfinding.md 
     - name: Spatial IO module 
       items:
       - name: Use the spatial IO module
@@ -383,14 +381,20 @@ items:
     href: how-to-show-attribution.md
 - name: Reference
   items:
-  - name: API and parameter extensions
-    items:
+  - name: Creator Indoor Maps
+    items:   
+    - name: Drawing error visualizer
+      href: drawing-error-visualizer.md
     - name: Drawing package requirements
       href: drawing-requirements.md
     - name: Drawing package guide
       href: drawing-package-guide.md
     - name: Dynamic maps StylesObject
       href: schema-stateset-stylesobject.md
+    - name: Facility Ontology
+      href: creator-facility-ontology.md
+  - name: API and parameter extensions
+    items:
     - name: Vehicle consumption model
       href: consumption-model.md
     - name: Extended GeoJSON format
@@ -399,50 +403,54 @@ items:
       href: geofence-geojson.md
     - name: Supported search categories
       href: supported-search-categories.md
-    - name: Facility Ontology
-      href: creator-facility-ontology.md
   - name: REST
     items:
-    - name: Data service
+    - name: Overview
+      href: /rest/api/maps
+    - name: Data
       href: /rest/api/maps/data
-    - name: Data service V2
+    - name: Data V2
       href: /rest/api/maps/data-v2
-    - name: Elevation service
+    - name: Elevation
       href: /rest/api/maps/elevation
-    - name: Geolocation service
+    - name: Geolocation
       href: /rest/api/maps/geolocation
-    - name: Render service
+    - name: Render
       href: /rest/api/maps/render
-    - name: Render service V2
+    - name: Render V2
       href: /rest/api/maps/render-v2
-    - name: Route service
+    - name: Route
       href: /rest/api/maps/route
-    - name: Search service
+    - name: Search
       href: /rest/api/maps/search
-    - name: Search service V2
+    - name: Search V2
       href: /rest/api/maps/search-v2
-    - name: Spatial service
+    - name: Spatial
       href: /rest/api/maps/spatial
-    - name: Timezone service
+    - name: Timezone
       href: /rest/api/maps/timezone
-    - name: Traffic service
+    - name: Traffic
       href: /rest/api/maps/traffic
-    - name: Weather services
+    - name: Weather
       href: /rest/api/maps/weather
-    - name: Maps Creator service
+    - name: Maps Creator
       items:
-      - name: Alias service
-        href: /rest/api/maps/v2/alias
-      - name: Conversion service
-        href: /rest/api/maps/v2/conversion
-      - name: Dataset service
-        href: /rest/api/maps/v2/dataset
-      - name: Feature State service
-        href: /rest/api/maps/v2/feature-state
-      - name: Tileset service
-        href: /rest/api/maps/v2/tileset
-      - name: WFS service
-        href: /rest/api/maps/v2/wfs
+      - name: Overview
+        href: /rest/api/maps-creator/
+      - name: V2
+        items:
+          - name: Alias
+            href: /rest/api/maps/v2/alias
+          - name: Conversion
+            href: /rest/api/maps/v2/conversion
+          - name: Dataset
+            href: /rest/api/maps/v2/dataset
+          - name: Feature State
+            href: /rest/api/maps/v2/feature-state
+          - name: Tileset
+            href: /rest/api/maps/v2/tileset
+          - name: WFS
+            href: /rest/api/maps/v2/wfs
       - name: V20220901Preview
         items:
         - name: Dataset


### PR DESCRIPTION
TOC Updates to Reference section:

Reference

 - Remove all next steps
- Add a top level section called “Creator Indoor Maps”
    - Move drawing-error-visualizer.md under “Creator Indoor Maps” from how-to section
- Move drawing-requirements.md under “Creator Indoor Maps”
    - Remove all next steps except the tutorial
- Move schema-stateset-stylesobject.md under “Creator Indoor Maps”
- Move creator-facility-ontology.md under “Creator Indoor Maps”

Other Tasks
- Add a _learn more_ to every article

> Learn more by reading:
> 
> > [!div class="nextstepaction"]
> > [Creator for indoor maps](creator-indoor-maps.md)