### PR TITLE
Update Linux command in vminsights-dependency-agent-maintenance.md

### DIFF
--- a/articles/azure-monitor/vm/vminsights-dependency-agent-maintenance.md
+++ b/articles/azure-monitor/vm/vminsights-dependency-agent-maintenance.md
@@ -75,7 +75,7 @@ You can download the latest version of the Linux agent from [here](https://aka.m
 2. Run the following command as root.
 
     ```bash
-    InstallDependencyAgent-Linux64.bin -s
+    ./InstallDependencyAgent-Linux64.bin -s
     ```
 
 If the Dependency agent fails to start, check the logs for detailed error information. On Linux agents, the log directory is */var/opt/microsoft/dependency-agent/log*. 


### PR DESCRIPTION
I encountered an error when executing the command provided in this document to install the Dependency Agent on a Linux VM.
The command was: InstallDependencyAgent-Linux64.bin -s. 
However, I think the correct command should be: ./InstallDependencyAgent-Linux64.bin -s.