### PR TITLE
Update data-retention-archive.md

### DIFF
--- a/articles/azure-monitor/logs/data-retention-archive.md
+++ b/articles/azure-monitor/logs/data-retention-archive.md
@@ -59,7 +59,7 @@ A Log Analytics workspace can contain several [types of tables](../logs/manage-l
 | Purge data from a Log Analytics workspace | `Microsoft.OperationalInsights/workspaces/purge/action` permissions to the Log Analytics workspace, as provided by the [Log Analytics Contributor built-in role](./manage-access.md#log-analytics-contributor), for example |
 ## Configure the default workspace retention
 
-You can set a Log Analytics workspace's default retention in the Azure portal to 30, 31, 60, 90, 120, 180, 270, 365, 550, and 730 days. You can apply a different setting to specific tables by [configuring retention and archive at the table level](#configure-retention-and-archive-at-the-table-level). If you're on the *free* tier, you need to upgrade to the paid tier to change the data retention period.
+By default, the data in a Log Analytics workspace is retained for 30 days. You can set a Log Analytics workspace's default retention in the Azure portal to 30, 31, 60, 90, 120, 180, 270, 365, 550, and 730 days. You can apply a different setting to specific tables by [configuring retention and archive at the table level](#configure-retention-and-archive-at-the-table-level). If you're on the *free* tier, you need to upgrade to the paid tier to change the data retention period.
 
 > [!IMPORTANT]
 > Workspaces with a 30-day retention might keep data for 31 days. If you need to retain data for 30 days only to comply with a privacy policy, configure the default workspace retention to 30 days using the API and update the `immediatePurgeDataOn30Days` workspace property to `true`. This operation is currently only supported using the [Workspaces - Update API](/rest/api/loganalytics/workspaces/update).


### PR DESCRIPTION
The following fact should be clearly stated in the doc for clarity:

"By default, the data in a Log Analytics workspace is retained for 30 days. "