### PR TITLE
Fixed formatting for NOTE block

### DIFF
--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -134,7 +134,7 @@ Use the [Azure Monitor REST API](/rest/api/monitor/diagnosticsettings/createorup
 
 ## Audit whitelist
 
-> ![NOTE]
+>[!NOTE]
 > This article contains references to a term that Microsoft no longer uses. When the term is removed from the software, we'll remove it from this article.
 
 By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. You can use the audit whitelist feature in Cassandra 3.11 to set what operations *don't* create an audit record. The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 


### PR DESCRIPTION
The NOTE block does not render correctly - it should be [!NOTE] instead of ![NOTE]

