### PR TITLE
Remove support for Private Custom Domain

### DIFF
--- a/articles/app-service/app-service-web-tutorial-custom-domain.md
+++ b/articles/app-service/app-service-web-tutorial-custom-domain.md
@@ -27,7 +27,7 @@ The DNS record type you need to add with your domain provider depends on the dom
 ## Prerequisites
 
 * [Create an App Service app](./index.yml), or use an app that you created for another tutorial. The web app's [App Service plan](overview-hosting-plans.md) must be a paid tier and not **Free (F1)**. See [Scale up an app](manage-scale-up.md#scale-up-your-pricing-tier) to update the tier.
-* Make sure you can edit the DNS records for your custom domain. To edit DNS records, you need access to the DNS registry for your domain provider, such as GoDaddy. For example, to add DNS entries for `contoso.com` and `www.contoso.com`, you must be able to configure the DNS settings for the `contoso.com` root domain. Your custom domains must be in a public DNS zone; private DNS zone is only supported on Internal Load Balancer (ILB) App Service Environment (ASE).
+* Make sure you can edit the DNS records for your custom domain. To edit DNS records, you need access to the DNS registry for your domain provider, such as GoDaddy. For example, to add DNS entries for `contoso.com` and `www.contoso.com`, you must be able to configure the DNS settings for the `contoso.com` root domain. Your custom domains must be in a public DNS zone; private DNS zones are not supported.
 * If you don't have a custom domain yet, you can [purchase an App Service domain](manage-custom-dns-buy-domain.md) instead.
 
 ## 1. Configure a custom domain


### PR DESCRIPTION
Private Custom Domains are not supported on AppServices. They used to be with ASEv2, when customers were able to choose their own domain, even if they didn't publicly own the domain, but this ability has since been removed. Customers can still create an ASEv2 despite ASEv3 being available, but they are no longer able to choose their own domain for it. If a customer wishes to add a domain to their AppService, they must own the domain and it must be publicly resolvable.