### PR TITLE
Add details to msal-net-user-gets-consent-for-multiple-resources.md

### DIFF
--- a/articles/active-directory/develop/msal-net-user-gets-consent-for-multiple-resources.md
+++ b/articles/active-directory/develop/msal-net-user-gets-consent-for-multiple-resources.md
@@ -17,7 +17,7 @@ ms.custom: devx-track-csharp, aaddev, devx-track-dotnet
 ---
 
 # User gets consent for several resources using MSAL.NET
-The Microsoft identity platform does not allow you to get a token for several resources at once. When using the Microsoft Authentication Library for .NET (MSAL.NET), the scopes parameter in the acquire token method should only contain scopes for a single resource. However, you can pre-consent to several resources upfront by specifying additional scopes using the `.WithExtraScopeToConsent` builder method.
+The Microsoft identity platform does not allow you to get a token for several resources at once. When using the Microsoft Authentication Library for .NET (MSAL.NET), the *scopes* parameter in the acquire token method should only contain scopes for a single resource. However, you can pre-consent to several resources upfront by specifying additional scopes using the `.WithExtraScopesToConsent` builder method.
 
 > [!NOTE]
 > Getting consent for several resources works for Microsoft identity platform, but not for Azure AD B2C. Azure AD B2C supports only admin consent, not user consent.
@@ -27,7 +27,7 @@ For example, if you have two resources that have 2 scopes each:
 - https:\//mytenant.onmicrosoft.com/customerapi (with 2 scopes `customer.read` and `customer.write`)
 - https:\//mytenant.onmicrosoft.com/vendorapi (with 2 scopes `vendor.read` and `vendor.write`)
 
-You should use the `.WithExtraScopeToConsent` modifier which has the *extraScopesToConsent* parameter as shown in the following example:
+You should use the `.WithExtraScopesToConsent` method which has the *extraScopesToConsent* parameter as shown in the following example:
 
 ```csharp
 string[] scopesForCustomerApi = new string[]
@@ -44,12 +44,12 @@ string[] scopesForVendorApi = new string[]
 var accounts = await app.GetAccountsAsync();
 var result = await app.AcquireTokenInteractive(scopesForCustomerApi)
                      .WithAccount(accounts.FirstOrDefault())
-                     .WithExtraScopeToConsent(scopesForVendorApi)
+                     .WithExtraScopesToConsent(scopesForVendorApi)
                      .ExecuteAsync();
 ```
 
-This will get you an access token for the first web API. Then, to access the second web API you can silently acquire the token from the token cache:
+`AcquireTokenInteractive` will return an access token for the first web API. Along with that access token, a refresh token will also be retrieved from Azure AD and cached. Then, to access the second web API, you can silently acquire the token using `AcquireTokenSilent`. MSAL will use the cached refresh token to retrieve from Azure AD the access token for the second web API.
 
 ```csharp
-AcquireTokenSilent(scopesForVendorApi, accounts.FirstOrDefault()).ExecuteAsync();
+var result = await AcquireTokenSilent(scopesForVendorApi, accounts.FirstOrDefault()).ExecuteAsync();
 ```


### PR DESCRIPTION
Updates the doc about how to retrieve tokens for multiple resources by clarifying how the second token is retrieved.