### PR TITLE
Update speech-container-howto-on-premises.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/speech-container-howto-on-premises.md
+++ b/articles/cognitive-services/Speech-Service/speech-container-howto-on-premises.md
@@ -76,7 +76,7 @@ textToSpeech:
   optimizeForTurboMode: true
   image:
     registry: mcr.microsoft.com
-    repository: azure-cognitive-services/speechservices/speech-to-text
+    repository: azure-cognitive-services/speechservices/text-to-speech
     tag: latest
     pullSecrets:
       - mcr # Or an existing secret


### PR DESCRIPTION
I believe the sample helm should be pointing at this image https://hub.docker.com/_/microsoft-azure-cognitive-services-speechservices-text-to-speech for text to speech rather than [speech-to-text](https://hub.docker.com/_/microsoft-azure-cognitive-services-speechservices-speech-to-text) as well.

This is to propose a simple update of the reference for text to speech container in the helm sample at https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-container-howto-on-premises#configure-helm-chart-values-for-deployment

Hope it helps