### PR TITLE
Fix incorrect description of Web PubSub authentication docs

### DIFF
--- a/articles/azure-web-pubsub/reference-rest-api-data-plane.md
+++ b/articles/azure-web-pubsub/reference-rest-api-data-plane.md
@@ -33,7 +33,7 @@ Below claims are required to be included in the JWT token.
 
 Claim Type | Is Required | Description
 ---|---|---
-`aud` | true | Should be the **SAME** as your HTTP request url, trailing slash and query parameters not included. For example, a broadcast request's audience looks like: `https://example.webpubsub.azure.com/api/hubs/myhub`.
+`aud` | true | Should be the **SAME** as your HTTP request url. For example, a broadcast request's audience looks like: `https://example.webpubsub.azure.com/api/hubs/myhub/:send?api-version=2023-07-01`.
 `exp` | true | Epoch time when this token will be expired.
 
 A pseudo code in JS:

--- a/articles/azure-web-pubsub/reference-rest-api-data-plane.md
+++ b/articles/azure-web-pubsub/reference-rest-api-data-plane.md
@@ -33,7 +33,7 @@ Below claims are required to be included in the JWT token.
 
 Claim Type | Is Required | Description
 ---|---|---
-`aud` | true | Should be the **SAME** as your HTTP request url. For example, a broadcast request's audience looks like: `https://example.webpubsub.azure.com/api/hubs/myhub/:send?api-version=2023-07-01`.
+`aud` | true | Should be the **SAME** as your HTTP request url. For example, a broadcast request's audience looks like: `https://example.webpubsub.azure.com/api/hubs/myhub/:send?api-version=2022-11-01`.
 `exp` | true | Epoch time when this token will be expired.
 
 A pseudo code in JS:


### PR DESCRIPTION
Fix the incorrect description of the contents of the JWT's audience. It is in
fact the exact same URL as the request URL - the query and the trailing slash
is kept, as can be seen in the official JS SDK [1].

Further, the example is wrong. The broadcast URL ends with /:send and also
requires the `api-version` query parameter to be set [2].

[1] https://github.com/Azure/azure-sdk-for-js/blob/3bdcd0818f48f94764d2dd76285189e9a1cc2952/sdk/web-pubsub/web-pubsub/src/webPubSubCredentialPolicy.ts#L29

[2] https://learn.microsoft.com/en-us/rest/api/webpubsub/dataplane/web-pub-sub/send-to-all?tabs=HTTP