### PR TITLE
Inaccurate placeholder text event-hub-assign-roles.md

### DIFF
--- a/includes/passwordless/event-hub/event-hub-assign-roles.md
+++ b/includes/passwordless/event-hub/event-hub-assign-roles.md
@@ -75,7 +75,7 @@ Copy the `Id` value from the preceding command output. You can then assign roles
 ```azurepowershell
 New-AzRoleAssignment -SignInName <user@domain> `
 -RoleDefinitionName "Azure Event Hubs Data Owner" `
--Scope <yourStorageAccountId>
+-Scope <yourResourceId>
 ```
 
 ---


### PR DESCRIPTION
Slight wording change to the example PowerShell command to add a role assignement as "yourStorageAccountId" may be confusing to new users or less experienced users. 

The placeholder suggests that you needed a Storage Account ID when it should be clearer that you need the ResourceId from the previous Get-AzResource command. 
