### PR TITLE
Fix incorrect default port number for proxy sidecar

### DIFF
--- a/articles/aks/workload-identity-overview.md
+++ b/articles/aks/workload-identity-overview.md
@@ -103,7 +103,7 @@ If you've used [Azure AD pod-managed identity][use-azure-ad-pod-identity], think
 |`azure.workload.identity/service-account-token-expiration` |Represents the `expirationSeconds` field for the projected service account token. It's an optional field that you configure to prevent any downtime caused by errors during service account token refresh. Kubernetes service account token expiry isn't correlated with Azure AD tokens. Azure AD tokens expire in 24 hours after they're issued. <sup>1</sup> |3600<br> Supported range is 3600-86400. |
 |`azure.workload.identity/skip-containers` |Represents a semi-colon-separated list of containers to skip adding projected service account token volume. For example `container1;container2`. |By default, the projected service account token volume is added to all containers if the service account is labeled with `azure.workload.identity/use: true`. |
 |`azure.workload.identity/inject-proxy-sidecar` |Injects a proxy init container and proxy sidecar into the pod. The proxy sidecar is used to intercept token requests to IMDS and acquire an Azure AD token on behalf of the user with federated identity credential. |true |
-|`azure.workload.identity/proxy-sidecar-port` |Represents the port of the proxy sidecar. |8080 |
+|`azure.workload.identity/proxy-sidecar-port` |Represents the port of the proxy sidecar. |8000 |
 
  <sup>1</sup> Takes precedence if the service account is also annotated.
 


### PR DESCRIPTION
The default port is 8000, not 8080. 
Ref [code](https://github.com/Azure/azure-workload-identity/blob/d25cbc15e3779c34dea9ea6ed134558ec9fade80/pkg/webhook/consts.go#L31) and [docs](https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html)