### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 *.h text
 
 # Include Markdown in the GitHub language breakdown statistics
-*.md linguist-detectable
+/*/*.md linguist-detectable
 
 # Denote all files that are truly binary and should not be modified.
 *.gif   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 *.h text
 
 # Include Markdown in the GitHub language breakdown statistics
-/*/*.md linguist-detectable
+/*/*.md linguist-detectable linguist-documentation=false
 
 # Denote all files that are truly binary and should not be modified.
 *.gif   binary


### PR DESCRIPTION
This PR is a follow-up on #109212. 

This PR will ensure that `.md` files at the root of the directory aren't included in language statistics:
ie.:
* CODE_OF_CONDUCT.md
* SECURITY.md
* ThirdPartyNotices.md

This is consistent with other important documentation repos such as the MDN [documentation repo](https://github.com/mdn/content/blob/main/.gitattributes) where they exclude `.md` files at the root one-by-one.