### PR TITLE
OpenAI Contribute Role must be at Sub level

### DIFF
--- a/articles/ai-services/openai/how-to/quota.md
+++ b/articles/ai-services/openai/how-to/quota.md
@@ -46,6 +46,7 @@ Post deployment you can adjust your TPM allocation by selecting **Edit deploymen
 
 > [!IMPORTANT]
 > Quotas and limits are subject to change, for the most up-date-information consult our [quotas and limits article](../quotas-limits.md).
+> At this time, creating deployments and assigning quota requires the [Cognitive Services OpenAI Contributor](/azure/role-based-access-control/built-in-roles#cognitive-services-openai-contributor) set at the subscription level (not the resource or resource group level)
 
 ## Model specific settings
 


### PR DESCRIPTION
Currently the Cognitive Services OpenAI Contributor role must be set at the subscription level, not the resource or resource group level. Users with Cognitive Services OpenAI Contributor role set at the non-subscription level will be able to access the OpenAI Studio but will be unable to create models or assign quota.