### PR TITLE
Update network-file-system-protocol-known-issues.md

### DIFF
--- a/articles/storage/blobs/network-file-system-protocol-known-issues.md
+++ b/articles/storage/blobs/network-file-system-protocol-known-issues.md
@@ -58,6 +58,10 @@ To see how each Blob Storage feature is supported in accounts that have NFS 3.0 
 > [!NOTE]
 > Static websites is an example of a partially supported feature because the configuration page for static websites does not yet appear in the Azure portal for accounts that have NFS 3.0 support enabled. You can enable static websites only by using PowerShell or Azure CLI.
 
+## Blob Storage Events
+
+Storage Events aren't supported for NFS specific operations. However, if you are performing Blob or Datalake storage operations on NFS enabled account, then the events shall get created based on the API being called.
+
 ## See also
 
 - [Network File System (NFS) 3.0 protocol support for Azure Blob Storage](network-file-system-protocol-support.md)

--- a/articles/storage/blobs/network-file-system-protocol-known-issues.md
+++ b/articles/storage/blobs/network-file-system-protocol-known-issues.md
@@ -58,9 +58,11 @@ To see how each Blob Storage feature is supported in accounts that have NFS 3.0 
 > [!NOTE]
 > Static websites is an example of a partially supported feature because the configuration page for static websites does not yet appear in the Azure portal for accounts that have NFS 3.0 support enabled. You can enable static websites only by using PowerShell or Azure CLI.
 
-## Blob Storage Events
+## Blob Storage events
 
-Storage Events aren't supported for NFS specific operations. However, if you are performing Blob or Datalake storage operations on NFS enabled account, then the events shall get created based on the API being called.
+The names of NFS operations don't appear in resource logs or in responses returned by the Event Grid. Only block blob operations appear. When your application makes a request by using the NFS 3.0 protocol, that request is translated into combination of block blob operations. For example, NFS 3.0 read Remote Procedure Call (RPC) requests are translated into Get Blob operation. NFS 3.0 write RPC requests are translated into a combination of Get Block List, Put Block, and Put Block List.
+
+Storage Events aren't supported for NFS specific operations. However, if you are performing blob or data lake storage operations on NFS enabled account, then the events shall get created based on the API being called.
 
 ## See also
 


### PR DESCRIPTION
Storage Events aren't supported for NFS specific operations. However, if you are performing Blob or Datalake storage operations on NFS enabled account, then the events shall get created based on the API being called.

We had a case wherein customer had concerns regarding clarity in the documentation. 

In the below link we although we have specified events aren't supported for NFS however if due to interoperability we call operation such as Put Blob, event will get generated for the same.

Hence added this section as a feedback for clarity

Please Review
https://learn.microsoft.com/en-us/azure/storage/blobs/storage-feature-support-in-storage-accounts