### PR TITLE
Missing mandatory parameters for Az CLI command

### DIFF
--- a/articles/machine-learning/how-to-troubleshoot-online-endpoints.md
+++ b/articles/machine-learning/how-to-troubleshoot-online-endpoints.md
@@ -421,7 +421,7 @@ You can also check if the blobs are present in the workspace storage account.
   #### [Azure CLI](#tab/cli)
 
   ```azurecli
-  az ml online-deployment get-logs --endpoint-name <endpoint-name> --name <deployment-name> –-container storage-initializer`
+  az ml online-deployment get-logs --endpoint-name <endpoint-name> --name <deployment-name> --resource-group <resource-group-name> --workspace-name <workspace-name> –-container storage-initializer
   ```
 
   #### [Python SDK](#tab/python)


### PR DESCRIPTION
"az ml online-deployment get-logs" command will fail, as it's missing mandatory parameters for the resource group and AML workspace names.

Added them and following naming convention for required user values.