### PR TITLE
Backup-ZRS

### DIFF
--- a/articles/postgresql/flexible-server/concepts-backup-restore.md
+++ b/articles/postgresql/flexible-server/concepts-backup-restore.md
@@ -39,7 +39,7 @@ Azure Database for PostgreSQL flexible server stores multiple copies of your bac
 
 Azure Database for PostgreSQL flexible server offers three options: 
 
-- **Zone-redundant backup storage**: This option is automatically chosen for regions that support availability zones. When the backups are stored in zone-redundant backup storage, multiple copies are not only stored within the same availability zone, but also replicated to another availability zone within the same region. 
+- **Zone-redundant backup storage**: This option is automatically chosen for regions that support availability zones. When the backups are stored in zone-redundant backup storage, multiple copies are not only stored within the same availability zone, but also replicated to other availability zones within the same region. 
 
   This option provides backup data availability across availability zones and restricts replication of data to within a country/region to meet data residency requirements. This option provides at least 99.9999999999 percent (12 nines) durability of backup objects over a year.  
 


### PR DESCRIPTION
Just a small rewarding, clearing the statement in case of ZRS backup support, we are copying to all other availability zone and not only one AZ (correct me if I'm wrong), that is based on [ZRS storage concept ](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy#redundancy-in-the-primary-region).