### PR TITLE
Update how-to-manage-environments-v2.md

### DIFF
--- a/articles/machine-learning/how-to-manage-environments-v2.md
+++ b/articles/machine-learning/how-to-manage-environments-v2.md
@@ -295,7 +295,7 @@ ml_client.environments.archive(name="docker-image-example", version="1")
 ---
 
 > [!IMPORTANT]
-> Archiving an environment's version does not delete the cached image in the container registry. If you wish to delete the cached image associated with a specific environment, you can use the command [az acr repository delete](https://learn.microsoft.com/cli/azure/acr/repository?view=azure-cli-latest#az-acr-repository-delete) on the environment's associated repository.
+> Archiving an environment's version does not delete the cached image in the container registry. If you wish to delete the cached image associated with a specific environment, you can use the command [az acr repository delete](/cli/azure/acr/repository?view=azure-cli-latest#az-acr-repository-delete) on the environment's associated repository.
 
 
 ## Use environments for training

--- a/articles/machine-learning/how-to-manage-environments-v2.md
+++ b/articles/machine-learning/how-to-manage-environments-v2.md
@@ -294,6 +294,8 @@ ml_client.environments.archive(name="docker-image-example", version="1")
 
 ---
 
+> [!IMPORTANT]
+> Archiving an environment's version does not delete the cached image in the container registry. If you wish to delete the cached image associated with a specific environment, you can use the command [az acr repository delete](https://learn.microsoft.com/cli/azure/acr/repository?view=azure-cli-latest#az-acr-repository-delete) on the environment's associated repository.
 
 
 ## Use environments for training


### PR DESCRIPTION
Guiding customers to AZ ACR documentation if they wish to delete the cached image associated with an AZ ML environment. I've seen cases where customers ask us how to delete them.