### PR TITLE
Update csi-secrets-store-nginx-tls.md

### DIFF
--- a/articles/aks/csi-secrets-store-nginx-tls.md
+++ b/articles/aks/csi-secrets-store-nginx-tls.md
@@ -229,7 +229,7 @@ Again, the instructions change slightly depending on your scenario. Follow the i
     spec:
       type: ClusterIP
       ports:
-     - port: 80
+      - port: 80
       selector:
         app: aks-helloworld-one
     ```
@@ -278,7 +278,7 @@ Again, the instructions change slightly depending on your scenario. Follow the i
     spec:
       type: ClusterIP
       ports:
-     - port: 80
+      - port: 80
       selector:
         app: aks-helloworld-two
     ```
@@ -334,7 +334,7 @@ Again, the instructions change slightly depending on your scenario. Follow the i
     spec:
       type: ClusterIP
       ports:
-     - port: 80
+      - port: 80
       selector:
         app: aks-helloworld-one
     ```
@@ -372,7 +372,7 @@ Again, the instructions change slightly depending on your scenario. Follow the i
     spec:
       type: ClusterIP
       ports:
-     - port: 80
+      - port: 80
       selector:
         app: aks-helloworld-two
     ```
@@ -400,11 +400,11 @@ We can now deploy a Kubernetes ingress resource referencing the secret.
     spec:
       ingressClassName: nginx
       tls:
-     - hosts:
+      - hosts:
         - demo.azure.com
         secretName: ingress-tls-csi
       rules:
-     - host: demo.azure.com
+      - host: demo.azure.com
         http:
           paths:
           - path: /hello-world-one(/|$)(.*)


### PR DESCRIPTION
I found 5 mistakes on the yamls file format, and the yaml files have been fixed.

on file aks-helloworld-one.yaml and aks-helloworld-two.yaml on the service section it will not create because the format was wrong 

  ports:
  - port: 80 the - it was before the ports:

and on the ingress file there was two mistakes :

  tls:
 - hosts: should be. 

  tls:
  - hosts:

and also :

  rules:
 - host: demo.azure.com should be 

  rules:
  - host: demo.azure.com

now the mistakes fixed to make sure once the customer trying to run those yaml files without an issues.