### PR TITLE
Fix bold markers in understanding-pricing.md

### DIFF
--- a/articles/application-gateway/understanding-pricing.md
+++ b/articles/application-gateway/understanding-pricing.md
@@ -48,6 +48,7 @@ The parameter with the highest utilization among these three parameters is used 
 
 #### Capacity Unit related to Instance Count
 <h4 id="instance-count"></h4>
+
 You can also pre-provision resources by specifying the **Instance Count**. Each instance guarantees a minimum of 10 capacity units in terms of processing capability. The same instance could potentially support more than 10 capacity units for different traffic patterns depending upon the capacity unit parameters.
 
 Manually defined scale and limits set for autoscaling (minimum or maximum) are set in terms of instance count. The manually set scale for instance count and the minimum instance count in autoscale config reserves 10 capacity units/instance. These reserved capacity units are billed as long as the application gateway is active regardless of the actual resource consumption. If actual consumption crosses the 10 capacity units/instance threshold, additional capacity units are billed under the variable component.


### PR DESCRIPTION
The document rendered with `**Instance Count**` instead of making it bold.