### PR TITLE
Remove deprecated az aks --docker-bridge-address option

### DIFF
--- a/articles/aks/private-clusters.md
+++ b/articles/aks/private-clusters.md
@@ -71,13 +71,9 @@ az aks create \
     --enable-private-cluster \
     --network-plugin azure \
     --vnet-subnet-id <subnet-id> \
-    --docker-bridge-address 172.17.0.1/16 \
     --dns-service-ip 10.2.0.10 \
     --service-cidr 10.2.0.0/24 
 ```
-
-> [!NOTE]
-> If the Docker bridge address CIDR *172.17.0.1/16* clashes with the subnet CIDR, change the Docker bridge address.
 
 ## Use custom domains
 


### PR DESCRIPTION
The instructions for creating a private AKS cluster with `az aks create` specify a `--docker-bridge-address` option; however, with azure-cli 2.57.0 this option results in the warning:

```
Option '--docker-bridge-address' has been deprecated and will be removed in a future release.
```

This PR suggests removing mention of `--docker-bridge-address` in the documentation.

Related: https://github.com/Azure/AKS/issues/3534
