### PR TITLE
Render image instead of MD tag.

### DIFF
--- a/articles/site-recovery/azure-to-azure-tutorial-failback.md
+++ b/articles/site-recovery/azure-to-azure-tutorial-failback.md
@@ -45,7 +45,7 @@ After VMs are reprotected, you can fail back to the primary region as needed.
 
 3. On the overview page, select **Failover**. Since we're not doing a test failover this time, we're prompted to verify.
 
-    [Page showing we agree to run failover without a test failover](./media/azure-to-azure-tutorial-failback/no-test.png)
+    ![Page showing we agree to run failover without a test failover](./media/azure-to-azure-tutorial-failback/no-test.png)
 
 4. In **Failover**, note the direction from secondary to primary, and select a recovery point. The Azure VM in the target (primary region) is created using data from this point.
    - **Latest processed**: Uses the latest recovery point processed by Site Recovery. The time stamp is shown. No time is spent processing data, so it provides a low recovery time objective (RTO).


### PR DESCRIPTION
There is an `!` (exclamation mark) missing in the markdown-tag of the second image on this page. This commit adds the missing `!`.