### PR TITLE
Remove blank space at the end of content-safety url

### DIFF
--- a/articles/ai-services/content-safety/how-to/custom-categories-rapid.md
+++ b/articles/ai-services/content-safety/how-to/custom-categories-rapid.md
@@ -50,7 +50,7 @@ In the commands below, replace `<your_api_key>`, `<your_endpoint>`, and other ne
 The following command creates an incident with a name and definition.
 
 ```bash
-curl --location --request PATCH 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview ' \
+curl --location --request PATCH 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -88,7 +88,7 @@ The following command creates an incident with a name and definition.
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "incidentName": "<text-incident-name>",
@@ -112,7 +112,7 @@ Use the following command to add text examples to the incident.
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:addIncidentSamples?api-version=2024-02-15-preview ' \
+curl --location 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:addIncidentSamples?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -130,7 +130,7 @@ curl --location 'https://<endpoint>/contentsafety/text/incidents/<text-incident-
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:addIncidentSamples?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:addIncidentSamples?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "IncidentSamples": [
@@ -195,7 +195,7 @@ Run the following command to analyze sample text content for the incident you ju
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location 'https://<endpoint>/contentsafety/text:detectIncidents?api-version=2024-02-15-preview ' \
+curl --location 'https://<endpoint>/contentsafety/text:detectIncidents?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -212,7 +212,7 @@ curl --location 'https://<endpoint>/contentsafety/text:detectIncidents?api-versi
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/text:detectIncidents?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text:detectIncidents?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "text": "<test-text>",
@@ -245,7 +245,7 @@ The following command creates an image incident:
 
 
 ```bash
-curl --location --request PATCH 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview ' \
+curl --location --request PATCH 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -281,7 +281,7 @@ The following command creates an image incident:
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "incidentName": "<image-incident-name>"
@@ -306,7 +306,7 @@ Use the following command to add examples images to your incident. The image sam
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:addIncidentSamples?api-version=2024-02-15-preview ' \
+curl --location 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:addIncidentSamples?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -327,7 +327,7 @@ curl --location 'https://<endpoint>/contentsafety/image/incidents/<image-inciden
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:addIncidentSamples?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:addIncidentSamples?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "IncidentSamples": [
@@ -391,7 +391,7 @@ Use the following command to upload a sample image and test it against the incid
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location 'https://<endpoint>/contentsafety/image:detectIncidents?api-version=2024-02-15-preview ' \
+curl --location 'https://<endpoint>/contentsafety/image:detectIncidents?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -412,7 +412,7 @@ curl --location 'https://<endpoint>/contentsafety/image:detectIncidents?api-vers
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/image:detectIncidents?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image:detectIncidents?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "image": {
@@ -446,7 +446,7 @@ The following operations are useful for managing incidents and incident samples.
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/text/incidents?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/text/incidents?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 
@@ -455,7 +455,7 @@ curl --location GET 'https://<endpoint>/contentsafety/text/incidents?api-version
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/text/incidents?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -473,7 +473,7 @@ print(response.text)
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 
@@ -482,7 +482,7 @@ curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incid
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -500,7 +500,7 @@ print(response.text)
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location --request DELETE 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview ' \
+curl --location --request DELETE 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 
@@ -509,7 +509,7 @@ curl --location --request DELETE 'https://<endpoint>/contentsafety/text/incident
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -529,7 +529,7 @@ This command retrieves the unique IDs of all the samples associated with a given
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 #### [Python](#tab/python)
@@ -537,7 +537,7 @@ curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incid
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -557,7 +557,7 @@ Use an incident sample ID to look up details about the sample.
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 #### [Python](#tab/python)
@@ -565,7 +565,7 @@ curl --location GET 'https://<endpoint>/contentsafety/text/incidents/<text-incid
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -585,7 +585,7 @@ Use an incident sample ID to retrieve and delete that sample.
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview ' \
+curl --location 'https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -600,7 +600,7 @@ curl --location 'https://<endpoint>/contentsafety/text/incidents/<text-incident-
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/text/incidents/<text-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "IncidentSampleIds": [
@@ -625,7 +625,7 @@ print(response.text)
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/image/incidents?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/image/incidents?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 
@@ -634,7 +634,7 @@ curl --location GET 'https://<endpoint>/contentsafety/image/incidents?api-versio
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/image/incidents?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -652,7 +652,7 @@ print(response.text)
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 #### [Python](#tab/python)
@@ -660,7 +660,7 @@ curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-inc
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -678,7 +678,7 @@ print(response.text)
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location --request DELETE 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview ' \
+curl --location --request DELETE 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 
@@ -687,7 +687,7 @@ curl --location --request DELETE 'https://<endpoint>/contentsafety/image/inciden
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -708,7 +708,7 @@ This command retrieves the unique IDs of all the samples associated with a given
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 #### [Python](#tab/python)
@@ -716,7 +716,7 @@ curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-inc
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -737,7 +737,7 @@ Use an incident sample ID to look up details about the sample.
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview ' \
+curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>'
 ```
 #### [Python](#tab/python)
@@ -745,7 +745,7 @@ curl --location GET 'https://<endpoint>/contentsafety/image/incidents/<image-inc
 ```python
 import requests
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>/incidentsamples/<your-incident-sample-id>?api-version=2024-02-15-preview"
 
 payload = {}
 headers = {
@@ -766,7 +766,7 @@ Use an incident sample ID to retrieve and delete that sample.
 #### [cURL](#tab/curl)
 
 ```bash
-curl --location 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview ' \
+curl --location 'https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview' \
 --header 'Ocp-Apim-Subscription-Key: <your-content-safety-key>' \
 --header 'Content-Type: application/json' \
 --data '{
@@ -781,7 +781,7 @@ curl --location 'https://<endpoint>/contentsafety/image/incidents/<image-inciden
 import requests
 import json
 
-url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview "
+url = "https://<endpoint>/contentsafety/image/incidents/<image-incident-name>:removeIncidentSamples?api-version=2024-02-15-preview"
 
 payload = json.dumps({
   "IncidentSampleIds": [


### PR DESCRIPTION
Remove blank space at the end of content safety url which is causing error when calling Custom Categories API