### PR TITLE
Update information regarding text split skill

### DIFF
--- a/articles/search/cognitive-search-skill-keyphrases.md
+++ b/articles/search/cognitive-search-skill-keyphrases.md
@@ -23,7 +23,7 @@ This capability is useful if you need to quickly identify the main talking point
 Microsoft.Skills.Text.KeyPhraseExtractionSkill 
 
 ## Data limits
-The maximum size of a record should be 50,000 characters as measured by [`String.Length`](/dotnet/api/system.string.length). If you need to break up your data before sending it to the key phrase extractor, consider using the [Text Split skill](cognitive-search-skill-textsplit.md).
+The maximum size of a record should be 50,000 characters as measured by [`String.Length`](/dotnet/api/system.string.length). If you need to break up your data before sending it to the key phrase extractor, consider using the [Text Split skill](cognitive-search-skill-textsplit.md). If you do use a text split skill, set the page length to 5000 for the best performance.
 
 ## Skill parameters
 


### PR DESCRIPTION
Text split skill was changed to a default of 5k in this PR: https://msdata.visualstudio.com/DefaultCollection/Azure%20Search/_git/AzureSearch/pullrequest/977487. When using the skill, using the default of 5k will yield the best results.