### PR TITLE
CSS Networking-AZFW update StartStop note

### DIFF
--- a/articles/firewall/firewall-faq.yml
+++ b/articles/firewall/firewall-faq.yml
@@ -147,7 +147,7 @@ sections:
 
           > [!NOTE]
           > You must reallocate a firewall and public IP to the original resource group and subscription. 
-          > When stop/start is performed, the private IP address of the firewall may change to a different IP addresss within the subnet.  This can effect connectivity of previously configured route tables. 
+          > When stop/start is performed, the private IP address of the firewall may change to a different IP address within the subnet.  This can affect the connectivity of previously configured route tables. 
 
       - question: How can I configure availability zones after deployment?
         answer: |

--- a/articles/firewall/firewall-faq.yml
+++ b/articles/firewall/firewall-faq.yml
@@ -146,8 +146,8 @@ sections:
           When you allocate and deallocate, [firewall billing](https://azure.microsoft.com/pricing/details/azure-firewall) stops and starts accordingly.
 
           > [!NOTE]
-          > You must reallocate a firewall and public IP to the original resource group and subscription.
-
+          > You must reallocate a firewall and public IP to the original resource group and subscription. 
+          > When stop/start is performed, the private IP address of the firewall may change to a different IP addresss within the subnet.  This can effect connectivity of previously configured route tables. 
 
       - question: How can I configure availability zones after deployment?
         answer: |


### PR DESCRIPTION
adding additional information to the note field of the stop/start command.  Start/Stop has the possibility of changing the Private ip address of the azfw upon reallocation.  There is not a way to guarantee it will get the previous assigned value.