### PR TITLE
Update migrate-dotnet-v3: Migration of JsonSerializerSettings

### DIFF
--- a/articles/cosmos-db/nosql/migrate-dotnet-v3.md
+++ b/articles/cosmos-db/nosql/migrate-dotnet-v3.md
@@ -273,6 +273,30 @@ The v3 SDK has built-in support for the bulk executor library, allowing you to u
 
 For more information, see [how to migrate from the bulk executor library to  bulk support in Azure Cosmos DB .NET V3 SDK](how-to-migrate-from-bulk-executor-library.md)
 
+### Custom serializer settings on operation levels
+The .NET V2 SDK allows setting *JsonSerializerSettings* in *RequestOptions* at the operational level used to deserialize the result document:
+```csharp
+// .NET V2 SDK
+var result = await container.ReplaceDocumentAsync(document, new RequestOptions { JsonSerializerSettings = customSerializerSettings })
+```
+Instead of this use .NET V3 SDK Stream API and apply custom serialization on the operation result:
+```csharp
+// .NET V3 SDK
+using(Response response = await this.container.ReplaceItemStreamAsync(stream, "itemId", new PartitionKey("itemPartitionKey"))
+{
+
+    using(Stream stream = response.ContentStream)
+    {
+        using (StreamReader streamReader = new StreamReader(stream))
+        {
+            // Read the stream and do dynamic deserialization based on type with a custom Serializer
+            string content =  streamReader.ReadToEndAsync();
+            SomeType result = CustomSerializer.Deserialize<SomeType>(content);
+        }
+    }
+}
+```
+
 ## Code snippet comparisons
 
 The following code snippet shows the differences in how resources are created between the .NET v2 and v3 SDKs:


### PR DESCRIPTION
Internal msdata supportability work item task: 1806840:

V2 SDK allows users to set Newtonsoft.Json SerializerSettings at the operation level.

We should document the migration path:
- Use Stream APIs and apply serialization on the resulting stream
- Have a custom Serializer that does dynamic deserialization based on the type