### PR TITLE
{AzureFunctions} Mention the Microsoft.Azure.Functions.Worker.Extensions.ServiceBus NuGet package.

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus-trigger.md
+++ b/articles/azure-functions/functions-bindings-service-bus-trigger.md
@@ -64,7 +64,7 @@ public static void Run(
 ```
 # [Isolated process](#tab/isolated-process)
 
-The following example shows a [C# function](dotnet-isolated-process-guide.md) that receives a Service Bus queue message, logs the message, and sends a message to different Service Bus queue:
+The following example shows a [C# function](dotnet-isolated-process-guide.md) that uses the `Microsoft.Azure.Functions.Worker.Extensions.ServiceBus` package to receive a Service Bus queue message, log the message and send a message to different Service Bus queue:
 
 :::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/ServiceBus/ServiceBusFunction.cs" range="10-25":::
 


### PR DESCRIPTION
fixes MicrosoftDocs/azure-docs#113106

We should mention the nuget package `Microsoft.Azure.Functions.Worker.Extensions.ServiceBus` details in the C# isolated function sample to avoid any confusion and enhance our documentation.

Docs link: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger?tabs=python-v2%2Cisolated-process%2Cextensionv5&pivots=programming-language-csharp#example