### PR TITLE
Update configure-wu-agent.md

### DIFF
--- a/articles/update-manager/configure-wu-agent.md
+++ b/articles/update-manager/configure-wu-agent.md
@@ -80,6 +80,11 @@ If your machine is patched using Azure Update Manager, and has Automatic updates
 
    :::image type="content" source="./media/configure-wu-agent/configure-updates-group-policy-inline.png" alt-text="Screenshot of selection or deselection of install updates for other Microsoft products." lightbox="./media/configure-wu-agent/configure-updates-group-policy-expanded.png":::
 
+For Windows Server 2022:
+1. Go to **Computer Configuration** > **Administrative Templates** > **Windows Components** > **Windows Update** > **Configure Automatic Updates**.
+1. Select **Configure Automatic Updates**.
+1. Select or deselect the **Install updates for other Microsoft products** option.
+![image](https://github.com/MicrosoftDocs/azure-docs/assets/86477713/2c96a2d1-6a42-414c-b057-535605bc26ee)
 
 ## Make WSUS configuration settings
 


### PR DESCRIPTION
Found that on Windows Server 2022 that the path for the local group policy was changed. Added a section for Windows Server 2022, and left the original.

Not sure if someone wants to remove the older area or leave it. 