### PR TITLE
Update storage-custom-domain-name.md

### DIFF
--- a/articles/storage/blobs/storage-custom-domain-name.md
+++ b/articles/storage/blobs/storage-custom-domain-name.md
@@ -189,9 +189,6 @@ The host name is the storage endpoint URL without the protocol identifier and th
 
 3. Copy the value of the **Blob service** endpoint or the **Static website** endpoint to a text file.
 
-   > [!NOTE]
-   > The Data Lake storage endpoint is not supported (For example: `https://mystorageaccount.dfs.core.windows.net/`).
-
 4. Remove the protocol identifier (For example: `HTTPS`) and the trailing slash from that string. The following table contains examples.
 
    | Type of endpoint |  endpoint | host name |


### PR DESCRIPTION
   > [!NOTE]
   > The Data Lake storage endpoint is not supported (For example: `https://mystorageaccount.dfs.core.windows.net/`).

Removed the above note as this sentence is contradicting to the original statement, which means data lake storage is supported with domain and the information is available in the same document in the line number 18