### PR TITLE
docs: fix broken link for Azure OpenAI request access form

### DIFF
--- a/articles/ai-services/openai/how-to/managed-identity.md
+++ b/articles/ai-services/openai/how-to/managed-identity.md
@@ -21,7 +21,7 @@ In the following sections, you'll use  the Azure CLI to assign roles, and obtain
 
 - An Azure subscription - <a href="https://azure.microsoft.com/free/cognitive-services" target="_blank">Create one for free</a>
 - Access granted to the Azure OpenAI Service in the desired Azure subscription
--   Currently, access to this service is granted only by application. You can apply for access to Azure OpenAI by completing the form at [https://aka.ms/oai/access</a>. Open an issue on this repo to contact us if you have an issue.
+-   Currently, access to this service is granted only by application. You can apply for access to Azure OpenAI by completing the [Request Access to Azure OpenAI Service form](https://aka.ms/oai/access). Open an issue on this repo to contact us if you have an issue.
 
 - [Custom subdomain names are required to enable features like Azure Active Directory (Azure AD) for authentication.](
 ../../cognitive-services-custom-subdomains.md)


### PR DESCRIPTION
The link in the documentation for the Azure OpenAI access request form was broken, since it contained a mix of Markdown-style opening tag `[` and HTML anchor-style closing tag `</a>`. I thought I'd send a quick PR with proposed fix.

Also, THANK YOU for the great documentation and invaluable work you do! 🙏👏 
It really makes a difference and is highly appreciated.
