### PR TITLE
Update how-to-connect-to-data-source-privately.md

### DIFF
--- a/articles/managed-grafana/how-to-connect-to-data-source-privately.md
+++ b/articles/managed-grafana/how-to-connect-to-data-source-privately.md
@@ -25,7 +25,7 @@ While managed private endpoints are free, there may be charges associated with p
 
 Managed private endpoints work with Azure services that support private link. Using them, you can connect your Azure Managed Grafana workspace to the following Azure data stores over private connectivity:
 
-- Azure Cosmos DB for Mongo DB
+- Azure Cosmos DB for Mongo DB ([Only for Request Unit (RU) architecture](/azure/cosmos-db/mongodb/introduction#request-unit-ru-architecture))
 - Azure Cosmos DB for PostgreSQL
 - Azure Data Explorer
 - Azure Monitor private link scope (for example, Log Analytics workspace)


### PR DESCRIPTION
Trying to create managed private endpoint to cosmos db for mongo but with no luck .

when we goes to private endpoint-resource type (azure cosmo DB) - ‘Target resource’ field shows ‘No Resources Found’.
![image](https://github.com/user-attachments/assets/0047833f-a9ab-466e-8ee8-37e1e70b7499)

Also tried to use “by resource ID”. It didn’t work as well.

I could repro on my end , what I figured out that if the mongo DB ([vCore architecture](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/introduction#vcore-architecture-recommended)) it will not work and "resource not found .

if the mongo db is ([Request Unit (RU) architecture](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/introduction#request-unit-ru-architecture)) its shows up as below :
![image](https://github.com/user-attachments/assets/0ce49342-bb38-48d9-bc2a-ef62a45d1c8a)

I have created mongo DB for both Approach 
![image](https://github.com/user-attachments/assets/dd5d2bab-4051-4fe1-85df-281eefc62f20)

on HAR Trace for mine ,  we can see the call for resourceType eq 'Microsoft.DocumentDB/databaseAccounts
![image](https://github.com/user-attachments/assets/86b87fef-8031-4d46-a7a0-304740cbef58)

and not calling /Microsoft.DocumentDB/mongoClusters/

According to Product Group team:

"_We currently only support "Microsoft.DocumentDB/databaseAccounts".
We can consider adding "Microsoft.DocumentDB/mongoClusters" support, but no ETA for now_."