### PR TITLE
Update cache-how-to-zone-redundancy.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
+++ b/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
@@ -13,7 +13,7 @@ ms.date: 06/07/2022
 
 In this article, you'll learn how to configure a zone-redundant Azure Cache instance using the Azure portal.
 
-Azure Cache for Redis Standard, Premium, and Enterprise tiers provide built-in redundancy by hosting each cache on two dedicated virtual machines (VMs). Even though these VMs are located in separate [Azure fault and update domains](../virtual-machines/availability.md) and highly available, they're susceptible to datacenter level failures. Azure Cache for Redis also supports zone redundancy in its Premium and Enterprise tiers. A zone-redundant cache runs on VMs spread across multiple [Availability Zones](../reliability/availability-zones-overview.md). It provides higher resilience and availability.
+Azure Cache for Redis Premium and Enterprise tiers provide built-in redundancy by hosting each cache on two dedicated virtual machines (VMs). Even though these VMs are located in separate [Azure fault and update domains](../virtual-machines/availability.md) and highly available, they're susceptible to datacenter level failures. Azure Cache for Redis also supports zone redundancy in its Premium and Enterprise tiers. A zone-redundant cache runs on VMs spread across multiple [Availability Zones](../reliability/availability-zones-overview.md). It provides higher resilience and availability.
 
 ## Prerequisites
 


### PR DESCRIPTION
Standard tier doesn't support zone redundancy in azure cache for redis. The same information is mentioned in the feature comparison section in -https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview#feature-comparison
