### PR TITLE
mention that custom DNS suffix is additional

### DIFF
--- a/articles/container-apps/environment-custom-dns-suffix.md
+++ b/articles/container-apps/environment-custom-dns-suffix.md
@@ -11,7 +11,7 @@ ms.author: cshoe
 
 # Custom environment DNS Suffix in Azure Container Apps (Preview)
 
-By default, an Azure Container Apps environment provides a DNS suffix in the format `<UNIQUE_IDENTIFIER>.<REGION_NAME>.azurecontainerapps.io`. Each container app in the environment generates a domain name based on this DNS suffix. You can configure a custom DNS suffix for your environment.
+By default, an Azure Container Apps environment provides a DNS suffix in the format `<UNIQUE_IDENTIFIER>.<REGION_NAME>.azurecontainerapps.io`. Each container app in the environment generates a domain name based on this DNS suffix. You can configure an additional custom DNS suffix for your environment. The container apps in the environment then generate domain names based on both the default and the custom DNS suffix.
 
 > [!NOTE]
 > To configure a custom domain for individual container apps, see [Custom domain names and certificates in Azure Container Apps](custom-domains-certificates.md).


### PR DESCRIPTION
I expected the custom domain name to replace the default one. Only by trying it, I found out that the custom domain name is used additionally, although it does not appear anywhere in the UI or container app resource properties.