### PR TITLE
Update backup-azure-delete-vault.md

### DIFF
--- a/articles/backup/backup-azure-delete-vault.md
+++ b/articles/backup/backup-azure-delete-vault.md
@@ -31,8 +31,8 @@ If you try to delete the vault without removing the dependencies, you'll encount
 
 > [!NOTE]  
 > Before deleting a Backup protection policy from a vault, you must ensure that
-> - the policy doesn't not have any associated Backup items
-> - each associated item is associated with some other policy
+> - the policy doesn't have any associated Backup items.
+> - each associated item is associated with some other policy.
 
 
 ## Delete a Recovery Services vault

--- a/articles/backup/backup-azure-delete-vault.md
+++ b/articles/backup/backup-azure-delete-vault.md
@@ -27,6 +27,14 @@ If you try to delete the vault without removing the dependencies, you'll encount
 
 - Recovery Services vault cannot be deleted as there are backup items in soft deleted state in the vault. The soft deleted items are permanently deleted after 14 days of delete operation. Please try vault deletion after the backup items are permanently deleted and there is no item in soft deleted state left in the vault. For more information, see [Soft delete for Azure Backup](./backup-azure-security-feature-cloud.md).
 
+
+
+> [!NOTE]  
+> Before deleting a Backup protection policy from a vault, you must ensure that
+> - the policy doesn't not have any associated Backup items
+> - each associated item is associated with some other policy
+
+
 ## Delete a Recovery Services vault
 
 > [!VIDEO https://www.youtube.com/embed/xg_TnyhK34o]


### PR DESCRIPTION
I'm afraid this page is a bit confusing to follow. To understand nuances of deleting a policy, I had to read it few times and still couldn't get it; I had to find my answer from [another page](https://learn.microsoft.com/en-us/powershell/module/az.recoveryservices/remove-azrecoveryservicesbackupprotectionpolicy)

But I found that page due to some 3rd party websites. I would suggest adding the following note so readers can easily understand requirements for deleting a policy (you can move the note to lower sections if you deem appropriate)


"> [!NOTE]  
> Before deleting a Backup protection policy from a vault, you must ensure that
> - the policy doesn't not have any associated Backup items
> - each associated item is associated with some other policy"