### PR TITLE
Add missing imports to the dotnet example for setting up Azure OpenTelemetry with ACS

### DIFF
--- a/articles/communication-services/quickstarts/includes/telemetry-app-insights-net.md
+++ b/articles/communication-services/quickstarts/includes/telemetry-app-insights-net.md
@@ -65,9 +65,12 @@ Use the following code to begin:
 
 ```csharp
 using System;
+using System.Diagnostics;
 using Azure.Communication;
 using Azure.Communication.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace TelemetryAppInsightsQuickstart


### PR DESCRIPTION
Adding missing dependencies to the setup code.