### PR TITLE
Fix input arg name for Python example

### DIFF
--- a/articles/azure-functions/functions-bindings-cosmosdb-v2-trigger.md
+++ b/articles/azure-functions/functions-bindings-cosmosdb-v2-trigger.md
@@ -301,7 +301,7 @@ import azure.functions as func
 app = func.FunctionApp()
 
 @app.function_name(name="CosmosDBTrigger")
-@app.cosmos_db_trigger(name="documents", 
+@app.cosmos_db_trigger(arg_name="documents", 
                        connection="CONNECTION_SETTING",
                        database_name="DB_NAME", 
                        container_name="CONTAINER_NAME", 


### PR DESCRIPTION
The input argument name is **arg_name** and not **name**  in python.