### PR TITLE
Typo "Azure DB for MySQL"→"Azure Database for MySQL"

### DIFF
--- a/articles/mysql/single-server/how-to-data-in-replication.md
+++ b/articles/mysql/single-server/how-to-data-in-replication.md
@@ -234,7 +234,7 @@ The following steps prepare and configure the MySQL server hosted on-premises, i
 
    All Data-in Replication functions are done by stored procedures. You can find all procedures at [Data-in Replication Stored Procedures](./reference-stored-procedures.md). The stored procedures can be run in the MySQL shell or MySQL Workbench.
 
-   To link two servers and start replication, login to the target replica server in the Azure DB for MySQL service and set the external instance as the source server. This is done by using the `mysql.az_replication_change_master` stored procedure on the Azure DB for MySQL server.
+   To link two servers and start replication, login to the target replica server in the Azure Database for MySQL service and set the external instance as the source server. This is done by using the `mysql.az_replication_change_master` stored procedure on the Azure Database for MySQL server.
 
    ```sql
    CALL mysql.az_replication_change_master('<master_host>', '<master_user>', '<master_password>', <master_port>, '<master_log_file>', <master_log_pos>, '<master_ssl_ca>');


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/mysql/single-server/how-to-data-in-replication 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/mysql/single-server/how-to-data-in-replication.md 
#PingMSFTDocs