### PR TITLE
Ca update mysql

### DIFF
--- a/articles/mysql/migrate/how-to-migrate-single-flexible-minimum-downtime.md
+++ b/articles/mysql/migrate/how-to-migrate-single-flexible-minimum-downtime.md
@@ -157,7 +157,7 @@ To configure Data in replication, perform the following steps:
 
     - If SSL enforcement is enabled, then:
 
-        i. Download the certificate needed to communicate over SSL with your Azure Database for MySQL server from [here](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem).
+        i. Download the certificate needed to communicate over SSL with your Azure Database for MySQL server from [here](https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem).
 
         ii. Open the file in notepad and paste the contents to the section “PLACE YOUR PUBLIC KEY CERTIFICATE'S CONTEXT HERE“.
 

--- a/articles/mysql/migrate/mysql-on-premises-azure-db/09-data-migration-with-mysql-workbench.md
+++ b/articles/mysql/migrate/mysql-on-premises-azure-db/09-data-migration-with-mysql-workbench.md
@@ -44,7 +44,7 @@ $serverName = "{SERVER\_NAME}";
 Get-AzMySqlConfiguration -ResourceGroupName $rgName -ServerName $serverName
 ```
 
-- To do the same with the mysql tool, download the [CA root certification](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem) to c:\\temp (make this directory).
+- To do the same with the mysql tool, download the [CA root certification](https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem) to c:\\temp (make this directory).
 
     > [!NOTE]
     > The certificate is subject to change. Reference [Configure SSL connectivity in your application to securely connect to Azure Database for MySQL](../../howto-configure-ssl.md) for the latest certificate information.

--- a/articles/mysql/single-server/concepts-ssl-connection-security.md
+++ b/articles/mysql/single-server/concepts-ssl-connection-security.md
@@ -34,9 +34,9 @@ When provisioning a new Azure Database for MySQL server through the Azure portal
 
 Connection strings for various programming languages are shown in the Azure portal. Those connection strings include the required SSL parameters to connect to your database. In the Azure portal, select your server. Under the **Settings** heading, select the **Connection strings**. The SSL parameter varies based on the connector, for example "ssl=true" or "sslmode=require" or "sslmode=required" and other variations.
 
-In some cases, applications require a local certificate file generated from a trusted Certificate Authority (CA) certificate file to connect securely. Currently customers can **only use** the predefined certificate to connect to an Azure Database for MySQL server, which is located at https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem. 
+In some cases, applications require a local certificate file generated from a trusted Certificate Authority (CA) certificate file to connect securely. Currently customers can **only use** the predefined certificate to connect to an Azure Database for MySQL server, which is located at https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem. 
 
-Similarly, the following links point to the certificates for servers in sovereign clouds: [Azure Government](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem), [Microsoft Azure operated by 21Vianet](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem), and [Azure Germany](https://www.d-trust.net/cgi-bin/D-TRUST_Root_Class_3_CA_2_2009.crt).
+Similarly, the following links point to the certificates for servers in sovereign clouds: [Azure Government](https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem), [Microsoft Azure operated by 21Vianet](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem), and [Azure Germany](https://www.d-trust.net/cgi-bin/D-TRUST_Root_Class_3_CA_2_2009.crt).
 
 To learn how to enable or disable SSL connection when developing application, refer to [How to configure SSL](how-to-configure-ssl.md).
 

--- a/articles/mysql/single-server/connect-nodejs.md
+++ b/articles/mysql/single-server/connect-nodejs.md
@@ -155,7 +155,7 @@ Get the connection information needed to connect to the Azure Database for MySQL
 
     **For Microsoft Internet Explorer and Microsoft Edge:** After the download has completed, rename the certificate to DigiCertGlobalRootCA.crt.pem.
 
-    See the following links for certificates for servers in sovereign clouds: [Azure Government](https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem), [Microsoft Azure operated by 21Vianet](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem), and [Azure Germany](https://www.d-trust.net/cgi-bin/D-TRUST_Root_Class_3_CA_2_2009.crt).
+    See the following links for certificates for servers in sovereign clouds: [Azure Government](https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem), [Microsoft Azure operated by 21Vianet](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem), and [Azure Germany](https://www.d-trust.net/cgi-bin/D-TRUST_Root_Class_3_CA_2_2009.crt).
 1. In the `ssl` config option, replace the `ca-cert` filename with the path to this local file.
 1. Open the command prompt or bash shell, and then change directory into your project folder `cd nodejsmysql`.
 1. To run the application, enter the node command followed by the file name, such as `node createtable.js`.


### PR DESCRIPTION
update old CA to newer CA link, because The migration from BaltimoreCyberTrustRoot to DigiCertGlobalRootG2 will be carried out across all regions of Azure starting October 2022 in phases.

https://learn.microsoft.com/en-us/azure/mysql/single-server/concepts-certificate-rotation#frequently-asked-questions