### PR TITLE
Clarification for Subnet Delegation

### DIFF
--- a/articles/api-management/virtual-network-concepts.md
+++ b/articles/api-management/virtual-network-concepts.md
@@ -66,6 +66,7 @@ The following are virtual network resource requirements for API Management. Some
 * An Azure Resource Manager virtual network is required.
 * You must provide a Standard SKU [public IPv4 address](../virtual-network/ip-services/public-ip-addresses.md#sku) in addition to specifying a virtual network and subnet.
 * The subnet used to connect to the API Management instance may contain other Azure resource types.
+* The subnet used to connect to the API Management instance should not have any delegations enabled. The "Delegate subnet to a service" setting for the subnet should be set to "None". 
 * A [network security group](../virtual-network/network-security-groups-overview.md) attached to the subnet above. A network security group (NSG) is required to explicitly allow inbound connectivity, because the load balancer used internally by API Management is secure by default and rejects all inbound traffic. 
 * The API Management service, virtual network and subnet, and public IP address resource must be in the same region and subscription.
 * For multi-region API Management deployments, configure virtual network resources separately for each location.
@@ -74,6 +75,7 @@ The following are virtual network resource requirements for API Management. Some
 
 * An Azure Resource Manager virtual network is required.
 * The subnet used to connect to the API Management instance must be dedicated to API Management. It can't contain other Azure resource types.
+* The subnet used to connect to the API Management instance should not have any delegations enabled. The "Delegate subnet to a service" setting for the subnet should be set to "None". 
 * The API Management service, virtual network, and subnet resources must be in the same region and subscription.
 * For multi-region API Management deployments, configure virtual network resources separately for each location.
 


### PR DESCRIPTION
We see several failures that customers experience when they enable subnet delegation for subnets where APIM will be deployed. This is a bit counter intuitive - as when customers create subnet from Portal, they have a tendency to enable delegation for Microsoft.ApiManagement. This causes a deployment failure that generates a support case. This clarity should help reduce that confusion.