### PR TITLE
Add statement about unplanned failovers in cache-best-practices-server-load.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-best-practices-server-load.md
+++ b/articles/azure-cache-for-redis/cache-best-practices-server-load.md
@@ -37,7 +37,7 @@ Redis server is a single-threaded system. Long running commands can cause late
 
 ## Monitor Server Load
 
-Add monitoring on server load to ensure you get notifications when high server load occurs. Monitoring can help you understand your application constraints. Then, you can work proactively to mitigate issues. We recommend trying to keep server load under 80% to avoid negative performance effects.
+Add monitoring on server load to ensure you get notifications when high server load occurs. Monitoring can help you understand your application constraints. Then, you can work proactively to mitigate issues. We recommend trying to keep server load under 80% to avoid negative performance effects. Sustained server load over 80% can lead to unplanned failovers.
 
 Currently, Azure Cache For Redis exposes two metrics in **Insights** under **Monitoring** on the Resource menu on the left of the portal: **CPU** and **Server Load**. Understanding what is measured by each metric is important when monitoring server load.
 


### PR DESCRIPTION
Based on a recent incident where sustained high server load caused failovers, it was suggested to update [Best practices for Using and Monitoring the Server Load - Azure Cache for Redis | Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-server-load#monitor-server-load) to add a statement about how sustained server load over 80% could lead to failovers.