### PR TITLE
docs(event-grid): Fix typo about encoding

### DIFF
--- a/articles/event-grid/authenticate-with-access-keys-shared-access-signatures.md
+++ b/articles/event-grid/authenticate-with-access-keys-shared-access-signatures.md
@@ -50,7 +50,7 @@ Shared Access Signatures (SAS) provides you with access control over resources w
 
 ## Shared Access Signature token
 
-You can generate a SAS token to be included when your client application communicates with Event Grid. SAS tokens for Event Grid resources are `Base64` encoded strings with the following format: `r={resource}&e={expiration_utc}&s={signature}`.
+You can generate a SAS token to be included when your client application communicates with Event Grid. SAS tokens for Event Grid resources are `URL` encoded strings with the following format: `r={resource}&e={expiration_utc}&s={signature}`.
 
 - `{resource}` is the URL that represents the Event Grid resource the client accesses.
   - The valid URL format for custom topics, domains, and partner namespaces is `https://<yourtopic>.<region>.eventgrid.azure.net/api/events`.


### PR DESCRIPTION
Hello everyone,

While reading these docs, I noticed something that I thought was not coherent. SAS Keys are not base-64 encoded strings, they are URL-encoded strings. Here is an example, taken from the docs:

`aeg-sas-token: r=https%3a%2f%2fmytopic.eventgrid.azure.net%2fapi%2fevents&e=6%2f15%2f2017+6%3a20%3a15+PM&s=XXXXXXXXXXXXX%2fBPjdDLOrc6THPy3tDcGHw1zP4OajQ%3d`

The Base64-encoded string is only the signature part, which is not the whole SAS token.

Cheers,

Loris

