### PR TITLE
Fix public key installation command for SSH into Windows VM

### DIFF
--- a/articles/virtual-machines/windows/connect-ssh.md
+++ b/articles/virtual-machines/windows/connect-ssh.md
@@ -220,13 +220,13 @@ and making sure the file has correct permissions.
 # [Azure CLI](#tab/azurecli)
 
 ```azurecli-interactive
-az vm run-command invoke -g $myResourceGroup -n $myVM --command-id RunPowerShellScript --scripts "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys';icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+az vm run-command invoke -g $myResourceGroup -n $myVM --command-id RunPowerShellScript --scripts "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
 ```
 
 # [Azure PowerShell](#tab/azurepowershell-interactive)
 
 ```azurepowershell-interactive
-Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -CommandId 'RunPowerShellScript' -ScriptString "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys';icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -CommandId 'RunPowerShellScript' -ScriptString "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
 ```
 
 # [ARM template](#tab/json)
@@ -239,7 +239,7 @@ Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -Command
   "location": "[parameters('location')]",
   "properties": {
     "source": {
-      "script": "MYPUBLICKEY | Add-Content 'C:\\ProgramData\\ssh\\administrators_authorized_keys';icacls.exe 'C:\\ProgramData\\ssh\\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'",
+      "script": "MYPUBLICKEY | Add-Content 'C:\\ProgramData\\ssh\\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\\ProgramData\\ssh\\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'",
     },
   }
 }
@@ -254,7 +254,7 @@ resource runPowerShellScript 'Microsoft.Compute/virtualMachines/runCommands@2022
   parent: virtualMachine
   properties: {
     source: {
-      script: "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys';icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+      script: "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
     }
   }
 }


### PR DESCRIPTION
Right now the PowerShell script to install the SSH Key into the Windows VM does not force UTF8 encoding.
When using SSH from the VM extension given in the article, it currently is not able to use the public key downloaded into it. Instead, it will constantly revert to user entry based password authentication as compared to RSA based authentication. 

OpenSSH does not have any warnings or errors even at the highest debug level on both client and host side (tested using `sshd.exe -ddd` on the host and `ssh -vvv` on the client, both Windows VMs, thus debugging this can be a hurdle for a developer, especially in business scenarios where RDP and other forms of direct access to the VM are blocked.

Using the `-Encoding UTF8` flag in the inline PowerShell script fixed the problem for several types of Windows VMs that I tested this on.