### PR TITLE
chore: Clearly describe that no Public IP will be created

### DIFF
--- a/articles/spring-apps/concept-outbound-type.md
+++ b/articles/spring-apps/concept-outbound-type.md
@@ -20,7 +20,7 @@ ms.custom: devx-track-java, engagement-fy23
 
 This article describes how to customize an instance's egress route to support custom network scenarios. For example, you might want to customize an instance's egress route for networks that disallow public IPs and require the instance to sit behind a network virtual appliance (NVA).
 
-By default, Azure Spring Apps provisions a Standard SKU Load Balancer that you can set up and use for egress. However, the default setup may not meet the requirements of all scenarios. For example, public IPs may not be allowed, or more hops may be required for egress.
+By default, Azure Spring Apps provisions a Standard SKU Load Balancer that you can set up and use for egress. However, the default setup may not meet the requirements of all scenarios. For example, public IPs may not be allowed, or more hops may be required for egress. By using this feature to customize egress, Azure Spring Apps won't create Azure Public IP resources.
 
 ## Prerequisites
 

--- a/articles/spring-apps/how-to-create-user-defined-route-instance.md
+++ b/articles/spring-apps/how-to-create-user-defined-route-instance.md
@@ -39,6 +39,7 @@ This diagram illustrates the following features of the architecture:
 * Each Azure Spring Apps instance is isolated within a dedicated subnet.
 * The firewall is owned and managed by customers. 
 * This structure ensures that the firewall enables a healthy environment for all the functions you need.
+* Azure Spring Apps is not automatically generating Azure Public IP resources.
 
 ### Define environment variables
 


### PR DESCRIPTION
chore: Clearly describe that no Public IP will be created when specifying outbound type to be UDR.