### PR TITLE
Clarified KeyVault name parameter for other clouds

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-azure-log-analytics.md
+++ b/articles/synapse-analytics/spark/apache-spark-azure-log-analytics.md
@@ -120,6 +120,7 @@ spark.synapse.logAnalytics.keyVault.linkedServiceName <LINKED_SERVICE_NAME>
 > [!NOTE]  
 > - For Azure China, the `spark.synapse.logAnalytics.uriSuffix` parameter should be `ods.opinsights.azure.cn`. 
 > - For Azure Government, the `spark.synapse.logAnalytics.uriSuffix` parameter should be `ods.opinsights.azure.us`. 
+> - For any cloud except AzureCloud, the `spark.synapse.logAnalytics.keyVault.name` parameter should be the fully qualified domain name (FQDN) of the Key Vault. For example, `AZURE_KEY_VAULT_NAME.vault.usgovcloudapi.net` for AzureUSGovernment.
 
 [uri_suffix]: ../../azure-monitor/logs/data-collector-api.md#request-uri
 

--- a/articles/synapse-analytics/spark/apache-spark-azure-log-analytics.md
+++ b/articles/synapse-analytics/spark/apache-spark-azure-log-analytics.md
@@ -120,7 +120,7 @@ spark.synapse.logAnalytics.keyVault.linkedServiceName <LINKED_SERVICE_NAME>
 > [!NOTE]  
 > - For Azure China, the `spark.synapse.logAnalytics.uriSuffix` parameter should be `ods.opinsights.azure.cn`. 
 > - For Azure Government, the `spark.synapse.logAnalytics.uriSuffix` parameter should be `ods.opinsights.azure.us`. 
-> - For any cloud except AzureCloud, the `spark.synapse.logAnalytics.keyVault.name` parameter should be the fully qualified domain name (FQDN) of the Key Vault. For example, `AZURE_KEY_VAULT_NAME.vault.usgovcloudapi.net` for AzureUSGovernment.
+> - For any cloud except Azure, the `spark.synapse.logAnalytics.keyVault.name` parameter should be the fully qualified domain name (FQDN) of the Key Vault. For example, `AZURE_KEY_VAULT_NAME.vault.usgovcloudapi.net` for AzureUSGovernment.
 
 [uri_suffix]: ../../azure-monitor/logs/data-collector-api.md#request-uri
 


### PR DESCRIPTION
Important note about the value of `spark.synapse.logAnalytics.keyVault.name` when the Key Vault account is not in AzureCloud.