### PR TITLE
Update manage-data-sources.md

### DIFF
--- a/articles/purview/manage-data-sources.md
+++ b/articles/purview/manage-data-sources.md
@@ -90,7 +90,7 @@ After you've registered your source, you can move it to another collection that 
 
    :::image type="content" source="media/manage-data-sources/select-collection.png" alt-text="Screenshot of the Move collection window, showing the drop down selection of collections.":::
 
-1. Your collection has been moved. It can take up to an hour for results to be fully seen across your Microsoft Purview environment. Your scans will move with your resource, but assets will remain in their original collection until your next scan, then they'll move to the new collection.
+1. Your data source has been moved. It can take up to an hour for results to be fully seen across your Microsoft Purview environment. Your scans will move with your resource, but assets will remain in their original collection until your next scan, then they'll move to the new collection.
 
 >[!NOTE]
 >If any of the assets from your source were moved manually to a different collection before the source was migrated, the scan won't take them to the new collection. They will remain in the collection you moved them to.


### PR DESCRIPTION
"Your collection has been moved" should be "Your data source has been moved". The data source is the object that is moved to the selected collection. The collection itself is not moved!

Confusion arises because the window in the previous step is called "Move collection". Apparently one and the same window is used for moving different asset types, so a generic name has been attached to it. It would have been clearer if the window had been called "Move data source" because you don't move the collection but the data source...