### PR TITLE
Update Send Request policy example syntax

### DIFF
--- a/articles/api-management/send-request-policy.md
+++ b/articles/api-management/send-request-policy.md
@@ -23,7 +23,7 @@ The `send-request` policy sends the provided request to the specified URL, waiti
 <send-request mode="new | copy" response-variable-name="" timeout="60 sec" ignore-error
 ="false | true">
   <set-url>request URL</set-url>
-  <set-method>.../set-method>
+  <set-method>...</set-method>
   <set-header>...</set-header>
   <set-body>...</set-body>
   <authentication-certificate thumbprint="thumbprint" />


### PR DESCRIPTION
## Context
This pull request proposes to fix an `XML` syntax error in the `api-management/send-request-policy` page. 

As the changeling shows, the closing tag for the `set-method` use is now correctly closed. 

Documentation link: [Send Request](https://learn.microsoft.com/en-us/azure/api-management/send-request-policy)