### PR TITLE
Update cache-how-to-monitor.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-monitor.md
+++ b/articles/azure-cache-for-redis/cache-how-to-monitor.md
@@ -167,6 +167,9 @@ In contrast, for clustered caches, we recommend using the metrics with the suffi
     - **Export** – when there's an issue related to Export RDB
     - **AADAuthenticationFailure** (preview) - when there's an authentication failure using Microsoft Entra access token
     - **AADTokenExpired** (preview) - when a Microsoft Entra access token used for authentication isn't renewed and it expires.
+> [!NOTE]
+> Errors metrics isn't available for Enterprise Tiers.
+
 - Evicted Keys
   - The number of items evicted from the cache during the specified reporting interval because of the `maxmemory` limit.
   - This number maps to `evicted_keys` from the Redis INFO command.


### PR DESCRIPTION
Errors metrics has been removed recently for Enterprise Tier cache. Recommending for a documentation update to have it clarified for customers that this metrics isn't available for Enterprise tiers.
Please review