### PR TITLE
Can set parameters iops/mbps for PremiumV2 disk

### DIFF
--- a/articles/aks/azure-csi-disk-storage-provision.md
+++ b/articles/aks/azure-csi-disk-storage-provision.md
@@ -46,8 +46,8 @@ The following table includes parameters you can use to define a custom storage c
 |fsType | File System Type | `ext4`, `ext3`, `ext2`, `xfs`, `btrfs` for Linux, `ntfs` for Windows | No | `ext4` for Linux, `ntfs` for Windows|
 |cachingMode | [Azure Data Disk Host Cache Setting][disk-host-cache-setting] | `None`, `ReadOnly`, `ReadWrite` | No | `ReadOnly`|
 |resourceGroup | Specify the resource group for the Azure Disks | Existing resource group name | No | If empty, driver uses the same resource group name as current AKS cluster|
-|DiskIOPSReadWrite | [UltraSSD disk][ultra-ssd-disks] or [PremiumSSD V2][PremiumV2_LRS] IOPS Capability (minimum: 2 IOPS/GiB) | 100~160000 | No | `500`|
-|DiskMBpsReadWrite | [UltraSSD disk][ultra-ssd-disks] or [PremiumSSD V2][PremiumV2_LRS] Throughput Capability(minimum: 0.032/GiB) | 1~2000 | No | `100`|
+|DiskIOPSReadWrite | [UltraSSD disk][ultra-ssd-disks] or [Premium SSD v2][premiumv2_lrs_disks] IOPS Capability (minimum: 2 IOPS/GiB) | 100~160000 | No | `500`|
+|DiskMBpsReadWrite | [UltraSSD disk][ultra-ssd-disks] or [Premium SSD v2][premiumv2_lrs_disks] Throughput Capability(minimum: 0.032/GiB) | 1~2000 | No | `100`|
 |LogicalSectorSize | Logical sector size in bytes for ultra disk. Supported values are 512 ad 4096. 4096 is the default. | `512`, `4096` | No | `4096`|
 |tags | Azure Disk [tags][azure-tags] | Tag format: `key1=val1,key2=val2` | No | ""|
 |diskEncryptionSetID | ResourceId of the disk encryption set to use for [enabling encryption at rest][disk-encryption] | format: `/subscriptions/{subs-id}/resourceGroups/{rg-name}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSet-name}` | No | ""|
@@ -407,6 +407,7 @@ kubectl delete -f azure-pvc.yaml
 [disk-host-cache-setting]: ../virtual-machines/windows/premium-storage-performance.md#disk-caching
 [use-ultra-disks]: use-ultra-disks.md
 [ultra-ssd-disks]: ../virtual-machines/linux/disks-ultra-ssd.md
+[premiumv2_lrs_disks]: ../virtual-machines/disks-types.md#premium-ssd-v2
 [azure-tags]: ../azure-resource-manager/management/tag-resources.md
 [disk-encryption]: ../virtual-machines/windows/disk-encryption.md
 [azure-disk-write-accelerator]: ../virtual-machines/windows/how-to-enable-write-accelerator.md

--- a/articles/aks/azure-csi-disk-storage-provision.md
+++ b/articles/aks/azure-csi-disk-storage-provision.md
@@ -46,8 +46,8 @@ The following table includes parameters you can use to define a custom storage c
 |fsType | File System Type | `ext4`, `ext3`, `ext2`, `xfs`, `btrfs` for Linux, `ntfs` for Windows | No | `ext4` for Linux, `ntfs` for Windows|
 |cachingMode | [Azure Data Disk Host Cache Setting][disk-host-cache-setting] | `None`, `ReadOnly`, `ReadWrite` | No | `ReadOnly`|
 |resourceGroup | Specify the resource group for the Azure Disks | Existing resource group name | No | If empty, driver uses the same resource group name as current AKS cluster|
-|DiskIOPSReadWrite | [UltraSSD disk][ultra-ssd-disks] IOPS Capability (minimum: 2 IOPS/GiB) | 100~160000 | No | `500`|
-|DiskMBpsReadWrite | [UltraSSD disk][ultra-ssd-disks] Throughput Capability(minimum: 0.032/GiB) | 1~2000 | No | `100`|
+|DiskIOPSReadWrite | [UltraSSD disk][ultra-ssd-disks] or [PremiumSSD V2][PremiumV2_LRS] IOPS Capability (minimum: 2 IOPS/GiB) | 100~160000 | No | `500`|
+|DiskMBpsReadWrite | [UltraSSD disk][ultra-ssd-disks] or [PremiumSSD V2][PremiumV2_LRS] Throughput Capability(minimum: 0.032/GiB) | 1~2000 | No | `100`|
 |LogicalSectorSize | Logical sector size in bytes for ultra disk. Supported values are 512 ad 4096. 4096 is the default. | `512`, `4096` | No | `4096`|
 |tags | Azure Disk [tags][azure-tags] | Tag format: `key1=val1,key2=val2` | No | ""|
 |diskEncryptionSetID | ResourceId of the disk encryption set to use for [enabling encryption at rest][disk-encryption] | format: `/subscriptions/{subs-id}/resourceGroups/{rg-name}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSet-name}` | No | ""|


### PR DESCRIPTION
According price calculator and doc, premium v2 allow to configure iops.

Tested on AKS, even faster than ultra-disk ^^

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ssd-fast
provisioner: disk.csi.azure.com
parameters:
  diskIopsReadWrite: '4000'
  diskMbpsReadWrite: '500'
  skuname: PremiumV2_LRS
reclaimPolicy: Delete
allowVolumeExpansion: true
volumeBindingMode: WaitForFirstConsumer
```

<img width="1574" alt="Capture d’écran, le 2024-03-23 à 21 31 19" src="https://github.com/MicrosoftDocs/azure-docs/assets/1219817/b5984d76-3b80-4fc1-9a54-358cd9ec822f">
