### PR TITLE
Removed commas from Bicep example

### DIFF
--- a/articles/cosmos-db/hierarchical-partition-keys.md
+++ b/articles/cosmos-db/hierarchical-partition-keys.md
@@ -204,8 +204,8 @@ For example, assume that you have a hierarchical partition key that's composed o
 ```bicep
 partitionKey: {
   paths: [
-    '/TenantId',
-    '/UserId',
+    '/TenantId'
+    '/UserId'
     '/SessionId'
   ]
   kind: 'MultiHash'


### PR DESCRIPTION
There are commas in the snippet of Bicep, which is not allowed in Bicep.