### PR TITLE
Update B2C default quota limits (total number of objects)

### DIFF
--- a/articles/active-directory-b2c/service-limits.md
+++ b/articles/active-directory-b2c/service-limits.md
@@ -164,8 +164,8 @@ The following table lists the administrative configuration limits in the Azure A
 |Number of sign-out URLs per application        |1          |
 |String Limit per Attribute      |250 Chars          |
 |Number of B2C tenants per subscription      |20         |
-|Total number of objects (user accounts and applications) per tenant (default limit)|1.25 million |
-|Total number of objects (user accounts and applications) per tenant (using a verified custom domain)|5.25 million |
+|Total number of objects (user accounts and applications) per tenant (default limit)|1 million |
+|Total number of objects (user accounts and applications) per tenant (using a verified custom domain)|5 million |
 |Levels of [inheritance](custom-policy-overview.md#inheritance-model) in custom policies     |10         |
 |Number of policies per Azure AD B2C tenant (user flows + custom policies)     |200          |
 |Maximum policy file size      |1024 KB          |


### PR DESCRIPTION
Updating to correct numbers for the default object limit for B2C tenants. The default limit should be 1 million which rises to 5 million on the addition of a verified domain.