### PR TITLE
Update configure-audit.md to select all audit events

### DIFF
--- a/articles/sentinel/sap/configure-audit.md
+++ b/articles/sentinel/sap/configure-audit.md
@@ -90,8 +90,6 @@ Track your SAP solution deployment journey through this series of articles:
 
 1. Under **Event Selection**, choose **Classic event selection** and select all the event types in the list. 
 
-    Alternatively, choose **Detail event selection**, review the list of message IDs listed in the [Recommended audit categories](#recommended-audit-categories) section of this article, and configure them in **Detail event selection**.
-
 1. Select **Save**.
 
     ![Screenshot showing Static profile settings.](./media/configure-audit/create-profile-settings.png)
@@ -99,63 +97,8 @@ Track your SAP solution deployment journey through this series of articles:
 1. You'll see that the **Static Configuration** section displays the newly created profile. Right-click the profile and select **Activate**.
 
 1. In the confirmation window select **Yes** to activate the newly created profile.
-
-### Recommended audit categories
-
-The following table lists Message IDs used by the Microsoft Sentinel solution for SAP® applications. In order for analytics rules to detect events properly, we strongly recommend configuring an audit policy that includes the message IDs listed below as a minimum.
-
-| Message ID | Message text | Category name | Event Weighting | Class Used in Rules |
-| - | - | - | - | - |
-| AU1 | Logon successful (type=&A, method=&C) | Logon | Severe | Used |
-| AU2 | Logon failed (reason=&B, type=&A, method=&C) | Logon | Critical | Used |
-| AU3 | Transaction &A started. | Transaction Start | Non-Critical | Used |
-| AU5 | RFC/CPIC logon successful (type=&A, method=&C) | RFC Login | Non-Critical | Used |
-| AU6 | RFC/CPIC logon failed, reason=&B, type=&A, method=&C | RFC Login | Critical | Used |
-| AU7 | User &A created. | User Master Record Change | Critical | Used |
-| AU8 | User &A deleted. | User Master Record Change | Severe | Used |
-| AU9 | User &A locked. | User Master Record Change | Severe | Used |
-| AUA | User &A unlocked. | User Master Record Change | Severe | Used |
-| AUB | Authorizations for user &A changed. | User Master Record Change | Severe | Used |
-| AUD | User master record &A changed. | User Master Record Change | Severe | Used |
-| AUE | Audit configuration changed | System | Critical | Used |
-| AUF | Audit: Slot &A: Class &B, Severity &C, User &D, Client &E, &F | System | Critical | Used |
-| AUG | Application server started | System | Critical | Used |
-| AUI | Audit: Slot &A Inactive | System | Critical | Used |
-| AUJ | Audit: Active status set to &1 | System | Critical with Monitor Alert | Used |
-| AUK | Successful RFC call &C (function group = &A) | RFC Start | Non-Critical | Used |
-| AUM | User &B locked in client &A after errors in password checks | Logon | Critical with Monitor Alert | Used |
-| AUO | Logon failed (reason = &B, type = &A) | Logon | Severe | Used |
-| AUP | Transaction &A locked | Transaction Start | Severe | Used |
-| AUQ | Transaction &A unlocked | Transaction Start | Severe | Used |
-| AUR | &A &B created | User Master Record Change | Severe | Used |
-| AUT | &A &B changed | User Master Record Change | Severe | Used |
-| AUW | Report &A started | Report Start | Non-Critical | Used |
-| AUY | Download &A Bytes to File &C | Other | Severe | Used |
-| BU1 | Password check failed for user &B in client &A | Other | Critical with Monitor Alert | Used |
-| BU2 | Password changed for user &B in client &A | User Master Record Change | Non-Critical | Used |
-| BU4 | Dynamic ABAP code: Event &A, event type &B, check total &C | Other | Non-Critical | Used |
-| BUG | HTTP Security Session Management was deactivated for client &A. | Other | Critical with Monitor Alert | Used |
-| BUI | SPNego replay attack detected (UPN=&A) | Logon | Critical | Used |
-| BUV | Invalid hash value &A. The context contains &B. | User Master Record Change | Critical | Used |
-| BUW | A refresh token issued to client &A was used by client &B. | User Master Record Change | Critical | Used |
-| CUK | C debugging activated | Other | Critical | Used |
-| CUL | Field content in debugger changed by user &A: &B (&C) | Other | Critical | Used |
-| CUM | Jump to ABAP Debugger by user &A: &B (&C) | Other | Critical | Used |
-| CUN | A process was stopped from the debugger by user &A (&C) | Other | Critical | Used |
-| CUO | Explicit database operation in debugger by user &A: &B (&C) | Other | Critical | Used |
-| CUP | Non-exclusive debugging session started by user &A (&C) | Other | Critical | Used |
-| CUS | Logical file name &B is not a valid alias for logical file name &A | Other | Severe | Used |
-| CUZ | Generic table access by RFC to &A with activity &B | RFC Start | Critical | Used |
-| DU1 | FTP server allowlist is empty | RFC Start | Severe | Used |
-| DU2 | FTP server allowlist is non-secure due to use of placeholders | RFC Start | Severe | Used |
-| DU8 | FTP connection request for server &A successful | RFC Start | Non-Critical | Used |
-| DU9 | Generic table access call to &A with activity &B (auth. check: &C ) | Transaction Start | Non-Critical | Used |
-| DUH | OAuth 2.0: Token declared invalid (OAuth client=&A, user=&B, token type=&C) | User Master Record Change | Severe with Monitor Alert | Used |
-| EU1 | System change options changed ( &A to &B ) | System | Critical | Used |
-| EU2 | Client &A settings changed ( &B ) | System | Critical | Used |
-| EUF | Could not call RFC function module &A | RFC Start | Non-Critical | Used |
-| FU0 | Exclusive security audit log medium changed (new status &A) | System | Critical | Used |
-| FU1 | RFC function &B with dynamic destination &C was called in program &A | RFC Start | Non-Critical | Used |
+   > [!NOTE]
+   > Static configuration only takes effect after a system restart. For an immediate setup, create an additional dynamic filter with the same properties, by right clicking the newly created static profile and selecting "apply to dynamic configuration". 
 
 ## Next steps
 


### PR DESCRIPTION
The selection of specific audit events in the configuration makes little sense as the recommended critical event list takes about 99% of the volume of ingestion, making the remaining events (which can be critical ) with higher ROI than the rest. 