### PR TITLE
fix powershell example for Protecting individual records

### DIFF
--- a/articles/dns/dns-protect-private-zones-recordsets.md
+++ b/articles/dns/dns-protect-private-zones-recordsets.md
@@ -245,7 +245,7 @@ Azure PowerShell
 $lvl = "<lock level>"
 $lnm = "<lock name>"
 $rnm = "<zone name>/<record set name>"
-$rty = "Microsoft.Network/privateDnsZones"
+$rty = "Microsoft.Network/privateDnsZones/<record type: A,AAAA,CNAME,MX,PTR,SRV or TXT>"
 $rsg = "<resource group name>"
 
 New-AzResourceLock -LockLevel $lvl -LockName $lnm -ResourceName $rnm -ResourceType $rty -ResourceGroupName $rsg


### PR DESCRIPTION
Updated the resourceType field with: "Microsoft.Network/privateDnsZones/<record type: A,AAAA,CNAME,MX,PTR,SRV or TXT>"

without this record type you will Lock the entire dns zone instead of the individual record.