### PR TITLE
Fix Kudu API scripts in deploy-zip.md

### DIFF
--- a/articles/app-service/deploy-zip.md
+++ b/articles/app-service/deploy-zip.md
@@ -66,10 +66,14 @@ Publish-AzWebApp -ResourceGroupName Default-Web-WestUS -Name MyApp -ArchivePath 
 
 # [Kudu API](#tab/api)
 
-The following example uses the cURL tool to deploy a ZIP package. Replace the placeholders `<username>`, `<zip-package-path>`, and `<app-name>`. When prompted by cURL, type in the [deployment password](deploy-configure-credentials.md).
+The following example uses the cURL tool to deploy a ZIP package. Replace the placeholders `<username>`, `<password>`, `<zip-package-path>`, and `<app-name>`. Use the [deployment credentials](deploy-configure-credentials.md) for authenticatio.
 
 ```bash
-curl -X POST -u <username:password> -T "@<zip-package-path>" https://<app-name>.scm.azurewebsites.net/api/publish?type=zip
+curl -X POST \
+     -H "Content-Type: application/octet-stream" \
+     -u '<username>:<password>' \
+     -T "<zip-package-path>" \
+     "https://<app-name>.scm.azurewebsites.net/api/zipdeploy"
 ```
 
 [!INCLUDE [deploying to network secured sites](../../includes/app-service-deploy-network-secured-sites.md)]
@@ -77,7 +81,11 @@ curl -X POST -u <username:password> -T "@<zip-package-path>" https://<app-name>.
 The following example uses the `packageUri` parameter to specify the URL of an Azure Storage account that the web app should pull the ZIP from.
 
 ```bash
-curl -X POST -u <username:password> https://<app-name>.scm.azurewebsites.net/api/publish -d '{"packageUri": "https://storagesample.blob.core.windows.net/sample-container/myapp.zip?sv=2021-10-01&sb&sig=slk22f3UrS823n4kSh8Skjpa7Naj4CG3"}'
+curl -X PUT \
+     -H "Content-Type: application/json" \
+     -u '<username>:<password>' \
+     -d '{"packageUri": "https://storagesample.blob.core.windows.net/sample-container/myapp.zip?sv=2021-10-01&sb&sig=slk22f3UrS823n4kSh8Skjpa7Naj4CG3"}' \
+     "https://<app-name>.scm.azurewebsites.net/api/zipdeploy"
 ```
 
 # [Kudu UI](#tab/kudu-ui)

--- a/articles/app-service/deploy-zip.md
+++ b/articles/app-service/deploy-zip.md
@@ -66,7 +66,7 @@ Publish-AzWebApp -ResourceGroupName Default-Web-WestUS -Name MyApp -ArchivePath 
 
 # [Kudu API](#tab/api)
 
-The following example uses the cURL tool to deploy a ZIP package. Replace the placeholders `<username>`, `<password>`, `<zip-package-path>`, and `<app-name>`. Use the [deployment credentials](deploy-configure-credentials.md) for authenticatio.
+The following example uses the cURL tool to deploy a ZIP package. Replace the placeholders `<username>`, `<password>`, `<zip-package-path>`, and `<app-name>`. Use the [deployment credentials](deploy-configure-credentials.md) for authentication.
 
 ```bash
 curl -X POST \


### PR DESCRIPTION
- Updated the Kudu API endpoints as `/api/publish` is not documented anywhere in the Kudu WIKI: https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url

- Added `Content-Type` headers as that is required when `WEBSITE_RUN_FROM_PACKAGE=1`. If omitted, a 500 Internal Server error is returned. That is how azure-cli does it: https://github.com/Azure/azure-cli/blob/d874fe3e73e5485aef26f173fa9391d848ee59bb/src/azure-cli/azure/cli/command_modules/appservice/custom.py#L598-L610

- Removed the info about curl prompting for a password as that is included in the command.

These changes should probably be reflected in the Azure Functions documentation as well? I do not have any functions set up to test it myself.
https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push#rest