### PR TITLE
Add upgrade steps for RHEL 8 to 9

### DIFF
--- a/articles/virtual-machines/workloads/redhat/redhat-in-place-upgrade.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-in-place-upgrade.md
@@ -24,6 +24,9 @@ ms.author: mamccrea
 ## What is RHEL in-place upgrade?
 During an in-place upgrade, the earlier RHEL OS major version will be replaced with the new RHEL OS major version without removing the earlier version first. The installed applications and utilities, along with the configurations and preferences, are incorporated into the new version.
 
+## Upgrade from RHEL 8 VMs to RHEL 9 VMs
+Instructions for an in-place upgrade from Red Hat Enterprise Linux 8 VMs to Red Hat Enterprise Linux 9 VMs on Azure is provided at the [Red Hat upgrading from RHEL 8 to RHEL 9 documentation here.](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/index)
+
 
 ## Upgrade from RHEL 7 VMs to RHEL 8 VMs
 Instructions for an in-place upgrade from Red Hat Enterprise Linux 7 VMs to Red Hat Enterprise Linux 8 VMs on Azure is provided at the [Red Hat upgrading from RHEL 7 to RHEL 8 documentation here.](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index)
@@ -37,5 +40,5 @@ Instructions for an in-place upgrade from Red Hat Enterprise Linux 7 SAP VMs to 
 * Learn more about [Red Hat images in Azure](./redhat-images.md).
 * Learn more about [Red Hat update infrastructure](./redhat-rhui.md).
 * Learn more about the [RHEL BYOS offer](./byos.md).
-* To learn more about the Red Hat in-place upgrade processes, see [Upgrading from RHEL 7 TO RHEL 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index) in the Red Hat documentation.
+* To learn more about the Red Hat in-place upgrade processes, see [Upgrading from RHEL 7 TO RHEL 8](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index) and [Upgrading from RHEL 8 to RHEL 9](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/upgrading_from_rhel_8_to_rhel_9/index) in the Red Hat documentation.
 * To learn more about Red Hat support policies for all versions of RHEL, see [Red Hat Enterprise Linux life cycle](https://access.redhat.com/support/policy/updates/errata) in the Red Hat documentation.


### PR DESCRIPTION
RHEL 9 has been out since May 2022, but we missed this doco update.