### PR TITLE
Update disks-prem-v2-limitations.md

### DIFF
--- a/includes/disks-prem-v2-limitations.md
+++ b/includes/disks-prem-v2-limitations.md
@@ -18,6 +18,6 @@ ms.custom:
 - Encryption at host is supported on Premium SSD v2 disks with some limitations and in select regions. For more information, see [Encryption at host](/azure/virtual-machines/disk-encryption#restrictions-1).
 - Azure Disk Encryption (guest VM encryption via Bitlocker/DM-Crypt) isn't supported for VMs with Premium SSD v2 disks. We recommend you to use encryption at rest with platform-managed or customer-managed keys, which is supported for Premium SSD v2. 
 - Currently, Premium SSD v2 disks can't be attached to VMs in Availability Sets. 
-- Azure Site Recovery is available in preview for VMs with Premium SSD v2 disks. [Preview Access](https://azure.microsoft.com/en-us/updates/premium-ssd-v2-asr-support/)
+- Azure Site Recovery is available in preview for VMs with Premium SSD v2 disks. [Preview Access](https://azure.microsoft.com/updates/premium-ssd-v2-asr-support/)
 - The size of a Premium SSD v2 can't be expanded without either deallocating the VM or detaching the disk.
 - Premium SSDv2 doesn't support host caching.

--- a/includes/disks-prem-v2-limitations.md
+++ b/includes/disks-prem-v2-limitations.md
@@ -18,6 +18,6 @@ ms.custom:
 - Encryption at host is supported on Premium SSD v2 disks with some limitations and in select regions. For more information, see [Encryption at host](/azure/virtual-machines/disk-encryption#restrictions-1).
 - Azure Disk Encryption (guest VM encryption via Bitlocker/DM-Crypt) isn't supported for VMs with Premium SSD v2 disks. We recommend you to use encryption at rest with platform-managed or customer-managed keys, which is supported for Premium SSD v2. 
 - Currently, Premium SSD v2 disks can't be attached to VMs in Availability Sets. 
-- Azure Site Recovery isn't supported for VMs with Premium SSD v2 disks.
+- Azure Site Recovery is available in preview for VMs with Premium SSD v2 disks. [Preview Access](https://azure.microsoft.com/en-us/updates/premium-ssd-v2-asr-support/)
 - The size of a Premium SSD v2 can't be expanded without either deallocating the VM or detaching the disk.
 - Premium SSDv2 doesn't support host caching.


### PR DESCRIPTION
Edited Line: 
Azure Site Recovery is available in preview for VMs with Premium SSD v2 disks. [Preview Access](https://azure.microsoft.com/en-us/updates/premium-ssd-v2-asr-support/)


OLD Line:
Azure Site Recovery isn't supported for VMs with Premium SSD v2 disks.


I'm VM team and In partnership with ASR Team, we propose to change this line, to give more visibility in preview features, to help improving the tests before going public preview