### PR TITLE
Update how-to-track-experiments-mlflow.md with information about filtering datasets

### DIFF
--- a/articles/machine-learning/how-to-track-experiments-mlflow.md
+++ b/articles/machine-learning/how-to-track-experiments-mlflow.md
@@ -388,6 +388,7 @@ The MLflow SDK exposes several methods to retrieve runs, including options to co
 | Filtering runs by metrics with special characters (escaped) | **&check;** |  |
 | Filtering runs by parameters | **&check;** | **&check;** |
 | Filtering runs by tags | **&check;** | **&check;** |
+| Filtering runs by datasets | **&check;** |  |
 | Filtering runs with numeric comparators (metrics) including `=`, `!=`, `>`, `>=`, `<`, and `<=`  | **&check;** | **&check;** |
 | Filtering runs with string comparators (params, tags, and attributes): `=` and `!=` | **&check;** | **&check;**<sup>2</sup> |
 | Filtering runs with string comparators (params, tags, and attributes): `LIKE`/`ILIKE` | **&check;** | **&check;** |


### PR DESCRIPTION
[The MLflow documentation](https://mlflow.org/docs/latest/search-runs.html#searching-by-dataset-information) mentions the capability of filtering runs by datasets. This is not supported when MLflow is used with Azure Machine Learning as a tracking backend.
This PR adds "Filtering by datasets" to the Support matrix section in the **how-to-track-experiments-mlflow.md** doc.