### PR TITLE
Update models.md to include correct dimension length for embedding ve…

### DIFF
--- a/articles/cognitive-services/openai/concepts/models.md
+++ b/articles/cognitive-services/openai/concepts/models.md
@@ -140,10 +140,13 @@ Currently, we offer three families of Embeddings models for different functional
 
 Each family includes models across a range of capability. The following list indicates the length of the numerical vector returned by the service, based on model capability:
 
-- Ada: 1024 dimensions
-- Babbage: 2048 dimensions
-- Curie: 4096 dimensions
-- Davinci: 12288 dimensions
+|  Base Model  |  Model(s)  |  Dimensions  |
+|---|---|---|
+| Ada | \*-001 (Version 1) | 1024 |
+| Ada | text-embedding-ada-002 (version 2) | 1536 |
+| Babbage |  | 2048 |
+| Curie |  | 4096 |
+| Davinci |  | 12288 |
 
 Davinci is the most capable, but is slower and more expensive than the other models. Ada is the least capable, but is both faster and cheaper.
 


### PR DESCRIPTION
…rsion 2 model

According to https://help.openai.com/en/articles/7437458-embeddings and my own local testing, the output dimensions for the text-embedding-ada-002 model is 1536 but this was not previously documented and it listed all of Ada models as having a dimension value of 1024.