### PR TITLE
Update alerts-create-metric-alert-rule.yml

### DIFF
--- a/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
+++ b/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
@@ -82,10 +82,6 @@ procedureSection:
         
         :::image type="content" source="media/alerts-create-new-alert-rule/alerts-select-resource.png" alt-text="Screenshot that shows the select resource pane for creating a new alert rule.":::
 
-> [!NOTE]  
-> Regardless of the scope, the evaluation of alert is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription level, its underlying resource groups and resources can trigger the alert. Also, if you set up separate alert rules on different scopes that monitor the same condition, then they'll always fire independently, even if the alert rules are stateful.
-      
-
   - title: |
       Configure the alert rule conditions
     summary: |

--- a/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
+++ b/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
@@ -76,7 +76,7 @@ procedureSection:
       Follow these steps:
     steps:
       - |
-        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Alerts can be scoped at subscription, resource group and resource level. If you scope at e.g. subscription, its underlying resource groups and resources can trigger the alert.
+        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Through the Azure Portal, you can scope alerts at single resource, single resource group, single subscription, multiple resources (of the same type) or multiple resource groups. Regardless of the scope defined, the evaluation is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription, its underlying resource groups and resources can trigger the alert.
       - |
         Select **Apply**.
         

--- a/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
+++ b/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
@@ -76,7 +76,7 @@ procedureSection:
       Follow these steps:
     steps:
       - |
-        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**.
+        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Alerts can be scoped at subscription, resource group and resource level. If you scope at e.g. subscription, its underlying resource groups and resources can trigger the alert.
       - |
         Select **Apply**.
         

--- a/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
+++ b/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
@@ -76,7 +76,7 @@ procedureSection:
       Follow these steps:
     steps:
       - |
-        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Through the Azure Portal, you can scope alerts at single resource, single resource group, single subscription, multiple resources (of the same type) or multiple resource groups. Regardless of the scope defined, the evaluation is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription, its underlying resource groups and resources can trigger the alert.
+        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Through the Azure Portal, you can scope your alerts at a single resource, single resource group, single subscription, multiple resources (of the same type) or multiple resource groups. Regardless of the scope defined, the evaluation of alert is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription level, its underlying resource groups and resources can trigger the alert.
       - |
         Select **Apply**.
         

--- a/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
+++ b/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
@@ -76,11 +76,15 @@ procedureSection:
       Follow these steps:
     steps:
       - |
-        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Through the Azure Portal, you can scope your alerts at a single resource, single resource group, single subscription, multiple resources (of the same type) or multiple resource groups. Regardless of the scope defined, the evaluation of alert is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription level, its underlying resource groups and resources can trigger the alert.
+        On the **Select a resource** pane, set the scope for your alert rule. You can filter by **subscription**, **resource type**, or **resource location**. Through the Azure Portal, you can scope your alerts at a single resource, single resource group, single subscription, multiple resources (of the same type) or multiple resource groups. However, you have more options if you define the scope through API.
       - |
         Select **Apply**.
         
         :::image type="content" source="media/alerts-create-new-alert-rule/alerts-select-resource.png" alt-text="Screenshot that shows the select resource pane for creating a new alert rule.":::
+
+> [!NOTE]  
+> Regardless of the scope, the evaluation of alert is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription level, its underlying resource groups and resources can trigger the alert. If you set up separate alert rules on different scopes that monitor the same condition, then they'll always fire independently, even if the alert rules are stateful.
+      
 
   - title: |
       Configure the alert rule conditions

--- a/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
+++ b/articles/azure-monitor/alerts/alerts-create-metric-alert-rule.yml
@@ -83,7 +83,7 @@ procedureSection:
         :::image type="content" source="media/alerts-create-new-alert-rule/alerts-select-resource.png" alt-text="Screenshot that shows the select resource pane for creating a new alert rule.":::
 
 > [!NOTE]  
-> Regardless of the scope, the evaluation of alert is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription level, its underlying resource groups and resources can trigger the alert. If you set up separate alert rules on different scopes that monitor the same condition, then they'll always fire independently, even if the alert rules are stateful.
+> Regardless of the scope, the evaluation of alert is always performed on the individual resource level, so for example, if you scope an alert at e.g. subscription level, its underlying resource groups and resources can trigger the alert. Also, if you set up separate alert rules on different scopes that monitor the same condition, then they'll always fire independently, even if the alert rules are stateful.
       
 
   - title: |


### PR DESCRIPTION
Current text only tells about filters, but it should also mention possible scope levels too. Also, I can't find any information on the doc about how does alert work for lower-level resources. For example, if an alert is scoped at subscription level, but the condition is met only at its underlying resource group level, what happens? Does subscription-level alert get triggered? Actually this is a tricky situation and I believe the documentation should clearly explain it. I've added it to the best of my knowledge, but feel free to edit / correct it:


"Alerts can be scoped at subscription, resource group and resource level. If you scope at e.g. subscription, its underlying resource groups and resources can trigger the alert."

PS: this and all my PRs follow Microsoft Certification Exam – Candidate Agreement and other relevant NDAs. 