### PR TITLE
Adding bicep linter rule explicit loc param

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -33,6 +33,9 @@ The following example shows the rules that are available for configuration.
         "decompiler-cleanup": {
           "level": "warning"
         },
+        "explicit-values-for-loc-params": {
+          "level": "warning"
+        },
         "max-outputs": {
           "level": "warning"
         },


### PR DESCRIPTION
Added a rule to the example, this rule was missing