### PR TITLE
Update retired postgres versions

### DIFF
--- a/articles/postgresql/single-server/concepts-version-policy.md
+++ b/articles/postgresql/single-server/concepts-version-policy.md
@@ -5,7 +5,7 @@ ms.service: postgresql
 ms.subservice: single-server
 ms.topic: conceptual
 ms.author: alkuchar
-author: AwdotiaRomanowna
+author: AlicjaKucharczyk
 
 ms.date: 09/14/2022
 ms.custom: fasttrack-edit, ignite-2022

--- a/articles/postgresql/single-server/concepts-version-policy.md
+++ b/articles/postgresql/single-server/concepts-version-policy.md
@@ -35,7 +35,7 @@ Azure Database for PostgreSQL supports the following database versions.
 | PostgreSQL 13 |   | X |
 | PostgreSQL 12 |   | X |
 | PostgreSQL 11 | X | X |
-| PostgreSQL 10 | X |   |
+| *PostgreSQL 10 (retired)* | See [policy](#retired-postgresql-engine-versions-not-supported-in-azure-database-for-postgresql) |  |
 | *PostgreSQL 9.6 (retired)* | See [policy](#retired-postgresql-engine-versions-not-supported-in-azure-database-for-postgresql) |  |
 | *PostgreSQL 9.5 (retired)* | See [policy](#retired-postgresql-engine-versions-not-supported-in-azure-database-for-postgresql) |  |
 
@@ -55,7 +55,7 @@ The table below provides the retirement details for PostgreSQL major versions. T
 | ------- | ---------- | ------------------------ | ---------------------- |
 | [PostgreSQL 9.5 (retired)](https://www.postgresql.org/about/news/postgresql-132-126-1111-1016-9621-and-9525-released-2165/)| [Features](https://www.postgresql.org/docs/9.5/release-9-5.html)  | April 18, 2018	| February 11, 2021
 | [PostgreSQL 9.6 (retired)](https://www.postgresql.org/about/news/postgresql-96-released-1703/) | [Features](https://wiki.postgresql.org/wiki/NewIn96) | April 18, 2018 | November 11, 2021
-| [PostgreSQL 10](https://www.postgresql.org/about/news/postgresql-10-released-1786/) | [Features](https://wiki.postgresql.org/wiki/New_in_postgres_10) | June 4, 2018	| November 10, 2022
+| [PostgreSQL 10 (retired)](https://www.postgresql.org/about/news/postgresql-10-released-1786/) | [Features](https://wiki.postgresql.org/wiki/New_in_postgres_10) | June 4, 2018	| November 10, 2022
 | [PostgreSQL 11](https://www.postgresql.org/about/news/postgresql-11-released-1894/) | [Features](https://www.postgresql.org/docs/11/release-11.html) | July 24, 2019	| November 9, 2024 [Single Server, Flexible Server] |
 | [PostgreSQL 12](https://www.postgresql.org/about/news/postgresql-12-released-1976/) | [Features](https://www.postgresql.org/docs/12/release-12.html) | Sept 22, 2020 	| November 14, 2024
 | [PostgreSQL 13](https://www.postgresql.org/about/news/postgresql-13-released-2077/) | [Features](https://www.postgresql.org/docs/13/release-13.html) | May 25, 2021 	| November 13, 2025


### PR DESCRIPTION
Looking at the dates listed below, this seems like an accurate update