### PR TITLE
Update how-to-managed-network.md

### DIFF
--- a/articles/machine-learning/how-to-managed-network.md
+++ b/articles/machine-learning/how-to-managed-network.md
@@ -651,8 +651,7 @@ To enable the [serverless spark jobs](how-to-submit-spark-jobs.md) for the manag
     ```
 
     # [Azure portal](#tab/portal)
-
-    Create a new compute instance or compute cluster, which also creates the managed virtual network.
+    Provisioning the managed Vnet for serverless Spark jobs is currently not supported through the Portal.
 
     ---
 


### PR DESCRIPTION
The current experience expects users to leverage the CLI/SDK to provision the managed VNet for spark serverless jobs.