### PR TITLE
Update expressroute-howto-linkvnet-arm.md

### DIFF
--- a/articles/expressroute/expressroute-howto-linkvnet-arm.md
+++ b/articles/expressroute/expressroute-howto-linkvnet-arm.md
@@ -224,7 +224,11 @@ Register-AzProviderFeature -FeatureName ExpressRoutePrivateEndpointGatewayBypass
 
 > [!NOTE]
 > You can use [Connection Monitor](how-to-configure-connection-monitor.md) to verify that your traffic is reaching the destination using FastPath.
->
+> 
+
+> [!NOTE]
+> FastPath and Private Link feature onboarding requires time to be enabled after request. You can expect about two weeks of delay until request is completed, so we encourage you to plan your deployment in advance with these timelines into consideration.
+> 
 
 ## Enroll in ExpressRoute FastPath features (preview)
 


### PR DESCRIPTION
Added text for expected delay as per email from AVGUPT and RITEWARI stating the following:

AVGUPT:
"Typical SLA for onboarding new customers is about two weeks, unfortunately it cannot be done on a 14h notice."

RITEWARI:
"ER FastPath enablement is currently opt-in with 2-week SLA"

As this is a pain point for a customer that was expecting to have this already enabled on PL when they enabled it on Circuit, we need public clarification to avoid customers falling into same confusion.