### PR TITLE
Fix sentence so it makes better sense.

### DIFF
--- a/articles/azure-functions/functions-scale.md
+++ b/articles/azure-functions/functions-scale.md
@@ -16,7 +16,7 @@ The Azure Functions hosting plan you choose dictates the following behaviors:
 * The resources available to each function app instance.
 * Support for advanced functionality, such as Azure Virtual Network connectivity.
 
-In addition to Azure Functions hosting, you can also host containerized function apps in containers can also be deployed to Kubernetes clusters and to Azure Container Apps. If you choose to host your functions in a Kubernetes cluster, consider using an [Azure Arc-enabled Kubernetes cluster](../azure-arc/kubernetes/overview.md). To learn more about deploying custom container apps, see [Azure Container Apps hosting of Azure Functions](./functions-container-apps-hosting.md).  
+In addition to Azure Functions hosting, you can also host containerized function apps in containers that can be deployed to Kubernetes clusters or to Azure Container Apps. If you choose to host your functions in a Kubernetes cluster, consider using an [Azure Arc-enabled Kubernetes cluster](../azure-arc/kubernetes/overview.md). To learn more about deploying custom container apps, see [Azure Container Apps hosting of Azure Functions](./functions-container-apps-hosting.md).  
 
 This article provides a detailed comparison between the various hosting plans, including container-based hosting options.
 


### PR DESCRIPTION
This sentence made very little sense. Hopefully this edit clears it up a bit.

```text
[...] you can also host containerized function apps in containers can also be deployed to Kubernetes clusters and to Azure Container Apps.
```