### PR TITLE
Further optimisation as per DRY principle

### DIFF
--- a/articles/ai-services/openai/how-to/function-calling.md
+++ b/articles/ai-services/openai/how-to/function-calling.md
@@ -134,7 +134,7 @@ if response_message.get("function_call"):
     messages.append( # adding assistant response to messages
         {
             "role": response_message["role"],
-            "name": response_message["function_call"]["name"],
+            "name": function_name,
             "content": response_message["function_call"]["arguments"],
         }
     )


### PR DESCRIPTION
We already have "function_name" variable that was assigned with the result of "response_message["function_call"]["name"]". That's why using principle of DRY (Don't Repeat Yourself), it's more Pythonic to re-use "function_name" in row 137, especially because the same is variable is used later in row 144.