### PR TITLE
Update expressroute-howto-coexist-resource-manager.md

### DIFF
--- a/articles/expressroute/expressroute-howto-coexist-resource-manager.md
+++ b/articles/expressroute/expressroute-howto-coexist-resource-manager.md
@@ -34,7 +34,6 @@ The steps to configure both scenarios are covered in this article. This article 
 * ExpressRoute-VPN Gateway coexist configurations are **not supported on the Basic SKU**.
 * If you want to use transit routing between ExpressRoute and VPN, **the ASN of Azure VPN Gateway must be set to 65515, and Azure Route Server should be used.** Azure VPN Gateway supports the BGP routing protocol. For ExpressRoute and Azure VPN to work together, you must keep the Autonomous System Number of your Azure VPN gateway at its default value, 65515. If you previously selected an ASN other than 65515 and you change the setting to 65515, you must reset the VPN gateway for the setting to take effect.
 * **The gateway subnet must be /27 or a shorter prefix**, such as /26, /25, or you receive an error message when you add the ExpressRoute virtual network gateway.
-* **Coexistence in a dual-stack virtual network is not supported.** If you're using ExpressRoute IPv6 support and a dual-stack ExpressRoute gateway, coexistence with VPN Gateway isn't possible.
 
 ## Configuration designs
 


### PR DESCRIPTION
Coexistence in a dual-stack virtual network is supported.

"VPN gateways currently support IPv4 traffic only, but they still can be deployed in a dual-stacked virtual network using Azure PowerShell and Azure CLI commands only." https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/ipv6-overview#limitations