### PR TITLE
"None" protocol is not supported

### DIFF
--- a/articles/active-directory-b2c/technicalprofiles.md
+++ b/articles/active-directory-b2c/technicalprofiles.md
@@ -116,7 +116,7 @@ The **Protocol** element specifies the protocol to be used for the communication
 
 | Attribute | Required | Description |
 | --------- | -------- | ----------- |
-| Name | Yes | The name of a valid protocol supported by Azure AD B2C that's used as part of the technical profile. Possible values are `OAuth1`, `OAuth2`, `SAML2`, `OpenIdConnect`, `Proprietary`, or `None`. |
+| Name | Yes | The name of a valid protocol supported by Azure AD B2C that's used as part of the technical profile. Possible values are `OAuth1`, `OAuth2`, `SAML2`, `OpenIdConnect`, `Proprietary`. |
 | Handler | No | When the protocol name is set to `Proprietary`, specifies the name of the assembly that's used by Azure AD B2C to determine the protocol handler. |
 
 ## Metadata


### PR DESCRIPTION
When trying to use Protocol="None" the policy will run into an exception such as:

An attempt was made to resolve a protocol handler for unsupported protocol \"None\" in technical profile with id \"SetErrorAccessRejected\" in policy with id \"B2C_1A_signup_signin\" for tenant with id \"xxxxx.onmicrosoft.com\".

This happenes regardless if you also set "Handler" to "None" or you omit it all togehter.