### PR TITLE
Update how-to-configure-coexisting-gateway-portal.md

### DIFF
--- a/articles/expressroute/how-to-configure-coexisting-gateway-portal.md
+++ b/articles/expressroute/how-to-configure-coexisting-gateway-portal.md
@@ -26,7 +26,8 @@ Configuring Site-to-Site VPN and ExpressRoute coexisting connections has several
 The steps to configure both scenarios are covered in this article. You can configure either gateway first. Typically, you incur no downtime when adding a new gateway or gateway connection.
 
 >[!NOTE]
->If you want to create a Site-to-Site VPN over an ExpressRoute connection, see [Site-to-site over Microsoft peering](site-to-site-vpn-over-microsoft-peering.md).
+> * If you want to create a Site-to-Site VPN over an ExpressRoute connection, see [Site-to-site over Microsoft peering](site-to-site-vpn-over-microsoft-peering.md).
+> * For ExpressRoute-VPN Gateway coexistence, if you’ve already deployed an ExpressRoute, you do not need to create a virtual network and gateway subnet as these are prerequisites in creating an ExpressRoute.
 >
 
 ## Limits and limitations


### PR DESCRIPTION
The following should clearly be stated in the doc for clarity:

"For ExpressRoute-VPN Gateway coexistence, if you’ve already deployed an ExpressRoute, you do not need to create a virtual network and gateway subnet as these are prerequisites in creating an ExpressRoute."