### PR TITLE
Typo "Azure DB for PostgreSQL"→"Azure Database for PostgreSQL"

### DIFF
--- a/articles/postgresql/single-server/quickstart-create-postgresql-server-database-using-bicep.md
+++ b/articles/postgresql/single-server/quickstart-create-postgresql-server-database-using-bicep.md
@@ -1,5 +1,5 @@
 ---
-title: 'Quickstart: Create an Azure DB for PostgreSQL - Bicep'
+title: 'Quickstart: Create an Azure Database for PostgreSQL - Bicep'
 description: In this quickstart, learn how to create an Azure Database for PostgreSQL single server using Bicep.
 ms.service: postgresql
 ms.subservice: single-server


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/postgresql/single-server/quickstart-create-postgresql-server-database-using-bicep?source=recommendations&tabs=CLI 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/postgresql/single-server/quickstart-create-postgresql-server-database-using-bicep.md 
#PingMSFTDocs