### PR TITLE
fix(policy effects): deployIfNotExists needs to start with a lower case

### DIFF
--- a/articles/governance/policy/concepts/effects.md
+++ b/articles/governance/policy/concepts/effects.md
@@ -667,7 +667,7 @@ If not, then a deployment to enable is executed.
     "equals": "Microsoft.Sql/servers/databases"
 },
 "then": {
-    "effect": "DeployIfNotExists",
+    "effect": "deployIfNotExists",
     "details": {
         "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
         "name": "current",


### PR DESCRIPTION
`deployIfNotExists` needs to start with a lower case in json. The current example is not valid.

See https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure#policy-rule