### PR TITLE
Update how-to-custom-domain-suffix.md

### DIFF
--- a/articles/app-service/environment/how-to-custom-domain-suffix.md
+++ b/articles/app-service/environment/how-to-custom-domain-suffix.md
@@ -30,6 +30,7 @@ Unlike earlier versions, the FTPS endpoints for your App Services on your App Se
 ## Prerequisites
 
 - ILB variation of App Service Environment v3.
+- The Azure Key Vault that has the certificate must be publicly accessible to fetch the certificate. 
 - Valid SSL/TLS certificate must be stored in an Azure Key Vault in .PFX format. For more information on using certificates with App Service, see [Add a TLS/SSL certificate in Azure App Service](../configure-ssl-certificate.md).
 
 ### Managed identity


### PR DESCRIPTION
Added that the Azure KV needs to keep the FW open to allow access to all public networks to fetch certificate. At the moment, if it is not open to allow all networks, customers run into an error with KV later that says the KV reference is inaccessible post migration.