### PR TITLE
Update how-to-secure-workspace-vnet.md

### DIFF
--- a/articles/machine-learning/how-to-secure-workspace-vnet.md
+++ b/articles/machine-learning/how-to-secure-workspace-vnet.md
@@ -273,7 +273,7 @@ Azure Container Registry can be configured to use a private endpoint. Use the fo
     az ml workspace update --name myworkspace --resource-group myresourcegroup --image-build-compute mycomputecluster
     ```
 
-    You can switch back to serverless compute by executing the same command and referencing the compute as an empty space: `--image-build-compute ' '`.
+    You can switch back to serverless compute by executing the same command and referencing the compute as an empty space: `--image-build-compute ''`.
 
     # [Python SDK](#tab/python)
 


### PR DESCRIPTION
Fixed a small typo that results in an error when setting image build compute with CLI.

There should be no space between the inverted commas.