### PR TITLE
Update azure dedicated-plan ASE v2 link to ASE v3

### DIFF
--- a/articles/azure-functions/dedicated-plan.md
+++ b/articles/azure-functions/dedicated-plan.md
@@ -41,7 +41,7 @@ Using an App Service plan, you can manually scale out by adding more VM instance
 
 ## App Service Environments
 
-Running in an App Service Environment (ASE) lets you fully isolate your functions and take advantage of higher numbers of instances than an App Service Plan. To get started, see [Introduction to the App Service Environments](../app-service/environment/intro.md).
+Running in an App Service Environment (ASE) lets you fully isolate your functions and take advantage of higher numbers of instances than an App Service Plan. To get started, see [Introduction to the App Service Environments](../app-service/environment/overview.md).
 
 If you just want to run your function app in a virtual network, you can do this using the [Premium plan](functions-premium-plan.md). To learn more, see [Establish Azure Functions private site access](functions-create-private-site-access.md). 
 


### PR DESCRIPTION
azure function dedicated-plan page link to ASE pointing to v2 instead of v3 which is the latest version