### PR TITLE
Update immutable-time-based-retention-policy-overview.md

### DIFF
--- a/articles/storage/blobs/immutable-time-based-retention-policy-overview.md
+++ b/articles/storage/blobs/immutable-time-based-retention-policy-overview.md
@@ -128,7 +128,7 @@ Unlocked time-based retention policies allow the **AllowProtectedAppendWrites** 
 
 ## Audit logging
 
-Each container with a time-based retention policy enabled provides a policy audit log. The audit log includes up to seven time-based retention commands for locked time-based retention policies. Log entries include the user ID, command type, time stamps, and retention interval. The audit log is retained for the lifetime of the policy, in accordance with the SEC 17a-4(f) regulatory guidelines.
+Each container with a time-based retention policy enabled provides a policy audit log. The audit log includes up to seven time-based retention commands for locked time-based retention policies. The Logging typically starts once you have locked the policy. Log entries include the user ID, command type, time stamps, and retention interval. The audit log is retained for the lifetime of the policy, in accordance with the SEC 17a-4(f) regulatory guidelines.
 
 The [Azure Activity log](../../azure-monitor/essentials/platform-logs-overview.md) provides a more comprehensive log of all management service activities. [Azure resource logs](../../azure-monitor/essentials/platform-logs-overview.md) retain information about data operations. It's the user's responsibility to store those logs persistently, as might be required for regulatory or other purposes.
 


### PR DESCRIPTION
The policy Audit logs for timebased retention stats populating once you have locked the policy and thereafter it will have details regarding when the policy was created, locked, extended etc.