### PR TITLE
fix addon name typo in confidential-nodes-aks-overview.md

### DIFF
--- a/articles/confidential-computing/confidential-nodes-aks-overview.md
+++ b/articles/confidential-computing/confidential-nodes-aks-overview.md
@@ -24,13 +24,13 @@ Azure Kubernetes Service (AKS) supports adding [Intel SGX confidential computing
 
 - Hardware based, process level container isolation through Intel SGX trusted execution environment (TEE)
 - Heterogenous node pool clusters (mix confidential and non-confidential node pools)
-- Encrypted Page Cache (EPC) memory-based pod scheduling through "Confcon" AKS addon
+- Encrypted Page Cache (EPC) memory-based pod scheduling through "confcom" AKS addon
 - Intel SGX DCAP driver pre-installed and kernel dependency installed
 - CPU consumption based horizontal pod autoscaling and cluster autoscaling
 - Linux Containers support through Ubuntu 18.04 Gen 2 VM worker nodes
 
 ## Confidential Computing add-on for AKS
-The add-on feature enables extra capability on AKS when running confidential computing Intel SGX capable node pools on the cluster. "Confcon" add-on on AKS enables the features below.
+The add-on feature enables extra capability on AKS when running confidential computing Intel SGX capable node pools on the cluster. "confcom" add-on on AKS enables the features below.
 
 #### Azure Device Plugin for Intel SGX <a id="sgx-plugin"></a>
 


### PR DESCRIPTION
Making spelling and capitalization for `confcom` addon consistent across other azure-docs articles like [this](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/confidential-computing/confidential-nodes-aks-addon.md#sample-implementation) and [this](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/confidential-computing/confidential-enclave-nodes-aks-get-started.md#create-an-aks-cluster-with-a-system-node-pool-and-aks-intel-sgx-addon)