### PR TITLE
Update api-management-howto-disaster-recovery-backup-restore.md

### DIFF
--- a/articles/api-management/api-management-howto-disaster-recovery-backup-restore.md
+++ b/articles/api-management/api-management-howto-disaster-recovery-backup-restore.md
@@ -222,7 +222,7 @@ $blobName="ContosoBackup.apimbackup;
 ```powershell
 $storageKey = (Get-AzStorageAccountKey -ResourceGroupName $storageResourceGroup -StorageAccountName $storageAccountName)[0].Value
 
-$storageContext = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageKey$st
+$storageContext = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageKey
 
 Restore-AzApiManagement -ResourceGroupName $apiManagementResourceGroup -Name $apiManagementName `
     -StorageContext $storageContext -SourceContainerName $containerName -SourceBlobName $blobName


### PR DESCRIPTION
section: Access using storage access key
line 225
change from: `-StorageAccountKey $storageKey$st`
change to: `-StorageAccountKey $storageKey`


not sure how the line 377 was changed in the process