### PR TITLE
Update backup-azure-vm-backup-faq.yml

### DIFF
--- a/articles/backup/backup-azure-vm-backup-faq.yml
+++ b/articles/backup/backup-azure-vm-backup-faq.yml
@@ -93,7 +93,7 @@ sections:
           The scheduled backup will be triggered within 2 hours of the scheduled backup time. For example, If 100 VMs have their backup start time scheduled at 2:00 AM, then by 4:00 AM at the latest all the 100 VMs will have their backup job in progress. If scheduled backups have been paused because of an outage and resumed or retried, then the backup can start outside of this scheduled two-hour window.
 
       - question: What is the minimum allowed retention range for a daily backup point?
-        answer: Azure Virtual Machine backup policy supports a minimum retention range from seven days up to 9999 days. Any modification to an existing VM backup policy with less than seven days will require an update to meet the minimum retention range of seven days.
+        answer: Azure Virtual Machine backup policy supports a minimum retention range from seven days up to 9999 days. By default, backups of VMs are kept for 180 days. Any modification to an existing VM backup policy with less than seven days will require an update to meet the minimum retention range of seven days.
 
       - question: What happens if I change the case of the name of my VM or my VM resource group?
         answer: If you change the case (to upper or lower) of your VM or VM resource group, the case of the backup item name won't change; this is expected Azure Backup behavior. The case change won't appear in the backup item, but is updated at the backend.


### PR DESCRIPTION
I've created this PR because the [old one](https://github.com/MicrosoftDocs/azure-docs/pull/123204) was closed and can't be reopened.

Following statement should be added so readers are informed because currently, there are confusing information scattered around the doc. Also, whenever readers are informed about the possible range, they should also be informed about the default option.

"By default, backups of VMs are kept for 180 days."


For example, according to [this page](https://learn.microsoft.com/en-us/azure/backup/backup-azure-arm-vms-prepare): "The daily backups are retained for 30 days.". There should be some clarification.