### PR TITLE
Removing the term preview from the content

### DIFF
--- a/articles/azure-monitor/containers/container-insights-logging-v2.md
+++ b/articles/azure-monitor/containers/container-insights-logging-v2.md
@@ -130,7 +130,7 @@ For Python:
 Customers must [enable ContainerLogV2](./container-insights-logging-v2.md#enable-the-containerlogv2-schema) for multi-line logging to work.
 
 ### How to enable 
-Multi-line logging is a preview feature and can be enabled by setting **enabled** flag to "true" under the `[log_collection_settings.enable_multiline_logs]` section in the the [config map](https://github.com/microsoft/Docker-Provider/blob/ci_prod/kubernetes/container-azm-ms-agentconfig.yaml)
+Multi-line logging feature can be enabled by setting **enabled** flag to "true" under the `[log_collection_settings.enable_multiline_logs]` section in the the [config map](https://github.com/microsoft/Docker-Provider/blob/ci_prod/kubernetes/container-azm-ms-agentconfig.yaml)
 
 ```yaml
 [log_collection_settings.enable_multiline_logs]


### PR DESCRIPTION
Multi-line logging is no longer a preview feature.