### PR TITLE
Step 4 uses incorrect syntax

### DIFF
--- a/articles/ai-services/computer-vision/how-to/video-retrieval.md
+++ b/articles/ai-services/computer-vision/how-to/video-retrieval.md
@@ -242,7 +242,7 @@ After you add video files to the index, you can search for specific videos using
 To perform a search using the "vision" feature, use the [Search By Text](https://eastus.dev.cognitive.microsoft.com/docs/services/ingestion-api-private-preview-2023-05-01-preview/operations/645db36646346106fcc477a2) API with the `vision` filter, specifying the query text and any other desired filters.
 
 ```bash
-POST -v -X "https://<YOUR_ENDPOINT_URL>/computervision/retrieval/indexes/my-video-index:queryByText?api-version=2023-05-01-preview" -H "Ocp-Apim-Subscription-Key: <YOUR_SUBSCRIPTION_KEY>" -H "Content-Type: application/json" --data-ascii "
+curl.exe -v -X POST "https://<YOUR_ENDPOINT_URL>/computervision/retrieval/indexes/my-video-index:queryByText?api-version=2023-05-01-preview" -H "Ocp-Apim-Subscription-Key: <YOUR_SUBSCRIPTION_KEY>" -H "Content-Type: application/json" --data-ascii "
 {
   'queryText': 'a man with black hoodie',
   'filters': {


### PR DESCRIPTION
Current implementation uses incorrect syntax of "POST -v -X". Updated to "curl.exe -v -X POST", which is also in sync with previous steps.