### PR TITLE
Update set-up-zone-redundancy-availability-zones.md

### DIFF
--- a/articles/logic-apps/set-up-zone-redundancy-availability-zones.md
+++ b/articles/logic-apps/set-up-zone-redundancy-availability-zones.md
@@ -30,7 +30,7 @@ Availability zone support is available for Standard logic apps, which are powere
 
 * You can enable availability zone redundancy *only for new* Standard logic apps with workflows that run in single-tenant Azure Logic Apps. You can't enable availability zone redundancy for existing Standard logic app workflows.
 
-* You can enable availability zone redundancy *only at creation time using Azure portal*. No programmatic tool support, such as Azure PowerShell or Azure CLI, currently exists to enable availability zone redundancy.
+* You can enable availability zone redundancy *only at creation time*. No programmatic tool support, such as Azure PowerShell or Azure CLI, currently exists to enable availability zone redundancy post creation.
 
 ### [Consumption (preview)](#tab/consumption)
 

--- a/articles/logic-apps/set-up-zone-redundancy-availability-zones.md
+++ b/articles/logic-apps/set-up-zone-redundancy-availability-zones.md
@@ -30,7 +30,7 @@ Availability zone support is available for Standard logic apps, which are powere
 
 * You can enable availability zone redundancy *only for new* Standard logic apps with workflows that run in single-tenant Azure Logic Apps. You can't enable availability zone redundancy for existing Standard logic app workflows.
 
-* You can enable availability zone redundancy *only at creation time*. No programmatic tool support, such as Azure PowerShell or Azure CLI, currently exists to enable availability zone redundancy post creation.
+* You can enable availability zone redundancy *only at creation time*. No programmatic tool support, such as Azure PowerShell or Azure CLI, currently exists to enable availability zone redundancy after creation.
 
 ### [Consumption (preview)](#tab/consumption)
 


### PR DESCRIPTION
Trying to remove the ambiguity from the following Consideration when deploying Zone Redundant Standard Logic Apps;

* You can enable availability zone redundancy *only at creation time using Azure portal*. No programmatic tool support, such as Azure PowerShell or Azure CLI, currently exists to enable availability zone redundancy.

The above reads to me (and some of my colleagues) that you can only deploy a zone redundant Standard Logic App/App Service if its done via the Azure Portal ONLY which isn't the case. App Service Plans can be deployed via all manner of CLI tools but Zone Redundancy cannot be enabled post creation. I feel like this consideration should be in fact worded like this;

* You can enable availability zone redundancy *only at creation time*. No programmatic tool support, such as Azure PowerShell or Azure CLI, currently exists to enable availability zone redundancy post creation.

Hopefully this removes some of the confusion!

To further demonstrate that the original could be confusing I found an old issue where a user was having the exact same thoughts I was;
https://github.com/Azure/logicapps/discussions/887