### PR TITLE
Updated event-hubs-c-getstarted-send.md

### DIFF
--- a/articles/event-hubs/event-hubs-c-getstarted-send.md
+++ b/articles/event-hubs/event-hubs-c-getstarted-send.md
@@ -59,6 +59,9 @@ In this section shows how to write a C app to send events to your event hub. The
     #include <string.h>
     #include <unistd.h>
     #include <stdlib.h>
+    #include <signal.h>
+
+    volatile sig_atomic_t stop = 0;
    
     #define check(messenger)                                                     \
       {                                                                          \
@@ -68,7 +71,13 @@ In this section shows how to write a C app to send events to your event hub. The
           die(__FILE__, __LINE__, pn_error_text(pn_messenger_error(messenger))); \
         }                                                                        \
       }
-   
+
+    void interrupt_handler(int signum){
+      if(signum == SIGINT){
+        stop = 1;
+      }
+    }
+        
     pn_timestamp_t time_now(void)
     {
       struct timeval now;
@@ -108,12 +117,13 @@ In this section shows how to write a C app to send events to your event hub. The
    
     int main(int argc, char** argv) {
         printf("Press Ctrl-C to stop the sender process\n");
+    	signal(SIGINT, inthand);
    
         pn_messenger_t *messenger = pn_messenger(NULL);
         pn_messenger_set_outgoing_window(messenger, 1);
         pn_messenger_start(messenger);
    
-        while(true) {
+        while(!stop) {
             sendMessage(messenger);
             printf("Sent message\n");
             sleep(1);

--- a/articles/event-hubs/event-hubs-c-getstarted-send.md
+++ b/articles/event-hubs/event-hubs-c-getstarted-send.md
@@ -117,7 +117,7 @@ In this section shows how to write a C app to send events to your event hub. The
    
     int main(int argc, char** argv) {
         printf("Press Ctrl-C to stop the sender process\n");
-    	signal(SIGINT, inthand);
+    	signal(SIGINT, interrupt_handler);
    
         pn_messenger_t *messenger = pn_messenger(NULL);
         pn_messenger_set_outgoing_window(messenger, 1);


### PR DESCRIPTION
Previously, the code never execute the free functions. Because there was an infinite loop above it.

while(true); 
//program never reaches this line
//release messenger resources
pn_messenger_stop(messenger);
pn_messenger_free(messenger);

Updated C program example to correctly handle the interrupt and release memory before exit.