### PR TITLE
Update cache-how-to-zone-redundancy.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
+++ b/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
@@ -15,9 +15,6 @@ In this article, you'll learn how to configure a zone-redundant Azure Cache inst
 
 Azure Cache for Redis Standard, Premium, and Enterprise tiers provide built-in redundancy by hosting each cache on two dedicated virtual machines (VMs). Even though these VMs are located in separate [Azure fault and update domains](../virtual-machines/availability.md) and highly available, they're susceptible to datacenter level failures. Azure Cache for Redis also supports zone redundancy in its Premium and Enterprise tiers. A zone-redundant cache runs on VMs spread across multiple [Availability Zones](../reliability/availability-zones-overview.md). It provides higher resilience and availability.
 
-> [!NOTE]
-> Data transfer between Azure Availability Zones will be charged at standard [bandwidth rates](https://azure.microsoft.com/pricing/details/bandwidth/).
-
 ## Prerequisites
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/free/)


### PR DESCRIPTION
Removed the note for Data transfer between Azure Availability Zones will be charged at standard bandwidth rates with the link to https://azure.microsoft.com/pricing/details/bandwidth.