### PR TITLE
Add warning about multi-DC scenario being unsupported

### DIFF
--- a/articles/azure-arc/data/plan-azure-arc-data-services.md
+++ b/articles/azure-arc/data/plan-azure-arc-data-services.md
@@ -140,7 +140,7 @@ As outlined in [Connectivity modes and requirements](./connectivity.md), you can
 After you've installed the Azure Arc data controller, you can create and access data services such as Azure Arc-enabled SQL Managed Instance or Azure Arc-enabled PostgreSQL server.
 
 ## Known limitations
-Currently, only one Azure Arc data controller per cluster is supported. However, you can create multiple Arc data services, such as Arc-enabled SQL Managed Instances and Arc-enabled PostgreSQL servers, that are managed by the same Azure Arc data controller.
+Currently, only one Azure Arc data controller per Kubernetes cluster is supported. However, you can create multiple Arc data services, such as Arc-enabled SQL Managed Instances and Arc-enabled PostgreSQL servers, that are managed by the same Azure Arc data controller.
 
 ## Next steps
 

--- a/articles/azure-arc/data/plan-azure-arc-data-services.md
+++ b/articles/azure-arc/data/plan-azure-arc-data-services.md
@@ -92,7 +92,6 @@ You can deploy Azure Arc-enabled data services on various types of Kubernetes cl
 - Additional [partner-validated Kubernetes distributions](./validation-program.md)
 
 > [!IMPORTANT]
-> * Currently, only one Azure Arc data controller per Kubernetes cluster is supported.
 > * The minimum supported version of Kubernetes is v1.21. For more information, see the "Known issues" section of [Release notes&nbsp;- Azure Arc-enabled data services](./release-notes.md#known-issues).
 > * The minimum supported version of OCP is 4.8.
 > * If you're using Azure Kubernetes Service, your cluster's worker node virtual machine (VM) size should be at least Standard_D8s_v3 and use Premium Disks. 
@@ -139,6 +138,9 @@ As outlined in [Connectivity modes and requirements](./connectivity.md), you can
    You can perform all three of these steps in a single step by using the Azure Arc data controller creation wizard in the Azure portal.
 
 After you've installed the Azure Arc data controller, you can create and access data services such as Azure Arc-enabled SQL Managed Instance or Azure Arc-enabled PostgreSQL server.
+
+## Known limitations
+Currently, only one Azure Arc data controller per cluster is supported. However, you can create multiple Arc data services, such as Arc-enabled SQL Managed Instances and Arc-enabled PostgreSQL servers, that are managed by the same Azure Arc data controller.
 
 ## Next steps
 

--- a/articles/azure-arc/data/plan-azure-arc-data-services.md
+++ b/articles/azure-arc/data/plan-azure-arc-data-services.md
@@ -140,7 +140,7 @@ As outlined in [Connectivity modes and requirements](./connectivity.md), you can
 After you've installed the Azure Arc data controller, you can create and access data services such as Azure Arc-enabled SQL Managed Instance or Azure Arc-enabled PostgreSQL server.
 
 ## Known limitations
-Currently, only one Azure Arc data controller per Kubernetes cluster is supported. However, you can create multiple Arc data services, such as Arc-enabled SQL Managed Instances and Arc-enabled PostgreSQL servers, that are managed by the same Azure Arc data controller.
+Currently, only one Azure Arc data controller per Kubernetes cluster is supported. However, you can create multiple Arc data services, such as Arc-enabled SQL managed instances and Arc-enabled PostgreSQL servers, that are managed by the same Azure Arc data controller.
 
 ## Next steps
 

--- a/articles/azure-arc/data/plan-azure-arc-data-services.md
+++ b/articles/azure-arc/data/plan-azure-arc-data-services.md
@@ -92,6 +92,7 @@ You can deploy Azure Arc-enabled data services on various types of Kubernetes cl
 - Additional [partner-validated Kubernetes distributions](./validation-program.md)
 
 > [!IMPORTANT]
+> * Currently, only one Azure Arc data controller per Kubernetes cluster is supported.
 > * The minimum supported version of Kubernetes is v1.21. For more information, see the "Known issues" section of [Release notes&nbsp;- Azure Arc-enabled data services](./release-notes.md#known-issues).
 > * The minimum supported version of OCP is 4.8.
 > * If you're using Azure Kubernetes Service, your cluster's worker node virtual machine (VM) size should be at least Standard_D8s_v3 and use Premium Disks. 


### PR DESCRIPTION
We should call out that we currently do not support more than one Azure Arc data controller in a Kubernetes cluster, even if they're in different namespaces.