### PR TITLE
Fix powershell multi-line command

### DIFF
--- a/articles/virtual-machines/windows/proximity-placement-groups.md
+++ b/articles/virtual-machines/windows/proximity-placement-groups.md
@@ -36,8 +36,8 @@ $ppg = New-AzProximityPlacementGroup `
    -Location $location `
    -Name $ppgName `
    -ResourceGroupName $resourceGroup `
-   -ProximityPlacementGroupType Standard
-   -Zone $zone
+   -ProximityPlacementGroupType Standard `
+   -Zone $zone `
    -IntentVMSizeList $vmSize1, $vmSize2
 ```
 


### PR DESCRIPTION
Added missing backticks on the New-AzProximityPlacementGroup multiline powershell command so that copy/paste into a terminal will work as expected