### PR TITLE
cleanup unused chatgpt_url

### DIFF
--- a/articles/ai-services/openai/includes/use-your-data-rest.md
+++ b/articles/ai-services/openai/includes/use-your-data-rest.md
@@ -23,8 +23,6 @@ To successfully make a call against Azure OpenAI, you need the following variabl
 | `AOAIEndpoint`               | This value can be found in the **Keys & Endpoint** section when examining your Azure OpenAI resource from the Azure portal. Alternatively, you can find the value in **Azure AI studio** > **Chat playground** > **Code view**. An example endpoint is: `https://my-resoruce.openai.azure.com`.|
 | `AOAIKey` | This value can be found in **Resource management** > **Keys & Endpoint** section when examining your Azure OpenAI resource from the Azure portal. You can use either `KEY1` or `KEY2`. Always having two keys allows you to securely rotate and regenerate keys without causing a service disruption. |
 | `AOAIDeploymentId` | This value corresponds to the custom name you chose for your deployment when you deployed a model. This value can be found under **Resource Management** > **Deployments** in the Azure portal or alternatively under **Management** > **Deployments** in Azure AI studio.|
-| `ChatGptUrl` | The Azure OpenAI ChatGPT endpoint that will be used to fulfill the request. This can be the same endpoint as `AoAIEndpoint`. |
-| `ChatGptKey` | If you are using the same Azure OpenAI resource for both `ChatGptUrl` and `AOAIEndpoint`, use the same value as `AOAIKey`. |
 | `SearchEndpoint` | This value can be found in the **Overview** section when examining your Azure Cognitive Search resource from the Azure portal. |
 | `SearchKey` | This value can be found in the **Resource management** > **Keys & Endpoint** section when examining your Azure Cognitive Search resource from the Azure portal. You can use either `KEY1` or `KEY2`. Always having two keys allows you to securely rotate and regenerate keys without causing a service disruption. |
 | `SearchIndex` | This value corresponds to the name of the index you created to store your data. You can find it in the **Overview** section when examining your Azure Cognitive Search resource from the Azure portal. |
@@ -41,12 +39,6 @@ setx AOAIKey REPLACE_WITH_YOUR_AOAI_KEY_VALUE_HERE
 ```
 ```CMD
 setx AOAIDeploymentId REPLACE_WITH_YOUR_AOAI_DEPLOYMENT_VALUE_HERE
-```
-```CMD
-setx ChatGptUrl REPLACE_WITH_YOUR_AOAI_COMPLETION_VALUE_HERE
-```
-```CMD
-setx ChatGptKey REPLACE_WITH_YOUR_AOAI_KEY_VALUE_HERE
 ```
 ```CMD
 setx SearchEndpoint REPLACE_WITH_YOUR_AZURE_SEARCH_RESOURCE_VALUE_HERE
@@ -73,13 +65,6 @@ setx SearchIndex REPLACE_WITH_YOUR_INDEX_NAME_HERE
 [System.Environment]::SetEnvironmentVariable('AOAIDeploymentId', 'REPLACE_WITH_YOUR_AOAI_DEPLOYMENT_VALUE_HERE', 'User')
 ```
 
-```powershell
-[System.Environment]::SetEnvironmentVariable('ChatGptUrl', 'REPLACE_WITH_YOUR_AOAI_COMPLETION_VALUE_HERE', 'User')
-```
-
-```powershell
-[System.Environment]::SetEnvironmentVariable('ChatGptKey', 'REPLACE_WITH_YOUR_AOAI_KEY_VALUE_HERE', 'User')
-```
 
 ```powershell
 [System.Environment]::SetEnvironmentVariable('SearchEndpoint', 'REPLACE_WITH_YOUR_AZURE_SEARCH_RESOURCE_VALUE_HERE', 'User')
@@ -103,12 +88,6 @@ export AOAIKey=REPLACE_WITH_YOUR_AOAI_KEY_VALUE_HERE
 ```
 ```Bash
 export AOAIDeploymentId=REPLACE_WITH_YOUR_AOAI_DEPLOYMENT_VALUE_HERE
-```
-```Bash
-export ChatGptUrl=REPLACE_WITH_YOUR_AOAI_COMPLETION_VALUE_HERE
-```
-```Bash
-export ChatGptKey=REPLACE_WITH_YOUR_AOAI_KEY_VALUE_HERE
 ```
 ```Bash
 export SearchEndpoint=REPLACE_WITH_YOUR_AZURE_SEARCH_RESOURCE_VALUE_HERE
@@ -138,8 +117,6 @@ To trigger a response from the model, you should end with a user message indicat
 curl -i -X POST $AOAIEndpoint/openai/deployments/$AOAIDeploymentId/extensions/chat/completions?api-version=2023-06-01-preview \
 -H "Content-Type: application/json" \
 -H "api-key: $AOAIKey" \
--H "chatgpt_url: $ChatGptUrl" \
--H "chatgpt_key: $ChatGptKey" \
 -d \
 '
 {

--- a/articles/ai-services/openai/reference.md
+++ b/articles/ai-services/openai/reference.md
@@ -310,8 +310,6 @@ POST {your-resource-name}/openai/deployments/{deployment-id}/extensions/chat/com
 curl -i -X POST YOUR_RESOURCE_NAME/openai/deployments/YOUR_DEPLOYMENT_NAME/extensions/chat/completions?api-version=2023-06-01-preview \
 -H "Content-Type: application/json" \
 -H "api-key: YOUR_API_KEY" \
--H "chatgpt_url: YOUR_RESOURCE_URL" \
--H "chatgpt_key: YOUR_API_KEY" \
 -d \
 '
 {


### PR DESCRIPTION
We introduced the hack/workaround of chatgpt_url at the beginning of the public preview because one of the feature was incomplete. Now we fully support the feature so remove the unused chatgpt_url - the API path already has the url so no need to duplicate the info in header.
This hack was never documented in swagger so it is not a breaking change.