### PR TITLE
Update information about the field "ports".md

### DIFF
--- a/articles/managed-grafana/tutorial-mpe-oss-prometheus.md
+++ b/articles/managed-grafana/tutorial-mpe-oss-prometheus.md
@@ -143,7 +143,7 @@ spec:
     - name: http-web
       protocol: TCP
       port: 9090
-      targetPort: 9090
+      targetPort: http-web # this information should be the same as the selector port configuration
 ```
 
 1. Run the following command to add the private link service to the Prometheus server.


### PR DESCRIPTION
Cxs are using the example on this article to deploy self managed Prometheus.
This YAML content is being used to create a PLS for Prometheus and other services running on AKS cluster and connected to Managed Grafana using Managed Private Endpoint. For example, the service "Loki" or some databases (like MySQL or PostgreSQL).

Bellow a test using all the configuration suggested in the doc:

[Add a private link service to the Prometheus server](https://learn.microsoft.com/en-us/azure/managed-grafana/tutorial-mpe-oss-prometheus#add-a-private-link-service-to-the-prometheus-server)

If i use this YAML file suggested, will be created a PLS with this structure: "_external port + protocol + target port_".
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/67d869f0-f6ea-4de0-a20f-48715967bc27)
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/26b71abd-8a16-4472-87bd-ba23bf59c6af)


But, if you see the "_selector_", the service used "**prometheus-kube-prometheus-prometheus**" uses the configuration "_external port + protocol + **port name**_".
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/7b49ff7c-f4da-4494-bab7-94acd512340c)

This is causing the communication failure when we create the managed private endpoint.
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/377a0648-bfd0-41ee-b278-20b4c77252f3)

If we change the private link service to the same structure as the selector used:
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/ae940f05-573b-4fca-9f97-66205c3a0709)

It works!
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/c98c46d4-3fb3-4d7c-9e4a-57bfc3ea0110)

The same for [Loki service](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/getting-started-with-azure-kubernetes-service-and-loki/ba-p/3406880).

Fail if:
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/8d35a01e-e388-4485-8bab-8744ed82c40b)
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/ed0ef017-de65-4398-ac37-eef5dd2e1ad2)


When i changed the PLS YAML:
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/d5c1d49d-2eb5-46c0-9b63-d82e026f546f)

It works!
![image](https://github.com/MicrosoftDocs/azure-docs/assets/38931377/205cf40b-6f75-4b8c-9084-0a60a57b3036)





