### PR TITLE
Typo with the container name

### DIFF
--- a/articles/aks/open-ai-quickstart.md
+++ b/articles/aks/open-ai-quickstart.md
@@ -210,7 +210,7 @@ Now that the application is deployed, you can deploy the Python-based microservi
           nodeSelector:
             "kubernetes.io/os": linux
           containers:
-          - name: order-service
+          - name: ai-service
             image: ghcr.io/azure-samples/aks-store-demo/ai-service:latest
             ports:
             - containerPort: 5001


### PR DESCRIPTION
Container name has a typo after some copy/paste. It's called "order-service" on this page, while on another page describing use of managed identity the same container name was correctly changed to "ai-service": https://learn.microsoft.com/en-us/azure/aks/open-ai-secure-access-quickstart.