### PR TITLE
Update regex in how-to-rename-azure-ad.md

### DIFF
--- a/articles/active-directory/fundamentals/how-to-rename-azure-ad.md
+++ b/articles/active-directory/fundamentals/how-to-rename-azure-ad.md
@@ -332,7 +332,7 @@ function Update-Terminology {
     foreach ($item in $Terminology.GetEnumerator()) {
         $old = [regex]::Escape($item.Key)
         $new = $item.Value
-        $toReplace = '(?<!(name=\"[^$]*|https?:\/\/aka.ms/[a-z|0-1]*))' + $($old)
+        $toReplace = '(?<!(name=\"[^$]{1,100}|https?://aka.ms/[a-z0-9/-]{1,100}))' + $($old)
 
         # Replace the old terminology with the new one
         $Content.Value = $Content.Value -replace $toReplace, $new


### PR DESCRIPTION
Various regex fixes

The pattern `[a-z|0-1]*` only matches letters and `|`, `0` and `1`. It should be changed to `[a-z0-9/-]*`. I am not sure about the intention for `name="[^$]*`, but it currently matches an unlimited number of non `$` characters. Finally slashes (`/`) does not need to be escaped in PowerShell. I also limited the number of repeats, to reduce execution time.

The final pattern:
```ps1
$toReplace = '(?<!(name=\"[^$]{1,100}|https?://aka.ms/[a-z0-9/-]{1,100}))' + $($old)
```

Page author: @CelesteDG