### PR TITLE
Update how-to-secure-workspace-vnet.md

### DIFF
--- a/articles/machine-learning/how-to-secure-workspace-vnet.md
+++ b/articles/machine-learning/how-to-secure-workspace-vnet.md
@@ -273,6 +273,8 @@ Azure Container Registry can be configured to use a private endpoint. Use the fo
     az ml workspace update --name myworkspace --resource-group myresourcegroup --image-build-compute mycomputecluster
     ```
 
+    You can switch back to serverless compute by executing the same command and leaving the `mycomputecluster` reference empty.
+
     # [Python SDK](#tab/python)
 
     The following code snippet demonstrates how to update the workspace to set a build compute using the [Azure Machine Learning SDK](/python/api/overview/azure/ai-ml-readme). Replace `mycomputecluster` with the name of the cluster to use:
@@ -297,7 +299,8 @@ Azure Container Registry can be configured to use a private endpoint. Use the fo
     # Update to use cpu-cluster for image builds
     ws.image_build_compute="cpu-cluster"
     ml_client.workspaces.begin_update(ws)
-    # To switch back to using ACR to build (if ACR is not in the VNet):
+    
+    # To switch back to serverless compute:
     # ws.image_build_compute = ''
     # ml_client.workspaces.begin_update(ws)
     ```
@@ -310,12 +313,6 @@ Azure Container Registry can be configured to use a private endpoint. Use the fo
     Currently there isn't a way to set the image build compute from the Azure portal.
 
     ---
-
-> [!TIP]
-> If you have configured your image build compute to use a compute cluster and want to reverse this decision, execute the same command but leave the image-build-compute reference empty:
-> ```azurecli
->   az ml workspace update --name myworkspace --resource-group myresourcegroup --image-build-compute ''
->    ```
 
 > [!TIP]
 > When ACR is behind a VNet, you can also [disable public access](../container-registry/container-registry-access-selected-networks.md#disable-public-network-access) to it.

--- a/articles/machine-learning/how-to-secure-workspace-vnet.md
+++ b/articles/machine-learning/how-to-secure-workspace-vnet.md
@@ -273,7 +273,7 @@ Azure Container Registry can be configured to use a private endpoint. Use the fo
     az ml workspace update --name myworkspace --resource-group myresourcegroup --image-build-compute mycomputecluster
     ```
 
-    You can switch back to serverless compute by executing the same command and leaving the `mycomputecluster` reference empty.
+    You can switch back to serverless compute by executing the same command and referencing the compute as an empty space: `--image-build-compute ' '`.
 
     # [Python SDK](#tab/python)
 


### PR DESCRIPTION
Comments in the Python code example were wrong (setting image_build_compute to an empty string will bring customer's workspace back to serverless compute, which is the default option, not ACR tasks). Fixed the comment in that Python SDK example and moved the tip I had written in the previous PR to the respective CLI tab.