### PR TITLE
The script needs more permission scope

### DIFF
--- a/articles/active-directory/develop/configure-token-lifetimes.md
+++ b/articles/active-directory/develop/configure-token-lifetimes.md
@@ -29,7 +29,7 @@ To get started, download the latest [Microsoft Graph PowerShell SDK](/powershell
 In the following steps, you'll create a policy that requires users to authenticate less frequently in your web app. This policy sets the lifetime of the access/ID tokens for your web app.
 
 ```powershell
-Connect-MgGraph -Scopes  "Policy.ReadWrite.ApplicationConfiguration"
+Connect-MgGraph -Scopes  "Policy.ReadWrite.ApplicationConfiguration","Policy.Read.All","Application.ReadWrite.All"
 
 # Create a token lifetime policy
 $params = @{


### PR DESCRIPTION
When I ran the script, it fails with "Insufficient privileges to complete the operation." error. The script only has "Policy.ReadWrite.ApplicationConfiguration".

"New-MgPolicyTokenLifetimePolicy" sends POST to https://graph.microsoft.com/v1.0/policies/tokenLifetimePolicies. "Get-MgPolicyTokenLifetimePolicy" sends GET to the same endpoint https://graph.microsoft.com/v1.0/policies/tokenLifetimePolicies "New-MgApplicationTokenLifetimePolicyByRef" sends POST to https://graph.microsoft.com/v1.0/applications/{AppID}/tokenLifetimePolicies/$ref

This doc shows "Policy.ReadWrite.ApplicationConfiguration" only POST but doesn't include GET. https://learn.microsoft.com/en-us/graph/permissions-reference#example-usage-32

This doc guides that these permissions are needed to run token lifetime policy. "Policy.ReadWrite.ApplicationConfiguration","Policy.Read.All","Application.ReadWrite.All" https://learn.microsoft.com/en-us/graph/api/application-post-tokenlifetimepolicies?view=graph-rest-1.0&tabs=http

When I edited the scope part (line 32) as below, I could run the whole script without an error. Connect-MgGraph -Scopes  "Policy.ReadWrite.ApplicationConfiguration","Policy.Read.All","Application.ReadWrite.All"

I also confirmed that after running the script the token lifetime was updated successfully from the token.