### PR TITLE
Update use-key-vault-references-spring-boot.md to add yaml configuration

### DIFF
--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -157,7 +157,27 @@ To add a secret to the vault, you need to take just a few additional steps. In t
 1. Create an environment variable called **APP_CONFIGURATION_ENDPOINT**. Set its value to the endpoint of your App Configuration store. You can find the endpoint on the **Access Keys** blade in the Azure portal. Restart the command prompt to allow the change to take effect.
 
 1. Open your configuration file in the *resources* folder. Update this file to use the **APP_CONFIGURATION_ENDPOINT** value. Remove any references to a connection string in this file.
-    #### [.properties](#tab/properties)
+### [yaml](#tab/yaml)
+
+    ```yaml
+    spring:
+      cloud:
+        azure:
+          appconfiguration:
+            stores:
+              - endpoint: ${APP_CONFIGURATION_ENDPOINT}
+    ```
+
+### [properties](#tab/properties)
+
+    ```properties
+    spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}
+    ```
+
+---
+
+> [!NOTE]
+> You can also use the [Spring Cloud Azure global configurations](../developer/java/spring-framework/authentication) to connect to Key Vault.
     ```properties
     spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}
     ```

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -156,12 +156,29 @@ To add a secret to the vault, you need to take just a few additional steps. In t
 
 1. Create an environment variable called **APP_CONFIGURATION_ENDPOINT**. Set its value to the endpoint of your App Configuration store. You can find the endpoint on the **Access Keys** blade in the Azure portal. Restart the command prompt to allow the change to take effect.
 
-1. Open *bootstrap.properties* in the *resources* folder. Update this file to use the **APP_CONFIGURATION_ENDPOINT** value. Remove any references to a connection string in this file.
-
+1. If your application is using a *bootstrap.properties*, open it in the *resources* folder. Update this file to use the **APP_CONFIGURATION_ENDPOINT** value. Remove any references to a connection string in this file.
+    #### [.properties](#tab/properties)
     ```properties
     spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}
     ```
-
+    If your application is using an *application.yaml* file in the *resources* folder. Add the following:
+    #### [.yaml](#tab/yaml)
+    ```yaml
+    spring:
+      cloud:
+        azure:
+          keyvault:
+            secret:
+              property-source-enabled: true
+              property-sources[0]:
+                credential:
+                  client-secret: "<<password returned from the creation of the service account>>"
+                  client-id: "<<appId returned from the creation of the service account>>"
+                profile:
+                  tenant-id: "<<tenant returned from the creation of the service account>>"
+                endpoint: "<<your key vault URI>>"
+    ```
+    
 1. Open *MessageProperties.java*. Add a new variable called *keyVaultMessage*:
 
     ```java

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -165,7 +165,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
         azure:
           appconfiguration:
             stores:
-              - endpoint: ${APP_CONFIGURATION_ENDPOINT}
+              endpoint: ${APP_CONFIGURATION_ENDPOINT}
     ```
 
     ### [properties](#tab/properties)

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -157,7 +157,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
 1. Create an environment variable called **APP_CONFIGURATION_ENDPOINT**. Set its value to the endpoint of your App Configuration store. You can find the endpoint on the **Access Keys** blade in the Azure portal. Restart the command prompt to allow the change to take effect.
 
 1. Open your configuration file in the *resources* folder. Update this file to use the **APP_CONFIGURATION_ENDPOINT** value. Remove any references to a connection string in this file.
-### [yaml](#tab/yaml)
+    ### [yaml](#tab/yaml)
 
     ```yaml
     spring:
@@ -168,37 +168,15 @@ To add a secret to the vault, you need to take just a few additional steps. In t
               - endpoint: ${APP_CONFIGURATION_ENDPOINT}
     ```
 
-### [properties](#tab/properties)
+    ### [properties](#tab/properties)
 
     ```properties
     spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}
     ```
-
----
 
 > [!NOTE]
 > You can also use the [Spring Cloud Azure global configurations](../developer/java/spring-framework/authentication) to connect to Key Vault.
-    ```properties
-    spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}
-    ```
-    If your application is using an *application.yaml* file, open it in the *resources* folder. Add the following to the file:
-    #### [.yaml](#tab/yaml)
-    ```yaml
-    spring:
-      cloud:
-        azure:
-          keyvault:
-            secret:
-              property-source-enabled: true
-              property-sources[0]:
-                credential:
-                  client-secret: "<<password returned from the creation of the service account>>"
-                  client-id: "<<appId returned from the creation of the service account>>"
-                profile:
-                  tenant-id: "<<tenant returned from the creation of the service account>>"
-                endpoint: "<<your key vault URI>>"
-    ```
-    
+
 1. Open *MessageProperties.java*. Add a new variable called *keyVaultMessage*:
 
     ```java

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -156,7 +156,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
 
 1. Create an environment variable called **APP_CONFIGURATION_ENDPOINT**. Set its value to the endpoint of your App Configuration store. You can find the endpoint on the **Access Keys** blade in the Azure portal. Restart the command prompt to allow the change to take effect.
 
-1. If your application is using a *bootstrap.properties*, open it in the *resources* folder. Update this file to use the **APP_CONFIGURATION_ENDPOINT** value. Remove any references to a connection string in this file.
+1. Open your configuration file in the *resources* folder. Update this file to use the **APP_CONFIGURATION_ENDPOINT** value. Remove any references to a connection string in this file.
     #### [.properties](#tab/properties)
     ```properties
     spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -161,7 +161,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
     ```properties
     spring.cloud.azure.appconfiguration.stores[0].endpoint= ${APP_CONFIGURATION_ENDPOINT}
     ```
-    If your application is using an *application.yaml* file in the *resources* folder. Add the following:
+    If your application is using an *application.yaml* file, open it in the *resources* folder. Add the following to the file:
     #### [.yaml](#tab/yaml)
     ```yaml
     spring:

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -175,7 +175,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
     ```
 
 > [!NOTE]
-> You can also use the [Spring Cloud Azure global configurations](./developer/java/spring-framework/authentication) to connect to Key Vault.
+> You can also use the [Spring Cloud Azure global configurations](https://learn.microsoft.com/azure/developer/java/spring-framework/authentication) to connect to Key Vault.
 
 1. Open *MessageProperties.java*. Add a new variable called *keyVaultMessage*:
 

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -175,7 +175,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
     ```
 
 > [!NOTE]
-> You can also use the [Spring Cloud Azure global configurations](../developer/java/spring-framework/authentication) to connect to Key Vault.
+> You can also use the [Spring Cloud Azure global configurations](./developer/java/spring-framework/authentication) to connect to Key Vault.
 
 1. Open *MessageProperties.java*. Add a new variable called *keyVaultMessage*:
 

--- a/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
+++ b/articles/azure-app-configuration/use-key-vault-references-spring-boot.md
@@ -175,7 +175,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
     ```
 
 > [!NOTE]
-> You can also use the [Spring Cloud Azure global configurations](https://learn.microsoft.com/azure/developer/java/spring-framework/authentication) to connect to Key Vault.
+> You can also use the [Spring Cloud Azure global configurations](/azure/developer/java/spring-framework/authentication) to connect to Key Vault.
 
 1. Open *MessageProperties.java*. Add a new variable called *keyVaultMessage*:
 


### PR DESCRIPTION
Hello,

I would like to submit this PR to contribute to the use-key-vault-references-spring-boot.md which is the documentation for using Azure Key Vault in a springboot application. I noticed that in the section Update your code to use a Key Vault reference, code snipet only for .properties file is provided.

I have suggested in the feedback https://github.com/MicrosoftDocs/azure-docs/issues/106155 if we could have a snippet for yaml as well. As per the comment of @mrm9084 , it would be good to have it.

In this PR, I have added the code snippet to the second sub-section of the section "Update your code to use a Key Vault reference". I also have modified this sub-section to clearly specify which one is the .properties configuration and which on is the .yaml. I think this will be helpful as many people are now using .yaml in springboot.

I hope this addition is useful and informative for your users. Please let me know if there are any changes you would like me to make or if you have any feedback.

Thank you for your time and consideration.