### PR TITLE
Update roles-for-resource-and-storage.md to prevent 403 error

### DIFF
--- a/articles/ai-services/language-service/custom-named-entity-recognition/includes/roles-for-resource-and-storage.md
+++ b/articles/ai-services/language-service/custom-named-entity-recognition/includes/roles-for-resource-and-storage.md
@@ -37,5 +37,16 @@ Use the following steps to set the required roles for your Language resource and
 5. Select **Select members**
 6. Select your subscription, and **Language** as the managed identity. You can search for user names in the **Select** field. 
 
+### Roles for your user
+> [!IMPORTANT]
+> If you skip this step you will have a 403 error when trying to connect to your custom project, it is important that your current user has this role to access storage account blob data even if you are the owner of the storage account.
+> 
+1. Go to your storage account page in the [Azure portal](https://portal.azure.com/).
+2. Select **Access Control (IAM)** in the left navigation menu.
+3. Select **Add** to **Add Role Assignments**, and choose the **Storage blob data contributor** role on the storage account.
+4. Within **Assign access to**, select **User, group, or service principal**. 
+5. Select **Select members**
+6. Select your User. You can search for user names in the **Select** field. 
+
 > [!IMPORTANT]
 > If you have a virtual network or private endpoint, be sure to select **Allow Azure services on the trusted services list to access this storage account** in the Azure portal.

--- a/articles/ai-services/language-service/custom-named-entity-recognition/includes/roles-for-resource-and-storage.md
+++ b/articles/ai-services/language-service/custom-named-entity-recognition/includes/roles-for-resource-and-storage.md
@@ -39,7 +39,7 @@ Use the following steps to set the required roles for your Language resource and
 
 ### Roles for your user
 > [!IMPORTANT]
-> If you skip this step you will have a 403 error when trying to connect to your custom project, it is important that your current user has this role to access storage account blob data even if you are the owner of the storage account.
+> If you skip this step, you'll have a 403 error when trying to connect to your custom project. It's important that your current user has this role to access storage account blob data, even if you're the owner of the storage account.
 > 
 1. Go to your storage account page in the [Azure portal](https://portal.azure.com/).
 2. Select **Access Control (IAM)** in the left navigation menu.


### PR DESCRIPTION
I'ved tried to follow the documentation and this was not working, after opening a ticket and checking with support there is a Role asssigment missing in the documentation, which I've added here, therefor this update to the documentation is adds the missing RBAC role for the current user, without this after creating a new custom entity recognition project it will fail with error 403.