### PR TITLE
Clarity on regional limit of Az OpenAI resources

### DIFF
--- a/articles/cognitive-services/openai/quotas-limits.md
+++ b/articles/cognitive-services/openai/quotas-limits.md
@@ -22,7 +22,7 @@ The following sections provide you with a quick guide to the quotas and limits t
 
 | Limit Name | Limit Value |
 |--|--|
-| OpenAI resources per region | 2 | 
+| OpenAI resources per region within Azure subscription | 2 | 
 | Requests per minute per model* | Davinci-models (002 and later): 120  <br> ChatGPT model (preview): 300 <br> GPT-4 models (preview): 18 <br> All other models: 300 |
 | Tokens per minute per model* | Davinci-models (002 and later): 40,000  <br> ChatGPT model: 120,000 <br> All other models: 120,000 |
 | Max fine-tuned model deployments* | 2 |


### PR DESCRIPTION
Currently, when Cx requests access to Azure OpenAI, they submit a single Gated request which may contain up to 3 Azure subscriptions. When we specify on our AOAI documentation page that there is a limit of 2 AOAI resources per region, they are not sure whether it's per AOAI Gated request or per Azure subscription.

One can get clarity only when you request a limit increase here: https://aka.ms/oai/resourceincrease. To avoid any confusion, would be great to indicate that the limit is per region and subscription, thanks.