### PR TITLE
KEDA moved to the Graduated maturity level (CNCF)

### DIFF
--- a/articles/aks/keda-about.md
+++ b/articles/aks/keda-about.md
@@ -9,7 +9,7 @@ ms.author: tomkerkhove
 
 # Simplified application autoscaling with Kubernetes Event-driven Autoscaling (KEDA) add-on (Preview)
 
-Kubernetes Event-driven Autoscaling (KEDA) is a single-purpose and lightweight component that strives to make application autoscaling simple and is a CNCF Incubation project.
+Kubernetes Event-driven Autoscaling (KEDA) is a single-purpose and lightweight component that strives to make application autoscaling simple and is a CNCF Graduate project.
 
 It applies event-driven autoscaling to scale your application to meet demand in a sustainable and cost-efficient manner with scale-to-zero.
 


### PR DESCRIPTION
KEDA moved to the Graduated maturity level (CNCF)

https://www.cncf.io/projects/keda/