### PR TITLE
Fix error in import-from-apim command line

### DIFF
--- a/articles/api-center/import-api-management-apis.md
+++ b/articles/api-center/import-api-management-apis.md
@@ -225,14 +225,14 @@ Use a wildcard (`*`) to specify all APIs from the API Management instance.
     #! /bin/bash
     apiIDs="$apimID/apis/*"
 
-    az apic service import-from-apim --service-name <api-center-name> --resource-group <resource-group-name> --source-resource-ids $apiIDs    
+    az apic service import-from-apim --service-name <api-center-name> --resource-group <resource-group-name> --source-resource-ids $apimID    
     ```
     
     ```azurecli 
     # PowerShell syntax
     $apiIDs=$apimID + "/apis/*"
 
-    az apic service import-from-apim --service-name <api-center-name> --resource-group <resource-group-name> --source-resource-ids $apiIDs    
+    az apic service import-from-apim --service-name <api-center-name> --resource-group <resource-group-name> --source-resource-ids $apimID    
     ```
 
     > [!NOTE]


### PR DESCRIPTION
The parameter used at the end of the command line was not the right one. It should be $apimID