### PR TITLE
fix: Missing markup for code example

### DIFF
--- a/articles/virtual-machines/extensions/custom-script-windows.md
+++ b/articles/virtual-machines/extensions/custom-script-windows.md
@@ -55,7 +55,7 @@ If your script is on a local server, you might still need to open other firewall
 ### Tips
 
 - Output is limited to the last 4,096 bytes.
-- Properly escaping characters will help ensure that strings are parsed correctly. For example, you always need two backslashes to escape a single literal backslash when dealing with file paths. Sample: {"commandToExecute": "C:\\Windows\\System32\\systeminfo.exe >> D:\\test.txt"}
+- Properly escaping characters will help ensure that strings are parsed correctly. For example, you always need two backslashes to escape a single literal backslash when dealing with file paths. Sample: `{"commandToExecute": "C:\\Windows\\System32\\systeminfo.exe >> D:\\test.txt"}`
 - The highest failure rate for this extension is due to syntax errors in the script. Verify that the script runs without errors. Put more logging into the script to make it easier to find failures.
 - Write scripts that are idempotent, so that running them more than once accidentally doesn't cause system changes.
 - Ensure that the scripts don't require user input when they run.


### PR DESCRIPTION
The missing Markdown markup led to broken
rendering of the JSON sample, that is, displaying
single backslash where double backslash is meant.

----

From current version of https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows

![image](https://github.com/MicrosoftDocs/azure-docs/assets/80741/a079ca79-f7cf-4197-8998-13a2664d81b6)


