### PR TITLE
Update relay-token-python.md

### DIFF
--- a/articles/communication-services/quickstarts/includes/relay-token-python.md
+++ b/articles/communication-services/quickstarts/includes/relay-token-python.md
@@ -91,9 +91,9 @@ user = identity_client.create_user()
 Call the Azure Communication token service to exchange the user access token for a TURN service token
 
 ```python
-relay_configuration = relay_client.get_relay_configuration(user)
+relay_configuration = relay_client.get_relay_configuration()
 
-for iceServer in config.ice_servers:
+for iceServer in relay_configuration.ice_servers:
     assert iceServer.username is not None
     print('Username: ' + iceServer.username)
 


### PR DESCRIPTION
- remove `user` argument to fix `TypeError: CommunicationRelayClient.get_relay_configuration() takes 1 positional argument but 2 were given` in line 94
- replace `config` with `relay_configuration` in line 96