### PR TITLE
Added missing location parameter to create vnet command in configure-kubenet

### DIFF
--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -116,6 +116,7 @@ For more information to help you decide which network model to use, see [Compare
         --address-prefixes 192.168.0.0/16 \
         --subnet-name myAKSSubnet \
         --subnet-prefix 192.168.1.0/24
+        --location eastus
     ```
 
 3. Get the subnet resource ID using the [`az network vnet subnet show`][az-network-vnet-subnet-show] command and store it as a variable named `SUBNET_ID` for later use.

--- a/articles/aks/configure-kubenet.md
+++ b/articles/aks/configure-kubenet.md
@@ -115,7 +115,7 @@ For more information to help you decide which network model to use, see [Compare
         --name myAKSVnet \
         --address-prefixes 192.168.0.0/16 \
         --subnet-name myAKSSubnet \
-        --subnet-prefix 192.168.1.0/24
+        --subnet-prefix 192.168.1.0/24 \
         --location eastus
     ```
 


### PR DESCRIPTION
Command to create virtual network along with subnet requires `--location` parameter, otherwise it fails with this error:
`ERROR: (LocationRequired) The location property is required for this definition.`