### PR TITLE
Java function app docs update: Multiple Jars is not officially supported

### DIFF
--- a/articles/azure-functions/functions-reference-java.md
+++ b/articles/azure-functions/functions-reference-java.md
@@ -93,7 +93,7 @@ FunctionsProject
 
 You can use a shared [host.json](functions-host-json.md) file to configure the function app. Each function has its own code file (.java) and binding configuration file (function.json).
 
-You can put more than one function in a project. Avoid putting your functions into separate jars, as this scenario is not officially supported. The `FunctionApp` in the target directory is what gets deployed to your function app in Azure.
+You can have more than one function in a project. However, don't put your functions into separate jars. Using multiple jars in a single function app isn't supported. The `FunctionApp` in the target directory is what gets deployed to your function app in Azure.
 
 ## Triggers and annotations
 

--- a/articles/azure-functions/functions-reference-java.md
+++ b/articles/azure-functions/functions-reference-java.md
@@ -93,7 +93,7 @@ FunctionsProject
 
 You can use a shared [host.json](functions-host-json.md) file to configure the function app. Each function has its own code file (.java) and binding configuration file (function.json).
 
-You can put more than one function in a project. Avoid putting your functions into separate jars. The `FunctionApp` in the target directory is what gets deployed to your function app in Azure.
+You can put more than one function in a project. Avoid putting your functions into separate jars, as this scenario is not officially supported. The `FunctionApp` in the target directory is what gets deployed to your function app in Azure.
 
 ## Triggers and annotations
 


### PR DESCRIPTION
The purpose of this PR is making clear that placing multiple functions in separate jars within the same function app is not supported as it can lead to intermittent issue, like JavaClass not found.

The propose change is a a direct output result from the ICM 518430212.

Also similar situation has been discussed before on this old github post https://github.com/Azure/azure-functions-java-worker/issues/68#issuecomment-389702917