### PR TITLE
MSSQL Images and Azure SQL Edge are using MSSQL_SA_PASSWORD env var not SA_PASSWORD

### DIFF
--- a/articles/azure-functions/durable/quickstart-mssql.md
+++ b/articles/azure-functions/durable/quickstart-mssql.md
@@ -81,7 +81,7 @@ $collation = "Latin1_General_100_BIN2_UTF8"
 docker pull mcr.microsoft.com/mssql/server:$tag
 
 # run the image and provide some basic setup parameters
-docker run --name mssql-server -e 'ACCEPT_EULA=Y' -e "SA_PASSWORD=$pw" -e "MSSQL_PID=$edition" -p ${port}:1433 -d mcr.microsoft.com/mssql/server:$tag
+docker run --name mssql-server -e 'ACCEPT_EULA=Y' -e "MSSQL_SA_PASSWORD=$pw" -e "MSSQL_PID=$edition" -p ${port}:1433 -d mcr.microsoft.com/mssql/server:$tag
 
 # wait a few seconds for the container to start...
 

--- a/articles/azure-sql-edge/deploy-kubernetes.md
+++ b/articles/azure-sql-edge/deploy-kubernetes.md
@@ -69,7 +69,7 @@ Create an SA password in the Kubernetes cluster. Kubernetes can manage sensitive
 The following command creates a password for the SA account:
 
    ```azurecli
-   kubectl create secret generic mssql --from-literal=SA_PASSWORD="MyC0m9l&xP@ssw0rd" -n <namespace name>
+   kubectl create secret generic mssql --from-literal=MSQL_SA_PASSWORD="MyC0m9l&xP@ssw0rd" -n <namespace name>
    ```
 
    Replace `MyC0m9l&xP@ssw0rd` with a complex password.
@@ -186,11 +186,11 @@ In this step, create a manifest to describe the container based on the Azure SQL
                  value: "Developer"
                - name: ACCEPT_EULA
                  value: "Y"
-               - name: SA_PASSWORD
+               - name: MSSQL_SA_PASSWORD
                  valueFrom:
                    secretKeyRef:
                      name: mssql
-                     key: SA_PASSWORD
+                     key: MSSQL_SA_PASSWORD
                - name: MSSQL_AGENT_ENABLED
                  value: "TRUE"
                - name: MSSQL_COLLATION
@@ -225,13 +225,13 @@ In this step, create a manifest to describe the container based on the Azure SQL
 
    * `persistentVolumeClaim`: This value requires an entry for `claimName:` that maps to the name used for the persistent volume claim. This tutorial uses `mssql-data`.
 
-   * `name: SA_PASSWORD`: Configures the container image to set the SA password, as defined in this section.
+   * `name: MSSQL_SA_PASSWORD`: Configures the container image to set the SA password, as defined in this section.
 
      ```yaml
      valueFrom:
        secretKeyRef:
          name: mssql
-         key: SA_PASSWORD
+         key: MSSQL_SA_PASSWORD
      ```
 
      When Kubernetes deploys the container, it refers to the secret named `mssql` to get the value for the password.


### PR DESCRIPTION
I'm updating references where the wrong environment variable, `SA_PASSWORD,` is used and replacing it with the proper one, `MSSQL_SA_PASSWORD`.

The `MSSQL_SA_PASSWORD` is used as an official parameter on many pages:
- https://hub.docker.com/r/microsoft/mssql-server
- https://learn.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver16&tabs=cli&pivots=cs1-bash#run-the-container-2
- https://learn.microsoft.com/en-us/azure/azure-sql-edge/disconnected-deployment
- https://learn.microsoft.com/en-us/azure/azure-sql-edge/configure#configure-by-using-environment-variables
- https://hub.docker.com/r/microsoft/azure-sql-edge