### PR TITLE
Update expressroute-bfd.md to clarify behavior on new peerings

### DIFF
--- a/articles/expressroute/expressroute-bfd.md
+++ b/articles/expressroute/expressroute-bfd.md
@@ -56,7 +56,7 @@ router bgp 65020
 ```
 
 >[!NOTE]
->To enable BFD under an already existing private or Microsoft peering, you'll need to reset the peering. This will need to be done on circuits configured with private peering before August 2018 and Microsoft peering before January 2020. See [Reset ExpressRoute peerings][ResetPeering]
+>To enable BFD under an already existing private or Microsoft peering, you'll need to reset the peering. This will need to be done on circuits configured with private peering before August 2018 and Microsoft peering before January 2020. See [Reset ExpressRoute peerings][ResetPeering]. While configuring BFD on your primary and secondary devices is optional, the BFD configuration on the Azure devices for new peerings is not optional and cannot be removed.
 >
 
 ## BFD Timer Negotiation


### PR DESCRIPTION
Added clarity that BFD configuration on the Azure devices is not optional and cannot be removed.