### PR TITLE
Update delete-resource-group.md

### DIFF
--- a/articles/azure-resource-manager/management/delete-resource-group.md
+++ b/articles/azure-resource-manager/management/delete-resource-group.md
@@ -13,6 +13,9 @@ ai-usage: ai-assisted
 
 This article shows how to delete resource groups and resources. It describes how Azure Resource Manager orders the deletion of resources when you delete a resource group.
 
+> [!NOTE]  
+> To delete a resource group, firstly you need to delete its underlying resource locks as well as backup data.
+> 
 ## How order of deletion is determined
 
 When you delete a resource group, Resource Manager determines the order to delete resources. It uses the following order:

--- a/articles/azure-resource-manager/management/delete-resource-group.md
+++ b/articles/azure-resource-manager/management/delete-resource-group.md
@@ -14,7 +14,7 @@ ai-usage: ai-assisted
 This article shows how to delete resource groups and resources. It describes how Azure Resource Manager orders the deletion of resources when you delete a resource group.
 
 > [!NOTE]  
-> To delete a resource group, you must first remove any underlying [resource locks](articles/azure-resource-manager/management/delete-resource-group.md) and backup data.
+> To delete a resource group, you must first remove any underlying [resource locks](https://github.com/MicrosoftDocs/azure-docs/pull/delete-resource-group.md) and backup data.
 >
 
 ## How order of deletion is determined

--- a/articles/azure-resource-manager/management/delete-resource-group.md
+++ b/articles/azure-resource-manager/management/delete-resource-group.md
@@ -14,8 +14,9 @@ ai-usage: ai-assisted
 This article shows how to delete resource groups and resources. It describes how Azure Resource Manager orders the deletion of resources when you delete a resource group.
 
 > [!NOTE]  
-> To delete a resource group, firstly you need to delete its underlying resource locks as well as backup data.
-> 
+> To delete a resource group, you must first remove any underlying [resource locks](articles/azure-resource-manager/management/delete-resource-group.md) and backup data.
+>
+
 ## How order of deletion is determined
 
 When you delete a resource group, Resource Manager determines the order to delete resources. It uses the following order:

--- a/articles/azure-resource-manager/management/delete-resource-group.md
+++ b/articles/azure-resource-manager/management/delete-resource-group.md
@@ -14,7 +14,7 @@ ai-usage: ai-assisted
 This article shows how to delete resource groups and resources. It describes how Azure Resource Manager orders the deletion of resources when you delete a resource group.
 
 > [!NOTE]  
-> To delete a resource group, you must first remove any underlying [resource locks](https://github.com/MicrosoftDocs/azure-docs/pull/delete-resource-group.md) and backup data.
+> To delete a resource group, you must first remove any underlying resource locks and backup data.
 >
 
 ## How order of deletion is determined


### PR DESCRIPTION
The following should be clearly stated in the doc because currently this information is scattered:

"To delete a resource group, firstly you need to delete its underlying resource locks as well as backup data."