### PR TITLE
Remove scenarios that require domain joining

### DIFF
--- a/articles/lab-services/administrator-guide.md
+++ b/articles/lab-services/administrator-guide.md
@@ -202,6 +202,9 @@ To obtain lab VMs with unique SID, create a lab without a template VM.  You must
 
 If you plan to use an endpoint management tool or similar software, we recommend that you don't use template VMs for your labs.
 
+## AAD register/join, Hybrid AAD join, or AD domain join
+To make labs easy to set up and manage, Azure Lab Services is designed with *no* requirement to register/join lab VMs to either Active Directory (AD) or Azure Active Directory (AAD).  As a result, Azure Lab Services *doesn’t* currently offer built-in support to register/join lab VMs.  Although it's possible to AAD register/join, Hybrid AAD join, or AD domain join lab VMs using other mechanisms, we do *not* recommend that you attempt to register/join lab VMs to either AD or AAD due to product limitations.
+
 ## Pricing
 
 ### Azure Lab Services

--- a/articles/lab-services/administrator-guide.md
+++ b/articles/lab-services/administrator-guide.md
@@ -202,8 +202,8 @@ To obtain lab VMs with unique SID, create a lab without a template VM.  You must
 
 If you plan to use an endpoint management tool or similar software, we recommend that you don't use template VMs for your labs.
 
-## AAD register/join, Hybrid AAD join, or AD domain join
-To make labs easy to set up and manage, Azure Lab Services is designed with *no* requirement to register/join lab VMs to either Active Directory (AD) or Azure Active Directory (AAD).  As a result, Azure Lab Services *doesn’t* currently offer built-in support to register/join lab VMs.  Although it's possible to AAD register/join, Hybrid AAD join, or AD domain join lab VMs using other mechanisms, we do *not* recommend that you attempt to register/join lab VMs to either AD or AAD due to product limitations.
+## Azure AD register/join, Hybrid Azure AD join, or AD domain join
+To make labs easy to set up and manage, Azure Lab Services is designed with *no* requirement to register/join lab VMs to either Active Directory (AD) or Azure Active Directory (Azure AD).  As a result, Azure Lab Services *doesn’t* currently offer built-in support to register/join lab VMs.  Although it's possible to Azure AD register/join, Hybrid Azure AD join, or AD domain join lab VMs using other mechanisms, we do *not* recommend that you attempt to register/join lab VMs to either AD or Azure AD due to product limitations.
 
 ## Pricing
 

--- a/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
+++ b/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
@@ -35,6 +35,7 @@ The following table lists common networking scenarios and topologies and their s
 | Use a connection broker, such as Parsec, for high-framerate gaming scenarios | Not recommended | This scenario isn’t directly supported with Azure Lab Services and would run into the same challenges as accessing lab VMs by private IP address. |
 | *Cyber field* scenario, consisting of a set of vulnerable VMs on the network for lab users to discover and hack into (ethical hacking)  | Yes | This scenario works with advanced networking for lab plans. Learn about the [ethical hacking class type](./class-type-ethical-hacking.md). |
 | Enable using Azure Bastion for lab VMs  | No | Azure Bastion isn't supported in Azure Lab Services. |
+| Set up line-of-sight to domain controller | No | Line-of-sight from a lab is required to Hybrid AAD join or AD domain join VMs; however, we do currently *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to the complexity involved with setup and managing orphaned devices in AD/AAD. |
 
 ## Next steps
 

--- a/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
+++ b/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
@@ -35,7 +35,7 @@ The following table lists common networking scenarios and topologies and their s
 | Use a connection broker, such as Parsec, for high-framerate gaming scenarios | Not recommended | This scenario isn’t directly supported with Azure Lab Services and would run into the same challenges as accessing lab VMs by private IP address. |
 | *Cyber field* scenario, consisting of a set of vulnerable VMs on the network for lab users to discover and hack into (ethical hacking)  | Yes | This scenario works with advanced networking for lab plans. Learn about the [ethical hacking class type](./class-type-ethical-hacking.md). |
 | Enable using Azure Bastion for lab VMs  | No | Azure Bastion isn't supported in Azure Lab Services. |
-| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab is to a domain controller is required to Hybrid AAD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to the complexity involved. |
+| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab to a domain controller is required to Hybrid AAD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to the complexity involved. |
 
 ## Next steps
 

--- a/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
+++ b/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
@@ -35,7 +35,7 @@ The following table lists common networking scenarios and topologies and their s
 | Use a connection broker, such as Parsec, for high-framerate gaming scenarios | Not recommended | This scenario isn’t directly supported with Azure Lab Services and would run into the same challenges as accessing lab VMs by private IP address. |
 | *Cyber field* scenario, consisting of a set of vulnerable VMs on the network for lab users to discover and hack into (ethical hacking)  | Yes | This scenario works with advanced networking for lab plans. Learn about the [ethical hacking class type](./class-type-ethical-hacking.md). |
 | Enable using Azure Bastion for lab VMs  | No | Azure Bastion isn't supported in Azure Lab Services. |
-| Set up line-of-sight to domain controller | No | Line-of-sight from a lab is required to Hybrid AAD join or AD domain join VMs; however, we do currently *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to the complexity involved with setup and managing orphaned devices in AD/AAD. |
+| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab is to a domain controller is required to Hybrid AAD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to the complexity involved. |
 
 ## Next steps
 

--- a/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
+++ b/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
@@ -35,7 +35,7 @@ The following table lists common networking scenarios and topologies and their s
 | Use a connection broker, such as Parsec, for high-framerate gaming scenarios | Not recommended | This scenario isn’t directly supported with Azure Lab Services and would run into the same challenges as accessing lab VMs by private IP address. |
 | *Cyber field* scenario, consisting of a set of vulnerable VMs on the network for lab users to discover and hack into (ethical hacking)  | Yes | This scenario works with advanced networking for lab plans. Learn about the [ethical hacking class type](./class-type-ethical-hacking.md). |
 | Enable using Azure Bastion for lab VMs  | No | Azure Bastion isn't supported in Azure Lab Services. |
-| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab to a domain controller is required to Hybrid AAD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to the complexity involved. |
+| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab to a domain controller is required to Hybrid AAD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to product limitations. |
 
 ## Next steps
 

--- a/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
+++ b/articles/lab-services/concept-lab-services-supported-networking-scenarios.md
@@ -35,7 +35,7 @@ The following table lists common networking scenarios and topologies and their s
 | Use a connection broker, such as Parsec, for high-framerate gaming scenarios | Not recommended | This scenario isn’t directly supported with Azure Lab Services and would run into the same challenges as accessing lab VMs by private IP address. |
 | *Cyber field* scenario, consisting of a set of vulnerable VMs on the network for lab users to discover and hack into (ethical hacking)  | Yes | This scenario works with advanced networking for lab plans. Learn about the [ethical hacking class type](./class-type-ethical-hacking.md). |
 | Enable using Azure Bastion for lab VMs  | No | Azure Bastion isn't supported in Azure Lab Services. |
-| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab to a domain controller is required to Hybrid AAD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be AAD joined/registered, Hybrid AAD joined, or AD domain joined due to product limitations. |
+| Set up line-of-sight to domain controller | Not recommended | Line-of-sight from a lab to a domain controller is required to Hybrid Azure AD join or AD domain join VMs; however, we currently do *not* recommend that lab VMs be Azure AD joined/registered, Hybrid Azure AD joined, or AD domain joined due to product limitations. |
 
 ## Next steps
 

--- a/articles/lab-services/how-to-prepare-windows-template.md
+++ b/articles/lab-services/how-to-prepare-windows-template.md
@@ -98,18 +98,6 @@ New-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\OneDrive"
     -Name "FilesOnDemandEnabled" -Value "00000001" -PropertyType DWORD
 ```
 
-### Silently sign in users to OneDrive
-
-You can configure OneDrive to automatically sign in with the Windows credentials of the logged on lab user.  Automatic sign-in is useful for scenarios where lab users signs in with their organizational account.
-
-Use the following PowerShell script to enable automatic sign-in:
-
-```powershell
-New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\OneDrive"
-New-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\OneDrive"
-    -Name "SilentAccountConfig" -Value "00000001" -PropertyType DWORD
-```
-
 ### Disable the OneDrive tutorial
 
 By default, after you finish the OneDrive setup, a tutorial is launched in the browser. Use the following script to disable the tutorial from showing:

--- a/articles/lab-services/how-to-prepare-windows-template.md
+++ b/articles/lab-services/how-to-prepare-windows-template.md
@@ -110,7 +110,7 @@ New-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\OneDrive"
 
 ### Set the maximum download size of a user's OneDrive
 
-To prevent that OneDrive automatically uses a large amount of disk space on the lab virtual machine when syncing files, you can configure a maximum size threshold. When a lab user has a OneDrive that's larger than the threshold (in MB), the user receives a prompt to choose which folders they want to sync before the OneDrive sync client (OneDrive.exe) downloads the files to the machine. This setting is used in combination with [automatic sign-in of users to OneDrive](#silently-sign-in-users-to-onedrive) and where [on-demand files](#use-onedrive-files-on-demand) isn't enabled.
+To prevent that OneDrive automatically uses a large amount of disk space on the lab virtual machine when syncing files, you can configure a maximum size threshold. When a lab user has a OneDrive that's larger than the threshold (in MB), the user receives a prompt to choose which folders they want to sync before the OneDrive sync client (OneDrive.exe) downloads the files to the machine. This setting is used where [on-demand files](#use-onedrive-files-on-demand) isn't enabled.
 
 Use the following PowerShell script to set the maximum size threshold. In our example, `1111-2222-3333-4444` is the organization ID and `0005000` sets a threshold of 5 GB.
 


### PR DESCRIPTION
Removing these scenarios in the docs because we're deprecating the domain join scripts and *not* recommending to customers that they either AD/AAD join or register their lab VMs.