### PR TITLE
Update tutorial-kubernetes-prepare-app.md and paas-services.md

### DIFF
--- a/articles/aks/tutorial-kubernetes-paas-services.md
+++ b/articles/aks/tutorial-kubernetes-paas-services.md
@@ -143,7 +143,7 @@ In previous tutorials, you used a RabbitMQ container to store orders submitted b
     ```
 
 2. Open the `aks-store-quickstart.yaml` file in a text editor.
-3. Remove the existing `rabbitmq` Deployment, ConfigMap, and Service sections and replace the existing `order-service` Deployment section with the following content:
+3. Remove the existing `rabbitmq` StatefulSet, ConfigMap, and Service sections and replace the existing `order-service` Deployment section with the following content:
 
     ```yaml
     apiVersion: apps/v1

--- a/articles/aks/tutorial-kubernetes-prepare-app.md
+++ b/articles/aks/tutorial-kubernetes-prepare-app.md
@@ -183,7 +183,7 @@ You can use [Docker Compose][docker-compose] to automate building container imag
 
 ### Docker
 
-1. Create the container image, download the Redis image, and start the application using the `docker compose` command:
+1. Create the container image, download the RabbitMQ image, and start the application using the `docker compose` command:
 
     ```console
     docker compose -f docker-compose-quickstart.yml up -d


### PR DESCRIPTION
Commit 1: If I am not mistaken, it's the RabbitMQ image being downloaded, maybe Redis was used in an older example (?)

Commit 2: In the corresponding yaml file, rabbitmq appears to be a StatefulSet instead of a Deployment, so it either should be corrected in the docs, or changed to Deployment in the yaml file in order to be accurate. The yaml file in question: (https://github.com/Azure-Samples/aks-store-demo/blob/main/aks-store-quickstart.yaml)