### PR TITLE
updated deprecated affinity labels deprecation warning

### DIFF
--- a/articles/aks/csi-migrate-in-tree-volumes.md
+++ b/articles/aks/csi-migrate-in-tree-volumes.md
@@ -21,7 +21,7 @@ To make this process as simple as possible, and to ensure no data loss, this art
 ## Migrate Disk volumes
 
 > [!NOTE]
-> The labels `failure-domain.beta.kubernetes.io/zone` and `failure-domain.beta.kubernetes.io/region` have been deprecated in AKS 1.24 and removed in 1.26. If your existing persistent volumes are still using nodeAffinity matching these two labels, you need to change them to `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels in the new persistent volume setting.
+> The labels `failure-domain.beta.kubernetes.io/zone` and `failure-domain.beta.kubernetes.io/region` have been deprecated in AKS 1.24 and removed in 1.28. If your existing persistent volumes are still using nodeAffinity matching these two labels, you need to change them to `topology.kubernetes.io/zone` and `topology.kubernetes.io/region` labels in the new persistent volume setting.
 
 Migration from in-tree to CSI is supported using two migration options:
 


### PR DESCRIPTION
see https://github.com/Azure/AKS/releases/tag/2023-06-25 - `failure-domain.beta.kubernetes.io/zone` and `failure-domain.beta.kubernetes.io/region` will be removed in 1.28 rather than 1.26 