### PR TITLE
RBAC / Web+Mobile: Remove internal-only resources

### DIFF
--- a/articles/role-based-access-control/permissions/web-and-mobile.md
+++ b/articles/role-based-access-control/permissions/web-and-mobile.md
@@ -602,11 +602,6 @@ Azure service: [App Service](/azure/app-service/), [Azure Functions](/azure/azur
 > | Microsoft.Web/serverfarms/eventGridFilters/delete | Delete Event Grid Filter on server farm. |
 > | Microsoft.Web/serverfarms/eventGridFilters/read | Get Event Grid Filter on server farm. |
 > | Microsoft.Web/serverfarms/eventGridFilters/write | Put Event Grid Filter on server farm. |
-> | microsoft.web/serverfarms/firstpartyapps/keyvaultsettings/read | Get first party Azure Key vault referenced settings for App Service Plan. |
-> | microsoft.web/serverfarms/firstpartyapps/keyvaultsettings/write | Create or Update first party Azure Key vault referenced settings for App Service Plan. |
-> | microsoft.web/serverfarms/firstpartyapps/settings/delete | Delete App Service Plans First Party Apps Settings. |
-> | microsoft.web/serverfarms/firstpartyapps/settings/read | Get App Service Plans First Party Apps Settings. |
-> | microsoft.web/serverfarms/firstpartyapps/settings/write | Update App Service Plans First Party Apps Settings. |
 > | microsoft.web/serverfarms/hybridconnectionnamespaces/relays/read | Get App Service Plans Hybrid Connection Namespaces Relays. |
 > | microsoft.web/serverfarms/hybridconnectionnamespaces/relays/delete | Delete App Service Plans Hybrid Connection Namespaces Relays. |
 > | microsoft.web/serverfarms/hybridconnectionnamespaces/relays/sites/read | Get App Service Plans Hybrid Connection Namespaces Relays Web Apps. |


### PR DESCRIPTION
Under the Microsoft.Web section of RBAC permissions here: https://learn.microsoft.com/en-us/azure/role-based-access-control/permissions/web-and-mobile#microsoftweb

Several resource types are listed which are not available to external customers.
microsoft.web/serverfarms/firstpartyapps/keyvaultsettings/read
microsoft.web/serverfarms/firstpartyapps/keyvaultsettings/write
microsoft.web/serverfarms/firstpartyapps/settings/delete
microsoft.web/serverfarms/firstpartyapps/settings/read
microsoft.web/serverfarms/firstpartyapps/settings/write

Any external customer trying to use any of these endpoints will be rejected after a subscription check.
We've had some support requests related to customers confused about what these are. Since no external customer will be able to interact with these resources, I am requesting to remove them from the document.