### PR TITLE
Update end-to-end-tls.md

### DIFF
--- a/articles/frontdoor/end-to-end-tls.md
+++ b/articles/frontdoor/end-to-end-tls.md
@@ -95,7 +95,7 @@ For the Azure Front Door managed certificate option, the certificates are manage
 
 For your own custom TLS/SSL certificate:
 
-1. You set the secret version to 'Latest' for the certificate to be automatically rotated to the latest version when a newer version of the certificate is available in your key vault. For custom certificates, the certificate gets auto-rotated within 1-2 days with a newer version of certificate, no matter what the certificate expired time is.
+1. You set the secret version to 'Latest' for the certificate to be automatically rotated to the latest version when a newer version of the certificate is available in your key vault. For custom certificates, the certificate gets auto-rotated within 3-4 days with a newer version of certificate, no matter what the certificate expired time is.
 
 1. If a specific version is selected, autorotation isn’t supported. You've will have to reselect the new version manually to rotate certificate. It takes up to 24 hours for the new version of the certificate/secret to be deployed.
 


### PR DESCRIPTION
In Azure Front Door classic, we have observed after troubleshooting a case that the new certificate version is not updated every 1-2 days, instead it occurs every 3-4 days.