### PR TITLE
Fix wrong model and version name

### DIFF
--- a/articles/ai-services/openai/concepts/use-your-data.md
+++ b/articles/ai-services/openai/concepts/use-your-data.md
@@ -592,7 +592,7 @@ Each user message can translate to multiple search queries, all of which get sen
 
 ## Regional availability and model support
 
-| Region | `gpt-35-turbo-16k (0613)` | `gpt-35-turbo (1106)` | `gpt-4-32k (0613)` | `gpt-4 (1106-preview)` | `gpt-4 (0125-preview)` | `gpt-4 (0613)`  | `gpt-4o`\*\* | `gpt-turbo (0409)` |
+| Region | `gpt-35-turbo-16k (0613)` | `gpt-35-turbo (1106)` | `gpt-4-32k (0613)` | `gpt-4 (1106-preview)` | `gpt-4 (0125-preview)` | `gpt-4 (0613)`  | `gpt-4o`\*\* | `gpt-4 (turbo-2024-04-09)` |
 |------|---|---|---|---|---|----|----|----|
 | Australia East | ✅ | ✅ | ✅ |✅ |   | ✅ | | | 
 | Canada East | ✅ | ✅ | ✅ |✅ |   | ✅ |  | | 


### PR DESCRIPTION
Based on https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models gpt-turbo (0409) is not correct but this must be gpt-4 (turbo-2024-04-09)