### PR TITLE
Clarified that Logic Apps can only be hosted on ASEv3 in supported regions

### DIFF
--- a/articles/app-service/environment/overview.md
+++ b/articles/app-service/environment/overview.md
@@ -23,7 +23,7 @@ An App Service Environment can host your:
 - Linux web apps
 - Docker containers (Windows and Linux)
 - Functions
-- Logic apps (Standard)
+- Logic apps (Standard) - in [supported regions](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=logic-apps&regions=all)
 
 App Service Environments are appropriate for application workloads that require:
 

--- a/articles/app-service/environment/overview.md
+++ b/articles/app-service/environment/overview.md
@@ -23,7 +23,7 @@ An App Service Environment can host your:
 - Linux web apps
 - Docker containers (Windows and Linux)
 - Functions
-- Logic apps (Standard) - in [supported regions](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=logic-apps&regions=all)
+- Logic apps (Standard) - in [supported regions](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=logic-apps&regions=all)
 
 App Service Environments are appropriate for application workloads that require:
 


### PR DESCRIPTION
Logic Apps can't be hosted on an ASEv3 in regions that don't have support. Issues such as the "API Connections" (Microsoft.Web/connections) are only available in the Logic Apps supported regions.

If you try to deploy a Logic App and its API Connections in an ASEv3 supported region (but not Logic App supported region), it fails.