### PR TITLE
Update elastic-san-connect-aks.md to conform to RFC-1123 on metadata.name

### DIFF
--- a/articles/storage/elastic-san/elastic-san-connect-aks.md
+++ b/articles/storage/elastic-san/elastic-san-connect-aks.md
@@ -81,7 +81,7 @@ Use the following example to create a storageclass.yml file. This file defines y
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: sanVolume
+  name: san-volume
 provisioner: manual
 ```
 


### PR DESCRIPTION
> Invalid value: "sanVolume": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

The change simply alters the docs to conform to `RFC-1123`.