### PR TITLE
App service public access still enable

### DIFF
--- a/articles/private-link/tutorial-dns-on-premises-private-resolver.md
+++ b/articles/private-link/tutorial-dns-on-premises-private-resolver.md
@@ -187,9 +187,15 @@ You'll create an Azure web app for the cloud resource accessed by the on-premise
 
 6. Select **Apply**.
 
-7. Select **Review + create**.
+7. Select **Next: Deployment**.
 
-8. Select **Create**.
+8. Select **Next: Networking**.
+
+9. Change 'Enable public access' to false.
+
+10. Select **Review + create**.
+
+11. Select **Create**.
 
 ## Create private endpoint
 


### PR DESCRIPTION
When following the tutorial, the app service, public access is still enable which means that the website is available outside of the vnet which contradict the tutorial. Need to disable the public access in order to block any connection outside the vnet