### PR TITLE
Update traffic-analytics-schema.md

### DIFF
--- a/articles/network-watcher/traffic-analytics-schema.md
+++ b/articles/network-watcher/traffic-analytics-schema.md
@@ -107,7 +107,6 @@ The following table lists the fields in the schema and what they signify.
 | SrcIP_s |	Source IP address |	Will be blank in case of AzurePublic and ExternalPublic flows. |
 | DestIP_s | Destination IP address	| Will be blank in case of AzurePublic and ExternalPublic flows. |
 | VMIP_s | IP of the VM	| Used for AzurePublic and ExternalPublic flows. |
-| PublicIP_s | Public IP addresses | Used for AzurePublic and ExternalPublic flows. |
 | DestPort_d | Destination Port | Port at which traffic is incoming. |
 | L4Protocol_s	| *	T <br> * U 	| Transport Protocol. T = TCP <br> U = UDP. |
 | L7Protocol_s	| Protocol Name	| Derived from destination port. |


### PR DESCRIPTION
Removed reference in schema table to field 'PublicIP_s'. This was identified as part of case 2304110060000554. On further investigation, it was found that this field was not supported and is likely a typo. To confirm, code history was checked by Niti Gupta and mentioned that no historical evidence of this field is present

