### PR TITLE
Fix missing MLClient parameter (workspace_name)

### DIFF
--- a/includes/machine-learning-mlflow-configure-tracking.md
+++ b/includes/machine-learning-mlflow-configure-tracking.md
@@ -59,7 +59,8 @@ ms.author: fasantia
     
         ml_client = MLClient(credential=DefaultAzureCredential(),
                                 subscription_id=subscription_id, 
-                                resource_group_name=resource_group)
+                                resource_group_name=resource_group,
+                                workspace_name=workspace_name)
         ```
     
         > [!IMPORTANT]


### PR DESCRIPTION
I added the `workspace_name=workspace_name` to the MLClient constructor.  Without this parameter, the next example statement on line 72 `mlflow_tracking_uri = ml_client.workspaces.get(ml_client.workspace_name).mlflow_tracking_uri` fails with the error "ValidationException: Please provide a workspace name or use a MLClient with a workspace name set."

By providing the workspace_name to the MLClient constructor the error is prevented.

Other examples in the docs do pass the workspace_name to the constructor: https://learn.microsoft.com/en-us/azure/machine-learning/how-to-debug-managed-online-endpoints-visual-studio-code?tabs=python#launch-development-container