### PR TITLE
Update README.md: adds link to Azure production doc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Azure Documentation
 
-Welcome to the open-source [documentation](/azure) of [Microsoft Azure](https://azure.microsoft.com). Please review this README file to understand how you can assist in contributing to the Microsoft Azure documentation. 
+Welcome to the open-source [documentation](https://learn.microsoft.com/en-us/azure/?product=popular) of [Microsoft Azure](https://azure.microsoft.com). Please review this README file to understand how you can assist in contributing to the Microsoft Azure documentation. 
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Azure Documentation
 
-Welcome to the open-source [documentation](https://learn.microsoft.com/en-us/azure/?product=popular) of [Microsoft Azure](https://azure.microsoft.com). Please review this README file to understand how you can assist in contributing to the Microsoft Azure documentation. 
+Welcome to the open-source [documentation](https://learn.microsoft.com/azure/?product=popular) of [Microsoft Azure](https://azure.microsoft.com). Please review this README file to understand how you can assist in contributing to the Microsoft Azure documentation. 
 
 ## Getting Started
 


### PR DESCRIPTION
Fixed Azure production documentation links: https://learn.microsoft.com/en-us/azure/?product=popular Previous link yielded a "404 - page not found" error