### PR TITLE
fix(Event Hubs): Log compaction Lightbox image corrected

### DIFF
--- a/articles/event-hubs/log-compaction.md
+++ b/articles/event-hubs/log-compaction.md
@@ -15,7 +15,7 @@ Log compaction is a way of retaining data in Event Hubs using event key based re
 
 As shown in the following image, an event log (of an event hub partition) may have multiple events with the same key. If you're using a compacted event hub, then Event Hubs service takes care of purging old events and only keeping the latest events of a given event key. 
 
-:::image type="content" source="./media/event-hubs-log-compaction/log-compaction.png" alt-text="Diagram showing how a topic gets compacted." lightbox="./media/event-hubs-resource-governance-overview/app-groups.png":::
+:::image type="content" source="./media/event-hubs-log-compaction/log-compaction.png" alt-text="Diagram showing how a topic gets compacted." lightbox="./media/event-hubs-log-compaction/log-compaction.png":::
 
 ### Compaction key
 The partition key that you set with each event is used as the compaction key. 


### PR DESCRIPTION
The first lightbox on the Log compaction page showed the second diagram of this page