### PR TITLE
Fix Typo in ACR required firewall openings

### DIFF
--- a/articles/container-apps/networking.md
+++ b/articles/container-apps/networking.md
@@ -204,7 +204,7 @@ Application rules allow or deny traffic based on the application layer. The foll
 | Scenarios | FQDNs | Description |
 |--|--|--|
 | All scenarios | `mcr.microsoft.com`, `*.data.mcr.microsoft.com` | These FQDNs for Microsoft Container Registry (MCR) are used by Azure Container Apps and either these application rules or the network rules for MCR must be added to the allowlist when using Azure Container Apps with Azure Firewall. |
-| Azure Container Registry (ACR) | *Your-ACR-address*, `*.blob.windows.net`, `login.microsoft.com` | These FQDNs are required when using Azure Container Apps with ACR and Azure Firewall. |
+| Azure Container Registry (ACR) | *Your-ACR-address*, `*.blob.core.windows.net`, `login.microsoft.com` | These FQDNs are required when using Azure Container Apps with ACR and Azure Firewall. |
 | Azure Key Vault | *Your-Azure-Key-Vault-address*, `login.microsoft.com` | These FQDNs are required in addition to the service tag required for the network rule for Azure Key Vault. |
 | Managed Identity | `*.identity.azure.net`, `login.microsoftonline.com`, `*.login.microsoftonline.com`, `*.login.microsoft.com` | These FQDNs are required when using managed identity with Azure Firewall in Azure Container Apps.
 | Docker Hub Registry | `hub.docker.com`, `registry-1.docker.io`, `production.cloudflare.docker.com` | If you're using [Docker Hub registry](https://docs.docker.com/desktop/allow-list/) and want to access it through the firewall, you need to add these FQDNs to the firewall. |


### PR DESCRIPTION
The firewall opening needs to be blob.core.windows.net for ACR. 

Example error message with the previous version (blob.windows... instead of blob.core...):
Failed to pull image "myregistry.azurecr.io/myimage:16102023": [rpc error: code = Unknown desc = failed to pull and unpack image "myregistry.azurecr.io/myimage:16102023": failed to copy: httpReadSeeker: failed open: failed to do request: Get "https://weumanaged15.blob.core.windows.net/xxxx/docker/registry/v2/blobs/sha256/fd/xxxx/data?se=2023-10-19T13%3A03%3A46Z&sig=xxxx%3D&sp=r&spr=https&sr=b&sv=2018-03-28&regid=xxxx": EOF, rpc error: code = Unknown desc = failed to pull and unpack image "myregistry.azurecr.io/myimage:16102023": failed to resolve reference "myregistry.azurecr.io/myimage:16102023": failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://myregistry.azurecr.io/oauth2/token?scope=repository%3Amyimage%3Apull&service=myregistry.azurecr.io: 401 Unauthorized]

