### PR TITLE
[OSDOCS-8698] Addressing issues and updating ARO restrict egress traffic doc

### DIFF
--- a/articles/openshift/howto-restrict-egress.md
+++ b/articles/openshift/howto-restrict-egress.md
@@ -10,66 +10,67 @@ ms.date: 10/10/2023
 ---
 # Control egress traffic for your Azure Red Hat OpenShift (ARO) cluster
 
-This article provides the necessary details that allow you to secure outbound traffic from your Azure Red Hat OpenShift cluster (ARO). With the release of the [Egress Lockdown Feature](./concepts-egress-lockdown.md), all of the required connections for a private cluster are proxied through the service. There are additional destinations that you may want to allow to use features such as Operator Hub, or Red Hat telemetry.  An [example](#private-aro-cluster-setup) is provided at the end showing how to configure these requirements with Azure Firewall. Keep in mind, you can apply this information to Azure Firewall or to any outbound restriction method or appliance.
+This article provides the necessary details that allow you to secure outbound traffic from your Azure Red Hat OpenShift cluster (ARO). With the release of the [Egress Lockdown Feature](./concepts-egress-lockdown.md), all of the required connections for an ARO cluster are proxied through the service. There are additional destinations that you may want to allow to use features such as Operator Hub or Red Hat telemetry. 
 
 > [!IMPORTANT]
 > Do not attempt these instructions on older ARO clusters if those clusters don't have the Egress Lockdown feature enabled. To enable the Egress Lockdown feature on older ARO clusters, see [Enable Egress Lockdown](./concepts-egress-lockdown.md#enable-egress-lockdown).
 
+## Endpoints proxied through the ARO service
 
-## Before you begin
-
-This article assumes that you're creating a new cluster. If you need a basic ARO cluster, see the [ARO quickstart](./tutorial-create-cluster.md).
-
-## Minimum Required FQDN - Proxied through ARO service
-
-This list is based on the list of FQDNs found in the OpenShift docs here: https://docs.openshift.com/container-platform/latest/installing/install_config/configuring-firewall.html
-
-The following FQDNs are proxied through the service, and won't need additional firewall rules. They're here for informational purposes.
+The following endpoints are proxied through the service, and do not need additional firewall rules. This list is here for informational purposes only.
 
 | Destination FQDN | Port | Use |
 | ----------- | ----------- | ------------- |
-| **`arosvc.azurecr.io`** | **HTTPS:443** | Global Internal Private registry for ARO Operators.  Required if you don't allow the service-endpoints Microsoft.ContainerRegistry on your subnets. |
-| **`arosvc.$REGION.data.azurecr.io`** | **HTTPS:443** | Regional Internal Private registry for ARO Operators.  Required if you don't allow the service-endpoints Microsoft.ContainerRegistry on your subnets. |
+| **`arosvc.azurecr.io`** | **HTTPS:443** | Global container registry for ARO required system images. |
+| **`arosvc.$REGION.data.azurecr.io`** | **HTTPS:443** | Regional container registry for ARO required system images. |
 | **`management.azure.com`** | **HTTPS:443** | Used by the cluster to access Azure APIs. |
 | **`login.microsoftonline.com`** | **HTTPS:443** | Used by the cluster for authentication to Azure. |
-| **`*.monitor.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
-| **`*.monitoring.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
-| **`*.blob.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
-| **`*.servicebus.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
-| **`*.table.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
-
-> [!NOTE] 
-> For many customers exposing *.blob, *.table and other large address spaces creates a potential data exfiltration concern. You may want to consider using the [OpenShift Egress Firewall](https://docs.openshift.com/container-platform/latest/networking/openshift_sdn/configuring-egress-firewall.html) to protect applications deployed in the cluster from reaching these destinations and use Azure Private Link for specific application needs.
+| **Specific subdomains of `monitor.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
+| **Specific subdomains of `monitoring.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
+| **Specific subdomains of `blob.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
+| **Specific subdomains of `servicebus.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
+| **Specific subdomains of `table.core.windows.net`** | **HTTPS:443** | Used for Microsoft Geneva Monitoring so that the ARO team can monitor the customer's cluster(s). |
 
 ---
 
-## List of optional FQDNs
+## List of optional endpoints
 
-### ADDITIONAL CONTAINER IMAGES
+### Additional container registry endpoints
 
-- **`registry.redhat.io`**: Used to provide images for things such as Operator Hub. 
-- **`*.quay.io`**: May be used to download images from the Red Hat managed Quay registry. Also a possible fall-back target for ARO required system images. If your firewall can't use wildcards, you can find the [full list of subdomains in the Red Hat documentation.](https://docs.openshift.com/container-platform/latest/installing/install_config/configuring-firewall.html)
+| Destination FQDN | Port | Use |
+| ----------- | ----------- | ------------- |
+| **`registry.redhat.io`** | **HTTPS:443** | Used to provide container images and operators from Red Hat. |
+| **`quay.io`** | **HTTPS:443** | Used to provide container images and operators from Red Hat and third-parties. |
+| **`cdn.quay.io`** | **HTTPS:443** | Used to provide container images and operators from Red Hat and third-parties. |
+| **`cdn01.quay.io`** | **HTTPS:443** | Used to provide container images and operators from Red Hat and third-parties. |
+| **`cdn02.quay.io`** | **HTTPS:443** | Used to provide container images and operators from Red Hat and third-parties. |
+| **`cdn03.quay.io`** | **HTTPS:443** | Used to provide container images and operators from Red Hat and third-parties. |
+| **`access.redhat.com`** | **HTTPS:443** | Used to provide container images and operators from Red Hat and third-parties. |
+| **`registry.access.redhat.com`** | **HTTPS:443** | Used to provide third-party container images and certified operators. |
+| **`registry.connect.redhat.com`** | **HTTPS:443** | Used to provide third-party container images and certified operators. |
+
+### Red Hat Telemetry and Red Hat Insights
+
+By default, ARO clusters are opted-out of Red Hat Telemetry  and Red Hat Insights. If you wish to opt-in to Red Hat telemetry, allow the following endpoints and [update your cluster's pull secret](./howto-add-update-pull-secret.md).
+
+| Destination FQDN | Port | Use |
+| ----------- | ----------- | ------------- |
+| **`cert-api.access.redhat.com`** | **HTTPS:443** | Used for Red Hat telemetry. |
+| **`api.access.redhat.com`** | **HTTPS:443** | Used for Red Hat telemetry. |
+| **`infogw.api.openshift.com`** | **HTTPS:443** | Used for Red Hat telemetry. |
+| **`console.redhat.com/api/ingress`** | **HTTPS:443** | Used in the cluster for the insights operator that integrates with Red Hat Insights. |
+
+For additional information on remote health monitoring and telemetry, see the [Red Hat OpenShift Container Platform documentation](https://docs.openshift.com/container-platform/latest/support/remote_health_monitoring/about-remote-health-monitoring.html).
+
+### Other additional OpenShift endpoints
+
+| Destination FQDN | Port | Use |
+| ----------- | ----------- | ------------- |
+| **`api.openshift.com`** | **HTTPS:443** | Used by the cluster to check if updates are available for the cluster. Alternatively, users can use the [OpenShift Upgrade Graph tool](https://access.redhat.com/labs/ocpupgradegraph/) to manually find an upgrade path. |
+| **`mirror.openshift.com`** | **HTTPS:443** | Required to access mirrored installation content and images. |
+| **`*.apps.<cluster_domain>*`** | **HTTPS:443** | When allowlisting domains, this is used in your corporate network to reach applications deployed in ARO, or to access the OpenShift console. |
 
 ---
-
-### TELEMETRY
-
-You can opt out of telemetry, but make sure you understand this feature before doing so: https://docs.openshift.com/container-platform/4.12/support/remote_health_monitoring/about-remote-health-monitoring.html
-- **`cert-api.access.redhat.com`**: Used for Red Hat telemetry.
-- **`api.access.redhat.com`**: Used for Red Hat telemetry.
-- **`infogw.api.openshift.com`**: Used for Red Hat telemetry.
-- **`https://cloud.redhat.com/api/ingress`**: Used in the cluster for the insights operator that integrates with Red Hat Insights (required in 4.10 and earlier only).
-- **`https://console.redhat.com/api/ingress`**: Used in the cluster for the insights operator that integrates with Red Hat Insights.
-
----
-
-### OTHER POSSIBLE OPENSHIFT REQUIREMENTS
-
-- **`mirror.openshift.com`**: Required to access mirrored installation content and images. This site is also a source of release image signatures.
-- **`*.apps.<cluster_name>.<base_domain>`** (OR EQUIVALENT ARO URL): When allowlisting domains, this is used in your corporate network to reach applications deployed in OpenShift, or to access the OpenShift console.
-- **`api.openshift.com`**: Used by the cluster for release graph parsing. https://access.redhat.com/labs/ocpupgradegraph/ can be used as an alternative.
-- **`registry.access.redhat.com`**: Registry access is required in your VDI or laptop environment to download dev images when using the ODO CLI tool. (This CLI tool is an alternative CLI tool for developers who aren't familiar with kubernetes). https://docs.openshift.com/container-platform/4.6/cli_reference/developer_cli_odo/understanding-odo.html
-- **`access.redhat.com`**: Used in conjunction with `registry.access.redhat.com` when pulling images. Failure to add this access could result in an error message.
 
 ## ARO integrations
 
@@ -77,7 +78,8 @@ You can opt out of telemetry, but make sure you understand this feature before d
 
 ARO clusters can be monitored using the Azure Monitor container insights extension. Review the pre-requisites and instructions for [enabling the extension](../azure-monitor/containers/container-insights-enable-arc-enabled-clusters.md).
 
-
+---
+<!-- @todo Migrate this to a secondary article if we find customer demand. 
 ## Private ARO cluster setup
 The goal is to secure ARO cluster by routing Egress traffic through an Azure Firewall
 ### Before:
@@ -373,4 +375,4 @@ az aro delete -n $CLUSTER -g $RESOURCEGROUP
 
 # Remove the resource group that contains the firewall, jumpbox and vnet
 az group delete -n $RESOURCEGROUP
-```
+``` -->


### PR DESCRIPTION
The Restrict egress traffic ARO support document ([https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress](https://learn.microsoft.com/en-us/azure/openshift/howto-restrict-egress)) includes an incorrect warning. The warning states:

> For many customers exposing *.blob, *.table and other large address spaces creates a potential data exfiltration concern. You may want to consider using the OpenShift Egress Firewall to protect applications deployed in the cluster from reaching these destinations and use Azure Private Link for specific application needs.

This is incorrect. We do not proxy/expose any endpoints that are wildcarded using the Private Link. In addition, the document states that we proxy all traffic from the following endpoints via the Private Link:

> *.monitor.core.windows.net
> *.monitoring.core.windows.net
> *.blob.core.windows.net
> *.servicebus.windows.net
> *.table.core.windows.net

This is also incorrect. We only proxy the necessary endpoints for the service through the proxy. Any endpoints that are not part of the service (for example, if someone created their own example.table.core.windows.net endpoint, they would not be able to route to it via the Private Link). 

In addition, the page includes various references to old OCP documentation, incorrect information around Red Hat Telemetry, and an outdated guide to how to use Azure Firewall with ARO. 

After discussion with @jboutaud, we removed the Azure Firewall with ARO section and will move it to another separate article as a secondary follow-up action. 

This PR addresses all the above issues.