### PR TITLE
Update find-unattached-disks.md

### DIFF
--- a/articles/virtual-machines/windows/find-unattached-disks.md
+++ b/articles/virtual-machines/windows/find-unattached-disks.md
@@ -82,6 +82,8 @@ foreach($storageAccount in $storageAccounts){
     }
 }
 ```
+>[!NOTE]
+>we cannot get the billing details of unattached managed disks from the Azure Portal. This can be acheived by adding tags to the unattached disks and filterring with the tag in the subscriptions,cost analysis tab.
 
 ## Next steps
 


### PR DESCRIPTION
we cannot get the billing details of unattached managed disks from the Azure Portal. This can be acheived by adding tags to the unattached disks and filterring with the tag in the subscriptions,cost analysis tab.