### PR TITLE
Update active-directory-develop-quickstart-register-app.md

### DIFF
--- a/includes/active-directory-develop-quickstart-register-app.md
+++ b/includes/active-directory-develop-quickstart-register-app.md
@@ -137,8 +137,8 @@ Client secrets are considered less secure than certificate credentials. Applicat
 
 For application security recommendations, see [Microsoft identity platform best practices and recommendations](../articles/active-directory/develop/identity-platform-integration-checklist.md#security).
 
-If you are using an Azure DevOps service connection that automatically creates a service principal, you need to update the client secret from the Azure DevOps portal site instead of directly updating the client secret. Please refer to this document on how to update the client secret from the Azure DevOps portal site.
-[Troubleshoot Azure Resource Manager service connections - Azure Pipelines | Microsoft Learn](/azure/devops/pipelines/release/azure-rm-endpoint?view=azure-devops#service-principals-token-expired)
+If you're using an Azure DevOps service connection that automatically creates a service principal, you need to update the client secret from the Azure DevOps portal site instead of directly updating the client secret. Refer to this document on how to update the client secret from the Azure DevOps portal site:
+[Troubleshoot Azure Resource Manager service connections](/azure/devops/pipelines/release/azure-rm-endpoint?view=azure-devops#service-principals-token-expired).
 
 ### Add a federated credential
 

--- a/includes/active-directory-develop-quickstart-register-app.md
+++ b/includes/active-directory-develop-quickstart-register-app.md
@@ -138,7 +138,7 @@ Client secrets are considered less secure than certificate credentials. Applicat
 For application security recommendations, see [Microsoft identity platform best practices and recommendations](../articles/active-directory/develop/identity-platform-integration-checklist.md#security).
 
 If you are using an Azure DevOps service connection that automatically creates a service principal, you need to update the client secret from the Azure DevOps portal site instead of directly updating the client secret. Please refer to this document on how to update the client secret from the Azure DevOps portal site.
-[Troubleshoot Azure Resource Manager service connections - Azure Pipelines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/azure-rm-endpoint?view=azure-devops#service-principals-token-expired)
+[Troubleshoot Azure Resource Manager service connections - Azure Pipelines | Microsoft Learn](/azure/devops/pipelines/release/azure-rm-endpoint?view=azure-devops#service-principals-token-expired)
 
 ### Add a federated credential
 

--- a/includes/active-directory-develop-quickstart-register-app.md
+++ b/includes/active-directory-develop-quickstart-register-app.md
@@ -137,6 +137,8 @@ Client secrets are considered less secure than certificate credentials. Applicat
 
 For application security recommendations, see [Microsoft identity platform best practices and recommendations](../articles/active-directory/develop/identity-platform-integration-checklist.md#security).
 
+If you are using an Azure DevOps service connection that automatically creates a service principal, you need to update the client secret from the Azure DevOps portal site instead of directly updating the client secret. Please refer to this document on how to update the client secret from the Azure DevOps portal site.
+[Troubleshoot Azure Resource Manager service connections - Azure Pipelines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/azure-rm-endpoint?view=azure-devops#service-principals-token-expired)
 
 ### Add a federated credential
 


### PR DESCRIPTION
When using a Service Connection that automatically creates a service principal for Azure DevOps, even if you add a new client secret from the Azure Portal, the newly added client secret is not used on the Service Connection side. This is by design.
For this scenario, you need to update the client secret from the Azure DevOps portal, but if you get the AADSTS7000222 error, the link below will be printed in the logs.
[Quickstart: Register an app in the Microsoft identity platform - Microsoft Entra | Microsoft Learn](https://learn.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret)

This document only guides how to add a new client secret. So, even if Azure DevOps users follow this procedure, he keeps getting AADSTS7000222 error, which often confuses Azure DevOps users.

For the above reasons, it would be helpful for Azure DevOps users if you could add documentation for updating the client secret from the Azure DevOps portal site.
[Troubleshoot Azure Resource Manager service connections - Azure Pipelines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/azure-rm-endpoint?view=azure-devops#service-principals-token-expired)
