### PR TITLE
Fix example in activity logs storage account name

### DIFF
--- a/articles/azure-monitor/essentials/activity-log.md
+++ b/articles/azure-monitor/essentials/activity-log.md
@@ -138,7 +138,7 @@ insights-activity-logs/resourceId=/SUBSCRIPTIONS/{subscription ID}/y={four-digit
 For example, a particular blob might have a name similar to:
 
 ```
-insights-logs-networksecuritygrouprulecounter/resourceId=/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/y=2020/m=06/d=08/h=18/m=00/PT1H.json
+insights-activity-logs/resourceId=/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/y=2020/m=06/d=08/h=18/m=00/PT1H.json
 ```
 
 Each PT1H.json blob contains a JSON object with events from log files that were received during the hour specified in the blob URL. During the present hour, events are appended to the PT1H.json file as they're received, regardless of when they were generated. The minute value in the URL, `m=00` is always `00` as blobs are created on a per hour basis.


### PR DESCRIPTION
It looked to be a copy/paste error from https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs#send-to-azure-storage