### PR TITLE
Update howto-vm-sign-in-azure-ad-linux.md

### DIFF
--- a/articles/active-directory/devices/howto-vm-sign-in-azure-ad-linux.md
+++ b/articles/active-directory/devices/howto-vm-sign-in-azure-ad-linux.md
@@ -190,7 +190,7 @@ There are two ways to configure role assignments for a VM:
 - Azure Cloud Shell experience
 
 > [!NOTE]
-> The Virtual Machine Administrator Login and Virtual Machine User Login roles use `dataActions` and can be assigned at the management group, subscription, resource group, or resource scope. We recommend that you assign the roles at the management group, subscription, or resource level and not at the individual VM level. This practice avoids the risk of reaching the [Azure role assignments limit](../../role-based-access-control/troubleshoot-limits.md) per subscription.
+> The Virtual Machine Administrator Login and Virtual Machine User Login roles use `dataActions` and can be assigned at the management group, subscription, resource group, or resource scope. We recommend that you assign the roles at the management group, subscription, or resource group level and not at the individual VM level. This practice avoids the risk of reaching the [Azure role assignments limit](../../role-based-access-control/troubleshoot-limits.md) per subscription.
 
 ### Azure AD portal
 


### PR DESCRIPTION
Fix note about the scope of the role assignment

The previously used "resource" phrase is the same as the "individual VM level" scope which the note warns about.