### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#119636

### DIFF
--- a/articles/ai-services/openai/how-to/assistant.md
+++ b/articles/ai-services/openai/how-to/assistant.md
@@ -365,7 +365,7 @@ We had requested that the model generate an image of a sine wave. In order to do
 
 ```python
 data = json.loads(messages.model_dump_json(indent=2))  # Load JSON data into a Python object
-image_file_id = data['data'][1]['content'][0]['image_file']['file_id']
+image_file_id = data['data'][0]['content'][0]['image_file']['file_id']
 
 print(image_file_id)  # Outputs: assistant-1YGVTvNzc2JXajI5JU9F0HMD
 ```


### PR DESCRIPTION
We have done changes in the line no:367
Note:it shoud write image_file_id = data['data'][0]['content'][0]['image_file']['file_id'] since data only have 1 length