### PR TITLE
Typo "a [Azure Machine Learning compute instance]"→"an [Azure～"

### DIFF
--- a/articles/machine-learning/how-to-setup-authentication.md
+++ b/articles/machine-learning/how-to-setup-authentication.md
@@ -35,7 +35,7 @@ Microsoft Entra Conditional Access can be used to further control or restrict ac
 ## Prerequisites
 
 * Create an [Azure Machine Learning workspace](how-to-manage-workspace.md).
-* [Configure your development environment](how-to-configure-environment.md) or use a [Azure Machine Learning compute instance](how-to-create-compute-instance.md) and install the [Azure Machine Learning SDK v2](https://aka.ms/sdk-v2-install).
+* [Configure your development environment](how-to-configure-environment.md) or use an [Azure Machine Learning compute instance](how-to-create-compute-instance.md) and install the [Azure Machine Learning SDK v2](https://aka.ms/sdk-v2-install).
 
 * Install the [Azure CLI](/cli/azure/install-azure-cli).
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/machine-learning/how-to-setup-authentication?view=azureml-api-2&tabs=sdk 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/machine-learning/how-to-setup-authentication.md 
#PingMSFTDocs