### PR TITLE
Added snippet to read RDS files in an R notebook

### DIFF
--- a/articles/machine-learning/how-to-r-interactive-development.md
+++ b/articles/machine-learning/how-to-r-interactive-development.md
@@ -143,6 +143,22 @@ You can also use a Datastore URI to access different files on a registered Datas
    })
    print(df)
    ```
+
+Using the same filestore object, you can read an RDS file, but you need to decompress the bytes before passing it to `readRDS()` as a `rawConnection`
+  
+  3. Read a serialized R object file (.RDS):
+   ```r
+   funcs <- import_builtins() # Add this with the other imports, gives access to built-in Python functions such as `list()`
+
+
+   r_object <- with(fs$open("<path>)", "r") %as% f, {
+    x <- as.raw(funcs$list(f$read))
+    decompressed_x <- memDecompress(x, type = "gzip", asChar = "FALSE")
+    conn <- rawConnection(decompressed_raw)
+    readRDS(conn) # readRDS will decompress automatically if provided with a path, but won't decompress if provided with a rawConnection
+   })
+   print(r_object)
+   ```
     
 ## Install R packages
 


### PR DESCRIPTION
Currently, the page only provides examples for CSV files. I'd like to add a snippet that I developed to read RDS files from a datastore using a filestore object.