### PR TITLE
Update lock-resources.md

### DIFF
--- a/articles/azure-resource-manager/management/lock-resources.md
+++ b/articles/azure-resource-manager/management/lock-resources.md
@@ -61,7 +61,7 @@ Applying locks can lead to unexpected results. Some operations, which don't seem
 - A read-only lock on a **storage account** protects RBAC assignments scoped for a storage account or a data container (blob container or queue).
 
 - A read-only lock on a **storage account** prevents the creation of a blob container.
-- ++ A read-only lock on a **storage account** prevents the creation of a blob container However,create container operation can be done through both control plane and data plane. And read-only lock only blocks control plane create container request, but user can  still be able create container through data plane (if they have sufficient RBAC permissions and allowed by network). 
+- ++ A read-only lock on a s**storage account** prevents the creation of a blob container. However, create operations on a storage account can be done through both the control plane and data plane. Read-only locks only block control plane create requests, but a user can still perform a valid create operation on the resource through the data plane.. 
 
 - A read-only lock or cannot-delete lock on a **storage account** doesn't prevent its data from deletion or modification. It also doesn't protect the data in a blob, queue, table, or file.
 

--- a/articles/azure-resource-manager/management/lock-resources.md
+++ b/articles/azure-resource-manager/management/lock-resources.md
@@ -61,7 +61,7 @@ Applying locks can lead to unexpected results. Some operations, which don't seem
 - A read-only lock on a **storage account** protects RBAC assignments scoped for a storage account or a data container (blob container or queue).
 
 - A read-only lock on a **storage account** prevents the creation of a blob container.
-- ++ A read-only lock on a s**storage account** prevents the creation of a blob container. However, create operations on a storage account can be done through both the control plane and data plane. Read-only locks only block control plane create requests, but a user can still perform a valid create operation on the resource through the data plane.. 
+-  A read-only lock on a **storage account** prevents the creation of a blob container. However, create operations on a storage account can be done through both the control plane and data plane. Read-only locks only block control plane create requests, but a user can still perform a valid create operation on the resource through the data plane.
 
 - A read-only lock or cannot-delete lock on a **storage account** doesn't prevent its data from deletion or modification. It also doesn't protect the data in a blob, queue, table, or file.
 

--- a/articles/azure-resource-manager/management/lock-resources.md
+++ b/articles/azure-resource-manager/management/lock-resources.md
@@ -61,6 +61,7 @@ Applying locks can lead to unexpected results. Some operations, which don't seem
 - A read-only lock on a **storage account** protects RBAC assignments scoped for a storage account or a data container (blob container or queue).
 
 - A read-only lock on a **storage account** prevents the creation of a blob container.
+- ++ A read-only lock on a **storage account** prevents the creation of a blob container However,create container operation can be done through both control plane and data plane. And read-only lock only blocks control plane create container request, but user can  still be able create container through data plane (if they have sufficient RBAC permissions and allowed by network). 
 
 - A read-only lock or cannot-delete lock on a **storage account** doesn't prevent its data from deletion or modification. It also doesn't protect the data in a blob, queue, table, or file.
 


### PR DESCRIPTION
Please update 65th line with the below Info

A read-only lock on a **storage account** prevents the creation of a blob container However,create container operation can be done through both control plane and data plane. And read-only lock only blocks control plane create container request, but user can  still be able create container through data plane (if they have sufficient RBAC permissions and allowed by network).