### PR TITLE
Compatibility issue between older version of Az CLI and the latest Az…

### DIFF
--- a/articles/machine-learning/how-to-configure-cli.md
+++ b/articles/machine-learning/how-to-configure-cli.md
@@ -31,7 +31,7 @@ The `ml` extension to the [Azure CLI](/cli/azure/) is the enhanced interface for
 
 ## Installation
 
-The new Machine Learning extension **requires Azure CLI version `>=2.15.0`**. Ensure this requirement is met:
+The new Machine Learning extension **requires Azure CLI version `>=2.38.0`**. Ensure this requirement is met:
 
 :::code language="azurecli" source="~/azureml-examples-main/cli/misc.sh" id="az_version":::
 


### PR DESCRIPTION
… CLI ML Extension

It's probably time to upgrade minimum Az CLI version recommendation from v2.15+ to v2.38+ :-). That's because the latest version of Az CLI ML extension brings the newer azure-storage-blob package, that depends on Azure Core v1.24, while previous Az CLI v2.37 and below were using Azure Core v1.21.1. As a result, ML extension gets installed and shown under *az extension list*, however any attempts to execute *az ml* commands fail. I made it work on my machine with Az CLI v2.37 only after upgrade to the latest Az CLI version with *az upgrade*.