### PR TITLE
Update functions-dotnet-dependency-injection.md

### DIFF
--- a/articles/azure-functions/functions-dotnet-dependency-injection.md
+++ b/articles/azure-functions/functions-dotnet-dependency-injection.md
@@ -71,6 +71,8 @@ A series of registration steps run before and after the runtime processes the st
 
 - *The dependency injection container only holds explicitly registered types*. The only services available as injectable types are what are setup in the `Configure` method. As a result, Functions-specific types like `BindingContext` and `ExecutionContext` aren't available during setup or as injectable types.
 
+- *Configuring ASP.NET authentication is not supported*. The Functions host configures ASP.NET authentication services in order to properly expose APIs to infrastucture services, such as the Azure portal. Additional configuration in a custom Startup class can override this configuration, causing unintended consequences. For example, calling `builder.Services.AddAuthentication()` can break authentication between the portal and the host, leading to messages such as "Azure Functions runtime is unreachable".
+
 ## Use injected dependencies
 
 Constructor injection is used to make your dependencies available in a function. The use of constructor injection requires that you do not use static classes for injected services or for your function classes.

--- a/articles/azure-functions/functions-recover-storage-account.md
+++ b/articles/azure-functions/functions-recover-storage-account.md
@@ -113,13 +113,17 @@ Your function app might be in an unresponsive state due to conflicting port assi
 
 By default, the container in which your function app runs uses port `:80`. When other services in the same container are also trying to using port `:80`, the function app can fail to start. If your logs show port conflicts, change the default ports.
 
-## Host ID collision 
+### Host ID collision 
 
 Starting with version 3.x of the Functions runtime, [host ID collision](storage-considerations.md#host-id-considerations) are detected and logged as a warning. In version 4.x, an error is logged and the host is stopped. If the runtime can't start for your function app, [review the logs](analyze-telemetry-data.md). If there's a warning or an error about host ID collisions, follow the mitigation steps in [Host ID considerations](storage-considerations.md#host-id-considerations).  
 
-## Read-only app settings
+### Read-only app settings
 
-Changing any _read-only_ [App Service application settings](../app-service/reference-app-settings.md#app-environment) can put your function app into an unreachable state. 
+Changing any _read-only_ [App Service application settings](../app-service/reference-app-settings.md#app-environment) can put your function app into an unreachable state.
+
+### ASP.NET authentication overrides
+
+Configuring ASP.NET authentication in a Functions startup class can override services that are required for the Azure portal to communicate with the host. This includes, but is not limited to, any calls to `AddAuthentication()`. If the host's authentication services are overridden and the portal cannot communicate with the host, it will consider the app unreachable. This may result in errors such as `No authentication handler is registered for the scheme 'ArmToken'.`.
 
 ## Next steps
 


### PR DESCRIPTION
Adding note about ASP.NET authentication

We've had support issues with this: https://github.com/Azure/azure-functions-host/issues/6805. This is not likely to be something we add support for in-proc as we're moving towards dotnet-isolated in the future. We should start calling this out to help prevent support issues.