### PR TITLE
Clarifying Access Time tracking effect

### DIFF
--- a/articles/storage/blobs/lifecycle-management-overview.md
+++ b/articles/storage/blobs/lifecycle-management-overview.md
@@ -177,7 +177,7 @@ The run conditions are based on age. Current versions use the last modified time
 | daysAfterLastAccessTimeGreaterThan<sup>1</sup> | Integer value indicating the age in days | The condition for a current version of a blob when access tracking is enabled |
 | daysAfterLastTierChangeGreaterThan | Integer value indicating the age in days after last blob tier change time | This condition applies only to `tierToArchive` actions and can be used only with the `daysAfterModificationGreaterThan` condition. |
 
-<sup>1</sup> If [last access time tracking](#move-data-based-on-last-accessed-time) is not enabled for a blob, **daysAfterLastAccessTimeGreaterThan** uses the date the lifecycle policy was enabled instead of the `LastAccessTime` property of the blob.
+<sup>1</sup> If [last access time tracking](#move-data-based-on-last-accessed-time) is not enabled for a blob, **daysAfterLastAccessTimeGreaterThan** uses the date the lifecycle policy was enabled instead of the `LastAccessTime` property of the blob. If last access time tracking is enabled, but the `LastAccessTime` property of a specific blog was not set yet, **daysAfterLastAccessTimeGreaterThan** uses the date access time tracking was enabled instead.
 
 ## Lifecycle policy completed event
 


### PR DESCRIPTION
Clarifying daysAfterLastAccessTimeGreaterThan effect on blobs having the `LastAccessTime` set to NULL, despite Access Tracking being enabled. This proposal is made based on feedback provided by @cipriangociman in a recent internal thread.