### PR TITLE
Added in Azure Files as supported

### DIFF
--- a/articles/storage/common/storage-solution-large-dataset-low-network.md
+++ b/articles/storage/common/storage-solution-large-dataset-low-network.md
@@ -57,7 +57,7 @@ The following table summarizes the differences in key capabilities.
 | **Use when data moves**     |Within a commerce boundary|Within a commerce boundary|Within a commerce boundary|Across geographic boundaries, e.g. US to EU|
 |    **Pricing**                      |    [Pricing](https://azure.microsoft.com/pricing/details/databox/disk/)                    |   [Pricing](https://azure.microsoft.com/pricing/details/storage/databox/)                                      |  [Pricing](https://azure.microsoft.com/pricing/details/storage/databox/heavy/)                               |   [Pricing](https://azure.microsoft.com/pricing/details/storage-import-export/)                            |
 
-*\* Data Box Disk does not support Large File Shares and does not preserve file metadata*
+*\* Data Box Disk does not support Large File Shares and does not preserve file metadata.*
 
 ## Next steps
 

--- a/articles/storage/common/storage-solution-large-dataset-low-network.md
+++ b/articles/storage/common/storage-solution-large-dataset-low-network.md
@@ -44,7 +44,7 @@ The following table summarizes the differences in key capabilities.
 |                                     |    Data Box Disk      |    Data Box                                      |    Data Box Heavy              |    Import/Export                       |
 |-------------------------------------|---------------------------------|--------------------------------------------------|------------------------------------------|----------------------------------------|
 |    **Data size**                    |    Up to 35 TBs                 |    Up to 80 TBs per device                       |    Up to 800 TB per device               |    Variable                            |
-|    **Data type**                    |    Azure Blobs                  |    Azure Blobs<br>Azure Files                    |    Azure Blobs<br>Azure Files            |    Azure Blobs<br>Azure Files          |
+|    **Data type**                    |    Azure Blobs<br>Azure Files*  |    Azure Blobs<br>Azure Files                    |    Azure Blobs<br>Azure Files            |    Azure Blobs<br>Azure Files          |
 |    **Form factor**                  |    5 SSDs per order             |    1 X 50-lbs. desktop-sized device per order    |    1 X ~500-lbs. large device per order    |    Up to 10 HDDs/SSDs per order        |
 |    **Initial setup time**           |    Low <br>(15 mins)            |    Low to moderate <br> (<30 mins)               |    Moderate<br>(1-2 hours)               |    Moderate to difficult<br>(variable) |
 |    **Send data to Azure**           |    Yes                          |    Yes                                           |    Yes                                   |    Yes                                 |
@@ -56,6 +56,8 @@ The following table summarizes the differences in key capabilities.
 |    **Shipping**                     |    Microsoft managed            |    Microsoft managed                             |    Microsoft managed                     |    Customer managed                    |
 | **Use when data moves**     |Within a commerce boundary|Within a commerce boundary|Within a commerce boundary|Across geographic boundaries, e.g. US to EU|
 |    **Pricing**                      |    [Pricing](https://azure.microsoft.com/pricing/details/databox/disk/)                    |   [Pricing](https://azure.microsoft.com/pricing/details/storage/databox/)                                      |  [Pricing](https://azure.microsoft.com/pricing/details/storage/databox/heavy/)                               |   [Pricing](https://azure.microsoft.com/pricing/details/storage-import-export/)                            |
+
+*\* Data Box Disk does not support Large File Shares and does not preserve file metadata*
 
 ## Next steps
 

--- a/articles/storage/common/storage-solution-large-dataset-moderate-high-network.md
+++ b/articles/storage/common/storage-solution-large-dataset-moderate-high-network.md
@@ -73,6 +73,8 @@ If using offline data transfer, use the following table to understand the differ
 | **Use when data moves**     |Within a commerce boundary|Within a commerce boundary|Within a commerce boundary|Across geographic boundaries, e.g. US to EU|
 |    **Pricing**                          |    [Pricing](https://azure.microsoft.com/pricing/details/databox/disk/)                    |   [Pricing](https://azure.microsoft.com/pricing/details/storage/databox/)                                      |  [Pricing](https://azure.microsoft.com/pricing/details/storage/databox/heavy/)                               |   [Pricing](https://azure.microsoft.com/pricing/details/storage-import-export/)                            |
 
+*\* Data Box Disk does not support Large File Shares and does not preserve file metadata*
+
 If using online data transfer, use the table in the following section for high network bandwidth.
 
 ### High network bandwidth
@@ -86,8 +88,6 @@ If using online data transfer, use the table in the following section for high n
 |    **Transfer from other clouds**   |    No                                        |    No                                        |    No                                                    |    Yes                                                                |
 |    **User type**                    |    IT Pro or dev                                       |    Dev                                       |    IT Pro                                                |    IT Pro                                                             |
 |    **Pricing**                      |    Free, data egress charges apply         |    Free, data egress charges apply         |    [Azure Stack Edge pricing](https://azure.microsoft.com/pricing/details/azure-stack/edge/) <br> [Data Box Gateway pricing](https://azure.microsoft.com/pricing/details/databox/gateway/)                                               |    [Pricing](https://azure.microsoft.com/pricing/details/data-factory/)                                                            |
-
-*\* Data Box Disk does not support Large File Shares and does not preserve file metadata*
 
 ## Next steps
 

--- a/articles/storage/common/storage-solution-large-dataset-moderate-high-network.md
+++ b/articles/storage/common/storage-solution-large-dataset-moderate-high-network.md
@@ -60,7 +60,7 @@ If using offline data transfer, use the following table to understand the differ
 |                                     |    Data Box Disk      |    Data Box                                      |    Data Box Heavy            |    Import/Export                       |
 |-------------------------------------|---------------------------------|--------------------------------------------------|------------------------------------------|----------------------------------------|
 |    **Data size**                    |    Up to 35 TBs                 |    Up to 80 TBs per device                       |    Up to 800 TB per device               |    Variable                            |
-|    **Data type**                    |    Azure Blobs<br>Azure Files   |    Azure Blobs<br>Azure Files                    |    Azure Blobs<br>Azure Files            |    Azure Blobs<br>Azure Files          |
+|    **Data type**                    |    Azure Blobs<br>Azure Files*   |    Azure Blobs<br>Azure Files                    |    Azure Blobs<br>Azure Files            |    Azure Blobs<br>Azure Files          |
 |    **Form factor**                  |    5 SSDs per order             |    1 X 50-lbs. desktop-sized device per order    |    1 X ~500-lbs. large device per order    |    Up to 10 HDDs/SSDs per order        |
 |    **Initial setup time**               |    Low <br>(15 mins)            |    Low to moderate <br> (<30 mins)               |    Moderate<br>(1-2 hours)               |    Moderate to difficult<br>(variable) |
 |    **Send data to Azure**           |    Yes                          |    Yes                                           |    Yes                                   |    Yes                                 |
@@ -86,6 +86,8 @@ If using online data transfer, use the table in the following section for high n
 |    **Transfer from other clouds**   |    No                                        |    No                                        |    No                                                    |    Yes                                                                |
 |    **User type**                    |    IT Pro or dev                                       |    Dev                                       |    IT Pro                                                |    IT Pro                                                             |
 |    **Pricing**                      |    Free, data egress charges apply         |    Free, data egress charges apply         |    [Azure Stack Edge pricing](https://azure.microsoft.com/pricing/details/azure-stack/edge/) <br> [Data Box Gateway pricing](https://azure.microsoft.com/pricing/details/databox/gateway/)                                               |    [Pricing](https://azure.microsoft.com/pricing/details/data-factory/)                                                            |
+
+*\* Data Box Disk does not support Large File Shares and does not preserve file metadata*
 
 ## Next steps
 

--- a/articles/storage/common/storage-solution-large-dataset-moderate-high-network.md
+++ b/articles/storage/common/storage-solution-large-dataset-moderate-high-network.md
@@ -60,7 +60,7 @@ If using offline data transfer, use the following table to understand the differ
 |                                     |    Data Box Disk      |    Data Box                                      |    Data Box Heavy            |    Import/Export                       |
 |-------------------------------------|---------------------------------|--------------------------------------------------|------------------------------------------|----------------------------------------|
 |    **Data size**                    |    Up to 35 TBs                 |    Up to 80 TBs per device                       |    Up to 800 TB per device               |    Variable                            |
-|    **Data type**                    |    Azure Blobs                  |    Azure Blobs<br>Azure Files                    |    Azure Blobs<br>Azure Files            |    Azure Blobs<br>Azure Files          |
+|    **Data type**                    |    Azure Blobs<br>Azure Files   |    Azure Blobs<br>Azure Files                    |    Azure Blobs<br>Azure Files            |    Azure Blobs<br>Azure Files          |
 |    **Form factor**                  |    5 SSDs per order             |    1 X 50-lbs. desktop-sized device per order    |    1 X ~500-lbs. large device per order    |    Up to 10 HDDs/SSDs per order        |
 |    **Initial setup time**               |    Low <br>(15 mins)            |    Low to moderate <br> (<30 mins)               |    Moderate<br>(1-2 hours)               |    Moderate to difficult<br>(variable) |
 |    **Send data to Azure**           |    Yes                          |    Yes                                           |    Yes                                   |    Yes                                 |


### PR DESCRIPTION
To Data Box Disks, as it is supported but not all of the features of Azure Files are supported.
Thought the docs were a little misleading for those who just need to copy files with no LFS or without fill file metadata

see the table at the bottom of here - https://learn.microsoft.com/en-us/azure/storage/files/storage-files-migration-overview#file-copy-tools