### PR TITLE
set retry limit to 0

### DIFF
--- a/articles/container-apps/tutorial-ci-cd-runners-jobs.md
+++ b/articles/container-apps/tutorial-ci-cd-runners-jobs.md
@@ -415,7 +415,7 @@ You can now create a job that uses to use the container image. In this section, 
     az containerapp job create -n "$JOB_NAME" -g "$RESOURCE_GROUP" --environment "$ENVIRONMENT" `
         --trigger-type Event `
         --replica-timeout 1800 `
-        --replica-retry-limit 1 `
+        --replica-retry-limit 0 `
         --replica-completion-count 1 `
         --parallelism 1 `
         --image "$CONTAINER_REGISTRY_NAME.azurecr.io/$CONTAINER_IMAGE_NAME" `
@@ -695,7 +695,7 @@ You can run a manual job to register an offline placeholder agent. The job runs 
     az containerapp job create -n "$PLACEHOLDER_JOB_NAME" -g "$RESOURCE_GROUP" --environment "$ENVIRONMENT" \
         --trigger-type Manual \
         --replica-timeout 300 \
-        --replica-retry-limit 1 \
+        --replica-retry-limit 0 \
         --replica-completion-count 1 \
         --parallelism 1 \
         --image "$CONTAINER_REGISTRY_NAME.azurecr.io/$CONTAINER_IMAGE_NAME" \


### PR DESCRIPTION
No need of retry as the different execution replica would create agent with different name. There is no way to continue a pipeline job with different agent. Having the retry option can lead to registering agents that would not be needed at that point and can timeout during execution on later basis.