### PR TITLE
Update backup-azure-restore-key-secret.md

### DIFF
--- a/articles/backup/backup-azure-restore-key-secret.md
+++ b/articles/backup/backup-azure-restore-key-secret.md
@@ -52,7 +52,7 @@ Once the JSON file is generated in the destination path mentioned above, generat
 ```powershell
 $keyDestination = 'C:\keyDetails.blob'
 [io.file]::WriteAllBytes($keyDestination, [System.Convert]::FromBase64String($encryptionObject.OsDiskKeyAndSecretDetails.KeyBackupData))
-Restore-AzureKeyVaultKey -VaultName '<target_key_vault_name>' -InputFile $keyDestination
+Restore-AzKeyVaultKey -VaultName '<target_key_vault_name>' -InputFile $keyDestination
 ```
 
 ## Restore secret


### PR DESCRIPTION
Restore-AzureKeyVaultKey gives error. Correct command should be Restore-AzKeyVaultKey

Wrong command:

PS C:\WINDOWS\system32> Restore-AzureKeyVaultKey -VaultName '<target_vault_name>' -InputFile $keyDestination

WARNING: Restore-AzureKeyVaultKey is not found. The most similar Azure PowerShell command is:
 Restore-AzKeyVaultKey
WARNING: The intelligent recommendation feature is in preview. Help us improve it by sharing your experience: https://go.microsoft.com/fwlink/?linkid=2202436
Restore-AzureKeyVaultKey : The term 'Restore-AzureKeyVaultKey' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ Restore-AzureKeyVaultKey -VaultName 'storagekvtanisha' -InputFile $ke ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Restore-AzureKeyVaultKey:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException


Correct command:

PS C:\WINDOWS\system32> Restore-AzKeyVaultKey -VaultName '<target_vault_name>' -InputFile $keyDestination


Vault/HSM Name : storagekvtanisha
Name           : key1
Key Type       : RSA
Key Size       : 2048
Curve Name     :
Version        : 496b727f64c248c7ba43c23551202db8
Id             : https://storagekvtanisha.vault.azure.net:443/keys/key1/496b727f64c248c7ba43c23551202db8
Enabled        : True
Expires        :
Not Before     :
Created        : 5/29/2024 4:46:07 AM
Updated        : 5/29/2024 4:46:07 AM
Recovery Level : Recoverable
Release Policy :
Tags           :