### PR TITLE
When conditionVersion is accidentially set to 1.0: "The given role assignment condition is invalid."

### DIFF
--- a/articles/role-based-access-control/conditions-troubleshoot.md
+++ b/articles/role-based-access-control/conditions-troubleshoot.md
@@ -49,11 +49,19 @@ When you try to add a role assignment with a condition, you get an error similar
 
 `The given role assignment condition is invalid.`
 
-**Cause**
+**Cause 1**
+
+The `conditionVersion` property is set to "1.0".
+
+**Solution 1**
+
+Set `conditionVersion` property to "2.0".
+
+**Cause 2**
 
 Your condition is not formatted correctly. 
 
-**Solution**
+**Solution 2**
 
 Fix any [condition format or syntax](conditions-format.md) issues. Alternatively, add the condition using the [visual editor in the Azure portal](conditions-role-assignments-portal.md).
 


### PR DESCRIPTION
Add cause and solution for https://github.com/MicrosoftDocs/azure-docs/issues/119449