### PR TITLE
Updating Best Practices for indexing in Azure Cosmos DB for MongoDB vCore

### DIFF
--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -48,14 +48,14 @@ Compound indexes should be used for the following scenarios:
 - Queries with filters on multiple fields and with one or more fields sorted in ascending or descending order
 
 Consider the following document within the cosmicworks database and employee collection
-```javascript
+```json
 {
-    firstName: 'Steve',
-    lastName: 'Smith',
-    companyName: 'Microsoft',
-    division: 'Azure',
-    subDivision: 'Data & AI',
-    timeInOrgInYears: '7'
+    "firstName": "Steve",
+    "lastName": "Smith",
+    "companyName": "Microsoft",
+    "division": "Azure",
+    "subDivision": "Data & AI",
+    "timeInOrgInYears": 7
 }
 ```
 
@@ -88,10 +88,10 @@ When a createIndex operation is in progress, the response will look like:
       "active": true,
       "type": "op",
       "opid": "30000451493:1719209762286363",
-      "op_prefix": Long('30000451493'),
-      "currentOpTime": ISODate('2024-06-24T06:16:02.000Z'),
+      "op_prefix": 30000451493,
+      "currentOpTime": "2024-06-24T06:16:02.000Z",
       "secs_running": Long('0'),
-      "command": { aggregate: '' },
+      "command": { "aggregate": "" },
       "op": "command",
       "waitingForLock": false
     },
@@ -100,14 +100,14 @@ When a createIndex operation is in progress, the response will look like:
       "active": true,
       "type": "op",
       "opid": "30000451876:1719209638351743",
-      "op_prefix": Long('30000451876'),
-      "currentOpTime": ISODate('2024-06-24T06:13:58.000Z'),
-      "secs_running": Long('124'),
-      "command": { createIndexes: '' },
+      "op_prefix": 30000451876,
+      "currentOpTime": "2024-06-24T06:13:58.000Z",
+      "secs_running": 124,
+      "command": { "createIndexes": "" },
       "op": workerCommand",
       "waitingForLock": false,
       "progress": {},
-      "msg": ''
+      "msg": ""
     }
   ],
   "ok": 1

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -30,7 +30,7 @@ When a new document is inserted for the first time or an existing document is up
 For optimal write performance, indexes should be created upfront before data is loaded. This ensures all documents that are inserted for the first time or subsequently updated or deleted will have the corresponding indexes updated as part of the write operation. If indexes are created after data has been ingested, additional server resources will be consumed to index historical data. Depending on the size of the historical data, this can be time consuming and can affect steady state write and read operations.
 
 > [!NOTE]
-    > For scenarios where indexes need to be added at a later time due to changes in read patterns, background indexing needs to be enabled on the cluster which can be enabled through a support ticket.
+For scenarios where indexes need to be added at a later time due to changes in read patterns, background indexing needs to be enabled on the cluster which can be enabled through a support ticket.
 
 ## For multiple indexes created on historical data, issue non-blocking createIndex commands for each field
 It is not always possible to plan for all query patterns upfront. Changing application needs will inevitably require fields to be added to the index at a later time on an active cluster with a large amount of historical data. In such scenarios, if multiple fields need to be added to the index, each createIndex command should be issued asynchronously without waiting on a response from the server.

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -1,52 +1,101 @@
 ---
-title:  Optimize index creation in Azure Cosmos DB for MongoDB vCore
+title:  Indexing Best Practices in Azure Cosmos DB for MongoDB vCore
 titleSuffix: Azure Cosmos DB for MongoDB vCore
 description: Use create Indexing for empty collections in Azure Cosmos DB for MongoDB vCore.
-author: khelanmodi
-ms.author: khelanmodi
+author: abinav2307
+ms.author: abinav2307
 ms.reviewer: sidandrews
 ms.service: cosmos-db
 ms.subservice: mongodb-vcore
 ms.topic: conceptual
-ms.date: 1/24/2024
+ms.date: 6/24/2024
 ---
 
-# Optimize index creation in Azure Cosmos DB for MongoDB vCore
+# Indexing Best Practices in Azure Cosmos DB for MongoDB vCore
 
 [!INCLUDE[MongoDB vCore](~/reusable-content/ce-skilling/azure/includes/cosmos-db/includes/appliesto-mongodb-vcore.md)]
 
 The `CreateIndexes` Command in Azure Cosmos DB for MongoDB vCore has an option to optimize index creation, especially beneficial for scenarios involving empty collections. This document outlines the usage and expected behavior of this new option.
 
-## Advantages in Specific Scenarios
+## Queryable fields should have indexes created
+Azure Cosmos DB for MongoDB vCore only indexes the _id field by default and all other fields are excluded. Thus, indexes should explicitly be created for all queryable fields for the workload.
 
-- **Efficiency in Migration Utilities**: This option is ideal in migration contexts, reducing the time for index creation by preventing delays caused by waiting for transactions with pre-existing snapshots.
-- **Streamlined Index Creation Process**: In Cosmos DB for MongoDB vCore, this translates to a simpler process with a single collection scan, enhancing efficiency.
-- **Enhanced Control**: Users gain more control over the indexing process, crucial in environments balancing read and write operations during index creation.
+## Avoid unnecessary indexes and indexing all fields
+While indexes should be created for all queryable fields other than the _id field, all fields should not be indexed if unnecessary.
 
-## Prerequisites
+When a new document is inserted for the first time or an existing document is updated or deleted, each of the specified fields in the index also needs to be updated. If the indexing policy contains a large number of fields (or all the fields in the document), additional time will be spent by the server in updating the corresponding indexes and write performance may be sub optimal. When running at scale, only the queryable fields should be indexed while all other fields not used in query predicates should be excluded from the index. 
 
-- An existing Azure Cosmos DB for MongoDB vCore cluster.
-  - If you don't have an Azure subscription, [create an account for free](https://azure.microsoft.com/free).
-  - If you have an existing Azure subscription, [create a new Azure Cosmos DB for MongoDB vCore cluster](quickstart-portal.md).
+## Create the necessary indexes prior to data ingestion
+For optimal write performance, indexes should be created upfront before data is loaded. This ensures all documents that are inserted for the first time or subsequently updated or deleted will have the corresponding indexes updated as part of the write operation. If indexes are created after data has been ingested, additional server resources will be consumed to index historical data. Depending on the size of the historical data, this can be time consuming and can affect steady state write and read operations.
 
-## Default Setting
+> [!NOTE]
+    > For scenarios where indexes need to be added at a later time due to changes in read patterns, background indexing needs to be enabled on the cluster which can be enabled through a support ticket.
 
-The default value of this option is `false`, ensuring backward compatibility and maintaining the existing non-blocking behavior.
+## For multiple indexes created on historical data, issue non-blocking createIndex commands for each field
+It is not always possible to plan for all query patterns upfront. Changing application needs will inevitably require fields to be added to the index at a later time on an active cluster with a large amount of historical data. In such scenarios, if multiple fields need to be added to the index, each createIndex command should be issued asynchronously without waiting on a response from the server.
+
+By default, Azure Cosmos DB for MongoDB vCore responds only after the index has been fully built on all the historically loaded documents. Depending on the size of the cluster and the volume of data already ingested, this can take time and may appear as though the server is not responding to the createIndex command. An independent call to getIndexes can be used to verify that the newly added field is now part of the list of fields to be indexed.
+
+## Track the status of a createIndex operation
+When indexes are added and historical data needs to be indexed, the progress of the index build operation(s) can be tracked using db.currentOp().
+
+Consider the example below, to track the indexing progress on a database named cosmicworks.
+```javascript
+use cosmicworks;
+db.currentOp()
+```
+
+When a createIndex operation is in progress, the response will look like:
+```json
+{
+  inprog: [
+    {
+      shard: 'defaultShard',
+      active: true,
+      type: 'op',
+      opid: '30000451493:1719209762286363',
+      op_prefix: Long('30000451493'),
+      currentOpTime: ISODate('2024-06-24T06:16:02.000Z'),
+      secs_running: Long('0'),
+      command: { aggregate: '' },
+      op: 'command',
+      waitingForLock: false
+    },
+    {
+      shard: 'defaultShard',
+      active: true,
+      type: 'op',
+      opid: '30000451876:1719209638351743',
+      op_prefix: Long('30000451876'),
+      currentOpTime: ISODate('2024-06-24T06:13:58.000Z'),
+      secs_running: Long('124'),
+      command: { createIndexes: '' },
+      op: 'workerCommand',
+      waitingForLock: false,
+      progress: {},
+      msg: ''
+    }
+  ],
+  ok: 1
+}
+```
+
+## Enable Large Index Keys by default
+Even if the documents do not contain keys that have a large number of characters or the documents do not have multiple levels of nesting, specifying large index keys ensures these scenarios are covered.
+
+Consider the example below to enable large index keys on a collection named large_index_coll within the cosmicworks database.
+
+```javascript
+use cosmicworks;
+db.runCommand({ "createIndexes": "large_index_coll", "indexes": [ { "key": { "ikey": 1 }, "name": "ikey_1", "enableLargeIndexKeys": true } ] })
+```
 
 ## Blocking Option
-
-The `CreateIndexes` Command includes a `{ "blocking": true }` option, designed to provide more control over the indexing process in an empty collection.
+For scenarios in which the index should strictly be created before data has been loaded and for new writes to be blocked until all the historical data has been fully indexed, the blocking option should be specified when creating the index.
 
 Setting `{ "blocking": true }` blocks all write operations (delete, update, insert) to the collection until index creation is completed. This feature is particularly useful in scenarios such as migration utilities where indexes are created on empty collections before data writes commence.
 
-## Create an index using the blocking option
-
-For simplicity, let us consider an example of a blog application with the following setup:
-
-- **Database name**: `cosmicworks`
-- **Collection name**: `products`
-
-To demonstrate the use of this new option in the `cosmicworks` database for an empty collection named `products`. This code snippet demonstrates how to use the blocking option, which will temporarily block write operations to the specified collection during index creation in an empty collection:
+Consider an example of the blocking option for index creation being specified on a products collection within the cosmicworks database:
 
 ```javascript
 use cosmicworks;
@@ -57,10 +106,6 @@ db.runCommand({
 })
 
 ```
-
-## Summary
-
-The introduction of the blocking option in the `CreateIndexes` Command of Azure Cosmos DB for MongoDB (vCore) is a strategic enhancement for optimizing index creation for an empty collection. This feature complements the existing non-blocking method, providing an additional tool for scenarios requiring efficient index creation on empty collections.
 
 ## Related content
 

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -101,7 +101,7 @@ db.runCommand(
 })
 ```
 
-## Blocking Option
+## Prioritizing Index Builds over new Write Operations using the Blocking Option
 For scenarios in which the index should strictly be created before data has been loaded and for new writes to be blocked until all the historical data has been fully indexed, the blocking option should be specified when creating the index.
 
 Setting `{ "blocking": true }` blocks all write operations (delete, update, insert) to the collection until index creation is completed. This feature is particularly useful in scenarios such as migration utilities where indexes are created on empty collections before data writes commence.

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -15,13 +15,14 @@ ms.date: 6/24/2024
 
 [!INCLUDE[MongoDB vCore](~/reusable-content/ce-skilling/azure/includes/cosmos-db/includes/appliesto-mongodb-vcore.md)]
 
-The `CreateIndexes` Command in Azure Cosmos DB for MongoDB vCore has an option to optimize index creation, especially beneficial for scenarios involving empty collections. This document outlines the usage and expected behavior of this new option.
+## Queryable fields should always have indexes created
+Read operations based on predicates and aggregates will first consult the index for the corresponding filters. In the absence of indexes, the database engine will perform a document scan to retrieve the matching documents. Scans will always be expensive and will get progressively more expensive as the volume of data in a collection continues to grow. Thus, indexes should always be created for all queryable fields.
 
-## Queryable fields should have indexes created
-Azure Cosmos DB for MongoDB vCore only indexes the _id field by default and all other fields are excluded. Thus, indexes should explicitly be created for all queryable fields for the workload.
+## Avoid unnecessary indexes and indexing all fields by default
+While indexes should be created for queryable fields, all fields within the document structure in a collection should not be indexed if unnecessary.
 
-## Avoid unnecessary indexes and indexing all fields
-While indexes should be created for all queryable fields other than the _id field, all fields should not be indexed if unnecessary.
+> [!TIP]
+> Azure Cosmos DB for MongoDB vCore only indexes the _id field by default. All other fields are not indexed by default. The fields to be indexed should be planned ahead of time to optimize for both read and write performance.
 
 When a new document is inserted for the first time or an existing document is updated or deleted, each of the specified fields in the index also needs to be updated. If the indexing policy contains a large number of fields (or all the fields in the document), additional time will be spent by the server in updating the corresponding indexes and write performance may be sub optimal. When running at scale, only the queryable fields should be indexed while all other fields not used in query predicates should be excluded from the index. 
 

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -90,7 +90,7 @@ When a createIndex operation is in progress, the response will look like:
       "opid": "30000451493:1719209762286363",
       "op_prefix": 30000451493,
       "currentOpTime": "2024-06-24T06:16:02.000Z",
-      "secs_running": Long('0'),
+      "secs_running": 0,
       "command": { "aggregate": "" },
       "op": "command",
       "waitingForLock": false
@@ -104,7 +104,7 @@ When a createIndex operation is in progress, the response will look like:
       "currentOpTime": "2024-06-24T06:13:58.000Z",
       "secs_running": 124,
       "command": { "createIndexes": "" },
-      "op": workerCommand",
+      "op": "workerCommand",
       "waitingForLock": false,
       "progress": {},
       "msg": ""

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -87,7 +87,17 @@ Consider the example below to enable large index keys on a collection named larg
 
 ```javascript
 use cosmicworks;
-db.runCommand({ "createIndexes": "large_index_coll", "indexes": [ { "key": { "ikey": 1 }, "name": "ikey_1", "enableLargeIndexKeys": true } ] })
+db.runCommand(
+{
+ "createIndexes": "large_index_coll",
+ "indexes": [
+    {
+        "key": { "ikey": 1 },
+        "name": "ikey_1",
+        "enableLargeIndexKeys": true
+    }
+    ]
+})
 ```
 
 ## Blocking Option

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -19,35 +19,38 @@ ms.date: 6/24/2024
 Read operations based on predicates and aggregates will first consult the index for the corresponding filters. In the absence of indexes, the database engine will perform a document scan to retrieve the matching documents. Scans will always be expensive and will get progressively more expensive as the volume of data in a collection continues to grow. For optimal queri performance, indexes should always be created for all queryable fields.
 
 ## Avoid unnecessary indexes and indexing all fields by default
-While indexes should be created for queryable fields, all fields within the document structure in a collection should not be indexed (either individually or through wildcard indexing) if they are not going to be part of query predicates or filters.
+While indexes should be created for all queryable fields, other fields within the document structure in a collection should not be indexed (either individually or through wildcard indexing) if they are not going to be part of query predicates or filters.
 
 > [!TIP]
-> Azure Cosmos DB for MongoDB vCore only indexes the _id field by default. All other fields are not indexed by default. The fields to be indexed should be planned ahead of time to optimize for both read and write performance.
+> Azure Cosmos DB for MongoDB vCore only indexes the _id field by default. All other fields are not indexed by default. The fields to be indexed should be planned ahead of time to maximize query performance while minimizing impact on write throughput from indexing too many fields.
 
-When a new document is inserted for the first time or an existing document is updated or deleted, each of the specified fields in the index also needs to be updated. If the indexing policy contains a large number of fields (or all the fields in the document), additional time will be spent by the server in updating the corresponding indexes and write performance may be sub optimal. When running at scale, only the queryable fields should be indexed while all other fields not used in query predicates should be excluded from the index. 
+When a new document is inserted for the first time or an existing document is updated or deleted, each of the specified fields in the index also needs to be updated. If the indexing policy contains a large number of fields (or all the fields in the document), additional resources will be consumed by the server in updating the corresponding indexes. When running at scale, only the queryable fields should be indexed while all other fields not used in query predicates should be excluded from the index. 
 
 ## Create the necessary indexes prior to data ingestion
-For optimal write performance, indexes should be created upfront before data is loaded. This ensures all documents that are inserted for the first time or subsequently updated or deleted will have the corresponding indexes updated as part of the write operation. If indexes are created after data has been ingested, additional server resources will be consumed to index historical data. Depending on the size of the historical data, this can be time consuming and can affect steady state write and read operations.
+For optimal performance, indexes should be created upfront before data is loaded. This ensures all documents that are inserted for the first time or subsequently updated or deleted will have the corresponding indexes updated synchronously as part of the write operation. If indexes are created after data has been ingested, additional server resources will be consumed to index historical data. Depending on the size of the historical data, this can be time consuming and could impact steady state read and write performance.
 
 > [!NOTE]
-For scenarios where indexes need to be added at a later time due to changes in read patterns, background indexing needs to be enabled on the cluster which can be enabled through a support ticket.
+For scenarios where indexes need to be added at a later time due to changes in read patterns, background indexing needs to be enabled on the cluster which can be done through a support ticket.
 
 ## For multiple indexes created on historical data, issue non-blocking createIndex commands for each field
-It is not always possible to plan for all query patterns upfront, particularly when application needs evolve over time. Changing business and application needs will inevitably require fields to be added to the index at a later time on a cluster with a large amount of historical data. In such scenarios, if one or more fields need to be added to the index, each createIndex command should be issued asynchronously without waiting on a response from the server.
+It is not always possible to plan for all query patterns upfront, particularly as application requirements evolve. Changing business and application needs will inevitably require fields to be added to the index on a cluster with a large amount of historical data. 
 
-By default, Azure Cosmos DB for MongoDB vCore responds to a createIndex operation only after the index has been fully built on all the historical data. Depending on the size of the cluster and the volume of data already ingested, this can take time and may appear as though the server is not responding to the createIndex command. 
+In such scenarios, each createIndex command should be issued asynchronously without waiting on a response from the server.
+
+> [!NOTE]
+By default, Azure Cosmos DB for MongoDB vCore responds to a createIndex operation only after the index has been fully built on the historical data. Depending on the size of the cluster and the volume of data already ingested, this can take time and may appear as though the server is not responding to the createIndex command. 
 
 If the createIndex commands are being issued through the Mongo Shell, use Ctrl + C to interrupt the command to stop waiting on a response and issue the next set of operations. 
 
 > [!NOTE]
-Using Ctrl + C to interrupt the createIndex command after it has been issued does not terminate the index build operation on the server. It simply stops the Shell from waiting on a response from the server, while the server asynchronously builds in the index over the existing documents in the collection.
+Using Ctrl + C to interrupt the createIndex command after it has been issued does not terminate the index build operation on the server. It simply stops the Shell from waiting on a response from the server, while the server asynchronously continues to build the index over the existing documents.
 
 ## Create Compound Indexes for queries with predicates on multiple fields
 Compound indexes should be used for the following scenarios:
 - Queries with filters on multiple fields
 - Queries with filters on multiple fields and with one or more fields sorted in ascending or descending order
 
-Consider the following document within the cosmicworks database and employee collection
+Consider the following document within the 'cosmicworks' database and 'employee' collection
 ```json
 {
     "firstName": "Steve",
@@ -73,7 +76,7 @@ db.employee.createIndex({"lastName" : 1, "timeInOrgInYears" : 1})
 ## Track the status of a createIndex operation
 When indexes are added and historical data needs to be indexed, the progress of the index build operation(s) can be tracked using db.currentOp().
 
-Consider the example below, to track the indexing progress on a database named cosmicworks.
+Consider the example below, to track the indexing progress on the 'cosmicworks' database.
 ```javascript
 use cosmicworks;
 db.currentOp()
@@ -115,9 +118,9 @@ When a createIndex operation is in progress, the response will look like:
 ```
 
 ## Enable Large Index Keys by default
-Even if the documents do not contain keys that have a large number of characters or the documents do not have multiple levels of nesting, specifying large index keys ensures these scenarios are covered.
+Even if the documents do not contain keys that have a large number of characters or the documents do not contain multiple levels of nesting, specifying large index keys ensures these scenarios are covered.
 
-Consider the example below to enable large index keys on a collection named large_index_coll within the cosmicworks database.
+Consider the example below to enable large index keys on the 'large_index_coll' collection within the 'cosmicworks' database.
 
 ```javascript
 use cosmicworks;
@@ -135,16 +138,16 @@ db.runCommand(
 ```
 
 ## Prioritizing Index Builds over new Write Operations using the Blocking Option
-For scenarios in which the index should strictly be created before data has been loaded and for new writes to be blocked until all the historical data has been fully indexed, the blocking option should be specified when creating the index.
+For scenarios in which the index should strictly be created before data has been loaded and for new writes to be blocked until historical data has been fully indexed, the blocking option should be specified when creating the index.
 
 Setting `{ "blocking": true }` blocks all write operations (delete, update, insert) to the collection until index creation is completed. This feature is particularly useful in scenarios such as migration utilities where indexes are created on empty collections before data writes commence.
 
-Consider an example of the blocking option for index creation being specified on a products collection within the cosmicworks database:
+Consider an example of the blocking option for index creation being specified on the 'employee' collection within the 'cosmicworks' database:
 
 ```javascript
 use cosmicworks;
 db.runCommand({
-  createIndexes: "products",
+  createIndexes: "employee",
   indexes: [{"key":{"name":1}, "name":"name_1"}],
   blocking: true
 })

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -46,7 +46,7 @@ db.currentOp()
 ```
 
 When a createIndex operation is in progress, the response will look like:
-```json
+```javascript
 {
   inprog: [
     {

--- a/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
+++ b/articles/cosmos-db/mongodb/vcore/how-to-create-indexes.md
@@ -16,7 +16,7 @@ ms.date: 6/24/2024
 [!INCLUDE[MongoDB vCore](~/reusable-content/ce-skilling/azure/includes/cosmos-db/includes/appliesto-mongodb-vcore.md)]
 
 ## Queryable fields should always have indexes created
-Read operations based on predicates and aggregates will first consult the index for the corresponding filters. In the absence of indexes, the database engine will perform a document scan to retrieve the matching documents. Scans will always be expensive and will get progressively more expensive as the volume of data in a collection continues to grow. Thus, indexes should always be created for all queryable fields.
+Read operations based on predicates and aggregates will first consult the index for the corresponding filters. In the absence of indexes, the database engine will perform a document scan to retrieve the matching documents. Scans will always be expensive and will get progressively more expensive as the volume of data in a collection continues to grow. For optimal queri performance, indexes should always be created for all queryable fields.
 
 ## Avoid unnecessary indexes and indexing all fields by default
 While indexes should be created for queryable fields, all fields within the document structure in a collection should not be indexed (either individually or through wildcard indexing) if they are not going to be part of query predicates or filters.


### PR DESCRIPTION
Previously, the indexing docs page for vCore only specified the blocking option to block new writes until historical data had been fully indexed.

This page has now been updated to include multiple scenarios that we have discovered and need to highlight for indexing best practices