### PR TITLE
Update azure-defender-storage-configure.md

### DIFF
--- a/articles/storage/common/azure-defender-storage-configure.md
+++ b/articles/storage/common/azure-defender-storage-configure.md
@@ -317,21 +317,26 @@ To enable and configure Microsoft Defender for Storage at the subscription level
 ```bicep
 param accountName string
 
-resource accountName_current 'Microsoft.Storage/storageAccounts/providers/DefenderForStorageSettings@2022-12-01-preview' = {
-  name: '${accountName}/Microsoft.Security/current'
-  properties: {
-    isEnabled: true
-    malwareScanning: {
-      onUpload: {
-        isEnabled: true
-        capGBPerMonth: 5000
-      }
-    }
-    sensitiveDataDiscovery: {
-      isEnabled: true
-    }
-    overrideSubscriptionLevelSettings: true
-  }
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: accountName
+}
+
+resource defenderForStorageSettings 'Microsoft.Security/DefenderForStorageSettings@2022-12-01-preview' = {
+  name: 'current'
+  scope: storageAccount
+  properties: {
+    isEnabled: true
+    malwareScanning: {
+      onUpload: {
+        isEnabled: true
+        capGBPerMonth: 5000
+      }
+    }
+    sensitiveDataDiscovery: {
+      isEnabled: true
+    }
+    overrideSubscriptionLevelSettings: true
+  }
 }
 ```
 


### PR DESCRIPTION
The current Bicep example for enabling on storage account gives a linting warning: 
`Type validation is not available for resource types declared containing a "/providers/" segment. Please instead use the "scope" property.`

I guess my suggestion is more in line with the recommendations, but it currently still gives a linting warning that I hope is related to API spec for 'Microsoft.Security/DefenderForStorageSettings@2022-12-01-preview' not being published yet. 
`Resource type "Microsoft.Security/DefenderForStorageSettings@2022-12-01-preview" does not have types available.`