### PR TITLE
Update code block in bicep-config.md to remove non-experimental features

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config.md
+++ b/articles/azure-resource-manager/bicep/bicep-config.md
@@ -41,7 +41,7 @@ You can enable preview features by adding:
 ```json
 {
   "experimentalFeaturesEnabled": {
-    "userDefinedTypes": true,
+    "userDefinedFunctions": true,
     "extensibility": true
   }
 }


### PR DESCRIPTION
Since `userDefinedTypes` is not an experimental feature, keeping it in the code block that represents only experimental features may create room for confusion or give an impression that this parameter must always be included for some reason. This PR removes non-experimental features from the code block in `bicep-config.md` to minimize confusion and make the content consistent with currently experimental features.