### PR TITLE
{AzureFunctions} EventHub trigger for C# isolated function 

### DIFF
--- a/includes/functions-bindings-event-hubs-trigger.md
+++ b/includes/functions-bindings-event-hubs-trigger.md
@@ -38,7 +38,7 @@ This article supports both programming models.
 
 The following example shows a [C# function](../articles/azure-functions/dotnet-isolated-process-guide.md) that is triggered based on an event hub, where the input message string is written to the logs:
 
-:::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/EventHubs/EventHubsFunction.cs" range="12-23":::
+:::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/EventHubs/EventHubsFunction.cs" range="12-31":::
 
 # [In-process model](#tab/in-process)
 


### PR DESCRIPTION
fixes MicrosoftDocs/azure-docs#116209

In [this docs](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger?tabs=python-v2%2Cisolated-process%2Cnodejs-v4%2Cfunctionsv2%2Cextensionv5&pivots=programming-language-csharp), the example doesn't show the `[EventHubTrigger]` on the function parameter. So filing this PR so that we show a few more lines from [the sample code](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/samples/Extensions/EventHubs/EventHubsFunction.cs) to avoid the confusion. 