### PR TITLE
Update provider-linux.md

### DIFF
--- a/articles/sap/monitor/provider-linux.md
+++ b/articles/sap/monitor/provider-linux.md
@@ -47,7 +47,7 @@ For example - https://github.com/prometheus/node_exporter/releases/download/v1.6
 # Change to the directory where you want to install the node exporter.
 
 wget https://github.com/prometheus/node_exporter/releases/download/v<xxx>/node_exporter-<xxx>.linux-amd64.tar.gz
-tar xvfz node_exporter-<xxx>.linux-amd64.tar.gz
+tar xzvf node_exporter-<xxx>.linux-amd64.tar.gz
 cd node_exporter-<xxx>linux-amd64
 nohup ./node_exporter --web.listen-address=":9100" &
 ```


### PR DESCRIPTION
just changed the order of the options on the tar command.  In the previous order, it didn't work as the "f" option expects the filename next.