### PR TITLE
Update f5-big-ip-kerberos-easy-button.md

### DIFF
--- a/articles/active-directory/manage-apps/f5-big-ip-kerberos-easy-button.md
+++ b/articles/active-directory/manage-apps/f5-big-ip-kerberos-easy-button.md
@@ -295,7 +295,7 @@ Select **Deploy** to commit settings and verify the application is in your tenan
 
 ## Active Directory KCD configurations
 
-For the BIG-IP APM to perform SSO to the back-end application on behalf of users, configure KCD in the target AD domain. Delegating authentication requires you provision the BIG-IP APM with a domain service account.
+For the BIG-IP APM to perform SSO to the back-end application on behalf of users, configure KCD in the target Active Directory (AD) domain. Delegating authentication requires you to provision the BIG-IP APM with a domain service account.
 
 Skip this section if your APM service account and delegation are set up. Otherwise, log into a domain controller with an Admin account.
 
@@ -303,66 +303,83 @@ For this scenario, the application is hosted on server APP-VM-01 and runs in the
 
 ### Create a BIG-IP APM delegation account 
 
-The BIG-IP doesn’t support group Managed Service Accounts (gMSA), therefore create a standard user account for the APM service account.
+The BIG-IP does not support group Managed Service Accounts (gMSA), therefore create a standard user account for the APM service account.
 
-1. Replace the **UserPrincipalName** and **SamAccountName** values with the values in your environment.
+1. Enter the following PowerShell command. Replace the **UserPrincipalName** and **SamAccountName** values with your environment values. For better security, use a dedicated SPN that matches the host header of the application.
 
-    ```New-ADUser -Name "F5 BIG-IP Delegation Account" -UserPrincipalName host/f5-big-ip.contoso.com@contoso.com -SamAccountName "f5-big-ip" -PasswordNeverExpires $true -Enabled $true -AccountPassword (Read-Host -AsSecureString "Account Password") ```
+    ```New-ADUser -Name "F5 BIG-IP Delegation Account" UserPrincipalName $HOST_SPN SamAccountName "f5-big-ip" -PasswordNeverExpires $true Enabled $true -AccountPassword (Read-Host -AsSecureString "Account Password") ```
+    
+    HOST_SPN = host/f5-big-ip.contoso.com@contoso.com
+    
+    >[!NOTE]
+    >When the Host is used, any application running on the host will delegate the account whereas when HTTPS is used, it will allow only HTTP protocol-related operations.
 
-2. Create a **Service Principal Name (SPN)** for the APM service account for performing delegation to the web application service account.
+2. Create a **Service Principal Name (SPN)** for the APM service account to use during delegation to the web application service account:
 
-     ```Set-AdUser -Identity f5-big-ip -ServicePrincipalNames @{Add="host/f5-big-ip.contoso.com"} ```
-
-3. Ensure the SPN shows against the APM service account.
+     ```Set-AdUser -Identity f5-big-ip -ServicePrincipalNames @Add="host/f5-big-ip.contoso.com"} ```
      
-     ```Get-ADUser -identity f5-big-ip -properties ServicePrincipalNames | Select-Object -ExpandProperty ServicePrincipalNames ```
+     >[!NOTE]
+     >It is mandatory to include the host/ part in the format of UserPrincipleName (host/name.domain@domain) or ServicePrincipleName (host/name.domain).
 
-4. Before specifying the target SPN that the APM service account should delegate to for the web application, you need to view its SPN configuration. Confirm your web application is running in the computer context, or a dedicated service account. Next, query that account object in AD to see its defined SPNs. Replace <name_of_account> with the account for your environment. 
+3. Before you specify the target SPN, view its SPN configuration. Ensure the SPN shows against the APM service account. The APM service account delegates for the web application:
 
-    ```Get-ADUser -identity <name_of _account> -properties ServicePrincipalNames | Select-Object -ExpandProperty ServicePrincipalNames ```
+* Confirm your web application is running in the computer context or a dedicated service account.
+* For the Computer context, use the following command to query the account object in the Active Directory to see its defined SPNs. Replace <name_of_account> with the account for your environment.
+     
+     ```Get-ADComputer -identity <name_of_account> -properties ServicePrincipalNames | Select-Object -ExpandProperty ServicePrincipalNames ```
+     
+     For example:
+     Get-ADUser -identity f5-big-ip -properties ServicePrincipalNames | Select-Object -ExpandProperty ServicePrincipalNames
 
-5. You can use an SPN defined against a web application service account, but for better security, use a dedicated SPN that matches the host header of the application. For example, the web application host header is myexpenses.contoso.com. You can add HTTP/myexpenses.contoso.com to the applications service account object in AD.
+* For the dedicated service account, use the following command to query the account object in Active Directory to see its defined SPNs. Replace <name_of_account> with the account for your environment.
 
-    ```Set-AdUser -Identity web_svc_account -ServicePrincipalNames @{Add="http/myexpenses.contoso.com"} ```
+     ```Get-ADUser -identity <name_of_account> -properties ServicePrincipalNames | Select-Object -ExpandProperty ServicePrincipalNames ```
+     
+     For example:
+     Get-ADComputer -identity f5-big-ip -properties ServicePrincipalNames | Select-Object -ExpandProperty ServicePrincipalNames
 
-Or if the app ran in the machine context, add the SPN to the object of the computer account in AD.
+4. If the application ran in the machine context, add the SPN to the object of the computer account in Active Directory: 
 
-   ```Set-ADComputer -Identity APP-VM-01 -ServicePrincipalNames @{Add="http/myexpenses.contoso.com"} ```
+    ```Set-ADComputer -Identity APP-VM-01 -ServicePrincipalNames @{Add="http/myexpenses.contoso.com"} ```
 
-With the SPNs defined, the APM service account needs trust to delegate to that service. The configuration varies depending on the topology of your BIG-IP and application server.
+With SPNs defined, establish trust for the APM service account delegate to that service. The configuration varies depending on the topology of your BIG-IP instance and application server.
 
 ### Configure BIG-IP and target application in the same domain
 
-1. Set trust for the APM service account to delegate authentication.
+1. Set trust for the APM service account to delegate authentication:
 
     ```Get-ADUser -Identity f5-big-ip | Set-ADAccountControl -TrustedToAuthForDelegation $true ```
 
-2. The APM service account needs to know the target SPN it’s trusted to delegate to, or which service for which it's allowed to request a Kerberos ticket. Set target SPN to the service account running your web application.
+2. The APM service account needs to know the target SPN it's trusted to delegate to. Set the target SPN to the service account running your web application:
 
     ```Set-ADUser -Identity f5-big-ip -Add @{'msDS-AllowedToDelegateTo'=@('HTTP/myexpenses.contoso.com')} ```
 
 >[!NOTE]
->You can complete these tasks with the Active Directory Users and Computers Microsoft Management Console (MMC) on a domain controller.
+>You can complete these tasks with the Active Directory Users and Computers, Microsoft Management Console (MMC) snap-in, on a domain controller.
 
 ### BIG-IP and application in different domains
 
-From the Windows Server 2012 version onward, cross-domain KCD uses resource-based constrained delegation (RCD). The constraints are for a service transferred from the domain administrator to the service administrator. The back-end service Administrator allows or denies SSO. This situation creates a different approach for configuration delegation, which is possible using PowerShell or ADSIEdit.
+In the Windows Server 2012 version, and higher, cross-domain KCD uses Resource-Based Constrained Delegation (RBCD). The constraints for a service are transferred from the domain administrator to the service administrator. This delegation allows the back-end service administrator to allow or deny SSO. This situation creates a different approach at configuration delegation, which is possible when you use PowerShell or Active Directory Service Interfaces Editor (ADSI Edit).
 
-You can use the PrincipalsAllowedToDelegateToAccount property of the applications service account (computer or dedicated service account) to grant delegation from the BIG-IP. For this scenario, use the following PowerShell command on a domain controller (Windows Server 2012 R2+) in the same domain as the application.
+You can use the PrincipalsAllowedToDelegateToAccount property of the application service account (computer or dedicated service account) to grant delegation from BIG-IP. For this scenario, use the following PowerShell command on a domain controller (Windows Server 2012 R2, or later) in the same domain as the application.
 
-Note the context for the following examples. 
+Use an SPN defined against a web application service account. For better security, use a dedicated SPN that matches the host header of the application. For example, because the web application host header in this example is myexpenses.contoso.com, add HTTP/myexpenses.contoso.com to the application service account object in Active Directory (AD):
 
-If the web_svc_account service runs in the context of a user account:
+    ```Set-AdUser -Identity web_svc_account -ServicePrincipalNames @{Add="http/myexpenses.contoso.com"} ```
 
- ```$big-ip= Get-ADComputer -Identity f5-big-ip -server dc.contoso.com ```
- ```Set-ADUser -Identity web_svc_account -PrincipalsAllowedToDelegateToAccount $big-ip ```
- ```Get-ADUser web_svc_account -Properties PrincipalsAllowedToDelegateToAccount ```
+For the following commands, note the context. 
 
-If the web_svc_account service runs in the context of a computer account:
+If the web_svc_account service runs in the context of a user account, use these commands:
 
  ```$big-ip= Get-ADComputer -Identity f5-big-ip -server dc.contoso.com ```
- ```Set-ADComputer -Identity web_svc_account -PrincipalsAllowedToDelegateToAccount $big-ip ```
- ```Get-ADComputer web_svc_account -Properties PrincipalsAllowedToDelegateToAccount ```
+ ```Set-ADUser -Identity web_svc_account -PrincipalsAllowedToDelegateToAccount ```
+ ```$big-ip Get-ADUser web_svc_account -Properties PrincipalsAllowedToDelegateToAccount ```
+
+If the web_svc_account service runs in the context of a computer account, use these commands:
+
+ ```$big-ip= Get-ADComputer -Identity f5-big-ip -server dc.contoso.com ```
+ ```Set-ADComputer -Identity web_svc_account -PrincipalsAllowedToDelegateToAccount ```
+ ```$big-ip Get-ADComputer web_svc_account -Properties PrincipalsAllowedToDelegateToAccount ```
 
 For more information, see [Kerberos Constrained Delegation across domains](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh831477(v=ws.11)).
 
@@ -430,5 +447,5 @@ If no error page appears, the issue is probably related to the back-end request,
 
 For more information, see:
 
-* dev/central: [APM variable assign examples](https://devcentral.f5.com/s/articles/apm-variable-assign-examples-1107)
-* AskF5: [Session Variables](https://techdocs.f5.com/en-us/bigip-15-0-0/big-ip-access-policy-manager-visual-policy-editor/session-variables.html)
+* dev/central: [APM variable assign examples](https://community.f5.com/t5/codeshare/apm-variable-assign-examples/ta-p/287962)
+* MyF5: [Session Variables](https://techdocs.f5.com/en-us/bigip-15-0-0/big-ip-access-policy-manager-visual-policy-editor/session-variables.html)


### PR DESCRIPTION
Revised the following sections of the document:
- Active Directory KCD configurations (Other title: Configure Active Directory Kerberos constrained delegation)
- Create a BIG-IP APM delegation account
- Configure BIG-IP and the target application in the same domain
- Configure BIG-IP and the target application in different domains

Corrected the redirect links at the bottom of the document:
- Changed from AskF5 to MyF5
- Modified the Devcentral document link to https://community.f5.com/t5/codeshare/apm-variable-assign-examples/ta-p/287962 

Following Microsoft documentation links are affected by the above specified changes:
- https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/f5-big-ip-kerberos-easy-button#create-a-big-ip-apm-delegation-account
- https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/f5-big-ip-kerberos-advanced#configure-active-directory-kerberos-constrained-delegation