### PR TITLE
Clarified which subscription key is used by the extension

### DIFF
--- a/articles/api-management/api-management-debug-policies.md
+++ b/articles/api-management/api-management-debug-policies.md
@@ -32,7 +32,7 @@ This article describes how to debug API Management policies using the [Azure API
 
 * This feature is only available in the **Developer** tier of API Management. Each API Management instance supports only one concurrent debugging session.
 
-* This feature uses the built-in (service-level) all-access subscription for debugging. The [**Allow tracing**](api-management-howto-api-inspector.md#verify-allow-tracing-setting) setting must be enabled in this subscription.
+* This feature uses the built-in (service-level) all-access subscription (display name "Built-in all-access subscription") for debugging. The [**Allow tracing**](api-management-howto-api-inspector.md#verify-allow-tracing-setting) setting must be enabled in this subscription.
 
 [!INCLUDE [api-management-tracing-alert](../../includes/api-management-tracing-alert.md)]
 


### PR DESCRIPTION
It isn't immediately clear from the docs which subscription key is used (other than it is some sort of master one), but they always have an immutable, static display name. This may help future people reading the docs to isolate which key the docs are referring to