### PR TITLE
Removing confusion on diagnostic logs source

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-troubleshoot.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-troubleshoot.md
@@ -104,14 +104,14 @@ To troubleshoot issues with deploying the Azure AD Kerberos Server, use the logs
 
 The Azure AD Kerberos Server PowerShell cmdlets in the [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module use the same logging as the standard Azure AD Connect Wizard. To view information or error details from the cmdlets, complete the following steps:
 
-1. On the machine where [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module was used, browse to `C:\ProgramData\AADConnect\`. This folder is hidden by default.
+1. On the machine where the [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module was used, browse to `C:\ProgramData\AADConnect\`. This folder is hidden by default.
 1. Open and view the most recent `trace-*.log` file located in the directory.
 
 #### Viewing the Azure AD Kerberos Server Objects
 
 To view the Azure AD Kerberos Server Objects and verify they are in good order, complete the following steps:
 
-1. On the Azure AD Connect Server or any other machine where [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module is installed, open PowerShell and navigate to `C:\Program Files\Microsoft Azure Active Directory Connect\AzureADKerberos\`
+1. On the Azure AD Connect Server or any other machine where the [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module is installed, open PowerShell and navigate to `C:\Program Files\Microsoft Azure Active Directory Connect\AzureADKerberos\`
 1. Run the following PowerShell commands to view the Azure AD Kerberos Server from both Azure AD and on-premises AD DS.
 
     Replace *corp.contoso.com* with the name of your on-premises AD DS domain.

--- a/articles/active-directory/authentication/howto-authentication-passwordless-troubleshoot.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-troubleshoot.md
@@ -98,20 +98,20 @@ The following events logs and registry key info is collected:
 
 ### Deployment Issues
 
-To troubleshoot issues with deploying the Azure AD Kerberos Server, use the new PowerShell module included with Azure AD Connect.
+To troubleshoot issues with deploying the Azure AD Kerberos Server, use the logs for the new [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) PowerShell module.
 
 #### Viewing the logs
 
-The Azure AD Kerberos Server PowerShell cmdlets use the same logging as the standard Azure AD Connect Wizard. To view information or error details from the cmdlets, complete the following steps:
+The Azure AD Kerberos Server PowerShell cmdlets in the [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module use the same logging as the standard Azure AD Connect Wizard. To view information or error details from the cmdlets, complete the following steps:
 
-1. On the Azure AD Connect Server, browse to `C:\ProgramData\AADConnect\`. This folder is hidden by default.
+1. On the machine where [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module was used, browse to `C:\ProgramData\AADConnect\`. This folder is hidden by default.
 1. Open and view the most recent `trace-*.log` file located in the directory.
 
 #### Viewing the Azure AD Kerberos Server Objects
 
 To view the Azure AD Kerberos Server Objects and verify they are in good order, complete the following steps:
 
-1. On the Azure AD Connect Server, open PowerShell and navigate to `C:\Program Files\Microsoft Azure Active Directory Connect\AzureADKerberos\`
+1. On the Azure AD Connect Server or any other machine where [AzureADHybridAuthenticationManagement](https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement) module is installed, open PowerShell and navigate to `C:\Program Files\Microsoft Azure Active Directory Connect\AzureADKerberos\`
 1. Run the following PowerShell commands to view the Azure AD Kerberos Server from both Azure AD and on-premises AD DS.
 
     Replace *corp.contoso.com* with the name of your on-premises AD DS domain.


### PR DESCRIPTION
Some customers have been installing the https://www.powershellgallery.com/packages/AzureADHybridAuthenticationManagement module on other machines such as domain controllers to attempt to configure the Azure AD Kerberos server object instead of using the module shipped with recent AAD Connect builds. Then they were gathering logs from the AAD Connect server as the instructions imply that's where they should gather them from. Updating this doc to emphasise logs should be gathered from wherever they installed/used the module.