### PR TITLE
Fix the "Deploy a PHP web app" link

### DIFF
--- a/articles/app-service/index.yml
+++ b/articles/app-service/index.yml
@@ -39,7 +39,7 @@ landingContent:
           - text: Deploy a Node.js web app
             url: quickstart-nodejs.md
           - text: Deploy a PHP web app
-            url: quickstart-golang.md           
+            url: quickstart-php.md           
           - text: Deploy a Java app
             url: quickstart-java.md
           - text: Create a WordPress site


### PR DESCRIPTION
Right now is point to the GO quickstart document instead of PHP