### PR TITLE
Fix invalid JSON example in api-management-howto-api-inspector.md

### DIFF
--- a/articles/api-management/api-management-howto-api-inspector.md
+++ b/articles/api-management/api-management-howto-api-inspector.md
@@ -90,7 +90,7 @@ Enable tracing by the following steps using calls to the API Management REST API
     {
         "credentialsExpireAfter": PT1H,
         "apiId": "<API resource ID>",
-        "purposes: ["tracing"]
+        "purposes": ["tracing"]
     }
     ```
         


### PR DESCRIPTION
Fixed invalid JSON structure in `api-management-howto-api-inspector.md`.