### PR TITLE
Update deploy-github-actions.md

### DIFF
--- a/articles/app-service/deploy-github-actions.md
+++ b/articles/app-service/deploy-github-actions.md
@@ -601,7 +601,7 @@ jobs:
           dotnet publish -c Release --property:PublishDir='${{ env.AZURE_WEBAPP_PACKAGE_PATH }}/myapp' 
           
       # Deploy to Azure Web apps
-      - name: 'Run Azure webapp deploy action using publish profile credentials'
+      - name: 'Run Azure webapp deploy action using Azure Credentials'
         uses: azure/webapps-deploy@v2
         with: 
           app-name: ${{ env.AZURE_WEBAPP_NAME }} # Replace with your app name
@@ -651,7 +651,7 @@ jobs:
     - name: Run MSBuild
       run: msbuild .\SampleWebApplication.sln
        
-    - name: 'Run Azure webapp deploy action using publish profile credentials'
+    - name: 'Run Azure webapp deploy action using Azure Credentials'
       uses: azure/webapps-deploy@v2
       with: 
         app-name: ${{ env.AZURE_WEBAPP_NAME }} # Replace with your app name


### PR DESCRIPTION
In Service Principal tab, task named as 'Run Azure webapp deploy action using publish profile credentials' which is creating confusion since it is deployment using service principal deployment.