### PR TITLE
Update configure-mirror-hyper-v.md

### DIFF
--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -179,7 +179,7 @@ Where:
 |**1010-1020** |VLAN range from which IoT traffic is mirrored |
 |**10** |tive VLAN ID of the environment |
 
-Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/powershell/module/hyper-v/set-vmnetworkadaptervlan) PowerShell cmdlet.
+Learn more about the [Set-VMNetworkAdapterVlan](docset/winserver2022-ps/hyper-v/Set-VMNetworkAdapterVlan.md) PowerShell cmdlet.
 
 [!INCLUDE [validate-traffic-mirroring](../includes/validate-traffic-mirroring.md)]
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -44,7 +44,7 @@ Where:
 |**vSwitch_Span** |Newly added SPAN virtual switch name |
 |**Ethernet** |Physical adapter name |
 
-Learn how to [Create and configure a virtual switch with Hyper-V](https://learn.microsoft.com/windows-server/virtualization/hyper-v/get-started/create-a-virtual-switch-for-hyper-v-virtual-machines?tabs=powershell#create-a-virtual-switch)
+Learn how to [Create and configure a virtual switch with Hyper-V](/windows-server/virtualization/hyper-v/get-started/create-a-virtual-switch-for-hyper-v-virtual-machines?tabs=powershell#create-a-virtual-switch)
 
 ### Create a new virtual switch with Hyper-V Manager
 
@@ -179,7 +179,7 @@ Where:
 |**1010-1020** |VLAN range from which IoT traffic is mirrored |
 |**10** |Native VLAN ID of the environment |
 
-Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/powershell/module/hyper-v/set-vmnetworkadaptervlan) PowerShell cmdlet.
+Learn more about the [Set-VMNetworkAdapterVlan](/powershell/module/hyper-v/set-vmnetworkadaptervlan) PowerShell cmdlet.
 
 [!INCLUDE [validate-traffic-mirroring](../includes/validate-traffic-mirroring.md)]
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -44,7 +44,7 @@ Where:
 |**vSwitch_Span** |Newly added SPAN virtual switch name |
 |**Ethernet** |Physical adapter name |
 
-Reference: [Create and configure a virtual switch with Hyper-V](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/get-started/create-a-virtual-switch-for-hyper-v-virtual-machines?tabs=powershell#create-a-virtual-switch)
+Learn how to [Create and configure a virtual switch with Hyper-V](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/get-started/create-a-virtual-switch-for-hyper-v-virtual-machines?tabs=powershell#create-a-virtual-switch)
 
 ### Create a new virtual switch with Hyper-V Manager
 
@@ -64,7 +64,7 @@ Reference: [Create and configure a virtual switch with Hyper-V](https://learn.mi
 
 ## Attach a SPAN Virtual Interface to the virtual switch
 
-Use Windows PowerShell or Hyper-V Manager to attach a SPAN virtual interface to the virtual switch you'd [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
+Use Windows PowerShell or Hyper-V Manager to attach a SPAN virtual interface to the virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v).
 
 If you use PowerShell, define the name of the newly added adapter hardware as `Monitor`. If you use Hyper-V Manager, the name of the newly added adapter hardware is set to `Network Adapter`.
 
@@ -165,9 +165,9 @@ Get-VMSwitchExtensionPortFeature -FeatureName "Ethernet Switch Port Security Set
 
 ## Configure VLAN settings for the Monitor adapter (if needed)
 
-In case the HYper-V server would sit in a diffeernt VLAN than the VLAN from which the mirrored traffic comes, the Monitor adapter must be set to accpet traffic from the mirrored VLANs
+If the Hyper-V server is located in a different VLAN than the VLAN from which the mirrored traffic originates, set the Monitor adapter to accept traffic from the mirrored VLANs.
 
-Use below PowerShell command to enable the Monitor adapter to accept traffic from the monitored traffic from different VLANs:
+Use this PowerShell command to enable the Monitor adapter to accept the monitored traffic from different VLANs:
 ```PowerShell
 Set-VMNetworkAdapterVlan -VMName VK-C1000V-LongRunning-650 -VMNetworkAdapterName Monitor -Trunk -AllowedVlanIdList 1010-1020 -NativeVlanId 10
 ```
@@ -179,7 +179,7 @@ Where:
 |**1010-1020** |VLAN range from which IoT traffic is mirrored |
 |**10** |tive VLAN ID of the environment |
 
-Reference: [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/en-us/powershell/module/hyper-v/set-vmnetworkadaptervlan?view=windowsserver2022-ps)
+Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/en-us/powershell/module/hyper-v/set-vmnetworkadaptervlan?view=windowsserver2022-ps) PowerShell cmdlet.
 
 [!INCLUDE [validate-traffic-mirroring](../includes/validate-traffic-mirroring.md)]
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -44,7 +44,7 @@ Where:
 |**vSwitch_Span** |Newly added SPAN virtual switch name |
 |**Ethernet** |Physical adapter name |
 
-Learn how to [Create and configure a virtual switch with Hyper-V](https://learn.microsoft.com/en-us/windows-server/virtualization/hyper-v/get-started/create-a-virtual-switch-for-hyper-v-virtual-machines?tabs=powershell#create-a-virtual-switch)
+Learn how to [Create and configure a virtual switch with Hyper-V](https://learn.microsoft.com/windows-server/virtualization/hyper-v/get-started/create-a-virtual-switch-for-hyper-v-virtual-machines?tabs=powershell#create-a-virtual-switch)
 
 ### Create a new virtual switch with Hyper-V Manager
 
@@ -64,13 +64,13 @@ Learn how to [Create and configure a virtual switch with Hyper-V](https://learn.
 
 ## Attach a SPAN Virtual Interface to the virtual switch
 
-Use Windows PowerShell or Hyper-V Manager to attach a SPAN virtual interface to the virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v).
+Use Windows PowerShell or Hyper-V Manager to attach a SPAN virtual interface to the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
 
 If you use PowerShell, define the name of the newly added adapter hardware as `Monitor`. If you use Hyper-V Manager, the name of the newly added adapter hardware is set to `Network Adapter`.
 
 ### Attach a SPAN virtual interface to the virtual switch with PowerShell
 
-1. Select the newly added SPAN virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v), and run the following command to add a new network adapter:
+1. Select the newly added SPAN virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v), and run the following command to add a new network adapter:
 
     ```powershell
     ADD-VMNetworkAdapter -VMName VK-C1000V-LongRunning-650 -Name Monitor -SwitchName vSwitch_Span
@@ -108,7 +108,7 @@ If you use PowerShell, define the name of the newly added adapter hardware as `M
 
 ## Turn on Microsoft NDIS capture extensions with PowerShell
 
-Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v).
+Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
 
 **To enable Microsoft NDIS capture extensions for your new virtual switch**:
 
@@ -118,7 +118,7 @@ Enable-VMSwitchExtension -VMSwitchName vSwitch_Span -Name "Microsoft NDIS Captur
 
 ## Turn on Microsoft NDIS capture extensions with Hyper-V Manager
 
-Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v).
+Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
 
 **To enable Microsoft NDIS capture extensions for your new virtual switch**:
 
@@ -134,7 +134,7 @@ Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/driver
 
 ## Configure the switch's mirroring mode
 
-Configure the mirroring mode on the virtual switch you'd [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v) so that the external port is defined as the mirroring source. This includes configuring the Hyper-V virtual switch (vSwitch_Span) to forward any traffic that comes to the external source port to a virtual network adapter configured as the destination.
+Configure the mirroring mode on the virtual switch you [created earlier](#create-a-new-virtual-switch-with-powershell) so that the external port is defined as the mirroring source. This includes configuring the Hyper-V virtual switch (vSwitch_Span) to forward any traffic that comes to the external source port to a virtual network adapter configured as the destination.
 
 To set the virtual switch's external port as the source mirror mode, run:
 
@@ -148,7 +148,7 @@ Where:
 
 | Parameter | Description |
 |--|--|
-|**vSwitch_Span** | Name of the virtual switch you'd [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v) |
+|**vSwitch_Span** | Name of the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v) |
 |**MonitorMode=2** | Source |
 |**MonitorMode=1** | Destination |
 |**MonitorMode=0** | None |
@@ -179,7 +179,7 @@ Where:
 |**1010-1020** |VLAN range from which IoT traffic is mirrored |
 |**10** |tive VLAN ID of the environment |
 
-Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/en-us/powershell/module/hyper-v/set-vmnetworkadaptervlan?view=windowsserver2022-ps) PowerShell cmdlet.
+Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/powershell/module/hyper-v/set-vmnetworkadaptervlan) PowerShell cmdlet.
 
 [!INCLUDE [validate-traffic-mirroring](../includes/validate-traffic-mirroring.md)]
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -179,7 +179,7 @@ Where:
 |**1010-1020** |VLAN range from which IoT traffic is mirrored |
 |**10** |tive VLAN ID of the environment |
 
-Learn more about the [Set-VMNetworkAdapterVlan](docset/winserver2022-ps/hyper-v/Set-VMNetworkAdapterVlan.md) PowerShell cmdlet.
+Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/powershell/module/hyper-v/set-vmnetworkadaptervlan) PowerShell cmdlet.
 
 [!INCLUDE [validate-traffic-mirroring](../includes/validate-traffic-mirroring.md)]
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -177,7 +177,7 @@ Where:
 |--|--|
 |**VK-C1000V-LongRunning-650** | CPPM VA name |
 |**1010-1020** |VLAN range from which IoT traffic is mirrored |
-|**10** |tive VLAN ID of the environment |
+|**10** |Native VLAN ID of the environment |
 
 Learn more about the [Set-VMNetworkAdapterVlan](https://learn.microsoft.com/powershell/module/hyper-v/set-vmnetworkadaptervlan) PowerShell cmdlet.
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -70,7 +70,7 @@ If you use PowerShell, define the name of the newly added adapter hardware as `M
 
 ### Attach a SPAN virtual interface to the virtual switch with PowerShell
 
-1. Select the newly added SPAN virtual switch you'd configured [earlier](#configure-a-traffic-mirroring-port-with-hyper-v), and run the following command to add a new network adapter:
+1. Select the newly added SPAN virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v), and run the following command to add a new network adapter:
 
     ```powershell
     ADD-VMNetworkAdapter -VMName VK-C1000V-LongRunning-650 -Name Monitor -SwitchName vSwitch_Span
@@ -108,7 +108,7 @@ If you use PowerShell, define the name of the newly added adapter hardware as `M
 
 ## Turn on Microsoft NDIS capture extensions with PowerShell
 
-Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you'd [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
+Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v).
 
 **To enable Microsoft NDIS capture extensions for your new virtual switch**:
 
@@ -118,7 +118,7 @@ Enable-VMSwitchExtension -VMSwitchName vSwitch_Span -Name "Microsoft NDIS Captur
 
 ## Turn on Microsoft NDIS capture extensions with Hyper-V Manager
 
-Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you'd [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
+Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you created when you [configured the traffic mirroring port](#configure-a-traffic-mirroring-port-with-hyper-v).
 
 **To enable Microsoft NDIS capture extensions for your new virtual switch**:
 

--- a/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
+++ b/articles/defender-for-iot/organizations/traffic-mirroring/configure-mirror-hyper-v.md
@@ -30,7 +30,7 @@ Before you start:
 
 - Ensure that the data port SPAN configuration isn't configured with an IP address.
 
-## Create new Hyper-V virtual switch to rely the mirrored traffic into the VM
+## Create new Hyper-V virtual switch to relay the mirrored traffic into the VM
 
 ### Create a new virtual switch with PowerShell
 
@@ -64,13 +64,13 @@ Learn how to [Create and configure a virtual switch with Hyper-V](https://learn.
 
 ## Attach a SPAN Virtual Interface to the virtual switch
 
-Use Windows PowerShell or Hyper-V Manager to attach a SPAN virtual interface to the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
+Use Windows PowerShell or Hyper-V Manager to attach a SPAN virtual interface to the virtual switch you [created earlier](#create-new-hyper-v-virtual-switch-to-relay-the-mirrored-traffic-into-the-vm).
 
 If you use PowerShell, define the name of the newly added adapter hardware as `Monitor`. If you use Hyper-V Manager, the name of the newly added adapter hardware is set to `Network Adapter`.
 
 ### Attach a SPAN virtual interface to the virtual switch with PowerShell
 
-1. Select the newly added SPAN virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v), and run the following command to add a new network adapter:
+1. Select the newly added SPAN virtual switch you [created earlier](#create-new-hyper-v-virtual-switch-to-relay-the-mirrored-traffic-into-the-vm), and run the following command to add a new network adapter:
 
     ```powershell
     ADD-VMNetworkAdapter -VMName VK-C1000V-LongRunning-650 -Name Monitor -SwitchName vSwitch_Span
@@ -108,7 +108,7 @@ If you use PowerShell, define the name of the newly added adapter hardware as `M
 
 ## Turn on Microsoft NDIS capture extensions with PowerShell
 
-Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
+Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you [created earlier](#create-new-hyper-v-virtual-switch-to-relay-the-mirrored-traffic-into-the-vm).
 
 **To enable Microsoft NDIS capture extensions for your new virtual switch**:
 
@@ -118,7 +118,7 @@ Enable-VMSwitchExtension -VMSwitchName vSwitch_Span -Name "Microsoft NDIS Captur
 
 ## Turn on Microsoft NDIS capture extensions with Hyper-V Manager
 
-Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v).
+Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/drivers/network/capturing-extensions) for the virtual switch you [created earlier](#create-new-hyper-v-virtual-switch-to-relay-the-mirrored-traffic-into-the-vm).
 
 **To enable Microsoft NDIS capture extensions for your new virtual switch**:
 
@@ -134,7 +134,7 @@ Turn on support for [Microsoft NDIS Capture Extensions](/windows-hardware/driver
 
 ## Configure the switch's mirroring mode
 
-Configure the mirroring mode on the virtual switch you [created earlier](#create-a-new-virtual-switch-with-powershell) so that the external port is defined as the mirroring source. This includes configuring the Hyper-V virtual switch (vSwitch_Span) to forward any traffic that comes to the external source port to a virtual network adapter configured as the destination.
+Configure the mirroring mode on the virtual switch you [created earlier](#create-new-hyper-v-virtual-switch-to-relay-the-mirrored-traffic-into-the-vm) so that the external port is defined as the mirroring source. This includes configuring the Hyper-V virtual switch (vSwitch_Span) to forward any traffic that comes to the external source port to a virtual network adapter configured as the destination.
 
 To set the virtual switch's external port as the source mirror mode, run:
 
@@ -148,7 +148,7 @@ Where:
 
 | Parameter | Description |
 |--|--|
-|**vSwitch_Span** | Name of the virtual switch you [created earlier](#configure-a-traffic-mirroring-port-with-hyper-v) |
+|**vSwitch_Span** | Name of the virtual switch you [created earlier](#create-new-hyper-v-virtual-switch-to-relay-the-mirrored-traffic-into-the-vm) |
 |**MonitorMode=2** | Source |
 |**MonitorMode=1** | Destination |
 |**MonitorMode=0** | None |


### PR DESCRIPTION
Added extra options to do the steps in PowerShell
Added a section to specify the VLAN config in case the monitored traffic comes from different VLAN(s) then the Hyper-V host sits in. Removed line "In the Hardware list, under the Network Adapter drop-down list, select Hardware Acceleration and clear the Virtual Machine Queue option for the monitoring network interface." as it was not reflected in the PowerShell version and I don't believe it is needed.