### PR TITLE
[Documentation]n Update the file sharing docs

### DIFF
--- a/articles/communication-services/tutorials/file-sharing-tutorial.md
+++ b/articles/communication-services/tutorials/file-sharing-tutorial.md
@@ -85,11 +85,11 @@ For this quickstart, we'll be modifying files inside of the `src` folder.
 
 ### Install the Package
 
-Use the `npm install` command to install the Azure Communication Services UI Library for JavaScript.
+Use the `npm install` command to install the beta Azure Communication Services UI Library for JavaScript.
 
 ```bash
 
-npm install @azure/communication-react
+npm install @azure/communication-react@1.5.1-beta.5
 
 ```
 


### PR DESCRIPTION
As per feedback npm instructions should point to beta version instead of GA