### PR TITLE
Update default-outbound-access.md

### DIFF
--- a/articles/virtual-network/ip-services/default-outbound-access.md
+++ b/articles/virtual-network/ip-services/default-outbound-access.md
@@ -20,7 +20,7 @@ Examples of explicit outbound connectivity are virtual machines:
 
 * Created within a subnet associated to a NAT gateway.
 
-* In the backend pool of a standard load balancer with outbound rules defined.
+* In the backend pool of a standard load balancer with or without outbound rules defined.
 
 * In the backend pool of a basic public load balancer.
 


### PR DESCRIPTION
Default outbound access is disabled when the VMs are in a Backend Pool of a Load Balancer without outbound rules too.