### PR TITLE
Update application-gateway-faq.yml | Can I change the virtual network or subnet for an existing application gateway?

### DIFF
--- a/articles/application-gateway/application-gateway-faq.yml
+++ b/articles/application-gateway/application-gateway-faq.yml
@@ -202,7 +202,7 @@ sections:
         
       - question: Can I change the virtual network or subnet for an existing application gateway?
         answer: |
-          You can move an application gateway across subnets within the same virtual network only. It's supported with v1 with a public and private frontend and v2 with a public frontend only. The application gateway should be in a *Stopped* state to perform this action. Stopping or starting v1 changes the public IP. This operation can only be done by using Azure PowerShell and the Azure CLI by running the following commands:
+          You can move an application gateway across subnets within the same virtual network only. It's supported with v1 with a public and private frontend (dynamic allocation) and v2 with a public frontend only. We cannot move the application gateway to another subnet if the private frontend IP configuration is statically allocated. The application gateway should be in a *Stopped* state to perform this action. Stopping or starting v1 changes the public IP. This operation can only be done by using Azure PowerShell and the Azure CLI by running the following commands:
           
           **Azure PowerShell**
 


### PR DESCRIPTION
Updating below FAQ question: 

Can I change the virtual network or subnet for an existing application gateway?

You can move an application gateway across subnets within the same virtual network only. It's supported with v1 with a public and private frontend and v2 with a public frontend only. The application gateway should be in a *Stopped* state to perform this action. Stopping or starting v1 changes the public IP. This operation can only be done by using Azure PowerShell and the Azure CLI by running the following commands:
 
Updated answer:
You can move an application gateway across subnets within the same virtual network only. It's supported with v1 with a public and private frontend **(dynamic allocation)** and v2 with a public frontend only. **We cannot move the application gateway to another subnet if the private frontend IP configuration is statically allocated**. The application gateway should be in a *Stopped* state to perform this action. Stopping or starting v1 changes the public IP. This operation can only be done by using Azure PowerShell and the Azure CLI by running the following commands:
          
-----------------

Now we can have static IP allocation for V1 Sku and we cannot move APP GW to another subnet when private frontend is statically allocated.

Observed this while working with a Cx who tried performing it with static private frontend IP. 

Tried adding an internal wiki -- but got suggestion to update the public doc instead. 

Internal wiki pull request: https://supp**************om/AzureNetworking/_git/AzureNetworking/pullrequest/70975?_a=files&path=/Azure-Application-Gateway/How-To/HowTo%253A-move-Application-Gateway-to-new-Subnet-within-the-Vnet.md