### PR TITLE
Update basic SAML configuration in optiturn-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/optiturn-tutorial.md
+++ b/articles/active-directory/saas-apps/optiturn-tutorial.md
@@ -69,7 +69,7 @@ Complete the following steps to enable Azure AD single sign-on in the Azure port
 	| `https://optiturn.com/sp` - production |
 	| `https://sandbox.optiturn.com/sp` - testing |
 
-        b. In the **Reply URL** textbox, type a URL using one of the following patterns:
+   b. In the **Reply URL** textbox, type a URL using one of the following patterns:
     
 	| **Reply URL** |
 	|------------|
@@ -79,8 +79,8 @@ Complete the following steps to enable Azure AD single sign-on in the Azure port
 	c. In the **Sign on URL** textbox, type one of the following:
 
 	| **Sign on URL** |
-	|----------|
-        | `https://optiturn.com/session/new` - production |
+	| ---------- |
+   | `https://optiturn.com/session/new` - production |
 	| `https://sandbox.optiturn.com/session/new` - testing |
 
 	> [!NOTE]

--- a/articles/active-directory/saas-apps/optiturn-tutorial.md
+++ b/articles/active-directory/saas-apps/optiturn-tutorial.md
@@ -84,7 +84,7 @@ Complete the following steps to enable Azure AD single sign-on in the Azure port
 	| `https://sandbox.optiturn.com/session/new` - testing |
 
 	> [!NOTE]
-   > <Customer_Name> should be replaced with a lowercased and underscored version of your company’s name. For example, Fake Corp. would become fake_corp. The [OptiTurn support team](mailto:support@optoro.com) can help choose this value.
+   > `<Customer_Name>` should be replaced with a lowercased and underscored version of your company’s name. For example, Fake Corp. would become fake_corp. The [OptiTurn support team](mailto:support@optoro.com) can help choose this value.
 
 1. OptiTurn application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your SAML token attributes configuration. The following screenshot shows the list of default attributes.
 

--- a/articles/active-directory/saas-apps/optiturn-tutorial.md
+++ b/articles/active-directory/saas-apps/optiturn-tutorial.md
@@ -62,25 +62,29 @@ Complete the following steps to enable Azure AD single sign-on in the Azure port
 
 1. On the **Basic SAML Configuration** section, perform the following steps:
 
-	a. In the **Identifier** textbox, type the URL:
-	`https://optiturn.com/sp`
+	a. In the **Identifier** textbox, type the URL using one of the following:
 
-    b. In the **Reply URL** textbox, type a URL using one of the following patterns:
+	| **Identifier** |
+	|------------|
+	| `https://optiturn.com/sp` - production |
+	| `https://sandbox.optiturn.com/sp` - testing |
+
+        b. In the **Reply URL** textbox, type a URL using one of the following patterns:
     
 	| **Reply URL** |
 	|------------|
-	| `https://optiturn.com/auth/saml/<Customer_Name>_azure_saml/callback` |
-	| `https://<Environment>.optiturn.com/auth/saml/<Customer_Name>_azure_saml/callback` |
+	| `https://optiturn.com/auth/saml/<Customer_Name>_azure_saml/callback` - production |
+	| `https://sandbox.optiturn.com/auth/saml/<Customer_Name>_azure_saml/callback` - testing |
 
-	c. In the **Sign on URL** textbox, type one of the following URL/pattern:
+	c. In the **Sign on URL** textbox, type one of the following:
 
 	| **Sign on URL** |
 	|----------|
-    | ` https://optiturn.com/session/new` |
-	| `https://<Environment>.optiturn.com/session/new` |
+        | `https://optiturn.com/session/new` - production |
+	| `https://sandbox.optiturn.com/session/new` - testing |
 
 	> [!NOTE]
-    > These values are not real. Update these values with the actual Reply URL and Sign on URL. Contact [OptiTurn support team](mailto:support@optoro.com) to get these values. You can also refer to the patterns shown in the **Basic SAML Configuration** section in the Azure portal.
+        > <Customer_Name> should be replaced with a lowercased and underscored version of your company’s name. For example, Fake Corp. would become fake_corp. The [OptiTurn support team](mailto:support@optoro.com) can help choose this value.
 
 1. OptiTurn application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your SAML token attributes configuration. The following screenshot shows the list of default attributes.
 

--- a/articles/active-directory/saas-apps/optiturn-tutorial.md
+++ b/articles/active-directory/saas-apps/optiturn-tutorial.md
@@ -79,12 +79,12 @@ Complete the following steps to enable Azure AD single sign-on in the Azure port
 	c. In the **Sign on URL** textbox, type one of the following:
 
 	| **Sign on URL** |
-	| ---------- |
+	|----------|
    | `https://optiturn.com/session/new` - production |
 	| `https://sandbox.optiturn.com/session/new` - testing |
 
 	> [!NOTE]
-        > <Customer_Name> should be replaced with a lowercased and underscored version of your company’s name. For example, Fake Corp. would become fake_corp. The [OptiTurn support team](mailto:support@optoro.com) can help choose this value.
+   > <Customer_Name> should be replaced with a lowercased and underscored version of your company’s name. For example, Fake Corp. would become fake_corp. The [OptiTurn support team](mailto:support@optoro.com) can help choose this value.
 
 1. OptiTurn application expects the SAML assertions in a specific format, which requires you to add custom attribute mappings to your SAML token attributes configuration. The following screenshot shows the list of default attributes.
 


### PR DESCRIPTION
I work for the company that owns the OptiTurn product, and I wanted to clarify a few things in our [Azure AD SAML tutorial](https://learn.microsoft.com/en-us/azure/active-directory/saas-apps/optiturn-tutorial). 

- Add a separate identity for testing environment. We had a customer report that they got an error using the same value for two applications. 
- Replace `<Environment>` with actual value. We only have the one test environment, so we might as well spell it out. 
- Clarify how to generate value for `<Customer_Name>`.