### PR TITLE
Update alerts-overview.md

### DIFF
--- a/articles/azure-monitor/alerts/alerts-overview.md
+++ b/articles/azure-monitor/alerts/alerts-overview.md
@@ -61,7 +61,7 @@ Alerts can be stateful or stateless.
 - Stateless alerts fire each time the condition is met, even if fired previously.
 - Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved.
 
-Alert status can be either New, Acknowledged, or Closed and it’s manually set by the Administrator. Alerts are stored for 30 days and are deleted after the 30-day retention period.
+Alert status can be either New, Acknowledged, or Closed and it can be manually set by the administrator. Alerts are stored for 30 days and are deleted after the 30-day retention period.
 
 ### Stateless alerts
 Stateless alerts fire each time the condition is met. The alert condition for all stateless alerts is always `fired`. 

--- a/articles/azure-monitor/alerts/alerts-overview.md
+++ b/articles/azure-monitor/alerts/alerts-overview.md
@@ -61,7 +61,7 @@ Alerts can be stateful or stateless.
 - Stateless alerts fire each time the condition is met, even if fired previously.
 - Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved.
 
-Alerts are stored for 30 days and are deleted after the 30-day retention period.
+Alert status can be either New, Acknowledged, or Closed and it’s manually set by the Administrator. Alerts are stored for 30 days and are deleted after the 30-day retention period.
 
 ### Stateless alerts
 Stateless alerts fire each time the condition is met. The alert condition for all stateless alerts is always `fired`. 


### PR DESCRIPTION
Alert status has been referenced in different parts of the doc but has but has never been explained. For example, in [here](https://learn.microsoft.com/en-us/system-center/scom/manage-alert-impact-closing), [here](https://learn.microsoft.com/en-us/azure/defender-for-iot/organizations/how-to-manage-cloud-alerts), and [here](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-manage-alert-instances).


 I've added following for clarification. 

"Alert status can be either New, Acknowledged, or Closed and it can be manually set by the Administrator."