### PR TITLE
Update configure-expressroute-private-peering.md

### DIFF
--- a/articles/expressroute/configure-expressroute-private-peering.md
+++ b/articles/expressroute/configure-expressroute-private-peering.md
@@ -78,7 +78,9 @@ In this tutorial, you learn how to:
     * **IPv4 Secondary subnet**: Enter the subnet for the secondary BGP peer.
     * **Enable IPv4 peering**: Check this box to enable IPv4 peering.  
     * **VLAN ID**: Enter the VLAN ID that you want to use for the private peering.
-    * **Shared key**: Enter an MD5 hash for the shared key. The use of a shared key is optional.
+    * **Shared key**: Enter the Password Phrase for the shared key(unencrypted). The use of a shared key is optional.
+> [!IMPORTANT]
+>  Some vendor uses Password encryption services for securing the passwords on On-prem Router configuration hence the password configured under BGP configuration on on-prem router might be an encrypted password. Kindly use the Password phrase instead of encrypted password under the shared key.
 
 1. Select **Save** to save the private peering configuration.
 


### PR DESCRIPTION
On below page 

https://learn.microsoft.com/en-us/azure/expressroute/configure-expressroute-private-peering#enable-private-peering

The statement about the shared key asks to Enter MD5 hash for the shared key.

"Shared key: Enter an MD5 hash for the shared key. The use of a shared key is optional."

If we calculate the MD5 hash for shared key "Microsoft" the MD5 hash value is - "140864078aeca1c7c35b4beb33c53c34"

This is 32 character long. while maximum permissible character to use for Shared key is 25 characters. So we cannot add the MD5 hash in shared key. Also from security point of view hash should be calculated by both end on the Password phrase.