### PR TITLE
Update automatic-vm-guest-patching.md - PowerShell command error

### DIFF
--- a/articles/virtual-machines/automatic-vm-guest-patching.md
+++ b/articles/virtual-machines/automatic-vm-guest-patching.md
@@ -239,7 +239,9 @@ Set-AzVMOperatingSystem -VM $VirtualMachine -Windows -ComputerName $ComputerName
 Use the [Set-AzVMOperatingSystem](/powershell/module/az.compute/set-azvmoperatingsystem) and [Update-AzVM](/powershell/module/az.compute/update-azvm) cmdlet to enable automatic VM guest patching on an existing VM.
 
 ```azurepowershell-interactive
-Get-AzVM -VM $VirtualMachine -Windows -ComputerName $ComputerName -Credential $Credential
+$VirtualMachineName='myVM'
+$ResourceGroupName='myResourceGroup'
+$VirtualMachine=Get-AzVM -ResourceGroupName $ResourceGroupName -Name $VirtualMachineName
 Set-AzVMOperatingSystem -VM $VirtualMachine -PatchMode "AutomaticByPlatform"
 Update-AzVM -VM $VirtualMachine
 ```
@@ -295,7 +297,9 @@ GET on `/subscriptions/subscription_id/resourceGroups/myResourceGroup/providers/
 Use the [Get-AzVM](/powershell/module/az.compute/get-azvm) cmdlet with the `-Status` parameter to access the instance view for your VM.
 
 ```azurepowershell-interactive
-Get-AzVM -ResourceGroupName "myResourceGroup" -Name "myVM" -Status
+$VirtualMachineName='myVM'
+$ResourceGroupName='myResourceGroup'
+Get-AzVM -ResourceGroupName $ResourceGroupName -Name $VirtualMachineName -Status -OutVariable VirtualMachine
 ```
 
 PowerShell currently only provides information on the patch extension. Information about `patchStatus` will also be available soon through PowerShell.

--- a/articles/virtual-machines/automatic-vm-guest-patching.md
+++ b/articles/virtual-machines/automatic-vm-guest-patching.md
@@ -239,9 +239,7 @@ Set-AzVMOperatingSystem -VM $VirtualMachine -Windows -ComputerName $ComputerName
 Use the [Set-AzVMOperatingSystem](/powershell/module/az.compute/set-azvmoperatingsystem) and [Update-AzVM](/powershell/module/az.compute/update-azvm) cmdlet to enable automatic VM guest patching on an existing VM.
 
 ```azurepowershell-interactive
-$VirtualMachineName='myVM'
-$ResourceGroupName='myResourceGroup'
-$VirtualMachine=Get-AzVM -ResourceGroupName $ResourceGroupName -Name $VirtualMachineName
+$VirtualMachine = Get-AzVM -ResourceGroupName "myResourceGroup" -Name "myVM"
 Set-AzVMOperatingSystem -VM $VirtualMachine -PatchMode "AutomaticByPlatform"
 Update-AzVM -VM $VirtualMachine
 ```
@@ -297,9 +295,7 @@ GET on `/subscriptions/subscription_id/resourceGroups/myResourceGroup/providers/
 Use the [Get-AzVM](/powershell/module/az.compute/get-azvm) cmdlet with the `-Status` parameter to access the instance view for your VM.
 
 ```azurepowershell-interactive
-$VirtualMachineName='myVM'
-$ResourceGroupName='myResourceGroup'
-Get-AzVM -ResourceGroupName $ResourceGroupName -Name $VirtualMachineName -Status -OutVariable VirtualMachine
+Get-AzVM -ResourceGroupName "myResourceGroup" -Name "myVM" -Status
 ```
 
 PowerShell currently only provides information on the patch extension. Information about `patchStatus` will also be available soon through PowerShell.


### PR DESCRIPTION
Update automatic-vm-guest-patching.md - PowerShell command for enabling/updating VM is wrong, using "Get-AzVM" you get the VM Object in the $VirtualMachine variable, after that you can perform any PowerShell commands with the "-VM $VirtualMachine" parameter, like the Set-AzVM* or the Update-AzVM*. Further the "Get-AzVM" command has no parameters for Credentials, OperatingSystem, ComputerName (just Name) or "VM". Also small update to the command "" for VM Status to have consistancy on this page to avoid user mistakes.