### PR TITLE
Fix Intel OPL example in trusted-hardware-identity-management.md

### DIFF
--- a/articles/security/fundamentals/trusted-hardware-identity-management.md
+++ b/articles/security/fundamentals/trusted-hardware-identity-management.md
@@ -92,7 +92,7 @@ The following code snippet is from an example of an Intel QPL configuration file
                     "metadata": "true" 
                 }, 
                 "params": { 
-                    "api-version  ": "2021-07-22-preview" 
+                    "api-version": "2021-07-22-preview" 
                 } 
             } 
         } 


### PR DESCRIPTION
The example was not working properly due to the whitespaces in the header parameter.

```
aesm_service[11962]: [QCNL] Encountered CURL error: (3) URL using bad/illegal format or missing URL
```