### PR TITLE
Update disks-copy-incremental-snapshot-across-regions.md

### DIFF
--- a/articles/virtual-machines/disks-copy-incremental-snapshot-across-regions.md
+++ b/articles/virtual-machines/disks-copy-incremental-snapshot-across-regions.md
@@ -26,7 +26,7 @@ This article covers copying an incremental snapshot from one region to another. 
 - If you use the REST API, you must use version 2020-12-01 or newer of the Azure Compute REST API.
 - You can only copy one incremental snapshot of a particular disk at a time.
 - Snapshots must be copied in the order they were created.
-- Copy of full snapshots to another region is not supported, only incremental snapshots are supported.
+- Only incremental snapshots can be copied across regions, full snapshots can't be copied across regions.
 
 
 ## Managed copy

--- a/articles/virtual-machines/disks-copy-incremental-snapshot-across-regions.md
+++ b/articles/virtual-machines/disks-copy-incremental-snapshot-across-regions.md
@@ -26,6 +26,8 @@ This article covers copying an incremental snapshot from one region to another. 
 - If you use the REST API, you must use version 2020-12-01 or newer of the Azure Compute REST API.
 - You can only copy one incremental snapshot of a particular disk at a time.
 - Snapshots must be copied in the order they were created.
+- Copy of full snapshots to another region is not supported, only incremental snapshots are supported.
+
 
 ## Managed copy
 

--- a/articles/virtual-machines/disks-copy-incremental-snapshot-across-regions.md
+++ b/articles/virtual-machines/disks-copy-incremental-snapshot-across-regions.md
@@ -26,7 +26,7 @@ This article covers copying an incremental snapshot from one region to another. 
 - If you use the REST API, you must use version 2020-12-01 or newer of the Azure Compute REST API.
 - You can only copy one incremental snapshot of a particular disk at a time.
 - Snapshots must be copied in the order they were created.
-- Only incremental snapshots can be copied across regions, full snapshots can't be copied across regions.
+- Only incremental snapshots can be copied across regions. Full snapshots can't be copied across regions.
 
 
 ## Managed copy


### PR DESCRIPTION

There is no info in any public document which states copy feature of full snapshot to another region is not supported. Incase if cx is trying to create full snapshot and copy that snapshot across regions the options are disabled and even region is also disabled. It won't work for powershell/CLI either.  So updating this public document with the restriction - Copy of full snapshots to another region is not supported, only incremental snapshots are supported.
<img width="860" alt="image" src="https://github.com/user-attachments/assets/91ebab07-251c-4503-9503-58d77315f60a">
