### PR TITLE
Update role-assignments-powershell.md

### DIFF
--- a/articles/role-based-access-control/role-assignments-powershell.md
+++ b/articles/role-based-access-control/role-assignments-powershell.md
@@ -190,10 +190,10 @@ New-AzRoleAssignment -ObjectId <objectId> `
 
 #### Assign a role for all blob containers in a storage account resource scope
 
-Assigns the [Storage Blob Data Contributor](built-in-roles.md#storage-blob-data-contributor) role to a service principal with object ID *55555555-5555-5555-5555-555555555555* at a resource scope for a storage account named *storage12345*.
+Assigns the [Storage Blob Data Contributor](built-in-roles.md#storage-blob-data-contributor) role to a service principal with object ID *55555555-5555-5555-5555-555555555555* and Application ID *66666666-6666-6666-6666-666666666666* at a resource scope for a storage account named *storage12345*.
 
 ```azurepowershell
-PS C:\> New-AzRoleAssignment -ObjectId 55555555-5555-5555-5555-555555555555 `
+PS C:\> New-AzRoleAssignment -ApplicationId 66666666-6666-6666-6666-666666666666 `
 -RoleDefinitionName "Storage Blob Data Contributor" `
 -Scope "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Example-Storage-rg/providers/Microsoft.Storage/storageAccounts/storage12345"
 
@@ -210,10 +210,10 @@ CanDelegate        : False
 
 #### Assign a role for a specific blob container resource scope
 
-Assigns the [Storage Blob Data Contributor](built-in-roles.md#storage-blob-data-contributor) role to a service principal with object ID *55555555-5555-5555-5555-555555555555* at a resource scope for a blob container named *blob-container-01*.
+Assigns the [Storage Blob Data Contributor](built-in-roles.md#storage-blob-data-contributor) role to a service principal with object ID *55555555-5555-5555-5555-555555555555* and Application ID *66666666-6666-6666-6666-666666666666* at a resource scope for a blob container named *blob-container-01*.
 
 ```azurepowershell
-PS C:\> New-AzRoleAssignment -ObjectId 55555555-5555-5555-5555-555555555555 `
+PS C:\> New-AzRoleAssignment -ApplicationId 66666666-6666-6666-6666-666666666666 `
 -RoleDefinitionName "Storage Blob Data Contributor" `
 -Scope "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Example-Storage-rg/providers/Microsoft.Storage/storageAccounts/storage12345/blobServices/default/containers/blob-container-01"
 


### PR DESCRIPTION
PS Script to assign a role to user at container level for Service Principal

The script is not working with Object ID. It is working only with Applicaiton ID for providing access to a Service principal at Resource level.

Script with changes made:
New-AzRoleAssignment -ApplicationId c******b-3**3-4**9-8**b-*******2064 ` -RoleDefinitionName "Storage Blob Data Contributor" ` -Scope "/subscriptions/893b8995-3ce8-4a47-97a3-57e8f0f63ef1/resourceGroups/MyRG/providers/Microsoft.Storage/storageAccounts/lkatepaga5/blobServices/default/containers/testrole" `
 
In document it is written as object ID which is not working as expected.