### PR TITLE
Explain multi-phase versioning of Service Fabric data contracts

### DIFF
--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -233,7 +233,7 @@ Alternatively, you can perform a multi-phase upgrade.
       in the V1 collection with the
       [IsolationLevel.Snapshot](/dotnet/api/microsoft.servicefabric.data.beta.ireliablestatemanager2.createtransaction)
       to avoid locking it for the entire duration of the copy process.
-    - For each key, use a separate transaction with the [IsolationLevel.ReadRepeatable](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.beta.isolationlevel) to 
+    - For each key, use a separate transaction with the [IsolationLevel.ReadRepeatable](/dotnet/api/microsoft.servicefabric.data.beta.isolationlevel) to 
         - [TryGetValueAsync](/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary-2.trygetvalueasync)
           from the V1 collection.
         - If the value has already been removed from the V1 collection since the copy process started,

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -213,7 +213,7 @@ Internally, Reliable Collections serialize your objects using .NET's DataContrac
 Furthermore, service code is upgraded one upgrade domain at a time. So, during an upgrade, you have two different versions of your service code running simultaneously. You must avoid having the new version of your service code use the new schema as old versions of your service code might not be able to handle the new schema. When possible, you should design each version of your service to be forward compatible by one version. Specifically, this means that V1 of your service code should be able to ignore any schema elements it does not explicitly handle. However, it must be able to save any data it doesn't explicitly know about and write it back out when updating a dictionary key or value.
 
 > [!WARNING]
-> While you can modify the schema of a key, you must ensure that your key's hash code and equals algorithms are stable. If you change how either of these algorithms operate, you will not be able to look up the key within the reliable dictionary ever again.
+> While you can modify the schema of a key, you must ensure that your key's hash code, equality and comparison algorithms are stable. If you change how either of these algorithms operate, you will not be able to look up the key within the reliable dictionary ever again.
 > .NET Strings can be used as a key but use the string itself as the key--do not use the result of String.GetHashCode as the key.
 
 Alternatively, you can perform a multi-phase upgrade. 

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -220,8 +220,8 @@ Furthermore, service code is upgraded one upgrade domain at a time. So, during a
 
 Alternatively, you can perform a multi-phase upgrade. 
 1. Upgrade service to a new version that
-    - has both the original version, V1 of the data contracts, and the new version, V2 of the data contracts.
-    - During this phase, the service must continue accessing data in the original, V1 collection using V1 data contracts.
+    - has both the original V1, and the new V2 version of the data contracts included in the service code package.
+    - performs all operations on the original, V1 collection using the V1 data contracts.
 2. Upgrade service to a new version that
     - creates a new, V2 collection;
     - performs add, update and delete operations on both V1 and V2 collections in a single transaction;
@@ -235,11 +235,11 @@ Alternatively, you can perform a multi-phase upgrade.
     - performs all operations on the V2 collection only;
     - going back to V1 is no longer possible with a service rollback and would require rolling forward with reversed steps 2-4.
 6. Upgrade service a new version that
-    - removes V1 collection from the [StateManager](/dotnet/api/microsoft.servicefabric.services.runtime.statefulservice.statemanager).
+    - removes the V1 collection from the [StateManager](/dotnet/api/microsoft.servicefabric.services.runtime.statefulservice.statemanager).
 7. Wait for log truncation.
     - By default, this happens every 50MB of writes (adds, updates, and removes) to reliable collections.
 8. Upgrade service to a new version that
-    - no longer has the V1 data contracts.
+    - no longer has the V1 data contracts included in the service code package.
 
 ## Next steps
 To learn about creating forward compatible data contracts, see [Forward-Compatible Data Contracts](/dotnet/framework/wcf/feature-details/forward-compatible-data-contracts)

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -221,7 +221,7 @@ Furthermore, service code is upgraded one upgrade domain at a time. So, during a
 Alternatively, you can perform a multi-phase upgrade. 
 1. Upgrade service to a new version that
     - has both the original V1, and the new V2 version of the data contracts included in the service code package;
-    - registers custom V2 [state serializers](https://learn.microsoft.com/azure/service-fabric/service-fabric-reliable-services-reliable-collections-serialization#custom-serialization), if needed;
+    - registers custom V2 [state serializers](/azure/service-fabric/service-fabric-reliable-services-reliable-collections-serialization#custom-serialization), if needed;
     - performs all operations on the original, V1 collection using the V1 data contracts.
 2. Upgrade service to a new version that
     - creates a new, V2 collection;
@@ -229,16 +229,16 @@ Alternatively, you can perform a multi-phase upgrade.
     - performs read operations on the V1 collection only.
 3. Copy all data from the V1 collection to the V2 collection.
     - This can be done in a background process by the service version deployed in step 2.
-    - [Enumerate all keys](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary2-2.createkeyenumerableasync)
+    - [Enumerate all keys](/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary2-2.createkeyenumerableasync)
       in the V1 collection with the
-      [IsolationLevel.Snapshot](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.beta.ireliablestatemanager2.createtransaction)
+      [IsolationLevel.Snapshot](/dotnet/api/microsoft.servicefabric.data.beta.ireliablestatemanager2.createtransaction)
       to avoid locking it for the entire duration of the copy process.
     - For each key, use a separate transaction with the [IsolationLevel.ReadRepeatable](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.beta.isolationlevel) to 
-        - [TryGetValueAsync](https://learn.microsoft.com/en-us/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary-2.trygetvalueasync)
+        - [TryGetValueAsync](/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary-2.trygetvalueasync)
           from the V1 collection.
         - If the value has already been removed from the V1 collection since the copy process started,
           the key should be skipped and not resurected in the V2 collection.
-        - [TryAddAsync](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary.tryaddasync)
+        - [TryAddAsync](/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary.tryaddasync)
           the value to the V2 collection.
         - If the value has already been added to the V2 collection since the copy process started,
           the key should be skipped.

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -225,19 +225,27 @@ Alternatively, you can perform a multi-phase upgrade.
     - performs all operations on the original, V1 collection using the V1 data contracts.
 2. Upgrade service to a new version that
     - creates a new, V2 collection;
-    - performs each add, update and delete operation on both V1 and V2 collections in a single transaction;
+    - performs each add, update and delete operation on first V1 and then V2 collections in a single transaction;
     - performs read operations on the V1 collection only.
 3. Copy all data from the V1 collection to the V2 collection.
     - This can be done in a background process by the service version deployed in step 2.
-    - Enumeration of all data should be done with the
+    - [Enumerate all keys](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary2-2.createkeyenumerableasync)
+      in the V1 collection with the
       [IsolationLevel.Snapshot](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.beta.ireliablestatemanager2.createtransaction)
-      to avoid locking the entire V1 collection for the entire duration.
-    - Copying of data from the V1 to the V2 collection should be done with
-      [TryAddAsync](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary.tryaddasync)
-      to preserve the latest V2 data that may have already been stored by the service add or update operations.
+      to avoid locking it for the entire duration of the copy process.
+    - For each key, use a separate transaction with the [IsolationLevel.ReadRepeatable](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.beta.isolationlevel) to 
+        - [TryGetValueAsync](https://learn.microsoft.com/en-us/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary-2.trygetvalueasync)
+          from the V1 collection.
+        - If the value has already been removed from the V1 collection since the copy process started,
+          the key should be skipped and not resurected in the V2 collection.
+        - [TryAddAsync](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary.tryaddasync)
+          the value to the V2 collection.
+        - If the value has already been added to the V2 collection since the copy process started,
+          the key should be skipped.
+        - The transaction should be committed if the `TryAddAsync` returns `true` and aborted if it returns `false`.
 4. Upgrade service to a new version that
     - performs read operations on the V2 collection only;
-    - still performs each add, update and delete operation on both V1 and V2 collections to maintain the option of rolling back to V1.
+    - still performs each add, update and delete operation on first V1 and then V2 collections to maintain the option of rolling back to V1.
 5. Upgrade service to a new version that
     - performs all operations on the V2 collection only;
     - going back to V1 is no longer possible with a service rollback and would require rolling forward with reversed steps 2-4.

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -224,7 +224,7 @@ Alternatively, you can perform a multi-phase upgrade.
     - registers custom V2 [state serializers](/azure/service-fabric/service-fabric-reliable-services-reliable-collections-serialization#custom-serialization), if needed;
     - performs all operations on the original, V1 collection using the V1 data contracts.
 2. Upgrade service to a new version that
-    - creates a new, V2 collection;
+    - [creates a new, V2 collection](/dotnet/api/microsoft.servicefabric.data.ireliablestatemanager.getoraddasync);
     - performs each add, update and delete operation on first V1 and then V2 collections in a single transaction;
     - performs read operations on the V1 collection only.
 3. Copy all data from the V1 collection to the V2 collection.
@@ -250,7 +250,7 @@ Alternatively, you can perform a multi-phase upgrade.
     - performs all operations on the V2 collection only;
     - going back to V1 is no longer possible with a service rollback and would require rolling forward with reversed steps 2-4.
 6. Upgrade service a new version that
-    - removes the V1 collection from the [StateManager](/dotnet/api/microsoft.servicefabric.services.runtime.statefulservice.statemanager).
+    - [removes the V1 collection](/dotnet/api/microsoft.servicefabric.data.ireliablestatemanager.removeasync).
 7. Wait for log truncation.
     - By default, this happens every 50MB of writes (adds, updates, and removes) to reliable collections.
 8. Upgrade service to a new version that

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -213,7 +213,9 @@ Internally, Reliable Collections serialize your objects using .NET's DataContrac
 Furthermore, service code is upgraded one upgrade domain at a time. So, during an upgrade, you have two different versions of your service code running simultaneously. You must avoid having the new version of your service code use the new schema as old versions of your service code might not be able to handle the new schema. When possible, you should design each version of your service to be forward compatible by one version. Specifically, this means that V1 of your service code should be able to ignore any schema elements it does not explicitly handle. However, it must be able to save any data it doesn't explicitly know about and write it back out when updating a dictionary key or value.
 
 > [!WARNING]
-> While you can modify the schema of a key, you must ensure that your key's hash code, equality and comparison algorithms are stable. If you change how either of these algorithms operate, you will not be able to look up the key within the reliable dictionary ever again.
+> While you can modify the schema of a key, you must ensure that your key's equality and comparison algorithms are stable.
+> Behavior of reliable collections after a change in either of these algorithms is undefined and may lead to data corruption, loss and
+> service crashes.
 > .NET Strings can be used as a key but use the string itself as the key--do not use the result of String.GetHashCode as the key.
 
 Alternatively, you can perform a multi-phase upgrade. 

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -225,11 +225,11 @@ Alternatively, you can perform a multi-phase upgrade.
 2. Upgrade service to a new version that
     - creates a new, V2 collection;
     - performs add, update and delete operations on both V1 and V2 collections in a single transaction;
-    - performs read operations on the V1 collection to maintain compatibility with replicas still running the older version
+    - performs read operations on the V1 collection only.
 3. Copy all data from the V1 collection to the V2 collection.
     - This can be done in a background process by the service version deployed in step 2.
 4. Upgrade service to a new version that
-    - performs read operations on the V2 collection;
+    - performs read operations on the V2 collection only;
     - still performs add, update and delete operations on both V1 and V2 collections to maintain the option of rolling back to V1.
 5. Upgrade service to a new version that
     - performs all operations on the V2 collection only;

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -242,7 +242,7 @@ Alternatively, you can perform a multi-phase upgrade.
           the value to the V2 collection.
         - If the value has already been added to the V2 collection since the copy process started,
           the key should be skipped.
-        - The transaction should be committed if the `TryAddAsync` returns `true` and aborted if it returns `false`.
+        - The transaction should be committed only if the `TryAddAsync` returns `true`.
 4. Upgrade service to a new version that
     - performs read operations on the V2 collection only;
     - still performs each add, update and delete operation on first V1 and then V2 collections to maintain the option of rolling back to V1.

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -220,7 +220,8 @@ Furthermore, service code is upgraded one upgrade domain at a time. So, during a
 
 Alternatively, you can perform a multi-phase upgrade. 
 1. Upgrade service to a new version that
-    - has both the original V1, and the new V2 version of the data contracts included in the service code package.
+    - has both the original V1, and the new V2 version of the data contracts included in the service code package;
+    - registers custom V2 [state serializers](https://learn.microsoft.com/azure/service-fabric/service-fabric-reliable-services-reliable-collections-serialization#custom-serialization), if needed;
     - performs all operations on the original, V1 collection using the V1 data contracts.
 2. Upgrade service to a new version that
     - creates a new, V2 collection;

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -248,14 +248,17 @@ Alternatively, you can perform a multi-phase upgrade.
 4. Upgrade service to a new version that
     - performs read operations on the V2 collection only;
     - still performs each add, update and delete operation on first V1 and then V2 collections to maintain the option of rolling back to V1.
-5. Upgrade service to a new version that
+5. Comprehensively test the service and confirm it is working as expected.
+    - If you missed any value access operation that wasn't updated to work on both V1 and V2 collection, you may notice missing data.
+    - If any data is missing roll back to Step 1, remove the V2 collection and repeat the process.
+6. Upgrade service to a new version that
     - performs all operations on the V2 collection only;
     - going back to V1 is no longer possible with a service rollback and would require rolling forward with reversed steps 2-4.
-6. Upgrade service a new version that
+7. Upgrade service a new version that
     - [removes the V1 collection](/dotnet/api/microsoft.servicefabric.data.ireliablestatemanager.removeasync).
-7. Wait for log truncation.
+8. Wait for log truncation.
     - By default, this happens every 50MB of writes (adds, updates, and removes) to reliable collections.
-8. Upgrade service to a new version that
+9. Upgrade service to a new version that
     - no longer has the V1 data contracts included in the service code package.
 
 ## Next steps

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -224,13 +224,19 @@ Alternatively, you can perform a multi-phase upgrade.
     - performs all operations on the original, V1 collection using the V1 data contracts.
 2. Upgrade service to a new version that
     - creates a new, V2 collection;
-    - performs add, update and delete operations on both V1 and V2 collections in a single transaction;
+    - performs each add, update and delete operation on both V1 and V2 collections in a single transaction;
     - performs read operations on the V1 collection only.
 3. Copy all data from the V1 collection to the V2 collection.
     - This can be done in a background process by the service version deployed in step 2.
+    - Enumeration of all data should be done with the
+      [IsolationLevel.Snapshot](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.beta.ireliablestatemanager2.createtransaction)
+      to avoid locking the entire V1 collection for the entire duration.
+    - Copying of data from the V1 to the V2 collection should be done with
+      [TryAddAsync](https://learn.microsoft.com/dotnet/api/microsoft.servicefabric.data.collections.ireliabledictionary.tryaddasync)
+      to preserve the latest V2 data that may have already been stored by the service add or update operations.
 4. Upgrade service to a new version that
     - performs read operations on the V2 collection only;
-    - still performs add, update and delete operations on both V1 and V2 collections to maintain the option of rolling back to V1.
+    - still performs each add, update and delete operation on both V1 and V2 collections to maintain the option of rolling back to V1.
 5. Upgrade service to a new version that
     - performs all operations on the V2 collection only;
     - going back to V1 is no longer possible with a service rollback and would require rolling forward with reversed steps 2-4.

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -219,26 +219,27 @@ Furthermore, service code is upgraded one upgrade domain at a time. So, during a
 > .NET Strings can be used as a key but use the string itself as the key--do not use the result of String.GetHashCode as the key.
 
 Alternatively, you can perform a multi-phase upgrade. 
-1. Deploy a new service version that
+1. Upgrade service to a new version that
     - has both the original version, V1 of the data contracts, and the new version, V2 of the data contracts.
     - During this phase, the service must continue accessing data in the original, V1 collection using V1 data contracts.
-2. Deploy a new service version where
-    - a new, V2 collection iscreated;
-    - all add, update and delete operations are performed on both V1 and V2 collections in a single transaction;
-    - all read operations are performed on the V1 collection to maintain compatibility with replicas still running the older version
-3. Copy all data from all data from the V1 collection to the V2 collection.
-    - this can be done by the same service version deployed in step 3;
-4. Deploy a new service version where
-    - all read operations are performed on the V2 collection;
-    - all add, update and delete operations are still performed on both V1 and V2 collections to maintain the option of rolling back to V1 if necessary.
-5. Deploy a new service version where
-    - all operations are performed on the V2 collection only;
+2. Upgrade service to a new version that
+    - creates a new, V2 collection;
+    - performs add, update and delete operations on both V1 and V2 collections in a single transaction;
+    - performs read operations on the V1 collection to maintain compatibility with replicas still running the older version
+3. Copy all data from the V1 collection to the V2 collection.
+    - This can be done in a background process by the service version deployed in step 3.
+4. Upgrade service to a new version that
+    - performs read operations on the V2 collection;
+    - still performs add, update and delete operations on both V1 and V2 collections to maintain the option of rolling back to V1.
+5. Upgrade service to a new version that
+    - performs all operations on the V2 collection only;
     - going back to V1 is no longer possible with a service rollback and would require rolling forward with reversed steps 2-4.
-6. Deploy a new service version that
+6. Upgrade service a new version that
     - removes V1 collection from the [StateManager](/dotnet/api/microsoft.servicefabric.services.runtime.statefulservice.statemanager).
-7. Wait for log truncation. By default, this happens every 50MB of writes (adds, updates, and removes) to reliable collections.
-8. Deploy a new version where
-    - the V1 data contract has been removed.
+7. Wait for log truncation.
+    - By default, this happens every 50MB of writes (adds, updates, and removes) to reliable collections.
+8. Upgrade service to a new version that
+    - no longer has the V1 data contracts.
 
 ## Next steps
 To learn about creating forward compatible data contracts, see [Forward-Compatible Data Contracts](/dotnet/framework/wcf/feature-details/forward-compatible-data-contracts)

--- a/articles/service-fabric/service-fabric-work-with-reliable-collections.md
+++ b/articles/service-fabric/service-fabric-work-with-reliable-collections.md
@@ -227,7 +227,7 @@ Alternatively, you can perform a multi-phase upgrade.
     - performs add, update and delete operations on both V1 and V2 collections in a single transaction;
     - performs read operations on the V1 collection to maintain compatibility with replicas still running the older version
 3. Copy all data from the V1 collection to the V2 collection.
-    - This can be done in a background process by the service version deployed in step 3.
+    - This can be done in a background process by the service version deployed in step 2.
 4. Upgrade service to a new version that
     - performs read operations on the V2 collection;
     - still performs add, update and delete operations on both V1 and V2 collections to maintain the option of rolling back to V1.


### PR DESCRIPTION
Expand the Working with Reliable Collections page to explain the process of multi-phase upgrade in more detail, specifically calling out the need to wait for log truncation.