### PR TITLE
Update ingress-controller-install-new.md

### DIFF
--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -148,22 +148,7 @@ To install Azure AD Pod Identity to your cluster:
 Kubernetes. We'll use it to install the `application-gateway-kubernetes-ingress` package:
 
 1. Install [Helm](../aks/kubernetes-helm.md) and run the following to add `application-gateway-kubernetes-ingress` helm package:
-
-    - *Kubernetes RBAC enabled* AKS cluster
-
-        ```bash
-        kubectl create serviceaccount --namespace kube-system tiller-sa
-        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller-sa
-        helm init --tiller-namespace kube-system --service-account tiller-sa
-        ```
-
-    - *Kubernetes RBAC disabled* AKS cluster
-
-        ```bash
-        helm init
-        ```
-
-1. Add the AGIC Helm repository:
+   Add the AGIC Helm repository:
     ```bash
     helm repo add application-gateway-kubernetes-ingress https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
     helm repo update


### PR DESCRIPTION
Removed below lines, as this is not required with helm v3. Which comes by default on Azure shell. Helm version 3 remove tiller related configuration, which were required with helm v 2: Reference internal workitem: 24504496
ICM Reference : 405025905

Error getting with helm init command, since helm is at version3

helm init --tiller-namespace kube-system --service-account tiller-sa

Error: unknown command "init" for "helm"

Did you mean this?

   lint
Run 'helm --help' for usage.

Removed below lines :
"""

    - *Kubernetes RBAC enabled* AKS cluster

        ```bash
        kubectl create serviceaccount --namespace kube-system tiller-sa
        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller-sa
        helm init --tiller-namespace kube-system --service-account tiller-sa
        ```

    - *Kubernetes RBAC disabled* AKS cluster

        ```bash
        helm init
        ```
"""