### PR TITLE
Get function is set with wrong parameters

### DIFF
--- a/articles/machine-learning/how-to-deploy-online-endpoints.md
+++ b/articles/machine-learning/how-to-deploy-online-endpoints.md
@@ -553,7 +553,7 @@ ml_client.online_endpoints.invoke(
 If you want to use a REST client (like curl), you must have the scoring URI. To get the scoring URI, run the following code. In the returned data, find the `scoring_uri` attribute. Sample curl based commands are available later in this doc.
 
 ```python
-endpoint = ml_client.online_endpoints.get(endpoint_name)
+endpoint = ml_client.online_endpoints.get(name=local_endpoint_name, local=True)
 scoring_uri = endpoint.scoring_uri
 ```
 


### PR DESCRIPTION
Get function should be fed with 'name=local_endpoint_name, local=True' parameters values, otherwise this will doubly fail. First of all, endpoint_name is not defined as a variable. Secondly, without local flag set to True, the code will search for endpoint name in Azure ML where it's not defined yet.