### PR TITLE
Updated branch reference for the tutorial

### DIFF
--- a/articles/container-registry/container-registry-tutorial-base-image-update.md
+++ b/articles/container-registry/container-registry-tutorial-base-image-update.md
@@ -88,7 +88,7 @@ az acr task create \
     --name baseexample1 \
     --image helloworld:{{.Run.ID}} \
     --arg REGISTRY_NAME=$ACR_NAME.azurecr.io \
-    --context https://github.com/$GIT_USER/acr-build-helloworld-node.git#main \
+    --context https://github.com/$GIT_USER/acr-build-helloworld-node.git#master \
     --file Dockerfile-app \
     --git-access-token $GIT_PAT
 ```


### PR DESCRIPTION
This pull request includes a minor change to the `az acr task create`  command in the `articles/container-registry/container-registry-tutorial-base-image-update.md` file. The change modifies the `--context` argument to point to the `master` branch instead of the `main` branch in the `acr-build-helloworld-node.git` repository.