### PR TITLE
Incorrect parameter name

### DIFF
--- a/articles/machine-learning/how-to-configure-network-isolation-with-v2.md
+++ b/articles/machine-learning/how-to-configure-network-isolation-with-v2.md
@@ -105,13 +105,13 @@ The Azure CLI [extension v1 for machine learning](./v1/reference-azure-machine-l
 > The `v1-legacy-mode` parameter is only available in version 1.41.0 or newer of the Azure CLI extension for machine learning v1 (`azure-cli-ml`). Use the `az version` command to view version information.
 
 ```azurecli
-az ml workspace update -g <myresourcegroup> -w <myworkspace> --v1-legacy-mode False
+az ml workspace update -g <myresourcegroup> -n <myworkspace> --v1-legacy-mode False
 ```
 
 The return value of the `az ml workspace update` command may not show the updated value. To view the current state of the parameter, use the following command:
  
 ```azurecli
-az ml workspace show -g <myresourcegroup> -w <myworkspace> --query v1LegacyMode
+az ml workspace show -g <myresourcegroup> -n <myworkspace> --query v1LegacyMode
 ```
 
 ---


### PR DESCRIPTION
Parameter for workspace name should be -n, not -w. Current command sample will fail because of the missing workspace name parameter.