### PR TITLE
Replace "ExpressRouteRoute" with "ExpressRoute" in expressroute-howto-set-global-reach.md

### DIFF
--- a/articles/expressroute/expressroute-howto-set-global-reach.md
+++ b/articles/expressroute/expressroute-howto-set-global-reach.md
@@ -12,7 +12,7 @@ ms.custom: devx-track-azurepowershell
 
 # Configure ExpressRoute Global Reach
 
-This article helps you configure ExpressRoute Global Reach using PowerShell. For more information, see [ExpressRouteRoute Global Reach](expressroute-global-reach.md).
+This article helps you configure ExpressRoute Global Reach using PowerShell. For more information, see [ExpressRoute Global Reach](expressroute-global-reach.md).
 
  ## Before you begin
 


### PR DESCRIPTION
Replace "ExpressRouteRoute" with "ExpressRoute" in expressroute-howto-set-global-reach.md to improve documentation.