### PR TITLE
Add Tunnelmole as an open source alternative to ngrok to some more docs

### DIFF
--- a/articles/azure-functions/durable/durable-functions-event-publishing.md
+++ b/articles/azure-functions/durable/durable-functions-event-publishing.md
@@ -249,7 +249,7 @@ The following list explains the lifecycle events schema:
 
 ## How to test locally
 
-To test locally, read [Local testing with viewer web app](../event-grid-how-tos.md#local-testing-with-viewer-web-app). You can also use the *ngrok* utility as shown in [this tutorial](../functions-event-grid-blob-trigger.md#start-local-debugging).
+To test locally, read [Local testing with viewer web app](../event-grid-how-tos.md#local-testing-with-viewer-web-app). You can also use the a tunneling utility as shown in [this tutorial](../functions-event-grid-blob-trigger.md#start-local-debugging).
 
 ## Next steps
 

--- a/articles/azure-functions/event-grid-how-tos.md
+++ b/articles/azure-functions/event-grid-how-tos.md
@@ -129,7 +129,7 @@ To test an Event Grid trigger locally, you have to get Event Grid HTTP requests 
 
 When you're done testing, you can use the same subscription for production by updating the endpoint. Use the [`az eventgrid event-subscription update`](/cli/azure/eventgrid/event-subscription#az-eventgrid-event-subscription-update) Azure CLI command.
 
-You can also use the *ngrok* utility to forward remote requests to your locally running functions. For more information, see [this tutorial](./functions-event-grid-blob-trigger.md#start-local-debugging).
+You can also use the *ngrok* or *tunnelmole* utilities to forward remote requests to your locally running functions. For more information, see [this tutorial](./functions-event-grid-blob-trigger.md#start-local-debugging).
 
 ### Create a viewer web app
 

--- a/articles/communication-services/how-tos/call-automation/record-every-call.md
+++ b/articles/communication-services/how-tos/call-automation/record-every-call.md
@@ -149,7 +149,7 @@ The Call Started event when a call start is formatted in the following way:
 
 ## Start recording
 
-1. Create a method to handle the `CallStarted` events. This method trigger recording to start when the call started.
+1. Create a method to handle the `CallStarted` events. This method triggers the start of the recording when the call starts.
 
 ```csharp
 
@@ -178,21 +178,31 @@ The Call Started event when a call start is formatted in the following way:
 
 ### Running locally
 
-To run the function locally, you can press `F5` in Visual Studio Code. We use [ngrok](https://ngrok.com/) to hook our locally running Azure Function with Azure Event Grid.
+1. To run the function locally, please press `F5` in Visual Studio Code. You can use [Tunnelmole](https://tunnelmole.com), a free and open source tunneling tool or [ngrok](https://ngrok.com), a popular closed source tunneling tool, to connect your locally running Azure Function with Azure Event Grid.
 
-1. Once the function is running, we configure ngrok. (You need to [download ngrok](https://ngrok.com/download) for your environment.)
+#### Tunnelmole
+After running the function, you can configure Tunnelmole. Follow the [Installation Guide](https://tunnelmole.com/docs/#installation) to get Tunnelmole installed.
 
+    ```bash
+     tmole 7071
+    ```
+
+    Copy the Tunnelmole link provided where your function is running.
+
+#### ngrok
+If you prefer to use ngrok, follow the below step. Remember to [download ngrok](https://ngrok.com/download) for your environment.
+   
     ```bash
      ngrok http 7071
     ```
 
     Copy the ngrok link provided where your function is running.
 
-2. Configure C`allStarted` events through Event Grid within your Azure Communication Services resource. We do this using the [Azure CLI](/cli/azure/install-azure-cli-windows?tabs=azure-cli). You need the resource ID for your Azure Communication Services resource found in the Azure portal. (The resource ID looks something like:  `/subscriptions/<<AZURE SUBSCRIPTION ID>>/resourceGroups/<<RESOURCE GROUP NAME>>/providers/Microsoft.Communication/CommunicationServices/<<RESOURCE NAME>>`)
+2. Configure `CallStarted` events through Event Grid within your Azure Communication Services resource. We do this using the [Azure CLI](/cli/azure/install-azure-cli-windows?tabs=azure-cli). You need the resource ID for your Azure Communication Services resource found in the Azure portal. (The resource ID looks something like: `/subscriptions/<<AZURE SUBSCRIPTION ID>>/resourceGroups/<<RESOURCE GROUP NAME>>/providers/Microsoft.Communication/CommunicationServices/<<RESOURCE NAME>>`)
 
     ```bash
 
-    az eventgrid event-subscription create --name "<<EVENT_SUBSCRIPTION_NAME>>" --endpoint-type webhook --endpoint "<<NGROK URL>>/runtime/webhooks/EventGrid?functionName=<<FUNCTION NAME>> " --source-resource-id "<<RESOURCE_ID>>"  --included-event-types Microsoft.Communication.CallStarted
+    az eventgrid event-subscription create --name "<<EVENT_SUBSCRIPTION_NAME>>" --endpoint-type webhook --endpoint "<<TUNNELMOLE or NGROK URL>>/runtime/webhooks/EventGrid?functionName=<<FUNCTION NAME>> " --source-resource-id "<<RESOURCE_ID>>"  --included-event-types Microsoft.Communication.CallStarted
 
     ```
 

--- a/articles/communication-services/how-tos/event-grid/local-testing-event-grid.md
+++ b/articles/communication-services/how-tos/event-grid/local-testing-event-grid.md
@@ -1,4 +1,5 @@
 ---
+
 title: Test your Event Grid handler locally
 titleSuffix: An Azure Communication Services how-to document
 description: In this how-to document, you can learn how to locally test your Event Grid handler for Azure Communication Services events with Postman.
@@ -20,15 +21,30 @@ Testing Event Grid triggered Azure Functions locally can be complicated. You don
 - Install [Postman](https://www.postman.com/downloads/).
 - Have a running Azure Function that can be triggered by Event Grid. If you don't have one, you can follow the [quickstart](../../../azure-functions/functions-bindings-event-grid-trigger.md?tabs=in-process%2Cextensionv3&pivots=programming-language-javascript) to create one.
 
-The Azure Function can be running either in Azure if you want to test it with some test events or if you want to test the entire flow locally (press `F5` in Visual Studio Code to run it locally). If you want to test the entire flow with an externally triggered webhook, you need to use [ngrok](https://ngrok.com/) to expose your locally running Azure Function
-to the public, allowing it to be triggered by internet sources (as an example from Azure Event WebHooks). Configure ngrok by running the command:
+The Azure Function can be running either in Azure if you want to test it with some test events or if you want to test the entire flow locally (press `F5` in Visual Studio Code to run it locally). If you want to test the entire flow with an externally triggered webhook, you need to use a tunneling tool to expose your locally running Azure Function to the public, allowing it to be triggered by internet sources (as an example from Azure Event WebHooks).
+
+We recommend using [Tunnelmole](https://tunnelmole.com), a free and open source tunneling tool, or [ngrok](https://ngrok.com/), a popular closed source tunneling tool.
+
+### Tunnelmole Configuration
+1. First, install Tunnelmole by following the [Installation Guide](https://tunnelmole.com/docs/#installation). For most use cases, this will be done with a single copied/pasted terminal command, but there are advanced options available including building from source, or using Tunnelmole as a dependency in JavaScript/TypeScript code.
+2. Run `tmole 7071` (replace `7071` with your listening port number if different). In the output, you'll get the URLs (one http and another https) of your tunnel. Be sure to use the https URL. 
+
+ ```bash
+
+tmole 7071
+
+ ```
+ 
+### ngrok Configuration
+To configure ngrok, run the following command:
 
 ```bash
 
-ngrok http 7071
+ngrok http 7071 
 
 ```
-It is worth remembering that exposing development resources publicly might not be considered as secure. That is why you can also run the entire workflow locally without ngrok by invoking requests to:
+
+It's worth remembering that exposing development resources publicly might not be considered secure. That's why you can also run the entire workflow locally without a tunneling tool by invoking requests to:
 ```
 http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
 ```
@@ -40,13 +56,11 @@ http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
     ![Screenshot of Postman body configuration.](media/postman-body.png)
 
 2. Select the `POST` method.
-
-3. Enter the URL of your Azure Function. Can either be the URL of the Azure Function running in Azure or the ngrok URL if you're running it locally. Ensure that you add the function name at the end of the URL: `/runtime/webhooks/EventGrid?functionName=<<FUNCTION_NAME>>`.
-
-4. Select the `Body` tab and select `raw` and `JSON` from the dropdown. In the body, you add a test schema for the event you want to trigger. For example, if you're testing an Azure Function that is triggered by receiving SMS events, you add the following:
+3. Enter the URL of your Azure Function. This can either be the URL of the Azure Function running in Azure, the Tunnelmole URL, or the ngrok URL if you're running it locally. Ensure that you add the function name at the end of the URL: `/runtime/webhooks/EventGrid?functionName=<<FUNCTION_NAME>>`.
+4. Select the `Body` tab and select `raw` and `JSON` from the dropdown. In the body, add a test schema for the event you want to trigger. For example, if you're testing an Azure Function that's triggered by receiving SMS events, you add the following:
 
     ```json
-    
+
     {
       "id": "Incoming_20200918002745d29ebbea-3341-4466-9690-0a03af35228e",
       "topic": "/subscriptions/50ad1522-5c2c-4d9a-a6c8-67c11ecb75b8/resourcegroups/acse2e/providers/microsoft.communication/communicationservices/{communication-services-resource-name}",
@@ -63,7 +77,7 @@ http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
       "metadataVersion": "1",
       "eventTime": "2020-09-18T00:27:47Z"
     }
-    
+
     ```
 
     You can find more information for the different event types used for Azure Communication Services in the [documentation](../../../event-grid/event-schema-communication-services.md).
@@ -79,4 +93,4 @@ http://localhost:7071/runtime/webhooks/EventGrid?functionName={functionname}
 
     ![Screenshot of Postman send button.](media/postman-send.png)
 
-    At this point, an event should trigger in your Azure Function. You can verify the event by looking at the execution of your Azure Function. You can then validate that the function is doing its job correctly.
+    At this point, an event should trigger in your Azure Function. You can verify the event by observing the execution of your Azure Function. You can then validate that the function is performing its task correctly.

--- a/articles/communication-services/quickstarts/sms/includes/receive-sms-js.md
+++ b/articles/communication-services/quickstarts/sms/includes/receive-sms-js.md
@@ -12,7 +12,6 @@ ms.topic: include
 ms.custom: include file
 ---
 
-
 Event Grid provides out of the box support for Azure Functions, making it easy to set up an event listener without the need to deal with the complexity of parsing headers or debugging webhooks. Using  the out of the box trigger, we can set up an Azure Function that runs each time an event is detected that matches the trigger. In this document, we focus on SMS received triggers.
 
 ## Setting up our local environment
@@ -109,9 +108,19 @@ From here, the possibilities are endless. From responding to a message with a pr
 
 ## Running locally
 
-To run the function locally, press `F5` in Visual Studio Code. We use [ngrok](https://ngrok.com/) to hook our locally running Azure Function with Azure Event Grid.
+To run the function locally, press `F5` in Visual Studio Code. To hook our locally running Azure Function with Azure Event Grid, we can use the free and open source tunneling tool, Tunnelmole, or the popular closed source tunneling tool, ngrok.
 
-1. Once the function is running, we configure ngrok. (You need to [download ngrok](https://ngrok.com/download) for your environment.)
+### Running with Tunnelmole
+1. Once the function is running, we configure Tunnelmole. (To use Tunnelmole, first install it following the [Installation Guide](https://tunnelmole.com/docs/#installation))
+
+    ```bash
+    tmole 7071
+    ```
+
+    Copy the HTTPS Tunnelmole link provided where your function is running.
+
+### Running with ngrok
+1. Alternatively, you can use ngrok. (To use ngrok, you need to [download ngrok](https://ngrok.com/download) for your environment.)
 
     ```bash
     ngrok http 7071
@@ -142,3 +151,4 @@ az eventgrid event-subscription update --name "<<EVENT_SUBSCRIPTION_NAME>>" --en
 Since we are updating the event subscription we created for local testing, make sure to use the same event subscription name you used above.
 
 You can test by sending an SMS to the phone number you have procured through Azure Communication Services resource.
+


### PR DESCRIPTION
Previously, Tunnelmole was added as an open source alternative to ngrok to the Cognitive Search docs in https://github.com/MicrosoftDocs/azure-docs/pull/117399

This PR adds it to
- Various Azure Functions docs
- Call automation
- Event Grid
- Communication Services