### PR TITLE
Change to the term Cores from Nodes

### DIFF
--- a/articles/data-factory/concepts-integration-runtime-performance.md
+++ b/articles/data-factory/concepts-integration-runtime-performance.md
@@ -33,7 +33,7 @@ Data flows distribute the data processing over different nodes in a Spark cluste
 
 The default cluster size is four driver nodes and four worker nodes (small).  As you process more data, larger clusters are recommended. Below are the possible sizing options:
 
-| Worker cores | Driver cores | Total cores | Notes |
+| Worker Nodes | Driver Nodes | Total Nodes | Notes |
 | ------------ | ------------ | ----------- | ----- |
 | 4 | 4 | 8 | Small |
 | 8 | 8 | 16 | Medium |


### PR DESCRIPTION
In the Documentation, there is no clarity of what is a core But it is using the term nodes everywhere to represent the number of instances that it will run. So I believe, even the table titles must be nodes, not cores, as I couldn't find any definition of cores in the IR documentation at all.