### PR TITLE
Update operator-best-practices-cluster-security.md

### DIFF
--- a/articles/aks/operator-best-practices-cluster-security.md
+++ b/articles/aks/operator-best-practices-cluster-security.md
@@ -53,6 +53,9 @@ For more information about Azure AD integration, Kubernetes RBAC, and Azure RBAC
 >
 > Add a network policy in all user namespaces to block pod egress to the metadata endpoint.
 
+> Note: For Network Policy Cluster needs to be created with attribute `--network-policy azure`
+> Example: `az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --network-plugin azure --network-policy azure`
+
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/articles/aks/operator-best-practices-cluster-security.md
+++ b/articles/aks/operator-best-practices-cluster-security.md
@@ -53,7 +53,8 @@ For more information about Azure AD integration, Kubernetes RBAC, and Azure RBAC
 >
 > Add a network policy in all user namespaces to block pod egress to the metadata endpoint.
 
-> Note: For Network Policy Cluster needs to be created with attribute `--network-policy azure`
+> [!Note]
+> For Network Policy Cluster needs to be created with attribute `--network-policy azure`
 > Example: `az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --network-plugin azure --network-policy azure`
 
 ```yaml

--- a/articles/aks/operator-best-practices-cluster-security.md
+++ b/articles/aks/operator-best-practices-cluster-security.md
@@ -53,9 +53,9 @@ For more information about Azure AD integration, Kubernetes RBAC, and Azure RBAC
 >
 > Add a network policy in all user namespaces to block pod egress to the metadata endpoint.
 
-> [!Note]
-> For Network Policy Cluster needs to be created with attribute `--network-policy azure`
-> Example: `az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --network-plugin azure --network-policy azure`
+> [!NOTE]
+> To implement Network Policy, include the attribute --network-policy azure when creating the AKS cluster. Use the following command to create the cluster
+> `az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --network-plugin azure --network-policy azure`
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/articles/aks/operator-best-practices-cluster-security.md
+++ b/articles/aks/operator-best-practices-cluster-security.md
@@ -54,7 +54,7 @@ For more information about Azure AD integration, Kubernetes RBAC, and Azure RBAC
 > Add a network policy in all user namespaces to block pod egress to the metadata endpoint.
 
 > [!NOTE]
-> To implement Network Policy, include the attribute --network-policy azure when creating the AKS cluster. Use the following command to create the cluster
+> To implement Network Policy, include the attribute `--network-policy azure` when creating the AKS cluster. Use the following command to create the cluster:
 > `az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --network-plugin azure --network-policy azure`
 
 ```yaml


### PR DESCRIPTION
Appended doc (line 56,57)  with below to avoid cluster configuration confusion :
> Note: For Network Policy Cluster needs to be created with attribute `--network-policy azure`
> Example: `az aks create -g myResourceGroup -n myManagedCluster --enable-managed-identity --network-plugin azure --network-policy azure`