### PR TITLE
Update functions-bindings-storage-blob-trigger.md

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-blob-trigger.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-trigger.md
@@ -529,6 +529,10 @@ JavaScript and Java functions load the entire blob into memory, and C# functions
 
 The [host.json](functions-host-json.md#blobs) file contains settings that control blob trigger behavior. See the [host.json settings](functions-bindings-storage-blob.md#hostjson-settings) section for details regarding available settings.
 
+## Note of Blob trigger
+
+Please allow Azure Function to access not only a blob but also a queue as Blob trigger uses Storage Queue. The queue is usually in a storage account defined by an app settings AzureWebJobsStorage.
+
 ## Next steps
 
 - [Read blob storage data when a function runs](./functions-bindings-storage-blob-input.md)


### PR DESCRIPTION
Hello,

I see some Blob trigger functions occur errors as it cannot access a queue storage. To avoid this issue, proposing an additional 
note to allow the access.