### PR TITLE
Removing Objectid from Examples

### DIFF
--- a/articles/active-directory-b2c/add-api-connector.md
+++ b/articles/active-directory-b2c/add-api-connector.md
@@ -9,7 +9,7 @@ ms.date: 12/20/2022
 author: garrodonnell
 ms.author: godonnell
 manager: CelesteDG
-ms.custom: "it-pro"
+ms.custom: "it-pro,b2c-support"
 zone_pivot_groups: b2c-policy-type
 ---
 
@@ -144,7 +144,6 @@ Content-type: application/json
      }
  ],
  "displayName": "John Smith",
- "objectId": "11111111-0000-0000-0000-000000000000",
  "givenName":"John",
  "surname":"Smith",
  "step": "PostFederationSignup",
@@ -198,7 +197,6 @@ Content-type: application/json
      }
  ],
  "displayName": "John Smith",
- "objectId": "11111111-0000-0000-0000-000000000000",
  "givenName":"John",
  "surname":"Smith",
  "jobTitle":"Supplier",


### PR DESCRIPTION
Removing Objectid from Examples PostFederationSignup and PostAttributeCollection as ObjectId will only be present when API is being called at PreTokenApplicationClaims Step