### PR TITLE
Update subscription-creation-schema.md

### DIFF
--- a/articles/event-grid/subscription-creation-schema.md
+++ b/articles/event-grid/subscription-creation-schema.md
@@ -59,7 +59,7 @@ The Event Subscription name must be 3-64 characters in length and can only conta
     },
     "filter": {
       "includedEventTypes": [ "Microsoft.Storage.BlobCreated", "Microsoft.Storage.BlobDeleted" ],
-      "subjectBeginsWith": "/blobServices/default/containers/mycontainer/log",
+      "subjectBeginsWith": "/blobServices/default/containers/mycontainer/blobs/log",
       "subjectEndsWith": ".jpg",
       "isSubjectCaseSensitive ": "true"
     }


### PR DESCRIPTION
In order for an event to fire when a specific file enters a container, the URI `/blob` is required. In the documentation, this was missing. I spent quite some time trying to figure out why my events were not firing. Once I added the `/blob` before the literal filename, all was well.