### PR TITLE
Updating time to connect for clarity

### DIFF
--- a/articles/virtual-desktop/insights-glossary.md
+++ b/articles/virtual-desktop/insights-glossary.md
@@ -165,7 +165,7 @@ When monitoring time to connect, keep in mind the following things:
 
   - Begins: [WVDConnection](/azure/azure-monitor/reference/tables/wvdconnections) state = started
 
-  - Ends: [WVDCheckpoints](/azure/azure-monitor/reference/tables/wvdcheckpoints) Name = ShellReady (desktops); Name = RdpShellAppExecuted (RemoteApp, for timing consider the first app launch only)
+  - Ends: [WVDCheckpoints](/azure/azure-monitor/reference/tables/wvdcheckpoints) Name = ShellReady (desktops); Name = RdpShellAppExecuted (RemoteApp. For timing, consider the first app launch only)
 
   For example, the time for a desktop experience to launch would be measured based on how long it takes to launch Windows Explorer (explorer.exe). The time for a remote application to launch would be measured based on the time taken to launch the first instance of the shell app for a connection.
   

--- a/articles/virtual-desktop/insights-glossary.md
+++ b/articles/virtual-desktop/insights-glossary.md
@@ -161,7 +161,7 @@ Time to connect has two stages:
 
 When monitoring time to connect, keep in mind the following things:
 
-- Time to connect is measured with the following checkpoints from Azure Virtual Desktop service diagnostics data. Note that the checkpoints used to denote when the connection has been established are different for a desktop versus a remote application scenario:
+- Time to connect is measured with the following checkpoints from Azure Virtual Desktop service diagnostics data. The checkpoints Insights uses to determine when the connection is established are different for a desktop versus a remote application scenario.
 
   - Begins: [WVDConnection](/azure/azure-monitor/reference/tables/wvdconnections) state = started
 

--- a/articles/virtual-desktop/insights-glossary.md
+++ b/articles/virtual-desktop/insights-glossary.md
@@ -170,7 +170,7 @@ When monitoring time to connect, keep in mind the following things:
   For example, the time for a desktop experience to launch would be measured based on how long it takes to launch Windows Explorer (explorer.exe). The time for a remote application to launch would be measured based on the time taken to launch the first instance of the shell app for a connection.
   
 >[!NOTE]
->It is possible for multiple shell app execution events to happen in the context of one connection if a user launches more than one remote application. To ensure an accurate representation of the time to connect, only the first execution checkpoint to occur in the connection should be used for a given connection.
+>If a user launches more than one remote application, sometimes the shell app can execute multiple times during a single connection. For an accurate measurement of time to connect, you should only use the first execution checkpoint for each connection.
 
 Example query:
 

--- a/articles/virtual-desktop/insights-glossary.md
+++ b/articles/virtual-desktop/insights-glossary.md
@@ -167,7 +167,7 @@ When monitoring time to connect, keep in mind the following things:
 
   - Ends: [WVDCheckpoints](/azure/azure-monitor/reference/tables/wvdcheckpoints) Name = ShellReady (desktops); Name = RdpShellAppExecuted (RemoteApp. For timing, consider the first app launch only)
 
-  For example, the time for a desktop experience to launch would be measured based on how long it takes to launch Windows Explorer (explorer.exe). The time for a remote application to launch would be measured based on the time taken to launch the first instance of the shell app for a connection.
+For example, Insights measures the time for a desktop experience to launch based on how long it takes to launch Windows Explorer. Insights also measures the time for a remote application to launch based on the time taken to launch the first instance of the shell app for a connection.
   
 >[!NOTE]
 >If a user launches more than one remote application, sometimes the shell app can execute multiple times during a single connection. For an accurate measurement of time to connect, you should only use the first execution checkpoint for each connection.

--- a/articles/virtual-desktop/insights-glossary.md
+++ b/articles/virtual-desktop/insights-glossary.md
@@ -172,21 +172,6 @@ For example, Insights measures the time for a desktop experience to launch based
 >[!NOTE]
 >If a user launches more than one remote application, sometimes the shell app can execute multiple times during a single connection. For an accurate measurement of time to connect, you should only use the first execution checkpoint for each connection.
 
-Example query:
-
-```kusto
-WVDConnections
-| where State == 'Started' and TimeGenerated > ago(1d)
-| extend StartTime=TimeGenerated
-| join kind=inner
-(
-    WVDCheckpoints    
-    | where Name == 'RdpShellAppExecuted'    
-    | summarize AppExecutedTime=min(TimeGenerated) by CorrelationId
-) on CorrelationId
-| project CorrelationId, SessionHostName, UserName, StartTime, TimeToConnect = (AppExecutedTime - StartTime)
-```
-
 - Establishing new sessions usually takes longer than reestablishing connections to existing sessions due to differences in the "logon" process for new and established connections. 
 
 - The time it takes for the user to provide credentials is subtracted from their time to connect to account for situations where a user either takes a while to enter credentials or use alternative authentication methods to sign in.


### PR DESCRIPTION
Updating the time to connect details with a note on the fact that multiple shell app executions can occur in one connection if a user launches multiple applications as well as more specificity on the differences between timing for desktop and remote app experiences. Also adding sample query.