### PR TITLE
Required consistency + bullet typos

### DIFF
--- a/articles/ai-services/translator/document-translation/reference/get-documents-status.md
+++ b/articles/ai-services/translator/document-translation/reference/get-documents-status.md
@@ -81,8 +81,8 @@ Request headers are:
 
 |Headers|Description|Condition|
 |--- |--- |---|
-|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|Required|
-|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.</br>&bullet.|
+|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|&bullet; **Required**|
+|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.|
 |**Content-Type**|The content type of the payload. The accepted value is **application/json** or **charset=UTF-8**.|&bullet; **Required**|
 
 ## Response status codes

--- a/articles/ai-services/translator/document-translation/reference/get-supported-glossary-formats.md
+++ b/articles/ai-services/translator/document-translation/reference/get-supported-glossary-formats.md
@@ -36,8 +36,8 @@ Request headers are:
 
 |Headers|Description|Condition|
 |--- |--- |---|
-|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|Required|
-|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.</br>&bullet.|
+|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|&bullet; **Required**|
+|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.|
 |**Content-Type**|The content type of the payload. The accepted value is **application/json** or **charset=UTF-8**.|&bullet; **Required**|
 
 

--- a/articles/ai-services/translator/document-translation/reference/get-translation-status.md
+++ b/articles/ai-services/translator/document-translation/reference/get-translation-status.md
@@ -54,8 +54,8 @@ Request headers are:
 
 |Headers|Description|Condition|
 |--- |--- |---|
-|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|Required|
-|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.</br>&bullet.|
+|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|&bullet; **Required**|
+|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.|
 |**Content-Type**|The content type of the payload. The accepted value is **application/json** or **charset=UTF-8**.|&bullet; **Required**|
 
 ## Response status codes

--- a/articles/ai-services/translator/document-translation/reference/get-translations-status.md
+++ b/articles/ai-services/translator/document-translation/reference/get-translations-status.md
@@ -67,8 +67,8 @@ Request headers are:
 
 |Headers|Description|Condition|
 |--- |--- |---|
-|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|Required|
-|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.</br>&bullet.|
+|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|&bullet; **Required**|
+|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.|
 |**Content-Type**|The content type of the payload. The accepted value is **application/json** or **charset=UTF-8**.|&bullet; **Required**|
 
 ## Response status codes

--- a/articles/ai-services/translator/document-translation/reference/start-batch-translation.md
+++ b/articles/ai-services/translator/document-translation/reference/start-batch-translation.md
@@ -40,8 +40,8 @@ Request headers are:
 
 |Headers|Description|Condition|
 |--- |--- |---|
-|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|Required|
-|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.</br>&bullet.|
+|**Ocp-Apim-Subscription-Key**|Your Translator service API key from the Azure portal.|&bullet; **Required**|
+|**Ocp-Apim-Subscription-Region**|The region where your resource was created. |&bullet; ***Required*** when using a regional (geographic) resource like **West US**.|
 |**Content-Type**|The content type of the payload. The accepted value is **application/json** or **charset=UTF-8**.|&bullet; **Required**|
 
 ## BatchRequest (body)


### PR DESCRIPTION
In the Azure AI Document Translation documents, there is some inconsistency in how the **required** condition in the table was visualized and a typo in the `&bullet.` output.

![image](https://github.com/user-attachments/assets/962725f2-4508-4ae1-9a96-0f723d3c8a37)
