### PR TITLE
Update generalize.md

### DIFF
--- a/articles/virtual-machines/generalize.md
+++ b/articles/virtual-machines/generalize.md
@@ -98,7 +98,7 @@ To generalize your Windows VM, follow these steps:
    Registry key Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\cdrom\start (Value 4 = disabled, expected value 1 = automatic) Make sure it is set to 1.
    ```
 > [!NOTE]
-   > Verify if any policies applied restricting removable storage access (example: Computer configuration\Administrative Templates\System\Removalble Storage Access\All Removalble Storage classes: Deny all access)
+   > Verify if any policies applied restricting removable storage access (example: Computer configuration\Administrative Templates\System\Removable Storage Access\All Removable Storage classes: Deny all access)
 
 
 5. Then change the directory to %windir%\system32\sysprep, and then run:

--- a/articles/virtual-machines/generalize.md
+++ b/articles/virtual-machines/generalize.md
@@ -81,8 +81,10 @@ Make sure the server roles running on the machine are supported by Sysprep. For 
 >
 > If you plan to run Sysprep before uploading your virtual hard disk (VHD) to Azure for the first time, make sure you have [prepared your VM](./windows/prepare-for-upload-vhd-image.md).  
 > 
-> We do not support custom answer file in the sysprep step, hence you should not use the "/unattend:_answerfile_" switch with your sysprep command.
-> 
+> We do not support custom answer file in the sysprep step, hence you should not use the "/unattend:_answerfile_" switch with your sysprep command.  
+>  
+> Azure platform mounts an ISO file to the DVD-ROM when a Windows VM is created from a generalized image. For this reason, the **DVD-ROM must be enabled in the OS in the generalized image**. If it is disabled, the Windows VM will be stuck at out-of-box experience (OOBE).
+
 
 To generalize your Windows VM, follow these steps:
 
@@ -91,6 +93,13 @@ To generalize your Windows VM, follow these steps:
 2. Open a Command Prompt window as an administrator. 
 
 3. Delete the panther directory (C:\Windows\Panther). 
+4. Verify if CD/DVD-ROM is enabled.If it is disabled, the Windows VM will be stuck at out-of-box experience (OOBE).  
+```
+   Registry key Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\cdrom\start (Value 4 = disabled, expected value 1 = automatic) Make sure it is set to 1.
+   ```
+> [!NOTE]
+   > Verify if any policies applied restricting removable storage access (example: Computer configuration\Administrative Templates\System\Removalble Storage Access\All Removalble Storage classes: Deny all access)
+
 
 5. Then change the directory to %windir%\system32\sysprep, and then run:
    ```


### PR DESCRIPTION
I am working as an Azure Cloud Engineer in Microsoft. Recently I received a customer support request where the customer was wondering why only for some of his VMs, he can see DVD E : drive and not for all his VMs. I did some research from my end and got to know that the CD/DVD-ROM drive may be present in some Azure VMs as Azure platform mounts ISO file to a DVD-ROM when a Windows VM is created from generalized image. For this reason, DVD-ROM must be enabled in guest OS VM. If it is disabled, guest VM is stuck at OOBE even a user believes he did everything correctly.

Users should not attempt to disable DVD-ROM as this will prevent a VM to be provisioned successfully. DVD rom disappears once a VM is deallocated and started again, so this can rarely be an issue. However, disabling DVD-ROM will yield bad results for image creation job and troubleshooting for this scenario will be very difficult once this issue happens.

When I checked this existing Microsoft document for generalizing a VM before image creation , I found that the above is not mentioned anywhere in it and it can cause serious issues for the customers as well as the troubleshooting engineer. Hence I have updated the Important notes as well as added a step to enable the DVD-ROM in the guest OS VM.

Please verify from your end and provide your feedback.