### PR TITLE
Update virtual-network-bandwidth-testing.md

### DIFF
--- a/articles/virtual-network/virtual-network-bandwidth-testing.md
+++ b/articles/virtual-network/virtual-network-bandwidth-testing.md
@@ -25,7 +25,7 @@ This article describes how to use the free NTTTCP tool from Microsoft to test ne
     - Note the number of VM cores and the receiver VM IP address to use in the commands. Both the sender and receiver commands use the receiver's IP address.
 
 >[!NOTE]
->Testing by using a virtual IP (VIP) is possible, but is beyond the scope of this article.
+>Testing by using a virtual IP is possible, but is beyond the scope of this article.
 
 **Examples used in this article**
 


### PR DESCRIPTION
Removing acronym only used once in article - As per Microsoft writing style guide:

https://learn.microsoft.com/en-us/style-guide/acronyms#dont-introduce-acronyms-that-are-used-just-once