### PR TITLE
Fix query to get the last_analyze value

### DIFF
--- a/articles/postgresql/flexible-server/how-to-autovacuum-tuning.md
+++ b/articles/postgresql/flexible-server/how-to-autovacuum-tuning.md
@@ -98,7 +98,7 @@ Use the following query to list the tables in a database and identify the tables
         ,C.reltuples AS reltuples
         ,round(current_setting('autovacuum_vacuum_threshold')::INTEGER + current_setting('autovacuum_vacuum_scale_factor')::NUMERIC * C.reltuples) AS av_threshold
         ,date_trunc('minute', greatest(pg_stat_get_last_vacuum_time(C.oid), pg_stat_get_last_autovacuum_time(C.oid))) AS last_vacuum
-        ,date_trunc('minute', greatest(pg_stat_get_last_analyze_time(C.oid), pg_stat_get_last_analyze_time(C.oid))) AS last_analyze
+        ,date_trunc('minute', greatest(pg_stat_get_last_analyze_time(C.oid), pg_stat_get_last_autoanalyze_time(C.oid))) AS last_analyze
       FROM pg_class C
       LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
       WHERE C.relkind IN (


### PR DESCRIPTION
Before, the query was just providing the greatest value of the same function call. Now, the query will get the value from the last time auto analyze was run.