### PR TITLE
Typo "[create a Azure Storage account]"→"[create an Azure～"

### DIFF
--- a/articles/service-connector/quickstart-cli-functions-connection.md
+++ b/articles/service-connector/quickstart-cli-functions-connection.md
@@ -19,7 +19,7 @@ This quickstart shows you how to connect Azure Functions to other Cloud resource
 
 - This quickstart requires version 2.30.0 or higher of the Azure CLI. If using Azure Cloud Shell, the latest version is already installed.
 - This quickstart assumes that you already have an Azure Function. If you don't have one yet, [create an Azure Function](../azure-functions/create-first-function-cli-python.md).
-- This quickstart assumes that you already have an Azure Storage account. If you don't have one yet, [create a Azure Storage account](../storage/common/storage-account-create.md).
+- This quickstart assumes that you already have an Azure Storage account. If you don't have one yet, [create an Azure Storage account](../storage/common/storage-account-create.md).
 
 ## Initial set-up
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/azure/service-connector/quickstart-cli-functions-connection?tabs=Using-access-key 
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/service-connector/quickstart-cli-functions-connection.md 
#PingMSFTDocs

https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal
![image](https://github.com/MicrosoftDocs/azure-docs/assets/40815708/480a6bfd-6492-4610-a915-d70fc56a43ae)