### PR TITLE
Update automation-create-alert-triggered-runbook.md

### DIFF
--- a/articles/automation/automation-create-alert-triggered-runbook.md
+++ b/articles/automation/automation-create-alert-triggered-runbook.md
@@ -13,6 +13,9 @@ ms.custom: devx-track-azurepowershell
 
 You can use [Azure Monitor](../azure-monitor/overview.md) to monitor base-level metrics and logs for most services in Azure. You can call Azure Automation runbooks by using [action groups](../azure-monitor/alerts/action-groups.md) to automate tasks based on alerts. This article shows you how to configure and run a runbook by using alerts.
 
+> [!NOTE]  
+> You can create a budget (in Azure Cost Management) and associate it with an Azure Automation runbook in order to stop resources once they reach a certain threshold.
+> 
 
 ## Prerequisites
 


### PR DESCRIPTION
Budgets and runbooks can be used together. But current documentation is disjointed. I've added this to inform readers about their capabilities:

"You can create a budget (in Azure Cost Management) and associate it with an Azure Automation runbook in order to stop resources once they reach a certain threshold."