### PR TITLE
Update external-ntpsource-configuration.md

### DIFF
--- a/articles/virtual-machines/windows/external-ntpsource-configuration.md
+++ b/articles/virtual-machines/windows/external-ntpsource-configuration.md
@@ -50,6 +50,9 @@ To check current time source in your **PDC**, from an elevated command prompt ru
 14. Link the GPO to the **Domain Controllers** Organizational Unit.
 
 >[!NOTE]
+>If the PDC is a virtual machine then set this value VMICTimeProvider equal to 0
+
+>[!NOTE]
 >It can take up to 15 minutes for these changes to be reflected by the system.
 
 From an elevated command prompt rerun *w32tm /query /source* and compare the output to the one you noted at the beginning of the configuration. Now it will be set to the NTP Server you chose.


### PR DESCRIPTION
This change is suggested as it´s needed to take into account whether the DC is virtual and if that's the case its needed to disable the VM Time sync host synchronization which is achieved by setting the VMICTimeProvider with the value of zero. So, after doing so the PDC will get the time from external NTP and not from the host.