### PR TITLE
[ContainerRegistry] Update documentation to include wildcard support for tokens and scope maps (container-registry-repository-scoped-permissions.md)

### DIFF
--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -166,6 +166,7 @@ This example creates a token with a wildcard.
 Wildcard permissions are additive, meaning that given a specific repository the resulting permissions will include the permissions for all the scope map rules that match the wildcard prefix.
 
 In this example, if a token is assigned to a scope map with the following repositories defined:
+
   |Repository  |Permission  |
   |---------|---------|
   |`sample/*`    | `content/read`  |

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -141,7 +141,7 @@ The output shows details about the token. By default, two passwords are generate
 
 ### Use wildcards to assign permissions to multiple repositories
 
-Scope maps allow to use wildcards to define permissions to multiple repositories that share the same prefix.
+Scope maps allow to use wildcards to define permissions to multiple repositories that share the same prefix. Repository specific permissions and wildcards can be used in the same scope map. 
 
 These can be created when a scope map is created and assigned to a token, or when a token is created and directly assigned to a repository.
 
@@ -172,10 +172,10 @@ In this example, if a token is assigned to a scope map with the following reposi
   |`sample/teamA/*`    | `content/write`  |
   |`sample/teamA/projectB`    | `content/delete`  |
 
-The token would have `[content/read, content/write, content/delete]` when accessing repository `sample/teamA/projectB`. And will have only `[content/read, content/write]` when accessing respository `sample/teamA/projectC`.
+The token would have `[content/read, content/write, content/delete]` when accessing repository `sample/teamA/projectB`. And will have only `[content/read, content/write]` when accessing repository `sample/teamA/projectC`.
 
 > [!NOTE]
-> Repositories using wildcards in the scope map should always end with a `/*` suffix to be valid and have a single wildcard character in the repository name.
+> Repositories using wildcards in the scope map should always end with a `/*` suffix to be valid, and have a single wildcard character in the repository name.
 > - `sample/*/teamA`: This is not a valid wildcard because it has a wildcard in the middle of the repository name.
 > - `sample/teamA*`: This is not a valid wildcard because it does not end with `/*`.
 > - `sample/teamA/*/projectB/*`: This is not a valid wildcard because it has multiple wildcards in the repository name.
@@ -184,7 +184,7 @@ The token would have `[content/read, content/write, content/delete]` when access
 
 Wildcards can also be applied at a root level. This means that any permissions assigned to the repository defined as `*`, will be applied registry wide.
 
-The following example creates a token with a root level wild card.
+The following example creates a token with a root level wild card that would give the token `[content/read, content/write]` permission to all repositories in the registry.
 ```azurecli
  az acr token create --name MyTokenWildcard --registry myregistry \
   --repository * \

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -139,31 +139,33 @@ The output shows details about the token. By default, two passwords are generate
 > [!NOTE]
 > To regenerate token passwords and expiration periods, see [Regenerate token passwords](#regenerate-token-passwords) later in this article.
 
-### Use wildcards to assign permissions to multiple repositories
+### How to use scope maps to define and assign permissions for multiple repositories?
 
-Scope maps allow to use wildcards to define permissions to multiple repositories that share the same prefix. Repository specific permissions and wildcards can be used in the same scope map. 
+Scope maps allow for the use of wildcards to define and grant similar permissions for multiple repositories sharing a common prefix. The repository specific permissions and wildcards can be used in the same scope map. This will allow flexibility to manage permissions for multiple repositories in a single scope map.
 
 These can be created when a scope map is created and assigned to a token, or when a token is created and directly assigned to a repository.
 
-This example creates a scope map with wild card and then assigns it to a token.
+The following example creates a scope map with wild card and then assigns it to a token.
+
 ```azurecli
 az acr scope-map create --name MyScopeMapWildcard --registry myregistry \
   --repository samples/* \
   content/write content/read \
   --description "Sample scope map with wildcards"
-
 az acr token create --name MyTokenWildcard \
   --registry myregistry \
   --scope-map MyScopeMapWildcard
 ```
-This example creates a token with a wildcard.
+
+The following example creates a token with a wildcard.
+
 ```azurecli
  az acr token create --name MyTokenWildcard --registry myregistry \
   --repository samples/* \
   content/write content/read \
 ```
 
-Wildcard permissions are additive, meaning that given a specific repository the resulting permissions will include the permissions for all the scope map rules that match the wildcard prefix.
+The wildcard permissions are additive, which means that when a specific repository is accessed, the resulting permissions will include the permissions for all the scope map rules that match the wildcard prefix.
 
 In this example, if a token is assigned to a scope map with the following repositories defined:
 
@@ -175,17 +177,20 @@ In this example, if a token is assigned to a scope map with the following reposi
 
 The token would have `[content/read, content/write, content/delete]` when accessing repository `sample/teamA/projectB`. And will have only `[content/read, content/write]` when accessing repository `sample/teamA/projectC`.
 
-> [!NOTE]
-> Repositories using wildcards in the scope map should always end with a `/*` suffix to be valid, and have a single wildcard character in the repository name.
-> - `sample/*/teamA`: This is not a valid wildcard because it has a wildcard in the middle of the repository name.
-> - `sample/teamA*`: This is not a valid wildcard because it does not end with `/*`.
-> - `sample/teamA/*/projectB/*`: This is not a valid wildcard because it has multiple wildcards in the repository name.
+> [!IMPORTANT]
+> Repositories using wildcards in the scope map should always end with a /* suffix to be valid, and have a single wildcard character in the repository name.
+> Here are some examples of invalid wildcards:
+>
+> * `sample/*/teamA` with a wildcard in the middle of the repository name.
+> * `sample/teamA*` with a wildcard does not end with `/*``.
+> * `sample/teamA/*/projectB/*` with multiple wildcards in the repository name.
 
 #### Root level wildcards
 
 Wildcards can also be applied at a root level. This means that any permissions assigned to the repository defined as `*`, will be applied registry wide.
 
-The following example creates a token with a root level wild card that would give the token `[content/read, content/write]` permission to all repositories in the registry.
+The example shows how to create a token with a root level wildcard that would give the token `[content/read, content/write]` permission to all repositories in the registry. This provides a simple way to grant permissions to all repositories in the registry without having to specify each repository individually.
+
 ```azurecli
  az acr token create --name MyTokenWildcard --registry myregistry \
   --repository * \

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -46,8 +46,6 @@ To configure repository-scoped permissions, you create a *token* with an associa
 
 * A **scope map** groups the repository permissions you apply to a token and can reapply to other tokens. Every token is associated with a single scope map. With a scope map, you can:
 
-   With a scope map:
-
   * Configure multiple tokens with identical permissions to a set of repositories.
   * Update token permissions when you add or remove repository actions in the scope map, or apply a different scope map.
 

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -141,11 +141,11 @@ The output shows details about the token. By default, two passwords are generate
 
 ### How to use scope maps to define and assign permissions for multiple repositories
 
-Scope maps allow for the use of a wildcard character to define and grant similar permissions for multiple repositories sharing a common prefix. The repository specific permissions and wildcards can be used in the same scope map. This will allow flexibility to manage permissions for multiple repositories in a single scope map.
+Scope maps allow for the use of a wildcard character to define and grant similar permissions for multiple repositories sharing a common prefix. Repositories specific permissions and repositories with a wildcard character can be used in the same scope map. This will allow flexibility to manage permissions for multiple repositories in a single scope map.
 
 These can be created when a scope map is created and assigned to a token, or when a token is created and directly assigned to a repository.
 
-The following example creates a scope map with wild card and then assigns it to a token.
+The following example creates a scope map with a wildcard character and then assigns it to a token.
 
 ```azurecli
 az acr scope-map create --name MyScopeMapWildcard --registry myregistry \

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -139,9 +139,9 @@ The output shows details about the token. By default, two passwords are generate
 > [!NOTE]
 > To regenerate token passwords and expiration periods, see [Regenerate token passwords](#regenerate-token-passwords) later in this article.
 
-### How to use scope maps to define and assign permissions for multiple repositories?
+### How to use scope maps to define and assign permissions for multiple repositories
 
-Scope maps allow for the use of wildcards to define and grant similar permissions for multiple repositories sharing a common prefix. The repository specific permissions and wildcards can be used in the same scope map. This will allow flexibility to manage permissions for multiple repositories in a single scope map.
+Scope maps allow for the use of a wildcard character to define and grant similar permissions for multiple repositories sharing a common prefix. The repository specific permissions and wildcards can be used in the same scope map. This will allow flexibility to manage permissions for multiple repositories in a single scope map.
 
 These can be created when a scope map is created and assigned to a token, or when a token is created and directly assigned to a repository.
 

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -1,6 +1,6 @@
 ---
 title: Permissions to repositories in Azure Container Registry
-description: Create a token with permissions scoped to repositories in a registry to pull or push images, or perform other actions
+description: Create a token to grant and manage repository scoped permissions within a container registry. The token helps to perform actions, such as pull images, push images, delete images, read metadata, and write metadata.
 ms.topic: article
 author: tejaswikolli-web
 ms.author: tejaswikolli
@@ -13,10 +13,10 @@ ms.devlang: azurecli
 
 This article describes how to create tokens and scope maps to manage access to repositories in your container registry. By creating tokens, a registry owner can provide users or services with scoped, time-limited access to repositories to pull or push images or perform other actions. A token provides more fine-grained permissions than other registry [authentication options](container-registry-authentication.md), which scope permissions to an entire registry.
 
-Scenarios for creating a token include:
+Common scenarios for creating a token includes:
 
-* Allow IoT devices with individual tokens to pull an image from a repository
-* Provide an external organization with permissions to a repository path
+* Allow IoT devices with individual tokens to pull an image from a repository.
+* Provide an external organization with permissions to a repository path.
 * Limit repository access to different user groups in your organization. For example, provide write and read access to developers who build images that target specific repositories, and read access to teams that deploy from those repositories.
 
 This feature is available in all the service tiers. For information about registry service tiers and limits, see [Azure Container Registry service tiers](container-registry-skus.md)
@@ -42,14 +42,14 @@ To configure repository-scoped permissions, you create a *token* with an associa
   |`metadata/write`     |  Write metadata to the repository  | Enable or disable read, write, or delete operations |
 
 > [!NOTE]
-> Permissions to allow catalog listing of repositories is not supported for repository-scoped permissions.
+> Repository-scoped permissions do not support the ability to list the catalog of all repositories in the registry.
 
-* A **scope map** groups the repository permissions you apply to a token, and can reapply to other tokens. Every token is associated with a single scope map.
+* A **scope map** groups the repository permissions you apply to a token and can reapply to other tokens. Every token is associated with a single scope map. With a scope map, you can:
 
    With a scope map:
 
-  * Configure multiple tokens with identical permissions to a set of repositories
-  * Update token permissions when you add or remove repository actions in the scope map, or apply a different scope map
+  * Configure multiple tokens with identical permissions to a set of repositories.
+  * Update token permissions when you add or remove repository actions in the scope map, or apply a different scope map.
 
   Azure Container Registry also provides several system-defined scope maps you can apply when creating tokens. The permissions of system-defined scope maps apply to all repositories in your registry.The individual *actions* corresponds to the limit of [Repositories per scope map.](container-registry-skus.md)
 
@@ -109,6 +109,7 @@ The output shows details about the token. By default, two passwords are generate
   "scopeMapId": "/subscriptions/xxxxxxxx-adbd-4cb4-c864-xxxxxxxxxxxx/resourceGroups/myresourcegroup/providers/Microsoft.ContainerRegistry/registries/myregistry/scopeMaps/MyToken-scope-map",
   "status": "enabled",
   "type": "Microsoft.ContainerRegistry/registries/tokens"
+}
 ```
 
 > [!NOTE]
@@ -144,9 +145,9 @@ The output shows details about the token. By default, two passwords are generate
 
 ### How to use scope maps to define and assign permissions for multiple repositories
 
-Scope maps allow for the use of a wildcard character to define and grant similar permissions for multiple repositories sharing a common prefix. Repositories specific permissions and repositories with a wildcard character can be used in the same scope map. This will allow flexibility to manage permissions for multiple repositories in a single scope map.
+A scope map allows for the use of a wildcard character to define and grant similar permissions for multiple repositories that share a common prefix. Repositories with specific permissions, repositories with a wildcard character can also be used in the same scope map. This provides flexibility in managing permissions for a multiple set of repositories in a single scope map.
 
-These can be created when a scope map is created and assigned to a token, or when a token is created and directly assigned to a repository.
+Repository permissions can be created when a scope map is created and assigned to a token. Alternatively, a token can be created and directly assigned to a repository.
 
 The following example creates a scope map with a wildcard character and then assigns it to a token.
 
@@ -170,7 +171,7 @@ The following example creates a token with a wildcard.
 
 The wildcard permissions are additive, which means that when a specific repository is accessed, the resulting permissions will include the permissions for all the scope map rules that match the wildcard prefix.
 
-In this example, if a token is assigned to a scope map with the following repositories defined:
+In this example, the scope map defines permissions for three different types of repositories:
 
   |Repository  |Permission  |
   |---------|---------|
@@ -178,10 +179,10 @@ In this example, if a token is assigned to a scope map with the following reposi
   |`sample/teamA/*`    | `content/write`  |
   |`sample/teamA/projectB`    | `content/delete`  |
 
-The token would have `[content/read, content/write, content/delete]` when accessing repository `sample/teamA/projectB`. And will have only `[content/read, content/write]` when accessing repository `sample/teamA/projectC`.
+The token is assigned a scope map to grant `[content/read, content/write, content/delete]` permissions for accessing repository `sample/teamA/projectB`. However, when the same token is used to access the `sample/teamA/projectC` repository, it only has `[content/read, content/write]` permissions.
 
 > [!IMPORTANT]
-> Repositories using wildcards in the scope map should always end with a /* suffix to be valid, and have a single wildcard character in the repository name.
+> Repositories using wildcards in the scope map should always end with a `/*` suffix to be valid and have a single wildcard character in the repository name.
 > Here are some examples of invalid wildcards:
 >
 > * `sample/*/teamA` with a wildcard in the middle of the repository name.
@@ -192,7 +193,7 @@ The token would have `[content/read, content/write, content/delete]` when access
 
 Wildcards can also be applied at a root level. This means that any permissions assigned to the repository defined as `*`, will be applied registry wide.
 
-The example shows how to create a token with a root level wildcard that would give the token `[content/read, content/write]` permission to all repositories in the registry. This provides a simple way to grant permissions to all repositories in the registry without having to specify each repository individually.
+The example shows how to create a token with a root level wildcard that would give the token `[content/read, content/write]` permissions to all repositories in the registry. This provides a simple way to grant permissions to all repositories in the registry without having to specify each repository individually.
 
 ```azurecli
  az acr token create --name MyTokenWildcard --registry myregistry \

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -41,6 +41,9 @@ To configure repository-scoped permissions, you create a *token* with an associa
   |`metadata/read`    | Read metadata from the repository   | List tags or manifests |
   |`metadata/write`     |  Write metadata to the repository  | Enable or disable read, write, or delete operations |
 
+> [!NOTE]
+> Permissions to allow catalog listing of repositories is not supported for repository-scoped permissions.
+
 * A **scope map** groups the repository permissions you apply to a token, and can reapply to other tokens. Every token is associated with a single scope map.
 
    With a scope map:
@@ -196,6 +199,12 @@ The example shows how to create a token with a root level wildcard that would gi
   --repository * \
   content/write content/read \
 ```
+
+> [!IMPORTANT]
+> If a wildcard rule encompasses a repository that does not exist yet, the wildcard rule's permissions will still apply to that repository name.
+> For example, a token that is assigned to a scope map that grants `[content/write, metadata/write]` permissions for `sample/*` repositories.
+> Additionally, suppose the repository `sample/teamC/teamCimage` does not exist yet.
+> The token will have permissions for pushing images to repository `sample/teamC/teamCimage`, which will simultaneously create the repository on successful push.
 
 ## Create token - portal
 

--- a/articles/container-registry/container-registry-repository-scoped-permissions.md
+++ b/articles/container-registry/container-registry-repository-scoped-permissions.md
@@ -13,7 +13,7 @@ ms.devlang: azurecli
 
 This article describes how to create tokens and scope maps to manage access to repositories in your container registry. By creating tokens, a registry owner can provide users or services with scoped, time-limited access to repositories to pull or push images or perform other actions. A token provides more fine-grained permissions than other registry [authentication options](container-registry-authentication.md), which scope permissions to an entire registry.
 
-Common scenarios for creating a token includes:
+Common scenarios for creating a token include:
 
 * Allow IoT devices with individual tokens to pull an image from a repository.
 * Provide an external organization with permissions to a repository path.


### PR DESCRIPTION
A feature has been added to include wildcards when defining repositories in an ACR scope map for authentication.
Before the change the repository path had to match exactly the image that the customer was trying to access.
Now paths can be created with a wildcard character to allow all repositories that match a prefix to be defined with a single rule.

Added examples and notes as necessary to indicate the limitations of the feature.