### PR TITLE
Update app-insights-azure-ad-api.md

### DIFF
--- a/articles/azure-monitor/app/app-insights-azure-ad-api.md
+++ b/articles/azure-monitor/app/app-insights-azure-ad-api.md
@@ -89,7 +89,7 @@ Use the token in requests to the Application Insights endpoint:
     POST /v1/apps/yous_app_id/query?timespan=P1D
     Host: https://api.applicationinsights.io
     Content-Type: application/json
-    Authorization: bearer <your access token>
+    Authorization: Bearer <your access token>
 
     Body:
     {


### PR DESCRIPTION
correct syntax error in code found in public facing documents:
https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-azure-ad-api#set-up-authentication


During the application registration process, an authentication error message occurs, even when all credentials are correct and properly entered.
Error Message:
 
error:{'message':'Valid authentication was not provided','code':'AuthorizationRequiredError','correlationId':'8d5f1a8a-b146-41a4-91af-cf204f34b3b6'}
 
Cause:
=====
 
Analysis:
 
Actions Taken/Troubleshooting:
Engaged Azure AD and Entra ID teams to verify authentication prerequisites, confirming correct configuration.
No authentication failure was observed during testing related to the provided error message.
Checked the customer's tenant in ACS; the correlation ID in the error message was not found.
Advised the customer to use an alternative LogAnalytics API, which worked successfully but was not the preferred choice.
Example: Go to Application Insights in Azure Portal, click on API Access, create a new API key, and use it in REST API calls in a header with Key = x-api-key.
Conducted further research, identified a syntax error in the spelling of the word "Bearer" in the provided code.
Discrepancy between KB article template and public forum template.
Corrected syntax in testing, and the authentication error was not reproducible.
 
KB article template:
POST /v1/apps/yous_app_id/query?timespan=P1D
    Host: https://api.applicationinsights.io/
    Content-Type: application/json
    Authorization: bearer <your access token>    <-----------Syntax error
    Body:
    {
    "query": "requests | take 10"
    }
 
Public forum template:
 curl -X POST -H"Content-Type: application/json" -H "Authorization: Bearer <your access token>"  <----------There is a capital B in Bearer here
-d '{"query": "AzureActivity | summarize count() by Category"}'  [https://api.loganalytics.azure.com/v1/workspaces/<your](https://api.loganalytics.azure.com/v1/workspaces/%3cyour) workspace id>/query?timespan=P1D