### PR TITLE
Fixed erroneous space within Blob FQDN on subdomain-takeover.md

### DIFF
--- a/articles/security/fundamentals/subdomain-takeover.md
+++ b/articles/security/fundamentals/subdomain-takeover.md
@@ -78,7 +78,7 @@ The tool supports the Azure resources listed in the following table. The tool ex
 | Service                   | Type                                        | FQDNproperty                               | Example                         |
 |---------------------------|---------------------------------------------|--------------------------------------------|---------------------------------|
 | Azure Front Door          | microsoft.network/frontdoors                | properties.cName                           | `abc.azurefd.net`               |
-| Azure Blob Storage        | microsoft.storage/storageaccounts           | properties.primaryEndpoints.blob           | `abc. blob.core.windows.net`    |
+| Azure Blob Storage        | microsoft.storage/storageaccounts           | properties.primaryEndpoints.blob           | `abc.blob.core.windows.net`    |
 | Azure CDN                 | microsoft.cdn/profiles/endpoints            | properties.hostName                        | `abc.azureedge.net`             |
 | Public IP addresses       | microsoft.network/publicipaddresses         | properties.dnsSettings.fqdn                | `abc.EastUs.cloudapp.azure.com` |
 | Azure Traffic Manager     | microsoft.network/trafficmanagerprofiles    | properties.dnsConfig.fqdn                  | `abc.trafficmanager.net`        |


### PR DESCRIPTION
Fixed erroneous space within 'Azure Blob Storage' FQDN within table on subdomain-takeover.md page