### PR TITLE
docs: fix typo in `LeastConnection`

### DIFF
--- a/articles/aks/configure-kube-proxy.md
+++ b/articles/aks/configure-kube-proxy.md
@@ -69,14 +69,14 @@ The full `kube-proxy` configuration structure can be found in the [AKS Cluster S
 - `mode` - can be set to `IPTABLES` or `IPVS`. Defaults to `IPTABLES`.
 - `ipvsConfig` - if `mode` is `IPVS`, this object contains IPVS-specific configuration properties.
   - `scheduler` - which connection scheduler to utilize. Supported values:
-    - `LeastConnections` - sends connections to the backend pod with the fewest connections
+    - `LeastConnection` - sends connections to the backend pod with the fewest connections
     - `RoundRobin` - distributes connections evenly between backend pods
   - `tcpFinTimeoutSeconds` - the value used for timeout after a FIN has been received in a TCP session
   - `tcpTimeoutSeconds` - the value used for timeout length for idle TCP sessions
   - `udpTimeoutSeconds` - the value used for timeout length for idle UDP sessions
 
 > [!NOTE]
-> IPVS load balancing operates in each node independently and is still only aware of connections flowing through the local node. This means that while `LeastConnections` results in more even load under higher number of connections, when low numbers of connections (# connects < 2 * node count) occur traffic may still be relatively unbalanced.
+> IPVS load balancing operates in each node independently and is still only aware of connections flowing through the local node. This means that while `LeastConnection` results in more even load under higher number of connections, when low numbers of connections (# connects < 2 * node count) occur traffic may still be relatively unbalanced.
 
 ## Utilize `kube-proxy` configuration in a new or existing AKS cluster using Azure CLI
 


### PR DESCRIPTION
Supported value is `LeastConnection` without the "s". The example is correct but the instructions are not.