### PR TITLE
Update howto-authorize-rest-api.md

### DIFF
--- a/articles/iot-central/core/howto-authorize-rest-api.md
+++ b/articles/iot-central/core/howto-authorize-rest-api.md
@@ -17,13 +17,13 @@ The IoT Central REST API lets you develop client applications that integrate wit
 
 Every IoT Central REST API call requires an authorization header that IoT Central uses to determine the identity of the caller and the permissions that caller is granted within the application.
 
-This article describes the types of token you can use in the authorization header, and how to get them.
+This article describes the types of token you can use in the authorization header, and how to get them. Please note that service principals are the recommended method for access management for IoT Central REST APIs.
 
 ## Token types
 
 To access an IoT Central application using the REST API, you can use an:
 
-- _Azure Active Directory bearer token_. A bearer token is associated with an Azure Active Directory user account or service principal. The token grants the caller the same permissions the user or service principal has in the IoT Central application.
+- _Azure Active Directory bearer token_. A bearer token is associated with an Azure Active Directory user account or service principal. The token grants the caller the same permissions the user or service principal has in the IoT Central application. 
 - IoT Central API token. An API token is associated with a role in your IoT Central application.
 
 Use a bearer token associated with your user account while you're developing and testing automation and scripts that use the REST API. Use a bearer token that's associated with a service principal for production automation and scripts. Use a bearer token in preference to an API token to reduce the risk of leaks and problems when tokens expire.


### PR DESCRIPTION
I added in a sentence to indicate that service principals are our recommended method for authentication