### PR TITLE
Update Gremlin documentation link

### DIFF
--- a/articles/cosmos-db/gremlin/tutorial-query.md
+++ b/articles/cosmos-db/gremlin/tutorial-query.md
@@ -15,7 +15,7 @@ ms.custom: devx-track-csharp, ignite-2022
 # Tutorial: Query Azure Cosmos DB for Gremlin by using Gremlin
 [!INCLUDE[Gremlin](../includes/appliesto-gremlin.md)]
 
-The Azure Cosmos DB [API for Gremlin](introduction.md) supports [Gremlin](https://github.com/tinkerpop/gremlin/wiki) queries. This article provides sample documents and queries to get you started. A detailed Gremlin reference is provided in the [Gremlin support](support.md) article.
+The Azure Cosmos DB [API for Gremlin](introduction.md) supports [Gremlin](https://tinkerpop.apache.org/gremlin.html) queries. This article provides sample documents and queries to get you started. A detailed Gremlin reference is provided in the [Gremlin support](support.md) article.
 
 This article covers the following tasks: 
 


### PR DESCRIPTION
Tinkerpop Wiki is outdated, updated Gremlin documentation is available on the Gremlin part of Apache Tinkerpop homepage.