### PR TITLE
Fix example JQ output (shows wrong humidity value)

### DIFF
--- a/articles/iot-operations/process-data/concept-jq-expression.md
+++ b/articles/iot-operations/process-data/concept-jq-expression.md
@@ -77,7 +77,7 @@ While this expression appears to change the input object, in jq it's producing a
 ```json
 {
   "temperature": 21,
-  "humidity": 65
+  "humidity": 63
 }
 ```
 


### PR DESCRIPTION
The example output doesn't match the expected output of the previous operation.