### PR TITLE
Variable missing an 's' and wrong port for WAC

### DIFF
--- a/articles/azure-arc/servers/ssh-arc-troubleshoot.md
+++ b/articles/azure-arc/servers/ssh-arc-troubleshoot.md
@@ -53,12 +53,12 @@ Resolution:
    ```powershell
    # Set 22 port:
    azcmagent config list
-   azcmagent config get incomingconnections.port
-   azcmagent config set incomingconnections.port 22
+   azcmagent config get incomingconnections.ports
+   azcmagent config set incomingconnections.ports 22
    azcmagent config
    
    # Add multiple ports:
-   azcmagent config set incomingconnections.port 22,3516
+   azcmagent config set incomingconnections.ports 22,6516
    ```
    
 ## Azure permissions issues


### PR DESCRIPTION
The variable incomingconnections.port is incorrect. It's "incomingconnections.ports" 

# Add multiple ports:
azcmagent config set incomingconnections.port 22,3516

In the line above the WAC portal Port is 6516 not 3516 by default. Copying this line causes two issues, 1. The variable is incorrect. 2. The port connection will break the WAC in Portal experience if copied as is.

Line should read:
# Add multiple ports:
azcmagent config set incomingconnections.ports 22,6516