### PR TITLE
Add CA Certificates as a limitation

### DIFF
--- a/articles/api-management/v2-service-tiers-overview.md
+++ b/articles/api-management/v2-service-tiers-overview.md
@@ -83,7 +83,8 @@ The following API Management capabilities are currently unavailable in the v2 ti
 * Inbound connection using a private endpoint
 * Injection in a VNet in external mode or internal mode
 * Upgrade to v2 tiers from v1 tiers 
-* Workspaces 
+* Workspaces
+* CA Certificates
 
 **Developer portal**
 * Delegation of user registration and product subscription


### PR DESCRIPTION
CA certificates are currently not supported in V2 tiers. We need to add this to our docs.