### PR TITLE
Fix articles/aks/azure-cni-overlay.md

### DIFF
--- a/articles/aks/azure-cni-overlay.md
+++ b/articles/aks/azure-cni-overlay.md
@@ -145,8 +145,6 @@ location="westcentralus"
 az aks create -n $clusterName -g $resourceGroup --location $location --network-plugin azure --network-plugin-mode overlay --pod-cidr 192.168.0.0/16
 ```
 
-This will perform a rolling upgrade of nodes in **all** nodepools simultaneously to Azure CNI overlay and should be treated like a node image upgrade. During the upgrade, traffic from an Overlay pod to a CNI v1 pod will be SNATed(Source Network Address Translation)
-
 ## Next steps
 
 To learn how to utilize AKS with your own Container Network Interface (CNI) plugin, see [Bring your own Container Network Interface (CNI) plugin](use-byo-cni.md).


### PR DESCRIPTION
A recent commit https://github.com/MicrosoftDocs/azure-docs/commit/c2f334ae1b0a520c0bdc74e278630f4ea0c70dc4 forgot to remove the last note about the effect of upgrading a cluster to Azure CNI Overlay.
This PR remove the note so the article remains consistent.
And hopefully we'll be able to perform the upgrade soon enough.