### PR TITLE
[CosmosDB] Fixed bug inside materialized views tutorial

### DIFF
--- a/articles/cosmos-db/nosql/materialized-views.md
+++ b/articles/cosmos-db/nosql/materialized-views.md
@@ -219,7 +219,7 @@ Once your account and Materialized View Builder is set up, you should be able to
                 "kind": "Hash"
               },
               "materializedViewDefinition": {
-                "sourceCollectionName": "mv-src",
+                "sourceCollectionId": "mv-src",
                 "definition": "SELECT s.accountId, s.emailAddress, CONCAT(s.name.first, s.name.last) FROM s"
               }
             },


### PR DESCRIPTION
Made following change to the materialized views NoSQL tutorial, step 3 of creating the materialized view. 

In the definition of the new (target) collection, inside the "materializedViewDefinition" section, the json field/key that defines the source collection should be "sourceCollectionId" instead of "sourceCollectionName"