### PR TITLE
Update how-to-stop-start-server-cli.md

### DIFF
--- a/articles/postgresql/flexible-server/how-to-stop-start-server-cli.md
+++ b/articles/postgresql/flexible-server/how-to-stop-start-server-cli.md
@@ -51,7 +51,7 @@ az postgres flexible-server stop  [--name]
 
 **Example without local context:**
 ```azurecli
-az postgres flexible-server stop  --resource-group --name myservername
+az postgres flexible-server stop  --resource-group resourcegroupname --name myservername
 ```
 
 **Example with local context:**


### PR DESCRIPTION
error appears 
`argument --resource-group/-g: expected one argument`

if no resource-group is passed