### PR TITLE
Update azure-kubernetes-recipe.md

### DIFF
--- a/articles/ai-services/containers/azure-kubernetes-recipe.md
+++ b/articles/ai-services/containers/azure-kubernetes-recipe.md
@@ -191,7 +191,7 @@ The following steps are needed to get the required information to connect your c
 1. Get your container registry ID.
 
     ```azurecli-interactive
-    az acr show --resource-group cogserv-container-rg --name pattyregistry --query "id" --o table
+    az acr show --resource-group cogserv-container-rg --name pattyregistry --query "id" --output table
     ```
 
     Save the output for the scope parameter value, `<acrId>`, in the next step. It looks like:


### PR DESCRIPTION
Replace deprecated --o with --output in az acr show example due to ambiguity error

Updated the `az acr show` command example in the documentation to replace the deprecated `--o` option with `--output` for specifying the output format. This change is made in response to the received ambiguity error: "ambiguous option: --o could match --only-show-errors, --output". Including the specific error message in this commit to highlight the issue and ensure the documentation aligns with the current Azure CLI behavior, thereby improving clarity and preventing potential confusion for users.
