### PR TITLE
Fix required URL for Arc ESU

### DIFF
--- a/articles/azure-arc/servers/includes/esu-network-requirements.md
+++ b/articles/azure-arc/servers/includes/esu-network-requirements.md
@@ -17,7 +17,7 @@ If you are using Azure Arc-enabled servers only for the purpose of Extended Secu
 |`management.azure.com`|Azure Resource Manager - to create or delete the Arc server resource|When connecting or disconnecting a server, only| Public, unless a [resource management private link](../../../azure-resource-manager/management/create-private-link-access-portal.md) is also configured |
 |`*.his.arc.azure.com`|Metadata and hybrid identity services|Always| Private |
 |`*.guestconfiguration.azure.com`| Extension management and guest configuration services |Always| Private |
-|`microsoft.com/pkiops/certs`| Certificate download for ESUs | ESUs enabled by Azure Arc | Public |
+|`www.microsoft.com/pkiops/certs`| Certificate download for ESUs | ESUs enabled by Azure Arc | Public |
 |`san-af-<region>-prod.azurewebsites.net`| Azure Arc data processing service| SQL Server ESUs | Public|
 
 #### [Azure Government](#tab/azure-government)
@@ -30,7 +30,7 @@ If you are using Azure Arc-enabled servers only for the purpose of Extended Secu
 |`management.usgovcloudapi.net`|Azure Resource Manager - to create or delete the Arc server resource|When connecting or disconnecting a server, only| Public, unless a [resource management private link](../../../azure-resource-manager/management/create-private-link-access-portal.md) is also configured |
 |`*.his.arc.azure.us`|Metadata and hybrid identity services|Always| Private |
 |`*.guestconfiguration.azure.us`| Extension management and guest configuration services |Always| Private |
-|`microsoft.com/pkiops/certs`| Certificate download for ESUs | ESUs enabled by Azure Arc | Public |
+|`www.microsoft.com/pkiops/certs`| Certificate download for ESUs | ESUs enabled by Azure Arc | Public |
 
 #### [Microsoft Azure operated by 21Vianet](#tab/azure-china)
 

--- a/articles/azure-arc/servers/includes/network-requirements.md
+++ b/articles/azure-arc/servers/includes/network-requirements.md
@@ -60,7 +60,7 @@ The table below lists the URLs that must be available in order to install and us
 |`dc.services.visualstudio.com`|Agent telemetry|Optional, not used in agent versions 1.24+| Public |
 | `san-af-<region>-prod.azurewebsites.net` | Azure Arc data processing service | For SQL Server enabled by Azure Arc. The Azure Extension for SQL Server uploads inventory and billing information to the data processing service. | Public |
 | `telemetry.<region>.arcdataservices.com` | For Arc SQL Server. Sends service telemetry and performance monitoring to Azure | Always | Public |
-|`microsoft.com/pkiops/certs`| Certificate download for ESUs |ESUs enabled by Azure Arc | Public |
+|`www.microsoft.com/pkiops/certs`| Certificate download for ESUs |ESUs enabled by Azure Arc | Public |
 
 > [!NOTE]
 > To translate the `*.servicebus.windows.net` wildcard into specific endpoints, use the command `\GET https://guestnotificationservice.azure.com/urls/allowlist?api-version=2020-01-01&location=<region>`. Within this command, the region must be specified for the `<region>` placeholder.

--- a/articles/azure-arc/servers/includes/network-requirements.md
+++ b/articles/azure-arc/servers/includes/network-requirements.md
@@ -84,7 +84,7 @@ The table below lists the URLs that must be available in order to install and us
 |`*.guestconfiguration.azure.us`| Extension management and guest configuration services |Always| Private |
 |`*.blob.core.usgovcloudapi.net`|Download source for Azure Arc-enabled servers extensions|Always, except when using private endpoints| Not used when private link is configured |
 |`dc.applicationinsights.us`|Agent telemetry|Optional, not used in agent versions 1.24+| Public |
-|`microsoft.com/pkiops/certs`| Certificate download for ESUs |ESUs enabled by Azure Arc | Public |
+|`www.microsoft.com/pkiops/certs`| Certificate download for ESUs |ESUs enabled by Azure Arc | Public |
 
 #### [Microsoft Azure operated by 21Vianet](#tab/azure-china)
 

--- a/articles/azure-arc/servers/troubleshoot-extended-security-updates.md
+++ b/articles/azure-arc/servers/troubleshoot-extended-security-updates.md
@@ -62,7 +62,7 @@ Ensure that both the licensing package and servicing stack update (SSU) are down
 
 If installing the Extended Security Update enabled by Azure Arc fails with errors such as "ESU: Trying to Check IMDS Again LastError=HRESULT_FROM_WIN32(12029)" or "ESU: Trying to Check IMDS Again LastError=HRESULT_FROM_WIN32(12002)", you may need to update the intermediate certificate authorities trusted by your computer using one of the following two methods:
 
-1. Configure your network firewall and/or proxy server to allow access from the Windows Server 2012 (R2) machines to `https://microsoft.com/pkiops/certs`. This will allow the machine to automatically retrieve updated intermediate certificates as required and is Microsoft's preferred approach.
+1. Configure your network firewall and/or proxy server to allow access from the Windows Server 2012 (R2) machines to `https://www.microsoft.com/pkiops/certs`. This will allow the machine to automatically retrieve updated intermediate certificates as required and is Microsoft's preferred approach.
 1. Download all intermediate CAs from a machine with internet access, copy them to each Windows Server 2012 (R2) machine, and import them to the machine's intermediate certificate authority store:
     1. Download the 4 intermediate CA certificates:
         1. [Microsoft Azure TLS Issuing CA 01](https://www.microsoft.com/pkiops/certs/Microsoft%20Azure%20TLS%20Issuing%20CA%2001%20-%20xsign.crt)


### PR DESCRIPTION
Hi 

The required intermediate CA certificates for Azure Arc ESU is hosted in `https://www.microsoft.com/pkiops/`. So `microsoft.com/pkiops/certs` should be changed to `www.microsoft.com/pkiops/certs` The customer who allows `microsoft.com` can't access `www.microsoft.com`.

Best regards.