### PR TITLE
docs(event-grid): Fix typo mixing up access keys and SAS keys

### DIFF
--- a/articles/event-grid/get-access-keys.md
+++ b/articles/event-grid/get-access-keys.md
@@ -13,9 +13,9 @@ Access keys are used to authenticate an application publishing events to Azure E
 This article describes how to get access keys for an Event Grid resource (topic or domain) using Azure portal, PowerShell, or CLI. 
 
 > [!IMPORTANT]
-> From August 5, 2024 to August 15, 2024, Azure Event Grid will rollout a security improvement which will increase the SAS key size from 44 to 84 characters. This change is being made to strengthen the security of your data in Event Grid resources. The change doesn't impact any application or service that currently publishes events to Event Grid with the old SAS key but it may impact only if you regenerate the SAS key of your Event Grid topics, domains, namespaces, and partner topics, after the update.
+> From August 5, 2024 to August 15, 2024, Azure Event Grid will rollout a security improvement which will increase the access key size from 44 to 84 characters. This change is being made to strengthen the security of your data in Event Grid resources. The change doesn't impact any application or service that currently publishes events to Event Grid with the old access key but it may impact only if you regenerate the access key of your Event Grid topics, domains, namespaces, and partner topics, after the update.
 > 
-> We recommend that you regenerate your SAS key on or after August 15, 2024. After regenerating the key, update any event publishing applications or services that use the old key to use the enhanced SAS key.
+> We recommend that you regenerate your access key on or after August 15, 2024. After regenerating the key, update any event publishing applications or services that use the old key to use the enhanced access key.
 
 
 ## Azure portal


### PR DESCRIPTION
Hello everyone,

While reading the docs, I noticed a confusion between access keys and SAS keys.

What is going to increase from 44 to 84 characters are not SAS keys, as they are way bigger strings, generated from multiple factors. 

This is a SAS: `r=https%3a%2f%2fmytopic.eventgrid.azure.net%2fapi%2fevents&e=6%2f15%2f2017+6%3a20%3a15+PM&s=XXXXXXXXXXXXX%2fBPjdDLOrc6THPy3tDcGHw1zP4OajQ%3d`

This is an access key: `abcdefghijklmnopqrstuvwxyz0123456789/+ABCDE=`

Cheers,

Loris