### PR TITLE
Typo "a _Azure AI services_"→"an _Azure AI services_"

### DIFF
--- a/articles/ai-services/LUIS/luis-container-howto.md
+++ b/articles/ai-services/LUIS/luis-container-howto.md
@@ -391,7 +391,7 @@ If you run the container with an output [mount](luis-container-configuration.md#
 
 ## Billing
 
-The LUIS container sends billing information to Azure, using a _Azure AI services_ resource on your Azure account.
+The LUIS container sends billing information to Azure, using an _Azure AI services_ resource on your Azure account.
 
 [!INCLUDE [Container's Billing Settings](../../../includes/cognitive-services-containers-how-to-billing-info.md)]
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/ai-services/luis/luis-container-howto?tabs=v3 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/ai-services/LUIS/luis-container-howto.md 
#PingMSFTDocs