### PR TITLE
Update files-troubleshoot-linux-nfs.md

### DIFF
--- a/articles/storage/files/files-troubleshoot-linux-nfs.md
+++ b/articles/storage/files/files-troubleshoot-linux-nfs.md
@@ -15,7 +15,7 @@ ms.custom: references_regions, devx-track-azurepowershell
 This article lists common issues related to NFS Azure file shares and provides potential causes and workarounds.
 
 > [!IMPORTANT]
-> The content of this article only applies to NFS shares. To troubleshoot SMB issues in Linux, see [Troubleshoot Azure Files problems in Linux (SMB)](files-troubleshoot-linux-smb.md). NFS Azure file shares aren't supported for Windows clients.
+> The content of this article only applies to NFS shares. To troubleshoot SMB issues in Linux, see [Troubleshoot Azure Files problems in Linux (SMB)](files-troubleshoot-linux-smb.md). NFS Azure file shares aren't supported for Windows clients and windows servers.
 
 ## Applies to
 | File share type | SMB | NFS |


### PR DESCRIPTION
NFS cannot be used with windows clients and windows servers. But this document says it cannot be used only for Windows clients which not a relavent information. Hence addind the word *server*