### PR TITLE
Update subscription verbiage

### DIFF
--- a/articles/active-directory/fundamentals/users-default-permissions.md
+++ b/articles/active-directory/fundamentals/users-default-permissions.md
@@ -40,7 +40,7 @@ Applications | <ul><li>Register (create) new applications<li>Enumerate the list 
 Devices</li></ul> | <ul><li>Enumerate the list of all devices<li>Read all properties of devices<li>Manage all properties of owned devices</li></ul> | No permissions | No permissions
 Organization | <ul><li>Read all company information<li>Read all domains<li>Read configuration of certificate-based authentication<li>Read all partner contracts</li></ul> | <ul><li>Read company display name<li>Read all domains<li>Read configuration of certificate-based authentication</li></ul> | <ul><li>Read company display name<li>Read all domains</li></ul>
 Roles and scopes | <ul><li>Read all administrative roles and memberships<li>Read all properties and membership of administrative units</li></ul> | No permissions | No permissions
-Subscriptions | <ul><li>Read all subscriptions<li>Enable service plan memberships</li></ul> | No permissions | No permissions
+Subscriptions | <ul><li>Read all licensing subscriptions<li>Enable service plan memberships</li></ul> | No permissions | No permissions
 Policies | <ul><li>Read all properties of policies<li>Manage all properties of owned policies</li></ul> | No permissions | No permissions
 
 ## Restrict member users' default permissions 


### PR DESCRIPTION
Tenant users by default cannot read AZURE subscriptions, but instead licensing subscriptions. Adding licensing creates clarity.