### PR TITLE
Update how-to-provision-single-device-linux-x509.md

### DIFF
--- a/articles/iot-edge/how-to-provision-single-device-linux-x509.md
+++ b/articles/iot-edge/how-to-provision-single-device-linux-x509.md
@@ -48,7 +48,6 @@ This article covers registering your IoT Edge device and installing IoT Edge on 
 
 <!-- Generate device identity certificates H2 and content -->
 [!INCLUDE [iot-edge-generate-device-identity-certs.md](includes/iot-edge-generate-device-identity-certs.md)]
-NOTE: When generating the device identity certificates, follow the steps for generating PRIMARY and SECONDARY certificates EVEN THOUGH the device is NOT downstream of a gateway device.
 
 <!-- Register your device and View provisioning information H2s and content -->
 [!INCLUDE [iot-edge-register-device-x509.md](includes/iot-edge-register-device-x509.md)]
@@ -94,10 +93,8 @@ Update the following fields:
 
 * **iothub_hostname**: Hostname of the IoT hub the device will connect to. For example, `{IoT hub name}.azure-devices.net`.
 * **device_id**: The ID that you provided when you registered the device.
-* **identity_cert**: URI to an identity certificate on the device, for example: `file:///path/identity_certificate.pem`. Or, dynamically issue the certificate using EST or a local certificate authority.
-* **identity_pk**: URI to the private key file for the provided identity certificate, for example: `file:///path/identity_key.pem`. Or, provide a PKCS#11 URI and then provide your configuration information in the **PKCS#11** section later in the config file.
-
-NOTE: Use the PRIMARY or SECONDARY certificate and key - NOT The device certificate generated in the certificate tutorial.
+* **identity_cert**: URI to one of the primary/secondary device certificates, for example: `file:///path/iot-device-<device ID>-primary.cert.pem`. Or, dynamically issue the certificate using EST or a local certificate authority.
+* **identity_pk**: URI to the private key file for the provided identity certificate, for example: `file:///path/iot-device-<device ID>-primary.key.pem`. Or, provide a PKCS#11 URI and then provide your configuration information in the **PKCS#11** section later in the config file.
 
 Save and close the file.
 

--- a/articles/iot-edge/how-to-provision-single-device-linux-x509.md
+++ b/articles/iot-edge/how-to-provision-single-device-linux-x509.md
@@ -48,6 +48,7 @@ This article covers registering your IoT Edge device and installing IoT Edge on 
 
 <!-- Generate device identity certificates H2 and content -->
 [!INCLUDE [iot-edge-generate-device-identity-certs.md](includes/iot-edge-generate-device-identity-certs.md)]
+NOTE: When generating the device identity certificates, follow the steps for generating PRIMARY and SECONDARY certificates EVEN THOUGH the device is NOT downstream of a gateway device.
 
 <!-- Register your device and View provisioning information H2s and content -->
 [!INCLUDE [iot-edge-register-device-x509.md](includes/iot-edge-register-device-x509.md)]
@@ -95,6 +96,8 @@ Update the following fields:
 * **device_id**: The ID that you provided when you registered the device.
 * **identity_cert**: URI to an identity certificate on the device, for example: `file:///path/identity_certificate.pem`. Or, dynamically issue the certificate using EST or a local certificate authority.
 * **identity_pk**: URI to the private key file for the provided identity certificate, for example: `file:///path/identity_key.pem`. Or, provide a PKCS#11 URI and then provide your configuration information in the **PKCS#11** section later in the config file.
+
+NOTE: Use the PRIMARY or SECONDARY certificate and key - NOT The device certificate generated in the certificate tutorial.
 
 Save and close the file.
 

--- a/articles/iot-edge/how-to-provision-single-device-linux-x509.md
+++ b/articles/iot-edge/how-to-provision-single-device-linux-x509.md
@@ -94,7 +94,7 @@ Update the following fields:
 * **iothub_hostname**: Hostname of the IoT hub the device will connect to. For example, `{IoT hub name}.azure-devices.net`.
 * **device_id**: The ID that you provided when you registered the device.
 * **identity_cert**: URI to one of the primary/secondary device certificates, for example: `file:///path/iot-device-<device ID>-primary.cert.pem`. Or, dynamically issue the certificate using EST or a local certificate authority.
-* **identity_pk**: URI to the private key file for the provided identity certificate, for example: `file:///path/iot-device-<device ID>-primary.key.pem`. Or, provide a PKCS#11 URI and then provide your configuration information in the **PKCS#11** section later in the config file.
+* **identity_pk**: URI to the private key file for the provided primary/secondary device certificate, for example: `file:///path/iot-device-<device ID>-primary.key.pem`. Or, provide a PKCS#11 URI and then provide your configuration information in the **PKCS#11** section later in the config file.
 
 Save and close the file.
 

--- a/articles/iot-edge/includes/iot-edge-generate-device-identity-certs.md
+++ b/articles/iot-edge/includes/iot-edge-generate-device-identity-certs.md
@@ -19,15 +19,15 @@ For more information about how the CA certificates are used in IoT Edge devices,
 
 You need the following files for manual provisioning with X.509:
 
-* Two of device identity certificates with their matching private key certificates in .cer or .pem formats.
+* Primary and secondary device certificates with their matching private key certificates in .cer or .pem formats.
 
   One set of certificate/key files is provided to the IoT Edge runtime. When you create device identity certificates, set the certificate common name (CN) with the device ID that you want the device to have in your IoT hub.
 
-* Thumbprints taken from both device identity certificates.
+* Thumbprints taken from both primary/secondary device certificates.
 
   Thumbprint values are 40-hex characters for SHA-1 hashes or 64-hex characters for SHA-256 hashes. Both thumbprints are provided to IoT Hub at the time of device registration.
 
-If you don't have certificates available, you can [Create demo certificates to test IoT Edge device features](../how-to-create-test-certificates.md). Follow the instructions in that article to set up certificate creation scripts, create a root CA certificate, and then create two IoT Edge device identity certificates.
+If you don't have certificates available, you can [Create demo certificates to test IoT Edge device features](../how-to-create-test-certificates.md). Follow the instructions in that article to set up certificate creation scripts, create a root CA certificate, and then create the primary/secondary identity certificates in the "Create downstream device certificates / Self-signed certificates" section.
 
 One way to retrieve the thumbprint from a certificate is with the following openssl command:
 


### PR DESCRIPTION
Fix documentation to make it more clear as to WHICH keys to generate and use when manually provisioning an IoT edge device with X509 self-signed certificates.