### PR TITLE
Small fix for TOC entry about using an AKS NAT Gateway

### DIFF
--- a/articles/aks/TOC.yml
+++ b/articles/aks/TOC.yml
@@ -471,7 +471,7 @@
               href: egress-udr.md
             - name: Use an HTTP proxy
               href: http-proxy.md
-            - name: Managed NAT Gateway
+            - name: Use a NAT Gateway
               href: nat-gateway.md
             - name: Outbound network and FQDN rules for AKS clusters
               href: outbound-rules-control-egress.md


### PR DESCRIPTION
The article talks about managed or user-assigned GW, so not only managed GW.

Also, "Use a ..." is more in line with the other articles.