### PR TITLE
Update manage-ssh-node-access.md

### DIFF
--- a/articles/aks/manage-ssh-node-access.md
+++ b/articles/aks/manage-ssh-node-access.md
@@ -39,7 +39,7 @@ Use the [az aks create][az-aks-create] command to deploy an AKS cluster with an 
 |SSH parameter |Description |Default value |
 |-----|-----|-----|
 |--generate-ssh-key |If you don't have your own SSH key, specify `--generate-ssh-key`. The Azure CLI first looks for the key in the `~/.ssh/` directory. If the key exists, it's used. If the key doesn't exist, the Azure CLI automatically generates a set of SSH keys and saves them in the specified or default directory.||
-|--ssh-key-vaule |Public key path or key contents to install on node VMs for SSH access. For example, `ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm`.|`~.ssh\id_rsa.pub` |
+|--ssh-key-value |Public key path or key contents to install on node VMs for SSH access. For example, `ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm`.|`~/.ssh/id_rsa.pub` |
 |--no-ssh-key | If you don't require an SSH key, specify this argument. However, AKS automatically generates a set of SSH keys because the Azure Virtual Machine resource dependency doesn’t support an empty SSH key file. As a result, the keys aren't returned and can't be used to SSH into the node VMs. ||
 
 >[!NOTE]


### PR DESCRIPTION
typo on flage --ssh-key-value, also used slash instead of backslash for linux