### PR TITLE
Added note about Excel table support

### DIFF
--- a/articles/ai-services/document-intelligence/concept-layout.md
+++ b/articles/ai-services/document-intelligence/concept-layout.md
@@ -330,6 +330,10 @@ Extracting tables is a key requirement for processing documents containing large
 
 ```
 
+> [!IMPORTANT]
+>
+> Table extraction from Excel files is not yet supported.
+
 ### Handwritten style for text lines
 
 The response includes classifying whether each text line is of handwriting style or not, along with a confidence score. For more information. *see*, [Handwritten language support](language-support-ocr.md). The following example shows an example JSON snippet.


### PR DESCRIPTION
Document Intelligence does not yet support table extraction from Excel files but this isn't mentioned in the documentation. Now it is!