### PR TITLE
Changing from `Pod Identity` to `Workload Identity`

### DIFF
--- a/articles/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller.md
+++ b/articles/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller.md
@@ -101,7 +101,7 @@ You need to complete the following tasks prior to deploying Application Gateway 
 
 ## Install the ALB Controller
 
-1. Create a user managed identity for ALB controller and federate the identity as Pod Identity to use in the AKS cluster.
+1. Create a user managed identity for ALB controller and federate the identity as Workload Identity to use in the AKS cluster.
 
     ```azurecli-interactive
     RESOURCE_GROUP='<your resource group name>'


### PR DESCRIPTION
Changing from `Pod Identity` to `Workload Identity` to avoid confusion since Pod Identity is deprecated.