### PR TITLE
Updated the note for custom sync rule for AAD Connect

### DIFF
--- a/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
+++ b/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
@@ -148,7 +148,8 @@ The following example will walk you through setting up a custom synchronization 
    18. Enable the scheduler again by running `Set-ADSyncScheduler -SyncCycleEnabled $true`.
 
 > [!NOTE]
-> **msDS-cloudExtensionAttribute1** is an example source.
+>- **msDS-cloudExtensionAttribute1** is an example source.
+>- **Starting [Azure AD Connect 2.0.3.0](https://learn.microsoft.com/en-us/azure/active-directory/hybrid/reference-connect-version-history#functional-changes-10), employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.**
 
 For more information, see [How to customize a synchronization rule](../hybrid/how-to-connect-create-custom-sync-rule.md) and [Make a change to the default configuration.](../hybrid/how-to-connect-sync-change-the-configuration.md)
 

--- a/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
+++ b/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
@@ -149,7 +149,7 @@ The following example will walk you through setting up a custom synchronization 
 
 > [!NOTE]
 >- **msDS-cloudExtensionAttribute1** is an example source.
->- **Starting [Azure AD Connect 2.0.3.0](https://learn.microsoft.com/en-us/azure/active-directory/hybrid/reference-connect-version-history#functional-changes-10), employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.**
+>- **Starting [Azure AD Connect 2.0.3.0](https://learn.microsoft.com/azure/active-directory/hybrid/reference-connect-version-history#functional-changes-10), employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.**
 
 For more information, see [How to customize a synchronization rule](../hybrid/how-to-connect-create-custom-sync-rule.md) and [Make a change to the default configuration.](../hybrid/how-to-connect-sync-change-the-configuration.md)
 

--- a/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
+++ b/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
@@ -149,7 +149,7 @@ The following example will walk you through setting up a custom synchronization 
 
 > [!NOTE]
 >- **msDS-cloudExtensionAttribute1** is an example source.
->- **Starting [Azure AD Connect 2.0.3.0](../hybrid/reference-connect-version-history.md#functional-changes-10), employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.**
+>- **Starting with [Azure AD Connect 2.0.3.0](../hybrid/reference-connect-version-history.md#functional-changes-10), `employeeHireDate` is added to the default 'Out to Azure AD' rule, so steps 10-16 are not required.**
 
 For more information, see [How to customize a synchronization rule](../hybrid/how-to-connect-create-custom-sync-rule.md) and [Make a change to the default configuration.](../hybrid/how-to-connect-sync-change-the-configuration.md)
 

--- a/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
+++ b/articles/active-directory/governance/how-to-lifecycle-workflow-sync-attributes.md
@@ -149,7 +149,7 @@ The following example will walk you through setting up a custom synchronization 
 
 > [!NOTE]
 >- **msDS-cloudExtensionAttribute1** is an example source.
->- **Starting [Azure AD Connect 2.0.3.0](https://learn.microsoft.com/azure/active-directory/hybrid/reference-connect-version-history#functional-changes-10), employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.**
+>- **Starting [Azure AD Connect 2.0.3.0](../hybrid/reference-connect-version-history.md#functional-changes-10), employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.**
 
 For more information, see [How to customize a synchronization rule](../hybrid/how-to-connect-create-custom-sync-rule.md) and [Make a change to the default configuration.](../hybrid/how-to-connect-sync-change-the-configuration.md)
 


### PR DESCRIPTION
I believe steps 10-16 not required as employeeHireDate is in default outbound rule to AAD from version 2.0.3.0. I haven't removed the steps (step 1-16) as we may have unsupported version of AADC (v1.x) still in use.

[!NOTE]

msDS-cloudExtensionAttribute1 is an example source. Starting Azure AD Connect 2.0.3.0, employeeHireDate is added to the default 'Out to AAD' rule so steps 10-16 is not required.