### PR TITLE
Add AAD graph to workspace management requirements

### DIFF
--- a/articles/synapse-analytics/security/how-to-connect-to-workspace-from-restricted-network.md
+++ b/articles/synapse-analytics/security/how-to-connect-to-workspace-from-restricted-network.md
@@ -125,9 +125,9 @@ Required for auth:
  
 Required for workspace/pool management: 
  - `management.azure.com`
+ - `graph.windows.net`
  - `{workspaceName}.[dev|sql].azuresynapse.net`
  - `{workspaceName}-ondemand.sql.azuresynapse.net`
-
 
 ## Appendix: DNS registration for private endpoint
 


### PR DESCRIPTION
Access to `graph.windows.net` is still needed as of today to assign Synapse roles to users in Synapse Studio. Although the AAD graph is already deprecated and has been for years for the time being it should be included in the docs.

We'll need to come back to this page once Synapse Studio fully migrates every functionality over to use Microsoft Graph.