### PR TITLE
Fix(Typo): self-harm category enum to SelfHarm

### DIFF
--- a/articles/ai-services/content-safety/concepts/harm-categories.md
+++ b/articles/ai-services/content-safety/concepts/harm-categories.md
@@ -27,7 +27,7 @@ Content Safety recognizes four distinct categories of objectionable content.
 | Hate      | The hate category describes language attacks or uses that include pejorative or discriminatory language with reference to a person or identity group on the basis of certain differentiating attributes of these groups including but not limited to race, ethnicity, nationality, gender identity and expression, sexual orientation, religion, immigration status, ability status, personal appearance, and body size.  |
 | Sexual    | The sexual category describes language related to anatomical organs and genitals, romantic relationships, acts portrayed in erotic or affectionate terms, physical sexual acts, including those portrayed as an assault or a forced sexual violent act against one’s will, prostitution, pornography, and abuse.  |
 | Violence  | The violence category describes language related to physical actions intended to hurt, injure, damage, or kill someone or something; describes weapons, etc. |
-| Self-harm | The self-harm category describes language related to physical actions intended to purposely hurt, injure, or damage one’s body, or kill oneself. |
+| SelfHarm | The self-harm category describes language related to physical actions intended to purposely hurt, injure, or damage one’s body, or kill oneself. |
 
 Classification can be multi-labeled. For example, when a text sample goes through the text moderation model, it could be classified as both Sexual content and Violence.
 


### PR DESCRIPTION
Fix a typo where self-harm category enum is actually "SelfHarm"