### PR TITLE
Added Clarity about Outbound PE Connectivity

### DIFF
--- a/includes/api-management-private-endpoint.md
+++ b/includes/api-management-private-endpoint.md
@@ -17,5 +17,7 @@ With a private endpoint and Private Link, you can:
 - Limit incoming traffic only to private endpoints, preventing data exfiltration.
 
 > [!IMPORTANT]
-> * You can only configure a private endpoint connection for **inbound** traffic to the API Management instance. Currently, outbound traffic isn't supported. Note that you may still use the external or internal [virtual network](../articles/api-management/virtual-network-concepts.md) model to establish outbound connectivity to private endpoints from your API Management instance.
+> * You can only configure a private endpoint connection for **inbound** traffic to the API Management instance. Currently, outbound traffic isn't supported. 
+> 
+>   You can use the external or internal [virtual network](/azure/api-management/virtual-network-concepts) model to establish outbound connectivity to private endpoints from your API Management instance.
 > * To enable private endpoints, the API Management instance can't already be configured with an external or internal [virtual network](../articles/api-management/virtual-network-concepts.md).  

--- a/includes/api-management-private-endpoint.md
+++ b/includes/api-management-private-endpoint.md
@@ -17,5 +17,5 @@ With a private endpoint and Private Link, you can:
 - Limit incoming traffic only to private endpoints, preventing data exfiltration.
 
 > [!IMPORTANT]
-> * You can only configure a private endpoint connection for **inbound** traffic to the API Management instance. Currently, outbound traffic isn't supported. 
+> * You can only configure a private endpoint connection for **inbound** traffic to the API Management instance. Currently, outbound traffic isn't supported. Note that you may still use the external or internal [virtual network](../articles/api-management/virtual-network-concepts.md) model to establish outbound connectivity to private endpoints from your API Management instance.
 > * To enable private endpoints, the API Management instance can't already be configured with an external or internal [virtual network](../articles/api-management/virtual-network-concepts.md).  


### PR DESCRIPTION
In the context of the main document ( https://learn.microsoft.com/en-us/azure/api-management/virtual-network-concepts?tabs=stv2 ), the statement "Currently, outbound traffic isn't supported" becomes conflicting. It gives an indication that APIM doesn't support outbound PE at all, which is not correct. Added clarity to avoid this confusion.