### PR TITLE
Update ingress-controller-install-existing.md

### DIFF
--- a/articles/application-gateway/ingress-controller-install-existing.md
+++ b/articles/application-gateway/ingress-controller-install-existing.md
@@ -44,22 +44,7 @@ Gateway should that become necessary
 Use [Cloud Shell](https://shell.azure.com/) to install Helm:
 
 1. Install [Helm](../aks/kubernetes-helm.md) and run the following to add `application-gateway-kubernetes-ingress` helm package:
-
-    - *Kubernetes RBAC enabled* AKS cluster
-
-    ```bash
-    kubectl create serviceaccount --namespace kube-system tiller-sa
-    kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller-sa
-    helm init --tiller-namespace kube-system --service-account tiller-sa
-    ```
-
-    - *Kubernetes RBAC disabled* AKS cluster
-
-    ```bash
-    helm init
-    ```
-
-1. Add the AGIC Helm repository:
+   Add the AGIC Helm repository:
     ```bash
     helm repo add application-gateway-kubernetes-ingress https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
     helm repo update


### PR DESCRIPTION
Removed below lines, as this is not required with helm v3. Which comes by default on Azure shell. Helm version 3 remove tiller related configuration, which were required with helm v 2: Reference internal workitem:  24504496
ICM Reference : 405025905
>>>
Error getting with helm init command, since helm is at version3

helm init --tiller-namespace kube-system --service-account tiller-sa

Error: unknown command "init" for "helm"

Did you mean this?

       lint

Run 'helm --help' for usage.
>>>

Lines deleted 
"""

    - *Kubernetes RBAC enabled* AKS cluster

    ```bash
    kubectl create serviceaccount --namespace kube-system tiller-sa
    kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller-sa
    helm init --tiller-namespace kube-system --service-account tiller-sa
    ```

    - *Kubernetes RBAC disabled* AKS cluster

    ```bash
    helm init
    ```
"""