### PR TITLE
Incorrect statement that each user needs to be invited as a guest.

### DIFF
--- a/articles/virtual-network/create-peering-different-subscriptions.md
+++ b/articles/virtual-network/create-peering-different-subscriptions.md
@@ -34,7 +34,11 @@ This tutorial peers virtual networks in the same region. You can also peer virtu
 
 - An Azure account with permissions in both subscriptions or an account in each subscription with the proper permissions to create a virtual network peering. For a list of permissions, see [Virtual network peering permissions](virtual-network-manage-peering.md#permissions).
 
-    - If the virtual networks are in different subscriptions and Active Directory tenants, add the user from each tenant as a guest in the opposite tenant. For more information about guest users, see [Add Azure Active Directory B2B collaboration users in the Azure portal](../active-directory/external-identities/add-users-administrator.md?toc=%2fazure%2fvirtual-network%2ftoc.json#add-guest-users-to-the-directory).
+    - If the virtual networks are in different subscriptions and Active Directory tenants, and you intend to separate the duty of managing the network belonging to each tenant, then add the user from each tenant as a guest in the opposite tenant and assign them a reader role to the virtual network.
+
+    - If the virtual networks are in different subscriptions and Active Directory tenants, and you do not intend to separate the duty of managing the network belonging to each tenant, then add the user from tenant A as a guest in the opposite tenant and assign them the correct permissions to establish a network peering. This user will be able to initiate and connect the network peering from each subscription.
+
+    - For more information about guest users, see [Add Azure Active Directory B2B collaboration users in the Azure portal](../active-directory/external-identities/add-users-administrator.md?toc=%2fazure%2fvirtual-network%2ftoc.json#add-guest-users-to-the-directory).
 
     - Each user must accept the guest user invitation from the opposite Azure Active Directory tenant.
 


### PR DESCRIPTION
Row 37.

    - If the virtual networks are in different subscriptions and Active Directory tenants, add the user from each tenant as a guest in the opposite tenant. For more information about guest users, see [Add Azure Active Directory B2B collaboration users in the Azure portal](../active-directory/external-identities/add-users-administrator.md?toc=%2fazure%2fvirtual-network%2ftoc.json#add-guest-users-to-the-directory).

There's no need for both users to be invited to each others Azure AD tenant as guest.

It's enough if User 1 in Tenant A is invited as a guest in Tenant B, and then assigned access, such as "Network contributor" on the virtual network in the subscription of Tenant B.

This is a question about separation of duty between the tenants but there are no technical restrictions to have a single user being able to initiating the peering for both tenants.

Then User 1 may first initiate the peering in the subscription of Tenant A, then using the portal experience and establishing the peering from the subscription of Tenant B.

The need to invite both users into each others tenants as guest is if you want to limit what actions they can do on your virtual network as guest. It could for example be that you only want them to Read the virtual network to initiate the peering.