### PR TITLE
Update configure-ssl-app-service-certificate.md

### DIFF
--- a/articles/app-service/configure-ssl-app-service-certificate.md
+++ b/articles/app-service/configure-ssl-app-service-certificate.md
@@ -238,6 +238,14 @@ The creation process makes the following changes:
     - **Microsoft certificate reseller CSM Resource Provider** (or `Microsoft.Azure.CertificateRegistration`)
 - Creates a [delete lock](../azure-resource-manager/management/lock-resources.md) on the vault called: `AppServiceCertificateLock` to prevent accidental deletion of the key vault.
 
+  #### Can App Service Certificate be used for other services?
+  Can certificate purchased via App Service Certificate can be exported and used with Application Gateway or any other 
+  service?
+  Yes, certificates can be purchased through App Service, then exported and uploaded for use with Application Gateway or 
+  any other service.
+  Please refer to the following blog article: https://azure.github.io/AppService/2017/02/24/Creating-a-local-PFX-copy-of- 
+  App-Service-Certificate.html
+  
 ## More resources
 
 * [Secure a custom DNS name with a TLS/SSL binding in Azure App Service](configure-ssl-bindings.md)

--- a/articles/app-service/configure-ssl-app-service-certificate.md
+++ b/articles/app-service/configure-ssl-app-service-certificate.md
@@ -243,9 +243,9 @@ The creation process makes the following changes:
   service?
   Yes, certificates can be purchased through App Service, then exported and uploaded for use with Application Gateway or 
   any other service.
-  Please refer to the following blog article: https://azure.github.io/AppService/2017/02/24/Creating-a-local-PFX-copy-of- 
+  Please refer to the following blog article: [https://azure.github.io/AppService/2017/02/24/Creating-a-local-PFX-copy-of- 
   App-Service-Certificate.html
-  
+  ](https://azure.github.io/AppService/2017/02/24/Creating-a-local-PFX-copy-of-App-Service-Certificate.html)
 ## More resources
 
 * [Secure a custom DNS name with a TLS/SSL binding in Azure App Service](configure-ssl-bindings.md)


### PR DESCRIPTION
Adding another FAQ afer line 240

 #### Can App Service Certificate be used for other services?
  Can certificate purchased via App Service Certificate can be exported and used with Application Gateway or any other 
  service?
  Yes, certificates can be purchased through App Service, then exported and uploaded for use with Application Gateway or 
  any other service.
  Please refer to the following blog article:   

[https://azure.github.io/AppService/2017/02/24/Creating-a-local-PFX-copy-of- App-Service-Certificate.html](https://azure.github.io/AppService/2017/02/24/Creating-a-local-PFX-copy-of-App-Service-Certificate.html)
