### PR TITLE
Update cache-tls-configuration.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-tls-configuration.md
+++ b/articles/azure-cache-for-redis/cache-tls-configuration.md
@@ -16,7 +16,7 @@ ms.author: franlanglois
 Transport Layer Security (TLS) is a cryptographic protocol that provides secure communication over a network. Azure Cache for Redis supports TLS on all tiers. When create a service that uses an Azure Cache for Redis instance, we strongly encourage you to connect using TLS.
 
 > [!IMPORTANT]
-> Starting October 1, 2024, TLS 1.0 and 1.1 will no longer be supported. You should use TLS 1.2 or 1.3 instead.
+> Starting November 01, 2024, TLS 1.0 and 1.1 will no longer be supported. You should use TLS 1.2 or 1.3 instead.
 >
 
 ## Scope of availability


### PR DESCRIPTION
Support for TLS 1.0/1.1 on Azure Cache for Redis ending on 31 October 2024. Add changes to update TLS 1.2 enforcement date.

Refer: 

https://azure.microsoft.com/en-us/updates/support-for-tls-1011-on-azure-cache-for-redis-ending-on-31-october-2024/
https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-remove-tls-10-11