### PR TITLE
We got some issues with ARO in Azure ARC.

### DIFF
--- a/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
+++ b/articles/azure-arc/kubernetes/quickstart-connect-cluster.md
@@ -238,6 +238,13 @@ Helm release deployment succeeded
 > [!IMPORTANT]
 > In some cases, deployment may fail due to a timeout error. Please see our [troubleshooting guide](troubleshooting.md#helm-timeout-error) for details on how to resolve this issue.
 
+> [!IMPORTANT]
+> If you are using ARO(Openshift) on Azure, you need to pass two more parameters the distribution and infrastructure as the command below.
+
+```azurecli
+az connectedk8s connect --name AzureArcTest1 --resource-group AzureArcTest --distribution openshift --infrastructure azure
+```
+
 ### [Azure PowerShell](#tab/azure-powershell)
 
 ```azurepowershell


### PR DESCRIPTION
When we add a new cluster in Azure ARC and the cluster is ARO, we had some issues to install the extensions available on Azure ARC.

Some time the cli gets the right values for OpenShift , but is the most of cases it does not get.

So adding the --distribution OpenShift and --infrastructure azure are needed for ARO.