### PR TITLE
Rotating password of identity source

### DIFF
--- a/articles/azure-vmware/configure-identity-source-vcenter.md
+++ b/articles/azure-vmware/configure-identity-source-vcenter.md
@@ -255,17 +255,22 @@ You'll run the `Remove-ExternalIdentitySources` cmdlet to remove all existing ex
 
 ## Rotate an existing external identity source account's username and/or password
 
-1. Use the [Get-ExternalIdentitySources](configure-identity-source-vcenter.md#list-external-identity) run command to pull current populated values.
+1. Rotate the password of account used for authentication with the AD source in the domain controller.
 
-1. Run [Remove-ExternalIdentitySource](configure-identity-source-vcenter.md#remove-existing-external-identity-sources) and provide DomainName of External Identity source you'd like to rotate.
+1. Select **Run command** > **Packages** > **Update-IdentitySourceCredential**.
+
+1. Provide the required values and the updated password, and then select **Run**.
+
+   | **Field** | **Value** |
+   | --- | --- |
+   | **Credential**  | The domain username and password used for authentication with the AD source (not cloudadmin). The user must be in the **username@avslab.local** format. |
+   | **DomainName**  |  The FQDN of the domain, for example **avslab.local**.  |
+
+1. Check **Notifications** or the **Run Execution Status** pane to see the progress.
+
 > [!IMPORTANT]
-> If you do not provide a DomainName, all external identity sources will be removed.
+> If you do not provide a DomainName, all external identity sources will be removed. The command **Update-IdentitySourceCredential** should be run only after the password is rotated in the domain controller.
 
-1. Run [New-LDAPSIdentitySource](configure-identity-source-vcenter.md#add-active-directory-over-ldap-with-ssl) or [New-LDAPIdentitySource](configure-identity-source-vcenter.md#add-active-directory-over-ldap) depending on your configuration. 
-
->[!NOTE]
->There is work to make this an easier process than it is today with a new run command.
->[PR with VMware](https://github.com/vmware/PowerCLI-Example-Scripts/pull/604)
 
 ## Next steps
 


### PR DESCRIPTION
A new command [`Update-IdentitySourceCredential` ](https://github.com/Azure/Microsoft.AVS.Management/pull/136)has been added to run command. Users can update the password with this command instead of removing and re-adding identity source. Update the corresponding docs.