### PR TITLE
Change string interpolation from pyspark to scala in scala code

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -110,9 +110,9 @@ Synapse allows users to set the linked service for a particular storage account.
 ```scala
 val sc = spark.sparkContext
 val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
-spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
-spark.conf.set(f"fs.azure.account.auth.type.{source_full_storage_account_name}", "SAS")
-spark.conf.set(f"fs.azure.sas.token.provider.type.{source_full_storage_account_name}", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
+spark.conf.set(s"spark.storage.synapse.$source_full_storage_account_name.linkedServiceName", "<LINKED SERVICE NAME>")
+spark.conf.set(s"fs.azure.account.auth.type.$source_full_storage_account_name", "SAS")
+spark.conf.set(s"fs.azure.sas.token.provider.type.$source_full_storage_account_name", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedSASProvider")
 
 val df = spark.read.csv("abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<FILE PATH>")
 
@@ -146,8 +146,8 @@ When the linked service authentication method is set to **Managed Identity** or 
 ```scala
 val sc = spark.sparkContext
 val source_full_storage_account_name = "teststorage.dfs.core.windows.net"
-spark.conf.set(f"spark.storage.synapse.{source_full_storage_account_name}.linkedServiceName", "<LINKED SERVICE NAME>")
-spark.conf.set(f"fs.azure.account.oauth.provider.type.{source_full_storage_account_name}", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider") 
+spark.conf.set(s"spark.storage.synapse.$source_full_storage_account_name.linkedServiceName", "<LINKED SERVICE NAME>")
+spark.conf.set(s"fs.azure.account.oauth.provider.type.$source_full_storage_account_name", "com.microsoft.azure.synapse.tokenlibrary.LinkedServiceBasedTokenProvider") 
 val df = spark.read.csv("abfss://<CONTAINER>@<ACCOUNT>.dfs.core.windows.net/<FILE PATH>")
 
 display(df.limit(10))


### PR DESCRIPTION
Fix of example in Scala that used Python string interpolation. This was tricky error as code runs and does not return any errors (as it just sets spark config). However linked service is not used for authentication.