### PR TITLE
Fix broken link and az cli query in firewall documentation

### DIFF
--- a/articles/firewall/protect-azure-kubernetes-service.md
+++ b/articles/firewall/protect-azure-kubernetes-service.md
@@ -252,7 +252,7 @@ CURRENT_IP=$(dig @resolver1.opendns.com ANY myip.opendns.com +short)
 az aks update -g $RG -n $AKSNAME --api-server-authorized-ip-ranges $CURRENT_IP/32
 ```
 
-Use the [az aks get-credentials](https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-get-credentials) command to configure `kubectl` to connect to your newly created Kubernetes cluster.
+Use the [az aks get-credentials](https://learn.microsoft.com/cli/azure/aks#az-aks-get-credentials) command to configure `kubectl` to connect to your newly created Kubernetes cluster.
 
 ```azurecli
 az aks get-credentials -g $RG -n $AKSNAME

--- a/articles/firewall/protect-azure-kubernetes-service.md
+++ b/articles/firewall/protect-azure-kubernetes-service.md
@@ -252,7 +252,7 @@ CURRENT_IP=$(dig @resolver1.opendns.com ANY myip.opendns.com +short)
 az aks update -g $RG -n $AKSNAME --api-server-authorized-ip-ranges $CURRENT_IP/32
 ```
 
-Use the [az aks get-credentials](https://learn.microsoft.com/cli/azure/aks#az-aks-get-credentials) command to configure `kubectl` to connect to your newly created Kubernetes cluster.
+Use the [az aks get-credentials](/cli/azure/aks#az-aks-get-credentials) command to configure `kubectl` to connect to your newly created Kubernetes cluster.
 
 ```azurecli
 az aks get-credentials -g $RG -n $AKSNAME

--- a/articles/firewall/protect-azure-kubernetes-service.md
+++ b/articles/firewall/protect-azure-kubernetes-service.md
@@ -144,7 +144,7 @@ When the previous command has succeeded, save the firewall frontend IP address f
 # Capture Firewall IP Address for Later Use
 
 FWPUBLIC_IP=$(az network public-ip show -g $RG -n $FWPUBLICIP_NAME --query "ipAddress" -o tsv)
-FWPRIVATE_IP=$(az network firewall show -g $RG -n $FWNAME --query "ipConfigurations[0].privateIpAddress" -o tsv)
+FWPRIVATE_IP=$(az network firewall show -g $RG -n $FWNAME --query "ipConfigurations[0].privateIPAddress" -o tsv)
 ```
 
 > [!NOTE]

--- a/articles/firewall/protect-azure-kubernetes-service.md
+++ b/articles/firewall/protect-azure-kubernetes-service.md
@@ -252,7 +252,7 @@ CURRENT_IP=$(dig @resolver1.opendns.com ANY myip.opendns.com +short)
 az aks update -g $RG -n $AKSNAME --api-server-authorized-ip-ranges $CURRENT_IP/32
 ```
 
-Use the [az aks get-credentials][az-aks-get-credentials] command to configure `kubectl` to connect to your newly created Kubernetes cluster.
+Use the [az aks get-credentials](https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-get-credentials) command to configure `kubectl` to connect to your newly created Kubernetes cluster.
 
 ```azurecli
 az aks get-credentials -g $RG -n $AKSNAME


### PR DESCRIPTION
1. The `az aks get-credentials` line had a broken link that led nowhere. I changed it to refer to the latest version of the `az aks get-credentials` command in the cli reference.

2. The portion of the script that was supposed to get the private IP for the firewall had a lowercase `P` in the query, but the actual field is `privateIPAddress`, with a capital `P`.