### PR TITLE
Update example powershell for app attach package objects

### DIFF
--- a/articles/virtual-desktop/app-attach-setup.md
+++ b/articles/virtual-desktop/app-attach-setup.md
@@ -94,7 +94,7 @@ In order to use MSIX app attach in Azure Virtual Desktop, you need to meet the p
 - If you want to use Azure PowerShell locally, see [Use Azure PowerShell with Azure Virtual Desktop](cli-powershell.md) to make sure you have the [Az.DesktopVirtualization](/powershell/module/az.desktopvirtualization) and [Microsoft Graph](/powershell/microsoftgraph/installation) PowerShell modules installed. Alternatively, use the [Azure Cloud Shell](../cloud-shell/overview.md).
 
 ::: zone pivot="app-attach"
-- You need to use version 4.2.0 or later of the *Az.DesktopVirtualization* PowerShell module, which contains the cmdlets that support app attach. You can download and install the Az.DesktopVirtualization PowerShell module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/Az.DesktopVirtualization/).
+- You need to use version 4.2.1 of the *Az.DesktopVirtualization* PowerShell module, which contains the cmdlets that support app attach. You can download and install the Az.DesktopVirtualization PowerShell module from the [PowerShell Gallery](https://www.powershellgallery.com/packages/Az.DesktopVirtualization/).
 ::: zone-end
 
 ::: zone pivot="app-attach"
@@ -102,7 +102,7 @@ In order to use MSIX app attach in Azure Virtual Desktop, you need to meet the p
 >
 > - All MSIX and Appx application packages include a certificate. You're responsible for making sure the certificates are trusted in your environment. Self-signed certificates are supported with the appropriate chain of trust.
 >
-> - You have to choose whether you want to use MSIX app attach or app attach with a host pool. You can't use both versions with the same host pool.
+> - You have to choose whether you want to use MSIX app attach or app attach with a host pool. You can't use both versions with the same package in the same host pool.
 ::: zone-end
 
 ::: zone pivot="msix-app-attach"
@@ -192,12 +192,13 @@ Here's how to add an MSIX or Appx image as an app attach package using the [Az.D
    Your output should be similar to the following output:
 
    ```output
-   CommandType     Name                                            Version    Source
-   -----------     ----                                            -------    ------
-   Function        Get-AzWvdAppAttachPackage                       4.2.0      Az.DesktopVirtualization
-   Function        New-AzWvdAppAttachPackage                       4.2.0      Az.DesktopVirtualization
-   Function        Remove-AzWvdAppAttachPackage                    4.2.0      Az.DesktopVirtualization
-   Function        Update-AzWvdAppAttachPackage                    4.2.0      Az.DesktopVirtualization
+CommandType     Name                                               Version    Source
+-----------     ----                                               -------    ------
+Function        Get-AzWvdAppAttachPackage                          4.2.1      Az.DesktopVirtualization
+Function        Import-AzWvdAppAttachPackageInfo                   4.2.1      Az.DesktopVirtualization
+Function        New-AzWvdAppAttachPackage                          4.2.1      Az.DesktopVirtualization
+Function        Remove-AzWvdAppAttachPackage                       4.2.1      Az.DesktopVirtualization
+Function        Update-AzWvdAppAttachPackage                       4.2.1      Az.DesktopVirtualization
    ```
 
 3. Get the properties of the image you want to add and store them in a variable by running the following command. You need to specify a host pool, but it can be any host pool where session hosts have access to the file share.
@@ -207,10 +208,10 @@ Here's how to add an MSIX or Appx image as an app attach package using the [Az.D
    $parameters = @{
        HostPoolName = '<HostPoolName>'
        ResourceGroupName = '<ResourceGroupName>'
-       Uri = '<UNCPathToImageFile>'
+       Path = '<UNCPathToImageFile>'
    }
 
-   $app = Expand-AzWvdMsixImage @parameters
+   $app = Import-AzWvdAppAttachPackageInfo @parameters
    ```
 
 4. Check you only have one object in the application properties by running the following command:
@@ -229,10 +230,10 @@ Here's how to add an MSIX or Appx image as an app attach package using the [Az.D
    $parameters = @{
        HostPoolName = '<HostPoolName>'
        ResourceGroupName = '<ResourceGroupName>'
-       Uri = '<UNCPathToImageFile>'
+       Path = '<UNCPathToImageFile>'
    }
 
-   $app = Expand-AzWvdMsixImage @parameters | ? PackageFullName -like *$packageFullName*
+   $app = Import-AzWvdAppAttachPackageInfo @parameters | ? ImagePackageFullName -like *$packageFullName*
    ```
 
 5. Add the image as an app attach package by running the following command. In this example, the [application state](app-attach-overview.md#application-state) is marked as *active*, the [application registration](app-attach-overview.md#application-registration) is set to **on-demand**, and [session host health check status](troubleshoot-statuses-checks.md) on failure is set to **NeedsAssistance**:
@@ -243,12 +244,12 @@ Here's how to add an MSIX or Appx image as an app attach package using the [Az.D
        ResourceGroupName = '<ResourceGroupName>'
        Location = '<AzureRegion>'
        FailHealthCheckOnStagingFailure = 'NeedsAssistance'
-       IsLogonBlocking = $false
-       DisplayName = '<AppDisplayName>'
-       IsActive = $true
+       ImageIsRegularRegistration = $false
+       ImageDisplayName = '<AppDisplayName>'
+       ImageIsActive = $true
    }
 
-   New-AzWvdAppAttachPackage -ImageObject $app @parameters
+   New-AzWvdAppAttachPackage -AppAttachPackage $app @parameters
    ```
 
    There's no output when the package is added successfully.
@@ -593,14 +594,15 @@ Here's how to update an existing package using the [Az.DesktopVirtualization](/p
 1. In the same PowerShell session, get the properties of the updated application and store them in a variable by running the following command:
 
    ```azurepowershell
+
    # Get the properties of the application
    $parameters = @{
        HostPoolName = '<HostPoolName>'
        ResourceGroupName = '<ResourceGroupName>'
-       Uri = '<UNCPathToImageFile>'
+       Path = '<UNCPathToImageFile>'
    }
 
-   $app = Expand-AzWvdMsixImage @parameters
+   $app = Import-AzWvdAppAttachPackageInfo @parameters
    ```
 
 1. Check you only have one object in the application properties by running the following command:
@@ -619,10 +621,10 @@ Here's how to update an existing package using the [Az.DesktopVirtualization](/p
    $parameters = @{
        HostPoolName = '<HostPoolName>'
        ResourceGroupName = '<ResourceGroupName>'
-       Uri = '<UNCPathToImageFile>'
+       Path = '<UNCPathToImageFile>'
    }
 
-   $app = Expand-AzWvdMsixImage @parameters | ? PackageFullName -like *$packageFullName*
+   $app = Import-AzWvdAppAttachPackageInfo @parameters | ? ImagePackageFullName -like *$packageFullName*
    ```
 
 1. Update an existing package by running the following command. The new disk image supersedes the existing one, but existing assignments are kept. Don't delete the existing image until users have stopped using it.
@@ -631,10 +633,9 @@ Here's how to update an existing package using the [Az.DesktopVirtualization](/p
    $parameters = @{
        Name = '<PackageName>'
        ResourceGroupName = '<ResourceGroupName>'
-       Location = '<AzureRegion>'
    }
 
-   Update-AzWvdAppAttachPackage -ImageObject $app @parameters
+   Update-AzWvdAppAttachPackage -AppAttachPackage $app @parameters
    ```
 
 ---
@@ -714,7 +715,7 @@ Here's how to add an MSIX package using the [Az.DesktopVirtualization](/powershe
 
 [!INCLUDE [include-cloud-shell-local-powershell](includes/include-cloud-shell-local-powershell.md)]
 
-2. Get the properties of the application in the MSI image you want to add and store them in a variable by running the following command:
+2. Get the properties of the application in the MSIX image you want to add and store them in a variable by running the following command:
 
    ```azurepowershell
    # Get the properties of the MSIX image

--- a/articles/virtual-desktop/app-attach-setup.md
+++ b/articles/virtual-desktop/app-attach-setup.md
@@ -192,13 +192,13 @@ Here's how to add an MSIX or Appx image as an app attach package using the [Az.D
    Your output should be similar to the following output:
 
    ```output
-CommandType     Name                                               Version    Source
------------     ----                                               -------    ------
-Function        Get-AzWvdAppAttachPackage                          4.2.1      Az.DesktopVirtualization
-Function        Import-AzWvdAppAttachPackageInfo                   4.2.1      Az.DesktopVirtualization
-Function        New-AzWvdAppAttachPackage                          4.2.1      Az.DesktopVirtualization
-Function        Remove-AzWvdAppAttachPackage                       4.2.1      Az.DesktopVirtualization
-Function        Update-AzWvdAppAttachPackage                       4.2.1      Az.DesktopVirtualization
+   CommandType     Name                                               Version    Source
+   -----------     ----                                               -------    ------
+   Function        Get-AzWvdAppAttachPackage                          4.2.1      Az.DesktopVirtualization
+   Function        Import-AzWvdAppAttachPackageInfo                   4.2.1      Az.DesktopVirtualization
+   Function        New-AzWvdAppAttachPackage                          4.2.1      Az.DesktopVirtualization
+   Function        Remove-AzWvdAppAttachPackage                       4.2.1      Az.DesktopVirtualization
+   Function        Update-AzWvdAppAttachPackage                       4.2.1      Az.DesktopVirtualization
    ```
 
 3. Get the properties of the image you want to add and store them in a variable by running the following command. You need to specify a host pool, but it can be any host pool where session hosts have access to the file share.


### PR DESCRIPTION
The documentation was written using the private preview powershell which had some differences from the public preview powershell. This makes the documentation correct for customers who are using the public preview powershell.