### PR TITLE
Update ddos-protection-features.md

### DIFF
--- a/articles/ddos-protection/ddos-protection-features.md
+++ b/articles/ddos-protection/ddos-protection-features.md
@@ -21,7 +21,7 @@ Azure DDoS Protection monitors actual traffic utilization and constantly compare
 During mitigation, traffic sent to the protected resource is redirected by the DDoS protection service and several checks are performed, such as:
 
 - Ensure packets conform to internet specifications and aren't malformed.
-- Interact with the client to determine if the traffic is potentially a spoofed packet (e.g: SYN Auth or SYN Cookie or by dropping a packet for the source to retransmit it).
+- Interact with the client to determine if the traffic is potentially a spoofed packet (for example: SYN Auth or SYN Cookie or by dropping a packet for the source to retransmit it).
 - Rate-limit packets, if no other enforcement method can be performed.
 
 Azure DDoS Protection drops attack traffic and forwards the remaining traffic to its intended destination. Within a few minutes of attack detection, you're notified using Azure Monitor metrics. By configuring logging on DDoS Protection telemetry, you can write the logs to available options for future analysis. Metric data in Azure Monitor for DDoS Protection is retained for 30 days.


### PR DESCRIPTION
The term 'e.g' is used in the Always-on traffic monitoring section of the article: https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-features#always-on-traffic-monitoring

As per Knowledge Management Quality & Style Review - Recommend using 'for example:' instead - Internal link to KM Quality & Style article with this info:  https://internal.evergreen.microsoft.com/en-us/topic/86dedf26-9578-55d2-9833-94057789d92c