### PR TITLE
Typo: include 'than' on line 32

### DIFF
--- a/articles/azure-resource-manager/bicep/child-resource-name-type.md
+++ b/articles/azure-resource-manager/bicep/child-resource-name-type.md
@@ -29,7 +29,7 @@ The **full name** of the child resource uses the pattern:
 {parent-resource-name}/{child-resource-name}
 ```
 
-If you have more two levels in the hierarchy, keep repeating parent names:
+If you have more than two levels in the hierarchy, keep repeating parent names:
 
 ```bicep
 {parent-resource-name}/{child-level1-resource-name}/{child-level2-resource-name}


### PR DESCRIPTION
Current sentence:
If you have more two levels in the hierarchy, keep repeating parent names:

I believe the word 'than' is missing in this sentence. Proposed update:
If you have more than two levels in the hierarchy, keep repeating parent names: