### PR TITLE
Update ingress-controller-install-existing.md

### DIFF
--- a/articles/application-gateway/ingress-controller-install-existing.md
+++ b/articles/application-gateway/ingress-controller-install-existing.md
@@ -168,10 +168,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: pet-supplies-ingress
-  annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
-
 spec:
+  ingressClassName: azure-application-gateway
   rules:
   - http:
       paths:


### PR DESCRIPTION
To avoid the following warning, this updates the manifest.

```
Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```