### PR TITLE
Update connect-cef-syslog.md to use python3 instead of python in command example

### DIFF
--- a/articles/sentinel/connect-cef-syslog.md
+++ b/articles/sentinel/connect-cef-syslog.md
@@ -77,7 +77,7 @@ Create the DCR for your Syslog-based logs using the Azure Monitor [guidelines](.
 1. Run this command to launch the installation script:
  
     ```python
-    sudo wget -O Forwarder_AMA_installer.py https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Syslog/Forwarder_AMA_installer.py&&sudo python Forwarder_AMA_installer.py 
+    sudo wget -O Forwarder_AMA_installer.py https://raw.githubusercontent.com/Azure/Azure-Sentinel/master/DataConnectors/Syslog/Forwarder_AMA_installer.py&&sudo python3 Forwarder_AMA_installer.py 
     ```
     The installation script configures the `rsyslog` or `syslog-ng` daemon to use the required protocol and restarts the daemon.  
 


### PR DESCRIPTION
Newer Linux distributions have generally abandoned the use of the "python" alias in favor of "python3". Some distributions do include the "alternatives" command to set the default "python" alias but this is only done by default in the older distros (e.g. RHEL/CentOS 7) and only for RHEL compatibles. Debian based distros no longer include a default alias for "python". 

Changing "python" to "python3" in the example command will improve customer experience as they are very likely to run the command on distributions of Linux that will not have the alias and will thus fail.

This also helps improve documentation consistency as in the Azure Monitor documentation the command example uses python3. https://learn.microsoft.com/en-us/azure/sentinel/forward-syslog-monitor-agent?bc=%2Fazure%2Fazure-monitor%2Fbreadcrumb%2Ftoc.json&toc=%2Fazure%2Fazure-monitor%2Ftoc.json#configure-linux-syslog-daemon