### PR TITLE
Update stream-analytics-quick-create-powershell.md

### DIFF
--- a/articles/stream-analytics/stream-analytics-quick-create-powershell.md
+++ b/articles/stream-analytics/stream-analytics-quick-create-powershell.md
@@ -142,32 +142,18 @@ The following Azure PowerShell code block uses commands to create blob storage t
 
 ## Create a Stream Analytics job
 
-Create a Stream Analytics job with [New-AzStreamAnalyticsJob](/powershell/module/az.streamanalytics/new-azstreamanalyticsjob) cmdlet. This cmdlet takes the job name, resource group name, and job definition as parameters. The job name can be any friendly name that identifies your job. It can have alphanumeric characters, hyphens, and underscores only and it must be between 3 and 63 characters long. The job definition is a JSON file that contains the properties required to create a job. On your local machine, create a file named `JobDefinition.json` and add the following JSON data to it:
+Create a Stream Analytics job with [New-AzStreamAnalyticsJob](/powershell/module/az.streamanalytics/new-azstreamanalyticsjob) cmdlet. This cmdlet takes the job name, resource group name, location, and sku name as parameters. The job name can be any friendly name that identifies your job. It can have alphanumeric characters, hyphens, and underscores only and it must be between 3 and 63 characters long.
 
-```json
-{
-  "location":"WestUS2",
-  "properties":{
-    "sku":{
-      "name":"standard"
-    },
-    "eventsOutOfOrderPolicy":"adjust",
-    "eventsOutOfOrderMaxDelayInSeconds":10,
-    "compatibilityLevel": 1.1
-  }
-}
-```
-
-Next, run the `New-AzStreamAnalyticsJob` cmdlet. Replace the value of `jobDefinitionFile` variable with the path where you've stored the job definition JSON file.
+Run the `New-AzStreamAnalyticsJob` cmdlet.
 
 ```powershell
 $jobName = "MyStreamingJob"
-$jobDefinitionFile = "C:\JobDefinition.json"
+$resourceGroup = "MyResourceGroup"
 New-AzStreamAnalyticsJob `
   -ResourceGroupName $resourceGroup `
-  -File $jobDefinitionFile `
   -Name $jobName `
-  -Force
+  -Location centralus `
+  -SkuName Standard
 ```
 
 ## Configure input to the job


### PR DESCRIPTION
Editing docs with updated powershell command to create ASA job.  According to https://learn.microsoft.com/en-us/powershell/module/az.streamanalytics/new-azstreamanalyticsjob?view=azps-9.7.1&viewFallbackFrom=azps-0.10.0 there is no longer a File parameter when creating the resource.