### PR TITLE
Update reset-redemption-status.md

### DIFF
--- a/articles/active-directory/external-identities/reset-redemption-status.md
+++ b/articles/active-directory/external-identities/reset-redemption-status.md
@@ -82,7 +82,7 @@ Connect-MgGraph -Scopes "User.ReadWrite.All"
 $user = Get-MgUser -Filter "startsWith(mail, 'john.doe@fabrikam.net')"
 New-MgInvitation `
     -InvitedUserEmailAddress $user.Mail `
-    -InviteRedirectUrl "http://myapps.microsoft.com" `
+    -InviteRedirectUrl "https://myapps.microsoft.com" `
     -ResetRedemption `
     -SendInvitationMessage `
     -InvitedUser $user


### PR DESCRIPTION
I create a pull request from customer feedback. Both inviteRedirectURLs are better to start "https:"

In this document, 
https://learn.microsoft.com/en-us/azure/active-directory/external-identities/reset-redemption-status#use-powershell-to-reset-redemption-status

- Example of "Use PowerShell to reset redemption status"
    -InviteRedirectUrl "http://myapps.microsoft.com" `

- Example of "Use Microsoft Graph API to reset redemption status"
"inviteRedirectUrl": "https://myapps.microsoft.com?tenantId=",  