### PR TITLE
fix python example

### DIFF
--- a/articles/app-service/includes/tutorial-connect-msi-azure-database/code-postgres-mi.md
+++ b/articles/app-service/includes/tutorial-connect-msi-azure-database/code-postgres-mi.md
@@ -1,5 +1,5 @@
 ---
-author: xiaofanzhou
+author: xfz11
 ms.service: service-connector
 ms.topic: include
 ms.date: 10/20/2023

--- a/articles/app-service/includes/tutorial-connect-msi-azure-database/code-postgres-mi.md
+++ b/articles/app-service/includes/tutorial-connect-msi-azure-database/code-postgres-mi.md
@@ -95,7 +95,7 @@ For more information, see the following resources:
      
     # Uncomment the following lines according to the authentication type.
     # For system-assigned identity.
-    # credential = DefaultAzureCredential()
+    # cred = DefaultAzureCredential()
 
     # For user-assigned identity.
     # managed_identity_client_id = os.getenv('AZURE_POSTGRESQL_CLIENTID')

--- a/articles/service-connector/includes/code-postgres-me-id.md
+++ b/articles/service-connector/includes/code-postgres-me-id.md
@@ -1,5 +1,5 @@
 ---
-author: xiaofanzhou
+author: xfz11
 ms.service: service-connector
 ms.topic: include
 ms.date: 10/20/2023

--- a/articles/service-connector/includes/code-postgres-me-id.md
+++ b/articles/service-connector/includes/code-postgres-me-id.md
@@ -109,7 +109,7 @@ For more tutorials, see [Use Spring Data JDBC with Azure Database for PostgreSQL
      
     # Uncomment the following lines according to the authentication type.
     # For system-assigned identity.
-    # credential = DefaultAzureCredential()
+    # cred = DefaultAzureCredential()
 
     # For user-assigned identity.
     # managed_identity_client_id = os.getenv('AZURE_POSTGRESQL_CLIENTID')


### PR DESCRIPTION
Fixed the python code example by changing the `DefaultAzureCredential()` to the correct variable name.