### PR TITLE
Add ballerina to supported languages in azure functions

### DIFF
--- a/includes/functions-portal-language-support.md
+++ b/includes/functions-portal-language-support.md
@@ -21,6 +21,7 @@ The following table shows which languages supported by Functions can run on Linu
 | [Java](../articles/azure-functions/functions-reference-java.md) | Java |✓ |✓ | |
 | [PowerShell](../articles/azure-functions/functions-reference-powershell.md) |PowerShell Core |✓ |✓ |✓ |
 | [TypeScript](../articles/azure-functions/functions-reference-node.md?tabs=typescript) | Node.js |✓ |✓ |  |
+| [Ballerina](https://ballerina.io/learn/azure-functions/) | Java | |✓ |  |
 | [Go/Rust/other](../articles/azure-functions/functions-custom-handlers.md) | Custom Handlers |✓ |✓ | |
  
 For more information on operating system and language support, see [Operating system/runtime support](../articles/azure-functions/functions-scale.md#operating-systemruntime).


### PR DESCRIPTION
Hi all,
This PR is to $Subject to azure functions docs. We are in the process of adding ecosystem support for [Ballerina](https://ballerina.io/) [Azure functions](https://ballerina.io/learn/azure-functions/). Recently, we've worked with the vscode team to add [ballerina support for azure functions vscode](https://github.com/microsoft/vscode-azurefunctions/pull/3584) as well. 

In this PR I've only edited the supported languages section as I'm not very aware of azure docs practices. I've noticed in other supported languages, all the docs are hosted in azure docs itself. If theres such a convention where you only host docs   in azure docs, I'm happy to create those pages(or anything else) as well.

Can a maintainer please review this and request more changes if needed? We are more than happy to contribute =)

Todos -:
Support for Linux OS is being discussed in https://github.com/Azure/azure-functions-host/issues/9668

