### PR TITLE
Add a note for default probes on Consumption V2

### DIFF
--- a/articles/container-apps/health-probes.md
+++ b/articles/container-apps/health-probes.md
@@ -164,7 +164,8 @@ The optional `failureThreshold` setting defines the number of attempts Container
 
 If ingress is enabled, the following default probes are automatically added to the main app container if none is defined for each type.
 
-Please note that default probes are currently **not** applied on Workload Profile envirnoments when using the Consumption plan.
+> [!NOTE]
+> Default probes are not applied on workload profile environments when using the Consumption plan.
 
 | Probe type | Default values |
 | -- | -- |

--- a/articles/container-apps/health-probes.md
+++ b/articles/container-apps/health-probes.md
@@ -165,7 +165,7 @@ The optional `failureThreshold` setting defines the number of attempts Container
 If ingress is enabled, the following default probes are automatically added to the main app container if none is defined for each type.
 
 > [!NOTE]
-> Default probes are not applied on workload profile environments when using the Consumption plan.
+> Default probes are currently not applied on workload profile environments when using the Consumption plan. This behavior may change in the future.
 
 | Probe type | Default values |
 | -- | -- |

--- a/articles/container-apps/health-probes.md
+++ b/articles/container-apps/health-probes.md
@@ -164,6 +164,8 @@ The optional `failureThreshold` setting defines the number of attempts Container
 
 If ingress is enabled, the following default probes are automatically added to the main app container if none is defined for each type.
 
+Please note that default probes are currently **not** applied on Workload Profile envirnoments when using the Consumption plan.
+
 | Probe type | Default values |
 | -- | -- |
 | Startup | Protocol: TCP<br>Port: ingress target port<br>Timeout: 3 seconds<br>Period: 1 second<br>Initial delay: 1 second<br>Success threshold: 1<br>Failure threshold: 240 |


### PR DESCRIPTION
Consumption V2 plans currently do not set default probes. Add a note in the docs to clarify.