### PR TITLE
Update parameter-files.md

### DIFF
--- a/articles/azure-resource-manager/bicep/parameter-files.md
+++ b/articles/azure-resource-manager/bicep/parameter-files.md
@@ -310,7 +310,7 @@ az deployment group create \
   --name ExampleDeployment \
   --resource-group ExampleGroup \
   --template-file storage.bicep \
-  --parameters @storage.bicepparam
+  --parameters storage.bicepparam
 ```
 
 For more information, see [Deploy resources with Bicep and Azure CLI](./deploy-cli.md#parameters). To deploy _.bicep_ files you need Azure CLI version 2.20 or higher.


### PR DESCRIPTION
The deployment example using the .bicepparam file w/ az cli was faulty, it seems like when deploying this way only the filename needs to be given in case of bicepparam, as opposed to @filename.json in case of a json-based parameter file.

It's stated correctly in the text above the code example.