### PR TITLE
Clarify Ingress secretName value requirement in web application routing docs

### DIFF
--- a/articles/aks/app-routing.md
+++ b/articles/aks/app-routing.md
@@ -482,7 +482,7 @@ OSM issues a certificate that Nginx uses as the client certificate to proxy HTTP
       tls:
      - hosts:
         - <Hostname>
-        secretName: keyvault-aks-helloworld
+        secretName: keyvault-<Ingress resource name>
     ```
 
 ### Create the resources on the cluster

--- a/articles/aks/app-routing.md
+++ b/articles/aks/app-routing.md
@@ -322,7 +322,7 @@ The application routing add-on creates an ingress class on the cluster called *w
 
     > [!NOTE]
     > Update *`<Hostname>`* with your DNS host name and *`<KeyVaultCertificateUri>`* with the ID returned from Azure Key Vault.
-    > The *`secretName`* key in the `tls` section defines the name of the secret that contains the certificate for this Ingress resource. This certificate will be presented in the browser when a client browses to the URL defined in the `<Hostname>` key. Make sure that the value of `secretName` is equal to `keyvault-` followed by the value of the Ingress resource name (from `metadata.name`). In the example yaml, secretName will need to be equal to `keyvault-aks-helloworld`.
+    > The *`secretName`* key in the `tls` section defines the name of the secret that contains the certificate for this Ingress resource. This certificate will be presented in the browser when a client browses to the URL defined in the `<Hostname>` key. Make sure that the value of `secretName` is equal to `keyvault-` followed by the value of the Ingress resource name (from `metadata.name`). In the example YAML, secretName will need to be equal to `keyvault-aks-helloworld`.
 
     ```yaml
     apiVersion: networking.k8s.io/v1
@@ -449,7 +449,7 @@ OSM issues a certificate that Nginx uses as the client certificate to proxy HTTP
 
     > [!NOTE]
     > Update *`<Hostname>`* with your DNS host name and *`<KeyVaultCertificateUri>`* with the ID returned from Azure Key Vault.
-    > The *`secretName`* key in the `tls` section defines the name of the secret that contains the certificate for this Ingress resource. This certificate will be presented in the browser when a client browses to the URL defined in the `<Hostname>` key. Make sure that the value of `secretName` is equal to `keyvault-` followed by the value of the Ingress resource name (from `metadata.name`). In the example yaml, secretName will need to be equal to `keyvault-aks-helloworld`.
+    > The *`secretName`* key in the `tls` section defines the name of the secret that contains the certificate for this Ingress resource. This certificate will be presented in the browser when a client browses to the URL defined in the `<Hostname>` key. Make sure that the value of `secretName` is equal to `keyvault-` followed by the value of the Ingress resource name (from `metadata.name`). In the example YAML, secretName will need to be equal to `keyvault-aks-helloworld`.
 
     ```yaml
     apiVersion: networking.k8s.io/v1

--- a/articles/aks/app-routing.md
+++ b/articles/aks/app-routing.md
@@ -321,7 +321,8 @@ The application routing add-on creates an ingress class on the cluster called *w
 2. Copy the following YAML into a new file named **ingress.yaml** and save the file to your local computer.
 
     > [!NOTE]
-    > Update *`<Hostname>`* with your DNS host name and *`<KeyVaultCertificateUri>`* with the ID returned from Azure Key Vault. `secretName` is the name of the secret that will be generated to store the certificate. This certificate will be presented in the browser.
+    > Update *`<Hostname>`* with your DNS host name and *`<KeyVaultCertificateUri>`* with the ID returned from Azure Key Vault.
+    > The *`secretName`* key in the `tls` section defines the name of the secret that contains the certificate for this Ingress resource. This certificate will be presented in the browser when a client browses to the URL defined in the `<Hostname>` key. Make sure that the value of `secretName` is equal to `keyvault-` followed by the value of the Ingress resource name (from `metadata.name`). In the example yaml, secretName will need to be equal to `keyvault-aks-helloworld`.
 
     ```yaml
     apiVersion: networking.k8s.io/v1
@@ -347,7 +348,7 @@ The application routing add-on creates an ingress class on the cluster called *w
       tls:
      - hosts:
         - <Hostname>
-        secretName: keyvault-aks-helloworld
+        secretName: keyvault-<Ingress resource name>
     ```
 
 ### Create the resources on the cluster
@@ -447,7 +448,8 @@ OSM issues a certificate that Nginx uses as the client certificate to proxy HTTP
 2. Copy the following YAML into a new file named **ingress.yaml** and save the file to your local computer.
 
     > [!NOTE]
-    > Update *`<Hostname>`* with your DNS host name and *`<KeyVaultCertificateUri>`* with the ID returned from Azure Key Vault. `secretName` is the name of the secret that will be generated to store the certificate. This certificate will be presented in the browser.
+    > Update *`<Hostname>`* with your DNS host name and *`<KeyVaultCertificateUri>`* with the ID returned from Azure Key Vault.
+    > The *`secretName`* key in the `tls` section defines the name of the secret that contains the certificate for this Ingress resource. This certificate will be presented in the browser when a client browses to the URL defined in the `<Hostname>` key. Make sure that the value of `secretName` is equal to `keyvault-` followed by the value of the Ingress resource name (from `metadata.name`). In the example yaml, secretName will need to be equal to `keyvault-aks-helloworld`.
 
     ```yaml
     apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
It took me a while to understand why my nginx controller was serving me the default fake Kubernetes TLS certificate instead of the one I had configured. It became clear that (presumably) the ingress controller creates a Kubernetes secret based on the name of the Ingress resource, prefixed by `keyvault-`. The value of `secretName` in the `tls` section of the Ingress resource needs to reflect that secret name, otherwise the secret will not be found but the Ingress will still be created and function (although without a proper TLS certificate).

This change to the docs will hopefully make that more clear. I did base this change on trial-and-error; if someone is able to point me to the code that creates the Kubernetes secret so I can actually see what the code does and cross-check that with my suggested edit, I would appreciate that very much.