### PR TITLE
Update move-resource-group-and-subscription.md

### DIFF
--- a/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
+++ b/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
@@ -19,6 +19,9 @@ If your move requires setting up new dependent resources, you'll experience an i
 
 Moving a resource only moves it to a new resource group or subscription. It doesn't change the location of the resource.
 
+> [!NOTE]  
+> You cannot move Azure resources to a another resource group or another subscription if there is a read-only lock whether in source or in destination. 
+
 ## Changed resource ID
 
 When you move a resource, you change its resource ID. The standard format for a resource ID is `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}`. When you move a resource to a new resource group or subscription, you change one or more values in that path.

--- a/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
+++ b/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
@@ -20,7 +20,7 @@ If your move requires setting up new dependent resources, you'll experience an i
 Moving a resource only moves it to a new resource group or subscription. It doesn't change the location of the resource.
 
 > [!NOTE]  
-> You cannot move Azure resources to a another resource group or another subscription if there is a read-only lock whether in source or in destination. 
+> You can't move Azure resources to another resource group or another subscription if there's a read-only lock, whether in the source or in the destination. 
 
 ## Changed resource ID
 


### PR DESCRIPTION
There is no mention of read-only locks in this page. Following should be clearly stated:

"You cannot move Azure resources to a another resource group or another subscription if there is a read-only lock whether in source or in destination. "