### PR TITLE
Typo "a Azure Stack"→"an Azure Stack"

### DIFF
--- a/articles/databox-online/azure-stack-edge-gpu-manage-shares.md
+++ b/articles/databox-online/azure-stack-edge-gpu-manage-shares.md
@@ -69,7 +69,7 @@ Do the following steps in the Azure portal to create a share.
 3. Select a **Type** for the share. The type can be **SMB** or **NFS**, with SMB being the default. SMB is the standard for Windows clients, and NFS is used for Linux clients. Depending upon whether you choose SMB or NFS shares, options presented are slightly different.
 
    > [!IMPORTANT]
-   > Make sure that the Azure Storage account that you use doesn't have immutability policies set on it if you're using it with a Azure Stack Edge Pro or Data Box Gateway device. For more information, see [Set and manage immutability policies for blob storage](../storage/blobs/immutable-policy-configure-version-scope.md).
+   > Make sure that the Azure Storage account that you use doesn't have immutability policies set on it if you're using it with an Azure Stack Edge Pro or Data Box Gateway device. For more information, see [Set and manage immutability policies for blob storage](../storage/blobs/immutable-policy-configure-version-scope.md).
 
 4. To easily access the shares from Edge compute modules, use the local mount point. Select **Use the share with Edge compute** so that the Edge module can use the compute with the local mount point.
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/databox-online/azure-stack-edge-gpu-manage-shares 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/databox-online/azure-stack-edge-gpu-manage-shares.md 
#PingMSFTDocs