### PR TITLE
Fix confusion between two attributes

### DIFF
--- a/articles/active-directory/external-identities/user-properties.md
+++ b/articles/active-directory/external-identities/user-properties.md
@@ -75,7 +75,7 @@ This property indicates the relationship of the user to the host tenancy. This p
 
 ### Identities
 
-This property indicates the user’s primary identity provider. A user can have several identity providers, which can be viewed by selecting the link next to **Identities** in the user’s profile or by querying the `onPremisesSyncEnabled` property via the Microsoft Graph API.
+This property indicates the user’s primary identity provider. A user can have several identity providers, which can be viewed by selecting the link next to **Identities** in the user’s profile or by querying the `identities` property via the Microsoft Graph API.
 
 > [!NOTE]
 > Identities and UserType are independent properties. A value of Identities does not imply a particular value for UserType


### PR DESCRIPTION
I believe there was a copy/paste mistake with below, and that the property should be `identities` in this section.
Proof that this attribute exists: https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#:~:text=%2C%20in).-,identities,-objectIdentity%20collection