### PR TITLE
use curl instead of wget

### DIFF
--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -105,7 +105,7 @@ Use the following procedure to lock a RHEL 8.x VM to a particular minor release.
 1. Get the EUS repository `config` file.
 
    ```bash
-   sudo wget https://rhelimage.blob.core.windows.net/repositories/rhui-microsoft-azure-rhel8-eus.config
+   curl -O https://rhelimage.blob.core.windows.net/repositories/rhui-microsoft-azure-rhel8-eus.config
    ```
 
 1. Add EUS repositories.
@@ -150,7 +150,7 @@ To remove the version lock, use the following commands. Run the commands as `roo
 1. Get the regular repositories `config` file.
 
     ```bash
-    sudo wget https://rhelimage.blob.core.windows.net/repositories/rhui-microsoft-azure-rhel8.config
+    curl -O https://rhelimage.blob.core.windows.net/repositories/rhui-microsoft-azure-rhel8.config
     ```
 
 1. Add non-EUS repository.


### PR DESCRIPTION
Use curl instead of wget. wget is not installed by default when we deploy VM from marketplace image. And sudo is not required to get config.