### PR TITLE
Update resource-classes-for-workload-management.md

### DIFF
--- a/articles/synapse-analytics/sql-data-warehouse/resource-classes-for-workload-management.md
+++ b/articles/synapse-analytics/sql-data-warehouse/resource-classes-for-workload-management.md
@@ -51,9 +51,8 @@ The static resource classes are implemented with these pre-defined database role
 
 Dynamic Resource Classes allocate a variable amount of memory depending on the current service level. While static resource classes are beneficial for higher concurrency and static data volumes, dynamic resource classes are better suited for a growing or variable amount of data.  When you scale up to a larger service level, your queries automatically get more memory.  
 
-The dynamic resource classes are implemented with these pre-defined database roles:
+Except smallrc, the dynamic resource classes are implemented with these pre-defined database roles:
 
-- smallrc
 - mediumrc
 - largerc
 - xlargerc


### PR DESCRIPTION
Removed smallrc from the list of dynamic resource classes implemented as pre-defined DB roles (since there is no pre-defined smallrc DB role).  This can cause confusion. Please refer to this Q & A: https://learn.microsoft.com/en-us/answers/questions/1832771/missing-smallrc-db-role-from-synapse-analytics-ded?comment=question#comment-1648660