### PR TITLE
Update how-to-recover-workspace-after-tenant-move.md

### DIFF
--- a/articles/synapse-analytics/how-to-recover-workspace-after-tenant-move.md
+++ b/articles/synapse-analytics/how-to-recover-workspace-after-tenant-move.md
@@ -149,6 +149,8 @@ $subscriptionId="Provide the subscription ID (GUID) of the subscription containi
 $resourceGroupName="Provide the name of the resource group containing your workspace"
 $workspaceName="Provide the name of your workspace"
 
+$contentType = 'application/json'
+
 $token = (Get-AzAccessToken -ResourceUrl "https://management.azure.com/").Token
 $header = @{Authorization="Bearer $token"}
 


### PR DESCRIPTION
It seems we need to set a value for $contentType, otherwise it will hit exception.  
$contentType = 'application/json'

PS C:\WINDOWS\system32> $bodyJson = @{identity= @{type='None'}}| ConvertTo-Json
Invoke-RestMethod -Method PATCH -Uri $url -ContentType $contentType -Headers $header -Body  $bodyJson;
Invoke-RestMethod : {"error":{"code":"UnsupportedMediaType","message":"The content media type '' is not supported. Only 'application/json' is supported."}}
At line:2 char:1
+ Invoke-RestMethod -Method PATCH -Uri $url -ContentType $contentType - ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand