### PR TITLE
Update how-to-configure-coexisting-gateway-portal.md

### DIFF
--- a/articles/expressroute/how-to-configure-coexisting-gateway-portal.md
+++ b/articles/expressroute/how-to-configure-coexisting-gateway-portal.md
@@ -36,7 +36,6 @@ The steps to configure both scenarios are covered in this article. You can confi
 * **Both the ExpressRoute and VPN gateways must be able to communicate with each other via BGP to function properly.** If using a UDR on the gateway subnet, ensure that it doesn't include a route for the gateway subnet range itself as this will interfere with BGP traffic.
 * **If you want to use transit routing between ExpressRoute and VPN, the ASN of Azure VPN Gateway must be set to 65515.** Azure VPN Gateway supports the BGP routing protocol. For ExpressRoute and Azure VPN to work together, you must keep the Autonomous System Number of your Azure VPN gateway at its default value, 65515. If you previously selected an ASN other than 65515 and you change the setting to 65515, you must reset the VPN gateway for the setting to take effect.
 * **The gateway subnet must be /27 or a shorter prefix**, such as /26, /25, or you receive an error message when you add the ExpressRoute virtual network gateway.
-* **Coexistence for IPv4 traffic only.** ExpressRoute co-existence with VPN gateway is supported, but only for IPv4 traffic. IPv6 traffic isn't supported for VPN gateways.
 
 ## Configuration designs
 


### PR DESCRIPTION
Coexistence in a dual-stack virtual network is supported.

"VPN gateways currently support IPv4 traffic only, but they still can be deployed in a dual-stacked virtual network using Azure PowerShell and Azure CLI commands only." https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/ipv6-overview#limitations