### PR TITLE
Update the upper limit number for "Custom neural model train"

### DIFF
--- a/articles/applied-ai-services/form-recognizer/concept-custom-neural.md
+++ b/articles/applied-ai-services/form-recognizer/concept-custom-neural.md
@@ -128,7 +128,7 @@ Values in training cases should be diverse and representative. For example, if a
 * The model doesn't recognize values split across page boundaries.
 * Custom neural models are only trained in English. Model performance is lower for documents in other languages.
 * If a dataset labeled for custom template models is used to train a custom neural model, the unsupported field types are ignored.
-* Custom neural models are limited to 20 build operations per month. Open a support request if you need the limit increased. For more information, see [Form Recognizer service quotas and limits](https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/service-limits?view=form-recog-3.0.0)
+* Custom neural models are limited to 20 build operations per month. Open a support request if you need the limit increased. For more information, see [Form Recognizer service quotas and limits](service-limits.md)
 
 ## Training a model
 

--- a/articles/applied-ai-services/form-recognizer/concept-custom-neural.md
+++ b/articles/applied-ai-services/form-recognizer/concept-custom-neural.md
@@ -128,7 +128,7 @@ Values in training cases should be diverse and representative. For example, if a
 * The model doesn't recognize values split across page boundaries.
 * Custom neural models are only trained in English. Model performance is lower for documents in other languages.
 * If a dataset labeled for custom template models is used to train a custom neural model, the unsupported field types are ignored.
-* Custom neural models are limited to 10 build operations per month. Open a support request if you need the limit increased.
+* Custom neural models are limited to 20 build operations per month. Open a support request if you need the limit increased. For more information, see [Form Recognizer service quotas and limits](https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/service-limits?view=form-recog-3.0.0)
 
 ## Training a model
 


### PR DESCRIPTION
Now the upper limit number for "Custom neural model train" is 20, not 10.

- Form Recognizer quotas and limits - Azure Applied AI Services | Microsoft Learn
https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/service-limits?view=form-recog-3.0.0#custom-model-usage
<img width="466" alt="image" src="https://github.com/MicrosoftDocs/azure-docs/assets/65746722/fe03b8af-7c0b-48a4-a114-d8da40d1a5d5">
