### PR TITLE
Update create-management-group-azure-cli.md

### DIFF
--- a/articles/governance/management-groups/create-management-group-azure-cli.md
+++ b/articles/governance/management-groups/create-management-group-azure-cli.md
@@ -35,7 +35,7 @@ directory. You receive a notification when the process is complete. For more inf
   [default management group](./how-to/protect-resource-hierarchy.md#setting-define-the-default-management-group)
   and the creator is given an Owner role assignment. Management group service allows this ability
   so that role assignments aren't needed at the root level. When the Root
-  Management Group when is created, users don't have access to it. To start using management groups, the service allows the creation of the initial management groups at the root level. For more information, see [Root management group for each directory](./overview.md#root-management-group-for-each-directory).
+  Management Group is created, users don't have access to it. To start using management groups, the service allows the creation of the initial management groups at the root level. For more information, see [Root management group for each directory](./overview.md#root-management-group-for-each-directory).
 
 [!INCLUDE [cloud-shell-try-it.md](~/reusable-content/ce-skilling/azure/includes/cloud-shell-try-it.md)]
 


### PR DESCRIPTION
When the Root Management Group when is created, users don't have access to it. --->
When the Root Management Group is created, users don't have access to it.

I assume that the second "when" is a typo (not required).