### PR TITLE
Removed extra parameters from the Set-AzVMOSDisk command

### DIFF
--- a/articles/virtual-machines/attach-os-disk.md
+++ b/articles/virtual-machines/attach-os-disk.md
@@ -169,8 +169,7 @@ $vm = Add-AzVMNetworkInterface -VM $vmConfig -Id $nic.Id
 Add the OS disk. Add the OS disk to the configuration by using [Set-AzVMOSDisk](/powershell/module/az.compute/set-azvmosdisk). This example sets the size of the disk to *128 GB* and attaches the disk as a *Windows* OS disk.
  
 ```powershell
-$vm = Set-AzVMOSDisk -VM $vm -ManagedDiskId $osDisk.Id -StorageAccountType Standard_LRS `
-    -DiskSizeInGB 128 -CreateOption Attach -Windows
+$vm = Set-AzVMOSDisk -VM $vm -ManagedDiskId $osDisk.Id -CreateOption Attach -Windows
 ```
 
 Create the VM by using [New-AzVM](/powershell/module/az.compute/new-azvm) with the configurations that we just created.


### PR DESCRIPTION
If the ManagedDiskId parameter is being passed with Set-AzVMOSDisk, the StorageAccountType and DiskSizeInGB parameters are not required.

Running the commands in the documentation produces the following error on deployment: "The entity name 'osDisk.name' is invalid according to its validation rule: ^[^_\W][\w-._]{0,79}(?<![-.])$. ErrorCode: InvalidParameter ErrorMessage: The entity name 'osDisk.name' is invalid according to its validation rule: ^[^_\W][\w-._]{0,79}(?<![-.])$. ErrorTarget: osDisk.name StatusCode: 400"

The command in the documentation has been modified to have a successful deployment.