### PR TITLE
Durable functions - return value as string

### DIFF
--- a/articles/azure-functions/durable/quickstart-python-vscode.md
+++ b/articles/azure-functions/durable/quickstart-python-vscode.md
@@ -246,7 +246,7 @@ def hello_orchestrator(context):
 # Activity
 @myApp.activity_trigger(input_name="city")
 def hello(city: str):
-    return "Hello " + city   
+    return f"Hello {city}"
 ```
 
 Review the table below for an explanation of each function and its purpose in the sample.


### PR DESCRIPTION
If you use the `def hello`function in the fan in fan out example, you can have bugs because the return value is not a string.
Using an f-string forces the type to be a string.

This is also the case in the github samples
https://github.com/Azure/azure-functions-durable-python/blob/main/samples-v2/function_chaining/function_app.py#L25