### PR TITLE
Change branding from Facebook Work Accounts to Meta Work Accounts

### DIFF
--- a/articles/active-directory/saas-apps/facebook-work-accounts-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/facebook-work-accounts-provisioning-tutorial.md
@@ -75,7 +75,7 @@ This section guides you through the steps to configure the Azure AD provisioning
 
 1. Under the **Mappings** section, select **Synchronize Azure Active Directory Users to Meta Work Accounts**.
 
-1. Review the user attributes that are synchronized from Azure AD to Meta Work Accounts in the **Attribute-Mapping** section. The attributes selected as **Matching** properties are used to match the user accounts in FMetaacebook Work Accounts for update operations. If you choose to change the [matching target attribute](../app-provisioning/customize-application-attributes.md), you will need to ensure that the Meta Work Accounts API supports filtering users based on that attribute. Select the **Save** button to commit any changes.
+1. Review the user attributes that are synchronized from Azure AD to Meta Work Accounts in the **Attribute-Mapping** section. The attributes selected as **Matching** properties are used to match the user accounts in Meta Work Accounts for update operations. If you choose to change the [matching target attribute](../app-provisioning/customize-application-attributes.md), you will need to ensure that the Meta Work Accounts API supports filtering users based on that attribute. Select the **Save** button to commit any changes.
 
     |Attribute|Type|Supported for filtering|
     |---|---|---|

--- a/articles/active-directory/saas-apps/facebook-work-accounts-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/facebook-work-accounts-provisioning-tutorial.md
@@ -1,6 +1,6 @@
 ---
-title: 'Tutorial: Configure Facebook Work Accounts for automatic user provisioning with Azure Active Directory | Microsoft Docs'
-description: Learn how to automatically provision and de-provision user accounts from Azure AD to Facebook Work Accounts.
+title: 'Tutorial: Configure Meta Work Accounts for automatic user provisioning with Azure Active Directory | Microsoft Docs'
+description: Learn how to automatically provision and de-provision user accounts from Azure AD to Meta Work Accounts.
 services: active-directory
 author: jeevansd
 manager: CelesteDG
@@ -13,17 +13,17 @@ ms.topic: tutorial
 ms.date: 01/06/2023
 ---
 
-# Tutorial: Configure Facebook Work Accounts for automatic user provisioning
+# Tutorial: Configure Meta Work Accounts for automatic user provisioning
 
-This tutorial describes the steps you need to perform in both Facebook Work Accounts and Azure Active Directory (Azure AD) to configure automatic user provisioning. When configured, Azure AD automatically provisions and de-provisions users and groups to [Facebook Work Accounts](https://work.facebook.com) using the Azure AD Provisioning service. For important details on what this service does, how it works, and frequently asked questions, see [Automate user provisioning and deprovisioning to SaaS applications with Azure Active Directory](../app-provisioning/user-provisioning.md).
+This tutorial describes the steps you need to perform in both Meta Work Accounts and Azure Active Directory (Azure AD) to configure automatic user provisioning. When configured, Azure AD automatically provisions and de-provisions users and groups to [Meta Work Accounts](https://work.meta.com) using the Azure AD Provisioning service. For important details on what this service does, how it works, and frequently asked questions, see [Automate user provisioning and deprovisioning to SaaS applications with Azure Active Directory](../app-provisioning/user-provisioning.md).
 
 ## Capabilities supported
 
 > [!div class="checklist"]
-> * Create users in Facebook Work Accounts
-> * Remove users in Facebook Work Accounts when they do not require access anymore
-> * Keep user attributes synchronized between Azure AD and Facebook Work Accounts
-> * Single sign-on to Facebook Work Accounts (recommended)
+> * Create users in Meta Work Accounts
+> * Remove users in Meta Work Accounts when they do not require access anymore
+> * Keep user attributes synchronized between Azure AD and Meta Work Accounts
+> * Single sign-on to Meta Work Accounts (recommended)
 
 ## Prerequisites
 
@@ -37,11 +37,11 @@ The scenario outlined in this tutorial assumes that you already have the followi
 
 1. Learn about [how the provisioning service works](../app-provisioning/user-provisioning.md).
 1. Determine who will be in [scope for provisioning](../app-provisioning/define-conditional-rules-for-provisioning-user-accounts.md).
-1. Determine what data to [map between Azure AD and Facebook Work Accounts](../app-provisioning/customize-application-attributes.md).
+1. Determine what data to [map between Azure AD and Meta Work Accounts](../app-provisioning/customize-application-attributes.md).
 
-## Step 2. Add Facebook Work Accounts from the Azure AD application gallery
+## Step 2. Add Meta Work Accounts from the Azure AD application gallery
 
-Add Facebook Work Accounts from the Azure AD application gallery to start managing provisioning to Facebook Work Accounts. If you have previously setup Facebook Work Accounts for SSO, you can use the same application. However it is recommended that you create a separate app when testing out the integration initially. Learn more about adding an application from the gallery [here](../manage-apps/add-application-portal.md).
+Add Meta Work Accounts from the Azure AD application gallery to start managing provisioning to Meta Work Accounts. If you have previously setup Meta Work Accounts for SSO, you can use the same application. However it is recommended that you create a separate app when testing out the integration initially. Learn more about adding an application from the gallery [here](../manage-apps/add-application-portal.md).
 
 ## Step 3. Define who will be in scope for provisioning
 
@@ -51,31 +51,31 @@ The Azure AD provisioning service allows you to scope who will be provisioned ba
 
 * If you need additional roles, you can [update the application manifest](../develop/howto-add-app-roles-in-azure-ad-apps.md) to add new roles.
 
-## Step 4. Configure automatic user provisioning to Facebook Work Accounts
+## Step 4. Configure automatic user provisioning to Meta Work Accounts
 
 This section guides you through the steps to configure the Azure AD provisioning service to create, update, and disable users and/or groups in TestApp based on user and/or group assignments in Azure AD.
 
-### To configure automatic user provisioning for Facebook Work Accounts in Azure AD:
+### To configure automatic user provisioning for Meta Work Accounts in Azure AD:
 
 1. Sign in to the [Azure portal](https://portal.azure.com). Select **Enterprise Applications**, then select **All applications**.
 
-1. In the applications list, select **Facebook Work Accounts**.
+1. In the applications list, select **Meta Work Accounts**.
 
 1. Select the **Provisioning** tab.
 
 1. Set the **Provisioning Mode** to **Automatic**.
 
-1. Under the **Admin Credentials** section, click on **Authorize**. You will be redirected to **Facebook Work Accounts**'s authorization page. Input your Facebook Work Accounts username and click on the **Continue** button. Click **Test Connection** to ensure Azure AD can connect to Facebook Work Accounts. If the connection fails, ensure your Facebook Work Accounts account has Admin permissions and try again.
+1. Under the **Admin Credentials** section, click on **Authorize**. You will be redirected to **Meta Work Accounts**'s authorization page. Input your Meta Work Accounts username and click on the **Continue** button. Click **Test Connection** to ensure Azure AD can connect to Meta Work Accounts. If the connection fails, ensure your Meta Work Accounts account has Admin permissions and try again.
 
-    :::image type="content" source="media/facebook-work-accounts-provisioning-tutorial/azure-connect.png" alt-text="Screenshot shows the Facebook Work Accounts authorization page.":::
+    :::image type="content" source="media/facebook-work-accounts-provisioning-tutorial/azure-connect.png" alt-text="Screenshot shows the Meta Work Accounts authorization page.":::
 
 1. In the **Notification Email** field, enter the email address of a person or group who should receive the provisioning error notifications and select the **Send an email notification when a failure occurs** check box.
 
 1. Select **Save**.
 
-1. Under the **Mappings** section, select **Synchronize Azure Active Directory Users to Facebook Work Accounts**.
+1. Under the **Mappings** section, select **Synchronize Azure Active Directory Users to Meta Work Accounts**.
 
-1. Review the user attributes that are synchronized from Azure AD to Facebook Work Accounts in the **Attribute-Mapping** section. The attributes selected as **Matching** properties are used to match the user accounts in Facebook Work Accounts for update operations. If you choose to change the [matching target attribute](../app-provisioning/customize-application-attributes.md), you will need to ensure that the Facebook Work Accounts API supports filtering users based on that attribute. Select the **Save** button to commit any changes.
+1. Review the user attributes that are synchronized from Azure AD to Meta Work Accounts in the **Attribute-Mapping** section. The attributes selected as **Matching** properties are used to match the user accounts in FMetaacebook Work Accounts for update operations. If you choose to change the [matching target attribute](../app-provisioning/customize-application-attributes.md), you will need to ensure that the Meta Work Accounts API supports filtering users based on that attribute. Select the **Save** button to commit any changes.
 
     |Attribute|Type|Supported for filtering|
     |---|---|---|
@@ -100,9 +100,9 @@ This section guides you through the steps to configure the Azure AD provisioning
 
 1. To configure scoping filters, refer to the following instructions provided in the [Scoping filter tutorial](../app-provisioning/define-conditional-rules-for-provisioning-user-accounts.md).
 
-1. To enable the Azure AD provisioning service for Facebook Work Accounts, change the **Provisioning Status** to **On** in the **Settings** section.
+1. To enable the Azure AD provisioning service for Meta Work Accounts, change the **Provisioning Status** to **On** in the **Settings** section.
 
-1. Define the users and/or groups that you would like to provision to Facebook Work Accounts by choosing the desired values in **Scope** in the **Settings** section.
+1. Define the users and/or groups that you would like to provision to Meta Work Accounts by choosing the desired values in **Scope** in the **Settings** section.
 
    ![Screenshot shows the Scope dropdown in the Settings section.](common/provisioning-scope.png)
 


### PR DESCRIPTION
This change has been reflected in both the Meta Work Accounts product and the Enterprise App offered in the Enterprise App directory. This change is in line with those changes