### PR TITLE
Fix wrong command in container-instances-egress-ip-address.md

### DIFF
--- a/articles/container-instances/container-instances-egress-ip-address.md
+++ b/articles/container-instances/container-instances-egress-ip-address.md
@@ -163,7 +163,7 @@ View the container logs to confirm the IP address is the same as the public IP a
 
 ```azurecli
 az container logs \
-  --sed 's/$RESOURCE_GROUP_NAME/$resourceGroup/g'
+  --resource-group $resourceGroup \
   --name testegress 
 ```
 


### PR DESCRIPTION
There is no argument called "sed" in "az container logs".
Ref: https://learn.microsoft.com/en-us/cli/azure/container?view=azure-cli-latest#az-container-logs