### PR TITLE
Update attach-managed-disk-portal.md

### DIFF
--- a/articles/virtual-machines/windows/attach-managed-disk-portal.md
+++ b/articles/virtual-machines/windows/attach-managed-disk-portal.md
@@ -42,6 +42,30 @@ This article shows you how to attach a new managed data disk to a Windows virtua
 1. A warning appears notifying you that formatting the disks erases all of the data. Select **OK**.
 1. When the formatting is complete, select **OK**.
 
+## Expanding without downtime classic VM SKU support
+
+If you're using a classic VM SKU, it might not support expanding disks without downtime.
+
+Use the following PowerShell script to determine which VM SKUs it's available with:
+
+```azurepowershell
+Connect-AzAccount
+$subscriptionId="yourSubID"
+$location="desiredRegion"
+Set-AzContext -Subscription $subscriptionId
+$vmSizes=Get-AzComputeResourceSku -Location $location | where{$_.ResourceType -eq 'virtualMachines'}
+
+foreach($vmSize in $vmSizes){
+    foreach($capability in $vmSize.Capabilities)
+    {
+       if(($capability.Name -eq "EphemeralOSDiskSupported" -and $capability.Value -eq "True") -or ($capability.Name -eq "PremiumIO" -and $capability.Value -eq "True") -or ($capability.Name -eq "HyperVGenerations" -and $capability.Value -match "V2"))
+        {
+            $vmSize.Name
+       }
+   }
+}
+```
+
 ## Next steps
 
 - You can also [attach a data disk by using PowerShell](attach-disk-ps.md).


### PR DESCRIPTION
For VM size Standard_D4_v3 unable to expand the data disk when VM is in powered on state.

Error: Change in disk property of VM of size 'Standard_D4_v3' is not supported.

Checked in one public doc: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/expand-disks?tabs=ubuntu#expanding-without-downtime-classic-vm-sku-support

Post running script we are able to check the supported SKUs.
So accordingly we deallocated the VM and then expanded the data disk.

Same information should be there in windows OS VM too.