### PR TITLE
Warning for deprecated aad-pod-identity

### DIFF
--- a/articles/aks/use-managed-identity.md
+++ b/articles/aks/use-managed-identity.md
@@ -10,6 +10,9 @@ ms.date: 01/24/2024
 
 # Use a managed identity in Azure Kubernetes Service (AKS)
 
+> [!WARNING]
+> As of October 24, 2022, AAD Pod Identity has been deprecated, and it has been replaced with [Azure Workload Identity](workload-identity-overview.md).
+
 Azure Kubernetes Service (AKS) clusters require an identity to access Azure resources like load balancers and managed disks. This identity can be a *managed identity* or *service principal*. A system-assigned managed identity is automatically created when you create an AKS cluster. This identity is managed by the Azure platform and doesn't require you to provision or rotate any secrets. For more information about managed identities in Microsoft Entra ID, see [Managed identities for Azure resources][managed-identity-resources-overview].
 
 AKS doesn't automatically create a [service principal](kubernetes-service-principal.md), so you have to create one. Clusters that use a service principal eventually expire, and the service principal must be renewed to avoid impacting cluster authentication with the identity. Managing service principals adds complexity, so it's easier to use managed identities instead. The same permission requirements apply for both service principals and managed identities. Managed identities use certificate-based authentication. Each managed identity's credentials have an expiration of *90 days* and are rolled after *45 days*. AKS uses both system-assigned and user-assigned managed identity types, and these identities are immutable.


### PR DESCRIPTION
According to the official documentation of AAD Pod Identity, (https://github.com/Azure/aad-pod-identity/tree/master?tab=readme-ov-file) it has been deprecated. The recommendation is to transition to Azure Workload Identity.