### PR TITLE
Fix inaccurate statement in keda-about.md

### DIFF
--- a/articles/aks/keda-about.md
+++ b/articles/aks/keda-about.md
@@ -20,7 +20,7 @@ The KEDA add-on makes it even easier by deploying a managed KEDA installation, p
 [KEDA][keda] provides two main components:
 
 - **KEDA operator** allows end-users to scale workloads in/out from 0 to N instances with support for Kubernetes Deployments, Jobs, StatefulSets or any custom resource that defines `/scale` subresource.
-- **Metrics server** exposes external metrics to Horizontal Pod Autoscaler (HPA) in Kubernetes for autoscaling purposes such as messages in a Kafka topic, or number of events in an Azure event hub. Due to upstream limitations, KEDA must be the only installed metric adapter.
+- **Metrics server** exposes external metrics to Horizontal Pod Autoscaler (HPA) in Kubernetes for autoscaling purposes such as messages in a Kafka topic, or number of events in an Azure event hub. Due to upstream limitations, KEDA must be the only installed external metric adapter.
 
 ![Diagram that shows the architecture of K E D A and how it extends Kubernetes instead of re-inventing the wheel.](./media/keda/architecture.png)
 

--- a/articles/aks/keda-about.md
+++ b/articles/aks/keda-about.md
@@ -53,7 +53,7 @@ The KEDA AKS add-on has the following limitations:
 
 * KEDA's [HTTP add-on (preview)][keda-http-add-on] to scale HTTP workloads isn't installed with the extension, but can be deployed separately.
 * KEDA's [external scaler for Azure Cosmos DB][keda-cosmos-db-scaler] to scale based on Azure Cosmos DB change feed isn't installed with the extension, but can be deployed separately.
-* Only one metric server is allowed in the Kubernetes cluster. Because of that the KEDA add-on should be the only metrics server inside the cluster.
+* Only one external metric server is allowed in the Kubernetes cluster. Because of that the KEDA add-on should be the only external metrics server inside the cluster.
     * Multiple KEDA installations aren't supported
 
 For general KEDA questions, we recommend [visiting the FAQ overview][keda-faq].


### PR DESCRIPTION
**Proposed change:**
Fix misleading statement in limitation section. 

**Related issues:**
- https://github.com/MicrosoftDocs/azure-docs/issues/123886

**Supporting point:**
In the official FAQ, it explicitly says "external" metrics server. If we don't make it clear, this statement will make the misleading like in: https://github.com/Azure/AKS/issues/4436, and cause the user tried to delete the built-in metrics-server.
![image](https://github.com/user-attachments/assets/cdce94d5-1b75-48af-beb7-c7fa6a154535)
Src: https://keda.sh/docs/2.14/faq/#can-i-run-multiple-metric-servers-serving-external-metrics-in-the-same-cluster


To be clear, there are three types of metrics for Kubernetes. It is important to clarify what kind of metrics should be KEDA unique.
![image](https://github.com/user-attachments/assets/7e061691-f402-48bc-bbbe-012c06fda3e4)
Src: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-metrics-apis


