### PR TITLE
MicrosoftDefenderForEndpoint

### DIFF
--- a/articles/virtual-network/service-tags-overview.md
+++ b/articles/virtual-network/service-tags-overview.md
@@ -114,7 +114,7 @@ By default, service tags reflect the ranges for the entire cloud. Some service t
 | **MicrosoftAzureFluidRelay** | This tag represents the IP addresses used for Azure Microsoft Fluid Relay Server. </br> **Note**: This tag has a dependency on the **AzureFrontDoor.Frontend** tag. | Outbound | No | Yes |
 | **MicrosoftCloudAppSecurity** | Microsoft Defender for Cloud Apps. | Outbound | No | Yes |
 | **MicrosoftContainerRegistry** | Container registry for Microsoft container images. <br/><br/>**Note**: This tag has a dependency on the **AzureFrontDoor.FirstParty** tag. | Outbound | Yes | Yes |
-| **MicrosoftDefenderForEndpoint** | Microsoft Defender for Endpoint <br/></br>**Please note this service tag is currently not available and in progress. We will update once it is ready for use.**| Both | No | Yes |
+| **MicrosoftDefenderForEndpoint** | Microsoft Defender for Endpoint <br/></br>| Both | No | Yes |
 | **PowerBI** | Power BI. | Both | No | Yes |
 | **PowerPlatformInfra** | This tag represents the IP addresses used by the infrastructure to host Power Platform services. | Outbound | Yes | Yes |
 | **PowerPlatformPlex** | This tag represents the IP addresses used by the infrastructure to host Power Platform extension execution on behalf of the customer. | Inbound | Yes | Yes |


### PR DESCRIPTION
The service tag; MicrosoftDefenderForEndpoint, is available and in use from the Portal. Requesting to update the documentation based on real world and previous comment on the service tag had no traceability to a date etc.