### PR TITLE
Update security-operations-devices.md

### DIFF
--- a/articles/active-directory/fundamentals/security-operations-devices.md
+++ b/articles/active-directory/fundamentals/security-operations-devices.md
@@ -84,13 +84,10 @@ Azure AD registered and Azure AD joined devices possess primary refresh tokens (
 
 You can create an alert that notifies appropriate administrators when a device is registered or joined without MFA by using Microsoft Sentinel.
 ~~~
-Sign-in logs
-
-    where ResourceDisplayName == "Device Registration Service"
-
-    where ConditionalAccessStatus == "success"
-
-    where AuthenticationRequirement <> "multiFactorAuthentication"
+SigninLogs
+| where ResourceDisplayName == "Device Registration Service"
+| where ConditionalAccessStatus == "success"
+| where AuthenticationRequirement <> "multiFactorAuthentication"
 ~~~
 
 You can also use [Microsoft Intune to set and monitor device compliance policies](/mem/intune/protect/device-compliance-get-started).
@@ -112,9 +109,7 @@ It might not be possible to block access to all cloud and software-as-a-service 
 
 ```
 SigninLogs
-
 | where DeviceDetail.isCompliant == false
-
 | where ConditionalAccessStatus == "success"
 ```
 
@@ -124,11 +119,8 @@ SigninLogs
 
 SigninLogs
 | where isempty(DeviceDetail.deviceId)
-
 | where AuthenticationRequirement == "singleFactorAuthentication"
-
 | where ResultType == "0"
-
 | where NetworkLocationDetails == "[]"
 ```
 
@@ -152,7 +144,6 @@ In LogAnalytics create a query such as
 
 ```
 AuditLogs
-
 | where OperationName == "Read BitLocker key" 
 ```
 


### PR DESCRIPTION
"Sign-in logs" table does not exist. Changed "Sign-in logs" to "SigninLogs" table that does exist. 

Each "where" operator needs to have a pipe before it. " | where ..."

Removed unecessary spacing between table name and conditional statements in all queries.