### PR TITLE
Update create-self-hosted-integration-runtime.md

### DIFF
--- a/articles/data-factory/create-self-hosted-integration-runtime.md
+++ b/articles/data-factory/create-self-hosted-integration-runtime.md
@@ -75,7 +75,7 @@ Installation of the self-hosted integration runtime on a domain controller isn't
 - Copy-activity runs happen with a specific frequency. Processor and RAM usage on the machine follows the same pattern with peak and idle times. Resource usage also depends heavily on the amount of data that is moved. When multiple copy jobs are in progress, you see resource usage go up during peak times.
 - Tasks might fail during extraction of data in Parquet, ORC, or Avro formats. For more on Parquet, see [Parquet format in Azure Data Factory](./format-parquet.md#using-self-hosted-integration-runtime). File creation runs on the self-hosted integration machine. To work as expected, file creation requires the following prerequisites:
   - [Visual C++ 2010 Redistributable](https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe) Package (x64)
-  - Java Runtime (JRE) version 11 from a JRE provider such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=11). Ensure that the JAVA_HOME environment variable is set to the JDK folder (and not just the JRE folder) you may also need to add the bin folder to your system's PATH environment variable.
+  - Java Runtime (JRE) version 11 from a JRE provider such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=11). To properly install JRE, you need to set the JAVA_HOME environment variable to the installation directory, add the bin directory to the PATH environment variable, and reboot your machine for the changes to take effect.
   >[!NOTE]
   >It might be necessary to adjust the Java settings if memory errors occur, as described in the [Parquet format](./format-parquet.md#using-self-hosted-integration-runtime) documentation.
   

--- a/articles/data-factory/create-self-hosted-integration-runtime.md
+++ b/articles/data-factory/create-self-hosted-integration-runtime.md
@@ -75,7 +75,7 @@ Installation of the self-hosted integration runtime on a domain controller isn't
 - Copy-activity runs happen with a specific frequency. Processor and RAM usage on the machine follows the same pattern with peak and idle times. Resource usage also depends heavily on the amount of data that is moved. When multiple copy jobs are in progress, you see resource usage go up during peak times.
 - Tasks might fail during extraction of data in Parquet, ORC, or Avro formats. For more on Parquet, see [Parquet format in Azure Data Factory](./format-parquet.md#using-self-hosted-integration-runtime). File creation runs on the self-hosted integration machine. To work as expected, file creation requires the following prerequisites:
   - [Visual C++ 2010 Redistributable](https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe) Package (x64)
-  - Java Runtime (JRE) version 8 from a JRE provider such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=8). Ensure that the JAVA_HOME environment variable is set to the JDK folder (and not just the JRE folder).
+  - Java Runtime (JRE) version 11 from a JRE provider such as [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=11). Ensure that the JAVA_HOME environment variable is set to the JDK folder (and not just the JRE folder) you may also need to add the bin folder to your system's PATH environment variable.
   >[!NOTE]
   >It might be necessary to adjust the Java settings if memory errors occur, as described in the [Parquet format](./format-parquet.md#using-self-hosted-integration-runtime) documentation.
   


### PR DESCRIPTION
Based on my most recent experience (2023-02-20) it looks Like JAVA 11 is the currently supported JRE / JDK Now (it is unclear if 8 is still supported or not. I had numerous JNI erros with 8 that seemed to go away after moving to 11). Also depending on the distro the bin folder may not get automatically added to the system path with the JRE install. I have added this as another thing to check. if the bin folder is not in the system path the SHIR will be unable to find the java.exe   Please verify this for technical accuracy thanks