### PR TITLE
remove parameter passed in mysqli_connect_errno()

### DIFF
--- a/articles/mysql/flexible-server/how-to-connect-tls-ssl.md
+++ b/articles/mysql/flexible-server/how-to-connect-tls-ssl.md
@@ -190,7 +190,7 @@ define('MYSQL_SSL_CERT','/FULLPATH/on-client/to/DigiCertGlobalRootCA.crt.pem');
 $conn = mysqli_init();
 mysqli_ssl_set($conn,NULL,NULL, "/var/www/html/DigiCertGlobalRootCA.crt.pem", NULL, NULL);
 mysqli_real_connect($conn, 'mydemoserver.mysql.database.azure.com', 'myadmin', 'yourpassword', 'quickstartdb', 3306, MYSQLI_CLIENT_SSL);
-if (mysqli_connect_errno($conn)) {
+if (mysqli_connect_errno()) {
 die('Failed to connect to MySQL: '.mysqli_connect_error());
 }
 ```


### PR DESCRIPTION
mysqli_connect_errno() has no parameter per https://www.php.net/manual/en/mysqli.connect-errno.php