### PR TITLE
Typo "a [Azure AI Search custom skill]"→"an [Azure AI Search～"

### DIFF
--- a/articles/search/vector-search-how-to-chunk-documents.md
+++ b/articles/search/vector-search-how-to-chunk-documents.md
@@ -119,7 +119,7 @@ mountains. /n You can both ski in winter and swim in summer.
 
 ## Try it out: Chunking and vector embedding generation sample
 
-A [fixed-sized chunking and embedding generation sample](https://github.com/Azure-Samples/azure-search-power-skills/blob/main/Vector/EmbeddingGenerator/README.md) demonstrates both chunking and vector embedding generation using [Azure OpenAI](/azure/ai-services/openai/) embedding models. This sample uses a [Azure AI Search custom skill](cognitive-search-custom-skill-web-api.md) in the [Power Skills repo](https://github.com/Azure-Samples/azure-search-power-skills/tree/main#readme) to wrap the chunking step.
+A [fixed-sized chunking and embedding generation sample](https://github.com/Azure-Samples/azure-search-power-skills/blob/main/Vector/EmbeddingGenerator/README.md) demonstrates both chunking and vector embedding generation using [Azure OpenAI](/azure/ai-services/openai/) embedding models. This sample uses an [Azure AI Search custom skill](cognitive-search-custom-skill-web-api.md) in the [Power Skills repo](https://github.com/Azure-Samples/azure-search-power-skills/tree/main#readme) to wrap the chunking step.
 
 This sample is built on LangChain, Azure OpenAI, and Azure AI Search.
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/search/vector-search-how-to-chunk-documents 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/search/vector-search-how-to-chunk-documents.md 
#PingMSFTDocs