### PR TITLE
fixed SignedOutCallbackPath

### DIFF
--- a/articles/active-directory-b2c/enable-authentication-web-application.md
+++ b/articles/active-directory-b2c/enable-authentication-web-application.md
@@ -260,7 +260,7 @@ Azure AD B2C identity provider settings are stored in the *appsettings.json* fil
   "Instance": "https://<your-tenant-name>.b2clogin.com",
   "ClientId": "<web-app-application-id>",
   "Domain": "<your-b2c-domain>",
-  "SignedOutCallbackPath": "/signout/<your-sign-up-in-policy>",
+  "SignedOutCallbackPath": "/signout-oidc
   "SignUpSignInPolicyId": "<your-sign-up-in-policy>"
 }
 ```


### PR DESCRIPTION
The sign-out URL shown in the documentation is wrong and won't work. Fixed accordingly.