### PR TITLE
Update vnet-custom-internal - delegation is needed from subnet

### DIFF
--- a/articles/container-apps/vnet-custom-internal.md
+++ b/articles/container-apps/vnet-custom-internal.md
@@ -95,6 +95,7 @@ az network vnet subnet create \
   --resource-group $RESOURCE_GROUP \
   --vnet-name $VNET_NAME \
   --name infrastructure-subnet \
+  --delegations Microsoft.Sql/managedInstances Microsoft.App/environments
   --address-prefixes 10.0.0.0/23
 ```
 
@@ -106,6 +107,13 @@ $SubnetArgs = @{
     AddressPrefix = '10.0.0.0/23'
 }
 $subnet = New-AzVirtualNetworkSubnetConfig @SubnetArgs
+
+$del = @{
+    Name = 'delegation'
+    ServiceName = 'Microsoft.App/environments'
+    Subnet = $subnet
+}
+$subnet = Add-AzDelegation @del
 ```
 
 ```azurepowershell-interactive


### PR DESCRIPTION
Microsoft.App/environments delegation is needed from the subnet.

Getting this error if delegation is not added:
The behavior of this command has been altered by the following extension: containerapp
No Log Analytics workspace provided.
Generating a Log Analytics workspace with name "workspace-mycontainerappsXXXXX"
**(ManagedEnvironmentSubnetDelegationError) The subnet of the environment must be delegated to the service 'Microsoft.App/environments'.**