### PR TITLE
Update backup-azure-diagnostic-events.md

### DIFF
--- a/articles/backup/backup-azure-diagnostic-events.md
+++ b/articles/backup/backup-azure-diagnostic-events.md
@@ -33,7 +33,7 @@ If you are still using the [legacy event](#legacy-event) AzureBackupReport, we r
 
 For more information, see [Data model for Azure Backup diagnostics events](./backup-azure-reports-data-model.md).
 
-Data for these events can be sent to either a storage account, a Log Analytics workspace, or an event hub. If you're sending this data to a Log Analytics workspace, select the **Resource specific** toggle on the **Diagnostics settings** screen. For more information, see the following sections.
+Data for these events can be sent to either a storage account, a Log Analytics workspace, or an event hub. Storage account needs to be in the same region as Recovery Services vaults however Log Analytics workspace can be in a different region.  If you're sending this data to a Log Analytics workspace, select the **Resource specific** toggle on the **Diagnostics settings** screen. For more information, see the following sections.
 
 ## Use diagnostics settings with Log Analytics
 

--- a/articles/backup/backup-azure-diagnostic-events.md
+++ b/articles/backup/backup-azure-diagnostic-events.md
@@ -33,7 +33,7 @@ If you are still using the [legacy event](#legacy-event) AzureBackupReport, we r
 
 For more information, see [Data model for Azure Backup diagnostics events](./backup-azure-reports-data-model.md).
 
-Data for these events can be sent to either a storage account, a Log Analytics workspace, or an event hub. Storage account needs to be in the same region as Recovery Services vaults however Log Analytics workspace can be in a different region.  If you're sending this data to a Log Analytics workspace, select the **Resource specific** toggle on the **Diagnostics settings** screen. For more information, see the following sections.
+Data for these events can be sent to either a storage account, a Log Analytics workspace, or an event hub. The storage account needs to be in the same region as the Recovery Services vaults. However, the Log Analytics workspace can be in a different region.  If you're sending this data to a Log Analytics workspace, select the **Resource specific** toggle on the **Diagnostics settings** screen. For more information, see the following sections.
 
 ## Use diagnostics settings with Log Analytics
 


### PR DESCRIPTION
The following fact  should be clearly mentioned in the doc (I couldn't find it anywhere in the existing doc)

"Storage account needs to be in the same region as Recovery Services vaults however Log Analytics workspace can be in a different region."