### PR TITLE
AKS still doesn't support AutoML jobs

### DIFF
--- a/includes/aml-compute-target-train.md
+++ b/includes/aml-compute-target-train.md
@@ -20,7 +20,7 @@ You can use any of the following resources for a training compute target for mos
 |[Local computer](../articles/machine-learning/v1/how-to-attach-compute-targets.md#local-computer)| Yes | &nbsp; | &nbsp; |
 |[Azure Machine Learning compute cluster](../articles/machine-learning/how-to-create-attach-compute-cluster.md)| Yes | Yes | Yes |
 |[Azure Machine Learning compute instance](../articles/machine-learning/how-to-create-manage-compute-instance.md) | Yes (through SDK)  | Yes | Yes |
-|[Azure Machine Learning Kubernetes](../articles/machine-learning/how-to-attach-kubernetes-anywhere.md) | &nbsp; | Yes | Yes |
+|[Azure Machine Learning Kubernetes](../articles/machine-learning/how-to-attach-kubernetes-anywhere.md) | | Yes | Yes |
 |[Remote VM](../articles/machine-learning/v1/how-to-attach-compute-targets.md#remote-virtual-machines) | Yes  | Yes | &nbsp; |
 |[Apache Spark pools (preview)](../articles/machine-learning/how-to-attach-compute-targets.md#apache-spark-pools)| Yes (SDK local mode only) | Yes | &nbsp; |
 |[Azure&nbsp;Databricks](../articles/machine-learning/v1/how-to-attach-compute-targets.md#azure-databricks)| Yes (SDK local mode only) | Yes | &nbsp; |

--- a/includes/aml-compute-target-train.md
+++ b/includes/aml-compute-target-train.md
@@ -20,7 +20,7 @@ You can use any of the following resources for a training compute target for mos
 |[Local computer](../articles/machine-learning/v1/how-to-attach-compute-targets.md#local-computer)| Yes | &nbsp; | &nbsp; |
 |[Azure Machine Learning compute cluster](../articles/machine-learning/how-to-create-attach-compute-cluster.md)| Yes | Yes | Yes |
 |[Azure Machine Learning compute instance](../articles/machine-learning/how-to-create-manage-compute-instance.md) | Yes (through SDK)  | Yes | Yes |
-|[Azure Machine Learning Kubernetes](../articles/machine-learning/how-to-attach-kubernetes-anywhere.md) | Yes | Yes | Yes |
+|[Azure Machine Learning Kubernetes](../articles/machine-learning/how-to-attach-kubernetes-anywhere.md) | &nbsp; | Yes | Yes |
 |[Remote VM](../articles/machine-learning/v1/how-to-attach-compute-targets.md#remote-virtual-machines) | Yes  | Yes | &nbsp; |
 |[Apache Spark pools (preview)](../articles/machine-learning/how-to-attach-compute-targets.md#apache-spark-pools)| Yes (SDK local mode only) | Yes | &nbsp; |
 |[Azure&nbsp;Databricks](../articles/machine-learning/v1/how-to-attach-compute-targets.md#azure-databricks)| Yes (SDK local mode only) | Yes | &nbsp; |


### PR DESCRIPTION
As confirmed by BK in the internal AVA, AKS currently doesn't support AutoML jobs.

This part of documentation is not correct and conflicts with this correct statement (https://learn.microsoft.com/en-gb/azure/machine-learning/how-to-configure-auto-train?view=azureml-api-2#compute-to-run-experiment), which indicates that only compute instances and compute clusters can be used in SDK v2 and CLI v2 for AutoML.

In the same way, when I open AutoML in portal UI, it doesn't show Kubernetes as supported "compute type". Thanks.