### PR TITLE
Document the new HttpContext binding for Azure Functions HTTP triggers

### DIFF
--- a/articles/azure-functions/dotnet-isolated-process-guide.md
+++ b/articles/azure-functions/dotnet-isolated-process-guide.md
@@ -433,6 +433,27 @@ To enable ASP.NET Core integration for HTTP:
     }
     ```
 
+1. Since version 1.?.? of the [Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore/) package, it is also possible to work directly with the `HttpContext`:
+
+    ```csharp
+    [Function("HttpFunction")]
+    public async Task RunAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get")] HttpContext httpContext)
+    {
+        static int WriteBody(PipeWriter writer)
+        {
+            ReadOnlySpan<byte> body = "Welcome to Azure Functions!"u8;
+            writer.Write(body);
+            return body.Length;
+        }
+        
+        var responseHeaders = httpContext.Response.GetTypedHeaders();
+        responseHeaders.ContentLength = WriteBody(httpContext.Response.BodyWriter);
+        responseHeaders.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Text.Plain);
+        await httpContext.Response.BodyWriter.FlushAsync();
+    }
+    ```
+
 ### Built-in HTTP model
 
 In the built-in model, the system translates the incoming HTTP request message into an [HttpRequestData] object that is passed to the function. This object provides data from the request, including `Headers`, `Cookies`, `Identities`, `URL`, and optionally a message `Body`. This object is a representation of the HTTP request but isn't directly connected to the underlying HTTP listener or the received message. 

--- a/articles/azure-functions/functions-bindings-http-webhook-trigger.md
+++ b/articles/azure-functions/functions-bindings-http-webhook-trigger.md
@@ -662,7 +662,8 @@ The trigger input type is declared as one of the following types:
 
 | Type              | Description | 
 |-|-|
-| [HttpRequest]     | _Use of this type requires that the app is configured with [ASP.NET Core integration in .NET Isolated]._<br/>This gives you full access to the request object and overall HttpContext. |
+| [HttpContext]     | _Use of this type requires that the app is configured with [ASP.NET Core integration in .NET Isolated]._<br/>This gives you full access to the HTTP context object. |
+| [HttpRequest]     | _Use of this type requires that the app is configured with [ASP.NET Core integration in .NET Isolated]._<br/>This gives you full access to the HTTP request object. |
 | [HttpRequestData] | A projection of the request object. |
 | A custom type     | When the body of the request is JSON, the runtime will try to parse it to set the object properties. |
 
@@ -692,7 +693,7 @@ namespace AspNetIntegration
 
 # [In-process model](#tab/in-process)   
 
-The trigger input type is declared as either `HttpRequest` or a custom type. If you choose `HttpRequest`, you get full access to the request object. For a custom type, the runtime tries to parse the JSON request body to set the object properties.
+The trigger input type is declared as either `HttpContext`,  `HttpRequest` or a custom type. If you choose `HttpContext` or `HttpRequest`, you get full access to the respectively the HTTP context or request object. For a custom type, the runtime tries to parse the JSON request body to set the object properties.
 
 ---
 
@@ -1216,6 +1217,7 @@ If a function that uses the HTTP trigger doesn't complete within 230 seconds, th
 [ASP.NET Core integration in .NET Isolated]: ./dotnet-isolated-process-guide.md#aspnet-core-integration
 [HttpRequestData]: /dotnet/api/microsoft.azure.functions.worker.http.httprequestdata
 [HttpResponseData]: /dotnet/api/microsoft.azure.functions.worker.http.httpresponsedata
+[HttpContext]: /dotnet/api/microsoft.aspnetcore.http.httpcontext
 [HttpRequest]: /dotnet/api/microsoft.aspnetcore.http.httprequest
 [HttpResponse]: /dotnet/api/microsoft.aspnetcore.http.httpresponse
 [IActionResult]: /dotnet/api/microsoft.aspnetcore.mvc.iactionresult


### PR DESCRIPTION
This pull request documents changes introduced in https://github.com/Azure/azure-functions-dotnet-worker/pull/2486 which has just been opened.

It is submitted as a draft because the new HttpContext binding feature has not yet been released. It mentions _version 1.?.?_ because the exact version number where will be introduced is not yet known. The version number will need to be updated before merging this pull request, after a new version of the [Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore/) package that includes this feature is released.