### PR TITLE
Update how-to-migrate-single-flexible-minimum-downtime.md

### DIFF
--- a/articles/mysql/migrate/how-to-migrate-single-flexible-minimum-downtime.md
+++ b/articles/mysql/migrate/how-to-migrate-single-flexible-minimum-downtime.md
@@ -157,7 +157,7 @@ To configure Data in replication, perform the following steps:
 
     - If SSL enforcement is enabled, then:
 
-        i. Download the certificate needed to communicate over SSL with your Azure Database for MySQL server from [here](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem).
+        i. Download the certificate needed to communicate over SSL with your Azure Database for MySQL server from [here](https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem).
 
         ii. Open the file in notepad and paste the contents to the section “PLACE YOUR PUBLIC KEY CERTIFICATE'S CONTEXT HERE“.
 


### PR DESCRIPTION
update old CA to newer CA link, because The migration from BaltimoreCyberTrustRoot to DigiCertGlobalRootG2 will be carried out across all regions of Azure starting October 2022 in phases.


https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-certificate-rotation#frequently-asked-questions