### PR TITLE
Update Azure Cosmos DB Emulator instructions for python

### DIFF
--- a/articles/cosmos-db/emulator.md
+++ b/articles/cosmos-db/emulator.md
@@ -51,7 +51,7 @@ Every request made against the emulator must be authenticated using a key over T
 
 ## Import emulator certificate
 
-In some cases, you may wish to manually import the TLS/SS certificate from the emulator's running container into your host machine. This step avoids bad practices like disabling TLS/SSL validation in the SDK. For more information, see [import certificate](how-to-develop-emulator.md#export-the-emulators-tlsssl-certificate).
+In some cases, you may wish to manually import the TLS/SS certificate from the emulator's running container into your host machine. This step avoids bad practices like disabling TLS/SSL validation in the SDK. For more information, see [import certificate](how-to-develop-emulator.md#import-the-emulators-tlsssl-certificate).
 
 ## Next step
 

--- a/articles/cosmos-db/how-to-develop-emulator.md
+++ b/articles/cosmos-db/how-to-develop-emulator.md
@@ -407,6 +407,20 @@ The certificate for the emulator is available at the path `_explorer/emulator.pe
     ```bash
     cp ~/emulatorcert.crt /usr/local/share/ca-certificates/
     ```
+1. Update CA certificates and regenerate the certificate bundle by using the appropriate command for your Linux distribution.
+    
+    For **Debian-based** systems (e.g., Ubuntu), use:
+
+    ```bash
+    sudo update-ca-certificates
+    ```
+
+    For **Red Hat-based** systems (e.g., CentOS, Fedora), use:
+    ```bash
+    sudo update-ca-trust
+    ```
+
+    For more detailed instructions, consult the documentation specific to your Linux distribution.
 
 ### [Windows (local)](#tab/windows)
 
@@ -559,12 +573,13 @@ Use the [Azure Cosmos DB API for NoSQL Python SDK](nosql/quickstart-python.md) t
 
     1. Once you have identified the DEFAULT_CA_BUNDLE_PATH, open a **new terminal** and run the following commands to append the emulator certificate to the certificate bundle:
         > [!IMPORTANT]
-        > If DEFAULT_CA_BUNDLE_PATH variable points to a system directory, you might encounter a **"Permission denied"** error. In this case, you will need to run the commands with elevated privileges (as root).
-        >
+        > If DEFAULT_CA_BUNDLE_PATH variable points to a **system directory**, you might encounter a **"Permission denied"** error. In this case, you will need to run the commands with elevated privileges (as root). Also, you will need to [update and regenerate the certificate bundle](#import-the-emulators-tlsssl-certificate) after executing the provided commands.
+
         ```bash
         # Add a new line to the certificate bundle
         echo >> /path/to/ca_bundle
         ```
+
         ```bash
         # Append the emulator certificate to the certificate bundle
         cat /path/to/emulatorcert.crt >> /path/to/ca_bundle

--- a/articles/cosmos-db/how-to-develop-emulator.md
+++ b/articles/cosmos-db/how-to-develop-emulator.md
@@ -467,7 +467,7 @@ Use the [Azure Cosmos DB API for NoSQL .NET SDK](nosql/quickstart-dotnet.md) to 
     ```
 
     > [!WARNING]
-    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#export-the-emulators-tlsssl-certificate). To resolve this, configure the client's options to disable TLS/SSL validation before creating the client:
+    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#import-the-emulators-tlsssl-certificate). To resolve this, configure the client's options to disable TLS/SSL validation before creating the client:
     >
     > ```csharp
     > CosmosClientOptions options = new ()
@@ -527,7 +527,7 @@ Use the [Azure Cosmos DB API for NoSQL Python SDK](nosql/quickstart-python.md) t
     ```
 
     > [!WARNING]
-    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#export-the-emulators-tlsssl-certificate). To resolve this, configure the application to disable TLS/SSL validation before creating the client:
+    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#import-the-emulators-tlsssl-certificate). To resolve this, configure the application to disable TLS/SSL validation before creating the client:
     >
     > ```python
     > import urllib3
@@ -613,7 +613,7 @@ Use the [Azure Cosmos DB API for NoSQL Node.js SDK](nosql/quickstart-nodejs.md) 
     ```
 
     > [!WARNING]
-    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#export-the-emulators-tlsssl-certificate). To resolve this, configure the application to disable TLS/SSL validation before creating the client:
+    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#import-the-emulators-tlsssl-certificate). To resolve this, configure the application to disable TLS/SSL validation before creating the client:
     >
     > ```javascript
     > process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0
@@ -749,7 +749,7 @@ Use the [MongoDB Node.js driver](mongodb/quickstart-nodejs.md) to connect to the
     ```
 
     > [!WARNING]
-    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#export-the-emulators-tlsssl-certificate). To resolve this, configure the application to disable TLS/SSL validation before creating the client:
+    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#import-the-emulators-tlsssl-certificate). To resolve this, configure the application to disable TLS/SSL validation before creating the client:
     >
     > ```javascript
     > const client = new MongoClient(
@@ -892,7 +892,7 @@ Use the [Apache Cassandra Node.js driver](cassandra/manage-data-nodejs.md) to us
     ```
 
     > [!WARNING]
-    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#export-the-emulators-tlsssl-certificate). To resolve this, configure the client to disable TLS/SSL validation:
+    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#import-the-emulators-tlsssl-certificate). To resolve this, configure the client to disable TLS/SSL validation:
     >
     > ```javascript
     > const client = new Client({
@@ -1170,7 +1170,7 @@ Use the [Azure Tables JavaScript SDK](cassandra/manage-data-nodejs.md) to use th
     ```
 
     > [!WARNING]
-    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#export-the-emulators-tlsssl-certificate). To resolve this, configure the client to disable TLS/SSL validation:
+    > If you get a SSL error, you may need to disable TLS/SSL for your application. This commonly occurs if you are developing on your local machine, using the Azure Cosmos DB emulator in a container, and have not [imported the container's SSL certificate](#import-the-emulators-tlsssl-certificate). To resolve this, configure the client to disable TLS/SSL validation:
     >
     > ```javascript
     > const client = TableClient.fromConnectionString(

--- a/articles/cosmos-db/how-to-develop-emulator.md
+++ b/articles/cosmos-db/how-to-develop-emulator.md
@@ -351,9 +351,9 @@ The Docker (Windows) container image doesn't support the API for MongoDB.
 
 ::: zone-end
 
-## Export the emulator's TLS/SSL certificate
+## Import the emulator's TLS/SSL certificate
 
-Export the certificate for the emulator to use the emulator with your preferred developer SDK without disable TLS/SSL on the client.
+Import the emulator's TLS/SSL certificate to use the emulator with your preferred developer SDK without disabling TLS/SSL on the client.
 
 ::: zone pivot="api-apache-cassandra,api-apache-gremlin,api-table"
 
@@ -371,7 +371,7 @@ The Windows local installation of the emulator automatically imports the TLS/SSL
 
 ### [Docker (Linux container)](#tab/docker-linux)
 
-The certificate for the emulator is available in the `_explorer/emulator.pem` path on the running container. Use `curl` to download the certificate from the running container to your local machine.
+The certificate for the emulator is available at the path `_explorer/emulator.pem` on the running container. Use `curl` to download the certificate from the running container to your local machine.
 
 ```bash
 curl -k https://localhost:8081/_explorer/emulator.pem > ~/emulatorcert.crt
@@ -391,7 +391,7 @@ The Windows local installation of the emulator automatically imports the TLS/SSL
 
 ### [Docker (Linux container) / Docker (Windows container)](#tab/docker-linux+docker-windows)
 
-The certificate for the emulator is available in the `_explorer/emulator.pem` path on the running container.
+The certificate for the emulator is available at the path `_explorer/emulator.pem` on the running container.
 
 1. Use `curl` to download the certificate from the running container to your local machine.
 
@@ -418,7 +418,7 @@ The Windows local installation of the emulator automatically imports the TLS/SSL
 
 ## Connect to the emulator from the SDK
 
-Each SDK includes a client class typically used to connect the SDK to your Azure Cosmos DB account. Using the [emulator's credentials](emulator.md#authentication), you can connect the SDK to the emulator instance instead.
+Each SDK includes a client class typically used to connect the SDK to your Azure Cosmos DB account. By using the [emulator's credentials](emulator.md#authentication), you can connect the SDK to the emulator instance instead.
 
 ::: zone pivot="api-nosql"  
 
@@ -535,6 +535,40 @@ Use the [Azure Cosmos DB API for NoSQL Python SDK](nosql/quickstart-python.md) t
     > urllib3.disable_warnings()
     > ```
     >
+
+    If you are still facing SSL errors, it is possible that Python is retrieving the certificates from a different certificate store. To determine the path where Python is looking for the certificates, follow these steps:
+    >[!IMPORTANT]
+    >If you are using a Python **virtual environment** (venv) ensure it is **activated** before running the commands!
+    1. Open a terminal
+    1. Start the Python interpreter by typing python or python3, depending on your Python version.
+    1. In the Python interpreter, run the following commands:
+        ```python
+        from requests.utils import DEFAULT_CA_BUNDLE_PATH
+        print(DEFAULT_CA_BUNDLE_PATH)
+        ```
+
+        **Inside a virtual environment**, the path may be (at least in Ubuntu):
+        ```bash
+        path/to/venv/lib/pythonX.XX/site-packages/certifi/cacert.pem
+        ```
+
+        **Outside of a virtual environment**, the path may be (at least in Ubuntu):
+        ```bash
+        /etc/ssl/certs/ca-certificates.crt
+        ```
+
+    1. Once you have identified the DEFAULT_CA_BUNDLE_PATH, open a **new terminal** and run the following commands to append the emulator certificate to the certificate bundle:
+        > [!IMPORTANT]
+        > If DEFAULT_CA_BUNDLE_PATH variable points to a system directory, you might encounter a **"Permission denied"** error. In this case, you will need to run the commands with elevated privileges (as root).
+        >
+        ```bash
+        # Add a new line to the certificate bundle
+        echo >> /path/to/ca_bundle
+        ```
+        ```bash
+        # Append the emulator certificate to the certificate bundle
+        cat /path/to/emulatorcert.crt >> /path/to/ca_bundle
+        ```
 
 ### [JavaScript / Node.js](#tab/javascript+nodejs)
 


### PR DESCRIPTION
Added additional information to help resolve SSL errors when connecting to the emulator using the Python SDK. Additionally, minor changes were introduced in other sections of the documentation.

The instructions added were inspired by this Stack Overflow answer:  [https://stackoverflow.com/a/31915123](url)