### PR TITLE
Update github-enterprise-managed-user-oidc-provisioning-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/github-enterprise-managed-user-oidc-provisioning-tutorial.md
+++ b/articles/active-directory/saas-apps/github-enterprise-managed-user-oidc-provisioning-tutorial.md
@@ -31,10 +31,6 @@ This tutorial describes the steps you need to perform in both GitHub Enterprise 
 > * Provision groups and group memberships in GitHub Enterprise Managed User (OIDC)
 > * [Single sign-on](../manage-apps/add-application-portal-setup-oidc-sso.md) to GitHub Enterprise Managed User (OIDC) (recommended).
 
-> [!NOTE]
-> This provisioning connector is enabled only for Enterprise Managed Users beta participants.
-
-
 ## Prerequisites
 
 The scenario outlined in this tutorial assumes that you already have the following prerequisites:


### PR DESCRIPTION
Removing the beta tag from OIDC since that shipped for at least a year now.