### PR TITLE
Update upgrade-to-data-lake-storage-gen2-how-to.md

### DIFF
--- a/articles/storage/blobs/upgrade-to-data-lake-storage-gen2-how-to.md
+++ b/articles/storage/blobs/upgrade-to-data-lake-storage-gen2-how-to.md
@@ -48,7 +48,6 @@ In some cases, you will have to allow time for clean-up operations after a featu
 > You cannot upgrade a storage account to Data Lake Storage that has **ever** had the change feed feature enabled.
 > Simply disabling change feed will not allow you to perform an upgrade. Instead, you must create an account with the hierarchical namespace feature enabled on it, and move then transfer your data into that account.
 
-> [!IMPORTANT]
 ### Remove page blobs from the storage account
 
 You cannot upgrade a storage account that contains page blobs. Make sure to remove page blobs from the storage account before you perform the upgrade. 

--- a/articles/storage/blobs/upgrade-to-data-lake-storage-gen2-how-to.md
+++ b/articles/storage/blobs/upgrade-to-data-lake-storage-gen2-how-to.md
@@ -48,6 +48,9 @@ In some cases, you will have to allow time for clean-up operations after a featu
 > You cannot upgrade a storage account to Data Lake Storage that has **ever** had the change feed feature enabled.
 > Simply disabling change feed will not allow you to perform an upgrade. Instead, you must create an account with the hierarchical namespace feature enabled on it, and move then transfer your data into that account.
 
+> [!IMPORTANT]
+> Please be aware that you will not be able to proceed with the ADLS Gen2 Storage account upgrade if the storage account contains page blobs. It is necessary to delete all page blobs from the account before initiating the upgrade process.
+
 ### Ensure the segments of each blob path are named
 
 The migration process creates a directory for each path segment of a blob. Data Lake Storage directories must have a name so for migration to succeed, each path segment in a virtual directory must have a name. The same requirement is true for segments that are named only with a space character. If any path segments are either unnamed (`//`) or named only with a space character (`_`), then before you proceed with the migration, you must copy those blobs to a new path that is compatible with these naming requirements.

--- a/articles/storage/blobs/upgrade-to-data-lake-storage-gen2-how-to.md
+++ b/articles/storage/blobs/upgrade-to-data-lake-storage-gen2-how-to.md
@@ -49,7 +49,9 @@ In some cases, you will have to allow time for clean-up operations after a featu
 > Simply disabling change feed will not allow you to perform an upgrade. Instead, you must create an account with the hierarchical namespace feature enabled on it, and move then transfer your data into that account.
 
 > [!IMPORTANT]
-> Please be aware that you will not be able to proceed with the ADLS Gen2 Storage account upgrade if the storage account contains page blobs. It is necessary to delete all page blobs from the account before initiating the upgrade process.
+### Remove page blobs from the storage account
+
+You cannot upgrade a storage account that contains page blobs. Make sure to remove page blobs from the storage account before you perform the upgrade. 
 
 ### Ensure the segments of each blob path are named
 


### PR DESCRIPTION
Added the Important pointer as below
Please be aware that you will not be able to proceed with the ADLS upgrade if the storage account contains page blobs. It is necessary to delete all page blobs from the account before initiating the upgrade process.
