### PR TITLE
Fixes request example spelling error

### DIFF
--- a/articles/healthcare-apis/dicom/export-files.md
+++ b/articles/healthcare-apis/dicom/export-files.md
@@ -120,7 +120,7 @@ POST /export HTTP/1.1
 Accept: */*
 Content-Type: application/json
 {
-    "sources": {
+    "source": {
         "type": "identifiers",
         "settings": {
             "values": [


### PR DESCRIPTION
The key "source" was misspelled as "sources", making the request invalid. The correct key is "source" as presented in previous example in the same page.