### PR TITLE
RDP Short path early notification

### DIFF
--- a/articles/virtual-desktop/rdp-shortpath.md
+++ b/articles/virtual-desktop/rdp-shortpath.md
@@ -39,6 +39,9 @@ Using RDP Shortpath has the following key benefits:
   - RDP Shortpath brings support for configuring Quality of Service (QoS) priority for RDP connections through Differentiated Services Code Point (DSCP) marks.
   - The RDP Shortpath transport allows limiting outbound network traffic by specifying a throttle rate for each session.
 
+> [!NOTE]
+> RDP Shortpath doesn't support Symmetric NAT, which is the mapping of a single private source *IP:Port* to a unique public destination *IP:Port*. This is because RDP Shortpath needs to reuse the same external port (or NAT binding) used in the initial connection. Where multiple paths are used, for example a highly available firewall pair, external port reuse cannot be guaranteed. Azure Firewall and Azure NAT Gateway use Symmetric NAT and so are not supported. For more information about NAT with Azure virtual networks, see [Source Network Address Translation with virtual networks](../virtual-network/nat-gateway/nat-gateway-resource.md#source-network-address-translation).
+
 ## How RDP Shortpath works
 
 To learn how RDP Shortpath works for managed networks and public networks, select each of the following tabs.
@@ -145,8 +148,7 @@ As RDP Shortpath uses UDP to establish a data flow, if a firewall on your networ
 
 If your users are in a scenario where RDP Shortpath for both managed network and public networks is available to them, then the first algorithm found will be used. The user will use whichever connection gets established first for that session.
 
-> [!NOTE]
-> RDP Shortpath doesn't support Symmetric NAT, which is the mapping of a single private source *IP:Port* to a unique public destination *IP:Port*. This is because RDP Shortpath needs to reuse the same external port (or NAT binding) used in the initial connection. Where multiple paths are used, for example a highly available firewall pair, external port reuse cannot be guaranteed. Azure Firewall and Azure NAT Gateway use Symmetric NAT and so are not supported. For more information about NAT with Azure virtual networks, see [Source Network Address Translation with virtual networks](../virtual-network/nat-gateway/nat-gateway-resource.md#source-network-address-translation).
+
 
 #### TURN availability (preview)
 


### PR DESCRIPTION
RDP Short path does not work with Azure firewall because of Symmetric NAT. Customers spend time to implement all the way before finding this bit of the information at the tail end. Early notification suggested by customers