### PR TITLE
Change AZ_CREDS to AZURE_CREDENTIALS to make it more coherent

### DIFF
--- a/articles/machine-learning/how-to-github-actions-machine-learning.md
+++ b/articles/machine-learning/how-to-github-actions-machine-learning.md
@@ -109,7 +109,7 @@ Your workflow file is made up of a trigger section and jobs:
         - name: azure login
           uses: azure/login@v1
           with:
-            creds: ${{secrets.AZ_CREDS}}
+            creds: ${{secrets.AZURE_CREDENTIALS}}
         - name: setup
           run: bash setup.sh
           working-directory: cli


### PR DESCRIPTION
In the beginning of the article you request the readers to name their service principal as AZURE_CREDENTIALS, whereas in the YAML you call AZ_CREDS which may be confusing for those ones who are discovering the ML Ops and Github actions in particular