### PR TITLE
[operator-nexus] Correct Cluster Extension Validation Command

### DIFF
--- a/articles/operator-nexus/howto-monitor-naks-cluster.md
+++ b/articles/operator-nexus/howto-monitor-naks-cluster.md
@@ -277,7 +277,7 @@ Validate the successful deployment of monitoring agents’ enablement on Nexus K
 az k8s-extension show --name azuremonitor-containers \
   --cluster-name "<Nexus Kubernetes cluster Name>" \
   --resource-group "<Nexus Kubernetes cluster Resource Group>" \
-  --cluster-type conectedClusters
+  --cluster-type connectedClusters
 ```
 
 Look for a Provisioning State of "Succeeded" for the extension. The "k8s-extension create" command may have also returned the status.


### PR DESCRIPTION
The cluster type argument in the az k8s-extension show command in the validate cluster extension section was missing an "n", meaning the command was invalid. Correcting this by adding the missing n.