### PR TITLE
Reusing the same AppId across publisher accounts

### DIFF
--- a/articles/marketplace/partner-center-portal/saas-fulfillment-apis-faq.yml
+++ b/articles/marketplace/partner-center-portal/saas-fulfillment-apis-faq.yml
@@ -91,6 +91,11 @@ sections:
           
           ![Customer unsubscribes in Microsoft's online store](media/saas-metering-service-integration-flow-e.png)
 
+      - question: |
+          Can I reuse the App Registration information across all SaaS offers in different publisher accounts?
+        answer: |
+          In mulitple publisher account scenario - AppId cannot be shared across different publisher accounts, which means an App registration information [AppId] used in SaaS offers within one publisher account cannot be re-used within SaaS Offers in different/other publisher accounts.
+
 additionalContent: |
 
   ## Next steps

--- a/articles/marketplace/partner-center-portal/saas-fulfillment-apis-faq.yml
+++ b/articles/marketplace/partner-center-portal/saas-fulfillment-apis-faq.yml
@@ -94,7 +94,7 @@ sections:
       - question: |
           Can I reuse the App Registration information across all SaaS offers in different publisher accounts?
         answer: |
-          In mulitple publisher account scenario - AppId cannot be shared across different publisher accounts, which means an App registration information [AppId] used in SaaS offers within one publisher account cannot be re-used within SaaS Offers in different/other publisher accounts.
+          In multiple publisher account scenarios - AppId can't be shared across different publisher accounts, which means an App registration information [AppId] used in SaaS offers within one publisher account can't be re-used within SaaS Offers in different/other publisher accounts.
 
 additionalContent: |
 


### PR DESCRIPTION
Added information on the Limitation of using the same AppId across offers in different publisher accounts.