### PR TITLE
Remove postgis_raster from concepts-major-version-upgrade.md

### DIFF
--- a/articles/postgresql/flexible-server/concepts-major-version-upgrade.md
+++ b/articles/postgresql/flexible-server/concepts-major-version-upgrade.md
@@ -55,7 +55,7 @@ If in-place major version upgrade pre-check operations fail, then the upgrade ab
 - In-place major version upgrade doesn't support certain extensions and there are some limitations to upgrading certain extensions. The extensions **Timescaledb**, **pgaudit**, **dblink**, **orafce**, **pg_partman**, and **postgres_fdw** are unsupported for all PostgreSQL versions. 
 
 -	When upgrading servers with PostGIS extension installed, set the `search_path` server parameter to explicitly include the schemas of the PostGIS extension, extensions that depend on PostGIS, and extensions that serve as dependencies for the below extensions.
-  **e.g postgis,postgis_raster,postgis_sfcgal,postgis_tiger_geocoder,postgis_topology,address_standardizer,address_standardizer_data_us,fuzzystrmatch (required for postgis_tiger_geocoder).**
+  **e.g postgis,postgis_sfcgal,postgis_tiger_geocoder,postgis_topology,address_standardizer,address_standardizer_data_us,fuzzystrmatch (required for postgis_tiger_geocoder).**
 
 -	Servers configured with logical replication slots aren't supported. 
 


### PR DESCRIPTION
The `postgis_raster` extension is no longer listed as supported on https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-extensions#extension-versions

Presenting `postgis_raster` in the PostgreSQL Flexible Server documentation may lead to readers' confusion.