### PR TITLE
Adding more references to current maximum number of data networks supported

### DIFF
--- a/articles/private-5g-core/commission-cluster.md
+++ b/articles/private-5g-core/commission-cluster.md
@@ -129,7 +129,7 @@ You can input all the settings on this page before selecting **Apply** at the bo
 
     You can name these networks yourself, but the name **must** match what you configure in the Azure portal when deploying Azure Private 5G Core. For example, you can use the names **N2**, **N3** and **N6-DN1**, **N6-DN2**, **N6-DN3** (for a 5G deployment with multiple data networks (DNs); just **N6** for a single DN deployment). You can optionally configure each virtual network with a virtual local area network identifier (VLAN ID) to enable layer 2 traffic separation. The following example is for a 5G multi-DN deployment without VLANs.
 :::zone pivot="ase-pro-2"
-3. Carry out the following procedure three times, plus once for each of the supplementary data networks (so five times in total if you have three data networks):
+3. Carry out the following procedure three times, plus once for each of the supplementary data networks (so five times in total if you have the maximum three data networks):
     1. Select **Add virtual network** and fill in the side panel:
           - **Virtual switch**: select **vswitch-port3** for N2 and N3, and select **vswitch-port4** for N6-DN1, N6-DN2, and N6-DN3.
           - **Name**: *N2*, *N3*, *N6-DN1*, *N6-DN2*, or *N6-DN3*.
@@ -146,7 +146,7 @@ You can input all the settings on this page before selecting **Apply** at the bo
 :::zone-end
 :::zone pivot="ase-pro-gpu"
 
-3. Carry out the following procedure three times, plus once for each of the supplementary data networks (so five times in total if you have three data networks):
+3. Carry out the following procedure three times, plus once for each of the supplementary data networks (so five times in total if you have the maximum three data networks):
     1. Select **Add virtual network** and fill in the side panel:
         - **Virtual switch**: select **vswitch-port5** for N2 and N3, and select **vswitch-port6** for N6-DN1, N6-DN2, and N6-DN3.
         - **Name**: *N2*, *N3*, *N6-DN1*, *N6-DN2*, or *N6-DN3*.

--- a/articles/private-5g-core/complete-private-mobile-network-prerequisites.md
+++ b/articles/private-5g-core/complete-private-mobile-network-prerequisites.md
@@ -28,7 +28,7 @@ Choose whether each site in the private mobile network should provide coverage f
 
 ## Allocate subnets and IP addresses
 
-Azure Private 5G Core requires a management network, access network, and one or more data networks. These networks can all be part of the same, larger network, or they can be separate. The approach you use depends on your traffic separation requirements.
+Azure Private 5G Core requires a management network, access network, and up to three data networks. These networks can all be part of the same, larger network, or they can be separate. The approach you use depends on your traffic separation requirements.
 
 For each of these networks, allocate a subnet and then identify the listed IP addresses. If you're deploying multiple sites, you'll need to collect this information for each site.
 

--- a/articles/private-5g-core/private-mobile-network-design-requirements.md
+++ b/articles/private-5g-core/private-mobile-network-design-requirements.md
@@ -70,7 +70,7 @@ There are multiple ways to set up your network for use with AP5GC. The exact set
   :::image type="content" source="media/private-mobile-network-design-requirements/layer-2-network.png" alt-text="Diagram of a layer 2 network." lightbox="media/private-mobile-network-design-requirements/layer-2-network.png":::
 
 - Layer 3 network with multiple data networks
-  - AP5GC can support multiple attached data networks, each with its own configuration for Domain Name System (DNS), UE IP address pools, N6 IP configuration, and NAT. The operator can provision UEs as subscribed in one or more data networks and apply data network-specific policy and quality of service (QoS) configuration.
+  - AP5GC can support up to three attached data networks, each with its own configuration for Domain Name System (DNS), UE IP address pools, N6 IP configuration, and NAT. The operator can provision UEs as subscribed in one or more data networks and apply data network-specific policy and quality of service (QoS) configuration.
   - This topology requires that the N6 interface is split into one subnet for each data network or one subnet for all data networks. This option therefore requires careful planning and configuration to prevent overlapping data network IP ranges or UE IP ranges.  
   :::image type="content" source="media/private-mobile-network-design-requirements/layer-3-network-with-multiple-dns.png" alt-text="Diagram of layer 3 network topology with multiple data networks." lightbox="media/private-mobile-network-design-requirements/layer-3-network-with-multiple-dns.png":::
 


### PR DESCRIPTION
A support engineer could not find information in the public docs about the maximum number of supported DNs. It is currently only mentioned in "Collect information for a site", so I've added references on other pages where support for multiple data networks is discussed. 