### PR TITLE
Update resource-manager-lock-resources.md

### DIFF
--- a/includes/resource-manager-lock-resources.md
+++ b/includes/resource-manager-lock-resources.md
@@ -9,7 +9,9 @@ ms.author: tomfitz
 1. In the Settings blade for the resource, resource group, or subscription that you wish to lock, select **Locks**.
 
     :::image type="content" source="media/resource-manager-lock-resources/select-lock.png" alt-text="Select lock.":::
-
+> [!NOTE]  
+> You cannot add a lock to management groups.
+> 
 1. To add a lock, select **Add**. If you want to create a lock at a parent level, select the parent. The currently selected resource inherits the lock from the parent. For example, you could lock the resource group to apply a lock to all its resources.
 
     :::image type="content" source="media/resource-manager-lock-resources/add-lock.png" alt-text="Add lock.":::

--- a/includes/resource-manager-lock-resources.md
+++ b/includes/resource-manager-lock-resources.md
@@ -9,9 +9,8 @@ ms.author: tomfitz
 1. In the Settings blade for the resource, resource group, or subscription that you wish to lock, select **Locks**.
 
     :::image type="content" source="media/resource-manager-lock-resources/select-lock.png" alt-text="Select lock.":::
-> [!NOTE]  
-> You cannot add a lock to management groups.
-> 
+   > [!NOTE]  
+   > You can't add a lock to management groups.
 1. To add a lock, select **Add**. If you want to create a lock at a parent level, select the parent. The currently selected resource inherits the lock from the parent. For example, you could lock the resource group to apply a lock to all its resources.
 
     :::image type="content" source="media/resource-manager-lock-resources/add-lock.png" alt-text="Add lock.":::


### PR DESCRIPTION
The fact that management groups can't get locks, isn't shown up while Googling and requires pre-existing knowledge or deciphering the existing doc. It should be clearly stated:

"You cannot add a lock to management groups."