### PR TITLE
Learning language configuration for PA

### DIFF
--- a/articles/cognitive-services/Speech-Service/how-to-pronunciation-assessment.md
+++ b/articles/cognitive-services/Speech-Service/how-to-pronunciation-assessment.md
@@ -36,6 +36,9 @@ You can get pronunciation assessment scores for:
 >
 > For information about availability of pronunciation assessment, see [supported languages](language-support.md?tabs=pronunciation-assessment) and [available regions](regions.md#speech-service).
 
+## Learning language configuration
+
+The default learning language is `en-US`. If you want to practice towards different accent learning purposes, you need to configure the setting to specify the language used for evaluation. To learn how to specify the learning language for pronunciation assessment in your own application, see sample code.
 
 ## Configuration parameters
 

--- a/articles/cognitive-services/Speech-Service/language-support.md
+++ b/articles/cognitive-services/Speech-Service/language-support.md
@@ -90,7 +90,7 @@ With the cross-lingual feature (preview), you can transfer your custom neural vo
 
 # [Pronunciation assessment](#tab/pronunciation-assessment)
 
-The table in this section summarizes the locales supported for pronunciation assessment, and each language is available on all [Speech-to-text regions](regions.md#speech-service). To align your teaching/learning language for pronunciation assessment, you should specify the language. The default language is set as `en-US`. For example, if you are learning British English, you should specify the language as `en-GB`. See sample code.
+The table in this section summarizes the locales supported for pronunciation assessment, and each language is available on all [Speech-to-text regions](regions.md#speech-service). You should specify the language that you are learning or practicing to improve pronunciation. The default language is set as `en-US`. For example, if you are learning British English, you should specify the language as `en-GB`. See sample code.
 
 [!INCLUDE [Language support include](includes/language-support/pronunciation-assessment.md)]
 

--- a/articles/cognitive-services/Speech-Service/language-support.md
+++ b/articles/cognitive-services/Speech-Service/language-support.md
@@ -90,7 +90,7 @@ With the cross-lingual feature (preview), you can transfer your custom neural vo
 
 # [Pronunciation assessment](#tab/pronunciation-assessment)
 
-The table in this section summarizes the locales supported for Pronunciation assessment, and each language is available on all [Speech-to-text regions](regions.md#speech-service).
+The table in this section summarizes the locales supported for pronunciation assessment, and each language is available on all [Speech-to-text regions](regions.md#speech-service). To align your teaching/learning language for pronunciation assessment, you should specify the language. The default language is set as `en-US`. For example, if you are learning British English, you should specify the language as `en-GB`. See sample code.
 
 [!INCLUDE [Language support include](includes/language-support/pronunciation-assessment.md)]
 


### PR DESCRIPTION
Update the gaps in the current PA docs: 
1) The default language is  en-US.
2) Adding：Learning language represents the language that learners wants to learn, not the learners speak. If learners want to practice a different accent, they need to specify the learning language accordingly.
3) Adding learning language configuration sample code.  (Preparing)