### PR TITLE
Fix continuous-integration-delivery-sample-script.md

### DIFF
--- a/articles/data-factory/continuous-integration-delivery-sample-script.md
+++ b/articles/data-factory/continuous-integration-delivery-sample-script.md
@@ -64,9 +64,8 @@ The following YAML code executes a script that can be used to stop triggers befo
               ScriptArguments: -armTemplate "<your-arm-template-location>" -ResourceGroupName <your-resource-group-name> -DataFactoryName <your-data-factory-name> -predeployment $true -deleteDeployment $false
               errorActionPreference: stop
               FailOnStandardError: False
-              azurePowerShellVersion: azurePowerShellVersion
-              preferredAzurePowerShellVersion: 3.1.0
-              pwsh: False
+              azurePowerShellVersion: 'LatestVersion'
+              pwsh: True
               workingDirectory: ../
 ```
 
@@ -81,9 +80,8 @@ The following YAML code executes a script that can be used to stop triggers befo
               ScriptArguments: -armTemplate "<your-arm-template-location>" -ResourceGroupName <your-resource-group-name> -DataFactoryName <your-data-factory-name>-predeployment $false -deleteDeployment $true
               errorActionPreference: stop
               FailOnStandardError: False
-              azurePowerShellVersion: azurePowerShellVersion
-              preferredAzurePowerShellVersion: 3.1.0
-              pwsh: False
+              azurePowerShellVersion: 'LatestVersion'
+              pwsh: True
               workingDirectory: ../
 ```
 


### PR DESCRIPTION
Fix documentation to match the readme section on the code's GitHub repo here: https://github.com/Azure/Azure-DataFactory/tree/main/SamplesV2/ContinuousIntegrationAndDelivery#readme

Changes to use Powershell 'LatestVersion' and Powershell Core (pwsh: true) as described in the GitHub repo above. Not using pwsh results in error "The token '&&' is not a valid statement separator in this version."

Change makes docs more reliable, wasted time following original documentation and debugging.