### PR TITLE
Updated incorrect logic on CompareClaimToValue string transformation

### DIFF
--- a/articles/active-directory-b2c/string-transformations.md
+++ b/articles/active-directory-b2c/string-transformations.md
@@ -217,7 +217,7 @@ Determines whether a claim value is equal to the input parameter value. Check ou
 
 ### Example of CompareClaimToValue
 
-Use this claims transformation to check if a claim is equal to a value you specified. For example, the following claims transformation checks if the value of the **termsOfUseConsentVersion** claim is equal to `v1`.
+Use this claims transformation to check if a claim is equal to a value you specified. For example, the following claims transformation checks if the value of the **termsOfUseConsentVersion** claim is equal to `V2`.
 
 ```xml
 <ClaimsTransformation Id="IsTermsOfUseConsentRequiredForVersion" TransformationMethod="CompareClaimToValue">
@@ -225,8 +225,8 @@ Use this claims transformation to check if a claim is equal to a value you speci
     <InputClaim ClaimTypeReferenceId="termsOfUseConsentVersion" TransformationClaimType="inputClaim1" />
   </InputClaims>
   <InputParameters>
-    <InputParameter Id="compareTo" DataType="string" Value="V1" />
-    <InputParameter Id="operator" DataType="string" Value="not equal" />
+    <InputParameter Id="compareTo" DataType="string" Value="V2" />
+    <InputParameter Id="operator" DataType="string" Value="NOT EQUAL" />
     <InputParameter Id="ignoreCase" DataType="string" Value="true" />
   </InputParameters>
   <OutputClaims>
@@ -238,8 +238,8 @@ Use this claims transformation to check if a claim is equal to a value you speci
 - Input claims:
   - **inputClaim1**: v1
 - Input parameters:
-  - **compareTo**: V1
-  - **operator**: EQUAL
+  - **compareTo**: V2
+  - **operator**: NOT EQUAL
   - **ignoreCase**:  true
 - Output claims:
   - **outputClaim**: true


### PR DESCRIPTION
Previous example: 

- Input claims:
  - inputClaim1: v1
- Input parameters:
  - compareTo: V1
- operator: EQUAL
  - ignoreCase: true
- Output claims:
  - outputClaim: true
  
Means the claim `termsOfUseConsentRequired` would be true - when it should be false.

Updated to:

- Input claims:
  - inputClaim1: v1
- Input parameters:
  - compareTo: V2
- operator: NOT EQUAL
  - ignoreCase: true
- Output claims:
  - outputClaim: true
  