### PR TITLE
[add] ssl flag to mongodump command

### DIFF
--- a/articles/cosmos-db/mongodb/tutorial-mongotools-cosmos-db.md
+++ b/articles/cosmos-db/mongodb/tutorial-mongotools-cosmos-db.md
@@ -140,7 +140,7 @@ The rest of this section will guide you through using the pair of tools you sele
 1. To create a BSON data dump of your MongoDB instance, open a terminal on the MongoDB instance machine. If it is a Linux machine, type
 
     ```bash
-    mongodump --host HOST:PORT --authenticationDatabase admin -u USERNAME -p PASSWORD --db edx --collection query --out edx-dump
+    mongodump --host HOST:PORT --authenticationDatabase admin -u USERNAME -p PASSWORD --db edx --collection query --ssl --out edx-dump
     ```
 
     *HOST*, *PORT*, *USERNAME*, and *PASSWORD* should be filled in based on the properties of your existing MongoDB database instance. You should see that an `edx-dump` directory is produced and that the directory structure of `edx-dump` reproduces the resource hierarchy (database and collection structure) of your source MongoDB instance. Each collection is represented by a BSON file:


### PR DESCRIPTION
Not adding --ssl flag would result in an error as like shown below as Cosmos DB enforces auth via SSL:

`2023-08-23T09:03:55.818+0800    Failed: can't create session: failed to connect to mongodb://xxx.mongo.cosmos.azure.com:10255/: server selection error: server selection timeout, current topology: { Type: Single, Servers: [{ Addr: xxx.mongo.cosmos.azure.com:10255, Type: Unknown, Last error: connection() error occurred during connection handshake: connection(xxx.mongo.cosmos.azure.com:10255[-13]) incomplete read of message header: read tcp 10.168.38.207:56326->40.112.241.48:10255: i/o timeout }, ] }
`