### PR TITLE
Doc Update - Scope maps and tokens does not support docker push and pull of signed image.

### DIFF
--- a/articles/container-registry/container-registry-content-trust.md
+++ b/articles/container-registry/container-registry-content-trust.md
@@ -15,6 +15,9 @@ Azure Container Registry implements Docker's [content trust][docker-content-trus
 > [!NOTE]
 > Content trust is a feature of the [Premium service tier](container-registry-skus.md) of Azure Container Registry.
 
+## Limitations
+- Token with repository-scoped permissions does not currently support docker push and pull of signed images.
+
 ## How content trust works
 
 Important to any distributed system designed with security in mind is verifying both the *source* and the *integrity* of data entering the system. Consumers of the data need to be able to verify both the publisher (source) of the data, as well as ensure it's not been modified after it was published (integrity). 


### PR DESCRIPTION
Scope maps and tokens does not support docker push and pull of signed image. This is not documented which leads to users doing unnecessary and failed attempts to make it work only to find out that it doesn't work and not supported. Adding to document will bring clarity. 