### PR TITLE
Update zip deployment Azure CLI command

### DIFF
--- a/articles/app-service/deploy-run-package.md
+++ b/articles/app-service/deploy-run-package.md
@@ -42,7 +42,7 @@ az webapp config appsettings set --resource-group <group-name> --name <app-name>
 The easiest way to run a package in your App Service is with the Azure CLI [az webapp deployment source config-zip](/cli/azure/webapp/deployment/source#az-webapp-deployment-source-config-zip) command. For example:
 
 ```azurecli-interactive
-az webapp deployment source config-zip --resource-group <group-name> --name <app-name> --src <filename>.zip
+az webapp deploy --resource-group <group-name> --name <app-name> --src-path <filename>.zip
 ```
 
 Because the `WEBSITE_RUN_FROM_PACKAGE` app setting is set, this command doesn't extract the package content to the *D:\home\site\wwwroot* directory of your app. Instead, it uploads the ZIP file as-is to *D:\home\data\SitePackages*, and creates a *packagename.txt* in the same directory, that contains the name of the ZIP package to load at runtime. If you upload your ZIP package in a different way (such as [FTP](deploy-ftp.md)), you need to create the *D:\home\data\SitePackages* directory and the *packagename.txt* file manually.


### PR DESCRIPTION
If you run

```bash
az webapp deployment source config-zip ...
```

the deployment will succeed but will issue the following warning before doing so:

```
This command has been deprecated and will be removed in a future release. Use 'az webapp deploy' instead.
```

I suggest updating the docs using the preferred command.