### PR TITLE
Update azure-web-apps-net-core.md, Change ApplicationInsightsAgent_EXTENSION_VERSION to ~3 for both Linux and Windows

### DIFF
--- a/articles/azure-monitor/app/azure-web-apps-net-core.md
+++ b/articles/azure-monitor/app/azure-web-apps-net-core.md
@@ -83,7 +83,7 @@ To enable telemetry collection with Application Insights, only the application s
 
 |App setting name |  Definition | Value |
 |-----------------|:------------|-------------:|
-|ApplicationInsightsAgent_EXTENSION_VERSION | Main extension, which controls runtime monitoring. | `~2` for Windows or `~3` for Linux |
+|ApplicationInsightsAgent_EXTENSION_VERSION | Main extension, which controls runtime monitoring. | `~3` |
 |XDT_MicrosoftApplicationInsights_Mode |  In default mode, only essential features are enabled to ensure optimal performance. | `disabled` or `recommended`. |
 |XDT_MicrosoftApplicationInsights_PreemptSdk | For ASP.NET Core apps only. Enables Interop (interoperation) with the Application Insights SDK. Loads the extension side by side with the SDK and uses it to send telemetry. (Disables the Application Insights SDK.) |`1`|
 


### PR DESCRIPTION
Change ApplicationInsightsAgent_EXTENSION_VERSION to ~3 for both Linux and Windows

**Description**
It seems Windows also uses ApplicationInsightsAgent_EXTENSION_VERSION = ~3 now.

When creating an App Service (Windows .net 6) in Azure Portal, if Application Insights is also enabled, ApplicationInsightsAgent_EXTENSION_VERSION = ~3 will be set.

// Deployment Screen
![image](https://github.com/MicrosoftDocs/azure-docs/assets/26296423/fb663279-a390-4e4d-8ef8-44b71c160407)

// Application setting screen
![image](https://github.com/MicrosoftDocs/azure-docs/assets/26296423/cc66a381-8f8c-41a1-8929-061eb2e4141c)

