### PR TITLE
Output binding must be "$return" instead of "res"

### DIFF
--- a/articles/azure-signalr/signalr-quickstart-azure-functions-python.md
+++ b/articles/azure-signalr/signalr-quickstart-azure-functions-python.md
@@ -69,7 +69,7 @@ This quickstart can be run on macOS, Windows, or Linux.
             {
               "type": "http",
               "direction": "out",
-              "name": "res"
+              "name": "$return"
             }
           ]
         }


### PR DESCRIPTION
**The output binding declared in `index/function.json` must be the return value.** Otherwise the `index` function won't start, and the error below will be printed:

```
...the following parameters are declared in function.json but not in Python: {'res'}...
```

To reproduce this error, simply run the function app locally in VS Code.

Reference:
* [Using the Azure Function return value](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-return-value?tabs=python)