### PR TITLE
Fixed latest version number in Cosmos DB emulator release notes

### DIFF
--- a/articles/cosmos-db/emulator-release-notes.md
+++ b/articles/cosmos-db/emulator-release-notes.md
@@ -15,13 +15,13 @@ ms.date: 09/11/2023
 The Azure Cosmos DB emulator is updated at a regular cadence with release notes provided in this article.
 
 > [!div class="nextstepaction"]
-> [Download latest version (``2.14.2``)](https://aka.ms/cosmosdb-emulator)
+> [Download latest version (``2.14.12``)](https://aka.ms/cosmosdb-emulator)
 
 ## Supported versions
 
 Only the most recent version of the Azure Cosmos DB emulator is actively supported.
 
-## Latest version ``2.14.2``
+## Latest version ``2.14.12``
 
 > *Released March 20, 2023*
 


### PR DESCRIPTION
Fixed latest version number in release notes to 2.14.12 instead of 2.14.2