### PR TITLE
Update app-service-move-limitations.md

### DIFF
--- a/articles/azure-resource-manager/management/move-limitations/app-service-move-limitations.md
+++ b/articles/azure-resource-manager/management/move-limitations/app-service-move-limitations.md
@@ -12,7 +12,7 @@ This article describes the steps to move App Service resources between resource 
 
 If you want to move App Services to a new region, see [Move an App Service resource to another region](../../../app-service/manage-move-across-regions.md).
 
-You can move App Service resources to a new resource group or subscription but you need to delete and upload its TLS/SSL certificates to the new new resource group or subscription. However, you can't move a free App Service managed certificate. For that scenario, see [Move with free managed certificates](#move-with-free-managed-certificates).
+You can move App Service resources to a new resource group or subscription but you need to delete and upload its TLS/SSL certificates to the new resource group or subscription. Also, you can't move a free App Service managed certificate. For that scenario, see [Move with free managed certificates](#move-with-free-managed-certificates).
 
 ## Move across subscriptions
 

--- a/articles/azure-resource-manager/management/move-limitations/app-service-move-limitations.md
+++ b/articles/azure-resource-manager/management/move-limitations/app-service-move-limitations.md
@@ -12,6 +12,8 @@ This article describes the steps to move App Service resources between resource 
 
 If you want to move App Services to a new region, see [Move an App Service resource to another region](../../../app-service/manage-move-across-regions.md).
 
+You can move App Service resources to a new resource group or subscription but you need to delete and upload its TLS/SSL certificates to the new new resource group or subscription. However, you can't move a free App Service managed certificate. For that scenario, see [Move with free managed certificates](#move-with-free-managed-certificates).
+
 ## Move across subscriptions
 
 When you move a Web App across subscriptions, the following guidance applies:
@@ -26,7 +28,6 @@ When you move a Web App across subscriptions, the following guidance applies:
 - App Service Environments can't be moved to a new resource group or subscription.
     - You can move a Web App and App Service plan hosted on an App Service Environment to a new subscription without moving the App Service Environment. The Web App and App Service plan that you move will always be associated with your initial App Service Environment. You can't move a Web App/App Service plan to a different App Service Environment.
     - If you need to move a Web App and App Service plan to a new App Service Environment, you'll need to recreate these resources in your new App Service Environment. Consider using the [backup and restore feature](../../../app-service/manage-backup.md) as way of recreating your resources in a different App Service Environment.
-- You can move a certificate bound to a web without deleting the TLS bindings, as long as the certificate is moved with all other resources in the resource group. However, you can't move a free App Service managed certificate. For that scenario, see [Move with free managed certificates](#move-with-free-managed-certificates).
 - App Service apps with private endpoints cannot be moved. Delete the private endpoint(s) and recreate it after the move.
 - App Service apps with virtual network integration cannot be moved. Remove the virtual network integration and reconnect it after the move.
 - App Service resources can only be moved from the resource group in which they were originally created. If an App Service resource is no longer in its original resource group, move it back to its original resource group. Then, move the resource across subscriptions. For help with finding the original resource group, see the next section.


### PR DESCRIPTION
I'm afraid  this page is a bit confusing: in the title, it tells about moving to a resource group and subscription but down in the page, it has section only for, and mainly / only describes moving  to a subscription (not resource group).

AFAIK, the way it describes restrictions about moving TLS, isn't technically correct. Also, that applies to both subscription and resource group. So, I've modified and re-arranged that paragraph:

"You can move App Service resources to a new resource group or subscription but you need to delete and upload its TLS/SSL certificates to the new resource group or subscription. Also, you can't move a free App Service managed certificate. For that scenario, see [Move with free managed certificates](#move-with-free-managed-certificates). "