### PR TITLE
Update ingress-controller-annotations.md to cover all current annotations

### DIFF
--- a/articles/application-gateway/ingress-controller-annotations.md
+++ b/articles/application-gateway/ingress-controller-annotations.md
@@ -87,7 +87,7 @@ In the previous example, you've defined an ingress resource named `go-server-ing
 
 ## Backend Hostname
 
-This annotations allows us to specify the host name that Application Gateway should use while talking to the Pods.
+This annotation allows us to specify the host name that Application Gateway should use while talking to the Pods.
 
 ### Usage
 
@@ -126,7 +126,7 @@ Application Gateway [can be configured](./application-gateway-probe-overview.md)
 `health-probe-hostname`: This annotation allows a custom hostname on the health probe.<br>
 `health-probe-port`: This annotation configures a custom health probe port.<br>
 `health-probe-path`: This annotation defines a path for the health probe.<br>
-`health-probe-status-code`: This annotation allows for the health probe to accept different http status codes.<br>
+`health-probe-status-code`: This annotation allows the health probe to accept different HTTP status codes.<br>
 `health-probe-interval`: This annotation defines the interval that the health probe runs at.<br>
 `health-probe-timeout`: This annotation defines how long the health probe will wait for a response before failing the probe.<br>
 `health-probe-unhealthy-threshold`: This annotation defines how many health probes must fail for the backend to be marked as unhealthy.
@@ -354,9 +354,9 @@ spec:
 
 ## Override Frontend Port
 
-The annotation allows to configure frontend listener to use different ports other than 80/443 for http/https.
+The annotation allows you to configure a frontend listener to use different ports other than 80/443 for http/https.
 
-If the port is within the App Gw authorized range (1 - 64999), this listener will be created on this specific port. If an invalid port or no port is set in the annotation, the configuration will fallback on default 80 or 443.
+If the port is within the App Gw authorized range (1 - 64999), this listener will be created on this specific port. If an invalid port or no port is set in the annotation, the configuration will fall back on default 80 or 443.
 
 ### Usage
 
@@ -516,7 +516,7 @@ spec:
 
 ## Application Gateway SSL Certificate
 
-The SSL certificate [can be configured to Application Gateway](https://learn.microsoft.com/cli/azure/network/application-gateway/ssl-cert#az-network-application-gateway-ssl-cert-create) either from a local PFX certificate file or a reference to a Azure Key Vault unversioned secret Id. When the annotation is present with a certificate name and the certificate is pre-installed in Application Gateway, Kubernetes Ingress controller will create a routing rule with a HTTPS listener and apply the changes to your App Gateway. appgw-ssl-certificate annotation can also be used together with ssl-redirect annotation in case of SSL redirect.
+The SSL certificate [can be configured to Application Gateway](/cli/azure/network/application-gateway/ssl-cert#az-network-application-gateway-ssl-cert-create) either from a local PFX certificate file or a reference to an Azure Key Vault unversioned secret ID. When the annotation is present with a certificate name and the certificate is pre-installed in Application Gateway, Kubernetes Ingress controller will create a routing rule with a HTTPS listener and apply the changes to your App Gateway. appgw-ssl-certificate annotation can also be used together with ssl-redirect annotation in case of SSL redirect.
 
 Please refer to appgw-ssl-certificate feature for more details.
 
@@ -590,7 +590,7 @@ spec:
 
 ## Application Gateway Trusted Root Certificate
 
-Users now can configure their own root certificates to Application Gateway to be trusted via AGIC. The annotaton appgw-trusted-root-certificate shall be used together with annotation backend-protocol to indicate end-to-end ssl encryption, multiple root certificates, separated by comma, if specified, e.g. "name-of-my-root-cert1,name-of-my-root-certificate2".
+Users now can configure their own root certificates to Application Gateway to be trusted via AGIC. The annotation appgw-trusted-root-certificate can be used together with annotation backend-protocol to indicate end-to-end ssl encryption, multiple root certificates, separated by comma, if specified, for example, "name-of-my-root-cert1,name-of-my-root-certificate2".
 
 ### Usage
 
@@ -659,11 +659,13 @@ spec:
 
 ## Rewrite Rule Set Custom Resource
 
-> **_NOTE:_** [Application Gateway for Containers](https://aka.ms/agc) has been released, which introduces numerous performance, resilience, and feature changes. Please consider leveraging Application Gateway for Containers for your next deployment.
+> [!Note] 
+> [Application Gateway for Containers](https://aka.ms/agc) has been released, which introduces numerous performance, resilience, and feature changes. Please consider leveraging Application Gateway for Containers for your next deployment.
 > URL Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](./for-containers/how-to-url-rewrite-gateway-api.md) and [here for Ingress API](for-containers/how-to-url-rewrite-ingress-api.md).
 > Header Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](./for-containers/how-to-header-rewrite-gateway-api.md).
 
-> Note: This feature is supported since 1.6.0-rc1. Please use [`appgw.ingress.kubernetes.io/rewrite-rule-set`](#rewrite-rule-set) which allows using an existing rewrite rule set on Application Gateway.
+> [!Note] 
+> This feature is supported since 1.6.0-rc1. Use [`appgw.ingress.kubernetes.io/rewrite-rule-set`](#rewrite-rule-set), which allows using an existing rewrite rule set on Application Gateway.
 
 Application Gateway allows you to rewrite selected content of requests and responses. With this feature, you can translate URLs, query string parameters as well as modify request and response headers. It also allows you to add conditions to ensure that the URL or the specified headers are rewritten only when certain conditions are met. These conditions are based on the request and response information. Rewrite Rule Set Custom Resource brings this feature to AGIC.
 
@@ -710,7 +712,7 @@ spec:
 
 ## Rule Priority
 
-This annotation allows for application gateway ingress controller to explicitly set the priority of the associated [Request Routing Rules.](./multiple-site-overview#request-routing-rules-evaluation-order)
+This annotation allows for application gateway ingress controller to explicitly set the priority of the associated [Request Routing Rules.](./multiple-site-overview.md#request-routing-rules-evaluation-order)
 
 ### Usage
 

--- a/articles/application-gateway/ingress-controller-annotations.md
+++ b/articles/application-gateway/ingress-controller-annotations.md
@@ -20,14 +20,31 @@ For an Ingress resource to be observed by AGIC, it **must be annotated** with `k
 | Annotation Key | Value Type | Default Value | Allowed Values |
 | -- | -- | -- | -- |
 | [appgw.ingress.kubernetes.io/backend-path-prefix](#backend-path-prefix) | `string` | `nil` ||
+| [appgw.ingress.kubernetes.io/backend-hostname](#backend-hostname) | `string` | `nil` ||
+| [appgw.ingress.kubernetes.io/health-probe-hostname](#custom-health-probe) | `string` | `127.0.0.1` ||
+| [appgw.ingress.kubernetes.io/health-probe-port](#custom-health-probe) | `int32` | `80` ||
+| [appgw.ingress.kubernetes.io/health-probe-path](#custom-health-probe) | `string` | `/` ||
+| [appgw.ingress.kubernetes.io/health-probe-status-code](#custom-health-probe) | `string` | `200-399` ||
+| [appgw.ingress.kubernetes.io/health-probe-interval](#custom-health-probe) | `int32` | `30` (seconds) ||
+| [appgw.ingress.kubernetes.io/health-probe-timeout](#custom-health-probe) | `int32` | `30` (seconds) ||
+| [appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold](#custom-health-probe) | `int32` | `3` ||
 | [appgw.ingress.kubernetes.io/ssl-redirect](#tls-redirect) | `bool` | `false` | |
 | [appgw.ingress.kubernetes.io/connection-draining](#connection-draining) | `bool` | `false` ||
 | [appgw.ingress.kubernetes.io/connection-draining-timeout](#connection-draining) | `int32` (seconds) | `30` ||
+| [appgw.ingress.kubernetes.io/use-private-ip](#use-private-ip) | `bool` | `false` ||
+| [appgw.ingress.kubernetes.io/override-frontend-port](#override-frontend-port) | `bool` | `false` ||
 | [appgw.ingress.kubernetes.io/cookie-based-affinity](#cookie-based-affinity) | `bool` | `false` ||
 | [appgw.ingress.kubernetes.io/request-timeout](#request-timeout) | `int32` (seconds) | `30` ||
 | [appgw.ingress.kubernetes.io/use-private-ip](#use-private-ip) | `bool` | `false` ||
 | [appgw.ingress.kubernetes.io/backend-protocol](#backend-protocol) | `string` | `http` | `http`, `https` |
+| [appgw.ingress.kubernetes.io/hostname-extension](#hostname-extension) | `string` | `nil` ||
+| [appgw.ingress.kubernetes.io/waf-policy-for-path](#waf-policy-for-path) | `string` | `nil` ||
+| [appgw.ingress.kubernetes.io/appgw-ssl-certificate](#application-gateway-ssl-certificate) | `string` | `nil` ||
+| [appgw.ingress.kubernetes.io/appgw-ssl-profile](#application-gateway-ssl-profile) | `string` | `nil` ||
+| [appgw.ingress.kubernetes.io/appgw-trusted-root-certificate](#application-gateway-trusted-root-certificate) | `string` | `nil` ||
 | [appgw.ingress.kubernetes.io/rewrite-rule-set](#rewrite-rule-set) | `string` | `nil`  ||
+| [appgw.ingress.kubernetes.io/rewrite-rule-set-custom-resource](#rewrite-rule-set-custom-resource) ||||
+| [appgw.ingress.kubernetes.io/rule-priority](#rule-priority) | `int32` | `nil` ||
 
 ## Backend Path Prefix
 
@@ -67,6 +84,94 @@ In the previous example, you've defined an ingress resource named `go-server-ing
 
 > [!NOTE]
 > In the above example, only one rule is defined. However, the annotations are applicable to the entire ingress resource, so if a user defined multiple rules, the backend path prefix would be set up for each of the paths specified. If a user wants different rules with different path prefixes (even for the same service), they would need to define different ingress resources.
+
+## Backend Hostname
+
+This annotations allows us to specify the host name that Application Gateway should use while talking to the Pods.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/backend-hostname: "internal.example.com"
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-timeout
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-hostname: "internal.example.com"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /hello/
+        backend:
+          service:
+            name: store-service
+            port:
+              number: 80
+        pathType: Exact
+```
+
+## Custom Health Probe
+
+Application Gateway [can be configured](./application-gateway-probe-overview.md) to send custom health probes to the backend address pool. When these annotations are present, Kubernetes Ingress controller [creates a custom probe](./application-gateway-create-probe-portal) to monitor the backend application and applies the changes to the application gateway.
+
+`health-probe-hostname`: This annotation allows a custom hostname on the health probe.<br>
+`health-probe-port`: This annotation configures a custom health probe port.<br>
+`health-probe-path`: This annotation defines a path for the health probe.<br>
+`health-probe-status-code`: This annotation allows for the health probe to accept different http status codes.<br>
+`health-probe-interval`: This annotation defines the interval that the health probe runs at.<br>
+`health-probe-timeout`: This annotation defines how long the health probe will wait for a response before failing the probe.<br>
+`health-probe-unhealthy-threshold`: This annotation defines how many health probes must fail for the backend to be marked as unhealthy.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/health-probe-hostname: "contoso.com"
+appgw.ingress.kubernetes.io/health-probe-port: 80
+appgw.ingress.kubernetes.io/health-probe-path: "/"
+appgw.ingress.kubernetes.io/health-probe-status-code: "100-599"
+appgw.ingress.kubernetes.io/health-probe-interval: 30
+appgw.ingress.kubernetes.io/health-probe-timeout: 30
+appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold: 2
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/health-probe-hostname: "contoso.com"
+    appgw.ingress.kubernetes.io/health-probe-port: 81
+    appgw.ingress.kubernetes.io/health-probe-path: "/probepath"
+    appgw.ingress.kubernetes.io/health-probe-status-code: "100-599"
+    appgw.ingress.kubernetes.io/health-probe-interval: 31
+    appgw.ingress.kubernetes.io/health-probe-timeout: 31
+    appgw.ingress.kubernetes.io/health-probe-unhealthy-threshold: 2
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Exact
+        backend:
+          service:
+            name: go-server-service
+            port:
+              number: 80
+```
 
 ## TLS Redirect
 
@@ -229,7 +334,7 @@ appgw.ingress.kubernetes.io/use-private-ip: "true"
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: go-server-ingress-timeout
+  name: go-server-ingress-privateip
   namespace: test-ag
   annotations:
     kubernetes.io/ingress.class: azure/application-gateway
@@ -238,7 +343,7 @@ spec:
   rules:
   - http:
       paths:
-      - path: /hello/
+      - path: /
         pathType: Exact
         backend:
           service:
@@ -246,6 +351,46 @@ spec:
             port:
               number: 80
 ```
+
+## Override Frontend Port
+
+The annotation allows to configure frontend listener to use different ports other than 80/443 for http/https.
+
+If the port is within the App Gw authorized range (1 - 64999), this listener will be created on this specific port. If an invalid port or no port is set in the annotation, the configuration will fallback on default 80 or 443.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/override-frontend-port: "port"
+
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-overridefrontendport
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/override-frontend-port: "8080"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /hello/
+        backend:
+          service:
+            name: store-service
+            port:
+              number: 80
+        pathType: Exact
+```
+
+> [!NOTE]
+>External request will need to target http://somehost:8080 instead of http://somehost.
 
 ## Backend Protocol
 
@@ -277,13 +422,205 @@ spec:
   rules:
   - http:
       paths:
-      - path: /hello/
+      - path: /
         pathType: Exact
         backend:
           service:
             name: go-server-service
             port:
               number: 443
+```
+
+## Hostname Extension
+
+Application Gateway can be configured to accept multiple hostnames. The hostname-extention annotation allows for this by letting you define multiple hostnames including wildcard hostnames. This will append the hostnames onto the FQDN that is defined in the ingress spec.rules.host on the frontend listener so it is [configured as a multisite listener.](./multiple-site-overview)
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/hostname-extension: "hostname1, hostname2"
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-multisite
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/hostname-extension: "hostname1, hostname2"
+spec:
+  rules:
+  - host: contoso.com
+    http:
+      paths:
+      - path: /
+        pathType: Exact
+        backend:
+          service:
+            name: go-server-service
+            port:
+              number: 443
+```
+
+> [!NOTE]
+> In the above example the listener would be configured to accept traffic for the hostnames "hostname1.contoso.com" and "hostname2.contoso.com"
+
+## WAF Policy for Path
+
+This annotation allows you to attach an already created WAF policy to the list paths for a host within a Kubernetes Ingress resource being annotated.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/waf-policy-for-path: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/SampleRG/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/AGICWAFPolcy"
+
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ad-server-ingress
+  namespace: commerce
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/waf-policy-for-path: "/subscriptions/abcd/resourceGroups/rg/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/adserver"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /ad-server
+        backend:
+          service:
+            name: ad-server
+            port:
+              number: 80
+        pathType: Exact
+      - path: /auth
+        backend:
+          service:
+            name: auth-server
+            port:
+              number: 80
+        pathType: Exact
+```
+
+> [!NOTE]
+> The WAF policy will be applied to both /ad-server and /auth URLs.
+
+## Application Gateway SSL Certificate
+
+The SSL certificate [can be configured to Application Gateway](https://learn.microsoft.com/en-us/cli/azure/network/application-gateway/ssl-cert?view=azure-cli-latest#az-network-application-gateway-ssl-cert-create) either from a local PFX certificate file or a reference to a Azure Key Vault unversioned secret Id. When the annotation is present with a certificate name and the certificate is pre-installed in Application Gateway, Kubernetes Ingress controller will create a routing rule with a HTTPS listener and apply the changes to your App Gateway. appgw-ssl-certificate annotation can also be used together with ssl-redirect annotation in case of SSL redirect.
+
+Please refer to appgw-ssl-certificate feature for more details.
+
+> [!NOTE]
+>  Annotation "appgw-ssl-certificate" will be ignored when TLS Spec is defined in ingress at the same time. If a user wants different certs with different hosts(multi tls certificate termination), they would need to define different ingress resources.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/appgw-ssl-certificate: "name-of-appgw-installed-certificate"
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-certificate
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/appgw-ssl-certificate: "name-of-appgw-installed-certificate"
+spec:
+  rules:
+  - host: www.contoso.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: websocket-repeater
+            port:
+              number: 80
+
+```
+
+## Application Gateway SSL Profile
+
+Users can configure a ssl profile on the Application Gateway per listener. When the annotation is present with a profile name and the profile is pre-installed in the Application Gateway, Kubernetes Ingress controller will create a routing rule with a HTTPS listener and apply the changes to your App Gateway.
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/appgw-ssl-certificate: "name-of-appgw-installed-certificate"
+appgw.ingress.kubernetes.io/appgw-ssl-profile: "SampleSSLProfile"
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-certificate
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/appgw-ssl-certificate: "name-of-appgw-installed-certificate"
+    appgw.ingress.kubernetes.io/appgw-ssl-profile: "SampleSSLProfile"
+spec:
+  rules:
+  - host: www.contoso.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: websocket-repeater
+            port:
+              number: 80
+```
+
+## Application Gateway Trusted Root Certificate
+
+Users now can configure their own root certificates to Application Gateway to be trusted via AGIC. The annotaton appgw-trusted-root-certificate shall be used together with annotation backend-protocol to indicate end-to-end ssl encryption, multiple root certificates, separated by comma, if specified, e.g. "name-of-my-root-cert1,name-of-my-root-certificate2".
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/backend-protocol: "https"
+appgw.ingress.kubernetes.io/appgw-trusted-root-certificate: "name-of-my-root-cert1"
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-certificate
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/backend-protocol: "https"
+    appgw.ingress.kubernetes.io/appgw-trusted-root-certificate: "name-of-my-root-cert1"
+spec:
+  rules:
+  - host: www.contoso.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: websocket-repeater
+            port:
+              number: 80
 ```
 
 ## Rewrite Rule Set
@@ -319,3 +656,90 @@ spec:
             port:
               number: 8080
 ```
+
+## Rewrite Rule Set Custom Resource
+
+> **_NOTE:_** [Application Gateway for Containers](https://aka.ms/agc) has been released, which introduces numerous performance, resilience, and feature changes. Please consider leveraging Application Gateway for Containers for your next deployment.
+> URL Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-url-rewrite-gateway-api?tabs=alb-managed) and [here for Ingress API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-url-rewrite-ingress-api?tabs=alb-managed).
+> Header Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-header-rewrite-gateway-api?tabs=alb-managed) and [here for Ingress API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-header-rewrite-ingress-api?tabs=alb-managed).
+
+> Note: This feature is supported since 1.6.0-rc1. Please use [`appgw.ingress.kubernetes.io/rewrite-rule-set`](#rewrite-rule-set) which allows using an existing rewrite rule set on Application Gateway.
+
+Application Gateway allows you to rewrite selected content of requests and responses. With this feature, you can translate URLs, query string parameters as well as modify request and response headers. It also allows you to add conditions to ensure that the URL or the specified headers are rewritten only when certain conditions are met. These conditions are based on the request and response information. Rewrite Rule Set Custom Resource brings this feature to AGIC.
+
+HTTP headers allow a client and server to pass additional information with a request or response. By rewriting these headers, you can accomplish important tasks, such as adding security-related header fields like HSTS/ X-XSS-Protection, removing response header fields that might reveal sensitive information, and removing port information from X-Forwarded-For headers.
+
+With URL rewrite capability, you can: - Rewrite the host name, path and query string of the request URL - Choose to rewrite the URL of all requests or only those requests which match one or more of the conditions you set. These conditions are based on the request and response properties (request header, response header and server variables). - Choose to route the request based on either the original URL or the rewritten URL
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/rewrite-rule-set-custom-resource
+```
+
+### Example
+
+```yaml
+apiVersion: appgw.ingress.azure.io/v1beta1 
+kind: AzureApplicationGatewayRewrite 
+metadata: 
+  name: my-rewrite-rule-set-custom-resource 
+spec: 
+  rewriteRules: 
+  - name: rule1 
+    ruleSequence: 21
+    conditions:
+  - ignoreCase: false
+    negate: false
+    variable: http_req_Host
+    pattern: example.com
+  actions:
+    requestHeaderConfigurations:
+    - actionType: set
+      headerName: incoming-test-header
+      headerValue: incoming-test-value
+    responseHeaderConfigurations:
+    - actionType: set
+      headerName: outgoing-test-header
+      headerValue: outgoing-test-value
+    urlConfiguration:
+      modifiedPath: "/api/"
+      modifiedQueryString: "query=test-value"
+      reroute: false
+```
+
+## Rule Priority
+
+This annotation allows for application gateway ingress controller to explicitly set the priority of the associated [Request Routing Rules.](./multiple-site-overview#request-routing-rules-evaluation-order)
+
+### Usage
+
+```yaml
+appgw.ingress.kubernetes.io/rule-priority:
+```
+
+### Example
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: go-server-ingress-rulepriority
+  namespace: test-ag
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/rule-priority: 10
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Exact
+        backend:
+          service:
+            name: go-server-service
+            port:
+              number: 8080
+```
+
+In the above example the request routing rule would have a priority of 10 set.

--- a/articles/application-gateway/ingress-controller-annotations.md
+++ b/articles/application-gateway/ingress-controller-annotations.md
@@ -121,7 +121,7 @@ spec:
 
 ## Custom Health Probe
 
-Application Gateway [can be configured](./application-gateway-probe-overview.md) to send custom health probes to the backend address pool. When these annotations are present, Kubernetes Ingress controller [creates a custom probe](./application-gateway-create-probe-portal) to monitor the backend application and applies the changes to the application gateway.
+Application Gateway [can be configured](./application-gateway-probe-overview.md) to send custom health probes to the backend address pool. When these annotations are present, Kubernetes Ingress controller [creates a custom probe](./application-gateway-create-probe-portal.md) to monitor the backend application and applies the changes to the application gateway.
 
 `health-probe-hostname`: This annotation allows a custom hostname on the health probe.<br>
 `health-probe-port`: This annotation configures a custom health probe port.<br>
@@ -433,7 +433,7 @@ spec:
 
 ## Hostname Extension
 
-Application Gateway can be configured to accept multiple hostnames. The hostname-extention annotation allows for this by letting you define multiple hostnames including wildcard hostnames. This will append the hostnames onto the FQDN that is defined in the ingress spec.rules.host on the frontend listener so it is [configured as a multisite listener.](./multiple-site-overview)
+Application Gateway can be configured to accept multiple hostnames. The hostname-extention annotation allows for this by letting you define multiple hostnames including wildcard hostnames. This will append the hostnames onto the FQDN that is defined in the ingress spec.rules.host on the frontend listener so it is [configured as a multisite listener.](./multiple-site-overview.md)
 
 ### Usage
 
@@ -516,7 +516,7 @@ spec:
 
 ## Application Gateway SSL Certificate
 
-The SSL certificate [can be configured to Application Gateway](https://learn.microsoft.com/en-us/cli/azure/network/application-gateway/ssl-cert?view=azure-cli-latest#az-network-application-gateway-ssl-cert-create) either from a local PFX certificate file or a reference to a Azure Key Vault unversioned secret Id. When the annotation is present with a certificate name and the certificate is pre-installed in Application Gateway, Kubernetes Ingress controller will create a routing rule with a HTTPS listener and apply the changes to your App Gateway. appgw-ssl-certificate annotation can also be used together with ssl-redirect annotation in case of SSL redirect.
+The SSL certificate [can be configured to Application Gateway](https://learn.microsoft.com/cli/azure/network/application-gateway/ssl-cert#az-network-application-gateway-ssl-cert-create) either from a local PFX certificate file or a reference to a Azure Key Vault unversioned secret Id. When the annotation is present with a certificate name and the certificate is pre-installed in Application Gateway, Kubernetes Ingress controller will create a routing rule with a HTTPS listener and apply the changes to your App Gateway. appgw-ssl-certificate annotation can also be used together with ssl-redirect annotation in case of SSL redirect.
 
 Please refer to appgw-ssl-certificate feature for more details.
 
@@ -660,8 +660,8 @@ spec:
 ## Rewrite Rule Set Custom Resource
 
 > **_NOTE:_** [Application Gateway for Containers](https://aka.ms/agc) has been released, which introduces numerous performance, resilience, and feature changes. Please consider leveraging Application Gateway for Containers for your next deployment.
-> URL Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-url-rewrite-gateway-api?tabs=alb-managed) and [here for Ingress API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-url-rewrite-ingress-api?tabs=alb-managed).
-> Header Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-header-rewrite-gateway-api?tabs=alb-managed) and [here for Ingress API](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-header-rewrite-ingress-api?tabs=alb-managed).
+> URL Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](./for-containers/how-to-url-rewrite-gateway-api.md) and [here for Ingress API](for-containers/how-to-url-rewrite-ingress-api.md).
+> Header Rewrite rules for Application Gateway for Containers may be found [here for Gateway API](./for-containers/how-to-header-rewrite-gateway-api.md).
 
 > Note: This feature is supported since 1.6.0-rc1. Please use [`appgw.ingress.kubernetes.io/rewrite-rule-set`](#rewrite-rule-set) which allows using an existing rewrite rule set on Application Gateway.
 


### PR DESCRIPTION
Proposing documentation updates to AGIC Annotations to a current complete list based on https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/pkg/annotations/ingress_annotations.go

Currently, the page is very dated and missing many annotations.