### PR TITLE
fido2-compatibility: linux firefox supported

### DIFF
--- a/articles/active-directory/authentication/fido2-compatibility.md
+++ b/articles/active-directory/authentication/fido2-compatibility.md
@@ -74,7 +74,7 @@ The following tables show which transports are supported for each platform. Supp
 |---------|------|-----|-----|
 | Edge    | &#10060; | &#10060; | &#10060; |
 | Chrome  | &#x2705; | &#10060; | &#10060; |
-| Firefox | &#10060; | &#10060; | &#10060; |
+| Firefox | &#x2705; | &#10060; | &#10060; |
 
 
 ### iOS


### PR DESCRIPTION
FIDO2 / WebAuthn is now supported in Firefox by default: https://www.mozilla.org/en-US/firefox/114.0/releasenotes
I've updated the documentation to reflect this. I'm not certain if NFC & BLE work, but USB is supported.

The Azure Login page still has FIDO2 feature flagged off for Firefox, so I've not updated the earlier section in the document.
It's possible to enable FIDO2 on Firefox on the Azure sign-in page by force enabling the feature flag with a patch.
I've raised a support case to hopefully get this fixed.