### PR TITLE
Fix command

### DIFF
--- a/articles/app-service/tutorial-auth-aad.md
+++ b/articles/app-service/tutorial-auth-aad.md
@@ -122,7 +122,7 @@ Create the resource group, web app plan, the web app and deploy in a single step
 1. Deploy the backend web app to same resource group and app plan. Because web app name has to be globally unique, replace `<back-end-app-name>` with a unique set of initials or numbers. 
 
     ```azurecli-interactive
-    az webapp up --resource-group myAuthResourceGroup --name <back-end-app-name> --plan myPlan --runtime "NODE:16-lts"
+    az webapp up --resource-group myAuthResourceGroup --name <back-end-app-name> --plan myPlan --sku FREE --location "West Europe" --runtime "NODE:16-lts"
     ```
 
 ::: zone-end


### PR DESCRIPTION
When executing the command, an error occurs as follows.

```
changeworld [ ~/js-e2e-web-app-easy-auth-app-to-app/frontend ]$ az webapp up --resource-group myAuthResourceGroupApps --name frontendApps --plan myPlanApps --sku FREE --location "West Europe" --os-type Linux --runtime "NODE:16-lts"
The webapp 'frontendApps' doesn't exist
Creating Resource group 'myAuthResourceGroupApps' ...
Resource group creation complete
Creating AppServicePlan 'myPlanApps' or Updating if already exists
Creating webapp 'frontendApps' ...
Configuring default logging for the app, if not already enabled
Creating zip with contents of dir /home/changeworld/js-e2e-web-app-easy-auth-app-to-app/frontend ...
Getting scm site credentials for zip deployment
Starting zip deployment. This operation can take a while to complete ...
Deployment endpoint responded with status code 202
You can launch the app at http://frontendapps.azurewebsites.net
Setting 'az webapp up' default arguments for current directory. Manage defaults with 'az configure --scope local'
--resource-group/-g default: myAuthResourceGroupApps
--sku default: FREE
--plan/-p default: myPlanApps
--location/-l default: westeurope
--name/-n default: frontendApps
{
  "URL": "http://frontendapps.azurewebsites.net",
  "appserviceplan": "myPlanApps",
  "location": "westeurope",
  "name": "frontendApps",
  "os": "Linux",
  "resourcegroup": "myAuthResourceGroupApps",
  "runtime_version": "NODE|16-lts",
  "runtime_version_detected": "-",
  "sku": "FREE",
  "src_path": "//home//changeworld//js-e2e-web-app-easy-auth-app-to-app//frontend"
}
changeworld [ ~/js-e2e-web-app-easy-auth-app-to-app/frontend ]$ cd ../backend
changeworld [ ~/js-e2e-web-app-easy-auth-app-to-app/backend ]$ az webapp up --resource-group myAuthResourceGroupApps --name backendApps --plan myPlanApps --runtime "NODE:16-lts"
The webapp 'backendApps' doesn't exist
Creating AppServicePlan 'myPlanApps' or Updating if already exists
(InvalidResourceLocation) The resource 'myPlanApps' already exists in location 'westeurope' in resource group 'myAuthResourceGroupApps'. A resource with the same name cannot be created in location 'eastus'. Please select a new resource name.
Code: InvalidResourceLocation
Message: The resource 'myPlanApps' already exists in location 'westeurope' in resource group 'myAuthResourceGroupApps'. A resource with the same name cannot be created in location 'eastus'. Please select a new resource name.
```

Therefore, it is correct to change to the following command.
`az webapp up --resource-group myAuthResourceGroup --name <back-end-app-name> --plan myPlan --sku FREE --location "West Europe" --runtime "NODE:16-lts"`

```
changeworld [ ~/js-e2e-web-app-easy-auth-app-to-app/backend ]$ az webapp up --resource-group myAuthResourceGroupApps --name backendApps --plan myPlanApps --sku FREE --location "West Europe" --runtime "NODE:16-lts"
The webapp 'backendApps' doesn't exist
Creating AppServicePlan 'myPlanApps' or Updating if already exists
Creating webapp 'backendApps' ...
Configuring default logging for the app, if not already enabled
Creating zip with contents of dir /home/changeworld/js-e2e-web-app-easy-auth-app-to-app/backend ...
Getting scm site credentials for zip deployment
Starting zip deployment. This operation can take a while to complete ...
Deployment endpoint responded with status code 202
You can launch the app at http://backendapps.azurewebsites.net
Setting 'az webapp up' default arguments for current directory. Manage defaults with 'az configure --scope local'
--resource-group/-g default: myAuthResourceGroupApps
--sku default: FREE
--plan/-p default: myPlanApps
--location/-l default: westeurope
--name/-n default: backendApps
{
  "URL": "http://backendapps.azurewebsites.net",
  "appserviceplan": "myPlanApps",
  "location": "westeurope",
  "name": "backendApps",
  "os": "Linux",
  "resourcegroup": "myAuthResourceGroupApps",
  "runtime_version": "NODE|16-lts",
  "runtime_version_detected": "-",
  "sku": "FREE",
  "src_path": "//home//changeworld//js-e2e-web-app-easy-auth-app-to-app//backend"
}
changeworld [ ~/js-e2e-web-app-easy-auth-app-to-app/backend ]$ 