### PR TITLE
Add note to prevent misleading in use-trusted-launch.md

### DIFF
--- a/articles/aks/use-trusted-launch.md
+++ b/articles/aks/use-trusted-launch.md
@@ -142,7 +142,10 @@ Update a node pool with trusted launch enabled using the [az aks nodepool update
    * **--enable-vtpm**: Enables vTPM and performs attestation by measuring the entire boot chain of your VM.
 
 > [!NOTE]
-> The existing nodepool must be using a trusted launch image in order to enable on an existing node pool. By default, creating a node pool with a TL-compatible configuration and the feature flag registered results in a trusted launch image. Without specifying `--enable-vtpm` or `--enable-secure-boot` parameters, they are disabled by default and you can enable later using `az aks nodepool update` command.
+> The existing nodepool must be using a trusted launch image in order to enable on an existing node pool. Hence, for the nodepools created before registering the `TrustedLaunchPreview` feature, you cannot update them with trusted launch enabled.
+> 
+> By default, creating a node pool with a TL-compatible configuration and the feature flag registered results in a trusted launch image. Without specifying `--enable-vtpm` or `--enable-secure-boot` parameters, they are disabled by default and you can enable later using `az aks nodepool update` command.
+
 
 > [!NOTE]
 > Secure Boot requires signed boot loaders, OS kernels, and drivers. If after enabling Secure Boot your nodes don't start, you can verify which boot components are responsible for Secure Boot failures within an Azure Linux Virtual Machine. See [verify Secure Boot failures][verify-secure-boot-failures].


### PR DESCRIPTION
**Proposed changes:** Add a note to make sure user know that past nodepool is not eligible for this feature. 

**Basis:**
The default image will be changed after enabling this feature. Since the nodepool's image cannot be changed, I made this PR to add one sentence for it (ofc I checked from my side).

Before: `AKSUbuntu-2204gen2containerd-202403.04.0`
After: `AKSUbuntu-2204gen2TLcontainerd-202403.04.0`

![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/ef132ee9-6c32-4629-bccb-c7d0dde53d3f)
(Caption: No way to change image for previous nodepools)
