### PR TITLE
Typo "Azure DB for PostgreSQL"→"Azure Database for PostgreSQL"

### DIFF
--- a/articles/postgresql/single-server/quickstart-create-postgresql-server-database-using-arm-template.md
+++ b/articles/postgresql/single-server/quickstart-create-postgresql-server-database-using-arm-template.md
@@ -1,5 +1,5 @@
 ---
-title: 'Quickstart: Create an Azure DB for PostgreSQL - ARM template'
+title: 'Quickstart: Create an Azure Database for PostgreSQL - ARM template'
 description: In this quickstart, learn how to create an Azure Database for PostgreSQL single server by using an Azure Resource Manager template.
 ms.service: postgresql
 ms.subservice: single-server


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/postgresql/single-server/quickstart-create-postgresql-server-database-using-arm-template?source=recommendations&tabs=azure-portal 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/postgresql/single-server/quickstart-create-postgresql-server-database-using-arm-template.md 
#PingMSFTDocs