### PR TITLE
fix: typo in cmd

### DIFF
--- a/articles/iot-hub-device-update/device-update-ubuntu-agent.md
+++ b/articles/iot-hub-device-update/device-update-ubuntu-agent.md
@@ -83,7 +83,7 @@ For convenience, this tutorial uses a [cloud-init](../virtual-machines/linux/usi
 1. Open the configuration details (See how to [set up configuration file here](device-update-configuration-file.md) with the command below. Set your connectionType as 'AIS' and connectionData as empty string. Please note that all values with the 'Place value here' tag must be set. See [Configuring a DU agent](./device-update-configuration-file.md#example-du-configjson-file-contents).
 
    ```bash
-   sudo /etc/adu/du-config.json
+   sudo nano /etc/adu/du-config.json
    ```
 
 1. Restart the Device Update agent.


### PR DESCRIPTION
### Main Changes

Fix bad reference, missing editor in the instruction. So I added `nano`: `sudo nano /etc/adu/du-config.json`

### Error details
![Captura de pantalla 2023-07-26 a las 13 27 36](https://github.com/MicrosoftDocs/azure-docs/assets/5110813/a3d80c0e-74ca-499c-8fc6-124b2ab4f819)

