### PR TITLE
Typo "a Azure region"→"an Azure region"

### DIFF
--- a/articles/machine-learning/how-to-share-models-pipelines-across-workspaces-with-registries.md
+++ b/articles/machine-learning/how-to-share-models-pipelines-across-workspaces-with-registries.md
@@ -338,7 +338,7 @@ jobs:
 The key aspect is that this pipeline is going to run in a workspace using a component that isn't in the specific workspace. The component is in a registry that can be used with any workspace in your organization. You can run this training job in any workspace you have access to without having worry about making the training code and environment available in that workspace. 
 
 > [!WARNING]
-> * Before running the pipeline job, confirm that the workspace in which you will run the job is in a Azure region that is supported by the registry in which you created the component.
+> * Before running the pipeline job, confirm that the workspace in which you will run the job is in an Azure region that is supported by the registry in which you created the component.
 > * Confirm that the workspace has a compute cluster with the name `cpu-cluster` or edit the `compute` field under `jobs.train_job.compute` with the name of your compute.
 
 Run the pipeline job with the `az ml job create` command.
@@ -387,7 +387,7 @@ print(pipeline_job)
 ```
 
 > [!WARNING]
-> * Confirm that the workspace in which you will run this job is in a Azure location that is supported by the registry in which you created the component before you run the pipeline job.
+> * Confirm that the workspace in which you will run this job is in an Azure location that is supported by the registry in which you created the component before you run the pipeline job.
 > * Confirm that the workspace has a compute cluster with the name `cpu-cluster` or update it `pipeline_job.settings.default_compute=<compute-cluster-name>`.
 
 Run the pipeline job and wait for it to complete. 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/machine-learning/how-to-share-models-pipelines-across-workspaces-with-registries?view=azureml-api-2&tabs=cli 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/machine-learning/how-to-share-models-pipelines-across-workspaces-with-registries.md 
#PingMSFTDocs