### PR TITLE
Update alerts-overview.md

### DIFF
--- a/articles/azure-monitor/alerts/alerts-overview.md
+++ b/articles/azure-monitor/alerts/alerts-overview.md
@@ -59,7 +59,9 @@ This table provides a brief description of each alert type. For more information
 
 Alerts can be stateful or stateless.
 - Stateless alerts fire each time the condition is met, even if fired previously.
-- Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved. A stateful alert isn't fired if there's already a fired alert on a specific time series. If, for example, there are 2 alert rules with the same condition, but one has a scope at a resource level and another alert rule has a scope at a resource group level, and an alert is triggered in a time series for one of those rules, the other rule will not trigger an alert until the first alert is resolved.
+- Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved. 
+
+Each alert rule is evaluated individually. There is no validation to check if there is another alert configured for the same conditions. If there is more than one alert rule configured for the same conditions, each of those alerts will fire when the conditions are met. 
 
 Alerts are stored for 30 days and are deleted after the 30-day retention period.
 

--- a/articles/azure-monitor/alerts/alerts-overview.md
+++ b/articles/azure-monitor/alerts/alerts-overview.md
@@ -59,7 +59,7 @@ This table provides a brief description of each alert type. For more information
 
 Alerts can be stateful or stateless.
 - Stateless alerts fire each time the condition is met, even if fired previously.
-- Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved. Stateful alerts aren't fired if there's already a fired alert on a specific time series. This is the case even if more than one stateful alerts have been applied on different scopes for the same condition, for example scoped on resource level and resource group level.
+- Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved. A stateful alert isn't fired if there's already a fired alert on a specific time series. If, for example, there are 2 alert rules with the same condition, but one has a scope at a resource level and another alert rule has a scope at a resource group level, and an alert is triggered in a time series for one of those rules, the other rule will not trigger an alert until the first alert is resolved.
 
 Alerts are stored for 30 days and are deleted after the 30-day retention period.
 

--- a/articles/azure-monitor/alerts/alerts-overview.md
+++ b/articles/azure-monitor/alerts/alerts-overview.md
@@ -59,13 +59,9 @@ This table provides a brief description of each alert type. For more information
 
 Alerts can be stateful or stateless.
 - Stateless alerts fire each time the condition is met, even if fired previously.
-- Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved.
+- Stateful alerts fire when the rule conditions are met, and will not fire again or trigger any more actions until the conditions are resolved. Stateful alerts aren't fired if there's already a fired alert on a specific time series. This is the case even if more than one stateful alerts have been applied on different scopes for the same condition, for example scoped on resource level and resource group level.
 
 Alerts are stored for 30 days and are deleted after the 30-day retention period.
-
-> [!NOTE]  
-> Metric alerts are stateful by default, so other alerts aren't fired if there's already a fired alert on a specific time series. This is the case even if more than one metric alert has been applied on different scopes, for example on resource level and resource group level.
-
 
 ### Stateless alerts
 Stateless alerts fire each time the condition is met. The alert condition for all stateless alerts is always `fired`. 

--- a/articles/azure-monitor/alerts/alerts-overview.md
+++ b/articles/azure-monitor/alerts/alerts-overview.md
@@ -63,6 +63,10 @@ Alerts can be stateful or stateless.
 
 Alerts are stored for 30 days and are deleted after the 30-day retention period.
 
+> [!NOTE]  
+> Metric alerts are stateful by default, so other alerts aren't fired if there's already a fired alert on a specific time series. This is the case even if more than one metric alert has been applied on different scopes, for example on resource level and resource group level.
+
+
 ### Stateless alerts
 Stateless alerts fire each time the condition is met. The alert condition for all stateless alerts is always `fired`. 
 


### PR DESCRIPTION
The following point hasn't been mentioned anywhere in the doc: what happens if multiple alerts (for the same condition) have been scoped on different levels? which one(s) get triggered? 

Also, the current explanation for stateful alerts is a bit vague, I'm afraid. I understood it only when I read other explanations. 

Anyway, I've added the following to clarify it so readers have a better understanding of nuances. Please feel free to tune it further.

> Stateful alerts aren't fired if there's already a fired alert on a specific time series. This is the case even if more than one stateful alerts have been applied on different scopes for the same condition, for example scoped on resource level and resource group level.