### PR TITLE
Inadequate Specification of HUBBLE_VERSION

### DIFF
--- a/articles/aks/advanced-network-observability-cli.md
+++ b/articles/aks/advanced-network-observability-cli.md
@@ -250,7 +250,7 @@ Install the Hubble CLI to access the data it collects using the following comman
 
 ```azurecli-interactive
 # Set environment variables
-export HUBBLE_VERSION=0.11  
+export HUBBLE_VERSION=v0.11.0  
 export HUBBLE_ARCH=amd64
 
 #Install Hubble CLI


### PR DESCRIPTION
With this HUBBLE_VERSION specification, curl results in a 404 error. Although it targets v0.11.0, I thought it necessary to make corrections as done in this commit.


Please note that the series of shell commands includes sudo, which I believe cannot be used in Azure Cloud Shell. Therefore, these commands might not be executable in Azure Cloud Shell. Please excuse me if my understanding is incorrect.
<https://learn.microsoft.com/en-us/azure/cloud-shell/faq-troubleshooting#i-want-to-install-a-tool-in-cloud-shell-that-requires-sudo-is-that-possible>