### PR TITLE
Fix relative links in container-registry-helm-repos.md

### DIFF
--- a/articles/container-registry/container-registry-helm-repos.md
+++ b/articles/container-registry/container-registry-helm-repos.md
@@ -65,7 +65,7 @@ The following resources are needed for the scenario in this article:
 
 - **An Azure container registry** in your Azure subscription. If needed, create a registry using the [Azure portal](container-registry-get-started-portal.md) or the [Azure CLI](container-registry-get-started-azure-cli.md).
 - **Helm client version 3.7 or later** - Run `helm version` to find your current version. For more information on how to install and upgrade Helm, see [Installing Helm][helm-install]. If you upgrade from an earlier version of Helm 3, review the [release notes](https://github.com/helm/helm/releases).
-- **A Kubernetes cluster** where you will install a Helm chart. If needed, create an AKS cluster [using the Azure CLI][./learn/quick-kubernetes-deploy-cli], [using Azure PowerShell][./learn/quick-kubernetes-deploy-powershell], or [using the Azure portal][./learn/quick-kubernetes-deploy-portal].
+- **A Kubernetes cluster** where you will install a Helm chart. If needed, create an AKS cluster [using the Azure CLI](./learn/quick-kubernetes-deploy-cli), [using Azure PowerShell](./learn/quick-kubernetes-deploy-powershell), or [using the Azure portal](./learn/quick-kubernetes-deploy-portal).
 - **Azure CLI version 2.0.71 or later** - Run `az --version` to find the version. If you need to install or upgrade, see [Install Azure CLI][azure-cli-install].
 
 ## Set up Helm client

--- a/articles/container-registry/container-registry-helm-repos.md
+++ b/articles/container-registry/container-registry-helm-repos.md
@@ -65,7 +65,7 @@ The following resources are needed for the scenario in this article:
 
 - **An Azure container registry** in your Azure subscription. If needed, create a registry using the [Azure portal](container-registry-get-started-portal.md) or the [Azure CLI](container-registry-get-started-azure-cli.md).
 - **Helm client version 3.7 or later** - Run `helm version` to find your current version. For more information on how to install and upgrade Helm, see [Installing Helm][helm-install]. If you upgrade from an earlier version of Helm 3, review the [release notes](https://github.com/helm/helm/releases).
-- **A Kubernetes cluster** where you will install a Helm chart. If needed, create an AKS cluster [using the Azure CLI](./learn/quick-kubernetes-deploy-cli), [using Azure PowerShell](./learn/quick-kubernetes-deploy-powershell), or [using the Azure portal](./learn/quick-kubernetes-deploy-portal).
+- **A Kubernetes cluster** where you will install a Helm chart. If needed, create an AKS cluster [using the Azure CLI](../aks/learn/quick-kubernetes-deploy-cli.md), [using Azure PowerShell](../aks/learn/quick-kubernetes-deploy-powershell.md), or [using the Azure portal](../aks/learn/quick-kubernetes-deploy-portal.md).
 - **Azure CLI version 2.0.71 or later** - Run `az --version` to find the version. If you need to install or upgrade, see [Install Azure CLI][azure-cli-install].
 
 ## Set up Helm client


### PR DESCRIPTION
Relative links for [ACR helm docs](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-helm-repos?WT.mc_id=containers-19838-ludossan#prerequisites) are currently not formatted correctly and appear like so:
```
[using the Azure CLI][./learn/quick-kubernetes-deploy-cli], [using Azure PowerShell][./learn/quick-kubernetes-deploy-powershell], or [using the Azure portal][./learn/quick-kubernetes-deploy-portal].
```