### PR TITLE
Fix (presumed) typo in `container-instances-managed-identity.md`

### DIFF
--- a/articles/container-instances/container-instances-managed-identity.md
+++ b/articles/container-instances/container-instances-managed-identity.md
@@ -327,7 +327,7 @@ On a container group, you can enable both a system-assigned identity and one or 
 
 ```json
 "identity": {
-    "type": "System Assigned, UserAssigned",
+    "type": "SystemAssigned, UserAssigned",
     "userAssignedIdentities": {
         "myResourceID1": {
             }


### PR DESCRIPTION
Every other instance of this string, in both JSON and YAML, is `SystemAssigned`, so I assume this instance should be `SystemAssigned` rather than `System Assigned` (with a space)?

(But since you're already parsing a comma-and-whitespace-separated string for this list of values, rather than just taking a JSON array, anything is possible)

Hopefully a useful drive-by typo improvement. I note that #113619 raises far more substantial issues with this page which still haven't been addressed.