### PR TITLE
OpenTelemetry Exporter: The option to specify connection string from app settings is not implemented

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-configuration.md
+++ b/articles/azure-monitor/app/opentelemetry-configuration.md
@@ -20,7 +20,7 @@ A connection string in Application Insights defines the target location for send
 
 ### [ASP.NET Core](#tab/aspnetcore)
 
-Use one of the following three ways to configure the connection string:
+Use one of the following two ways to configure the connection string:
 
 - Add `UseAzureMonitor()` to your application startup. Depending on your version of .NET, it is in either your `startup.cs` or `program.cs` class.
     ```csharp

--- a/articles/azure-monitor/app/opentelemetry-configuration.md
+++ b/articles/azure-monitor/app/opentelemetry-configuration.md
@@ -43,20 +43,11 @@ Use one of the following three ways to configure the connection string:
    ```console
    APPLICATIONINSIGHTS_CONNECTION_STRING=<Your Connection String>
    ```
-- Add the following section to your `appsettings.json` config file:
-  ```json
-  {
-    "AzureMonitor": {
-        "ConnectionString": "<Your Connection String>"
-    }
-  }
-  ```
   
 > [!NOTE]
 > If you set the connection string in more than one place, we adhere to the following precedence:
 > 1. Code
 > 2. Environment Variable
-> 3. Configuration File
 
 ### [.NET](#tab/net)
 


### PR DESCRIPTION
I found no evidence that the suggested third method works - neither when I tested it nor in the code.
Here is the method that tries to find the connection string - https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/Internals/AzureMonitorTransmitter.cs#L61-L78