### PR TITLE
Update cache-store-policy.md

### DIFF
--- a/articles/api-management/cache-store-policy.md
+++ b/articles/api-management/cache-store-policy.md
@@ -34,7 +34,7 @@ The `cache-store` policy caches responses according to the specified cache setti
 | Attribute         | Description                                            | Required | Default |
 | ----------------- | ------------------------------------------------------ | -------- | ------- |
 | duration         | Time-to-live of the cached entries, specified in seconds. Policy expressions are allowed.    | Yes      | N/A               |
-| cache-response         | Set to `true` to cache the current HTTP response. If the attribute is omitted or set to `false`, only HTTP responses with the status code `200 OK` are cached. Policy expressions are allowed.                          | No      | `false`               |
+| cache-response         | Set to `true` to cache the current HTTP response. If the attribute is omitted, only HTTP responses with the status code `200 OK` are cached. Policy expressions are allowed.                          | No      | `false`               |
 
 ## Usage
 


### PR DESCRIPTION
Upon testing, if the cache-response is set to false, the response will always be ignored, if omitted only responses with 200 status ok are cached, if set to true, response will always be cached. The ms doc has to be modified as well.