### PR TITLE
Update application-security-groups.md

### DIFF
--- a/articles/virtual-network/application-security-groups.md
+++ b/articles/virtual-network/application-security-groups.md
@@ -15,7 +15,7 @@ Application security groups enable you to configure network security as a natura
 
 :::image type="content" source="./media/security-groups/application-security-groups.png" alt-text="Diagram of Application security groups.":::
 
-In the previous picture, *NIC1* and *NIC2* are members of the *AsgWeb* application security group. *NIC3* is a member of the *AsgLogic* application security group. *NIC4* is a member of the *AsgDb* application security group. Though each network interface (NIC) in this example is a member of only one network security group, a network interface can be a member of multiple application security groups, up to the [Azure limits](../azure-resource-manager/management/azure-subscription-service-limits.md?toc=%2fazure%2fvirtual-network%2ftoc.json#azure-resource-manager-virtual-networking-limits). None of the network interfaces have an associated network security group. *NSG1* is associated to both subnets and contains the following rules:
+In the previous picture, *NIC1* and *NIC2* are members of the *AsgWeb* application security group. *NIC3* is a member of the *AsgLogic* application security group. *NIC4* is a member of the *AsgDb* application security group. Though each network interface (NIC) in this example is a member of only one application security group, a network interface can be a member of multiple application security groups, up to the [Azure limits](../azure-resource-manager/management/azure-subscription-service-limits.md?toc=%2fazure%2fvirtual-network%2ftoc.json#azure-resource-manager-virtual-networking-limits). None of the network interfaces have an associated network security group. *NSG1* is associated to both subnets and contains the following rules:
 
 ## Allow-HTTP-Inbound-Internet
 


### PR DESCRIPTION
### Summary
- Updated [Update application-security-groups.md#L18](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/virtual-network/application-security-groups.md?plain=1#L18).
- Based on the context ([the previous sentence](https://learn.microsoft.com/en-us/azure/virtual-network/application-security-groups#:~:text=In%20the%20previous%20picture%2C%20NIC1%20and%20NIC2%20are%20members%20of%20the%20AsgWeb%20application%20security%20group.%20NIC3%20is%20a%20member%20of%20the%20AsgLogic%20application%20security%20group.%20NIC4%20is%20a%20member%20of%20the%20AsgDb%20application%20security%20group.)), it should be `Though each network interface (NIC) in this example is a member of only one **application** security group`.
- Otherwise, this paragraph is contradictory, if you check `each network interface (NIC) in this example is a member of only one network security group` and `None of the network interfaces have an associated network security group`