### PR TITLE
Update remove-public-ip-address-vm.md

### DIFF
--- a/articles/virtual-network/ip-services/remove-public-ip-address-vm.md
+++ b/articles/virtual-network/ip-services/remove-public-ip-address-vm.md
@@ -52,7 +52,7 @@ az network nic ip-config update \
  --name ipconfigmyVM \
  --resource-group myResourceGroup \
  --nic-name myVMNic \
- --public-ip-address ''
+ --public-ip-address null
 ```
 
 - If you don't know the name of the network interface attached to your VM, use the [az vm nic list](/cli/azure/vm/nic#az-vm-nic-list) command to view them. For example, the following command lists the names of the network interfaces attached to a VM named *myVM* in a resource group named *myResourceGroup*:


### PR DESCRIPTION
Fix wrong value for public-ip-address argument.

With empty string, I got the following error:
```
(InvalidResourceReference) Resource /subscriptions/<subscription-id>/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/ referenced by resource /subscriptions/<subscription-id>/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/vm-eth2 was not found. Please make sure that the referenced resource exists, and that both resources are in the same region.
Code: InvalidResourceReference
```