### PR TITLE
Option on retrieving AML token via REST API

### DIFF
--- a/articles/machine-learning/how-to-authenticate-online-endpoint.md
+++ b/articles/machine-learning/how-to-authenticate-online-endpoint.md
@@ -35,6 +35,8 @@ Access to retrieve the key or token for an online endpoint is restricted by Azur
 
 For more information on using Azure RBAC with Azure Machine Learning, see [Manage access to Azure Machine Learning](how-to-assign-roles.md).
 
+On the option to retrieve the token via REST API, see [Invoke the endpoint to score data with your model](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-deploy-with-rest?view=azureml-api-2#invoke-the-endpoint-to-score-data-with-your-model)
+
 # [Azure CLI](#tab/azure-cli)
 
 To get the key or token, use [az ml online-endpoint get-credentials](/cli/azure/ml/online-endpoint#az-ml-online-endpoint-get-credentials). This command returns a JSON document that contains the key or token.

--- a/articles/machine-learning/how-to-authenticate-online-endpoint.md
+++ b/articles/machine-learning/how-to-authenticate-online-endpoint.md
@@ -35,7 +35,7 @@ Access to retrieve the key or token for an online endpoint is restricted by Azur
 
 For more information on using Azure RBAC with Azure Machine Learning, see [Manage access to Azure Machine Learning](how-to-assign-roles.md).
 
-On the option to retrieve the token via REST API, see [Invoke the endpoint to score data with your model](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-deploy-with-rest?view=azureml-api-2#invoke-the-endpoint-to-score-data-with-your-model)
+On the option to retrieve the token via REST API, see [Invoke the endpoint to score data with your model](how-to-deploy-with-rest.md#invoke-the-endpoint-to-score-data-with-your-model).
 
 # [Azure CLI](#tab/azure-cli)
 


### PR DESCRIPTION
Current documentation page lists only 2 options to retrieve the token: via Az CLI or Python SDK. We need to provide reference to REST API, as it's also a valid option.

This will help our customers to get information about all 3 currently available options from the right online endpoint auths documentation page. Thanks.