### PR TITLE
AIO - Manage Secrets - adding preconfigure service principal and key vault policies

### DIFF
--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -26,11 +26,11 @@ Azure IoT Operations supports Azure Key Vault for storing secrets and certificat
 
 For more information, see [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli).
 
-## Configure a Service Principal and Key Vault upfront
+## Configure service principal and Azure Key Vault upfront
 
-In case your Azure account executing the `az iot ops init` command does not have permissions to query the Azure Resource Graph and create Service Principal, you can prepare these upfront and use extra arguments when running the CLI command as described in [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli).
+If the Azure account executing the `az iot ops init` command does not have permissions to query the Azure Resource Graph and create service principals, you can prepare these upfront and use extra arguments when running the CLI command as described in [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli).
 
-### Configure Service Principal interact with Key Vault via Microsoft Entra ID
+### Configure service principal for interacting with Azure Key Vault via Microsoft Entra ID
 
 Follow these steps to create a new Application Registration that will be used by the AIO application to authenticate to Key Vault.
 
@@ -54,9 +54,9 @@ First, register an application with Microsoft Entra ID.
 
    When your application is created, you are directed to its resource page.
 
-1. Copy the **Application (client) ID** from the app registration overview page. You'll use this value in the next section.
+1. Copy the **Application (client) ID** from the app registration overview page. You'll use this value as an argument when running Azure IoT Operations deployment.
 
-Next, give your application permissions for your key vault.
+Next, give your application permissions for key vault.
 
 1. On the resource page for your app, select **API permissions** from the **Manage** section of the app menu.
 
@@ -80,29 +80,33 @@ Create a client secret that will be added to your Kubernetes cluster to authenti
 
 1. Copy the **Value** and **Secret ID** from your new secret. You'll use these values later below.
 
-1. In the App Registration home screen, click on the **Application name** link under **Managed application in local directory**. This opens the Enterprise Application properties. Copy the Object ID to use later.
+Retrieve the service principal Object Id
+
+1. On the **Overview** page for your app, under the section **Essentials**, click on the **Application name** link under **Managed application in local directory**. This opens the Enterprise Application properties. Copy the Object Id to use later.
 
 ### Create an Azure Key Vault
 
-1. Create a new Azure Key Vault account and ensure it has the **Permission Model** to Vault access policy.
+Create a new Azure Key Vault service and ensure it has the **Permission Model** to Vault access policy.
 
 ```bash
 az keyvault create --enable-rbac-authorization false --name "<your unique key vault name>" --resource-group "<the name of the resource group>"
 ```
-1. If you have an existing Key Vault, you can change the Permission Model by executing the following:
+If you have an existing Key Vault, you can change the Permission Model by executing the following:
 
 ```bash
 az keyvault update --name "<your unique key vault name>" --resource-group "<the name of the resource group>" --enable-rbac-authorization false 
 ```
-1. You will need the Key Vault Resource ID below, to retrieve it run:
+You will need the Key Vault Resource ID below, to retrieve it run:
 
 ```bash
 az keyvault show --name "<your unique key vault name>" --resource-group "<the name of the resource group>" --query id  -o tsv
 ```
 
-### Set Service Principal's Access Policy in Key Vault
+### Set service principal access policy in Azue Key Vault
 
-The newly created Service Principal needs **Secret** `list` and `get` access policy in order for the Azure IoT Operations to work with the secret store. Run the following to assign **secret** `get` and `list` permissions to the Service Principal.
+The newly created service principal needs **Secret** `list` and `get` access policy for the Azure IoT Operations to work with the secret store. 
+
+Run the following to assign **secret** `get` and `list` permissions to the service principal.
 
 ```bash
 
@@ -110,10 +114,11 @@ az keyvault set-policy --name "<your unique key vault name>" --resource-group "<
 
 ```
 
-### Passing in Service Principal and Key Vault arguments when running Azure IoT Operations deployment
+### Passing in service principal and Azure Key Vault arguments when running Azure IoT Operations deployment
 
-When following the guide [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli), you will need to pass in additional flags to the `az iot ops init` command in order to use the pre-configured Service Principal and Key Vault.
-For example, the following shows how to prepare the cluster for Azure IoT Operations without fully deploying it.
+When following the guide [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli), you will need to pass in additional flags to the `az iot ops init` command in order to use the pre-configured service principal and key vault.
+
+For example, the following shows how to prepare the cluster for Azure IoT Operations without fully deploying it by using `--no-deploy` flag. You can also run the command without this argument for a default Azure IoT Operations deployment.
 
 ```bash
 

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -91,7 +91,7 @@ Create a new Azure Key Vault service and ensure it has the **Permission Model** 
 ```bash
 az keyvault create --enable-rbac-authorization false --name "<your unique key vault name>" --resource-group "<the name of the resource group>"
 ```
-If you have an existing Key Vault, you can change the Permission Model by executing the following:
+If you have an existing key vault, you can change the permission model by executing the following:
 
 ```bash
 az keyvault update --name "<your unique key vault name>" --resource-group "<the name of the resource group>" --enable-rbac-authorization false 

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -82,7 +82,7 @@ Create a client secret that will be added to your Kubernetes cluster to authenti
 
 Retrieve the service principal Object Id
 
-1. On the **Overview** page for your app, under the section **Essentials**, click on the **Application name** link under **Managed application in local directory**. This opens the Enterprise Application properties. Copy the Object Id to use later.
+1. On the **Overview** page for your app, under the section **Essentials**, click on the **Application name** link under **Managed application in local directory**. This opens the Enterprise Application properties. Copy the Object Id to use when you run `az iot ops init`.
 
 ### Create an Azure Key Vault
 

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -118,7 +118,7 @@ az keyvault set-policy --name "<your unique key vault name>" --resource-group "<
 
 When following the guide [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli), you will need to pass in additional flags to the `az iot ops init` command in order to use the pre-configured service principal and key vault.
 
-For example, the following shows how to prepare the cluster for Azure IoT Operations without fully deploying it by using `--no-deploy` flag. You can also run the command without this argument for a default Azure IoT Operations deployment.
+The following example shows how to prepare the cluster for Azure IoT Operations without fully deploying it by using `--no-deploy` flag. You can also run the command without this argument for a default Azure IoT Operations deployment.
 
 ```bash
 

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -86,7 +86,7 @@ Retrieve the service principal Object Id
 
 ### Create an Azure Key Vault
 
-Create a new Azure Key Vault service and ensure it has the **Permission Model** to Vault access policy.
+Create a new Azure Key Vault service and ensure it has the **Permission Model** set to Vault access policy.
 
 ```bash
 az keyvault create --enable-rbac-authorization false --name "<your unique key vault name>" --resource-group "<the name of the resource group>"

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -96,7 +96,7 @@ If you have an existing key vault, you can change the permission model by execut
 ```bash
 az keyvault update --name "<your unique key vault name>" --resource-group "<the name of the resource group>" --enable-rbac-authorization false 
 ```
-You will need the Key Vault Resource ID below, to retrieve it run:
+You will need the Key Vault resource ID when you run `az iot ops init`. To retrieve the resource ID, run:
 
 ```bash
 az keyvault show --name "<your unique key vault name>" --resource-group "<the name of the resource group>" --query id  -o tsv

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -109,9 +109,7 @@ The newly created service principal needs **Secret** `list` and `get` access pol
 Run the following to assign **secret** `get` and `list` permissions to the service principal.
 
 ```bash
-
 az keyvault set-policy --name "<your unique key vault name>" --resource-group "<the name of the resource group>" --object-id <Object ID copied from Enterprise Application SP in Microsoft Entra ID> --secret-permissions get list --key-permissions get list
-
 ```
 
 ### Pass service principal and Key Vault arguments to Azure IoT Operations deployment
@@ -121,14 +119,12 @@ When following the guide [Deploy Azure IoT Operations extensions](./howto-deploy
 The following example shows how to prepare the cluster for Azure IoT Operations without fully deploying it by using `--no-deploy` flag. You can also run the command without this argument for a default Azure IoT Operations deployment.
 
 ```bash
-
 az iot ops init --name "<your unique key vault name>" --resource-group "<the name of the resource group>" \
     --kv-id <Key Vault Resource ID> \
     --sp-app-id <Application registration App ID (client ID) from Microsoft Entra ID> \
     --sp-object-id <Object ID copied from Enterprise Application in Microsoft Entra ID> \
     --sp-secret "<Client Secret from App registration in Microsoft Entra ID>" \
     --no-deploy
-
 ```
 
 ## Add a secret to an Azure IoT Operations component

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -123,9 +123,9 @@ For example, the following shows how to prepare the cluster for Azure IoT Operat
 ```bash
 
 az iot ops init --name "<your unique key vault name>" --resource-group "<the name of the resource group>" \
-    --kv-id <Key Vault Resource ID retrieved above> \
-    --sp-app-id <Application registration App ID (client ID) from Microsoft Entra ID above> \
-    --sp-object-id <Object ID copied from Enterprise Application in Microsoft Entra ID above> \
+    --kv-id <Key Vault Resource ID> \
+    --sp-app-id <Application registration App ID (client ID) from Microsoft Entra ID> \
+    --sp-object-id <Object ID copied from Enterprise Application in Microsoft Entra ID> \
     --sp-secret "<Client Secret from App registration in Microsoft Entra ID>" \
     --no-deploy
 

--- a/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
+++ b/articles/iot-operations/deploy-iot-ops/howto-manage-secrets.md
@@ -114,7 +114,7 @@ az keyvault set-policy --name "<your unique key vault name>" --resource-group "<
 
 ```
 
-### Passing in service principal and Azure Key Vault arguments when running Azure IoT Operations deployment
+### Pass service principal and Key Vault arguments to Azure IoT Operations deployment
 
 When following the guide [Deploy Azure IoT Operations extensions](./howto-deploy-iot-operations.md?tabs=cli), you will need to pass in additional flags to the `az iot ops init` command in order to use the pre-configured service principal and key vault.
 


### PR DESCRIPTION
- Added back the description to service principal for AIO
- Include info on retrieving the SP Object ID
- Include creation of Key Vault
- Include setting SP access policy on Key Vault
- Show `az iot ops` command with the additional flags for SP

It is potentially relevant to have the Quickstart tutorial also point to this article for pre-configuration of service principal when account permissions are limited. I did not change that doc though.