### PR TITLE
Rename dataSources to data_sources in gpt-with-vision.md

### DIFF
--- a/articles/ai-services/openai/how-to/gpt-with-vision.md
+++ b/articles/ai-services/openai/how-to/gpt-with-vision.md
@@ -271,7 +271,7 @@ Send a POST request to `https://{RESOURCE_NAME}.openai.azure.com/openai/deployme
 
 The format is similar to that of the chat completions API for GPT-4, but the message content can be an array containing strings and images (either a valid HTTP or HTTPS URL to an image, or a base-64-encoded image).
 
-You must also include the `enhancements` and `dataSources` objects. `enhancements` represents the specific Vision enhancement features requested in the chat. It has a `grounding` and `ocr` property, which both have a boolean `enabled` property. Use these to request the OCR service and/or the object detection/grounding service. `dataSources` represents the Computer Vision resource data that's needed for Vision enhancement. It has a `type` property which should be `"AzureComputerVision"` and a `parameters` property. Set the `endpoint` and `key` to the endpoint URL and access key of your Computer Vision resource. 
+You must also include the `enhancements` and `data_sources` objects. `enhancements` represents the specific Vision enhancement features requested in the chat. It has a `grounding` and `ocr` property, which both have a boolean `enabled` property. Use these to request the OCR service and/or the object detection/grounding service. `data_sources` represents the Computer Vision resource data that's needed for Vision enhancement. It has a `type` property which should be `"AzureComputerVision"` and a `parameters` property. Set the `endpoint` and `key` to the endpoint URL and access key of your Computer Vision resource. 
 
 > [!IMPORTANT]
 > Remember to set a `"max_tokens"` value, or the return output will be cut off.
@@ -287,7 +287,7 @@ You must also include the `enhancements` and `dataSources` objects. `enhancement
               "enabled": true
             }
     },
-    "dataSources": [
+    "data_sources": [
     {
         "type": "AzureComputerVision",
         "parameters": {
@@ -323,11 +323,11 @@ You must also include the `enhancements` and `dataSources` objects. `enhancement
 
 #### [Python](#tab/python)
 
-You call the same method as in the previous step, but include the new *extra_body* parameter. It contains the `enhancements` and `dataSources` fields. 
+You call the same method as in the previous step, but include the new *extra_body* parameter. It contains the `enhancements` and `data_sources` fields. 
 
 `enhancements` represents the specific Vision enhancement features requested in the chat. It has a `grounding` and `ocr` field, which both have a boolean `enabled` property. Use these to request the OCR service and/or the object detection/grounding service. 
 
-`dataSources` represents the Computer Vision resource data that's needed for Vision enhancement. It has a `type` field which should be `"AzureComputerVision"` and a `parameters` field. Set the `endpoint` and `key` to the endpoint URL and access key of your Computer Vision resource. R
+`data_sources` represents the Computer Vision resource data that's needed for Vision enhancement. It has a `type` field which should be `"AzureComputerVision"` and a `parameters` field. Set the `endpoint` and `key` to the endpoint URL and access key of your Computer Vision resource. R
 
 > [!IMPORTANT]
 > Remember to set a `"max_tokens"` value, or the return output will be cut off.
@@ -352,7 +352,7 @@ response = client.chat.completions.create(
         ] } 
     ],
     extra_body={
-        "dataSources": [
+        "data_sources": [
             {
                 "type": "AzureComputerVision",
                 "parameters": {
@@ -583,7 +583,7 @@ To use a User assigned identity on your Azure AI Services resource, follow these
                   "enabled": true
                 }
         },
-        "dataSources": [
+        "data_sources": [
         {
             "type": "AzureComputerVisionVideoIndex",
             "parameters": {
@@ -616,15 +616,15 @@ To use a User assigned identity on your Azure AI Services resource, follow these
     } 
     ```
 
-    The request includes the `enhancements` and `dataSources` objects. `enhancements` represents the specific Vision enhancement features requested in the chat. `dataSources` represents the Computer Vision resource data that's needed for Vision enhancement. It has a `type` property which should be `"AzureComputerVisionVideoIndex"` and a `parameters` property which contains your AI Vision and video information.
+    The request includes the `enhancements` and `data_sources` objects. `enhancements` represents the specific Vision enhancement features requested in the chat. `data_sources` represents the Computer Vision resource data that's needed for Vision enhancement. It has a `type` property which should be `"AzureComputerVisionVideoIndex"` and a `parameters` property which contains your AI Vision and video information.
 1. Fill in all the `<placeholder>` fields above with your own information: enter the endpoint URLs and keys of your OpenAI and AI Vision resources where appropriate, and retrieve the video index information from the earlier step.
 1. Send the POST request to the API endpoint. It should contain your OpenAI and AI Vision credentials, the name of your video index, and the ID and SAS URL of a single video.
 
 #### [Python](#tab/python)
 
-In your Python script, call the client's **create** method as in the previous sections, but include the *extra_body* parameter. Here, it contains the `enhancements` and `dataSources` fields. `enhancements` represents the specific Vision enhancement features requested in the chat. It has a `video` field, which has a boolean `enabled` property. Use this to request the video retrieval service. 
+In your Python script, call the client's **create** method as in the previous sections, but include the *extra_body* parameter. Here, it contains the `enhancements` and `data_sources` fields. `enhancements` represents the specific Vision enhancement features requested in the chat. It has a `video` field, which has a boolean `enabled` property. Use this to request the video retrieval service. 
 
-`dataSources` represents the external resource data that's needed for Vision enhancement. It has a `type` field which should be `"AzureComputerVisionVideoIndex"` and a `parameters` field. 
+`data_sources` represents the external resource data that's needed for Vision enhancement. It has a `type` field which should be `"AzureComputerVisionVideoIndex"` and a `parameters` field. 
 
 Set the `computerVisionBaseUrl` and `computerVisionApiKey` to the endpoint URL and access key of your Computer Vision resource. Set `indexName` to the name of your video index. Set `videoUrls` to a list of SAS URLs of your videos. 
 
@@ -648,7 +648,7 @@ response = client.chat.completions.create(
         ] } 
     ],
     extra_body={
-        "dataSources": [
+        "data_sources": [
             {
                 "type": "AzureComputerVisionVideoIndex",
                 "parameters": {
@@ -672,12 +672,12 @@ print(response)
 ---
 
 > [!IMPORTANT]
-> The `"dataSources"` object's content varies depending on which Azure resource type and authentication method you're using. See the following reference:
+> The `"data_sources"` object's content varies depending on which Azure resource type and authentication method you're using. See the following reference:
 > 
 > #### [Azure OpenAI resource](#tab/resource)
 > 
 > ```json
-> "dataSources": [
+> "data_sources": [
 > {
 >     "type": "AzureComputerVisionVideoIndex",
 >     "parameters": {
@@ -692,7 +692,7 @@ print(response)
 > #### [Azure AIServices resource + SAS authentication](#tab/resource-sas)
 > 
 > ```json
-> "dataSources": [
+> "data_sources": [
 > {
 >     "type": "AzureComputerVisionVideoIndex",
 >     "parameters": {
@@ -705,7 +705,7 @@ print(response)
 > #### [Azure AIServices resource + Managed Identities](#tab/resource-mi)
 > 
 > ```json
-> "dataSources": [
+> "data_sources": [
 > {
 >     "type": "AzureComputerVisionVideoIndex",
 >     "parameters": {


### PR DESCRIPTION
Apparently `dataSources`, used to configure chat extensions such as vision enhancement, was renamed to `data_sources` from [_2023-12-01-preview_](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2023-12-01-preview/inference.json) to [_2024-02-15-preview_](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/preview/2024-02-15-preview/inference.json)

Should I include some indication to use `dataSources` in _2023-12-01-preview_ and previous versions?