### PR TITLE
Update expand-disks.md

### DIFF
--- a/articles/virtual-machines/linux/expand-disks.md
+++ b/articles/virtual-machines/linux/expand-disks.md
@@ -81,6 +81,10 @@ In the following samples, replace example parameter names such as *myResourceGro
 
 > [!IMPORTANT]
 > If your disk meets the requirements in [Expand without downtime](#expand-without-downtime), you can skip step 1 and 3.
+>
+> Shrinking an existing disk isn’t supported and may result in data loss.
+> 
+> After expanding the disks, you need to [Expand the volume in the operating system](#expand-the-volume-in-the-operating-system) to take advantage of the larger disk.
 
 1. Operations on virtual hard disks can't be performed with the VM running. Deallocate your VM with [az vm deallocate](/cli/azure/vm#az-vm-deallocate). The following example deallocates the VM named *myVM* in the resource group named *myResourceGroup*:
 


### PR DESCRIPTION
Unless you use Expand without downtime, expanding a data disk requires the VM to be deallocated.

Shrinking an existing disk isn’t supported and may result in data loss.

After expanding the disks, you need to Expand the volume in the operating system to take advantage of the larger disk.