### PR TITLE
Update cli-manage.md

### DIFF
--- a/articles/virtual-machines/linux/cli-manage.md
+++ b/articles/virtual-machines/linux/cli-manage.md
@@ -53,6 +53,7 @@ For more detailed help with specific command line switches and options, you can 
 | Task | Azure CLI commands |
 | --- | --- |
 | Add a data disk to a VM | `az vm disk attach --resource-group myResourceGroup --vm-name myVM --disk myDataDisk --size-gb 128 --new` |
+| List attached disks to a VM | `az vm show --resource-group groupName --name vmName --query "storageProfile"` |
 | Remove a data disk from a VM | `az vm disk detach --resource-group myResourceGroup --vm-name myVM --disk myDataDisk` |
 | Resize a disk | `az disk update --resource-group myResourceGroup --name myDataDisk --size-gb 256` |
 | Snapshot a disk | `az snapshot create --resource-group myResourceGroup --name mySnapshot --source myDataDisk` |


### PR DESCRIPTION
Requirement: How to list disk attached to a vm with cli command line
 
Azure VM just have two disk types, so you can list all disks Id associated with the VM through two CLI commands with the two types:
Data disk:
az vm show -d -g groupName -n vmName --query "storageProfile.dataDisks[].managedDisk.id"
Os disk:
az vm show -d -g groupName -n vmName --query "storageProfile.osDisk.managedDisk.id"
 
If you want both type of disks at one place then you can use below command:
 
az vm show --resource-group groupName --name vmName --query "storageProfile"

PS /home/manisha> az vm show --resource-group starrg --name testvm2019 --query "storageProfile"   
{
  "dataDisks": [],
  "diskControllerType": "SCSI",
  "imageReference": {
    "communityGalleryImageId": null,
    "exactVersion": "17763.4499.230621",
    "id": null,
    "offer": "WindowsServer",
    "publisher": "MicrosoftWindowsServer",
    "sharedGalleryImageId": null,
    "sku": "2019-datacenter-gensecond",
    "version": "latest"
  },
  "osDisk": {
    "caching": "ReadWrite",
    "createOption": "FromImage",
    "deleteOption": "Delete",
    "diffDiskSettings": null,
    "diskSizeGb": null,
    "encryptionSettings": null,
    "image": null,
    "managedDisk": {
      "diskEncryptionSet": null,
      "id": "/subscriptions/6b26da86-6cfd-4198-afde-fb754b11c54e/resourceGroups/StarRG/providers/Microsoft.Compute/disks/testvm2019_disk1_885ae8ee7c5a4d0e85a2d434eba1cfdf",
      "resourceGroup": "StarRG",
      "securityProfile": null,
      "storageAccountType": null
    },
    "name": "testvm2019_disk1_885ae8ee7c5a4d0e85a2d434eba1cfdf",
    "osType": "Windows",
    "vhd": null,
    "writeAcceleratorEnabled": null
  }
}