### PR TITLE
Typo "a _Azure AI services_"→"an _Azure AI services_"

### DIFF
--- a/articles/ai-services/computer-vision/computer-vision-resource-container-config.md
+++ b/articles/ai-services/computer-vision/computer-vision-resource-container-config.md
@@ -54,7 +54,7 @@ This setting can be found in the following place:
 
 ## Billing configuration setting
 
-The `Billing` setting specifies the endpoint URI of the _Azure AI services_ resource on Azure used to meter billing information for the container. You must specify a value for this configuration setting, and the value must be a valid endpoint URI for a _Azure AI services_ resource on Azure. The container reports usage about every 10 to 15 minutes.
+The `Billing` setting specifies the endpoint URI of the _Azure AI services_ resource on Azure used to meter billing information for the container. You must specify a value for this configuration setting, and the value must be a valid endpoint URI for an _Azure AI services_ resource on Azure. The container reports usage about every 10 to 15 minutes.
 
 This setting can be found in the following place:
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/ai-services/computer-vision/computer-vision-resource-container-config?tabs=version-3-2 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/ai-services/computer-vision/computer-vision-resource-container-config.md 
#PingMSFTDocs