### PR TITLE
Update tutorial-ingress-controller-add-on-existing.md

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
@@ -84,7 +84,7 @@ az aks enable-addons -n myCluster -g myResourceGroup -a ingress-appgw --appgw-id
 If you'd like to use Azure portal to enable AGIC add-on, go to [(https://aka.ms/azure/portal/aks/agic)](https://aka.ms/azure/portal/aks/agic) and navigate to your AKS cluster through the portal link. From there, go to the Networking tab within your AKS cluster. You'll see an application gateway ingress controller section, which allows you to enable/disable the ingress controller add-on using the Azure portal. Select the box next to **Enable ingress controller**, and then select the application gateway you created, **myApplicationGateway** from the dropdown menu. Select **Save**.
 
 > [!CAUTION]
-> When you use an application gateway in a different resource group, the managed identity created **_ingressapplicationgateway-{AKSNAME}_** once this add-on is enabled in the AKS nodes resource group must have Contributor role set in the Application Gateway resource as well as Reader role set in the Application Gateway resource group.
+> When you use an application gateway and its Virtual Network in a different resource group from the AKS cluster and node resource group **MC_resource-group-name_cluster-name_location** , the managed identity created **_ingressapplicationgateway-{AKSNAME}_** once this add-on is enabled in the AKS nodes resource group must have Contributor role set in the Application Gateway and its Virtual Network resource as well as Reader role set in the Application Gateway resource group.
 
 :::image type="content" source="./media/tutorial-ingress-controller-add-on-existing/portal-ingress-controller-add-on.png" alt-text="Screenshot showing how to enable application gateway ingress controller from the networking page of the Azure Kubernetes Service.":::
 


### PR DESCRIPTION
When you use an application gateway and its Virtual Network in a different resource group from the AKS cluster and node resource group **MC_resource-group-name_cluster-name_location** , the managed identity created **_ingressapplicationgateway-{AKSNAME}_** once this add-on is enabled in the AKS nodes resource group must have Contributor role set in the Application Gateway and its Virtual Network resource as well as Reader role set in the Application Gateway resource group.