### PR TITLE
Update identity-provider-generic-openid-connect.md

### DIFF
--- a/articles/active-directory-b2c/identity-provider-generic-openid-connect.md
+++ b/articles/active-directory-b2c/identity-provider-generic-openid-connect.md
@@ -81,6 +81,7 @@ Define the OpenId Connect identity provider by adding it to the **ClaimsProvider
             <OutputClaim ClaimTypeReferenceId="email" PartnerClaimType="email" />
             <OutputClaim ClaimTypeReferenceId="authenticationSource" DefaultValue="socialIdpAuthentication" AlwaysUseDefaultValue="true" />
             <OutputClaim ClaimTypeReferenceId="identityProvider" PartnerClaimType="iss" />
+            <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="oid"/>
           </OutputClaims>
           <OutputClaimsTransformations>
             <OutputClaimsTransformation ReferenceId="CreateRandomUPNUserName"/>


### PR DESCRIPTION
Signing-in to an Azure AD tenant requires that the user performing the sign-in flow already has an attribute such as object ID that will identify them on the Azure AD tenant they are signing-in to. Object IDs of every user is different on every Azure AD tenant irrespective of their root Azure AD tenant, this attribute is not transferred from directory to directory and only a sign-up process will create this attribute for users on Azure AD.

Without objectId claim the signin flow return the error AADB2C90037: An error occurred while processing the request. Please contact administrator of the site you are trying to access.