### PR TITLE
docs: fix sentence in RBAC how-to

### DIFF
--- a/articles/ai-services/openai/how-to/role-based-access-control.md
+++ b/articles/ai-services/openai/how-to/role-based-access-control.md
@@ -14,7 +14,7 @@ recommendations: false
 
 # Role-based access control for Azure OpenAI Service
 
-Azure OpenAI Service supports Azure role-based access control (Azure RBAC), an authorization system for managing individual access to Azure resources. Using Azure RBAC, you assign different team members different levels of permissions based on their needs for a given project. For more information, see the [Azure RBAC documentation](../../../role-based-access-control/index.yml) for more information.
+Azure OpenAI Service supports Azure role-based access control (Azure RBAC), an authorization system for managing individual access to Azure resources. Using Azure RBAC, you assign different team members different levels of permissions based on their needs for a given project. For more information, see the [Azure RBAC documentation](../../../role-based-access-control/index.yml).
 
 ## Add role assignment to an Azure OpenAI resource
 


### PR DESCRIPTION
The `for more information` part is duplicated. It currently reads "For more information, see ... for more information." I thought I'd send a quick PR with a fix.

Also, THANK YOU for the great documentation and invaluable work you do! 🙏👏
It really makes a difference and is highly appreciated.

 