### PR TITLE
Quick fixes in Language Summarization related docs

### DIFF
--- a/articles/ai-services/language-service/language-studio.md
+++ b/articles/ai-services/language-service/language-studio.md
@@ -66,7 +66,8 @@ When you're ready to use Language Studio features on your own text data, you wil
 
 If you're sending conversational text to supported features in Language Studio, be aware of the following input requirements: 
 * The text you send must be a conversational dialog between two or more participants.
-* Each line must start with the name of the participant, followed by a `:`, and followed by what they say.
+* Except issue/resolution summarization, each line must start with the name of the participant, followed by a `:`, and followed by what they say.
+* To use issue and resolution aspects in conversation summarization, each line must start with the role of the participant between "Customer" and "Agent" spelled in English, followed by a ':' before what they say in any supported languages. Names of participants, followed by the role, are optional. 
 * Each participant must be on a new line. If multiple participants' utterances are on the same line, it will be processed as one line of the conversation.
 
 See the following example for how you should structure conversational text you want to send.

--- a/articles/ai-services/language-service/summarization/overview.md
+++ b/articles/ai-services/language-service/summarization/overview.md
@@ -77,8 +77,10 @@ This documentation contains the following article types:
 Conversation summarization supports the following features:
 
 * **Issue/resolution summarization**: A call center specific feature that gives a summary of issues and resolutions in conversations between customer-service agents and your customers.
-* **Chapter title summarization**: Gives suggested chapter titles of the input conversation.
-* **Narrative summarization**: Gives call notes, meeting notes or chat summaries of the input conversation.
+* **Chapter title summarization**: Segments a conversation into chapters based on the topics discussed in the conversation, and gives suggested chapter titles of the input conversation.
+* **Recap**: Summarizes a conversation into a brief paragraph.
+* **Narrative summarization**: Generates detail call notes, meeting notes or chat summaries of the input conversation.
+* **Follow-up tasks**: Gives a list of follow-up tasks discussed in the input conversation.
 
 ## When to use issue and resolution summarization
 


### PR DESCRIPTION
Updated 1) Language Studio doc to clarify the text formats used in Summarization try-out; and 2) added new aspects in the conversation summarization overview doc. 