### PR TITLE
Update bastion-connect-vm-rdp-windows.md

### DIFF
--- a/articles/bastion/bastion-connect-vm-rdp-windows.md
+++ b/articles/bastion/bastion-connect-vm-rdp-windows.md
@@ -53,6 +53,9 @@ See the [Azure Bastion FAQ](bastion-faq.md) for additional requirements.
 ## <a name="rdp"></a>Connect
 
 [!INCLUDE [Connect to a Windows VM](../../includes/bastion-vm-rdp.md)]
+
+> [!NOTE]  
+> Network Security Group (NSG) rules by default allow virtual machines within the same virtual network to communicate with each other. So, while you are connected to the virtual machine, you can RDP to other virtual machines within the virtual network.
  
 ## Next steps
 


### PR DESCRIPTION
The following should be clearly stated in the doc:

"Network Security Group (NSG) rules by default allow virtual machines within the same virtual network to communicate with each other. So, while you are connected to the virtual machine, you can RDP to other virtual machines within the virtual network."