### PR TITLE
Added details to embedding code

### DIFF
--- a/articles/ai-services/openai/how-to/migration.md
+++ b/articles/ai-services/openai/how-to/migration.md
@@ -196,7 +196,7 @@ client = AzureOpenAI(
 
 response = client.embeddings.create(
     input = "Your text string goes here",
-    model= "text-embedding-ada-002"
+    model= "text-embedding-ada-002"  # model = "deployment_name".
 )
 
 print(response.model_dump_json(indent=2))


### PR DESCRIPTION
Added a comment regarding the model used in the embedding code. From the way it was written, it seems that the model should be used (e.g. "text-embedding-ada-002") instead the model name that the user gives to the deployed model should be used.