### PR TITLE
changing SA_PASSWORD to proper env variable MSSQL_SA_PASSWORD

### DIFF
--- a/articles/azure-sql-edge/connect.md
+++ b/articles/azure-sql-edge/connect.md
@@ -46,7 +46,7 @@ To connect to an Azure SQL Edge Database Engine from a network machine, you need
     }
     ```
 
-- **SA password for the Azure SQL Edge instance**: This is the value specified for the `SA_PASSWORD` environment variable during deployment of Azure SQL Edge.
+- **SA password for the Azure SQL Edge instance**: This is the value specified for the `MSSQL_SA_PASSWORD` environment variable during deployment of Azure SQL Edge.
 
 ## Connect to the Database Engine from within the container
 


### PR DESCRIPTION
As per other documentation, you use `MSSQL_SA_PASSWORD` for the SA password, not the `SA_PASSWORD` variable. if not, then other pages need to be updated

for instance:
https://learn.microsoft.com/en-us/azure/azure-sql-edge/disconnected-deployment - uses `MSSQL_SA_PASSWORD`
https://learn.microsoft.com/en-us/azure/azure-sql-edge/configure#configure-by-using-environment-variables - uses `MSSQL_SA_PASSWORD`