### PR TITLE
Update prerequisites for Content Safety Studio

### DIFF
--- a/articles/ai-services/content-safety/studio-quickstart.md
+++ b/articles/ai-services/content-safety/studio-quickstart.md
@@ -23,6 +23,7 @@ In this quickstart, get started with the Azure AI Content Safety service using C
 
 * An active Azure account. If you don't have one, you can [create one for free](https://azure.microsoft.com/free/cognitive-services/).
 * A [Content Safety](https://aka.ms/acs-create) Azure resource.
+* `Cognitive Services User` role assigned to the Content Safety resource in the desired Azure subscription.
 * Sign in to [Content Safety Studio](https://contentsafety.cognitive.azure.com) with your Azure subscription and Content Safety resource. 
 
 

--- a/articles/ai-services/content-safety/studio-quickstart.md
+++ b/articles/ai-services/content-safety/studio-quickstart.md
@@ -23,7 +23,7 @@ In this quickstart, get started with the Azure AI Content Safety service using C
 
 * An active Azure account. If you don't have one, you can [create one for free](https://azure.microsoft.com/free/cognitive-services/).
 * A [Content Safety](https://aka.ms/acs-create) Azure resource.
-* `Cognitive Services User` role assigned to the Content Safety resource in the desired Azure subscription.
+* The `Cognitive Services User` role assigned to the Content Safety resource in the desired Azure subscription.
 * Sign in to [Content Safety Studio](https://contentsafety.cognitive.azure.com) with your Azure subscription and Content Safety resource. 
 
 


### PR DESCRIPTION
"Cognitive Services User" role must be mentioned as one of prerequisites because Content Safety Studio does not support key-based authentication and Owner / Contributor role are not enough.