### PR TITLE
Update deploy-staging-slots.md

### DIFF
--- a/articles/app-service/deploy-staging-slots.md
+++ b/articles/app-service/deploy-staging-slots.md
@@ -23,6 +23,9 @@ Deploying your application to a nonproduction slot has the following benefits:
 * Deploying an app to a slot first and swapping it into production makes sure that all instances of the slot are warmed up before being swapped into production. This eliminates downtime when you deploy your app. The traffic redirection is seamless, and no requests are dropped because of swap operations. You can automate this entire workflow by configuring [auto swap](#Auto-Swap) when pre-swap validation isn't needed.
 * After a swap, the slot with previously staged app now has the previous production app. If the changes swapped into the production slot aren't as you expect, you can perform the same swap immediately to get your "last known good site" back.
 
+> [!NOTE]
+> Swapping is faster than [backup](./manage-backup.md) because you firstly you need to configure backup settings of the app then you can restore to previous state. Also, App Service stops the target app or target slot while restoring a backup.
+
 Each App Service plan tier supports a different number of deployment slots. There's no extra charge for using deployment slots. To find out the number of slots your app's tier supports, see [App Service limits](../azure-resource-manager/management/azure-subscription-service-limits.md#app-service-limits). 
 
 To scale your app to a different tier, make sure that the target tier supports the number of slots your app already uses. For example, if your app has more than five slots, you can't scale it down to the **Standard** tier, because the **Standard** tier supports only five deployment slots. 


### PR DESCRIPTION
The difference between swapping and backup should be clearly explained in the doc. I've added the following for further clarity:

"Swapping is faster than backup because you firstly you need to configure backup settings of the app then you can restore to previous state. Also, App Service stops the target app or target slot while restoring a backup."

PS: this and all my PRs follow Microsoft Certification Exam – Candidate Agreement and other relevant NDAs. 