### PR TITLE
Fixed typo on example code.

### DIFF
--- a/articles/ai-services/openai/tutorials/fine-tune.md
+++ b/articles/ai-services/openai/tutorials/fine-tune.md
@@ -394,7 +394,7 @@ job_id = response.id
 # The fine-tuning job will take some time to start and complete.
 
 print("Job ID:", response.id)
-print("Status:", response.id)
+print("Status:", response.status)
 print(response.model_dump_json(indent=2))
 ```
 


### PR DESCRIPTION
- Fixed the printing of job status from `response.id` to `response.status`.