### PR TITLE
Update set-up-zone-redundancy-availability-zones.md

### DIFF
--- a/articles/logic-apps/set-up-zone-redundancy-availability-zones.md
+++ b/articles/logic-apps/set-up-zone-redundancy-availability-zones.md
@@ -10,7 +10,7 @@ ms.custom: references_regions
 #Customer intent: As a developer, I want to protect logic apps from regional failures by setting up availability zones.
 ---
 
-# Protect logic apps from region failures with zone redundancy and availability zones
+# Protect logic apps from zonal failures with zone redundancy and availability zones
 
 [!INCLUDE [logic-apps-sku-consumption-standard](../../includes/logic-apps-sku-consumption-standard.md)]
 


### PR DESCRIPTION
The title says protect logic apps from regional failure but it should instead be zonal failure. The tile is slightly misleading. Please review and correct it.