### PR TITLE
Add information about types, variables & function imports

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -53,7 +53,7 @@ You can enable preview features by adding:
 The preceding sample enables 'userDefineTypes' and 'extensibility`. The available experimental features include:
 
 - **assertions**: Should be enabled in tandem with `testFramework` experimental feature flag for expected functionality. Allows you to author boolean assertions using the `assert` keyword comparing the actual value of a parameter, variable, or resource name to an expected value. Assert statements can only be written directly within the Bicep file whose resources they reference. For more information, see [Bicep Experimental Test Framework](https://github.com/Azure/bicep/issues/11967).
-- **compileTimeImports**: Allows you to use symbols defined in another template. See [Import user-defined data types](./bicep-import.md#imports-in-bicep).
+- **compileTimeImports**: Allows you to use symbols defined in another Bicep file. See [Import types, variables and functions](./bicep-import.md#import-types-variables-and-functions-preview).
 - **extensibility**: Allows Bicep to use a provider model to deploy non-ARM resources. Currently, we only support a Kubernetes provider. See [Bicep extensibility Kubernetes provider](./bicep-extensibility-kubernetes-provider.md).
 - **sourceMapping**: Enables basic source mapping to map an error location returned in the ARM template layer back to the relevant location in the Bicep file.
 - **resourceTypedParamsAndOutputs**: Enables the type for a parameter or output to be of type resource to make it easier to pass resource references between modules. This feature is only partially implemented. See [Simplifying resource referencing](https://github.com/azure/bicep/issues/2245).

--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -53,7 +53,7 @@ You can enable preview features by adding:
 The preceding sample enables 'userDefineTypes' and 'extensibility`. The available experimental features include:
 
 - **assertions**: Should be enabled in tandem with `testFramework` experimental feature flag for expected functionality. Allows you to author boolean assertions using the `assert` keyword comparing the actual value of a parameter, variable, or resource name to an expected value. Assert statements can only be written directly within the Bicep file whose resources they reference. For more information, see [Bicep Experimental Test Framework](https://github.com/Azure/bicep/issues/11967).
-- **compileTimeImports**: Allows you to use symbols defined in another template. See [Import user-defined data types](./bicep-import.md#import-user-defined-data-types-preview).
+- **compileTimeImports**: Allows you to use symbols defined in another template. See [Import user-defined data types](./bicep-import.md#imports-in-bicep).
 - **extensibility**: Allows Bicep to use a provider model to deploy non-ARM resources. Currently, we only support a Kubernetes provider. See [Bicep extensibility Kubernetes provider](./bicep-extensibility-kubernetes-provider.md).
 - **sourceMapping**: Enables basic source mapping to map an error location returned in the ARM template layer back to the relevant location in the Bicep file.
 - **resourceTypedParamsAndOutputs**: Enables the type for a parameter or output to be of type resource to make it easier to pass resource references between modules. This feature is only partially implemented. See [Simplifying resource referencing](https://github.com/azure/bicep/issues/2245).

--- a/articles/azure-resource-manager/bicep/bicep-import.md
+++ b/articles/azure-resource-manager/bicep/bicep-import.md
@@ -1,66 +1,97 @@
 ---
-title: Import Bicep namespaces
-description: Describes how to import Bicep namespaces.
+title: Imports in Bicep
+description: Describes how to import shared functionality and namespaces in Bicep.
 ms.topic: conceptual
 ms.custom: devx-track-bicep
 ms.date: 09/21/2023
 ---
 
-# Import Bicep namespaces
+# Imports in Bicep
 
-This article describes the syntax you use to import user-defined data types and the Bicep namespaces including the Bicep extensibility providers.
+This article describes the syntax you use to export and import shared functionality, as well as namespaces for Bicep extensibility providers.
 
-## Import user-defined data types (Preview)
+## Exporting types, variables and functions (Preview)
 
-[Bicep version 0.21.1 or newer](./install.md) is required to use this feature. The experimental flag `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features).
+> [!NOTE]
+> [Bicep version 0.23.X or newer](./install.md) is required to use this feature. The experimental feature `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features). For user-defined functions, the experimental feature `userDefinedFunctions` must also be enabled.
 
+The `@export()` decorator is used to indicate that a given statement can be imported by another file. This decorator is only valid on type, variable and function statements. Variable statements marked with `@export()` must be compile-time constants.
 
-The syntax for importing [user-defined data type](./user-defined-data-types.md) is:
-
-```bicep
-import {<user-defined-data-type-name>, <user-defined-data-type-name>, ...} from '<bicep-file-name>'
-```
-
-or with wildcard syntax:
+The syntax for exporting functionality for use in other Bicep files is:
 
 ```bicep
-import * as <namespace> from '<bicep-file-name>'
+@export()
+<statement_to_export>
 ```
 
-You can mix and match the two preceding syntaxes.
+## Import types, variables and functions (Preview)
 
-Only user-defined data types that bear the [@export() decorator](./user-defined-data-types.md#import-types-between-bicep-files-preview) can be imported. Currently, this decorator can only be used on [`type`](./user-defined-data-types.md) statements.
+> [!NOTE]
+> [Bicep version 0.23.X or newer](./install.md) is required to use this feature. The experimental feature `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features). For user-defined functions, the experimental feature `userDefinedFunctions` must also be enabled.
 
-Imported types can be used anywhere a user-defined type might be, for example, within the type clauses of type, param, and output statements.
+The syntax for importing functionality from another Bicep file is:
+
+```bicep
+import {<symbol_name>, <symbol_name>, ...} from '<bicep_file_name>'
+```
+
+With optional aliasing to rename symbols:
+
+```bicep
+import {<symbol_name> as <alias_name>, ...} from '<bicep_file_name>'
+```
+
+Using the wildcard import syntax:
+
+```bicep
+import * as <alias_name> from '<bicep_file_name>'
+```
+
+You can mix and match the preceding syntaxes. To access imported symbols using the wildcard syntax, you must use the `.` operator: `<alias_name>.<exported_symbol>`.
+
+Only statements that have been [exported](#exporting-types-variables-and-functions-preview) in the file being referenced are available to be imported.
+
+Functionality that has been imported from another file can be used without restrictions. For example, imported variables can be used anywhere a variable declared in-file would normally be valid.
 
 ### Example
 
-myTypes.bicep
+module.bicep
 
 ```bicep
 @export()
-type myString = string
+type myObjectType = {
+  foo: string
+  bar: int
+}
 
 @export()
-type myInt = int
+var myConstant = 'This is a constant value'
+
+@export()
+func sayHello(name string) string => 'Hello ${name}!'
 ```
 
 main.bicep
 
 ```bicep
-import * as myImports from 'myTypes.bicep'
-import {myInt} from 'myTypes.bicep'
+import * as myImports from 'exports.bicep'
+import {myObjectType, sayHello} from 'exports.bicep'
 
-param exampleString myImports.myString = 'Bicep'
-param exampleInt myInt = 3
+param exampleObject myObjectType = {
+  foo: myImports.myConstant
+  bar: 0
+}
 
-output outString myImports.myString = exampleString
-output outInt myInt = exampleInt
+output greeting string = sayHello('Bicep user')
+output exampleObject myImports.myObjectType = exampleObject
 ```
 
-## Import namespaces and extensibility providers
+## Import namespaces and extensibility providers (Preview)
 
-The syntax for importing the namespaces is:
+> [!NOTE]
+> The experimental feature `extensibility` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features) to use this feature.
+
+The syntax for importing namespaces is:
 
 ```bicep
 import 'az@1.0.0'
@@ -70,6 +101,12 @@ import 'sys@1.0.0'
 Both `az` and `sys` are Bicep built-in namespaces. They are imported by default. For more information about the data types and the functions defined in `az` and `sys`, see [Data types](./data-types.md) and  [Bicep functions](./bicep-functions.md).
 
 The syntax for importing Bicep extensibility providers is:
+
+```bicep
+import '<provider-name>@<provider-version>'
+```
+
+The syntax for importing Bicep extensibility providers which require configuration is:
 
 ```bicep
 import '<provider-name>@<provider-version>' with {

--- a/articles/azure-resource-manager/bicep/bicep-import.md
+++ b/articles/azure-resource-manager/bicep/bicep-import.md
@@ -13,7 +13,7 @@ This article describes the syntax you use to export and import shared functional
 ## Exporting types, variables and functions (Preview)
 
 > [!NOTE]
-> [Bicep version 0.23.X or newer](./install.md) is required to use this feature. The experimental feature `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features). For user-defined functions, the experimental feature `userDefinedFunctions` must also be enabled.
+> [Bicep version 0.23 or newer](./install.md) is required to use this feature. The experimental feature `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features). For user-defined functions, the experimental feature `userDefinedFunctions` must also be enabled.
 
 The `@export()` decorator is used to indicate that a given statement can be imported by another file. This decorator is only valid on type, variable and function statements. Variable statements marked with `@export()` must be compile-time constants.
 

--- a/articles/azure-resource-manager/bicep/user-defined-functions.md
+++ b/articles/azure-resource-manager/bicep/user-defined-functions.md
@@ -102,7 +102,6 @@ When defining a user function, there are some restrictions:
 
 * The function can't access variables.
 * The function can only use parameters that are defined in the function.
-* The function can't call other user-defined functions.
 * The function can't use the [reference](bicep-functions-resource.md#reference) function or any of the [list](bicep-functions-resource.md#list) functions.
 * Parameters for the function can't have default values.
 


### PR DESCRIPTION
Note that I've left the version requirement as "0.23.X" for the upcoming Bicep release. We'll need to hold off merging this until then, and update this value once done.