### PR TITLE
Adding Windows 10/11 Provision for Students

### DIFF
--- a/articles/education-hub/azure-dev-tools-teaching/program-faq.yml
+++ b/articles/education-hub/azure-dev-tools-teaching/program-faq.yml
@@ -59,7 +59,7 @@ sections:
              :::column-end:::
           :::row-end:::
        
-       - question: |
+      - question: |
           Can I deploy Windows 10 and Windows 11 VMs with my Azure for Students subscription?
         answer: |
           Yes, as a benefit of your Azure for Students subscription, you may use Windows 10 and 11 virtual machines without the need for a Windows 11 Enterprise license.

--- a/articles/education-hub/azure-dev-tools-teaching/program-faq.yml
+++ b/articles/education-hub/azure-dev-tools-teaching/program-faq.yml
@@ -58,6 +58,11 @@ sections:
           Windows Server<br>
              :::column-end:::
           :::row-end:::
+       
+       - question: |
+          Can I deploy Windows 10 and Windows 11 VMs with my Azure for Students subscription?
+        answer: |
+          Yes, as a benefit of your Azure for Students subscription, you may use Windows 10 and 11 virtual machines without the need for a Windows 11 Enterprise license.
           
       - question: |
           Can I get Azure for Students again next year?

--- a/articles/education-hub/azure-dev-tools-teaching/program-faq.yml
+++ b/articles/education-hub/azure-dev-tools-teaching/program-faq.yml
@@ -2,7 +2,7 @@
 metadata:
   title: Frequently asked questions about Azure for Students and Azure Dev Tools for Teaching
   description: Find answers to some common questions about Azure for Students, Azure for Students Starter, and Azure Dev Tools for Teaching.
-  author: v-dihans
+  author: rymend
   ms.author: rymend	
   ms.service: azure-education
   ms.topic: faq


### PR DESCRIPTION
Previously, only users with a multi-tenant hosting rights license could deploy Windows 10/11 virtual machines on Azure. This almost entirely excluded free trial and student users from deploying these types of VMs since the vast majority of these users would not have that type of enterprise license. The Azure portal team has worked with the Licensing Business planning team to include free trial and student subscriptions in the Windows 10/11 licensing program on Azure so that these users are allowed to deploy these images as well. Please reach out to andrewpham@microsoft.com if more details are needed.
