### PR TITLE
added already available code samples to doco

### DIFF
--- a/articles/dev-box/index.yml
+++ b/articles/dev-box/index.yml
@@ -95,3 +95,11 @@ landingContent:
             url: https://learn.microsoft.com/en-us/azure/dev-box/cli-reference-subset
           - text: REST API
             url: https://aka.ms/dev-box/restapidocs
+
+   # Card
+  - title: Dev Center Quick Start Samples
+    linkLists:
+        - linkListType: sample
+          links:
+          - text: Dev Center Samples
+            url: https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.devcenter


### PR DESCRIPTION
Added available Azure / azure-quickstart-templates dev center code samples. 
These aren't immediately available and a bit of search is needed to find them.
By placing them at this level, users can quickly find samples on how to deploy their dev centers using bicep.