### PR TITLE
Update qs-configure-powershell-windows-vm.md

### DIFF
--- a/articles/active-directory/managed-identities-azure-resources/qs-configure-powershell-windows-vm.md
+++ b/articles/active-directory/managed-identities-azure-resources/qs-configure-powershell-windows-vm.md
@@ -95,7 +95,7 @@ If you have a Virtual Machine that no longer needs the system-assigned managed i
 
    ```azurepowershell-interactive
    $vm = Get-AzVM -ResourceGroupName myResourceGroup -Name myVM
-   Update-AzVm -ResourceGroupName myResourceGroup -VM $vm -IdentityType "UserAssigned"
+   Update-AzVm -ResourceGroupName myResourceGroup -VM $vm -IdentityType "UserAssigned" -IdentityID "/subscriptions/<SUBSCRIPTION ID>/resourcegroups/<RESROURCE GROUP>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<USER ASSIGNED IDENTITY NAME>..."
    ```
 
 If you have a virtual machine that no longer needs system-assigned managed identity and it has no user-assigned managed identities, use the following commands:


### PR DESCRIPTION
When -IdentityType is set to 'UserAssigned', Update-AzVM requires an IdentityID be passed as well.  So, to remove the System assigned identity while leaving the User Assigned will require passing the ID of the User Assigned Identity that will remain.