### PR TITLE
Update static-ip.md

### DIFF
--- a/articles/aks/static-ip.md
+++ b/articles/aks/static-ip.md
@@ -42,7 +42,7 @@ This article shows you how to create a static public IP address and assign it to
 
     ```azurecli-interactive
     az network public-ip create \
-        --resource-group myNetworkResourceGroup \
+        --resource-group <node resource group> \
         --name myAKSPublicIP \
         --sku Standard \
         --allocation-method static


### PR DESCRIPTION
Hi, I tried to create a static IP for my cluster load balancer and encountered errors when the cluster was trying to obtain an IP address. Changing the target resource group (to node rg) for creating the static IP resource fixed the issue. 
If it is not supposed to work like this, please confirm that the static IP resource should be in the AKS resource group and not in the generated node resource group.