### PR TITLE
Update_service_account_cmdlet.md

### DIFF
--- a/articles/storage/files/storage-files-identity-ad-ds-enable.md
+++ b/articles/storage/files/storage-files-identity-ad-ds-enable.md
@@ -193,10 +193,14 @@ To enable AES-256 encryption, follow the steps in this section. If you plan to u
 
 Replace `<domain-object-identity>` and `<domain-name>` with your values, then run the following cmdlet to configure AES-256 support. You must have AD PowerShell cmdlets installed and execute the cmdlet in PowerShell 5.1 with elevated privileges.
 
+For Computer account run below cmdlet:
 ```powershell
 Set-ADComputer -Identity <domain-object-identity> -Server <domain-name> -KerberosEncryptionType "AES256"
 ```
-
+For service logon account run below cmdlet:
+```powershell
+Set-ADUser -Identity <domain-object-identity> -Server <domain-name> -KerberosEncryptionType "AES256"
+```
 After you've run the above cmdlet, replace `<domain-object-identity>` in the following script with your value, then run the script to refresh your domain object password:
 
 ```powershell


### PR DESCRIPTION
In the section where we are manually enabling the AES 256 encryption, it is mentioned that the storage account can be a computer account or a service logon account. The powershell cmdlet to enable encryption is mentioned only for a computer account and not a service logon account. This creates some confusion when someone is following the document because if they have a service logon account this command does not work and they think that this command should only be used to change encryption whether it is computer account or service logon account. So, I think it will be easy for readers to understand if we clearly mention both the cmdlets for different types of account.