### PR TITLE
Update functions-bindings-service-bus-trigger.md

### DIFF
--- a/articles/azure-functions/functions-bindings-service-bus-trigger.md
+++ b/articles/azure-functions/functions-bindings-service-bus-trigger.md
@@ -304,7 +304,7 @@ def test_function(message: func.ServiceBusMessage):
 
 # [v1](#tab/python-v1)
 
-A Service Bus binding is defined in *function.json* where *type* is set to `serviceBusTrigger` and the topic is set by `topicName`.
+A Service Bus binding is defined in *function.json* where *type* is set to `serviceBusTrigger`, the topic is set by `topicName` and the subscription is set by `subscriptionName`.
 
 ```json
 {
@@ -315,6 +315,7 @@ A Service Bus binding is defined in *function.json* where *type* is set to `serv
      "direction": "in",
      "name": "msg",
      "topicName": "inputtopic",
+     "subscriptionName": "inputsubscription",
      "connection": "AzureServiceBusConnectionString"
    }
   ]


### PR DESCRIPTION
Update docs to include the subscrition name for python v1. My containerized azure function was not starting due to this missing parameter.