### PR TITLE
updating workload file to use `slight-rust-hello`'s `v0.3.3` instead of `latest`

### DIFF
--- a/articles/aks/use-wasi-node-pools.md
+++ b/articles/aks/use-wasi-node-pools.md
@@ -169,7 +169,7 @@ spec:
       runtimeClassName: wasmtime-slight-v1
       containers:
         - name: hello-slight
-          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:latest
+          image: ghcr.io/deislabs/containerd-wasm-shims/examples/slight-rust-hello:v0.3.3
           command: ["/"]
           resources:
             requests:


### PR DESCRIPTION
While trying to build today, we realized `latest` was broken. To avoid any other users running into this issue, it's best to target a specific version that was tested and is guaranteed to provide a great OOB experience in this tutorial.