### PR TITLE
Specify bindings as a Managed Functions constraint

### DIFF
--- a/articles/static-web-apps/apis-functions.md
+++ b/articles/static-web-apps/apis-functions.md
@@ -23,7 +23,7 @@ The following table contrasts the differences between using managed and existing
 
 | Feature | Managed Functions | Bring your own Functions |
 |---|---|---|
-| Access to Azure Functions [triggers](../azure-functions/functions-triggers-bindings.md#supported-bindings) | HTTP only | All |
+| Access to Azure Functions [triggers and bindings](../azure-functions/functions-triggers-bindings.md#supported-bindings) | HTTP only | All |
 | Supported Azure Functions [runtimes](../azure-functions/supported-languages.md#languages-by-runtime-version)<sup>1</sup> | Node.js 12<br>Node.js 14<br>Node.js 16<br>Node.js 18 (public preview)<br>.NET Core 3.1<br>.NET 6.0<br>.NET 7.0<br>Python 3.8<br>Python 3.9<br>Python 3.10 | All |
 | Supported Azure Functions [hosting plans](../azure-functions/functions-scale.md) | Consumption | Consumption<br>Premium<br>Dedicated |
 | [Integrated security](user-information.md) with direct access to user authentication and role-based authorization data | ✔ | ✔ |
@@ -60,7 +60,7 @@ In addition to the Static Web Apps API [constraints](apis-overview.md#constraint
 
 | Managed functions | Bring your own functions |
 |---|---|
-| <ul><li>Triggers are limited to [HTTP](../azure-functions/functions-bindings-http-webhook.md).</li><li>The Azure Functions app must either be in Node.js 12, Node.js 14, Node.js 16, Node.js 18 (public preview), .NET Core 3.1, .NET 6.0, Python 3.8, Python 3.9 or Python 3.10 .</li><li>Some application settings are managed by the service, therefore the following prefixes are reserved by the runtime:<ul><li>*APPSETTING\_, AZUREBLOBSTORAGE\_, AZUREFILESSTORAGE\_, AZURE_FUNCTION\_, CONTAINER\_, DIAGNOSTICS\_, DOCKER\_, FUNCTIONS\_, IDENTITY\_, MACHINEKEY\_, MAINSITE\_, MSDEPLOY\_, SCMSITE\_, SCM\_, WEBSITES\_, WEBSITE\_, WEBSOCKET\_, AzureWeb*</li></ul></li><li>Some application tags are internally used by the service. Therefore, the following tags are reserved:<ul><li> *AccountId, EnvironmentId, FunctionAppId*.</li></ul></li></ul> | <ul><li>You are responsible to manage the Functions app deployment.</li></ul> |
+| <ul><li>Triggers and bindings are limited to [HTTP](../azure-functions/functions-bindings-http-webhook.md).</li><li>The Azure Functions app must either be in Node.js 12, Node.js 14, Node.js 16, Node.js 18 (public preview), .NET Core 3.1, .NET 6.0, Python 3.8, Python 3.9 or Python 3.10 .</li><li>Some application settings are managed by the service, therefore the following prefixes are reserved by the runtime:<ul><li>*APPSETTING\_, AZUREBLOBSTORAGE\_, AZUREFILESSTORAGE\_, AZURE_FUNCTION\_, CONTAINER\_, DIAGNOSTICS\_, DOCKER\_, FUNCTIONS\_, IDENTITY\_, MACHINEKEY\_, MAINSITE\_, MSDEPLOY\_, SCMSITE\_, SCM\_, WEBSITES\_, WEBSITE\_, WEBSOCKET\_, AzureWeb*</li></ul></li><li>Some application tags are internally used by the service. Therefore, the following tags are reserved:<ul><li> *AccountId, EnvironmentId, FunctionAppId*.</li></ul></li></ul> | <ul><li>You are responsible to manage the Functions app deployment.</li></ul> |
 
 ## Next steps
 


### PR DESCRIPTION
As worded, one could expect Input and Output *bindings* to be available to Managed Functions - "triggers" is its own column in the linked table after all.  

An [example](https://learn.microsoft.com/en-us/answers/questions/1348197/azure-function-in-static-web-app-fails-to-load-aft) of this issue;  Partial response being "Currently, only HTTP trigger/bindings are supported in Static Web Apps."