### PR TITLE
SAML signing cert on metadata xml.md

### DIFF
--- a/articles/active-directory/saas-apps/palo-alto-networks-globalprotect-tutorial.md
+++ b/articles/active-directory/saas-apps/palo-alto-networks-globalprotect-tutorial.md
@@ -82,7 +82,7 @@ Follow these steps to enable Azure AD SSO in the Azure portal.
 	> [!NOTE]
 	> These values are not real. Update these values with the actual Sign on URL and Identifier. Contact [Palo Alto Networks - GlobalProtect Client support team](https://support.paloaltonetworks.com/support) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
 
-1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Federation Metadata XML** and select **Download** to download the certificate and save it on your computer.
+1. On the **Set up single sign-on with SAML** page, in the **SAML Signing Certificate** section,  find **Federation Metadata XML** and select **Download** to download the certificate and save it on your computer. All SAML signing certificates including Inactive certificates will be shown up on Federation Metadata XML file.
 
 	![The Certificate download link](common/metadataxml.png)
 


### PR DESCRIPTION
It is by design that all SAML signing certificates including Inactive certificates will be shown up on Federation Metadata XML file. Palo Alto Global Protect chooses old certificate when there are multiple signing certificate on metadata xml file. Some customers asked about if Azure AD emitting all certificate is by design and it will be great to document this line.