### PR TITLE
functions-infrastructure-as-code.md: missing DOCKER_REGISTRY_SERVER_* settings leads to HTTP/500

### DIFF
--- a/articles/azure-functions/functions-infrastructure-as-code.md
+++ b/articles/azure-functions/functions-infrastructure-as-code.md
@@ -1370,6 +1370,8 @@ If you're deploying a [containerized function app](./functions-how-to-custom-con
 + Set any required [`DOCKER_REGISTRY_SERVER_*`](#application-configuration) settings when obtaining the container from a private registry. 
 + Set [`WEBSITES_ENABLE_APP_SERVICE_STORAGE`](../app-service/reference-app-settings.md#custom-containers) application setting to `false`. 
 
+If some settings are missing, the application provisioning may fail with a HTTP/500 error "Function App provisioning failed."
+
 For more information, see [Application configuration](#application-configuration).
 
 ### [Bicep](#tab/bicep)


### PR DESCRIPTION
Add more information about unexpected and undocumented behaviour if DOCKER_REGISTRY_SERVER_* settings are missing for a private repo reference.