### PR TITLE
Emphasize that the documentation of each binding library should be read

### DIFF
--- a/includes/functions-dotnet-migrate-packages-v4-isolated.md
+++ b/includes/functions-dotnet-migrate-packages-v4-isolated.md
@@ -36,7 +36,7 @@ See [Supported bindings](../articles/azure-functions/functions-triggers-bindings
 
 > [!TIP]
 > The binding packages might require you to update your `host.json` file, be sure to read the documentation of each binding package used.
-> For example, the service bus bindings have breaking changes in the structure as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cfunctionsv2%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
+> For example, the service bus bindings have breaking changes in the structure as described [here](/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cfunctionsv2%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
 
 **Your isolated worker model application should not reference any packages in the `Microsoft.Azure.WebJobs.*` namespaces or `Microsoft.Azure.Functions.Extensions`.** If you have any remaining references to these, they should be removed.
 

--- a/includes/functions-dotnet-migrate-packages-v4-isolated.md
+++ b/includes/functions-dotnet-migrate-packages-v4-isolated.md
@@ -34,6 +34,10 @@ Depending on the triggers and bindings your app uses, your app might need to ref
 
 See [Supported bindings](../articles/azure-functions/functions-triggers-bindings.md#supported-bindings) for a complete list of extensions to consider, and consult each extension's documentation for full installation instructions for the isolated process model. Be sure to install the latest stable version of any packages you are targeting.
 
+> [!TIP]
+> The binding packages might require you to update your `host.json` file, be sure to read the documentation of each binding package used.
+> For example, the service bus bindings have breaking changes in the structure as described [here](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cfunctionsv2%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
+
 **Your isolated worker model application should not reference any packages in the `Microsoft.Azure.WebJobs.*` namespaces or `Microsoft.Azure.Functions.Extensions`.** If you have any remaining references to these, they should be removed.
 
 > [!TIP]

--- a/includes/functions-dotnet-migrate-packages-v4-isolated.md
+++ b/includes/functions-dotnet-migrate-packages-v4-isolated.md
@@ -36,7 +36,7 @@ See [Supported bindings](../articles/azure-functions/functions-triggers-bindings
 
 > [!TIP]
 > Any changes to extension versions during this process might require you to update your `host.json` file as well. Be sure to read the documentation of each extension that you use.
-> For example, the Service Bus extension has breaking changes in the structure between versions 4.x and 5.x, as described [here](/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
+> For example, the Service Bus extension has breaking changes in the structure between versions 4.x and 5.x. For more information, see [Azure Service Bus bindings for Azure Functions](/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
 
 **Your isolated worker model application should not reference any packages in the `Microsoft.Azure.WebJobs.*` namespaces or `Microsoft.Azure.Functions.Extensions`.** If you have any remaining references to these, they should be removed.
 

--- a/includes/functions-dotnet-migrate-packages-v4-isolated.md
+++ b/includes/functions-dotnet-migrate-packages-v4-isolated.md
@@ -35,8 +35,8 @@ Depending on the triggers and bindings your app uses, your app might need to ref
 See [Supported bindings](../articles/azure-functions/functions-triggers-bindings.md#supported-bindings) for a complete list of extensions to consider, and consult each extension's documentation for full installation instructions for the isolated process model. Be sure to install the latest stable version of any packages you are targeting.
 
 > [!TIP]
-> The binding packages might require you to update your `host.json` file, be sure to read the documentation of each binding package used.
-> For example, the service bus bindings have breaking changes in the structure as described [here](/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cfunctionsv2%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
+> Any changes to extension versions during this process might require you to update your `host.json` file as well. Be sure to read the documentation of each extension that you use.
+> For example, the Service Bus extension has breaking changes in the structure between versions 4.x and 5.x, as described [here](/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings).
 
 **Your isolated worker model application should not reference any packages in the `Microsoft.Azure.WebJobs.*` namespaces or `Microsoft.Azure.Functions.Extensions`.** If you have any remaining references to these, they should be removed.
 


### PR DESCRIPTION
When migrating to the isolated worker model it's required to use the latest nuget packages for [function bindings](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model?tabs=net8#package-references). By adding tohse nuget packages the supported `host.json` format changes. This is not clear from the document and can cause big difference at run-time.

For example, the bindings for service bus triggers where the settings for `maxConcurrentCalls` used to be nested below `messageHandlerOptions` and are now moved up.
https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus?tabs=isolated-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-csharp#hostjson-settings

This PR adds a note to emphasize the risk of not reading the binding library documentation.
