### PR TITLE
Indicating mapped directory details

### DIFF
--- a/articles/sentinel/notebooks-hunt.md
+++ b/articles/sentinel/notebooks-hunt.md
@@ -142,7 +142,7 @@ After you've created an AML workspace, start launching your notebooks in your Az
 
     When you've found the notebook you want to use, select **Create from template** and **Save** to clone it into your own workspace.
 
-    Edit the name as needed. If the notebook already exists in your workspace, you can overwrite the existing notebook or create a new one.
+    Edit the name as needed. If the notebook already exists in your workspace, you can overwrite the existing notebook or create a new one. By default, your notebook will be saved in /Users/<Your_User_Name>/ directory of selected AML workspace.
 
     :::image type="content" source="media/notebooks/save-notebook.png" alt-text="Save a notebook to clone it to your own workspace.":::
 


### PR DESCRIPTION
Our current documentation doesn't specify where notebooks are saved into, as users don't have a choice to specify the path. That's why added clarity that it should be located under /Users/<Your_User_Name>/ directory.