### PR TITLE
Fix preferredBatchSizeInKilobytes

### DIFF
--- a/articles/event-grid/handler-functions.md
+++ b/articles/event-grid/handler-functions.md
@@ -47,7 +47,7 @@ We recommend that you use the first approach (Event Grid trigger) as it has the 
 			{
 				"resourceId": "/subscriptions/<AZURE SUBSCRIPTION ID>/resourceGroups/<RESOURCE GROUP NAME>/providers/Microsoft.Web/sites/<FUNCTION APP NAME>/functions/<FUNCTION NAME>",
 				"maxEventsPerBatch": 10,
-				"preferredBatchSizeInKilobytes": 6400
+				"preferredBatchSizeInKilobytes": 64
 			}
 		},
 		"eventDeliverySchema": "EventGridSchema"


### PR DESCRIPTION
The "_REST example (for PUT)_" section is using an incorrect value for `preferredBatchSizeInKilobytes`. The value should be `64` instead of `6400`.

![image](https://user-images.githubusercontent.com/2101647/233350621-1d61126f-ba57-4ea1-aedf-1494997c1ccc.png)

Fix #108510