### PR TITLE
GPU multi instance doc update

### DIFF
--- a/articles/aks/gpu-multi-instance.md
+++ b/articles/aks/gpu-multi-instance.md
@@ -14,7 +14,7 @@ This article will walk you through how to create a multi-instance GPU node pool 
 
 ## GPU Instance Profile 
 
-GPU Instance Profiles define how a GPU will be partitioned. The following table shows the available GPU Instance Profile for the `Standard_ND96asr_v4`, the only instance type that supports the A100 GPU at this time.
+GPU Instance Profiles define how a GPU will be partitioned. The following table shows the available GPU Instance Profile for the `Standard_ND96asr_v4`
 
 
 | Profile Name | Fraction of SM |Fraction of Memory  | Number of Instances created |
@@ -146,34 +146,106 @@ kubectl describe node mignode
 ```
 If you're using single strategy, you'll see:
 ```
-Allocable:
+Allocatable:
     nvidia.com/gpu: 56
 ```
 If you're using mixed strategy, you'll see:
 ```
-Allocable:
+Allocatable:
     nvidia.com/mig-1g.5gb: 56
 ```
 
 ### Schedule work
-Use the `kubectl` run command to schedule work using single strategy:
-```
-kubectl run -it --rm \
---image=nvidia/cuda:11.0-base \
---restart=Never \
---limits=nvidia.com/gpu=1 \
-single-strategy-example -- nvidia-smi -L
-```
 
-Use the `kubectl` run command to schedule work using mixed strategy:
-```
-kubectl run -it --rm \
---image=nvidia/cuda:11.0-base \
---restart=Never \
---limits=nvidia.com/mig-1g.5gb=1 \
-mixed-strategy-example -- nvidia-smi -L
-```
+The following examples are based on cuda base image version 12.1.1 for Ubuntu22.04, tagged as `12.1.1-base-ubuntu22.04`.
 
+- Single strategy
+
+1. Create a file named `single-strategy-example.yaml` and copy in the following manifest.
+
+    ```yaml 
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nvidia-single
+    spec:
+      containers:
+      - name: nvidia-single
+        image: nvidia/cuda:12.1.1-base-ubuntu22.04
+        command: ["/bin/sh"]
+        args: ["-c","sleep 1000"]
+        resources:
+          limits:
+            "nvidia.com/gpu": 1
+    ```
+
+2. Deploy the application using the [`kubectl apply`][kubectl-apply] command and specify the name of your YAML manifest.
+
+    ```
+    kubectl apply -f single-strategy-example.yaml
+    ```
+    
+3. Verify the allocated GPU devices using the [`kubectl exec`][kubectl-exec] command. This command returns a list of the cluster nodes.
+
+    ```
+    kubectl exec nvidia-single -- nvidia-smi -L
+    ```
+
+    The following example resembles output showing successfully created deployments and services.
+
+    ```output
+    GPU 0: NVIDIA A100 40GB PCIe (UUID: GPU-48aeb943-9458-4282-da24-e5f49e0db44b)
+    MIG 1g.5gb     Device  0: (UUID: MIG-fb42055e-9e53-5764-9278-438605a3014c)
+    MIG 1g.5gb     Device  1: (UUID: MIG-3d4db13e-c42d-5555-98f4-8b50389791bc)
+    MIG 1g.5gb     Device  2: (UUID: MIG-de819d17-9382-56a2-b9ca-aec36c88014f)
+    MIG 1g.5gb     Device  3: (UUID: MIG-50ab4b32-92db-5567-bf6d-fac646fe29f2)
+    MIG 1g.5gb     Device  4: (UUID: MIG-7b6b1b6e-5101-58a4-b5f5-21563789e62e)
+    MIG 1g.5gb     Device  5: (UUID: MIG-14549027-dd49-5cc0-bca4-55e67011bd85)
+    MIG 1g.5gb     Device  6: (UUID: MIG-37e055e8-8890-567f-a646-ebf9fde3ce7a)
+    ```
+
+- Mixed mode strategy
+
+1. Create a file named `mixed-strategy-example.yaml` and copy in the following manifest.
+
+    ```yaml
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nvidia-mixed
+    spec:
+      containers:
+      - name: nvidia-mixed
+        image: nvidia/cuda:12.1.1-base-ubuntu22.04
+        command: ["/bin/sh"]
+        args: ["-c","sleep 100"]
+        resources:
+          limits:
+            "nvidia.com/mig-1g.5gb": 1
+    ```
+
+2. Deploy the application using the [`kubectl apply`][kubectl-apply] command and specify the name of your YAML manifest.
+
+    ```
+    kubectl apply -f mixed-strategy-example.yaml
+    ```
+    
+3. Verify the allocated GPU devices using the [`kubectl exec`][kubectl-exec] command. This command returns a list of the cluster nodes.
+
+    ```
+    kubectl exec nvidia-mixed -- nvidia-smi -L
+    ```
+
+    The following example resembles output showing successfully created deployments and services.
+
+    ```output
+    GPU 0: NVIDIA A100 40GB PCIe (UUID: GPU-48aeb943-9458-4282-da24-e5f49e0db44b)
+    MIG 1g.5gb     Device  0: (UUID: MIG-fb42055e-9e53-5764-9278-438605a3014c)
+    ```
+
+> [!IMPORTANT]
+> The "latest" tag for CUDA images has been deprecated on Docker Hub.
+> Please refer to [NVIDIA's repository](https://hub.docker.com/r/nvidia/cuda/tags) for the latest images and corresponding tags
 
 ## Troubleshooting
 - If you do not see multi-instance GPU capability after the node pool has been created, confirm the API version is not older than 2021-08-01.

--- a/articles/aks/gpu-multi-instance.md
+++ b/articles/aks/gpu-multi-instance.md
@@ -179,13 +179,13 @@ The following examples are based on cuda base image version 12.1.1 for Ubuntu22.
             "nvidia.com/gpu": 1
     ```
 
-2. Deploy the application using the [`kubectl apply`][kubectl-apply] command and specify the name of your YAML manifest.
+2. Deploy the application using the `kubectl apply` command and specify the name of your YAML manifest.
 
     ```
     kubectl apply -f single-strategy-example.yaml
     ```
     
-3. Verify the allocated GPU devices using the [`kubectl exec`][kubectl-exec] command. This command returns a list of the cluster nodes.
+3. Verify the allocated GPU devices using the `kubectl exec` command. This command returns a list of the cluster nodes.
 
     ```
     kubectl exec nvidia-single -- nvidia-smi -L
@@ -224,13 +224,13 @@ The following examples are based on cuda base image version 12.1.1 for Ubuntu22.
             "nvidia.com/mig-1g.5gb": 1
     ```
 
-2. Deploy the application using the [`kubectl apply`][kubectl-apply] command and specify the name of your YAML manifest.
+2. Deploy the application using the `kubectl apply` command and specify the name of your YAML manifest.
 
     ```
     kubectl apply -f mixed-strategy-example.yaml
     ```
     
-3. Verify the allocated GPU devices using the [`kubectl exec`][kubectl-exec] command. This command returns a list of the cluster nodes.
+3. Verify the allocated GPU devices using the `kubectl exec` command. This command returns a list of the cluster nodes.
 
     ```
     kubectl exec nvidia-mixed -- nvidia-smi -L


### PR DESCRIPTION
1. Removed reference to ND96asr_v4 being the only SKU supporting A100 GPU. NC_A100_v4/NDm_A100_v4 series are also eligible.

2. Fixed typo under Confirm multi-instance GPU capability referencing "Allocable" (should be "Allocatable")

3. Reworked the schedule work section

3.1 kubectl --limits flag has been deprecated and no longer works. --override flags can be used as an alternative, but results were inconsistent with kubectl run.

3.1.2 Changed the scheduling work strategy to deployment manifests w/ execution command + output for a consistent experience.

3.2 Added a reference to nvidia's deprecating the latest tag on their docker repo - pulling a base image of nvidia/cuda will not work. The full tag needs to be used