### PR TITLE
Improve Github owner documentation

### DIFF
--- a/articles/data-factory/source-control.md
+++ b/articles/data-factory/source-control.md
@@ -154,6 +154,11 @@ For repositories owned by GitHub organization account, the admin has to authoriz
 
 :::image type="content" source="media/author-visually/github-configure-repository-pane.png" alt-text=" Screenshot showing GitHub Configure a repository pane.":::
 
+> [!NOTE]
+> if you recieve this error: ***Failed to list GitHub repositories. Please make sure the account name is correct and you have permission to perform the action.***
+> Ensure that you are using the correct owner name and not the GitHub repository URL. For example, if the repository URL is **https://github.com/contoso/contoso-ads**, the owner is **contoso**, not the full URL.
+
+
 :::image type="content" source="media/author-visually/use-github-enterprise-server-pane.png" alt-text="Screenshot showing GitHub Configure a repository using enterprise server pane.":::
 
 :::image type="content" source="media/author-visually/github-integration-image2.png" alt-text="GitHub repository settings":::


### PR DESCRIPTION
the picture does not provide a clear example of the value that should be provided for owner this leaves some ambiguity about the value needed either the full url or just the owner name. 

for reference see this answer on stack overflow:
https://stackoverflow.com/questions/71950079/how-to-connect-azure-synapse-and-an-enterprise-git-repo-using-personal-access-to

I've attempted to leave add this information to make it easier to troubleshoot.