### PR TITLE
Bug with R SDK, not generating conda for trained R models

### DIFF
--- a/articles/machine-learning/how-to-r-train-model.md
+++ b/articles/machine-learning/how-to-r-train-model.md
@@ -154,7 +154,7 @@ Once you've submitted the job, you can check the status and results in studio:
 Finally, once the training job is complete, register your model if you want to deploy it.  Start in the studio from the page showing your job details.
 
 1. On the toolbar at the top, select **+ Register model**.
-1. Select **MLflow** for the **Model type**.
+1. Select **Unspecified type** for the **Model type**.
 1. Select the folder which contains the model.
 1. Select **Next**.
 1. Supply the name you wish to use for your model.  Add **Description**, **Version**, and **Tags** if you wish.


### PR DESCRIPTION
At the moment, R SDK doesn't generate conda YAML file and that's why registration of trained R model as "MLFlow" one fails.

Recommendation is to change the model type to "Unspecified" for now and switch it to "MLFlow" only when SDK team will enable additional functionality. Please, refer to internal ICM # 388306942 for some further details. Thank you.