### PR TITLE
Fixing permissions in the sample code

### DIFF
--- a/articles/defender-for-cloud/github-action.md
+++ b/articles/defender-for-cloud/github-action.md
@@ -75,6 +75,7 @@ Microsoft Security DevOps uses the following Open Source tools:
         permissions:
           contents: read
           id-token: write
+          security-events: write
     
         steps:
 


### PR DESCRIPTION
Thank you for the wonderful documentation! I am a beginner currently studying Microsoft Security DevOps.

I encountered an issue where the sample code did not work properly, specifically during the "Upload alerts to Security tab" step, where I can see an error. The issue stemmed from not having granted the `security-events: write` permission. The "**[CodeQL Action](https://github.com/github/codeql-action)**" used in this step requires the `security-events: write` permission.

> All advanced setup code scanning workflows must have the `security-events: write` permission. Workflows in private repositories must additionally have the `contents: read` permission. For more information, see "[Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)." 

↑([Quoted from the README of the CodeQL Action repo](https://github.com/github/codeql-action))
