### PR TITLE
Remove duplicated services

### DIFF
--- a/articles/reliability/availability-zones-migration-overview.md
+++ b/articles/reliability/availability-zones-migration-overview.md
@@ -23,8 +23,7 @@ The table below lists each product that offers migration guidance and/or informa
 | **Products**  | 
 | --- | 
 | [Azure Application Gateway (V2)](migrate-app-gateway-v2.md) |
-| [Azure Backup](migrate-recovery-services-vault.md)  | 
-| [Azure Site Recovery](migrate-recovery-services-vault.md) |
+| [Azure Backup and Azure Site Recovery](migrate-recovery-services-vault.md)  | 
 | [Azure Storage account: Blob Storage, Azure Data Lake Storage, Files Storage](migrate-storage.md) |
 | [Azure Storage: Managed Disks](migrate-vm.md)|
 | [Azure Virtual Machines and Azure Virtual Machine Scale Sets](migrate-vm.md)|  

--- a/articles/reliability/availability-zones-migration-overview.md
+++ b/articles/reliability/availability-zones-migration-overview.md
@@ -25,13 +25,9 @@ The table below lists each product that offers migration guidance and/or informa
 | [Azure Application Gateway (V2)](migrate-app-gateway-v2.md) |
 | [Azure Backup](migrate-recovery-services-vault.md)  | 
 | [Azure Site Recovery](migrate-recovery-services-vault.md) |
-| [Azure Storage account](migrate-storage.md) |
-| [Azure Storage: Azure Data Lake Storage](migrate-storage.md) |
-| [Azure Storage: Disk Storage](migrate-storage.md)|
-| [Azure Storage: Blob Storage](migrate-storage.md) |
-| [Azure Storage: Managed Disks](migrate-storage.md)|
-| [Azure Virtual Machine Scale Sets](migrate-vm.md)|
-| [Azure Virtual Machines](migrate-vm.md) |  
+| [Azure Storage account: Blob Storage, Azure Data Lake Storage, Files Storage](migrate-storage.md) |
+| [Azure Storage: Managed Disks](migrate-vm.md)|
+| [Azure Virtual Machines and Azure Virtual Machine Scale Sets](migrate-vm.md)|  
 
 \*VMs that support availability zones: AV2-series, B-series, DSv2-series, DSv3-series, Dv2-series, Dv3-series, ESv3-series, Ev3-series, F-series, FS-series, FSv2-series, and M-series.
 
@@ -40,13 +36,19 @@ The table below lists each product that offers migration guidance and/or informa
 | **Products**   | 
 | --- | 
 | [Azure API Management](migrate-api-mgt.md)|
+| [Azure App Configuration](migrate-app-configuration.md)|
+| [Azure App Service](migrate-app-service.md)|
 | [Azure App Service: App Service Environment](migrate-app-service-environment.md)|
 | [Azure Cache for Redis](migrate-cache-redis.md)|
-| [Azure Container Instances](migrate-container-instances.md) |
-| [Azure Database for MySQL - Flexible Server](migrate-database-mysql-flex.md) |
+| [Azure Cognitive Search](migrate-search-service.md)|
+| [Azure Container Instances](migrate-container-instances.md)|
+| [Azure Database for MySQL - Flexible Server](migrate-database-mysql-flex.md)|
 | [Azure Monitor: Log Analytics](migrate-monitor-log-analytics.md)|
-| Azure Storage: [Files Storage](migrate-storage.md)|
 
+## Workload and general guidance
+| **Workloads**   | 
+| --- | 
+| [Azure Kubernetes Service (AKS) and MySQL Flexible Server](migrate-workload-aks-mysql.md)|
 
 ## Next steps
 

--- a/articles/reliability/availability-zones-migration-overview.md
+++ b/articles/reliability/availability-zones-migration-overview.md
@@ -32,17 +32,6 @@ The table below lists each product that offers migration guidance and/or informa
 | [Azure Storage: Managed Disks](migrate-storage.md)|
 | [Azure Virtual Machine Scale Sets](migrate-vm.md)|
 | [Azure Virtual Machines](migrate-vm.md) |  
-| Virtual Machines: [Av2-Series](migrate-vm.md) |
-| Virtual Machines: [Bs-Series](migrate-vm.md) |
-| Virtual Machines: [DSv2-Series](migrate-vm.md) |
-| Virtual Machines: [DSv3-Series](migrate-vm.md) |
-| Virtual Machines: [Dv2-Series](migrate-vm.md) |
-| Virtual Machines: [Dv3-Series](migrate-vm.md) |
-| Virtual Machines: [ESv3-Series](migrate-vm.md) |
-| Virtual Machines: [Ev3-Series](migrate-vm.md) |
-| Virtual Machines: [F-Series](migrate-vm.md) | 
-| Virtual Machines: [FS-Series](migrate-vm.md) |
-| Virtual Machines: [Azure Compute Gallery](migrate-vm.md)|  
 
 \*VMs that support availability zones: AV2-series, B-series, DSv2-series, DSv3-series, Dv2-series, Dv3-series, ESv3-series, Ev3-series, F-series, FS-series, FSv2-series, and M-series.
 
@@ -57,17 +46,6 @@ The table below lists each product that offers migration guidance and/or informa
 | [Azure Database for MySQL - Flexible Server](migrate-database-mysql-flex.md) |
 | [Azure Monitor: Log Analytics](migrate-monitor-log-analytics.md)|
 | Azure Storage: [Files Storage](migrate-storage.md)|
-| Virtual Machines: [Azure Dedicated Host](migrate-vm.md) |
-| Virtual Machines: [Ddsv4-Series](migrate-vm.md) |
-| Virtual Machines: [Ddv4-Series](migrate-vm.md) |
-| Virtual Machines: [Dsv4-Series](migrate-vm.md) |
-| Virtual Machines: [Dv4-Series](migrate-vm.md) |
-| Virtual Machines: [Edsv4-Series](migrate-vm.md) |
-| Virtual Machines: [Edv4-Series](migrate-vm.md) |
-| Virtual Machines: [Esv4-Series](migrate-vm.md) |
-| Virtual Machines: [Ev4-Series](migrate-vm.md) |
-| Virtual Machines: [Fsv2-Series](migrate-vm.md) |
-| Virtual Machines: [M-Series](migrate-vm.md) |
 
 
 ## Next steps


### PR DESCRIPTION
Hi, I'm Penny Ko from MSFT.
I would like to remove the duplicated services Virtual Machines: Av2-Series, Bs-Series, ... and the Virtual Machines: Azure Compute Gallery. All different VM services are pointing to the same doc, and the Azure Compute Gallery is not related to the https://learn.microsoft.com/en-us/azure/reliability/migrate-vm doc, it should redirect to the setting mentioned in https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#high-availability .