### PR TITLE
[Model Monitor] - Add target column name for the adv-data-drift signal.

### DIFF
--- a/articles/machine-learning/how-to-monitor-model-performance.md
+++ b/articles/machine-learning/how-to-monitor-model-performance.md
@@ -234,6 +234,7 @@ create_monitor:
           path: azureml:my_model_training_data:1 # use training data as comparison baseline
           type: mltable
         dataset_context: training
+        target_column_name: fraud_detected
       features: 
         top_n_feature_importance: 20 # monitor drift for top 20 features
       metric_thresholds:
@@ -556,6 +557,7 @@ create_monitor:
           path: azureml:my_model_training_data:1 # use training data as comparison baseline
           type: mltable
         dataset_context: training
+        target_column_name: fraud_detected
       features: 
         top_n_feature_importance: 20 # monitor drift for top 20 features
       metric_thresholds:


### PR DESCRIPTION
CLI yaml spec was missing the target column name for the advanced-data-drift signal.