### PR TITLE
Update information about the automatic enablement of Security Defaults

### DIFF
--- a/articles/active-directory/fundamentals/concept-fundamentals-security-defaults.md
+++ b/articles/active-directory/fundamentals/concept-fundamentals-security-defaults.md
@@ -45,7 +45,7 @@ Security defaults make it easier to help protect your organization from these id
 If your tenant was created on or after October 22, 2019, security defaults may be enabled in your tenant. To protect all of our users, security defaults are being rolled out to all new tenants at creation. 
 
 > [!NOTE]
-> To help protect organizations, we're always working to improve the security of Microsoft account services. As part of this, free tenants not actively using multifactor authentication for all their users will be periodically notified for the automatic enablement of the security defaults setting. After this setting is enabled, all users in the organization will need to register for multifactor authentication. To avoid confusion, please refer to the email you received and alternatively you can [disable security defaults](#disabling-security-defaults) after it's enabled.
+> To help protect organizations, we're always working to improve the security of Microsoft account services. As part of this, free tenants not actively using multifactor authentication for all their users will be periodically notified for the automatic enablement of the security defaults setting. After this setting is enabled, all users in the organization will need to register for multifactor authentication. To avoid confusion, please refer to the email you received and alternatively you can [disable security defaults](#disabling-security-defaults) after it's enabled. Automatic enablement of Security Defaults feature is not targeted for tenants that have at least one Conditional Access Policy created.
 
 To enable security defaults in your directory:
 


### PR DESCRIPTION
As per Alex's blog post https://techcommunity.microsoft.com/t5/microsoft-entra-azure-ad-blog/raising-the-baseline-security-for-all-organizations-in-the-world/ba-p/3299048, automatic enablement won't affect tenants that has Conditional Access policies created. I'm updating the document with that information since there are several cases being opened on CSS on this regard.