### PR TITLE
Added tools example to avoid confusion

### DIFF
--- a/articles/defender-for-cloud/azure-devops-extension.yml
+++ b/articles/defender-for-cloud/azure-devops-extension.yml
@@ -110,7 +110,7 @@ procedureSection:
               # policy: 'azuredevops' | 'microsoft' | 'none'. Optional. The name of a well-known Microsoft policy to determine the tools/checks to run. If no configuration file or list of tools is provided, the policy may instruct MSDO which tools to run. Default: azuredevops.
               # categories: string. Optional. A comma-separated list of analyzer categories to run. Values: 'code', 'artifacts', 'IaC', 'containers'. Example: 'IaC, containers'. Defaults to all.
               # languages: string. Optional. A comma-separated list of languages to analyze. Example: 'javascript,typescript'. Defaults to all.
-              # tools: string. Optional. A comma-separated list of analyzer tools to run. Values: 'bandit', 'binskim', 'checkov', 'eslint', 'templateanalyzer', 'terrascan', 'trivy'.
+              # tools: string. Optional. A comma-separated list of analyzer tools to run. Values: 'bandit', 'binskim', 'checkov', 'eslint', 'templateanalyzer', 'terrascan', 'trivy'. Example 'templatenanalyzer, trivy'
               # break: boolean. Optional. If true, will fail this build step if any high severity level results are found. Default: false.
               # publish: boolean. Optional. If true, will publish the output SARIF results file to the chosen pipeline artifact. Default: true.
               # artifactName: string. Optional. The name of the pipeline artifact to publish the SARIF result file to. Default: CodeAnalysisLogs*.


### PR DESCRIPTION
Before this change the `yaml` example shows that the tools property requires a string but the possible values were a scalar expression which caused the pipeline definition to be invalid when parsing.

This change added an Example to the `tools` property so that it's consistent with the `categories` example provided.

I contemplated removing the single quotes but the example may be more readable.