### PR TITLE
Include name and role claims in ClaimsIdentity

### DIFF
--- a/articles/app-service/configure-authentication-user-identities.md
+++ b/articles/app-service/configure-authentication-user-identities.md
@@ -110,7 +110,7 @@ public static class ClaimsPrincipalParser
          *  other .NET code.
          */
 
-        var identity = new ClaimsIdentity(principal.IdentityProvider);
+        var identity = new ClaimsIdentity(principal.IdentityProvider, principal.NameClaimType, principal.RoleClaimType);
         identity.AddClaims(principal.Claims.Select(c => new Claim(c.Type, c.Value)));
         
         return new ClaimsPrincipal(identity);


### PR DESCRIPTION
This is in order to fix #108332 : In order for name and roles to be filled you need to specify the claims intended to be used.