### PR TITLE
Update functions-app-settings.md

### DIFF
--- a/articles/azure-functions/functions-app-settings.md
+++ b/articles/azure-functions/functions-app-settings.md
@@ -22,7 +22,7 @@ When using app settings, you should be aware of the following considerations:
 
 + Changes to function app settings require your function app to be restarted.
 
-+ In setting names, double-underscore (`__`) and colon (`:`) are considered reserved values. Double-underscores are interpreted as hierarchical delimiters on both Windows and Linux, and colons are interpreted in the same way only on Linux. For example, the setting `AzureFunctionsWebHost__hostid=somehost_123456` would be interpreted as the following JSON object:
++ In setting names, double-underscore (`__`) and colon (`:`) are considered reserved values. Double-underscores are interpreted as hierarchical delimiters on both Windows and Linux, and colons are interpreted in the same way only on Windows. For example, the setting `AzureFunctionsWebHost__hostid=somehost_123456` would be interpreted as the following JSON object:
 
     ```json
     "AzureFunctionsWebHost": {


### PR DESCRIPTION
I believe the wrong OS was references here, and that colon (:) is only supported on Windows, (as it is interpreted by bash as a delimiter on a Linux host trying to set the env var) 

Not using colon in things on Linux is also referenced in:  https://github.com/Azure/azure-functions-host/wiki/Host-IDs https://github.com/microsoft/azure-pipelines-tasks/issues/12376

This also covers the colon bash incompatability
https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0&tabs=basicconfiguration