### PR TITLE
Update hdinsight-restrict-public-connectivity.md

### DIFF
--- a/articles/hdinsight/hdinsight-restrict-public-connectivity.md
+++ b/articles/hdinsight/hdinsight-restrict-public-connectivity.md
@@ -26,6 +26,9 @@ By default, the HDInsight resource provider uses an *inbound* connection to the 
 
 In this configuration, without an inbound connection, there's no need to configure inbound service tags in the network security group. There's also no need to bypass the firewall or network virtual appliance via user-defined routes.
 
+> [!NOTE]
+> Implementations in Microsoft Azure Government may still require the inbound service tags in the network security group and user defined routes.
+
 After you create your cluster, set up proper DNS resolution by adding DNS records that are needed for your restricted HDInsight cluster. The following canonical name DNS record (CNAME) is created in the Azure-managed public DNS zone: `azurehdinsight.net`.
 
 ```dns


### PR DESCRIPTION
In the testing that I did for a MAG implementation, the ARM template configured with the outbound value did not deploy with an internal error UNLESS the inbound NSG rule and UDR routing back to the internet was setup. 

With this in place the implementation worked as planned and was a great security improvement with integrated vnet configuration. If you don't like the phrasing please disregard. Wanted to provide the information for those in the same situation.