### PR TITLE
Update how-to-use-enterprise-api-portal.md

### DIFF
--- a/articles/spring-apps/how-to-use-enterprise-api-portal.md
+++ b/articles/spring-apps/how-to-use-enterprise-api-portal.md
@@ -121,7 +121,7 @@ This section describes how to view and try out APIs with schema definitions in A
                "Method=PUT"
             ],
             "filters": [
-               "StripPrefix=0",
+               "StripPrefix=0"
             ]
          }
       ]


### PR DESCRIPTION
JSON syntax error (removed trailing comma in filters)

```
"filters": [
            "StripPrefix=0",
         ]
```