### PR TITLE
Fix: MyEventType has an additional curly brace at the end

### DIFF
--- a/articles/azure-functions/functions-bindings-event-grid-trigger.md
+++ b/articles/azure-functions/functions-bindings-event-grid-trigger.md
@@ -44,7 +44,7 @@ The type of the input parameter used with an Event Grid trigger depends on these
 
 When running your C# function in an isolated worker process, you need to define a custom type for event properties. The following example defines a `MyEventType` class.
 
-:::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/EventGrid/EventGridFunction.cs" range="35-49":::
+:::code language="csharp" source="~/azure-functions-dotnet-worker/samples/Extensions/EventGrid/EventGridFunction.cs" range="35-48":::
 
 The following example shows how the custom type is used in both the trigger and an Event Grid output binding:
 


### PR DESCRIPTION
Remove the additional curly brace at the end in `MyEventType`.