### PR TITLE
removing the statement that dedicated outbound ip address have been removed

### DIFF
--- a/articles/openshift/concepts-networking.md
+++ b/articles/openshift/concepts-networking.md
@@ -117,7 +117,6 @@ With the support of OpenShift 4.5, Azure Red Hat OpenShift introduced a few sign
 As included in the diagram above, you'll notice a few changes:
 
 * Previously, Azure Red Hat OpenShift used two public LoadBalancers: one for the API server and one for the worker node pool. With this architecture update, the two public LoadBalancers have been consolidated under a single LoadBalancer. 
-* To reduce complexity, the dedicated outbound IP address resources have been removed.
 * The ARO control plane now shares the same network security group as the ARO worker nodes.
 
 For more information on OpenShift 4.5 and later, check out the [OpenShift 4.5 release notes](https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html).


### PR DESCRIPTION
This architecture https://learn.microsoft.com/en-us/azure/openshift/concepts-networking#whats-new-starting-with-openshift-45 causes the impression that after version 4.5 the public-ip from the API Server internal load balancer was removed. It says "to reduce complexity, the dedicated outbound IP address resources have been removed"

But this is true only if you register for the preview feature of UDRs: https://learn.microsoft.com/en-us/azure/openshift/howto-create-private-cluster-4x#create-a-private-cluster-without-a-public-ip-address-preview

That said, if you don't register for this feature, the cluster will be created with 2 public ip's, so it's incorrect to say that after 4.5 was removed.

Also, it would be nice to remove the reference to 4.5 and what things looked like before 4.5 since the release date of Openshift 4.5 was July 16th 2020. It causes a lot of confusion when customer ask difference between 4 and 4.5 and we are on 4.10/11.