### PR TITLE
bump azure/login@v2

### DIFF
--- a/articles/app-service/deploy-github-actions.md
+++ b/articles/app-service/deploy-github-actions.md
@@ -196,7 +196,7 @@ To use [user-level credentials](#1-generate-deployment-credentials), paste the e
 When you configure the GitHub workflow file later, you use the secret for the input `creds` of the [Azure/login](https://github.com/marketplace/actions/azure-login). For example:
 
 ```yaml
-- uses: azure/login@v1
+- uses: azure/login@v2
   with:
     creds: ${{ secrets.AZURE_CREDENTIALS }}
 ```

--- a/articles/app-service/deploy-github-actions.md
+++ b/articles/app-service/deploy-github-actions.md
@@ -301,4 +301,3 @@ Check out references on Azure GitHub Actions and workflows:
 - [Azure/k8s-deploy action](https://github.com/Azure/k8s-deploy)
 - [Actions workflows to deploy to Azure](https://github.com/Azure/actions-workflow-samples)
 - [Starter Workflows](https://github.com/actions/starter-workflows)
-- [Events that trigger workflows](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)

--- a/articles/app-service/deploy-github-actions.md
+++ b/articles/app-service/deploy-github-actions.md
@@ -301,3 +301,4 @@ Check out references on Azure GitHub Actions and workflows:
 - [Azure/k8s-deploy action](https://github.com/Azure/k8s-deploy)
 - [Actions workflows to deploy to Azure](https://github.com/Azure/actions-workflow-samples)
 - [Starter Workflows](https://github.com/actions/starter-workflows)
+- [Events that trigger workflows](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)


### PR DESCRIPTION
Upgrade the course content example azure/login to latest major version

There are other areas of the content where dependabot or other tools may be used to upgrade the references to older action versions.