### PR TITLE
Fix Python syntax error in partial-document-update-getting-started.md

### DIFF
--- a/articles/cosmos-db/partial-document-update-getting-started.md
+++ b/articles/cosmos-db/partial-document-update-getting-started.md
@@ -291,7 +291,7 @@ Support for Partial Document Update (Patch API) in the [Azure Cosmos DB Python S
     ```python
     operations =
     [
-        { op: 'replace', path: '/price', value: 355.45 }
+        { 'op': 'replace', 'path': '/price', 'value': 355.45 }
     ]
     
     response = container.patch_item(item='e379aea5-63f5-4623-9a9b-4cd9b33b91d5', partition_key='road-bikes', patch_operations=operations)
@@ -303,8 +303,8 @@ Support for Partial Document Update (Patch API) in the [Azure Cosmos DB Python S
     ```python
     operations =
     [
-        { op: 'add', path: '/color', value: 'silver' },
-        { op: 'remove', path: '/used' }
+        { 'op': 'add', 'path': '/color', 'value': 'silver' },
+        { 'op': 'remove', 'path': '/used' }
     ]
     
     response = container.patch_item(item='e379aea5-63f5-4623-9a9b-4cd9b33b91d5', partition_key='road-bikes', patch_operations=operations)
@@ -318,7 +318,7 @@ Support for Partial Document Update (Patch API) in the [Azure Cosmos DB Python S
 
     operations =
     [
-        { op: 'replace', path: '/price', value: 100.00 }
+        { 'op': 'replace', 'path': '/price', 'value': 100.00 }
     ]
 
     try:


### PR DESCRIPTION
## Changes
Added quotes to the top-level keys in the Python preview on `partial-document-update-getting-started.md`.