### PR TITLE
Update concept-authentication-default-enablement.md

### DIFF
--- a/articles/active-directory/authentication/concept-authentication-default-enablement.md
+++ b/articles/active-directory/authentication/concept-authentication-default-enablement.md
@@ -53,7 +53,7 @@ The following table lists each setting that can be set to Microsoft managed and 
 
 | Setting                                                                                         | Configuration |
 |-------------------------------------------------------------------------------------------------|---------------|
-| [Registration campaign](how-to-mfa-registration-campaign.md)                                    | Beginning in July, 2023, enabled for text message and voice call users with free and trial subscriptions.      |
+| [Registration campaign](how-to-mfa-registration-campaign.md)                                    | Beginning in July, 2023, enabled for text message and voice call users.      |
 | [Location in Microsoft Authenticator notifications](how-to-mfa-additional-context.md)           | Disabled      |
 | [Application name in Microsoft Authenticator notifications](how-to-mfa-additional-context.md)   | Disabled      |
 | [System-preferred MFA](concept-system-preferred-multifactor-authentication.md)                  | Enabled       |


### PR DESCRIPTION
We've been receiving lots of support requests where the registration campaign also applies to P1 and P2 tenants, and the information that it only applies to trial and free tenants can cause misunderstanding.