### PR TITLE
Typo "Azure DB for MySQL"→"Azure Database for MySQL"

### DIFF
--- a/articles/mysql/flexible-server/quickstart-create-arm-template.md
+++ b/articles/mysql/flexible-server/quickstart-create-arm-template.md
@@ -1,5 +1,5 @@
 ---
-title: 'Quickstart: Create an Azure DB for MySQL - Flexible Server - ARM template'
+title: 'Quickstart: Create an Azure Database for MySQL - Flexible Server - ARM template'
 description: In this Quickstart, learn how to create an Azure Database for MySQL - Flexible Server using ARM template.
 ms.service: mysql
 ms.subservice: flexible-server


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/mysql/flexible-server/quickstart-create-arm-template?source=recommendations&tabs=CLI 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/mysql/flexible-server/quickstart-create-arm-template.md 
#PingMSFTDocs