### PR TITLE
Update lock-resources.md

### DIFF
--- a/articles/azure-resource-manager/management/lock-resources.md
+++ b/articles/azure-resource-manager/management/lock-resources.md
@@ -77,7 +77,7 @@ Applying locks can lead to unexpected results. Some operations, which don't seem
 
 - A read-only lock on a **resource group** that contains a **virtual machine** prevents all users from starting or restarting a virtual machine. These operations require a POST method request.
 
-- A read-only lock on a **resource group** prevents you from moving existing **resources** in or out of the resource group.
+- A read-only lock on a **resource group** prevents you from moving existing **resources** in or out of the resource group. But note that a **resource** with read-only lock can be moved to another resource group.
 
 - A read-only lock on a **resource group** that contains an **automation account** prevents all runbooks from starting. These operations require a POST method request.
 


### PR DESCRIPTION
Following should be added so readers have a better clarity of the nuances, in one place:

"A read-only lock on a **resource group** prevents you from moving existing **resources** in or out of the resource group. But note that a **resource** with read-only lock can be moved to another resource group."