### PR TITLE
Update what-is-cloud-sync.md

### DIFF
--- a/articles/active-directory/hybrid/cloud-sync/what-is-cloud-sync.md
+++ b/articles/active-directory/hybrid/cloud-sync/what-is-cloud-sync.md
@@ -79,7 +79,7 @@ The following table provides a comparison between Microsoft Entra Connect and Mi
 | Support for device writeback|● |Customers should use [Cloud Kerberos trust](/windows/security/identity-protection/hello-for-business/hello-hybrid-cloud-kerberos-trust?tabs=intune) for this moving forward|
 | Support for group writeback|● | |
 | Support for merging user attributes from multiple domains|● | |
-| Active Directory Domain Services support|● | |
+| Microsoft Entra Domain Services support|● | |
 | [Exchange hybrid writeback](exchange-hybrid.md) |● |● |
 | Unlimited number of objects per AD domain |● | |
 | Support for up to 150,000 objects per AD domain |● |● |


### PR DESCRIPTION
Line 82 was referred to Active directory domain services, on checking this wiki, it should be Azure Active Directory Domain Services, Due to Entra we have changed the terminology of Azure ADDS to Microsoft Entra Domain Services. 

Hence updated the same and created a PR, please review the same and approve it. 

https://supportability.visualstudio.com/AzureAD/_wiki/wikis/AzureAD/236881/Azure-AD-Cloud-Sync?anchor=comparison-between-azure-ad-connect-and-cloud-sync