### PR TITLE
Add Active-Active caveat to the multi-key commands

### DIFF
--- a/articles/azure-cache-for-redis/cache-best-practices-enterprise-tiers.md
+++ b/articles/azure-cache-for-redis/cache-best-practices-enterprise-tiers.md
@@ -108,7 +108,8 @@ The _Enterprise clustering policy_ is a simpler configuration that utilizes a si
 
 Because the Enterprise tiers use a clustered configuration, you might see `CROSSSLOT` exceptions on commands that operate on multiple keys. Behavior varies depending on the clustering policy used. If you use the OSS clustering policy, multi-key commands require all keys to be mapped to [the same hash slot](https://docs.redis.com/latest/rs/databases/configure/oss-cluster-api/#multi-key-command-support). 
 
-You might also see `CROSSSLOT` errors with Enterprise clustering policy. Only the following multi-key commands are allowed across slots with Enterprise clustering: `DEL`, `MSET`, `MGET`, `EXISTS`, `UNLINK`, and `TOUCH`. For more information, see [Database clustering](https://docs.redis.com/latest/rs/databases/durability-ha/clustering/#multikey-operations).
+You might also see `CROSSSLOT` errors with Enterprise clustering policy. Only the following multi-key commands are allowed across slots with Enterprise clustering: `DEL`, `MSET`, `MGET`, `EXISTS`, `UNLINK`, and `TOUCH`. 
+In Active-Active databases, multi-key write commands (`DEL`, `MSET`, `UNLINK`) can only be run on keys that are in the same slot. However, the following multi-key commands are allowed across slots in Active-Active databases: `MGET`, `EXISTS`, and `TOUCH`. For more information, see [Database clustering](https://docs.redis.com/latest/rs/databases/durability-ha/clustering/#multikey-operations).
 
 ## Handling Region Down Scenarios with Active Geo-Replication
 


### PR DESCRIPTION
Based on Redis's documentation: https://docs.redis.com/latest/rs/databases/durability-ha/clustering/#multikey-operations

We were missing the caveat that some multi-key write commands won't work in Active-Active databases