### PR TITLE
Update the "location" parameter for restore CLI command

### DIFF
--- a/articles/cosmos-db/how-to-setup-customer-managed-keys.md
+++ b/articles/cosmos-db/how-to-setup-customer-managed-keys.md
@@ -554,7 +554,7 @@ Use the Azure CLI to restore a continuous account that is already configured usi
         --resource-group $resourceGroupName \
         --account-name $sourceAccountName \
         --target-database-account-name $targetAccountName \
-        --locations regionName=$location \
+        --location $location \
         --restore-timestamp $timestamp \
         --assign-identity $identityId \
         --default-identity "UserAssignedIdentity=$identityId" \


### PR DESCRIPTION
Update the "location" parameter for restore CLI command. This is the parameter for restore location, so it has different format than the "locations" parameter when creating the account.