### PR TITLE
Update cluster-connect.md

### DIFF
--- a/articles/operator-nexus/includes/kubernetes-cluster/cluster-connect.md
+++ b/articles/operator-nexus/includes/kubernetes-cluster/cluster-connect.md
@@ -32,7 +32,7 @@ To access your cluster, you need to set up the cluster connect `kubeconfig`. Aft
 4. Use `kubectl` to send requests to the cluster:
 
     ```console
-    kubectl get nodes
+    kubectl get pods -A
     ```
     You should now see a response from the cluster containing the list of all nodes.
 


### PR DESCRIPTION
In the context of the RBAC using AAD groups article, the reader is given an example to set up a clusterrolebinding based on the built-in "view" role in kubernetes, but that role actually doesn't allow listing nodes. Changing the example kubectl command to list pods instead.