### PR TITLE
Update cache-network-isolation.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-network-isolation.md
+++ b/articles/azure-cache-for-redis/cache-network-isolation.md
@@ -26,7 +26,7 @@ Azure Private Link provides private connectivity from a virtual network to Azure
 ### Limitations of Private Link
 
 - Network security groups (NSG) are disabled for private endpoints. However, if there are other resources on the subnet, NSG enforcement will apply to those resources.
-- Currently, portal console support, and persistence to firewall storage accounts aren't supported.
+- Currently, portal console support, import/export and persistence to firewall storage accounts aren't supported.
 - To connect to a clustered cache, `publicNetworkAccess` needs to be set to `Disabled`, and there can only be one private endpoint connection.
 
 > [!NOTE]


### PR DESCRIPTION
Currently Redis Enterprise only uses the private endpoint for inbound connections. Outgoing connections like export/import, which are Redis Enterprise reaching out to some other resource, are currently not supported for the private endpoint. Hence, Import/Export is also isn't supported., This was learned while working as part of support case and hence raising a request to get this updated in the docs as well.