### PR TITLE
Update stop-cluster-upgrade-api-breaking-changes.md

### DIFF
--- a/articles/aks/stop-cluster-upgrade-api-breaking-changes.md
+++ b/articles/aks/stop-cluster-upgrade-api-breaking-changes.md
@@ -6,9 +6,7 @@ ms.custom: azure-kubernetes-service
 ms.date: 10/19/2023
 ---
 
-# Stop Azure Kubernetes Service (AKS) cluster upgrades automatically on API breaking changes (Preview)
-
-[!INCLUDE [preview features callout](./includes/preview/preview-callout.md)]
+# Stop Azure Kubernetes Service (AKS) cluster upgrades automatically on API breaking changes 
 
 To stay within a supported Kubernetes version, you have to upgrade your cluster at least once per year and prepare for all possible disruptions. These disruptions include ones caused by API breaking changes, deprecations, and dependencies such as Helm and Container Storage Interface (CSI). It can be difficult to anticipate these disruptions and migrate critical workloads without experiencing any downtime.
 
@@ -53,9 +51,6 @@ You have two options to mitigate the issue. You can either [remove usage of depr
 You can also check past API usage by enabling [Container Insights][container-insights] and exploring kube audit logs. Check the verb in the deprecated API usage to understand if it's a [watch][k8s-api] use case.
 
 ### Bypass validation to ignore API changes
-
-> [!NOTE]
-> This method requires you to use the `aks-preview` Azure CLI extension version 0.5.134 or later. This method isn't recommended, as deprecated APIs in the targeted Kubernetes version may not work long term. We recommend removing them as soon as possible after the upgrade completes.
 
 * Bypass validation to ignore API breaking changes using the [`az aks update`][az-aks-update] command. Specify the `enable-force-upgrade` flag and set the `upgrade-override-until` property to define the end of the window during which validation is bypassed. If no value is set, it defaults the window to three days from the current time. The date and time you specify must be in the future.
 


### PR DESCRIPTION
According to the AKS release notes, this feature is no longer in preview. https://github.com/Azure/AKS/releases/tag/2023-10-08

Removed all references to preview, including for the CLI, since it appears that the az aks update command now has the --upgrade-override-until parameter https://learn.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-update