### PR TITLE
Update event-filtering.md with ArrayOfObject exception

### DIFF
--- a/articles/event-grid/event-filtering.md
+++ b/articles/event-grid/event-filtering.md
@@ -180,6 +180,10 @@ For **custom input schema**, use the event data fields (like `data.key1`). To ac
 	},
 ```
 
+> [!NOTE]
+> Event Grid doesn't support filtering on an array of objects. Only allows String, Boolean, Numbers and Array of the same types (like integer array or string array).
+ 
+
 ## Values
 The values can be: number, string, boolean, or array
 

--- a/articles/event-grid/event-filtering.md
+++ b/articles/event-grid/event-filtering.md
@@ -181,7 +181,7 @@ For **custom input schema**, use the event data fields (like `data.key1`). To ac
 ```
 
 > [!NOTE]
-> Event Grid doesn't support filtering on an array of objects. Only allows String, Boolean, Numbers and Array of the same types (like integer array or string array).
+> Event Grid doesn't support filtering on an array of objects. It only allows String, Boolean, Numbers, and Array of the same types (like integer array or string array).
  
 
 ## Values


### PR DESCRIPTION
Adding an exception.
Event Grid doesn't support filtering on an array of objects. Only allows String, Boolean, Numbers and Array of the same types (like integer array or string array). https://learn.microsoft.com/en-us/answers/questions/978455/event-grid-topic-how-to-filter-array-values