### PR TITLE
Update create-pool-extensions.md example to use Azure Linux

### DIFF
--- a/articles/batch/create-pool-extensions.md
+++ b/articles/batch/create-pool-extensions.md
@@ -61,12 +61,12 @@ Request Body
         "deploymentConfiguration": {
             "virtualMachineConfiguration": {
                 "imageReference": {
-                    "publisher": "almalinux",
-                    "offer": "almalinux",
-                    "sku": "9-gen1",
+                    "publisher": "microsoftcblmariner",
+                    "offer": "cbl-mariner",
+                    "sku": "cbl-mariner-2",
                     "version": "latest"
                 },
-                "nodeAgentSkuId": "batch.node.el 9",
+                "nodeAgentSkuId": "batch.node.mariner 2.0",
                 "extensions": [
                     {
                         "name": "secretext",


### PR DESCRIPTION
The current example uses Alma Linux as an example for the Azure Key Vault VM Extension. This extension only support Ubuntu or Azure Linux (Mariner). This change updates the code example to use Azure Linux.