### PR TITLE
remove parameter passed in mysqli_connect_errno()

### DIFF
--- a/articles/mysql/single-server/how-to-configure-ssl.md
+++ b/articles/mysql/single-server/how-to-configure-ssl.md
@@ -93,7 +93,7 @@ Refer to the list of [compatible drivers](concepts-compatibility.md) supported b
 $conn = mysqli_init();
 mysqli_ssl_set($conn,NULL,NULL, "/var/www/html/BaltimoreCyberTrustRoot.crt.pem", NULL, NULL);
 mysqli_real_connect($conn, 'mydemoserver.mysql.database.azure.com', 'myadmin@mydemoserver', 'yourpassword', 'quickstartdb', 3306, MYSQLI_CLIENT_SSL);
-if (mysqli_connect_errno($conn)) {
+if (mysqli_connect_errno()) {
 die('Failed to connect to MySQL: '.mysqli_connect_error());
 }
 ```


### PR DESCRIPTION
mysqli_connect_errno() has no parameter per https://www.php.net/manual/en/mysqli.connect-errno.php