### PR TITLE
Updated opentelemetry-enable.md

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-enable.md
+++ b/articles/azure-monitor/app/opentelemetry-enable.md
@@ -259,8 +259,8 @@ To paste your Connection String, select from the following options:
   Create a configuration file named `applicationinsights.json`, and place it in the same directory as `applicationinsights-agent-3.5.2.jar` with the following content:
 
    ```json
-   {
-     "connectionString": "<Your Connection String>"
+   "AzureMonitor": {
+     "ConnectionString": "<Your Connection String>"
    }
    ```
 


### PR DESCRIPTION
The description for configuring the connection string in the app settings was fixed. Only adding the the braces without putting it in a section will not work.