### PR TITLE
Correct provider registration parameter in Resource Bridge redeployment

### DIFF
--- a/articles/azure-arc/resource-bridge/troubleshoot-resource-bridge.md
+++ b/articles/azure-arc/resource-bridge/troubleshoot-resource-bridge.md
@@ -67,8 +67,8 @@ To resolve this problem, delete the resource bridge, register the providers, the
 1. Register the providers:
 
    ```azurecli
-   az provider register --namespace Microsoft.ExtendedLocation –wait
-   az provider register --namespace Microsoft.ResourceConnector –wait
+   az provider register --namespace Microsoft.ExtendedLocation –-wait
+   az provider register --namespace Microsoft.ResourceConnector –-wait
    ```
 
 1. Redeploy the resource bridge.


### PR DESCRIPTION
Change the '-wait' to '--wait' to reflect the correct way the wait parameter should be passed to the command.