### PR TITLE
{AzureAPIM} APIM with AAD integration should have reference to `validate-azure-ad-token` policy

### DIFF
--- a/includes/api-management-configure-validate-jwt.md
+++ b/includes/api-management-configure-validate-jwt.md
@@ -26,4 +26,4 @@ The following example policy, when added to the `<inbound>` policy section, chec
 > [!NOTE]
 > The preceding `openid-config` URL corresponds to the v2 endpoint. For the v1 `openid-config` endpoint, use `https://login.microsoftonline.com/{aad-tenant}/.well-known/openid-configuration`.
 
-For information on how to configure policies, see [Set or edit policies](../articles/api-management/set-edit-policies.md). Refer to the [validate-jwt](../articles/api-management/validate-jwt-policy.md) reference for more customization on JWT validations.
+For information on how to configure policies, see [Set or edit policies](../articles/api-management/set-edit-policies.md). Refer to the [validate-jwt](../articles/api-management/validate-jwt-policy.md) reference for more customization on JWT validations. To validate a JWT that was provided by the Azure Active Directory service, API Management also provides the [`validate-azure-ad-token`](../articles/api-management/validate-azure-ad-token-policy.md) policy. 


### PR DESCRIPTION
Add reference to the `validate-azure-ad-token` policy in the below documentation:

https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad.

This PR fixes this documentation and adds the reference to  `validate-azure-ad-token` policy.

fixes MicrosoftDocs/azure-docs#110557

