### PR TITLE
Update authorize-access-azure-active-directory.md

### DIFF
--- a/articles/storage/blobs/authorize-access-azure-active-directory.md
+++ b/articles/storage/blobs/authorize-access-azure-active-directory.md
@@ -18,6 +18,8 @@ Authorization with Microsoft Entra ID provides superior security and ease of use
 
 Authorization with Microsoft Entra ID is available for all general-purpose and Blob storage accounts in all public regions and national clouds. Only storage accounts created with the Azure Resource Manager deployment model support Microsoft Entra authorization.
 
+The **defaultToOAuthAuthentication** property of a storage account is not set by default and does not return a value until you explicitly set it.
+
 Blob storage additionally supports creating shared access signatures (SAS) that are signed with Microsoft Entra credentials. For more information, see [Grant limited access to data with shared access signatures](../common/storage-sas-overview.md).
 
 <a name='overview-of-azure-ad-for-blobs'></a>


### PR DESCRIPTION
The defaultToOAuthAuthentication property of a storage account is not set by default.

When trying from Portal, the value gets explicitly set for this either true or false depending upon if we select that option during the creation of account. However, if we try Powershell and don't set this property, the value doesn't get set explicitly and shall return a null for this property. 

Updating documentation to clarify the same.