### PR TITLE
Update code for connect with linked service

### DIFF
--- a/articles/synapse-analytics/spark/tutorial-spark-pool-filesystem-spec.md
+++ b/articles/synapse-analytics/spark/tutorial-spark-pool-filesystem-spec.md
@@ -105,10 +105,9 @@ FSSPEC can read/write ADLS data by specifying the linked service name.
    import fsspec
    import pandas
    
-   adls_account_name = '' #Provide exact ADLS account name
-   sas_key = TokenLibrary.getConnectionString(<LinkedServiceName>)
+   linked_service_name = '' #Provide exact Linked Service Name
    
-   fsspec_handle = fsspec.open('abfs[s]://<container>/<path-to-file>', account_name =    adls_account_name, sas_token=sas_key)
+   fsspec_handle = fsspec.open('abfs[s]://<container>/<path-to-file>', storage_options={'linked_service': linked_service_name})
    
    with fsspec_handle.open() as f:
        df = pandas.read_csv(f)
@@ -117,17 +116,16 @@ FSSPEC can read/write ADLS data by specifying the linked service name.
    import fsspec
    import pandas
    
-   adls_account_name = '' #Provide exact ADLS account name
+   linked_service_name = '' #Provide exact Linked Service Name
    
    data = pandas.DataFrame({'Name':['Tom', 'nick', 'krish', 'jack'], 'Age':[20, 21, 19, 18]})
-   sas_key = TokenLibrary.getConnectionString(<LinkedServiceName>) 
    
-   fsspec_handle = fsspec.open('abfs[s]://<container>/<path-to-file>', account_name =    adls_account_name, sas_token=sas_key, mode="wt") 
+   fsspec_handle = fsspec.open('abfs[s]://<container>/<path-to-file>', storage_options={'linked_service': linked_service_name}, mode="wt") 
    
    with fsspec_handle.open() as f:
        data.to_csv(f) 
    ```
-
+   
 ## Upload file from local file system to default ADLS storage account of Synapse workspace
 
 FSSPEC can upload a file from the local file system to a Synapse workspace default ADLS storage account.


### PR DESCRIPTION
The old version code always need a sas_key generated from the given linked service, but in some workspaces, `TokenLibrary.getConnectionString(<LinkedServiceName>)` will return an OAuth token, which doesn't work with  `fsspec_handle = fsspec.open('abfs[s]://<container>/<path-to-file>', account_name = adls_account_name, sas_token=sas_key)`