### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/tutorial-create-user-flows.md
+++ b/articles/active-directory-b2c/tutorial-create-user-flows.md
@@ -225,7 +225,7 @@ Now, grant permissions to the API scope you exposed earlier in the *IdentityExpe
 
 1. In the left menu, under **Manage**, select **API permissions**.
 1. Under **Configured permissions**, select **Add a permission**.
-1. Select the **My APIs** tab, then select the **IdentityExperienceFramework** application.
+1. Select the **APIs my organization uses** tab, then select the **IdentityExperienceFramework** application.
 1. Under **Permission**, select the **user_impersonation** scope that you defined earlier.
 1. Select **Add permissions**. As directed, wait a few minutes before proceeding to the next step.
 1. Select **Grant admin consent for *<your tenant name)>***.


### PR DESCRIPTION
'My APIs' tab does not display the IdentityExperienceFramework application.
The IdentityExperienceFramework application is visible on the 'APIs my organization uses' tab.

Evidence 1: <img width="848" alt="evi1" src="https://github.com/changeworld/azure-docs/assets/1207985/98294c41-b46d-42f5-a1c2-dcfb7f4e1315">
Evidence 2: 
<img width="834" alt="evi2" src="https://github.com/changeworld/azure-docs/assets/1207985/eb7b59a9-1341-466e-bb7a-e0fd647bdd79">
