### PR TITLE
Clarify what the SamplingPercentage number is

### DIFF
--- a/articles/azure-monitor/app/sampling.md
+++ b/articles/azure-monitor/app/sampling.md
@@ -268,13 +268,15 @@ In Metrics Explorer, rates such as request and exception counts are multiplied b
     ```
 
 1. **Enable the fixed-rate sampling module.** Add this snippet to [`ApplicationInsights.config`](./configuration-with-applicationinsights-config.md):
+
+    In this example, SamplingPercentage is 20, so **20%** of all items will be sampled. Values in Metrics Explorer will be multiplied by (100/20) = **5** to compensate.
    
     ```xml
     <TelemetryProcessors>
         <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.SamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
             <!-- Set a percentage close to 100/N where N is an integer. -->
             <!-- E.g. 50 (=100/2), 33.33 (=100/3), 25 (=100/4), 20, 1 (=100/100), 0.1 (=100/1000) -->
-            <SamplingPercentage>10</SamplingPercentage>
+            <SamplingPercentage>20</SamplingPercentage>
         </Add>
     </TelemetryProcessors>
     ```


### PR DESCRIPTION
A co-worker was quite confused by the original documentation because he thought the value to write in `SamplingPercentage` in the code was the N denominator, when he actually needed to write the percentage itself. The documentation was confusing because it spent too much time talking about N.

I have added a short paragraph before this code block that accomplishes the following goals:

- Shows the difference in meaning between SamplingPercentage and N
- Shows that the value to write in `SamplingPercentage` is the actual percentage
- States why N needs to be an integer - it's so Metrics Explorer can multiply it precisely

Let me know if you'd like any changes! 😊