### PR TITLE
Update api-management-multi-region-concepts.md

### DIFF
--- a/includes/api-management-multi-region-concepts.md
+++ b/includes/api-management-multi-region-concepts.md
@@ -11,7 +11,7 @@ ms.author: danlep
 
 * Gateway configurations such as APIs and policy definitions are regularly synchronized between the primary and secondary regions you add. Multi-region deployment provides availability of the API gateway in more than one region and provides service availability if one region goes offline.
 
-* When API Management receives public HTTP requests to the traffic manager endpoint(applies for external vnet and none modes of Apim), traffic is routed to a regional gateway based on lowest latency, which can reduce latency experienced by geographically distributed API consumers. 
+* When API Management receives public HTTP requests to the traffic manager endpoint (applies for the external VNet and non-networked modes of API Management), traffic is routed to a regional gateway based on lowest latency, which can reduce latency experienced by geographically distributed API consumers. 
 
 * If a region goes offline, API requests are automatically routed around the failed region to the next closest gateway.
 

--- a/includes/api-management-multi-region-concepts.md
+++ b/includes/api-management-multi-region-concepts.md
@@ -11,7 +11,7 @@ ms.author: danlep
 
 * Gateway configurations such as APIs and policy definitions are regularly synchronized between the primary and secondary regions you add. Multi-region deployment provides availability of the API gateway in more than one region and provides service availability if one region goes offline.
 
-* When API Management receives public HTTP requests to the primary gateway endpoint, traffic is routed to a regional gateway based on lowest latency, which can reduce latency experienced by geographically distributed API consumers. 
+* When API Management receives public HTTP requests to the traffic manager endpoint(applies for external vnet and none modes of Apim), traffic is routed to a regional gateway based on lowest latency, which can reduce latency experienced by geographically distributed API consumers. 
 
 * If a region goes offline, API requests are automatically routed around the failed region to the next closest gateway.
 


### PR DESCRIPTION
When API Management receives public HTTP requests to the traffic manager endpoint(applies for external vnet and none modes of Apim), traffic is routed to a regional gateway based on lowest latency, which can reduce latency experienced by geographically distributed API consumers