### PR TITLE
Update oracle-reference-architecture.md

### DIFF
--- a/articles/virtual-machines/workloads/oracle/oracle-reference-architecture.md
+++ b/articles/virtual-machines/workloads/oracle/oracle-reference-architecture.md
@@ -106,9 +106,9 @@ The following diagram is a high availability architecture using Oracle Data Guar
 
 :::image type="content" source="./media/oracle-reference-architecture/oracledb_dg_fs_az.png" alt-text="Diagram that shows Oracle database using availability zones with Data Guard Far Sync & Broker - FSFO." lightbox="./media/oracle-reference-architecture/oracledb_dg_fs_az.png":::
 
-In the preceding architecture, there's a Far Sync instance deployed in the same availability zone as the database instance to reduce the latency between the two. In cases where the application is latency sensitive, consider deploying your database and Far Sync instance or instances in a [proximity placement group](../../../virtual-machines/linux/proximity-placement-groups.md).
+In the preceding architecture, there's a Far Sync instance deployed in a different availability zone as the database instance to ensure zero data loss and automatic failover in case of availability zone failure. In cases where the application is latency sensitive, consider deploying your database and Far Sync instance or instances in the same availability zone in a [proximity placement group](../../../virtual-machines/linux/proximity-placement-groups.md).
 
-The following diagram is an architecture that uses Oracle Data Guard FSFO and Far Sync to achieve high availability and disaster recovery:
+The following diagram is an architecture that uses Oracle Data Guard FSFO and Far Sync to achieve high availability and disaster recovery: 
 
 :::image type="content" source="./media/oracle-reference-architecture/oracledb_dg_fs_az_dr.png" alt-text="Diagram that shows Oracle Database using availability zones for disaster recovery with Data Guard Far Sync and Broker - FSFO." lightbox="./media/oracle-reference-architecture/oracledb_dg_fs_az_dr.png":::
 


### PR DESCRIPTION
Dear Microsoft team,

My name is Sinan Petrus Toma, Principal Product Manager at the Oracle Database High Availability product management team. More often, we get into discussions with customers running into issues (e.g., no automatic failover in case of AZ failure) when putting the Far Sync instance in the same AZ as the primary.  In Data Guard Maximum Availability mode, the standby needs to contact the Far Sync instance to ensure zero data loss before allowing automatic failover. As Far Sync is not reachable, no automatic failover is possible.  Also, the main purpose of Far Sync is to ensure zero data loss at any distance. In case of AZ failure, both primary and Far Sync are affected and there is no zero data loss guarantee.

We from Oracle suggest recommending Far Sync in another AZ by default, and only if the application is latency sensitive, then Far Sync in the same AZ. If you send me a copy of the diagram (./media/oracle-reference-architecture/oracledb_dg_fs_az_dr.png) I'm happy to edit it with Oracle's recommendations and send it back to you. My email is sinan.petrus.toma@oracle.com
Also, I'm happy to jump on a call and discuss further.  Thank you,
Sinan