### PR TITLE
Version for runtime changed from 3 to 4

### DIFF
--- a/articles/azure-functions/create-first-function-cli-powershell.md
+++ b/articles/azure-functions/create-first-function-cli-powershell.md
@@ -112,7 +112,7 @@ Each binding requires a direction, a type, and a unique name. The HTTP trigger h
     # [Azure CLI](#tab/azure-cli)
 
     ```azurecli
-    az functionapp create --resource-group AzureFunctionsQuickstart-rg --consumption-plan-location <REGION> --runtime powershell --functions-version 3 --name <APP_NAME> --storage-account <STORAGE_NAME>
+    az functionapp create --resource-group AzureFunctionsQuickstart-rg --consumption-plan-location <REGION> --runtime powershell --functions-version 4 --name <APP_NAME> --storage-account <STORAGE_NAME>
     ```
 
     The [az functionapp create](/cli/azure/functionapp#az-functionapp-create) command creates the function app in Azure.


### PR DESCRIPTION
The old value (3) will lead to the error
"Could not find a runtime version for runtime {} with functions version {} and os {}Run 'az functionapp list-runtimes' for more details on supported runtimes." For PowerShell based apps the runtime version needs to be set to 4.