### PR TITLE
Remove inter-zone charge in firewall doc due to new announcement

### DIFF
--- a/articles/firewall/features.md
+++ b/articles/firewall/features.md
@@ -49,7 +49,7 @@ Azure Firewall can be configured during deployment to span multiple Availability
 
 You can also associate Azure Firewall to a specific zone just for proximity reasons, using the service standard 99.95% SLA.
 
-There's no extra cost for a firewall deployed in more than one Availability Zone. However, there are added costs for inbound and outbound data transfers associated with Availability Zones. For more information, see [Bandwidth pricing details](https://azure.microsoft.com/pricing/details/bandwidth/).
+There's no extra cost for a firewall deployed in more than one Availability Zone. Also, Microsoft has announced that Azure will not charge for the data transfer across availability zones regardless of using private or public IPs on your Azure resources [link](https://azure.microsoft.com/updates/update-on-interavailability-zone-data-transfer-pricing/) .
 
 As the firewall scales, it creates instances in the zones it's in. So, if the firewall is in Zone 1 only, new instances are created in Zone 1. If the firewall is in all three zones, then it creates instances across the three zones as it scales.
 

--- a/articles/firewall/features.md
+++ b/articles/firewall/features.md
@@ -49,7 +49,7 @@ Azure Firewall can be configured during deployment to span multiple Availability
 
 You can also associate Azure Firewall to a specific zone just for proximity reasons, using the service standard 99.95% SLA.
 
-There's no extra cost for a firewall deployed in more than one Availability Zone. Also, Microsoft has announced that Azure will not charge for the data transfer across availability zones regardless of using private or public IPs on your Azure resources [link](https://azure.microsoft.com/updates/update-on-interavailability-zone-data-transfer-pricing/) .
+There's no extra cost for a firewall deployed in more than one Availability Zone. Also, Microsoft has announced that Azure won't charge for the data transfer across availability zones, regardless of whether you use private or public IPs on your [Azure resources](https://azure.microsoft.com/updates/update-on-interavailability-zone-data-transfer-pricing/).
 
 As the firewall scales, it creates instances in the zones it's in. So, if the firewall is in Zone 1 only, new instances are created in Zone 1. If the firewall is in all three zones, then it creates instances across the three zones as it scales.
 


### PR DESCRIPTION
Hi @vhorne ,

Penny Ko from MSFT here. I came across this doc and noticed that it's mentioning about the inter-AZ cost previously Azure was planning to charge. However, Microsoft has announced that Azure will not charge for the data transfer across availability zones regardless of using private or public IPs on your Azure resources https://azure.microsoft.com/updates/update-on-interavailability-zone-data-transfer-pricing/ .  

The Bandwidth pricing page has also been updated with the removal of the previous language regarding costs -
[Pricing - Bandwidth | Microsoft Azure](https://azure.microsoft.com/en-us/pricing/details/bandwidth/)

Please kindly help to check if this is within your scope whether there are other docs that would need updates. Thank you!!