### PR TITLE
Update link to Quick Edits to Documentation page in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Please use the Feedback tool at the bottom of any article to submit bugs and sug
 
 ### Editing in GitHub
 
-Follow the guidance for [Quick edits to existing documents](https://learn.microsoft.com/en-us/contribute/content/#quick-edits-to-documentation) in our contributor guide.
+Follow the guidance for [Quick edits to existing documents](https://learn.microsoft.com/contribute/content/#quick-edits-to-documentation) in our contributor guide.
 
 ### Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Please use the Feedback tool at the bottom of any article to submit bugs and sug
 
 ### Editing in GitHub
 
-Follow the guidance for [Quick edits to existing documents]([https://learn.microsoft.com/contribute/#quick-edits-to-documentation](https://learn.microsoft.com/en-us/contribute/content/#quick-edits-to-documentation)) in our contributor guide.
+Follow the guidance for [Quick edits to existing documents](https://learn.microsoft.com/en-us/contribute/content/#quick-edits-to-documentation) in our contributor guide.
 
 ### Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Please use the Feedback tool at the bottom of any article to submit bugs and sug
 
 ### Editing in GitHub
 
-Follow the guidance for [Quick edits to existing documents](https://learn.microsoft.com/contribute/#quick-edits-to-documentation) in our contributor guide.
+Follow the guidance for [Quick edits to existing documents]([https://learn.microsoft.com/contribute/#quick-edits-to-documentation](https://learn.microsoft.com/en-us/contribute/content/#quick-edits-to-documentation)) in our contributor guide.
 
 ### Pull requests
 


### PR DESCRIPTION
The old link is broken, updating to correct link.