### PR TITLE
Fix swapped DCR/DCE templates on Log Ingestion tutorial

### DIFF
--- a/articles/azure-monitor/logs/tutorial-logs-ingestion-api.md
+++ b/articles/azure-monitor/logs/tutorial-logs-ingestion-api.md
@@ -244,12 +244,6 @@ The [DCR](../essentials/data-collection-rule-overview.md) defines how the data w
                 "metadata": {
                     "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
                 }
-            },
-            "endpointResourceId": {
-                "type": "string",
-                "metadata": {
-                    "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
-                }
             }
         },
         "resources": [
@@ -259,7 +253,6 @@ The [DCR](../essentials/data-collection-rule-overview.md) defines how the data w
                 "location": "[parameters('location')]",
                 "apiVersion": "2021-09-01-preview",
                 "properties": {
-                    "dataCollectionEndpointId": "[parameters('endpointResourceId')]",
                     "streamDeclarations": {
                         "Custom-MyTableRawData": {
                             "columns": [
@@ -349,6 +342,12 @@ The [DCR](../essentials/data-collection-rule-overview.md) defines how the data w
                 "metadata": {
                     "description": "Specifies the Azure resource ID of the Log Analytics workspace to use."
                 }
+            },
+            "endpointResourceId": {
+                "type": "string",
+                "metadata": {
+                    "description": "Specifies the Azure resource ID of the Data Collection Endpoint to use."
+                }
             }
         },
         "resources": [
@@ -358,6 +357,7 @@ The [DCR](../essentials/data-collection-rule-overview.md) defines how the data w
                 "location": "[parameters('location')]",
                 "apiVersion": "2021-09-01-preview",
                 "properties": {
+                    "dataCollectionEndpointId": "[parameters('endpointResourceId')]",
                     "streamDeclarations": {
                         "Custom-MyTableRawData": {
                             "columns": [


### PR DESCRIPTION
The DCR and DCE templates appear to be swapped. This change corrects the required parameters on the templates.