### PR TITLE
Add clarifications for string key reliable collection sort order

### DIFF
--- a/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
+++ b/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
@@ -35,7 +35,7 @@ The guidelines are organized as simple recommendations prefixed with the terms *
   Only one user thread operation is supported within a transaction. Otherwise, it will cause memory leak and lock issues.
 * Consider dispose transaction as soon as possible after commit completes (especially if using ConcurrentQueue).
 * Do not perform any blocking code inside a transaction.
-* When [string](/dotnet/api/system.string) is used as the key for a reliable dictionary, the sorting order will be using [default string comparer CurrentCulture](/dotnet/api/system.string.compare#system-string-compare(system-string-system-string)). Please note that the CurrentCulture sorting order is different from [Ordinal string comparer](/dotnet/api/system.stringcomparer.ordinal). 
+* When [string](/dotnet/api/system.string) is used as the key for a reliable dictionary, the sorting order uses [default string comparer CurrentCulture](/dotnet/api/system.string.compare#system-string-compare(system-string-system-string)). Note that the CurrentCulture sorting order is different from [Ordinal string comparer](/dotnet/api/system.stringcomparer.ordinal). 
 
 Here are some things to keep in mind:
 

--- a/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
+++ b/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
@@ -35,7 +35,7 @@ The guidelines are organized as simple recommendations prefixed with the terms *
   Only one user thread operation is supported within a transaction. Otherwise, it will cause memory leak and lock issues.
 * Consider dispose transaction as soon as possible after commit completes (especially if using ConcurrentQueue).
 * Do not perform any blocking code inside a transaction.
-* When [string](/dotnet/api/system.string) is used as key for reliable dictionary, the sorting order will be using [default string comparer CurrentCulture](/dotnet/api/system.string.compare#system-string-compare(system-string-system-string)). Please note that the CurrentCulture sorting order is different from [Ordinal string comparer](/dotnet/api/system.stringcomparer.ordinal). 
+* When [string](/dotnet/api/system.string) is used as the key for a reliable dictionary, the sorting order will be using [default string comparer CurrentCulture](/dotnet/api/system.string.compare#system-string-compare(system-string-system-string)). Please note that the CurrentCulture sorting order is different from [Ordinal string comparer](/dotnet/api/system.stringcomparer.ordinal). 
 
 Here are some things to keep in mind:
 

--- a/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
+++ b/articles/service-fabric/service-fabric-reliable-services-reliable-collections-guidelines.md
@@ -35,6 +35,7 @@ The guidelines are organized as simple recommendations prefixed with the terms *
   Only one user thread operation is supported within a transaction. Otherwise, it will cause memory leak and lock issues.
 * Consider dispose transaction as soon as possible after commit completes (especially if using ConcurrentQueue).
 * Do not perform any blocking code inside a transaction.
+* When [string](/dotnet/api/system.string) is used as key for reliable dictionary, the sorting order will be using [default string comparer CurrentCulture](/dotnet/api/system.string.compare#system-string-compare(system-string-system-string)). Please note that the CurrentCulture sorting order is different from [Ordinal string comparer](/dotnet/api/system.stringcomparer.ordinal). 
 
 Here are some things to keep in mind:
 


### PR DESCRIPTION
This doc change let the customer know that the RC is currently using CurrentCulture sort order for string key. 