### PR TITLE
Update how-to-access-azureml-behind-firewall.md

### DIFF
--- a/articles/machine-learning/how-to-access-azureml-behind-firewall.md
+++ b/articles/machine-learning/how-to-access-azureml-behind-firewall.md
@@ -453,8 +453,7 @@ __Docker images maintained by Azure Machine Learning__
 | Microsoft Container Registry | mcr.microsoft.com</br>\*.data.mcr.microsoft.com | TCP | 443 |
 
 > [!TIP]
-> * __Azure Container Registry__ is required for any custom Docker image. This includes small modifications (such as additional packages) to base images provided by Microsoft. It is also required by the internal training job submission process of Azure Machine Learning.
-> * __Microsoft Container Registry__ is only needed if you plan on using the _default Docker images provided by Microsoft_, and _enabling user-managed dependencies_.
+> * __Azure Container Registry__ is required for any custom Docker image. This includes small modifications (such as additional packages) to base images provided by Microsoft. It is also required by the internal training job submission process of Azure Machine Learning. Furthermore, __Microsoft Container Registry__ is always needed regardless of the scenario.
 > * If you plan on using federated identity, follow the [Best practices for securing Active Directory Federation Services](/windows-server/identity/ad-fs/deployment/best-practices-securing-ad-fs) article.
 
 Also, use the information in the [compute with public IP](#scenario-using-compute-cluster-or-compute-instance-with-a-public-ip) section to add IP addresses for `BatchNodeManagement` and `AzureMachineLearning`.


### PR DESCRIPTION
The information provided is false.

Microsoft Container Registry is always needed, regardless of the scenario. This is because there are some base images that are always pulled from MCR in every environment build job. 2 Examples of these images given below:
mcr.microsoft.com/azumeml/runtime/cap/.................installed:westeurope-stable
mcr.microsoft.com/azumeml/runtime/exe/.................installed:westeurope-stable