### PR TITLE
Update web-app-routing.md

### DIFF
--- a/articles/aks/web-app-routing.md
+++ b/articles/aks/web-app-routing.md
@@ -63,15 +63,7 @@ az keyvault create -g <ResourceGroupName> -l <Location> -n <KeyVaultName>
 
 ### Import certificate to Azure Key Vault
 
-Import the SSL certificate into Azure Key Vault.
-
-```azurecli-interactive
-az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx
-```
-
-### Import certificate to Azure Key Vault 
-
-Import the SSL certificate into Azure Key Vault
+Import the SSL certificate into Azure Key Vault. If your certificate is password protected, you can pass the password through the `--password` flag.
 
 ```azurecli-interactive
 az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx [--password <certificate password if specified>]

--- a/articles/aks/web-app-routing.md
+++ b/articles/aks/web-app-routing.md
@@ -69,12 +69,12 @@ Import the SSL certificate into Azure Key Vault.
 az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx
 ```
 
-### Import certificate to Azure Key Vault with password if specified while exporting the SSL cert 
+### Import certificate to Azure Key Vault 
 
-Import the SSL certificate into Azure Key Vault with password
+Import the SSL certificate into Azure Key Vault
 
 ```azurecli-interactive
-az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx --password <Password>
+az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx [--password <certificate password if specified>]
 ```
 
 ### Create an Azure DNS zone

--- a/articles/aks/web-app-routing.md
+++ b/articles/aks/web-app-routing.md
@@ -69,6 +69,14 @@ Import the SSL certificate into Azure Key Vault.
 az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx
 ```
 
+### Import certificate to Azure Key Vault with password if specified while exporting the SSL cert 
+
+Import the SSL certificate into Azure Key Vault with password
+
+```azurecli-interactive
+az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx --password <Password>
+```
+
 ### Create an Azure DNS zone
 
 If you want the add-on to automatically manage creating hostnames via Azure DNS, you need to [create an Azure DNS zone](../dns/dns-getstarted-cli.md) if you don't have one already.


### PR DESCRIPTION
### Import certificate to Azure Key Vault with password if specified while exporting the SSL cert 

Import the SSL certificate into Azure Key Vault with password.

```azurecli-interactive
az keyvault certificate import --vault-name <KeyVaultName> -n <KeyVaultCertificateName> -f aks-ingress-tls.pfx --password <Password>
```

Need to add --password parameter. Without that, az keyvault certificate import failed. It gives error - "We could not parse the provided certificate as .pem or .pfx. Please verify the certificate with OpenSSL."