### PR TITLE
fix type of `threshold` from "string" to "int"

### DIFF
--- a/articles/azure-monitor/alerts/resource-manager-alerts-log.md
+++ b/articles/azure-monitor/alerts/resource-manager-alerts-log.md
@@ -467,7 +467,7 @@ resource alert 'Microsoft.Insights/scheduledQueryRules@2021-08-01' = {
       "value": "GreaterThan"
     },
     "threshold": {
-      "value": "80"
+      "value": 80
     },
     "timeAggregation": {
       "value": "Average"

--- a/articles/azure-monitor/alerts/resource-manager-alerts-metric.md
+++ b/articles/azure-monitor/alerts/resource-manager-alerts-metric.md
@@ -347,7 +347,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       "value": "GreaterThan"
     },
     "threshold": {
-      "value": "80"
+      "value": 80
     },
     "timeAggregation": {
       "value": "Average"
@@ -1014,7 +1014,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
           }
         ],
         "operator": "GreaterThan",
-        "threshold": "5",
+        "threshold": 5,
         "timeAggregation": "Total"
       }
     },
@@ -1030,7 +1030,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
           }
         ],
         "operator": "GreaterThan",
-        "threshold": "250",
+        "threshold": 250,
         "timeAggregation": "Average"
       }
     },
@@ -1307,7 +1307,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
           }
         ],
         "operator": "GreaterThan",
-        "threshold": "5",
+        "threshold": 5,
         "timeAggregation": "Total"
       }
     },
@@ -1940,7 +1940,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       "value": "GreaterThan"
     },
     "threshold": {
-      "value": "80"
+      "value": 80
     },
     "timeAggregation": {
       "value": "Average"
@@ -2282,8 +2282,8 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       }
     },
     "threshold": {
-      "type": "string",
-      "defaultValue": "0",
+      "type": "int",
+      "defaultValue": 0,
       "metadata": {
         "description": "The threshold value at which the alert is activated."
       }
@@ -2420,7 +2420,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       "value": "GreaterThan"
     },
     "threshold": {
-      "value": "0"
+      "value": 0
     },
     "timeAggregation": {
       "value": "Average"
@@ -3231,8 +3231,8 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       }
     },
     "threshold": {
-      "type": "string",
-      "defaultValue": "0",
+      "type": "int",
+      "defaultValue": 0,
       "metadata": {
         "description": "The threshold value at which the alert is activated."
       }
@@ -3369,7 +3369,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       "value": "GreaterThan"
     },
     "threshold": {
-      "value": "0"
+      "value": 0
     },
     "timeAggregation": {
       "value": "Average"
@@ -4179,8 +4179,8 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       }
     },
     "threshold": {
-      "type": "string",
-      "defaultValue": "0",
+      "type": "int",
+      "defaultValue": 0,
       "metadata": {
         "description": "The threshold value at which the alert is activated."
       }
@@ -4318,7 +4318,7 @@ resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
       "value": "GreaterThan"
     },
     "threshold": {
-      "value": "0"
+      "value": 0
     },
     "timeAggregation": {
       "value": "Average"


### PR DESCRIPTION
# Summary
This PR addresses the incorrect definition of the threshold property in the Microsoft.Insights/metricAlerts and Microsoft.Insights/scheduledQueryRules resource types when written in Bicep. The threshold property should be of type `"int"` as per documentation ([metricAlerts](https://learn.microsoft.com/en-us/azure/templates/microsoft.insights/metricalerts?pivots=deployment-language-bicep), [scheduledQueryRules](https://learn.microsoft.com/en-us/azure/templates/microsoft.insights/2021-08-01/scheduledqueryrules?pivots=deployment-language-bicep)).

# Details
In the current files, the threshold property is defined as a `"string"`. Although deployment is still possible with a `"string"`, it triggers the following warning during deployment:

```
Warning BCP036: The property "threshold" expected a value of type `"int"` but the provided value is of type `"string"`. If this is an inaccuracy in the documentation, please report it to the Bicep Team. [https://aka.ms/bicep-type-issues]
```

Additionally, when threshold is defined as an `"int"` in the template files, deployment fails`. This means [this sample code](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/resource-manager-alerts-metric?tabs=bicep#single-criteria-static-threshold) does not work and results in an error.

# Solution
In this PR, I have corrected the threshold property in all sample code instances to be of type `"int"`. This will eliminate user confusion and ensure proper functionality without deployment warnings or errors.