### PR TITLE
Delete unnecessary argument to avoid unintended error

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
@@ -64,7 +64,7 @@ You'll now deploy a new application gateway, to simulate having an existing appl
 ```azurecli-interactive
 az network public-ip create -n myPublicIp -g myResourceGroup --allocation-method Static --sku Standard
 az network vnet create -n myVnet -g myResourceGroup --address-prefix 10.0.0.0/16 --subnet-name mySubnet --subnet-prefix 10.0.0.0/24 
-az network application-gateway create -n myApplicationGateway -l eastus -g myResourceGroup --sku Standard_v2 --public-ip-address myPublicIp --vnet-name myVnet --subnet mySubnet --priority 100
+az network application-gateway create -n myApplicationGateway -g myResourceGroup --sku Standard_v2 --public-ip-address myPublicIp --vnet-name myVnet --subnet mySubnet --priority 100
 ```
 
 > [!NOTE]


### PR DESCRIPTION
For others who do not want to create the resources under East US (or existing resource group but not under East US) but wants to follow the tutorial, this little change will help them to avoid unnecessary error.

To reviewer:
It was already indicated that the resources is created in eastus by default as the resource group is created in eastus: https://github.com/MicrosoftDocs/azure-docs/pull/113996/files#diff-d2bf5dd17d4ba956c82ec34840abd78dacfc04b9a77cefa0cde3692d76e6c48aR38

Hence, the `-l eastus` here (Line 67) is totally unnecessary, and it will disturb followers to create resources in other location. 