### PR TITLE
Provide working samples

### DIFF
--- a/articles/trusted-signing/how-to-signing-integrations.md
+++ b/articles/trusted-signing/how-to-signing-integrations.md
@@ -53,7 +53,7 @@ To download and install SignTool:
 
 1. Install SignTool from the Windows SDK (minimum version: 10.0.2261.755).
 
-Another option is to use the latest *nuget.exe* file to download and extract the latest SDK Build Tools NuGet package by using PowerShell:
+Another option is to use the latest *nuget.exe* file to download and extract the latest Windows SDK Build Tools NuGet package by using PowerShell:
 
 1. Download *nuget.exe* by running the following download command:  
 
@@ -61,10 +61,10 @@ Another option is to use the latest *nuget.exe* file to download and extract the
    Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\nuget.exe  
    ```
 
-1. Install *nuget.exe* by running the following installation command:
+1. Download and extract Windows SDK Build Tools NuGet package by running the following installation command:
 
    ```powershell
-   .\nuget.exe install Microsoft.Windows.SDK.BuildTools -Version 10.0.20348.19 
+   .\nuget.exe install Microsoft.Windows.SDK.BuildTools -Version 10.0.22621.3233 -x
    ```
 
 ### Download and install .NET 8.0 Runtime
@@ -84,17 +84,23 @@ To download and install the Trusted Signing dlib package (a .zip file):
 
 1. Extract the Trusted Signing dlib zipped content and install it on your signing node in your choice of directory. The node must be the node where you'll use SignTool to sign files.
 
+Another option is to download the [Trusted Signing dlib package](https://www.nuget.org/packages/Microsoft.Trusted.Signing.Client) via NuGet similar like the Windows SDK Build Tools NuGet package:
+
+```powershell
+.\nuget.exe install Microsoft.Trusted.Signing.Client -Version 1.0.53 -x
+```
+
 ### Create a JSON file
 
 To sign by using Trusted Signing, you need to provide the details of your Trusted Signing account and certificate profile that were created as part of the prerequisites. You provide this information on a JSON file by completing these steps:
 
 1. Create a new JSON file (for example, *metadata.json*).
-1. Add the specific values for your Trusted Signing account and certificate profile to the JSON file. The Trusted Signing account is interchangeably called *code signing account*. For more information, see the *metadata.sample.json* file that’s included in the Trusted Signing dlib package or use the following example:
+1. Add the specific values for your Trusted Signing account and certificate profile to the JSON file. For more information, see the *metadata.sample.json* file that’s included in the Trusted Signing dlib package or use the following example:
 
    ```json
    {
      "Endpoint": "<Trusted Signing account endpoint>",
-     "TrustedSigningAccountName": "<Trusted Signing account name>",
+     "CodeSigningAccountName": "<Trusted Signing account name>",
      "CertificateProfileName": "<certificate profile name>",
      "CorrelationId": "<Optional CorrelationId value>"
    }


### PR DESCRIPTION
The NuGet sample contained a Microsoft.Windows.SDK.BuildTools package version which is not compatible with Trusted Signing.
According to the description a minimum version of **10.0.2261.755** is required. Currently the latest non pre-release version is **10.0.22621.3233**.

Added a sample for getting the Microsoft.Trusted.Signing.Client via NuGet.

Fixed JSON meta data sample. `TrustedSigningAccountName` is not working with the latest Microsoft.Trusted.Signing.Client and Microsoft.Windows.SDK.BuildTools.