### PR TITLE
Add service connector to the AKS workload identity docs as an equivalent solution

### DIFF
--- a/articles/aks/workload-identity-deploy-cluster.md
+++ b/articles/aks/workload-identity-deploy-cluster.md
@@ -27,6 +27,9 @@ This article assumes you have a basic understanding of Kubernetes concepts. For 
 
 - If you have multiple Azure subscriptions, select the appropriate subscription ID in which the resources should be billed using the [az account][az-account] command.
 
+> [!NOTE]
+> Instead of configuring all steps manually, there is another implementation called _Service Connector_ which will help you configure some steps automatically and achieve the same outcome. See also: [Tutorial: Connect to Azure storage account in Azure Kubernetes Service (AKS) with Service Connector using workload identity][tutorial-python-aks-storage-workload-identity].
+
 ## Export environment variables
 
 To help simplify steps to configure the identities required, the steps below define
@@ -268,6 +271,7 @@ In this article, you deployed a Kubernetes cluster and configured it to use a wo
 [az-keyvault-list]: /cli/azure/keyvault#az-keyvault-list
 [aks-identity-concepts]: concepts-identity.md
 [az-account]: /cli/azure/account
+[tutorial-python-aks-storage-workload-identity]: ../service-connector/tutorial-python-aks-storage-workload-identity.md
 [az-aks-create]: /cli/azure/aks#az-aks-create
 [az aks update]: /cli/azure/aks#az-aks-update
 [aks-two-resource-groups]: faq.md#why-are-two-resource-groups-created-with-aks

--- a/articles/aks/workload-identity-overview.md
+++ b/articles/aks/workload-identity-overview.md
@@ -20,6 +20,9 @@ Microsoft Entra Workload ID works especially well with the [Azure Identity clien
 
 This article helps you understand this new authentication feature, and reviews the options available to plan your project strategy and potential migration from Microsoft Entra pod-managed identity.
 
+> [!NOTE]
+> Instead of configuring all steps manually, there is another implementation called _Service Connector_ which will help you configure some steps automatically. See also: [What is Service Connector?][service-connector-overview]
+
 ## Dependencies
 
 - AKS supports Microsoft Entra Workload ID on version 1.22 and higher.
@@ -303,6 +306,7 @@ The following table summarizes our migration or deployment recommendations for w
 [virtual-kubelet]: https://virtual-kubelet.io/docs/
 
 <!-- INTERNAL LINKS -->
+[service-connector-overview]: ../service-connector/overview.md
 [use-azure-ad-pod-identity]: use-azure-ad-pod-identity.md
 [azure-ad-workload-identity]: ../active-directory/develop/workload-identities-overview.md
 [microsoft-authentication-library]: ../active-directory/develop/msal-overview.md


### PR DESCRIPTION
**Proposed change:** Provide service connector to the AKS workload identity docs as an equivalent solution

**Basis:**
If you check the process, they are doing essentially the same thing: https://github.com/Azure/AKS/issues/4197
Should be good enough to provide as alternative solution for reference.  