### PR TITLE
Update authorize-data-operations-portal.md

### DIFF
--- a/articles/storage/blobs/authorize-data-operations-portal.md
+++ b/articles/storage/blobs/authorize-data-operations-portal.md
@@ -126,6 +126,8 @@ To update this setting for an existing storage account, follow these steps:
 
     :::image type="content" source="media/authorize-data-operations-portal/default-auth-account-update-portal.png" alt-text="Screenshot showing how to configure default Microsoft Entra authorization in Azure portal for existing account":::
 
+The **defaultToOAuthAuthentication** property of a storage account is not set by default and does not return a value until you explicitly set it.
+
 ## Next steps
 
 - [Authorize access to data in Azure Storage](../common/authorize-data-access.md)


### PR DESCRIPTION
The defaultToOAuthAuthentication property of a storage account is not set by default.

When trying from Portal, the value gets explicitly set for this either true or false depending upon if we select that option during the creation of account. However, if we try Powershell and don't set this property, the value doesn't get set explicitly and shall return a null for this property.

Updating documentation to clarify the same.