### PR TITLE
Update licensing-groups-resolve-problems.md

### DIFF
--- a/articles/active-directory/enterprise-users/licensing-groups-resolve-problems.md
+++ b/articles/active-directory/enterprise-users/licensing-groups-resolve-problems.md
@@ -62,11 +62,9 @@ To see which users and groups are consuming licenses, select a product. Under **
 
 **Problem:** One of the products that's specified in the group contains a service plan that conflicts with another service plan that's already assigned to the user via a different product. Some service plans are configured in a way that they can't be assigned to the same user as another, related service plan.
 
-Consider the following example. A user has a license for Office 365 Enterprise *E1* assigned directly, with all the plans enabled. The user has been added to a group that has the Office 365 Enterprise *E3* product assigned to it. The E3 product contains service plans that can't overlap with the plans that are included in E1, so the group license assignment fails with the “Conflicting service plans” error. In this example, the conflicting service plans are:
-
-- Exchange Online (Plan 2) conflicts with Exchange Online (Plan 1).
-
-To solve this conflict, you need to disable one of the plans. You can disable the E1 license that's directly assigned to the user. Or, you need to modify the entire group license assignment and disable the plans in the E3 license. Alternatively, you might decide to remove the E1 license from the user if it's redundant in the context of the E3 license.
+> [!TIP]
+> Exchange Online Plan1 and Plan2 were previously non-duplicable service plans. However, now they are service plans that can be duplicated.
+> If you are experiencing conflicts with these service plans, please try reprocessing them.
 
 The decision about how to resolve conflicting product licenses always belongs to the administrator. Azure AD doesn't automatically resolve license conflicts.
 


### PR DESCRIPTION
According to this document, Exchange Online plan1 and plan2 can be duplicated. No conflict anymore.
https://techcommunity.microsoft.com/t5/exchange-team-blog/introducing-support-for-concurrent-exchange-online-license/ba-p/3721098

Update this article and delete an explanation about the conflict. 