### PR TITLE
Update Dapr extension for AKS document to add details for managing Dapr versioning

### DIFF
--- a/articles/aks/dapr-settings.md
+++ b/articles/aks/dapr-settings.md
@@ -189,16 +189,27 @@ If you want to use an outbound proxy with the Dapr extension for AKS, you can do
    - `NO_PROXY`
 1. [Installing the proxy certificate in the sidecar](https://docs.dapr.io/operations/configuration/install-certificates/).
 
+## Updating your Dapr installation version
+
+If you are on a specific Dapr version and you don't have `--auto-upgrade-minor-version` available, you can use the following command to upgrade or downgrade Dapr:
+
+```azurecli
+az k8s-extension update --cluster-type managedClusters \
+--cluster-name myAKSCluster \
+--resource-group myResourceGroup \
+--name dapr \
+--version 1.12.0 # Version to upgrade or downgrade to
+```
+
 ## Using Azure Linux-based images
 
 From Dapr version 1.8.0, you can use Azure Linux images with the Dapr extension. To use them, set the`global.tag` flag:
 
 ```azurecli
-az k8s-extension upgrade --cluster-type managedClusters \
+az k8s-extension update --cluster-type managedClusters \
 --cluster-name myAKSCluster \
 --resource-group myResourceGroup \
 --name dapr \
---extension-type Microsoft.Dapr \
 --set global.tag=1.10.0-mariner
 ```
 
@@ -211,16 +222,10 @@ az k8s-extension upgrade --cluster-type managedClusters \
 With Dapr version 1.9.2, CRDs are automatically upgraded when the extension upgrades. To disable this setting, you can set `hooks.applyCrds` to `false`. 
 
 ```azurecli
-az k8s-extension upgrade --cluster-type managedClusters \
+az k8s-extension update --cluster-type managedClusters \
 --cluster-name myAKSCluster \
 --resource-group myResourceGroup \
 --name dapr \
---extension-type Microsoft.Dapr \
---auto-upgrade-minor-version true \
---configuration-settings "global.ha.enabled=true" \
---configuration-settings "dapr_operator.replicaCount=2" \
---configuration-settings "global.daprControlPlaneOs=linux” \
---configuration-settings "global.daprControlPlaneArch=amd64” \
 --configuration-settings "hooks.applyCrds=false"
 ```
 

--- a/articles/aks/dapr-settings.md
+++ b/articles/aks/dapr-settings.md
@@ -201,6 +201,12 @@ az k8s-extension update --cluster-type managedClusters \
 --version 1.12.0 # Version to upgrade or downgrade to
 ```
 
+**Note** that this will update the Dapr control plane only, restart your application deployments to update the Dapr sidecars:
+
+```bash
+kubectl rollout restart deploy/<DEPLOYMENT-NAME>
+```
+
 ## Using Azure Linux-based images
 
 From Dapr version 1.8.0, you can use Azure Linux images with the Dapr extension. To use them, set the`global.tag` flag:

--- a/articles/aks/dapr-settings.md
+++ b/articles/aks/dapr-settings.md
@@ -201,7 +201,7 @@ az k8s-extension update --cluster-type managedClusters \
 --version 1.12.0 # Version to upgrade or downgrade to
 ```
 
-**Note** that this will update the Dapr control plane only, restart your application deployments to update the Dapr sidecars:
+The above command updates the Dapr control plane **only.** To update the Dapr sidecars, restart your application deployments:
 
 ```bash
 kubectl rollout restart deploy/<DEPLOYMENT-NAME>

--- a/articles/aks/dapr-settings.md
+++ b/articles/aks/dapr-settings.md
@@ -201,7 +201,7 @@ az k8s-extension update --cluster-type managedClusters \
 --version 1.12.0 # Version to upgrade or downgrade to
 ```
 
-The above command updates the Dapr control plane **only.** To update the Dapr sidecars, restart your application deployments:
+The preceding command updates the Dapr control plane *only.* To update the Dapr sidecars, restart your application deployments:
 
 ```bash
 kubectl rollout restart deploy/<DEPLOYMENT-NAME>

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -189,7 +189,7 @@ az k8s-extension create --cluster-type managedClusters \
 ### Configuring automatic updates to Dapr control plane
 
 > [!WARNING]
-> For production environments, enabling auto-upgrade-minor-version is not recommended. This option is suitable for dev or test environments only.
+> You should only enable automatic updates to the Dapr control plan in dev or test environments. Auto-upgrade is not suitable for production environments.
 
 If you install Dapr without specifying a version, `--auto-upgrade-minor-version` **is automatically enabled**. This means that Dapr control plane will automatically update its minor version on new releases.
 You can disable auto-update by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `false`. 

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -157,17 +157,23 @@ When installing the Dapr extension, use the flag value that corresponds to your 
 > [!NOTE]
 > If you're using Dapr OSS on your AKS cluster and would like to install the Dapr extension for AKS, read more about [how to successfully migrate to the Dapr extension][dapr-migration]. 
 
-Create the Dapr extension, which installs Dapr on your AKS or Arc-enabled Kubernetes cluster. For example, for an AKS cluster:
+Create the Dapr extension, which installs Dapr on your AKS or Arc-enabled Kubernetes cluster. 
 
+For example, install the latest version of Dapr via the Dapr extension on your AKS cluster:
 ```azurecli
 az k8s-extension create --cluster-type managedClusters \
 --cluster-name myAKSCluster \
 --resource-group myResourceGroup \
 --name dapr \
---extension-type Microsoft.Dapr
+--extension-type Microsoft.Dapr \
+--auto-upgrade-minor-version false
 ```
 
-You have the option of allowing Dapr to auto-update its minor version by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `true`:
+You have the option of allowing Dapr to auto-update its minor version by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `true`. 
+Note, the versioning of Dapr is in the format `MAJOR.MINOR.PATCH`, which means `1.11.0` to `1.12.0` is a minor version upgrade.
+
+> [!WARNING]
+> For production environments, we do not recommend enabling auto-upgrade-minor-version. This option is suitable for dev or test environments only.
 
 ```azurecli
 --auto-upgrade-minor-version true
@@ -191,7 +197,7 @@ For example:
 > [!NOTE]
 > Dapr is supported with a rolling window, including only the current and previous versions. It is your operational responsibility to remain up to date with these supported versions. If you have an older version of Dapr, you may have to do intermediate upgrades to get to a supported version.
 
-The same command-line argument is used for installing a specific version of Dapr or rolling back to a previous version. Set `--auto-upgrade-minor-version` to `false` and `--version` to the version of Dapr you wish to install. If the `version` parameter is omitted, the extension installs the latest version of Dapr. For example, to use Dapr X.X.X: 
+The same command-line argument is used for installing a specific version of Dapr or rolling back to a previous version. Set `--auto-upgrade-minor-version` to `false` and `--version` to the version of Dapr you wish to install. If the `version` parameter is omitted, the extension installs the latest version of Dapr. For example, to use Dapr X.X.X:
 
 ```azurecli
 az k8s-extension create --cluster-type managedClusters \

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -169,30 +169,7 @@ az k8s-extension create --cluster-type managedClusters \
 --auto-upgrade-minor-version false
 ```
 
-You have the option of allowing Dapr to auto-update its minor version by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `true`. 
-[Dapr versioning is in `MAJOR.MINOR.PATCH` format](https://docs.dapr.io/operations/support/support-versioning/#versioning), which means `1.11.0` to `1.12.0` is a _minor_ version upgrade.
-
-> [!WARNING]
-> For production environments, enabling auto-upgrade-minor-version is not recommended. This option is suitable for dev or test environments only.
-
-```azurecli
---auto-upgrade-minor-version true
-```
-
-When configuring the extension, you can choose to install Dapr from a particular `--release-train`. Specify one of the two release train values:
-
-| Value    | Description                               |
-| -------- | ----------------------------------------- |
-| `stable` | Default.                                  |
-| `dev`    | Early releases, can contain experimental features. Not suitable for production. |
-
-For example:
-
-```azurecli
---release-train stable
-```
-
-## Targeting a specific Dapr version
+### Targeting a specific Dapr version
 
 > [!NOTE]
 > Dapr is supported with a rolling window, including only the current and previous versions. It is your operational responsibility to remain up to date with these supported versions. If you have an older version of Dapr, you may have to do intermediate upgrades to get to a supported version.
@@ -207,6 +184,35 @@ az k8s-extension create --cluster-type managedClusters \
 --extension-type Microsoft.Dapr \
 --auto-upgrade-minor-version false \
 --version X.X.X
+```
+
+### Configuring automatic updates to Dapr control plane
+
+> [!WARNING]
+> For production environments, enabling auto-upgrade-minor-version is not recommended. This option is suitable for dev or test environments only.
+
+If you install Dapr without specifying a version, `--auto-upgrade-minor-version` **is automatically enabled**. This means that Dapr control plane will automatically update its minor version on new releases.
+You can disable auto-update by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `false`. 
+[Dapr versioning is in `MAJOR.MINOR.PATCH` format](https://docs.dapr.io/operations/support/support-versioning/#versioning), which means `1.11.0` to `1.12.0` is a _minor_ version upgrade.
+
+```azurecli
+--auto-upgrade-minor-version true
+```
+
+
+### Choosing a release train
+
+When configuring the extension, you can choose to install Dapr from a particular `--release-train`. Specify one of the two release train values:
+
+| Value    | Description                               |
+| -------- | ----------------------------------------- |
+| `stable` | Default.                                  |
+| `dev`    | Early releases, can contain experimental features. Not suitable for production. |
+
+For example:
+
+```azurecli
+--release-train stable
 ```
 
 ## Troubleshooting extension errors

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -173,7 +173,7 @@ You have the option of allowing Dapr to auto-update its minor version by specify
 Note, the versioning of Dapr is in the format `MAJOR.MINOR.PATCH`, which means `1.11.0` to `1.12.0` is a minor version upgrade.
 
 > [!WARNING]
-> For production environments, we do not recommend enabling auto-upgrade-minor-version. This option is suitable for dev or test environments only.
+> For production environments, enabling auto-upgrade-minor-version is not recommended. This option is suitable for dev or test environments only.
 
 ```azurecli
 --auto-upgrade-minor-version true

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -191,7 +191,7 @@ az k8s-extension create --cluster-type managedClusters \
 > [!WARNING]
 > You should only enable automatic updates to the Dapr control plan in dev or test environments. Auto-upgrade is not suitable for production environments.
 
-If you install Dapr without specifying a version, `--auto-upgrade-minor-version` **is automatically enabled**. This means that Dapr control plane will automatically update its minor version on new releases.
+If you install Dapr without specifying a version, `--auto-upgrade-minor-version` **is automatically enabled**, configuring the Dapr control plane to automatically update its minor version on new releases.
 You can disable auto-update by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `false`. 
 [Dapr versioning is in `MAJOR.MINOR.PATCH` format](https://docs.dapr.io/operations/support/support-versioning/#versioning), which means `1.11.0` to `1.12.0` is a _minor_ version upgrade.
 

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -189,9 +189,9 @@ az k8s-extension create --cluster-type managedClusters \
 ### Configuring automatic updates to Dapr control plane
 
 > [!WARNING]
-> You should only enable automatic updates to the Dapr control plan in dev or test environments. Auto-upgrade is not suitable for production environments.
+> You should enable automatic updates to the Dapr control plan only in dev or test environments. Auto-upgrade is not suitable for production environments.
 
-If you install Dapr without specifying a version, `--auto-upgrade-minor-version` **is automatically enabled**, configuring the Dapr control plane to automatically update its minor version on new releases.
+If you install Dapr without specifying a version, `--auto-upgrade-minor-version` *is automatically enabled*, configuring the Dapr control plane to automatically update its minor version on new releases.
 You can disable auto-update by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `false`. 
 [Dapr versioning is in `MAJOR.MINOR.PATCH` format](https://docs.dapr.io/operations/support/support-versioning/#versioning), which means `1.11.0` to `1.12.0` is a _minor_ version upgrade.
 

--- a/articles/aks/dapr.md
+++ b/articles/aks/dapr.md
@@ -170,7 +170,7 @@ az k8s-extension create --cluster-type managedClusters \
 ```
 
 You have the option of allowing Dapr to auto-update its minor version by specifying the `--auto-upgrade-minor-version` parameter and setting the value to `true`. 
-Note, the versioning of Dapr is in the format `MAJOR.MINOR.PATCH`, which means `1.11.0` to `1.12.0` is a minor version upgrade.
+[Dapr versioning is in `MAJOR.MINOR.PATCH` format](https://docs.dapr.io/operations/support/support-versioning/#versioning), which means `1.11.0` to `1.12.0` is a _minor_ version upgrade.
 
 > [!WARNING]
 > For production environments, enabling auto-upgrade-minor-version is not recommended. This option is suitable for dev or test environments only.


### PR DESCRIPTION
This PR
- Warns users to not use auto-upgrade in prod
- Explain auto-upgrade with an example
- Fixes `upgrade` command to use `update`
- Adds docs on upgrading/downgrading Dapr