### PR TITLE
Remove Microsoft.Storage/dataMovers in Resource Graph reference

### DIFF
--- a/articles/governance/resource-graph/reference/supported-tables-resources.md
+++ b/articles/governance/resource-graph/reference/supported-tables-resources.md
@@ -864,7 +864,6 @@ For sample queries for this table, see [Resource Graph sample queries for resour
 - microsoft.sqlvirtualmachine/sqlvirtualmachinegroups
 - microsoft.SqlVirtualMachine/SqlVirtualMachines (SQL virtual machines)
 - microsoft.sqlvm/dwvm
-- microsoft.storage/datamovers
 - microsoft.Storage/StorageAccounts (Storage accounts)
   - Sample query: [Find storage accounts with a specific case-insensitive tag on the resource group](../samples/samples-by-category.md#find-storage-accounts-with-a-specific-case-insensitive-tag-on-the-resource-group)
   - Sample query: [Find storage accounts with a specific case-sensitive tag on the resource group](../samples/samples-by-category.md#find-storage-accounts-with-a-specific-case-sensitive-tag-on-the-resource-group)


### PR DESCRIPTION
Microsft.Storage/dataMovers was a private preview resource type and is retired now. The service is now available in GA as Azure Storage Mover under the Microsoft.StorageMover resource provider.