### PR TITLE
Utilize KMSI when performing SSO between MSAL and Safari 

### DIFF
--- a/articles/active-directory/develop/single-sign-on-macos-ios.md
+++ b/articles/active-directory/develop/single-sign-on-macos-ios.md
@@ -35,6 +35,9 @@ If you use the default web view in your app to sign in users, you'll get automat
 
 This type of SSO is currently not available on macOS. MSAL on macOS only supports WKWebView which doesn't have SSO support with Safari.
 
+> [!NOTE]
+> KMSI must be enabled and selected on Azure B2C policies in order for SSO to work correctly. 
+
 - **Silent SSO between ADAL and MSAL macOS/iOS apps**
 
 MSAL Objective-C support migration and SSO with ADAL Objective-C-based apps. The apps must be distributed by the same Apple Developer.

--- a/articles/active-directory/develop/single-sign-on-macos-ios.md
+++ b/articles/active-directory/develop/single-sign-on-macos-ios.md
@@ -36,7 +36,7 @@ If you use the default web view in your app to sign in users, you'll get automat
 This type of SSO is currently not available on macOS. MSAL on macOS only supports WKWebView which doesn't have SSO support with Safari.
 
 > [!NOTE]
-> KMSI must be enabled and selected on Azure B2C policies in order for SSO to work correctly. 
+> iOS clears session cookies right away after login due to the use of temporary browser to perform login. This browser does not share any of the session cookies. To make SSO work on iOS, KMSI must be enabled to utilize persistent cookies. 
 
 - **Silent SSO between ADAL and MSAL macOS/iOS apps**
 


### PR DESCRIPTION
Added note to document the use of KMSI to perform SSO when using MSAL and Safari 