### PR TITLE
Update blob-inventory.md

### DIFF
--- a/articles/storage/blobs/blob-inventory.md
+++ b/articles/storage/blobs/blob-inventory.md
@@ -387,8 +387,6 @@ Pricing for inventory is based on the number of blobs and containers that are sc
 
 After inventory files are created, additional standard data storage and operations charges will be incurred for storing, reading, and writing the inventory-generated files in the account.
 
-After an inventory report is complete, additional standard data storage and operations charges are incurred for storing, reading, and writing the inventory report in the storage account.
-
 If a rule contains a prefix that overlaps with a prefix of any other rule, then the same blob can appear in more than one inventory report. In this case, you're billed for both instances. For example, assume that the `prefixMatch` element of one rule is set to `["inventory-blob-1", "inventory-blob-2"]`, and the `prefixMatch` element of another rule is set to `["inventory-blob-10", "inventory-blob-20"]`. An object named `inventory-blob-200` appears in both inventory reports.
 
 Snapshots and versions of a blob also count towards billing even if you've set `includeSnapshots` and `includeVersions` filters to `false`. Those filter values don't affect billing. You can use them only to filter what appears in the report.


### PR DESCRIPTION
"After an inventory report is complete, additional standard data storage and operations charges are incurred for storing, reading, and writing the inventory report in the storage account." is a repeated content which can make user confuse. Hence, this can be removed from the document.

Reason:
In previous statement, Inventory-files refer to .checksum, .json and comma-separated values (CSV) or Apache Parquet format files. Therefore, writing same statement for inventory report (comma-separated values (CSV) or Apache Parquet format files) can make reader confused.