### PR TITLE
Add information on config_file_location to Static Web Apps docs

### DIFF
--- a/articles/static-web-apps/build-configuration.md
+++ b/articles/static-web-apps/build-configuration.md
@@ -27,6 +27,7 @@ The following table lists the available configuration settings.
 | `skip_api_build` | Set the value to `true` to skip building the API functions. | No |
 | `cwd`<br />(Azure Pipelines only) | Absolute path to the working folder. Defaults to `$(System.DefaultWorkingDirectory)`. | No |
 | `build_timeout_in_minutes` | Set this value to customize the build timeout. Defaults to `15`. | No |
+| `config_file_location` | This folder contains the `staticwebapp.config.json` file. Defaults to `app_location` or any subfolder under it. | No |
 
 With these settings, you can set up GitHub Actions or [Azure Pipelines](get-started-portal.md?pivots=azure-devops) to run continuous integration/continuous delivery (CI/CD) for your static web app.
 

--- a/articles/static-web-apps/configuration.md
+++ b/articles/static-web-apps/configuration.md
@@ -30,7 +30,7 @@ You can define configuration for Azure Static Web Apps in the _staticwebapp.conf
 
 ## File location
 
-The recommended location for the _staticwebapp.config.json_ is in the folder set as the `app_location` in the [workflow file](./build-configuration.md). However, the file may be placed in any subfolder within the folder set as the `app_location`.
+The recommended location for the _staticwebapp.config.json_ is in the folder set as the `app_location` in the [workflow file](./build-configuration.md). However, the file may be placed in any subfolder within the folder set as the `app_location` or a specific folder set at `config_file_location`. 
 
 See the [example configuration](#example-configuration-file) file for details.
 


### PR DESCRIPTION
I noticed this undocumented feature here https://github.com/Azure/static-web-apps/issues/372#issuecomment-873122983

We tried and it does work on DevOps. Let me know if this is something you'd like documented, or if more detail is needed.