### PR TITLE
Update run-command.md

### DIFF
--- a/articles/virtual-machines/windows/run-command.md
+++ b/articles/virtual-machines/windows/run-command.md
@@ -78,7 +78,7 @@ The entity was not found in this Azure location
 | **EnableRemotePS** | Configures the machine to enable remote PowerShell. |
 | **EnableWindowsUpdate** | Enable Windows Update Automatic Updates |
 | **IPConfig** | Shows detailed information for the IP address, subnet mask, and default gateway for each adapter bound to TCP/IP. |
-| **RDPSetting** | Checks registry settings and domain policy settings. Suggests policy actions if the machine is part of a domain or modifies the settings to default values. |
+| **RDPSettings** | Checks registry settings and domain policy settings. Suggests policy actions if the machine is part of a domain or modifies the settings to default values. |
 | **ResetRDPCert** | Removes the TLS/SSL certificate tied to the RDP listener and restores the RDP listener security to default. Use this script if you see any issues with the certificate. |
 | **SetRDPPort** | Sets the default or user-specified port number for Remote Desktop connections. Enables firewall rules for inbound access to the port. |
 


### PR DESCRIPTION
RDPSettings was missing an "s". 
Running the Invoke-AzVmssVMRunCommand or the Invoke-AzVMRunCommand with the -CommandId RDPSetting instead of -CommandId RDPSettings the cmdlet throws a 404 not found error.