### PR TITLE
Update remove-public-ip-address-vm.md

### DIFF
--- a/articles/virtual-network/ip-services/remove-public-ip-address-vm.md
+++ b/articles/virtual-network/ip-services/remove-public-ip-address-vm.md
@@ -110,7 +110,7 @@ The following example dissociates a public IP address named *myVMPublicIP* from 
   
 ```azurepowershell
 $nic = Get-AzNetworkInterface -Name myVMNic -ResourceGroup myResourceGroup
-$nic.IpConfigurations.publicipaddress.id = $null
+$nic.IpConfigurations[0].PublicIpAddress = $null
 Set-AzNetworkInterface -NetworkInterface $nic
 ```
 


### PR DESCRIPTION
If there's multiple private ip address in NIC, assign $null to `.publicipaddress.id` will always fail.
Similar to https://github.com/Azure/azure-powershell/blob/27beea6e4b5c3c60c95e86dc1a7693bf691ef79c/src/Network/Network/help/Set-AzNetworkInterface.md?plain=1#L29