### PR TITLE
Making clarity for Diagnostics setting meaning 

### DIFF
--- a/articles/api-management/trace-policy.md
+++ b/articles/api-management/trace-policy.md
@@ -14,8 +14,8 @@ ms.author: danlep
 The `trace` policy adds a custom trace into the request tracing output in the test console, Application Insights telemetries, and/or resource logs.
 
 -   The policy adds a custom trace to the [request tracing](./api-management-howto-api-inspector.md) output in the test console when tracing is triggered, that is, `Ocp-Apim-Trace` request header is present and set to `true` and `Ocp-Apim-Subscription-Key` request header is present and holds a valid key that allows tracing.
--   The policy creates a [Trace](../azure-monitor/app/data-model-complete.md#trace) telemetry in Application Insights, when [Application Insights integration](./api-management-howto-app-insights.md) is enabled and the `severity` specified in the policy is equal to or greater than the `verbosity` specified in the diagnostic setting.
--   The policy adds a property in the log entry when [resource logs](./api-management-howto-use-azure-monitor.md#resource-logs) are enabled and the severity level specified in the policy is at or higher than the verbosity level specified in the diagnostic setting.
+-   The policy creates a [Trace](../azure-monitor/app/data-model-complete.md#trace) telemetry in Application Insights, when [Application Insights integration](./api-management-howto-app-insights.md) is enabled and the `severity` specified in the policy is equal to or greater than the `verbosity` specified in the [diagnostic setting](./diagnostic-logs-reference.md).
+-   The policy adds a property in the log entry when [resource logs](./api-management-howto-use-azure-monitor.md#resource-logs) are enabled and the severity level specified in the policy is at or higher than the verbosity level specified in the [diagnostic setting](./diagnostic-logs-reference.md).
 -   The policy is not affected by Application Insights sampling. All invocations of the policy will be logged.
 
 [!INCLUDE [api-management-tracing-alert](../../includes/api-management-tracing-alert.md)]


### PR DESCRIPTION
Since the diagnostic setting is used interchangeability between APIM level and API levels causing the confusion. Hence proposing a link to denote API diagnostics setting is what referring here