### PR TITLE
Update redundancy-migration.md

### DIFF
--- a/articles/storage/common/redundancy-migration.md
+++ b/articles/storage/common/redundancy-migration.md
@@ -115,7 +115,7 @@ az storage account update \
 
 ### Perform a conversion
 
-A redundancy "conversion" is the process of changing the zone-redundancy aspect of a storage account.
+A redundancy "conversion" is the process of changing the zone-redundancy aspect of a storage account. Conversion was formerly known as "live migration".
 
 During a conversion, there's [no data loss or application downtime required](#downtime-requirements).
 


### PR DESCRIPTION
In many 3rd party websites and even Microsoft's own forum, there are many references to "live migration" (see examples below). I guess this is an old name but I see no mention of it in the doc, which is confusing. I've clarified it to prevent confusion:

"Conversion was formerly known as "live migration""

Few examples:
https://learn.microsoft.com/en-us/answers/questions/1215467/clarifications-required-on-storage-redundancy

https://learn.microsoft.com/en-us/answers/questions/311529/azure-storage-account-switch-between-types-of-repl