### PR TITLE
Minor changes

### DIFF
--- a/articles/openshift/howto-gpu-workloads.md
+++ b/articles/openshift/howto-gpu-workloads.md
@@ -244,8 +244,12 @@ This section explains how to create the `nvidia-gpu-operator` namespace, set up 
    ```bash
    CHANNEL=$(oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}')
    ```
-> **_NOTE:_** If your cluster was created without providing the pull secret, the cluster will not include samples or operators from Red Hat or from certified partners. This will result in the following error message: 
-> *Error from server (NotFound): packagemanifests.packages.operators.coreos.com "gpu-operator-certified" not found.* To add your Red Hat pull secret on an Azure Red Hat OpenShift cluster, [follow this guidance](howto-add-update-pull-secret.md).
+> [!NOTE] 
+> If your cluster was created without providing the pull secret, the cluster won't include samples or operators from Red Hat or from certified partners. This will result in the following error message: 
+> 
+> *Error from server (NotFound): packagemanifests.packages.operators.coreos.com "gpu-operator-certified" not found.* 
+>
+> To add your Red Hat pull secret on an Azure Red Hat OpenShift cluster, [follow this guidance](howto-add-update-pull-secret.md).
 
 1. Get latest Nvidia package using the following command:
 

--- a/articles/openshift/howto-gpu-workloads.md
+++ b/articles/openshift/howto-gpu-workloads.md
@@ -244,6 +244,8 @@ This section explains how to create the `nvidia-gpu-operator` namespace, set up 
    ```bash
    CHANNEL=$(oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}')
    ```
+> **_NOTE:_** Be aware that if your cluster was created without providing the pull secret, the cluster will not include samples or operators from Red Hat or from certified partners, which  will cause an error message saying: 
+> *Error from server (NotFound): packagemanifests.packages.operators.coreos.com "gpu-operator-certified" not found.* To add your Red Hat pull secret on an Azure Red Hat OpenShift cluster, [follow this guidance](howto-add-update-pull-secret.md).
 
 1. Get latest Nvidia package using the following command:
 

--- a/articles/openshift/howto-gpu-workloads.md
+++ b/articles/openshift/howto-gpu-workloads.md
@@ -244,7 +244,7 @@ This section explains how to create the `nvidia-gpu-operator` namespace, set up 
    ```bash
    CHANNEL=$(oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}')
    ```
-> **_NOTE:_** Be aware that if your cluster was created without providing the pull secret, the cluster will not include samples or operators from Red Hat or from certified partners, which  will cause an error message saying: 
+> **_NOTE:_** If your cluster was created without providing the pull secret, the cluster will not include samples or operators from Red Hat or from certified partners. This will result in the following error message: 
 > *Error from server (NotFound): packagemanifests.packages.operators.coreos.com "gpu-operator-certified" not found.* To add your Red Hat pull secret on an Azure Red Hat OpenShift cluster, [follow this guidance](howto-add-update-pull-secret.md).
 
 1. Get latest Nvidia package using the following command:

--- a/articles/openshift/howto-gpu-workloads.md
+++ b/articles/openshift/howto-gpu-workloads.md
@@ -58,7 +58,7 @@ ARO supports the following GPU workers:
 
 1. Enter **quotas** in the search box, then select **Compute**.
 
-1. In the search box, enter **NCAv3_T4**, check the box for the region your cluster is in, and then select **Request quota increase**.
+1. In the search box, enter **NCAsv3_T4**, check the box for the region your cluster is in, and then select **Request quota increase**.
 
 1. Configure quota.
 
@@ -149,13 +149,13 @@ ARO uses Kubernetes MachineSet to create machine sets. The procedure below expla
 1. Change the `.spec.selector.matchLabels.machine.openshift.io/cluster-api-machineset` field to match the `.metadata.name` field.
 
    ```bash
-   jq '.spec.selector.matchLabels."machine.openshift.io/cluster-api-machineset" = "nvidia-worker-southcentralus1"' gpu_machineset.json| sponge gpu_machineset.json
+   jq '.spec.selector.matchLabels."machine.openshift.io/cluster-api-machineset" = "nvidia-worker-<region><az>"' gpu_machineset.json| sponge gpu_machineset.json
    ```
 
 1. Change the `.spec.template.metadata.labels.machine.openshift.io/cluster-api-machineset` to match the `.metadata.name` field.
 
    ```bash
-   jq '.spec.template.metadata.labels."machine.openshift.io/cluster-api-machineset" = "nvidia-worker-southcentralus1"' gpu_machineset.json| sponge gpu_machineset.json
+   jq '.spec.template.metadata.labels."machine.openshift.io/cluster-api-machineset" = "nvidia-worker-<region><az>"' gpu_machineset.json| sponge gpu_machineset.json
    ```
 
 1. Change the `spec.template.spec.providerSpec.value.vmSize` to match the desired GPU instance type from Azure.


### PR DESCRIPTION
- Changing to the correct instance name NCAsv3_T4 instead of NCAv3_T4. 
- Changing the .metadata.name to use the same pattern of nvidia-worker-<region><az> instead of nvidia-worker-southcentralus1
- Adding a note about an error that will happen if there is no pull secret added on the cluster during the add of the Nvidia channel
