### PR TITLE
Add information about exporting B2C Consumer users and how UPN info i…

### DIFF
--- a/articles/active-directory-b2c/manage-users-portal.md
+++ b/articles/active-directory-b2c/manage-users-portal.md
@@ -73,6 +73,17 @@ To reset a user's password:
 
 For details about restoring a user within the first 30 days after deletion, or for permanently deleting a user, see [Restore or remove a recently deleted user using Azure Active Directory](../active-directory/fundamentals/active-directory-users-restore.md).
 
+
+## Exporting Consumer Users
+
+1. In your Azure AD B2C directory, search for **Azure Active Directory**. 
+2. Select **Users**, and then select **Bulk Operations** and **Download Users**.
+3. Select **Start** and then select **File is ready! Click here to download**.
+ 
+
+When downloading users via Bulk Operations option, the CSV file will bring users with their UPN attribute with the format *objectID@B2CDomain*. This is by design since that's the way the UPN information is stored in the B2C tenant.
+
+
 ## Next steps
 
 For automated user management scenarios, for example migrating users from another identity provider to your Azure AD B2C directory, see [Azure AD B2C: User migration](user-migration.md).

--- a/articles/active-directory-b2c/manage-users-portal.md
+++ b/articles/active-directory-b2c/manage-users-portal.md
@@ -74,11 +74,11 @@ To reset a user's password:
 For details about restoring a user within the first 30 days after deletion, or for permanently deleting a user, see [Restore or remove a recently deleted user using Azure Active Directory](../active-directory/fundamentals/active-directory-users-restore.md).
 
 
-## Exporting Consumer Users
+## Export consumer users
 
 1. In your Azure AD B2C directory, search for **Azure Active Directory**. 
 2. Select **Users**, and then select **Bulk Operations** and **Download Users**.
-3. Select **Start** and then select **File is ready! Click here to download**.
+3. Select **Start**, and then select **File is ready! Click here to download**.
  
 
 When downloading users via Bulk Operations option, the CSV file will bring users with their UPN attribute with the format *objectID@B2CDomain*. This is by design since that's the way the UPN information is stored in the B2C tenant.


### PR DESCRIPTION
…s exhibited

Suggestion to add the information on how to export a csv file with the B2C Consumer users and also the important information about how UPN information is brought into that file. UPN information come with the objectID@B2CDomain format and might cause some confusion to the customers as this is expected.