### PR TITLE
NetappStorageReservedCapacity links to reservation recommendations

### DIFF
--- a/articles/advisor/advisor-reference-cost-recommendations.md
+++ b/articles/advisor/advisor-reference-cost-recommendations.md
@@ -256,7 +256,7 @@ Learn more about [Subscription - AzureVMwareSolutionReservedCapacity (Consider A
 
 We analyzed your NetApp Storage usage over last 30 days and calculated reserved instance purchase that would maximize your savings. With reserved instance you can pre-purchase hourly usage and save over your current on-demand costs. Reserved instance is a billing benefit and will automatically apply to new or existing deployments. Saving estimates are calculated for individual subscriptions and the usage pattern observed over last 30 days. Shared scope recommendations are available in reservation purchase experience and can increase savings further.
 
-Learn more about [Subscription - NetAppStorageReservedCapacity (Consider NetApp Storage reserved instance to save over your on-demand costs)](../cost-management-billing/reservations/reserved-instance-purchase-recommendations.md).
+Learn more about [Subscription - NetAppStorageReservedCapacity (Consider NetApp Storage reserved instance to save over your on-demand costs)](../storage/files/files-reserve-capacity.md).
 
 ### Consider Azure Managed Disk reserved instance to save over your on-demand costs
 


### PR DESCRIPTION
Proposed an update to update the link under "Consider Netapp Storage reserved instance to save over on-demand costs" section. 

Current link is pointing to reservation recommendations which is confusing the customers and support team refering the documentation to understand Netapps reservation. 

Proposed document link: https://learn.microsoft.com/en-us/azure/storage/files/files-reserve-capacity

As Azure NetApps service use same reservation as storage files, routing customer to the proposed document link will be helpful