### PR TITLE
Added "168.63.129.16 isn't resolved by reverse DNS lookup" on what-is…

### DIFF
--- a/articles/virtual-network/what-is-ip-address-168-63-129-16.md
+++ b/articles/virtual-network/what-is-ip-address-168-63-129-16.md
@@ -35,6 +35,8 @@ The public IP address 168.63.129.16 is used in all regions and all national clou
 
   By default DNS communication isn't subject to the configured network security groups unless targeted using the [AzurePlatformDNS](../virtual-network/service-tags-overview.md#available-service-tags) service tag. To block DNS traffic to Azure DNS through NSG, create an outbound rule to deny traffic to [AzurePlatformDNS](../virtual-network/service-tags-overview.md#available-service-tags). Specify **"Any"** as **"Source"**, **"*"** as **"Destination port ranges"**, **"Any"** as protocol and **"Deny"** as action.
 
+  In addition, 168.63.129.16 isn't resolved by reverse DNS lookup, which means that you cannot get any FQDN if you would want to get the FQDN using reverse lookup commands such as `host`, `nslookup`, or `dig -x` with 168.63.129.16. 
+
 - When the VM is part of a load balancer backend pool, [health probe](../load-balancer/load-balancer-custom-probe-overview.md) communication should be allowed to originate from 168.63.129.16. The default network security group configuration has a rule that allows this communication. This rule uses the [AzureLoadBalancer](../virtual-network/service-tags-overview.md#available-service-tags) service tag. If desired, this traffic can be blocked by configuring the network security group. The configuration of the block result in probes that fail.
 
 ## Troubleshoot connectivity

--- a/articles/virtual-network/what-is-ip-address-168-63-129-16.md
+++ b/articles/virtual-network/what-is-ip-address-168-63-129-16.md
@@ -35,7 +35,7 @@ The public IP address 168.63.129.16 is used in all regions and all national clou
 
   By default DNS communication isn't subject to the configured network security groups unless targeted using the [AzurePlatformDNS](../virtual-network/service-tags-overview.md#available-service-tags) service tag. To block DNS traffic to Azure DNS through NSG, create an outbound rule to deny traffic to [AzurePlatformDNS](../virtual-network/service-tags-overview.md#available-service-tags). Specify **"Any"** as **"Source"**, **"*"** as **"Destination port ranges"**, **"Any"** as protocol and **"Deny"** as action.
 
-  In addition, 168.63.129.16 isn't resolved by reverse DNS lookup, which means that you cannot get any FQDN if you would want to get the FQDN using reverse lookup commands such as `host`, `nslookup`, or `dig -x` with 168.63.129.16. 
+  Additionally, the IP address 168.63.129.16 does not support reverse DNS lookup. This means if you try to retrieve the Fully Qualified Domain Name (FQDN) using reverse lookup commands like `host`, `nslookup`, or `dig -x` on 168.63.129.16, you won't receive any FQDN.
 
 - When the VM is part of a load balancer backend pool, [health probe](../load-balancer/load-balancer-custom-probe-overview.md) communication should be allowed to originate from 168.63.129.16. The default network security group configuration has a rule that allows this communication. This rule uses the [AzureLoadBalancer](../virtual-network/service-tags-overview.md#available-service-tags) service tag. If desired, this traffic can be blocked by configuring the network security group. The configuration of the block result in probes that fail.
 


### PR DESCRIPTION
I anticipate it's an Azure specification. Is it correct? If it's correct, we hope it will be clear in the document.

Because 8.8.8.8 and 1.1.1.1 are reverse-resolved to their FQDNs, new Azure users expect 168.63.129.16 to be reverse-resolved in the same behavior.

```console
% dig +short -x 168.63.129.16         
% dig +short -x 1.1.1.1      
one.one.one.one.
% dig +short -x 8.8.8.8      
dns.google.
```
```console
% dig -x 168.63.129.16 

; <<>> DiG 9.10.6 <<>> -x 168.63.129.16
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 44126
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;16.129.63.168.in-addr.arpa.	IN	PTR

;; AUTHORITY SECTION:
63.168.in-addr.arpa.	249	IN	SOA	ns1-02.azure-dns.com. azuredns-hostmaster.microsoft.com. 1 3600 300 2419200 300

;; Query time: 40 msec
;; SERVER: 172.24.0.1#53(172.24.0.1)
;; WHEN: Thu Jun 06 17:25:50 JST 2024
;; MSG SIZE  rcvd: 141

````