### PR TITLE
Update data-lake-storage-access-control.md

### DIFF
--- a/articles/storage/blobs/data-lake-storage-access-control.md
+++ b/articles/storage/blobs/data-lake-storage-access-control.md
@@ -46,7 +46,8 @@ To set file and directory level permissions, see any of the following articles:
 |REST API |[Path - Update](/rest/api/storageservices/datalakestoragegen2/path/update)|
 
 > [!IMPORTANT]
-> If the security principal is a *service* principal, it's important to use the object ID of the service principal and not the object ID of the related app registration. To get the object ID of the service principal open the Azure CLI, and then use this command: `az ad sp show --id <Your App ID> --query objectId`. make sure to replace the `<Your App ID>` placeholder with the App ID of your app registration.
+> If the security principal is a *service* principal, it's important to use the object ID of the service principal and not the object ID of the related app registration. To get the object ID of the service principal open the Azure CLI, and then use this command: `az ad sp show --id <Your App ID> --query objectId`. make sure to replace the `<Your App ID>` placeholder with the App ID of your app registration. 
+++Here the service principal identities referred as users.
 
 ## Types of ACLs
 


### PR DESCRIPTION
Added the content in the line 50. 
the service principal's object ID which is associated to App registration should be treated as user when assigning ACL. Customers are getting confused and assigning it as group which is failing with authorization error please refer this thread for more information: https://github.com/MicrosoftDocs/azure-docs/issues/105127