### PR TITLE
Update authorize-oauth-rest.md

### DIFF
--- a/articles/storage/files/authorize-oauth-rest.md
+++ b/articles/storage/files/authorize-oauth-rest.md
@@ -108,7 +108,7 @@ namespace FilesOAuthSample
             string aadEndpoint = "";
             string accountUri = "";
             string connectionString = "";
-            string shareName = "testShare";
+            string shareName = "test-share";
             string directoryName = "testDirectory";
             string fileName = "testFile"; 
 
@@ -124,11 +124,11 @@ namespace FilesOAuthSample
                     AuthorityHost = new Uri(aadEndpoint)
                 });
 
-            ShareClientOptions clientOptions = new ShareClientOptions(ShareClientOptions.ServiceVersion.V2021_12_02);
+            ShareClientOptions clientOptions = new ShareClientOptions(ShareClientOptions.ServiceVersion.V2023_05_03);
 
             // Set Allow Trailing Dot and Source Allow Trailing Dot.
             clientOptions.AllowTrailingDot = true;
-            clientOptions.SourceAllowTrailingDot = true;
+            clientOptions.AllowSourceTrailingDot = true;
 
             // x-ms-file-intent=backup will automatically be applied to all APIs
             // where it is required in derived clients.


### PR DESCRIPTION
- Update the service version in ShareClientOptions: The current service version in the example does not support the Bearer authentication scheme for files. Additionally, it does not support trailing dot headers. To address these limitations, update the Service Version to the latest available version.

- Correct the option name for trailing dots: The erroneous option 'SourceAllowTrailingDot' in the example should be replaced with the correct option name 'AllowSourceTrailingDot'. 
- Change the File Share variable name: The current file share name 'testShare' is not in compliance with the naming conventions, which only allow lowercase letters. Change the share name to 'test-share' to adhere to these conventions.