### PR TITLE
Updating instructions to make them easier to follow and implement

### DIFF
--- a/articles/active-directory/authentication/concept-certificate-based-authentication-certificateuserids.md
+++ b/articles/active-directory/authentication/concept-certificate-based-authentication-certificateuserids.md
@@ -91,13 +91,21 @@ To update certificate user IDs for federated users, configure Azure AD Connect t
 
 ### Synchronize X509:\<PN>PrincipalNameValue
  
-To synchronize X509:\<PN>PrincipalNameValue, create an outbound synchronization rule, and choose **Expression** in the flow type. Choose the target attribute as \<certificateUserIds>, and in the source field, add the expression <"X509:\<PN>"&[userPrincipalName]>. If your source attribute isn't userPrincipalName, you can change the expression accordingly.
+To synchronize X509:\<PN>PrincipalNameValue, create an outbound synchronization rule, and choose **Expression** in the flow type. Choose the target attribute as **certificateUserIds**, and in the source field, add the following expression. If your source attribute isn't userPrincipalName, you can change the expression accordingly.
+
+```
+"X509:\<PN>"&[userPrincipalName]
+```
  
 :::image type="content" border="true" source="./media/concept-certificate-based-authentication-certificateuserids/pnexpression.png" alt-text="Screenshot of how to sync x509.":::
  
 ### Synchronize X509:\<RFC822>RFC822Name
 
-To synchronize X509:\<RFC822>RFC822Name, create an outbound synchronization rule, choose **Expression** in the flow type. Choose the target attribute as \<certificateUserIds>, and in the source field, add the expression <"X509:\<RFC822>"&[userPrincipalName]>. If your source attribute isn't userPrincipalName, you can change the expression accordingly.  
+To synchronize X509:\<RFC822>RFC822Name, create an outbound synchronization rule, choose **Expression** in the flow type. Choose the target attribute as **certificateUserIds**, and in the source field, add the following expression. If your source attribute isn't userPrincipalName, you can change the expression accordingly.  
+
+```
+"X509:\<RFC822>"&[userPrincipalName]
+```
 
 :::image type="content" border="true" source="./media/concept-certificate-based-authentication-certificateuserids/rfc822expression.png" alt-text="Screenshot of how to sync RFC822Name.":::
 
@@ -122,10 +130,32 @@ AlternativeSecurityId isn't part of the default attributes. An administrator nee
 
 1. Create an inbound synchronization rule to transform from altSecurityIdentities to alternateSecurityId attribute.
 
+In the inbound rule, use the following options.
+
+|Option | Value |
+|-------|-------|
+|Name | Descriptive name of the rule, such as: In from AD - altSecurityIdentities |
+|Connected System | Your on-premises AD domain |
+|Connected System Object Type | user |
+|Metaverse Object Type | person |
+|Precedence | Choose a random high number not currently used |
+
+Then proceed to the Transformations tab and do a direct mapping of the target attribute of **alternativeSecurityId** to **altSecurityIdentities** as shown below.
+
    :::image type="content" border="true" source="./media/concept-certificate-based-authentication-certificateuserids/alt-security-identity-inbound.png" alt-text="Screenshot of how to transform from altSecurityIdentities to alternateSecurityId attribute":::
 
 1. Create an outbound synchronization rule to transform from alternateSecurityId attribute to certificateUserIds
 alt-security-identity-add.
+
+|Option | Value |
+|-------|-------|
+|Name | Descriptive name of the rule, such as: Out to AAD - certificateUserIds |
+|Connected System | Your Azure AD doamin |
+|Connected System Object Type | user |
+|Metaverse Object Type | person |
+|Precedence | Choose a random high number not currently used |
+
+Then proceed to the Transformations tab and change your FlowType option to *Expression*, the target attribute to **certificateUserIds** and then input the below expression in to the Source field.
 
    :::image type="content" border="true" source="./media/concept-certificate-based-authentication-certificateuserids/alt-security-identity-outbound.png" alt-text="Screenshot of outbound synchronization rule to transform from alternateSecurityId attribute to certificateUserIds":::
 

--- a/articles/active-directory/authentication/concept-certificate-based-authentication-certificateuserids.md
+++ b/articles/active-directory/authentication/concept-certificate-based-authentication-certificateuserids.md
@@ -130,32 +130,32 @@ AlternativeSecurityId isn't part of the default attributes. An administrator nee
 
 1. Create an inbound synchronization rule to transform from altSecurityIdentities to alternateSecurityId attribute.
 
-In the inbound rule, use the following options.
-
-|Option | Value |
-|-------|-------|
-|Name | Descriptive name of the rule, such as: In from AD - altSecurityIdentities |
-|Connected System | Your on-premises AD domain |
-|Connected System Object Type | user |
-|Metaverse Object Type | person |
-|Precedence | Choose a random high number not currently used |
-
-Then proceed to the Transformations tab and do a direct mapping of the target attribute of **alternativeSecurityId** to **altSecurityIdentities** as shown below.
+   In the inbound rule, use the following options.
+  
+   |Option | Value |
+   |-------|-------|
+   |Name | Descriptive name of the rule, such as: In from AD - altSecurityIdentities |
+   |Connected System | Your on-premises AD domain |
+   |Connected System Object Type | user |
+   |Metaverse Object Type | person |
+   |Precedence | Choose a random high number not currently used |
+  
+   Then proceed to the Transformations tab and do a direct mapping of the target attribute of **alternativeSecurityId** to **altSecurityIdentities** as shown below.
 
    :::image type="content" border="true" source="./media/concept-certificate-based-authentication-certificateuserids/alt-security-identity-inbound.png" alt-text="Screenshot of how to transform from altSecurityIdentities to alternateSecurityId attribute":::
 
 1. Create an outbound synchronization rule to transform from alternateSecurityId attribute to certificateUserIds
 alt-security-identity-add.
 
-|Option | Value |
-|-------|-------|
-|Name | Descriptive name of the rule, such as: Out to AAD - certificateUserIds |
-|Connected System | Your Azure AD doamin |
-|Connected System Object Type | user |
-|Metaverse Object Type | person |
-|Precedence | Choose a random high number not currently used |
-
-Then proceed to the Transformations tab and change your FlowType option to *Expression*, the target attribute to **certificateUserIds** and then input the below expression in to the Source field.
+   |Option | Value |
+   |-------|-------|
+   |Name | Descriptive name of the rule, such as: Out to AAD - certificateUserIds |
+   |Connected System | Your Azure AD doamin |
+   |Connected System Object Type | user |
+   |Metaverse Object Type | person |
+   |Precedence | Choose a random high number not currently used |
+    
+   Then proceed to the Transformations tab and change your FlowType option to *Expression*, the target attribute to **certificateUserIds** and then input the below expression in to the Source field.
 
    :::image type="content" border="true" source="./media/concept-certificate-based-authentication-certificateuserids/alt-security-identity-outbound.png" alt-text="Screenshot of outbound synchronization rule to transform from alternateSecurityId attribute to certificateUserIds":::
 


### PR DESCRIPTION
There were several pieces of this article that did not work well for someone following instructions, such as brackets (<>) around values that broke expressions, and also there was no guidance given for the options when creating new inbound and outbound synchronization rules when syncing altternativeSecurityId. This should make the article easier for someone to go through and implement the changes.