### PR TITLE
RBAC role to create new index

### DIFF
--- a/articles/ai-services/openai/concepts/use-your-data.md
+++ b/articles/ai-services/openai/concepts/use-your-data.md
@@ -92,7 +92,7 @@ To add a new data source to your Azure OpenAI resource, you need the following A
 |---------|---------|
 |[Cognitive Services Contributor](../how-to/role-based-access-control.md#cognitive-services-contributor) | You want to use Azure OpenAI on your data. |
 |[Search Index Data Contributor](/azure/role-based-access-control/built-in-roles#search-index-data-contributor)     | You have an existing Azure Cognitive Search index that you want to use, instead of creating a new one.        |
-|[Search Service Contributor](/azure/role-based-access-control/built-in-roles#search-service-contributor)     | You plan to creating new Azure Cognitive Search index.        |
+|[Search Service Contributor](/azure/role-based-access-control/built-in-roles#search-service-contributor)     | You plan to create a new Azure Cognitive Search index.        |
 |[Storage Blob Data Contributor](/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor)     | You have an existing Blob storage container that you want to use, instead of creating a new one.        |
 
 ## Document-level access control

--- a/articles/ai-services/openai/concepts/use-your-data.md
+++ b/articles/ai-services/openai/concepts/use-your-data.md
@@ -92,6 +92,7 @@ To add a new data source to your Azure OpenAI resource, you need the following A
 |---------|---------|
 |[Cognitive Services Contributor](../how-to/role-based-access-control.md#cognitive-services-contributor) | You want to use Azure OpenAI on your data. |
 |[Search Index Data Contributor](/azure/role-based-access-control/built-in-roles#search-index-data-contributor)     | You have an existing Azure Cognitive Search index that you want to use, instead of creating a new one.        |
+|[Search Service Contributor](/azure/role-based-access-control/built-in-roles#search-service-contributor)     | You plan to creating new Azure Cognitive Search index.        |
 |[Storage Blob Data Contributor](/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor)     | You have an existing Blob storage container that you want to use, instead of creating a new one.        |
 
 ## Document-level access control


### PR DESCRIPTION
Current documentation lists Cog Search RBAC role only for the scenario where an index already exists. To create new index, additional Cog Search RBAC role is required: Search Service Contributor.