### PR TITLE
Update action-groups.md

### DIFF
--- a/articles/azure-monitor/alerts/action-groups.md
+++ b/articles/azure-monitor/alerts/action-groups.md
@@ -23,6 +23,7 @@ Global requests from clients can be processed by action group services in any re
 - You can add up to five action groups to an alert rule.
 - Action groups are executed concurrently, in no specific order.
 - Multiple alert rules can use the same action group.
+- Action groups are created for each unique set of users that will be notified. For example, if User1, User2 and User3 have to be notified for two alert rules, you need to create only one action group.
 
 ## Create an action group in the Azure portal
 1. Go to the [Azure portal](https://portal.azure.com/).

--- a/articles/azure-monitor/alerts/action-groups.md
+++ b/articles/azure-monitor/alerts/action-groups.md
@@ -23,7 +23,7 @@ Global requests from clients can be processed by action group services in any re
 - You can add up to five action groups to an alert rule.
 - Action groups are executed concurrently, in no specific order.
 - Multiple alert rules can use the same action group.
-- Action groups are created for each unique set of users that will be notified. For example, if User1, User2 and User3 have to be notified for two alert rules, you need to create only one action group.
+- Action Groups are defined by the unique set of actions and the users to be notified. For example, if you want to notify User1, User2 and User3 by email for two different alert rules, you only need to create one action group which you can apply to both alert rules.
 
 ## Create an action group in the Azure portal
 1. Go to the [Azure portal](https://portal.azure.com/).


### PR DESCRIPTION
The following fact hasn't been mentioned anywhere in the doc:

"Action groups are created for each unique set of users that will be notified. For example, if User1, User2 and User3 have to be notified for two alert rules, you need to create only one action group."