### PR TITLE
Update attach-disk-portal.md

### DIFF
--- a/articles/virtual-machines/linux/attach-disk-portal.md
+++ b/articles/virtual-machines/linux/attach-disk-portal.md
@@ -115,7 +115,7 @@ The following example uses `parted` on `/dev/sdc`, which is where the first data
 
 ```bash
 sudo parted /dev/sdc --script mklabel gpt mkpart xfspart xfs 0% 100%
-sudo mkfs.xfs /dev/sdc
+sudo mkfs.xfs /dev/sdc1
 sudo partprobe /dev/sdc1
 ```
 


### PR DESCRIPTION
Fixed a serious problem
The command "mkfs.xfs /dev/sdc" is wrong, which causes the signature of the xfs partition created in the previous step to be overwritten, it should be "mkfs.xfs /dev/sdc1".