### PR TITLE
Update how-to-recover-workspace-after-tenant-move.md

### DIFF
--- a/articles/synapse-analytics/how-to-recover-workspace-after-tenant-move.md
+++ b/articles/synapse-analytics/how-to-recover-workspace-after-tenant-move.md
@@ -151,6 +151,7 @@ $workspaceName="Provide the name of your workspace"
 
 $token = (Get-AzAccessToken -ResourceUrl "https://management.azure.com/").Token
 $header = @{Authorization="Bearer $token"}
+$contentType = "application/json"
 
 $url = "https://management.azure.com/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Synapse/workspaces/$workspaceName\?api-version=2021-06-01" 
 ```


### PR DESCRIPTION
Upon testing followed by Powershell sample part, I found there is missing contentType variable definition which causes command failed.

So, adding: $contentType = "application/json" under Powershell sample to fix the doc issue
