### PR TITLE
Update information regarding text split skill

### DIFF
--- a/articles/search/cognitive-search-skill-text-translation.md
+++ b/articles/search/cognitive-search-skill-text-translation.md
@@ -31,7 +31,7 @@ Microsoft.Skills.Text.TranslationSkill
 
 ## Data limits
 
-The maximum size of a record should be 50,000 characters as measured by [`String.Length`](/dotnet/api/system.string.length). If you need to break up your data before sending it to the text translation skill, consider using the [Text Split skill](cognitive-search-skill-textsplit.md).
+The maximum size of a record should be 50,000 characters as measured by [`String.Length`](/dotnet/api/system.string.length). If you need to break up your data before sending it to the text translation skill, consider using the [Text Split skill](cognitive-search-skill-textsplit.md). If you do use a text split skill, set the page length to 5000 for the best performance.
 
 ## Skill parameters
 


### PR DESCRIPTION
Text split skill was changed to a default of 5k in this PR: https://msdata.visualstudio.com/DefaultCollection/Azure%20Search/_git/AzureSearch/pullrequest/977487. When using the skill, using the default of 5k will yield the best results.