### PR TITLE
Clarify Minimum Value Positioning for Runtime.Backend.FlowRunTimeout Setting

### DIFF
--- a/articles/logic-apps/edit-app-settings-host-settings.md
+++ b/articles/logic-apps/edit-app-settings-host-settings.md
@@ -183,7 +183,7 @@ The following settings work only for workflows that start with a recurrence-base
 
 | Setting | Default value | Description |
 |---------|---------------|-------------|
-| `Runtime.Backend.FlowRunTimeout` | `90.00:00:00` <br>(90 days) | Sets the amount of time a workflow can continue running before forcing a timeout. <br><br>**Important**: Make sure this value is less than or equal to the value for the app setting named `Workflows.RuntimeConfiguration.RetentionInDays`. Otherwise, run histories can get deleted before the associated jobs are complete. The minimum value for this setting is 7 days. |
+| `Runtime.Backend.FlowRunTimeout` | `90.00:00:00` <br>(90 days) | Sets the amount of time a workflow can continue running before forcing a timeout. **The minimum value for this setting is 7 days.** <br><br>**Important**: Make sure this value is less than or equal to the value for the app setting named `Workflows.RuntimeConfiguration.RetentionInDays`. Otherwise, run histories can get deleted before the associated jobs are complete. |
 | `Runtime.FlowMaintenanceJob.RetentionCooldownInterval` | `7.00:00:00` <br>(7 days) | Sets the amount of time in days as the interval between when to check for and delete run history that you no longer want to keep. |
 
 <a name="run-actions"></a>

--- a/articles/logic-apps/edit-app-settings-host-settings.md
+++ b/articles/logic-apps/edit-app-settings-host-settings.md
@@ -183,7 +183,7 @@ The following settings work only for workflows that start with a recurrence-base
 
 | Setting | Default value | Description |
 |---------|---------------|-------------|
-| `Runtime.Backend.FlowRunTimeout` | `90.00:00:00` <br>(90 days) | Sets the amount of time a workflow can continue running before forcing a timeout. **The minimum value for this setting is 7 days.** <br><br>**Important**: Make sure this value is less than or equal to the value for the app setting named `Workflows.RuntimeConfiguration.RetentionInDays`. Otherwise, run histories can get deleted before the associated jobs are complete. |
+| `Runtime.Backend.FlowRunTimeout` | `90.00:00:00` <br>(90 days) | Sets the amount of time a workflow can continue running before forcing a timeout. The minimum value for this setting is 7 days. <br><br>**Important**: Make sure this value is less than or equal to the value for the app setting named `Workflows.RuntimeConfiguration.RetentionInDays`. Otherwise, run histories can get deleted before the associated jobs are complete. |
 | `Runtime.FlowMaintenanceJob.RetentionCooldownInterval` | `7.00:00:00` <br>(7 days) | Sets the amount of time in days as the interval between when to check for and delete run history that you no longer want to keep. |
 
 <a name="run-actions"></a>


### PR DESCRIPTION
This PR aims to enhance clarity in the documentation for the Runtime.Backend.FlowRunTimeout setting. I noticed that the positioning of the "minimum value" note was a bit misleading, possibly causing confusion for users who might think the minimum value doesn't apply to the mentioned setting.

There was a bug raised in the logic apps repo based on this confusion.
https://github.com/Azure/logicapps/issues/782

**Changes Made:**

Moved the "The minimum value for this setting is 7 days." statement to a more logical position, ensuring it directly associates with the Runtime.Backend.FlowRunTimeout setting.
This adjustment aims to provide clarity and prevent potential misunderstandings about the setting's constraints.