### PR TITLE
Removed word Elevated

### DIFF
--- a/articles/active-directory/develop/howto-create-self-signed-certificate.md
+++ b/articles/active-directory/develop/howto-create-self-signed-certificate.md
@@ -46,7 +46,7 @@ To customize the start and expiry date and other properties of the certificate, 
 
 Use the certificate you create using this method to authenticate from an application running from your machine. For example, authenticate from Windows PowerShell.
 
-In an elevated PowerShell prompt, run the following command and leave the PowerShell console session open. Replace `{certificateName}` with the name that you wish to give to your certificate.
+In an PowerShell prompt, run the following command and leave the PowerShell console session open. Replace `{certificateName}` with the name that you wish to give to your certificate.
 
 ```powershell
 $certname = "{certificateName}"    ## Replace {certificateName}

--- a/articles/active-directory/develop/howto-create-self-signed-certificate.md
+++ b/articles/active-directory/develop/howto-create-self-signed-certificate.md
@@ -46,7 +46,7 @@ To customize the start and expiry date and other properties of the certificate, 
 
 Use the certificate you create using this method to authenticate from an application running from your machine. For example, authenticate from Windows PowerShell.
 
-In an PowerShell prompt, run the following command and leave the PowerShell console session open. Replace `{certificateName}` with the name that you wish to give to your certificate.
+In a PowerShell prompt, run the following command and leave the PowerShell console session open. Replace `{certificateName}` with the name that you wish to give to your certificate.
 
 ```powershell
 $certname = "{certificateName}"    ## Replace {certificateName}


### PR DESCRIPTION
Removed the word Elevated.

To create and place a certifiacte in the users personal certicate store, no elevated Powershell is needed.

It is important to use least privilige.