### PR TITLE
consistent punctuation in functions-bindings-intro.md

### DIFF
--- a/includes/functions-bindings-intro.md
+++ b/includes/functions-bindings-intro.md
@@ -8,9 +8,9 @@ ms.author: glenga
 
 This is reference information for Azure Functions developers. If you're new to Azure Functions, start with the following resources:
 
-* [Azure Functions developer reference](../articles/azure-functions/functions-reference.md).
+* [Azure Functions developer reference](../articles/azure-functions/functions-reference.md)
 ::: zone pivot="programming-language-csharp"
-* [Create your first function](../articles/azure-functions/create-first-function-vs-code-csharp.md).
+* [Create your first function](../articles/azure-functions/create-first-function-vs-code-csharp.md)
 
 * C# developer references:
     * [In-process class library](../articles/azure-functions/functions-dotnet-class-library.md)
@@ -18,25 +18,25 @@ This is reference information for Azure Functions developers. If you're new to A
     * [C# script](../articles/azure-functions/functions-reference-csharp.md)
 ::: zone-end  
 ::: zone pivot="programming-language-javascript"  
-* [Create your first function](../articles/azure-functions/create-first-function-vs-code-node.md). 
+* [Create your first function](../articles/azure-functions/create-first-function-vs-code-node.md)
 
-* [JavaScript developer reference](../articles/azure-functions/functions-reference-node.md?tabs=javascript).
+* [JavaScript developer reference](../articles/azure-functions/functions-reference-node.md?tabs=javascript)
 ::: zone-end
 ::: zone pivot="programming-language-java"
-* [Create your first function](../articles/azure-functions/create-first-function-cli-java.md).
+* [Create your first function](../articles/azure-functions/create-first-function-cli-java.md)
 
-* [Java developer reference](../articles/azure-functions/functions-reference-java.md).
+* [Java developer reference](../articles/azure-functions/functions-reference-java.md)
 ::: zone-end  
 ::: zone pivot="programming-language-python"  
-* [Create your first function](../articles/azure-functions/create-first-function-vs-code-python.md).
+* [Create your first function](../articles/azure-functions/create-first-function-vs-code-python.md)
 
-* [Python developer reference](../articles/azure-functions/functions-reference-python.md).
+* [Python developer reference](../articles/azure-functions/functions-reference-python.md)
 ::: zone-end  
 ::: zone pivot="programming-language-powershell"
-* [Create your first function](../articles/azure-functions/create-first-function-vs-code-powershell.md).
+* [Create your first function](../articles/azure-functions/create-first-function-vs-code-powershell.md)
 
-* [PowerShell developer reference](../articles/azure-functions/functions-reference-powershell.md).
+* [PowerShell developer reference](../articles/azure-functions/functions-reference-powershell.md)
 ::: zone-end 
-* [Azure Functions triggers and bindings concepts](../articles/azure-functions/functions-triggers-bindings.md).
+* [Azure Functions triggers and bindings concepts](../articles/azure-functions/functions-triggers-bindings.md)
 
-* [Code and test Azure Functions locally](../articles/azure-functions/functions-develop-local.md).
+* [Code and test Azure Functions locally](../articles/azure-functions/functions-develop-local.md)

--- a/includes/functions-bindings-intro.md
+++ b/includes/functions-bindings-intro.md
@@ -8,7 +8,7 @@ ms.author: glenga
 
 This is reference information for Azure Functions developers. If you're new to Azure Functions, start with the following resources:
 
-* [Azure Functions developer reference.](../articles/azure-functions/functions-reference.md)
+* [Azure Functions developer reference](../articles/azure-functions/functions-reference.md).
 ::: zone pivot="programming-language-csharp"
 * [Create your first function](../articles/azure-functions/create-first-function-vs-code-csharp.md).
 
@@ -30,13 +30,13 @@ This is reference information for Azure Functions developers. If you're new to A
 ::: zone pivot="programming-language-python"  
 * [Create your first function](../articles/azure-functions/create-first-function-vs-code-python.md).
 
-* [Python developer reference](../articles/azure-functions/functions-reference-python.md)
+* [Python developer reference](../articles/azure-functions/functions-reference-python.md).
 ::: zone-end  
 ::: zone pivot="programming-language-powershell"
 * [Create your first function](../articles/azure-functions/create-first-function-vs-code-powershell.md).
 
-* [PowerShell developer reference](../articles/azure-functions/functions-reference-powershell.md)
+* [PowerShell developer reference](../articles/azure-functions/functions-reference-powershell.md).
 ::: zone-end 
-* [Azure Functions triggers and bindings concepts.](../articles/azure-functions/functions-triggers-bindings.md).
+* [Azure Functions triggers and bindings concepts](../articles/azure-functions/functions-triggers-bindings.md).
 
-* [Code and test Azure Functions locally.](../articles/azure-functions/functions-develop-local.md).
+* [Code and test Azure Functions locally](../articles/azure-functions/functions-develop-local.md).


### PR DESCRIPTION
Disclaimer: I am a Microsoft employee.



Noticed some duplicate punctuation while reading this doc: [Timer trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer).

![image](https://github.com/MicrosoftDocs/azure-docs/assets/130192961/b37c9e5e-d14d-4cfd-b409-8989bffa94ac)

The punctuation in this section was very inconsistent, so while I was here I edited it to use a single style ("no-punctuation-after-bullet-points"). Not sure what the MSFT style guide says, but I think this makes the most sense here.

## Changes
* remove duplicate punctuation
* make all punctuation in the snippet consistent by removing punctuation after bullet points