### PR TITLE
Fix typo in bicep-config.md

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -38,7 +38,7 @@ You can enable preview features by adding:
 ```json
 {
   "experimentalFeaturesEnabled": {
-    "userDefineTypes": true,
+    "userDefinedTypes": true,
     "extensibility": true
   }
 }


### PR DESCRIPTION
There is a small typo in a field name.