### PR TITLE
Update data-types.md with correction of example code

### DIFF
--- a/articles/azure-resource-manager/bicep/data-types.md
+++ b/articles/azure-resource-manager/bicep/data-types.md
@@ -83,7 +83,7 @@ param emptyArray array = []
 param numberArray array = [1, 2, 3]
 
 output foo bool = empty(emptyArray) || emptyArray[0] == 'bar'
-output bar bool = length(numberArray) >= 3 || numberArray[3] == 4
+output bar bool = length(numberArray) <= 3 || numberArray[3] == 4
 ```
 
 ## Booleans


### PR DESCRIPTION
The example for handling out of bounds errors in array indexing used >= instead of <= incorrectly in the second example of using || operator. Using >= would result in the error still occurring for array lengths of 0-2.