### PR TITLE
Add parameter usage warning for NFS in azure-files-csi.md

### DIFF
--- a/articles/aks/azure-files-csi.md
+++ b/articles/aks/azure-files-csi.md
@@ -349,7 +349,7 @@ mountOptions:
 Create a file named `nfs-sc.yaml` and copy the manifest below. For a list of supported `mountOptions`, see [NFS mount options][nfs-file-share-mount-options].
 
 > [!NOTE]
-> `vers`, `minorversion`, `sec` has been preset since [AKS v20240123](https://github.com/Azure/AKS/releases/tag/2024-01-23) and no longer can be configured. See [discussion](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1692). 
+> `vers`, `minorversion`, `sec` have been preset by the Azure File CSI driver, and hence setting values for these options is not supported. See [discussion](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1692). 
 
 ```yml
 apiVersion: storage.k8s.io/v1

--- a/articles/aks/azure-files-csi.md
+++ b/articles/aks/azure-files-csi.md
@@ -348,6 +348,9 @@ mountOptions:
 
 Create a file named `nfs-sc.yaml` and copy the manifest below. For a list of supported `mountOptions`, see [NFS mount options][nfs-file-share-mount-options]
 
+> [!NOTE]
+> `vers`, `minorversion`, `sec` has been preset since [AKS v20240123](https://github.com/Azure/AKS/releases/tag/2024-01-23) and no longer can be configured. See [discussion](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1692). 
+
 ```yml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/articles/aks/azure-files-csi.md
+++ b/articles/aks/azure-files-csi.md
@@ -346,7 +346,7 @@ mountOptions:
 
 ### Create NFS file share storage class
 
-Create a file named `nfs-sc.yaml` and copy the manifest below. For a list of supported `mountOptions`, see [NFS mount options][nfs-file-share-mount-options]
+Create a file named `nfs-sc.yaml` and copy the manifest below. For a list of supported `mountOptions`, see [NFS mount options][nfs-file-share-mount-options].
 
 > [!NOTE]
 > `vers`, `minorversion`, `sec` has been preset since [AKS v20240123](https://github.com/Azure/AKS/releases/tag/2024-01-23) and no longer can be configured. See [discussion](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1692). 

--- a/articles/aks/azure-files-csi.md
+++ b/articles/aks/azure-files-csi.md
@@ -349,7 +349,7 @@ mountOptions:
 Create a file named `nfs-sc.yaml` and copy the manifest below. For a list of supported `mountOptions`, see [NFS mount options][nfs-file-share-mount-options].
 
 > [!NOTE]
-> `vers`, `minorversion`, `sec` have been preset by the Azure File CSI driver, and hence setting values for these options is not supported. See [discussion](https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/1692). 
+> `vers`, `minorversion`, `sec` are configured by the Azure File CSI driver. Specifying a value in your manifest for these properties aren't supported.
 
 ```yml
 apiVersion: storage.k8s.io/v1


### PR DESCRIPTION
Base:
https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/a3f36edefed5c0eefebcbeb868cba3e941904c28/pkg/azurefile/nodeserver.go#L308

Current document statement makes `vers`, `minorversion`, `sec` like something configurable.   
> Create NFS file share storage class
> Create a file named nfs-sc.yaml and copy the manifest below. For a list of supported mountOptions, see [NFS mount options](https://learn.microsoft.com/en-us/azure/storage/files/storage-files-how-to-mount-nfs-shares#mount-options)

The link to "NFS mount options" list a bunch of options and there is no warning telling customer that some of parameters are no longer configurable.  

Since these parameters are now fixed and no longer being configurable since `v20240123`, the statement needs to be changed relatively to avoid customer being misleaded. 
