### PR TITLE
Clarify the 120 nodes limit cluster type in ARO FAQ

### DIFF
--- a/articles/openshift/openshift-faq.yml
+++ b/articles/openshift/openshift-faq.yml
@@ -31,7 +31,7 @@ sections:
         answer: |
           The actual number of supported pods depends on an application’s memory, CPU, and storage requirements.
           
-          Azure Red Hat OpenShift 4.x has a 250 pod-per-node limit and a 60 compute node limit. These limits cap the maximum number of pods supported in a cluster to 250&times;60 = 15,000. For a private cluster without any public IPs (i.e., created using [User Defined Routing (UDR)](howto-create-private-cluster-4x.md#create-a-private-cluster-without-a-public-ip-address) and running version 4.11 or higher), the limits are 120 compute nodes and 30,000 pods.
+          Azure Red Hat OpenShift 4.x has a 250 pod-per-node limit and a 60 compute node limit. These limits cap the maximum number of pods supported in a cluster to 250&times;60 = 15,000. For a private cluster without any public IPs (for example, created by using [User Defined Routing (UDR)](howto-create-private-cluster-4x.md#create-a-private-cluster-without-a-public-ip-address) and running version 4.11 or higher), the limits are 120 compute nodes and 30,000 pods.
           
       - question: Can a cluster have compute nodes across multiple Azure regions?
         answer: No. All nodes in an Azure Red Hat OpenShift cluster must originate in the same Azure region.

--- a/articles/openshift/openshift-faq.yml
+++ b/articles/openshift/openshift-faq.yml
@@ -31,7 +31,7 @@ sections:
         answer: |
           The actual number of supported pods depends on an application’s memory, CPU, and storage requirements.
           
-          Azure Red Hat OpenShift 4.x has a 250 pod-per-node limit and a 60 compute node limit. These limits cap the maximum number of pods supported in a cluster to 250&times;60 = 15,000. For a private cluster without any Public IPs, i.e. created using User Defined Routing (UDR) and runs version 4.11 or higher, the limits are 120 compute nodes and 30,000 pods.
+          Azure Red Hat OpenShift 4.x has a 250 pod-per-node limit and a 60 compute node limit. These limits cap the maximum number of pods supported in a cluster to 250&times;60 = 15,000. For a private cluster without any public IPs (i.e., created using [User Defined Routing (UDR)](howto-create-private-cluster-4x.md#create-a-private-cluster-without-a-public-ip-address) and running version 4.11 or higher), the limits are 120 compute nodes and 30,000 pods.
           
       - question: Can a cluster have compute nodes across multiple Azure regions?
         answer: No. All nodes in an Azure Red Hat OpenShift cluster must originate in the same Azure region.

--- a/articles/openshift/openshift-faq.yml
+++ b/articles/openshift/openshift-faq.yml
@@ -31,7 +31,7 @@ sections:
         answer: |
           The actual number of supported pods depends on an application’s memory, CPU, and storage requirements.
           
-          Azure Red Hat OpenShift 4.x has a 250 pod-per-node limit and a 60 compute node limit. These limits cap the maximum number of pods supported in a cluster to 250&times;60 = 15,000. If the cluster is created using User Defined Routing (UDR) and runs version 4.11 or higher, the limits are 120 compute nodes and 30,000 pods.
+          Azure Red Hat OpenShift 4.x has a 250 pod-per-node limit and a 60 compute node limit. These limits cap the maximum number of pods supported in a cluster to 250&times;60 = 15,000. For a private cluster without any Public IPs, i.e. created using User Defined Routing (UDR) and runs version 4.11 or higher, the limits are 120 compute nodes and 30,000 pods.
           
       - question: Can a cluster have compute nodes across multiple Azure regions?
         answer: No. All nodes in an Azure Red Hat OpenShift cluster must originate in the same Azure region.


### PR DESCRIPTION
It's not entirely clear when we just state: If the cluster is created using User Defined Routing (UDR). We need to set the right expectations by referring to private clusters without any public IPs for outbound.