### PR TITLE
Removed a Basic SKU public IP as a mitigation option.

### DIFF
--- a/articles/virtual-network/ip-services/default-outbound-access.md
+++ b/articles/virtual-network/ip-services/default-outbound-access.md
@@ -64,8 +64,6 @@ There are multiple ways to turn off default outbound access:
     * Associate a NAT gateway to the subnet of your virtual machine.
 
     * Associate a standard load balancer configured with outbound rules.
-
-    * Associate a Basic public IP to the virtual machine's network interface (if there's only one network interface).
     
     * Associate a Standard public IP to any of the virtual machine's network interfaces (if there are multiple network interfaces, having a single NIC with a standard public IP prevents default outbound access for the virtual machine).
 


### PR DESCRIPTION
Basic SKU public IPs go end of life the same day Default outbound access does so is not a valid mitigation step.

On September 30, 2025, Basic SKU public IPs will be retired. For more information, see the official announcement. If you are currently using Basic SKU public IPs, make sure to upgrade to Standard SKU public IPs prior to the retirement date. For guidance on upgrading, visit Upgrading a basic public IP address to Standard SKU - Guidance.

https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses