### PR TITLE
{AzureML} fix for the type from v2 to v1 about the support lifecycle.

### DIFF
--- a/articles/machine-learning/concept-v2.md
+++ b/articles/machine-learning/concept-v2.md
@@ -92,7 +92,7 @@ SDK v2 is useful in the following scenarios:
 
 ## Should I use v1 or v2?
 
-Support for CLI v2 will end on September 30, 2025.  
+Support for CLI v1 will end on September 30, 2025.  
 
 We encourage you to migrate your code for both CLI and SDK v1 to CLI and SDK v2. For more information, see [Upgrade to v2](how-to-migrate-from-v1.md).
 


### PR DESCRIPTION
fixes MicrosoftDocs/azure-docs#119101

Support for the v1 extension will end on September 30, 2025. 

This PR fixes the type mentioned in the article.

Content: [Azure Machine Learning CLI & SDK v2 - Azure Machine Learning](https://learn.microsoft.com/en-us/azure/machine-learning/concept-v2?view=azureml-api-2)
Content Source: [articles/machine-learning/concept-v2.md](https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/machine-learning/concept-v2.md)

