### PR TITLE
Update disk-encryption.md

### DIFF
--- a/articles/virtual-machines/disk-encryption.md
+++ b/articles/virtual-machines/disk-encryption.md
@@ -52,7 +52,7 @@ Managed disks and the Key Vault or managed HSM must be in the same Azure region,
 You must grant access to managed disks in your Key Vault or managed HSM to use your keys for encrypting and decrypting the DEK. This allows you full control of your data and keys. You can disable your keys or revoke access to managed disks at any time. You can also audit the encryption key usage with Azure Key Vault monitoring to ensure that only managed disks or other trusted Azure services are accessing your keys.
 
 > [!IMPORTANT]
-> When a key is either disabled, deleted, or expired, any VMs with either OS or data disks using that key will automatically shut down. After the automated shut down, VMs won't boot until the key is enabled again, or you assign a new key.
+> When a key is either disabled, deleted, or expired, any VMs with either OS or data disks using that key will go into failed state if deallocated. VMs won't boot until the key is enabled again, or you assign a new key.
 > 
 > Generally, disk I/O (read or write operations) start to fail one hour after a key is either disabled, deleted, or expired.
 


### PR DESCRIPTION
When a key is expired, VMs will not shutdown automatically. This has been tested and checked with ADE SMEs.