### PR TITLE
Only APIM Gateway endpoint supports inbound Private Link connection.

### DIFF
--- a/articles/private-link/private-endpoint-dns.md
+++ b/articles/private-link/private-endpoint-dns.md
@@ -99,7 +99,7 @@ For Azure services, use the recommended zone names as described in the following
 | Azure Data Explorer (Microsoft.Kusto) | privatelink.{regionName}.kusto.windows.net | {regionName}.kusto.windows.net |
 | Azure Static Web Apps (Microsoft.Web/staticSites) / staticSites | privatelink.azurestaticapps.net </br> privatelink.{partitionId}.azurestaticapps.net | azurestaticapps.net </br> {partitionId}.azurestaticapps.net |
 | Azure Migrate (Microsoft.Migrate) / migrate projects, assessment project and discovery site | privatelink.prod.migration.windowsazure.com | prod.migration.windowsazure.com |
-| Azure API Management (Microsoft.ApiManagement/service) / gateway | privatelink.azure-api.net </br> privatelink.developer.azure-api.net | azure-api.net </br> developer.azure-api.net |
+| Azure API Management (Microsoft.ApiManagement/service) / gateway | privatelink.azure-api.net  | azure-api.net  |
 | Microsoft PowerBI (Microsoft.PowerBI/privateLinkServicesForPowerBI) | privatelink.analysis.windows.net </br> privatelink.pbidedicated.windows.net </br> privatelink.tip1.powerquery.microsoft.com | analysis.windows.net </br> pbidedicated.windows.net </br> tip1.powerquery.microsoft.com |
 | Azure Bot Service (Microsoft.BotService/botServices) / Bot | privatelink.directline.botframework.com | directline.botframework.com </br> europe.directline.botframework.com |
 | Azure Bot Service (Microsoft.BotService/botServices) / Token | privatelink.token.botframework.com | token.botframework.com </br> europe.token.botframework.com |


### PR DESCRIPTION
Only the API Management instance's Gateway endpoint supports inbound Private Link connections.

in this document, they mentioned endpoint "privatelink.developer.azure-api.net" (developer portal end point), which is not supported in apim expect gateway