### PR TITLE
Error when specifying @role_name = NULL in code example, will have unexpected side effect and create a null named database role

### DIFF
--- a/articles/data-factory/tutorial-incremental-copy-change-data-capture-feature-portal.md
+++ b/articles/data-factory/tutorial-incremental-copy-change-data-capture-feature-portal.md
@@ -76,7 +76,7 @@ If you don't have an Azure subscription, create a [free](https://azure.microsoft
     EXEC sys.sp_cdc_enable_table
     @source_schema = 'dbo',
     @source_name = 'customers', 
-    @role_name = 'null',
+    @role_name = NULL,
     @supports_net_changes = 1
     ```
 5. Insert data into the customers table by running the following command:


### PR DESCRIPTION
'null' (between quotes) was specified, which will actually trigger the creation of a Database role named null......... This is not what the author wanted to illustrate here, which is the activation of CDC on a table WITHOUT using a gating role (which translates to the code @role_name = NULL)