### PR TITLE
Added example for specifying how @allowed is implemented with union values

### DIFF
--- a/articles/azure-resource-manager/bicep/user-defined-data-types.md
+++ b/articles/azure-resource-manager/bicep/user-defined-data-types.md
@@ -92,6 +92,14 @@ The valid type expressions include:
     }
     ```
 
+    As `@allowed` isn't a valid decorator on user-defined types, the set of allowed values is specified using a union syntax on the same line as the key. The type is not necessary as it is inferred from the provided values.
+
+    ```bicep
+    type obj = {
+      level: ('bronze' | 'silver' | 'gold')
+    }
+    ```
+
     **Recursion**
 
     Object types may use direct or indirect recursion so long as at least leg of the path to the recursion point is optional. For example, the `myObjectType` definition in the following example is valid because the directly recursive `recursiveProp` property is optional:

--- a/articles/azure-resource-manager/bicep/user-defined-data-types.md
+++ b/articles/azure-resource-manager/bicep/user-defined-data-types.md
@@ -96,7 +96,7 @@ The valid type expressions include:
 
     ```bicep
     type obj = {
-      level: ('bronze' | 'silver' | 'gold')
+      level: 'bronze' | 'silver' | 'gold'
     }
     ```
 


### PR DESCRIPTION
Per the discussion in the [Bicep repo](https://github.com/Azure/bicep/issues/9395), user-defined types do not use the `@allowed` decorator and instead opt to use a union-style approach. As these aren't otherwise documented and it's a bit tougher finding this issue in the GitHub docs, I saw fit to add a little example here so I and others can quickly understand the intended and supported syntax.