### PR TITLE
Add LogLevel for Blob Storage module

### DIFF
--- a/articles/iot-edge/how-to-store-data-blob.md
+++ b/articles/iot-edge/how-to-store-data-blob.md
@@ -155,7 +155,7 @@ sudo chmod -R 700 <blob-dir>
 
 ## Configure log files
 
-The default output log level is 'Info'.  To change the output log level, Set the `LogLevel` environment variable for this module in the deployment manifest. `LogLevel` accepts the following values: 
+The default output log level is 'Info'.  To change the output log level, set the `LogLevel` environment variable for this module in the deployment manifest. `LogLevel` accepts the following values: 
 
 * Critical
 * Error

--- a/articles/iot-edge/how-to-store-data-blob.md
+++ b/articles/iot-edge/how-to-store-data-blob.md
@@ -155,9 +155,7 @@ sudo chmod -R 700 <blob-dir>
 
 ## Configure log files
 
-For information on configuring log files for your module, see these [production best practices](./production-checklist.md#set-up-logs-and-diagnostics).
-
-To configure the output log level, you can set `LogLevel` environment variable for this module. `LogLevel` can take the following values (the default value is set to `Info`):
+The default output log level is 'Info'.  To change the output log level, Set the `LogLevel` environment variable for this module in the deployment manifest. `LogLevel` accepts the following values: 
 
 * Critical
 * Error
@@ -165,6 +163,7 @@ To configure the output log level, you can set `LogLevel` environment variable f
 * Info
 * Debug
 
+For information on configuring log files for your module, see these [production best practices](./production-checklist.md#set-up-logs-and-diagnostics).
 ## Connect to your blob storage module
 
 You can use the account name and account key that you configured for your module to access the blob storage on your IoT Edge device.

--- a/articles/iot-edge/how-to-store-data-blob.md
+++ b/articles/iot-edge/how-to-store-data-blob.md
@@ -157,6 +157,14 @@ sudo chmod -R 700 <blob-dir>
 
 For information on configuring log files for your module, see these [production best practices](./production-checklist.md#set-up-logs-and-diagnostics).
 
+To configure the output log level, you can set `LogLevel` environment variable for this module. `LogLevel` can take the following values (the default value is set to `Info`):
+
+* Critical
+* Error
+* Warning
+* Info
+* Debug
+
 ## Connect to your blob storage module
 
 You can use the account name and account key that you configured for your module to access the blob storage on your IoT Edge device.


### PR DESCRIPTION
Add description of "LogLevel" environment variable to configure the output log level from Blob Storage module on IoT Edge.