### PR TITLE
Update latest domain in outbound-rules-control-egress.md

### DIFF
--- a/articles/aks/outbound-rules-control-egress.md
+++ b/articles/aks/outbound-rules-control-egress.md
@@ -60,7 +60,7 @@ The following network and FQDN/application rules are required for an AKS cluster
 |----------------------------------|-----------------|----------|
 | **`*.hcp.<location>.azmk8s.io`** | **`HTTPS:443`** | Required for Node <-> API server communication. Replace *\<location\>* with the region where your AKS cluster is deployed. This is required for clusters with *konnectivity-agent* enabled. Konnectivity also uses Application-Layer Protocol Negotiation (ALPN) to communicate between agent and server. Blocking or rewriting the ALPN extension will cause a failure. This isn't required for [private clusters][private-clusters]. |
 | **`mcr.microsoft.com`**          | **`HTTPS:443`** | Required to access images in Microsoft Container Registry (MCR). This registry contains first-party images/charts (for example, coreDNS, etc.). These images are required for the correct creation and functioning of the cluster, including scale and upgrade operations.  |
-| **`*.data.mcr.microsoft.com`**   | **`HTTPS:443`** | Required for MCR storage backed by the Azure content delivery network (CDN). |
+| **`*.data.mcr.microsoft.com`**, **`mcr-0001.mcr-msedge.net`**   | **`HTTPS:443`** | Required for MCR storage backed by the Azure content delivery network (CDN). |
 | **`management.azure.com`**       | **`HTTPS:443`** | Required for Kubernetes operations against the Azure API. |
 | **`login.microsoftonline.com`**  | **`HTTPS:443`** | Required for Microsoft Entra authentication. |
 | **`packages.microsoft.com`**     | **`HTTPS:443`** | This address is the Microsoft packages repository used for cached *apt-get* operations.  Example packages include Moby, PowerShell, and Azure CLI. |


### PR DESCRIPTION
**Proposed change:**
Add new domain which is regarding latest MCR change. The current setting will cause AKS node pool goes into failed status or failed to scale out. 

**Supporting point:**
Currently, due to MCR change to resolve throttling issue, which will result in DNS record change, the AKS may fail if only set FQDN as in current version of document (because of missing rules).
The changes are still ongoing, the domain may still subject to change in near future. But for now just simply add this domain as reference for users emerging audit purpose. We can add more relative domains (or delete old domains) when everything is settled down. But anyway, it is causing problem now and something needs to be done. 
Kindly check DNS record change history here: https://dnshistory.org/dns-records/mcr.microsoft.com
```
dig mcr.microsoft.com

; <<>> DiG 9.18.18-0ubuntu0.22.04.2-Ubuntu <<>> mcr.microsoft.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 2189
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;mcr.microsoft.com.             IN      A

;; ANSWER SECTION:
mcr.microsoft.com.      873     IN      CNAME   global.fe.mscr.io.
global.fe.mscr.io.      37      IN      CNAME   mcr.trafficmanager.net.
mcr.trafficmanager.net. 37      IN      CNAME   mcr-0001.mcr-msedge.net.
mcr-0001.mcr-msedge.net. 7      IN      A       150.171.69.10
mcr-0001.mcr-msedge.net. 7      IN      A       150.171.70.10

;; Query time: 4 msec
;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
;; WHEN: Fri Jun 14 09:17:23 UTC 2024
;; MSG SIZE  rcvd: 179
```