### PR TITLE
fixed custom-accelerator create command

### DIFF
--- a/articles/spring-apps/how-to-use-accelerator.md
+++ b/articles/spring-apps/how-to-use-accelerator.md
@@ -319,7 +319,7 @@ To configure a certificate for an accelerator, open the **Accelerators** section
 Use the following command to configure a certificate for the accelerator:
 
 ```azurecli
-az spring application-accelerator customized-accelerator add \
+az spring application-accelerator customized-accelerator create \
     --resource-group <resource-group-name> \
     --service <service-instance-name> \
     --name <customized-accelerator-name> \


### PR DESCRIPTION
Prior documentation stated command should be `az spring application-accelerator customized-accelerator add` to add a new customized app accelerator.

Per the latest spring extension (1.14.0) the correct command is `az spring application-accelerator customized-accelerator create`