### PR TITLE
Update storage-use-azcopy-files.md

### DIFF
--- a/articles/storage/common/storage-use-azcopy-files.md
+++ b/articles/storage/common/storage-use-azcopy-files.md
@@ -57,7 +57,7 @@ This section contains the following examples:
 > For a complete list, see [options](storage-ref-azcopy-copy.md#options).
 
 > [!NOTE]
-> AzCopy doesn't automatically calculate and store the file's md5 hash code for blobs (>256 MB).If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.
+> AzCopy doesn't automatically calculates and stores the file's md5 hash code for a file greater than 256 MB.If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.
 
 ### Upload a file
 

--- a/articles/storage/common/storage-use-azcopy-files.md
+++ b/articles/storage/common/storage-use-azcopy-files.md
@@ -57,7 +57,7 @@ This section contains the following examples:
 > For a complete list, see [options](storage-ref-azcopy-copy.md#options).
 
 > [!NOTE]
-> AzCopy doesn't automatically calculate and store the file's md5 hash code .If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.For smaller blobs (<256MB IIRC), the service computes md5 hash code automatically.
+> AzCopy doesn't automatically calculate and store the file's md5 hash code for blobs (>256 MB).If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.
 
 ### Upload a file
 

--- a/articles/storage/common/storage-use-azcopy-files.md
+++ b/articles/storage/common/storage-use-azcopy-files.md
@@ -57,7 +57,7 @@ This section contains the following examples:
 > For a complete list, see [options](storage-ref-azcopy-copy.md#options).
 
 > [!NOTE]
-> AzCopy doesn't automatically calculate and store the file's md5 hash code. If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.
+> AzCopy doesn't automatically calculate and store the file's md5 hash code .If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.For smaller blobs (<256MB IIRC), the service computes md5 hash code automatically.
 
 ### Upload a file
 

--- a/articles/storage/common/storage-use-azcopy-files.md
+++ b/articles/storage/common/storage-use-azcopy-files.md
@@ -57,7 +57,7 @@ This section contains the following examples:
 > For a complete list, see [options](storage-ref-azcopy-copy.md#options).
 
 > [!NOTE]
-> AzCopy doesn't automatically calculates and stores the file's md5 hash code for a file greater than 256 MB.If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.
+> AzCopy doesn't automatically calculate and store the file's md5 hash code for a file greater than 256 MB.If you want AzCopy to do that, then append the `--put-md5` flag to each copy command. That way, when the file is downloaded, AzCopy calculates an MD5 hash for downloaded data and verifies that the MD5 hash stored in the file's `Content-md5` property matches the calculated hash.
 
 ### Upload a file
 


### PR DESCRIPTION
Updated Note section with below details:

For smaller blobs (<256MB IIRC), the service computes md5 hash code automatically.