### PR TITLE
Updating on the troubleshooting section

### DIFF
--- a/articles/openshift/howto-service-principal-credential-rotation.md
+++ b/articles/openshift/howto-service-principal-credential-rotation.md
@@ -88,7 +88,7 @@ To check the expiration date of service principal credentials run the following:
 # Service principal expiry in ISO 8601 UTC format
 SP_ID=$(az aro show --name MyManagedCluster --resource-group MyResourceGroup \
     --query servicePrincipalProfile.clientId -o tsv)
-az ad app credential list --id $SP_ID --query "[].endDate" -o tsv
+az ad app credential list --id $SP_ID --query "[].endDateTime" -o tsv
 ```
 If the service principal credentials are expired please update using one of the two credential rotation methods.
 


### PR DESCRIPTION
The key that contains the expiration time is currently called endDateTime, not endDate. output example:
```
$ az ad app credential list --id $SP_ID 
[
  {
    "customKeyIdentifier": "abcdefghijklmnopqrstuvxyz",
    "displayName": null,
    "endDateTime": "2299-12-31T00:00:00Z",
    "hint": "24b",
    "keyId": "abcd1234-ab12-ab12-ab12-abcdef123456",
    "secretText": null,
    "startDateTime": "2023-02-15T21:38:02.84925Z"
  }
]
```