### PR TITLE
Fix missing commas in bicep-config-linter.md

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -47,13 +47,13 @@ The following example shows the rules that are available for configuration.
         },
         "nested-deployment-template-scoping": {
           "level": "error"
-        }
+        },
         "no-conflicting-metadata" : {
           "level": "warning"
         },
         "no-deployments-resources" : {
           "level": "warning"
-        }
+        },
         "no-hardcoded-env-urls": {
           "level": "warning"
         },


### PR DESCRIPTION
The example `bicepconfig.json` has two missing commas in _Add linter settings in the Bicep config file_ [article](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-config-linter).