### PR TITLE
Update handle-email-events.md

### DIFF
--- a/articles/communication-services/quickstarts/email/handle-email-events.md
+++ b/articles/communication-services/quickstarts/email/handle-email-events.md
@@ -88,7 +88,7 @@ To generate and receive Email events, take the steps in the following sections.
 
 To view event triggers, we need to generate some events. To trigger an event, [send email](../email/send-email.md) using the Email domain resource attached to the Communication Services resource.
 
-- `Email Delivery Report Received` events are generated when the Email status is in terminal state, i.e. Delivered, Failed, FilteredSpam, Quarantined.
+- `Email Delivery Report Received` events are generated when the Email status is in terminal state, e.g Delivered, Failed, FilteredSpam, Quarantined.
 - `Email Engagement Tracking Report Received` events are generated when the email sent is either opened or a link within the email is clicked. To trigger an event, you need to turn on the `User Interaction Tracking` option on the Email domain resource
 
 Check out the full list of [events that Communication Services supports](../../../event-grid/event-schema-communication-services.md).

--- a/articles/communication-services/quickstarts/email/handle-email-events.md
+++ b/articles/communication-services/quickstarts/email/handle-email-events.md
@@ -88,7 +88,8 @@ To generate and receive Email events, take the steps in the following sections.
 
 To view event triggers, we need to generate some events. To trigger an event, [send email](../email/send-email.md) using the Email domain resource attached to the Communication Services resource.
 
-- `Email Delivery Report Received` events are generated when the Email status is in terminal state, e.g Delivered, Failed, FilteredSpam, Quarantined.
+- `Email Delivery Report Received` events are generated when the Email status is in terminal state, like Delivered, Failed, FilteredSpam, Quarantined.
+
 - `Email Engagement Tracking Report Received` events are generated when the email sent is either opened or a link within the email is clicked. To trigger an event, you need to turn on the `User Interaction Tracking` option on the Email domain resource
 
 Check out the full list of [events that Communication Services supports](../../../event-grid/event-schema-communication-services.md).


### PR DESCRIPTION
As far as I check the following document, "Email Delivery Report Received" events are generated even in cases (like "Bounced") other than Delivered, Failed, FilteredSpam, Quarantined.

[Microsoft.Communication.EmailDeliveryReportReceived event](https://learn.microsoft.com/en-us/azure/event-grid/communication-services-email-events#microsoftcommunicationemaildeliveryreportreceived-event)

If my recognition is correct, I think that the word "i.e." would be incorrect and "e.g" would be correct.