### PR TITLE
Update "Add Groups step"

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key.md
@@ -47,7 +47,7 @@ Registration features for passwordless authentication methods rely on the combin
 
 1. Sign in to the [Azure portal](https://portal.azure.com).
 1. Browse to **Azure Active Directory** > **Security** > **Authentication methods** > **Authentication method policy**.
-1. Under the method **FIDO2 Security Key**, click **All users**, or click **Add groups** to select specific groups.
+1. Under the method **FIDO2 Security Key**, click **All users**, or click **Add groups** to select specific groups. **Only security groups are supported**.
 1. **Save** the configuration.
 
    >[!NOTE]

--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key.md
@@ -47,7 +47,7 @@ Registration features for passwordless authentication methods rely on the combin
 
 1. Sign in to the [Azure portal](https://portal.azure.com).
 1. Browse to **Azure Active Directory** > **Security** > **Authentication methods** > **Authentication method policy**.
-1. Under the method **FIDO2 Security Key**, click **All users**, or click **Add groups** to select specific groups. **Only security groups are supported**.
+1. Under the method **FIDO2 Security Key**, click **All users**, or click **Add groups** to select specific groups. *Only security groups are supported*.
 1. **Save** the configuration.
 
    >[!NOTE]


### PR DESCRIPTION
Based on a case I worked with and an IcM, M365 groups do not work to enable FIDO keys registration Added the following information on Step 3 - **Only security groups are supported**