### PR TITLE
Clarifying that adding service endpoint to Storage account is not same as creating storage account in a private network

### DIFF
--- a/articles/azure-resource-manager/templates/deployment-script-template.md
+++ b/articles/azure-resource-manager/templates/deployment-script-template.md
@@ -660,7 +660,7 @@ The identity that your deployment script uses needs to be authorized to work wit
 With Microsoft.Resources/deploymentScripts version 2023-08-01, you can run deployment scripts in private networks with some additional configurations.
 
 - Create a user-assigned managed identity, and specify it in the `identity` property. To assign the identity, see [Identity](#identity).
-- Create a storage account in the private network, and specify the deployment script to use the existing storage account. To specify an existing storage account, see [Use existing storage account](#use-existing-storage-account). Some additional configuration is required for the storage account.
+- Create a storage account, and specify the deployment script to use the existing storage account. To specify an existing storage account, see [Use existing storage account](#use-existing-storage-account). Some additional configuration is required for the storage account.
 
     1. Open the storage account in the [Azure portal](https://portal.azure.com).
     1. From the left menu, select **Access Control (IAM)**, and then select the **Role assignments** tab.


### PR DESCRIPTION
Azure Storage account cannot be created in a private network. Instead we allow traffic from private network to storage account using service endpoint. This is different from services that are part of the vnet. So it would be great to rephrase "create a storage account in a private network" as "create a storage account". The section below talks about how to integrate the storage account with a VNET, so the meaning should still be clear.