### PR TITLE
vm eviction rates are per hour

### DIFF
--- a/articles/virtual-machines/spot-vms.md
+++ b/articles/virtual-machines/spot-vms.md
@@ -79,6 +79,9 @@ With variable pricing, you have option to set a max price, in US dollars (USD), 
 
 You can see historical pricing and eviction rates per size in a region in the portal while you are creating the VM. After selecting the checkbox to **Run with Azure Spot discount**, a link will appear under the size selection of the VM titled **View pricing history and compare prices in nearby regions**. By selecting that link you will be able to see a table or graph of spot pricing for the specified VM size.   The pricing and eviction rates in the following images are only examples. 
 
+> [!TIP]
+> Eviction rates are quoted _per hour_. For example, an eviction rate of 10% means a VM has a 10% chance of being evicted within the next hour, based on historical eviction data of the last 28 days.
+
 **Chart**:
 
 :::image type="content" source="./media/spot-chart.png" alt-text="Screenshot of the region options with the difference in pricing and eviction rates as a chart.":::


### PR DESCRIPTION
The documentation did not provide insight into how to how to interpret eviction rates in absolute terms (i.e. beyond comparing between different VM types).

This commit moves information from the Q&A section [1] to the documentation.

[1] https://learn.microsoft.com/en-us/answers/questions/1193700/how-to-interpret-spotevictionrate-in-azure-resourc?page=1&source=docs#answer-1192845