### PR TITLE
Audit whitelist for Cassandra 4 and later

### DIFF
--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -137,7 +137,10 @@ Use the [Azure Monitor REST API](/rest/api/monitor/diagnosticsettings/createorup
 >[!NOTE]
 > This article contains references to a term that Microsoft no longer uses. When the term is removed from the software, we'll remove it from this article.
 
-By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. You can use the audit whitelist feature in Cassandra 3.11 to set what operations *don't* create an audit record. The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 
+By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. 
+
+### Cassandra 3.11
+You can use the audit whitelist feature in Cassandra 3.11 to set what operations *don't* create an audit record. The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 
 
 Examples:
 
@@ -165,6 +168,9 @@ Examples:
   ```
   cassandra@cqlsh> LIST ROLES;
   ```
+
+### Cassandra 4 and later
+TODO
 
 ## Next steps
 

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -172,7 +172,19 @@ Examples:
 ### Cassandra 4 and later
 In Cassandra 4 and the later, whitelist could be configured ... 
 
+included_keyspaces: Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces
 
+excluded_keyspaces: Comma separated list of keyspaces to be excluded from audit log, default - excludes no keyspace except system, system_schema and system_virtual_schema
+
+included_categories: Comma separated list of Audit Log Categories to be included in audit log, default - includes all categories
+
+excluded_categories: Comma separated list of Audit Log Categories to be excluded from audit log, default - excludes no category
+
+included_users: Comma separated list of users to be included in audit log, default - includes all users
+
+excluded_users: Comma separated list of users to be excluded from audit log, default - excludes no user
+
+List of available categories are: QUERY, DML, DDL, DCL, OTHER, AUTH, ERROR, PREPARE
 
 ## Next steps
 

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -186,6 +186,10 @@ excluded_users: Comma separated list of users to be excluded from audit log, def
 
 List of available categories are: QUERY, DML, DDL, DCL, OTHER, AUTH, ERROR, PREPARE
 
+audit_logging_options:
+    included_keyspaces: keyspace1,keyspace2
+    included_categories: AUTH,ERROR,DCL,DDL
+
 ## Next steps
 
 * For detailed information about how to create a diagnostic setting by using the Azure portal, CLI, or PowerShell, see [create diagnostic setting to collect platform logs and metrics in Azure](../azure-monitor/essentials/diagnostic-settings.md) article.

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -170,7 +170,9 @@ Examples:
   ```
 
 ### Cassandra 4 and later
-TODO
+In Cassandra 4 and the later, whitelist could be configured ... 
+
+
 
 ## Next steps
 

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -137,10 +137,10 @@ Use the [Azure Monitor REST API](/rest/api/monitor/diagnosticsettings/createorup
 >[!NOTE]
 > This article contains references to a term that Microsoft no longer uses. When the term is removed from the software, we'll remove it from this article.
 
-By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. You can use the audit whitelist feature to set what operations *don't* create an audit record. 
+By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. To manage this, you could use whitelist to selectively include or exclude specific audit records.
 
 ### Cassandra 3.11
-The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 
+In Cassandra 3.11, you can use the audit whitelist feature to set what operations *don't* create an audit record. The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 
 
 Examples:
 
@@ -169,16 +169,16 @@ Examples:
   cassandra@cqlsh> LIST ROLES;
   ```
 
-### Cassandra 4 and later versions
-In Cassandra 4 and later versions, you can configure your whitelist in Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](https://learn.microsoft.com/en-us/azure/managed-instance-apache-cassandra/create-cluster-portal#update-cassandra-configuration). The available options are as follows:
+### Cassandra 4 and later
+In Cassandra 4 and later, you can configure your whitelist in the Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](https://learn.microsoft.com/en-us/azure/managed-instance-apache-cassandra/create-cluster-portal#update-cassandra-configuration). The available options are as follows:
 ```
 audit_logging_options:
-  included_keyspaces: <Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces>
-  excluded_keyspaces: <Comma separated list of keyspaces to be excluded from audit log, default - excludes no keyspace except system, system_schema and system_virtual_schema>
-  included_categories: <Comma separated list of Audit Log Categories to be included in audit log, default - includes all categories>
-  excluded_categories: <Comma separated list of Audit Log Categories to be excluded from audit log, default - excludes no category>
-  included_users: <Comma separated list of users to be included in audit log, default - includes all users>
-  excluded_users: <Comma separated list of users to be excluded from audit log, default - excludes no user>
+    included_keyspaces: <Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces>
+    excluded_keyspaces: <Comma separated list of keyspaces to be excluded from audit log, default - excludes no keyspace except system, system_schema and system_virtual_schema>
+    included_categories: <Comma separated list of Audit Log Categories to be included in audit log, default - includes all categories>
+    excluded_categories: <Comma separated list of Audit Log Categories to be excluded from audit log, default - excludes no category>
+    included_users: <Comma separated list of users to be included in audit log, default - includes all users>
+    excluded_users: <Comma separated list of users to be excluded from audit log, default - excludes no user>
 ```
 
 List of available categories are: QUERY, DML, DDL, DCL, OTHER, AUTH, ERROR, PREPARE

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -137,10 +137,10 @@ Use the [Azure Monitor REST API](/rest/api/monitor/diagnosticsettings/createorup
 >[!NOTE]
 > This article contains references to a term that Microsoft no longer uses. When the term is removed from the software, we'll remove it from this article.
 
-By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. 
+By default, audit logging creates a record for every login attempt and CQL query. The result can be rather overwhelming and increase overhead. You can use the audit whitelist feature to set what operations *don't* create an audit record. 
 
 ### Cassandra 3.11
-You can use the audit whitelist feature in Cassandra 3.11 to set what operations *don't* create an audit record. The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 
+The audit whitelist feature is enabled by default in Cassandra 3.11. To learn how to configure your whitelist, see [Role-based whitelist management](https://github.com/Ericsson/ecaudit/blob/release/c2.2/doc/role_whitelist_management.md). 
 
 Examples:
 
@@ -170,7 +170,7 @@ Examples:
   ```
 
 ### Cassandra 4 and later versions
-In Cassandra 4 and later versions, you can configure a whitelist in the Cassandra configuration in the portal. The available options are as follows:
+In Cassandra 4 and later versions, you can configure your whitelist in Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](https://learn.microsoft.com/en-us/azure/managed-instance-apache-cassandra/create-cluster-portal#update-cassandra-configuration). The available options are as follows:
 ```
 audit_logging_options:
   included_keyspaces: <Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces>
@@ -190,7 +190,7 @@ audit_logging_options:
     included_categories: AUTH,ERROR,DCL,DDL
 ```
 
-By default, the configuration sets included_categories to AUTH,ERROR,DCL,DDL.
+By default, the configuration sets `included_categories` to `AUTH,ERROR,DCL,DDL`.
 
 ## Next steps
 

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -169,26 +169,28 @@ Examples:
   cassandra@cqlsh> LIST ROLES;
   ```
 
-### Cassandra 4 and later
-In Cassandra 4 and the later, whitelist could be configured ... 
-
-included_keyspaces: Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces
-
-excluded_keyspaces: Comma separated list of keyspaces to be excluded from audit log, default - excludes no keyspace except system, system_schema and system_virtual_schema
-
-included_categories: Comma separated list of Audit Log Categories to be included in audit log, default - includes all categories
-
-excluded_categories: Comma separated list of Audit Log Categories to be excluded from audit log, default - excludes no category
-
-included_users: Comma separated list of users to be included in audit log, default - includes all users
-
-excluded_users: Comma separated list of users to be excluded from audit log, default - excludes no user
+### Cassandra 4 and later versions
+In Cassandra 4 and later versions, you can configure a whitelist in the Cassandra configuration in the portal. The available options are as follows:
+```
+audit_logging_options:
+  included_keyspaces: <Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces>
+  excluded_keyspaces: <Comma separated list of keyspaces to be excluded from audit log, default - excludes no keyspace except system, system_schema and system_virtual_schema>
+  included_categories: <Comma separated list of Audit Log Categories to be included in audit log, default - includes all categories>
+  excluded_categories: <Comma separated list of Audit Log Categories to be excluded from audit log, default - excludes no category>
+  included_users: <Comma separated list of users to be included in audit log, default - includes all users>
+  excluded_users: <Comma separated list of users to be excluded from audit log, default - excludes no user>
+```
 
 List of available categories are: QUERY, DML, DDL, DCL, OTHER, AUTH, ERROR, PREPARE
 
+Here's an example configuration:
+```
 audit_logging_options:
     included_keyspaces: keyspace1,keyspace2
     included_categories: AUTH,ERROR,DCL,DDL
+```
+
+By default, the configuration sets included_categories to AUTH,ERROR,DCL,DDL.
 
 ## Next steps
 

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -170,7 +170,7 @@ Examples:
   ```
 
 ### Cassandra 4 and later
-In Cassandra 4 and later, you can configure your whitelist in the Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](https://learn.microsoft.com/en-us/azure/managed-instance-apache-cassandra/create-cluster-portal#update-cassandra-configuration). The available options are as follows:
+In Cassandra 4 and later, you can configure your whitelist in the Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](create-cluster-portal.md#update-cassandra-configuration). The available options are as follows:
 ```
 audit_logging_options:
     included_keyspaces: <Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces>

--- a/articles/managed-instance-apache-cassandra/monitor-clusters.md
+++ b/articles/managed-instance-apache-cassandra/monitor-clusters.md
@@ -170,7 +170,7 @@ Examples:
   ```
 
 ### Cassandra 4 and later
-In Cassandra 4 and later, you can configure your whitelist in the Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](create-cluster-portal.md#update-cassandra-configuration). The available options are as follows:
+In Cassandra 4 and later, you can configure your whitelist in the Cassandra configuration. For detailed guidance on updating the Cassandra configuration, please refer to [Update Cassandra Configuration](create-cluster-portal.md#update-cassandra-configuration). The available options are as follows (Reference: [Cassandra Audit Logging Documentation](https://cassandra.apache.org/doc/stable/cassandra/operating/audit_logging.html)):
 ```
 audit_logging_options:
     included_keyspaces: <Comma separated list of keyspaces to be included in audit log, default - includes all keyspaces>


### PR DESCRIPTION
Now we support audit whitelist for Cassandra 4 and later, thus updating the doc accordingly. 