### PR TITLE
Update azure-arc-enable-cluster.md

### DIFF
--- a/articles/container-apps/azure-arc-create-container-app.md
+++ b/articles/container-apps/azure-arc-create-container-app.md
@@ -35,8 +35,7 @@ Next, add the required Azure CLI extensions.
 
 ```azurecli-interactive
 az extension add --upgrade --yes --name customlocation
-az extension remove --name containerapp
-az extension add -s https://aka.ms/acaarccli/containerapp-latest-py2.py3-none-any.whl --yes
+az extension add --name containerapp  --upgrade --yes
 ```
 
 ## Create a resource group

--- a/articles/container-apps/azure-arc-enable-cluster.md
+++ b/articles/container-apps/azure-arc-enable-cluster.md
@@ -48,7 +48,7 @@ az extension add --name connectedk8s  --upgrade --yes
 az extension add --name k8s-extension --upgrade --yes
 az extension add --name customlocation --upgrade --yes
 az extension remove --name containerapp
-az extension add --source https://aka.ms/acaarccli/containerapp-latest-py2.py3-none-any.whl --yes
+az extension add --name containerapp  --upgrade --yes
 ```
 
 # [PowerShell](#tab/azure-powershell)

--- a/articles/container-apps/azure-arc-enable-cluster.md
+++ b/articles/container-apps/azure-arc-enable-cluster.md
@@ -44,7 +44,7 @@ Install the following Azure CLI extensions.
 # [Azure CLI](#tab/azure-cli)
 
 ```azurecli-interactive
- add --name connectedk8s  --upgrade --yes
+az extension add --name connectedk8s --upgrade --yes
 az extension add --name k8s-extension --upgrade --yes
 az extension add --name customlocation --upgrade --yes
 az extension remove --name containerapp

--- a/articles/container-apps/azure-arc-enable-cluster.md
+++ b/articles/container-apps/azure-arc-enable-cluster.md
@@ -44,7 +44,7 @@ Install the following Azure CLI extensions.
 # [Azure CLI](#tab/azure-cli)
 
 ```azurecli-interactive
-az extension add --name connectedk8s  --upgrade --yes
+ add --name connectedk8s  --upgrade --yes
 az extension add --name k8s-extension --upgrade --yes
 az extension add --name customlocation --upgrade --yes
 az extension remove --name containerapp
@@ -57,8 +57,7 @@ az extension add --name containerapp  --upgrade --yes
 az extension add --name connectedk8s  --upgrade --yes
 az extension add --name k8s-extension --upgrade --yes
 az extension add --name customlocation --upgrade --yes
-az extension remove --name containerapp
-az extension add --source https://aka.ms/acaarccli/containerapp-latest-py2.py3-none-any.whl --yes
+az extension add --name containerapp  --upgrade --yes
 ```
 
 ---

--- a/articles/container-apps/azure-arc-enable-cluster.md
+++ b/articles/container-apps/azure-arc-enable-cluster.md
@@ -47,7 +47,6 @@ Install the following Azure CLI extensions.
 az extension add --name connectedk8s --upgrade --yes
 az extension add --name k8s-extension --upgrade --yes
 az extension add --name customlocation --upgrade --yes
-az extension remove --name containerapp
 az extension add --name containerapp  --upgrade --yes
 ```
 


### PR DESCRIPTION
We have move all the Arc related logic to containerapp extension in  azure-cli-extensions repo, so customers don't need to use the private version.