### PR TITLE
Replace invisible character in network-observability-managed-cli.md

### DIFF
--- a/articles/aks/network-observability-managed-cli.md
+++ b/articles/aks/network-observability-managed-cli.md
@@ -116,8 +116,8 @@ Use [az aks update](/cli/azure/aks#az-aks-update) to enable Network Observabilit
 
 ```azurecli-interactive
 az aks update \
-    --resource-group myResourceGroup \
-    --name myAKSCluster \
+    --resource-group myResourceGroup \
+    --name myAKSCluster \
     --enable-network-observability 
 ```
 


### PR DESCRIPTION
![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/b218b214-49c9-4226-93b6-2a88dad7748f)
![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/45e0c73b-99e4-4493-b090-648c1b8fb0d1)

I wonder why `U+202f` is here.
You must download this file and then find out this is not space. On GitHub Web, both of characters are presenting as space (which is hard to know there is difference behind). But if you copy the command from Microsoft document, it will present as its nature form. 