### PR TITLE
Update author-policies-for-arrays.md

### DIFF
--- a/articles/governance/policy/how-to/author-policies-for-arrays.md
+++ b/articles/governance/policy/how-to/author-policies-for-arrays.md
@@ -59,7 +59,9 @@ can be rewritten as follows:
             "displayName": "Allowed locations",
             "strongType": "location"
         },
-        "defaultValue": "eastus2",
+        "defaultValue": [
+            "eastus2"
+        ],
         "allowedValues": [
             "eastus2",
             "eastus",


### PR DESCRIPTION
Example code for Array Parameter will fail with the error:  The policy parameter 'allowedLocations' default value does not match the expected parameter type defined in the policy definition. Details 'The expected policy parameter type: 'Array'. The actual policy parameter type 'String'.'.

Update to code example for the defaultValue to match the type of Array by adding the required brackets.