### PR TITLE
Update embedded-login.md

### DIFF
--- a/articles/active-directory-b2c/embedded-login.md
+++ b/articles/active-directory-b2c/embedded-login.md
@@ -73,6 +73,7 @@ The **Sources** attribute contains the URI of your web application. Add a space 
 - The URI must be trusted and owned by your application.
 - The URI must use the https scheme.  
 - The full URI of the web app must be specified. Wildcards are not supported.
+- B2C Journey Framing allows only 2-7 characters domain name to align with commonly recognized TLDs.
 
 In addition, we recommend that you also block your own domain name from being embedded in an iframe by setting the `Content-Security-Policy` and `X-Frame-Options` headers respectively on your application pages. This will mitigate security concerns around older browsers related to nested embedding of iframes.
 

--- a/articles/active-directory-b2c/embedded-login.md
+++ b/articles/active-directory-b2c/embedded-login.md
@@ -73,7 +73,7 @@ The **Sources** attribute contains the URI of your web application. Add a space 
 - The URI must be trusted and owned by your application.
 - The URI must use the https scheme.  
 - The full URI of the web app must be specified. Wildcards are not supported.
-- B2C Journey Framing allows only 2-7 characters domain name to align with commonly recognized TLDs.
+- The **JourneyFraming** element only allows site URLs with a **two to seven-character** Top-level domain (TLD) to align with commonly recognized TLDs.
 
 In addition, we recommend that you also block your own domain name from being embedded in an iframe by setting the `Content-Security-Policy` and `X-Frame-Options` headers respectively on your application pages. This will mitigate security concerns around older browsers related to nested embedding of iframes.
 


### PR DESCRIPTION
Added line 76 to add restriction on domain name length.

B2C won't allow uploading the custom policy if that criteria aren't met. 