### PR TITLE
Add Functions guidance regarding consistency of VNET content routing settings

### DIFF
--- a/articles/azure-functions/configure-networking-how-to.md
+++ b/articles/azure-functions/configure-networking-how-to.md
@@ -91,6 +91,9 @@ You should now route your function app's traffic to go through the virtual netwo
 
     * In the same page, check the box for **Content storage** under **Configuration routing**.
 
+> [!IMPORTANT]
+> If multiple Function Apps in the same App Service Plan use the same Azure Files account with the same credentials, they should also all use the same value for content share routing to ensure that traffic is consistently routed through the intended network. A mismatch in settings may result in traffic being routed through public networks, resulting in access being blocked by storage account network rules.
+
 ### 4. Update application settings
 
 Finally, you need to update your application settings to point at the new secure storage account.

--- a/articles/azure-functions/functions-app-settings.md
+++ b/articles/azure-functions/functions-app-settings.md
@@ -624,6 +624,9 @@ Azure Files doesn't support using managed identity when accessing the file share
 > [!IMPORTANT]
 > WEBSITE_CONTENTOVERVNET is a legacy app setting that has been replaced by the [vnetContentShareEnabled](#vnetcontentshareenabled) site property.
 
+> [!IMPORTANT]
+> If multiple Function Apps in the same App Service Plan use the same Azure Files account with the same credentials, they should also all use the same value for WEBSITE_CONTENTOVERVNET to ensure that traffic is consistently routed through the intended network. A mismatch in settings may result in traffic being routed through public networks, resulting in access being blocked by storage account network rules.
+
 A value of `1` enables your function app to scale when you have your storage account restricted to a virtual network. You should enable this setting when restricting your storage account to a virtual network. Only required when using `WEBSITE_CONTENTSHARE` and `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`. To learn more, see [Restrict your storage account to a virtual network](configure-networking-how-to.md#restrict-your-storage-account-to-a-virtual-network).
 
 |Key|Sample value|
@@ -831,6 +834,9 @@ Sets the specific version of PowerShell on which your functions run. For more in
 When running locally, you instead use the [`FUNCTIONS_WORKER_RUNTIME_VERSION`](functions-reference-powershell.md#running-local-on-a-specific-version) setting in the local.settings.json file. 
 
 ### vnetContentShareEnabled
+
+> [!IMPORTANT]
+> If multiple Function Apps in the same App Service Plan use the same Azure Files account with the same credentials, they should also all use the same value for vnetContentShareEnabled to ensure that traffic is consistently routed through the intended network. A mismatch in settings may result in traffic being routed through public networks, resulting in access being blocked by storage account network rules.
 
 Apps running in a Premium plan use a file share to store content. The name of this content share is stored in the [`WEBSITE_CONTENTSHARE`](#website_contentshare) app setting and its connection string is stored in [`WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`](#website_contentazurefileconnectionstring). To route traffic between your function app and content share through a virtual network, you must also set `vnetContentShareEnabled` to `true`. Enabling this site property is a requirement when [restricting your storage account to a virtual network](configure-networking-how-to.md#restrict-your-storage-account-to-a-virtual-network) in the Elastic Premium and Dedicated hosting plans.
 


### PR DESCRIPTION
Some customers have reported issues with accessing Functions content storage when they have multiple apps accessing the same Azure Files account with different values for the WEBSITE_CONTENTOVERVNET and vnetContentShareEnabled settings.

This PR adds guidance in the relevant documentation pages indicating that apps in the same plan using the same storage credentials should use the same values for these settings.