### PR TITLE
Adding section links to calling events and updating descriptions

### DIFF
--- a/articles/event-grid/communication-services-chat-events.md
+++ b/articles/event-grid/communication-services-chat-events.md
@@ -14,7 +14,7 @@ Azure Communication Services emits chat events only when Azure Communication Ser
 
 ## Event types
 
-Azure Communication Services emits chat events on two different levels: **User-level** and **Thread-level**. User-level events pertain to a specific user on the chat thread and are delivered once per user. Thread-level events pertain to the entire chat thread and and delivered once per thread. For example: if there are 10 users in a thread, there will be one thread-level event and 10 user-level events, one for each user, when a message is received in a thread.
+Azure Communication Services emits chat events on two different levels: **User-level** and **Thread-level**. User-level events pertain to a specific user on the chat thread and are delivered once per user. Thread-level events pertain to the entire chat thread and are delivered once per thread. For example: if there are 10 users in a thread, there will be one thread-level event and 10 user-level events, one for each user, when a message is received in a thread.
 
 Azure Communication Services emits the following chat event types:
 
@@ -33,7 +33,7 @@ Azure Communication Services emits the following chat event types:
 | [Microsoft.Communication.ChatThreadParticipantAdded](#microsoftcommunicationchatthreadparticipantadded-event) | `Thread` | Published when a new participant is added to a chat thread  |
 | [Microsoft.Communication.ChatThreadParticipantRemoved](#microsoftcommunicationchatthreadparticipantremoved-event) | `Thread` | Published when a participant is removed from a chat thread  |  
 | [Microsoft.Communication.ChatMessageReceivedInThread](#microsoftcommunicationchatmessagereceivedinthread-event) |  `Thread` |Published when a message is received in a chat thread  |    
-| [Microsoft.Communication.ChatThreadPropertiesUpdated](#microsoftcommunicationchatthreadpropertiesupdated-event)| `Thread` | Published when a chat thread's properties are updated.|    
+| [Microsoft.Communication.ChatThreadPropertiesUpdated](#microsoftcommunicationchatthreadpropertiesupdated-event)| `Thread` | Published when a chat thread's properties are updated |    
 | [Microsoft.Communication.ChatMessageEditedInThread](#microsoftcommunicationchatmessageeditedinthread-event) |  `Thread` |Published when a message is edited in a chat thread |  
 | [Microsoft.Communication.ChatMessageDeletedInThread](#microsoftcommunicationchatmessagedeletedinthread-event) |  `Thread` |Published when a message is deleted in  a chat thread  |  
 

--- a/articles/event-grid/communication-services-voice-video-events.md
+++ b/articles/event-grid/communication-services-voice-video-events.md
@@ -17,12 +17,12 @@ Azure Communication Services emits the following voice and video calling event t
 
 | Event type                                                  | Description                                                                                    |
 | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Microsoft.Communication.RecordingFileStatusUpdated | Published when recording file is available |
-| Microsoft.Communication.CallStarted | Published when call is started  |
-| Microsoft.Communication.CallEnded   | Published when call is ended  |
-| Microsoft.Communication.CallParticipantAdded | Published when participant is added  |
-| Microsoft.Communication.CallParticipantRemoved | Published when participant is removed  |
-| Microsoft.Communication.IncomingCall | Published when there is an incoming call  |
+| [Microsoft.Communication.RecordingFileStatusUpdated](#microsoftcommunicationrecordingfilestatusupdated) | Published when a recording file is available |
+| [Microsoft.Communication.CallStarted](#microsoftcommunicationcallstarted) | Published when a call is started  |
+| [Microsoft.Communication.CallEnded](#microsoftcommunicationcallended)   | Published when a call ends  |
+| [Microsoft.Communication.CallParticipantAdded](#microsoftcommunicationcallparticipantadded) | Published when a participant is added  |
+| [Microsoft.Communication.CallParticipantRemoved](#microsoftcommunicationcallparticipantremoved) | Published when a participant is removed  |
+| [Microsoft.Communication.IncomingCall](#microsoftcommunicationincomingcall) | Published when there is an incoming call  |
 
 ## Event responses
 

--- a/articles/event-grid/communication-services-voice-video-events.md
+++ b/articles/event-grid/communication-services-voice-video-events.md
@@ -20,8 +20,8 @@ Azure Communication Services emits the following voice and video calling event t
 | [Microsoft.Communication.RecordingFileStatusUpdated](#microsoftcommunicationrecordingfilestatusupdated) | Published when a recording file is available |
 | [Microsoft.Communication.CallStarted](#microsoftcommunicationcallstarted) | Published when a call is started  |
 | [Microsoft.Communication.CallEnded](#microsoftcommunicationcallended)   | Published when a call ends  |
-| [Microsoft.Communication.CallParticipantAdded](#microsoftcommunicationcallparticipantadded) | Published when a participant is added  |
-| [Microsoft.Communication.CallParticipantRemoved](#microsoftcommunicationcallparticipantremoved) | Published when a participant is removed  |
+| [Microsoft.Communication.CallParticipantAdded](#microsoftcommunicationcallparticipantadded) | Published when a participant is added to a call AND they join it |
+| [Microsoft.Communication.CallParticipantRemoved](#microsoftcommunicationcallparticipantremoved) | Published when a participant leaves or is removed from a call  |
 | [Microsoft.Communication.IncomingCall](#microsoftcommunicationincomingcall) | Published when there is an incoming call  |
 
 ## Event responses


### PR DESCRIPTION
- Added section links for the voice and video calling events
  - Each event in the `Event Types` table now links directly to the corresponding event data section
- Updated descriptions of the following voice and video events to better describe when they are raised
  - `Microsoft.Communication.CallParticipantAdded`
  - `Microsoft.Communication.CallParticipantRemoved`
- Minor punctuation updates for chat events 