### PR TITLE
Update AP5GC pcap and ping docs

### DIFF
--- a/articles/private-5g-core/data-plane-packet-capture.md
+++ b/articles/private-5g-core/data-plane-packet-capture.md
@@ -12,7 +12,7 @@ ms.custom: template-how-to, devx-track-azurecli
 
 # Perform packet capture on a packet core instance
 
-Packet capture for control or data plane packets is performed using the **UPF Trace** tool. UPF Trace is similar to **tcpdump**, a data-network packet analyzer computer program that runs on a command line interface (CLI). You can use UPF Trace to monitor and record packets on any user plane interface on the access network (N3 interface) or data network (N6 interface) on your device, as well as the control plane (N2 interface). You can access UPF Trace using the Azure portal or the Azure CLI.
+Packet capture for control or data plane packets is performed using the **MEC-Dataplane Trace** tool. MEC-Dataplane (MEC-DP) Trace is similar to **tcpdump**, a data-network packet analyzer computer program that runs on a command line interface (CLI). You can use MEC-DP Trace to monitor and record packets on any user plane interface on the access network (N3 interface) or data network (N6 interface) on your device, as well as the control plane (N2 interface). You can access MEC-DP Trace using the Azure portal or the Azure CLI.
 
 Packet capture works by mirroring packets to a Linux kernel interface, which can then be monitored using tcpdump. In this how-to guide, you'll learn how to perform packet capture on a packet core instance.
 
@@ -58,16 +58,16 @@ To perform packet capture using the command line, you must:
 
 ## Performing packet capture using the Azure CLI
 
-1. In a command line with kubectl access to the Azure Arc-enabled Kubernetes cluster, enter the UPF-PP troubleshooter pod:
+1. In a command line with kubectl access to the Azure Arc-enabled Kubernetes cluster, enter the MEC-DP troubleshooter pod:
 
     ```azurecli
-    kubectl exec -it -n core core-upf-pp-0 -c troubleshooter -- bash
+    kubectl exec -it -n core core-mec-dp-0 -c troubleshooter -- bash
     ```
 
 1. View the list of configured user plane interfaces:
 
     ```azurecli
-    upft list
+    mect list
     ```
 
     This should report a single interface on the control plane network (N2), a single interface on the access network (N3) and an interface for each attached data network (N6). For example:
@@ -80,9 +80,9 @@ To perform packet capture using the command line, you must:
     n6trace2 (Data Network: test)
     ```
 
-1. Run `upftdump` with any parameters that you would usually pass to tcpdump. In particular, `-i` to specify the interface, and `-w` to specify where to write to. Close the UPFT tool when done by pressing <kbd>Ctrl + C</kbd>. The following examples are common use cases:
-    - To run capture packets on all interfaces run `upftdump -i any -w any.pcap`
-    - To run capture packets for the N3 interface and the N6 interface for a single data network, enter the UPF-PP troubleshooter pod in two separate windows. In one window run `upftdump -i n3trace -w n3.pcap` and in the other window run `upftdump -i <N6 interface> -w n6.pcap` (use the N6 interface for the data network as identified in step 2).
+1. Run `mectdump` with any parameters that you would usually pass to tcpdump. In particular, `-i` to specify the interface, and `-w` to specify where to write to. Close the `mectdump` tool when done by pressing <kbd>Ctrl + C</kbd>. The following examples are common use cases:
+    - To run capture packets on all interfaces run `mectdump -i any -w any.pcap`
+    - To run capture packets for the N3 interface and the N6 interface for a single data network, enter the MEC-DP troubleshooter pod in two separate windows. In one window run `mectdump -i n3trace -w n3.pcap` and in the other window run `mectdump -i <N6 interface> -w n6.pcap` (use the N6 interface for the data network as identified in step 2).
 
     > [!IMPORTANT]
     > Packet capture files might be large, particularly when running packet capture on all interfaces. Specify filters when running packet capture to reduce the file size - see the tcpdump documentation for the available filters.
@@ -96,7 +96,7 @@ To perform packet capture using the command line, you must:
 1. Copy the output files:
 
     ```azurecli
-    kubectl cp -n core core-upf-pp-0:<path to output file> <location to copy to> -c troubleshooter
+    kubectl cp -n core core-mec-dp-0:<path to output file> <location to copy to> -c troubleshooter
     ```
 
     The `tcpdump` might have been stopped in the middle of writing a packet, which can cause this step to produce an error stating `unexpected EOF`. However, your file should have copied successfully, but you can check your target output file to confirm.
@@ -104,7 +104,7 @@ To perform packet capture using the command line, you must:
 1. Remove the output files:
 
     ```azurecli
-        kubectl exec -it -n core core-upf-pp-0 -c troubleshooter -- rm <path to output file>
+        kubectl exec -it -n core core-mec-dp-0 -c troubleshooter -- rm <path to output file>
     ```
 
 ## Next steps

--- a/articles/private-5g-core/ping-traceroute.md
+++ b/articles/private-5g-core/ping-traceroute.md
@@ -27,16 +27,16 @@ To access the local UI, see [Tutorial: Connect to Azure Stack Edge Pro with GPU]
 
 ## Run the ping and traceroute tools
 
-1. In a command line with kubectl access to the Azure Arc-enabled Kubernetes cluster, enter the UPF-PP troubleshooter pod:
+1. In a command line with kubectl access to the Azure Arc-enabled Kubernetes cluster, enter the MEC-DP troubleshooter pod:
 
     ```azurecli
-    kubectl exec -it -n core core-upf-pp-0 -c troubleshooter -- bash
+    kubectl exec -it -n core core-mec-dp-0 -c troubleshooter -- bash
     ```
 
 1. View the list of configured user plane interfaces:
 
     ```azurecli
-    upft list
+    mect list
     ```
 
     This should report a single interface on the control plane network (N2), a single interface on the access network (N3) and an interface for each attached data network (N6). For example:


### PR DESCRIPTION
Update AP5GC packet capture and ping/traceroute docs to reflect UPF-PP -> MEC-DP rename in AP5GC 2401 (preview release) and 2402 (public release).

Note, 2402 is not publicly available yet, so let's sit on this PR until it is released.