### PR TITLE
[Azure Functions] [Flex Consumption] Add limitation for the subnet name for Flex Consumption

### DIFF
--- a/articles/azure-functions/flex-consumption-how-to.md
+++ b/articles/azure-functions/flex-consumption-how-to.md
@@ -225,6 +225,9 @@ You can use Maven to create a Flex Consumption hosted function app and required 
 
 You can enable [virtual network integration](functions-networking-options.md#virtual-network-integration) for your app in a Flex Consumption plan. The examples in this section assume that you already have [created a virtual network with subnet](../virtual-network/quick-create-cli.md#create-a-virtual-network-and-subnet) in your account. You can enable virtual network integration when you create your app or at a later time.
 
+> [!IMPORTANT]
+> Do not use underscores (_) in subnet names. This is a known limitation during the Public Preview phase of Flex Consumption.
+
 To enable virtual networking when you create your app:
 
 ### [Azure CLI](#tab/azure-cli)

--- a/articles/azure-functions/flex-consumption-how-to.md
+++ b/articles/azure-functions/flex-consumption-how-to.md
@@ -226,7 +226,7 @@ You can use Maven to create a Flex Consumption hosted function app and required 
 You can enable [virtual network integration](functions-networking-options.md#virtual-network-integration) for your app in a Flex Consumption plan. The examples in this section assume that you already have [created a virtual network with subnet](../virtual-network/quick-create-cli.md#create-a-virtual-network-and-subnet) in your account. You can enable virtual network integration when you create your app or at a later time.
 
 > [!IMPORTANT]
-> Do not use underscores (_) in subnet names. This is a known limitation during the Public Preview phase of Flex Consumption.
+> The Flex Consumption plan currently doesn't support subnets with names that contain underscore (`_`) characters. 
 
 To enable virtual networking when you create your app:
 


### PR DESCRIPTION
Flex Consumption sku has known limitations that we can't use _ for the subnet name.
_ is allowed on Subnet name. Many customers encountered this issue.