### PR TITLE
Email one-time passcode is available in Teams (common endpoint)

### DIFF
--- a/articles/active-directory/external-identities/one-time-passcode.md
+++ b/articles/active-directory/external-identities/one-time-passcode.md
@@ -39,6 +39,9 @@ Email one-time passcode guest users can also use application endpoints that incl
 
 You can also give email one-time passcode guest users a direct link to an application or resource by including your tenant information, for example `https://myapps.microsoft.com/signin/Twitter/<application ID?tenantId=<your tenant ID>`.
 
+> [!NOTE]
+> Email one-time passcode guest users can sign in to Microsoft Teams directly from the common endpoint without choosing **Sign-in options**. During the sign-in process to Microsoft Teams, the guest user can select a link to send a one-time passcode.
+
 ## User experience for one-time passcode guest users
 
 When the email one-time passcode feature is enabled, newly invited users [who meet certain conditions](#when-does-a-guest-user-get-a-one-time-passcode) will use one-time passcode authentication. Guest users who redeemed an invitation before email one-time passcode was enabled will continue to use their same authentication method.


### PR DESCRIPTION
As documented, email one-time passcode guest users need to click "Sign-in options" to select their sign-in tenant. This is because email one-time passcode does not work in common endpoint. However, email one-time passcode does work in common endpoint when users are signing in to Microsoft Teams by clicking "sign in with a one-time code sent to your email" link below. Azure AD shows a special sign-in page when users are signing in to Teams. I added a note to tell sign-in to Microsoft team is an exception.

![image](https://github.com/MicrosoftDocs/azure-docs/assets/36251880/017dc01d-e617-4c42-9eca-1201d51a690a)
