### PR TITLE
Remove extra dots from `staticwebapp.config.json`

### DIFF
--- a/includes/static-web-apps-languages-runtimes.md
+++ b/includes/static-web-apps-languages-runtimes.md
@@ -39,7 +39,7 @@ The following example demonstrates how to update the `TargetFramework` element f
 
 ### Node.js
 
-The following example configuration demonstrates how to use the `apiRuntime` property to select Node.js 16 as the API language runtime version in the _staticwebapp.config..json_ file.
+The following example configuration demonstrates how to use the `apiRuntime` property to select Node.js 16 as the API language runtime version in the _staticwebapp.config.json_ file.
 
 ```json
 {
@@ -53,7 +53,7 @@ The following example configuration demonstrates how to use the `apiRuntime` pro
 
 ### Python
 
-The following example configuration demonstrates how to use the `apiRuntime` property to select Python 3.8 as the API language runtime version in the _staticwebapp.config..json_ file.
+The following example configuration demonstrates how to use the `apiRuntime` property to select Python 3.8 as the API language runtime version in the _staticwebapp.config.json_ file.
 
 ```json
 {


### PR DESCRIPTION
Just removing some extra dots that snuck their way into the filenames. Thanks for maintaining these docs!