### PR TITLE
Functions support only Linux Docker Containers

### DIFF
--- a/articles/app-service/environment/overview.md
+++ b/articles/app-service/environment/overview.md
@@ -20,7 +20,7 @@ An App Service Environment can host your:
 - Windows web apps
 - Linux web apps
 - Docker containers (Windows and Linux)
-- Functions
+- Functions (Windows and Linux code-only functions, Only Linux Docker containers)
 - Logic apps (Standard)
 
 App Service Environments are appropriate for application workloads that require:


### PR DESCRIPTION
Specify that both Windows and Linux code-only apps are supported for Fucntions. And that only Linux Docker Containers supported for Functions.