### PR TITLE
Update use-key-vault-references-dotnet-core.md

### DIFF
--- a/articles/azure-app-configuration/use-key-vault-references-dotnet-core.md
+++ b/articles/azure-app-configuration/use-key-vault-references-dotnet-core.md
@@ -171,7 +171,7 @@ To add a secret to the vault, you need to take just a few additional steps. In t
 
 ## Grant your app access to Key Vault
 
-Azure App Configuration won't access your key vault. Your app will read from Key Vault directly, so you need to grant your app read access to the secrets in your key vault. This way, the secret always stays with your app. The access can be granted using either a [Key Vault access policy](../key-vault/general/assign-access-policy-portal.md) or [Azure role-based access control](../key-vault/general/rbac-guide.md).
+Azure App Configuration won't access your key vault. Your app will read from Key Vault directly, so you need to grant your app access to the secrets in your key vault. This way, the secret always stays with your app. The access can be granted using either a [Key Vault access policy](../key-vault/general/assign-access-policy-portal.md) or [Azure role-based access control](../key-vault/general/rbac-guide.md).
 
 You use `DefaultAzureCredential` in your code above. It's an aggregated token credential that automatically tries a number of credential types, like `EnvironmentCredential`, `ManagedIdentityCredential`, `SharedTokenCacheCredential`, and `VisualStudioCredential`. For more information, see [DefaultAzureCredential Class](/dotnet/api/azure.identity.defaultazurecredential). You can replace `DefaultAzureCredential` with any credential type explicitly. However, using `DefaultAzureCredential` enables you to have the same code that runs in both local and Azure environments. For example, you grant your own credential access to your key vault. `DefaultAzureCredential` automatically falls back to `SharedTokenCacheCredential` or `VisualStudioCredential` when you use Visual Studio for local development.
 


### PR DESCRIPTION
This is a pitfall in the documentation. "read access" may mislead users to assign "Key Vault Secrets Reader" role. However, the correct way is to assign "Key Vault Secrets User" role.