### PR TITLE
Remove Five9 from the list of unsupported SFTP clients for Azure Blob Storage

### DIFF
--- a/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
@@ -22,7 +22,6 @@ This article describes limitations and known issues of SFTP support for Azure Bl
 
 The following clients are known to be incompatible with SFTP for Azure Blob Storage. For more information, see [Supported algorithms](secure-file-transfer-protocol-support.md#supported-algorithms).
 
-- Five9
 - Kemp
 - paramiko 1.16.0
 - SSH.NET 2016.1.0

--- a/articles/storage/blobs/secure-file-transfer-protocol-support.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-support.md
@@ -182,6 +182,7 @@ The following clients have compatible algorithm support with SFTP for Azure Blob
 - Cyberduck 7.8.2+
 - edtFTPjPRO 7.0.0+
 - FileZilla 3.53.0+
+- Five9
 - libssh 0.9.5+
 - Maverick Legacy 1.7.15+
 - Moveit 12.7


### PR DESCRIPTION
My colleagues and I are using Five9 with Azure Blob Storage via SFTP. It works:
![image](https://github.com/user-attachments/assets/bbd0c9a0-a828-47ce-a0bd-b065aac544be)
