### PR TITLE
Adding new FrontDoor reliability recommendation

### DIFF
--- a/articles/advisor/advisor-reference-reliability-recommendations.md
+++ b/articles/advisor/advisor-reference-reliability-recommendations.md
@@ -645,12 +645,13 @@ In active-active configuration, both instances of the VPN gateway establish S2S 
 
 Learn more about [Virtual network gateway - VNetGatewayActiveActive (Enable Active-Active gateways for redundancy)](https://aka.ms/aa_vpnha_learnmore).
 
+<!--
 ### Use HEAD health probes
 
 For health probes, it’s a good practice to use the HEAD method, which reduces the amount of traffic load on your origins.
 
 Learn more about [Front Door - Use HEAD health probes](https://aka.ms/afd-use-health-probes).
-
+-->
 ### Use managed TLS certificates
 
 Front Door management of your TLS certificates reduces your operational costs and helps you to avoid costly outages caused by forgetting to renew a certificate.
@@ -662,6 +663,12 @@ Learn more about [Use managed TLS certificates](https://aka.ms/afd-use-managed-t
 If you only have a single origin, Front Door always routes traffic to that origin even if its health probe reports an unhealthy status. The status of the health probe doesn't do anything to change Front Door's behavior. In this scenario, health probes don't provide a benefit and you should disable them to reduce the traffic on your origin.
 
 Learn more about [Health probe best practices](https://aka.ms/afd-disable-health-probes).
+
+### Use the same domain name on Front Door and your origin
+
+We recommend that you preserve the original HTTP host name when you use a reverse proxy in front of a web application. Having a different host name at the reverse proxy than the one that's provided to the back-end application server can lead to cookies or redirect URLs that don't work properly. For example, session state can get lost, authentication can fail, or back-end URLs can inadvertently be exposed to end users. You can avoid these problems by preserving the host name of the initial request so that the application server sees the same domain as the web browser.
+
+Learn more about [Use the same domain name on Front Door and your origin](https://aka.ms/afd-same-domain-origin).
 
 ## SAP for Azure
 

--- a/articles/advisor/advisor-reference-reliability-recommendations.md
+++ b/articles/advisor/advisor-reference-reliability-recommendations.md
@@ -664,11 +664,11 @@ If you only have a single origin, Front Door always routes traffic to that origi
 
 Learn more about [Health probe best practices](https://aka.ms/afd-disable-health-probes).
 
-### Use the same domain name on Front Door and your origin
+### Use the same domain name on Azure Front Door and your origin
 
 We recommend that you preserve the original HTTP host name when you use a reverse proxy in front of a web application. Having a different host name at the reverse proxy than the one that's provided to the back-end application server can lead to cookies or redirect URLs that don't work properly. For example, session state can get lost, authentication can fail, or back-end URLs can inadvertently be exposed to end users. You can avoid these problems by preserving the host name of the initial request so that the application server sees the same domain as the web browser.
 
-Learn more about [Use the same domain name on Front Door and your origin](https://aka.ms/afd-same-domain-origin).
+Learn more about [Use the same domain name on Azure Front Door and your origin](https://aka.ms/afd-same-domain-origin).
 
 ## SAP for Azure
 


### PR DESCRIPTION
- Added "Use the same domain name on Front Door and your origin"
- Removed (temporarily) "Use managed TLS certificates". It will be added back after some technical issues are sorted out