### PR TITLE
Typo "with a Azure DevOps"→"with an Azure DevOps"

### DIFF
--- a/articles/app-service/scripts/cli-continuous-deployment-vsts.md
+++ b/articles/app-service/scripts/cli-continuous-deployment-vsts.md
@@ -36,7 +36,7 @@ Create the following variables containing your Azure DevOps information.
 
 ```azurecli
 gitrepo=<Replace with your Azure DevOps Services (formerly Visual Studio Team Services, or VSTS) repo URL>
-token=<Replace with a Azure DevOps Services (formerly Visual Studio Team Services, or VSTS) personal access token>
+token=<Replace with an Azure DevOps Services (formerly Visual Studio Team Services, or VSTS) personal access token>
 ```
 
 Configure continuous deployment from Azure DevOps Services (formerly Visual Studio Team Services, or VSTS). The `--git-token` parameter is required only once per Azure account (Azure remembers token).


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/app-service/scripts/cli-continuous-deployment-vsts 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/app-service/scripts/cli-continuous-deployment-vsts.md 
#PingMSFTDocs