### PR TITLE
Typo "Azure Container Service" to "Azure Kubernetes Service"

### DIFF
--- a/articles/aks/use-byo-cni.md
+++ b/articles/aks/use-byo-cni.md
@@ -170,7 +170,7 @@ At this point, the cluster is ready for installation of a CNI plugin.
 Learn more about networking in AKS in the following articles:
 
 * [Use a static IP address with the Azure Kubernetes Service (AKS) load balancer](static-ip.md)
-* [Use an internal load balancer with Azure Container Service (AKS)](internal-lb.md)
+* [Use an internal load balancer with Azure Kubernetes Service (AKS)](internal-lb.md)
 * [Create a basic ingress controller with external network connectivity][aks-ingress-basic]
 * [Enable the HTTP application routing add-on][aks-http-app-routing]
 * [Create an ingress controller that uses an internal, private network and IP address][aks-ingress-internal]


### PR DESCRIPTION
Name of the Link in this page(use-byo-cni.md) and the actual title of the page(internal-lb.md) seems to be different.