### PR TITLE
Update network-file-system-protocol-support-how-to.md

### DIFF
--- a/articles/storage/blobs/network-file-system-protocol-support-how-to.md
+++ b/articles/storage/blobs/network-file-system-protocol-support-how-to.md
@@ -126,7 +126,7 @@ Create a directory on your Linux system and then mount the container in the stor
    - For a temporary mount that doesn't persist across reboots, run the following command: 
     
      ```
-     mount -t aznfs -o sec=sys,vers=3,nolock,proto=tcp <storage-account-name>.blob.core.windows.net:/<storage-account-name>/<container-name>  /nfsdatain 
+     mount -t aznfs -o sec=sys,vers=3,nolock,proto=tcp <storage-account-name>.blob.core.windows.net:/<storage-account-name>/<container-name>  /nfsdata
      ``` 
      
      > [!TIP]


### PR DESCRIPTION
Step 6: Mount the container. 
For a temporary mount the container after creating a sample directory at /nfsdata. However, to avoid confusion while mapping the mount point, we suggest renaming the temporary mount example from /nfsdatain to /nfsdata for a successful mount. 

Temporary mount current example: mount -t aznfs -o sec=sys,vers=3,nolock,proto=tcp <storage-account-name>.blob.core.windows.net:/<storage-account-name>/<container-name>  /nfsdatain