### PR TITLE
Is there a missing "No ealier than" statement on "gpt-35-turbo" 0613 retirement date?

### DIFF
--- a/articles/ai-services/openai/concepts/model-retirements.md
+++ b/articles/ai-services/openai/concepts/model-retirements.md
@@ -61,7 +61,7 @@ These models are currently available for use in Azure OpenAI Service.
 | Model | Version | Retirement date |
 | ---- | ---- | ---- |
 | `gpt-35-turbo` | 0301 | No earlier than October 1, 2024 |
-| `gpt-35-turbo`<br>`gpt-35-turbo-16k` | 0613 | October 1, 2024 |
+| `gpt-35-turbo`<br>`gpt-35-turbo-16k` | 0613 | No earlier than October 1, 2024 |
 | `gpt-35-turbo` | 1106 | No earlier than Nov 17, 2024 |
 | `gpt-35-turbo` | 0125 | No earlier than Feb 22, 2025 |
 | `gpt-4`<br>`gpt-4-32k` | 0314 | **Deprecation:** October 1, 2024 <br> **Retirement:** June 6, 2025 |


### PR DESCRIPTION
Is there a missing "No ealier than" statement on "gpt-35-turbo" 0613 retirement date?

There seems to be a discrepancy that 0601 (which was released after 0301) is scheduled to retire earlier than 0301.

<img width="670" alt="image" src="https://github.com/MicrosoftDocs/azure-docs/assets/65746722/8baf4605-5670-4ead-9519-47179975cdbe">
