### PR TITLE
Update reference.md

### DIFF
--- a/articles/ai-services/openai/reference.md
+++ b/articles/ai-services/openai/reference.md
@@ -443,7 +443,7 @@ curl -X POST https://{your-resource-name}.openai.azure.com/openai/deployments/{d
 
 #### Example response
 
-The operation returns a `202` status code and an `GenerateImagesResponse` JSON object containing the ID and status of the operation.
+The operation returns a `200` status code and an `GenerateImagesResponse` JSON object containing the created image(s).
 
 ```json
 { 


### PR DESCRIPTION
the documentation stated that a 202 was returned with information on the status of the image but that's how the original image API worked; the new one with DALLE returns a 200 and contains the image.