### PR TITLE
Add faq for firewall enabled Storage Account

### DIFF
--- a/articles/ai-services/document-intelligence/faq.yml
+++ b/articles/ai-services/document-intelligence/faq.yml
@@ -445,6 +445,12 @@ sections:
 
           - Switching subscriptions or resources can be done under Settings -> Resource tab.
 
+      - question: |
+          My Storage Account is configured with firewall and get AuthorizationFailure on Project Share, Auto Label or OCR Upgrade.
+        answer: |
+
+          Please add our website IP address, 20.3.165.95, to the allowlist of firewall. This is Document Intelligence Studio's dedicated IP address and can be safely allowed.
+
   - name: Containers
     questions:
       - question: |

--- a/articles/ai-services/document-intelligence/faq.yml
+++ b/articles/ai-services/document-intelligence/faq.yml
@@ -446,7 +446,7 @@ sections:
           - Switching subscriptions or resources can be done under Settings -> Resource tab.
 
       - question: |
-          Why am I receiving an AuthorizationFailure error on Project Sharing, Auto Label, or OCR Upgrade when my Storage Account is configured with a firewall?
+          Why am I receiving an AuthorizationFailure error on Auto Label or OCR Upgrade when my Storage Account is configured with a firewall?
         answer: |
 
           Please add our website IP address, 20.3.165.95, to the allowlist of firewall. This is Document Intelligence Studio's dedicated IP address and can be safely allowed.

--- a/articles/ai-services/document-intelligence/faq.yml
+++ b/articles/ai-services/document-intelligence/faq.yml
@@ -446,7 +446,7 @@ sections:
           - Switching subscriptions or resources can be done under Settings -> Resource tab.
 
       - question: |
-          My Storage Account is configured with firewall and get AuthorizationFailure on Project Share, Auto Label or OCR Upgrade.
+          Why am I receiving an AuthorizationFailure error on Project Sharing, Auto Label, or OCR Upgrade when my Storage Account is configured with a firewall?
         answer: |
 
           Please add our website IP address, 20.3.165.95, to the allowlist of firewall. This is Document Intelligence Studio's dedicated IP address and can be safely allowed.


### PR DESCRIPTION
Indicate users to allow our backend ip address to access their Storage Account.