### PR TITLE
Change "IMPORTANT NOTE" regarding SNAT

### DIFF
--- a/articles/private-link/inspect-traffic-with-azure-firewall.md
+++ b/articles/private-link/inspect-traffic-with-azure-firewall.md
@@ -35,7 +35,7 @@ Azure Firewall filters traffic using either:
 * [FQDN in application rules](../firewall/features.md#application-fqdn-filtering-rules) for HTTP, HTTPS, and MSSQL. 
 
 > [!IMPORTANT] 
-> The use of application rules over network rules is recommended when inspecting traffic destined to private endpoints in order to maintain flow symmetry. If network rules are used, or an NVA is used instead of Azure Firewall, SNAT must be configured for traffic destined to private endpoints.
+> The use of application rules over network rules is recommended when inspecting traffic destined to private endpoints in order to maintain flow symmetry. If network rules are used, or an NVA is used instead of Azure Firewall, SNAT must be configured for traffic destined to private endpoints in order to maintain flow symmetry.
 
 > [!NOTE]
 > SQL FQDN filtering is supported in [proxy-mode](/azure/azure-sql/database/connectivity-architecture#connection-policy) only (port 1433). **Proxy** mode can result in more latency compared to *redirect*. If you want to continue using redirect mode, which is the default for clients connecting within Azure, you can filter access using FQDN in firewall network rules.


### PR DESCRIPTION
Regarding the sentence "If network rules are used, or an NVA is used instead of Azure Firewall, SNAT must be configured for traffic destined to private endpoints." on line 38... I recommend changing it to "If network rules are used, or an NVA is used instead of Azure Firewall, SNAT must be configured for traffic destined to private endpoints in order to maintain flow symmetry."

This more clearly illustrates to users that SNAT must be configured, otherwise traffic may not flow as intended. This causes network connectivity issues for customers.

If you have more questions or concerns, reach out to acasillas@microsoft.com to discuss further. Thanks for your consideration.