### PR TITLE
Fix typo - readd waagent to command

### DIFF
--- a/articles/virtual-machines/linux/create-upload-generic.md
+++ b/articles/virtual-machines/linux/create-upload-generic.md
@@ -340,7 +340,7 @@ The [Azure Linux Agent](../extensions/agent-linux.md) `waagent` provisions a Lin
    ```bash
    sudo rm -f /var/log/waagent.log
    sudo cloud-init clean
-   sudo  -force -deprovision+user
+   sudo waagent -force -deprovision+user
    sudo rm -f ~/.bash_history
    sudo export HISTSIZE=0
    ```  


### PR DESCRIPTION
It appears that "waagent" was removed from part of the command here, which would explain why my VM wasn't provisioning.