### PR TITLE
Added note with command invoke size limit

### DIFF
--- a/articles/aks/access-private-cluster.md
+++ b/articles/aks/access-private-cluster.md
@@ -28,6 +28,9 @@ The pod created by the `run` command provides `helm` and the latest compatible v
 
 `command invoke` runs the commands from your cluster, so any commands run in this manner are subject to your configured networking restrictions and any other configured restrictions. Make sure there are enough nodes and resources in your cluster to schedule this command pod.
 
+> [!NOTE]
+> The output for `command invoke` is limited to 512kB in size. 
+
 ## Run commands on your AKS cluster
 
 ### [Azure CLI - `command invoke`](#tab/azure-cli)


### PR DESCRIPTION
The output for command invoke is limited to 512kB, though it wasn't documented. Added the note to the public docs so customers know.