### PR TITLE
Update Non compliance example

### DIFF
--- a/includes/resource-graph/samples/bycat/azure-policy.md
+++ b/includes/resource-graph/samples/bycat/azure-policy.md
@@ -123,15 +123,16 @@ Search-AzGraph -Query "PolicyResources | where type =~ 'Microsoft.PolicyInsights
 Provides a list of all resources types that are in a `NonCompliant` state.
 
 ```kusto
-PolicyResources
+"PolicyResources
 | where type == 'microsoft.policyinsights/policystates'
 | where properties.complianceState == 'NonCompliant'
+| extend NonCompliantResourceId = properties.resourceId, PolicyAssignmentName = properties.policyAssignmentName"
 ```
 
 # [Azure CLI](#tab/azure-cli)
 
 ```azurecli-interactive
-az graph query -q "PolicyResources | where type == 'microsoft.policyinsights/policystates' | where properties.complianceState == 'NonCompliant'"
+az graph query -q "PolicyResources | where type == 'microsoft.policyinsights/policystates' | where properties.complianceState == 'NonCompliant' | extend NonCompliantResourceId = properties.resourceId, PolicyAssignmentName = properties.policyAssignmentName"
 ```
 
 # [Azure PowerShell](#tab/azure-powershell)


### PR DESCRIPTION
Updated non compliance example to be more useful by showing actual non compliant resource ID and the policy assignment name that it is non compliant for