### PR TITLE
Update monitor-cache-reference.md with caution for total keys

### DIFF
--- a/articles/azure-cache-for-redis/monitor-cache-reference.md
+++ b/articles/azure-cache-for-redis/monitor-cache-reference.md
@@ -135,7 +135,7 @@ The following list provides details and more information about the supported Azu
 - Total Keys  
   - The maximum number of keys in the cache during the past reporting time period. This number maps to `keyspace` from the Redis INFO command.
     
-  > [!CAUTION]
+  > [!IMPORTANT]
   > Because of a limitation in the underlying metrics system for caches with clustering enabled, Total Keys return the maximum number of keys of the shard that had the maximum number of keys during the reporting interval.
 - Total Operations
   - The total number of commands processed by the cache server during the specified reporting interval. This value maps to `total_commands_processed` from the Redis INFO command. When Azure Cache for Redis is used purely for pub/sub, there are no metrics for `Cache Hits`, `Cache Misses`, `Gets`, or `Sets`, but there are `Total Operations` metrics that reflect the cache usage for pub/sub operations.

--- a/articles/azure-cache-for-redis/monitor-cache-reference.md
+++ b/articles/azure-cache-for-redis/monitor-cache-reference.md
@@ -133,7 +133,10 @@ The following list provides details and more information about the supported Azu
 - Sets
   - The number of set operations to the cache during the specified reporting interval. This value is the sum of the following values from the Redis INFO all command: `cmdstat_set`, `cmdstat_hset`, `cmdstat_hmset`, `cmdstat_hsetnx`, `cmdstat_lset`, `cmdstat_mset`, `cmdstat_msetnx`, `cmdstat_setbit`, `cmdstat_setex`, `cmdstat_setrange`, and `cmdstat_setnx`.
 - Total Keys  
-  - The maximum number of keys in the cache during the past reporting time period. This number maps to `keyspace` from the Redis INFO command. Because of a limitation in the underlying metrics system for caches with clustering enabled, Total Keys return the maximum number of keys of the shard that had the maximum number of keys during the reporting interval.
+  - The maximum number of keys in the cache during the past reporting time period. This number maps to `keyspace` from the Redis INFO command.
+    
+  > [!CAUTION]
+  > Because of a limitation in the underlying metrics system for caches with clustering enabled, Total Keys return the maximum number of keys of the shard that had the maximum number of keys during the reporting interval.
 - Total Operations
   - The total number of commands processed by the cache server during the specified reporting interval. This value maps to `total_commands_processed` from the Redis INFO command. When Azure Cache for Redis is used purely for pub/sub, there are no metrics for `Cache Hits`, `Cache Misses`, `Gets`, or `Sets`, but there are `Total Operations` metrics that reflect the cache usage for pub/sub operations.
 - Used Memory

--- a/articles/azure-cache-for-redis/monitor-cache-reference.md
+++ b/articles/azure-cache-for-redis/monitor-cache-reference.md
@@ -4,7 +4,7 @@ description: This article contains important reference material you need when yo
 ms.date: 05/13/2024
 ms.custom: horz-monitor
 ms.topic: reference
-author: robb
+author: rboucher
 ms.author: robb
 ms.service: cache
 ---

--- a/articles/azure-cache-for-redis/monitor-cache-reference.md
+++ b/articles/azure-cache-for-redis/monitor-cache-reference.md
@@ -137,6 +137,7 @@ The following list provides details and more information about the supported Azu
     
   > [!IMPORTANT]
   > Because of a limitation in the underlying metrics system for caches with clustering enabled, Total Keys return the maximum number of keys of the shard that had the maximum number of keys during the reporting interval.
+  
 - Total Operations
   - The total number of commands processed by the cache server during the specified reporting interval. This value maps to `total_commands_processed` from the Redis INFO command. When Azure Cache for Redis is used purely for pub/sub, there are no metrics for `Cache Hits`, `Cache Misses`, `Gets`, or `Sets`, but there are `Total Operations` metrics that reflect the cache usage for pub/sub operations.
 - Used Memory


### PR DESCRIPTION
add a caution label for the limitation of total keys, as expected behavior would be that it is the maximum of all shards combined, and no the total keys of the shard with most keys