### PR TITLE
Update link to download redis-cli

### DIFF
--- a/articles/azure-cache-for-redis/cache-development-faq.yml
+++ b/articles/azure-cache-for-redis/cache-development-faq.yml
@@ -100,7 +100,7 @@ sections:
           
           * If you have a Standard or Premium cache, you can run Redis commands using the [Redis Console](cache-configure.md#redis-console). The Redis console provides a secure way to run Redis commands in the Azure portal.
           * You can also use the Redis command-line tools. To use them, do the following steps:
-          * Download the [Redis command-line tools](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-redis-cli-tool#install-redis-cli).
+          * Download the [Redis command-line tools](/azure/azure-cache-for-redis/cache-how-to-redis-cli-tool#install-redis-cli).
           * Connect to the cache using `redis-cli.exe`. Pass in the cache endpoint using the -h switch and the key using -a as shown in the following example:
           * `redis-cli -h <Azure Cache for Redis name>.redis.cache.windows.net -a <key>`
           

--- a/articles/azure-cache-for-redis/cache-development-faq.yml
+++ b/articles/azure-cache-for-redis/cache-development-faq.yml
@@ -100,7 +100,7 @@ sections:
           
           * If you have a Standard or Premium cache, you can run Redis commands using the [Redis Console](cache-configure.md#redis-console). The Redis console provides a secure way to run Redis commands in the Azure portal.
           * You can also use the Redis command-line tools. To use them, do the following steps:
-          * Download the [Redis command-line tools](https://github.com/MSOpenTech/redis/releases/).
+          * Download the [Redis command-line tools](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-redis-cli-tool#install-redis-cli).
           * Connect to the cache using `redis-cli.exe`. Pass in the cache endpoint using the -h switch and the key using -a as shown in the following example:
           * `redis-cli -h <Azure Cache for Redis name>.redis.cache.windows.net -a <key>`
           


### PR DESCRIPTION
Previews link sent you to a repo to download tools that were 8 years old. The new link sends you to the article correctly guiding you through installing the latest