### PR TITLE
Update hdinsight-restrict-public-connectivity.md

### DIFF
--- a/articles/hdinsight/hdinsight-restrict-public-connectivity.md
+++ b/articles/hdinsight/hdinsight-restrict-public-connectivity.md
@@ -131,7 +131,7 @@ Configuring `resourceProviderConnection` to *outbound* also allows you to access
 - SQL metastores: Apache Ranger, Ambari, Oozie, and Hive
 - Azure Key Vault 
 
-It isn't mandatory to use private endpoints for these resources. But if you plan to use private endpoints for these resources, you must create the resources and configure the private endpoints and DNS entries before you create the HDInsight cluster. All these resources should be accessible from inside the cluster subnet, either through a private endpoint or otherwise.
+It isn't mandatory to use private endpoints for these resources. But if you plan to use private endpoints for these resources, you must create the resources and configure the private endpoints and DNS entries before you create the HDInsight cluster. All these resources should be accessible from inside the cluster subnet, either through a private endpoint or otherwise. If you planning to use a private endpoint its recommended to leverage the cluster subnet.
 
 When you connect to Azure Data Lake Storage Gen2 over a private endpoint, make sure that the Gen2 storage account has an endpoint set for both `blob` and `dfs`. For more information, see [Create a private endpoint](../private-link/create-private-endpoint-portal.md).
 

--- a/articles/hdinsight/hdinsight-restrict-public-connectivity.md
+++ b/articles/hdinsight/hdinsight-restrict-public-connectivity.md
@@ -131,7 +131,7 @@ Configuring `resourceProviderConnection` to *outbound* also allows you to access
 - SQL metastores: Apache Ranger, Ambari, Oozie, and Hive
 - Azure Key Vault 
 
-It isn't mandatory to use private endpoints for these resources. But if you plan to use private endpoints for these resources, you must create the resources and configure the private endpoints and DNS entries before you create the HDInsight cluster. All these resources should be accessible from inside the cluster subnet, either through a private endpoint or otherwise. If you are planning to use a private endpoint its recommended to leverage the cluster subnet.
+It isn't mandatory to use private endpoints for these resources. But if you plan to use private endpoints for these resources, you must create the resources and configure the private endpoints and DNS entries before you create the HDInsight cluster. All these resources should be accessible from inside the cluster subnet, either through a private endpoint or otherwise. If you're planning to use a private endpoint, it's recommended to leverage the cluster subnet.
 
 When you connect to Azure Data Lake Storage Gen2 over a private endpoint, make sure that the Gen2 storage account has an endpoint set for both `blob` and `dfs`. For more information, see [Create a private endpoint](../private-link/create-private-endpoint-portal.md).
 

--- a/articles/hdinsight/hdinsight-restrict-public-connectivity.md
+++ b/articles/hdinsight/hdinsight-restrict-public-connectivity.md
@@ -131,7 +131,7 @@ Configuring `resourceProviderConnection` to *outbound* also allows you to access
 - SQL metastores: Apache Ranger, Ambari, Oozie, and Hive
 - Azure Key Vault 
 
-It isn't mandatory to use private endpoints for these resources. But if you plan to use private endpoints for these resources, you must create the resources and configure the private endpoints and DNS entries before you create the HDInsight cluster. All these resources should be accessible from inside the cluster subnet, either through a private endpoint or otherwise. If you planning to use a private endpoint its recommended to leverage the cluster subnet.
+It isn't mandatory to use private endpoints for these resources. But if you plan to use private endpoints for these resources, you must create the resources and configure the private endpoints and DNS entries before you create the HDInsight cluster. All these resources should be accessible from inside the cluster subnet, either through a private endpoint or otherwise. If you are planning to use a private endpoint its recommended to leverage the cluster subnet.
 
 When you connect to Azure Data Lake Storage Gen2 over a private endpoint, make sure that the Gen2 storage account has an endpoint set for both `blob` and `dfs`. For more information, see [Create a private endpoint](../private-link/create-private-endpoint-portal.md).
 


### PR DESCRIPTION
Added an additional sentence to recommend placing dependent resources with private endpoints on the cluster subnet. This was a gotcha that I encountered leveraging a different subnet on the same vnet. The diagram earlier shows this configuration, but its not obvious that a different subnet would prevent connectivity.