### PR TITLE
Removes wrong import statement

### DIFF
--- a/articles/open-datasets/dataset-taxi-yellow.md
+++ b/articles/open-datasets/dataset-taxi-yellow.md
@@ -111,7 +111,7 @@ azure_storage_sas_token = r""
 container_name = "nyctlc"
 folder_name = "yellow"
 
-from azure.storage.blob import BlockBlobServicefrom azure.storage.blob import BlobServiceClient, BlobClient, ContainerClient
+from azure.storage.blob import BlobServiceClient, BlobClient, ContainerClient
 
 if azure_storage_account_name is None or azure_storage_sas_token is None:
     raise Exception(


### PR DESCRIPTION
The original import statement had this typo: `BlockBlobServicefrom`.
Furthermore, it seems to me that it is not possible to import this class (`BlockBlobService`) at all from this package, so I remove this line.