### PR TITLE
Removed the Vertical Autoscaling Link

### DIFF
--- a/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-autoscale-portal.md
+++ b/articles/virtual-machine-scale-sets/virtual-machine-scale-sets-autoscale-portal.md
@@ -119,8 +119,7 @@ To see how your autoscale rules are applied, select **Run history** across the t
 
 
 ## Next steps
-In this article, you learned how to use autoscale rules to scale horizontally and increase or decrease the *number* of VM instances in your scale set. You can also scale vertically to increase or decrease the VM instance *size*. For more information, see [Vertical autoscale with Virtual Machine Scale Sets](virtual-machine-scale-sets-vertical-scale-reprovision.md).
-
+In this article, you learned how to use autoscale rules to scale horizontally and increase or decrease the *number* of VM instances in your scale set. 
 For information on how to manage your VM instances, see [Manage Virtual Machine Scale Sets with Azure PowerShell](./virtual-machine-scale-sets-manage-powershell.md).
 
 To learn how to generate alerts when your autoscale rules trigger, see [Use autoscale actions to send email and webhook alert notifications in Azure Monitor](../azure-monitor/autoscale/autoscale-webhook-email.md). You can also [Use audit logs to send email and webhook alert notifications in Azure Monitor](../azure-monitor/alerts/alerts-log-webhook.md).


### PR DESCRIPTION
Vertical Autoscaling is not supported 
The Entry with the link was misleading 

Refer Link : https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview#horizontal-vs-vertical-scaling

I tried doing that as well and there are'nt any options for vertical autoscaling directly