### PR TITLE
Update concept-system-preferred-multifactor-authentication.md

### DIFF
--- a/articles/active-directory/authentication/concept-system-preferred-multifactor-authentication.md
+++ b/articles/active-directory/authentication/concept-system-preferred-multifactor-authentication.md
@@ -111,11 +111,11 @@ A fix for [FIDO2 security keys](../develop/support-fido2-authentication.md#mobil
 When a user signs in, the authentication process checks which authentication methods are registered for the user. The user is prompted to sign-in with the most secure method according to the following order. The order of authentication methods is dynamic. It's updated as the security landscape changes, and as better authentication methods emerge. Click the link for information about each method.
 
 1. [Temporary Access Pass](howto-authentication-temporary-access-pass.md)
+1. [Certificate-based authentication](concept-certificate-based-authentication.md)
 1. [FIDO2 security key](concept-authentication-passwordless.md#fido2-security-keys)
 1. [Microsoft Authenticator notifications](concept-authentication-authenticator-app.md)
 1. [Time-based one-time password (TOTP)](concept-authentication-oath-tokens.md)<sup>1</sup>
 1. [Telephony](concept-authentication-phone-options.md)<sup>2</sup>
-1. [Certificate-based authentication](concept-certificate-based-authentication.md)
 
 <sup>1</sup> Includes hardware or software TOTP from Microsoft Authenticator, Authenticator Lite, or third-party applications.
 


### PR DESCRIPTION
Changed System preferred order for Certificate based from last option to be the 2nd as mentioned on wiki doc: https://supportability.visualstudio.com/AzureAD/_wiki/wikis/AzureAD/857237/Azure-AD-System-Preferred-MFA-Method-Policy?anchor=order-of-authentication-methods