### PR TITLE
Update how-to-create-vector-index.md

### DIFF
--- a/articles/machine-learning/how-to-create-vector-index.md
+++ b/articles/machine-learning/how-to-create-vector-index.md
@@ -79,7 +79,7 @@ After you create a vector index, you can add it to a prompt flow from the prompt
 
     :::image type="content" source="media/how-to-create-vector-index/configure-index-lookup-tool.png" alt-text="Screenshot that shows the Vector Index Lookup tool.":::
 
-1. Select the **mlindex_content** value box, and select your index. The tool should detect the index created in the "Create a vector index" section of the tutorial. After filling in all the necessary information, select save to close the generate drawer.
+1. Select the **mlindex_content** value box, and select your Registered Index. The tool should detect the index created in the "Create a vector index" section of the tutorial. After filling in all the necessary information, select save to close the generate drawer.
 
 1. Enter the queries and query_types to be performed against the index. 
    


### PR DESCRIPTION
Clarifying that the Index type is Registered Index which lets you select the one created above. The statement left a gap where if you selected FAISS having previously selected FAISS to create the vector database.