### PR TITLE
Removing a policy from an app is not recognized.

### DIFF
--- a/articles/active-directory/develop/configure-token-lifetimes.md
+++ b/articles/active-directory/develop/configure-token-lifetimes.md
@@ -54,9 +54,6 @@ New-MgApplicationTokenLifetimePolicyByRef -ApplicationId $applicationObjectId -B
 # List the token lifetime policy on the app
 Get-MgApplicationTokenLifetimePolicy -ApplicationId $applicationObjectId
 
-# Remove the policy from the app
-Remove-MgApplicationTokenLifetimePolicyByRef -ApplicationId $applicationObjectId -TokenLifetimePolicyId $tokenLifetimePolicyId
-
 # Delete the policy
 Remove-MgPolicyTokenLifetimePolicy -TokenLifetimePolicyId $tokenLifetimePolicyId
 ```


### PR DESCRIPTION
I tried to run line 58 "Remove-MgApplicationTokenLifetimePolicyByRef -ApplicationId $applicationObjectId -TokenLifetimePolicyId $tokenLifetimePolicyId" but I got error as below. "Remove-MgApplicationTokenLifetimePolicyByRef : The term 'Remove-MgApplicationTokenLifetimePolicyByRef' is not recognized as the name of a cmdlet, function, script file, or operable program. Check  the spelling of the name, or if a path was included, verify that the path is correct and try again."

I see "Remove-MgApplicationTokenLifetimePolicyByRef" is under "Microsoft.Graph.Applications" module.  https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.applications/remove-mgapplicationtokenlifetimepolicybyref?view=graph-powershell-1.0

So I imported the module with "Import-Module Microsoft.Graph.Applications". But I got same error. It seems "Remove-MgApplicationTokenLifetimePolicyByRef" is not working at all.

I ran "Remove-MgPolicyTokenLifetimePolicy -TokenLifetimePolicyId $tokenLifetimePolicyId" which is deleting the policy instead of removing the policy from the app. It deleted the policy and the policy was removed from the app. 

I suggest removing line of "Remove-MgApplicationTokenLifetimePolicyByRef" until we confirm it is working.