### PR TITLE
Fix invalid field name

### DIFF
--- a/articles/kubernetes-fleet/resource-propagation.md
+++ b/articles/kubernetes-fleet/resource-propagation.md
@@ -58,7 +58,7 @@ spec:
     placementType: PickAll
     affinity:
         clusterAffinity:
-            requiredDuringSchedulingIgnoredDuringExection:
+            requiredDuringSchedulingIgnoredDuringExecution:
                 clusterSelectorTerms:
                 - labelSelector:
                     matchLabels:


### PR DESCRIPTION
The field name `requiredDuringSchedulingIgnoredDuringExection` in the yaml is invalid. The actual name is `requiredDuringSchedulingIgnoredDuringExecution`.

```
Error from server (BadRequest): error when creating "crp-1.yaml": ClusterResourcePlacement in version "v1beta1" cannot be handled as a ClusterResourcePlacement: strict decoding error: unknown field "spec.policy.affinity.clusterAffinity.requiredDuringSchedulingIgnoredDuringExection"
```
