### PR TITLE
Update documentation about integrating KEDA with managed prometheus

### DIFF
--- a/articles/azure-monitor/containers/integrate-keda.md
+++ b/articles/azure-monitor/containers/integrate-keda.md
@@ -29,7 +29,7 @@ This article walks you through the steps to integrate KEDA into your AKS cluster
 
 + Azure Kubernetes Service (AKS) cluster
 + Prometheus sending metrics to an Azure Monitor workspace. For more information, see [Azure Monitor managed service for Prometheus](../essentials/prometheus-metrics-overview.md).
-+ Microsoft Entra Workload ID, see [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/).
++ Microsoft Entra Workload ID. For more information, see [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/).
 
 ## Set up a workload identity
 

--- a/articles/azure-monitor/containers/integrate-keda.md
+++ b/articles/azure-monitor/containers/integrate-keda.md
@@ -29,7 +29,7 @@ This article walks you through the steps to integrate KEDA into your AKS cluster
 
 + Azure Kubernetes Service (AKS) cluster
 + Prometheus sending metrics to an Azure Monitor workspace. For more information, see [Azure Monitor managed service for Prometheus](../essentials/prometheus-metrics-overview.md).
-
++ Microsoft Entra Workload ID, see [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/).
 
 ## Set up a workload identity
 


### PR DESCRIPTION
Current documentation doesn't clarify that Azure Workload Identity Webhook has to be already deployed in cluster or the example doesn't work. This requirement is obvious for power users but it can be confusing for newcomers.

Fixes https://github.com/MicrosoftDocs/azure-docs/issues/117442