### PR TITLE
Clarify that Gen2 VMs are not supported on Standard_NC24rs_v3

### DIFF
--- a/articles/virtual-machines/ncv3-series.md
+++ b/articles/virtual-machines/ncv3-series.md
@@ -5,7 +5,7 @@ author: vikancha-MSFT
 ms.service: virtual-machines
 ms.subservice: sizes
 ms.topic: conceptual
-ms.date: 12/21/2022
+ms.date: 12/20/2023
 ms.author: vikancha
 ---
 
@@ -20,11 +20,13 @@ NCv3-series VMs are powered by NVIDIA Tesla V100 GPUs. These GPUs can provide 1.
 [Ultra Disks](disks-types.md#ultra-disks): Supported ([Learn more](https://techcommunity.microsoft.com/t5/azure-compute/ultra-disk-storage-for-hpc-and-gpu-vms/ba-p/2189312) about availability, usage and performance) <br>
 [Live Migration](maintenance-and-updates.md): Not Supported<br>
 [Memory Preserving Updates](maintenance-and-updates.md): Not Supported<br>
-[VM Generation Support](generation-2.md): Generation 1 and 2<br>
+[VM Generation Support](generation-2.md): Generation 1 and 2*<br>
 [Accelerated Networking](../virtual-network/create-vm-accelerated-networking-cli.md): Not Supported<br>
 [Ephemeral OS Disks](ephemeral-os-disks.md): Supported<br>
 Nvidia NVLink Interconnect: Not Supported<br>
 [Nested Virtualization](/virtualization/hyper-v-on-windows/user-guide/nested-virtualization): Not Supported <br>
+
+>*Standard_NC24rs_v3 is not supported on Generation 2 VMs.
 
 > [!IMPORTANT]
 > For this VM series, the vCPU (core) quota in your subscription is initially set to 0 in each region. [Request a vCPU quota increase](../azure-portal/supportability/regional-quota-requests.md) for this series in an [available region](https://azure.microsoft.com/regions/services/). These SKUs aren't available to trial or Visual Studio Subscriber Azure subscriptions. Your subscription level might not support selecting or deploying these SKUs. 


### PR DESCRIPTION
Clarify that Standard_NC24rs_v3 does not support generation 2 VMs. This was confirmed during the investigation of a customer incident. The docs should be updated to clarify the restriction for the RDMA-enabled SKU.