### PR TITLE
Update limits of App Gateway

### DIFF
--- a/articles/application-gateway/application-gateway-faq.yml
+++ b/articles/application-gateway/application-gateway-faq.yml
@@ -402,7 +402,7 @@ sections:
         answer: |
           Yes, the Application Gateway v2 SKU supports Key Vault. For more information, see [TLS termination with Key Vault certificates](key-vault-certs.md).
           
-      - question: How do I configure HTTPS listeners for .com and .NET sites? 
+      - question: How do I configure HTTPS listeners for .com and .net sites? 
         answer: |
           For multiple domain-based (host-based) routing, you can create multisite listeners, set up listeners that use HTTPS as the protocol, and associate the listeners with the routing rules. For more information, see [Hosting multiple sites by using Application Gateway](./multiple-site-overview.md).
           

--- a/includes/application-gateway-limits.md
+++ b/includes/application-gateway-limits.md
@@ -26,6 +26,7 @@ ms.author: greglin
 | Request timeout maximum to external backend |4 minutes | |
 | Number of sites |100<sup>1</sup> |1 per HTTP listener |
 | URL maps per listener |1 | |
+| Host names per listener |5 | |
 | Maximum path-based rules per URL map|100||
 | Redirect configurations |100<sup>1</sup>| |
 | Number of rewrite rule sets |400| |


### PR DESCRIPTION
Also:
- Lowercase ".NET" to avoid confusion with the framework and have consistency with `.com`.