### PR TITLE
FinOps Documentation / Updated toc.yml to include capabities-strucutre.md

### DIFF
--- a/articles/cost-management-billing/finops/toc.yml
+++ b/articles/cost-management-billing/finops/toc.yml
@@ -36,7 +36,7 @@
     - name: Managing anomalies
       href: capabilities-anomalies.md
     - name: Establishing a decision and accountability structure
-      href: capabilities-commitment-discounts.md
+      href: capabilities-structure.md
   - name: Cloud usage optimization
     items:
     - name: Resource utilization and efficiency


### PR DESCRIPTION
Link for Establishing a decision and accountability structure doc is wrong. 

Updated toc.yml and fixed the href of capabilities-structure.md