### PR TITLE
Remove Google DNS servers

### DIFF
--- a/articles/active-directory/hybrid/tutorial-password-hash-sync.md
+++ b/articles/active-directory/hybrid/tutorial-password-hash-sync.md
@@ -113,7 +113,7 @@ Before you install Windows Server AD, run a script that installs prerequisites:
     $ipprefix = "24" 
     $ipgw = "10.0.1.1" 
     $ipdns = "10.0.1.117"
-    $ipdns2 = "8.8.8.8" 
+    $ipdns2 = "4.2.2.2" 
     $ipif = (Get-NetAdapter).ifIndex 
     $featureLogPath = "c:\poshlog\featurelog.txt" 
     $newname = "DC1"


### PR DESCRIPTION
The server 8.8.8.8 specified in the DNS adapter properties is Google DNS.  Recommend changing it to another public DNS host that allows recursive queries who is not a competitor, such as 4.2.2.2 (Level 3).