### PR TITLE
Update backup-instant-restore-capability.md

### DIFF
--- a/articles/backup/backup-instant-restore-capability.md
+++ b/articles/backup/backup-instant-restore-capability.md
@@ -43,6 +43,7 @@ By default, snapshots are retained for two days. This feature allows restore ope
 * For premium storage accounts, the snapshots taken for instant recovery points count towards the 10-TB limit of allocated space.
 * You get an ability to configure the snapshot retention based on the restore needs. Depending on the requirement, you can set the snapshot retention to a minimum of one day in the backup policy pane as explained below. This will help you save cost for snapshot retention if you don’t perform restores frequently.
 * It's a one directional upgrade. Once upgraded to Instant restore, you can't go back.
+* When using an Instant Restore recovery point, you must restore the VM or disks to a subscription and resource group that do not require CMK-encrypted disks via Azure Policy. 
 
 >[!NOTE]
 >With this instant restore upgrade, the snapshot retention duration of all the customers (**new and existing both included**) will be set to a default value of two days. However, you can set the duration according to your requirement to any value between 1 to 5 days.


### PR DESCRIPTION
We've discovered when restoring a VM at a scope that requires CMK-encrypted disks, the restore will fail when using a snapshot/Instant Restore recovery point. Just want to add a bullet calling this out.