### PR TITLE
[Application Gateway] Added the limit of trusted client CA certificate chains

### DIFF
--- a/includes/application-gateway-limits.md
+++ b/includes/application-gateway-limits.md
@@ -19,6 +19,7 @@ ms.author: greglin
 | SSL certificates |100<sup>1</sup> |1 per HTTP listener |
 | Maximum SSL certificate size |V1 SKU - 10 KB<br>V2 SKU - 16 KB| |
 | Maximum trusted client CA certificate size | 25 KB| 25 KB is the maximum aggregated size of root and intermediate certificates contained in an uploaded pem or cer file. |
+| Maximum trusted client CA certificate chains | 5 | |
 | Authentication certificates |100 | |
 | Trusted root certificates |100 | |
 | Request timeout minimum |1 second | |


### PR DESCRIPTION
Added the limit of having maximum 5 trusted client CA certificate chains for mTLS within the Application Gateway. 
This was earlier mentioned in issue #96866 also.

The limit is also described in the general docs of the Mutual TLS at https://learn.microsoft.com/en-us/azure/application-gateway/mutual-authentication-overview?tabs=powershell#mutual-authentication.