### PR TITLE
Update how-to-connection.md

### DIFF
--- a/articles/machine-learning/how-to-connection.md
+++ b/articles/machine-learning/how-to-connection.md
@@ -434,7 +434,7 @@ The following example creates a Python feed connection. This connection is authe
 
 ```python
 from azure.ai.ml.entities import WorkspaceConnection
-from azure.ai.ml.entities import UsernamePasswordConfiguration, ManagedIdentityConfiguration  
+from azure.ai.ml.entities import UsernamePasswordConfiguration, PatTokenConfiguration
 
 
 name = "my_pfeed_conn"
@@ -501,25 +501,82 @@ The following example creates an Azure Container Registry connection. This conne
 
 ```python
 from azure.ai.ml.entities import WorkspaceConnection
-from azure.ai.ml.entities import UsernamePasswordConfiguration, PatTokenConfiguration  
+from azure.ai.ml.entities import UsernamePasswordConfiguration, ManagedIdentityConfiguration
 
-
-name = "my_acr_conn"
-
-target = "https://XXXXXXXXX.core.windows.net/mycontainer"
-
+# Using ManagedIdentityConfiguration
 wps_connection = WorkspaceConnection(
-    name=name,
+    name=<my_acr_conn>,
     type="container_registry",
-    target=target,
+    target=<my_acr_url>,
     credentials=ManagedIdentityConfiguration (client_id="xxxxx", resource_id="xxxxx"),    
 )
 ml_client.connections.create_or_update(workspace_connection=wps_connection)
+
+# Using UsernamePasswordConfiguration
+wps_connection = WorkspaceConnection(
+    name=<my_acr_conn>,
+    type="container_registry",
+    target=<my_acr_url>,
+    credentials=UsernamePasswordConfiguration(username="xxxxx", password="xxxxx"),
+)
+ml_client.connections.create_or_update(workspace_connection=wps_connection)
+
+#Note: You can also set these credentials as environment variables or secrets in your keyvault for added security.
 ```
 
 # [Studio](#tab/azure-studio)
 
 You can't create an Azure Container Registry connection in studio.
+
+---
+
+### Third-Party Container Registries
+
+# [Azure CLI](#tab/cli)
+
+Create a connection to other third-party container registries with the following YAML file. Be sure to update the appropriate values:
+
+* Connect using a username and password:
+
+   ```yml
+   name: test_ws_conn_cr_user_pass
+   type: container_registry
+   target: https://test-feed.com2
+   credentials:
+      type: username_password
+      username: contoso
+      password: pass
+   ```
+
+Create the Azure Machine Learning connection in the CLI:
+
+```azurecli
+az ml connection create --file connection.yaml
+```
+
+# [Python SDK](#tab/python)
+
+The following example creates an Azure Container Registry connection. This connection is authenticated using a managed identity:
+
+```python
+from azure.ai.ml.entities import WorkspaceConnection
+from azure.ai.ml.entities import UsernamePasswordConfiguration
+
+wps_connection = WorkspaceConnection(
+    name=<my_acr_conn>,
+    type="container_registry",
+    target=<my_acr_url>,
+    credentials=UsernamePasswordConfiguration(username="xxxxx", password="xxxxx"),
+)
+ml_client.connections.create_or_update(workspace_connection=wps_connection)
+
+#Note: You can also set these credentials as environment variables or secrets in your keyvault for added security.
+```
+
+# [Studio](#tab/azure-studio)
+
+You can't create an Azure Container Registry connection in studio.
+
 
 ---
 

--- a/articles/machine-learning/how-to-connection.md
+++ b/articles/machine-learning/how-to-connection.md
@@ -363,17 +363,14 @@ The following example creates a Git connection to a GitHub repo. This connection
 from azure.ai.ml.entities import WorkspaceConnection
 from azure.ai.ml.entities import PatTokenConfiguration
 
-
-name = "my_git_conn"
-
-target = "https://github.com/myaccount/myrepo"
-
 wps_connection = WorkspaceConnection(
-    name=name,
+    name=<my_git_conn>,
     type="git",
-    target=target,
-    credentials=PatTokenConfiguration(pat="XXXXXXXXX"),    
+    target=<my_git_url>,
+    credentials=PatTokenConfiguration(pat="XXXXXXXXX"),
+    #credentials=None   
 )
+
 ml_client.connections.create_or_update(workspace_connection=wps_connection)
 ```
 

--- a/articles/machine-learning/how-to-connection.md
+++ b/articles/machine-learning/how-to-connection.md
@@ -361,7 +361,7 @@ The following example creates a Git connection to a GitHub repo. This connection
 
 ```python
 from azure.ai.ml.entities import WorkspaceConnection
-from azure.ai.ml.entities import UsernamePasswordConfiguration, PatTokenConfiguration
+from azure.ai.ml.entities import PatTokenConfiguration
 
 
 name = "my_git_conn"
@@ -401,19 +401,6 @@ Create a connection to a Python feed with one of following YAML file. Be sure to
       pat: dummy_pat
    ```
 
-* Connect using a username and password:
-
-   ```yml
-   name: test_ws_conn_python_user_pass
-   type: python_feed
-   target: https://test-feed.com
-   credentials:
-      type: username_password
-      username: john
-      password: pass
-
-   ```
-
 * Connect to a public feed (no credentials):
 
    ```yml
@@ -430,24 +417,17 @@ az ml connection create --file connection.yaml
 
 # [Python SDK](#tab/python)
 
-The following example creates a Python feed connection. This connection is authenticated with a personal access token (PAT) or a username and password:
+The following example creates a Python feed connection. This connection is authenticated with a personal access token (PAT):
 
 ```python
 from azure.ai.ml.entities import WorkspaceConnection
-from azure.ai.ml.entities import UsernamePasswordConfiguration, PatTokenConfiguration
-
-
-name = "my_pfeed_conn"
-
-target = "https://XXXXXXXXX.core.windows.net/mycontainer"
+from azure.ai.ml.entities import PatTokenConfiguration
 
 wps_connection = WorkspaceConnection(
-    name=name,
+    name=<my_pdfeed_conn>,
     type="python_feed",
-    target=target,
-    #credentials=UsernamePasswordConfiguration(username="xxxxx", password="xxxxx"), 
-    credentials=PatTokenConfiguration(pat="XXXXXXXXX"),    
-
+    target=<my_pfeed_url>,
+    credentials=PatTokenConfiguration(pat="XXXXXXXXX"),
     #credentials=None
 )
 ml_client.connections.create_or_update(workspace_connection=wps_connection)
@@ -497,7 +477,7 @@ az ml connection create --file connection.yaml
 
 # [Python SDK](#tab/python)
 
-The following example creates an Azure Container Registry connection. This connection is authenticated using a managed identity:
+The following example creates an Azure Container Registry connection either with ManagedIdentityConfiguration or UsernamePasswordConfiguration:
 
 ```python
 from azure.ai.ml.entities import WorkspaceConnection
@@ -556,7 +536,7 @@ az ml connection create --file connection.yaml
 
 # [Python SDK](#tab/python)
 
-The following example creates an Azure Container Registry connection. This connection is authenticated using a managed identity:
+The following example creates a connection to a Container Registry using UsernamePasswordConfiguration:
 
 ```python
 from azure.ai.ml.entities import WorkspaceConnection


### PR DESCRIPTION
Fixed two python scripts that had incorrect imports.

Added tip on how to improve security if customers don't want to expose credentials in python code.

Added a Third-Party Container Registry connection guide that is already available and that is different from ACR (third-party only works with username+password, ACR works with MSI and username+password).