### PR TITLE
Added "modifyTime" to file properties section

### DIFF
--- a/articles/synapse-analytics/spark/microsoft-spark-utilities.md
+++ b/articles/synapse-analytics/spark/microsoft-spark-utilities.md
@@ -281,14 +281,14 @@ mssparkutils.fs.ls("Your directory path")
 
 ### View file properties
 
-Returns file properties including file name, file path, file size, and whether it is a directory and a file.
+Returns file properties including file name, file path, file size, file modification time, and whether it is a directory and a file.
 
 :::zone pivot = "programming-language-python"
 
 ```python
 files = mssparkutils.fs.ls('Your directory path')
 for file in files:
-    print(file.name, file.isDir, file.isFile, file.path, file.size)
+    print(file.name, file.isDir, file.isFile, file.path, file.size, file.modifyTime)
 ```
 ::: zone-end
 
@@ -297,7 +297,7 @@ for file in files:
 ```scala
 val files = mssparkutils.fs.ls("/")
 files.foreach{
-    file => println(file.name,file.isDir,file.isFile,file.size)
+    file => println(file.name,file.isDir,file.isFile,file.size,file.modifyTime)
 }
 ```
 
@@ -319,7 +319,7 @@ foreach(var File in Files) {
 ```r
 files <- mssparkutils.fs.ls("/")
 for (file in files) {
-    writeLines(paste(file$name, file$isDir, file$isFile, file$size))
+    writeLines(paste(file$name, file$isDir, file$isFile, file$size, file$modifyTime))
 }
 ```
 


### PR DESCRIPTION
I added the variable modifyTime of the FileInfo Class to the section "View file properties". Unfortunately this property is not available in C#.
I was looking for a way to get the last modified timestamp of a file or directory in Synapse (using `mssparkutils.fs.ls`) and didn't find it in the documentation, so I decided to add it