### PR TITLE
grammar and end-links in Add HTML markers to the map etc

### DIFF
--- a/articles/azure-maps/map-add-custom-html.md
+++ b/articles/azure-maps/map-add-custom-html.md
@@ -23,7 +23,7 @@ This article shows you how to add a custom HTML such as an image file to the map
 
 The [HtmlMarker] class has a default style. You can customize the marker by setting the color and text options of the marker. The default style of the HTML marker class is an SVG template that has a `{color}` and `{text}` placeholder. Set the color and text properties in the HTML marker options for a quick customization.
 
-The following code creates an HTML marker, and sets the color property to "DodgerBlue" and the text property to "10". A popup is attached to the marker and `click` event is used to toggle the visibility of the popup.
+The following code creates an HTML marker, and sets the color property to `DodgerBlue` and the text property to `10`. A popup is attached to the marker and `click` event is used to toggle the visibility of the popup.
 
 ```javascript
 //Create an HTML marker and add it to the map.
@@ -60,7 +60,7 @@ The default `htmlContent` of an Html marker is an SVG template with place folder
 
 For a complete working sample of how to create a custom SVG template and use it with the HtmlMarker class, see [HTML Marker with Custom SVG Template] in the [Azure Maps Samples]. When running this sample, select the button in the upper left hand side of the window labeled **Update Marker Options** to change the `color` and `text` options from the SVG template used in the HtmlMarker. For the source code for this sample, see [HTML Marker with Custom SVG Template source code].
 
-:::image type="content" source="./media/map-add-custom-html/html-marker-with-custom-svg-template.png" alt-text="Screenshot showing a map of the world with a custom SVG template used with the HtmlMarker class and a button labeled update marker options, that when selected changes the color and text options from the SVG template used in the HtmlMarker. ":::
+:::image type="content" source="./media/map-add-custom-html/html-marker-with-custom-svg-template.png" alt-text="Screenshot showing a map of the world with a custom SVG template used with the HtmlMarker class. It includes a button labeled update marker options, that when selected changes the color and text options from the SVG template used in the HtmlMarker. ":::
 
 <!-------------------------------------------------------------------
 <iframe height='500' scrolling='no' title='HTML Marker with Custom SVG Template' src='//codepen.io/azuremaps/embed/LXqMWx/?height=500&theme-id=0&default-tab=js,result&embed-version=2&editable=true' frameborder='no' loading="lazy" allowtransparency='true' allowfullscreen='true'>See the Pen <a href='https://codepen.io/azuremaps/pen/LXqMWx/'>HTML Marker with Custom SVG Template</a> by Azure Maps (<a href='https://codepen.io/azuremaps'>@azuremaps</a>) on <a href='https://codepen.io'>CodePen</a>.

--- a/articles/azure-maps/map-add-drawing-toolbar.md
+++ b/articles/azure-maps/map-add-drawing-toolbar.md
@@ -11,7 +11,7 @@ services: azure-maps
 
 # Add a drawing tools toolbar to a map
 
-This article shows you how to use the Drawing Tools module and display the drawing toolbar on the map. The [DrawingToolbar](/javascript/api/azure-maps-drawing-tools/atlas.control.drawingtoolbar) control adds the drawing toolbar on the map. You will learn how to create maps with only one and all drawing tools and how to customize the rendering of the drawing shapes in the drawing manager.
+This article shows you how to use the Drawing Tools module and display the drawing toolbar on the map. The [Drawing toolbar] control adds the drawing toolbar on the map. You learn how to create maps with only one and all drawing tools and how to customize the rendering of the drawing shapes in the drawing manager.
 
 ## Add drawing toolbar
 
@@ -66,7 +66,7 @@ The following screenshot shows a sample of an instance of the drawing manager th
 
 The style of the shapes that are drawn can be customized by retrieving the underlying layers of the drawing manager by using the `drawingManager.getLayers()` and `drawingManager.getPreviewLayers()` functions and then setting options on the individual layers. The drag handles that appear for coordinates when editing a shape are HTML markers. The style of the drag handles can be customized by passing HTML marker options into the `dragHandleStyle` and `secondaryDragHandleStyle` options of the drawing manager.  
 
-The following code gets the rendering layers from the drawing manager and modifies their options to change rendering style for drawing. In this case, points will be rendered with a blue marker icon. Lines will be red and four pixels wide. Polygons will have a green fill color and an orange outline. It then changes the styles of the drag handles to be square icons.
+The following code gets the rendering layers from the drawing manager and modifies their options to change rendering style for drawing. In this case, points are rendered with a blue marker icon. Lines are red and four pixels wide. Polygons have a green fill color and an orange outline. It then changes the styles of the drag handles to be square icons.
 
 ```javascript
 //Get rendering layers of drawing manager.
@@ -134,27 +134,27 @@ For a complete working sample that demonstrates how to customize the rendering o
 
 ## Next steps
 
-Learn how to use additional features of the drawing tools module:
+Learn how to use more features of the drawing tools module:
 
 > [!div class="nextstepaction"]
-> [Get shape data](map-get-shape-data.md)
+> [Get shape data]
 
 > [!div class="nextstepaction"]
-> [React to drawing events](drawing-tools-events.md)
+> [React to drawing events]
 
 > [!div class="nextstepaction"]
-> [Interaction types and keyboard shortcuts](drawing-tools-interactions-keyboard-shortcuts.md)
+> [Interaction types and keyboard shortcuts]
 
 Learn more about the classes and methods used in this article:
 
 > [!div class="nextstepaction"]
-> [Map](/javascript/api/azure-maps-control/atlas.map)
+> [Map]
 
 > [!div class="nextstepaction"]
-> [Drawing toolbar](/javascript/api/azure-maps-drawing-tools/atlas.control.drawingtoolbar)
+> [Drawing toolbar]
 
 > [!div class="nextstepaction"]
-> [Drawing manager](/javascript/api/azure-maps-drawing-tools/atlas.drawing.drawingmanager)
+> [Drawing manager]
 
 [Azure Maps Samples]: https://samples.azuremaps.com
 [Add drawing toolbar to map]: https://samples.azuremaps.com/drawing-tools-module/add-drawing-toolbar-to-map
@@ -162,3 +162,9 @@ Learn more about the classes and methods used in this article:
 
 [Add drawing toolbar to map source code]: https://github.com/Azure-Samples/AzureMapsCodeSamples/blob/main/Samples/Drawing%20Tools%20Module/Add%20drawing%20toolbar%20to%20map/Add%20drawing%20toolbar%20to%20map.html
 [Change drawing rendering style source code]: https://github.com/Azure-Samples/AzureMapsCodeSamples/blob/main/Samples/Drawing%20Tools%20Module/Change%20drawing%20rendering%20style/Change%20drawing%20rendering%20style.html
+[Drawing toolbar]: /javascript/api/azure-maps-drawing-tools/atlas.control.drawingtoolbar
+[Get shape data]: map-get-shape-data.md
+[React to drawing events]: drawing-tools-events.md
+[Interaction types and keyboard shortcuts]: drawing-tools-interactions-keyboard-shortcuts.md
+[Map]: /javascript/api/azure-maps-control/atlas.map
+[Drawing manager]: /javascript/api/azure-maps-drawing-tools/atlas.drawing.drawingmanager

--- a/articles/azure-maps/map-add-heat-map-layer-android.md
+++ b/articles/azure-maps/map-add-heat-map-layer-android.md
@@ -32,13 +32,13 @@ You can use heat maps in many different scenarios, including:
 
 ## Prerequisites
 
-Be sure to complete the steps in the [Quickstart: Create an Android app](quick-android-map.md) document. Code blocks in this article can be inserted into the maps `onReady` event handler.
+Be sure to complete the steps in the [Quickstart: Create an Android app] document. Code blocks in this article can be inserted into the maps `onReady` event handler.
 
 ## Add a heat map layer
 
 To render a data source of points as a heat map, pass your data source into an instance of the `HeatMapLayer` class, and add it to the map.
 
-The following code sample loads a GeoJSON feed of earthquakes from the past week and renders them as a heat map. Each data point is rendered with a radius of 10 pixels at all zoom levels. To ensure a better user experience, the heat map is below the label layer so the labels stay clearly visible. The data in this sample is from the [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/). This sample loads GeoJSON data from the web using the data import utility code block provided in the [Create a data source](create-data-source-android-sdk.md) document.
+The following code sample loads a GeoJSON feed of earthquakes from the past week and renders them as a heat map. Each data point is rendered with a radius of 10 pixels at all zoom levels. To ensure a better user experience, the heat map is below the label layer so the labels stay clearly visible. The data in this sample is from the [USGS Earthquake Hazards Program]. This sample loads GeoJSON data from the web using the data import utility code block provided in the [Create a data source] document.
 
 ::: zone pivot="programming-language-java-android"
 
@@ -118,7 +118,7 @@ The previous example customized the heat map by setting the radius and opacity o
 - `sourceLayer`: If the data source connected to the layer is a vector tile source, a source layer within the vector tiles must be specified.
 - `visible`: Hides or shows the layer.
 
-This following is an example of a heat map where a liner interpolation expression is used to create a smooth color gradient. The `mag` property defined in the data is used with an exponential interpolation to set the weight or relevance of each data point.
+The following code snippet is an example of a heat map where a liner interpolation expression is used to create a smooth color gradient. The `mag` property defined in the data is used with an exponential interpolation to set the weight or relevance of each data point.
 
 ::: zone pivot="programming-language-java-android"
 
@@ -254,7 +254,7 @@ The following video shows a map running the above code, which scales the radius 
 
 ![Animation showing a map zooming with a heat map layer showing a consistent geospatial size](media/map-add-heat-map-layer-android/android-consistent-zoomable-heat-map-layer.gif)
 
-The `zoom` expression can only be used in `step` and `interpolate` expressions. The following expression can be used to approximate a radius in meters. This expression uses a placeholder `radiusMeters` which you should replace with your desired radius. This expression calculates the approximate pixel radius for a zoom level at the equator for zoom levels 0 and 24, and uses an `exponential interpolation` expression to scale between these values the same way the tiling system in the map works.
+The `zoom` expression can only be used in `step` and `interpolate` expressions. The following expression can be used to approximate a radius in meters. This expression uses a placeholder `radiusMeters`, which you should replace with your desired radius. This expression calculates the approximate pixel radius for a zoom level at the equator for zoom levels 0 and 24, and uses an `exponential interpolation` expression to scale between these values the same way the tiling system in the map works.
 
 ::: zone pivot="programming-language-java-android"
 
@@ -309,7 +309,12 @@ interpolate(
 For more code examples to add to your maps, see the following articles:
 
 > [!div class="nextstepaction"]
-> [Create a data source](create-data-source-android-sdk.md)
+> [Create a data source]
 
 > [!div class="nextstepaction"]
-> [Use data-driven style expressions](data-driven-style-expressions-android-sdk.md)
+> [Use data-driven style expressions]
+
+[Quickstart: Create an Android app]: quick-android-map.md
+[USGS Earthquake Hazards Program]: https://earthquake.usgs.gov
+[Create a data source]: create-data-source-android-sdk.md
+[Use data-driven style expressions]: data-driven-style-expressions-android-sdk.md


### PR DESCRIPTION
Improved grammar and converted inline links to end-links in articles:
1.  [Add HTML markers to the map](https://learn.microsoft.com/azure/azure-maps/map-add-custom-html)
2. [Add a drawing tools toolbar to a map](https://learn.microsoft.com/azure/azure-maps/map-add-drawing-toolbar)
3. [Add a heat map layer (Android SDK)](https://learn.microsoft.com/azure/azure-maps/map-add-heat-map-layer-android)
