### PR TITLE
Add missing NC 100 v4-series GPUs

### DIFF
--- a/articles/virtual-machines/sizes-gpu.md
+++ b/articles/virtual-machines/sizes-gpu.md
@@ -21,7 +21,8 @@ GPU optimized VM sizes are specialized virtual machines available with single, m
 
 - The [NCv3-series](ncv3-series.md) and [NC T4_v3-series](nct4-v3-series.md) sizes are optimized for compute-intensive GPU-accelerated applications. Some examples are CUDA and OpenCL-based applications and simulations, AI, and Deep Learning. The NC T4 v3-series is focused on inference workloads featuring NVIDIA's Tesla T4 GPU and AMD EPYC2 Rome processor. The NCv3-series is focused on high-performance computing and AI workloads featuring NVIDIA’s Tesla V100 GPU.
 
-- The  [NC 100 v4-series](nc-a100-v4-series.md) sizes are focused on midrange AI training and batch inference workload.  The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB PCIe Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload.
+- The [NC 100 v4-series](nc-a100-v4-series.md) sizes are focused on midrange AI training and batch inference workload.  The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB PCIe Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload.
+
 - The [ND A100 v4-series](nda100-v4-series.md) sizes are focused on scale-up and scale-out deep learning training and accelerated HPC applications. The ND A100 v4-series uses 8 NVIDIA A100 TensorCore GPUs, each available with a 200 Gigabit Mellanox InfiniBand HDR connection and 40 GB of GPU memory.
 
 - [NGads V620-series](ngads-v-620-series.md) VM sizes are optimized for high performance, interactive gaming experiences hosted in Azure.  They're powered by AMD Radeon PRO V620 GPUs and AMD EPYC 7763 (Milan) CPUs.

--- a/articles/virtual-machines/sizes-gpu.md
+++ b/articles/virtual-machines/sizes-gpu.md
@@ -21,7 +21,7 @@ GPU optimized VM sizes are specialized virtual machines available with single, m
 
 - The [NCv3-series](ncv3-series.md) and [NC T4_v3-series](nct4-v3-series.md) sizes are optimized for compute-intensive GPU-accelerated applications. Some examples are CUDA and OpenCL-based applications and simulations, AI, and Deep Learning. The NC T4 v3-series is focused on inference workloads featuring NVIDIA's Tesla T4 GPU and AMD EPYC2 Rome processor. The NCv3-series is focused on high-performance computing and AI workloads featuring NVIDIA’s Tesla V100 GPU.
 
-- The [NC 100 v4-series](nc-a100-v4-series.md) sizes are focused on midrange AI training and batch inference workload.  The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB PCIe Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload.
+- The [NC 100 v4-series](nc-a100-v4-series.md) sizes are focused on midrange AI training and batch inference workload. The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB PCIe Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload.
 
 - The [ND A100 v4-series](nda100-v4-series.md) sizes are focused on scale-up and scale-out deep learning training and accelerated HPC applications. The ND A100 v4-series uses 8 NVIDIA A100 TensorCore GPUs, each available with a 200 Gigabit Mellanox InfiniBand HDR connection and 40 GB of GPU memory.
 

--- a/articles/virtual-machines/sizes-gpu.md
+++ b/articles/virtual-machines/sizes-gpu.md
@@ -21,7 +21,8 @@ GPU optimized VM sizes are specialized virtual machines available with single, m
 
 - The [NCv3-series](ncv3-series.md) and [NC T4_v3-series](nct4-v3-series.md) sizes are optimized for compute-intensive GPU-accelerated applications. Some examples are CUDA and OpenCL-based applications and simulations, AI, and Deep Learning. The NC T4 v3-series is focused on inference workloads featuring NVIDIA's Tesla T4 GPU and AMD EPYC2 Rome processor. The NCv3-series is focused on high-performance computing and AI workloads featuring NVIDIA’s Tesla V100 GPU.
 
-- The [NC 100 v4-series](nc-a100-v4-series.md) and [ND A100 v4-series](nda100-v4-series.md) sizes are focused on scale-up and scale-out deep learning training and accelerated HPC applications. The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload. The ND A100 v4-series uses 8 NVIDIA A100 TensorCore GPUs, each available with a 200 Gigabit Mellanox InfiniBand HDR connection and 40 GB of GPU memory.
+- The  [NC 100 v4-series](nc-a100-v4-series.md) sizes are focused on midrange AI training and batch inference workload.  The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB PCIe Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload.
+- The [ND A100 v4-series](nda100-v4-series.md) sizes are focused on scale-up and scale-out deep learning training and accelerated HPC applications. The ND A100 v4-series uses 8 NVIDIA A100 TensorCore GPUs, each available with a 200 Gigabit Mellanox InfiniBand HDR connection and 40 GB of GPU memory.
 
 - [NGads V620-series](ngads-v-620-series.md) VM sizes are optimized for high performance, interactive gaming experiences hosted in Azure.  They're powered by AMD Radeon PRO V620 GPUs and AMD EPYC 7763 (Milan) CPUs.
 

--- a/articles/virtual-machines/sizes-gpu.md
+++ b/articles/virtual-machines/sizes-gpu.md
@@ -21,9 +21,9 @@ GPU optimized VM sizes are specialized virtual machines available with single, m
 
 - The [NCv3-series](ncv3-series.md) and [NC T4_v3-series](nct4-v3-series.md) sizes are optimized for compute-intensive GPU-accelerated applications. Some examples are CUDA and OpenCL-based applications and simulations, AI, and Deep Learning. The NC T4 v3-series is focused on inference workloads featuring NVIDIA's Tesla T4 GPU and AMD EPYC2 Rome processor. The NCv3-series is focused on high-performance computing and AI workloads featuring NVIDIA’s Tesla V100 GPU.
 
-- The [ND A100 v4-series](nda100-v4-series.md) size is focused on scale-up and scale-out deep learning training and accelerated HPC applications. The ND A100 v4-series uses 8 NVIDIA A100 TensorCore GPUs, each available with a 200 Gigabit Mellanox InfiniBand HDR connection and 40 GB of GPU memory.
+- The [NC 100 v4-series](nc-a100-v4-series.md) and [ND A100 v4-series](nda100-v4-series.md) sizes are focused on scale-up and scale-out deep learning training and accelerated HPC applications. The NC A100 v4-series offers flexibility to select one, two, or four NVIDIA A100 80GB Tensor Core GPUs per VM to leverage the right-size GPU acceleration for your workload. The ND A100 v4-series uses 8 NVIDIA A100 TensorCore GPUs, each available with a 200 Gigabit Mellanox InfiniBand HDR connection and 40 GB of GPU memory.
 
-- [NGads V620-series)](ngads-v-620-series.md) VM sizes are optimized for high performance, interactive gaming experiences hosted in Azure.  They're powered by AMD Radeon PRO V620 GPUs and AMD EPYC 7763 (Milan) CPUs.
+- [NGads V620-series](ngads-v-620-series.md) VM sizes are optimized for high performance, interactive gaming experiences hosted in Azure.  They're powered by AMD Radeon PRO V620 GPUs and AMD EPYC 7763 (Milan) CPUs.
 
 - [NV-series](nv-series.md) and [NVv3-series](nvv3-series.md) sizes are optimized and designed for remote visualization, streaming, gaming, encoding, and VDI scenarios using frameworks such as OpenGL and DirectX. These VMs are backed by the NVIDIA Tesla M60 GPU.
 


### PR DESCRIPTION
GPU docs are missing NC 100 v4-series https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-machines/nc-a100-v4-series.md