### PR TITLE
What PNA stands for

### DIFF
--- a/articles/ai-studio/how-to/create-azure-ai-resource.md
+++ b/articles/ai-studio/how-to/create-azure-ai-resource.md
@@ -114,7 +114,7 @@ At Azure AI hub resource creation, select between the networking isolation modes
 
 At Azure AI hub resource creation in the Azure portal, creation of associated Azure AI services, Storage account, Key vault, Application insights, and Container registry is given. These resources are found on the Resources tab during creation. 
 
-To connect to Azure AI services (Azure OpenAI, Azure AI Search, and Azure AI Content Safety) or storage accounts in Azure AI Studio, create a private endpoint in your virtual network. Ensure the PNA flag is disabled when creating the private endpoint connection. For more about Azure AI services connections, follow documentation [here](../../ai-services/cognitive-services-virtual-networks.md). You can optionally bring your own (BYO) search, but this requires a private endpoint connection from your virtual network.
+To connect to Azure AI services (Azure OpenAI, Azure AI Search, and Azure AI Content Safety) or storage accounts in Azure AI Studio, create a private endpoint in your virtual network. Ensure the PNA (Public Network Access) flag is disabled when creating the private endpoint connection. For more about Azure AI services connections, follow documentation [here](../../ai-services/cognitive-services-virtual-networks.md). You can optionally bring your own (BYO) search, but this requires a private endpoint connection from your virtual network.
 
 ### Encryption
 Projects that use the same Azure AI hub resource, share their encryption configuration. Encryption mode can be set only at the time of Azure AI hub resource creation between Microsoft-managed keys and Customer-managed keys. 


### PR DESCRIPTION
For the private endpoint config, there is a reference to "PNA flag". It's not a common abbreviation and that's why we need to clarify that it's a "Public Network Access" configuration, especially because it's in a tab different from the Private Endpoints config.