### PR TITLE
Document way to create Flux resources with non-supported parameters

### DIFF
--- a/articles/azure-arc/kubernetes/tutorial-use-gitops-flux2.md
+++ b/articles/azure-arc/kubernetes/tutorial-use-gitops-flux2.md
@@ -497,7 +497,7 @@ To view detailed conditions for a configuration object, select its name.
 Flux supports many parameters to enable various scenarios. For a description of all parameters that Flux supports, see the [official Flux documentation](https://fluxcd.io/docs/). Flux in Azure doesn't support all parameters yet. Let us know if a parameter you need is missing from the Azure implementation.
 
 For more information about available parameters and how to use them, see [GitOps Flux v2 configurations with AKS and Azure Arc-enabled Kubernetes](conceptual-gitops-flux2.md#parameters).
-A workaround to deploy Flux resources with non-supported parameters is to define the required Flux custom resources (for example [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/), [Kustomization](https://fluxcd.io/flux/components/kustomize/kustomization/) etc.) inside your git repository, and deploy these resources with the `az k8s-configuration flux create` command. You will then still be able to access your Flux resources through the Azure Arc UI.
+A workaround to deploy Flux resources with non-supported parameters is to define the required Flux custom resources inside your git repository. For example, [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/), [Kustomization](https://fluxcd.io/flux/components/kustomize/kustomization/), etcetera. Then deploy these resources with the `az k8s-configuration flux create` command. You will then still be able to access your Flux resources through the Azure Arc UI.
 
 ## Manage cluster configuration by using the Flux Kustomize controller
 

--- a/articles/azure-arc/kubernetes/tutorial-use-gitops-flux2.md
+++ b/articles/azure-arc/kubernetes/tutorial-use-gitops-flux2.md
@@ -497,13 +497,13 @@ To view detailed conditions for a configuration object, select its name.
 Flux supports many parameters to enable various scenarios. For a description of all parameters that Flux supports, see the [official Flux documentation](https://fluxcd.io/docs/). Flux in Azure doesn't support all parameters yet. Let us know if a parameter you need is missing from the Azure implementation.
 
 For more information about available parameters and how to use them, see [GitOps Flux v2 configurations with AKS and Azure Arc-enabled Kubernetes](conceptual-gitops-flux2.md#parameters).
-A workaround to deploy Flux resources with non-supported parameters is to define the required Flux custom resources (for example [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/), [Kustomization](https://fluxcd.io/flux/components/kustomize/kustomization/) etc.) inside your git repository, and deploy these resources with the `az k8s-extension create` command. You will then still be able to access your Flux resources through the Azure Arc UI.
+A workaround to deploy Flux resources with non-supported parameters is to define the required Flux custom resources (for example [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/), [Kustomization](https://fluxcd.io/flux/components/kustomize/kustomization/) etc.) inside your git repository, and deploy these resources with the `az k8s-configuration flux create` command. You will then still be able to access your Flux resources through the Azure Arc UI.
 
 ## Manage cluster configuration by using the Flux Kustomize controller
 
 The [Flux Kustomize controller](https://fluxcd.io/docs/components/kustomize/) is installed as part of the `microsoft.flux` cluster extension. It allows the declarative management of cluster configuration and application deployment by using Kubernetes manifests synced from a Git repository. These Kubernetes manifests can optionally include a *kustomize.yaml* file.
 
-For usage details, see the following resiyrces:
+For usage details, see the following resources:
 
 * [Flux Kustomize controller](https://fluxcd.io/docs/components/kustomize/)
 * [Kustomize reference documents](https://kubectl.docs.kubernetes.io/references/kustomize/)

--- a/articles/azure-arc/kubernetes/tutorial-use-gitops-flux2.md
+++ b/articles/azure-arc/kubernetes/tutorial-use-gitops-flux2.md
@@ -497,6 +497,7 @@ To view detailed conditions for a configuration object, select its name.
 Flux supports many parameters to enable various scenarios. For a description of all parameters that Flux supports, see the [official Flux documentation](https://fluxcd.io/docs/). Flux in Azure doesn't support all parameters yet. Let us know if a parameter you need is missing from the Azure implementation.
 
 For more information about available parameters and how to use them, see [GitOps Flux v2 configurations with AKS and Azure Arc-enabled Kubernetes](conceptual-gitops-flux2.md#parameters).
+A workaround to deploy Flux resources with non-supported parameters is to define the required Flux custom resources (for example [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/), [Kustomization](https://fluxcd.io/flux/components/kustomize/kustomization/) etc.) inside your git repository, and deploy these resources with the `az k8s-extension create` command. You will then still be able to access your Flux resources through the Azure Arc UI.
 
 ## Manage cluster configuration by using the Flux Kustomize controller
 


### PR DESCRIPTION
Flux in Azure doesn't support all Kustomization and GitRpository parameters yet.
Documented a workaround to deploy Flux resources with non-supported parameters (for example [spec.include](https://fluxcd.io/flux/components/source/gitrepositories/#include)).
With this workaround we can still see the deployed Flux resources on the azure arc ui.