### PR TITLE
Clarify the meaning of the attestation report

### DIFF
--- a/articles/container-instances/container-instances-tutorial-deploy-confidential-container-default-portal.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-confidential-container-default-portal.md
@@ -65,7 +65,10 @@ Open the overview for the container group by navigating to **Resource Groups** >
 
 2. Once its status is *Running*, navigate to the IP address in your browser. 
 
-:::image type="content" source="media/container-instances-confidential-containers-tutorials/confidential-containers-aci-hello-world.png" alt-text="Screenshot of the hello world application running, PNG.":::
+    :::image type="content" source="media/container-instances-confidential-containers-tutorials/confidential-containers-aci-hello-world.png" alt-text="Screenshot of the hello world application running, PNG.":::
+
+    The presence of the attestation report below the Azure Container Instances logo confirms that the container is running on hardware that supports a hardware-based and attested trusted execution environment (TEE).
+    If you deploy to hardware that does not support a TEE, for example by choosing a region where the ACI Confidential SKU is not available, no attestation report will be shown.
 
 Congratulations! You have deployed a confidential container on Azure Container Instances which is displaying a hardware attestation report in your browser. 
 

--- a/articles/container-instances/container-instances-tutorial-deploy-confidential-container-default-portal.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-confidential-container-default-portal.md
@@ -68,7 +68,7 @@ Open the overview for the container group by navigating to **Resource Groups** >
     :::image type="content" source="media/container-instances-confidential-containers-tutorials/confidential-containers-aci-hello-world.png" alt-text="Screenshot of the hello world application running, PNG.":::
 
     The presence of the attestation report below the Azure Container Instances logo confirms that the container is running on hardware that supports a hardware-based and attested trusted execution environment (TEE).
-    If you deploy to hardware that does not support a TEE, for example by choosing a region where the ACI Confidential SKU is not available, no attestation report will be shown.
+    If you deploy to hardware that does not support a TEE, for example by choosing a region where the [ACI Confidential SKU is not available](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-region-availability#linux-container-groups), no attestation report will be shown.
 
 Congratulations! You have deployed a confidential container on Azure Container Instances which is displaying a hardware attestation report in your browser. 
 

--- a/articles/container-instances/container-instances-tutorial-deploy-confidential-container-default-portal.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-confidential-container-default-portal.md
@@ -68,7 +68,7 @@ Open the overview for the container group by navigating to **Resource Groups** >
     :::image type="content" source="media/container-instances-confidential-containers-tutorials/confidential-containers-aci-hello-world.png" alt-text="Screenshot of the hello world application running, PNG.":::
 
     The presence of the attestation report below the Azure Container Instances logo confirms that the container is running on hardware that supports a hardware-based and attested trusted execution environment (TEE).
-    If you deploy to hardware that does not support a TEE, for example by choosing a region where the [ACI Confidential SKU is not available](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-region-availability#linux-container-groups), no attestation report will be shown.
+    If you deploy to hardware that does not support a TEE, for example by choosing a region where the [ACI Confidential SKU is not available](./container-instances-region-availability.md#linux-container-groups), no attestation report will be shown.
 
 Congratulations! You have deployed a confidential container on Azure Container Instances which is displaying a hardware attestation report in your browser. 
 

--- a/articles/container-instances/container-instances-tutorial-deploy-confidential-containers-cce-arm.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-confidential-containers-cce-arm.md
@@ -194,7 +194,7 @@ With the ARM template that you've crafted and the Azure CLI confcom extension, y
 
    * **Subscription**: select an Azure subscription.
    * **Resource group**: select **Create new**, enter a unique name for the resource group, and then select **OK**.
-   * **Location**: select a location for the resource group. Choose a region where the [Confidential SKU is supported](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-region-availability#linux-container-groups). Example: **North Europe**.
+   * **Location**: select a location for the resource group. Choose a region where the [Confidential SKU is supported](./container-instances-region-availability.md#linux-container-groups). Example: **North Europe**.
    * **Name**: accept the generated name for the instance, or enter a name.
    * **Image**: accept the default image name. This sample Linux image displays a hardware attestation.
 

--- a/articles/container-instances/container-instances-tutorial-deploy-confidential-containers-cce-arm.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-confidential-containers-cce-arm.md
@@ -194,7 +194,7 @@ With the ARM template that you've crafted and the Azure CLI confcom extension, y
 
    * **Subscription**: select an Azure subscription.
    * **Resource group**: select **Create new**, enter a unique name for the resource group, and then select **OK**.
-   * **Location**: select a location for the resource group. Example: **North Europe**.
+   * **Location**: select a location for the resource group. Choose a region where the [Confidential SKU is supported](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-region-availability#linux-container-groups). Example: **North Europe**.
    * **Name**: accept the generated name for the instance, or enter a name.
    * **Image**: accept the default image name. This sample Linux image displays a hardware attestation.
 

--- a/articles/container-instances/container-instances-tutorial-deploy-confidential-containers-cce-arm.md
+++ b/articles/container-instances/container-instances-tutorial-deploy-confidential-containers-cce-arm.md
@@ -224,6 +224,9 @@ Use the Azure portal or a tool such as the [Azure CLI](container-instances-quick
 
     ![Screenshot of browser view of app deployed using Azure Container Instances, PNG.](media/container-instances-confidential-containers-tutorials/confidential-containers-aci-hello-world.png)
 
+    The presence of the attestation report below the Azure Container Instances logo confirms that the container is running on hardware that supports a TEE.
+    If you deploy to hardware that does not support a TEE, for example by choosing a region where the ACI Confidential SKU is not available, no attestation report will be shown.
+
 ## Next Steps  
 
 Now that you have deployed a confidential container group on ACI, you can learn more about how policies are enforced. 


### PR DESCRIPTION
Make it explicit that no attestation report is shown when running on hardware that does not support a TEE. See the [related discussion](https://github.com/MicrosoftDocs/azure-docs/issues/110742).

