### PR TITLE
Add link of Java workload destination to existing docs

### DIFF
--- a/articles/app-service/configure-language-java.md
+++ b/articles/app-service/configure-language-java.md
@@ -15,7 +15,7 @@ ms.author: cephalin
 # Configure a Java app for Azure App Service
 
 > [!NOTE]
-> For Spring applications, we recommend using Azure Spring Apps. However, you can still use Azure App Service as a destination. 
+> For Spring applications, we recommend using Azure Spring Apps. However, you can still use Azure App Service as a destination. See [Java Workload Destination Guidance](https://aka.ms/javadestinations) for advice.
 
 Azure App Service lets Java developers to quickly build, deploy, and scale their Java SE, Tomcat, and JBoss EAP web applications on a fully managed service. Deploy applications with Maven plugins, from the command line, or in editors like IntelliJ, Eclipse, or Visual Studio Code.
 

--- a/articles/app-service/tutorial-java-spring-cosmosdb.md
+++ b/articles/app-service/tutorial-java-spring-cosmosdb.md
@@ -12,7 +12,7 @@ ms.custom: mvc, devx-track-java, devx-track-azurecli, devx-track-extended-java, 
 # Tutorial: Build a Java Spring Boot web app with Azure App Service on Linux and Azure Cosmos DB
 
 > [!NOTE]
-> For Spring applications, we recommend using Azure Spring Apps. However, you can still use Azure App Service as a destination.
+> For Spring applications, we recommend using Azure Spring Apps. However, you can still use Azure App Service as a destination. See [Java Workload Destination Guidance](https://aka.ms/javadestinations) for advice.
 
 This tutorial walks you through the process of building, configuring, deploying, and scaling Java web apps on Azure. 
 When you are finished, you will have a [Spring Boot](https://spring.io/projects/spring-boot) application storing data in [Azure Cosmos DB](../cosmos-db/index.yml) running on [Azure App Service on Linux](overview.md).

--- a/articles/cosmos-db/nosql/tutorial-springboot-azure-kubernetes-service.md
+++ b/articles/cosmos-db/nosql/tutorial-springboot-azure-kubernetes-service.md
@@ -16,7 +16,7 @@ ms.custom: mode-api, devx-track-azurecli, build-2023, build-2023-dataai
 [!INCLUDE[NoSQL](../includes/appliesto-nosql.md)]
 
 > [!NOTE]
-> For Spring Boot applications, we recommend using Azure Spring Apps. However, you can still use Azure Kubernetes Service as a destination.
+> For Spring Boot applications, we recommend using Azure Spring Apps. However, you can still use Azure Kubernetes Service as a destination. See [Java Workload Destination Guidance](https://aka.ms/javadestinations) for advice.
 
 In this tutorial, you will set up and deploy a Spring Boot application that exposes REST APIs to perform CRUD operations on data in Azure Cosmos DB (API for NoSQL account). You will package the application as Docker image, push it to Azure Container Registry, deploy to Azure Kubernetes Service and test the application.
 

--- a/articles/mysql/flexible-server/tutorial-deploy-springboot-on-aks-vnet.md
+++ b/articles/mysql/flexible-server/tutorial-deploy-springboot-on-aks-vnet.md
@@ -18,7 +18,7 @@ In this tutorial, you'll learn how to deploy a [Spring Boot](https://spring.io/p
 
 > [!NOTE]
 > This tutorial assumes a basic understanding of Kubernetes concepts, Java Spring Boot and MySQL.
-> For Spring Boot applications, we recommend using Azure Spring Apps. However, you can still use Azure Kubernetes Services as a destination. 
+> For Spring Boot applications, we recommend using Azure Spring Apps. However, you can still use Azure Kubernetes Services as a destination. See [Java Workload Destination Guidance](https://aka.ms/javadestinations) for advice.
 
 ## Prerequisites
 


### PR DESCRIPTION
Our new page https://aka.ms/javadestinations, therefore we are adding link to existing doc for reference