### PR TITLE
Fix typo in section: Time before telemetry gets to destination

### DIFF
--- a/articles/azure-monitor/essentials/diagnostic-settings.md
+++ b/articles/azure-monitor/essentials/diagnostic-settings.md
@@ -103,7 +103,7 @@ This section discusses requirements and limitations.
 
 ### Time before telemetry gets to destination
 
-Once you have set up a diagnostic setting, data should start flowing to your selected destination(s) with 90 minutes. If you get no information within 24 hours, then either 
+Once you have set up a diagnostic setting, data should start flowing to your selected destination(s) within 90 minutes. If you get no information within 24 hours, then either 
 - no logs are being generated or 
 - something is wrong in the underlying routing mechanism. Try disabling the configuration and then reenabling it. Contact Azure support through the Azure portal if you continue to have issues. 
 


### PR DESCRIPTION
Change (emphasis mine)

> data should start flowing to your selected destination(s) *with* 90 minutes.

to

> data should start flowing to your selected destination(s) within 90 minutes.