### PR TITLE
Added note on behavior when setting DNS suffixes directly within VMs

### DIFF
--- a/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
+++ b/articles/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances.md
@@ -367,6 +367,9 @@ When you're using your own DNS servers, Azure enables you to specify multiple DN
 > [!NOTE]
 > Network connection properties, such as DNS server IPs, should not be edited directly within VMs. This is because they might get erased during service heal when the virtual network adaptor gets replaced. This applies to both Windows and Linux VMs.
 
+> [!NOTE]
+> Modifying the DNS suffix settings directly within the VMs can disrupt network connectivity, potentially causing traffic to the VMs to be interrupted or lost. To resolve this issue, a restart of the VMs is necessary.
+
 When you're using the Azure Resource Manager deployment model, you can specify DNS servers for a virtual network and a network interface. For details, see [Manage a virtual network](manage-virtual-network.md) and [Manage a network interface](virtual-network-network-interface.md).
 
 > [!NOTE]


### PR DESCRIPTION
Please add to the documentation as we have received several SRs of a scenario where the connection was disconnected when Cx set the DNS suffix directly in the VMs and a restart of the VM was required to recover.