### PR TITLE
Update functions-bindings-cosmosdb-v2-input.md

### DIFF
--- a/articles/azure-functions/functions-bindings-cosmosdb-v2-input.md
+++ b/articles/azure-functions/functions-bindings-cosmosdb-v2-input.md
@@ -1288,8 +1288,6 @@ app = func.FunctionApp()
 def test_function(msg: func.QueueMessage,
                   inputDocument: func.DocumentList, 
                   outputDocument: func.Out[func.Document]):
-     document = documents[id]
-     document["text"] = "This was updated!"
      doc = inputDocument[0]
      doc["text"] = "This was updated!"
      outputDocument.set(doc)


### PR DESCRIPTION
Removed references to documents variable in "Queue trigger..."/python-v2 (variable not defined in function inputs or decorator args).

Trying to implement existing test_function results in 404