### PR TITLE
Updating the replication appliance requirement to use Windows 2016

### DIFF
--- a/articles/migrate/migrate-support-matrix-physical-migration.md
+++ b/articles/migrate/migrate-support-matrix-physical-migration.md
@@ -63,7 +63,7 @@ The table summarizes support for physical servers, AWS VMs, and GCP VMs that you
 
 ## Replication appliance requirements
 
-If you set up the replication appliance manually, then make sure that it complies with the requirements summarized in the table. When you set up the Azure Migrate replication appliance as an VMware VM using the OVA template provided in the Azure Migrate hub, the appliance is set up with Windows Server 2022, and complies with the support requirements. 
+If you set up the replication appliance manually, then make sure that it complies with the requirements summarized in the table. When you set up the Azure Migrate replication appliance as an VMware VM using the OVA template provided in the Azure Migrate hub, the appliance is set up with Windows Server 2016, and complies with the support requirements. 
 
 - Learn about [replication appliance requirements](migrate-replication-appliance.md#appliance-requirements).
 - Install MySQL on the appliance. Learn about [installation options](migrate-replication-appliance.md#mysql-installation).


### PR DESCRIPTION
Updating the replication appliance requirement to use Windows 2016 from 2022, which was updated by mistake.