### PR TITLE
fix typo change "databaseaccount" to "mongocluster"

### DIFF
--- a/articles/cosmos-db/mongodb/vcore/quickstart-bicep.md
+++ b/articles/cosmos-db/mongodb/vcore/quickstart-bicep.md
@@ -76,7 +76,7 @@ resource firewallRules 'Microsoft.DocumentDB/mongoClusters/firewallRules@2022-10
 
 Two Azure resources are defined in the Bicep file:
 
-- [`Microsoft.DocumentDB/databaseAccounts`](/azure/templates/microsoft.documentdb/databaseAccounts?pivots=deployment-language-bicep): Creates an Azure Cosmos DB for MongoDB vCore cluster.
+- [`Microsoft.DocumentDB/mongoclusters`](/azure/templates/microsoft.documentdb/mongoclusters?pivots=deployment-language-bicep): Creates an Azure Cosmos DB for MongoDB vCore cluster.
   - [`Microsoft.DocumentDB/databaseAccounts/sqlDatabases`](/azure/templates/microsoft.documentdb/databaseAccounts?pivots=deployment-language-bicep): Creates firewall rules for the Azure Cosmos DB for MongoDB vCore cluster.
 
 ## Deploy the Bicep file

--- a/articles/cosmos-db/mongodb/vcore/quickstart-bicep.md
+++ b/articles/cosmos-db/mongodb/vcore/quickstart-bicep.md
@@ -77,7 +77,7 @@ resource firewallRules 'Microsoft.DocumentDB/mongoClusters/firewallRules@2022-10
 Two Azure resources are defined in the Bicep file:
 
 - [`Microsoft.DocumentDB/mongoclusters`](/azure/templates/microsoft.documentdb/mongoclusters?pivots=deployment-language-bicep): Creates an Azure Cosmos DB for MongoDB vCore cluster.
-  - [`Microsoft.DocumentDB/databaseAccounts/sqlDatabases`](/azure/templates/microsoft.documentdb/databaseAccounts?pivots=deployment-language-bicep): Creates firewall rules for the Azure Cosmos DB for MongoDB vCore cluster.
+  - [`Microsoft.DocumentDB/mongoClusters/firewallRules`](/azure/templates/microsoft.documentdb/mongoclusters?pivots=deployment-language-bicep): Creates firewall rules for the Azure Cosmos DB for MongoDB vCore cluster.
 
 ## Deploy the Bicep file
 


### PR DESCRIPTION
Database account are not the resource that creates the mongoDB vCore cluster it's for mongoDB only. The right one as mentioned in the bicep above at line 47 is mongocluster.