### PR TITLE
Update tutorial-multiple-sites-cli.md

### DIFF
--- a/articles/application-gateway/tutorial-multiple-sites-cli.md
+++ b/articles/application-gateway/tutorial-multiple-sites-cli.md
@@ -177,12 +177,12 @@ In order to ensure that more specific rules are processed first, use the rule pr
 ```azurecli-interactive
 az network application-gateway rule create \
   --gateway-name myAppGateway \
-  --name wccontosoRule \
+  --name contosoRule \
   --resource-group myResourceGroupAG \
-  --http-listener wccontosoListener \
+  --http-listener contosoListener \
   --rule-type Basic \
   --priority 200 \
-  --address-pool wccontosoPool
+  --address-pool contosoPool
 
 az network application-gateway rule create \
   --gateway-name myAppGateway \


### PR DESCRIPTION
 az network application-gateway rule create \
  --gateway-name myAppGateway \
  --name wccontosoRule \
  --resource-group appgw-RG \
  --http-listener wccontosoListener \
  --rule-type Basic \
  --priority 200 \
  --address-pool wccontosoPool
(InvalidResourceReference) Resource /subscriptions/1c3acab3-e7ec-4699-9a31-d885ccdafcfb/resourceGroups/appgw-RG/providers/Microsoft.Network/applicationGateways/myAppGateway/httpListeners/wccontosoListener referenced by resource /subscriptions/1c3acab3-e7ec-4699-9a31-d885ccdafcfb/resourceGroups/appgw-RG/providers/Microsoft.Network/applicationGateways/myAppGateway/requestRoutingRules/wccontosoRule was not found. Please make sure that the referenced resource exists, and that both resources are in the same region. Code: InvalidResourceReference
Message: Resource /subscriptions/1c3acab3-e7ec-4699-9a31-d885ccdafcfb/resourceGroups/appgw-RG/providers/Microsoft.Network/applicationGateways/myAppGateway/httpListeners/wccontosoListener referenced by resource /subscriptions/1c3acab3-e7ec-4699-9a31-d885ccdafcfb/resourceGroups/appgw-RG/providers/Microsoft.Network/applicationGateways/myAppGateway/requestRoutingRules/wccontosoRule was not found. Please make sure that the referenced resource exists, and that both resources are in the same region.

Changed wccontosorule to contosorule and also for backend pool and listener name contosolistener.