### PR TITLE
Removing ambiguity from the write accelerator recommendation

### DIFF
--- a/articles/sap/workloads/hana-vm-premium-ssd-v1.md
+++ b/articles/sap/workloads/hana-vm-premium-ssd-v1.md
@@ -41,7 +41,7 @@ The caching recommendations for Azure premium disks below are assuming the I/O c
 **Recommendation: As a result of these observed I/O patterns by SAP HANA, the caching for the different volumes using Azure premium storage should be set like:**
 
 - **/hana/data** - None or read caching
-- **/hana/log** - None. Enable Write Accelerator for M- and Mv2-Series VMs, the option in Azure portal is "None + Write Accelerator".
+- **/hana/log** - None. Enable Write Accelerator for M- and Mv2-Series VMs, the option in the Azure portal is "None + Write Accelerator."
 - **/hana/shared** - read caching
 - **OS disk** - don't change default caching that is set by Azure at creation time of the VM
 

--- a/articles/sap/workloads/hana-vm-premium-ssd-v1.md
+++ b/articles/sap/workloads/hana-vm-premium-ssd-v1.md
@@ -40,8 +40,8 @@ The caching recommendations for Azure premium disks below are assuming the I/O c
 
 **Recommendation: As a result of these observed I/O patterns by SAP HANA, the caching for the different volumes using Azure premium storage should be set like:**
 
-- **/hana/data** - no caching or read caching
-- **/hana/log** - no caching - exception for M- and Mv2-Series VMs where Azure Write Accelerator should be enabled 
+- **/hana/data** - None or read caching
+- **/hana/log** - None. Enable Write Accelerator for M- and Mv2-Series VMs, the option in Azure portal is "None + Write Accelerator".
 - **/hana/shared** - read caching
 - **OS disk** - don't change default caching that is set by Azure at creation time of the VM
 


### PR DESCRIPTION
The current wording is somewhat confusing leading to customers often using an incorrect setting "Read-only + Write Accelerator".