### PR TITLE
specify double-quote on Content-Type:application/json

### DIFF
--- a/articles/machine-learning/how-to-inference-server-http.md
+++ b/articles/machine-learning/how-to-inference-server-http.md
@@ -225,7 +225,7 @@ In this section, we'll run the server locally with [sample files](https://github
     Use the `curl` command to send an example request to the server and receive a scoring result.
 
     ```bash
-    curl --request POST "127.0.0.1:5001/score" --header 'Content-Type:application/json' --data @sample-request.json
+    curl --request POST "127.0.0.1:5001/score" --header "Content-Type:application/json" --data @sample-request.json
     ```
 
     The scoring result will be returned if there's no problem in your scoring script. If you find something wrong, you can try to update the scoring script, and launch the server again to test the updated script.


### PR DESCRIPTION
when calling the header with single quotes, it fails to recognize header. Instead, specify "Content-Type:application/json"