### PR TITLE
Additional explanation about regex group transformation 

### DIFF
--- a/articles/active-directory/hybrid/connect/how-to-connect-fed-group-claims.md
+++ b/articles/active-directory/hybrid/connect/how-to-connect-fed-group-claims.md
@@ -186,7 +186,7 @@ For more information about regex replace and capture groups, see [The Regular Ex
 >[!NOTE]
 > As described in the Azure AD documentation, you can't modify a restricted claim by using a policy. The data source can't be changed, and no transformation is applied when you're generating these claims. The group claim is still a restricted claim, so you need to customize the groups by changing the name. If you select a restricted name for the name of your custom group claim, the claim will be ignored at runtime. 
 >
-> You can also use the regex transform feature as a filter, because any groups that don't match the regex pattern will not be emitted in the resulting claim.
+> You can also use the regex transform feature as a filter, because any groups that don't match the regex pattern will not be emitted in the resulting claim. Regex transform will work only when a user is a member of a smaller number of groups than the limitation. 
 >
 >If the transform applied to the original groups claim results in a new custom claim, then the original groups claim will be omitted from the token. However, if the configured regex doesn't match any value in the original list, then the custom claim will not be present and the original groups claim will be included in the token.
 


### PR DESCRIPTION
Regex transform is a feature under group transformation. So it works only when the user is a member of less than 150 groups for SAML. A customer complained about this document as it is not clear enough. The customer tried to use regex transform to avoid the number of groups limit but of course it didn't work. The customer complained that this document is not clear with that. So I'm proposing this change.