### PR TITLE
possible misleading documentation

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-enable.md
+++ b/articles/azure-monitor/app/opentelemetry-enable.md
@@ -79,7 +79,11 @@ dotnet add package --prerelease Azure.Monitor.OpenTelemetry.Exporter -s https://
 
 #### [Java](#tab/java)
 
-Download the [applicationinsights-agent-3.4.11.jar](https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.4.11/applicationinsights-agent-3.4.11.jar) file.
+To download the agent, please go to https://github.com/microsoft/ApplicationInsights-Java/releases/, copy the .jar file link for the desired releas (right-click -> copy link, eg: https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.4.11/applicationinsights-agent-3.4.11.jar)
+
+Then use:
+- curl (for linux environment): curl -L -o applicationinsights-agent-3.4.11.jar https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.4.11/applicationinsights-agent-3.4.11.jar)
+- wget (for powershell): wget -O applicationinsights-agent-3.4.11.jar https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.4.11/applicationinsights-agent-3.4.11.jar
 
 > [!WARNING]
 >


### PR DESCRIPTION
I noticed the .jar file is always corrupted (and half of the size in MB) when downloading via browser, either from documentation, either from Github releases link Tried Edge, Mozilla,Chrome with various settings. I got it fully downloaded via curl or wget. I might be wrong and it might be a problem with my env, please let me know.