### PR TITLE
add warning for azureml-fe logging

### DIFF
--- a/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
+++ b/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
@@ -90,6 +90,9 @@ The front-end component (azureml-fe) that routes incoming inference requests to 
 > [!IMPORTANT]
 > When using a cluster configured as `dev-test`, the self-scaler is *disabled*. Even for FastProd/DenseProd clusters, Self-Scaler is only enabled when telemetry shows that it's needed.
 
+> [!IMPORTANT]
+> Azure Machine Learning does not upload and or save container logs, even for system containers. For full debuggability, you should [enable Container Insights for your AKS cluster](../../azure-monitor/containers/kubernetes-monitoring-enable.md#enable-container-insights) on your own to save and manage container logs, and share the related logs with AML team. Otherwise, AML does not commit SLA on azureml-fe related issues.
+
 > [!NOTE]
 > The maximum request payload is 100MB.
 

--- a/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
+++ b/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
@@ -91,7 +91,7 @@ The front-end component (azureml-fe) that routes incoming inference requests to 
 > When using a cluster configured as `dev-test`, the self-scaler is *disabled*. Even for FastProd/DenseProd clusters, Self-Scaler is only enabled when telemetry shows that it's needed.
 
 > [!IMPORTANT]
-> Azure Machine Learning does not upload and or save container logs, even for system containers. For full debuggability, you should [enable Container Insights for your AKS cluster](../../azure-monitor/containers/kubernetes-monitoring-enable.md#enable-container-insights) on your own to save and manage container logs, and share the related logs with AML team. Otherwise, AML does not commit SLA on azureml-fe related issues.
+> Azure Machine Learning does not upload and or save container logs, even for system containers. For full debuggability, you should [enable Container Insights for your AKS cluster](../../azure-monitor/containers/kubernetes-monitoring-enable.md#enable-container-insights) on your own to save and manage container logs, and share the related logs with AML team when necessary. Otherwise, AML does not commit SLA on azureml-fe related issues.
 
 > [!NOTE]
 > The maximum request payload is 100MB.

--- a/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
+++ b/articles/machine-learning/v1/how-to-deploy-azure-kubernetes-service.md
@@ -7,8 +7,8 @@ ms.service: machine-learning
 ms.subservice: inferencing
 ms.topic: how-to
 ms.custom: UpdateFrequency5, deploy, cliv1, sdkv1
-author: bozhong68
-ms.author: bozhlin
+author: Martin-Jia
+ms.author: mingj
 ms.reviewer: larryfr
 ms.date: 03/08/2024
 ---


### PR DESCRIPTION
Now for AKS compute targets, we have ended uploading azureml-fe logs to our system managed kusto logs. Add this warning to let the customers to manage the logs on their own.