### PR TITLE
Update configure-customer-managed-key.md

### DIFF
--- a/articles/service-bus-messaging/configure-customer-managed-key.md
+++ b/articles/service-bus-messaging/configure-customer-managed-key.md
@@ -77,7 +77,7 @@ After you enable customer-managed keys, you need to associate the customer manag
     >     * [Set up the access policy](../key-vault/general/assign-access-policy-portal.md) for the managed identity for the secondary namespace to the key vault.
     >     * Pair the primary and secondary namespaces.
     >    
-    >   * Once paired, the secondary namespace will use the key vault configured for the primary namespace. If the key vault for both namespaces are different before Geo-DR pairing, the user must delegate an access policy or RBAC role for the managed identity of the secondary namespace in the key vault associated with primary namespace.
+    >   * Once paired, the secondary namespace will use the key vault configured for the primary namespace. If the key vault for both namespaces is different before Geo-DR pairing, the user must delegate an access policy or RBAC role for the managed identity of the secondary namespace in the key vault associated with primary namespace.
 
 ## Managed identities
 There are two types of managed identities that you can assign to a Service Bus namespace.

--- a/articles/service-bus-messaging/configure-customer-managed-key.md
+++ b/articles/service-bus-messaging/configure-customer-managed-key.md
@@ -77,7 +77,7 @@ After you enable customer-managed keys, you need to associate the customer manag
     >     * [Set up the access policy](../key-vault/general/assign-access-policy-portal.md) for the managed identity for the secondary namespace to the key vault.
     >     * Pair the primary and secondary namespaces.
     >    
-    >   * Once paired, secondary namespace will use the key vault configured for primary namespace. If key vault for both namespaces are different before Geo-DR pairing, then user must delegate access policy or RBAC role for the managed identity of secondary namespace in the key vault associated with primary namespace.
+    >   * Once paired, the secondary namespace will use the key vault configured for the primary namespace. If the key vault for both namespaces are different before Geo-DR pairing, the user must delegate an access policy or RBAC role for the managed identity of the secondary namespace in the key vault associated with primary namespace.
 
 ## Managed identities
 There are two types of managed identities that you can assign to a Service Bus namespace.

--- a/articles/service-bus-messaging/configure-customer-managed-key.md
+++ b/articles/service-bus-messaging/configure-customer-managed-key.md
@@ -76,6 +76,8 @@ After you enable customer-managed keys, you need to associate the customer manag
     >   * If you are looking to enable Geo-DR on a Service Bus namespace where customer managed key is already set up, then -
     >     * [Set up the access policy](../key-vault/general/assign-access-policy-portal.md) for the managed identity for the secondary namespace to the key vault.
     >     * Pair the primary and secondary namespaces.
+    >    
+    >   * Once paired, secondary namespace will use the key vault configured for primary namespace. If key vault for both namespaces are different before Geo-DR pairing, then user must delegate access policy or RBAC role for the managed identity of secondary namespace in the key vault associated with primary namespace.
 
 ## Managed identities
 There are two types of managed identities that you can assign to a Service Bus namespace.


### PR DESCRIPTION
Geo DR and CMK destination:

As Geo-DR in ServiceBus copies the CMK destination for primary to secondary namespace, so if a user has two different KeyVault for primary and secondary before pairing and delegate roles seperately, then user will face unauthorization error.

To make it more clear, adding it as a note. 