### PR TITLE
Fix public key installation command for SSH into Windows VM

### DIFF
--- a/articles/virtual-machines/windows/connect-ssh.md
+++ b/articles/virtual-machines/windows/connect-ssh.md
@@ -220,13 +220,13 @@ and making sure the file has correct permissions.
 # [Azure CLI](#tab/azurecli)
 
 ```azurecli-interactive
-az vm run-command invoke -g $myResourceGroup -n $myVM --command-id RunPowerShellScript --scripts "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys';icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+az vm run-command invoke -g $myResourceGroup -n $myVM --command-id RunPowerShellScript --scripts "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
 ```
 
 # [Azure PowerShell](#tab/azurepowershell-interactive)
 
 ```azurepowershell-interactive
-Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -CommandId 'RunPowerShellScript' -ScriptString "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys';icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -CommandId 'RunPowerShellScript' -ScriptString "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
 ```
 
 # [ARM template](#tab/json)
@@ -238,9 +238,10 @@ Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -Command
   "name": "[concat(parameters('VMName'), '/RunPowerShellScript')]",
   "location": "[parameters('location')]",
   "properties": {
+    "timeoutInSeconds":600
     "source": {
-      "script": "MYPUBLICKEY | Add-Content 'C:\\ProgramData\\ssh\\administrators_authorized_keys';icacls.exe 'C:\\ProgramData\\ssh\\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'",
-    },
+      "script": "MYPUBLICKEY | Add-Content 'C:\\ProgramData\\ssh\\administrators_authorized_keys -Encoding UTF8';icacls.exe 'C:\\ProgramData\\ssh\\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+    }
   }
 }
 ```
@@ -253,8 +254,9 @@ resource runPowerShellScript 'Microsoft.Compute/virtualMachines/runCommands@2022
   location: resourceGroup().location
   parent: virtualMachine
   properties: {
+    timeoutInSeconds: 600
     source: {
-      script: "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys';icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
+      script: "MYPUBLICKEY | Add-Content 'C:\ProgramData\ssh\administrators_authorized_keys' -Encoding UTF8;icacls.exe 'C:\ProgramData\ssh\administrators_authorized_keys' /inheritance:r /grant 'Administrators:F' /grant 'SYSTEM:F'"
     }
   }
 }

--- a/articles/virtual-machines/windows/connect-ssh.md
+++ b/articles/virtual-machines/windows/connect-ssh.md
@@ -28,66 +28,7 @@ The examples below use variables. You can set variables in your environment as f
 
 First, you'll need to enable SSH in your Windows machine.
 
-**Windows Server 2019 and newer**
-
-Following the Windows Server documentation page
-[Get started with OpenSSH](/windows-server/administration/openssh/openssh_install_firstuse),
-run the command `Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0`
-to enable the built-in capability, start the service, and open the Windows Firewall port.
-
-You can use the Azure RunCommand extension to complete this task.
-
-# [Azure CLI](#tab/azurecli)
-
-```azurecli-interactive
-az vm run-command invoke -g $myResourceGroup -n $myVM --command-id RunPowerShellScript --scripts "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"
-```
-
-# [Azure PowerShell](#tab/azurepowershell-interactive)
-
-```azurepowershell-interactive
-Invoke-AzVMRunCommand -ResourceGroupName $myResourceGroup -VMName $myVM -CommandId 'RunPowerShellScript' -ScriptString "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"
-```
-
-# [ARM template](#tab/json)
-
-```json
-{
-  "type": "Microsoft.Compute/virtualMachines/runCommands",
-  "apiVersion": "2022-03-01",
-  "name": "[concat(parameters('VMName'), '/RunPowerShellScript')]",
-  "location": "[parameters('location')]",
-  "properties": {
-    "source": {
-      "script": "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0",
-    },
-  }
-}
-```
-
-# [Bicep](#tab/bicep)
-
-```bicep
-resource runPowerShellScript 'Microsoft.Compute/virtualMachines/runCommands@2022-03-01' = {
-  name: 'RunPowerShellScript'
-  location: resourceGroup().location
-  parent: virtualMachine
-  properties: {
-    source: {
-      script: 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
-    }
-  }
-}
-```
-
----
-
-
-**Windows Server 2016 and older**
-
-- Deploy the SSH extension for Windows. The extension provides an automated installation of the
-  Win32 OpenSSH solution, similar to enabling the capability in newer versions of Windows. Use the
-  following examples to deploy the extension.
+Deploy the SSH extension for Windows. The extension provides an automated installation of the Win32 OpenSSH solution, similar to enabling the capability in newer versions of Windows. Use the following examples to deploy the extension.
 
 # [Azure CLI](#tab/azurecli)
 


### PR DESCRIPTION
Right now the PowerShell script to install the SSH Key into the Windows VM does not force UTF8 encoding.
When using SSH from the VM extension given in the article, it currently is not able to use the public key downloaded into it. Instead, it will constantly revert to user entry based password authentication as compared to RSA based authentication.

OpenSSH does not have any warnings or errors even at the highest debug level on both client and host side (tested using `sshd.exe -ddd` on the host and `ssh -vvv` on the client), both Windows VMs, thus debugging this can be a hurdle for a developer, especially in business scenarios where RDP and other forms of direct access to the VM are blocked.

Using the `-Encoding UTF8` flag in the inline PowerShell script fixed the problem for several types of Windows VMs that I tested this on.

Furthermore, when running `Microsoft.Compute/virtualMachines/runCommands` through an ARM template without a `timeoutInSeconds` property, it seems like it defaults to 0, which means that the command never runs. Since ARM templates have limited debuggability, this fix should also save developer time. 

Last change is to remove the command that installs OpenSSH.Server for machines after 2019. That command didn't work for any of the machines, and instead the command stating to work for machines before 2016 works for both Windows Server and Windows VM machines fine. 