### PR TITLE
Update quickstart-create-and-configure-devcenter.md

### DIFF
--- a/articles/deployment-environments/quickstart-create-and-configure-devcenter.md
+++ b/articles/deployment-environments/quickstart-create-and-configure-devcenter.md
@@ -100,7 +100,9 @@ Using an authentication token like a GitHub personal access token (PAT) enables 
     :::image type="content" source="media/quickstart-create-and-configure-devcenter/generate-git-hub-token.png" alt-text="Screenshot that shows the GitHub Tokens (classic) configuration page.":::
 
 1. Select **Generate token**.
-1. On the Personal access tokens (classic) page, copy the new token.
+1. On the Personal access tokens (classic) page:
+    - In the **Configure SSO** box, authorize single sign-on **microsoft** organization.
+    - Copy the new token.
  
     :::image type="content" source="media/quickstart-create-and-configure-devcenter/copy-new-token.png" alt-text="Screenshot that shows the new GitHub token with the copy button highlighted.":::
 


### PR DESCRIPTION
When creating a new Github PAT, in case not authorized yet, the user will need to configure SSO to authorize the PAT token to access the Azure/deployment-environments.  If SSO is not configured properly, the sync on Key Vault may fail.