### PR TITLE
Update azure-services-resource-providers.md

### DIFF
--- a/articles/azure-resource-manager/management/azure-services-resource-providers.md
+++ b/articles/azure-resource-manager/management/azure-services-resource-providers.md
@@ -178,7 +178,6 @@ The resources providers that are marked with **- registered** are registered by 
 | Microsoft.TimeSeriesInsights | [Azure Time Series Insights](../../time-series-insights/index.yml) |
 | Microsoft.Token | Token |
 | Microsoft.VirtualMachineImages | [Azure Image Builder](../../virtual-machines/image-builder-overview.md) |
-| microsoft.visualstudio | [Azure DevOps](/azure/devops/) |
 | Microsoft.VMware | [Azure VMware Solution](../../azure-vmware/index.yml) |
 | Microsoft.VMwareCloudSimple | [Azure VMware Solution by CloudSimple](../../vmware-cloudsimple/index.md) |
 | Microsoft.VSOnline | [Azure DevOps](/azure/devops/) |

--- a/articles/azure-resource-manager/management/azure-services-resource-providers.md
+++ b/articles/azure-resource-manager/management/azure-services-resource-providers.md
@@ -83,7 +83,6 @@ The resources providers that are marked with **- registered** are registered by 
 | Microsoft.DesktopVirtualization | [Azure Virtual Desktop](../../virtual-desktop/index.yml) |
 | Microsoft.Devices | [Azure IoT Hub](../../iot-hub/index.yml)<br />[Azure IoT Hub Device Provisioning Service](../../iot-dps/index.yml) |
 | Microsoft.DeviceUpdate | [Device Update for IoT Hub](../../iot-hub-device-update/index.yml)
-| Microsoft.DevOps | [Azure DevOps](/azure/devops/) |
 | Microsoft.DevSpaces | [Azure Dev Spaces](/previous-versions/azure/dev-spaces/) |
 | Microsoft.DevTestLab | [Azure Lab Services](../../lab-services/index.yml) |
 | Microsoft.DigitalTwins | [Azure Digital Twins](../../digital-twins/overview.md) |
@@ -178,6 +177,7 @@ The resources providers that are marked with **- registered** are registered by 
 | Microsoft.TimeSeriesInsights | [Azure Time Series Insights](../../time-series-insights/index.yml) |
 | Microsoft.Token | Token |
 | Microsoft.VirtualMachineImages | [Azure Image Builder](../../virtual-machines/image-builder-overview.md) |
+| microsoft.visualstudio | [Azure DevOps](/azure/devops/) |
 | Microsoft.VMware | [Azure VMware Solution](../../azure-vmware/index.yml) |
 | Microsoft.VMwareCloudSimple | [Azure VMware Solution by CloudSimple](../../vmware-cloudsimple/index.md) |
 | Microsoft.VSOnline | [Azure DevOps](/azure/devops/) |


### PR DESCRIPTION
Taking microsoft.devops from: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-services-resource-providers

 

we need to remove Microsoft.Devops from the list as it has been updated to decommissioned/hidden in manifest

https://armmanifest.visualstudio.com/One/_git/Manifest/commit/bdb7e836a5fd353717d1851bfbdbf42546e7f8eb?refName=refs%2Fheads%2Fmaster&path=%2FMICROSOFT.DEVOPS%2FPROD%2FMANIFEST.JSON&_a=compare

CSS is receiving cases due to this.

