### PR TITLE
Adding documentation for making 429s non-retriable

### DIFF
--- a/articles/communication-services/quickstarts/email/includes/send-email-js.md
+++ b/articles/communication-services/quickstarts/email/includes/send-email-js.md
@@ -283,3 +283,37 @@ const response = await emailClient.send(message);
 ```
 
 You can download the sample app demonstrating this action from [GitHub](https://github.com/Azure-Samples/communication-services-javascript-quickstarts/tree/main/send-email-advanced/send-email-attachments)
+
+### Throw an exception when email sending tier limit is reached
+
+There are per minute and per hour limits to the amount of emails you can send using the Azure Communication Email Service. When you have reached these limits, any further `beginSend` calls will recieve a `429: Too Many Requests` response. By default, the SDK is configured to retry these requests after waiting a certain period of time. We recommend you [set up logging with the Azure SDK](https://learn.microsoft.com/en-us/javascript/api/overview/azure/logger-readme?view=azure-node-latest) to capture these response codes.
+
+If setting up logging is not an option, you can manually define a custom policy as shown below. 
+
+```javascript
+const catch429Policy = {
+  name: "catch429Policy",
+  async sendRequest(request, next) {
+    const response = await next(request);
+    if (response.status === 429) {
+      throw new Error("Tier limit reached");
+    }
+    return response;
+  }
+};
+```
+
+Add this policy to your email client. This will ensure that 429 response codes throw an exception rather than being retried.
+
+```java
+const clientOptions = {
+  additionalPolicies: [
+    {
+      policy: catch429Policy,
+      position: "perRetry"
+    }
+  ]
+}
+
+const emailClient = new EmailClient(connectionString, clientOptions);
+```

--- a/articles/communication-services/quickstarts/email/includes/send-email-net.md
+++ b/articles/communication-services/quickstarts/email/includes/send-email-net.md
@@ -413,4 +413,36 @@ emailMessage.Attachments.Add(emailAttachment);
 
 You can download the sample app demonstrating this action from [GitHub](https://github.com/Azure-Samples/communication-services-dotnet-quickstarts/tree/main/SendEmailAdvanced/SendEmailWithAttachments)
 
+### Throw an exception when email sending tier limit is reached
 
+There are per minute and per hour limits to the amount of emails you can send using the Azure Communication Email Service. When you have reached these limits, any further `SendAsync` calls will recieve a `429: Too Many Requests` response. By default, the SDK is configured to retry these requests after waiting a certain period of time. We recommend you [set up logging with the Azure SDK](https://learn.microsoft.com/en-us/azure/developer/java/sdk/logging-overview) to capture these response codes.
+
+If setting up logging is not an option, you can manually define a custom policy as shown below. 
+
+```csharp
+using Azure.Core.Pipeline;
+
+public class Catch429Policy : HttpPipelineSynchronousPolicy
+{
+    public override void OnReceivedResponse(HttpMessage message)
+    {
+        if (message.Response.Status == 429)
+        {
+            throw new Exception("Tier limit reached.");
+        }
+        else
+        {
+            base.OnReceivedResponse(message);
+        }
+    }
+}
+```
+
+Add this policy to your email client. This will ensure that 429 response codes throw an exception rather than being retried.
+
+```csharp
+EmailClientOptions emailClientOptions = new EmailClientOptions();
+emailClientOptions.AddPolicy(new Catch429Policy(), HttpPipelinePosition.PerRetry);
+
+EmailClient emailClient = new EmailClient(connectionString, emailClientOptions);
+```

--- a/articles/communication-services/quickstarts/email/includes/send-email-python.md
+++ b/articles/communication-services/quickstarts/email/includes/send-email-python.md
@@ -347,3 +347,17 @@ message = {
 ```
 
 You can download the sample app demonstrating this action from [GitHub](https://github.com/Azure-Samples/communication-services-java-quickstarts/tree/main/send-email)
+
+### Throw an exception when email sending tier limit is reached
+
+There are per minute and per hour limits to the amount of emails you can send using the Azure Communication Email Service. When you have reached these limits, any further `begin_send` calls will recieve a `429: Too Many Requests` response. By default, the SDK is configured to retry these requests after waiting a certain period of time. We recommend you [set up logging with the Azure SDK](https://learn.microsoft.com/en-us/azure/developer/python/sdk/azure-sdk-logging) to capture these response codes.
+
+If setting up logging is not an option, you can manually define a custom response hook and add it to your email client as shown below. This will ensure that 429 response codes throw an exception rather than being retried.
+
+```python
+def callback(response):
+    if response.http_response.status_code == 429:
+        raise Exception("Tier limit reached)
+
+email_client = EmailClient.from_connection_string(<connection_string>, raw_response_hook=callback)
+```


### PR DESCRIPTION
We received customer feedback about how 429 errors were being handled by the SDK. Customers get this response code when they've reached the tier limit for sending emails. These requests are retried based on the Retry-After header, giving the impression that the application was hanging.

These doc changes recommend logging as an approach to capture these response codes. They also provide samples on how to throw an exception when 429s are recieved.