### PR TITLE
Add interactive terminal to AKS Fleet guides

### DIFF
--- a/articles/kubernetes-fleet/configuration-propagation.md
+++ b/articles/kubernetes-fleet/configuration-propagation.md
@@ -21,7 +21,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 * Set the following environment variables and obtain the kubeconfigs for the fleet and all member clusters:
 
-    ```bash
+    ```azurecli-interactive
     export GROUP=<resource-group>
     export FLEET=<fleet-name>
     export MEMBER_CLUSTER_1=aks-member-1
@@ -43,7 +43,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 1. Create a sample namespace by running the following command on the fleet cluster:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl create namespace hello-world
     ```
 
@@ -75,7 +75,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 1. Apply the `ClusterResourcePlacement`:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl apply -f crp.yaml
     ```
 
@@ -87,7 +87,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 1. Check the status of the `ClusterResourcePlacement`:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl get clusterresourceplacements
     ```
 
@@ -100,7 +100,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 1. On each member cluster, check if the namespace has been propagated:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-1 kubectl get namespace hello-world
     ```
 
@@ -111,7 +111,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
     hello-world   Active   96s
     ```
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-2 kubectl get namespace hello-world
     ```
 
@@ -122,7 +122,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
     hello-world   Active   1m16s
     ```
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-3 kubectl get namespace hello-world
     ```
 
@@ -141,7 +141,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 1. Create a sample namespace by running the following command:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl create namespace hello-world-1
     ```
 
@@ -166,14 +166,14 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
     Apply this `ClusterResourcePlacement` to the cluster:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl apply -f crp-1.yaml
     ```
 
 1. Check the status of the `ClusterResourcePlacement`:
 
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl get clusterresourceplacements
     ```
 
@@ -186,7 +186,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
 
 1. On each AKS cluster, run the following command to see if the namespace has been propagated:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-1 kubectl get namespace hello-world-1
     ```
 
@@ -197,7 +197,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
     hello-world-1   Active   70s
     ```
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-2 kubectl get namespace hello-world-1
     ```
 
@@ -207,7 +207,7 @@ Platform admins and application developers need a way to deploy the same Kuberne
     Error from server (NotFound): namespaces "hello-world-1" not found
     ```
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-3 kubectl get namespace hello-world-1
     ```
 

--- a/articles/kubernetes-fleet/l4-load-balancing.md
+++ b/articles/kubernetes-fleet/l4-load-balancing.md
@@ -33,7 +33,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 * Set the following environment variables and obtain the kubeconfigs for the fleet and all member clusters:
 
-    ```bash
+    ```azurecli-interactive
     export GROUP=<resource-group>
     export FLEET=<fleet-name>
     export MEMBER_CLUSTER_1=aks-member-1
@@ -55,7 +55,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Create a namespace on the fleet cluster:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl create namespace kuard-demo
     ```
 
@@ -67,7 +67,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Apply the Deployment, Service, ServiceExport objects:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl apply -f https://raw.githubusercontent.com/Azure/AKS/master/examples/fleet/kuard/kuard-export-service.yaml
     ```
 
@@ -103,7 +103,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Apply the `ClusterResourcePlacement`:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl apply -f crp-2.yaml
     ```
 
@@ -116,7 +116,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 1. Check the status of the `ClusterResourcePlacement`:
 
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=fleet kubectl get clusterresourceplacements
     ```
 
@@ -132,7 +132,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Check the member clusters in `eastus` region to see if the service is successfully exported:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-1 kubectl get serviceexport kuard --namespace kuard-demo
     ```
 
@@ -143,7 +143,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
     kuard   True       False           25s
     ```
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-2 kubectl get serviceexport kuard --namespace kuard-demo
     ```
 
@@ -161,7 +161,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Apply the MultiClusterService on one of these members to load balance across the service endpoints in these clusters:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-1 kubectl apply -f https://raw.githubusercontent.com/Azure/AKS/master/examples/fleet/kuard/kuard-mcs.yaml
     ```
 
@@ -188,7 +188,7 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Verify the MultiClusterService is valid by running the following command:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-1 kubectl get multiclusterservice kuard --namespace kuard-demo
     ```
 
@@ -203,16 +203,16 @@ In this how-to guide, you'll set up layer 4 load balancing across workloads depl
 
 1. Run the following command multiple times using the External IP address from above:
 
-    ```bash
+    ```azurecli-interactive
     curl <a.b.c.d>:8080 | grep addrs 
     ```
 
     Notice that the IPs of the pods serving the request is changing and that these pods are from member clusters `aks-member-1` and `aks-member-2` from the `eastus` region. You can verify the pod IPs by running the following commands on the clusters from `eastus` region:
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-1 kubectl get pods -n kuard-demo -o wide
     ```
 
-    ```bash
+    ```azurecli-interactive
     KUBECONFIG=aks-member-2 kubectl get pods -n kuard-demo -o wide
     ```

--- a/articles/kubernetes-fleet/quickstart-create-fleet-and-members.md
+++ b/articles/kubernetes-fleet/quickstart-create-fleet-and-members.md
@@ -393,7 +393,7 @@ An Azure Kubernetes Fleet Manager resource is itself a Kubernetes cluster that y
 
 1. Verify the status of the member clusters:
 
-    ```bash
+    ```azurecli-interactive
     kubectl get memberclusters
     ```
 

--- a/articles/kubernetes-fleet/update-orchestration.md
+++ b/articles/kubernetes-fleet/update-orchestration.md
@@ -21,7 +21,7 @@ Platform admins who are managing Kubernetes fleets with a large number of cluste
 
 * Set the following environment variables:
 
-  ```bash
+  ```azurecli-interactive
   export GROUP=<resource-group>
   export FLEET=<fleet-name>
   ```


### PR DESCRIPTION
This PR simply modifies the markdown in the guides so that the language tags for all runnable commands is: `azurecli-interactive`. This is meant to be a small quality-of-life improvement that makes it easier to follow along with the guides by using the interactive shell in the browser. Although some of these are pure bash commands, they are arguably meant to be run in the same context as the azurecli commands. Thus, I thought changing the tag so the "Open in Cloudshell" button appears made sense. 