### PR TITLE
Update transform-data-using-script.md

### DIFF
--- a/articles/data-factory/transform-data-using-script.md
+++ b/articles/data-factory/transform-data-using-script.md
@@ -157,7 +157,7 @@ Sample output:
 > - Since the output has size / rows limitation, the output will be truncated in following order: logs -> parameters -> rows. Note, this applies to a single script block, which means the output rows of next script block won’t evict previous logs. 
 > - Any error caused by log won’t fail the activity. 
 > - For consuming activity output resultSets in down stream activity please refer to the [Lookup activity result documentation](control-flow-lookup-activity.md#use-the-lookup-activity-result).
-> - Use outputLogs when you are using 'PRINT' statements for logging purpose. If query returns resultSets, it will be available in the activity output and will be limited to 5000 rows/ 2MB size limit. 
+> - Use outputLogs when you are using 'PRINT' statements for logging purpose. If query returns resultSets, it will be available in the activity output and will be limited to 5000 rows/ 4MB size limit. 
 
 ## Configure the Script activity using UI
 
@@ -174,7 +174,7 @@ Inline scripts integrate well with Pipeline CI/CD since the script is stored as 
 Logging options:
 
 - _Disable_ - No execution output is logged.
-- _Activity output_ - The script execution output is appended to the activity output. It can be consumed by downstream activities. The output size is limited to 2MB.  
+- _Activity output_ - The script execution output is appended to the activity output. It can be consumed by downstream activities. The output size is limited to 4MB.  
 - _External storage_ - Persists output to storage.  Use this option if the output size is greater than 2MB or you would like to explicitly persist the output on your storage account.
  
 > [!NOTE]


### PR DESCRIPTION
I'm not 100% certain but there are references to a 5k rows 2mb limit in the article, however I know that the limit for the lookup activity is 5k rows 4mb. I would assume that this limit the same on both can someone from product please confirm?