### PR TITLE
Update mqtt-routing-filtering.md

### DIFF
--- a/articles/event-grid/mqtt-routing-filtering.md
+++ b/articles/event-grid/mqtt-routing-filtering.md
@@ -59,9 +59,9 @@ If you send a non-JSON payload that is still UFT-8, it will be serialized as a J
 You can use the following filter to filter all the messages that include the word “Contoso”:
 ```azurecli-interactive
 "advancedFilters": [{
-    "operatorType": "`StringContains` ",
+    "operatorType": "StringContains",
     "key": "data",
-    "value": “Contoso”
+    "value": "Contoso"
 }]
 ```
 
@@ -82,9 +82,9 @@ You can use the following filter to filter all the messages coming from your cli
 
 ```azurecli-interactive
 "advancedFilters": [{"
-    operatorType": "`StringContains` ",
-    "key": "`clienttype`", 
-    "value": “sensor”
+    operatorType": "StringContains",
+    "key": "clienttype", 
+    "value": "sensor"
 }]
 ```
 


### PR DESCRIPTION
I compared the JSON notations with https://learn.microsoft.com/azure/event-grid/event-filtering?WT.mc_id=AZ-MVP-5002324#stringcontains .

* It seems the backticks are unnecessary inside the quotes
* some unnecessary spaces
* use of double-quotes is not consistent