### PR TITLE
Correct the link to the example authentication-authorization-overview.md

### DIFF
--- a/articles/api-management/authentication-authorization-overview.md
+++ b/articles/api-management/authentication-authorization-overview.md
@@ -123,7 +123,7 @@ Examples:
 
 * [Configure credential manager - Microsoft Graph API](credentials-how-to-azure-ad.md)
 * [Configure credential manager - GitHub API](credentials-how-to-github.md)
-* [Configure credential manager - user delegated access to backend APIs](credentials-how-to-github.md)
+* [Configure credential manager - user delegated access to backend APIs](credentials-how-to-user-delegated.md)
 
 ## Other options to secure APIs
 


### PR DESCRIPTION
The text of the link says "user delegated access to backend APIs", but the link itself points to the Github example.
This change should point to the right example.