### PR TITLE
fix instruction of name of DNS Zone

### DIFF
--- a/articles/dns/dns-delegate-domain-azure-dns.md
+++ b/articles/dns/dns-delegate-domain-azure-dns.md
@@ -54,7 +54,7 @@ Sign in to the Azure portal at https://portal.azure.com.
     | Resource group | Select **Create new** </br> In **Name**, enter **myResourceGroup** </br> Select **OK**. |
     | **Instance details** |       |
     | This zone is a child of an existing zone already hosted in Azure DNS | Clear this checkbox since the DNS zone isn't a [child zone](./tutorial-public-dns-zones-child.md). |
-    | Name | Enter your parent DNS zone name. |
+    | Name | Enter your DNS zone name. |
     | Resource group location | Select the resource group location. </br> The resource group location doesn't affect your DNS zone service, which is global and not bound to a location. |
 
     :::image type="content" source="./media/dns-delegate-domain-azure-dns/create-parent-dns-zone.png" alt-text="Screenshot of Create D N S zone page showing the settings used in this tutorial to create a parent D N S zone.":::


### PR DESCRIPTION
* remove "parent" for "Setting: Name" from its "Value"

Since there is "Setting: Parent zone" for "your parent DNS zone name", the extra "parent" may confuse the reader.