### PR TITLE
Fix a error responses example

### DIFF
--- a/articles/active-directory-b2c/openid-connect.md
+++ b/articles/active-directory-b2c/openid-connect.md
@@ -198,8 +198,8 @@ Error responses look like:
 
 ```json
 {
-    "error": "access_denied",
-    "error_description": "The user revoked access to the app."
+    "error": "invalid_grant",
+    "error_description": "AADB2C90080: The provided grant has expired. Please re-authenticate and try again. Current time: 1705367452, Grant issued time: 1704865840, Grant expiration time: 1704866140\r\nCorrelation ID: xxxxxxxx-xxxx-xxxX-xxxx-xxxxxxxxxxxx\r\nTimestamp: 2024-01-16 01:10:52Z\r\n"
 }
 ```
 
@@ -275,8 +275,8 @@ Error responses look like:
 
 ```json
 {
-    "error": "access_denied",
-    "error_description": "The user revoked access to the app.",
+    "error": "invalid_grant",
+    "error_description": "AADB2C90129: The provided grant has been revoked. Please reauthenticate and try again.\r\nCorrelation ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\r\nTimestamp: 2024-01-16 01:21:18Z\r\n",
 }
 ```
 

--- a/articles/active-directory-b2c/openid-connect.md
+++ b/articles/active-directory-b2c/openid-connect.md
@@ -90,7 +90,7 @@ Error responses can also be sent to the `redirect_uri` parameter so that the app
 ```http
 GET https://jwt.ms/#
 error=access_denied
-&error_description=AADB2C90091%3a+The+user+has+cancelled+entering+self-asserted+information.%0d%0aCorrelation+ID%3a+xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx%0d%0aTimestamp%3a+2024-01-05+14%3a23%3a27Z%0d%0a
+&error_description=AADB2C90091%3a+The+user+has+cancelled+entering+self-asserted+information.%0d%0aCorrelation+ID%3a+xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx%0d%0aTimestamp%3a+xxxx-xx-xx+xx%3a23%3a27Z%0d%0a
 &state=arbitrary_data_you_can_receive_in_the_response
 ```
 

--- a/articles/active-directory-b2c/openid-connect.md
+++ b/articles/active-directory-b2c/openid-connect.md
@@ -276,7 +276,7 @@ Error responses look like:
 ```json
 {
     "error": "invalid_grant",
-    "error_description": "AADB2C90129: The provided grant has been revoked. Please reauthenticate and try again.\r\nCorrelation ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\r\nTimestamp: 2024-01-16 01:21:18Z\r\n",
+    "error_description": "AADB2C90129: The provided grant has been revoked. Please reauthenticate and try again.\r\nCorrelation ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\r\nTimestamp: xxxx-xx-xx xx:xx:xxZ\r\n",
 }
 ```
 

--- a/articles/active-directory-b2c/openid-connect.md
+++ b/articles/active-directory-b2c/openid-connect.md
@@ -90,7 +90,7 @@ Error responses can also be sent to the `redirect_uri` parameter so that the app
 ```http
 GET https://jwt.ms/#
 error=access_denied
-&error_description=the+user+canceled+the+authentication
+&error_description=AADB2C90091%3a+The+user+has+cancelled+entering+self-asserted+information.%0d%0aCorrelation+ID%3a+xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx%0d%0aTimestamp%3a+2024-01-05+14%3a23%3a27Z%0d%0a
 &state=arbitrary_data_you_can_receive_in_the_response
 ```
 

--- a/articles/active-directory-b2c/openid-connect.md
+++ b/articles/active-directory-b2c/openid-connect.md
@@ -199,7 +199,7 @@ Error responses look like:
 ```json
 {
     "error": "invalid_grant",
-    "error_description": "AADB2C90080: The provided grant has expired. Please re-authenticate and try again. Current time: 1705367452, Grant issued time: 1704865840, Grant expiration time: 1704866140\r\nCorrelation ID: xxxxxxxx-xxxx-xxxX-xxxx-xxxxxxxxxxxx\r\nTimestamp: 2024-01-16 01:10:52Z\r\n"
+    "error_description": "AADB2C90080: The provided grant has expired. Please re-authenticate and try again. Current time: xxxxxxxxxx, Grant issued time: xxxxxxxxxx, Grant expiration time: xxxxxxxxxx\r\nCorrelation ID: xxxxxxxx-xxxx-xxxX-xxxx-xxxxxxxxxxxx\r\nTimestamp: xxxx-xx-16 xx:10:52Z\r\n"
 }
 ```
 


### PR DESCRIPTION
An error_description containing the error code is returned, but the error_description in the document did not contain the error code.
How the error code is included is very important information for the application's error handling.
https://learn.microsoft.com/en-us/azure/active-directory-b2c/error-codes

