### PR TITLE
Format sample JSON in alert schema doc

### DIFF
--- a/articles/azure-monitor/alerts/alerts-common-schema.md
+++ b/articles/azure-monitor/alerts/alerts-common-schema.md
@@ -82,10 +82,10 @@ The common schema includes information about the affected resource and the cause
           }
         ]
       }
-      },
-      "customProperties":{
-        "Key1": "Value1",
-        "Key2": "Value2"
+    },
+    "customProperties": {
+      "Key1": "Value1",
+      "Key2": "Value2"
     }
   }
 }


### PR DESCRIPTION
At a glance, the sample JSON in the "Common alert schema" doc makes it seem like the `customProperties` object is on the same level as the children of `alertContext`.

I re-formatted the sample JSON to avoid this confusion. 