### PR TITLE
Update trusted-launch-faq.md

### DIFF
--- a/articles/virtual-machines/trusted-launch-faq.md
+++ b/articles/virtual-machines/trusted-launch-faq.md
@@ -357,6 +357,9 @@ Architecture      : x64
 
 ---
 
+### How external communication drivers work with Trusted Launch VMs ?
+
+Adding COM ports require disabling of Secure Boot. Hence, COM ports are disabled by default in Trusted Launch VMs.
 
 ## Power states
 

--- a/articles/virtual-machines/trusted-launch-faq.md
+++ b/articles/virtual-machines/trusted-launch-faq.md
@@ -359,7 +359,7 @@ Architecture      : x64
 
 ### How external communication drivers work with Trusted Launch VMs ?
 
-Adding COM ports require disabling of Secure Boot. Hence, COM ports are disabled by default in Trusted Launch VMs.
+Adding COM ports requires disabling Secure Boot. Hence, COM ports are disabled by default in Trusted Launch VMs.
 
 ## Power states
 


### PR DESCRIPTION
How external communication drivers work with Trusted Launch VMs ? 

Adding COM ports require disabling of Secure Boot. Hence, COM ports are disabled by default in Trusted Launch VMs.