### PR TITLE
Update azure-cni-overlay.md

### DIFF
--- a/articles/aks/azure-cni-overlay.md
+++ b/articles/aks/azure-cni-overlay.md
@@ -29,23 +29,6 @@ You can provide outbound (egress) connectivity to the internet for Overlay pods 
 
 You can configure ingress connectivity to the cluster using an ingress controller, such as Nginx or [HTTP application routing](./http-application-routing.md). You cannot configure ingress connectivity using Azure App Gateway. For details see [Limitations with Azure CNI Overlay](#limitations-with-azure-cni-overlay).
 
-## Limitations
-
-Azure CNI Overlay networking in AKS currently has the following limitations:
-
-* In case you are using your own subnet to deploy the cluster, the names of the subnet, VNET and resource group which contains the VNET, must be 63 characters or less. This comes from the fact that these names will be used as labels in AKS worker nodes, and are therefore subjected to [Kubernetes label syntax rules](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set).  
-
-## Regional availability for ARM64 node pools
-
-Azure CNI Overlay is currently unavailable for ARM64 node pools in the following regions:
-
-- East US 2
-- France Central
-- Southeast Asia
-- South Central US
-- West Europe
-- West US 3
-
 ## Differences between Kubenet and Azure CNI Overlay
 
 Like Azure CNI Overlay, Kubenet assigns IP addresses to pods from an address space logically different from the VNet, but it has scaling and other limitations. The below table provides a detailed comparison between Kubenet and Azure CNI Overlay. If you don't want to assign VNet IP addresses to pods due to IP shortage, we recommend using Azure CNI Overlay.


### PR DESCRIPTION
removed limitation in regions not support ARM64, since it's present today. This is not relevant anymore. ARM64 is now supported in all regions in Overlay.