### PR TITLE
Update design-guidance-for-replicated-tables.md

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
+++ b/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
@@ -186,7 +186,7 @@ To trigger a rebuild, run the following statement on each table in the preceding
 SELECT TOP 1 * FROM [ReplicatedTable]
 ```
 
-To monitor the rebuild process, you can use 'sys.dm_pdw_exec_requests,' where the command will start with 'BuildReplicatedTableCache' as shown below
+To monitor the rebuild process, you can use [sys.dm_pdw_exec_requests](/sql/relational-databases/system-dynamic-management-views/sys-dm-pdw-exec-requests-transact-sql?view=azure-sqldw-latest&preserve-view=true), where the `command` will start with 'BuildReplicatedTableCache'. For example:
 
 ```sql
 -- Monitor Build Replicated Cache

--- a/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
+++ b/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
@@ -163,6 +163,8 @@ For example, this load pattern loads data from four sources, but only invokes on
 
 To ensure consistent query execution times, consider forcing the build of the replicated tables after a batch load. Otherwise, the first query will still use data movement to complete the query.
 
+The 'Build Replicated Table Cache' operation can execute up to two operations simultaneously. For example, if you attempt to rebuild the cache for five tables, the system will utilize a staticrc20 (which cannot be modified) to concurrently build two tables at the time. Therefore, it is recommended to avoid using large replicated tables exceeding 2 GB, as this may slow down the cache rebuild across the nodes and increase the overall time.
+
 This query uses the [sys.pdw_replicated_table_cache_state](/sql/relational-databases/system-catalog-views/sys-pdw-replicated-table-cache-state-transact-sql?toc=/azure/synapse-analytics/sql-data-warehouse/toc.json&bc=/azure/synapse-analytics/sql-data-warehouse/breadcrumb/toc.json&view=azure-sqldw-latest&preserve-view=true) DMV to list the replicated tables that have been modified, but not rebuilt.
 
 ```sql
@@ -183,6 +185,18 @@ To trigger a rebuild, run the following statement on each table in the preceding
 ```sql
 SELECT TOP 1 * FROM [ReplicatedTable]
 ```
+
+To monitor the rebuild process, you can use 'sys.dm_pdw_exec_requests,' where the command will start with 'BuildReplicatedTableCache' as shown below
+
+```sql
+-- Monitor Build Replicated Cache
+SELECT *
+FROM sys.dm_pdw_exec_requests
+WHERE command like 'BuildReplicatedTableCache%'
+```
+
+> [!TIP]
+> [Table size queries](https://learn.microsoft.com/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview#table-size-queries) can be used to verify which table(s) have a replicated distribution policy and whose size is more than 2 GB.
 
 ## Next steps
 

--- a/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
+++ b/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
@@ -196,7 +196,7 @@ WHERE command like 'BuildReplicatedTableCache%'
 ```
 
 > [!TIP]
-> [Table size queries](https://learn.microsoft.com/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview#table-size-queries) can be used to verify which table(s) have a replicated distribution policy and whose size is more than 2 GB.
+> [Table size queries](/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-overview#table-size-queries) can be used to verify which table(s) have a replicated distribution policy and which are larger than 2 GB.
 
 ## Next steps
 

--- a/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
+++ b/articles/synapse-analytics/sql-data-warehouse/design-guidance-for-replicated-tables.md
@@ -3,7 +3,7 @@ title: Design guidance for replicated tables
 description: Recommendations for designing replicated tables in Synapse SQL pool
 author: WilliamDAssafMSFT
 ms.author: wiassaf
-ms.date: 09/27/2022
+ms.date: 01/09/2024
 ms.service: synapse-analytics
 ms.subservice: sql-dw
 ms.topic: conceptual


### PR DESCRIPTION
-- Add a Tip to verify which replicated tables size is over 2 GB 
-- Add a new section to explain more about the replication process and that we can rebuild 2 tables at a time