### PR TITLE
Adding "ID" to Microsoft Entra reference

### DIFF
--- a/articles/ai-services/openai/how-to/switching-endpoints.md
+++ b/articles/ai-services/openai/how-to/switching-endpoints.md
@@ -61,7 +61,7 @@ client = AzureOpenAI(
 
 <a name='azure-active-directory-authentication'></a>
 
-### Microsoft Entra authentication
+### Microsoft Entra ID authentication
 
 <table>
 <tr>


### PR DESCRIPTION
Suggesting to update "Microsoft Entra" to "Microsoft Entra ID" to reflect correct brand name, as per this: https://www.microsoft.com/en-gb/security/business/identity-access/microsoft-entra-id