### PR TITLE
Fix pgaadauth_create_principal_with_oid function name in PostgreSQL docs

### DIFF
--- a/articles/postgresql/flexible-server/how-to-manage-azure-ad-users.md
+++ b/articles/postgresql/flexible-server/how-to-manage-azure-ad-users.md
@@ -112,7 +112,7 @@ DROP ROLE rolename;
 ## Create a role using Microsoft Entra object identifier
 
 ```sql
-pg_catalog.pgaadauth_create_principal(roleName text, objectId text, objectType text, isAdmin boolean, isMfa boolean)
+pg_catalog.pgaadauth_create_principal_with_oid(roleName text, objectId text, objectType text, isAdmin boolean, isMfa boolean)
 ```
 
 #### Arguments


### PR DESCRIPTION
To create a PostgreSQL role with service principal ObjectId, the function name should be `pgaadauth_create_principal_with_oid`, not `pgaadauth_create_principal`, which is only for creating with service principal display name.