### PR TITLE
Update monitor-virtual-machine-alerts.md

### DIFF
--- a/articles/azure-monitor/vm/monitor-virtual-machine-alerts.md
+++ b/articles/azure-monitor/vm/monitor-virtual-machine-alerts.md
@@ -98,7 +98,7 @@ The following section lists common alert rules for virtual machines in Azure Mon
 ### Machine availability
 One of the most common monitoring requirements for a virtual machine is to create an alert if it stops running. The best method is to create a metric alert rule in Azure Monitor by using the VM availability metric, which is currently in public preview. For a walk-through on this metric, see [Create availability alert rule for Azure virtual machine](tutorial-monitor-vm-alert-availability.md).
 
-Take note that an alert rule is limited to one activity log signal. So for every condition, one alert rule must be created e.g. "starts or stops the virtual machine" requires two alert rules. However, to be alerted when VM is restarted, only one alert rule is needed. 
+An alert rule is limited to one activity log signal. So for every condition, one alert rule must be created. For example, "starts or stops the virtual machine" requires two alert rules. However, to be alerted when VM is restarted, only one alert rule is needed. 
 
 As described in [Scaling alert rules](#scaling-alert-rules), create an availability alert rule by using a subscription or resource group as the target resource. The rule applies to multiple virtual machines, including new machines that you create after the alert rule.
 

--- a/articles/azure-monitor/vm/monitor-virtual-machine-alerts.md
+++ b/articles/azure-monitor/vm/monitor-virtual-machine-alerts.md
@@ -95,8 +95,10 @@ The following section lists common alert rules for virtual machines in Azure Mon
 > [!NOTE]
 > The details for log search alerts provided here are using data collected by using [VM Insights](vminsights-overview.md), which provides a set of common performance counters for the client operating system. This name is independent of the operating system type.
 
-### Machine unavailable
+### Machine availability
 One of the most common monitoring requirements for a virtual machine is to create an alert if it stops running. The best method is to create a metric alert rule in Azure Monitor by using the VM availability metric, which is currently in public preview. For a walk-through on this metric, see [Create availability alert rule for Azure virtual machine](tutorial-monitor-vm-alert-availability.md).
+
+Take note that an alert rule is limited to one activity log signal. So for every condition, one alert rule must be created e.g. "starts or stops the virtual machine" requires two alert rules. However, to be alerted when VM is restarted, only one alert rule is needed. 
 
 As described in [Scaling alert rules](#scaling-alert-rules), create an availability alert rule by using a subscription or resource group as the target resource. The rule applies to multiple virtual machines, including new machines that you create after the alert rule.
 


### PR DESCRIPTION
The following facts haven't been mentioned anywhere in the doc, so I've added them

"an alert rule is limited to one activity log signal. So for every condition, one alert rule must be created e.g. "starts or stops the virtual machine" requires two alert rules. However, to be alerted when VM is restarted, only one alert rule is needed. "