### PR TITLE
Update quickstart links in home page

### DIFF
--- a/articles/azure-app-configuration/index.yml
+++ b/articles/azure-app-configuration/index.yml
@@ -82,8 +82,8 @@ landingContent:
           url: quickstart-java-spring-app.md
         - text: Code a Python app
           url: quickstart-python-provider.md
-        - text: Azure Resource Manager deployment
-          url: quickstart-deployment-overview.md       
+        - text: Code a JavaScript app
+          url: quickstart-javascript-provider.md
         - text: Azure Container Apps
           url: quickstart-container-apps.md
       - linkListType: tutorial

--- a/articles/azure-app-configuration/index.yml
+++ b/articles/azure-app-configuration/index.yml
@@ -81,7 +81,9 @@ landingContent:
         - text: Code a Java Spring app
           url: quickstart-java-spring-app.md
         - text: Code a Python app
-          url: quickstart-python.md
+          url: quickstart-python-provider.md
+        - text: Code a JavaScript app
+          url: quickstart-javascript-provider.md
         - text: Azure Resource Manager deployment
           url: quickstart-deployment-overview.md       
         - text: Azure Container Apps

--- a/articles/azure-app-configuration/index.yml
+++ b/articles/azure-app-configuration/index.yml
@@ -82,8 +82,6 @@ landingContent:
           url: quickstart-java-spring-app.md
         - text: Code a Python app
           url: quickstart-python-provider.md
-        - text: Code a JavaScript app
-          url: quickstart-javascript-provider.md
         - text: Azure Resource Manager deployment
           url: quickstart-deployment-overview.md       
         - text: Azure Container Apps


### PR DESCRIPTION
This PR updates links in the docs homepage:
- update link for python, pointing to provider instead of sdk.
- ~add quickstart link for JavaScript provider.~