### PR TITLE
Update cdn-create-a-storage-account-with-cdn.md

### DIFF
--- a/articles/cdn/cdn-create-a-storage-account-with-cdn.md
+++ b/articles/cdn/cdn-create-a-storage-account-with-cdn.md
@@ -24,7 +24,7 @@ Sign in to the [Azure portal](https://portal.azure.com) with your Azure account.
 
 ## Create a storage account
 
-A storage account gives access to Azure Storage services. The storage account represents the highest level of the namespace for accessing each of the Azure Storage service components: Azure Blob, Queue, and Table storage. For more information, see [Introduction to Microsoft Azure Storage](../storage/common/storage-introduction.md).
+A storage account gives access to Azure Storage services. The storage account represents the highest level of the namespace for accessing each of the Azure Storage service components: Azure Blob, Queue, and Table storage. Take note that Azure Files can be only accessed through SMB protocol and cannot be put directly behind an Azure CDN which only supports HTTP(80) and HTTPS(443) protocols. For more information, see [Introduction to Microsoft Azure Storage](../storage/common/storage-introduction.md).
 
 To create a storage account, you must be either the service administrator or a coadministrator for the associated subscription.
 


### PR DESCRIPTION
The following fact  should be clearly mentioned in the doc:

"Take note that Azure Files can be only accessed through SMB protocol and cannot be put directly behind an Azure CDN which only supports HTTP(80) and HTTPS(443) protocols."

PS: this and all my PRs follow Microsoft Certification Exam – Candidate Agreement and other relevant NDAs. 