### PR TITLE
pollingIntervalInS; where S means String

### DIFF
--- a/articles/virtual-machines/extensions/key-vault-windows.md
+++ b/articles/virtual-machines/extensions/key-vault-windows.md
@@ -116,7 +116,7 @@ The following JSON shows the schema for the Key Vault VM extension. Before you c
       "autoUpgradeMinorVersion": true,
       "settings": {
          "secretsManagementSettings": {
-             "pollingIntervalInS": <A string that specifies the polling interval in seconds. Example: 3600>,
+             "pollingIntervalInS": <A string that specifies the polling interval in seconds. Example: "3600">,
              "linkOnRenewal": <Windows only. Ensures s-channel binding when the certificate renews without necessitating redeployment. Example: true>,
              "requireInitialSync": <Initial synchronization of certificates. Example: true>,
              "observedCertificates": <An array of KeyVault URIs that represent monitored certificates, including certificate store location and ACL permission to certificate private key. Example: 
@@ -192,8 +192,8 @@ The JSON schema includes the following properties.
 | `apiVersion` | 2022-08-01 | date |
 | `publisher` | Microsoft.Azure.KeyVault | string |
 | `type` | KeyVaultForWindows | string |
-| `typeHandlerVersion` | 3.0 | int |
-| `pollingIntervalInS` | 3600 | string |
+| `typeHandlerVersion` | "3.0" | string |
+| `pollingIntervalInS` | "3600" | string |
 | `linkOnRenewal` (optional) | true | boolean |
 | `requireInitialSync` (optional) | false | boolean |
 | `observedCertificates`  | [{...}, {...}] | string array |
@@ -212,8 +212,8 @@ The JSON schema includes the following properties.
 | `apiVersion` | 2022-08-01 | date |
 | `publisher` | Microsoft.Azure.KeyVault | string |
 | `type` | KeyVaultForWindows | string |
-| `typeHandlerVersion` | 1.0 | int |
-| `pollingIntervalInS` | 3600 | string |
+| `typeHandlerVersion` | "1.0" | string |
+| `pollingIntervalInS` | "3600" | string |
 | `certificateStoreName` | MY | string |
 | `linkOnRenewal` | true | boolean |
 | `certificateStoreLocation`  | LocalMachine or CurrentUser (case sensitive) | string |
@@ -250,7 +250,7 @@ The following JSON snippets provide example settings for an ARM template deploym
       "autoUpgradeMinorVersion": true,
       "settings": {
          "secretsManagementSettings": {
-             "pollingIntervalInS": <A string that specifies the polling interval in seconds. Example: 3600>,
+             "pollingIntervalInS": <A string that specifies the polling interval in seconds. Example: "3600">,
              "linkOnRenewal": <Windows only. Ensures s-channel binding when the certificate renews without necessitating redeployment. Example: true>,
              "observedCertificates": <An array of KeyVault URIs that represent monitored certificates, including certificate store location and ACL permission to certificate private key. Example:
              [
@@ -301,7 +301,7 @@ The following JSON snippets provide example settings for an ARM template deploym
       "autoUpgradeMinorVersion": true,
       "settings": {
          "secretsManagementSettings": {
-            "pollingIntervalInS": <A string that specifies the polling interval in seconds. Example: 3600>,
+            "pollingIntervalInS": <A string that specifies the polling interval in seconds. Example: "3600">,
             "linkOnRenewal": <Windows only. Ensures s-channel binding when the certificate renews without necessitating redeployment. Example: true>,          
             "certificateStoreName": <The certificate store name. Example: "MY">,
             "certificateStoreLocation": <The certificate store location, which currently works locally only. Example: "LocalMachine">,


### PR DESCRIPTION
The pollingIntervalInS should be formatted as a String. In the example it is formatted as an Integer. The typeHandlerVersion should be formatted as a String. in the table it is defined as an Integer.

---
#### Document Details

⚠ *Do not edit this section. It is required for learn.microsoft.com ➟ GitHub issue linking.*

* ID: a52b0724-6b3b-0daf-7749-d18104d6a40b
* Version Independent ID: 56e5c7c4-f456-fc2e-99da-2771eb162947
* Content: [Azure Key Vault VM extension for Windows - Azure Virtual Machines](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/key-vault-windows?tabs=version3)
* Content Source: [articles/virtual-machines/extensions/key-vault-windows.md](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/extensions/key-vault-windows.md)
* Service: **virtual-machines**
* Sub-service: **extensions**
* GitHub Login: @msmbaldwin
* Microsoft Alias: **mbaldwin**