### PR TITLE
Update ACS Get Phone Number quickstart

### DIFF
--- a/articles/communication-services/quickstarts/telephony/get-phone-number.md
+++ b/articles/communication-services/quickstarts/telephony/get-phone-number.md
@@ -10,7 +10,7 @@ ms.topic: quickstart
 ms.service: azure-communication-services
 ms.subservice: pstn
 ms.custom: references_regions, mode-other, devx-track-extended-java, devx-track-js, devx-track-python
-zone_pivot_groups: acs-azcli-azp-azpnew-java-net-python-csharp-js
+zone_pivot_groups: acs-azp-azpnew-azcli-java-csharp-js-python
 ---
 
 # Quickstart: Get and manage phone numbers
@@ -32,7 +32,7 @@ zone_pivot_groups: acs-azcli-azp-azpnew-java-net-python-csharp-js
 ::: zone-end
 
 ::: zone pivot="programming-language-csharp"
-[!INCLUDE [Azure portal](./includes/phone-numbers-net.md)]
+[!INCLUDE [C#](./includes/phone-numbers-net.md)]
 ::: zone-end
 
 ::: zone pivot="programming-language-java"

--- a/articles/zone-pivot-groups.yml
+++ b/articles/zone-pivot-groups.yml
@@ -1712,16 +1712,16 @@ groups:
     title: JavaScript
   - id: programming-language-python
     title: Python
-- id: acs-azcli-azp-azpnew-java-net-python-csharp-js
+- id: acs-azp-azpnew-azcli-java-csharp-js-python
   title: Platform
   prompt: Choose a platform
   pivots:
-  - id: platform-azcli
-    title: Azure CLI
   - id: platform-azp
     title: Azure portal
   - id: platform-azp-new
     title: Azure portal (new)
+  - id: platform-azcli
+    title: Azure CLI
   - id: programming-language-java
     title: Java
   - id: programming-language-csharp


### PR DESCRIPTION
Currently the Azure CLI for phone numbers is the default pivot for the get phone numbers quickstart, but it does not offer the key functionalities such as searching, purchasing, updating and releasing phone numbers, as such this PR will make the Azure portal the default pivot for the quickstart.

The Zone pivot group id has been edited to a new id that matches the intended behaviour.