### PR TITLE
Update inbound-provisioning-api-issues.md

### DIFF
--- a/articles/active-directory/app-provisioning/inbound-provisioning-api-issues.md
+++ b/articles/active-directory/app-provisioning/inbound-provisioning-api-issues.md
@@ -40,10 +40,13 @@ This document covers commonly encountered errors and issues with inbound provisi
 
 **Probable causes**
 1. Your API-driven provisioning app is paused. 
-1. The provisioning service is yet to update the provisioning logs with the bulk request processing details. 
+1. The provisioning service is yet to update the provisioning logs with the bulk request processing details.
+2. Your On-premises provisioning agent status is inactive ( If you are running the API-driven inbound user provisioning to on-premises AD) [https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/inbound-provisioning-api-configure-app]. 
+
 
 **Resolution:**
 1. Verify that your provisioning app is running. If it isn't running, select the menu option **Start provisioning** to process the data.
+2. Turn your On-premises provisioning agent status to active by restarting the On-premise agent. . 
 1. Expect 5 to 10-minute delay between processing the request and writing to the provisioning logs. If your API client is sending data to the provisioning /bulkUpload API endpoint, then introduce a time delay between the request invocation and provisioning logs query. 
 
 ### Forbidden 403 response code 

--- a/articles/active-directory/app-provisioning/inbound-provisioning-api-issues.md
+++ b/articles/active-directory/app-provisioning/inbound-provisioning-api-issues.md
@@ -41,12 +41,12 @@ This document covers commonly encountered errors and issues with inbound provisi
 **Probable causes**
 1. Your API-driven provisioning app is paused. 
 1. The provisioning service is yet to update the provisioning logs with the bulk request processing details.
-2. Your On-premises provisioning agent status is inactive ( If you are running the API-driven inbound user provisioning to on-premises AD) [https://learn.microsoft.com/en-us/azure/active-directory/app-provisioning/inbound-provisioning-api-configure-app]. 
+2. Your On-premises provisioning agent status is inactive (If you are running the [/API-driven inbound user provisioning to on-premises AD](https://go.microsoft.com/fwlink/?linkid=2245182)).
 
 
 **Resolution:**
 1. Verify that your provisioning app is running. If it isn't running, select the menu option **Start provisioning** to process the data.
-2. Turn your On-premises provisioning agent status to active by restarting the On-premise agent. . 
+2. Turn your On-premises provisioning agent status to active by restarting the On-premise agent.
 1. Expect 5 to 10-minute delay between processing the request and writing to the provisioning logs. If your API client is sending data to the provisioning /bulkUpload API endpoint, then introduce a time delay between the request invocation and provisioning logs query. 
 
 ### Forbidden 403 response code 

--- a/articles/active-directory/app-provisioning/inbound-provisioning-api-issues.md
+++ b/articles/active-directory/app-provisioning/inbound-provisioning-api-issues.md
@@ -41,7 +41,7 @@ This document covers commonly encountered errors and issues with inbound provisi
 **Probable causes**
 1. Your API-driven provisioning app is paused. 
 1. The provisioning service is yet to update the provisioning logs with the bulk request processing details.
-2. Your On-premises provisioning agent status is inactive (If you are running the [/API-driven inbound user provisioning to on-premises AD](https://go.microsoft.com/fwlink/?linkid=2245182)).
+2. Your On-premises provisioning agent status is inactive (If you are running the [/API-driven inbound user provisioning to on-premises Active Directory](https://go.microsoft.com/fwlink/?linkid=2245182)).
 
 
 **Resolution:**


### PR DESCRIPTION
If the on-prem agent is not active, there will be no users provisioned. This applies to those using the API-driven inbound user provisioning to on-premises AD.