### PR TITLE
Update networking.md

### DIFF
--- a/articles/role-based-access-control/built-in-roles/networking.md
+++ b/articles/role-based-access-control/built-in-roles/networking.md
@@ -597,7 +597,7 @@ Lets you manage DNS zones and record sets in Azure DNS, but does not let you con
 
 ## Network Contributor
 
-Lets you manage networks, but not access to them.
+Lets you manage networks, but not access to them. This role does not grant you permission to deploy or manage Virtual Machines.
 
 > [!div class="mx-tableFixed"]
 > | Actions | Description |


### PR DESCRIPTION
In the doc, it's clearly stated that Virtual Machine Contributor cannot manage VNets. (below is the source). It should also clearly be stated that Network Contributor cannot deploy VMs. I've added it.

Source: https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/compute#virtual-machine-contributor