### PR TITLE
Update link to azure-servicebus-jms

### DIFF
--- a/articles/service-bus-messaging/how-to-use-java-message-service-20.md
+++ b/articles/service-bus-messaging/how-to-use-java-message-service-20.md
@@ -37,10 +37,10 @@ To learn more about how to prepare your developer environment for Java on Azure,
 
 To utilize all the features available in the premium tier, add the following library to the build path of the project.
 
-[Azure-servicebus-jms](https://search.maven.org/artifact/com.microsoft.azure/azure-servicebus-jms)
+[Azure-servicebus-jms](https://central.sonatype.com/artifact/com.microsoft.azure/azure-servicebus-jms/1.0.0)
 
 > [!NOTE]
-> To add the [Azure-servicebus-jms](https://search.maven.org/artifact/com.microsoft.azure/azure-servicebus-jms) to the build path, use the preferred dependency management tool for your project like [Maven](https://maven.apache.org/) or [Gradle](https://gradle.org/).
+> To add the [Azure-servicebus-jms](https://central.sonatype.com/artifact/com.microsoft.azure/azure-servicebus-jms/1.0.0) to the build path, use the preferred dependency management tool for your project like [Maven](https://maven.apache.org/) or [Gradle](https://gradle.org/).
 
 ## Coding Java applications
 


### PR DESCRIPTION
Users that land on search.maven.org using the old URL are being redirected to central.sonatype.com but the redirection is broken and the user ends up on the home page of central.sonatype.com instead of being taken directly to the azure-servicebus-jms package page.