### PR TITLE
Update expressroute-circuit-peerings.md

### DIFF
--- a/articles/expressroute/expressroute-circuit-peerings.md
+++ b/articles/expressroute/expressroute-circuit-peerings.md
@@ -51,9 +51,9 @@ Default quotas and limits apply for every ExpressRoute circuit. Refer to the [Az
 
 ## <a name="routingdomains"></a>ExpressRoute peering
 
-An ExpressRoute circuit has multiple routing domains/peerings associated with it: Azure public, Azure private, and Microsoft. Each peering is configured identically on a pair of routers (in active-active or load sharing configuration) for high availability. Azure services are categorized as *Azure public* and *Azure private* to represent the IP addressing schemes.
+An ExpressRoute circuit has two routing domains/peerings associated with it: Azure Private and Microsoft. Each peering is configured identically on a pair of routers (in active-active or load sharing configuration) for high availability. Azure services are categorized as *Azure public* and *Azure private* to represent the IP addressing schemes.
 
-![Diagram showing how Azure public, Azure private, and Microsoft peerings are configured in an ExpressRoute circuit.](./media/expressroute-circuit-peerings/expressroute-peerings.png)
+![Diagram showing how Azure Private and Microsoft peerings are configured in an ExpressRoute circuit.](./media/expressroute-circuit-peerings/expressroute-peerings.png)
 
 ### <a name="privatepeering"></a>Azure private peering
 
@@ -74,7 +74,7 @@ For more information on services supported, costs, and configuration details, se
 
 ## <a name="peeringcompare"></a>Peering comparison
 
-The following table compares the three peerings:
+The following table compares the two peerings:
 
 [!INCLUDE [peering comparison](../../includes/expressroute-peering-comparison.md)]
 


### PR DESCRIPTION
Removing references of 'Azure Public' Peering option which hasn't been deployable since 2018, and retired on March 31, 2024

https://azure.microsoft.com/en-us/updates/retirement-notice-migrate-from-public-peering-by-march-31-2024/#:~:text=No%20new%20ExpressRoute%20Public%20Peering%20connections%20have%20been,Peering%20will%20be%20retired%20on%2031st%20March%202024.