### PR TITLE
Update how-to-connect-sync-staging-server.md

### DIFF
--- a/articles/active-directory/hybrid/connect/how-to-connect-sync-staging-server.md
+++ b/articles/active-directory/hybrid/connect/how-to-connect-sync-staging-server.md
@@ -143,7 +143,7 @@ When this is completed, you will be prompted with a screen that confirms Staging
 You can click Exit to finish this.
 
 6. You can confirm that the server is successfully in Staging Mode by opening the Synchronization Service console.  
-From here, there should be no more Export jobs since the change and Full & Delta Imports will be suffixed with "(Stage Only)" like below:  
+From here, there should be no more Export jobs since the change like below:  
 
    > [!div class="mx-imgBorder"]
    > ![Screenshot shows Sync Service console on the Active Azure AD Connect dialog box.](media/how-to-connect-sync-staging-server/active-server-sync-server-mgmr.png)


### PR DESCRIPTION
removed misleading information for delta and full import run profiles, where the suffix: "(stage only)" should refer to staging mode of the server, what is basically not true.