### PR TITLE
Update extension-based-hybrid-runbook-worker.md

### DIFF
--- a/articles/automation/troubleshoot/extension-based-hybrid-runbook-worker.md
+++ b/articles/automation/troubleshoot/extension-based-hybrid-runbook-worker.md
@@ -111,13 +111,25 @@ Jobs fail and go into a suspended state on the Hybrid Runbook Worker. The Micros
 When a system has UAC/LUA in place, permissions must be granted directly and not through any group membership and when user has to elevate permissions, the jobs begin to fail.
 
 #### Resolution
-For Custom user on the Hybrid Runbook Worker, update the permissions in the following folders:
+For Custom user on the Hybrid Runbook Worker, update the permissions in the following folders and registry:
 
-| Folder |Permissions |
+| Folder | Permissions |
 |--- | --- |
 | `C:\ProgramData\AzureConnectedMachineAgent\Tokens` | Read |
 | `C:\Packages\Plugins\Microsoft.Azure.Automation.HybridWorker.HybridWorkerForWindows` | Read and Execute |
 
+| Registry | Permissions |
+|--- | --- |
+| `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\EventLog` | Read |
+| `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinSock2\Parameters` | Full access |
+| `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Wbem\CIMOM` | Full access |
+| `HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\SystemCertificates\Root` | Full access |
+| `HKEY_LOCAL_MACHINE\Software\Microsoft\SystemCertificates` | Full access |
+| `HKEY_LOCAL_MACHINE\Software\Microsoft\EnterpriseCertificates` | Full access |
+| `HKEY_LOCAL_MACHINE\software\Microsoft\HybridRunbookWorker` | Full access |
+| `HKEY_LOCAL_MACHINE\software\Microsoft\HybridRunbookWorkerV2` | Full access |
+| `HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed` | Full access |
+| `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\PnpLockdownFiles` | Full access |
 
 ### Scenario: Job failed to start as the Hybrid Worker wasn't available when the scheduled job started
 


### PR DESCRIPTION
Based on my test and issues me and my college had on this with a Hybrid worker and a custom account (not SYSTEM) at a customer project, we had the same issues with this that the jobs just hang too in "queued" after a reboot of the server where the Plugins "Microsoft.Azure.Automation.HybridWorker.HybridWorkerForWindows" is installed on (works fine until the reboot for many days) - and we find this to: https://learn.microsoft.com/en-us/answers/questions/1434892/permission-required-to-start-azure-runbook-on-hybr

This is needed to be added to get it to work...

Just tested today for v. 1.13 - so until this is fixed IL will have this added, as that helps a lot if using a custom identity (we had used hours of debugging...)