### PR TITLE
Enhance clarity for workaround with unsupported Connection String Types

### DIFF
--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -214,10 +214,15 @@ At runtime, connection strings are available as environment variables, prefixed 
 * MySQL: `MYSQLCONNSTR_` 
 * SQLAzure: `SQLAZURECONNSTR_` 
 * Custom: `CUSTOMCONNSTR_`
-* PostgreSQL: `POSTGRESQLCONNSTR_`  
+* PostgreSQL: `POSTGRESQLCONNSTR_`
+* Notification Hub: `NOTIFICATIONHUBCONNSTR_`
+* Service Bus: `SERVICEBUSCONNSTR_`
+* Event Hub: `EVENTHUBCONNSTR_`
+* Document Db: `DOCDBCONNSTR_`
+* Redis Cache: `REDISCACHECONNSTR_`
 
 >[!Note]
-> .NET apps targeting PostgreSQL should set the connection string to **Custom** as workaround for a [knows issue in .NET EnvironmentVariablesConfigurationProvider](https://github.com/dotnet/runtime/issues/36123) 
+> .NET apps targeting PostgreSQL, Notification Hub, Service Bus, Event Hub, Document Db and Redis Cache should set the connection string to **Custom** as workaround for a [knows issue in .NET EnvironmentVariablesConfigurationProvider](https://github.com/dotnet/runtime/issues/36123) 
 >
 
 For example, a MySQL connection string named *connectionstring1* can be accessed as the environment variable `MYSQLCONNSTR_connectionString1`. For language-stack specific steps, see:

--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -222,7 +222,7 @@ At runtime, connection strings are available as environment variables, prefixed 
 * Redis Cache: `REDISCACHECONNSTR_`
 
 >[!Note]
-> .NET apps targeting PostgreSQL, Notification Hub, Service Bus, Event Hub, Document Db and Redis Cache should set the connection string to **Custom** as workaround for a [knows issue in .NET EnvironmentVariablesConfigurationProvider](https://github.com/dotnet/runtime/issues/36123) 
+> .NET apps targeting PostgreSQL, Notification Hub, Service Bus, Event Hub, Document Db and Redis Cache should set the connection string to **Custom** as workaround for a [known issue in .NET EnvironmentVariablesConfigurationProvider](https://github.com/dotnet/runtime/issues/36123) 
 >
 
 For example, a MySQL connection string named *connectionstring1* can be accessed as the environment variable `MYSQLCONNSTR_connectionString1`. For language-stack specific steps, see:


### PR DESCRIPTION
This commit expands the workaround for connection string types that are not properly handled by the `EnvironmentVariablesConfigurationProvider`, as detailed in [the already referenced issue](https://github.com/dotnet/runtime/issues/36123). It clarifies that the "Custom" connection string type should be used not only for PostgreSQL but also for Notification Hub, Service Bus, Event Hub, Document Db and Redis Cache. 

Additionally, this update completes the list of connection string types currently available in Azure App Service, along with their respective environment variable prefixes, ensuring comprehensive guidance for users.



