### PR TITLE
Required parameters of AZ ML command are missing

### DIFF
--- a/articles/machine-learning/how-to-authenticate-online-endpoint.md
+++ b/articles/machine-learning/how-to-authenticate-online-endpoint.md
@@ -48,7 +48,7 @@ ENDPOINT_CRED=$(az ml online-endpoint get-credentials -n $ENDPOINT_NAME -g $RESO
 __Tokens__ will be returned in the `accessToken` field:
 
 ```azurecli
-ENDPOINT_CRED=$(az ml online-endpoint get-credentials -n $ENDPOINT_NAME -o tsv --query accessToken)
+ENDPOINT_CRED=$(az ml online-endpoint get-credentials -n $ENDPOINT_NAME -g $RESOURCE_GROUP -w $WORKSPACE_NAME -o tsv --query accessToken)
 ```
 
 Additionally, the `expiryTimeUtc` and `refreshAfterTimeUtc` fields contain the token expiration and refresh times. 

--- a/articles/machine-learning/how-to-authenticate-online-endpoint.md
+++ b/articles/machine-learning/how-to-authenticate-online-endpoint.md
@@ -42,7 +42,7 @@ To get the key or token, use [az ml online-endpoint get-credentials](/cli/azure/
 __Keys__ will be returned in the `primaryKey` and `secondaryKey` fields. The following example shows how to use the `--query` parameter to return only the primary key:
 
 ```azurecli
-ENDPOINT_CRED=$(az ml online-endpoint get-credentials -n $ENDPOINT_NAME -o tsv --query primaryKey)
+ENDPOINT_CRED=$(az ml online-endpoint get-credentials -n $ENDPOINT_NAME -g $RESOURCE_GROUP -w $WORKSPACE_NAME -o tsv --query primaryKey)
 ```
 
 __Tokens__ will be returned in the `accessToken` field:


### PR DESCRIPTION
"az ml online-endpoint get-credentials" has 3 required parameters:  -n (Name of the online endpoint), -g (Name of resource group), -w (Name of the Azure ML workspace).

In provided example, only -n is present. That's why attempts to execute this command will fail with an error: "the following arguments are required: --resource-group/-g, --workspace-name/-w".