### PR TITLE
Update details for Usage Summary Reports Reader

### DIFF
--- a/articles/active-directory/roles/permissions-reference.md
+++ b/articles/active-directory/roles/permissions-reference.md
@@ -2312,7 +2312,15 @@ Assign the Tenant Creator role to users who need to do the following tasks:
 
 ## Usage Summary Reports Reader
 
-Users with this role can access tenant level aggregated data and associated insights in Microsoft 365 admin center for Usage and Productivity Score but cannot access any user level details or insights. In Microsoft 365 admin center for the two reports, we differentiate between tenant level aggregated data and user level details. This role gives an extra layer of protection on individual user identifiable data, which was requested by both customers and legal teams.
+Assign the Usage Summary Reports Reader role to users who need to do the following:
+
+- View the Usage reports and Adoption Score
+- View the Usage reports and Adoption Score
+
+> [!NOTE]
+> This role only allows users to view organizational-level data with the following exceptions:
+> Member users can view user management data and settings.
+> Guest users assigned this role can not view user management data and settings.
 
 > [!div class="mx-tableFixed"]
 > | Actions | Description |


### PR DESCRIPTION
Information about the Usage Summary Reports Reader was incorrect and misleading. There are no plans on changing this role so requesting content be updated to match what's currently in the M365 admin center.