### PR TITLE
Update advisor-reference-cost-recommendations.md

### DIFF
--- a/articles/advisor/advisor-reference-cost-recommendations.md
+++ b/articles/advisor/advisor-reference-cost-recommendations.md
@@ -174,6 +174,9 @@ We've analyzed the usage patterns of your virtual machine scale sets over the pa
 
 Learn more about [Virtual machine scale set - LowUsageVmss (Right-size or shutdown underutilized virtual machine scale sets)](https://aka.ms/aa_lowusagerec_vmss_learnmore).
 
+> [!TIP]  
+> If you are unsure whether you can shutdown an idle resource without causing a chaos, you can firstly restrict access to the resource. Make sure the resource's role is restricted, too. Leave the resource up for a few weeks and if nobody has connected to it or has complained, chances are the resource can be shut down safely.
+
 ### Use Virtual Machines with Ephemeral OS Disk enabled to save cost and get better performance
 
 With Ephemeral OS Disk, You get these benefits: Save on storage cost for OS disk. Get lower read/write latency to OS disk. Faster VM Reimage operation by resetting OS (and Temporary disk) to its original state. It's preferable to use Ephemeral OS Disk for short-lived IaaS VMs or VMs with stateless workloads.

--- a/articles/advisor/advisor-reference-cost-recommendations.md
+++ b/articles/advisor/advisor-reference-cost-recommendations.md
@@ -175,7 +175,7 @@ We've analyzed the usage patterns of your virtual machine scale sets over the pa
 Learn more about [Virtual machine scale set - LowUsageVmss (Right-size or shutdown underutilized virtual machine scale sets)](https://aka.ms/aa_lowusagerec_vmss_learnmore).
 
 > [!TIP]  
-> If you are unsure whether you can shutdown an idle resource without causing a chaos, you can firstly restrict access to the resource. Make sure the resource's role is restricted, too. Leave the resource up for a few weeks and if nobody has connected to it or has complained, chances are the resource can be shut down safely.
+> If you're unsure whether you can shut down an idle resource without causing chaos, you can first restrict access to the resource. Make sure the resource's role is restricted, too. Leave the resource up for a few weeks, and if nobody has connected to it or has complained, chances are the resource can be shut down safely.
 
 ### Use Virtual Machines with Ephemeral OS Disk enabled to save cost and get better performance
 


### PR DESCRIPTION
Added following tip to help users shut down resources more delicately:

"If you are unsure whether you can shutdown an idle resource without causing a chaos, you can firstly restrict access to the resource. Make sure the resource's role is restricted, too. Leave the resource up for a few weeks and if nobody has connected to it or has complained, chances are the resource can be shut down safely."