### PR TITLE
Line 175 - Correcting a typo within a typo

### DIFF
--- a/articles/defender-for-cloud/workflow-automation.md
+++ b/articles/defender-for-cloud/workflow-automation.md
@@ -172,7 +172,7 @@ Unfortunately, this change came with an unavoidable breaking change. The breakin
     | Deploy Workflow Automation for Microsoft Defender for Cloud recommendations | When a Microsoft Defender for Cloud Recommendation is created or triggered |
     | Deploy Workflow Automation for Microsoft Defender for Cloud regulatory compliance | When a Microsoft Defender for Cloud Regulatory Compliance Assessment is created or triggered |
 
-    <sup><a name="footnote1"></a>1</sup> The typo `Clou dAlert` is intentional.
+    <sup><a name="footnote1"></a>1</sup> The typo `Cloud dAlert` is intentional.
 
 ## Next steps
 


### PR DESCRIPTION
In line 175 we explain customers that the name "Cloud dAlert" is not a typo. We actually made a typo on the explanation by writing "Clou dalert" So we had a typo within an explanation that a typo is not a typo