### PR TITLE
Update deprecated autoscaler API in ingress-controller-autoscale-pods.md

### DIFF
--- a/articles/application-gateway/ingress-controller-autoscale-pods.md
+++ b/articles/application-gateway/ingress-controller-autoscale-pods.md
@@ -98,7 +98,7 @@ In following example, we target a sample deployment `aspnet`. We scale up Pods w
 
 Replace your target deployment name and apply the following auto scale configuration:
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: deployment-scaler


### PR DESCRIPTION
**Proposed change:**
Update deprecated API to the supported one. 

**Supporting point:**
When creating with current yaml, it mentioned that `autoscaling/v2beta1` is not supported:  
![image](https://github.com/user-attachments/assets/a3de8ab8-5e5e-44bc-a1c8-99417ad63138)
