### PR TITLE
Complete name of OAuth flow to include PKCE

### DIFF
--- a/articles/active-directory/develop/single-page-app-quickstart.md
+++ b/articles/active-directory/develop/single-page-app-quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart: Sign in users in single-page apps (SPA) with authorization code with Proof Key for Code Exchange (PKCE)"
+title: "Quickstart: Sign in users in single-page apps (SPA) by using the authorization code with Proof Key for Code Exchange (PKCE)"
 description: In this quickstart, learn how a JavaScript single-page application (SPA) can sign in users of personal accounts, work accounts, and school accounts by using the authorization code flow with Proof Key for Code Exchange (PKCE).
 services: active-directory
 author: Dickson-Mwendia

--- a/articles/active-directory/develop/single-page-app-quickstart.md
+++ b/articles/active-directory/develop/single-page-app-quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: "Quickstart: Sign in users in single-page apps (SPA) with authorization code with Proof Key for Code Exchange (PKCE)"
-description: In this quickstart, learn how a JavaScript single-page application (SPA) can sign in users of personal accounts, work accounts, and school accounts by using the authorization code flow.
+description: In this quickstart, learn how a JavaScript single-page application (SPA) can sign in users of personal accounts, work accounts, and school accounts by using the authorization code flow with Proof Key for Code Exchange (PKCE).
 services: active-directory
 author: Dickson-Mwendia
 manager: CelesteDG

--- a/articles/active-directory/develop/single-page-app-quickstart.md
+++ b/articles/active-directory/develop/single-page-app-quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart: Sign in users in single-page apps (SPA) with authorization code"
+title: "Quickstart: Sign in users in single-page apps (SPA) with authorization code with Proof Key for Code Exchange (PKCE)"
 description: In this quickstart, learn how a JavaScript single-page application (SPA) can sign in users of personal accounts, work accounts, and school accounts by using the authorization code flow.
 services: active-directory
 author: Dickson-Mwendia
@@ -16,7 +16,7 @@ zone_pivot_groups: single-page-app-quickstart
 #Customer intent: As an app developer, I want to learn how to get access tokens and refresh tokens by using the Microsoft identity platform so that my single-page app can sign in users of personal accounts, work accounts, and school accounts.
 ---
 
-# Quickstart: Sign in users in single-page apps (SPA) via the authorization code flow
+# Quickstart: Sign in users in single-page apps (SPA) via the authorization code flow with Proof Key for Code Exchange (PKCE)
 
 ::: zone pivot="devlang-angular"
 [!INCLUDE [angular](./includes/single-page-app/quickstart-angular.md)]


### PR DESCRIPTION
Want to specifically specify that the flow that's being used is the Auth Code with PCKE instead of just Auth Code. Important distinction for SPAs where PCKE is needed.