### PR TITLE
Update disks-prem-v2-limitations.md

### DIFF
--- a/includes/disks-prem-v2-limitations.md
+++ b/includes/disks-prem-v2-limitations.md
@@ -16,3 +16,4 @@
 - Azure Disk Encryption (guest VM encryption via Bitlocker/DM-Crypt) isn't supported for VMs with Premium SSD v2 disks. We recommend you to use encryption at rest with platform-managed or customer-managed keys, which is supported for Premium SSD v2. 
 - Currently, Premium SSD v2 disks can't be attached to VMs in Availability Sets.
 - Azure Backup and Azure Site Recovery aren't supported for VMs with Premium SSD v2 disks. 
+- Premium SSD v2 disks cannot directly created and attached to the already existing VMs. Create a new Premium SSD v2 disk in the same zone and region as the VM and then attach the disk to the existing VM.


### PR DESCRIPTION
We can not directly create and attach the Premium SSD v2 disk to an existing VM using an option under Disks "Create and attach a new disk" . It will be greyed out and give error: "Premium SSD v2 is not registered for the selected subscription". So, we need to create a new Premium SSD v2 disk in the same zone, region as the VM and then attach it to the VM.