### PR TITLE
Update sas-expiration-policy.md to indicate user delegation keys work

### DIFF
--- a/articles/storage/common/sas-expiration-policy.md
+++ b/articles/storage/common/sas-expiration-policy.md
@@ -33,7 +33,7 @@ When a SAS expiration policy is in effect for the storage account, the signed st
 
 ## Configure a SAS expiration policy
 
-When you configure a SAS expiration policy on a storage account, the policy applies to each type of SAS that is signed with the account key. The types of shared access signatures that are signed with the account key are the service SAS and the account SAS.
+When you configure a SAS expiration policy on a storage account, the policy applies to each type of SAS that is signed with the account key or with a user delegation key. The types of shared access signatures that are signed with the account key are the service SAS and the account SAS.
 
 ### Do I need to rotate the account access keys first?
 


### PR DESCRIPTION
Current text implies that SAS tokens signed with a user delegation (rather than an account key) key are excluded from expiration policy monitoring.  However, I just tried it, and the warnings are generated for user delegation SAS tokens as well.  This commit clarifies that.