### PR TITLE
Warn of limitation for CDN-managed certificates on apex domains

### DIFF
--- a/articles/cdn/onboard-apex-domain.md
+++ b/articles/cdn/onboard-apex-domain.md
@@ -25,7 +25,7 @@ Mapping your apex or root domain to your CDN profile requires CNAME flattening o
 You can use the Azure portal to onboard an apex domain on your CDN and enable HTTPS on it by associating it with a certificate for TLS termination. Apex domains are also referred as root or naked domains.
 
 > [!IMPORTANT]
-> CDN-managed certificates are not available for root or apex domains. If your Azure CDN custom domain is a root or apex domain, you must use the Bring your own certificate feature.
+> CDN-managed certificates are not available for root or apex domains. If your Azure CDN custom domain is a root or apex domain, you must use the *Bring Your Own Certificate (BYOC)* feature.
 >
 
 ## Create an alias record for zone apex

--- a/articles/cdn/onboard-apex-domain.md
+++ b/articles/cdn/onboard-apex-domain.md
@@ -24,6 +24,10 @@ Mapping your apex or root domain to your CDN profile requires CNAME flattening o
 
 You can use the Azure portal to onboard an apex domain on your CDN and enable HTTPS on it by associating it with a certificate for TLS termination. Apex domains are also referred as root or naked domains.
 
+> [!IMPORTANT]
+> CDN-managed certificates are not available for root or apex domains. If your Azure CDN custom domain is a root or apex domain, you must use the Bring your own certificate feature.
+>
+
 ## Create an alias record for zone apex
 
 1. Open **Azure DNS** configuration for the domain to be onboarded.


### PR DESCRIPTION
Explain that CDN-managed certificates are not supported for apex domains. 

This explanation is the same as for https://learn.microsoft.com/en-us/azure/cdn/cdn-custom-ssl?tabs=option-1-default-enable-https-with-a-cdn-managed-certificate, but increased visibility on the docs for apex onboarding would have helped me avoid a CDN-managed certificate which ended up expiring(!) due to this limitation.