### PR TITLE
Typo fix when calling const

### DIFF
--- a/articles/applied-ai-services/form-recognizer/quickstarts/includes/v3-javascript-sdk.md
+++ b/articles/applied-ai-services/form-recognizer/quickstarts/includes/v3-javascript-sdk.md
@@ -220,7 +220,7 @@ Extract text, selection marks, text styles, table structures, and bounding regio
   async function main() {
     const client = new DocumentAnalysisClient(endpoint, new AzureKeyCredential(key));
 
-    const poller = await client.beginAnalyzeDocumentFromUrl("prebuilt-layout", formUrlLayout);
+    const poller = await client.beginAnalyzeDocumentFromUrl("prebuilt-layout", formUrl);
 
     const {
         pages,


### PR DESCRIPTION
In the layout sample code when the const `formUrl` is used in `beginAnalyzeDocumentFromUrl` it is referred to as `formUrlLayout` so the code does not run. Changing it to `formUrl` enables the code to run correctly.