### PR TITLE
Fix typo on azure-kubernetes-service-cluster-manage-backups.md

### DIFF
--- a/articles/backup/azure-kubernetes-service-cluster-manage-backups.md
+++ b/articles/backup/azure-kubernetes-service-cluster-manage-backups.md
@@ -130,7 +130,7 @@ To enable Trusted Access between Backup vault and AKS cluster, use the following
    az aks trustedaccess rolebinding create \
    -g $myResourceGroup \ 
    --cluster-name $myAKSCluster 
-   –n <randomRoleBindingName> \ 
+   -n <randomRoleBindingName> \ 
    --source-resource-id <vaultID> \ 
    --roles Microsoft.DataProtection/backupVaults/backup-operator   
    ```


### PR DESCRIPTION
`–` and `-` is not same.