### PR TITLE
Remove elevation service references from Azure Maps articles #2

### DIFF
--- a/articles/azure-maps/migrate-from-bing-maps-web-services.md
+++ b/articles/azure-maps/migrate-from-bing-maps-web-services.md
@@ -38,15 +38,11 @@ The following table provides the Azure Maps service APIs that provide similar fu
 | Spatial Data Services (SDS)           | [Search] + [Route] + other Azure Services |
 | Time Zone                             | [Time Zone]                               |
 | Traffic Incidents                     | [Traffic Incident Details]                |
-| Elevations                            | <sup>1</sup>                              |
-
-<sup>1</sup> Azure Maps [Elevation services](/rest/api/maps/elevation) have been [deprecated](https://azure.microsoft.com/updates/azure-maps-elevation-apis-and-render-v2-dem-tiles-will-be-retired-on-5-may-2023). For more information on how to include this functionality in your Azure Maps, see [Create elevation data & services](elevation-data-services.md).
 
 The following service APIs aren't currently available in Azure Maps:
 
 * Optimized Itinerary Routes - Planned. Azure Maps Route API does support traveling salesmen optimization for a single vehicle.
 * Imagery Metadata – Primarily used for getting tile URLs in Bing Maps. Azure Maps has a standalone service for directly accessing map tiles.
-* Azure Maps [Elevation services](/rest/api/maps/elevation) have been [deprecated](https://azure.microsoft.com/updates/azure-maps-elevation-apis-and-render-v2-dem-tiles-will-be-retired-on-5-may-2023). For more information on how to include this functionality in your Azure Maps, see [Create elevation data & services](elevation-data-services.md)
 
 Azure Maps also has these REST web services:
 
@@ -689,7 +685,6 @@ Learn more about the Azure Maps REST services.
 [POST Route directions]: /rest/api/maps/route/postroutedirections
 [Route]: /rest/api/maps/route
 [Time Zone]: /rest/api/maps/timezone
-[Elevation]: /rest/api/maps/elevation
 
 [Azure Maps Creator]: creator-indoor-maps.md
 [Spatial operations]: /rest/api/maps/spatial

--- a/articles/azure-maps/migrate-from-bing-maps.md
+++ b/articles/azure-maps/migrate-from-bing-maps.md
@@ -53,7 +53,6 @@ The following table provides a high-level list of Bing Maps features and the rel
 | Autosuggest                           | ✓                  |
 | Directions (including truck)          | ✓                  |
 | Distance Matrix                       | ✓                  |
-| Elevations                            | <sup>1</sup>       |
 | Imagery – Static Map                  | ✓                  |
 | Imagery Metadata                      | ✓                  |
 | Isochrones                            | ✓                  |
@@ -67,8 +66,6 @@ The following table provides a high-level list of Bing Maps features and the rel
 | Time Zone                             | ✓                  |
 | Traffic Incidents                     | ✓                  |
 | Configuration driven maps             | N/A                |
-
-<sup>1</sup> Azure Maps [Elevation services](/rest/api/maps/elevation) have been [deprecated](https://azure.microsoft.com/updates/azure-maps-elevation-apis-and-render-v2-dem-tiles-will-be-retired-on-5-may-2023). For more information on how to include this functionality in your Azure Maps, see [Create elevation data & services](elevation-data-services.md).
 
 Bing Maps provides basic key-based authentication. Azure Maps provides both basic key-based authentication and highly secure, Azure Active Directory authentication.
 

--- a/articles/azure-maps/migrate-from-google-maps-web-app.md
+++ b/articles/azure-maps/migrate-from-google-maps-web-app.md
@@ -73,9 +73,6 @@ The table lists key API features in the Google Maps V3 JavaScript SDK and the su
 | Geocoder service        | ✓                          |
 | Directions service      | ✓                          |
 | Distance Matrix service | ✓                          |
-| Elevation service       | <sup>1</sup>               |
-
-<sup>1</sup> Azure Maps [Elevation services](/rest/api/maps/elevation) have been [deprecated](https://azure.microsoft.com/updates/azure-maps-elevation-apis-and-render-v2-dem-tiles-will-be-retired-on-5-may-2023). For more information on how to include this functionality in your Azure Maps, see [Create elevation data & services](elevation-data-services.md).
 
 ## Notable differences in the web SDKs
 

--- a/articles/azure-maps/migrate-from-google-maps-web-services.md
+++ b/articles/azure-maps/migrate-from-google-maps-web-services.md
@@ -44,9 +44,6 @@ The table shows the Azure Maps service APIs, which have a similar functionality 
 | Speed Limits            | See [Reverse geocode a coordinate] section.    |
 | Static Map              | [Render]                                       |
 | Time Zone               | [Time Zone]                                    |
-| Elevation               | [Elevation]<sup>1</sup>                        |
-
-<sup>1</sup> Azure Maps [Elevation services](/rest/api/maps/elevation) have been [deprecated](https://azure.microsoft.com/updates/azure-maps-elevation-apis-and-render-v2-dem-tiles-will-be-retired-on-5-may-2023). For more information on how to include this functionality in your Azure Maps, see [Create elevation data & services](elevation-data-services.md).
 
 The following service APIs aren't currently available in Azure Maps:
 
@@ -507,7 +504,6 @@ Learn more about Azure Maps REST services:
 [Reverse geocode a coordinate]: #reverse-geocode-a-coordinate
 [Render]: /rest/api/maps/render/getmapimage
 [Time Zone]: /rest/api/maps/timezone
-[Elevation]: /rest/api/maps/elevation
 [Basic snap to road logic]: https://samples.azuremaps.com/?sample=basic-snap-to-road-logic
 [Spatial operations]: /rest/api/maps/spatial
 [Traffic]: /rest/api/maps/traffic

--- a/articles/azure-maps/migrate-from-google-maps.md
+++ b/articles/azure-maps/migrate-from-google-maps.md
@@ -46,7 +46,6 @@ The table provides a high-level list of Azure Maps features, which correspond to
 | REST Service APIs           | ✓                                      |
 | Directions (Routing)        | ✓                                      |
 | Distance Matrix             | ✓                                      |
-| Elevation                   | <sup>1</sup>                           |
 | Geocoding (Forward/Reverse) | ✓                                      |
 | Geolocation                 | ✓                                      |
 | Nearest Roads               | ✓                                      |
@@ -61,8 +60,6 @@ The table provides a high-level list of Azure Maps features, which correspond to
 | Time Zone                   | ✓                                      |
 | Maps Embedded API           | N/A                                    |
 | Map URLs                    | N/A                                    |
-
-<sup>1</sup> Azure Maps [Elevation services] have been [deprecated]. For more information how to include this functionality in your Azure Maps, see [Create elevation data & services].
 
 Google Maps provides basic key-based authentication. Azure Maps provides both basic key-based authentication and Azure Active Directory authentication. Azure Active Directory authentication provides more security features, compared to the basic key-based authentication.
 
@@ -150,8 +147,3 @@ Learn the details of how to migrate your Google Maps application with these arti
 [Azure Maps Q&A]: https://aka.ms/AzureMapsFeedback
 
 [Azure support options]: https://azure.microsoft.com/support/options
-
-<!---------------------------------------------------->
-[Elevation services]: /rest/api/maps/elevation
-[deprecated]: https://azure.microsoft.com/updates/azure-maps-elevation-apis-and-render-v2-dem-tiles-will-be-retired-on-5-may-2023
-[Create elevation data & services]: elevation-data-services.md


### PR DESCRIPTION
- Removed elevation service from the file migrate-from-bing-maps-web-services.md 
- Removed elevation service from the file migrate-from-bing-maps.md
- Removed elevation service from the file migrate-from-google-maps-web-app.md
- Removed elevation service from the file migrate-from-google-maps-web-services.md
- Removed elevation service from the file migrate-from-google-maps.md