### PR TITLE
Removed Router ASN: Unless necessary, leave the default.

### DIFF
--- a/includes/virtual-wan-hub-basics.md
+++ b/includes/virtual-wan-hub-basics.md
@@ -19,4 +19,3 @@ ms.topic: include
    * **Hub private address space**: The hub's address range in CIDR notation. The minimum address space is /24 to create a hub.
    * **Virtual hub capacity**: Select from the dropdown. For more information, see [Virtual hub settings](../articles/virtual-wan/hub-settings.md).
    * **Hub routing preference**: This field is only available as part of the virtual hub routing preference preview and can only be viewed in the [preview portal](https://portal.azure.com/?feature.customRouterAsn=true&feature.virtualWanRoutingPreference=true#home). See [Virtual hub routing preference](../articles/virtual-wan/about-virtual-hub-routing-preference.md) for more information.
-   * **Router ASN**: Unless necessary, leave the default.


### PR DESCRIPTION
Currently changing HUB router ASN is not an option, so removing this line from the public docs.