### PR TITLE
Update azure-to-azure-how-to-reprotect.md

### DIFF
--- a/articles/site-recovery/azure-to-azure-how-to-reprotect.md
+++ b/articles/site-recovery/azure-to-azure-how-to-reprotect.md
@@ -18,7 +18,7 @@ When you [fail over](site-recovery-failover.md) Azure virtual machines from one 
 
 ## Prerequisites
 
-- The virtual machine failover from the primary to secondary region must be committed.
+- The virtual machine failover from the primary to secondary region must be committed. The VM Status must be *Failover committed* before you start.
 - The primary target site should be available, and you should be able to access or create resources in that region.
 
 ## Reprotect a virtual machine

--- a/articles/site-recovery/azure-to-azure-how-to-reprotect.md
+++ b/articles/site-recovery/azure-to-azure-how-to-reprotect.md
@@ -18,7 +18,7 @@ When you [fail over](site-recovery-failover.md) Azure virtual machines from one 
 
 ## Prerequisites
 
-- The virtual machine failover from the primary to secondary region must be committed. The VM Status must be *Failover committed* before you start.
+- The virtual machine failover from the primary to secondary region must be committed. The virtual machine status must be **Failover committed** before you start.
 - The primary target site should be available, and you should be able to access or create resources in that region.
 
 ## Reprotect a virtual machine


### PR DESCRIPTION
The following should be added for better clarity and to be consistent with other pages in the doc:

"The VM Status must be *Failover committed* before you start."

Other relevant pages in the doc:
https://learn.microsoft.com/en-us/azure/site-recovery/azure-to-azure-tutorial-failover-failback