### PR TITLE
Typo "Azure database for PostgreSQL"→"Azure Database for PostgreSQL"

### DIFF
--- a/articles/data-factory/connector-azure-database-for-postgresql.md
+++ b/articles/data-factory/connector-azure-database-for-postgresql.md
@@ -41,7 +41,7 @@ The three activities work on all Azure Database for PostgreSQL deployment option
 
 [!INCLUDE [data-factory-v2-connector-get-started](includes/data-factory-v2-connector-get-started.md)]
 
-## Create a linked service to Azure database for PostgreSQL using UI
+## Create a linked service to Azure Database for PostgreSQL using UI
 
 Use the following steps to create a linked service to Azure database for PostgreSQL in the Azure portal UI.
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/data-factory/connector-azure-database-for-postgresql?tabs=data-factory 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/data-factory/connector-azure-database-for-postgresql.md 
#PingMSFTDocs