### PR TITLE
Replace 'System' by 'system' to use System-Managed Identity

### DIFF
--- a/articles/container-apps/manage-secrets.md
+++ b/articles/container-apps/manage-secrets.md
@@ -162,14 +162,14 @@ Secrets are defined at the application level in the `resources.properties.config
             {
                 "name": "queue-connection-string",
                 "keyVaultUrl": "<KEY-VAULT-SECRET-URI>",
-                "identity": "System"
+                "identity": "system"
             }],
         }
     }
 }
 ```
 
-Here, a connection string to a queue storage account is declared in the `secrets` array. Its value is automatically retrieved from Key Vault using the specified identity. To use a user managed identity, replace `System` with the identity's resource ID.
+Here, a connection string to a queue storage account is declared in the `secrets` array. Its value is automatically retrieved from Key Vault using the specified identity. To use a user managed identity, replace `system` with the identity's resource ID.
 
 Replace `<KEY-VAULT-SECRET-URI>` with the URI of your secret in Key Vault.
 
@@ -191,7 +191,7 @@ az containerapp create \
   --secrets "queue-connection-string=keyvaultref:<KEY_VAULT_SECRET_URI>,identityref:<USER_ASSIGNED_IDENTITY_ID>"
 ```
 
-Here, a connection string to a queue storage account is declared in the `--secrets` parameter. Replace `<KEY_VAULT_SECRET_URI>` with the URI of your secret in Key Vault. Replace `<USER_ASSIGNED_IDENTITY_ID>` with the resource ID of the user assigned identity. For system assigned identity, use `System` instead of the resource ID.
+Here, a connection string to a queue storage account is declared in the `--secrets` parameter. Replace `<KEY_VAULT_SECRET_URI>` with the URI of your secret in Key Vault. Replace `<USER_ASSIGNED_IDENTITY_ID>` with the resource ID of the user assigned identity. For system assigned identity, use `system` instead of the resource ID.
 
 > [!NOTE]
 > The user assigned identity must have access to read the secret in Key Vault. System assigned identity can't be used with the create command because it's not available until after the container app is created.


### PR DESCRIPTION
Replace 'System' by 'system' to use System-Managed Identity to access key vault secret

When creating a secret referencing a key vault secret in the portal and exporting the ARM template, it uses 'system'. When creating with 'System' using az cli, it is not recognized in the portal when the secret is edited. For Dapr component, it is 'system' and not 'System'. I think the correct value is 'system' and not 'System'.