### PR TITLE
docs(rbac-permissions.md): Include RBAC and permissions for Private Endpoint Approval

### DIFF
--- a/articles/private-link/rbac-permissions.md
+++ b/articles/private-link/rbac-permissions.md
@@ -129,6 +129,16 @@ This section lists the granular permissions required to deploy a private link se
 }
 ```
 
+## Approval RBAC for private endpoint
+
+Typically, a network administrator creates a private endpoint. Depending on your Azure role-based access control (RBAC) permissions, a private endpoint that you create is either *automatically approved* to send traffic to the API Management instance, or requires the resource owner to *manually approve* the connection.
+
+
+|Approval method     |Minimum RBAC permissions  |
+|---------|---------|
+|Automatic     | `Microsoft.Network/virtualNetworks/**`<br/>`Microsoft.Network/virtualNetworks/subnets/**`<br/>`Microsoft.Network/privateEndpoints/**`<br/>`Microsoft.Network/networkinterfaces/**`<br/>`Microsoft.Network/locations/availablePrivateEndpointTypes/read`<br/>`Microsoft.ApiManagement/service/**`<br/>`Microsoft.ApiManagement/service/privateEndpointConnections/**`        |
+|Manual     | `Microsoft.Network/virtualNetworks/**`<br/>`Microsoft.Network/virtualNetworks/subnets/**`<br/>`Microsoft.Network/privateEndpoints/**`<br/>`Microsoft.Network/networkinterfaces/**`<br/>`Microsoft.Network/locations/availablePrivateEndpointTypes/read`           |
+
 ## Next steps
 
 For more information on private endpoint and private link services in Azure Private link, see:


### PR DESCRIPTION
Include roles and permissions on exactly "who" can Approve an incoming private endpoint connection.  
This is critical as enterprise users has strict role-based-access control on who can do the Approval.   

Proposed content is from this link:
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/api-management/private-endpoint.md