### PR TITLE
Remove duplicated handler in az cli example

### DIFF
--- a/articles/iot-hub-device-update/create-update.md
+++ b/articles/iot-hub-device-update/create-update.md
@@ -75,7 +75,7 @@ az iot du update init v5 \
     --update-name AptUpdate \
     --update-version 1.0.0 \
     --compat manufacturer=Contoso model=Vacuum \
-    --step handler=handler=microsoft/script:1 properties='{"installedCriteria": "1.0"}' \
+    --step handler=microsoft/script:1 properties='{"installedCriteria": "1.0"}' \
     --file path=/my/apt/manifest/file
 ```
 


### PR DESCRIPTION
The handler entry in --step parameter is doubled causing incorrect handler entry in the update manifest:
```json
"handler": "handler=microsoft/script:1",
```

