### PR TITLE
slight change to wording on idle timeout question

### DIFF
--- a/articles/firewall/firewall-faq.yml
+++ b/articles/firewall/firewall-faq.yml
@@ -299,7 +299,7 @@ sections:
 
       - question: What is the TCP Idle Timeout for Azure Firewall?
         answer: |
-          A standard behavior of a network firewall is to ensure TCP connections are kept alive and to promptly close them if there's no activity. Azure Firewall TCP Idle Timeout is four minutes. This setting isn't user configurable, but you can contact Azure Support to increase the Idle Timeout for inbound connections up to 30 minutes. Idle Timeout for east-west traffic cannot be changed.
+          A standard behavior of a network firewall is to ensure TCP connections are kept alive and to promptly close them if there's no activity. Azure Firewall TCP Idle Timeout is four minutes. This setting isn't user configurable, but you can contact Azure Support to increase the Idle Timeout for inbound and outbound connections up to 30 minutes. Idle Timeout for east-west traffic cannot be changed.
 
           If a period of inactivity is longer than the timeout value, there's no guarantee that the TCP or HTTP session is maintained. A common practice is to use a TCP keep-alive. This practice keeps the connection active for a longer period. For more information, see the [.NET examples](/dotnet/api/system.net.servicepoint.settcpkeepalive).
 


### PR DESCRIPTION
There was a recent change to this FAQ question to reflect that the outbound idle timeout value CAN be modified. Requesting to further modify this answer to add and not omit "outbound" from the description that the idle timeout value can be modified by Azure Support.