### PR TITLE
Specified supported version of xliff

### DIFF
--- a/articles/cognitive-services/Translator/document-translation/overview.md
+++ b/articles/cognitive-services/Translator/document-translation/overview.md
@@ -56,7 +56,7 @@ Document Translation supports the following document file types:
 |Adobe PDF|`pdf`|Portable document file format. Document Translation uses optical character recognition (OCR) technology to extract and translate text in scanned PDF document while retaining the original layout.|
 |Comma-Separated Values |`csv`| A comma-delimited raw-data file used by spreadsheet programs.|
 |HTML|`html`, `htm`|Hyper Text Markup Language.|
-|Localization Interchange File Format|xlf| A parallel document format, export of Translation Memory systems. The languages used are defined inside the file.|
+|Localization Interchange File Format|`xlf`| A parallel document format, export of Translation Memory systems. The languages used are defined inside the file. Only XLIFF 1.2 is supported|
 |Markdown| `markdown`, `mdown`, `mkdn`, `md`, `mkd`, `mdwn`, `mdtxt`, `mdtext`, `rmd`| A lightweight markup language for creating formatted text.|
 |M&#8203;HTML|`mthml`, `mht`| A web page archive format used to combine HTML code and its companion resources.|
 |Microsoft Excel|`xls`, `xlsx`|A spreadsheet file for data analysis and documentation.|

--- a/articles/cognitive-services/Translator/document-translation/overview.md
+++ b/articles/cognitive-services/Translator/document-translation/overview.md
@@ -56,7 +56,7 @@ Document Translation supports the following document file types:
 |Adobe PDF|`pdf`|Portable document file format. Document Translation uses optical character recognition (OCR) technology to extract and translate text in scanned PDF document while retaining the original layout.|
 |Comma-Separated Values |`csv`| A comma-delimited raw-data file used by spreadsheet programs.|
 |HTML|`html`, `htm`|Hyper Text Markup Language.|
-|Localization Interchange File Format|`xlf`| A parallel document format, export of Translation Memory systems. The languages used are defined inside the file. Only XLIFF 1.2 is supported|
+|Localization Interchange File Format|`xlf`| A parallel document format, export of Translation Memory systems. The languages used are defined inside the file. Only XLIFF 1.0, 1.1 and 1.2 are supported|
 |Markdown| `markdown`, `mdown`, `mkdn`, `md`, `mkd`, `mdwn`, `mdtxt`, `mdtext`, `rmd`| A lightweight markup language for creating formatted text.|
 |M&#8203;HTML|`mthml`, `mht`| A web page archive format used to combine HTML code and its companion resources.|
 |Microsoft Excel|`xls`, `xlsx`|A spreadsheet file for data analysis and documentation.|


### PR DESCRIPTION
Custom translator doesn't support XLIFF 2.0 although it is a well supported format. I think it should be specified so that there are no confusions.

See the supported versions [here]( https://learn.microsoft.com/en-us/azure/cognitive-services/Translator/document-translation/reference/get-supported-document-formats#:~:text=%22format%22%3A%20%22XLIFF%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22fileExtensions%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22.xlf%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22contentTypes%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22application/xliff%2Bxml%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22versions%22%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%221.0%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%221.1%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%221.2%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%5D)