### PR TITLE
Update faq.md - Add DefaultIngressClass

### DIFF
--- a/articles/aks/faq.md
+++ b/articles/aks/faq.md
@@ -103,6 +103,7 @@ AKS supports the following [admission controllers][admission-controllers]:
 - *NamespaceLifecycle*
 - *LimitRanger*
 - *ServiceAccount*
+- *DefaultIngressClass*
 - *DefaultStorageClass*
 - *DefaultTolerationSeconds*
 - *MutatingAdmissionWebhook*


### PR DESCRIPTION
I think the list is not complete and missing the DefaultIngressClass admission controller.

In our AKS clusters, with multiple ingress controllers deployed, a default ingress class is configured. We realized that new ingress objects without the IngressClassName field set are automatically configure with the default ingress class we have defined, so it is clear to us that the DefaultIngressClass should be enabled on AKS.