### PR TITLE
Update machine-learning-udf.md  to add warning about ml endpoint calls from portal query editor

### DIFF
--- a/articles/stream-analytics/machine-learning-udf.md
+++ b/articles/stream-analytics/machine-learning-udf.md
@@ -55,7 +55,7 @@ The following table describes each property of Azure Machine Learning Service fu
 When your Stream Analytics query invokes an Azure Machine Learning UDF, the job creates a JSON serialized request to the web service. The request is based on a model-specific schema that Stream Analytics infers from the endpoint's swagger.
 
 > [!WARNING]
-> Machine Learning endpoints are not called when you're testing with the Azure Portal query editor, this is because the job is not running. For testing the endpoint call from the portal, the Stream Analytics job needs to be running.  
+> Machine Learning endpoints aren't called when you're testing with the Azure portal query editor because the job isn't running. To test the endpoint call from the portal, the Stream Analytics job needs to be running.  
 
 The following Stream Analytics query is an example of how to invoke an Azure Machine Learning UDF:
 

--- a/articles/stream-analytics/machine-learning-udf.md
+++ b/articles/stream-analytics/machine-learning-udf.md
@@ -54,6 +54,9 @@ The following table describes each property of Azure Machine Learning Service fu
 
 When your Stream Analytics query invokes an Azure Machine Learning UDF, the job creates a JSON serialized request to the web service. The request is based on a model-specific schema that Stream Analytics infers from the endpoint's swagger.
 
+> [!WARNING]
+> Machine Learning endpoints are not called when you're testing with the Azure Portal query editor, this is because the job is not running. For testing the endpoint call from the portal, the Stream Analytics job needs to be running.  
+
 The following Stream Analytics query is an example of how to invoke an Azure Machine Learning UDF:
 
 ```SQL


### PR DESCRIPTION
Add warning about running the Stream Analytics job when testing the ML Endpoint call from the portal query editor.

More details
----

When testing the Stream Analytics calls to the ML Studio Endpoint from the Azure Portal query editor using udf functions, the calls don't work, they are only actually executed when the Stream Job is running.

Just spent a few hours before finding [this stackoverflow answer](https://stackoverflow.com/a/41084814/13854896). Then this issue is there since 2016 😞 


