### PR TITLE
Fix: Incorrect curl usage in App Service Zip Deploy docs

### DIFF
--- a/includes/app-service-deploy-zip-push-rest.md
+++ b/includes/app-service-deploy-zip-push-rest.md
@@ -16,7 +16,7 @@ For the HTTP BASIC authentication, you need your App Service deployment credenti
 The following example uses the cURL tool to deploy a .zip file. Replace the placeholders `<deployment_user>`, `<zip_file_path>`, and `<app_name>`. When prompted by cURL, type in the password.
 
 ```bash
-curl -X POST -u <deployment_user> --data-binary @"<zip_file_path>" https://<app_name>.scm.azurewebsites.net/api/zipdeploy
+curl -X POST -u <deployment_user> --data-binary "@<zip_file_path>" https://<app_name>.scm.azurewebsites.net/api/zipdeploy
 ```
 
 This request triggers push deployment from the uploaded .zip file. You can review the current and past deployments by using the `https://<app_name>.scm.azurewebsites.net/api/deployments` endpoint, as shown in the following cURL example. Again, replace `<app_name>` with the name of your app and `<deployment_user>` with the username of your deployment credentials.

--- a/includes/app-service-deploy-zip-push-rest.md
+++ b/includes/app-service-deploy-zip-push-rest.md
@@ -37,7 +37,7 @@ A valid Azure AD access token for the the user or service principal performing t
 
 ```bash
 curl -X POST \
-    --data-binary @"<zip_file_path>" \
+    --data-binary "@<zip_file_path>" \
     -H "Authorization: Bearer <access_token>" \
     "https://<app_name>.scm.azurewebsites.net/api/zipdeploy"
 ```

--- a/includes/app-service-deploy-zip-push-rest.md
+++ b/includes/app-service-deploy-zip-push-rest.md
@@ -7,7 +7,7 @@ ms.author: cephalin
 ---
 ## <a name="rest"></a>Deploy ZIP file with REST APIs 
 
-You can use the [deployment service REST APIs](https://github.com/projectkudu/kudu/wiki/REST-API) to deploy the .zip file to your app in Azure. To deploy, send a POST request to https://<app_name>.scm.azurewebsites.net/api/zipdeploy. The POST request must contain the .zip file in the message body. The deployment credentials for your app are provided in the request by using HTTP BASIC authentication. For more information, see the [.zip push deployment reference](https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file). 
+You can use the [deployment service REST APIs](https://github.com/projectkudu/kudu/wiki/REST-API) to deploy the .zip file to your app in Azure. To deploy, send a POST request to `https://<app_name>.scm.azurewebsites.net/api/zipdeploy`. The POST request must contain the .zip file in the message body. The deployment credentials for your app are provided in the request by using HTTP BASIC authentication. For more information, see the [.zip push deployment reference](https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file). 
 
 For the HTTP BASIC authentication, you need your App Service deployment credentials. To see how to set your deployment credentials, see [Set and reset user-level credentials](../articles/app-service/deploy-configure-credentials.md#userscope).
 


### PR DESCRIPTION
This change fixes an issue with the `curl` example command. The way that `--data-binary` includes files requires that the argument value starts with an `@` sign.

From the [man page](https://www.man7.org/linux/man-pages/man1/curl.1.html):

```
       --data-binary <data>
              (HTTP) This posts data exactly as specified with no extra
              processing whatsoever.

              If you start the data with the letter @, the rest should
              be a filename.
       ...

       Example:
               curl --data-binary @filename https://example.com/
```

I ran an issue while using this method to push a deployment, because without the `@` correctly positioned, `curl` would push the literal path text, and the deployment would fail. When I moved it to the correct position, it works now.

This also adds monospace formatting around one of the instances of the zip deploy URL which didn't have it.