### PR TITLE
Fix typo in "deployment-stacks.md" which leads to runtime error

### DIFF
--- a/articles/azure-resource-manager/bicep/deployment-stacks.md
+++ b/articles/azure-resource-manager/bicep/deployment-stacks.md
@@ -598,7 +598,7 @@ The Azure PowerShell includes these parameters to customize the deny assignment:
 - `DenySettingsMode`: Defines the operations that are prohibited on the managed resources to safeguard against unauthorized security principals attempting to delete or update them. This restriction applies to everyone unless explicitly granted access. The values include: `None`, `DenyDelete`, and `DenyWriteAndDelete`.
 - `DenySettingsApplyToChildScopes`: Deny settings are applied to nested resources under managed resources.
 - `DenySettingsExcludedActions`: List of role-based management operations that are excluded from the deny settings. Up to 200 actions are permitted.
-- `DenySettingsExcludedPrincipals`: List of Azure Active Directory (Azure AD) principal IDs excluded from the lock. Up to five principals are permitted.
+- `DenySettingsExcludedPrincipal`: List of Azure Active Directory (Azure AD) principal IDs excluded from the lock. Up to five principals are permitted.
 
 # [CLI](#tab/azure-cli)
 
@@ -626,7 +626,7 @@ New-AzResourceGroupDeploymentStack `
   -TemplateFile "<bicep-file-name>" `
   -DenySettingsMode "DenyDelete" `
   -DenySettingsExcludedActions "Microsoft.Compute/virtualMachines/write Microsoft.StorageAccounts/delete" `
-  -DenySettingsExcludedPrincipals "<object-id>" "<object-id>"
+  -DenySettingsExcludedPrincipal "<object-id>" "<object-id>"
 ```
 
 # [CLI](#tab/azure-cli)
@@ -658,7 +658,7 @@ New-AzSubscriptionDeploymentStack `
   -TemplateFile "<bicep-file-name>" `
   -DenySettingsMode "DenyDelete" `
   -DenySettingsExcludedActions "Microsoft.Compute/virtualMachines/write Microsoft.StorageAccounts/delete" `
-  -DenySettingsExcludedPrincipals "<object-id>" "<object-id>"
+  -DenySettingsExcludedPrincipal "<object-id>" "<object-id>"
 ```
 
 Use the `DeploymentResourceGroupName` parameter to specify the resource group name at which the deployment stack is created. If a scope isn't specified, it uses the scope of the deployment stack.
@@ -694,7 +694,7 @@ New-AzManagmentGroupDeploymentStack `
   -TemplateFile "<bicep-file-name>" `
   -DenySettingsMode "DenyDelete" `
   -DenySettingsExcludedActions "Microsoft.Compute/virtualMachines/write Microsoft.StorageAccounts/delete" `
-  -DenySettingsExcludedPrincipals "<object-id>" "<object-id>"
+  -DenySettingsExcludedPrincipal "<object-id>" "<object-id>"
 ```
 
 Use the `DeploymentSubscriptionId ` parameter to specify the subscription ID at which the deployment stack is created. If a scope isn't specified, it uses the scope of the deployment stack.


### PR DESCRIPTION
Fixing typo DenySettingsExcludedPrincipals --> DenySettingsExcludedPrincipal.

Ref to dev:
https://github.com/Azure/azure-powershell/blob/81d8f8b62d556a94f850edfbb0756fcc95bf3a4a/src/Resources/Resources/help/New-AzResourceGroupDeploymentStack.md#L4

