### PR TITLE
Update models.md

### DIFF
--- a/articles/ai-services/openai/concepts/models.md
+++ b/articles/ai-services/openai/concepts/models.md
@@ -56,7 +56,7 @@ You need to [create](../how-to/create-resource.md) or use an existing resource i
 
 When your resource is created, you can [deploy](../how-to/create-resource.md#deploy-a-model) the GPT-4o models. If you are performing a programmatic deployment, the **model** names are:
 
-- `gpt-4o`, **Version**  `2024-05-13`
+- `gpt-4o`, **Version**  `2024-04-01-preview`
 - `gpt-4o-mini` **Version** `2024-07-18`
 
 ### GPT-4 Turbo


### PR DESCRIPTION
I discovered when gpt4-o went into GA that version 2024-05-13 does not work, and that you need to use the 2024-04-01-preview version. Even the Azure OpenAI playground still uses 2024-04-01-preview even though the GUI says 2024-05-13.
Today, many months later its still the same issue.
Take a look at my blogpost here, where i mention the issue:
https://alexholmeset.blog/2024/05/22/use-the-azure-openai-gpt-4o-all-in-one-model-with-powershell/