### PR TITLE
Update to diagnostic-logs.md for Bastion Logs

### DIFF
--- a/articles/bastion/diagnostic-logs.md
+++ b/articles/bastion/diagnostic-logs.md
@@ -13,6 +13,9 @@ ms.author: cherylmc
 
 As users connect to workloads using Azure Bastion, Bastion can log diagnostics of the remote sessions. You can then use the diagnostics to view which users connected to which workloads, at what time, from where, and other such relevant logging information. In order to use the diagnostics, you must enable diagnostics logs on Azure Bastion. This article helps you enable diagnostics logs, and then view the logs.
 
+>[!NOTE]
+>To view all resource logs available for Bastion, select each of the resource logs. If you exclude the 'All Logs' setting, you will not see all the available resource logs.
+
 ## <a name="enable"></a>Enable the resource log
 
 1. In the [Azure portal](https://portal.azure.com), go to your Azure Bastion resource and select **Diagnostics settings** from the Azure Bastion page.


### PR DESCRIPTION
Included a note to help clarify to the reader that they must select each of the resource logs if they want to view all resource logs available for Bastion. Readers can be confused when enabling logging without this informative note.