### PR TITLE
Synapse: Add note on limitation of usage of managed identity in notebooks

### DIFF
--- a/articles/synapse-analytics/synapse-service-identity.md
+++ b/articles/synapse-analytics/synapse-service-identity.md
@@ -315,7 +315,7 @@ You can easily execute Synapse Spark Notebooks with the system assigned managed 
 ![synapse-run-as-msi-3](https://user-images.githubusercontent.com/81656932/179053008-0f495b93-4948-48c8-9496-345c58187502.png)
 
 >[!NOTE]
->  Synapse notebooks and Spark job definitions only support the use of system assigned managed identity through linked services and the [mssparkutils APIs](spark/apache-spark-secure-credentials-with-tokenlibrary). MSAL and other authentication libraries cannot use the system assigned managed identity. You can instead generate a service principal and store the credentials in Key Vault.
+>  Synapse notebooks and Spark job definitions only support the use of system-assigned managed identity through linked services and the [mssparkutils APIs](./spark/apache-spark-secure-credentials-with-tokenlibrary.md). MSAL and other authentication libraries can't use the system-assigned managed identity. You can instead generate a service principal and store the credentials in Key Vault.
 
 ## User-assigned managed identity
 

--- a/articles/synapse-analytics/synapse-service-identity.md
+++ b/articles/synapse-analytics/synapse-service-identity.md
@@ -314,6 +314,9 @@ You can easily execute Synapse Spark Notebooks with the system assigned managed 
 
 ![synapse-run-as-msi-3](https://user-images.githubusercontent.com/81656932/179053008-0f495b93-4948-48c8-9496-345c58187502.png)
 
+>[!NOTE]
+>  Synapse notebooks and Spark job definitions only support the use of system assigned managed identity through linked services and the [mssparkutils APIs](spark/apache-spark-secure-credentials-with-tokenlibrary). MSAL and other authentication libraries cannot use the system assigned managed identity. You can instead generate a service principal and store the credentials in Key Vault.
+
 ## User-assigned managed identity
 
 You can create, delete, manage user-assigned managed identities in Microsoft Entra ID. For more details refer to [Create, list, delete, or assign a role to a user-assigned managed identity using the Azure portal](../active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal.md). 


### PR DESCRIPTION
I believe this documentation will be useful as I expected managed identity to work the same as Azure VMs, Functions, etc. and being able to use MSAL and authenticate to any arbitrary service.  However, after testing, it doesn't work and I see many support articles on this online.