### PR TITLE
Corrected command for Granting extension identity permissions to Storage account

### DIFF
--- a/articles/backup/azure-kubernetes-service-cluster-manage-backups.md
+++ b/articles/backup/azure-kubernetes-service-cluster-manage-backups.md
@@ -120,7 +120,7 @@ To stop the Backup Extension install operation, use the following command:
 To provide *Storage Account Contributor Permission* to the Extension Identity on storage account, run the following command:
 
    ```azurecli-interactive
-   az role assignment create --assignee-object-id $(az k8s-extension show --name azure-aks-backup --cluster-name <aksclustername> --resource-group <aksclusterrg> --cluster-type managedClusters --query identity.principalId --output tsv) --role 'Storage Blob Data Contributor' --scope /subscriptions/<subscriptionid>/resourceGroups/<storageaccountrg>/providers/Microsoft.Storage/storageAccounts/<storageaccountname> 
+   az role assignment create --assignee-object-id $(az k8s-extension show --name azure-aks-backup --cluster-name <aksclustername> --resource-group <aksclusterrg> --cluster-type managedClusters --query aksAssignedIdentity.principalId --output tsv) --role 'Storage Blob Data Contributor' --scope /subscriptions/<subscriptionid>/resourceGroups/<storageaccountrg>/providers/Microsoft.Storage/storageAccounts/<storageaccountname> 
    ```
 
 


### PR DESCRIPTION
The command should use aksAssignedIdentity.principalId instead of identity.principalId

```
azadmin@jumpbox:~$ az k8s-extension show --name azure-aks-backup --cluster-name m1chianProdAks --resource-group m1chianProdRG --cluster-type managedClusters
{
  "aksAssignedIdentity": {
    "principalId": "cc413d45-b38b-46e5-8a0c-e9853825dd5a",
    "tenantId": null,
    "type": null
  },

<output truncated>
```

```
azadmin@jumpbox:~$ az k8s-extension show --name azure-aks-backup --cluster-name m1chianProdAks --resource-group m1chianProdRG --cluster-type managedClusters --query aksAssignedIdentity.principalId --output tsv
cc413d45-b38b-46e5-8a0c-e9853825dd5a
```