### PR TITLE
Fix wrong command in container-registry-transfer-prerequisites.md

### DIFF
--- a/articles/container-registry/container-registry-transfer-prerequisites.md
+++ b/articles/container-registry/container-registry-transfer-prerequisites.md
@@ -80,14 +80,14 @@ Transfer uses shared access signature (SAS) tokens to access the storage account
 
 ### Generate SAS token for export
 
-Run the [az storage account generate-sas][az-storage-account-generate-sas] command to generate a SAS token for the container in the source storage account, used for artifact export.
+Run the [az storage container generate-sas][az-storage-container-generate-sas] command to generate a SAS token for the container in the source storage account, used for artifact export.
 
 *Recommended token permissions*: Read, Write, List, Add.
 
 In the following example, command output is assigned to the EXPORT_SAS environment variable, prefixed with the '?' character. Update the `--expiry` value for your environment:
 
 ```azurecli
-EXPORT_SAS=?$(az storage account generate-sas \
+EXPORT_SAS=?$(az storage container generate-sas \
   --name transfer \
   --account-name $SOURCE_SA \
   --expiry 2021-01-01 \
@@ -162,4 +162,3 @@ az keyvault secret set \
 [az-acr-import]: /cli/azure/acr#az_acr_import
 [az-resource-delete]: /cli/azure/resource#az_resource_delete
 [kv-managed-sas]: ../key-vault/secrets/overview-storage-keys.md
-[az-storage-account-generate-sas]: /cli/azure/storage/account#az-storage-account-generate-sas


### PR DESCRIPTION
There is no need for `az storage account generate-sas`. Also if using `az storage account generate-sas`, the example command is wrong. 