### PR TITLE
Update outdated command in private-link-configure.md

### DIFF
--- a/articles/azure-monitor/logs/private-link-configure.md
+++ b/articles/azure-monitor/logs/private-link-configure.md
@@ -125,7 +125,7 @@ To create and manage Private Link Scopes, use the [REST API](/rest/api/monitor/p
 The following CLI command creates a new AMPLS resource named `"my-scope"`, with both query and ingestion access modes set to `Open`.
 
 ```
-az resource create -g "my-resource-group" --name "my-scope" --api-version "2021-07-01-preview" --resource-type Microsoft.Insights/privateLinkScopes --properties "{\"accessModeSettings\":{\"queryAccessMode\":\"Open\", \"ingestionAccessMode\":\"Open\"}}"
+az resource create -g "my-resource-group" --name "my-scope" -l global --api-version "2021-07-01-preview" --resource-type Microsoft.Insights/privateLinkScopes --properties "{\"accessModeSettings\":{\"queryAccessMode\":\"Open\", \"ingestionAccessMode\":\"Open\"}}"
 ```
 
 #### Create an AMPLS with mixed access modes: PowerShell example


### PR DESCRIPTION
**Proposed change:** Update outdated non-executable command with `-l global`.
**Result:**
```
az resource create -n ${ampls} -g ${rG} -l global --api-version "2021-07-01-preview" --resource-type Microsoft.Insights/privateLinkScopes --properties "{\"accessModeSettings\":{\"queryAccessMode\":\"Open\", \"ingestionAccessMode\":\"Open\"}}"
{
  "etag": "\"40019e80-0100-0200-0300-112203201010\"",
  "extendedLocation": null,
  (...no need more lines)
```
![image](https://github.com/MicrosoftDocs/azure-docs/assets/142381267/414ab79c-a091-4f75-931d-117552c676d3)

**Basis:**
The current command cannot be executed:
```
/# az resource create -g ${rG} --name ${ampls} --api-version "2021-07-01-preview" --resource-type Microsoft.Insights/privateLinkScopes --properties "{\"accessModeSettings\":{\"queryAccessMode\":\"Open\", \"ingestionAccessMode\":\"Open\"}}"
(LocationNotAvailableForResourceType) The provided location 'eastus2' is not available for resource type 'microsoft.insights/privateLinkScopes'. List of available regions for the resource type is 'global'.
Code: LocationNotAvailableForResourceType
Message: The provided location 'eastus2' is not available for resource type 'microsoft.insights/privateLinkScopes'. List of available regions for the resource type is 'global'.
```