### PR TITLE
Added File extension information for Leak

### DIFF
--- a/articles/active-directory/identity-protection/howto-identity-protection-simulate-risk.md
+++ b/articles/active-directory/identity-protection/howto-identity-protection-simulate-risk.md
@@ -97,7 +97,7 @@ This risk detection indicates that the application's valid credentials have been
    
 5. Get the TenantID and Application(Client)ID in the **Overview** page.
 6. Ensure you disable the application via **Azure Active Directory** > **Enterprise Application** > **Properties** > Set **Enabled for users to sign-in** to **No**.
-7. Create a **public** GitHub Repository, add the following config and commit the change.
+7. Create a **public** GitHub Repository, add the following config and commit the change as a file with the .txt extension.
    ```GitHub file
      "AadClientId": "XXXX-2dd4-4645-98c2-960cf76a4357",
      "AadSecret": "p3n7Q~XXXX",


### PR DESCRIPTION
While working in IcM 369181172, learned we only consider for scan some file extensions. Customer created a file named 'config_info' and didn't get detections.  It's useful to add details to it about the extension so that testing is consistently working and we avoid those honest mistakes in the future.