### PR TITLE
Fix command in vm-generalized-image-version.md

### DIFF
--- a/articles/virtual-machines/vm-generalized-image-version.md
+++ b/articles/virtual-machines/vm-generalized-image-version.md
@@ -501,7 +501,7 @@ location="<location where the image is replicated>"
 user='<username for the VM>'
 name='<name for the VM>'
 
-az group create --location --resource-group $resourcegroup
+az group create --location $location --resource-group $resourcegroup
 az vm create \
   --resource-group $resourcegroup \
   --name $name \


### PR DESCRIPTION
## Why

from https://learn.microsoft.com/en-us/azure/virtual-machines/vm-generalized-image-version?tabs=cli%2Ccli2%2Ccli3%2Ccli4#rbac---shared-from-another-tenant

![image](https://github.com/MicrosoftDocs/azure-docs/assets/2929102/63821adc-fa12-4081-9cdb-4247e7d8b1a4)

This command does not work. Please take a look at it below.

```console
$ az group create --location --resource-group $resourcegroup
argument --location/-l: expected one argument

Examples from AI knowledge base:
az group create --location westus --resource-group MyResourceGroup
Create a new resource group in the West US region.

az group create --location westeurope --resource-group MyResourceGroup --tags {tags}
Create a new resource group. (autogenerated)

az account list-locations
List supported regions for the current subscription. (autogenerated)

https://docs.microsoft.com/en-US/cli/azure/group#az_group_create
Read more about the command in reference docs
```

## What

I fixed the command. And I have checked the following on my PC.

```console
[2023/06/01 15:32:08] sakabekodai@~/src/github.com/koudaiii/azure-docs (patch-7)(minikube)
$ location="japaneast"
[2023/06/01 15:32:21] sakabekodai@~/src/github.com/koudaiii/azure-docs (patch-7)(minikube)
$ resourcegroup="test"
[2023/06/01 15:32:28] sakabekodai@~/src/github.com/MicrosoftDocs/azure-docs (patch-7)(minikube)
$ az group create --location $location --resource-group $resourcegroup

Location    Name
----------  ------
japaneast   test
```