### PR TITLE
Highlight IP Address information on non-interactive events

### DIFF
--- a/articles/active-directory/reports-monitoring/concept-all-sign-ins.md
+++ b/articles/active-directory/reports-monitoring/concept-all-sign-ins.md
@@ -142,7 +142,7 @@ Sign-ins are aggregated in the non-interactive users when the following data mat
 - Status
 - Resource ID
 
-The IP address of non-interactive sign-ins doesn't match the actual source IP of where the refresh token request is coming from. Instead, it shows the original IP used for the original token issuance.
+>[!NOTE] The IP address of non-interactive sign-ins performed by [confidential clients](../develop/msal-client-applications.md) doesn't match the actual source IP of where the refresh token request is coming from. Instead, it shows the original IP used for the original token issuance.
 
 ### Service principal sign-ins
 


### PR DESCRIPTION
The goal is to highlight what IP Address information gets displayed on Azure AD Sign-in logs for non-interactive events performed by confidential clients.