### PR TITLE
Update Manually Renew method.

### DIFF
--- a/articles/app-service/manage-custom-dns-buy-domain.md
+++ b/articles/app-service/manage-custom-dns-buy-domain.md
@@ -136,12 +136,10 @@ If launched from an app's **Custom domains** page, the App Service domain wizard
 
 ## Renew the domain
 
-The App Service domain you bought is valid for one year from the time of purchase. You can configure to renew your domain automatically, which will charge your payment method when your domain renews the following year. You can also manually renew your domain name up to 90 days ahead of domain expiration.
+The App Service domain you bought is valid for one year from the time of purchase. You can configure to renew your domain automatically, or you can also manually renew your domain name up to 90 days ahead of domain expiration. You will be billed for the cost of the domain upon successful auto or manual renewal and your domain expiration will be extended for another year.
 
 > [!NOTE]
-> - Manually renew will result in a one-year postponement of the domain's expiration date.
-> - You will be billed when you manually renew your domain.
-> - For .nl domains, you can only manually renew the domain starting 90 days ahead of domain expiration and up to the 20th of the month before the expiration date. You will not be able to renew the domain after this period even if the domain has not yet expired.
+> For .nl domains, you can only manually renew the domain starting 90 days ahead of domain expiration and up to the 20th of the month before the expiration date. You will not be able to renew the domain after this period even if the domain has not yet expired.
 > 
 
 If you want to configure automatic renewal, or if you want to manually renew your domain, follow the steps here.

--- a/articles/app-service/manage-custom-dns-buy-domain.md
+++ b/articles/app-service/manage-custom-dns-buy-domain.md
@@ -139,7 +139,8 @@ If launched from an app's **Custom domains** page, the App Service domain wizard
 The App Service domain you bought is valid for one year from the time of purchase. You can configure to renew your domain automatically, which will charge your payment method when your domain renews the following year. You can also manually renew your domain name up to 90 days ahead of domain expiration.
 
 > [!NOTE]
-> For .nl domains, you can only manually renew the domain starting 90 days ahead of domain expiration and up to the 20th of the month before the expiration date. You will not be able to renew the domain after this period even if the domain has not yet expired.
+> - Manually renew will result in a one-year postponement of the domain's expiration date.
+> - For .nl domains, you can only manually renew the domain starting 90 days ahead of domain expiration and up to the 20th of the month before the expiration date. You will not be able to renew the domain after this period even if the domain has not yet expired.
 > 
 
 If you want to configure automatic renewal, or if you want to manually renew your domain, follow the steps here.

--- a/articles/app-service/manage-custom-dns-buy-domain.md
+++ b/articles/app-service/manage-custom-dns-buy-domain.md
@@ -140,6 +140,7 @@ The App Service domain you bought is valid for one year from the time of purchas
 
 > [!NOTE]
 > - Manually renew will result in a one-year postponement of the domain's expiration date.
+> - You will be billed when you manually renew your domain.
 > - For .nl domains, you can only manually renew the domain starting 90 days ahead of domain expiration and up to the 20th of the month before the expiration date. You will not be able to renew the domain after this period even if the domain has not yet expired.
 > 
 

--- a/articles/app-service/manage-custom-dns-buy-domain.md
+++ b/articles/app-service/manage-custom-dns-buy-domain.md
@@ -136,7 +136,7 @@ If launched from an app's **Custom domains** page, the App Service domain wizard
 
 ## Renew the domain
 
-The App Service domain you bought is valid for one year from the time of purchase. You can configure to renew your domain automatically, or you can also manually renew your domain name up to 90 days ahead of domain expiration. You will be billed for the cost of the domain upon successful auto or manual renewal and your domain expiration will be extended for another year.
+The App Service domain you bought is valid for one year from the time of purchase. You can configure to renew your domain automatically, or you can also manually renew your domain name up to 90 days ahead of domain expiration. Upon successful auto or manual renewal, you will be billed for the cost of the domain and your domain expiration will be extended for another year.
 
 > [!NOTE]
 > For .nl domains, you can only manually renew the domain starting 90 days ahead of domain expiration and up to the 20th of the month before the expiration date. You will not be able to renew the domain after this period even if the domain has not yet expired.


### PR DESCRIPTION
Added some information.

- Manually renew will result in a one-year postponement of the domain's expiration date.
- You will be billed when you manually renew your domain.