### PR TITLE
Update api-management-howto-properties.md

### DIFF
--- a/articles/api-management/api-management-howto-properties.md
+++ b/articles/api-management/api-management-howto-properties.md
@@ -42,7 +42,8 @@ Using key vault secrets is recommended because it helps improve API Management s
 * Secrets stored in key vaults can be reused across services
 * Granular [access policies](/azure/key-vault/general/security-features#privileged-access) can be applied to secrets
 * Secrets updated in the key vault are automatically rotated in API Management. After update in the key vault, a named value in API Management is updated within 4 hours. You can also manually refresh the secret using the Azure portal or via the management REST API.
-
+ > [!NOTE]
+    The secrets stored in Azure Key Vault must be between 1 and 4096 characters, as API Management cannot retrieve values that exceed this limit.
 ## Prerequisites
 
 * If you have not created an API Management service instance yet, see [Create an API Management service instance](get-started-create-service-instance.md).

--- a/articles/api-management/api-management-howto-properties.md
+++ b/articles/api-management/api-management-howto-properties.md
@@ -42,8 +42,8 @@ Using key vault secrets is recommended because it helps improve API Management s
 * Secrets stored in key vaults can be reused across services
 * Granular [access policies](/azure/key-vault/general/security-features#privileged-access) can be applied to secrets
 * Secrets updated in the key vault are automatically rotated in API Management. After update in the key vault, a named value in API Management is updated within 4 hours. You can also manually refresh the secret using the Azure portal or via the management REST API.
- > [!NOTE]
-    The secrets stored in Azure Key Vault must be between 1 and 4096 characters, as API Management cannot retrieve values that exceed this limit.
+> [!NOTE]
+> The secrets stored in Azure Key Vault must be between 1 and 4096 characters, as API Management cannot retrieve values that exceed this limit.
 ## Prerequisites
 
 * If you have not created an API Management service instance yet, see [Create an API Management service instance](get-started-create-service-instance.md).

--- a/articles/api-management/api-management-howto-properties.md
+++ b/articles/api-management/api-management-howto-properties.md
@@ -42,6 +42,7 @@ Using key vault secrets is recommended because it helps improve API Management s
 * Secrets stored in key vaults can be reused across services
 * Granular [access policies](/azure/key-vault/general/security-features#privileged-access) can be applied to secrets
 * Secrets updated in the key vault are automatically rotated in API Management. After update in the key vault, a named value in API Management is updated within 4 hours. You can also manually refresh the secret using the Azure portal or via the management REST API.
+
 > [!NOTE]
 > The secrets stored in Azure Key Vault must be between 1 and 4096 characters, as API Management cannot retrieve values that exceed this limit.
 ## Prerequisites


### PR DESCRIPTION
This update adds a clarification regarding the limitations for secrets stored in Azure Key Vault. Specifically, it informs users that secrets must be between 1 and 4096 characters, as values exceeding this limit cannot be retrieved by API Management.