### PR TITLE
Typo "a Amazon account"→"an Amazon account"

### DIFF
--- a/articles/active-directory-b2c/identity-provider-amazon.md
+++ b/articles/active-directory-b2c/identity-provider-amazon.md
@@ -91,7 +91,7 @@ You need to store the client secret that you previously recorded in your Azure A
 
 ## Configure Amazon as an identity provider
 
-To enable users to sign in using a Amazon account, you need to define the account as a claims provider. that Azure AD B2C can communicate with through an endpoint. The endpoint provides a set of claims that are used by Azure AD B2C to verify that a specific user has authenticated.
+To enable users to sign in using an Amazon account, you need to define the account as a claims provider. that Azure AD B2C can communicate with through an endpoint. The endpoint provides a set of claims that are used by Azure AD B2C to verify that a specific user has authenticated.
 
 You can define an Amazon account as a claims provider by adding it to the **ClaimsProviders** element in the extension file of your policy.
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/active-directory-b2c/identity-provider-amazon?pivots=b2c-custom-policy 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/active-directory-b2c/identity-provider-amazon.md 
#PingMSFTDocs