### PR TITLE
Line no 72 need to be edited.

### DIFF
--- a/articles/cognitive-services/Translator/document-translation/how-to-guides/create-sas-tokens.md
+++ b/articles/cognitive-services/Translator/document-translation/how-to-guides/create-sas-tokens.md
@@ -70,6 +70,7 @@ Go to the [Azure portal](https://portal.azure.com/#home) and navigate to your co
     * When you create a shared access signature (SAS), the default duration is 48 hours. After 48 hours, you'll need to create a new token.
     * Consider setting a longer duration period for the time you'll be using your storage account for Translator Service operations.
     * The value for the expiry time is a maximum of seven days from the creation of the SAS token.
+    * There's no maximum time limit imposed by Azure on the expiry of a SAS URL, however, it's recommended to configure an expiration policy for shared access signatures on your storage accounts.https://learn.microsoft.com/en-us/azure/storage/common/sas-expiration-policy
 
 1. The **Allowed IP addresses** field is optional and specifies an IP address or a range of IP addresses from which to accept requests. If the request IP address doesn't match the IP address or address range specified on the SAS token, it won't be authorized.
 


### PR DESCRIPTION
One of my customers reach out to me about the below statement on SAS expiry time. As per my research, there's no maximum time limit imposed by Azure on the expiry of a SAS URL. We can set it to 9999-12-31T23:59:59Z so that it never expires. 

"The value for the expiry time is a maximum of seven days from the creation of the SAS token"