### PR TITLE
Add url for library installation walkthrough on index

### DIFF
--- a/articles/kinect-dk/index.yml
+++ b/articles/kinect-dk/index.yml
@@ -34,6 +34,8 @@ landingContent:
     linkLists:
       - linkListType: download
         links:
+          - text: Azure Kinect NuGet library
+            url: add-library-to-project.md
           - text: Azure Kinect Sensor SDK
             url: sensor-sdk-download.md
           - text: Azure Kinect Body Tracking SDK


### PR DESCRIPTION
Add url for the installation of the library in Visual Studio in the linkListType "Download" section of the Kinect docs index