### PR TITLE
Update cache-how-to-premium-persistence.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -97,7 +97,7 @@ On the **Enterprise** and **Enterprise Flash** tiers, data is persisted to a man
     The first backup starts once the backup frequency interval elapses.
   
    > [!NOTE]
-   > When RDB files are backed up to storage, they are stored in the form of page blobs. If you are using storage account with HNS Enabled, persistence will tend to fail as page blobs aren't supported in Storage accounts with HNS enabled (ADLS Gen2) 
+   > When RDB files are backed up to storage, they are stored in the form of page blobs. If you're using a storage account with HNS enabled, persistence will tend to fail because page blobs aren't supported in storage accounts with HNS enabled (ADLS Gen2). 
   
 9. To enable AOF persistence, select **AOF** and configure the settings.
 

--- a/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
+++ b/articles/azure-cache-for-redis/cache-how-to-premium-persistence.md
@@ -97,7 +97,7 @@ On the **Enterprise** and **Enterprise Flash** tiers, data is persisted to a man
     The first backup starts once the backup frequency interval elapses.
   
    > [!NOTE]
-   > When RDB files are backed up to storage, they are stored in the form of page blobs.
+   > When RDB files are backed up to storage, they are stored in the form of page blobs. If you are using storage account with HNS Enabled, persistence will tend to fail as page blobs aren't supported in Storage accounts with HNS enabled (ADLS Gen2) 
   
 9. To enable AOF persistence, select **AOF** and configure the settings.
 


### PR DESCRIPTION
If you are using storage account with HNS Enabled, persistence will tend to fail as page blobs aren't supported in Storage accounts with HNS enabled (ADLS Gen2). At times customers tend to use ADLS Gen2 account for configuration and then don't see backup happening.