### PR TITLE
Fix role assignment param values for managed storage accounts

### DIFF
--- a/articles/key-vault/secrets/overview-storage-keys.md
+++ b/articles/key-vault/secrets/overview-storage-keys.md
@@ -70,11 +70,11 @@ az login
 Use the Azure CLI [az role assignment create](/cli/azure/role/assignment) command to give Key Vault access your storage account. Provide the command the following parameter values:
 
 - `--role`: Pass the "Storage Account Key Operator Service Role" Azure role. This role limits the access scope to your storage account. For a classic storage account, pass "Classic Storage Account Key Operator Service Role" instead.
-- `--assignee`: Pass the value "https://vault.azure.net", which is the url for Key Vault in the Azure public cloud. (For Azure Government cloud use '--assignee-object-id' instead, see [Service principal application ID](#service-principal-application-id).)
+- `--assignee`: Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.
 - `--scope`: Pass your storage account resource ID, which is in the form `/subscriptions/<subscriptionID>/resourceGroups/<StorageAccountResourceGroupName>/providers/Microsoft.Storage/storageAccounts/<YourStorageAccountName>`. Find your subscription ID, by using the Azure CLI [az account list](/cli/azure/account?#az-account-list) command. Find your storage account name and storage account resource group, by using the Azure CLI [az storage account list](/cli/azure/storage/account?#az-storage-account-list) command.
 
 ```azurecli-interactive
-az role assignment create --role "Storage Account Key Operator Service Role" --assignee "https://vault.azure.net" --scope "/subscriptions/<subscriptionID>/resourceGroups/<StorageAccountResourceGroupName>/providers/Microsoft.Storage/storageAccounts/<YourStorageAccountName>"
+az role assignment create --role "Storage Account Key Operator Service Role" --assignee "John.Doe@Contoso.com" --scope "/subscriptions/<subscriptionID>/resourceGroups/<StorageAccountResourceGroupName>/providers/Microsoft.Storage/storageAccounts/<YourStorageAccountName>"
  ```
 ### Give your user account permission to managed storage accounts
 


### PR DESCRIPTION
Change cmdlet from 

az role assignment create --role "Storage Account Key Operator Service Role" --assignee "https://vault.azure.net" --scope "/subscriptions/subscriptionID/resourceGroups/StorageAccountResourceGroupName/providers/Microsoft.Storage/storageAccounts/YourStorageAccountName"

to

az role assignment create --role "Storage Account Key Operator Service Role" --assignee "John.Doe@Contoso.com" --scope "/subscriptions/subscriptionID/resourceGroups/StorageAccountResourceGroupName/providers/Microsoft.Storage/storageAccounts/YourStorageAccountName"


--assignee parameter should represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name and not a Vault URI

If a vault URI is used it errors out with the following " Cannot find user or service principal in graph database for 'https://xxx.vault.azure.net/'. If the assignee is an appId, make sure the corresponding service principal is created with 'az ad sp create --id https://xxx.vault.azure.net/'.