### PR TITLE
Fix "Invalid image debian" error in VM create command

### DIFF
--- a/articles/virtual-machines/linux/quick-create-cli.md
+++ b/articles/virtual-machines/linux/quick-create-cli.md
@@ -36,7 +36,7 @@ Environment variables are commonly used in Linux to centralize configuration dat
 export RESOURCE_GROUP_NAME=myResourceGroup
 export LOCATION=eastus
 export VM_NAME=myVM
-export VM_IMAGE=debian
+export VM_IMAGE=Debian11
 export ADMIN_USERNAME=azureuser
 ```
 


### PR DESCRIPTION
The image urn alias used in the command 'debian' is not available anymore and throws the following error:

Invalid image "debian". Use a valid image URN, custom image name, custom image id, VHD blob URI, or pick an image from ['CentOS85Gen2', 'Debian11', 'FlatcarLinuxFreeGen2', 'OpenSuseLeap154Gen2', 'RHELRaw8LVMGen2', 'SuseSles15SP3', 'Ubuntu2204', 'Win2022Datacenter', 'Win2022AzureEditionCore', 'Win2019Datacenter', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1']. See vm create -h for more information on specifying an image.

The supported urn Alias for debian as of now is Debian11. So changing it to that.