### PR TITLE
fix bash code to attach to interactive command prompt

### DIFF
--- a/articles/azure-sql-edge/connect.md
+++ b/articles/azure-sql-edge/connect.md
@@ -54,7 +54,7 @@ The [SQL Server command-line tools](/sql/linux/sql-server-linux-setup-tools) are
 1. Use the `docker exec -it` command to start an interactive bash shell inside your running container. In the following example, `e69e056c702d` is the container ID.
 
     ```bash
-    docker exec -it <Azure SQL Edge container ID or name> /bin/bash
+    docker exec -it e69e056c702d /bin/bash
     ```
 
     > [!TIP]


### PR DESCRIPTION
In the documentation it mentions that `e69e056c702d` is the ID of the container as shown in the example, however the ID was missing in the bash code example. this change should make it more clear.