### PR TITLE
Update web-calling-push-notifications-sample.md

### DIFF
--- a/articles/communication-services/samples/web-calling-push-notifications-sample.md
+++ b/articles/communication-services/samples/web-calling-push-notifications-sample.md
@@ -3,8 +3,8 @@ author: chriswhilar
 title: ACS Web Calling SDK - Web push notifications
 description: Quickstart tutorial for ACS Web Calling SDK push notifications
 ms.service: azure-communication-services
-ms.topic: include
-ms.date: 03/20/2023
+ms.topic: overview
+ms.date: 04/04/2023
 ms.author: chwhilar
 ---
 


### PR DESCRIPTION
 Updating `ms.topic` from `include` to `overview` to match other similar pages, as a simple correction but also to see if it affects indexing/search.

@chriswhilar I confirmed that the Azure Portal search uses the Learn catalog search API as of very recently, the same API that the Learn search page uses. While digging into why I can't get this page to show up in the Documentation section of the Azure Portal search results, I found that a search on the Learn search page with the same criteria that the portal uses (namely, checking the box for the "Azure" product facet) indeed has the same problem. Eliminating the product criteria returns many more results, like 10x, but with a good query like "acs web push notifications" it's the top hit. I'm not sure why that would be, but taking a stab at it with this.

The new [code sample itself](https://learn.microsoft.com/en-us/samples/azure-samples/communication-services-javascript-quickstarts/acs-web-calling-sdk---web-push-notifications-architecture-quickstart/) doesn't show up in catalog search API results yet (the samples browser search uses a different API/index). I imagine it just hasn't been indexed into the full-site search yet, so we'll give it some time.