### PR TITLE
Remove outdated deployment disclaimer

### DIFF
--- a/articles/virtual-machines/instance-metadata-service.md
+++ b/articles/virtual-machines/instance-metadata-service.md
@@ -300,9 +300,6 @@ The IMDS API contains multiple endpoint categories representing different data s
 
 ## Versions
 
-> [!NOTE]
-> This feature was released alongside version 2020-10-01, which is currently being rolled out and may not yet be available in every region.
-
 ### List API versions
 
 Returns the set of supported API versions.


### PR DESCRIPTION
This is highly outdated, the deployment has since finished.