### PR TITLE
Update availability-azure-functions.md

### DIFF
--- a/articles/azure-monitor/app/availability-azure-functions.md
+++ b/articles/azure-monitor/app/availability-azure-functions.md
@@ -26,7 +26,7 @@ Start by reviewing the graph on the **Availability** tab of your Application Ins
 
 > [!NOTE]
 > Tests created with `TrackAvailability()` will appear with **CUSTOM** next to the test name.
-> Similar to standard web tests, we recommended a minimum of five test locations for TrackAvailability() to ensure you can distinguish problems in your website from network issues.
+> Similar to standard web tests, we recommend a minimum of five test locations for TrackAvailability() to ensure you can distinguish problems in your website from network issues.
 
  :::image type="content" source="media/availability-azure-functions/availability-custom.png" alt-text="Screenshot that shows the Availability tab with successful results." lightbox="media/availability-azure-functions/availability-custom.png":::
 

--- a/articles/azure-monitor/app/availability-azure-functions.md
+++ b/articles/azure-monitor/app/availability-azure-functions.md
@@ -26,6 +26,7 @@ Start by reviewing the graph on the **Availability** tab of your Application Ins
 
 > [!NOTE]
 > Tests created with `TrackAvailability()` will appear with **CUSTOM** next to the test name.
+> Similar to standard web tests, we recommended a minimum of five test locations for TrackAvailability() to ensure you can distinguish problems in your website from network issues.
 
  :::image type="content" source="media/availability-azure-functions/availability-custom.png" alt-text="Screenshot that shows the Availability tab with successful results." lightbox="media/availability-azure-functions/availability-custom.png":::
 


### PR DESCRIPTION
Similar to URL and standard tests, customers leveraging the  Track Availability must follow the minimum recommendation of 5 locations. Ref: SR 2406130040005859, where our Govt customer questioned why this has not been mentioned on our public doc. so adding a small note that this applies to trackavailability as well