### PR TITLE
Update cache-how-to-zone-redundancy.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
+++ b/articles/azure-cache-for-redis/cache-how-to-zone-redundancy.md
@@ -55,7 +55,7 @@ To create a cache, follow these steps:
     > [!IMPORTANT]
     > Enabling Automatic Zone Allocation is currently NOT supported for Geo Replicated caches or caches with VNET injection.
 
-1. Availability zones can be selected manually for Premium tier caches. The count of availability zones must always be less than or equal to the Replica count for the cache.
+1. Availability zones can be selected manually for Premium tier caches. The number of availability zones must always be less than or equal to the total number of nodes for the cache.
 
    :::image type="content" source="media/cache-how-to-zone-redundancy/cache-premium-replica-count.png" alt-text="Screenshot showing Availability zones set to one and Replica count set to three.":::
 


### PR DESCRIPTION
The total number of availability zones must not exceed the combined count of nodes within the cache, including both the Primary and Replica nodes. For instance, it's feasible to set up a cache configuration with one replica and two availability zones. Therefore, the documentation should clarify that this limitation applies to the total number of nodes, not solely to replicas.