### PR TITLE
Brycechen msft patch 2

### DIFF
--- a/articles/spring-apps/how-to-bind-cosmos.md
+++ b/articles/spring-apps/how-to-bind-cosmos.md
@@ -90,7 +90,7 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
        --target-resource-group $COSMOSDB_RESOURCE_GROUP \
        --account $COSMOSDB_ACCOUNT_NAME \
        --database $DATABASE_NAME \
-       --system-assigned-identity
+       --secret
    ```
 
    > [!NOTE]

--- a/articles/spring-apps/how-to-bind-cosmos.md
+++ b/articles/spring-apps/how-to-bind-cosmos.md
@@ -89,7 +89,6 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
        --resource-group $AZURE_SPRING_APPS_RESOURCE_GROUP \
        --service $AZURE_SPRING_APPS_SERVICE_INSTANCE_NAME \
        --app $APP_NAME \
-       --deployment $DEPLOYMENT_NAME \
        --target-resource-group $COSMOSDB_RESOURCE_GROUP \
        --account $COSMOSDB_ACCOUNT_NAME \
        --database $DATABASE_NAME \

--- a/articles/spring-apps/how-to-bind-cosmos.md
+++ b/articles/spring-apps/how-to-bind-cosmos.md
@@ -76,7 +76,7 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
 
 ### [Service Connector](#tab/Service-Connector)
 
-1. Use the Azure CLI to configure your Spring app to connect to a Cosmos NoSQL Database (as an example) with a connection string by using the `az spring connection create` command, as shown in the following example. Please replace the variables in the example with your actual resource names.
+1. Use the Azure CLI to configure your Spring app to connect to a Cosmos NoSQL Database (as an example) with a connection string by using the `az spring connection create` command, as shown in the following example. Please replace the variables in the example with actual values.
 
    > [!NOTE]
    > If you're using Cosmos Cassandra, use `--key_space` instead of `--database`. If you're using Cosmos Table, use `--table` instead of `--database`. See more details at [Service Connector Azure CLI](../service-connector/quickstart-cli-spring-cloud-connection.md).

--- a/articles/spring-apps/how-to-bind-cosmos.md
+++ b/articles/spring-apps/how-to-bind-cosmos.md
@@ -76,7 +76,7 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
 
 ### [Service Connector](#tab/Service-Connector)
 
-1. Use the Azure CLI to configure your Spring app to connect to a Cosmos NoSQL Database (as an example) with a connection string by using the `az spring connection create` command, as shown in the following example.
+1. Use the Azure CLI to configure your Spring app to connect to a Cosmos NoSQL Database (as an example) with a connection string by using the `az spring connection create` command, as shown in the following example. Please replace the variables in the example with your actual resource names.
 
    > [!NOTE]
    > If you're using Cosmos Cassandra, use `--key_space` instead of `--database`. If you're using Cosmos Table, use `--table` instead of `--database`. See more details at [Service Connector Azure CLI](../service-connector/quickstart-cli-spring-cloud-connection.md).

--- a/articles/spring-apps/how-to-bind-cosmos.md
+++ b/articles/spring-apps/how-to-bind-cosmos.md
@@ -76,7 +76,7 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
 
 ### [Service Connector](#tab/Service-Connector)
 
-1. Use the Azure CLI to configure your Spring app to connect to a Cosmos SQL Database with a system-assigned managed identity by using the `az spring connection create` command, as shown in the following example.
+1. Use the Azure CLI to configure your Spring app to connect to a Cosmos NoSQL Database (as an example) with a connection string by using the `az spring connection create` command, as shown in the following example.
 
    > [!NOTE]
    > Updating Azure Cosmos DB database settings can take a few minutes to complete.

--- a/articles/spring-apps/how-to-bind-cosmos.md
+++ b/articles/spring-apps/how-to-bind-cosmos.md
@@ -79,6 +79,9 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
 1. Use the Azure CLI to configure your Spring app to connect to a Cosmos NoSQL Database (as an example) with a connection string by using the `az spring connection create` command, as shown in the following example.
 
    > [!NOTE]
+   > If you're using Cosmos Cassandra, use `--key_space` instead of `--database`. If you're using Cosmos Table, use `--table` instead of `--database`. See more details at [Service Connector Azure CLI](../service-connector/quickstart-cli-spring-cloud-connection.md).
+   
+   > [!NOTE]
    > Updating Azure Cosmos DB database settings can take a few minutes to complete.
 
    ```azurecli
@@ -95,8 +98,6 @@ If you don't have a deployed Azure Spring Apps instance, follow the steps in the
 
    > [!NOTE]
    > If you're using [Service Connector](../service-connector/overview.md) for the first time, start by running the command `az provider register --namespace Microsoft.ServiceLinker` to register the Service Connector resource provider.
-   >
-   > If you're using Cosmos Cassandra, use a `--key_space` instead of `--database`.
 
    > [!TIP]
    > Run the command `az spring connection list-support-types --output table` to get a list of supported target services and authentication methods for Azure Spring Apps. If the `az spring` command isn't recognized by the system, check that you have installed the required extension by running `az extension add --name spring`.

--- a/articles/spring-apps/how-to-bind-mysql.md
+++ b/articles/spring-apps/how-to-bind-mysql.md
@@ -68,7 +68,7 @@ Follow these steps to configure your Spring app to connect to an Azure Database 
        --target-resource-group $MYSQL_RESOURCE_GROUP \
        --server $MYSQL_SERVER_NAME \
        --database $DATABASE_NAME \
-       --system-assigned-identity
+       --system-identity
    ```
 
 ### [Service Binding](#tab/Service-Binding)

--- a/articles/spring-apps/how-to-bind-mysql.md
+++ b/articles/spring-apps/how-to-bind-mysql.md
@@ -68,7 +68,7 @@ Follow these steps to configure your Spring app to connect to an Azure Database 
        --target-resource-group $MYSQL_RESOURCE_GROUP \
        --server $MYSQL_SERVER_NAME \
        --database $DATABASE_NAME \
-       --system-identity
+       --secret
    ```
 
 ### [Service Binding](#tab/Service-Binding)

--- a/articles/spring-apps/how-to-bind-mysql.md
+++ b/articles/spring-apps/how-to-bind-mysql.md
@@ -49,14 +49,8 @@ With Azure Spring Apps, you can bind select Azure services to your applications 
 
 ### [Service Connector](#tab/Service-Connector)
 
-Follow these steps to configure your Spring app to connect to an Azure Database for MySQL Flexible Server with a system-assigned managed identity.
+Follow these steps to configure your Spring app to connect to an Azure Database for MySQL Flexible Server with database username and password.
 
-1. Install the Service Connector passwordless extension for the Azure CLI.
-
-   ```azurecli
-   az extension add --name serviceconnector-passwordless --upgrade
-   ```
-   
 1. Run the `az spring connection create` command, as shown in the following example.
 
    ```azurecli
@@ -68,7 +62,7 @@ Follow these steps to configure your Spring app to connect to an Azure Database 
        --target-resource-group $MYSQL_RESOURCE_GROUP \
        --server $MYSQL_SERVER_NAME \
        --database $DATABASE_NAME \
-       --secret
+       --secret name=$DATABASE_USERNAME secret=$DATABASE_PASSWORD
    ```
 
 ### [Service Binding](#tab/Service-Binding)

--- a/articles/spring-apps/how-to-bind-mysql.md
+++ b/articles/spring-apps/how-to-bind-mysql.md
@@ -51,7 +51,7 @@ With Azure Spring Apps, you can bind select Azure services to your applications 
 
 Follow these steps to configure your Spring app to connect to an Azure Database for MySQL Flexible Server with database username and password.
 
-1. Run the `az spring connection create` command, as shown in the following example. Please replace the variables in the example with your actual resource names.
+1. Run the `az spring connection create` command, as shown in the following example. Please replace the variables in the example with actual values.
 
    ```azurecli
    az spring connection create mysql-flexible \

--- a/articles/spring-apps/how-to-bind-mysql.md
+++ b/articles/spring-apps/how-to-bind-mysql.md
@@ -51,14 +51,13 @@ With Azure Spring Apps, you can bind select Azure services to your applications 
 
 Follow these steps to configure your Spring app to connect to an Azure Database for MySQL Flexible Server with database username and password.
 
-1. Run the `az spring connection create` command, as shown in the following example.
+1. Run the `az spring connection create` command, as shown in the following example. Please replace the variables in the example with your actual resource names.
 
    ```azurecli
    az spring connection create mysql-flexible \
        --resource-group $AZURE_SPRING_APPS_RESOURCE_GROUP \
        --service $AZURE_SPRING_APPS_SERVICE_INSTANCE_NAME \
        --app $APP_NAME \
-       --deployment $DEPLOYMENT_NAME \
        --target-resource-group $MYSQL_RESOURCE_GROUP \
        --server $MYSQL_SERVER_NAME \
        --database $DATABASE_NAME \


### PR DESCRIPTION
 The tutorial need to be fixed. There's a wrong argument --system-assigned-identity for Service Connector, use --system-identity instead. ServiceConnector doesn't support spring apps with system identity now, use --secret instead