### PR TITLE
Update upgrade-cluster.md

### DIFF
--- a/articles/aks/upgrade-cluster.md
+++ b/articles/aks/upgrade-cluster.md
@@ -250,7 +250,7 @@ To confirm that the upgrade was successful, navigate to your AKS cluster in the 
 When you upgrade your cluster, the following Kubernetes events may occur on each node:
 
 - Surge – Create surge node.
-- Drain – Pods are being evicted from the node. Each pod has a 30-minute timeout to complete the eviction.
+- Drain – Pods are being evicted from the node. Each pod has a 30-seconds timeout to complete the eviction.
 - Update – Update of a node has succeeded or failed.
 - Delete – Deleted a surge node.
 

--- a/articles/aks/upgrade-cluster.md
+++ b/articles/aks/upgrade-cluster.md
@@ -250,7 +250,7 @@ To confirm that the upgrade was successful, navigate to your AKS cluster in the 
 When you upgrade your cluster, the following Kubernetes events may occur on each node:
 
 - Surge – Create surge node.
-- Drain – Pods are being evicted from the node. Each pod has a 30-seconds timeout to complete the eviction.
+- Drain – Pods are being evicted from the node. Each pod has a 30-second timeout to complete the eviction.
 - Update – Update of a node has succeeded or failed.
 - Delete – Deleted a surge node.
 


### PR DESCRIPTION
I think the sentence '_Drain – Pods are being evicted from the node. Each pod has a 30-**minute** timeout to complete the eviction_.' might be wrong.
Pods are showing '**terminationGracePeriodSeconds: 30**', which means 30 seconds. 
That's because I'm suggesting the new sentence: 
_'Drain – Pods are being evicted from the node. Each pod has a 30-**seconds** timeout to complete the eviction_.' 
or 
_'Drain – Pods are being evicted from the node. Each **node** has a 30-minute timeout to complete the eviction_.'