### PR TITLE
output file limit hint and align with resource files

### DIFF
--- a/articles/batch/managed-identity-pools.md
+++ b/articles/batch/managed-identity-pools.md
@@ -112,7 +112,7 @@ Azure Container Registry, support managed identities. For more information on us
 see the following links:
 
 - [Resource files](resource-files.md)
-- [Output files](batch-task-output-files.md#specify-output-files-using-managed-identity)
+- [Output files](batch-task-output-files.md#using-managed-identity)
 - [Azure Container Registry](batch-docker-container-workloads.md#managed-identity-support-for-acr)
 - [Azure Blob container file system](virtual-file-mount.md#azure-blob-container)
 


### PR DESCRIPTION
Azure Batch Output Files have a similar limit as Resource Files (see [Creating and using resource files](https://learn.microsoft.com/en-us/azure/batch/resource-files#many-resource-files)).

This pull request:
1. Adjusts the layout of the docs page to group relevant subtopics under a single section. It splits the prerequisites (creating a container) and the actual definition of output files. The section _Specify output files for task output_ now groups:
   (1) Using a Shared Access Signature
   (2) Using Managed Identity
   (3) Specify a file pattern for matching
   (4) Specify an upload condition
   (5) Disambiguate files with the same name
   
   (1) and (2) now align with resource-files.md. (3) to (5) are sub topics to configure Output files further.

2. This enables also adding a new sub section _Many Output Files_ to inform users about the limit that the Azure Batch API imposes (similar to the Resource Files) and suggest options to work with these limits.

Let me know what you think (fyi: @alfpark , @Padmalathas)