### PR TITLE
Improve `az acr credential-set` command documentation

### DIFF
--- a/articles/container-registry/container-registry-artifact-cache.md
+++ b/articles/container-registry/container-registry-artifact-cache.md
@@ -170,7 +170,7 @@ Before configuring the Credentials, you have to create and store secrets in the 
     ```azurecli-interactive
     az acr credential-set create 
     -r MyRegistry \
-    -n MyRule \
+    -n MyDockerHubCredSet \
     -l docker.io \ 
     -u https://MyKeyvault.vault.azure.net/secrets/usernamesecret \
     -p https://MyKeyvault.vault.azure.net/secrets/passwordsecret
@@ -181,15 +181,15 @@ Before configuring the Credentials, you have to create and store secrets in the 
     - For example, to update the username or password KV secret ID on the credentials for a given `MyRegistry` Azure Container Registry.
 
     ```azurecli-interactive
-    az acr credential-set update -r MyRegistry -n MyRule -p https://MyKeyvault.vault.azure.net/secrets/newsecretname
+    az acr credential-set update -r MyRegistry -n MyDockerHubCredSet -p https://MyKeyvault.vault.azure.net/secrets/newsecretname
     ```
 
-3. Run [az-acr-credential-set-show][az-acr-credential-set-show] to show the credentials. 
+3. Run [az acr credential-set show][az-acr-credential-set-show] to show the credentials. 
 
-    - For example, to show the credentials for a given `MyRegistry` Azure Container Registry.
+    - For example, to show a credential set in a given `MyRegistry` Azure Container Registry.
 
     ```azurecli-interactive
-    az acr credential-set show -r MyRegistry -n MyCredSet
+    az acr credential-set show -r MyRegistry -n MyDockerHubCredSet
     ```
 
 ### Configure and create a cache rule with the credentials 
@@ -199,7 +199,7 @@ Before configuring the Credentials, you have to create and store secrets in the 
     - For example, to create a cache rule with the credentials for a given `MyRegistry` Azure Container Registry.
 
     ```azurecli-interactive
-    az acr cache create -r MyRegistry -n MyRule -s docker.io/library/ubuntu -t ubuntu -c MyCredSet
+    az acr cache create -r MyRegistry -n MyRule -s docker.io/library/ubuntu -t ubuntu -c MyDockerHubCredSet
     ```
 
 2. Run [az acr cache update][az-acr-cache-update] command to update the credentials on a cache rule.
@@ -230,7 +230,7 @@ Before configuring the Credentials, you have to create and store secrets in the 
 
     ```azurecli-interactive
     PRINCIPAL_ID=$(az acr credential-set show 
-                    -n MyCredSet \ 
+                    -n MyDockerHubCredSet \ 
                     -r MyRegistry  \
                     --query 'identity.principalId' \ 
                     -o tsv) 
@@ -282,12 +282,12 @@ Before configuring the Credentials, you have to create and store secrets in the 
     az acr credential-set list -r MyRegistry
     ```
 
-4. Run [az-acr-credential-set-delete][az-acr-credential-set-delete] to delete the credentials. 
+4. Run [az acr credential-set delete][az-acr-credential-set-delete] to delete the credentials. 
 
     - For example, to delete the credentials for a given `MyRegistry` Azure Container Registry.
 
     ```azurecli-interactive
-    az acr credential-set delete -r MyRegistry -n MyCredSet
+    az acr credential-set delete -r MyRegistry -n MyDockerHubCredSet
     ```
 
 :::zone-end


### PR DESCRIPTION
The CLI documentation for `az acr credential-set` is confusing. In the example it uses `az acr credential-set create -r MyRegistry -n MyRule` to demonstrate how to create a credential set. Technically there is no errors in this command, however the term `MyRule` has been used to refer to an ACR cache rule in other examples on the page. For customer who is new to Azure Container Registry this can be very confusing, as they started grappling with new concepts such as _cache rule_ and _credential set_.

This commit introduces small polishes to make the documentation clearer:
- Use `MyDockerHubCredSet` when demonstrating how to operate credential set. This name is carefully chosen as it clearly identifies itself as a _credential set_, also it implies it stores credentials for DockerHub, and customer could create other credential sets for other registries.
- Fixed small errors on section heading, i.e. from `az-acr-credential-set-show` to `az acr credential-set show`.