### PR TITLE
Defender for Cloud on Management Group Tip

### DIFF
--- a/articles/defender-for-cloud/onboard-management-group.md
+++ b/articles/defender-for-cloud/onboard-management-group.md
@@ -38,6 +38,10 @@ When the definition is assigned, it will:
 
 The remediation task will then enable Defender for Cloud's basic functionality on the non-compliant subscriptions.
 
+    > [!TIP]
+    > Make sure the resource provider _Microsoft.Security_ is enabled for the management group:
+    > `az provider register --namespace Microsoft.Security --management-group-id …`
+
 ## Optional modifications
 
 There are various ways you might choose to modify the Azure Policy definition: 

--- a/articles/defender-for-cloud/onboard-management-group.md
+++ b/articles/defender-for-cloud/onboard-management-group.md
@@ -39,7 +39,11 @@ When the definition is assigned, it will:
 The remediation task will then enable Defender for Cloud's basic functionality on the non-compliant subscriptions.
 
     > [!TIP]
-    > Make sure the resource provider _Microsoft.Security_ is enabled for the management group: az provider register --namespace Microsoft.Security --management-group-id …
+    > Make sure the resource provider _Microsoft.Security_ is enabled for the management group:
+
+    ```
+    az provider register --namespace Microsoft.Security --management-group-id …
+    ```
 
 ## Optional modifications
 

--- a/articles/defender-for-cloud/onboard-management-group.md
+++ b/articles/defender-for-cloud/onboard-management-group.md
@@ -39,8 +39,7 @@ When the definition is assigned, it will:
 The remediation task will then enable Defender for Cloud's basic functionality on the non-compliant subscriptions.
 
     > [!TIP]
-    > Make sure the resource provider _Microsoft.Security_ is enabled for the management group:
-    > `az provider register --namespace Microsoft.Security --management-group-id …`
+    > Make sure the resource provider _Microsoft.Security_ is enabled for the management group: az provider register --namespace Microsoft.Security --management-group-id …
 
 ## Optional modifications
 


### PR DESCRIPTION
This isn't really documented, but if the resource provider _Microsoft.Security_ isn't enabled for all subscriptions, then the policy will fail and just mark the subscription as non-compliant, but not actually enforce Defender for Cloud.

I believe there is no Azure Portal UI for enabling this, so I only provided a `az`-cli command.