### PR TITLE
Remove B2C from maximum requests limit

### DIFF
--- a/articles/active-directory-b2c/service-limits.md
+++ b/articles/active-directory-b2c/service-limits.md
@@ -32,7 +32,7 @@ The number of users able to authenticate through an Azure AD B2C tenant is gated
 
 |Category |Limit    |
 |---------|---------|
-|Maximum requests per IP per Azure AD B2C tenant       |6,000/5min          |
+|Maximum requests per IP per Azure AD tenant       |6,000/5min          |
 |Maximum requests per Azure AD B2C tenant     |200/sec          |
 
 ## Endpoint request usage


### PR DESCRIPTION
I would like to propose removing "B2C" from `Maximum requests per IP per Azure AD B2C tenant       |6,000/5min`

---

We have run into an issue with the B2C where **multiple Azure AD B2C tenants** were throttled at the same time, where it was only one environment/Azure B2C tenant causing the issue. They were being called from the same IP-Address.

Through a support request with Microsoft we received the following response:
"Throttling 429 errors happen at **AAD gateway level**. The gateway is the first hop into MS infrastructure and all requests go through it. After the requests get to the gateway they are forwarded to the proper service, in this case to B2C service. 
 
The values you have in that document mean that if there are over 250 request per sec coming through the gate with final destination at the same b2c tenant, only 200 requests will pass and 50 will be throttled. You'd get 50 http 429 errors.  
 
Now, the same logic is applied to the IP address. If there are over 6000 requests per 5 min coming from the same IP address only 6000 will be redirected to the tenant, all others will be throttled the same way."
 
So it seems like throttling happens at the AAD gateway level and not the B2C for a specific IP-Address.