### PR TITLE
Fix format and update outdated API in ingress-controller-autoscale-pods.md

### DIFF
--- a/articles/application-gateway/ingress-controller-autoscale-pods.md
+++ b/articles/application-gateway/ingress-controller-autoscale-pods.md
@@ -30,9 +30,9 @@ Use following two components:
 1. First, create a Microsoft Entra service principal and assign it `Monitoring Reader` access over Application Gateway's resource group.
 
     ```azurecli
-        applicationGatewayGroupName="<application-gateway-group-id>"
-        applicationGatewayGroupId=$(az group show -g $applicationGatewayGroupName -o tsv --query "id")
-        az ad sp create-for-rbac -n "azure-k8s-metric-adapter-sp" --role "Monitoring Reader" --scopes applicationGatewayGroupId
+    applicationGatewayGroupName="<application-gateway-group-id>"
+    applicationGatewayGroupId=$(az group show -g $applicationGatewayGroupName -o tsv --query "id")
+    az ad sp create-for-rbac -n "azure-k8s-metric-adapter-sp" --role "Monitoring Reader" --scopes applicationGatewayGroupId
     ```
 
 1. Now, deploy the [`Azure Kubernetes Metric Adapter`](https://github.com/Azure/azure-k8s-metrics-adapter) using the Microsoft Entra service principal created previously.
@@ -98,7 +98,7 @@ In following example, we target a sample deployment `aspnet`. We scale up Pods w
 
 Replace your target deployment name and apply the following auto scale configuration:
 ```yaml
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: deployment-scaler


### PR DESCRIPTION
**Proposed changes:**
1. Fix format
2. Update API from `autoscaling/v2beta1` to `autoscaling/v2`, as  `autoscaling/v2beta1` is being deprecated a long time ago.

**Supporting points:**
For point 1: it is not well-formatted now so it needs to be fixed.
![image](https://github.com/user-attachments/assets/53616630-df68-413d-a811-f406f40d1df1)
For point 2: the below is from official changelog.
![image](https://github.com/user-attachments/assets/3afad460-b66f-4ed3-b61a-f394602ba1a4)
Src: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125
