### PR TITLE
Explicitly highlight Delete permission

### DIFF
--- a/articles/machine-learning/how-to-assign-roles.md
+++ b/articles/machine-learning/how-to-assign-roles.md
@@ -36,7 +36,7 @@ Azure Machine Learning workspaces have a five built-in roles that are available 
 | Role | Access level |
 | --- | --- |
 | **AzureML Data Scientist** | Can perform all actions within an Azure Machine Learning workspace, except for creating or deleting compute resources and modifying the workspace itself. |
-| **AzureML Compute Operator** | Can create, manage, delete and access compute resources within a workspace.|
+| **AzureML Compute Operator** | Can create, manage, delete, and access compute resources within a workspace.|
 | **Reader** | Read-only actions in the workspace. Readers can list and view assets, including [datastore](how-to-access-data.md) credentials, in a workspace. Readers can't create or update these assets. |
 | **Contributor** | View, create, edit, or delete (where applicable) assets in a workspace. For example, contributors can create an experiment, create or attach a compute cluster, submit a run, and deploy a web service. |
 | **Owner** | Full access to the workspace, including the ability to view, create, edit, or delete (where applicable) assets in a workspace. Additionally, you can change role assignments. |

--- a/articles/machine-learning/how-to-assign-roles.md
+++ b/articles/machine-learning/how-to-assign-roles.md
@@ -36,7 +36,7 @@ Azure Machine Learning workspaces have a five built-in roles that are available 
 | Role | Access level |
 | --- | --- |
 | **AzureML Data Scientist** | Can perform all actions within an Azure Machine Learning workspace, except for creating or deleting compute resources and modifying the workspace itself. |
-| **AzureML Compute Operator** | Can create, manage and access compute resources within a workspace.|
+| **AzureML Compute Operator** | Can create, manage, delete and access compute resources within a workspace.|
 | **Reader** | Read-only actions in the workspace. Readers can list and view assets, including [datastore](how-to-access-data.md) credentials, in a workspace. Readers can't create or update these assets. |
 | **Contributor** | View, create, edit, or delete (where applicable) assets in a workspace. For example, contributors can create an experiment, create or attach a compute cluster, submit a run, and deploy a web service. |
 | **Owner** | Full access to the workspace, including the ability to view, create, edit, or delete (where applicable) assets in a workspace. Additionally, you can change role assignments. |


### PR DESCRIPTION
For AzureML Data Scientist role, we explicitly indicate that it doesn't cover creation and deletion of AzureML compute resources. However, for AzureML Compute Operator it's a bit more vague. In the current format it describes this role to create, manage and access compute resources. Explicit indication of "delete" permission can add more clarity and inform the customer that missing create/delete permissions in Data Scientist role can be compensated by assignment of Compute Operator role.