### PR TITLE
Update functions-bindings-cosmosdb-v2-trigger.md

### DIFF
--- a/articles/azure-functions/functions-bindings-cosmosdb-v2-trigger.md
+++ b/articles/azure-functions/functions-bindings-cosmosdb-v2-trigger.md
@@ -334,11 +334,12 @@ import azure.functions as func
 app = func.FunctionApp()
 
 @app.function_name(name="CosmosDBTrigger")
-@app.cosmos_db_trigger(arg_name="documents", 
+@app.cosmos_db_trigger(name="documents", 
+                       connection="CONNECTION_SETTING",
                        database_name="DB_NAME", 
-                       collection_name="COLLECTION_NAME", 
-                       connection_string_setting="CONNECTION_SETTING",
- lease_collection_name="leases", create_lease_collection_if_not_exists="true")
+                       container_name="CONTAINER_NAME", 
+                       lease_container_name="leases",
+                       create_lease_container_if_not_exists="true")
 def test_function(documents: func.DocumentList) -> str:
     if documents:
         logging.info('Document id: %s', documents[0]['id'])


### PR DESCRIPTION
This sample code doesn't work. It's old implementation of the decorator for CosmosDBTrigger class.

According to the definition of decorator in azure-functions-python-library/azure/functions/decorators /cosmosdb.py, it should be like this.

https://github.com/Azure/azure-functions-python-library/blob/dev/azure/functions/decorators/cosmosdb.py