### PR TITLE
Update Known Limitations for Azure Files Share

### DIFF
--- a/articles/aks/virtual-nodes.md
+++ b/articles/aks/virtual-nodes.md
@@ -40,7 +40,7 @@ Virtual nodes functionality is heavily dependent on ACI's feature set. In additi
 * Virtual nodes support scheduling Linux pods. You can manually install the open source [Virtual Kubelet ACI](https://github.com/virtual-kubelet/azure-aci) provider to schedule Windows Server containers to ACI.
 * Virtual nodes require AKS clusters with Azure CNI networking.
 * Using api server authorized ip ranges for AKS.
-* Volume mounting Azure Files share support [General-purpose V2](../storage/common/storage-account-overview.md#types-of-storage-accounts) and [General-purpose V1](../storage/common/storage-account-overview.md#types-of-storage-accounts). Follow the instructions for mounting [a volume with Azure Files share](azure-files-csi.md).
+* Volume mounting Azure Files share support [General-purpose V2](../storage/common/storage-account-overview.md#types-of-storage-accounts) and [General-purpose V1](../storage/common/storage-account-overview.md#types-of-storage-accounts). But virtual nodes currently don't support [Persistent Volumes](concepts-storage.md#persistent-volumes) and [Persistent Volume Claims](concepts-storage.md#persistent-volume-claims). Follow the instructions for mounting [a volume with Azure Files share as an inline volume](azure-csi-files-storage-provision.md#mount-file-share-as-an-inline-volume).
 * Using IPv6 isn't supported.
 * Virtual nodes don't support the [Container hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) feature.
 

--- a/articles/aks/virtual-nodes.md
+++ b/articles/aks/virtual-nodes.md
@@ -40,7 +40,7 @@ Virtual nodes functionality is heavily dependent on ACI's feature set. In additi
 * Virtual nodes support scheduling Linux pods. You can manually install the open source [Virtual Kubelet ACI](https://github.com/virtual-kubelet/azure-aci) provider to schedule Windows Server containers to ACI.
 * Virtual nodes require AKS clusters with Azure CNI networking.
 * Using api server authorized ip ranges for AKS.
-* Volume mounting Azure Files share support [General-purpose V2](../storage/common/storage-account-overview.md#types-of-storage-accounts) and [General-purpose V1](../storage/common/storage-account-overview.md#types-of-storage-accounts). But virtual nodes currently don't support [Persistent Volumes](concepts-storage.md#persistent-volumes) and [Persistent Volume Claims](concepts-storage.md#persistent-volume-claims). Follow the instructions for mounting [a volume with Azure Files share as an inline volume](azure-csi-files-storage-provision.md#mount-file-share-as-an-inline-volume).
+* Volume mounting Azure Files share support [General-purpose V2](../storage/common/storage-account-overview.md#types-of-storage-accounts) and [General-purpose V1](../storage/common/storage-account-overview.md#types-of-storage-accounts). However, virtual nodes currently don't support [Persistent Volumes](concepts-storage.md#persistent-volumes) and [Persistent Volume Claims](concepts-storage.md#persistent-volume-claims). Follow the instructions for mounting [a volume with Azure Files share as an inline volume](azure-csi-files-storage-provision.md#mount-file-share-as-an-inline-volume).
 * Using IPv6 isn't supported.
 * Virtual nodes don't support the [Container hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) feature.
 


### PR DESCRIPTION
The original text was not clear, so I have clarified the following. Virtual nodes currently don't support Persistent Volumes and Persistent Volume Claims. In addition, the document linked to as an example in "Follow the instructions for mounting a volume with Azure Files share." is incorrect, so the link changed to an example of an inline volume.

@MGoedtel,
This is a reopening of the #84855 / [PR#84891](https://github.com/MicrosoftDocs/azure-docs/pull/84891) with an update of the linked document to the CSI storage driver.
Thanks.