### PR TITLE
Add description for AS Number requirements.

### DIFF
--- a/includes/expressroute-peering-comparison.md
+++ b/includes/expressroute-peering-comparison.md
@@ -11,7 +11,7 @@ ms.author: cherylmc
 | **Max. # IPv4 prefixes supported per peering** |4000 by default, 10,000 with ExpressRoute Premium |200 |200 |
 | **Max. # IPv6 prefixes supported per peering** |100 |200 |N/A |
 | **IP address ranges supported** |Any valid IP address within your WAN. |Public IP addresses owned by you or your connectivity provider. |Public IP addresses owned by you or your connectivity provider. |
-| **AS Number requirements** |Private and public AS numbers. You must own the public AS number if you choose to use one. |Private and public AS numbers. However, you must prove ownership of public IP addresses. |Private and public AS numbers. However, you must prove ownership of public IP addresses. |
+| **AS Number requirements** |Private and public AS numbers. You must own the public AS number if you choose to use one. |You can set private and public AS numbers for peer ASN. However, you must prove ownership of public IP addresses. Note: If you use customer ASN, you can set public ASN only.|Private and public AS numbers. However, you must prove ownership of public IP addresses. |
 | **IP protocols supported**| IPv4, IPv6 |  IPv4, IPv6 | IPv4 |
 | **Routing Interface IP addresses** |RFC1918 and public IP addresses |Public IP addresses registered to you in routing registries. |Public IP addresses registered to you in routing registries. |
 | **MD5 Hash support** |Yes |Yes |Yes |


### PR DESCRIPTION
In Microsoft Peering, we can set peer ASN and customer ASN.

Peer ASN can be public and private ASN, but customer ASN can only be public ASN.
We need to add this explanation because the current documentation confuses customers.
