### PR TITLE
[AKS Best Security Practices] Remove confusing note about using Pod Identity instead of blocking the Instance Metadata API

### DIFF
--- a/articles/aks/operator-best-practices-cluster-security.md
+++ b/articles/aks/operator-best-practices-cluster-security.md
@@ -71,10 +71,6 @@ spec:
         - 169.254.169.254/32
 ```
 
-> [!NOTE]
-> Alternatively you can use [Pod Identity](./use-azure-ad-pod-identity.md) though this is in Public Preview.  It has a pod (NMI) that runs as a DaemonSet on each node in the AKS cluster. NMI intercepts security token requests to the Azure Instance Metadata Service on each node, redirect them to itself and validates if the pod has access to the identity it's requesting a token for and fetch the token from the Azure AD tenant on behalf of the application.
->
-
 ## Secure container access to resources
 
 > **Best practice guidance**


### PR DESCRIPTION
The current docs essentially say "instead of blocking access to the Instance Metadata API, you can use [Azure AD pod-managed identity](https://learn.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity)".

But then the Azure AD pod-managed identity page explicitly states:

![image](https://user-images.githubusercontent.com/136675/231435993-78a41da6-32df-4161-9f6c-761c6013e4f9.png)

And [Azure AD Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) is based on K8s service account tokens, not Metadata API interception - consequently, we still need to block access to the Metadata API from pods.