### PR TITLE
Update deploy-run-package.md

### DIFF
--- a/articles/app-service/deploy-run-package.md
+++ b/articles/app-service/deploy-run-package.md
@@ -51,7 +51,10 @@ The command also restarts the app. Because `WEBSITE_RUN_FROM_PACKAGE` is set, Ap
 
 ## Run from external URL instead
 
-You can also run a package from an external URL, such as Azure Blob Storage. You can use the [Azure Storage Explorer](../vs-azure-tools-storage-manage-with-storage-explorer.md) to upload package files to your Blob storage account. You should use a private storage container with a [Shared Access Signature (SAS)](../vs-azure-tools-storage-manage-with-storage-explorer.md#generate-a-sas-in-storage-explorer) or [use a managed identity](#access-a-package-in-azure-blob-storage-using-a-managed-identity) to enable the App Service runtime to access the package securely. 
+You can also run a package from an external URL, such as Azure Blob Storage. You can use the [Azure Storage Explorer](../vs-azure-tools-storage-manage-with-storage-explorer.md) to upload package files to your Blob storage account. You should use a private storage container with a [Shared Access Signature (SAS)](../vs-azure-tools-storage-manage-with-storage-explorer.md#generate-a-sas-in-storage-explorer) or [use a managed identity](#access-a-package-in-azure-blob-storage-using-a-managed-identity) to enable the App Service runtime to access the package securely.
+
+> [!NOTE]
+> Currently, an existing App Service resource that runs a local package cannot be migrated to run from a remote package. You will have to create a new App Service resource configured to run from an external URL.
 
 Once you upload your file to Blob storage and have an SAS URL for the file, set the `WEBSITE_RUN_FROM_PACKAGE` app setting to the URL. The following example does it by using Azure CLI:
 


### PR DESCRIPTION
Update the App Service deployment doc to note that an App Service resource running from a local package cannot be migrated to use an external URL. A new resource must be created and configured to do so. Our team has tested and confirmed this behavior. Function Apps suffer from a similar limitation.