### PR TITLE
Update docs for AzDO onboarding delay

### DIFF
--- a/articles/defender-for-cloud/quickstart-onboard-devops.md
+++ b/articles/defender-for-cloud/quickstart-onboard-devops.md
@@ -87,7 +87,7 @@ To connect your Azure DevOps organization to Defender for Cloud by using a nativ
 > [!NOTE]
 > To ensure proper functionality of advanced DevOps posture capabilities in Defender for Cloud, only one instance of an Azure DevOps organization can be onboarded to the Azure Tenant you're creating a connector in.
 
-The **DevOps security** blade shows your onboarded repositories grouped by Organization. The **Recommendations** blade shows all security assessments related to Azure DevOps repositories.
+The **DevOps security** blade shows your onboarded repositories grouped by Organization. The **Recommendations** blade shows all security assessments related to Azure DevOps repositories.  The onboarding may take up to 8 hours to show the initial DevOps security results.
 
 ## Next steps
 

--- a/articles/defender-for-cloud/quickstart-onboard-devops.md
+++ b/articles/defender-for-cloud/quickstart-onboard-devops.md
@@ -87,7 +87,7 @@ To connect your Azure DevOps organization to Defender for Cloud by using a nativ
 > [!NOTE]
 > To ensure proper functionality of advanced DevOps posture capabilities in Defender for Cloud, only one instance of an Azure DevOps organization can be onboarded to the Azure Tenant you're creating a connector in.
 
-The **DevOps security** blade shows your onboarded repositories grouped by Organization. The **Recommendations** blade shows all security assessments related to Azure DevOps repositories.  The onboarding may take up to 8 hours to show the initial DevOps security results.
+Upon successful onboarding, DevOps resources (e.g., repositories, builds) will be present within the Inventory and DevOps security pages. It may take up to 8 hours for resources to appear. Security scanning recommendations may require [an additional step to configure your pipelines](azure-devops-extension.md). Refresh intervals for security findings vary by recommendation and details can be found on the Recommendations page.
 
 ## Next steps
 

--- a/articles/defender-for-cloud/quickstart-onboard-github.md
+++ b/articles/defender-for-cloud/quickstart-onboard-github.md
@@ -90,7 +90,7 @@ The Defender for Cloud service automatically discovers the organizations where y
 > [!NOTE]
 > To ensure proper functionality of advanced DevOps posture capabilities in Defender for Cloud, only one instance of a GitHub organization can be onboarded to the Azure Tenant you are creating a connector in.
 
-The **DevOps security** pane shows your onboarded repositories grouped by Organization. The **Recommendations** pane shows all security assessments related to GitHub repositories.
+The **DevOps security** pane shows your onboarded repositories grouped by Organization. The **Recommendations** pane shows all security assessments related to GitHub repositories.  The onboarding may take up to 8 hours to show the initial DevOps security results.
 
 ## Next steps
 

--- a/articles/defender-for-cloud/quickstart-onboard-github.md
+++ b/articles/defender-for-cloud/quickstart-onboard-github.md
@@ -90,7 +90,7 @@ The Defender for Cloud service automatically discovers the organizations where y
 > [!NOTE]
 > To ensure proper functionality of advanced DevOps posture capabilities in Defender for Cloud, only one instance of a GitHub organization can be onboarded to the Azure Tenant you are creating a connector in.
 
-The **DevOps security** pane shows your onboarded repositories grouped by Organization. The **Recommendations** pane shows all security assessments related to GitHub repositories.  The onboarding may take up to 8 hours to show the initial DevOps security results.
+Upon successful onboarding, DevOps resources (e.g., repositories, builds) will be present within the Inventory and DevOps security pages. It may take up to 8 hours for resources to appear. Security scanning recommendations may require [an additional step to configure your pipelines](azure-devops-extension.md). Refresh intervals for security findings vary by recommendation and details can be found on the Recommendations page.
 
 ## Next steps
 


### PR DESCRIPTION
* [`articles/defender-for-cloud/quickstart-onboard-devops.md`](diffhunk://#diff-97129f69994224089dafdbaa2a20c016a65f3bd66c03f098f341c726aa20ef21L90-R90): Added a note in the **DevOps security** section stating that the onboarding may take up to 8 hours to show the initial DevOps security results.
* [`articles/defender-for-cloud/quickstart-onboard-github.md`](diffhunk://#diff-6a8f4faa3c8cd5758d05a4383eb1c3c4df6c28e01b65390c67dbb590cd1e3f36L93-R93): Added a similar note in the **DevOps security** section for GitHub repositories.