### PR TITLE
Update how-to-track-experiments.md :: Replace external joblib

### DIFF
--- a/articles/machine-learning/data-science-virtual-machine/how-to-track-experiments.md
+++ b/articles/machine-learning/data-science-virtual-machine/how-to-track-experiments.md
@@ -62,7 +62,7 @@ from sklearn.datasets import load_diabetes
 from sklearn.linear_model import Ridge
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import train_test_split
-from sklearn.externals import joblib
+import joblib
 
 X, y = load_diabetes(return_X_y = True)
 columns = ['age', 'gender', 'bmi', 'bp', 's1', 's2', 's3', 's4', 's5', 's6']


### PR DESCRIPTION
Replace sklearn.externals.joblib deprecated in 0.21 --> use joblib directly as recommended by sklearn https://scikit-learn.org/stable/model_persistence.html