### PR TITLE
Fix wrong command in cluster-autoscaler.md

### DIFF
--- a/articles/aks/cluster-autoscaler.md
+++ b/articles/aks/cluster-autoscaler.md
@@ -206,7 +206,7 @@ The following table lists the available settings for the cluster autoscaler prof
     az aks update \
         --resource-group myResourceGroup \
         --name myAKSCluster \
-        --cluster-autoscaler-profile scan-interval=30s, scale-down-delay-after-add=0s,scale-down-delay-after-failure=30s,scale-down-unneeded-time=3m,scale-down-unready-time=3m,max-graceful-termination-sec=30,skip-nodes-with-local-storage=false,max-empty-bulk-delete=1000,max-total-unready-percentage=100,ok-total-unready-count=1000,max-node-provision-time=15m
+        --cluster-autoscaler-profile scan-interval=30s,scale-down-delay-after-add=0m,scale-down-delay-after-failure=1m,scale-down-unneeded-time=3m,scale-down-unready-time=3m,max-graceful-termination-sec=30,skip-nodes-with-local-storage=false,max-empty-bulk-delete=1000,max-total-unready-percentage=100,ok-total-unready-count=1000,max-node-provision-time=15m
    ```
 ### Configure cluster autoscaler profile for bursty workloads
    ```azurecli-interactive


### PR DESCRIPTION
**Proposed changes:** Fix wrong command which is not executable. 
**Result:**
Environment: Cloud Shell
```
az aks update -n ${aks} -g ${rG} --cluster-autoscaler-profile scan-interval=30s,scale-down-delay-after-add=0m,scale-down-delay-after-failure=1m,scale-down-unneeded-time=3m,scale-down-unready-time=3m,max-graceful-termination-sec=30,skip-nodes-with-local-storage=false,max-empty-bulk-delete=1000,max-total-unready-percentage=100,ok-total-unready-count=1000,max-node-provision-time=15m
{
  "aadProfile": null,
  "addonProfiles": {
    "azurepolicy": {
      "config": null,
      "enabled": true,
      ...(no need to expand)
```

**Supporting points:**
The current command is not executable due to:
1. There is a space behind `scan-interval`, which is not supported:
```
joey [ ~ ]$ az aks update -n ${aks} -g ${rG} --cluster-autoscaler-profile scan-interval=30s, scale-down-delay-after-add=0s,scale-down-delay-after-failure=30s,scale-down-unneeded-time=3m,scale-down-unready-time=3m,max-graceful-termination-sec=30,skip-nodes-with-local-storage=false,max-empty-bulk-delete=1000,max-total-unready-percentage=100,ok-total-unready-count=1000,max-node-provision-time=15m
Empty key specified for cluster-autoscaler-profile
```
2. The value's unit (e.g. h, m, s) for the parameter is wrong:
```
joey [ ~ ]$ az aks update -n ${aks} -g ${rG} --cluster-autoscaler-profile scan-interval=30s,scale-down-delay-after-add=0s,scale-down-delay-after-failure=30s,scale-down-unneeded-time=3m,scale-down-unready-time=3m,max-graceful-termination-sec=30,skip-nodes-with-local-storage=false,max-empty-bulk-delete=1000,max-total-unready-percentage=100,ok-total-unready-count=1000,max-node-provision-time=15m
(InvalidParameter) Invalid value specified for the cluster-autoscaler parameter 'scale-down-delay-after-add'. Please refer to https://aka.ms/cluster-autoscaler for more details.
Code: InvalidParameter
Message: Invalid value specified for the cluster-autoscaler parameter 'scale-down-delay-after-add'. Please refer to https://aka.ms/cluster-autoscaler for more details.
```