### PR TITLE
Add note of health probe in ingress-basic.md

### DIFF
--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -65,7 +65,7 @@ helm install ingress-nginx ingress-nginx/ingress-nginx `
 
 > [!NOTE]
 > In this tutorial, "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path" is being set to "/healthz". This means if the response code of the requests to "/healthz" is not "200", the whole ingress controller will be down. You can modify the value to other URI in your own scenario. You cannot delete this part or unset the value, or the ingress controller will still be down.
-> The package "ingress-nginx" used in this tutorial, which is provided by [Kubernetes official](https://github.com/kubernetes/ingress-nginx), will always return "200" response code if requesting "/healthz", as it is designed as "[default backend](https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/)" for users to have a quick start.
+> The package "ingress-nginx" used in this tutorial, which is provided by [Kubernetes official](https://github.com/kubernetes/ingress-nginx), will always return "200" response code if requesting "/healthz", as it is designed as "[default backend](https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/)" for users to have a quick start, unless it is being overwritten by ingress rules.
 
 ---
 

--- a/articles/aks/ingress-basic.md
+++ b/articles/aks/ingress-basic.md
@@ -63,6 +63,10 @@ helm install ingress-nginx ingress-nginx/ingress-nginx `
   --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz
 ```
 
+> [!NOTE]
+> In this tutorial, "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path" is being set to "/healthz". This means if the response code of the requests to "/healthz" is not "200", the whole ingress controller will be down. You can modify the value to other URI in your own scenario. You cannot delete this part or unset the value, or the ingress controller will still be down.
+> The package "ingress-nginx" used in this tutorial, which is provided by [Kubernetes official](https://github.com/kubernetes/ingress-nginx), will always return "200" response code if requesting "/healthz", as it is designed as "[default backend](https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/)" for users to have a quick start.
+
 ---
 
 ## Customized configuration


### PR DESCRIPTION
**Proposed changes:** Add explanation about health probe. 
This commit is being made is because many users are having problem on understanding it and making wrong configuration.   
  
**Basis**: 
1. https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview#probe-protocol  
> An HTTP/HTTPS probe fails when: 1. Probe endpoint returns an HTTP response code other than 200 (for example, 403, 404, or 500)  

Note: "other than 200", not "2xx".  
  
2. https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/  
> /healthz that returns 200