### PR TITLE
Adding Additional reason to FAQ for disabled device

### DIFF
--- a/articles/active-directory/devices/faq.yml
+++ b/articles/active-directory/devices/faq.yml
@@ -60,6 +60,7 @@ sections:
           - User disables the device from the My Apps portal. 
           - An administrator (or user) deletes or disables the device in the Azure portal or by using PowerShell
           - Hybrid Azure AD joined only: An administrator removes the devices OU out of sync scope resulting in the devices being deleted from Azure AD
+          - Hybrid Azure AD joined only: An administrator disables the computer account on premise resulting in the device being disabled in Azure AD
           - Upgrading Azure AD connect to the version 1.4.xx.x. [Understanding Azure AD Connect 1.4.xx.x and device disappearance](/troubleshoot/azure/active-directory/reference-connect-device-disappearance).
 
           

--- a/articles/active-directory/devices/faq.yml
+++ b/articles/active-directory/devices/faq.yml
@@ -60,7 +60,7 @@ sections:
           - User disables the device from the My Apps portal. 
           - An administrator (or user) deletes or disables the device in the Azure portal or by using PowerShell
           - Hybrid Azure AD joined only: An administrator removes the devices OU out of sync scope resulting in the devices being deleted from Azure AD
-          - Hybrid Azure AD joined only: An administrator disables the computer account on premise resulting in the device being disabled in Azure AD
+          - Hybrid Azure AD joined only: An administrator disables the computer account on premises, resulting in the device being disabled in Azure AD
           - Upgrading Azure AD connect to the version 1.4.xx.x. [Understanding Azure AD Connect 1.4.xx.x and device disappearance](/troubleshoot/azure/active-directory/reference-connect-device-disappearance).
 
           


### PR DESCRIPTION
A device can also be disabled on premise in a hybrid scenario, which will result in  AD Connect process occurring, that will disable the device. I think adding it here makes a lot of sense.