### PR TITLE
Update exchange-and-refund-azure-reservations.md

### DIFF
--- a/articles/cost-management-billing/reservations/exchange-and-refund-azure-reservations.md
+++ b/articles/cost-management-billing/reservations/exchange-and-refund-azure-reservations.md
@@ -118,7 +118,7 @@ Azure has the following policies for cancellations, exchanges, and refunds.
 - The new reservation's lifetime commitment should equal or be greater than the returned reservation's remaining commitment. Example: for a three-year reservation that's 100 USD per month and exchanged after the 18th payment, the new reservation's lifetime commitment should be 1,800 USD or more (paid monthly or upfront).
 - The new reservation purchased as part of exchange has a new term starting from the time of exchange.
 - There's no penalty or annual limits for exchanges.
-- Exchanges will be unavailable for all compute reservations - Azure Reserved Virtual Machine Instances, Azure Dedicated Host reservations, and Azure App Services reservations - purchased on or after **January 1, 2024**. Compute reservations purchased **prior to January 1, 2024** will reserve the right to **exchange one more time** after the policy change goes into effect. For more information about the exchange policy change, see [Changes to the Azure reservation exchange policy](reservation-exchange-policy-changes.md).
+- Exchanges will be unavailable for all compute reservations - Azure Reserved Virtual Machine Instances, Azure Dedicated Host reservations, and Azure App Services reservations - purchased on or after **July 1, 2024**. Compute reservations purchased **prior to July 1, 2024** will reserve the right to **exchange one more time** after the policy change goes into effect. For more information about the exchange policy change, see [Changes to the Azure reservation exchange policy](reservation-exchange-policy-changes.md).
 
 **Refund policies**
 


### PR DESCRIPTION
According to the Azure reservation exchange policy, grace period was changed from "January 1, 2024 " to "July 1, 2024 " on Exchange policies section.