### PR TITLE
Removing \ in front of Issuer URL

### DIFF
--- a/articles/sentinel/connect-google-cloud-platform.md
+++ b/articles/sentinel/connect-google-cloud-platform.md
@@ -151,7 +151,7 @@ This section shows you how to set up the GCP environment manually. Alternatively
 
 1. To add a provider to the pool:
     - Select **OIDC** 
-    - Type the **Issuer (URL)**: https://sts.windows.net/33e01921-4d64-4f8c-a055-5bdaffd5e33d    
+    - Type the **Issuer (URL)**: `https://sts.windows.net/33e01921-4d64-4f8c-a055-5bdaffd5e33d`    
     - Next to **Audiences**, select **Allowed audiences**, and next to **Audience 1**, type: *api://2041288c-b303-4ca0-9076-9612db3beeb2*. 
 
         :::image type="content" source="media/connect-google-cloud-platform/gcp-add-provider-pool.png" alt-text="Screenshot of adding the provider to the pool when creating the GCP workload identity federation.":::

--- a/articles/sentinel/connect-google-cloud-platform.md
+++ b/articles/sentinel/connect-google-cloud-platform.md
@@ -151,7 +151,7 @@ This section shows you how to set up the GCP environment manually. Alternatively
 
 1. To add a provider to the pool:
     - Select **OIDC** 
-    - Type the **Issuer (URL)**: \https://sts.windows.net/33e01921-4d64-4f8c-a055-5bdaffd5e33d    
+    - Type the **Issuer (URL)**: https://sts.windows.net/33e01921-4d64-4f8c-a055-5bdaffd5e33d    
     - Next to **Audiences**, select **Allowed audiences**, and next to **Audience 1**, type: *api://2041288c-b303-4ca0-9076-9612db3beeb2*. 
 
         :::image type="content" source="media/connect-google-cloud-platform/gcp-add-provider-pool.png" alt-text="Screenshot of adding the provider to the pool when creating the GCP workload identity federation.":::


### PR DESCRIPTION
The \ seems to be mistakenly present in front of Issuer URL. The picture does not even show it