### PR TITLE
Add note about "Use for sign-in"

### DIFF
--- a/articles/active-directory/authentication/how-to-authentication-methods-manage.md
+++ b/articles/active-directory/authentication/how-to-authentication-methods-manage.md
@@ -133,6 +133,9 @@ The legacy MFA policy has separate controls for **SMS** and **Phone calls**. But
 
 The Authentication methods policy has controls for **SMS** and **Voice calls**, matching the legacy MFA policy. If your tenant is using SSPR and **Mobile phone** is enabled, you'll want to enable both **SMS** and **Voice calls** in the Authentication methods policy. If your tenant is using SSPR and **Office phone** is enabled, you'll want to enable **Voice calls** in the Authentication methods policy, and ensure that the **Office phone** option is enabled. 
 
+> [!NOTE] 
+> The **Use for sign-in** option is default enabled on **SMS** settings. This option enables SMS sign-in. If SMS sign-in is enabled for users, they will be skipped from cross-tenant synchronization. If you are using cross-tenant synchronization, disable SMS Sign-in for target users.
+
 ### OATH tokens
 
 The OATH token controls in the legacy MFA and SSPR policies were single controls that enabled the use of three different types of OATH tokens: the Microsoft Authenticator app, third-party software OATH TOTP code generator apps, and hardware OATH tokens.

--- a/articles/active-directory/authentication/how-to-authentication-methods-manage.md
+++ b/articles/active-directory/authentication/how-to-authentication-methods-manage.md
@@ -134,7 +134,7 @@ The legacy MFA policy has separate controls for **SMS** and **Phone calls**. But
 The Authentication methods policy has controls for **SMS** and **Voice calls**, matching the legacy MFA policy. If your tenant is using SSPR and **Mobile phone** is enabled, you'll want to enable both **SMS** and **Voice calls** in the Authentication methods policy. If your tenant is using SSPR and **Office phone** is enabled, you'll want to enable **Voice calls** in the Authentication methods policy, and ensure that the **Office phone** option is enabled. 
 
 > [!NOTE] 
-> The **Use for sign-in** option is default enabled on **SMS** settings. This option enables SMS sign-in. If SMS sign-in is enabled for users, they will be skipped from cross-tenant synchronization. If you are using cross-tenant synchronization, disable SMS Sign-in for target users.
+> The **Use for sign-in** option is default enabled on **SMS** settings. This option enables SMS sign-in. If SMS sign-in is enabled for users, they will be skipped from cross-tenant synchronization. If you are using cross-tenant synchronization or don't want to enable SMS sign-in, disable SMS Sign-in for target users.
 
 ### OATH tokens
 


### PR DESCRIPTION
In SMS settings, "User for sign-in" option is default enabled when the setting is enabled. This option is about "SMS sign-in". However, if this option is enabled, users are skipped from cross tenant synchronization. One of my customers is unexpectedly impacted by this setting. 