### PR TITLE
Update bicep-import.md to remove experimental notices

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-import.md
+++ b/articles/azure-resource-manager/bicep/bicep-import.md
@@ -12,9 +12,6 @@ This article describes the syntax you use to export and import shared functional
 
 ## Exporting types, variables and functions (Preview)
 
-> [!NOTE]
-> [Bicep CLI version 0.23.X or higher](./install.md) is required to use this feature. The experimental feature `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features). For user-defined functions, the experimental feature `userDefinedFunctions` must also be enabled.
-
 The `@export()` decorator is used to indicate that a given statement can be imported by another file. This decorator is only valid on type, variable and function statements. Variable statements marked with `@export()` must be compile-time constants.
 
 The syntax for exporting functionality for use in other Bicep files is:
@@ -25,9 +22,6 @@ The syntax for exporting functionality for use in other Bicep files is:
 ```
 
 ## Import types, variables and functions (Preview)
-
-> [!NOTE]
-> [Bicep CLI version 0.23.X or higher](./install.md) is required to use this feature. The experimental feature `compileTimeImports` must be enabled from the [Bicep config file](./bicep-config.md#enable-experimental-features). For user-defined functions, the experimental feature `userDefinedFunctions` must also be enabled.
 
 The syntax for importing functionality from another Bicep file is:
 


### PR DESCRIPTION
Removing "experimental" notes as `compileTimeImports` and `userDefinedFunctions` are now no longer experimental.