### PR TITLE
Update lifecycle-management-policy-configure.md

### DIFF
--- a/articles/storage/blobs/lifecycle-management-policy-configure.md
+++ b/articles/storage/blobs/lifecycle-management-policy-configure.md
@@ -27,6 +27,9 @@ When the selected condition is true, then the management policy performs the spe
 
 For a blob snapshot or version, the condition that is checked is the number of days since the snapshot or version was created.
 
+> [!NOTE]  
+> Lifecycle management policies are supported for block blobs and append blobs in general-purpose v2, premium block blob, and Blob Storage accounts.
+
 ## Optionally enable access time tracking
 
 Before you configure a lifecycle management policy, you can choose to enable blob access time tracking. When access time tracking is enabled, a lifecycle management policy can include an action based on the time that the blob was last accessed with a read or write operation. To minimize the effect on read access latency, only the first read of the last 24 hours updates the last access time. Subsequent reads in the same 24-hour period don't update the last access time. If a blob is modified between reads, the last access time is the more recent of the two values.


### PR DESCRIPTION
Given the nature of this page, following statement should be added in here, too, for the sake of clarity:

"Lifecycle management policies are supported for block blobs and append blobs in general-purpose v2, premium block blob, and Blob Storage accounts."