### PR TITLE
Update acu.md

### DIFF
--- a/articles/virtual-machines/acu.md
+++ b/articles/virtual-machines/acu.md
@@ -68,7 +68,13 @@ The concept of the Azure Compute Unit (ACU) provides a way of comparing compute 
 | [Mv2](msv2-mdsv2-series.md) | 240 - 280 | 2:1\*\*\* |
 | [NVv4](nvv4-series.md) |230 - 260** | 2:1\*\*\*\* |
 
-Processor model information for each SKU is available in the SKU documentation (see links above).  Optimal performance may require the latest VM images (OS and [VM generation](generation-2.md)) to ensure the latest updates and fastest drivers.
+Processor model information for each SKU is available in the SKU documentation (see links above).  Optimal performance may require the latest VM images (OS and [VM generation](generation-2.md)) to ensure the latest updates and fastest drivers.  
+
+For example, if you have an Azure VM with size **Standard_D4v3** which offers 4 vCPUs (refer [Dv3-series](dv3-dsv3-series.md)). As mentioned in above table for size **D_v3**, the ratio for vCPU:cores is **2:1**, and hence size Standard_ D4v3 will offer **2 cores**.
+
+ > [!NOTE]
+        You can also check the cores offered by existing VM size for windows VM by checking the system summary:
+Go to Run-->search for msinfo32 --> Processor
 
 ### VM Series Retiring
 


### PR DESCRIPTION
Sometimes customers open a support case to understand how to calculate the number of cores offered by each Azure VM size along with the respective virtual processors(vCPUs) as they are unable to check it following the available public documents.

Currently customers can only see the details like RAM, number of vCPUs, and disk related configurations like max IOPs, temp disks, etc, from the VM's "Size" section in Azure Portal as well as by referring to the MS Public documents available.

If customers need to have a specific number of cores for running their application with optimum efficiency on the Azure VM, they open a support case as they are unable to opt for specific VM size or series which will provide them the required number of cores along with the respective virtual processors(vCPUs).

Hence I have just added an example and also a note section on how to check the cores offered by an VM SKU in Azure.