### PR TITLE
Update redhat-rhui.md: removed UsGOV IPs and improved the public doc

### DIFF
--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -212,7 +212,7 @@ australiaeast - 20.248.180.252
 southeastasia - 20.24.186.80
 
 # Azure US Government.
-# These IPs are deprecated since 10th April 2023. Newer RHEL images are already redirected to Public region for updates. If you have already added below IPs to your UDR/firewall, you are not required to remove these IPs until next update on this doc.
+# The below mentioned IPs are deprecated since 10th April 2023. Newer RHEL images are already redirected to Public region for updates. If you have already added below IPs to your UDR/firewall, you are not required to remove these IPs until next update on this doc.
 # For RHUI 4 connections, use public RHUI IPs as provided above.
 13.72.186.193
 13.72.14.155

--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -212,14 +212,15 @@ australiaeast - 20.248.180.252
 southeastasia - 20.24.186.80
 
 # Azure US Government.
-# The below mentioned IPs are deprecated since 10th April 2023. Newer RHEL images are already redirected to Public region for updates. If you have already added below IPs to your UDR/firewall, you are not required to remove these IPs until next update on this doc.
+# To be deprecated after 10th April 2023.
+# Newer RHEL images are already redirected to Public region for updates. If you have already added below IPs to your UDR/firewall, you are not required to remove these IPs until next update on this doc.
 # For RHUI 4 connections, use public RHUI IPs as provided above.
 13.72.186.193
 13.72.14.155
 52.244.249.194
 ```
 > [!NOTE]
-> As of October 12th 2023 all PAYG clients will be directed to the RHUI4 IPs in phases over next two months. During this time the RHUI3 IPs will exist for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs should be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. You should not remove RHUI3 IPs to continue receiving updates during the transition period.
+> As of October 12, 2023, all pay-as-you-go (PAYG) clients will be directed to the Red Hat Update Infrastructure (RHUI) 4 IPs in phase over the next two months. During this time, the RHUI3 IPs will remain for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs must be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. Do not remove RHUI3 IPs to continue receiving updates during the transition period.
 
 > [!NOTE]
 > The new Azure US Government images, as of January 2020, uses Public IP mentioned previously under the Azure Global header.

--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -192,7 +192,7 @@ Run the following as root:
 
 RHUI is available in all regions where RHEL on-demand images are available. Availability currently includes all public regions listed in the [Azure status dashboard](https://azure.microsoft.com/status/), Azure US Government, and Microsoft Azure Germany regions.
 
-If you're using a network configuration `(custom Firewall or UDR configurations)` to further restrict https access from RHEL PAYG VMs, make sure the following IPs are allowed for `yum update` to work depending on your environment:
+If you're using a network configuration (custom Firewall or UDR configurations) to further restrict `https` access from RHEL PAYG VMs, make sure the following IPs are allowed for `yum update` to work depending on your environment:
 
 ```output
 # Azure Global

--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -219,11 +219,13 @@ southeastasia - 20.24.186.80
 13.72.14.155
 52.244.249.194
 ```
-> [!NOTE]
-> As of October 12, 2023, all pay-as-you-go (PAYG) clients will be directed to the Red Hat Update Infrastructure (RHUI) 4 IPs in phase over the next two months. During this time, the RHUI3 IPs will remain for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs must be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. Do not remove RHUI3 IPs to continue receiving updates during the transition period.
 
 > [!NOTE]
-> The new Azure US Government images, as of January 2020, uses Public IP mentioned previously under the Azure Global header.
+> 
+> - As of October 12, 2023, all pay-as-you-go (PAYG) clients will be directed to the Red Hat Update Infrastructure (RHUI) 4 IPs in phase over the next two months. During this time, the RHUI3 IPs will remain for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs must be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. Do not remove RHUI3 IPs to continue receiving updates during the transition period.
+>
+> - Also, the new Azure US Government images, as of January 2020, uses Public IP mentioned previously under the Azure Global header.
+
 >
 > Also, Azure Germany is deprecated in favor of public Germany regions. We recommend for Azure Germany customers to start pointing to public RHUI by using the steps in [Manual update procedure to use the Azure RHUI servers](#manual-update-procedure-to-use-the-azure-rhui-servers).
 

--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -211,7 +211,15 @@ eastus - 52.142.4.99
 australiaeast - 20.248.180.252
 southeastasia - 20.24.186.80
 
+# Azure US Government.
+# These IPs are deprecated since 10th April 2023. Newer RHEL images are already redirected to Public region for updates. If you have already added below IPs to your UDR/firewall, you are not required to remove these IPs until next update on this doc.
+# For RHUI 4 connections, use public RHUI IPs as provided above.
+13.72.186.193
+13.72.14.155
+52.244.249.194
 ```
+> [!NOTE]
+> As of October 12th 2023 all PAYG clients will be directed to the RHUI4 IPs. During this time the RHUI3 IPs will exist for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs should be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. You should not remove RHUI3 IPs to continue receiving updates during the transition period.
 
 > [!NOTE]
 > The new Azure US Government images, as of January 2020, uses Public IP mentioned previously under the Azure Global header.
@@ -242,7 +250,7 @@ If you experience problems connecting to Azure RHUI from your Azure RHEL PAYG VM
 
 In September 2016, Azure deployed an updated Azure RHUI. In April 2017, the old Azure RHUI was shut down. If you have been using the RHEL PAYG images or their snapshots from September 2016 or later, you're automatically connecting to the new Azure RHUI. If, however, you have older snapshots on your VMs, you need to manually update their configuration to access the Azure RHUI as described in a following section.
 
-The new Azure RHUI servers are deployed with [Azure Traffic Manager](https://azure.microsoft.com/services/traffic-manager/). In Traffic Manager, any VM can use a single endpoint, rhui-1.microsoft.com, regardless of region.
+The new Azure RHUI servers are deployed with [Azure Traffic Manager](https://azure.microsoft.com/services/traffic-manager/). In Traffic Manager, any VM can use a single endpoint, rhui-1.microsoft.com and rhui4-1.microfot.com, regardless of region.
 
 ### Manual update procedure to use the Azure RHUI servers
 

--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -192,7 +192,7 @@ Run the following as root:
 
 RHUI is available in all regions where RHEL on-demand images are available. Availability currently includes all public regions listed in the [Azure status dashboard](https://azure.microsoft.com/status/), Azure US Government, and Microsoft Azure Germany regions.
 
-If you're using a network configuration to further restrict access from RHEL PAYG VMs, make sure the following IPs are allowed for `yum update` to work depending on your environment:
+If you're using a network configuration `(custom Firewall or UDR configurations)` to further restrict https access from RHEL PAYG VMs, make sure the following IPs are allowed for `yum update` to work depending on your environment:
 
 ```output
 # Azure Global
@@ -203,19 +203,13 @@ RHUI 3
 52.174.163.213
 52.237.203.198
 
+# For RHUI 4 connections, You are required to allow all IPs in your firewall/UDR configuration as updates are delivered from the nearest healthy region.
 RHUI 4
 westeurope - 52.136.197.163
 southcentralus - 20.225.226.182
 eastus - 52.142.4.99
 australiaeast - 20.248.180.252
 southeastasia - 20.24.186.80
-
-# Azure US Government.
-# To be deprecated after 10th April 2023.
-# For RHUI 4 connections, use public RHUI IPs as provided above.
-13.72.186.193
-13.72.14.155
-52.244.249.194
 
 ```
 

--- a/articles/virtual-machines/workloads/redhat/redhat-rhui.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-rhui.md
@@ -219,7 +219,7 @@ southeastasia - 20.24.186.80
 52.244.249.194
 ```
 > [!NOTE]
-> As of October 12th 2023 all PAYG clients will be directed to the RHUI4 IPs. During this time the RHUI3 IPs will exist for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs should be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. You should not remove RHUI3 IPs to continue receiving updates during the transition period.
+> As of October 12th 2023 all PAYG clients will be directed to the RHUI4 IPs in phases over next two months. During this time the RHUI3 IPs will exist for continued updates but will be removed at a future time. Existing routes and rules allowing access to RHUI3 IPs should be updated to also include RHUI4 IP addresses for uninterrupted access to packages and updates. You should not remove RHUI3 IPs to continue receiving updates during the transition period.
 
 > [!NOTE]
 > The new Azure US Government images, as of January 2020, uses Public IP mentioned previously under the Azure Global header.


### PR DESCRIPTION
We got the following feedback from the Support team:
1. remove the UsGov IPs from the doc to avoid confusion
2. specify the word "UDR" in the documents in the form of a note to help them with the action item once they reach the RHUI MS doc page.
3. We need to specify who would be impacted in the MS docs
4. Add a note for Customers to add all Ips instead of adding a region

With this PR I removed UsGOV IPs and improved the doc by specifying who will be impacted and what are the action items.


![image](https://github.com/MicrosoftDocs/azure-docs/assets/50854544/d80cf9a9-082d-4f34-929b-9d8f2ed7b966)


