### PR TITLE
Update ingress-controller-install-new.md

### DIFF
--- a/articles/application-gateway/ingress-controller-install-new.md
+++ b/articles/application-gateway/ingress-controller-install-new.md
@@ -293,7 +293,7 @@ spec:
   - image: "mcr.microsoft.com/dotnet/core/samples:aspnetapp"
     name: aspnetapp-image
     ports:
-    - containerPort: 80
+    - containerPort: 8080
       protocol: TCP
 
 ---
@@ -308,7 +308,7 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 80
+    targetPort: 8080
 
 ---
 
@@ -323,6 +323,7 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: Exact
         backend:
           serviceName: aspnetapp
           servicePort: 80


### PR DESCRIPTION
1. Kestrel listens to the port 8080.  Azure App Gateway Backend is unhealthy because of Port 80 mentioned in Pod's Container Port and Service definition's TargetPort. 
2. Ingress Controller definition throw error because of the missing pathType property.