### PR TITLE
Update Max Scale Units

### DIFF
--- a/includes/api-management-service-limits.md
+++ b/includes/api-management-service-limits.md
@@ -14,7 +14,7 @@ ms.custom: Include file
 
 | Resource | Limit |
 | ---------------------------------------------------------------------- | -------------------------- |
-| Maximum number of scale units | 12 per region<sup>1</sup> |
+| Maximum number of scale units | 31 per region<sup>1</sup> |
 | Cache size | 5 GiB per unit<sup>2</sup> |
 | Concurrent back-end connections<sup>3</sup> per HTTP authority | 2,048 per unit<sup>4</sup> |
 | Maximum cached response size | 2 MiB |


### PR DESCRIPTION
We recently increased the default max limit for Scale Units in Premium SKU. It used to be 12 units, and we have recently increased it to 31 units.