### PR TITLE
Add end quote to openai example

### DIFF
--- a/articles/ai-services/openai/how-to/switching-endpoints.md
+++ b/articles/ai-services/openai/how-to/switching-endpoints.md
@@ -123,7 +123,7 @@ OpenAI uses the `model` keyword argument to specify what model to use. Azure Ope
 ```python
 completion = client.completions.create(
     model='gpt-3.5-turbo-instruct',
-    prompt="<prompt>)
+    prompt="<prompt>")
 )
 
 chat_completion = client.chat.completions.create(


### PR DESCRIPTION
Without the end quote the syntax highlighting is off and hard to read. Also fixes copying this entire code chunk so user can just fill in the <prompt> string