### PR TITLE
Update Infinite Campus SSO tutorial

### DIFF
--- a/articles/active-directory/saas-apps/infinitecampus-tutorial.md
+++ b/articles/active-directory/saas-apps/infinitecampus-tutorial.md
@@ -57,7 +57,6 @@ To configure and test Azure AD SSO with Infinite Campus, perform the following s
     1. **[Create an Azure AD test user](#create-an-azure-ad-test-user)** - to test Azure AD single sign-on with B.Simon.
     1. **[Assign the Azure AD test user](#assign-the-azure-ad-test-user)** - to enable B.Simon to use Azure AD single sign-on.
 1. **[Configure Infinite Campus SSO](#configure-infinite-campus-sso)** - to configure the single sign-on settings on application side.
-    1. **[Create Infinite Campus test user](#create-infinite-campus-test-user)** - to have a counterpart of B.Simon in Infinite Campus that is linked to the Azure AD representation of user.
 1. **[Test SSO](#test-sso)** - to verify whether the configuration works.
 
 ## Configure Azure AD SSO
@@ -133,7 +132,7 @@ See Infinite Campus' [documentation](https://kb.infinitecampus.com/help/sso-serv
 The SAML certificate this integration relies on will eventually need to be renewed so users can continue logging into Infinite Campus through single sign-on. For districts with proper Campus Messenger Email Settings established, Infinite Campus will send warning emails as the certificate expiration approaches. (Subject: "Action required: Your certificate is expiring.") 
 
 These are the steps to take to replace an expiring SAML certificate: 
-1. Have your district's Microsoft Azure Active Directory admin sign in to the Azure portal [aad.portal.azure.com](aad.portal.azure.com)
+1. Have your district's Microsoft Azure Active Directory admin sign in to the Azure portal
 1.	On the left navigation pane, select the Azure Active Directory service.
 1.	Navigate to Enterprise Applications and select your Infinite Campus application set up previously. (If you have multiple Infinite Campus environments like a sandbox or staging site, you will have multiple Infinite Campus applications set up here. You will need to complete this process in each respective Infinite Campus environment for any with an expiring certificate.)
 1.	Select Single Sign-On
@@ -147,7 +146,7 @@ These are the steps to take to replace an expiring SAML certificate:
 1.	Select the three dots next to the old certificate. Select Delete Certificate.
 1.	Return to Infinite Campus and hit the Sync button next to the Metadata URL again. It will say "IDP Synchronization successful" again. Hit OK and Save again.
 
-This completes the process of replacing an expiring certificate. For additional details see Infinite Campus' [documentation](https://kb.infinitecampus.com/help/sso-service-provider-configuration#certificate-expiration-warnings).
+This completes the process of replacing an expiring certificate. For additional details see Infinite Campus' [documentation](https://kb.infinitecampus.com/help/sso-service-provider-configuration#SSOServiceProviderConfiguration-CertificateExpirationWarnings).
 
 
 ## Next steps

--- a/articles/active-directory/saas-apps/infinitecampus-tutorial.md
+++ b/articles/active-directory/saas-apps/infinitecampus-tutorial.md
@@ -108,33 +108,9 @@ In this section, you'll enable B.Simon to use Azure single sign-on by granting a
 
 ## Configure Infinite Campus SSO
 
-1. In a different web browser window, sign in to Infinite Campus as a Security Administrator.
+For detailed steps on how to configure SSO within Infinite Campus, [please follow the steps in this document](https://kb.infinitecampus.com/help/sso-service-provider-configuration#SSOServiceProviderConfiguration-EnableandConfigureSAMLSSOFunctionality).
 
-2. On the left side of menu, click **System Administration**.
-
-	![The Admin](./media/infinitecampus-tutorial/admin.png)
-
-3. Navigate to **User Security** > **SAML Management** > **SSO Service Provider Configuration**.
-
-	![The saml](./media/infinitecampus-tutorial/security.png)
-
-4. On the **SSO Service Provider Configuration** page, perform the following steps:
-
-	![The sso](./media/infinitecampus-tutorial/configuration.png)
-
-	a. Select **Enable SAML Single Sign On**.
-
-	b. Edit the **Optional Attribute Name** to contain **name**.
-
-	c. On the **Select an option to retrieve Identity Provider (IDP) server data** section, select **Metadata URL**, paste the **App Federation Metadata Url** value, which you have copied from the Azure portal in the box, and then click **Sync**.
-
-	d. After clicking **Sync** the values get auto-populated in **SSO Service Provider Configuration** page. These values can be verified to match the values seen in Step 4 above.
-
-	e. Click **Save**.
-
-### Create Infinite Campus test user
-
-Infinite Campus has a demographics centered architecture. Please contact [Infinite Campus support team](mailto:sales@infinitecampus.com) to add the users in the Infinite Campus platform.
+Once you have completed configuring SSO within Infinite Campus, if you would like users to be signed out their Azure SSO connection when logging out of Infinite Campus, [follow these steps](https://kb.infinitecampus.com/help/sso-service-provider-configuration#SSOServiceProviderConfiguration-AddtheInfiniteCampusLogoutURLtotheMicrosoftAzureSAMLSSOConfiguration).
 
 ## Test SSO
 
@@ -146,6 +122,35 @@ In this section, you test your Azure AD single sign-on configuration with follow
 
 * You can use Microsoft My Apps. When you click the Infinite Campus tile in the My Apps, this will redirect to Infinite Campus Sign-on URL. For more information about the My Apps, see [Introduction to the My Apps](https://support.microsoft.com/account-billing/sign-in-and-start-apps-from-the-my-apps-portal-2f3b1bae-0e5a-4a86-a33e-876fbd2a4510).
 
+## Configure Azure SSO for Non-Production Infinite Campus Environments (sandbox, staging)
+
+If your district has additional Infinite Campus environments, this entire setup process must be repeated for each environment. For example, if your district has an Infinite Campus sandbox site, add the Infinite Campus app from the gallery again and complete the process while referencing the SSO Service Provider Configuration screen within your Infinite Campus sandbox site. If your district also has, for example, an Infinite Campus staging site, you will need to complete this process a third time.
+
+See Infinite Campus' [documentation](https://kb.infinitecampus.com/help/sso-service-provider-configuration#sandbox/staging/non-production-environments) for more information about this process. 
+
+## Replacing an Expiring SAML Certificate
+
+The SAML certificate this integration relies on will eventually need to be renewed so users can continue logging into Infinite Campus through single sign-on. For districts with proper Campus Messenger Email Settings established, Infinite Campus will send warning emails as the certificate expiration approaches. (Subject: "Action required: Your certificate is expiring.") 
+
+These are the steps to take to replace an expiring SAML certificate: 
+1. Have your district's Microsoft Azure Active Directory admin sign in to the Azure portal [aad.portal.azure.com](aad.portal.azure.com)
+1.	On the left navigation pane, select the Azure Active Directory service.
+1.	Navigate to Enterprise Applications and select your Infinite Campus application set up previously. (If you have multiple Infinite Campus environments like a sandbox or staging site, you will have multiple Infinite Campus applications set up here. You will need to complete this process in each respective Infinite Campus environment for any with an expiring certificate.)
+1.	Select Single Sign-On
+1.	Navigate to the SAML Certificate and copy the App Federation Metadata URL,
+1.	Within Infinite Campus, navigate to the SSO Service Provider Configuration tool, select the configuration, and paste the App Federation Metadata URL copied in the previous step into the Metadata URL field.
+1.	In a separate window, go back to the Azure portal. Under SAML Certificates, in the Token Signing Certificate area, select Edit
+1.	Select New Certificate. Modify the expiration date if desired. 
+1.	Select Save. (Leave the Signing Option and Signing Algorithm as-is)
+1.	Return to the Infinite Campus window and click the Sync button next to the Metadata URL. It will say "IDP Synchronization successful". Select OK and Save.
+1.	Return to the Azure portal, still on the SAML Signing Certificate edit screen, select the three dots (...) next to the new certificate. Select Make Certificate Active and click Save.
+1.	Select the three dots next to the old certificate. Select Delete Certificate.
+1.	Return to Infinite Campus and hit the Sync button next to the Metadata URL again. It will say "IDP Synchronization successful" again. Hit OK and Save again.
+
+This completes the process of replacing an expiring certificate. For additional details see Infinite Campus' [documentation](https://kb.infinitecampus.com/help/sso-service-provider-configuration#certificate-expiration-warnings).
+
+
 ## Next steps
 
 Once you configure Infinite Campus you can enforce session control, which protects exfiltration and infiltration of your organization’s sensitive data in real time. Session control extends from Conditional Access. [Learn how to enforce session control with Microsoft Defender for Cloud Apps](/cloud-app-security/proxy-deployment-aad).
+


### PR DESCRIPTION
Routine maintenance on Infinite Campus SSO tutorial:

1. Replace "Configure Infinite Campus SSO" section with link to Infinite Campus living documentation
2. Add section on configuring SSO for non-production environments
3. Add section on replacing an expiring SAML cert