### PR TITLE
Update workload-identity-deploy-cluster.md

### DIFF
--- a/articles/aks/workload-identity-deploy-cluster.md
+++ b/articles/aks/workload-identity-deploy-cluster.md
@@ -176,7 +176,7 @@ You can retrieve this information using the Azure CLI command: [az keyvault list
 To disable the Azure AD workload identity on the AKS cluster where it's been enabled and configured, you can run the following command:
 
 ```azurecli
-az aks update --resource-group myResourceGroup --name myAKSCluster --enable-workload-identity false
+az aks update --resource-group myResourceGroup --name myAKSCluster --disable-workload-identity
 ```
 
 ## Next steps


### PR DESCRIPTION
Looks like, based on [az cli code](https://github.com/Azure/azure-cli/blob/4c08ce6f9e2ec551b28bcf0e3a06d8b0e1f801c9/src/azure-cli/azure/cli/command_modules/acs/_params.py#L332) and actually running it, `--disable-workload-identity` is the right flag for turning of WID for an AKS cluster.