### PR TITLE
Grammar and minor content updates to virtual-network-tcpip-performanc…

### DIFF
--- a/articles/virtual-network/virtual-network-tcpip-performance-tuning.md
+++ b/articles/virtual-network/virtual-network-tcpip-performance-tuning.md
@@ -296,7 +296,7 @@ A number of the performance maximums in this article are related to the network 
 
 TCP performance relies heavily on RTT and packet Loss. The PING utility available in Windows and Linux provides the easiest way to measure RTT and packet loss. The output of PING will show the minimum/maximum/average latency between a source and destination. It will also show packet loss. PING uses the ICMP protocol by default. You can use PsPing to test TCP RTT. For more information, see [PsPing](/sysinternals/downloads/psping).
 
-Neither ICMP nor TCP pings measure the accelerated networking datapath. To measure this, please read about Latte and SockPerf in [this article](/azure/virtual-network/virtual-network-test-latency).
+Neither ICMP nor TCP pings measure the accelerated networking datapath. To measure this, please read about Latte and SockPerf in [this article](./virtual-network-test-latency.md).
 
 ### Measure actual bandwidth of a virtual machine
 

--- a/articles/virtual-network/virtual-network-tcpip-performance-tuning.md
+++ b/articles/virtual-network/virtual-network-tcpip-performance-tuning.md
@@ -21,7 +21,7 @@ This article discusses common TCP/IP performance tuning techniques and some thin
 
 #### MTU
 
-The maximum transmission unit (MTU) is the largest size frame (packet), specified in bytes, that can be sent over a network interface. The MTU is a configurable setting. The default MTU used on Azure VMs, and the default setting on most network devices globally, is 1,500 bytes.
+The maximum transmission unit (MTU) is the largest size frame (packet plus network access headers), specified in bytes, that can be sent over a network interface. The MTU is a configurable setting. The default MTU used on Azure VMs, and the default setting on most network devices globally, is 1,500 bytes.
 
 #### Fragmentation
 
@@ -258,7 +258,7 @@ For more information, see [Virtual machine network bandwidth](./virtual-machine-
 
 As discussed throughout this article, factors on the internet and outside the control of Azure can affect network performance. Here are some of those factors:
 
-- **Latency**: The round-trip time between two destinations can be affected by issues on intermediate networks, by traffic that doesn't take the "shortest" distance path, and by suboptimal peering paths.
+- **Latency**: The round-trip time between two endpoints can be affected by issues on intermediate networks, by traffic that doesn't take the "shortest" distance path, and by suboptimal peering paths.
 
 - **Packet loss**: Packet loss can be caused by network congestion, physical path issues, and underperforming network devices.
 
@@ -270,7 +270,7 @@ Traceroute is a good tool for measuring network performance characteristics (lik
 
 Along with the considerations discussed earlier in this article, the topology of a virtual network can affect the network's performance. For example, a hub-and-spoke design that backhauls traffic globally to a single-hub virtual network will introduce network latency, which will affect overall network performance.
 
-The number of network devices that network traffic passes through can also affect overall latency. For example, in a hub-and-spoke design, if traffic passes through a spoke network virtual appliance and a hub virtual appliance before transiting to the internet, the network virtual appliances can introduce latency.
+The number of network devices that network traffic passes through can also affect overall latency. For example, in a hub-and-spoke design, if traffic passes through a spoke network virtual appliance and a hub virtual appliance before transiting to the internet, the network virtual appliances will introduce some latency.
 
 ### Azure regions, virtual networks, and latency
 
@@ -278,7 +278,7 @@ Azure regions are made up of multiple datacenters that exist within a general ge
 
 For example, two VMs that are in the same virtual network and subnet might be in different racks, rows, or even datacenters. They could be separated by feet of fiber optic cable or by kilometers of fiber optic cable. This variation could introduce variable latency (a few milliseconds difference) between different VMs.
 
-The geographic placement of VMs, and the potential resulting latency between two VMs, can be influenced by the configuration of availability sets and Availability Zones. But the distance between datacenters in a region is region-specific and primarily influenced by datacenter topology in the region.
+The geographic placement of VMs, and the potential resulting latency between two VMs, can be influenced by the configuration of availability sets, proximity placement groups, and availability zones. But the distance between datacenters in a region is region-specific and primarily influenced by datacenter topology in the region.
 
 ### Source NAT port exhaustion
 
@@ -296,6 +296,8 @@ A number of the performance maximums in this article are related to the network 
 
 TCP performance relies heavily on RTT and packet Loss. The PING utility available in Windows and Linux provides the easiest way to measure RTT and packet loss. The output of PING will show the minimum/maximum/average latency between a source and destination. It will also show packet loss. PING uses the ICMP protocol by default. You can use PsPing to test TCP RTT. For more information, see [PsPing](/sysinternals/downloads/psping).
 
+Neither ICMP nor TCP pings measure the accelerated networking datapath. To measure this, please read about Latte and SockPerf in [this article](/azure/virtual-network/virtual-network-test-latency).
+
 ### Measure actual bandwidth of a virtual machine
 
 To accurately measure the bandwidth of Azure VMs, follow [this guidance](./virtual-network-bandwidth-testing.md).
@@ -308,7 +310,7 @@ For more details on testing other scenarios, see these articles:
 
 ### Detect inefficient TCP behaviors
 
-In packet captures, Azure customers might see TCP packets with TCP flags (SACK, DUP ACK, RETRANSMIT, and FAST RETRANSMIT) that could indicate network performance problems. These packets specifically indicate network inefficiencies that result from packet loss. But packet loss isn't necessarily caused by Azure performance problems. Performance problems could be the result of application problems, operating system problems, or other problems that might not be directly related to the Azure platform.
+In packet captures, Azure customers might see TCP packets with TCP flags (SACK, DUP ACK, RETRANSMIT, and FAST RETRANSMIT) that could indicate network performance problems. These packets specifically indicate network inefficiencies that result from packet loss. But packet loss isn't necessarily caused by Azure performance problems. Performance issues could be the result of application, operating system, or other problems that might not be directly related to the Azure platform.
 
 Also, keep in mind that some retransmission and duplicate ACKs are normal on a network. TCP protocols were built to be reliable. Evidence of these TCP packets in a packet capture doesn't necessarily indicate a systemic network problem, unless they're excessive.
 


### PR DESCRIPTION
…e-tuning.md

--Expand on frame vs packet.  The current verbage suggests they're the same thing. 
--Changed 'destinations' to 'endpoints'.  A conversation has a a single destination. 
--Virtual appliances will introduce latency, but not necessarily to a negative degree. Changed to more accurate language, but softened the impact with 'some'. 
--Added logical inclusion of 'proximity placement groups' along with 'availability sets' and 'availability zones'. 
--Removed capitalization of 'Availability Zones', it is not capitalized in other documents like: 
https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview 
--This is a wonderful place to introduce latte and sockperf, so added to latency testing section. 
--Fixed predicament with a sentence that used 'problems' far too many times.