### PR TITLE
Added label 'azure.workload.identity/use: "true"'

### DIFF
--- a/articles/aks/learn/tutorial-kubernetes-workload-identity.md
+++ b/articles/aks/learn/tutorial-kubernetes-workload-identity.md
@@ -196,6 +196,8 @@ kind: Pod
 metadata:
   name: quick-start
   namespace: ${SERVICE_ACCOUNT_NAMESPACE}
+  labels:
+    azure.workload.identity/use: "true"
 spec:
   serviceAccountName: ${SERVICE_ACCOUNT_NAME}
   containers:


### PR DESCRIPTION
The bash code snippet that deploys a pod to Kubernetes with an Azure Managed Identity Service Account configured is missing the mandatory tag 'azure.workload.identity/use: "true"'.

This fixes issue #108460.