### PR TITLE
add verbiage to reduce confusion for new azure function developers copying code from docs

### DIFF
--- a/articles/azure-functions/dotnet-isolated-process-guide.md
+++ b/articles/azure-functions/dotnet-isolated-process-guide.md
@@ -77,6 +77,16 @@ The following code shows an example of a [HostBuilder] pipeline:
 
 :::code language="csharp" source="~/azure-functions-dotnet-worker/samples/FunctionApp/Program.cs" id="docsnippet_startup":::
 
+> [!NOTE]
+> The above example from [HostBuilder] pipeline has a line demonstrating dependency injection:
+> 
+> ```csharp
+> s.AddSingleton<IHttpResponderService, DefaultHttpResponderService>();
+> ```
+> 
+> **You can safely ignore this line.** This is sample code only. `IHttpResponderService` and `DefaultHttpResponderService`
+> are not built-in Azure Function SDK types and are not relevant to a production application.
+
 This code requires `using Microsoft.Extensions.DependencyInjection;`.
 
 Before calling `Build()` on the `HostBuilder`, you should:


### PR DESCRIPTION
PR to address confusion for new Azure Function Developers which copy & paste code from the Azure Docs to bootstrap their app. You can see this confusion in issue #100912.

This adds a simple NOTE below the code sample in an effort to make it more obvious that the confusing line of code is only relevant in the referenced sample and is not needed in a production app.

Offending line:
```csharp
s.AddSingleton<IHttpResponderService, DefaultHttpResponderService>();
```

In my opinion the primary cause of the confusion is that the name of the sample class and interface (`IHttpResponderService` and `DefaultHttpResponderService`) are named similarly to what one expects from BCL / Framework / SDK code leading one to believe this is recommended configuration.

Adding to this confusion is that the other lines in the code snippet actually are recommended practice.

[Link to published docs](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=linux#start-up-and-configuration) for convenience.