### PR TITLE
Fixing whitespaces

### DIFF
--- a/articles/api-management/validate-client-certificate-policy.md
+++ b/articles/api-management/validate-client-certificate-policy.md
@@ -35,7 +35,7 @@ For more information about custom CA certificates and certificate authorities, s
     validate-not-after="true | false" 
     ignore-error="true | false">
     <identities>
-        <identity 
+        <identity
             thumbprint="certificate thumbprint"
             serial-number="certificate serial number"
             common-name="certificate common name"
@@ -43,7 +43,7 @@ For more information about custom CA certificates and certificate authorities, s
             dns-name="certificate DNS name"
             issuer-subject="certificate issuer"
             issuer-thumbprint="certificate issuer thumbprint"
-            issuer-certificate-id="certificate identifier" />
+            issuer-certificate-id="certificate identifier"/>
     </identities>
 </validate-client-certificate> 
 ```


### PR DESCRIPTION
Currently, the code snippet is not copy-paste friendly. It contains the whitespaces that causes editor issue when saving the policy:

The ' ' character, hexadecimal value 0xA0, cannot be included in a name.