### PR TITLE
Add ExpressRoute to KV Trusted Services List

### DIFF
--- a/articles/key-vault/general/overview-vnet-service-endpoints.md
+++ b/articles/key-vault/general/overview-vnet-service-endpoints.md
@@ -65,6 +65,7 @@ Here's a list of trusted services that are allowed to access a key vault if the 
 | Azure Disk Encryption volume encryption service|Allow access to BitLocker Key (Windows VM) or DM Passphrase (Linux VM), and Key Encryption Key, during virtual machine deployment. This enables [Azure Disk Encryption](../../security/fundamentals/encryption-overview.md).|
 | Azure Disk Storage | When configured with a Disk Encryption Set (DES). For more information, see [Server-side encryption of Azure Disk Storage using customer-managed keys](../../virtual-machines/disk-encryption.md#customer-managed-keys).|
 | Azure Event Hubs|[Allow access to a key vault for customer-managed keys scenario](../../event-hubs/configure-customer-managed-key.md)|
+| Azure ExpressRoute | [When using MACsec with ExpressRoute Direct](../../expressroute/expressroute-howto-macsec.md)|
 | Azure Firewall Premium| [Azure Firewall Premium certificates](../../firewall/premium-certificates.md)|
 | Azure Front Door Classic|[Using Key Vault certificates for HTTPS](../../frontdoor/front-door-custom-domain-https.md#prepare-your-key-vault-and-certificate)
 | Azure Front Door Standard/Premium|[Using Key Vault certificates for HTTPS](../../frontdoor/standard-premium/how-to-configure-https-custom-domain.md#prepare-your-key-vault-and-certificate)


### PR DESCRIPTION
ExpressRoute MACsec is already enabled as a trusted service but missing from the KV Trusted services list. FAQ -> https://learn.microsoft.com/en-us/azure/expressroute/expressroute-about-encryption#can-i-enable-azure-key-vault-firewall-policies-when-storing-macsec-keys