### PR TITLE
Update install-office-on-wvd-master-image.md

### DIFF
--- a/articles/virtual-desktop/install-office-on-wvd-master-image.md
+++ b/articles/virtual-desktop/install-office-on-wvd-master-image.md
@@ -128,7 +128,7 @@ Here's how to install OneDrive in per-machine mode:
 5. Run this command to install OneDrive in per-machine mode:
 
     ```cmd
-    Run "[staged location]\OneDriveSetup.exe" /allusers
+    "[staged location]\OneDriveSetup.exe" /allusers
     ```
 
 6. Run this command to configure OneDrive to start at sign in for all users:


### PR DESCRIPTION
Replace (starting at line 128)

5. Run this command to install OneDrive in per-machine mode:

    ```cmd
    run "[staged location]\OneDriveSetup.exe" /allusers
    ```

with

5. Run this command to install OneDrive in per-machine mode:

    ```cmd
    "[staged location]\OneDriveSetup.exe" /allusers
    ```

Reason:
Using previous version causes "'Run' is not recognized as an internal or external command, operable program or batch file." error in windows Terminal, with a similar error in Powershell.