### PR TITLE
Update autoscale-predictive.md

### DIFF
--- a/articles/azure-monitor/autoscale/autoscale-predictive.md
+++ b/articles/azure-monitor/autoscale/autoscale-predictive.md
@@ -168,7 +168,7 @@ PS G:\works\kusto_onboard\test_arm_template> new-azurermresourcegroupdeployment 
 	"resources": [{
 			"type": "Microsoft.Insights/autoscalesettings",
 			"name": "cpuPredictiveAutoscale",
-			"apiVersion": "2015-04-01",
+			"apiVersion": "2022-10-01",
 			"location": "[parameters('location')]",
 			"properties": {
 				"profiles": [{
@@ -243,7 +243,7 @@ PS G:\works\kusto_onboard\test_arm_template> new-azurermresourcegroupdeployment 
 }
 ```
 
-**autoscale-only-parameters.json**
+**autoscale_only_parameters.json**
 ```json
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",


### PR DESCRIPTION
fix API version as the [`predictiveAutoscalePolicy`](https://github.com/Azure/azure-rest-api-specs/blob/2455fb21a4bd29399209b0c8583edf1f39cdb35d/specification/monitor/resource-manager/Microsoft.Insights/stable/2022-10-01/autoscale_API.json#L684) property is only available in 2022-10-01.

fix the filename to align with command line:
https://github.com/MicrosoftDocs/azure-docs/blob/0efa28d3509064cbbfc7783e14aa96304ce0fa2f/articles/azure-monitor/autoscale/autoscale-predictive.md?plain=1#L77-L79