### PR TITLE
Inaccurate syntax of Az CLI command

### DIFF
--- a/articles/ai-services/openai/encrypt-data-at-rest.md
+++ b/articles/ai-services/openai/encrypt-data-at-rest.md
@@ -121,8 +121,8 @@ To delete the individual versions of a key, run the [az-keyvault-key-delete](/cl
 
 ```azurecli
 az keyvault key delete  \
-  --name <key-vault-name> \
-  --object-id $identityPrincipalID \                     
+  --vault-name <key-vault-name> \
+  --id <key-ID>                     
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
Updated syntax of Az CLI command to delete Key Vault's key. Please, see references to the latest syntax here: https://learn.microsoft.com/en-us/cli/azure/keyvault/key?view=azure-cli-latest#az-keyvault-key-delete.