### PR TITLE
ANPEEE: BGP Prefix not required on Address Prefix CLI

### DIFF
--- a/articles/vpn-gateway/bgp-how-to-cli.md
+++ b/articles/vpn-gateway/bgp-how-to-cli.md
@@ -121,6 +121,7 @@ This exercise continues to build the configuration shown in the diagram. Be sure
 
 * The local network gateway can be in the same location and resource group as the VPN gateway, or it can be in a different location and resource group. This example shows the gateways in different resource groups in different locations.
 * The minimum prefix that you need to declare for the local network gateway is the host address of your BGP peer IP address on your VPN device. In this case, it's a /32 prefix of 10.51.255.254/32.
+* You can also leave the prefix empty if you're using BGP to connect to this network. Azure VPN gateway will internally add a route of your BGP peer IP address to the corresponding IPsec tunnel.
 * As a reminder, you must use different BGP ASNs between your on-premises networks and the Azure virtual network. If they're the same, you need to change your VNet ASN if your on-premises VPN devices already use the ASN to peer with other BGP neighbors.
 
 Before you proceed, make sure that you've completed the [Enable BGP for your VPN gateway](#enablebgp) section of this exercise. Notice that in this example, you create a new resource group. Also, notice the two additional parameters for the local network gateway: `Asn` and `BgpPeerAddress`.


### PR DESCRIPTION
Adding the same info from Portal doc to CLI doc, stating that is not required to use the AddressPrefix field if BGP is configured.