### PR TITLE
Update virtual-network-network-interface.md

### DIFF
--- a/articles/virtual-network/virtual-network-network-interface.md
+++ b/articles/virtual-network/virtual-network-network-interface.md
@@ -277,7 +277,9 @@ Use [Get-AzNetworkInterface](/powershell/module/az.network/get-aznetworkinterfac
 ```azurepowershell-interactive
 Get-AzNetworkInterface -Name myNIC -ResourceGroupName myResourceGroup
 ```
-
+> [!NOTE]  
+> You can associate NSGs to virtual machine's NIC for granular traffic restriction within a virtual network or a subnet. For example, if you have dev, test and production VMs within a virtual network, you can associate separate NSGs to their NICs to control and restrict their corresponding traffic. However, Azure recommends assigning NSGs at subnet level to reduce complexity.
+> 
 ---
 
 ## Change network interface settings


### PR DESCRIPTION
I recommend to add the following to inform readers about capabilities of NSGs:

"You can associate NSGs to virtual machine's NIC for granular traffic restriction within a virtual network or a subnet. For example, if you have dev, test and production VMs within a virtual network, you can associate separate NSGs to their NICs to control and restrict their corresponding traffic. However, Azure recommends assigning NSGs at subnet level to reduce complexity."