### PR TITLE
Typo fix on the sql server HA solution

### DIFF
--- a/articles/azure-vmware/migrate-sql-server-always-on-availability-group.md
+++ b/articles/azure-vmware/migrate-sql-server-always-on-availability-group.md
@@ -51,7 +51,7 @@ The following table indicates the estimated downtime for migration of each SQL S
 |:---|:-----|:-----|
 | **SQL Server standalone instance** | Low | Migration is done using VMware vMotion, the database is available during migration time, but it isn't recommended to commit any critical data during it. |
 | **SQL Server Always On Availability Group** | Low | The primary replica will always be available during the migration of the first secondary replica and the secondary replica will become the primary after the initial failover to Azure. |
-| **SQL Server Always On Failover Customer Instance** | High | All nodes of the cluster are shut down and migrated using VMware HCX Cold Migration. Downtime duration depends upon database size and private network speed to Azure cloud. |
+| **SQL Server Always On Failover Cluster Instance** | High | All nodes of the cluster are shut down and migrated using VMware HCX Cold Migration. Downtime duration depends upon database size and private network speed to Azure cloud. |
 
 ## Windows Server Failover Cluster quorum considerations
 

--- a/articles/azure-vmware/migrate-sql-server-failover-cluster.md
+++ b/articles/azure-vmware/migrate-sql-server-failover-cluster.md
@@ -57,7 +57,7 @@ The following table indicates the estimated downtime for migration of each SQL S
 |:---|:-----|:-----|
 | **SQL Server standalone instance** | Low | Migration is done using VMware vMotion, the database is available during migration time, but it isn't recommended to commit any critical data during it. |
 | **SQL Server Always On Availability Group** | Low | The primary replica will always be available during the migration of the first secondary replica and the secondary replica will become the primary after the initial failover to Azure. |
-| **SQL Server Always On Failover Customer Instance** | High | All nodes of the cluster are shut down and migrated using VMware HCX Cold Migration. Downtime duration depends upon database size and private network speed to Azure cloud. |
+| **SQL Server Always On Failover Cluster Instance** | High | All nodes of the cluster are shut down and migrated using VMware HCX Cold Migration. Downtime duration depends upon database size and private network speed to Azure cloud. |
 
 ## Windows Server Failover Cluster quorum considerations
 

--- a/articles/azure-vmware/migrate-sql-server-standalone-cluster.md
+++ b/articles/azure-vmware/migrate-sql-server-standalone-cluster.md
@@ -76,7 +76,7 @@ The following table indicates the estimated downtime for migration of each SQL S
 |:---|:-----|:-----|
 | **SQL Server standalone instance** | Low | Migration is done using VMware vMotion, the database is available during migration time, but it isn't recommended to commit any critical data during it. |
 | **SQL Server Always On Availability Group** | Low | The primary replica will always be available during the migration of the first secondary replica and the secondary replica will become the primary after the initial failover to Azure. |
-| **SQL Server Always On Failover Customer Instance** | High | All nodes of the cluster are shut down and migrated using VMware HCX Cold Migration. Downtime duration depends upon database size and private network speed to Azure cloud. |
+| **SQL Server Always On Failover Cluster Instance** | High | All nodes of the cluster are shut down and migrated using VMware HCX Cold Migration. Downtime duration depends upon database size and private network speed to Azure cloud. |
 
 ## Executing the migration
 


### PR DESCRIPTION
Commit:
doc: Update migrate-sql-server-standalone-cluster.md
fixed typo (SQL Server Always On Failover Customer Instance > SQL Server Always On Failover Cluster Instance)