### PR TITLE
Update embedded-speech.md

### DIFF
--- a/articles/ai-services/speech-service/embedded-speech.md
+++ b/articles/ai-services/speech-service/embedded-speech.md
@@ -14,9 +14,6 @@ zone_pivot_groups: programming-languages-set-thirteen
 
 # Embedded Speech
 
-> [!CAUTION]
-> This article references CentOS, a Linux distribution that is nearing End Of Life (EOL) status. Please consider your use and planning accordingly.
-
 Embedded Speech is designed for on-device [speech to text](speech-to-text.md) and [text to speech](text-to-speech.md) scenarios where cloud connectivity is intermittent or unavailable. For example, you can use embedded speech in industrial equipment, a voice enabled air conditioning unit, or a car that might travel out of range. You can also develop hybrid cloud and offline solutions. For scenarios where your devices must be in a secure environment like a bank or government entity, you should first consider [disconnected containers](../containers/disconnected-containers.md). 
 
 > [!IMPORTANT]


### PR DESCRIPTION
Remove the superfluous CentOS 7 EOL notice at the top, since the only occasion where CentOS is mentioned in the article is "Embedded speech isn't supported on RHEL/CentOS 7." Thus the EOL notice has no actual relevance and only acts as a red herring to customers who visit the page for the first time.