### PR TITLE
Update concept-responsible-ai-dashboard.md

### DIFF
--- a/articles/machine-learning/concept-responsible-ai-dashboard.md
+++ b/articles/machine-learning/concept-responsible-ai-dashboard.md
@@ -171,7 +171,7 @@ The following people can use the Responsible AI dashboard, and its corresponding
 - The Responsible AI dashboard currently supports numeric or categorical features. For categorical features, the user has to explicitly specify the feature names.  
 - The Responsible AI dashboard currently doesn't support datasets with more than 10K columns.
 - The Responsible AI dashboard currently doesn't support AutoML MLFlow model.
-- The Responsible AI dashboard currently doesn't support registered AutoML models from the UI.
+- The Responsible AI dashboard currently doesn't support registered AutoML models.
 
 
 ## Next steps


### PR DESCRIPTION
- The Responsible AI dashboard currently doesn't support registered AutoML models from the UI.

Responsible AI dashboard doesn't work with registered AutoML models overall. Doing it through the SDK instead of the UI also resulted in an error.