### PR TITLE
Add missing using statements

### DIFF
--- a/articles/ai-services/openai/includes/use-your-data-dotnet.md
+++ b/articles/ai-services/openai/includes/use-your-data-dotnet.md
@@ -19,6 +19,8 @@ From the project directory, open the *Program.cs* file and replace its contents 
 ```csharp
 using Azure;
 using Azure.AI.OpenAI;
+using Azure.AI.OpenAI.Chat;
+using OpenAI.Chat;
 using System.Text.Json;
 using static System.Environment;
 


### PR DESCRIPTION
Add using statements that were missing in the C# quickstart documentation. This was causing build errors.

In commit `aaece61` @alexwolfmsft did [the same for the asychronous code](https://github.com/MicrosoftDocs/azure-docs/commit/aaece6184a49ba5a7fceca8996385296d0e7bce5#diff-94c31b05ad441401b35783704a62e4d48891828cf64cf5f9201f0d903fcd4f05). This PR is for code example without response streaming.