### PR TITLE
Removed the part about MCAS integration-Deprecated

### DIFF
--- a/articles/defender-for-cloud/defender-for-resource-manager-introduction.md
+++ b/articles/defender-for-cloud/defender-for-resource-manager-introduction.md
@@ -15,15 +15,6 @@ The cloud management layer is a crucial service connected to all your cloud reso
 
 Microsoft Defender for Resource Manager automatically monitors the resource management operations in your organization, whether they're performed through the Azure portal, Azure REST APIs, Azure CLI, or other Azure programmatic clients. Defender for Cloud runs advanced security analytics to detect threats and alerts you about suspicious activity.
 
->[!NOTE]
-> Some of these analytics are powered by [Microsoft Defender for Cloud Apps](/cloud-app-security/what-is-cloud-app-security) (formerly known as Microsoft Cloud App Security). To benefit from these analytics, you must activate a Defender for Cloud Apps license. If you have a Defender for Cloud Apps license, then these alerts are enabled by default. To disable the alerts:
->
-> 1. From Defender for Cloud's menu, open **Environment settings**.
-> 1. Select the subscription you want to change.
-> 1. Select **Integrations**.
-> 1. Clear **Allow Microsoft Defender for Cloud Apps to access my data**, and select **Save**.
-
-
 ## Availability
 
 |Aspect|Details|


### PR DESCRIPTION
The following part is referring to a deprecated feature hence needed to be removed:  Reference on the deprecation: https://learn.microsoft.com/en-us/azure/defender-for-cloud/upcoming-changes#three-alerts-in-the-defender-for-resource-manager-plan-will-be-deprecated 

"Some of these analytics are powered by Microsoft Defender for Cloud Apps (formerly known as Microsoft Cloud App Security). To benefit from these analytics, you must activate a Defender for Cloud Apps license. If you have a Defender for Cloud Apps license, then these alerts are enabled by default. To disable the alerts:

From Defender for Cloud's menu, open Environment settings. Select the subscription you want to change.
Select Integrations.
Clear Allow Microsoft Defender for Cloud Apps to access my data, and select Save."