### PR TITLE
Update configure-common.md

### DIFF
--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -446,7 +446,7 @@ Here, you can configure some common settings for the app. Some settings require 
     - **Always On**: Keeps the app loaded even when there's no traffic. When **Always On** isn't turned on (default), the app is unloaded after 20 minutes without any incoming requests. The unloaded app can cause high latency for new requests because of its warm-up time. When **Always On** is turned on, the front-end load balancer sends a GET request to the application root every five minutes. The continuous ping prevents the app from being unloaded.
     
         Always On is required for continuous WebJobs or for WebJobs that are triggered using a CRON expression.
-    - **ARR affinity**: In a multi-instance deployment, ensure that the client is routed to the same instance for the life of the session. You can set this option to **Off** for stateless applications.
+    - **Session affinity**: In a multi-instance deployment, ensure that the client is routed to the same instance for the life of the session. You can set this option to **Off** for stateless applications.
     - **HTTPS Only**: When enabled, all HTTP traffic is redirected to HTTPS.
     - **Minimum TLS version**: Select the minimum TLS encryption version required by your app.
 - **Debugging**: Enable remote debugging for [ASP.NET](troubleshoot-dotnet-visual-studio.md#remotedebug), [ASP.NET Core](/visualstudio/debugger/remote-debugging-azure), or [Node.js](configure-language-nodejs.md#debug-remotely) apps. This option turns off automatically after 48 hours.


### PR DESCRIPTION
In azure portal the setting's title has been changed to Session Affinity. So, it would be great if we can change "ARR to Session" to prevent confusions like "what is ARR affinity?" "why we can't see it in the portal"