### PR TITLE
Note on CNAME matching account name

### DIFF
--- a/articles/storage/files/storage-files-identity-multiple-forests.md
+++ b/articles/storage/files/storage-files-identity-multiple-forests.md
@@ -146,7 +146,7 @@ To use this method, complete the following steps:
 Now, from domain-joined clients, you should be able to use storage accounts joined to any forest.
 
 > [!NOTE]
-> Ensure hostname part of the FQDN matches the storage account name as described above. Otherwise you will get an access denied with the error "The filename, directory name, or volume label syntax is incorrect.". A network trace will show STATUS_OBJECT_NAME_INVALID (0xc0000033) message during the SMB session setup.
+> Ensure hostname part of the FQDN matches the storage account name as described above. Otherwise you will get an access denied error "The filename, directory name, or volume label syntax is incorrect." A network trace will show STATUS_OBJECT_NAME_INVALID (0xc0000033) message during the SMB session setup.
 
 
 

--- a/articles/storage/files/storage-files-identity-multiple-forests.md
+++ b/articles/storage/files/storage-files-identity-multiple-forests.md
@@ -146,7 +146,7 @@ To use this method, complete the following steps:
 Now, from domain-joined clients, you should be able to use storage accounts joined to any forest.
 
 > [!NOTE]
-> Ensure hostname part of the FQDN matches the storage account name as described above. Otherwise you will get an access denied error "The filename, directory name, or volume label syntax is incorrect." A network trace will show STATUS_OBJECT_NAME_INVALID (0xc0000033) message during the SMB session setup.
+> Ensure hostname part of the FQDN matches the storage account name as described above. Otherwise you will get an access denied error: "The filename, directory name, or volume label syntax is incorrect." A network trace will show STATUS_OBJECT_NAME_INVALID (0xc0000033) message during the SMB session setup.
 
 
 

--- a/articles/storage/files/storage-files-identity-multiple-forests.md
+++ b/articles/storage/files/storage-files-identity-multiple-forests.md
@@ -145,6 +145,11 @@ To use this method, complete the following steps:
 
 Now, from domain-joined clients, you should be able to use storage accounts joined to any forest.
 
+> [!NOTE]
+> Ensure hostname part of the FQDN matches the storage account name as described above. Otherwise you will get an access denied with the error "The filename, directory name, or volume label syntax is incorrect.". A network trace will show STATUS_OBJECT_NAME_INVALID (0xc0000033) message during the SMB session setup.
+
+
+
 ### Add custom name suffix and routing rule
 
 If you've already modified the storage account name suffix and added a CNAME record as described in the previous section, you can skip this step. If you'd rather not make DNS changes or modify the storage account name suffix, you can configure a suffix routing rule from **Forest 1** to **Forest 2** for a custom suffix of **file.core.windows.net**.


### PR DESCRIPTION
Connection returns "The filename, directory name, or volume label syntax is incorrect." if not match.