### PR TITLE
Add section in the troubleshooting doc

### DIFF
--- a/articles/azure-monitor/profiler/profiler-troubleshooting.md
+++ b/articles/azure-monitor/profiler/profiler-troubleshooting.md
@@ -93,7 +93,8 @@ Even when the Profiler is enabled, it may not capture or upload traces, especial
       1. Click on the **Triggers** button. 
       1. In the Trigger Settings, ensure the **Sampling** toggle is on.
 
-1. Still no traces uploaded? Please let us know at [serviceprofilerhelp@microsoft.com](mailto:serviceprofilerhelp@microsoft.com).
+1. **Still no traces uploaded?**  
+    [Create a support request](https://ms.portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/overview?DMC=troubleshoot), or ask [Azure community support](/answers/products/azure?product=all). You can also submit product feedback to [Azure feedback community](https://feedback.azure.com/d365community).
 
 ## Double counting in parallel threads
 

--- a/articles/azure-monitor/profiler/profiler-troubleshooting.md
+++ b/articles/azure-monitor/profiler/profiler-troubleshooting.md
@@ -78,7 +78,8 @@ Search for trace messages and custom events sent by Profiler to your Application
 
 Even when the Profiler is enabled, it may not capture or upload traces, especially in these situations:
 
-1. No incoming requests to your application - you can manually invoke your application or create an [availability test](https://learn.microsoft.com/azure/azure-monitor/app/availability), or a [load test](https://learn.microsoft.com/azure/load-testing/overview-what-is-azure-load-testing). 
+1. **No incoming requests to your application:**   
+     You can manually invoke your application or create an [availability test](../app/availability.md), or a [load test](../../load-testing/overview-what-is-azure-load-testing.md). 
 
 1. No incoming telemetry acknowledged by Application Insights - if there is traffic coming to your application - validate that there are incoming requests showing in Application Insights [Live Metrics](https://learn.microsoft.com/azure/azure-monitor/app/live-stream). If the `Incoming Requests` charts are empty (no data or showing zero) - please [troubleshoot Application Insights](https://learn.microsoft.com/troubleshoot/azure/azure-monitor/app-insights/telemetry/asp-net-troubleshoot-no-data). If you are hosting your .NET application on Azure App Service - follow [this is specific troubleshooting](https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps-net#troubleshooting).
 

--- a/articles/azure-monitor/profiler/profiler-troubleshooting.md
+++ b/articles/azure-monitor/profiler/profiler-troubleshooting.md
@@ -74,6 +74,18 @@ Search for trace messages and custom events sent by Profiler to your Application
 
    If no records are displayed, Profiler isn't running or took too long to respond. Make sure [Profiler is enabled on your Azure service](./profiler.md).
 
+## Profiler is on, but no traces captured
+
+Even when the Profiler is enabled it may not capture or upload traces, especially in these situations:
+
+1. No incoming requests to your application - you can manually invoke your application or create an [availability test](https://learn.microsoft.com/azure/azure-monitor/app/availability), or a [load test](https://learn.microsoft.com/azure/load-testing/overview-what-is-azure-load-testing). 
+
+1. No incoming telemetry acknowledged by Application Insights - if there is traffic coming to your application - validate that there are incoming requests showing in Application Insights [Live Metrics](https://learn.microsoft.com/azure/azure-monitor/app/live-stream). If the `Incoming Requests` charts are empty (no data or showing zero) - please [troubleshoot Application Insights](https://learn.microsoft.com/troubleshoot/azure/azure-monitor/app-insights/telemetry/asp-net-troubleshoot-no-data). If you are hosting your .NET application on Azure App Service - follow [this is specific troubleshooting](https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps-net#troubleshooting).
+
+1. Profiler setting for Sampling is turned off - if still no profiler traces are available, please check the Profiler Sampling setting. Open **Application Insights**, **Performance** page, click on **Profiler** and then on **Triggers** button in the Application Insights Profiler. In the Trigger Settings, ensure the **Sampling** is on.
+
+1. Still no traces uploaded? Please let us know at [serviceprofilerhelp@microsoft.com](mailto:serviceprofilerhelp@microsoft.com).
+
 ## Double counting in parallel threads
 
 When two or more parallel threads are associated with a request, the total time metric in the stack viewer might be more than the duration of the request. In that case, the total thread time is more than the actual elapsed time.

--- a/articles/azure-monitor/profiler/profiler-troubleshooting.md
+++ b/articles/azure-monitor/profiler/profiler-troubleshooting.md
@@ -81,7 +81,10 @@ Even when the Profiler is enabled, it may not capture or upload traces, especial
 1. **No incoming requests to your application:**   
      You can manually invoke your application or create an [availability test](../app/availability.md), or a [load test](../../load-testing/overview-what-is-azure-load-testing.md). 
 
-1. No incoming telemetry acknowledged by Application Insights - if there is traffic coming to your application - validate that there are incoming requests showing in Application Insights [Live Metrics](https://learn.microsoft.com/azure/azure-monitor/app/live-stream). If the `Incoming Requests` charts are empty (no data or showing zero) - please [troubleshoot Application Insights](https://learn.microsoft.com/troubleshoot/azure/azure-monitor/app-insights/telemetry/asp-net-troubleshoot-no-data). If you are hosting your .NET application on Azure App Service - follow [this is specific troubleshooting](https://learn.microsoft.com/azure/azure-monitor/app/azure-web-apps-net#troubleshooting).
+1. **No incoming telemetry acknowledged by Application Insights:**  
+    - If there is traffic coming to your application: validate that there are incoming requests showing in Application Insights [Live Metrics](../app/live-stream.md). 
+    - If the `Incoming Requests` charts are empty (no data or showing zero): [troubleshoot Application Insights](/troubleshoot/azure/azure-monitor/app-insights/telemetry/asp-net-troubleshoot-no-data). 
+    - If you are hosting your .NET application on Azure App Service: [try the App Service .NET troubleshooting steps](../app/azure-web-apps-net.md#troubleshooting).
 
 1. Profiler setting for Sampling is turned off - if still no profiler traces are available, please check the Profiler Sampling setting. Open **Application Insights**, **Performance** page, click on **Profiler** and then on **Triggers** button in the Application Insights Profiler. In the Trigger Settings, ensure the **Sampling** is on.
 

--- a/articles/azure-monitor/profiler/profiler-troubleshooting.md
+++ b/articles/azure-monitor/profiler/profiler-troubleshooting.md
@@ -76,7 +76,7 @@ Search for trace messages and custom events sent by Profiler to your Application
 
 ## Profiler is on, but no traces captured
 
-Even when the Profiler is enabled it may not capture or upload traces, especially in these situations:
+Even when the Profiler is enabled, it may not capture or upload traces, especially in these situations:
 
 1. No incoming requests to your application - you can manually invoke your application or create an [availability test](https://learn.microsoft.com/azure/azure-monitor/app/availability), or a [load test](https://learn.microsoft.com/azure/load-testing/overview-what-is-azure-load-testing). 
 

--- a/articles/azure-monitor/profiler/profiler-troubleshooting.md
+++ b/articles/azure-monitor/profiler/profiler-troubleshooting.md
@@ -86,7 +86,12 @@ Even when the Profiler is enabled, it may not capture or upload traces, especial
     - If the `Incoming Requests` charts are empty (no data or showing zero): [troubleshoot Application Insights](/troubleshoot/azure/azure-monitor/app-insights/telemetry/asp-net-troubleshoot-no-data). 
     - If you are hosting your .NET application on Azure App Service: [try the App Service .NET troubleshooting steps](../app/azure-web-apps-net.md#troubleshooting).
 
-1. Profiler setting for Sampling is turned off - if still no profiler traces are available, please check the Profiler Sampling setting. Open **Application Insights**, **Performance** page, click on **Profiler** and then on **Triggers** button in the Application Insights Profiler. In the Trigger Settings, ensure the **Sampling** is on.
+1. **Profiler setting for Sampling is turned off:**   
+    If still no profiler traces are available, check the Profiler Sampling setting.   
+      1. Open **Application Insights** > **Performance** blade. 
+      1. Click on **Profiler**.
+      1. Click on the **Triggers** button. 
+      1. In the Trigger Settings, ensure the **Sampling** toggle is on.
 
 1. Still no traces uploaded? Please let us know at [serviceprofilerhelp@microsoft.com](mailto:serviceprofilerhelp@microsoft.com).
 


### PR DESCRIPTION
Coming from a CRI that no application insights request was captured leading to no profiling traces.