### PR TITLE
Update hdinsight-release-notes.md

### DIFF
--- a/articles/hdinsight/hdinsight-release-notes.md
+++ b/articles/hdinsight/hdinsight-release-notes.md
@@ -4,7 +4,7 @@ description: Latest release notes for Azure HDInsight. Get development tips and 
 ms.custom: references_regions
 ms.service: hdinsight
 ms.topic: conceptual
-ms.date: 02/18/2024
+ms.date: 02/19/2024
 ---
 
 # Azure HDInsight release notes
@@ -72,4 +72,4 @@ We are listening: You’re welcome to add more ideas and other topics here and v
 ### Next steps
 * [Azure HDInsight: Frequently asked questions](./hdinsight-faq.yml)
 * [Configure the OS patching schedule for Linux-based HDInsight clusters](./hdinsight-os-patching.md)
-* Previous [release note](/azure/hdinsight/hdinsight-release-notes-archive#release-date--january-10-2024)
+* Previous [release note](./hdinsight-release-notes-archive#release-date--january-10-2024)

--- a/articles/hdinsight/hdinsight-release-notes.md
+++ b/articles/hdinsight/hdinsight-release-notes.md
@@ -72,4 +72,4 @@ We are listening: You’re welcome to add more ideas and other topics here and v
 ### Next steps
 * [Azure HDInsight: Frequently asked questions](./hdinsight-faq.yml)
 * [Configure the OS patching schedule for Linux-based HDInsight clusters](./hdinsight-os-patching.md)
-* Previous [release note](./hdinsight-release-notes-archive#release-date--january-10-2024)
+* Previous [release note](/azure/hdinsight/hdinsight-release-notes-archive#release-date--january-10-2024)

--- a/articles/hdinsight/hdinsight-release-notes.md
+++ b/articles/hdinsight/hdinsight-release-notes.md
@@ -4,7 +4,7 @@ description: Latest release notes for Azure HDInsight. Get development tips and 
 ms.custom: references_regions
 ms.service: hdinsight
 ms.topic: conceptual
-ms.date: 02/15/2024
+ms.date: 02/18/2024
 ---
 
 # Azure HDInsight release notes
@@ -72,4 +72,4 @@ We are listening: You’re welcome to add more ideas and other topics here and v
 ### Next steps
 * [Azure HDInsight: Frequently asked questions](./hdinsight-faq.yml)
 * [Configure the OS patching schedule for Linux-based HDInsight clusters](./hdinsight-os-patching.md)
-* Previous [release note](/azure/hdinsight/hdinsight-release-notes-archive#release-date--october-26-2023)
+* Previous [release note](/azure/hdinsight/hdinsight-release-notes-archive#release-date--january-10-2024)


### PR DESCRIPTION
Pointing the previous release notes to Jan 2024 section  instead of October 2023 release notes section