### PR TITLE
Update apex-domain-external.md

### DIFF
--- a/articles/static-web-apps/apex-domain-external.md
+++ b/articles/static-web-apps/apex-domain-external.md
@@ -31,6 +31,10 @@ This guide demonstrates three options for configuring an apex domain.
 
 * Use the steps to [set up with an A Record](#set-up-with-an-a-record) if the above options do not suit you. With an `A` record, your traffic is directed to a single Static Web Apps host, and your app no longer benefit from the performance improvements provided by global distribution.
 
+> [!NOTE]  
+> `CNAME` record maps a domain name to another domain (or subdomain) whereas `A` record maps a domain name to an IP address. If the IP address changes, a `CNAME` entry is still valid, unlike `A` record.
+
+
 ## Set up with an ALIAS record
 
 Before you create the `ALIAS` record, you first need to validate that you own the domain.


### PR DESCRIPTION
Following should be added so readers have a better understanding of difference between the two records:


"`CNAME` record maps a domain name to another domain (or subdomain) whereas `A` record maps a domain name to an IP address. If the IP address changes, a `CNAME` entry is still valid, unlike `A` record."