### PR TITLE
Update Public IP's in lines 116 thru 160

### DIFF
--- a/articles/expressroute/expressroute-troubleshooting-arp-resource-manager.md
+++ b/articles/expressroute/expressroute-troubleshooting-arp-resource-manager.md
@@ -113,8 +113,8 @@ Sample output for one of the paths:
 ```output
 Age InterfaceProperty IpAddress  MacAddress    
 --- ----------------- ---------  ----------    
- 10 On-Prem           65.0.0.1   ffff.eeee.dddd
-  0 Microsoft         65.0.0.2   aaaa.bbbb.cccc
+ 10 On-Prem           20.33.0.1   ffff.eeee.dddd
+  0 Microsoft         20.33.0.2   aaaa.bbbb.cccc
 ```
 
 
@@ -131,15 +131,15 @@ The ARP table of a peering can be used to determine and validate layer 2 configu
 ```output
 Age InterfaceProperty IpAddress  MacAddress    
 --- ----------------- ---------  ----------    
- 10 On-Prem           65.0.0.1   ffff.eeee.dddd
-  0 Microsoft         65.0.0.2   aaaa.bbbb.cccc
+ 10 On-Prem           20.33.0.1   ffff.eeee.dddd
+  0 Microsoft         20.33.0.2   aaaa.bbbb.cccc
 ```
 or
 
 ```output
 Age InterfaceProperty IpAddress  MacAddress    
 --- ----------------- ---------  ----------    
- 10 On-Prem           65.0.0.1   ffff.eeee.dddd
+ 10 On-Prem           20.33.0.1   ffff.eeee.dddd
 ```
 
 ### ARP table when on-premises / connectivity provider side has problems
@@ -149,15 +149,15 @@ If a problem with the on-premises or connectivity provider occurs, the ARP table
 ```output
 Age InterfaceProperty IpAddress  MacAddress    
 --- ----------------- ---------  ----------   
-  0 On-Prem           65.0.0.1   Incomplete
-  0 Microsoft         65.0.0.2   aaaa.bbbb.cccc
+  0 On-Prem           20.33.0.1   Incomplete
+  0 Microsoft         20.33.0.2   aaaa.bbbb.cccc
 ```
 or
    
 ```output
 Age InterfaceProperty IpAddress  MacAddress    
 --- ----------------- ---------  ----------    
-  0 Microsoft         65.0.0.2   aaaa.bbbb.cccc
+  0 Microsoft         20.33.0.2   aaaa.bbbb.cccc
 ```  
 
 > [!NOTE]


### PR DESCRIPTION
Changing Public IP's listed in lines 116 thru 160, because these are Amazon IP's and not Microsoft. ARIN shows 65.0.0.1 and 65.0.0.2 belong to Amazon, changing to reflect MSFT public IP's instead