### PR TITLE
Update Python web app tutorial to complete connection settings steps for Flask apps

### DIFF
--- a/articles/app-service/tutorial-python-postgresql-app.md
+++ b/articles/app-service/tutorial-python-postgresql-app.md
@@ -289,6 +289,22 @@ The creation wizard generated the connectivity variables for you already as [app
     :::column:::
     :::column-end:::
 :::row-end:::
+:::row:::
+    :::column span="2":::
+        **Step 4:** Back in the **Configuration** page, select **New application setting**. Name the setting `SECRET_KEY`. Paste the value from the previous value. Select **OK**.
+    :::column-end:::
+    :::column:::
+        :::image type="content" source="./media/tutorial-python-postgresql-app/azure-portal-app-service-app-setting.png" alt-text="A screenshot showing how to set the SECRET_KEY app setting in the Azure portal (Django)." lightbox="./media/tutorial-python-postgresql-app/azure-portal-app-service-app-setting.png":::
+    :::column-end:::
+:::row-end:::
+:::row:::
+    :::column span="2":::
+        **Step 5:** Select **Save**.
+    :::column-end:::
+    :::column:::
+        :::image type="content" source="./media/tutorial-python-postgresql-app/azure-portal-app-service-app-setting-save.png" alt-text="A screenshot showing how to save the SECRET_KEY app setting in the Azure portal (Django)." lightbox="./media/tutorial-python-postgresql-app/azure-portal-app-service-app-setting-save.png":::
+    :::column-end:::
+:::row-end:::
 
 ### [Django](#tab/django)
 


### PR DESCRIPTION
This pull request includes a change to the `articles/app-service/tutorial-python-postgresql-app.md` file to add steps on how to configure application settings for deploying a Flask app in the Azure portal. Specifically, this PR adds the steps on how to add the `SECRET_KEY` required for [enabling CSRFProtect](https://flask-wtf.readthedocs.io/en/0.15.x/csrf/#setup) when deploying the app.

This pull request would close https://github.com/MicrosoftDocs/azure-docs/issues/123961