### PR TITLE
Update the license requirement for branding

### DIFF
--- a/articles/active-directory/fundamentals/customize-branding.md
+++ b/articles/active-directory/fundamentals/customize-branding.md
@@ -32,7 +32,9 @@ Adding custom branding requires one of the following licenses:
 - Azure AD Premium 2
 - Office 365 (for Office apps)
 
-At least 1 license above in the tenant is sufficient to add and manage the company branding feature. Azure AD Premium editions are available for customers in China using the worldwide instance of Azure AD. Azure AD Premium editions aren't currently supported in the Azure service operated by 21Vianet in China. For more information about licensing and editions, see [Sign up for Azure AD Premium](active-directory-get-started-premium.md).
+At least one of the previously listed licenses is sufficient to add and manage the company branding in your tenant.
+
+Azure AD Premium editions are available for customers in China using the worldwide instance of Azure AD. Azure AD Premium editions aren't currently supported in the Azure service operated by 21Vianet in China. For more information about licensing and editions, see [Sign up for Azure AD Premium](active-directory-get-started-premium.md).
 
 The **Global Administrator** role is required to customize company branding.
 

--- a/articles/active-directory/fundamentals/customize-branding.md
+++ b/articles/active-directory/fundamentals/customize-branding.md
@@ -32,7 +32,7 @@ Adding custom branding requires one of the following licenses:
 - Azure AD Premium 2
 - Office 365 (for Office apps)
 
-Azure AD Premium editions are available for customers in China using the worldwide instance of Azure AD. Azure AD Premium editions aren't currently supported in the Azure service operated by 21Vianet in China. For more information about licensing and editions, see [Sign up for Azure AD Premium](active-directory-get-started-premium.md).
+At least 1 license above in the tenant is sufficient to add and manage the company branding feature. Azure AD Premium editions are available for customers in China using the worldwide instance of Azure AD. Azure AD Premium editions aren't currently supported in the Azure service operated by 21Vianet in China. For more information about licensing and editions, see [Sign up for Azure AD Premium](active-directory-get-started-premium.md).
 
 The **Global Administrator** role is required to customize company branding.
 


### PR DESCRIPTION
I worked with Sasha Mars and confirmed one license is sufficient to set/manage Azure AD company branding feature. To use the company branding feature, we need at least 1 P1/P2/Office licenses. We do not need licenses for all the users who use the customized sign-in page.