### PR TITLE
Fix KQL for Trace Errors/Warnings

### DIFF
--- a/articles/azure-functions/durable/durable-functions-troubleshooting-guide.md
+++ b/articles/azure-functions/durable/durable-functions-troubleshooting-guide.md
@@ -129,7 +129,7 @@ traces
 | extend status = customDimensions["prop__status"]
 | extend details = customDimensions["prop__Details"] 
 | extend reason = customDimensions["prop__reason"]
-| where severityLevel > 1 // to see all logs of  severity level "Information" or greater.
+| where severityLevel => 1 // to see all logs of severity level "Information" or greater.
 | where instanceId == orchestrationInstanceID
 | sort by timestamp asc 
 ```

--- a/articles/azure-functions/durable/durable-functions-troubleshooting-guide.md
+++ b/articles/azure-functions/durable/durable-functions-troubleshooting-guide.md
@@ -129,7 +129,7 @@ traces
 | extend status = customDimensions["prop__status"]
 | extend details = customDimensions["prop__Details"] 
 | extend reason = customDimensions["prop__reason"]
-| where severityLevel => 1 // to see all logs of severity level "Information" or greater.
+| where severityLevel >= 1 // to see all logs of severity level "Information" or greater.
 | where instanceId == orchestrationInstanceID
 | sort by timestamp asc 
 ```


### PR DESCRIPTION
To see all logs of severity level "Information" or greater it should be >= 1