### PR TITLE
Update FormatLocalizedString limits wording

### DIFF
--- a/articles/active-directory-b2c/string-transformations.md
+++ b/articles/active-directory-b2c/string-transformations.md
@@ -408,7 +408,7 @@ Formats multiple claims according to a provided localized format string. This tr
 | OutputClaim | outputClaim | string | The claim that is produced after this claims transformation has been invoked. |
 
 > [!NOTE]
-> There are no limits to the number of input claims that can be specified, but the maximum length of the formated string is 4000.
+> There is no limit to the number of input claims that you can specify, but the maximum length of the formatted string is 4000.
 
 To use the FormatLocalizedString claims transformation:
 

--- a/articles/active-directory-b2c/string-transformations.md
+++ b/articles/active-directory-b2c/string-transformations.md
@@ -408,7 +408,7 @@ Formats multiple claims according to a provided localized format string. This tr
 | OutputClaim | outputClaim | string | The claim that is produced after this claims transformation has been invoked. |
 
 > [!NOTE]
-> String format maximum allowed size is 4000.
+> There are no limits to the number of input claims that can be specified, but the maximum length of the formated string is 4000.
 
 To use the FormatLocalizedString claims transformation:
 


### PR DESCRIPTION
Clarified there are no limits on the number of input claims for `FormatLocalizedString`. 

I have tested this to 101 claims, so there appears to be no practical limit.