### PR TITLE
Update chatgpt-dotnet.md code examples to use the correct chat message objects

### DIFF
--- a/articles/ai-services/openai/includes/chatgpt-dotnet.md
+++ b/articles/ai-services/openai/includes/chatgpt-dotnet.md
@@ -59,10 +59,10 @@ var chatCompletionsOptions = new ChatCompletionsOptions()
     DeploymentName = "gpt-35-turbo", //This must match the custom deployment name you chose for your model
     Messages =
     {
-        new ChatMessage(ChatRole.System, "You are a helpful assistant."),
-        new ChatMessage(ChatRole.User, "Does Azure OpenAI support customer managed keys?"),
-        new ChatMessage(ChatRole.Assistant, "Yes, customer managed keys are supported by Azure OpenAI."),
-        new ChatMessage(ChatRole.User, "Do other Azure AI services support this too?"),
+        new ChatRequestSystemMessage("You are a helpful assistant."),
+        new ChatRequestUserMessage("Does Azure OpenAI support customer managed keys?"),
+        new ChatRequestAssistantMessage("Yes, customer managed keys are supported by Azure OpenAI."),
+        new ChatRequestUserMessage("Do other Azure AI services support this too?"),
     },
     MaxTokens = 100
 };
@@ -106,10 +106,10 @@ var chatCompletionsOptions = new ChatCompletionsOptions()
     DeploymentName= "gpt-35-turbo", //This must match the custom deployment name you chose for your model
     Messages =
     {
-        new ChatMessage(ChatRole.System, "You are a helpful assistant."),
-        new ChatMessage(ChatRole.User, "Does Azure OpenAI support customer managed keys?"),
-        new ChatMessage(ChatRole.Assistant, "Yes, customer managed keys are supported by Azure OpenAI."),
-        new ChatMessage(ChatRole.User, "Do other Azure AI services support this too?"),
+        new ChatRequestSystemMessage("You are a helpful assistant."),
+        new ChatRequestUserMessage("Does Azure OpenAI support customer managed keys?"),
+        new ChatRequestAssistantMessage("Yes, customer managed keys are supported by Azure OpenAI."),
+        new ChatRequestUserMessage("Do other Azure AI services support this too?"),
     },
     MaxTokens = 100
 };


### PR DESCRIPTION
In the documentation the code examples use the following for the Messages values in the ChatCompletionsOptions object. However as of **version 1.0.0-beta.11** this is incorrect.

The current example is as follows:

```c#
var chatCompletionsOptions = new ChatCompletionsOptions()
{
    DeploymentName = "gpt-35-turbo", //This must match the custom deployment name you chose for your model
    Messages =
    {
        new ChatMessage(ChatRole.System, "You are a helpful assistant."),
        new ChatMessage(ChatRole.User, "Does Azure OpenAI support customer managed keys?"),
        new ChatMessage(ChatRole.Assistant, "Yes, customer managed keys are supported by Azure OpenAI."),
        new ChatMessage(ChatRole.User, "Do other Azure AI services support this too?"),
    },
    MaxTokens = 100
};
``` 

Whereas the expected code, according to the current version is as follows:

```c#
var chatCompletionsOptions = new ChatCompletionsOptions()
{
    DeploymentName = "gpt-35-turbo", //This must match the custom deployment name you chose for your model
    Messages =
    {
        new ChatRequestSystemMessage("You are a helpful assistant."),
        new ChatRequestUserMessage("Does Azure OpenAI support customer managed keys?"),
        new ChatRequestAssistantMessage("Yes, customer managed keys are supported by Azure OpenAI."),
        new ChatRequestUserMessage("Do other Azure AI services support this too?"),
    },
    MaxTokens = 100
};
};
``` 