### PR TITLE
Update network-observability-managed-cli.md

### DIFF
--- a/articles/aks/network-observability-managed-cli.md
+++ b/articles/aks/network-observability-managed-cli.md
@@ -231,36 +231,36 @@ az aks get-credentials --name myAKSCluster --resource-group myResourceGroup
 
     ```yaml
     global:
-      scrape_interval: 30s
-    scrape_configs:
-      - job_name: "cilium-pods"
-        kubernetes_sd_configs:
-          - role: pod
-        relabel_configs:
-          - source_labels: [__meta_kubernetes_pod_container_name]
-            action: keep
-            regex: cilium-agent
-          - source_labels:
-              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-            separator: ":"
-            regex: ([^:]+)(?::\d+)?
-            target_label: __address__
-            replacement: ${1}:${2}
-            action: replace
-          - source_labels: [__meta_kubernetes_pod_node_name]
-            action: replace
-            target_label: instance
-          - source_labels: [__meta_kubernetes_pod_label_k8s_app]
-            action: replace
-            target_label: k8s_app
-          - source_labels: [__meta_kubernetes_pod_name]
-            action: replace
-            regex: (.*)
-            target_label: pod
-        metric_relabel_configs:
-          - source_labels: [__name__]
-            action: keep
-            regex: (.*)
+  scrape_interval: 30s
+scrape_configs:
+  - job_name: "cilium-pods"
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: cilium-agent
+      - source_labels:
+          [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        separator: ":"
+        regex: ([^:]+)(?::\d+)?
+        target_label: __address__
+        replacement: ${1}:${2}
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: instance
+      - source_labels: [__meta_kubernetes_pod_label_k8s_app]
+        action: replace
+        target_label: k8s_app
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        regex: (.*)
+        target_label: pod
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        action: keep
+        regex: (.*)
     ```
 
 1. To create the `configmap`, use the following example:


### PR DESCRIPTION
The prometheus-config configmap contains CRLF instead of LF which issues in loading the configmap changes in deployment. Have replaced the CRLF with LF and committed the changes.

Previous configmap had CRLF which led to unsuccessful load of configmap and cilium Grafana dashboard had no metric, also cilium pods were not showing up Prometheus UP in targets, here is how the configmap looks when described: 
![image](https://github.com/MicrosoftDocs/azure-docs/assets/11813857/4f775ab6-8bfe-4914-81cd-2a9d7eef25a0)
Had to clean the configmap using the following command to convert CRLF to LF:

`sed -i -E 's/[[:space:]]+$//g' prometheus-config`

Post this the CRLF got removed from the configmap and led to successful load of configmap, here is how the configmap look when described subsequently:
![image](https://github.com/MicrosoftDocs/azure-docs/assets/11813857/5b488db2-4df9-4a19-a832-1e15a769945f)

After this the metrics are correctly populated in Grafana dashboard:
![image](https://github.com/MicrosoftDocs/azure-docs/assets/11813857/6a434577-68a6-43cc-b62f-3f4cf6a95efa)
