### PR TITLE
fix(downstream-api-from-api-docs): Updates code snippet

### DIFF
--- a/articles/active-directory/develop/scenario-web-api-call-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-api-call-api-app-configuration.md
@@ -126,7 +126,7 @@ using Microsoft.Identity.Web;
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddMicrosoftIdentityWebApi(Configuration, "AzureAd")
     .EnableTokenAcquisitionToCallDownstreamApi()
-    .AddDownstreamWebApi("MyApi", Configuration.GetSection("GraphBeta"))
+    .AddDownstreamApi("MyApi", Configuration.GetSection("GraphBeta"))
     .AddInMemoryTokenCaches();
 // ...
 ```


### PR DESCRIPTION
Aims to replace the Obsoleted method call mentioned in the code snippet in Option 2 (call a downstream api):
- Using the existing code snippet when working with the latest Microsoft.Identity.Web package (v2.50) to use the updated (non-obsoleted) method.
- Not sure if this is definitely the right method to replace this with, or where else in the documentation this also might need updating, but it resolved the Obsoleted error message I was seeing when following the current guidance