### PR TITLE
Update tutorial-publisher-deploy-opc-publisher-standalone.md

### DIFF
--- a/articles/industrial-iot/tutorial-publisher-deploy-opc-publisher-standalone.md
+++ b/articles/industrial-iot/tutorial-publisher-deploy-opc-publisher-standalone.md
@@ -53,7 +53,7 @@ A typical set of IoT Edge Module Container Create Options for OPC Publisher is:
 {
     "Hostname": "opcpublisher",
     "Cmd": [
-        "--pf=./pn.json",
+        "--pf=/appdata/pn.json",
         "--aa"
     ],
     "HostConfig": {


### PR DESCRIPTION
As seen in multiple examples [here](https://www.linkedin.com/pulse/step-by-step-guide-installing-opc-publisher-azure-iot-kevin-hilscher/) and [here](https://github.com/Azure/Industrial-IoT/blob/main/docs/opc-publisher/readme.md#specifying-container-create-options-in-the-azure-portal) the --pf filename should have a path beginning with the local folder name of the related binding.