### PR TITLE
Update object-replication-overview.md

### DIFF
--- a/articles/storage/blobs/object-replication-overview.md
+++ b/articles/storage/blobs/object-replication-overview.md
@@ -108,6 +108,9 @@ The source and destination containers must both exist before you can specify the
 
 You can call the [Set Blob Tier](/rest/api/storageservices/set-blob-tier) operation on a blob in the destination container to move it to the archive tier. For more information about the archive tier, see [Hot, Cool, and Archive access tiers for blob data](access-tiers-overview.md#archive-access-tier).
 
+> [!NOTE]
+>  Changing the access tier of blob of source blob won't change the access tier of destination blob as [Set Blob Tier](/rest/api/storageservices/set-blob-tier) ins't implicit part of object replication. 
+
 ## Policy definition file
 
 An object replication policy is defined by JSON file. You can get the policy definition file from an existing object replication policy. You can also create an object replication policy by uploading a policy definition file.


### PR DESCRIPTION
Changing tier of source blob doesn't get replicated to destination. Adding a pointer to clarify the same.