### PR TITLE
{AzureAnomalyDetector} `import os`  statement is missing in the python sample

### DIFF
--- a/articles/ai-services/Anomaly-Detector/includes/quickstarts/anomaly-detector-client-library-python.md
+++ b/articles/ai-services/Anomaly-Detector/includes/quickstarts/anomaly-detector-client-library-python.md
@@ -185,6 +185,7 @@ To visualize the anomalies and change points in relation to the sample data seri
     import pandas as pd
     import matplotlib.pyplot as plt
     import matplotlib.dates as mdates
+    import os
 
     API_KEY = os.environ['ANOMALY_DETECTOR_API_KEY']
     ENDPOINT = os.environ['ANOMALY_DETECTOR_ENDPOINT']


### PR DESCRIPTION
`import os`  statement is missing in the python sample provided in this learn docs:  https://learn.microsoft.com/en-us/azure/ai-services/anomaly-detector/quickstarts/client-libraries?tabs=command-line&pivots=programming-language-python#visualize-results

Without this statement, you will encounter the below error:

```
API_KEY = os.environ['ANOMALY_DETECTOR_API_KEY']
              ^^
NameError: name 'os' is not defined
```
