### PR TITLE
Update support information about Insights for C# in an isolated process -  update to "monitor executions in Azure Functions" article

### DIFF
--- a/articles/azure-functions/functions-monitoring.md
+++ b/articles/azure-functions/functions-monitoring.md
@@ -89,7 +89,7 @@ In [C#](functions-dotnet-class-library.md#log-custom-telemetry-in-c-functions), 
 
 ### Dependencies
 
-Starting with version 2.x of Functions, Application Insights automatically collects data on dependencies for bindings that use certain client SDKs. Application Insights distributed tracing and dependency tracking aren't currently supported for C# apps running in an [isolated worker process](dotnet-isolated-process-guide.md). Application Insights collects data on the following dependencies:
+Starting with version 2.x of Functions, Application Insights automatically collects data on dependencies for bindings that use certain client SDKs. Support for Application Insights distributed tracing and dependency tracking is currently in preview for C# apps running in an [isolated worker process](dotnet-isolated-process-guide.md). Application Insights collects data on the following dependencies:
 
 + Azure Cosmos DB 
 + Azure Event Hubs


### PR DESCRIPTION
Change (Application Insights distributed tracing and dependency tracking aren't currently supported for C# apps running in an isolated worker process.) to (Support for Application Insights distributed tracing and dependency tracking is currently in preview for C# apps running in an isolated worker process). 

Reference:
-) [Differences between in-process and isolated worker process .NET Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-in-process-differences) article.
-) https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.ApplicationInsights