### PR TITLE
Remove the option --docker-bridge-address from the example

### DIFF
--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -148,7 +148,6 @@ For more information to help you decide which network model to use, see [Compare
     * This address range must be large enough to accommodate the number of nodes that you expect to scale up to. You can't change this address range once the cluster is deployed.
     * The pod IP address range is used to assign a */24* address space to each node in the cluster. In the following example, the *--pod-cidr* of *10.244.0.0/16* assigns the first node *10.244.0.0/24*, the second node *10.244.1.0/24*, and the third node *10.244.2.0/24*.
     * As the cluster scales or upgrades, the Azure platform continues to assign a pod IP address range to each new node.
-  * *--docker-bridge-address* is optional. The address lets the AKS nodes communicate with the underlying management platform. This IP address must not be within the virtual network IP address range of your cluster and shouldn't overlap with other address ranges in use on your network. The default value is 172.17.0.1/16.
 
 > [!NOTE]
 > If you want to enable an AKS cluster to include a [Calico network policy][calico-network-policies], you can use the following command:

--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -157,7 +157,8 @@ For more information to help you decide which network model to use, see [Compare
 >     --resource-group myResourceGroup \
 >     --name myAKSCluster \
 >     --node-count 3 \
->     --network-plugin kubenet --network-policy calico \
+>     --network-plugin kubenet \
+>     --network-policy calico \
 >     --vnet-subnet-id $SUBNET_ID 
 > ```
 

--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -137,7 +137,6 @@ For more information to help you decide which network model to use, see [Compare
         --service-cidr 10.0.0.0/16 \
         --dns-service-ip 10.0.0.10 \
         --pod-cidr 10.244.0.0/16 \
-        --docker-bridge-address 172.17.0.1/16 \
         --vnet-subnet-id $SUBNET_ID    
     ```
 


### PR DESCRIPTION
Option '--docker-bridge-address' has been deprecated and will be removed in a future release.