### PR TITLE
Refine statement to make difference between different CNIs in azure-cni-overview.md

### DIFF
--- a/articles/aks/azure-cni-overview.md
+++ b/articles/aks/azure-cni-overview.md
@@ -17,7 +17,7 @@ By default, AKS clusters use [kubenet][kubenet] and create a virtual network and
 
 With [Azure Container Networking Interface (CNI)][cni-networking], every pod gets an IP address from the subnet and can be accessed directly. Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod. These IP addresses must be unique across your network space and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, and often leads to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.  
 
-Note that this article is only introducing traditional CNI, for [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], check the relative documents instead.  
+Note that this article is only introducing traditional Azure CNI. For [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], check the relative documents instead.  
 
 ## Prerequisites
 
@@ -128,7 +128,7 @@ Although it's technically possible to specify a service address range within the
 
   Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod.
   
-  But for [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address for any traffic from the pod.
+  But for [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address for any traffic from the pod. This is because the [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation] implements [Microsoft Azure Container Networking][github-azure-container-networking] infrastructure, which gives end-to-end experience. Hence, it eliminates the use of [`ip-masq-agent`][ip-masq-agent], which is still used by traditional Azure CNI.  
 
 * **Can I configure per-pod network policies?**
 
@@ -178,6 +178,8 @@ Learn more about networking in AKS in the following articles:
 [cni-networking]: https://github.com/Azure/azure-container-networking/blob/master/docs/cni.md
 [kubenet]: concepts-network.md#kubenet-basic-networking
 [github]: https://raw.githubusercontent.com/microsoft/Docker-Provider/ci_prod/kubernetes/container-azm-ms-agentconfig.yaml
+[github-azure-container-networking]: https://github.com/Azure/azure-container-networking
+[ip-masq-agent]: https://kubernetes.io/docs/tasks/administer-cluster/ip-masq-agent/
 
 <!-- LINKS - Internal -->
 [az-aks-create]: /cli/azure/aks#az_aks_create

--- a/articles/aks/azure-cni-overview.md
+++ b/articles/aks/azure-cni-overview.md
@@ -17,7 +17,9 @@ By default, AKS clusters use [kubenet][kubenet] and create a virtual network and
 
 With [Azure Container Networking Interface (CNI)][cni-networking], every pod gets an IP address from the subnet and can be accessed directly. Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod. These IP addresses must be unique across your network space and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, and often leads to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.  
 
-Note that this article is only introducing traditional Azure CNI. For [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], check the relative documents instead.  
+> [!NOTE]
+> 
+> This article is only introducing traditional Azure CNI. For [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], refer to their documentation instead.  
 
 ## Prerequisites
 

--- a/articles/aks/azure-cni-overview.md
+++ b/articles/aks/azure-cni-overview.md
@@ -17,7 +17,7 @@ By default, AKS clusters use [kubenet][kubenet] and create a virtual network and
 
 With [Azure Container Networking Interface (CNI)][cni-networking], every pod gets an IP address from the subnet and can be accessed directly. Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod. These IP addresses must be unique across your network space and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, and often leads to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.  
 
-Note that this article is only introducing traditional CNI, for [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], check the relative document instead.  
+Note that this article is only introducing traditional CNI, for [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], check the relative documents instead.  
 
 ## Prerequisites
 
@@ -128,7 +128,7 @@ Although it's technically possible to specify a service address range within the
 
   Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod.
   
-  But for "Azure CNI for dynamic IP allocation", no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address.
+  But for "Azure CNI for dynamic IP allocation", no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address for any traffic from the pod.
 
 * **Can I configure per-pod network policies?**
 

--- a/articles/aks/azure-cni-overview.md
+++ b/articles/aks/azure-cni-overview.md
@@ -15,7 +15,9 @@ ms.date: 9/13/2023
 
 By default, AKS clusters use [kubenet][kubenet] and create a virtual network and subnet. With *kubenet*, nodes get an IP address from a virtual network subnet. Network address translation (NAT) is then configured on the nodes, and pods receive an IP address "hidden" behind the node IP. This approach reduces the number of IP addresses that you need to reserve in your network space for pods to use.
 
-With [Azure Container Networking Interface (CNI)][cni-networking], every pod gets an IP address from the subnet and can be accessed directly. Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod. These IP addresses must be unique across your network space and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, and often leads to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.
+With [Azure Container Networking Interface (CNI)][cni-networking], every pod gets an IP address from the subnet and can be accessed directly. Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod. These IP addresses must be unique across your network space and must be planned in advance. Each node has a configuration parameter for the maximum number of pods that it supports. The equivalent number of IP addresses per node are then reserved up front for that node. This approach requires more planning, and often leads to IP address exhaustion or the need to rebuild clusters in a larger subnet as your application demands grow.  
+
+Note that this article is only introducing traditional CNI, for [Azure CNI Overlay][azure-cni-overlay] and [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], check the relative document instead.  
 
 ## Prerequisites
 
@@ -120,11 +122,13 @@ Although it's technically possible to specify a service address range within the
 
 * **Can I deploy VMs in my cluster subnet?**
 
-  Yes.
+  Yes. But for "Azure CNI for dynamic IP allocation", the VMs cannot be deployed in Pod's subnet. 
 
 * **What source IP do external systems see for traffic that originates in an Azure CNI-enabled pod?**
 
   Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod.
+  
+  But for "Azure CNI for dynamic IP allocation", no matter the connection is inside the same virtual network or cross virtual network, the pod IP is always the source address.
 
 * **Can I configure per-pod network policies?**
 
@@ -196,3 +200,5 @@ Learn more about networking in AKS in the following articles:
 [network-comparisons]: concepts-network.md#compare-network-models
 [system-node-pools]: use-system-pools.md
 [prerequisites]: configure-azure-cni.md#prerequisites
+[azure-cni-overlay]: azure-cni-overlay.md
+[configure-azure-cni-dynamic-ip-allocation]: configure-azure-cni-dynamic-ip-allocation.md

--- a/articles/aks/azure-cni-overview.md
+++ b/articles/aks/azure-cni-overview.md
@@ -122,13 +122,13 @@ Although it's technically possible to specify a service address range within the
 
 * **Can I deploy VMs in my cluster subnet?**
 
-  Yes. But for "Azure CNI for dynamic IP allocation", the VMs cannot be deployed in Pod's subnet. 
+  Yes. But for "Azure CNI for dynamic IP allocation", the VMs cannot be deployed in pod's subnet. 
 
 * **What source IP do external systems see for traffic that originates in an Azure CNI-enabled pod?**
 
   Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod.
   
-  But for "Azure CNI for dynamic IP allocation", no matter the connection is inside the same virtual network or cross virtual network, the pod IP is always the source address.
+  But for "Azure CNI for dynamic IP allocation", no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address.
 
 * **Can I configure per-pod network policies?**
 

--- a/articles/aks/azure-cni-overview.md
+++ b/articles/aks/azure-cni-overview.md
@@ -122,13 +122,13 @@ Although it's technically possible to specify a service address range within the
 
 * **Can I deploy VMs in my cluster subnet?**
 
-  Yes. But for "Azure CNI for dynamic IP allocation", the VMs cannot be deployed in pod's subnet. 
+  Yes. But for [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], the VMs cannot be deployed in pod's subnet. 
 
 * **What source IP do external systems see for traffic that originates in an Azure CNI-enabled pod?**
 
   Systems in the same virtual network as the AKS cluster see the pod IP as the source address for any traffic from the pod. Systems outside the AKS cluster virtual network see the node IP as the source address for any traffic from the pod.
   
-  But for "Azure CNI for dynamic IP allocation", no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address for any traffic from the pod.
+  But for [Azure CNI for dynamic IP allocation][configure-azure-cni-dynamic-ip-allocation], no matter the connection is inside the same virtual network or cross virtual networks, the pod IP is always the source address for any traffic from the pod.
 
 * **Can I configure per-pod network policies?**
 


### PR DESCRIPTION
**Proposed changes:** Add more explanation to explain how it works in different CNIs.

**Basis:**
Users can be confused because customer prefer to believe these three CNIs works as same in the scope of network flow because they are all "Azure CNI".


For the fact check:
![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/17b7d853-ae46-4c0c-aa7f-1f0163630d3a)
![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/2da42347-389d-4ab7-b105-1aa10437a68b)  
![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/203bc7bb-6e96-4abd-9673-264df3ae09ef)  
You can see even from different VNet, Pod IP is still act as src IP if using Pod subnet feature (dynamic IP allocation feature). 