### PR TITLE
Add note for resource provider

### DIFF
--- a/articles/ai-services/cognitive-services-virtual-networks.md
+++ b/articles/ai-services/cognitive-services-virtual-networks.md
@@ -169,7 +169,7 @@ You can manage default network access rules for Azure AI services resources thro
 
 ## Grant access from a virtual network
 
-You can configure Azure AI services resources to allow access from specific subnets only. The allowed subnets might belong to a virtual network in the same subscription or in a different subscription. The other subscription can belong to a different Microsoft Entra tenant.
+You can configure Azure AI services resources to allow access from specific subnets only. The allowed subnets might belong to a virtual network in the same subscription or in a different subscription. The other subscription can belong to a different Microsoft Entra tenant. When the subnet belongs to a different subscription, Microsoft.CognitiveServices resource provider needs to be also registered for that subscription.
 
 Enable a *service endpoint* for Azure AI services within the virtual network. The service endpoint routes traffic from the virtual network through an optimal path to the Azure AI service. For more information, see [Virtual Network service endpoints](../virtual-network/virtual-network-service-endpoints-overview.md).
 

--- a/articles/ai-services/cognitive-services-virtual-networks.md
+++ b/articles/ai-services/cognitive-services-virtual-networks.md
@@ -169,7 +169,7 @@ You can manage default network access rules for Azure AI services resources thro
 
 ## Grant access from a virtual network
 
-You can configure Azure AI services resources to allow access from specific subnets only. The allowed subnets might belong to a virtual network in the same subscription or in a different subscription. The other subscription can belong to a different Microsoft Entra tenant. When the subnet belongs to a different subscription, Microsoft.CognitiveServices resource provider needs to be also registered for that subscription.
+You can configure Azure AI services resources to allow access from specific subnets only. The allowed subnets might belong to a virtual network in the same subscription or in a different subscription. The other subscription can belong to a different Microsoft Entra tenant. When the subnet belongs to a different subscription, the Microsoft.CognitiveServices resource provider needs to be also registered for that subscription.
 
 Enable a *service endpoint* for Azure AI services within the virtual network. The service endpoint routes traffic from the virtual network through an optimal path to the Azure AI service. For more information, see [Virtual Network service endpoints](../virtual-network/virtual-network-service-endpoints-overview.md).
 


### PR DESCRIPTION
Add note for the case that allowed subnet belongs to a different subscription. In this case, users need to register Microsoft.CognitiveServices for the other subscirption too.