### PR TITLE
Correction of typo about SSH

### DIFF
--- a/articles/ai-studio/how-to/create-manage-compute.md
+++ b/articles/ai-studio/how-to/create-manage-compute.md
@@ -65,7 +65,6 @@ To create a compute instance in Azure AI Studio:
     - **Assign to another user**: You can create a compute instance on behalf of another user. Note that a compute instance can't be shared. It can only be used by a single assigned user. By default, it will be assigned to the creator and you can change this to a different user.
     - **Assign a managed identity**: You can attach system assigned or user assigned managed identities to grant access to resources. The name of the created system managed identity will be in the format `/workspace-name/computes/compute-instance-name` in your Microsoft Entra ID.
     - **Enable SSH access**: Enter credentials for an administrator user account that will be created on each compute node. These can be used to SSH to the compute nodes.
-Note that disabling SSH prevents SSH access from the public internet. When a private virtual network is used, users can still SSH from within the virtual network.
 
 1. On the **Applications** page you can add custom applications to use on your compute instance, such as RStudio or Posit Workbench. Then select **Next**.
 1. On the **Tags** page you can add additional information to categorize the resources you create. Then select **Review + Create** or **Next** to review your settings.


### PR DESCRIPTION
Removing reference to a private SSH connection. As confirmed by SWE, it's a typo and this kind of connectivity is not supported yet.