### PR TITLE
Powershell multiline endings

### DIFF
--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -253,8 +253,8 @@ helm install ingress-nginx ingress-nginx/ingress-nginx `
     --set controller.image.tag=$ControllerTag `
     --set controller.image.digest="" `
     --set controller.admissionWebhooks.patch.nodeSelector."kubernetes\.io/os"=linux `
-    --set controller.service.loadBalancerIP=10.224.0.42 \
-    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-internal"=true \
+    --set controller.service.loadBalancerIP=10.224.0.42 `
+    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-internal"=true `
     --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz `
     --set controller.admissionWebhooks.patch.image.registry=$AcrUrl `
     --set controller.admissionWebhooks.patch.image.image=$PatchImage `


### PR DESCRIPTION
Change the \ characters to ` for helm install commands when creating an internal ingress.