### PR TITLE
Update durable-functions-timers.md

### DIFF
--- a/articles/azure-functions/durable/durable-functions-timers.md
+++ b/articles/azure-functions/durable/durable-functions-timers.md
@@ -42,7 +42,7 @@ durable_timeout_task = context.create_timer(due_time)
 
 ```powershell
 # Put the orchestrator to sleep for 72 hours
-@duration = New-TimeSpan -Hours 72
+$duration = New-TimeSpan -Hours 72
 Start-DurableTimer -Duration $duration
 ```
 


### PR DESCRIPTION
Replaced an `@` with a `$` for declaring a TimeSpan variable called duration in the first PowerShell example. This should fix #117090 as I don't believe PowerShell allows declaring a variable using the `@` symbol.