### PR TITLE
Update prometheus-metrics-troubleshoot.md - Fix incorrect port number in docs (9091 -> 9090)

### DIFF
--- a/articles/azure-monitor/essentials/prometheus-metrics-troubleshoot.md
+++ b/articles/azure-monitor/essentials/prometheus-metrics-troubleshoot.md
@@ -118,10 +118,10 @@ The metrics addon can be configured to run in debug mode by changing the configm
 When enabled, all Prometheus metrics that are scraped are hosted at port 9090. Run the following command:
 
 ```
-kubectl port-forward <ama-metrics pod name> -n kube-system 9091
+kubectl port-forward <ama-metrics pod name> -n kube-system 9090
 ``` 
 
-Go to `127.0.0.1:9091/metrics` in a browser to see if the metrics were scraped by the OpenTelemetry Collector. This user interface can be accessed for every `ama-metrics-*` pod. If metrics aren't there, there could be an issue with the metric or label name lengths or the number of labels. Also check for exceeding the ingestion quota for Prometheus metrics as specified in this article.
+Go to `127.0.0.1:9090/metrics` in a browser to see if the metrics were scraped by the OpenTelemetry Collector. This user interface can be accessed for every `ama-metrics-*` pod. If metrics aren't there, there could be an issue with the metric or label name lengths or the number of labels. Also check for exceeding the ingestion quota for Prometheus metrics as specified in this article.
 
 ## Metric names, label names & label values
 


### PR DESCRIPTION
This PR fixes a disparity in the docs in which both the ports 9091 and 9090 are mentioned - but only 9090 is the correct port.