### PR TITLE
Added managed batch endpoint information

### DIFF
--- a/articles/machine-learning/how-to-manage-quotas.md
+++ b/articles/machine-learning/how-to-manage-quotas.md
@@ -168,7 +168,7 @@ Azure Machine Learning kubernetes online endpoints have limits described in the 
 | Number of deployments per endpoint | 20 |
 | Max request time-out at endpoint level  | 300 seconds |
 
-The sum of kubernetes online endpoints and managed online endpoints under each subscription can't exceed 50. Similarly, the sum of kubernetes online deployments and managed online deployments under each subscription can't exceed 200.
+The sum of kubernetes online endpoint, managed online endpoint, and managed batch endpoint under each subscription can't exceed 50. Similarly, the sum of kubernetes online deployments and managed online deployments and managed batch deployments under each subscription can't exceed 200.
 
 ### Azure Machine Learning pipelines
 [Azure Machine Learning pipelines](concept-ml-pipelines.md) have the following limits.


### PR DESCRIPTION
The following sites have information about quotas for managed online endpoints and Kubernetes online endpoints, which can be created for a total of 50 endpoints. There is no mention of a quota for batch endpoints, so it doesn't seem to be limited, but in reality, the sum of online endpoints and batch endpoints is limited by quotas.

https://learn.microsoft.com/en-us/azure/machine-learning/how-to-manage-quotas?view=azureml-api-2#azure-machine-learning-kubernetes-online-endpoints
> The sum of kubernetes online endpoints and managed online endpoints under each subscription cannot exceed 50. Similarly, the sum of kubernetes online deployments and managed online deployments under each subscription cannot exceed 200.

related to https://github.com/MicrosoftDocs/azure-docs/issues/108069