### PR TITLE
Add the limitation for circuit breaker

### DIFF
--- a/articles/api-management/backends.md
+++ b/articles/api-management/backends.md
@@ -263,7 +263,8 @@ Include a JSON snippet similar to the following in your ARM template for a backe
 
 ## Limitation
 
-For **Developer** and **Premium** tiers, an API Management instance deployed in an [internal virtual network](api-management-using-with-internal-vnet.md) can throw HTTP 500 `BackendConnectionFailure` errors when the gateway endpoint URL and backend URL are the same. If you encounter this limitation, follow the instructions in the [Self-Chained API Management request limitation in internal virtual network mode](https://techcommunity.microsoft.com/t5/azure-paas-blog/self-chained-apim-request-limitation-in-internal-virtual-network/ba-p/1940417) article in the Tech Community blog. 
+- For **Developer** and **Premium** tiers, an API Management instance deployed in an [internal virtual network](api-management-using-with-internal-vnet.md) can throw HTTP 500 `BackendConnectionFailure` errors when the gateway endpoint URL and backend URL are the same. If you encounter this limitation, follow the instructions in the [Self-Chained API Management request limitation in internal virtual network mode](https://techcommunity.microsoft.com/t5/azure-paas-blog/self-chained-apim-request-limitation-in-internal-virtual-network/ba-p/1940417) article in the Tech Community blog.
+- Currently, only one rule can be configured for the circuit breaker. If you set 2 or more rules under the "circuitBreaker.rules" in your ARM template, you will get "ValidationError" and fail to deploy it. 
 
 ## Related content
 


### PR DESCRIPTION
Currently only one rule can be configured for the circuit breaker. However, there is no statement about it. We can know it only after try to deploy multiple rules for circuit breaker.

In this change, I added the statement in the "Limitation" section. I think it is also good to add "Note" sections under the "Circuit Breaker" section.
Anyway, I think this document should have this statement to describe users about current limitation.