### PR TITLE
Update manage-access.md

### DIFF
--- a/articles/copilot/manage-access.md
+++ b/articles/copilot/manage-access.md
@@ -15,7 +15,7 @@ author: JnHs
 > [!NOTE]
 > We're currently in the process of rolling out Microsoft Copilot in Azure (preview) to all Azure tenants. We'll remove this note once the functionality is available to all users.
 
-By default, Copilot in Azure is available to all users in a tenant. However, [Global Administrators](/entra/identity/role-based-access-control/permissions-reference#global-administrator) can choose to control access to Copilot in Azure for their organization. If you turn off access for your tenant, you can still grant access to specific Microsoft Entra users or groups.
+By default, Copilot in Azure is available to all users in a tenant. However, [Global Administrators](/entra/identity/role-based-access-control/permissions-reference#global-administrator), with owner RBAC role at resource provider scope can choose to control access to Copilot in Azure for their organization. If you turn off access for your tenant, you can still grant access to specific Microsoft Entra users or groups.
 
 As always, Microsoft Copilot in Azure only has access to resources that the user has access to. It can only take actions that the user has permission to perform, and requires confirmation before making changes. Copilot in Azure complies with all existing access management rules and protections such as Azure role-based access control (Azure RBAC), Privileged Identity Management, Azure Policy, and resource locks.
 


### PR DESCRIPTION
We had a case where global administror were unable to use the access management tab in copilot for azure since they did not have the owner RBAC role at resource provider level. This was suggested on the below ICM

https://portal.microsofticm.com/imp/v3/incidents/incident/518629972/summary