### PR TITLE
Update PS custom role definition name

### DIFF
--- a/articles/azure-resource-manager/bicep/key-vault-parameter.md
+++ b/articles/azure-resource-manager/bicep/key-vault-parameter.md
@@ -141,7 +141,7 @@ The following procedure shows how to create a role with the minimum permission, 
     New-AzRoleDefinition -InputFile "<path-to-role-file>"
     New-AzRoleAssignment `
       -ResourceGroupName ExampleGroup `
-      -RoleDefinitionName "Key Vault resource manager template deployment operator" `
+      -RoleDefinitionName "Key Vault Bicep deployment operator" `
       -SignInName <user-principal-name>
     ```
 


### PR DESCRIPTION
In the section,  [Grant Access to the Secrets](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/key-vault-parameter?tabs=azure-powershell#grant-access-to-the-secrets), Step 2, it is written for the user to create the custom role using the JSON definition, but it uses the name "Key Vault resource manager template deployment operator" as a value for the parameter "-RoleDefinitionName" which does not reflect what was provided in the JSON definition (e.g. "Key Vault Bicep deployment operator") in the previous step. 

In my edit, I changed the value of the parameter to match what is written in the JSON definition. This will help create consistency for those following the tutorial using the copy/paste operations.

