### PR TITLE
Update mssparkutils doc

### DIFF
--- a/articles/synapse-analytics/spark/synapse-file-mount-api.md
+++ b/articles/synapse-analytics/spark/synapse-file-mount-api.md
@@ -38,7 +38,7 @@ The example assumes that you have one Data Lake Storage Gen2 account named `stor
 
 ![Screenshot of a Data Lake Storage Gen2 storage account.](./media/synapse-file-mount-api/gen2-storage-account.png)
 
-To mount the container called `mycontainer`, `mssparkutils` first needs to check whether you have the permission to access the container. Currently, Azure Synapse Analytics supports three authentication methods for the trigger mount operation: `LinkedService`, `accountKey`, and `sastoken`. 
+To mount the container called `mycontainer`, `mssparkutils` first needs to check whether you have the permission to access the container. Currently, Azure Synapse Analytics supports three authentication methods for the trigger mount operation: `linkedService`, `accountKey`, and `sastoken`. 
 
 ### Mount by using a linked service (recommended)
 
@@ -72,7 +72,7 @@ After you create linked service successfully, you can easily mount the container
 mssparkutils.fs.mount( 
     "abfss://mycontainer@<accountname>.dfs.core.windows.net", 
     "/test", 
-    {"LinkedService":"mygen2account"} 
+    {"linkedService": "mygen2account"} 
 ) 
 ``` 
 
@@ -81,21 +81,21 @@ mssparkutils.fs.mount(
 > ```python
 > from notebookutils import mssparkutils 
 > ```
-> Mount parameters:
-> - fileCacheTimeout: Blobs will be cached in the local temp folder for 120 seconds by default. During this time, blobfuse won't check whether the file is up to date or not. The parameter could be set to change the default timeout time. When multiple clients modify files at the same time, in order to avoid inconsistencies between local and remote files, we recommend shortening the cache time, or even changing it to 0, and always getting the latest files from the server.
-> - timeout: The mount operation timeout is 120 seconds by default. The parameter could be set to change the default timeout time. When there are too many executors or when the mount times out, we recommend increasing the value.
-> - scope: The scope parameter is used to specify the scope of the mount. The default value is "job." If the scope is set to "job," the mount is visible only to the current cluster. If the scope is set to "workspace," the mount is visible to all notebooks in the current workspace, and the mount point is automatically created if it doesn't exist. Add the same parameters to the unmount API to unmount the mount point. The workspace level mount is only supported for linked service authentication.
->
-> You can use these parameters like this:
-> ```python
-> mssparkutils.fs.mount(
->    "abfss://mycontainer@<accountname>.dfs.core.windows.net",
->    "/test",
->    {"linkedService":"mygen2account", "fileCacheTimeout": 120, "timeout": 120}
-> )
-> ```
-> 
 > We don't recommend that you mount a root folder, no matter which authentication method you use.
+
+Mount parameters:
+- fileCacheTimeout: Blobs will be cached in the local temp folder for 120 seconds by default. During this time, blobfuse won't check whether the file is up to date or not. The parameter could be set to change the default timeout time. When multiple clients modify files at the same time, in order to avoid inconsistencies between local and remote files, we recommend shortening the cache time, or even changing it to 0, and always getting the latest files from the server.
+- timeout: The mount operation timeout is 120 seconds by default. The parameter could be set to change the default timeout time. When there are too many executors or when the mount times out, we recommend increasing the value.
+- scope: The scope parameter is used to specify the scope of the mount. The default value is "job." If the scope is set to "job," the mount is visible only to the current cluster. If the scope is set to "workspace," the mount is visible to all notebooks in the current workspace, and the mount point is automatically created if it doesn't exist. Add the same parameters to the unmount API to unmount the mount point. The workspace level mount is only supported for linked service authentication.
+
+You can use these parameters like this:
+```python
+mssparkutils.fs.mount(
+    "abfss://mycontainer@<accountname>.dfs.core.windows.net",
+    "/test",
+    {"linkedService":"mygen2account", "fileCacheTimeout": 120, "timeout": 120}
+)
+```
 
 
 ### Mount via shared access signature token or account key  
@@ -166,47 +166,44 @@ f.close()
 
 The main purpose of the mount operation is to let customers access the data stored in a remote storage account by using a local file system API. You can also access the data by using the `mssparkutils fs` API with a mounted path as a parameter. The path format used here is a little different. 
 
-Assume that you mounted the Data Lake Storage Gen2 container `mycontainer` to `/test` by using the mount API. When you access the data by using a local file system API, the path format is like this: 
-
-`/synfs/{jobId}/test/{filename}`
+Assuming you've mounted the Data Lake Storage Gen2 container mycontainer to /test using the mount API. When accessing the data through a local file system API:
+- For Spark versions less than or equal to 3.3, the path format is `/synfs/{jobId}/test/{filename}`.
+- For Spark versions greater than or equal to 3.4, the path format is `/synfs/notebook/{jobId}/test/{filename}`.
 
 We recommend using a `mssparkutils.fs.getMountPath()` to get the accurate path:
 
 ```python
-path = mssparkutils.fs.getMountPath("/test") # equals to /synfs/{jobId}/test
+path = mssparkutils.fs.getMountPath("/test")
 ```
 
-When you want to access the data by using the `mssparkutils fs` API, the path format is like this: 
+> [!NOTE]
+> When you mount the storage with `workspace` scope, the mount point is created under the `/synfs/workspace` folder. And you need to use `mssparkutils.fs.getMountPath("/test", "workspace")` to get the accurate path.
 
-`synfs:/{jobId}/test/{filename}`
+When you want to access the data by using the `mssparkutils fs` API, the path format is like this: `synfs:/notebook/{jobId}/test/{filename}`. You can see that `synfs` is used as the schema in this case, instead of a part of the mounted path. Of course, you can also use the local file system schema to access the data. For example, `file:/synfs/notebook/{jobId}/test/{filename}`.
 
-You can see that `synfs` is used as the schema in this case, instead of a part of the mounted path. 
-
-The following three examples show how to access a file with a mount point path by using `mssparkutils fs`. In the examples, `49` is a Spark job ID that we got from calling `mssparkutils.env.getJobId()`. 
+The following three examples show how to access a file with a mount point path by using `mssparkutils fs`.
 
 + List directories:  
 
     ```python 
-    mssparkutils.fs.ls("synfs:/49/test") 
+    mssparkutils.fs.ls(f'file:{mssparkutils.fs.getMountPath("/test")}') 
     ``` 
 
 + Read file content: 
 
     ```python 
-    mssparkutils.fs.head("synfs:/49/test/myFile.txt") 
+    mssparkutils.fs.head(f'file:{mssparkutils.fs.getMountPath("/test")}/myFile.csv') 
     ``` 
 
 + Create a directory: 
 
     ```python 
-    mssparkutils.fs.mkdirs("synfs:/49/test/newdir") 
+    mssparkutils.fs.mkdirs(f'file:{mssparkutils.fs.getMountPath("/test")}/myDir') 
     ``` 
 
 ## Access files under the mount point by using the Spark read API 
 
-You can provide a parameter to access the data through the Spark read API. The path format here is the same when you use the `mssparkutils fs` API: 
-
-`synfs:/{jobId}/test/{filename}`
+You can provide a parameter to access the data through the Spark read API. The path format here is the same when you use the `mssparkutils fs` API.
 
 <a id="read-file-from-a-mounted-gen2-storage-account"></a>
 ### Read a file from a mounted Data Lake Storage Gen2 storage account 
@@ -216,7 +213,7 @@ The following example assumes that a Data Lake Storage Gen2 storage account was 
 ```python 
 %%pyspark 
 
-df = spark.read.load("synfs:/49/test/myFile.csv", format='csv') 
+df = spark.read.load(f'file:{mssparkutils.fs.getMountPath("/test")}/myFile.csv', format='csv') 
 df.show() 
 ``` 
 
@@ -242,7 +239,7 @@ If you mounted a Blob Storage account and want to access it by using `mssparkuti
     mssparkutils.fs.mount( 
         "wasbs://mycontainer@<blobStorageAccountName>.blob.core.windows.net", 
         "/test", 
-        Map("LinkedService" -> "myblobstorageaccount") 
+        Map("linkedService" -> "myblobstorageaccount") 
     ) 
     ``` 
 
@@ -250,7 +247,7 @@ If you mounted a Blob Storage account and want to access it by using `mssparkuti
 
     ```python
         # mount the Blob Storage container, and then read the file by using a mount path
-        with open("/synfs/64/test/myFile.txt") as f:
+        with open(mssparkutils.fs.getMountPath("/test") + "/myFile.txt") as f:
         print(f.read())
     ```
 
@@ -259,7 +256,7 @@ If you mounted a Blob Storage account and want to access it by using `mssparkuti
     ```python
     %%spark
     // mount blob storage container and then read file using mount path
-    val df = spark.read.text("synfs:/49/test/myFile.txt")
+    val df = spark.read.text(f'file:{mssparkutils.fs.getMountPath("/test")}/myFile.txt')
     df.show()
     ```
 
@@ -273,11 +270,13 @@ mssparkutils.fs.unmount("/test")
 
 ## Known limitations
 
-+ The `mssparkutils fs help` function hasn't added the description about the mount/unmount part yet. 
-
 + The unmount mechanism is not automatic. When the application run finishes, to unmount the mount point to release the disk space, you need to explicitly call an unmount API in your code. Otherwise, the mount point will still exist in the node after the application run finishes. 
 
 + Mounting a Data Lake Storage Gen1 storage account is not supported for now. 
+
+## Known issues:
+
++ In Spark 3.4, the mount points might be unavailable when there are multiple active sessions running in parallel in the same cluster. You can mount with `workspace` scope to avoid this issue.
 
 ## Next steps
 


### PR DESCRIPTION
This pull request includes changes to the `articles/synapse-analytics/spark/synapse-file-mount-api.md` file. The changes mainly focus on updating the syntax for authentication methods and mount parameters, and providing more detailed instructions for accessing data using different Spark versions and APIs.

Here are the most important changes:

Authentication and Mount Parameters:

* Updated the authentication method syntax from `LinkedService` to `linkedService` in the instructions for mounting a container. [[1]](diffhunk://#diff-63e6be80665f6679a0b0869b93837a2a2e68c3ffa0601c647de5b6ffecbb1332L41-R41) [[2]](diffhunk://#diff-63e6be80665f6679a0b0869b93837a2a2e68c3ffa0601c647de5b6ffecbb1332L75-R75)
* Improved the formatting and clarity of the section describing mount parameters.

Accessing Data:

* Provided separate instructions for accessing data using local file system API based on Spark versions less than or equal to 3.3 and greater than or equal to 3.4.
* Updated the examples of accessing a file with a mount point path using `mssparkutils fs` to reflect the changes in Spark versions.
* Updated the syntax for accessing the data through the Spark read API.

Mounting Blob Storage:

* Updated the syntax for mounting a Blob Storage account from `LinkedService` to `linkedService`.
* Updated the instructions for reading a file using a mount path after mounting a Blob Storage container. [[1]](diffhunk://#diff-63e6be80665f6679a0b0869b93837a2a2e68c3ffa0601c647de5b6ffecbb1332L245-R250) [[2]](diffhunk://#diff-63e6be80665f6679a0b0869b93837a2a2e68c3ffa0601c647de5b6ffecbb1332L262-R259)

Known Limitations and Issues:

* Removed the point about the `mssparkutils fs help` function not having a description about the mount/unmount part.
* Added a known issue about mount points possibly being unavailable when multiple active sessions are running in parallel in the same cluster in Spark 3.4.