### PR TITLE
Fix missing parts and refine in workload-identity-deploy-cluster.md

### DIFF
--- a/articles/aks/workload-identity-deploy-cluster.md
+++ b/articles/aks/workload-identity-deploy-cluster.md
@@ -171,7 +171,7 @@ You can retrieve this information using the Azure CLI command: [az keyvault list
     ```azurecli-interactive
     export KEYVAULT_RESOURCE_GROUP="myResourceGroup"
     export KEYVAULT_NAME="myKeyVault"
-    export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${KEYVAULT_RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -o tsv)"
+    export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -o tsv)"
 
     az keyvault set-policy --name "${KEYVAULT_NAME}" --secret-permissions get --spn "${USER_ASSIGNED_CLIENT_ID}"
     ```

--- a/articles/aks/workload-identity-deploy-cluster.md
+++ b/articles/aks/workload-identity-deploy-cluster.md
@@ -139,7 +139,7 @@ cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
-  name: quick-start
+  name: your-pod
   namespace: "${SERVICE_ACCOUNT_NAMESPACE}"
   labels:
     azure.workload.identity/use: "true"

--- a/articles/aks/workload-identity-deploy-cluster.md
+++ b/articles/aks/workload-identity-deploy-cluster.md
@@ -66,16 +66,16 @@ az aks update -g "${RESOURCE_GROUP}" -n myAKSCluster --enable-oidc-issuer --enab
 To get the OIDC Issuer URL and save it to an environmental variable, run the following command. Replace the default value for the arguments `-n`, which is the name of the cluster:
 
 ```bash
-export AKS_OIDC_ISSUER="$(az aks show -n myAKSCluster -g "${RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -otsv)"
+export AKS_OIDC_ISSUER="$(az aks show -n myAKSCluster -g "${RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -o tsv)"
 ```
 
 The variable should contain the Issuer URL similar to the following example:
 
 ```output
-https://eastus.oic.prod-aks.azure.com/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/
+https://eastus.oic.prod-aks.azure.com/00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111/
 ```
 
-By default, the Issuer is set to use the base URL `https://{region}.oic.prod-aks.azure.com/{uuid}`, where the value for `{region}` matches the location the AKS cluster is deployed in. The value `{uuid}` represents the OIDC key.
+By default, the Issuer is set to use the base URL `https://{region}.oic.prod-aks.azure.com/{tenant_id}/{uuid}`, where the value for `{region}` matches the location the AKS cluster is deployed in. The value `{uuid}` represents the OIDC key.
 
 ## Create a managed identity
 
@@ -88,7 +88,7 @@ az identity create --name "${USER_ASSIGNED_IDENTITY_NAME}" --resource-group "${R
 Next, let's create a variable for the managed identity ID.
 
 ```bash
-export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)"
+export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -o tsv)"
 ```
 
 ## Create Kubernetes service account
@@ -116,7 +116,7 @@ EOF
 The following output resembles successful creation of the identity:
 
 ```output
-Serviceaccount/workload-identity-sa created
+serviceaccount/workload-identity-sa created
 ```
 
 ## Establish federated identity credential
@@ -145,27 +145,15 @@ metadata:
     azure.workload.identity/use: "true"
 spec:
   serviceAccountName: "${SERVICE_ACCOUNT_NAME}"
+  containers:
+    - image: <your image>
+      name: <containerName>
 EOF
 ```
 
 > [!IMPORTANT]
 > Ensure your application pods using workload identity have added the following label `azure.workload.identity/use: "true"` to your pod spec, otherwise the pods fail after their restarted.
 
-```bash
-kubectl apply -f <your application>
-```
-
-To check whether all properties are injected properly by the webhook, use the [kubectl describe][kubectl-describe] command:
-
-```bash
-kubectl describe pod containerName
-```
-
-To verify that pod is able to get a token and access the resource, use the kubectl logs command:
-
-```bash
-kubectl logs containerName
-```
 
 ## Optional - Grant permissions to access Azure Key Vault
 
@@ -181,20 +169,82 @@ You can retrieve this information using the Azure CLI command: [az keyvault list
 1. Set an access policy for the managed identity to access secrets in your Key Vault by running the following commands:
 
     ```azurecli-interactive
-    export RESOURCE_GROUP="myResourceGroup"
-    export USER_ASSIGNED_IDENTITY_NAME="myIdentity"
+    export KEYVAULT_RESOURCE_GROUP="myResourceGroup"
     export KEYVAULT_NAME="myKeyVault"
-    export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)"
+    export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${KEYVAULT_RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -o tsv)"
 
     az keyvault set-policy --name "${KEYVAULT_NAME}" --secret-permissions get --spn "${USER_ASSIGNED_CLIENT_ID}"
     ```
+
+2. Create a secret in Key Vault:
+
+    ```azurecli-interactive
+    export KEYVAULT_SECRET_NAME="my-secret"
+
+    az keyvault secret set --vault-name "${KEYVAULT_NAME}" \
+       --name "${KEYVAULT_SECRET_NAME}" \
+       --value "Hello\!"
+    ```
+
+3. Export Key Vault URL:
+    ```azurecli-interactive
+    export KEYVAULT_URL="$(az keyvault show -g ${RESOURCE_GROUP} -n ${KEYVAULT_NAME} --query properties.vaultUri -o tsv)"
+    ```
+
+4. Deploy a pod that references the service account and Key Vault URL above:
+
+    ```yml
+    cat <<EOF | kubectl apply -f -
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: quick-start
+      namespace: ${SERVICE_ACCOUNT_NAMESPACE}
+      labels:
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+      containers:
+        - image: ghcr.io/azure/azure-workload-identity/msal-go
+          name: oidc
+          env:
+          - name: KEYVAULT_URL
+            value: ${KEYVAULT_URL}
+          - name: SECRET_NAME
+            value: ${KEYVAULT_SECRET_NAME}
+      nodeSelector:
+        kubernetes.io/os: linux
+    EOF
+    ```
+
+To check whether all properties are injected properly by the webhook, use the [kubectl describe][kubectl-describe] command:
+
+```bash
+kubectl describe pod quick-start | grep "SECRET_NAME:"
+```
+
+If successful, the output should be similar to the following:  
+```bash
+      SECRET_NAME:                 ${KEYVAULT_SECRET_NAME}
+```
+
+To verify that pod is able to get a token and access the resource, use the kubectl logs command:
+
+```bash
+kubectl logs quick-start
+```
+
+If successful, the output should be similar to the following:  
+```bash
+I0114 10:35:09.795900       1 main.go:63] "successfully got secret" secret="Hello\\!"
+```
 
 ## Disable workload identity
 
 To disable the Microsoft Entra Workload ID on the AKS cluster where it's been enabled and configured, you can run the following command:
 
 ```azurecli-interactive
-az aks update --resource-group myResourceGroup --name myAKSCluster --disable-workload-identity
+az aks update --resource-group "${RESOURCE_GROUP}" --name myAKSCluster --disable-workload-identity
 ```
 
 ## Next steps

--- a/articles/aks/workload-identity-deploy-cluster.md
+++ b/articles/aks/workload-identity-deploy-cluster.md
@@ -188,7 +188,7 @@ You can retrieve this information using the Azure CLI command: [az keyvault list
 
 3. Export Key Vault URL:
     ```azurecli-interactive
-    export KEYVAULT_URL="$(az keyvault show -g ${RESOURCE_GROUP} -n ${KEYVAULT_NAME} --query properties.vaultUri -o tsv)"
+    export KEYVAULT_URL="$(az keyvault show -g ${KEYVAULT_RESOURCE_GROUP} -n ${KEYVAULT_NAME} --query properties.vaultUri -o tsv)"
     ```
 
 4. Deploy a pod that references the service account and Key Vault URL above:


### PR DESCRIPTION
**1. Modify "-otsv" to "-o tsv"**

I understand these commands can be executed, but I am not sure if it supposed to be running with "-otsv", it should not be supposed to be like this. This is too weird.  

**2. Refine the description of OIDC_ISSUER**

Give more detail to prevent misunderstanding, like believing "/00000000-0000-0000-0000-000000000000/11111111-1111-1111-1111-111111111111/" is representing oidc key.  

**3. Refine the part of "Deploy your application"**
Even don't want to give exact image name, it is too awful to give an incorrect/substandard yaml.  

**4. Refine the part "Optional - Grant permissions to access Azure Key Vault"**

a. We have set environment with same name before. So delete/refine the repeating part. Or user may overwrite the environment parameter by accident.   
b. It looks like this part is incomplete. There is no way there is only one step.   
c. The steps to verify tokens is in the incorrect section.