### PR TITLE
damienbod/cross-tenant-synchronization-configure-graph-easy-to-use

### DIFF
--- a/articles/active-directory/multi-tenant-organizations/cross-tenant-synchronization-configure-graph.md
+++ b/articles/active-directory/multi-tenant-organizations/cross-tenant-synchronization-configure-graph.md
@@ -75,8 +75,8 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
 
 1. Get the tenant ID of the source and target tenants. The example configuration described in this article uses the following tenant IDs:
 
-    - Source tenant ID: {source-tenant-id}
-    - Target tenant ID: {target-tenant-id}
+    - Source tenant ID: {sourceTenantId}
+    - Target tenant ID: {targetTenantId}
 
 ## Step 2: Enable user synchronization in the target tenant
 
@@ -91,7 +91,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     Content-Type: application/json
     
     {
-      "tenantId": "{source-tenant-id}"
+      "tenantId": "{sourceTenantId}"
     }
     ```
     
@@ -103,7 +103,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     
     {
       "@odata.context": "https://graph.microsoft.com/beta/$metadata#policies/crossTenantAccessPolicy/partners/$entity",
-      "tenantId": "{source-tenant-id}",
+      "tenantId": "{sourceTenantId}",
       "isServiceProvider": null,
       "inboundTrust": null,
       "b2bCollaborationOutbound": null,
@@ -129,7 +129,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PUT https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-tenant-id}/identitySynchronization
+    PUT https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{sourceTenantId}/identitySynchronization
     Content-type: application/json
     
     {
@@ -156,7 +156,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-tenant-id}
+    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{sourceTenantId}
     Content-Type: application/json
     
     {
@@ -187,7 +187,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     Content-Type: application/json
     
     {
-      "tenantId": "{target-tenant-id}"
+      "tenantId": "{targetTenantId}"
     }
     ```
     
@@ -199,7 +199,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     
     {
       "@odata.context": "https://graph.microsoft.com/beta/$metadata#policies/crossTenantAccessPolicy/partners/$entity",
-      "tenantId": "{target-tenant-id}",
+      "tenantId": "{targetTenantId}",
       "isServiceProvider": null,
       "inboundTrust": null,
       "b2bCollaborationOutbound": null,
@@ -225,7 +225,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{target-tenant-id}
+    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{targetTenantId}
     Content-Type: application/json
     
     {
@@ -290,7 +290,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
             "appId": "{appId}",
             "appDisplayName": "Fabrikam",
             "applicationTemplateId": "518e5f48-1fc8-4c48-9387-9fdf28b0dfe7",
-            "appOwnerTenantId": "{target-tenant-id}",
+            "appOwnerTenantId": "{targetTenantId}",
             "appRoleAssignmentRequired": true,
             "displayName": "Fabrikam",
             "errorUrl": null,
@@ -342,7 +342,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
         "credentials": [
             {
                 "key": "CompanyId",
-                "value": "{target-tenant-id}"
+                "value": "{targetTenantId}"
             },
             {
                 "key": "AuthenticationType",
@@ -439,7 +439,7 @@ In the source tenant, to enable provisioning, create a provisioning job.
         "value": [ 
             { 
                 "key": "CompanyId", 
-                "value": "{target-tenant-id}" 
+                "value": "{targetTenantId}" 
             },
             {
                 "key": "AuthenticationType",
@@ -645,7 +645,7 @@ Now that you have a configuration, you can test on-demand provisioning with one 
             {
                 "id": "{id}",
                 "activityDateTime": "2022-12-11T00:40:37Z",
-                "tenantId": "{target-tenant-id}",
+                "tenantId": "{targetTenantId}",
                 "jobId": "{jobId}",
                 "cycleId": "{cycleId}",
                 "changeId": "{changeId}",

--- a/articles/active-directory/multi-tenant-organizations/cross-tenant-synchronization-configure-graph.md
+++ b/articles/active-directory/multi-tenant-organizations/cross-tenant-synchronization-configure-graph.md
@@ -75,8 +75,8 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
 
 1. Get the tenant ID of the source and target tenants. The example configuration described in this article uses the following tenant IDs:
 
-    - Source tenant ID: {source-targetId}
-    - Target tenant ID: {target-targetId}
+    - Source tenant ID: {source-tenant-id}
+    - Target tenant ID: {target-tenant-id}
 
 ## Step 2: Enable user synchronization in the target tenant
 
@@ -91,7 +91,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     Content-Type: application/json
     
     {
-      "tenantId": "{source-targetId}"
+      "tenantId": "{source-tenant-id}"
     }
     ```
     
@@ -103,7 +103,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     
     {
       "@odata.context": "https://graph.microsoft.com/beta/$metadata#policies/crossTenantAccessPolicy/partners/$entity",
-      "tenantId": "{source-targetId}",
+      "tenantId": "{source-tenant-id}",
       "isServiceProvider": null,
       "inboundTrust": null,
       "b2bCollaborationOutbound": null,
@@ -129,7 +129,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PUT https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-targetId}/identitySynchronization
+    PUT https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-tenant-id}/identitySynchronization
     Content-type: application/json
     
     {
@@ -156,7 +156,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-targetId}
+    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-tenant-id}
     Content-Type: application/json
     
     {
@@ -187,7 +187,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     Content-Type: application/json
     
     {
-      "tenantId": "{target-targetId}"
+      "tenantId": "{target-tenant-id}"
     }
     ```
     
@@ -199,7 +199,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     
     {
       "@odata.context": "https://graph.microsoft.com/beta/$metadata#policies/crossTenantAccessPolicy/partners/$entity",
-      "tenantId": "{target-targetId}",
+      "tenantId": "{target-tenant-id}",
       "isServiceProvider": null,
       "inboundTrust": null,
       "b2bCollaborationOutbound": null,
@@ -225,7 +225,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{target-targetId}
+    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{target-tenant-id}
     Content-Type: application/json
     
     {
@@ -290,7 +290,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
             "appId": "{appId}",
             "appDisplayName": "Fabrikam",
             "applicationTemplateId": "518e5f48-1fc8-4c48-9387-9fdf28b0dfe7",
-            "appOwnerTenantId": "{target-targetId}",
+            "appOwnerTenantId": "{target-tenant-id}",
             "appRoleAssignmentRequired": true,
             "displayName": "Fabrikam",
             "errorUrl": null,
@@ -342,7 +342,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
         "credentials": [
             {
                 "key": "CompanyId",
-                "value": "{target-targetId}"
+                "value": "{target-tenant-id}"
             },
             {
                 "key": "AuthenticationType",
@@ -439,7 +439,7 @@ In the source tenant, to enable provisioning, create a provisioning job.
         "value": [ 
             { 
                 "key": "CompanyId", 
-                "value": "{target-targetId}" 
+                "value": "{target-tenant-id}" 
             },
             {
                 "key": "AuthenticationType",
@@ -645,7 +645,7 @@ Now that you have a configuration, you can test on-demand provisioning with one 
             {
                 "id": "{id}",
                 "activityDateTime": "2022-12-11T00:40:37Z",
-                "tenantId": "{target-targetId}",
+                "tenantId": "{target-tenant-id}",
                 "jobId": "{jobId}",
                 "cycleId": "{cycleId}",
                 "changeId": "{changeId}",

--- a/articles/active-directory/multi-tenant-organizations/cross-tenant-synchronization-configure-graph.md
+++ b/articles/active-directory/multi-tenant-organizations/cross-tenant-synchronization-configure-graph.md
@@ -75,8 +75,8 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
 
 1. Get the tenant ID of the source and target tenants. The example configuration described in this article uses the following tenant IDs:
 
-    - Source tenant ID: 3d0f5dec-5d3d-455c-8016-e2af1ae4d31a
-    - Target tenant ID: 376a1f89-b02f-4a85-8252-2974d1984d14
+    - Source tenant ID: {source-targetId}
+    - Target tenant ID: {target-targetId}
 
 ## Step 2: Enable user synchronization in the target tenant
 
@@ -91,7 +91,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     Content-Type: application/json
     
     {
-      "tenantId": "3d0f5dec-5d3d-455c-8016-e2af1ae4d31a"
+      "tenantId": "{source-targetId}"
     }
     ```
     
@@ -103,7 +103,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     
     {
       "@odata.context": "https://graph.microsoft.com/beta/$metadata#policies/crossTenantAccessPolicy/partners/$entity",
-      "tenantId": "3d0f5dec-5d3d-455c-8016-e2af1ae4d31a",
+      "tenantId": "{source-targetId}",
       "isServiceProvider": null,
       "inboundTrust": null,
       "b2bCollaborationOutbound": null,
@@ -129,7 +129,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PUT https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/3d0f5dec-5d3d-455c-8016-e2af1ae4d31a/identitySynchronization
+    PUT https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-targetId}/identitySynchronization
     Content-type: application/json
     
     {
@@ -156,7 +156,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/3d0f5dec-5d3d-455c-8016-e2af1ae4d31a
+    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{source-targetId}
     Content-Type: application/json
     
     {
@@ -187,7 +187,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     Content-Type: application/json
     
     {
-      "tenantId": "376a1f89-b02f-4a85-8252-2974d1984d14"
+      "tenantId": "{target-targetId}"
     }
     ```
     
@@ -199,7 +199,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     
     {
       "@odata.context": "https://graph.microsoft.com/beta/$metadata#policies/crossTenantAccessPolicy/partners/$entity",
-      "tenantId": "376a1f89-b02f-4a85-8252-2974d1984d14",
+      "tenantId": "{target-targetId}",
       "isServiceProvider": null,
       "inboundTrust": null,
       "b2bCollaborationOutbound": null,
@@ -225,7 +225,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
     **Request**
     
     ```http
-    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/376a1f89-b02f-4a85-8252-2974d1984d14
+    PATCH https://graph.microsoft.com/beta/policies/crossTenantAccessPolicy/partners/{target-targetId}
     Content-Type: application/json
     
     {
@@ -290,7 +290,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
             "appId": "{appId}",
             "appDisplayName": "Fabrikam",
             "applicationTemplateId": "518e5f48-1fc8-4c48-9387-9fdf28b0dfe7",
-            "appOwnerTenantId": "376a1f89-b02f-4a85-8252-2974d1984d14",
+            "appOwnerTenantId": "{target-targetId}",
             "appRoleAssignmentRequired": true,
             "displayName": "Fabrikam",
             "errorUrl": null,
@@ -342,7 +342,7 @@ These steps describe how to use Microsoft Graph Explorer (recommended), but you 
         "credentials": [
             {
                 "key": "CompanyId",
-                "value": "376a1f89-b02f-4a85-8252-2974d1984d14"
+                "value": "{target-targetId}"
             },
             {
                 "key": "AuthenticationType",
@@ -439,7 +439,7 @@ In the source tenant, to enable provisioning, create a provisioning job.
         "value": [ 
             { 
                 "key": "CompanyId", 
-                "value": "376a1f89-b02f-4a85-8252-2974d1984d14" 
+                "value": "{target-targetId}" 
             },
             {
                 "key": "AuthenticationType",
@@ -645,7 +645,7 @@ Now that you have a configuration, you can test on-demand provisioning with one 
             {
                 "id": "{id}",
                 "activityDateTime": "2022-12-11T00:40:37Z",
-                "tenantId": "376a1f89-b02f-4a85-8252-2974d1984d14",
+                "tenantId": "{target-targetId}",
                 "jobId": "{jobId}",
                 "cycleId": "{cycleId}",
                 "changeId": "{changeId}",


### PR DESCRIPTION
I updated the examples to make it easier to implement the Microsoft Graph examples by adding placeholders for the source and target tenant Ids to replace. I found it hard to keep scrolling up and down the page to check which is the source and which is the target tenant guid. I think this change would make it easier to use the docs.