### PR TITLE
Fix docker login command to be easily copied from developers

### DIFF
--- a/articles/container-registry/container-registry-authentication.md
+++ b/articles/container-registry/container-registry-authentication.md
@@ -79,7 +79,7 @@ TOKEN=$(az acr login --name <acrName> --expose-token --output tsv --query access
 Then, run `docker login`, passing `00000000-0000-0000-0000-000000000000` as the username and using the access token as password:
 
 ```console
-•	docker login myregistry.azurecr.io --username 00000000-0000-0000-0000-000000000000 --password-stdin <<< $TOKEN
+docker login myregistry.azurecr.io --username 00000000-0000-0000-0000-000000000000 --password-stdin <<< $TOKEN
 ```
 Likewise, you can use the token returned by `az acr login` with the `helm registry login` command to authenticate with the registry:
 


### PR DESCRIPTION
Fixed docker login command (a character was included that could not be used in CLI command execution) to allow developers to copy and paste it more easily