### PR TITLE
Update immutable-storage-overview.md

### DIFF
--- a/articles/storage/blobs/immutable-storage-overview.md
+++ b/articles/storage/blobs/immutable-storage-overview.md
@@ -146,6 +146,9 @@ When you enable blob inventory, Azure Storage generates an inventory report on a
 
 For more information about blob inventory, see [Azure Storage blob inventory](blob-inventory.md).
 
+> [!NOTE]
+> A version-level immutable policy on the account can prevent an inventory job configuration. Also, if there is an immutable policy configured on the destination container of inventory report then also, the report configuration will tend to fail. 
+
 ## Pricing
 
 There is no additional capacity charge for using immutable storage. Immutable data is priced in the same way as mutable data. For pricing details on Azure Blob Storage, see the [Azure Storage pricing page](https://azure.microsoft.com/pricing/details/storage/blobs/).

--- a/articles/storage/blobs/immutable-storage-overview.md
+++ b/articles/storage/blobs/immutable-storage-overview.md
@@ -147,7 +147,7 @@ When you enable blob inventory, Azure Storage generates an inventory report on a
 For more information about blob inventory, see [Azure Storage blob inventory](blob-inventory.md).
 
 > [!NOTE]
-> A version-level immutable policy on the account can prevent an inventory job configuration. Also, if there is an immutable policy configured on the destination container of inventory report then also, the report configuration will tend to fail. 
+> You can't configure an inventory policy in an account if support for version-level immutability is enabled on that account, or if support for version-level immutability is enabled on the destination container that is defined in the inventory policy. 
 
 ## Pricing
 


### PR DESCRIPTION
If there is version level Immutable policy configured on the account level, the inventory report tends to fails as it is a conflicting feature. Additionally, if there an immutable policy configured on the destination containers of the report, then also the report shall tend to fail.

Adding both the scenarios on this documentation too and in the same request for review.