### PR TITLE
Indentation correction - prometheus-sidecar-remote-write-managed-identity-yaml.md

### DIFF
--- a/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
+++ b/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
@@ -1,7 +1,7 @@
 prometheus:
   prometheusSpec:
     externalLabels:
-          cluster: <AKS-CLUSTER-NAME>
+          cluster: AKS-CLUSTER-NAME
 
     ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write    
     remoteWrite:

--- a/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
+++ b/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
@@ -2,7 +2,7 @@
 prometheus:
   prometheusSpec:
     externalLabels:
-          cluster: AKS-CLUSTER-NAME
+          cluster: <AKS-CLUSTER-NAME>
 
     ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write    
     remoteWrite:

--- a/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
+++ b/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
@@ -1,26 +1,16 @@
----
-author: EdB-MSFT
-ms.author: edbaynash
-ms.service: azure-monitor
-ms.topic: include
-ms.date: 11/12/2023
----
-
-```yml
 prometheus:
   prometheusSpec:
     externalLabels:
-      cluster: <AKS-CLUSTER-NAME>
+          cluster: <AKS-CLUSTER-NAME>
 
-  ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write    
-  remoteWrite:
-  - url: 'http://localhost:8081/api/v1/write'
-  
+    ## https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write    
+    remoteWrite:
+    - url: 'http://localhost:8081/api/v1/write'
   ## Azure Managed Prometheus currently exports some default mixins in Grafana. 
   ## These mixins are compatible with Azure Monitor agent on your Azure Kubernetes Service cluster. 
   ## However, these mixins aren't compatible with Prometheus metrics scraped by the Kube Prometheus stack. 
   ## In order to make these mixins compatible, uncomment remote write relabel configuration below:
-  
+
   ## writeRelabelConfigs:
   ##   - sourceLabels: [metrics_path]
   ##     regex: /metrics/cadvisor
@@ -32,36 +22,34 @@ prometheus:
   ##     targetLabel: job
   ##     replacement: node
   ##     action: replace
-  
-  containers:
-  - name: prom-remotewrite
-    image: <CONTAINER-IMAGE-VERSION>
-    imagePullPolicy: Always
-    ports:
-    - name: rw-port
-      containerPort: 8081
-    livenessProbe:
-      httpGet:
-        path: /health
-        port: rw-port
+    containers:
+    - name: prom-remotewrite
+      image: <CONTAINER-IMAGE-VERSION>
+      imagePullPolicy: Always
+      ports:
+        - name: rw-port
+          containerPort: 8081
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: rw-port
         initialDelaySeconds: 10
         timeoutSeconds: 10
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: rw-port
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: rw-port
         initialDelaySeconds: 10
         timeoutSeconds: 10
-    env:
-    - name: INGESTION_URL
-      value: <INGESTION_URL>
-    - name: LISTENING_PORT
-      value: '8081'
-    - name: IDENTITY_TYPE
-      value: userAssigned
-    - name: AZURE_CLIENT_ID
-      value: <MANAGED-IDENTITY-CLIENT-ID>
+      env:
+      - name: INGESTION_URL
+        value: <INGESTION_URL>
+      - name: LISTENING_PORT
+        value: '8081'
+      - name: IDENTITY_TYPE
+        value: userAssigned
+      - name: AZURE_CLIENT_ID
+        value: <MANAGED-IDENTITY-CLIENT-ID>
       # Optional parameter
-    - name: CLUSTER
-      value: <CLUSTER-NAME>
-```
+      - name: CLUSTER
+        value: <CLUSTER-NAME>

--- a/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
+++ b/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
@@ -1,3 +1,4 @@
+```yml
 prometheus:
   prometheusSpec:
     externalLabels:
@@ -53,3 +54,4 @@ prometheus:
       # Optional parameter
       - name: CLUSTER
         value: <CLUSTER-NAME>
+```

--- a/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
+++ b/articles/azure-monitor/includes/prometheus-sidecar-remote-write-managed-identity-yaml.md
@@ -1,3 +1,10 @@
+author: EdB-MSFT
+ms.author: edbaynash
+ms.service: azure-monitor
+ms.topic: include
+ms.date: 11/12/2023
+---
+
 ```yml
 prometheus:
   prometheusSpec:


### PR DESCRIPTION
Ensured the self-managed Prometheus was correct created, and all pods are working well.

![prometheus-self](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/2a53cfb8-2489-499e-bdbc-afb004f2101a)
 
If I use this exactly yaml file "https://learn.microsoft.com/en-us/azure/azure-monitor/containers/prometheus-remote-write-managed-identity#deploy-side-car-and-configure-remote-write-on-the-prometheus-server", just copy all content and insert cluster information the pod is updated but the container “prom-remotewrite” is not created.
   
![pods](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/1f51c954-469c-4906-a65b-0f1b9b513fe5)

No error messages. Theoretically, the deployment was finished correctly.

![deployment](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/73dadf53-e00c-48d0-a36f-ff56b25fad0b)

Please follow the yaml sample with indentation corrections.
![correct](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/a9d88365-1a2f-49bd-b93d-a6e588885a5a)
