### PR TITLE
update csi-secrets-store-identity-access.md

### DIFF
--- a/articles/aks/csi-secrets-store-identity-access.md
+++ b/articles/aks/csi-secrets-store-identity-access.md
@@ -201,7 +201,7 @@ In this security model, you can grant access to your cluster's resources to team
     Alternatively, you can create a new managed identity and assign it to your virtual machine (VM) scale set or to each VM instance in your availability set using the following commands.
 
     ```azurecli-interactive
-    az identity create -resource-group <resource-group> --name <identity-name>
+    az identity create --resource-group <resource-group> --name <identity-name>
     az vmss identity assign --resource-group <resource-group> --name <agent-pool-vmss> --identities <identity-resource-id>
     az vm identity assign --resource-group <resource-group> --name <agent-pool-vm> --identities <identity-resource-id>
 


### PR DESCRIPTION
fix azure cli syntax issue, it should be: 
az identity create --resource-group <resource-group> --name <identity-name>
instead of (missing -, which will return error from Azure cli): 
az identity create -resource-group <resource-group> --name <identity-name>