### PR TITLE
Fix the tutorial to delete an ARO cluster

### DIFF
--- a/articles/openshift/tutorial-delete-cluster.md
+++ b/articles/openshift/tutorial-delete-cluster.md
@@ -36,20 +36,19 @@ If you have access to multiple subscriptions, run `az account set -s {subscripti
 
 ## Delete the cluster
 
-In previous tutorials, the following variables were set.
+In previous tutorials, the following variable was set:
 
 ```bash
-CLUSTER=yourclustername
 RESOURCEGROUP=yourresourcegroup
 ```
 
-Using these values, delete your cluster:
+Using this value, delete your cluster:
 
 ```azurecli
-az aro delete --resource-group $RESOURCEGROUP --name $CLUSTER
+az group delete --name $RESOURCEGROUP
 ```
 
-You'll then be prompted to confirm if you want to delete the cluster. After you confirm with `y`, it will take several minutes to delete the cluster. When the command finishes, the entire resource group and all resources inside it, including the cluster, will be deleted.
+You'll then be prompted to confirm if you are sure you want to perform this operation. After you confirm with `y`, it will take several minutes to delete the cluster. When the command finishes, the entire resource group and all resources inside it, including the cluster and the virtual network, will be deleted.
 
 ## Next steps
 


### PR DESCRIPTION
The description of the command to delete the ARO cluster is not accurate:

> az aro delete --resource-group $RESOURCEGROUP --name $CLUSTER
>
> You'll then be prompted to confirm if you want to delete the cluster. After you confirm with y, it will take several minutes to delete the cluster. When the command finishes, the entire resource group and all resources inside it, including the cluster, will be deleted.

It is not true because that command only deletes the cluster. The virtual network and the resource group will not be touched. 

This commit modifies the tutorial by suggesting deleting the entire resource group when user wants to delete the cluster. Doing so, it is also aligned with [the AKS tutorial](https://github.com/MicrosoftDocs/azure-docs/blob/79b00df6030259cca58dd32cf6359dabf3e055fa/articles/aks/tutorial-kubernetes-upgrade-cluster.md?plain=1#L252-L258).