### PR TITLE
Update active-directory-schema-extensions.md

### DIFF
--- a/articles/active-directory/develop/active-directory-schema-extensions.md
+++ b/articles/active-directory/develop/active-directory-schema-extensions.md
@@ -50,7 +50,7 @@ For example, here is a claims-mapping policy to emit a single claim from a direc
         "ClaimsSchema": [{
                 "Source": "User",
                 "ExtensionID": "extension_xxxxxxx_test",
-                "JWTClaimType": "http://schemas.contoso.com/identity/claims/exampleclaim"
+                "JWTClaimType": "exampleclaim"
             },
         ]
     }


### PR DESCRIPTION
Based on the information here: https://learn.microsoft.com/en-us/azure/active-directory/develop/reference-claims-mapping-policy-type and the following statement:

> Claim Type: The JwtClaimType and SamlClaimType elements define which claim this claim schema entry refers to. 
    * The JwtClaimType must contain the name of the claim to be emitted in JWTs. 
    * The SamlClaimType must contain the URI of the claim to be emitted in SAML tokens.


I suspect the `JWTClaimType` example given here should *not* be a URI. This change reflects that, although it would be good for someone more experienced on this to confirm that `exampleclaim` would be a valid value (I'm unclear whether this must match the value in `ExtensionID` or not.