### PR TITLE
Unnecessary syntax highlight

### DIFF
--- a/articles/machine-learning/how-to-deploy-online-endpoints.md
+++ b/articles/machine-learning/how-to-deploy-online-endpoints.md
@@ -508,7 +508,7 @@ ml_client.online_endpoints.get(name=local_endpoint_name, local=True)
 
 The method returns [`ManagedOnlineEndpoint` entity](/python/api/azure-ai-ml/azure.ai.ml.entities.managedonlineendpoint). The `provisioning_state` is `Succeeded`.
 
-```python
+```
 ManagedOnlineEndpoint({'public_network_access': None, 'provisioning_state': 'Succeeded', 'scoring_uri': 'http://localhost:49158/score', 'swagger_uri': None, 'name': 'local-10061534497697', 'description': 'this is a sample local endpoint', 'tags': {}, 'properties': {}, 'id': None, 'Resource__source_path': None, 'base_path': '/path/to/your/working/directory', 'creation_context': None, 'serialize': <msrest.serialization.Serializer object at 0x7ffb781bccd0>, 'auth_mode': 'key', 'location': 'local', 'identity': None, 'traffic': {}, 'mirror_traffic': {}, 'kind': None})
 ```
 


### PR DESCRIPTION
Syntax highlight is slightly confusing, as technically this is the outcome of the previously executed Python command, not a Python code on its own.