### PR TITLE
Application Gateway WAF policy (DRS 2.1) missing rule 942130 added to documentation.

### DIFF
--- a/articles/web-application-firewall/ag/application-gateway-crs-rulegroups-rules.md
+++ b/articles/web-application-firewall/ag/application-gateway-crs-rulegroups-rules.md
@@ -392,6 +392,7 @@ The following rule groups and rules are available when using Web Application Fir
 |942100|SQL Injection Attack Detected via libinjection|
 |942110|SQL Injection Attack: Common Injection Testing Detected|
 |942120|SQL Injection Attack: SQL Operator Detected|
+|942130|SQL Injection Attack: SQL Tautology Detected.|
 |942140|SQL Injection Attack: Common DB Names Detected|
 |942150|SQL Injection Attack|
 |942160|Detects blind sqli tests using sleep() or benchmark().|


### PR DESCRIPTION
Added the rule and the description to the documentation. 

This is the documentation as I've found it. 
![image](https://github.com/user-attachments/assets/1f230a1a-ad47-4b81-bc94-81679adc4c2d)

Here is a screenshot of the Rule which is missing in the documentation.
![image](https://github.com/user-attachments/assets/a861cb13-52ac-4644-983a-2fb0fa86890b)
