### PR TITLE
Missing variable initialisation

### DIFF
--- a/articles/ai-services/openai/how-to/function-calling.md
+++ b/articles/ai-services/openai/how-to/function-calling.md
@@ -125,8 +125,10 @@ if response_message.get("function_call"):
     available_functions = {
             "search_hotels": search_hotels,
     }
+    function_to_call = available_functions[function_name] 
+
     function_args = json.loads(response_message["function_call"]["arguments"])
-    function_response = fuction_to_call(**function_args)
+    function_response = function_to_call(**function_args)
 
     # Add the assistant response and function response to the messages
     messages.append( # adding assistant response to messages


### PR DESCRIPTION
"function_to_call" was not assigned with any function references and that's why code would fail. As per the original code from the Azure Samples repo, this line is missing:

function_to_call = available_functions[function_name]