### PR TITLE
Correct the names of the built in roles for EventGrid

### DIFF
--- a/articles/event-grid/security-authorization.md
+++ b/articles/event-grid/security-authorization.md
@@ -32,10 +32,10 @@ The Event Grid Contributor role allows you to create and manage Event Grid resou
 
 | Role | Description |
 | ---- | ----------- | 
-| [Event Grid Subscription Reader](../role-based-access-control/built-in-roles.md#eventgrid-eventsubscription-reader) | Lets you read Event Grid event subscriptions. |
-| [Event Grid Subscription Contributor](../role-based-access-control/built-in-roles.md#eventgrid-eventsubscription-contributor) | Lets you manage Event Grid event subscription operations. |
-| [Event Grid Contributor](../role-based-access-control/built-in-roles.md#eventgrid-contributor) | Lets you create and manage Event Grid resources. |
-| [Event Grid Data Sender](../role-based-access-control/built-in-roles.md#eventgrid-data-sender) | Lets you send events to Event Grid topics. |
+| [EventGrid EventSubscription Reader](../role-based-access-control/built-in-roles.md#eventgrid-eventsubscription-reader) | Lets you read Event Grid event subscriptions. |
+| [EventGrid EventSubscription Contributor](../role-based-access-control/built-in-roles.md#eventgrid-eventsubscription-contributor) | Lets you manage Event Grid event subscription operations. |
+| [EventGrid Contributor](../role-based-access-control/built-in-roles.md#eventgrid-contributor) | Lets you create and manage Event Grid resources. |
+| [EventGrid Data Sender](../role-based-access-control/built-in-roles.md#eventgrid-data-sender) | Lets you send events to Event Grid topics. |
 
 
 > [!NOTE]


### PR DESCRIPTION
Correct role names:

https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#eventgrid-contributor
https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#eventgrid-data-sender
https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#eventgrid-eventsubscription-contributor
https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#eventgrid-eventsubscription-reader