### PR TITLE
Update how-to-develop-emulator.md

### DIFF
--- a/articles/cosmos-db/how-to-develop-emulator.md
+++ b/articles/cosmos-db/how-to-develop-emulator.md
@@ -476,7 +476,8 @@ Use the [Azure Cosmos DB API for NoSQL .NET SDK](nosql/quickstart-dotnet.md) to 
     >     {
     >         ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
     >     }),
-    >     ConnectionMode = ConnectionMode.Gateway
+    >     ConnectionMode = ConnectionMode.Gateway,
+    >     LimitToEndpoint = true
     > };
     >
     > using CosmosClient client = new(


### PR DESCRIPTION
If the "LimitToEndpoint = true" configuration option is not added to the CosmosClientOptions and the user is testing locally, the cosmos client never returns a response and just continually spins.  It appears that it just keeps trying to connect, but doesn't timeout correctly or has no limit.  I was able to reproduce in the cosmos db .net sample for createitem and was able to fix this issue by adding this option.