### PR TITLE
Update PowerShell code snippet

### DIFF
--- a/articles/storage/common/storage-use-azcopy-authorize-azure-active-directory.md
+++ b/articles/storage/common/storage-use-azcopy-authorize-azure-active-directory.md
@@ -318,8 +318,8 @@ If you sign in by using Azure PowerShell, then Azure PowerShell obtains an OAuth
 
 To enable AzCopy to use that token, type the following command, and then press the ENTER key.
 
-```bash
-export AZCOPY_AUTO_LOGIN_TYPE=PSCREDS
+```PowerShell
+set AZCOPY_AUTO_LOGIN_TYPE=PSCREDS
 ```
 
 For more information about how to sign in with the Azure PowerShell, see [Sign in with Azure PowerShell](/powershell/azure/authenticate-azureps).

--- a/articles/storage/common/storage-use-azcopy-authorize-azure-active-directory.md
+++ b/articles/storage/common/storage-use-azcopy-authorize-azure-active-directory.md
@@ -319,7 +319,7 @@ If you sign in by using Azure PowerShell, then Azure PowerShell obtains an OAuth
 To enable AzCopy to use that token, type the following command, and then press the ENTER key.
 
 ```PowerShell
-set AZCOPY_AUTO_LOGIN_TYPE=PSCREDS
+set AZCOPY_AUTO_LOGIN_TYPE=PSCRED
 ```
 
 For more information about how to sign in with the Azure PowerShell, see [Sign in with Azure PowerShell](/powershell/azure/authenticate-azureps).


### PR DESCRIPTION
The code snippet for setting the AZCOPY_AUTO_LOGIN_TYPE environment variable in PowerShell inadvertently display the code for bash. This PR fixes that.