### PR TITLE
Update concept-compute-target.md

### DIFF
--- a/articles/machine-learning/concept-compute-target.md
+++ b/articles/machine-learning/concept-compute-target.md
@@ -141,12 +141,12 @@ While Azure Machine Learning supports these VM series, they might not be availab
 :::moniker range="azureml-api-1"
 > [!NOTE]
 > Azure Machine Learning doesn't support all VM sizes that Azure Compute supports. To list the available VM sizes, use the following method:
-> * [REST API](https://learn.microsoft.com/en-us/rest/api/azureml/virtual-machine-sizes/list?view=rest-azureml-2024-04-01&tabs=HTTP)
+> * [REST API](/rest/api/azureml/virtual-machine-sizes/list)
 :::moniker-end
 :::moniker range="azureml-api-2"
 > [!NOTE]
 > Azure Machine Learning doesn't support all VM sizes that Azure Compute supports. To list the available VM sizes, use one of the following methods:
-> * [REST API](https://learn.microsoft.com/rest/api/azureml/virtual-machine-sizes/list?view=rest-azureml-2024-04-01&tabs=HTTP)
+> * [REST API](/rest/api/azureml/virtual-machine-sizes/list)
 > * The [Azure CLI extension 2.0 for machine learning](how-to-configure-cli.md) command, [az ml compute list-sizes](/cli/azure/ml/compute#az-ml-compute-list-sizes).
 :::moniker-end
 

--- a/articles/machine-learning/concept-compute-target.md
+++ b/articles/machine-learning/concept-compute-target.md
@@ -141,12 +141,12 @@ While Azure Machine Learning supports these VM series, they might not be availab
 :::moniker range="azureml-api-1"
 > [!NOTE]
 > Azure Machine Learning doesn't support all VM sizes that Azure Compute supports. To list the available VM sizes, use the following method:
-> * [REST API](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2020-08-01/examples/ListVMSizesResult.json)
+> * [REST API](https://learn.microsoft.com/en-us/rest/api/azureml/virtual-machine-sizes/list?view=rest-azureml-2024-04-01&tabs=HTTP)
 :::moniker-end
 :::moniker range="azureml-api-2"
 > [!NOTE]
 > Azure Machine Learning doesn't support all VM sizes that Azure Compute supports. To list the available VM sizes, use one of the following methods:
-> * [REST API](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/machinelearningservices/resource-manager/Microsoft.MachineLearningServices/stable/2020-08-01/examples/ListVMSizesResult.json)
+> * [REST API](https://learn.microsoft.com/rest/api/azureml/virtual-machine-sizes/list?view=rest-azureml-2024-04-01&tabs=HTTP)
 > * The [Azure CLI extension 2.0 for machine learning](how-to-configure-cli.md) command, [az ml compute list-sizes](/cli/azure/ml/compute#az-ml-compute-list-sizes).
 :::moniker-end
 


### PR DESCRIPTION
corrected the links to list the VM size, correcting the links to REST API reference in the attached screenshot
<img width="461" alt="image" src="https://github.com/MicrosoftDocs/azure-docs/assets/139238878/71308dc1-b484-4a60-89b2-52008b1b7ebb">


