### PR TITLE
fix arguments of Azure ML for AKS

### DIFF
--- a/articles/aks/cluster-extensions.md
+++ b/articles/aks/cluster-extensions.md
@@ -87,7 +87,7 @@ For supported Kubernetes versions, refer to the corresponding documentation for 
 Create a new extension instance with `k8s-extension create`, passing in values for the mandatory parameters. The below command creates an Azure Machine Learning extension instance on your AKS cluster:
 
 ```azurecli
-az k8s-extension create --name aml-compute --extension-type Microsoft.AzureML.Kubernetes --scope cluster --cluster-name <clusterName> --resource-group <resourceGroupName> --cluster-type managedClusters --configuration-settings enableInference=True allowInsecureConnections=True
+az k8s-extension create --name azureml --extension-type Microsoft.AzureML.Kubernetes --scope cluster --cluster-name <clusterName> --resource-group <resourceGroupName> --cluster-type managedClusters --configuration-settings enableInference=True allowInsecureConnections=True inferenceRouterServiceType=LoadBalancer
 ```
 
 > [!NOTE]
@@ -142,7 +142,7 @@ az k8s-extension list --cluster-name <clusterName> --resource-group <resourceGro
 Update an existing extension instance with `k8s-extension update`, passing in values for the mandatory parameters. The below command updates the auto-upgrade setting for an Azure Machine Learning extension instance:
 
 ```azurecli
-az k8s-extension update --name azureml --extension-type Microsoft.AzureML.Kubernetes --scope cluster --cluster-name <clusterName> --resource-group <resourceGroupName> --cluster-type managedClusters
+az k8s-extension update --name azureml --cluster-name <clusterName> --resource-group <resourceGroupName> --cluster-type managedClusters
 ```
 
 **Required parameters**


### PR DESCRIPTION
* add `inferenceRouterServiceType` to avoid the error in the end
* use the same name `azureml` across the document
* remove non-existent argument for `update`

> To use inference, please specify inferenceRouterServiceType=ClusterIP or inferenceRouterServiceType=NodePort or inferenceRouterServiceType=LoadBalancer in --configuration-settings and also set internalLoadBalancerProvider=azure if your aks only supports internal load balancer.Check https://aka.ms/arcmltsg for more information.

