### PR TITLE
Update claims value in claims challenge

### DIFF
--- a/articles/active-directory/develop/claims-challenge.md
+++ b/articles/active-directory/develop/claims-challenge.md
@@ -34,7 +34,7 @@ Here's an example:
 ```https
 HTTP 401; Unauthorized
 
-www-authenticate =Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiYzEifX19"
+www-authenticate =Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", error="insufficient_claims", claims="eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiY3AxIn19fQ=="
 ```
 
  **HTTP Status Code**: Must be **401 Unauthorized**.


### PR DESCRIPTION
Claims value provided currently decodes to: `{"access_token":{"acrs":{"essential":true,"value":"c1"}}}` instead of the expected "value" of `cp1`.

Base64 encoded claims value should decode to: `{"access_token":{"acrs":{"essential":true,"value":"cp1"}}}` from the description in the docs further down outlining the contents of the response headers.