### PR TITLE
Fix typo in paragraph of user defined types

### DIFF
--- a/articles/azure-resource-manager/bicep/user-defined-data-types.md
+++ b/articles/azure-resource-manager/bicep/user-defined-data-types.md
@@ -218,4 +218,4 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
 
 ## Next steps
 
-- For a list of the Bicep date types, see [Data types](./data-types.md).
+- For a list of the Bicep data types, see [Data types](./data-types.md).


### PR DESCRIPTION
Just a minor typo in the docs. We are referencing Data, not Dates here.