### PR TITLE
Updated supported RHEL versions to remove 7.10 and change to 7.9

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-linux.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-linux.md
@@ -43,7 +43,7 @@ The following Linux distributions are currently supported for deployments in a s
 | CentOS | CentOS 7, CentOS 8 |
 | Debian | Debian 9, Debian 10, Debian 11 |
 | openSUSE | openSUSE Leap 42.3, openSUSE Leap 15.1+ |
-| RedHat Enterprise Linux (RHEL) | RHEL 7.4 to RHEL 7.10, RHEL 8.3+ |
+| RedHat Enterprise Linux (RHEL) | RHEL 7.4 to RHEL 7.9, RHEL 8.3+ |
 | SUSE Linux Enterprise Server (SLES) | SLES 12, SLES 15.1+ |
 | Ubuntu Server | Ubuntu Server 16.04 to Ubuntu Server 22.04 |
 


### PR DESCRIPTION
RHEL 7.10 is not a release by Red Hat that is known; updated doc to reflect 7.9 as the latest version.