### PR TITLE
Add .NET 8 to runtimes for SWA

### DIFF
--- a/includes/static-web-apps-languages-runtimes.md
+++ b/includes/static-web-apps-languages-runtimes.md
@@ -14,6 +14,7 @@ To configure the API language runtime version, set the `apiRuntime` property in 
 | .NET 6.0 in-process | Windows | 4.x | `dotnet:6.0` | - |
 | .NET 6.0 isolated | Windows | 4.x | `dotnet-isolated:6.0` | - |
 | .NET 7.0 isolated | Windows | 4.x | `dotnet-isolated:7.0` | - |
+| .NET 8.0 isolated | Windows | 4.x | `dotnet-isolated:8.0` | - |
 | Node.js 12.x | Linux | 3.x | `node:12` | December 3, 2022 |
 | Node.js 14.x | Linux | 4.x | `node:14` | - |
 | Node.js 16.x | Linux | 4.x | `node:16` | - |


### PR DESCRIPTION
As support was announced yesterday, and I tested running my own site using .NET 8, I added .NET 8 to the list of supported runtime