### PR TITLE
Update quickstart-protected-material.md

### DIFF
--- a/articles/ai-services/content-safety/quickstart-protected-material.md
+++ b/articles/ai-services/content-safety/quickstart-protected-material.md
@@ -34,7 +34,7 @@ The following section walks through a sample request with cURL. Paste the comman
     > [!TIP]
     > Text size and granularity
     >
-    > The default maximum length for text submissions is **1K** characters. The minimum length is **110** characters. Protected material detection is meant to be run on LLM completions, not user prompts.
+    > The default maximum length for text submissions is **1K** characters. The minimum length is **111** characters. Protected material detection is meant to be run on LLM completions, not user prompts.
 
 ```shell
 curl --location --request POST '<endpoint>/contentsafety/text:detectProtectedMaterial?api-version=2023-10-15-preview' \


### PR DESCRIPTION
The minimum length should be 111, instead of 110 characters