### PR TITLE
Update opentelemetry-add-modify.md - fix python telemetry filter

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-add-modify.md
+++ b/articles/azure-monitor/app/opentelemetry-add-modify.md
@@ -2224,7 +2224,7 @@ Use the add [custom property example](#add-a-custom-property-to-a-span), but rep
     class SpanFilteringProcessor(SpanProcessor):
     
         # Prevents exporting spans from internal activities.
-        def on_start(self, span):
+        def on_start(self, span, parent_context):
             # Check if the span is an internal activity.
             if span._kind is SpanKind.INTERNAL:
                 # Create a new span context with the following properties:
@@ -2237,7 +2237,7 @@ Use the add [custom property example](#add-a-custom-property-to-a-span), but rep
                     span.context.trace_id,
                     span.context.span_id,
                     span.context.is_remote,
-                    TraceFlags.DEFAULT,
+                    TraceFlags(TraceFlags.DEFAULT),
                     span.context.trace_state,
                 )
     


### PR DESCRIPTION
Fixes python telemetry filter example:
- missing parameter on `SpanProcessor.on_start`
- value passed to trace_flags