### PR TITLE
Fix KeyError by correcting image_file_id index

### DIFF
--- a/articles/ai-services/openai/how-to/assistant.md
+++ b/articles/ai-services/openai/how-to/assistant.md
@@ -365,7 +365,7 @@ We had requested that the model generate an image of a sine wave. In order to do
 
 ```python
 data = json.loads(messages.model_dump_json(indent=2))  # Load JSON data into a Python object
-image_file_id = data['data'][1]['content'][0]['image_file']['file_id']
+image_file_id = data['data'][0]['content'][0]['image_file']['file_id']
 
 print(image_file_id)  # Outputs: assistant-1YGVTvNzc2JXajI5JU9F0HMD
 ```


### PR DESCRIPTION
Changed the indexing in the assignment of image_file_id to use the first item in the data list. Previously, using the second item (data['data'][1]) caused a KeyError because the correct image file ID is located in the first item (data['data'][0]). This update ensures the proper retrieval of the image_file_id, allowing the function to operate correctly.