### PR TITLE
Add Tunnelmole as an open source tunnelling option

### DIFF
--- a/articles/search/cognitive-search-how-to-debug-skillset.md
+++ b/articles/search/cognitive-search-how-to-debug-skillset.md
@@ -159,17 +159,17 @@ Custom skills can be more challenging to debug because the code runs externally,
 Tunnelmole is an open source tunneling tool that can create a public URL that forwards requests to your local machine through a tunnel.
 
 1. Install Tunnelmole:
-  - npm:  `npm install -g tunnelmole`
-  - Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
-  - Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
-  - Windows: Install by using npm. Or if you don't have NodeJS installed, download the [precompiled .exe file for Windows](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
+   - npm:  `npm install -g tunnelmole`
+   - Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
+   - Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
+   - Windows: Install by using npm. Or if you don't have NodeJS installed, download the [precompiled .exe file for Windows](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
 
 2. Run this command to create a new tunnel:
-  ```console
-  ➜  ~ tmole 7071
-  http://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
-  https://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
-  ```
+   ```console
+   ➜  ~ tmole 7071
+   http://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
+   https://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
+   ```
 
 In the preceding example, `https://m5hdpb-ip-49-183-170-144.tunnelmole.net` forwards to port `7071` on your local machine, which is the default port where Azure functions are exposed.
 

--- a/articles/search/cognitive-search-how-to-debug-skillset.md
+++ b/articles/search/cognitive-search-how-to-debug-skillset.md
@@ -151,20 +151,20 @@ If skills produce output but the search index is empty, check the field mappings
 
 ## Debug a custom skill locally
 
-Custom skills can be more challenging to debug because the code runs externally, so the debug session can't be used to debug them. This section describes how to locally debug your Custom Web API skill, debug session, Visual Studio Code and [ngrok](https://ngrok.com/docs). This technique works with custom skills that execute in [Azure Functions](../azure-functions/functions-overview.md) or any other Web Framework that runs locally (for example, [FastAPI](https://fastapi.tiangolo.com/)).
+Custom skills can be more challenging to debug because the code runs externally, so the debug session can't be used to debug them. This section describes how to locally debug your Custom Web API skill, debug session, Visual Studio Code and [ngrok](https://ngrok.com/docs) or [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client). This technique works with custom skills that execute in [Azure Functions](../azure-functions/functions-overview.md) or any other Web Framework that runs locally (for example, [FastAPI](https://fastapi.tiangolo.com/)).
 
-### Get a Public URL
+### Get a public URL
 
 #### Using Tunnelmole
-Tunnelmole is an open source tunneling tool that can create a Public URL that forwards to your local machine through a tunnel.
+Tunnelmole is an open source tunneling tool that can create a public URL that forwards requests to your local machine through a tunnel.
 
-1. Install Tunnelmole
+1. Install Tunnelmole:
 - NPM:  `npm install -g tunnelmole`
 - Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
 - Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
 - Windows: Install with NPM, or if you don't have NodeJS installed, download the precompiled `exe` file for Windows [here](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
 
-2. Then run this command to create a new tunnel
+2. Then run this command to create a new tunnel:
 ```console
 ➜  ~ tmole 7071
 http://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071

--- a/articles/search/cognitive-search-how-to-debug-skillset.md
+++ b/articles/search/cognitive-search-how-to-debug-skillset.md
@@ -159,19 +159,19 @@ Custom skills can be more challenging to debug because the code runs externally,
 Tunnelmole is an open source tunneling tool that can create a public URL that forwards requests to your local machine through a tunnel.
 
 1. Install Tunnelmole:
-- NPM:  `npm install -g tunnelmole`
-- Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
-- Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
-- Windows: Install with NPM, or if you don't have NodeJS installed, download the precompiled `exe` file for Windows [here](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
+  - npm:  `npm install -g tunnelmole`
+  - Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
+  - Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
+  - Windows: Install by using npm. Or if you don't have NodeJS installed, download the [precompiled .exe file for Windows](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
 
-2. Then run this command to create a new tunnel:
-```console
-➜  ~ tmole 7071
-http://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
-https://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
-```
+2. Run this command to create a new tunnel:
+  ```console
+  ➜  ~ tmole 7071
+  http://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
+  https://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
+  ```
 
-In the above example, `https://m5hdpb-ip-49-183-170-144.tunnelmole.net` forwards to port `7071` on your local machine, which is the default port Azure functions are exposed on.
+In the preceding example, `https://m5hdpb-ip-49-183-170-144.tunnelmole.net` forwards to port `7071` on your local machine, which is the default port where Azure functions are exposed.
 
 #### Using ngrok
 
@@ -196,7 +196,7 @@ In the above example, `https://m5hdpb-ip-49-183-170-144.tunnelmole.net` forwards
 
 ### Configure in Azure portal
 
-Within the debug session, modify your Custom Web API Skill URI to call the tunnelmole or ngrok forwarding URL. Ensure that you append "/api/FunctionName" when using Azure Function for executing the skillset code.
+Within the debug session, modify your Custom Web API Skill URI to call the Tunnelmole or ngrok forwarding URL. Ensure that you append "/api/FunctionName" when using Azure Function for executing the skillset code.
 
 You can edit the skill definition in the portal.
 

--- a/articles/search/cognitive-search-how-to-debug-skillset.md
+++ b/articles/search/cognitive-search-how-to-debug-skillset.md
@@ -153,15 +153,35 @@ If skills produce output but the search index is empty, check the field mappings
 
 Custom skills can be more challenging to debug because the code runs externally, so the debug session can't be used to debug them. This section describes how to locally debug your Custom Web API skill, debug session, Visual Studio Code and [ngrok](https://ngrok.com/docs). This technique works with custom skills that execute in [Azure Functions](../azure-functions/functions-overview.md) or any other Web Framework that runs locally (for example, [FastAPI](https://fastapi.tiangolo.com/)).
 
-### Run ngrok
+### Get a Public URL
 
-[**ngrok**](https://ngrok.com/docs) is a cross-platform application that can create a tunneling or forwarding URL, so that internet requests reach your local machine. Use ngrok to forward requests from an enrichment pipeline in your search service to your machine to allow local debugging.
+#### Using Tunnelmole
+Tunnelmole is an open source tunneling tool that can create a Public URL that forwards to your local machine through a tunnel.
+
+1. Install Tunnelmole
+- NPM:  `npm install -g tunnelmole`
+- Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
+- Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
+- Windows: Install with NPM, or if you don't have NodeJS installed, download the precompiled `exe` file for Windows [here](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
+
+2. Then run this command to create a new tunnel
+```console
+➜  ~ tmole 7071
+http://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
+https://m5hdpb-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:7071
+```
+
+In the above example, `https://m5hdpb-ip-49-183-170-144.tunnelmole.net` forwards to port `7071` on your local machine, which is the default port Azure functions are exposed on.
+
+#### Using ngrok
+
+[**ngrok**](https://ngrok.com/docs) is a popular, closed source, cross-platform application that can create a tunneling or forwarding URL, so that internet requests reach your local machine. Use ngrok to forward requests from an enrichment pipeline in your search service to your machine to allow local debugging.
 
 1. Install ngrok.
 
-1. Open a terminal and go to the folder with the ngrok executable.
+2. Open a terminal and go to the folder with the ngrok executable.
 
-1. Run ngrok with the following command to create a new tunnel:
+3. Run ngrok with the following command to create a new tunnel:
 
     ```console
     ngrok http 7071 
@@ -170,13 +190,13 @@ Custom skills can be more challenging to debug because the code runs externally,
     > [!NOTE]
     > By default, Azure functions are exposed on 7071. Other tools and configurations might require that you provide a different port.
 
-1. When ngrok starts, copy and save the public forwarding URL for the next step. The forwarding URL is randomly generated.
+4. When ngrok starts, copy and save the public forwarding URL for the next step. The forwarding URL is randomly generated.
 
    :::image type="content" source="media/cognitive-search-debug/ngrok.png" alt-text="Screenshot of ngrok terminal." border="false":::
 
 ### Configure in Azure portal
 
-Within the debug session, modify your Custom Web API Skill URI to call the ngrok forwarding URL. Ensure that you append "/api/FunctionName" when using Azure Function for executing the skillset code.
+Within the debug session, modify your Custom Web API Skill URI to call the tunnelmole or ngrok forwarding URL. Ensure that you append "/api/FunctionName" when using Azure Function for executing the skillset code.
 
 You can edit the skill definition in the portal.
 


### PR DESCRIPTION
This PR adds [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) as a tunneling option.

Tunnelmole is a FOSS tunneling solution with a growing community. It can be self hosted with the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service) or users can use the hosted service, which is the default. Both the client and service are open source.

Example:
```
➜  ~ tmole 8000
http://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
https://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
```