### PR TITLE
URL *pytorch.org perimts an insecure configuration

### DIFF
--- a/articles/machine-learning/includes/recommended-network-outbound.md
+++ b/articles/machine-learning/includes/recommended-network-outbound.md
@@ -14,5 +14,5 @@ ms.author: larryfr
 | `anaconda.com`<br>`*.anaconda.com` | Used to install default packages. |
 | `*.anaconda.org` | Used to get repo data. |
 | `pypi.org` | Used to list dependencies from the default index, if any, and the index isn't overwritten by user settings. If the index is overwritten, you must also allow `*.pythonhosted.org`. |
-| `pytorch.org<br>*.pytorch.org` | Used by some examples based on PyTorch. |
+| `pytorch.org`<br>`*.pytorch.org` | Used by some examples based on PyTorch. |
 | `*.tensorflow.org` | Used by some examples based on Tensorflow. |

--- a/articles/machine-learning/includes/recommended-network-outbound.md
+++ b/articles/machine-learning/includes/recommended-network-outbound.md
@@ -14,5 +14,5 @@ ms.author: larryfr
 | `anaconda.com`<br>`*.anaconda.com` | Used to install default packages. |
 | `*.anaconda.org` | Used to get repo data. |
 | `pypi.org` | Used to list dependencies from the default index, if any, and the index isn't overwritten by user settings. If the index is overwritten, you must also allow `*.pythonhosted.org`. |
-| `*pytorch.org` | Used by some examples based on PyTorch. |
+| `pytorch.org<br>*.pytorch.org` | Used by some examples based on PyTorch. |
 | `*.tensorflow.org` | Used by some examples based on Tensorflow. |


### PR DESCRIPTION
The URL `*pytorch.org` is documented in this page as a recommended configuration. However `*pytorch.org` allows bad actors to register domains such as `myBadSitePytorch.org` to match firewall rules configured as per the documentation.

Updated the example to explicitly use the naked domain `pytorch.org` and the wildcard for sub-domains `*.pytorch.org`.

