### PR TITLE
Update maintenance-scheduling.md

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/maintenance-scheduling.md
+++ b/articles/synapse-analytics/sql-data-warehouse/maintenance-scheduling.md
@@ -32,8 +32,6 @@ All maintenance operations should finish within the specified maintenance window
 
 Integration with Service Health notifications and the Resource Health Check Monitor allows customers to stay informed of impending maintenance activity. This automation takes advantage of Azure Monitor. You can decide how you want to be notified of impending maintenance events. Also, you can choose which automated flows will help you manage downtime and minimize operational impact.
 
-A 24-hour advance notification precedes all maintenance events that aren't for the DW400c and lower tiers.
-
 > [!NOTE]
 > In the event we are required to deploy a time critical update, advanced notification times may be significantly reduced. This could occur outside an identified maintenance window due to the critical nature of the update.
 

--- a/articles/synapse-analytics/sql-data-warehouse/maintenance-scheduling.md
+++ b/articles/synapse-analytics/sql-data-warehouse/maintenance-scheduling.md
@@ -33,7 +33,7 @@ All maintenance operations should finish within the specified maintenance window
 Integration with Service Health notifications and the Resource Health Check Monitor allows customers to stay informed of impending maintenance activity. This automation takes advantage of Azure Monitor. You can decide how you want to be notified of impending maintenance events. Also, you can choose which automated flows will help you manage downtime and minimize operational impact.
 
 > [!NOTE]
-> In the event we are required to deploy a time critical update, advanced notification times may be significantly reduced. This could occur outside an identified maintenance window due to the critical nature of the update.
+> A 24-hour advance notification precedes all maintenance events. In the event we are required to deploy a time critical update, advanced notification times may be significantly reduced. This could occur outside an identified maintenance window due to the critical nature of the update.
 
 If you received advance notification that maintenance will take place, but maintenance can't be performed during the time period in the notification, you'll receive a cancellation notification. Maintenance will then resume during the next scheduled maintenance period.
 


### PR DESCRIPTION
Remove the below incorrect sentence.

A 24-hour advance notification precedes all maintenance events that aren't for the DW400c and lower tiers.