### PR TITLE
Backticks were off and language formatting was off

### DIFF
--- a/articles/azure-signalr/signalr-quickstart-azure-functions-python.md
+++ b/articles/azure-signalr/signalr-quickstart-azure-functions-python.md
@@ -92,7 +92,7 @@ You can use this sample function as a template for your own functions.
 
 1. Edit *index/\__init\__.py* and replace the contents with the following code:
 
-  ```javascript
+  ```python
   import os
 
   import azure.functions as func
@@ -100,7 +100,7 @@ You can use this sample function as a template for your own functions.
   def main(req: func.HttpRequest) -> func.HttpResponse:
       f = open(os.path.dirname(os.path.realpath(__file__)) + '/../content/index.html')
       return func.HttpResponse(f.read(), mimetype='text/html')
-        ```
+  ```
 
 ### Create the negotiate function
 


### PR DESCRIPTION
When I was going through the instructions, I understood what it was referencing, but I originally thought the command line statements prior in the instructions would've generated the file that says 'Edit negotiate\__init__.py', but I couldn't find the negotiate subfolder.

I then realized it was accidentally placed into the instructions prior as quoted code syntax

Following that the instructions were marked as javascript, but I believe they should be Python.