### PR TITLE
Update how-to-mltable.md Amended notes and corrected mltable.save arguments

### DIFF
--- a/articles/machine-learning/how-to-mltable.md
+++ b/articles/machine-learning/how-to-mltable.md
@@ -221,7 +221,7 @@ tbl.save("./titanic")
 > [!IMPORTANT]
 > - If colocated == True, then we will copy the data to the same folder with MLTable yaml file if they are not currently colocated, and we will use relative paths in MLTable yaml.
 > - If colocated == False, we will not move the data and we will use absolute paths for cloud data and use relative paths for local data.
-> - We don’t support this parameter combination: data is in local, colocated == False, `save_path_dirc` is a cloud directory. Please upload your local data to cloud and use the cloud data paths for MLTable instead.
+> - We don’t support this parameter combination: data is in local, colocated == False, `path` targets a cloud directory. Please upload your local data to cloud and use the cloud data paths for MLTable instead.
 > - Parameters `show_progress` (default as True), `allow_copy_errors` (default as False), `overwrite`(default as True) are optional.
 >
 

--- a/articles/machine-learning/how-to-mltable.md
+++ b/articles/machine-learning/how-to-mltable.md
@@ -209,7 +209,7 @@ You can choose to save the MLTable yaml file to a cloud storage, or you can also
 ```python
 # save the data loading steps in an MLTable file to a cloud storage
 # NOTE: the tbl object was defined in the previous snippet.
-tbl.save(save_path_dirc= "azureml://subscriptions/<subid>/resourcegroups/<rgname>/workspaces/<wsname>/datastores/<name>/paths/titanic", collocated=True, show_progress=True, allow_copy_errors=False, overwrite=True)
+tbl.save(path="azureml://subscriptions/<subid>/resourcegroups/<rgname>/workspaces/<wsname>/datastores/<name>/paths/titanic", colocated=True, show_progress=True, overwrite=True)
 ```
 
 ```python
@@ -219,9 +219,9 @@ tbl.save("./titanic")
 ```
 
 > [!IMPORTANT]
-> - If collocated == True, then we will copy the data to the same folder with MLTable yaml file if they are not currently collocated, and we will use relative paths in MLTable yaml.
-> - If collocated == False, we will not move the data and we will use absolute paths for cloud data and use relative paths for local data.
-> - We don’t support this parameter combination: data is in local, collocated == False, `save_path_dirc` is a cloud directory. Please upload your local data to cloud and use the cloud data paths for MLTable instead.
+> - If colocated == True, then we will copy the data to the same folder with MLTable yaml file if they are not currently colocated, and we will use relative paths in MLTable yaml.
+> - If colocated == False, we will not move the data and we will use absolute paths for cloud data and use relative paths for local data.
+> - We don’t support this parameter combination: data is in local, colocated == False, `save_path_dirc` is a cloud directory. Please upload your local data to cloud and use the cloud data paths for MLTable instead.
 > - Parameters `show_progress` (default as True), `allow_copy_errors` (default as False), `overwrite`(default as True) are optional.
 >
 

--- a/articles/machine-learning/how-to-mltable.md
+++ b/articles/machine-learning/how-to-mltable.md
@@ -222,7 +222,6 @@ tbl.save("./titanic")
 > - If colocated == True, then we will copy the data to the same folder with MLTable yaml file if they are not currently colocated, and we will use relative paths in MLTable yaml.
 > - If colocated == False, we will not move the data and we will use absolute paths for cloud data and use relative paths for local data.
 > - We don’t support this parameter combination: data is in local, colocated == False, `path` targets a cloud directory. Please upload your local data to cloud and use the cloud data paths for MLTable instead.
-> - Parameters `show_progress` (default as True), `allow_copy_errors` (default as False), `overwrite`(default as True) are optional.
 >
 
 


### PR DESCRIPTION
Amendments to the following:
- The documentation has two `l`s for co-located, and this is incorrect.
- The documentation uses the arguments `allow_copy_errors` and `save_path_dirc`, and these are invalid as of today
- The documentation shows optional args with the incorrect defaults, and MLTable documentation states they are required -- removed this point.

I've tested this with a remote save to two remote examples - Azure Blob storage and Data Lake - using `path=f"azureml://subscriptions/{subscription_id}/resourcegroups/{resource_group}/workspaces/{workspace_name}/datastores/{datastore_name}/paths/{destination_path}"` where the datastore was replaced with the blob/lakes as registered datastores in my AML workspace. 

For reference, here's the MLTable class https://learn.microsoft.com/en-us/python/api/mltable/mltable.mltable.mltable?view=azure-ml-py#mltable-mltable-mltable-save