### PR TITLE
Provide more information regarding constructing the admin consent URL.

### DIFF
--- a/articles/active-directory/manage-apps/grant-admin-consent.md
+++ b/articles/active-directory/manage-apps/grant-admin-consent.md
@@ -80,10 +80,11 @@ https://login.microsoftonline.com/{organization}/adminconsent?client_id={client-
 where:
 
 - `{client-id}` is the application's client ID (also known as app ID).
-- `{organization}` is the tenant ID or any verified domain name of the tenant you want to consent the application in. You can use the value `common`, which will cause the consent to happen in the home tenant of the user you sign in with.
+- `{organization}` is the tenant ID or any verified domain name of the tenant you want to consent the application in. You can use the value `organizations`, which will cause the consent to happen in the home tenant of the user you sign in with.
 
 As always, carefully review the permissions an application requests before granting consent.
 
+For more information regarding constructing the tenant-wide admin consent URL, see [Grant tenant-wide admin consent to an application](../develop/v2-admin-consent.md)
 
 :::zone-end
 

--- a/articles/active-directory/manage-apps/grant-admin-consent.md
+++ b/articles/active-directory/manage-apps/grant-admin-consent.md
@@ -84,7 +84,7 @@ where:
 
 As always, carefully review the permissions an application requests before granting consent.
 
-For more information regarding constructing the tenant-wide admin consent URL, see [Grant tenant-wide admin consent to an application](../develop/v2-admin-consent.md)
+For more information on constructing the tenant-wide admin consent URL, see [Admin consent on the Microsoft identity platform](../develop/v2-admin-consent.md).
 
 :::zone-end
 


### PR DESCRIPTION
The current guidance for generating the admin consent URL on this page dictates that `common` should be used in the case where the tenant ID is not known, this is in conflict with the documentation in the page ["Admin consent on the Microsoft identity platform"](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-admin-consent), which states 

> The directory tenant that you want to request permission from. Can be provided in GUID or friendly name format OR generically referenced with organizations as seen in the example. **Do not use 'common'**, as personal accounts cannot provide admin consent except in the context of a tenant. To ensure best compatibility with personal accounts that manage tenants, use the tenant ID when possible.

I also included a link to this page to provide more information to the reader.