### PR TITLE
Edited partprobe command

### DIFF
--- a/articles/virtual-machines/linux/add-disk.md
+++ b/articles/virtual-machines/linux/add-disk.md
@@ -100,7 +100,7 @@ The following example uses `parted` on `/dev/sdc`, which is where the first data
 
 ```bash
 sudo parted /dev/sdc --script mklabel gpt mkpart xfspart xfs 0% 100%
-sudo partprobe /dev/sdc1
+sudo partprobe /dev/sdc
 sudo mkfs.xfs /dev/sdc1
 ```
 


### PR DESCRIPTION
There is no need to specify the partition number with the `partprobe` command. It already detects and updates all partitions on the disk.

Ran into issue while following the documentation where it would show:
```bash
azureuser@MC-Server:~$ sudo parted /dev/sdc --script mklabel gpt mkpart xfspart xfs 0% 100%
azureuser@MC-Server:~$ sudo partprobe /dev/sdc1
Error: Could not stat device /dev/sdc1 - No such file or directory.
```