### PR TITLE
Static Web Apps: fix env name in the workflow for static rendering

### DIFF
--- a/articles/static-web-apps/deploy-nextjs-static-export.md
+++ b/articles/static-web-apps/deploy-nextjs-static-export.md
@@ -148,7 +148,7 @@ By default, the application is treated as a hybrid rendered Next.js application,
               api_location: "" # Api source code path - optional
               output_location: "" # Built app content directory - optional
             env: # Add environment variables here
-              is_static_export: true
+              IS_STATIC_EXPORT: true
     ```
 
     ### [Azure Pipelines](#tab/azure-pipelines)


### PR DESCRIPTION
This PR introduces fixes for the https://learn.microsoft.com/en-us/azure/static-web-apps/deploy-nextjs-static-export?tabs=github-actions page in the section **Configuring Static Rendering**.
It fixes env variable name for the GitHub Actions workflow. I am not sure whether this change should also be made for the Azure Pipelines sections because I followed this tutorial for the GitHub Actions only and faced this inconsistency.