### PR TITLE
Clarifiy ELS deployment requirements

### DIFF
--- a/articles/virtual-machines/workloads/redhat/redhat-extended-lifecycle-support.md
+++ b/articles/virtual-machines/workloads/redhat/redhat-extended-lifecycle-support.md
@@ -79,7 +79,7 @@ They continue to run but will no longer receive security updates and support, le
 [FAQ: Red Hat Enterprise Linux 7 reaches End of Maintenance Phase and transitions to Extended Life Phase - Red Hat Customer Portal] (https://access.redhat.com/articles/7005471)
 
 #### Why is the SaaS offer asking for Resource Group (RG) information when purchasing? 
-Azure provides four levels of management: management groups, subscriptions, resource groups, and resources. Resource Groups are used to organize your Azure resources more effectively. If you are applying the RHEL 7 ELS offer to VMs within a Resource Group, Azure prompts you for the name of the Resource Group. The offer is applied to each of the RHEL 7 ELS VMs within it.
+Azure provides four levels of management: management groups, subscriptions, resource groups, and resources. Resource Groups are used to organize your Azure resources more effectively. The RHEL 7 ELS offer only needs to be purchased one for each Azure subscription containing the RHEL 7 VMs, the Resource Group selected is a placeholder to link your subscription with the Red Hat offering and enable the ELS add-on on your environment. 
 
 ## Next steps
 


### PR DESCRIPTION
The actual answer could generate some confusion on the customer side. It seems that you need to buy the offer as many times as resource groups containing RHEL 7 VMs you have. However, it has been confirmed by our support team that it's not true.

You can buy it once per subscription and all the VMs for that subscription could get access to the ELS add-on. 

More info on support case number 2406260050000122 