### PR TITLE
docs(work-with-threat-indicators.md): Remove redundant "P" for platforms

### DIFF
--- a/articles/sentinel/work-with-threat-indicators.md
+++ b/articles/sentinel/work-with-threat-indicators.md
@@ -145,4 +145,4 @@ In this article, you learned all the ways to work with threat intelligence indic
 - [Understand threat intelligence in Microsoft Sentinel](understand-threat-intelligence.md).
 - Connect Microsoft Sentinel to [STIX/TAXII threat intelligence feeds](./connect-threat-intelligence-taxii.md).
 - [Connect threat intelligence platforms](./connect-threat-intelligence-tip.md) to Microsoft Sentinel.
-- See which [TI platforms, TAXII feeds, and enrichments](threat-intelligence-integration.md) can be readily integrated with Microsoft Sentinel.
+- See which [TIPs, TAXII feeds, and enrichments](threat-intelligence-integration.md) can be readily integrated with Microsoft Sentinel.

--- a/articles/sentinel/work-with-threat-indicators.md
+++ b/articles/sentinel/work-with-threat-indicators.md
@@ -145,4 +145,4 @@ In this article, you learned all the ways to work with threat intelligence indic
 - [Understand threat intelligence in Microsoft Sentinel](understand-threat-intelligence.md).
 - Connect Microsoft Sentinel to [STIX/TAXII threat intelligence feeds](./connect-threat-intelligence-taxii.md).
 - [Connect threat intelligence platforms](./connect-threat-intelligence-tip.md) to Microsoft Sentinel.
-- See which [TIP platforms, TAXII feeds, and enrichments](threat-intelligence-integration.md) can be readily integrated with Microsoft Sentinel.
+- See which [TI platforms, TAXII feeds, and enrichments](threat-intelligence-integration.md) can be readily integrated with Microsoft Sentinel.


### PR DESCRIPTION
Remove redundant "P" for platforms. Threat Intelligence Platform (TIP)