### PR TITLE
Specify an example id for cost management export

### DIFF
--- a/articles/cost-management-billing/costs/tutorial-export-acm-data.md
+++ b/articles/cost-management-billing/costs/tutorial-export-acm-data.md
@@ -115,7 +115,8 @@ Start by preparing your environment for the Azure CLI:
 
    ```azurecli
    az costmanagement export create --name DemoExport --type ActualCost \
-   --scope "subscriptions/00000000-0000-0000-0000-000000000000" --storage-account-id cmdemo \
+   --scope "subscriptions/00000000-0000-0000-0000-000000000000" \
+   --storage-account-id /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TreyNetwork/providers/Microsoft.Storage/storageAccounts/cmdemo \
    --storage-container democontainer --timeframe MonthToDate --recurrence Daily \
    --recurrence-period from="2020-06-01T00:00:00Z" to="2020-10-31T00:00:00Z" \
    --schedule-status Active --storage-directory demodirectory


### PR DESCRIPTION
When I tried this out I was confused and assumed that it was after the storage account name that I was pasting there.
Turns out it was after the full ID like you would expect but the docs were confusing.

I'd suggest you might want to put in a callout that you can't put a recurrence period in the past as well.
and possible just make the `to` a date in the future, the portal inserts `2050-02-01T00:00:00+00:00`