### PR TITLE
Update ClaimTypeReferenceId

### DIFF
--- a/articles/active-directory-b2c/partner-xid.md
+++ b/articles/active-directory-b2c/partner-xid.md
@@ -182,8 +182,8 @@ Get the custom policy starter packs from GitHub, then update the XML files in th
         </InputClaims>
         <OutputClaims>
           <!-- Claims parsed from your REST API -->
-          <OutputClaim ClaimTypeReferenceId="last_name" PartnerClaimType="givenName" />
-          <OutputClaim ClaimTypeReferenceId="first_name" PartnerClaimType="surname" />
+          <OutputClaim ClaimTypeReferenceId="last_name" />
+          <OutputClaim ClaimTypeReferenceId="first_name" />
           <OutputClaim ClaimTypeReferenceId="previous_name" />
           <OutputClaim ClaimTypeReferenceId="year" />
           <OutputClaim ClaimTypeReferenceId="month" />


### PR DESCRIPTION
As described in [xID Client API Docs (x-id.me)](https://document.x-id.me/docs#Userdata), xID returns last_name and first_name as claims. However, original documentation uses givenName and surname as PartnerClaimType. 
