### PR TITLE
Update manage-soc-with-incident-metrics.md

### DIFF
--- a/articles/sentinel/manage-soc-with-incident-metrics.md
+++ b/articles/sentinel/manage-soc-with-incident-metrics.md
@@ -43,7 +43,7 @@ SecurityIncident
 | where Severity in ('High','Medium','Low', 'Informational')
 ```
 
-Mean time to closure:
+Closure time by percentile:
 ```Kusto
 SecurityIncident
 | summarize arg_max(TimeGenerated,*) by IncidentNumber 
@@ -52,7 +52,7 @@ SecurityIncident
   90th_Percentile=percentile(TimeToClosure, 90),99th_Percentile=percentile(TimeToClosure, 99)
 ```
 
-Mean time to triage:
+Triage time by percentile:
 ```Kusto
 SecurityIncident
 | summarize arg_max(TimeGenerated,*) by IncidentNumber 


### PR DESCRIPTION
These queries do not produce a 'mean'.  They produce a summarization of the data by various percentiles.  Even the 50th percentile is not the 'mean', it would be the median.

This changes the header above the queries to more accurately describe what you will get when you run them.