### PR TITLE
Update how-to-configure-student-usage.md

### DIFF
--- a/articles/lab-services/how-to-configure-student-usage.md
+++ b/articles/lab-services/how-to-configure-student-usage.md
@@ -69,7 +69,7 @@ To sync a lab with an existing Azure AD group:
 
     Optionally, you can select **Sync** in the **Users** tab to manually synchronize to the latest changes in the Azure AD group.
     
-Users are auto registered to the lab and VMs are automatically assigned when the VM pool syncs with the AAD group. Educators don't need to send invitations and students don't need to register for the lab separately.    
+Users are auto-registered to the lab and VMs are automatically assigned when the VM pool syncs with the Azure AD group. Educators don't need to send invitations and students don't need to register for the lab separately.    
 
 ### Automatic management of virtual machines based on changes to the Azure AD group
 

--- a/articles/lab-services/how-to-configure-student-usage.md
+++ b/articles/lab-services/how-to-configure-student-usage.md
@@ -68,8 +68,8 @@ To sync a lab with an existing Azure AD group:
     Azure Lab Services automatically pulls the list of users from Azure AD, and refreshes the list every 24 hours.
 
     Optionally, you can select **Sync** in the **Users** tab to manually synchronize to the latest changes in the Azure AD group.
-
-You can now start inviting users to your lab. Learn how to [send invitations to lab users](#send-invitations-to-users).
+    
+Users are auto registered to the lab and VMs are automatically assigned when the VM pool syncs with the AAD group. Educators don't need to send invitations and students don't need to register for the lab separately.    
 
 ### Automatic management of virtual machines based on changes to the Azure AD group
 


### PR DESCRIPTION
Clarified the behavior that VMs are automatically assigned to users when AAD groups are used, and there isn't the need to send an invitation email.  This was based on a recent question we got from a customer/field because the current doc is misleading.