### PR TITLE
Fix example code in Azure OpenAI function calling document

### DIFF
--- a/articles/ai-services/openai/how-to/function-calling.md
+++ b/articles/ai-services/openai/how-to/function-calling.md
@@ -131,13 +131,7 @@ if response_message.get("function_call"):
     function_response = function_to_call(**function_args)
 
     # Add the assistant response and function response to the messages
-    messages.append( # adding assistant response to messages
-        {
-            "role": response_message["role"],
-            "name": response_message["function_call"]["name"],
-            "content": response_message["function_call"]["arguments"],
-        }
-    )
+    messages.append(response_message) # adding assistant response to messages
     messages.append( # adding function response to messages
         {
             "role": "function",


### PR DESCRIPTION
According to the [OpenAI document](https://platform.openai.com/docs/guides/gpt/function-calling), the original response message with `function_call` property should be directly appended to messages, instead of treating function call arguments as `content`.