### PR TITLE
Update go.md for openai

### DIFF
--- a/articles/ai-services/openai/includes/go.md
+++ b/articles/ai-services/openai/includes/go.md
@@ -41,6 +41,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 func main() {
@@ -54,7 +55,7 @@ func main() {
 		return
 	}
 
-	keyCredential, err := azopenai.NewKeyCredential(azureOpenAIKey)
+	keyCredential := azcore.NewKeyCredential(azureOpenAIKey)
 
 	if err != nil {
 		// TODO: handle error


### PR DESCRIPTION
According to 
https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai#NewClientWithKeyCredential 
we need to use `azcore.NewKeyCredential(key)`
from https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azcore#NewKeyCredential
Not `keyCredential, err := azopenai.NewKeyCredential(azureOpenAIKey)` that is shown in the example