### PR TITLE
Note about Token Store for Claims Mapping to work

### DIFF
--- a/articles/app-service/configure-authentication-user-identities.md
+++ b/articles/app-service/configure-authentication-user-identities.md
@@ -28,7 +28,7 @@ For [Azure Functions](../azure-functions/functions-overview.md), `ClaimsPrincipa
 For .NET Core, [Microsoft.Identity.Web](https://www.nuget.org/packages/Microsoft.Identity.Web/) supports populating the current user with App Service authentication. To learn more, you can read about it on the [Microsoft.Identity.Web wiki](https://github.com/AzureAD/microsoft-identity-web/wiki/1.2.0#integration-with-azure-app-services-authentication-of-web-apps-running-with-microsoftidentityweb), or see it demonstrated in [this tutorial for a web app accessing Microsoft Graph](./scenario-secure-app-access-microsoft-graph-as-user.md?tabs=command-line#install-client-library-packages).
 
 > [!NOTE]
-> For claims mapping to work, you must enable the [Token store](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#token-store).
+> For claims mapping to work, you must enable the [Token store](overview-authentication-authorization.md#token-store).
 
 ## Access user claims using the API
 

--- a/articles/app-service/configure-authentication-user-identities.md
+++ b/articles/app-service/configure-authentication-user-identities.md
@@ -27,6 +27,9 @@ For [Azure Functions](../azure-functions/functions-overview.md), `ClaimsPrincipa
 
 For .NET Core, [Microsoft.Identity.Web](https://www.nuget.org/packages/Microsoft.Identity.Web/) supports populating the current user with App Service authentication. To learn more, you can read about it on the [Microsoft.Identity.Web wiki](https://github.com/AzureAD/microsoft-identity-web/wiki/1.2.0#integration-with-azure-app-services-authentication-of-web-apps-running-with-microsoftidentityweb), or see it demonstrated in [this tutorial for a web app accessing Microsoft Graph](./scenario-secure-app-access-microsoft-graph-as-user.md?tabs=command-line#install-client-library-packages).
 
+> [!NOTE]
+> For claims mapping to work, you must enable the [Token store](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization#token-store).
+
 ## Access user claims using the API
 
 If the [token store](overview-authentication-authorization.md#token-store) is enabled for your app, you can also obtain additional details on the authenticated user by calling `/.auth/me`. 


### PR DESCRIPTION
If the token store is disabled (non-default) then the AAD ID token (`X-MS-TOKEN-AAD-ID-TOKEN`) is not sent and at least the big `Microsoft.Identity.Web` SDK can't map the weird `X-MS-CLIENT-PRINCIPAL` (non-JWT) to a ClaimsPrincipal