### PR TITLE
Clarification on CNAME support

### DIFF
--- a/includes/storage-files-aad-permissions-and-mounting.md
+++ b/includes/storage-files-aad-permissions-and-mounting.md
@@ -132,7 +132,7 @@ Sign in to the domain-joined VM using the Azure AD identity to which you granted
 
 Run the PowerShell script below or [use the Azure portal](../articles/storage/files/storage-files-quick-create-use-windows.md#map-the-azure-file-share-to-a-windows-drive) to persistently mount the Azure file share and map it to drive Z: on Windows. If Z: is already in use, replace it with an available drive letter. Because you've been authenticated, you won't need to provide the storage account key. The script will check to see if this storage account is accessible via TCP port 445, which is the port SMB uses. Remember to replace `<storage-account-name>` and `<file-share-name>` with your own values. For more information, see [Use an Azure file share with Windows](../articles/storage/files/storage-how-to-use-files-windows.md).
 
-Always mount Azure file shares using file.core.windows.net, even if you set up a private endpoint for your share. Using CNAME for file share mount isn't supported for identity-based authentication.
+Always mount Azure file shares using file.core.windows.net, even if you set up a private endpoint for your share using AAD-based authentication. Using CNAME for file share mount isn't supported for AAD-based authentication, only for ADDS-based authentication.
 
 ```powershell
 $connectTestResult = Test-NetConnection -ComputerName <storage-account-name>.file.core.windows.net -Port 445

--- a/includes/storage-files-aad-permissions-and-mounting.md
+++ b/includes/storage-files-aad-permissions-and-mounting.md
@@ -132,7 +132,7 @@ Sign in to the domain-joined VM using the Azure AD identity to which you granted
 
 Run the PowerShell script below or [use the Azure portal](../articles/storage/files/storage-files-quick-create-use-windows.md#map-the-azure-file-share-to-a-windows-drive) to persistently mount the Azure file share and map it to drive Z: on Windows. If Z: is already in use, replace it with an available drive letter. Because you've been authenticated, you won't need to provide the storage account key. The script will check to see if this storage account is accessible via TCP port 445, which is the port SMB uses. Remember to replace `<storage-account-name>` and `<file-share-name>` with your own values. For more information, see [Use an Azure file share with Windows](../articles/storage/files/storage-how-to-use-files-windows.md).
 
-Always mount Azure file shares using file.core.windows.net, even if you set up a private endpoint for your share using AAD-based authentication. Using CNAME for file share mount isn't supported for AAD-based authentication, only for ADDS-based authentication.
+Always mount Azure file shares using file.core.windows.net, even if you set up a private endpoint for your share using AAD-based authentication. Using CNAME for file share mount isn't supported for Azure AD-based authentication, only for AD DS-based authentication.
 
 ```powershell
 $connectTestResult = Test-NetConnection -ComputerName <storage-account-name>.file.core.windows.net -Port 445


### PR DESCRIPTION
ADDS documentation refers to use of CNAMEs in multi-forest scenarios, so the not supported relates only to AAD-based authentication.