### PR TITLE
Add info: Docker Webhook not supported for Functions Elastic Premium Plan

### DIFF
--- a/articles/azure-functions/functions-how-to-custom-container.md
+++ b/articles/azure-functions/functions-how-to-custom-container.md
@@ -195,6 +195,7 @@ Azure Functions lets you work with application settings for containerized functi
 ## Enable continuous deployment to Azure
 
 You can enable Azure Functions to automatically update your deployment of an image whenever you update the image in the registry.
+> Note: Continuous Deployment from an image registery is currently not supported for Functions Elastic Premium plan.
 
 1. Use the following command to enable continuous deployment and to get the webhook URL:
 

--- a/articles/azure-functions/functions-how-to-custom-container.md
+++ b/articles/azure-functions/functions-how-to-custom-container.md
@@ -195,7 +195,7 @@ Azure Functions lets you work with application settings for containerized functi
 ## Enable continuous deployment to Azure
 
 > [!IMPORTANT]
-> Webhook-based deployment isn't currently supported when running your container in an [Elastic Premium plan](functions-premium.md). If you need to use the continuous deployment method described in this section, instead deploy your container in an [App Service plan](dedicated-plan.md). When running in an Elastic Premium plan, you need to manually restart your app whenever you make updates to your container in the repository.
+> Webhook-based deployment isn't currently supported when running your container in an [Elastic Premium plan](functions-premium-plan.md). If you need to use the continuous deployment method described in this section, instead deploy your container in an [App Service plan](dedicated-plan.md). When running in an Elastic Premium plan, you need to manually restart your app whenever you make updates to your container in the repository.
 
 You can enable Azure Functions to automatically update your deployment of an image whenever you update the image in the registry.
 

--- a/articles/azure-functions/functions-how-to-custom-container.md
+++ b/articles/azure-functions/functions-how-to-custom-container.md
@@ -194,8 +194,10 @@ Azure Functions lets you work with application settings for containerized functi
 :::zone pivot="azure-functions"
 ## Enable continuous deployment to Azure
 
+> [!IMPORTANT]
+> Webhook-based deployment isn't currently supported when running your container in an [Elastic Premium plan](functions-premium.md). If you need to use the continuous deployment method described in this section, instead deploy your container in an [App Service plan](dedicated-plan.md). When running in an Elastic Premium plan, you need to manually restart your app whenever you make updates to your container in the repository.
+
 You can enable Azure Functions to automatically update your deployment of an image whenever you update the image in the registry.
-> Note: Continuous Deployment from an image registry is currently not supported for Elastic Premium plan.
 
 1. Use the following command to enable continuous deployment and to get the webhook URL:
 

--- a/articles/azure-functions/functions-how-to-custom-container.md
+++ b/articles/azure-functions/functions-how-to-custom-container.md
@@ -195,7 +195,7 @@ Azure Functions lets you work with application settings for containerized functi
 ## Enable continuous deployment to Azure
 
 You can enable Azure Functions to automatically update your deployment of an image whenever you update the image in the registry.
-> Note: Continuous Deployment from an image registery is currently not supported for Functions Elastic Premium plan.
+> Note: Continuous Deployment from an image registry is currently not supported for Functions Elastic Premium plan.
 
 1. Use the following command to enable continuous deployment and to get the webhook URL:
 

--- a/articles/azure-functions/functions-how-to-custom-container.md
+++ b/articles/azure-functions/functions-how-to-custom-container.md
@@ -195,7 +195,7 @@ Azure Functions lets you work with application settings for containerized functi
 ## Enable continuous deployment to Azure
 
 You can enable Azure Functions to automatically update your deployment of an image whenever you update the image in the registry.
-> Note: Continuous Deployment from an image registry is currently not supported for Functions Elastic Premium plan.
+> Note: Continuous Deployment from an image registry is currently not supported for Elastic Premium plan.
 
 1. Use the following command to enable continuous deployment and to get the webhook URL:
 


### PR DESCRIPTION
Currently the CD mechanism using docker webhook is unsupported for function apps using Elastic Premium plan. Adding a note to the docs for this exclusion 