### PR TITLE
Fix a typo in az CLI queue creation command

### DIFF
--- a/articles/container-apps/background-processing.md
+++ b/articles/container-apps/background-processing.md
@@ -141,7 +141,7 @@ Now you can create the message queue.
 
 ```azurecli
 az storage queue create \
-  --name 'myqueue" \
+  --name "myqueue" \
   --account-name $STORAGE_ACCOUNT_NAME \
   --connection-string $QUEUE_CONNECTION_STRING
 ```


### PR DESCRIPTION
Wrong quote/char in queue name made the command fail in az CLI