### PR TITLE
Update api-management-howto-app-insights.md

### DIFF
--- a/articles/api-management/api-management-howto-app-insights.md
+++ b/articles/api-management/api-management-howto-app-insights.md
@@ -174,6 +174,11 @@ To improve performance issues, skip:
 >
 >
 
+## Troubleshooting
+
+Addressing the issue of telemetry data flow from API Management to Application Insights:
++ Investigate the landing zone and confirm whether a linked AMPLS (Azure Monitor Private Link Scope) resource exists within the VNET where the API Management resource is connected. AMPLS resources have a global scope across subscriptions and are responsible for managing data query and ingestion for all Azure Monitor resources. It's possible that the AMPLS has been configured with a Private-Only access mode specifically for data ingestion. In such instances, it becomes necessary to include the Application Insights resource and its associated Log Analytics resource in the AMPLS. Once this addition is made, the API Management data will be successfully ingested into the Application Insights resource, resolving the telemetry data transmission issue.
+
 ## Next steps
 
 + Learn more about [Azure Application Insights](/azure/application-insights/).

--- a/articles/api-management/api-management-howto-app-insights.md
+++ b/articles/api-management/api-management-howto-app-insights.md
@@ -177,7 +177,7 @@ To improve performance issues, skip:
 ## Troubleshooting
 
 Addressing the issue of telemetry data flow from API Management to Application Insights:
-+ Investigate the landing zone and confirm whether a linked AMPLS (Azure Monitor Private Link Scope) resource exists within the VNET where the API Management resource is connected. AMPLS resources have a global scope across subscriptions and are responsible for managing data query and ingestion for all Azure Monitor resources. It's possible that the AMPLS has been configured with a Private-Only access mode specifically for data ingestion. In such instances, it becomes necessary to include the Application Insights resource and its associated Log Analytics resource in the AMPLS. Once this addition is made, the API Management data will be successfully ingested into the Application Insights resource, resolving the telemetry data transmission issue.
++ Investigate whether a linked Azure Monitor Private Link Scope (AMPLS) resource exists within the VNet where the API Management resource is connected. AMPLS resources have a global scope across subscriptions and are responsible for managing data query and ingestion for all Azure Monitor resources. It's possible that the AMPLS has been configured with a Private-Only access mode specifically for data ingestion. In such instances, include the Application Insights resource and its associated Log Analytics resource in the AMPLS. Once this addition is made, the API Management data will be successfully ingested into the Application Insights resource, resolving the telemetry data transmission issue.
 
 ## Next steps
 


### PR DESCRIPTION
Here is a troubleshooting scenario that addresses the issue of telemetry data flow from API Management to Application Insights. 

The solution involves investigating the landing zone to check for the presence of a linked AMPLS (Azure Monitor Private Link Scope) resource within the VNET where the API Management resource is connected. 

AMPLS resources have a global scope across subscriptions and play a crucial role in managing data query and ingestion for all Azure Monitor resources. 

By examining the configuration, we determine if the AMPLS has been set to a Private-Only access mode specifically for data ingestion. To resolve this, the pull request includes the addition of the Application Insights resource and its associated Log Analytics resource to the AMPLS. 

Once implemented, this solution ensures the successful ingestion of API Management data into the App Insights resource, effectively resolving the telemetry data transmission issue.