### PR TITLE
Synapse Analytics: Add example usage of validateDeploy in YAML deployment pipeline

### DIFF
--- a/articles/synapse-analytics/cicd/continuous-integration-delivery.md
+++ b/articles/synapse-analytics/cicd/continuous-integration-delivery.md
@@ -190,6 +190,35 @@ The deployment task supports 3 types of operations,  validate only, deploy and v
    > [!NOTE]
    > The deployment task needs to download dependency JS files from this endpoint **web.azuresynapse.net** when the operation type is selected as **Validate** or **Validate and deploy**. Please ensure the endpoint **web.azuresynapse.net** is allowed if network policies are enabled on the VM.
 
+The validate and deploy operation works in both classic and YAML pipeline. The sample YAML file is as below: 
+
+ ```yaml
+    pool:
+      vmImage: ubuntu-latest
+
+    resources:
+      repositories:
+      - repository: <repository name>
+        type: git
+        name: <name>
+        ref: <user/collaboration branch>
+
+    steps:
+      - checkout: <name>
+      - task: Synapse workspace deployment@2
+        continueOnError: true    
+        inputs:
+          operation: 'validateDeploy'
+          ArtifactsFolder: '$(System.DefaultWorkingDirectory)/ArtifactFolder'
+          TargetWorkspaceName: 'target workspace name'
+          azureSubscription: 'target Azure resource manager connection name'
+          ResourceGroupName: 'target workspace resource group'
+          DeleteArtifactsNotInTemplate: true
+          OverrideArmParameters: >
+            -key1 value1
+            -key2 value2
+``` 
+
 **Deploy**  The inputs of the operation deploy include Synapse workspace template and parameter template, which can be created after publishing in the workspace publish branch or after the validation. It is same as the version 1.x. 
 
 You can choose the operation types based on the use case. Following part is an example of the deploy.


### PR DESCRIPTION
The documentation describes how to use validate in a Azure DevOps YAML pipeline and how to use validateDeploy in a Github actions but not how to use validateDeploy in an Azure DevOps YAML pipeline.  Notably, there are some key differences which confused me as well as other people: OverrideArmParameters refers to a path in Github actions but is inline in Azure DevOps (see for example https://learn.microsoft.com/en-us/answers/questions/1386464/overridearmparameters-with-synapse-workspace-deplo)