### PR TITLE
Update deployment.md

### DIFF
--- a/articles/cloud-shell/vnet/deployment.md
+++ b/articles/cloud-shell/vnet/deployment.md
@@ -162,7 +162,7 @@ Fill out the form with the following information:
 | **Nsg Name**                        | Enter the name of the NSG. The deployment creates this NSG and assigns an access rule to it.                          |
 | **Azure Container Instance OID**    | Fill in the value from the prerequisite information that you gathered.<br>The example in this article uses `8fe7fd25-33fe-4f89-ade3-0e705fcf4370`.     |
 | **Container Subnet Name**           | Defaults to `cloudshellsubnet`. Enter the name of the subnet for your container.                                                               |
-| **Container Subnet Address Prefix** | The example in this article uses `10.1.0.0/16`, which provides 65,543 IP addresses for Cloud Shell instances.                                          |
+| **Container Subnet Address Prefix** | The example in this article uses `10.0.1.0/24`, which provides 254 IP addresses for Cloud Shell instances.                                          |
 | **Relay Subnet Name**               | Defaults to `relaysubnet`. Enter the name of the subnet that contains your relay.                                                                 |
 | **Relay Subnet Address Prefix**     | The example in this article uses `10.0.2.0/24`.                                                                                                        |
 | **Storage Subnet Name**             | Defaults to `storagesubnet`. Enter the name of the subnet that contains your storage.                                                             |


### PR DESCRIPTION
1. When I have used the subnet range "10.1.0.0/16" mentioned in the document, the deployment is getting failed as the IP address range are outside vnet. The error I am getting is that "Subnet 'cloudshellsubnet' is not valid because its IP address range is outside the IP address range of virtual network 'vnet1'. (Code: NetcfgSubnetRangeOutsideVnet)".
2. I have tested different scenario by taking different IP ranges, attaching the error screenshot for this IP range as well 10.0.0.0/16 where I am getting error as "Subnet 'cloudshellsubnet' is not valid because its IP address range overlaps with that of an existing subnet in virtual network 'vnet-cloudshell-eastus'. (Code: NetcfgSubnetRangesOverlap)"
3. Attaching the error screenshot for reference
![error 1](https://github.com/user-attachments/assets/d588b2b3-e3e7-40ee-bc4d-7d813a17e34f)
![error 2](https://github.com/user-attachments/assets/46d5bd39-cdc8-4edf-939f-d40391e3c931)


