### PR TITLE
AdversarialSimulator(s): Change workspace_name to project_name

### DIFF
--- a/articles/ai-studio/how-to/develop/simulator-interaction-data.md
+++ b/articles/ai-studio/how-to/develop/simulator-interaction-data.md
@@ -37,7 +37,7 @@ from azure.identity import DefaultAzureCredential
 azure_ai_project = {
     "subscription_id": <sub_ID>,
     "resource_group_name": <resource_group_name>,
-    "workspace_name": <workspace_name>,
+    "project_name": <project_name>,
     "credential": DefaultAzureCredential(),
 }
 ```


### PR DESCRIPTION
According to the [source](https://github.com/microsoft/promptflow/blob/c1f0f6da37ab671521db6f2fff67b4ae24da678a/src/promptflow-evals/promptflow/evals/synthetic/adversarial_simulator.py#L69C12-L69C24) the parameter is named *project_name*.