### PR TITLE
Added a non supported scenario

### DIFF
--- a/articles/active-directory-b2c/faq.yml
+++ b/articles/active-directory-b2c/faq.yml
@@ -9,7 +9,7 @@ metadata:
   ms.service: active-directory
   ms.workload: identity
   ms.topic: faq
-  ms.date: 02/09/2023
+  ms.date: 03/15/2023
   ms.author: godonnell
   ms.subservice: B2C
   ms.custom: "b2c-support"
@@ -255,6 +255,11 @@ sections:
           1. Wait for 10 minutes.
           
           1. Retrieve the `RefreshToken` again.
+          
+      - question: |
+          In a web browser, I signed into multiple applications with multiple tabs using the same B2C tenant. When I attempt to perform a single sign out, not all of the applications are signed out. Why is that? 
+        answer: |
+          Currently, single sign out is not supported in this specific scenario.  This is due to cookie contention, since it operates on the same cookies.
           
       - question: |
           How do I report issues with Azure AD B2C?

--- a/articles/active-directory-b2c/faq.yml
+++ b/articles/active-directory-b2c/faq.yml
@@ -257,9 +257,9 @@ sections:
           1. Retrieve the `RefreshToken` again.
           
       - question: |
-          In a web browser, I signed into multiple applications with multiple tabs using the same B2C tenant. When I attempt to perform a single sign out, not all of the applications are signed out. Why is that? 
+         I use multiple tabs in a web browser to sign in to multiple applications that I registered in the same Azure AD B2C tenant. When I try to perform a single sign out, not all of the applications are signed out. Why does this happen? 
         answer: |
-          Currently, single sign out is not supported in this specific scenario.  This is due to cookie contention, since it operates on the same cookies.
+          Currently, Azure AD B2C doesn't support single sign out for this specific scenario. It's caused by cookie contention as all the applications operates on the same cookie simultaneously.
           
       - question: |
           How do I report issues with Azure AD B2C?


### PR DESCRIPTION
SSO is not yet supported for multiple applications with multiple tabs using the same B2C tenant.