### PR TITLE
Added WAF string match values per match condition

### DIFF
--- a/includes/application-gateway-limits.md
+++ b/includes/application-gateway-limits.md
@@ -44,6 +44,7 @@ ms.author: greglin
 | Maximum WAF custom rules|100||
 | WAF IP address ranges per match condition|540<br>600 - with CRS 3.2 or newer|
 | Maximum WAF exclusions per Application Gateway|40<br>200 - with CRS 3.2 or newer|
+| WAF string match values per match condition|10||
 
 <sup>1</sup> The number of resources listed in the table applies to standard Application Gateway SKUs and WAF-enabled SKUs running CRS 3.2 or higher. For WAF-enabled SKUs running CRS 3.1 or lower, the supported number is 40. For more information, see [WAF engine](../articles/web-application-firewall/ag/waf-engine.md).
 


### PR DESCRIPTION
WAF string match values per match condition that is stated under the "Azure Front Door" limitations also apply to the Application gateway limitations