### PR TITLE
Update how-to-manage-device-certificates.md

### DIFF
--- a/articles/iot-edge/how-to-manage-device-certificates.md
+++ b/articles/iot-edge/how-to-manage-device-certificates.md
@@ -178,7 +178,7 @@ Installing the certificate to the trust bundle file makes it available to contai
   ```bash
   sudo cp /var/aziot/certs/my-root-ca.pem /usr/local/share/ca-certificates/my-root-ca.pem.crt
 
-  sudo update-ca-trust
+  sudo update-ca-certificates
   ```
 
 # [IoT Edge for Linux on Windows (EFLOW)](#tab/windows)


### PR DESCRIPTION
On Linux (e.g. Ubuntu and Debian), use the  update-ca-certificates command to update the certificate store