### PR TITLE
Update how-to-manage-models-mlflow.md: Python fix

### DIFF
--- a/articles/machine-learning/how-to-manage-models-mlflow.md
+++ b/articles/machine-learning/how-to-manage-models-mlflow.md
@@ -24,7 +24,7 @@ Azure Machine Learning supports MLflow for model management. Such approach repre
 * Some operations may be executed directly using the MLflow fluent API (`mlflow.<method>`). However, others may require to create an MLflow client, which allows to communicate with Azure Machine Learning in the MLflow protocol. You can create an `MlflowClient` object as follows. This tutorial uses the object `client` to refer to such MLflow client.
 
     ```python
-    using mlflow
+    import mlflow
 
     client = mlflow.tracking.MlflowClient()
     ```


### PR DESCRIPTION
s/using mlflow/import mlflow/

The command to import a module is "import" not "using"