### PR TITLE
Release new confluence SSO plugin version 6.3.9

### DIFF
--- a/articles/active-directory/saas-apps/ms-confluence-jira-plugin-adminguide.md
+++ b/articles/active-directory/saas-apps/ms-confluence-jira-plugin-adminguide.md
@@ -130,7 +130,7 @@ The following image shows the configuration screen in both Jira and Confluence:
 |  1.0.20         |   Bug Fixes:                                                                              | Jira Core and Software:             |
 |                 |   JIRA SAML SSO add-on redirects to incorrect URL from mobile browser.                 |  7.0.0 to 9.5.0                     |
 |                 |   The mark log section after enabling the JIRA plugin.                                 |                                     |
-|                 |   The last login date for a user doesn't update when user signs in via SSO            |                                     |
+|                 |   The last login date for a user doesn't update when user signs in via SSO.           |                                     |
 |                 |                                                                                           |                                     |
 |  1.0.19         |   New Feature:                                                                            | Jira Core and Software:             |
 |                 |    Application Proxy Support - Checkbox on the configure plugin screen to toggle the App Proxy mode so as to make the Reply URL editable as per the need to point the App Proxy mode so as to make the Reply URL editable as per the need to point it to the proxy server URL |  6.0 to 9.3.1           |


### PR DESCRIPTION
Dear Team,
A new Confluence build version 6.3.9 has been released by fixing the following bugs. Kindly check and approve the PR.
[System Error: Metadata link cannot be configured on SSO plugins] 
Regards ,
Sagar Patil