### PR TITLE
Updated the SSL certificate change as described in the documentation due to the error "Error: self-signed certificate in certificate chain".

### DIFF
--- a/articles/mysql/single-server/connect-nodejs.md
+++ b/articles/mysql/single-server/connect-nodejs.md
@@ -101,9 +101,9 @@ Get the connection information needed to connect to the Azure Database for MySQL
 
 1. Paste the JavaScript code into new text files, and then save it into a project folder with file extension .js (such as C:\nodejsmysql\createtable.js or /home/username/nodejsmysql/createtable.js).
 1. Replace `host`, `user`, `password` and `database` config options in the code with the values that you specified when you created the server and database.
-1. **Obtain SSL certificate**: Download the certificate needed to communicate over SSL with your Azure Database for MySQL server from [https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem) and save the certificate file to your local drive.
+1. **Obtain SSL certificate**: Download the certificate needed to communicate over SSL with your Azure Database for MySQL server from [https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem) and save the certificate file to your local drive.
 
-    **For Microsoft Internet Explorer and Microsoft Edge:** After the download has completed, rename the certificate to BaltimoreCyberTrustRoot.crt.pem.
+    **For Microsoft Internet Explorer and Microsoft Edge:** After the download has completed, rename the certificate to DigiCertGlobalRootCA.crt.pem.
 
     See the following links for certificates for servers in sovereign clouds: [Azure Government](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem), [Azure China](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem), and [Azure Germany](https://www.d-trust.net/cgi-bin/D-TRUST_Root_Class_3_CA_2_2009.crt).
 1. In the `ssl` config option, replace the `ca-cert` filename with the path to this local file.
@@ -128,7 +128,7 @@ var config =
     password: 'your_password',
     database: 'quickstartdb',
     port: 3306,
-    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_BaltimoreCyberTrustRoot.crt.pem")}
+    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_DigiCertGlobalRootCA.crt.pem")}
 };
 
 const conn = new mysql.createConnection(config);
@@ -195,7 +195,7 @@ var config =
     password: 'your_password',
     database: 'quickstartdb',
     port: 3306,
-    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_BaltimoreCyberTrustRoot.crt.pem")}
+    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_DigiCertGlobalRootCA.crt.pem")}
 };
 
 const conn = new mysql.createConnection(config);
@@ -247,7 +247,7 @@ var config =
     password: 'your_password',
     database: 'quickstartdb',
     port: 3306,
-    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_BaltimoreCyberTrustRoot.crt.pem")}
+    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_DigiCertGlobalRootCA.crt.pem")}
 };
 
 const conn = new mysql.createConnection(config);
@@ -296,7 +296,7 @@ var config =
     password: 'your_password',
     database: 'quickstartdb',
     port: 3306,
-    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_BaltimoreCyberTrustRoot.crt.pem")}
+    ssl: {ca: fs.readFileSync("your_path_to_ca_cert_file_DigiCertGlobalRootCA.crt.pem")}
 };
 
 const conn = new mysql.createConnection(config);


### PR DESCRIPTION
I suggest changing the SSL certificate listed in the documentation from ``BaltimoreCyberTrustRoot.crt.pem`` to ``DigiCertGlobalRootCA.crt.pem``

I have tried to connect to Azure Database for MySQL from Node.js according to the following documentation.

[https://learn.microsoft.com/ja-jp/azure/mysql/single-server/connect-nodejs](connect-nodejs)

However, I got an error ```Error: self-signed certificate in certificate chain``` and could not connect to the database.

```
Error: self-signed certificate in certificate chain
    at TLSSocket.<anonymous> (/Users/XXX/node_modules/mysql/lib/Connection.js:317:48)
    at TLSSocket.emit (node:events:513:28)
    at TLSSocket._finishInit (node:_tls_wrap:959:8)
    at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:743:12)
```

I haven't been able to track down the exact cause, but the SSL certificate I downloaded from the Azure Portal "Azure Database for MySQL flexible server -> Networking -> Download SSL Certificate" was ```DigiCertGlobalRootCA.crt```, so I believe this is the correct one.