### PR TITLE
Adds missing word in dotnet-isolated-process-guide.md

### DIFF
--- a/articles/azure-functions/dotnet-isolated-process-guide.md
+++ b/articles/azure-functions/dotnet-isolated-process-guide.md
@@ -432,7 +432,7 @@ var host = new HostBuilder()
 
 ### Application Insights
 
-You can configure your isolated process application to emit logs directly [Application Insights](../azure-monitor/app/app-insights-overview.md?tabs=net). This behavior replaces the default behavior of [relaying logs through the host](./configure-monitoring.md#custom-application-logs), and is recommended because it gives you control over how those logs are emitted. 
+You can configure your isolated process application to emit logs directly to [Application Insights](../azure-monitor/app/app-insights-overview.md?tabs=net). This behavior replaces the default behavior of [relaying logs through the host](./configure-monitoring.md#custom-application-logs), and is recommended because it gives you control over how those logs are emitted. 
 
 #### Install packages
 


### PR DESCRIPTION
The addition of the word _to_ in "You can configure your isolated process application to emit logs directly _to_ [Application Insights]" makes this read more easily.