### PR TITLE
Update site-recovery-faq.yml

### DIFF
--- a/articles/site-recovery/site-recovery-faq.yml
+++ b/articles/site-recovery/site-recovery-faq.yml
@@ -258,9 +258,9 @@ sections:
         answer: |
               Yes, [ExpressRoute can be used](concepts-expressroute-with-site-recovery.md) to replicate on-premises virtual machines to Azure.
 
-              - Azure Site Recovery replicates data to an Azure Storage over a public endpoint. You need to set up [Microsoft peering](../expressroute/expressroute-circuit-peerings.md#microsoftpeering) or use an existing [public peering](../expressroute/about-public-peering.md) (deprecated for new circuits)  to use ExpressRoute for Site Recovery replication.
+              - Azure Site Recovery replicates data to an Azure Storage over a public endpoint. You need to set up [Microsoft peering](../expressroute/expressroute-circuit-peerings.md#microsoftpeering) or use an existing [public peering](../expressroute/about-public-peering.md) (deprecated for new circuits) to use ExpressRoute for Site Recovery replication.
               - Microsoft peering is the recommended routing domain for replication.
-              - Replication is not supported over private peering.
+              - Replication is supported over private peering only when private endpoints are enabled for the vault.
               - If you're protecting VMware machines or physical machines, ensure that the [Networking Requirements](vmware-azure-configuration-server-requirements.md#network-requirements) for Configuration Server are also met. Connectivity to specific URLs is required by Configuration Server for orchestration of Site Recovery replication. ExpressRoute cannot be used for this connectivity.
               - After the virtual machines have been failed over to an Azure virtual network you can access them using the [private peering](../expressroute/expressroute-circuit-peerings.md#privatepeering) setup with the Azure virtual network.
 


### PR DESCRIPTION
Suggested private peering support clarification based on text at [Azure ExpressRoute with Azure Site Recovery](https://learn.microsoft.com/en-us/azure/site-recovery/concepts-expressroute-with-site-recovery#on-premises-to-azure-replication-with-expressroute) page which states:

> Note that replication is supported over private peering only when private ends points are enabled for the vault.

