### PR TITLE
Update verbiage related to MCSB default

### DIFF
--- a/articles/defender-for-cloud/release-notes.md
+++ b/articles/defender-for-cloud/release-notes.md
@@ -120,7 +120,7 @@ This feature is part of the Defender CSPM (Cloud Security Posture Management) pl
 
 Microsoft Defender for Cloud is announcing that the Microsoft cloud security benchmark (MCSB) version 1.0 is now Generally Available (GA). 
 
-MCSB version 1.0 replaces the Azure Security Benchmark (ASB) version 3 as Microsoft Defender for Cloud's default security policy for identifying security vulnerabilities in your cloud environments according to common security frameworks and best practices. MCSB version 1.0 appears as the default compliance standard in the compliance dashboard and is enabled by default for all Defender for Cloud customers.
+MCSB version 1.0 appears as the default compliance standard in the compliance dashboard and is enabled by default for all Defender for Cloud customers.
 
 You can also learn [How Microsoft cloud security benchmark (MCSB) helps you succeed in your cloud security journey](https://techcommunity.microsoft.com/t5/microsoft-defender-for-cloud/announcing-microsoft-cloud-security-benchmark-v1-general/ba-p/3763013).
 


### PR DESCRIPTION
Based on my understanding, this statement is not accurate, "MCSB version 1.0 replaces the Azure Security Benchmark (ASB) version 3 as Microsoft Defender for Cloud's default security policy for identifying security vulnerabilities in your cloud environments according to common security frameworks and best practices."

MCSB is the default policy in the Defender for Cloud REGULATORY compliance blade, but ASB is still the default initiative assigned to derive secure score.