### PR TITLE
feat: removed preview from sampling

### DIFF
--- a/articles/azure-monitor/app/java-standalone-config.md
+++ b/articles/azure-monitor/app/java-standalone-config.md
@@ -173,9 +173,7 @@ You can also set the sampling percentage by using the environment variable `APPL
 > [!NOTE]
 > For the sampling percentage, choose a percentage that's close to 100/N, where N is an integer. Currently, sampling doesn't support other values.
 
-## Sampling overrides (preview)
-
-This feature is in preview, starting from 3.0.3.
+## Sampling overrides
 
 Sampling overrides allow you to override the [default sampling percentage](#sampling). For example, you can:
 

--- a/articles/azure-monitor/app/java-standalone-upgrade-from-2x.md
+++ b/articles/azure-monitor/app/java-standalone-upgrade-from-2x.md
@@ -57,7 +57,7 @@ Or using [inherited attributes](./java-standalone-config.md#inherited-attribute-
 
 2.x SDK TelemetryProcessors don't run when using the 3.x agent.
 Many of the use cases that previously required writing a `TelemetryProcessor` can be solved in Application Insights Java 3.x
-by configuring [sampling overrides](./java-standalone-config.md#sampling-overrides-preview).
+by configuring [sampling overrides](./java-standalone-config.md#sampling-overrides).
 
 ## Multiple applications in a single JVM
 

--- a/articles/azure-monitor/app/opentelemetry-add-modify.md
+++ b/articles/azure-monitor/app/opentelemetry-add-modify.md
@@ -2087,7 +2087,7 @@ You might use the following ways to filter out telemetry before it leaves your a
 
 ### [Java](#tab/java)
 
-See [sampling overrides](java-standalone-config.md#sampling-overrides-preview) and [telemetry processors](java-standalone-telemetry-processors.md).
+See [sampling overrides](java-standalone-config.md#sampling-overrides) and [telemetry processors](java-standalone-telemetry-processors.md).
 
 ### [Node.js](#tab/nodejs)
 


### PR DESCRIPTION
sampling override is in GA from 3.5.0 version, hence removed preview heading. 