### PR TITLE
Escape $ to avoid unintentional special formatting

### DIFF
--- a/articles/service-bus-messaging/service-bus-faq.yml
+++ b/articles/service-bus-messaging/service-bus-faq.yml
@@ -149,13 +149,13 @@ sections:
           No. Service Bus doesn't charge for storage. However, there's a quota limiting the maximum amount of data that can be persisted per queue/topic. See the next FAQ.
 
       - question: |
-          I have a Service Bus Standard namespace. Why do I see charges under resource group '$system'?
+          I have a Service Bus Standard namespace. Why do I see charges under resource group '\$system'?
         answer: |
-          Azure Service Bus recently upgraded the billing components. Because of this change, if you have a Service Bus Standard namespace, you may see line items for the resource '/subscriptions/<azure_subscription_id>/resourceGroups/$system/providers/Microsoft.ServiceBus/namespaces/$system' under resource group '$system'.
+          Azure Service Bus recently upgraded the billing components. Because of this change, if you have a Service Bus Standard namespace, you may see line items for the resource '/subscriptions/<azure_subscription_id>/resourceGroups/\$system/providers/Microsoft.ServiceBus/namespaces/\$system' under resource group '\$system'.
           
           These charges represent the base charge per Azure subscription that has provisioned a Service Bus Standard namespace. 
           
-          It's important to note that these charges aren't new, that is, they existed in the previous billing model too. The only change is that they're now listed under '$system'. It's done because of constraints in the new billing system that groups subscription level charges, not tied to a specific resource, under the '$system' resource ID.
+          It's important to note that these charges aren't new, that is, they existed in the previous billing model too. The only change is that they're now listed under '\$system'. It's done because of constraints in the new billing system that groups subscription level charges, not tied to a specific resource, under the '\$system' resource ID.
           
           ## Quotas
 


### PR DESCRIPTION
It turns out the `$` character is parsed as the delimiter for special formatting which makes the text italic, and also changes the font (I think).

This is not the desired behaviour when trying to quote the resource group named $system.

See the following example of this unintentional formatting.
![Screenshot of unintentional formatting](https://github.com/MicrosoftDocs/azure-docs/assets/7239065/75699ccc-60cb-4807-adda-861a8039e783)
