### PR TITLE
Update spark-create-operations.md

### DIFF
--- a/articles/cosmos-db/cassandra/spark-create-operations.md
+++ b/articles/cosmos-db/cassandra/spark-create-operations.md
@@ -90,9 +90,6 @@ booksDF.write
   .save()
 ```
 
-> [!NOTE]
-> Column-level TTL is not supported yet.
-
 #### Validate in cqlsh
 
 ```sql


### PR DESCRIPTION
Column-Level TTL is now supported in the Cassandra API. Removing an outdated note.