### PR TITLE
Update cache-best-practices-kubernetes.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-best-practices-kubernetes.md
+++ b/articles/azure-cache-for-redis/cache-best-practices-kubernetes.md
@@ -33,6 +33,12 @@ If your Azure Cache for Redis client application runs on a Linux-based container
 
 Currently, Azure Cache for Redis uses ports 15000-15019 for clustered caches to expose cluster nodes to client applications. As documented [here](https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio), the same ports are also used by *Istio.io* sidecar proxy called *Envoy* and could interfere with creating connections, especially on port 15006.
 
+To make istio work with azure redis cluster, you may exclude the potential collision ports with [istio annotation](https://istio.io/latest/docs/reference/config/annotations/)
+```
+annotations:
+  traffic.sidecar.istio.io/excludeOutboundPorts: "15000,15001,15004,15006,15008,15009,15020"
+```
+
 To avoid connection interference, we recommend:
 
 - Consider using a non-clustered cache or an Enterprise tier cache instead


### PR DESCRIPTION
Add istio annotation `traffic.sidecar.istio.io/excludeOutboundPorts` to make istio work with Azure Cache Redis in cluster mode.

This recommendation is based on #: 2309220030003590