### PR TITLE
Update linux-vm-connect.md

### DIFF
--- a/articles/virtual-machines/linux-vm-connect.md
+++ b/articles/virtual-machines/linux-vm-connect.md
@@ -92,7 +92,7 @@ Once the above prerequisites are met, you're ready to connect to your VM. Open y
     If you have never connected to this VM before, you're asked to verify the hosts fingerprint. It's tempting to accept the fingerprint presented, but that exposes you to a potential person in the middle attack. You should always validate the hosts fingerprint. You only need to do this the first time you connect from a client. To get the host fingerprint via the portal, use the Run Command feature to execute the command:
 
      ```bash
-     ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub | awk '{print $2}'
+     ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub | awk '{print $2}'
      ```
 5. Success! You should now be connected to your VM. If you're unable to connect, see [Troubleshoot SSH connections](/troubleshoot/azure/virtual-machines/troubleshoot-ssh-connection).
 
@@ -106,7 +106,7 @@ Once the above prerequisites are met, you're ready to connect to your VM. Open y
     If you have never connected to the desired VM from your current SSH client before you're asked to verify the host's fingerprint. While the default option is to accept the fingerprint presented, you're exposed to a possible "person in the middle attack". You should always validate the host's fingerprint, which only needs to be done the first time your client connects. To obtain the host fingerprint via the portal, use the Run Command feature to execute the command:
 
     ```bash
-    ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub | awk '{print $2}'
+    ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub | awk '{print $2}'
     ```
 
 3. Success! You should now be connected to your VM. If you're unable to connect, see our [troubleshooting guide](/troubleshoot/azure/virtual-machines/troubleshoot-ssh-connection).
@@ -128,7 +128,7 @@ Once the above prerequisites are met, you're ready to connect to your VM. Open y
 
     If you have never connected to the desired VM from your current SSH client before you're asked to verify the host's fingerprint. While the default option is to accept the fingerprint presented, you're exposed to a possible "person in the middle attack". You should always validate the host's fingerprint, which only needs to be done the first time your client connects. To obtain the host fingerprint via the portal, use the Run Command feature to execute the command:
     ```bash
-    ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub | awk '{print $2}'
+    ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub | awk '{print $2}'
     ```
 
 3. Success! You should now be connected to your VM. If you're unable to connect, see [Troubleshoot SSH connections](/troubleshoot/azure/virtual-machines/troubleshoot-ssh-connection).
@@ -150,8 +150,7 @@ Once the above prerequisites are met, you're ready to connect to your VM. Open y
     If you have never connected to the desired VM from your current SSH client before you're asked to verify the host's fingerprint. While the default option is to accept the fingerprint presented, you're exposed to a possible "person in the middle attack". You should always validate the host's fingerprint, which only needs to be done the first time your client connects. To obtain the host fingerprint via the portal, use the Run Command feature to execute the command:
 
     ```azurepowershell-interactive
-    Invoke-AzVMRunCommand -ResourceGroupName 'myResourceGroup' -VMName 'myVM' -CommandId 'RunPowerShellScript' -ScriptString
-    'ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub | awk '{print $2}''
+    Invoke-AzVMRunCommand -ResourceGroupName 'myResourceGroup' -VMName 'myVM' -CommandId 'RunShellScript' -ScriptString "ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub | awk '{print $2}'"
     ```
 
 4. Success! You should now be connected to your VM. If you're unable to connect, see [Troubleshoot SSH connections](/troubleshoot/azure/virtual-machines/troubleshoot-ssh-connection).
@@ -174,7 +173,7 @@ Once the above prerequisites are met, you're ready to connect to your VM. Open y
     If you have never connected to the desired VM from your current SSH client before you're asked to verify the host's fingerprint. While the default option is to accept the fingerprint presented, you're exposed to a possible "person in the middle attack". You should always validate the host's fingerprint, which only needs to be done the first time your client connects. To obtain the host fingerprint via the portal, use the Run Command feature to execute the command:
 
     ```bash
-    ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub | awk '{print $2}'
+    ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub | awk '{print $2}'
     ```
 
 3. Success! You should now be connected to your VM. If you're unable to connect using the methods above, see [Troubleshoot SSH connections](/troubleshoot/azure/virtual-machines/troubleshoot-ssh-connection).


### PR DESCRIPTION
Fix incorrect powershell newline and script string quotation marks in articles/virtual-machines/linux-vm-connect.md that made copying and pasting interactive azure powershell not work well.

Replace usage of ecdsa with ed25519 when checking ssh fingerprints, since ed25519 has been the default for OpenSSH since v8.2 (2020-02-14).