### PR TITLE
Update user-defined-routes.md

### DIFF
--- a/articles/container-apps/user-defined-routes.md
+++ b/articles/container-apps/user-defined-routes.md
@@ -114,8 +114,8 @@ Your virtual networks in Azure have default route tables in place when you creat
 
     | Setting      | Action      |
     |--|--|
-    | **Address prefix** | Select the virtual network for your container app. |
-    | **Next hop type** | Select the subnet your for container app.  |
+    | **Virtual network** | Select the virtual network for your container app. |
+    | **Subnet** | Select the subnet your for container app.  |
 
 1. Select **OK**.
 


### PR DESCRIPTION
Could you check this documentation mistakes?
Although the Setting names are listed as "Address prefix" and "Next hop type", I think they are "Virtual network" and "Subnet" to be exact.
The following is a screenshot when setting up in Portal.
![image](https://github.com/MicrosoftDocs/azure-docs/assets/42292917/bf219483-21ce-47ab-a048-fc0d4043a783)
