### PR TITLE
Update how-to-connect-syncservice-duplicate-attribute-resiliency.md

### DIFF
--- a/articles/active-directory/hybrid/how-to-connect-syncservice-duplicate-attribute-resiliency.md
+++ b/articles/active-directory/hybrid/how-to-connect-syncservice-duplicate-attribute-resiliency.md
@@ -74,8 +74,7 @@ Then, use the following cmdlets and operators to view errors in different ways:
 2. [By Property Type](#by-property-type)
 3. [By Conflicting Value](#by-conflicting-value)
 4. [Using a String Search](#using-a-string-search)
-5. Sorted
-6. [In a Limited Quantity or All](#in-a-limited-quantity-or-all)
+5. [In a Limited Quantity or All](#in-a-limited-quantity-or-all)
 
 #### See all
 Once connected, to see a general list of attribute provisioning errors in the tenant run:


### PR DESCRIPTION
Looks like this article has not been updated since 2016. It still mentions as "Current behavior" before Attribute resiliency feature existed. Additionally, we no longer send email report with address conflicts, for many years now.