### PR TITLE
Clarify customer responsibility for FHIR Server maintenance and compliance

### DIFF
--- a/articles/healthcare-apis/azure-api-for-fhir/fhir-faq.yml
+++ b/articles/healthcare-apis/azure-api-for-fhir/fhir-faq.yml
@@ -64,7 +64,7 @@ sections:
         answer: |
           Azure API for FHIR is a hosted and managed version of the open-source Microsoft FHIR Server for Azure. In the managed service, Microsoft provides all maintenance and updates. 
           
-          When you run the FHIR Server for Azure, you have direct access to the underlying services, but we're responsible for maintaining and updating the server and all required compliance work if you're storing PHI data.
+          When you run the FHIR Server for Azure, you have direct access to the underlying services, but you're responsible for maintaining and updating the server and all required compliance work if you're storing PHI data.
           
       - question: |
           In which regions is Azure API for FHIR available?


### PR DESCRIPTION
The previous wording of 'we're responsible' seems incorrect and implies Microsoft is responsible for maintenance and compliance of a deployed FHIR Server. FHIR Server is the DIY open-source option. This is inconsistent with Azure API for FHIR being a managed service, where maintenance by Microsoft is a feature, and compliance is managed through lack of underlying access to the data for the customer.

This change is to correct to 'you're responsible'.