### PR TITLE
Added the term "Elastic" to a few key documents 

### DIFF
--- a/articles/azure-functions/configure-networking-how-to.md
+++ b/articles/azure-functions/configure-networking-how-to.md
@@ -62,8 +62,8 @@ To secure the storage for an existing function app:
     | Setting name | Value | Comment |
     |----|----|----|
     | `AzureWebJobsStorage`| Storage connection string | This is the connection string for a secured storage account. |
-    | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` |  Storage connection string | This is the connection string for a secured storage account. This setting is required for Consumption and Premium plan apps on both Windows and Linux. It's not required for Dedicated plan apps, which aren't dynamically scaled by Functions. |
-    | `WEBSITE_CONTENTSHARE` | File share | The name of the file share created in the secured storage account where the project deployment files reside. This setting is required for Consumption and Premium plan apps on both Windows and Linux. It's not required for Dedicated plan apps, which aren't dynamically scaled by Functions. |
+    | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` |  Storage connection string | This is the connection string for a secured storage account. This setting is required for Consumption and Elastic Premium plan apps on both Windows and Linux. It's not required for Dedicated plan apps, which aren't dynamically scaled by Functions. |
+    | `WEBSITE_CONTENTSHARE` | File share | The name of the file share created in the secured storage account where the project deployment files reside. This setting is required for Consumption and Elastic Premium plan apps on both Windows and Linux. It's not required for Dedicated plan apps, which aren't dynamically scaled by Functions. |
     | `WEBSITE_CONTENTOVERVNET` | 1 | A value of 1 enables your function app to scale when you have your storage account restricted to a virtual network. You should enable this setting when restricting your storage account to a virtual network. |
 
 1. Select **Save** to save the application settings. Changing app settings causes the app to restart.  

--- a/articles/azure-functions/functions-app-settings.md
+++ b/articles/azure-functions/functions-app-settings.md
@@ -614,7 +614,7 @@ Azure Files doesn't support using managed identity when accessing the file share
 
 ## WEBSITE\_CONTENTOVERVNET
 
-A value of `1` enables your function app to scale when you have your storage account restricted to a virtual network. You should enable this setting when restricting your storage account to a virtual network. To learn more, see [Restrict your storage account to a virtual network](configure-networking-how-to.md#restrict-your-storage-account-to-a-virtual-network).
+A value of `1` enables your function app to scale when you have your storage account restricted to a virtual network. You should enable this setting when restricting your storage account to a virtual network. Only required when using `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`. To learn more, see [Restrict your storage account to a virtual network](configure-networking-how-to.md#restrict-your-storage-account-to-a-virtual-network).
 
 |Key|Sample value|
 |---|------------|

--- a/articles/azure-functions/functions-recover-storage-account.md
+++ b/articles/azure-functions/functions-recover-storage-account.md
@@ -31,7 +31,7 @@ In the preceding step, if you can't find a storage account connection string, it
 
 * Required:
   * [`AzureWebJobsStorage`](./functions-app-settings.md#azurewebjobsstorage)
-* Required for Premium plan functions:
+* Required for Elastic Premium and Consumption plan functions:
   * [`WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`](./functions-app-settings.md)
   * [`WEBSITE_CONTENTSHARE`](./functions-app-settings.md)
 


### PR DESCRIPTION
The objective of the propose changes is to clarify the term Premium Plan = Elastic Premium Plan to avoid confusions with the App Settings "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING", "WEBSITE_CONTENTSHARE" and "
WEBSITE_CONTENTOVERVNET" that are commonly added to Dedicated Premium Plans which do not need them.