### PR TITLE
Update howto-authentication-passwordless-security-key-on-premises.md

### DIFF
--- a/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
+++ b/articles/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises.md
@@ -186,14 +186,16 @@ Run the following steps in each domain and forest in your organization that cont
 
 You can view and verify the newly created Microsoft Entra Kerberos server by using the following command:
 
+
 ```powershell
-Get-AzureADKerberosServer -Domain $domain -CloudCredential $cloudCred -DomainCredential $domainCred
+ # When prompted to provide domain credentials use the userprincipalname format for the username instead of domain\username
+Get-AzureADKerberosServer -Domain $domain -UserPrincipalName $userPrincipalName -DomainCredential (get-credential)
 ```
 
 This command outputs the properties of the Microsoft Entra Kerberos server. You can review the properties to verify that everything is in good order.
 
 > [!NOTE]
-> Running against another domain by supplying the credential will connect over NTLM, and then it fails. If the users are in the Protected Users security group in Active Directory, complete these steps to resolve the issue: Sign in as another domain user in **ADConnect** and don’t supply "-domainCredential". The Kerberos ticket of the user that's currently signed in is used. You can confirm by executing `whoami /groups` to validate whether the user has the required permissions in Active Directory to execute the preceding command.
+> Running against another domain by supplying the credential in domain\username format will connect over NTLM, and then it fails. However, using the userprincipalname format for the domain administrator will ensure RPC bind to the DC is attempted using Kerberos correctly. If the users are in the Protected Users security group in Active Directory, complete these steps to resolve the issue: Sign in as another domain user in **ADConnect** and don’t supply "-domainCredential". The Kerberos ticket of the user that's currently signed in is used. You can confirm by executing `whoami /groups` to validate whether the user has the required permissions in Active Directory to execute the preceding command.
  
 | Property | Description |
 | --- | --- |


### PR DESCRIPTION
I have provided alternate syntax which avoids the NTLM authentication failure when the PowerShell  is executed on a machine that is not in the same domain as the targeted domain for the cmdlet. Using -domaincredential $somecreds format where $somecreds is provided as domain\admin and password combination (instead of UPN and password) fails. The use of -userprincipalname is more likely to be of use as a majority of the admins will not be using this without having to do modern authentication for MFA.