### PR TITLE
Making description of unsupported PartialArmTemplates feature more current.

### DIFF
--- a/articles/data-factory/continuous-integration-delivery.md
+++ b/articles/data-factory/continuous-integration-delivery.md
@@ -100,13 +100,9 @@ If you're using Git integration with your data factory and have a CI/CD pipeline
 
 -   You can't currently export and import alerts and matrices as parameters. 
 
-- In the code repository under the *adf_publish* branch, a folder named 'PartialArmTemplates' is currently added beside the 'linkedTemplates' folder, 'ARMTemplateForFactory.json' and 'ARMTemplateParametersForFactory.json' files as part of publishing with source control. 
+- PartialArmTemplates in your publish branch are no longer supported as of 1-Novemebet 2021. If your project utilised this feature, please switch to a supported mechanism for deployments, using: 'ARMTemplateForFactory.json' or 'linkedTemplates' files.
 
     :::image type="content" source="media/continuous-integration-delivery/partial-arm-templates-folder.png" alt-text="Diagram of 'PartialArmTemplates' folder.":::
-
-    We will no longer be publishing 'PartialArmTemplates' to the *adf_publish* branch starting 1-November 2021.    
-
-    **No action is required unless you are using 'PartialArmTemplates'. Otherwise, switch to any supported mechanism for deployments using: 'ARMTemplateForFactory.json' or 'linkedTemplates' files.**
 
 ## Related content
 


### PR DESCRIPTION
The current description of the lack of feature support is outdated, as it refers to changes made in the past as future changes.