### PR TITLE
docs(key-vault): use correct reference in quick-create-cli.md

### DIFF
--- a/articles/key-vault/secrets/quick-create-cli.md
+++ b/articles/key-vault/secrets/quick-create-cli.md
@@ -30,7 +30,7 @@ This quickstart requires version 2.0.4 or later of the Azure CLI. If using Azure
 
 ## Give your user account permissions to manage secrets in Key Vault
 
-[!INCLUDE [Using RBAC to provide access to a key vault](../includes/key-vault-quickstart-rbac-cli.md)]
+[!INCLUDE [Using RBAC to provide access to a key vault](../includes/rbac/upn-secrets-officer-cli.md)]
 
 ## Add a secret to Key Vault
 


### PR DESCRIPTION
It is suggested to assign the role "Key Vault Secrets User". However, to set a secret in KeyVault, we need more permissions. The built-in role "Key Vault Secrets Officer" should be enough for the actions defined in the document.

Document: https://github.com/MicrosoftDocs/azure-docs/blob/955de83641b2a5c5679b458799a1352c193853a6/articles/key-vault/secrets/quick-create-cli.md