### PR TITLE
Typo: 2 scenarios described with the same config

### DIFF
--- a/articles/machine-learning/how-to-administrate-data-authentication.md
+++ b/articles/machine-learning/how-to-administrate-data-authentication.md
@@ -96,7 +96,7 @@ When an Azure Storage account is behind a virtual network, the storage firewall 
 When the workspace uses a private endpoint and the storage account is also in the VNet, there are extra validation requirements when using studio:
 
 * If the storage account uses a __service endpoint__, the workspace private endpoint and storage service endpoint must be in the same subnet of the VNet.
-* If the storage account uses a __private endpoint__, the workspace private endpoint and storage service endpoint must be in the same VNet. In this case, they can be in different subnets.
+* If the storage account uses a __private endpoint__, the workspace private endpoint and storage private endpoint must be in the same VNet. In this case, they can be in different subnets.
 
 ## Azure Data Lake Storage Gen1
 

--- a/articles/machine-learning/how-to-administrate-data-authentication.md
+++ b/articles/machine-learning/how-to-administrate-data-authentication.md
@@ -7,7 +7,7 @@ ms.service: machine-learning
 ms.subservice: enterprise-readiness
 ms.topic: how-to
 ms.author: xunwan
-author: xunwan
+author: SturgeonMi
 ms.reviewer: larryfr
 ms.date: 01/20/2023
 ms.custom: engagement-fy23


### PR DESCRIPTION
- Above sentence already explained situation with the service endpoint;
- Second sentence started with a "private endpoint" scenario, but then mistakenly referred to the "service endpoint" again instead of a correct "private endpoint".