### PR TITLE
Fix: Typo in functions-develop-vs-code.md. Corrected "baswed" to "based"

### DIFF
--- a/articles/azure-functions/functions-develop-vs-code.md
+++ b/articles/azure-functions/functions-develop-vs-code.md
@@ -209,7 +209,7 @@ At this point, you can do one of these tasks:
 
 ## Add a function to your project
 
-You can add a new function to an existing project baswed on one of the predefined Functions trigger templates. To add a new function trigger, select F1 to open the command palette, and then search for and run the command **Azure Functions: Create Function**. Follow the prompts to choose your trigger type and define the required attributes of the trigger. If your trigger requires an access key or connection string to connect to a service, get it ready before you create the function trigger.
+You can add a new function to an existing project based on one of the predefined Functions trigger templates. To add a new function trigger, select F1 to open the command palette, and then search for and run the command **Azure Functions: Create Function**. Follow the prompts to choose your trigger type and define the required attributes of the trigger. If your trigger requires an access key or connection string to connect to a service, get it ready before you create the function trigger.
 
 ::: zone pivot="programming-language-csharp"  
 The results of this action are that a new C# class library (.cs) file is added to your project.


### PR DESCRIPTION
## Description
This pull request addresses a minor typo in the documentation where the word "baswed" was used instead of "based". I've corrected this error to ensure clarity and accuracy in the content.

## Changes Made
Corrected the typo from "baswed" to "based" in articles/azure-functions/functions-develop-vs-code.md.

## Screenshots
Attached is a screenshot highlighting the error in the documentation for reference.

![image](https://github.com/MicrosoftDocs/azure-docs/assets/68476835/7f363428-1391-4b78-9976-b829d1423e7e)


## Additional Information
No other changes have been made in this pull request. This fix is purely cosmetic and does not impact the functionality of the documentation.

Please review and merge at your earliest convenience. Thank you!