### PR TITLE
Fixed json example in bicep-config-linter.md

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -116,7 +116,7 @@ The following example shows the rules that are available for configuration.
           "maxAllowedAgeInDays": 730
         },
         "use-recent-module-versions": {
-          "level": "warning",
+          "level": "warning"
         },
         "use-resource-id-functions": {
           "level": "warning"


### PR DESCRIPTION
JSON is currently no valid, this PR removes a trailing comma.