### PR TITLE
Added VS Code installation notes when needing to go through a proxy

### DIFF
--- a/includes/machine-learning-public-internet-access.md
+++ b/includes/machine-learning-public-internet-access.md
@@ -62,6 +62,9 @@ You may also need to allow __outbound__ traffic to Visual Studio Code and non-Mi
 | **marketplace.visualstudio.com**</br>**vscode.blob.core.windows.net**</br>**\*.gallerycdn.vsassets.io** | Required to download and install VS Code extensions. These enable the remote connection to Compute Instances provided by the Azure ML extension for VS Code, see [Connect to an Azure Machine Learning compute instance in Visual Studio Code](../articles/machine-learning/how-to-set-up-vs-code-remote.md) for more information. |
 | **raw.githubusercontent.com/microsoft/vscode-tools-for-ai/master/azureml_remote_websocket_server/\*** | Used to retrieve websocket server bits, which are installed on the compute instance. The websocket server is used to transmit requests from Visual Studio Code client (desktop application) to Visual Studio Code server running on the compute instance.|
 
+> [!NOTE]
+> When using the [Azure Machine Learning VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-ai) the remote compute instance will require an access to public repositories to install the packages required by the extension. If the compute instance requires a proxy to access these public repositories or the Internet, you will need to set and export the `HTTP_PROXY` and `HTTPS_PROXY` environment variables in the `~/.bashrc` file of the compute instance. This process can be automated at provisioning time by using a [custom script](/machine-learning/how-to-customize-compute-instance).
+
 When using Azure Kubernetes Service (AKS) with Azure Machine Learning, allow the following traffic to the AKS VNet:
 
 * General inbound/outbound requirements for AKS as described in the [Restrict egress traffic in Azure Kubernetes Service](../articles/aks/limit-egress-traffic.md) article.


### PR DESCRIPTION
Following a discussion with isism in relation with support case 2302020030002653, added a note documenting how to configure a proxy to enable the Azure Machine Learning VS Code Extension to successfully install on compute instances requiring a proxy for Internet access.