### PR TITLE
DDoS Protection does not support NAT Gateway

### DIFF
--- a/articles/ddos-protection/ddos-protection-reference-architectures.md
+++ b/articles/ddos-protection/ddos-protection-reference-architectures.md
@@ -38,6 +38,7 @@ Unsupported resources include:
 * Azure API Management in deployment modes other than the supported modes.
 * PaaS services (multi-tenant) including Azure App Service Environment for Power Apps.
 * Protected resources that include public IPs created from public IP address prefix.
+* NAT Gateway.
 
 [!INCLUDE [ddos-waf-recommendation](../../includes/ddos-waf-recommendation.md)]
 


### PR DESCRIPTION
DDoS Protection does not support the NAT Gateway, as mentioned in the following document:
https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-sku-comparison#limitations
>Protecting a public IP resource attached to a NAT Gateway isn't supported.

