### PR TITLE
fix: remove redundant empty last row in table keyvault auth req

### DIFF
--- a/articles/key-vault/general/authentication-requests-and-responses.md
+++ b/articles/key-vault/general/authentication-requests-and-responses.md
@@ -2,7 +2,7 @@
 title: Authentication, requests and responses
 description: Learn how Azure Key Vault uses JSON-formatted requests and responses and about required authentication for using a key vault.
 services: key-vault
-author: mbaldwin
+author: msmbaldwin
 manager: msmbaldwin
 
 ms.service: key-vault

--- a/articles/key-vault/general/authentication-requests-and-responses.md
+++ b/articles/key-vault/general/authentication-requests-and-responses.md
@@ -31,7 +31,6 @@ Here are the URL suffixes used to access each type of object
 |Secrets|/secrets|
 |Certificates| /certificates|
 |Storage account keys|/storageaccounts
-||
 
 Azure Key Vault supports JSON formatted requests and responses. Requests to the Azure Key Vault are directed to a valid Azure Key Vault URL using HTTPS with some URL parameters and JSON encoded request and response bodies.
 


### PR DESCRIPTION
Removed redunant last empty row in the table of Key Vault page "authentication-requests-and-responses"