### PR TITLE
Update Required Permissions on 3D Scenes for Azure Digital Twins Docs

### DIFF
--- a/articles/digital-twins/how-to-use-3d-scenes-studio.md
+++ b/articles/digital-twins/how-to-use-3d-scenes-studio.md
@@ -30,7 +30,7 @@ To use 3D Scenes Studio, you'll need the following resources:
     * Take note of the *URL* of your storage account to use later.
 * A private container in the storage account. For instructions, see [Create a container](../storage/blobs/storage-quickstart-blobs-portal.md#create-a-container).
     * Take note of the *name* of your storage container to use later.
-* *Storage Blob Data Owner* or *Storage Blob Data Contributor* and also at least *Reader* roles are needed access to your storage resources . You can grant required roles at either the storage account level or the container level. For instructions and more information about permissions to Azure storage, see [Assign an Azure role](../storage/blobs/assign-azure-role-data-access.md?tabs=portal#assign-an-azure-role).
+* *Storage Blob Data Owner* or *Storage Blob Data Contributor* and also at least *Reader* roles are needed to access your storage resources . You can grant required roles at either the storage account level or the container level. For instructions and more information about permissions to Azure storage, see [Assign an Azure role](../storage/blobs/assign-azure-role-data-access.md?tabs=portal#assign-an-azure-role).
 * Configure CORS for your storage account (see details in the following sub-section).
 
 ### Configure CORS

--- a/articles/digital-twins/how-to-use-3d-scenes-studio.md
+++ b/articles/digital-twins/how-to-use-3d-scenes-studio.md
@@ -30,7 +30,7 @@ To use 3D Scenes Studio, you'll need the following resources:
     * Take note of the *URL* of your storage account to use later.
 * A private container in the storage account. For instructions, see [Create a container](../storage/blobs/storage-quickstart-blobs-portal.md#create-a-container).
     * Take note of the *name* of your storage container to use later.
-* *Storage Blob Data Owner* or *Storage Blob Data Contributor* and also at least *Reader* roles are needed to access your storage resources . You can grant required roles at either the storage account level or the container level. For instructions and more information about permissions to Azure storage, see [Assign an Azure role](../storage/blobs/assign-azure-role-data-access.md?tabs=portal#assign-an-azure-role).
+* *Storage Blob Data Owner* or *Storage Blob Data Contributor* and also at least *Reader* roles are needed to access your storage resources. You can grant required roles at either the storage account level or the container level. For instructions and more information about permissions to Azure storage, see [Assign an Azure role](../storage/blobs/assign-azure-role-data-access.md?tabs=portal#assign-an-azure-role).
 * Configure CORS for your storage account (see details in the following sub-section).
 
 ### Configure CORS

--- a/articles/digital-twins/how-to-use-3d-scenes-studio.md
+++ b/articles/digital-twins/how-to-use-3d-scenes-studio.md
@@ -30,7 +30,7 @@ To use 3D Scenes Studio, you'll need the following resources:
     * Take note of the *URL* of your storage account to use later.
 * A private container in the storage account. For instructions, see [Create a container](../storage/blobs/storage-quickstart-blobs-portal.md#create-a-container).
     * Take note of the *name* of your storage container to use later.
-* *Storage Blob Data Owner* or *Storage Blob Data Contributor* access to your storage resources. You can grant required roles at either the storage account level or the container level. For instructions and more information about permissions to Azure storage, see [Assign an Azure role](../storage/blobs/assign-azure-role-data-access.md?tabs=portal#assign-an-azure-role).
+* *Storage Blob Data Owner* or *Storage Blob Data Contributor* and also at least *Reader* roles are needed access to your storage resources . You can grant required roles at either the storage account level or the container level. For instructions and more information about permissions to Azure storage, see [Assign an Azure role](../storage/blobs/assign-azure-role-data-access.md?tabs=portal#assign-an-azure-role).
 * Configure CORS for your storage account (see details in the following sub-section).
 
 ### Configure CORS


### PR DESCRIPTION
- The ability to interact with a 3D scene requires at least  the `Reader` role on the storage account in addition to `Storage Blob Data **`roles. This update ensures that a user has all the required prerequisites when attempting to create a 3D scene in ADT 