### PR TITLE
Update network-file-system-protocol-support-how-to.md

### DIFF
--- a/articles/storage/blobs/network-file-system-protocol-support-how-to.md
+++ b/articles/storage/blobs/network-file-system-protocol-support-how-to.md
@@ -104,6 +104,9 @@ Create a directory on your Linux system, and then mount the container in the sto
      mount -o sec=sys,vers=3,nolock,proto=tcp <storage-account-name>.blob.core.windows.net:/<storage-account-name>/<container-name>  /nfsdata
      ```
 
+> [!NOTE]
+> Other nfs v3 mount options can be used awhile mounting as they are all mostly client side options and only affect the client behaviours. For sec option, **sys** is the only supported values as of now. 
+
 ## Resolve common errors
 
 |Error | Cause/resolution|

--- a/articles/storage/blobs/network-file-system-protocol-support-how-to.md
+++ b/articles/storage/blobs/network-file-system-protocol-support-how-to.md
@@ -105,7 +105,7 @@ Create a directory on your Linux system, and then mount the container in the sto
      ```
 
 > [!NOTE]
-> Other nfs v3 mount options can be used awhile mounting as they are all mostly client side options and only affect the client behaviours. For sec option, **sys** is the only supported values as of now. 
+> Other optional parameters are available with the mount command. Those parameters primarily affect client-side behavior. `sys` is the only value that is currently supported by the `sec` option.
 
 ## Resolve common errors
 


### PR DESCRIPTION
There are other options as part of mounting not specified but available. Customer can use them and it mostly affects client side behavior.

For sys (security) option, only sys is the currently supported value.

Proposing for having this information documented