### PR TITLE
Under system managed devices - This section is not true "The new Get-…

### DIFF
--- a/articles/active-directory/devices/manage-stale-devices.md
+++ b/articles/active-directory/devices/manage-stale-devices.md
@@ -90,7 +90,7 @@ If your device is under control of Intune or any other MDM solution, retire the 
 
 ### System-managed devices
 
-Don't delete system-managed devices. These devices are generally devices such as Autopilot. Once deleted, these devices can't be reprovisioned. The new `Get-AzureADDevice` cmdlet excludes system-managed devices by default. 
+Don't delete system-managed devices. These devices are generally devices such as Autopilot. Once deleted, these devices can't be reprovisioned.
 
 ### Hybrid Azure AD joined devices
 


### PR DESCRIPTION
…AzureADDevice cmdlet excludes system-managed devices by default."

Under system managed devices - This section is not true "The new Get-AzureADDevice cmdlet excludes system-managed devices by default."

We have tested that in the lab and Identity Devices dev manager (Satheesh Dabbiru) confirmed that they are not sure how this information got there as they have not shared that information.

Please remove that line from the article as it creates confusion for our customer.