### PR TITLE
Update ingress-controller-install-existing.md

### DIFF
--- a/articles/application-gateway/ingress-controller-install-existing.md
+++ b/articles/application-gateway/ingress-controller-install-existing.md
@@ -130,7 +130,10 @@ looks like: `/subscriptions/A/resourceGroups/B/providers/Microsoft.Network/appli
     ```
 
 >[!NOTE]
-> If the virtual network Application Gateway is deployed into doesn't reside in the same resource group as the AKS nodes, please ensure the identity used by AGIC has the **Microsoft.Network/virtualNetworks/subnets/join/action** permission delegated to the subnet Application Gateway is deployed into. If a custom role is not defined with this permission, you may use the built-in **Network Contributor** role, which contains the **Microsoft.Network/virtualNetworks/subnets/join/action** permission.
+> If you're deploying an Application Gateway in a virtual network (VNet) that's in a different resource group from your Azure Kubernetes Service (AKS) nodes, it's important to make sure that the identity used by the Application Gateway Ingress Controller (AGIC) has specific permissions. The necessary permission is `Microsoft.Network/virtualNetworks/subnets/join/action`, which allows the AGIC to interact with the subnet where the Application Gateway is located.
+
+> If you don't already have a custom role with this permission, you can assign the built-in "Network Contributor" role to the identity. This role already includes the required `Microsoft.Network/virtualNetworks/subnets/join/action` permission. Assigning this role is crucial for ensuring that the AGIC can effectively manage and update the Application Gateway based on the configurations and needs of your AKS setup.
+
 
 ## Using a Service Principal
 


### PR DESCRIPTION
Title: Clarification of Permission Requirements for AGIC and Application Gateway Deployment Summary
This pull request updates the documentation regarding the deployment of Application Gateway in a different resource group from Azure Kubernetes Service (AKS) nodes. The intention is to enhance clarity and comprehension for users setting up Application Gateway Ingress Controller (AGIC).

Justification
Enhanced Clarity: The original phrasing was somewhat technical and could be challenging to understand for users not deeply familiar with Azure role-based access control. The rephrasing aims to make the instructions more accessible to a broader audience.

Emphasizing the Importance of Correct Permissions: The updated text underscores the necessity of having the Microsoft.Network/virtualNetworks/subnets/join/action permission for AGIC. This is crucial for successful deployment and operation.

Guidance on Role Assignment: The revision explicitly suggests using the "Network Contributor" role if a custom role isn't available. This direct recommendation can aid users in quicker decision-making.

Preventing Potential Configuration Issues: By making the requirements clearer, the update seeks to reduce the likelihood of misconfigurations that could arise from misunderstandings about permission and role requirements.

Conclusion
The proposed changes aim to improve the usability of our documentation, ensuring that users have a smoother experience with Azure's networking and Kubernetes services. This clarity is essential for effective setup and minimizes potential support queries related to misconfiguration.