### PR TITLE
Change "code" command to use lower case "c", due to case sensitivity

### DIFF
--- a/articles/cloud-shell/cloud-shell-predictive-intellisense.md
+++ b/articles/cloud-shell/cloud-shell-predictive-intellisense.md
@@ -124,7 +124,7 @@ open-source editor to edit the profile. To learn more, see [Azure Cloud Shell ed
 Use the built-in Cloud Shell editor to edit the profile:
 
 ```powershell
-Code $Profile
+code $Profile
 ```
 
 ## Next steps


### PR DESCRIPTION
Otherwise it'll show the following error when running in Cloud Shell


> PS /home/simon> Code $Profile    
> Code: The term 'Code' is not recognized as a name of a cmdlet, function, script file, or executable program.
> Check the spelling of the name, or if a path was included, verify that the path is correct and try again.