### PR TITLE
Update configure-private-link.md - call out azure ai and azure ai search resources to remain public

### DIFF
--- a/articles/ai-studio/how-to/configure-private-link.md
+++ b/articles/ai-studio/how-to/configure-private-link.md
@@ -22,9 +22,10 @@ We have two network isolation aspects. One is the network isolation to access an
 
 You get several Azure AI default resources in your resource group. You need to configure following network isolation configurations.
 
-- Disable public network access flag of Azure AI default resources such as Storage, Key Vault, Container Registry. Azure AI services and Azure AI Search should be public.
+- Disable public network access flag of Azure AI default resources such as Storage, Key Vault, Container Registry.
 - Establish private endpoint connection to Azure AI default resource. Note that you need to have blob and file PE for the default storage account.
 - [Managed identity configurations](#managed-identity-configuration) to allow Azure AI hub resources access your storage account if it's private.
+- Azure AI services and Azure AI Search should be public.
 
 
 ## Prerequisites


### PR DESCRIPTION
Azure AI and Azure AI Search services to remain public.

It is important to call out that Azure AI Services and Azure AI Search resources need to remain public.  The current version of this document makes it easy to overlook this assertion.