### PR TITLE
Adding missing resource provider, fixing code

### DIFF
--- a/articles/virtual-machines/windows/image-builder-powershell.md
+++ b/articles/virtual-machines/windows/image-builder-powershell.md
@@ -104,7 +104,7 @@ Grant Azure image builder permissions to create images in the specified resource
 1. Create a user identity.
 
    ```azurepowershell-interactive
-   New-AzUserAssignedIdentity -ResourceGroupName $imageResourceGroup -Name $identityName
+   New-AzUserAssignedIdentity -ResourceGroupName $imageResourceGroup -Name $identityName -Location $location
    ```
 
 1. Store the identity resource and principal IDs in variables.

--- a/articles/virtual-machines/windows/image-builder-powershell.md
+++ b/articles/virtual-machines/windows/image-builder-powershell.md
@@ -45,9 +45,10 @@ If you haven't already done so, register the following resource providers to use
 - Microsoft.Storage
 - Microsoft.Network
 - Microsoft.VirtualMachineImages
+- Microsoft.ManagedIdentity
 
 ```azurepowershell-interactive
-Get-AzResourceProvider -ProviderNamespace Microsoft.Compute, Microsoft.KeyVault, Microsoft.Storage, Microsoft.VirtualMachineImages, Microsoft.Network |
+Get-AzResourceProvider -ProviderNamespace Microsoft.Compute, Microsoft.KeyVault, Microsoft.Storage, Microsoft.VirtualMachineImages, Microsoft.Network, Microsoft.ManagedIdentity |
   Where-Object RegistrationState -ne Registered |
     Register-AzResourceProvider
 ```
@@ -119,7 +120,7 @@ Grant Azure image builder permissions to create images in the specified resource
 
    ```azurepowershell-interactive
    $myRoleImageCreationUrl = 'https://raw.githubusercontent.com/azure/azvmimagebuilder/master/solutions/12_Creating_AIB_Security_Roles/aibRoleImageCreation.json'
-   $myRoleImageCreationPath = "$env:TEMP\myRoleImageCreation.json"
+   $myRoleImageCreationPath = "myRoleImageCreation.json"
 
    Invoke-WebRequest -Uri $myRoleImageCreationUrl -OutFile $myRoleImageCreationPath -UseBasicParsing
 
@@ -224,7 +225,7 @@ Grant Azure image builder permissions to create images in the specified resource
    ```azurepowershell-interactive
    $ImgCustomParams02 = @{
      FileCustomizer = $true
-     CustomizerName = 'downloadBuildArtifacts'
+     Name = 'downloadBuildArtifacts'
      Destination = 'c:\\buildArtifacts\\index.html'
      SourceUri = 'https://raw.githubusercontent.com/azure/azvmimagebuilder/master/quickquickstarts/exampleArtifacts/buildArtifacts/index.html'
    }


### PR DESCRIPTION
The resource provider "Microsoft.ManagedIdentity" is missing in the Register features section. The user identity would failed if not registered. 

The section Assign permissions for the identity to distribute the images will failed with the message "access to path /myRoleImageCreation.json is denied". Changing the variable $myRoleImageCreationPath = "$env:TEMP\myRoleImageCreation.json" to $myRoleImageCreationPath = "myRoleImageCreation.json" 

Step 4 in the section Create an image will fail with message "a parameter cannot be found that matches parameter name CustomizerName". Changin the parameter "CustomizerName = 'downloadBuildArtifacts' " to "Name = 'downloadBuildArtifacts' "