### PR TITLE
Update users-default-permissions.md

### DIFF
--- a/articles/active-directory/fundamentals/users-default-permissions.md
+++ b/articles/active-directory/fundamentals/users-default-permissions.md
@@ -132,10 +132,10 @@ Users can perform the following actions on owned enterprise applications. An ent
 | microsoft.directory/servicePrincipals/permissions/update | Update the `servicePrincipals.permissions` property in Azure AD. |
 | microsoft.directory/servicePrincipals/policies/update | Update the `servicePrincipals.policies` property in Azure AD. |
 | microsoft.directory/signInReports/allProperties/read | Read all properties (including privileged properties) on sign-in reports in Azure AD. |
-| microsoft.directory/servicePrincipals/synchronizationCredentials/manage |	Manage application provisioning secrets and credentials
-| microsoft.directory/servicePrincipals/synchronizationJobs/manage |	Start, restart, and pause application provisioning synchronization jobs
-| microsoft.directory/servicePrincipals/synchronizationSchema/manage |	Create and manage application provisioning synchronization jobs and schema
-| microsoft.directory/servicePrincipals/synchronization/standard/read |	Read provisioning settings associated with your service principal
+| microsoft.directory/servicePrincipals/synchronizationCredentials/manage |	Manage application provisioning secrets and credentials |
+| microsoft.directory/servicePrincipals/synchronizationJobs/manage |	Start, restart, and pause application provisioning synchronization jobs |
+| microsoft.directory/servicePrincipals/synchronizationSchema/manage |	Create and manage application provisioning synchronization jobs and schema |
+| microsoft.directory/servicePrincipals/synchronization/standard/read |	Read provisioning settings associated with your service principal |
 
 #### Owned devices
 Users can perform the following actions on owned devices:

--- a/articles/active-directory/fundamentals/users-default-permissions.md
+++ b/articles/active-directory/fundamentals/users-default-permissions.md
@@ -132,6 +132,10 @@ Users can perform the following actions on owned enterprise applications. An ent
 | microsoft.directory/servicePrincipals/permissions/update | Update the `servicePrincipals.permissions` property in Azure AD. |
 | microsoft.directory/servicePrincipals/policies/update | Update the `servicePrincipals.policies` property in Azure AD. |
 | microsoft.directory/signInReports/allProperties/read | Read all properties (including privileged properties) on sign-in reports in Azure AD. |
+| microsoft.directory/servicePrincipals/synchronizationCredentials/manage |	Manage application provisioning secrets and credentials
+| microsoft.directory/servicePrincipals/synchronizationJobs/manage |	Start, restart, and pause application provisioning synchronization jobs
+| microsoft.directory/servicePrincipals/synchronizationSchema/manage |	Create and manage application provisioning synchronization jobs and schema
+| microsoft.directory/servicePrincipals/synchronization/standard/read |	Read provisioning settings associated with your service principal
 
 #### Owned devices
 Users can perform the following actions on owned devices:


### PR DESCRIPTION
Enterprise Application Owners can manage provisioning settings for the Service Principals they own, but this is not reflected in the actions listed for Owned enterprise applications:

Enterprise application owner permissions

When a user adds a new enterprise application, they're automatically added as an owner. As an owner, they can manage the tenant-specific configuration of the application, such as the SSO configuration, PROVISIONING, and user assignments.