### PR TITLE
Update ueba-reference.md

### DIFF
--- a/articles/sentinel/ueba-reference.md
+++ b/articles/sentinel/ueba-reference.md
@@ -21,7 +21,7 @@ These are the data sources from which the UEBA engine collects and analyzes data
 | **Azure Active Directory**<br>Sign-in logs | All |
 | **Azure Active Directory**<br>Audit logs | ApplicationManagement<br>DirectoryManagement<br>GroupManagement<br>Device<br>RoleManagement<br>UserManagementCategory |
 | **Azure Activity logs** | Authorization<br>AzureActiveDirectory<br>Billing<br>Compute<br>Consumption<br>KeyVault<br>Devices<br>Network<br>Resources<br>Intune<br>Logic<br>Sql<br>Storage |
-| **Windows Security events** | 4624: An account was successfully logged on<br>4625: An account failed to log on<br>4648: A logon was attempted using explicit credentials<br>4672: Special privileges assigned to new logon<br>4688: A new process has been created |
+| **Windows Security events** | The following events are read both from the SecurityEvent as well as the WindowsEvent table. The EventSource may appear as SecurityEvent in both cases for both sources <br>4624: An account was successfully logged on<br>4625: An account failed to log on<br>4648: A logon was attempted using explicit credentials<br>4672: Special privileges assigned to new logon<br>4688: A new process has been created |
 
 ## UEBA enrichments
 


### PR DESCRIPTION
Security Events reads both from WindowsEvent (used for WEF) and SecurityEvent, but we don't clarify this anywhere. The EventSource on the BehaviorAnalytics table appears as SecurityEvent even for customers who only use WindowsEvent (a customer showed me), and it is confusing, hence I think it needs clarification in the docs