### PR TITLE
Update how-to-create-azure-support-request.md

### DIFF
--- a/articles/azure-portal/supportability/how-to-create-azure-support-request.md
+++ b/articles/azure-portal/supportability/how-to-create-azure-support-request.md
@@ -93,7 +93,7 @@ Next, we collect more details about the problem. Providing thorough and detailed
 1. In the **Support method** section, select the **Support plan**,  the **Severity** level, depending on the business impact. The [maximum available severity level and time to respond](https://azure.microsoft.com/support/plans/response/) depends on your [support plan](https://azure.microsoft.com/support/plans) and the country/region in which you're located, including the timing of business hours in that country/region.
 
 > [!TIP]
-> To add a Support plan that requires an Access ID and Contract ID, select Help + Support > Support plans > Link support benefits. When a limited support plan expires or has no support incidents remaining it will not be available for selection.
+> To add a support plan that requires an **Access ID** and **Contract ID**, select **Help + Support** > **Support plans** > **Link support benefits**. When a limited support plan expires or has no support incidents remaining, it won't be available to select.
 
 
 1. Provide your preferred contact method, your availability, and your preferred support language. Confirm that your country/region setting is accurate, as this setting affects the business hours in which a support engineer can work on your request.

--- a/articles/azure-portal/supportability/how-to-create-azure-support-request.md
+++ b/articles/azure-portal/supportability/how-to-create-azure-support-request.md
@@ -90,7 +90,11 @@ Next, we collect more details about the problem. Providing thorough and detailed
 
    In some cases, you may see additional options. For example, for certain types of Virtual Machine problem types, you can choose whether to [allow access to a virtual machine's memory](#memory-dump-collection).
 
-1. In the **Support method** section, select the **Severity** level, depending on the business impact. The [maximum available severity level and time to respond](https://azure.microsoft.com/support/plans/response/) depends on your [support plan](https://azure.microsoft.com/support/plans) and the country/region in which you're located, including the timing of business hours in that country/region.
+1. In the **Support method** section, select the **Support plan**,  the **Severity** level, depending on the business impact. The [maximum available severity level and time to respond](https://azure.microsoft.com/support/plans/response/) depends on your [support plan](https://azure.microsoft.com/support/plans) and the country/region in which you're located, including the timing of business hours in that country/region.
+
+> [!TIP]
+> To add a Support plan that requires an Access ID and Contract ID, select Help + Support > Support plans > Link support benefits. When a limited support plan expires or has no support incidents remaining it will not be available for selection.
+
 
 1. Provide your preferred contact method, your availability, and your preferred support language. Confirm that your country/region setting is accurate, as this setting affects the business hours in which a support engineer can work on your request.
 

--- a/articles/azure-portal/supportability/how-to-create-azure-support-request.md
+++ b/articles/azure-portal/supportability/how-to-create-azure-support-request.md
@@ -92,8 +92,8 @@ Next, we collect more details about the problem. Providing thorough and detailed
 
 1. In the **Support method** section, select the **Support plan**,  the **Severity** level, depending on the business impact. The [maximum available severity level and time to respond](https://azure.microsoft.com/support/plans/response/) depends on your [support plan](https://azure.microsoft.com/support/plans) and the country/region in which you're located, including the timing of business hours in that country/region.
 
-> [!TIP]
-> To add a support plan that requires an **Access ID** and **Contract ID**, select **Help + Support** > **Support plans** > **Link support benefits**. When a limited support plan expires or has no support incidents remaining, it won't be available to select.
+   > [!TIP]
+   > To add a support plan that requires an **Access ID** and **Contract ID**, select **Help + Support** > **Support plans** > **Link support benefits**. When a limited support plan expires or has no support incidents remaining, it won't be available to select.
 
 
 1. Provide your preferred contact method, your availability, and your preferred support language. Confirm that your country/region setting is accurate, as this setting affects the business hours in which a support engineer can work on your request.


### PR DESCRIPTION
Add minimal text to explain how to add a support plan using access ID and contract ID and limited support plans are hidden when they expire or run out of support incidents. Changes in Partner signature support will require a manual add of the support contract from July and it is hard to find where you add a suppot contract in azure. Most portals include a way to add in the create request workflow - except azure. Impacts 166k support incidents.  Feel free to contact acussons for more information. Previously discussed with John Lou.