### PR TITLE
Update Dependency Agent requirements

### DIFF
--- a/articles/azure-monitor/vm/vminsights-dependency-agent-maintenance.md
+++ b/articles/azure-monitor/vm/vminsights-dependency-agent-maintenance.md
@@ -22,7 +22,7 @@ The Dependency Agent collects data about processes running on the virtual machin
 
 - The Dependency Agent requires the Azure Monitor Agent to be installed on the same machine.
 - On both the Windows and Linux versions, the Dependency Agent collects data using a user-space service and a kernel driver. 
-    - Dependency Agent supports the same [Windows versions that Azure Monitor Agent supports](../agents/agents-overview.md#supported-operating-systems), except Windows Server 2008 SP2, Windows Server 2022, and Azure Stack HCI.
+    - Dependency Agent supports the same [Windows versions that Azure Monitor Agent supports](../agents/agents-overview.md#supported-operating-systems), except Windows Server 2008 SP2 and Azure Stack HCI.
     - For Linux, see [Dependency Agent Linux support](#dependency-agent-linux-support).
 
 ## Install or upgrade Dependency Agent 


### PR DESCRIPTION
Windows Server 2022 is listed as unsupported OS for the Dependency agent. This is contractionary to the statements from the following links:

- https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-dependency-windows#operating-system
- https://learn.microsoft.com/en-us/azure/azure-monitor/vm/vminsights-enable-overview#supported-operating-systems