### PR TITLE
Update vpn-gateway-about-vpngateways.md

### DIFF
--- a/articles/vpn-gateway/vpn-gateway-about-vpngateways.md
+++ b/articles/vpn-gateway/vpn-gateway-about-vpngateways.md
@@ -38,6 +38,8 @@ Here are some of the key scenarios for VPN Gateway:
 
   * **ExpressRoute + VPN Gateway:** A combination of ExpressRoute + VPN Gateway connections (coexisting connections).
 
+* Use VPN Gateway as [a hub](./vpn-gateway-peering-gateway-transit.md) to connect with spokes such as peered networks, site-to-site connections, point-to-site connections and VNet-to-VNet connections. 
+
 ## <a name="connectivity"></a> Planning and design
 
 Because you can create multiple connection configurations using VPN Gateway, you need to determine which configuration best fits your needs. Point-to-site, site-to-site, and coexisting ExpressRoute/site-to-site connections all have different instructions and resource configuration requirements.


### PR DESCRIPTION
Surprisingly, this page has no mention of peering. It can give impression that VPN Gateway doesn't support VNet peering. I've added the following use case to disambiguate:

"Use VPN Gateway as a hub to connect with spokes such as peered networks, site-to-site connections, point-to-site connections and VNet-to-VNet connections."