### PR TITLE
Make `email_pattern` future-proof w.r.t. RegExp `v` flag

### DIFF
--- a/articles/active-directory-b2c/language-customization.md
+++ b/articles/active-directory-b2c/language-customization.md
@@ -285,7 +285,7 @@ You configure localized resources elements for the content definition and any la
       <LocalizedString ElementType="UxElement" StringId="local_intro_email">#Iniciar sesión con su cuenta existente</LocalizedString>
       <LocalizedString ElementType="UxElement" StringId="invalid_email">#Escriba una dirección de correo electrónico válida</LocalizedString>
       <LocalizedString ElementType="UxElement" StringId="unknown_error">#Tenemos problemas para iniciar su sesión. Vuelva a intentarlo más tarde.  </LocalizedString>
-      <LocalizedString ElementType="UxElement" StringId="email_pattern">^[a-zA-Z0-9.!#$%&amp;'^_`{}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$</LocalizedString>
+      <LocalizedString ElementType="UxElement" StringId="email_pattern">^[a-zA-Z0-9.!#$%&amp;'^_`\{\}~\-]+@[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]+)*$</LocalizedString>
       <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfInvalidPassword">#Su contraseña es incorrecta.</LocalizedString>
       <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfClaimsPrincipalDoesNotExist">#Parece que no podemos encontrar su cuenta.</LocalizedString>
       <LocalizedString ElementType="ErrorMessage" StringId="UserMessageIfOldPasswordUsed">#Parece que ha usado una contraseña antigua.</LocalizedString>

--- a/articles/active-directory-b2c/localization-string-ids.md
+++ b/articles/active-directory-b2c/localization-string-ids.md
@@ -36,7 +36,7 @@ The following IDs are used for a content definition with an ID of `api.signupors
 | `logonIdentifier_email` | Email Address | `< 2.0.0` |
 | `requiredField_email` | Please enter your email | `< 2.0.0` |
 | `invalid_email` | Please enter a valid email address | `< 2.0.0` |
-| `email_pattern` | ```^[a-zA-Z0-9.!#$%&''\*+/=?^\_\`{\|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)\*$``` | `< 2.0.0` |
+| `email_pattern` | ```^[a-zA-Z0-9.!#$%&'*+\/=?^_`\{\|\}~\-]+@[a-zA-Z0-9\-]+(?:\\.[a-zA-Z0-9\-]+)\*$``` | `< 2.0.0` |
 | `local_intro_username` | Sign in with your user name | `< 2.0.0` |
 | `logonIdentifier_username` | Username | `< 2.0.0` |
 | `requiredField_username` | Please enter your user name | `< 2.0.0` |


### PR DESCRIPTION
A proposed change upgrades the HTML `pattern` attribute to use the RegExp `v` flag instead of the `u` flag behind the scenes.

This patch updates `email_pattern` to be compatible with both `u` and `v` flags, future-proofing the pattern.

More background: https://groups.google.com/a/chromium.org/g/blink-dev/c/gIyvMw0n2qw