### PR TITLE
 Add 'scriptType: pscore' to Azure CLI documentation

### DIFF
--- a/articles/postgresql/flexible-server/azure-pipelines-deploy-database-task.md
+++ b/articles/postgresql/flexible-server/azure-pipelines-deploy-database-task.md
@@ -33,6 +33,7 @@ The following example illustrates how to pass database arguments and run `execut
   displayName: Azure CLI
   inputs:
     azureSubscription: <Name of the Azure Resource Manager service connection>
+    scriptType: 'pscore'
     scriptLocation: inlineScript
     arguments:
       -SERVERNAME mydemoserver `
@@ -55,6 +56,7 @@ The following example illustrates how to run an inline SQL script using `execute
   displayName: Azure CLI
   inputs:
     azureSubscription: <Name of the Azure Resource Manager service connection>
+    scriptType: 'pscore'
     scriptLocation: inlineScript
     arguments:
       -SERVERNAME mydemoserver `


### PR DESCRIPTION
This pull request aims to enhance the documentation for the Azure CLI task by adding scriptType: 'pscore' as a valid option. Currently, when attempting to execute a PowerShell script inline using the AzureCLI task, users encounter an error stating: "Script failed with error: Error: Input required: scriptType." This error occurs because the documentation lacks clarity on specifying the script type when using inline scripts with AzureCLI.

By adding scriptType: 'pscore' to the documentation, users will have clear guidance on how to properly configure the task for executing PowerShell scripts inline. This addition will improve the user experience by reducing confusion and ensuring smooth execution of PowerShell scripts within Azure Pipelines.

This change does not affect the functionality of the task itself but enhances the usability and clarity of the documentation, ultimately benefiting users who rely on Azure Pipelines for their continuous integration and deployment workflows.