### PR TITLE
Defender for IoT Sample CLI SPAN port configuration (Cisco 2960) command fix

### DIFF
--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-span.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-span.md
@@ -33,7 +33,7 @@ Cisco2960# configure terminal
 Cisco2960(config)# monitor session 1 source interface fastehernet 0/2 - 23 rx
 Cisco2960(config)# monitor session 1 destination interface fastethernet 0/24
 Cisco2960(config)# end
-Cisco2960# show monitor 1
+Cisco2960# show monitor session 1
 Cisco2960# running-copy startup-config
 ```
 


### PR DESCRIPTION
On our documentation there is a sample that for CLI SPAN port configuration (Cisco 2960). On that sample set of commands, at line 5, we have a command: Cisco2960# show monitor 1. This command is missing the key 'session'. It should be:
Cisco2960# show monitor session 1

The suggested fix adds the missing 'session' keyword on line 5.

Here is the link to the documentation page that has missing 'session' keyword:

https://learn.microsoft.com/en-us/azure/defender-for-iot/organizations/traffic-mirroring/configure-mirror-span#sample-cli-span-port-configuration-cisco-2960