### PR TITLE
Docs: fix incorrect deploy command in "Create an environment by using the Azure Developer CLI"

### DIFF
--- a/articles/deployment-environments/how-to-create-environment-with-azure-developer.md
+++ b/articles/deployment-environments/how-to-create-environment-with-azure-developer.md
@@ -374,7 +374,7 @@ When your environment is provisioned, you can deploy your code to the environmen
 Deploy your application code to the remote Azure Deployment Environments environment you provisioned using the following command:
 
 ```bash
-azd env deploy
+azd deploy
 ```
 Deploying your code to the remote environment can take several minutes. 
 
@@ -399,7 +399,7 @@ For this sample application, you see something like this:
 Deploy your application code to the remote Azure Deployment Environments environment you provisioned using the following command:
 
 ```bash
-azd env deploy
+azd deploy
 ```
 Deploying your code to the remote environment can take several minutes. 
 


### PR DESCRIPTION
Fixing a small error: the command to deploy is `azd deploy`, not `azd env deploy`