### PR TITLE
BTP solution migration to unlimited public preview

### DIFF
--- a/articles/sentinel/sap/deploy-sap-btp-solution.md
+++ b/articles/sentinel/sap/deploy-sap-btp-solution.md
@@ -16,12 +16,6 @@ This article describes how to deploy the Microsoft Sentinel Solution for SAP® B
 
 ## Prerequisites
 
-### Fill in the sign-up form
-
-To get started, **first [complete the sign-up form](https://forms.microsoft.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR5CavmNiVgxCqhcQeRrOyvxUM0Q3NVdHU1hWNjMzQkM3RVNNNldTR1hYOS4u)** so that we can provision your subscription with access to the preview. We’ll send a confirmation email once your subscription is active.
-
-### Additional prerequisites
-
 Before you begin, verify that:
 
 - The Microsoft Sentinel solution is enabled. 
@@ -55,10 +49,10 @@ Before you begin, verify that:
     - **uaa.clientsecret**: `682323d2-42a0-45db-a939-74639efde986$gR3x3ohHTB8iyYSKHW0SNIWG4G0tQkkMdBwO7lKhwcQ=`
     - **uaa.url**: `https://915a0312trial.authentication.us10.hana.ondemand.com`
 
-1. Log into the Azure portal with the [solution preview feature flag](https://portal.azure.com/?feature.loadTemplateSolutions=true). 
+1. Log into the [Azure portal](https://portal.azure.com/).
 1. Navigate to the **Microsoft Sentinel** service.
 1. Select **Content hub**, and in the search bar, search for *BTP*.
-1. Select **Sentinel Solution for SAP BTP**.
+1. Select **SAP BTP**.
 1. Select **Install**.
 
     For more information about how to manage the solution components, see [Discover and deploy out-of-the-box content](../sentinel-solutions-deploy.md).


### PR DESCRIPTION
The BTP solution moved from a limited (sign up based) public preview to regular (unlimited public preview). Removing the need to sign up and to use the private preview flag. The updated and ungated solution is fully approved and available in content hub and marketplace. You can update the documentation to reflect it without waiting to any additional confirmation.