### PR TITLE
Obsolete model reference type, that breaks the code for SDK v.2

### DIFF
--- a/articles/machine-learning/how-to-train-model.md
+++ b/articles/machine-learning/how-to-train-model.md
@@ -299,13 +299,13 @@ The following examples demonstrate how to register a model in your AzureML works
 
 ```python
 from azure.ai.ml.entities import Model
-from azure.ai.ml.constants import ModelType
+from azure.ai.ml.constants import AssetTypes
 
 run_model = Model(
     path="azureml://jobs/{}/outputs/artifacts/paths/model/".format(returned_job.name),
     name="run-model-example",
     description="Model created from run.",
-    type=ModelType.MLFLOW
+    type=AssetTypes.MLFLOW_MODEL
 )
 
 ml_client.models.create_or_update(run_model)


### PR DESCRIPTION
Use of "from azure.ai.ml.constants import ModelType" and setting Model type with "type=ModelType.MLFLOW" makes the code execution fail, with error saying that MLFLOW is not supported type and advising that one of the supported ones is mlflow_model. Got this resolved only after changing constant set to "from azure.ai.ml.constants import AssetTypes" and setting Model type with "type=AssetTypes.MLFLOW_MODEL".