### PR TITLE
Include Markdown in the GitHub language breakdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,9 @@
 *.c text
 *.h text
 
+# Include Markdown in the GitHub language breakdown statistics
+*.md linguist-detectable
+
 # Denote all files that are truly binary and should not be modified.
 *.gif   binary
 *.ico   binary


### PR DESCRIPTION
Currently, this repo is labelled as containing 100% PowerShell.
However, this repo isn't really about PowerShell, it's about documentation (in the form of Markdown).

For this reason, I suggest adding a [Linguist override](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#detectable) to the `.gitattribute` file so that Markdown can be included in the GitHub language breakdown statistics.

This way, the language breakdown would change from :
![image](https://user-images.githubusercontent.com/31558169/236698974-6e7b83cb-8d90-40a5-a443-73deef420ae1.png)

to:
![image](https://user-images.githubusercontent.com/31558169/236698984-470e9338-dbfb-4188-b450-5e04ed8d306f.png)



This would make things clearer for anyone stumbling on this repo by clarifying its content and purpose.

<hr>

**Potential questions:**
<details><summary>Will this affect anything else?</summary>

The only things affected by this change are the language stats bar and the main language badge that will appear alongside the repo (when it appears in searches for instance).

![image](https://user-images.githubusercontent.com/31558169/236698990-3754d2e7-dc7e-43a0-895b-309e78730ced.png)

</details>
<details><summary>Why isn't Markdown detected by default?</summary>

[Linguist](https://github.com/github-linguist/linguist) (the tool that calculates the language breakdown) automatically excludes documentation and any `*.md` files. This is the right thing to do for ordinary repos that contain an application or code snippets because the language breakdown of the code should reflect the languages and technologies used. The amount of documentation is not relevant in that case. Since this is the "normal" situation for a GitHub repo, that explains why it is the default behavior for Linguist. This means that a repo like this one, where the main purpose is to supply documentation, needs to override that behavior to fit its specificity.

</details>