### PR TITLE
Update quickstart-dotnet-core-app.md for .NET 6+

### DIFF
--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -62,7 +62,21 @@ You use the [.NET Core command-line interface (CLI)](/dotnet/core/tools/) to cre
     using Microsoft.Extensions.Configuration.AzureAppConfiguration;
     ```
 
-4. Update the `Main` method to use App Configuration by calling the `builder.AddAzureAppConfiguration()` method.
+4. Use App Configuration by calling the `builder.AddAzureAppConfiguration()` method.
+
+    #### [.NET 6.x](#tab/core6x)
+
+    ```csharp
+    var builder = new ConfigurationBuilder();
+    builder.AddAzureAppConfiguration(Environment.GetEnvironmentVariable("ConnectionString"));
+
+    var config = builder.Build();
+    Console.WriteLine(config["TestApp:Settings:Message"] ?? "Hello world!");
+    ```
+
+    #### [.NET Core 3.x](#tab/core3x)
+
+    Update the `Main` method.
 
     ```csharp
     static void Main(string[] args)
@@ -75,15 +89,6 @@ You use the [.NET Core command-line interface (CLI)](/dotnet/core/tools/) to cre
     }
     ```
 
-    Note: If you are using .NET 6 or above, the `Main` method is not generated and you can use below statements directly.
-
-    ```csharp
-    var builder = new ConfigurationBuilder();
-    builder.AddAzureAppConfiguration(Environment.GetEnvironmentVariable("ConnectionString"));
-
-    var config = builder.Build();
-    Console.WriteLine(config["TestApp:Settings:Message"] ?? "Hello world!");
-    ```
 ## Build and run the app locally
 
 1. Set an environment variable named **ConnectionString**, and set it to the access key to your App Configuration store. At the command line, run the following command:

--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -62,7 +62,7 @@ You use the [.NET Core command-line interface (CLI)](/dotnet/core/tools/) to cre
     using Microsoft.Extensions.Configuration.AzureAppConfiguration;
     ```
 
-4. Use App Configuration by calling the `builder.AddAzureAppConfiguration()` method.
+4. Update the code to use App Configuration by calling the `builder.AddAzureAppConfiguration()` method.
 
     #### [.NET 6.x](#tab/core6x)
 
@@ -75,8 +75,6 @@ You use the [.NET Core command-line interface (CLI)](/dotnet/core/tools/) to cre
     ```
 
     #### [.NET Core 3.x](#tab/core3x)
-
-    Update the `Main` method.
 
     ```csharp
     static void Main(string[] args)

--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -75,6 +75,15 @@ You use the [.NET Core command-line interface (CLI)](/dotnet/core/tools/) to cre
     }
     ```
 
+    Note: If you are using .NET 6 or above, the `Main` method is not generated and you can use below statements directly.
+
+    ```csharp
+    var builder = new ConfigurationBuilder();
+    builder.AddAzureAppConfiguration(Environment.GetEnvironmentVariable("ConnectionString"));
+
+    var config = builder.Build();
+    Console.WriteLine(config["TestApp:Settings:Message"] ?? "Hello world!");
+    ```
 ## Build and run the app locally
 
 1. Set an environment variable named **ConnectionString**, and set it to the access key to your App Configuration store. At the command line, run the following command:


### PR DESCRIPTION
I'm using .NET 7, and `dotnet new console` generates a `Program.cs as` file as below, without namespace/class/Main method.

```csharp
// See https://aka.ms/new-console-template for more information
Console.WriteLine("Hello, World!");
```

For a new user to .NET, without knowing namespace/class, simply copying the given Main method into Program.cs would not work.