### PR TITLE
Update concept-best-practices-collections.md

### DIFF
--- a/articles/purview/concept-best-practices-collections.md
+++ b/articles/purview/concept-best-practices-collections.md
@@ -70,7 +70,7 @@ Consider deploying collections in Microsoft Purview to fulfill the following req
 
 - When you run a new scan, by default, the scan is deployed in the same collection as the data source. You can optionally select a different subcollection to run the scan. As a result, the assets will belong under the subcollection. 
 
-- Currently, moving data sources across collections isn't allowed. If you need to move a data source under a different collection, you need to delete all assets, remove the data source from the original collection, and re-register the data source under the destination collection.
+- Moving data sources across collections is allowed if the user is granted the Data Source Admin role for the source and destination collections. 
 
 - Moving assets across collections is allowed if the user is granted the Data Curator role for the source and destination collections. 
 
@@ -79,13 +79,6 @@ Consider deploying collections in Microsoft Purview to fulfill the following req
 - You can delete a collection if it does not have any assets, associated scans, data sources or child collections.
 
 - Data sources, scans, and assets must belong to a collection if they exist in the Microsoft Purview data map.    
-
-<!-- 
-- Moving data sources across collections is allowed if the user is granted the Data Source Admin role for the source and destination collections. 
-
-- Moving assets across collections is allowed if the user is granted the Data Curator role for the source and destination collections. 
-
--->
 
 ## Define an authorization model
 


### PR DESCRIPTION
1) New feature of moving data sources (which is correctly described here: https://learn.microsoft.com/en-us/azure/purview/manage-data-sources#move-sources-between-collections) is not yet described on this page, therefor I replaced this sentence: "- Currently, moving data sources across collections isn't allowed. If you need to move a data source under a different collection, you need to delete all assets, remove the data source from the original collection, and re-register the data source under the destination collection." I replaced it with this sentence (which was already there in comment):  "- Moving data sources across collections is allowed if the user is granted the Data Source Admin role for the source and destination collections."

2) In the source of this page the following section (in comment) can be removed, as both statements (of 2 new features) are now part of this page. Apparantly both were already documented in comment, waiting untill the feature was general available. So I deleted this part: "<!-- 
- Moving data sources across collections is allowed if the user is granted the Data Source Admin role for the source and destination collections. 

- Moving assets across collections is allowed if the user is granted the Data Curator role for the source and destination collections. 

-->"