### PR TITLE
Fix grammar

### DIFF
--- a/articles/private-link/private-link-faq.yml
+++ b/articles/private-link/private-link-faq.yml
@@ -89,7 +89,7 @@ sections:
       - question: |
           Do private endpoints support ICMP traffic?
         answer: |
-          TCP and UDP traffic are only supported for a private endpoint. For more information, see [Private Link limitations](./private-link-service-overview.md#limitations).
+          Only TCP and UDP traffic are supported for a private endpoint. For more information, see [Private Link limitations](./private-link-service-overview.md#limitations).
           
   - name: Private Link Service
     questions:


### PR DESCRIPTION
The original placement of the word "only" suggested that private link was the only Azure service supporting TCP and UDP.  The new placement makes it clear that only TCP and UDP are supported by Private Link.