### PR TITLE
Update tenant-management-directory-quota to default Azure AD B2C quota

### DIFF
--- a/articles/active-directory-b2c/tenant-management-directory-quota.md
+++ b/articles/active-directory-b2c/tenant-management-directory-quota.md
@@ -65,7 +65,7 @@ The response from the API call looks similar to the following json:
         {
             "directorySizeQuota": {
                 "used": 211802,
-                "total": 300000
+                "total": 50000000
             }
         }
     ]


### PR DESCRIPTION
Updated API response from the Microsoft Entra ID default quota total to the default Azure AD B2C directory size quota total.