### PR TITLE
Corrected misleading information

### DIFF
--- a/articles/storage/files/storage-files-active-directory-overview.md
+++ b/articles/storage/files/storage-files-active-directory-overview.md
@@ -118,7 +118,7 @@ The following diagram represents the workflow for Azure AD DS authentication to 
 
 1. You don't need to create the identity in Azure AD DS to represent the storage account. This is performed by the enablement process in the background.
 
-2. All users that exist in Azure AD can be authenticated and authorized. The user can be cloud-only or hybrid. The sync from Azure AD to Azure AD DS is managed by the platform without requiring any user configuration. However, the client must be joined to the Azure AD DS hosted domain. It can't be Azure AD joined or registered. Azure AD DS doesn't support non-cloud VMs (i.e. user laptops, workstations, VMs in other clouds, etc.) being domain-joined to the Azure AD DS hosted domain.
+2. All users that exist in Azure AD can be authenticated and authorized. The user can be cloud-only or hybrid. The sync from Azure AD to Azure AD DS is managed by the platform without requiring any user configuration. VMs can access Azure File Share using Azure AD DS authentication if there is line of sight to Azure AD DS. This usually requires site-to-site or point-to-site to allow this connectivity.
 
 :::image type="content" source="media/storage-files-active-directory-overview/files-azure-ad-ds-auth-diagram.png" alt-text="Diagram of configuration for Azure AD DS authentication with Azure Files over SMB.":::
 


### PR DESCRIPTION
All users that exist in Azure AD can be authenticated and authorized. The user can be cloud-only or hybrid. The sync from Azure AD to Azure AD DS is managed by the platform without requiring any user configuration. However, the client must be joined to the Azure AD DS hosted domain. It can't be Azure AD joined or registered. Azure AD DS doesn't support non-cloud VMs (i.e. user laptops, workstations, VMs in other clouds, etc.) being domain-joined to the Azure AD DS hosted domain.

--- This information is misleading, I have updated the Doc with the corrected info as below 

All users that exist in Azure AD can be authenticated and authorized. The user can be cloud-only or hybrid. The sync from Azure AD to Azure AD DS is managed by the platform without requiring any user configuration. VMs can access Azure File Share using Azure AD DS authentication if there is line of sight to Azure AD DS. This usually requires site-to-site or point-to-site to allow this connectivity.