### PR TITLE
Update skus.md

### DIFF
--- a/articles/load-balancer/skus.md
+++ b/articles/load-balancer/skus.md
@@ -27,7 +27,7 @@ To compare and understand the differences between Basic and Standard SKU, see th
 | **Scenario** |  Equipped for load-balancing network layer traffic when high performance and ultra-low latency is needed. Routes traffic within and across regions, and to availability zones for high resiliency. | Equipped for small-scale applications that don't need high availability or redundancy. Not compatible with availability zones. |
 | **Backend type** | IP based, NIC based | NIC based |
 | **Protocol** | TCP, UDP | TCP, UDP |
-| **Backend pool endpoints** | Any virtual machines or virtual machine scale sets in a single virtual network | Virtual machines in a single availability set or virtual machine scale set |
+| **Backend pool endpoints** | Any virtual machines or virtual machine scale sets or availability set in a single virtual network | Virtual machines in a single availability set or virtual machine scale set |
 | **[Health probes](./load-balancer-custom-probe-overview.md#probe-protocol)** | TCP, HTTP, HTTPS | TCP, HTTP |
 | **[Health probe down behavior](./load-balancer-custom-probe-overview.md#probe-down-behavior)** | TCP connections stay alive on an instance probe down __and__ on all probes down. | TCP connections stay alive on an instance probe down. All TCP connections end when all probes are down. |
 | **Availability Zones** | Zone-redundant, zonal, or non-zonal frontend IP configurations can be used for inbound and outbound traffic | Not available |


### PR DESCRIPTION
As per other pages in documentation, standard load balancer, too, supports Availability Set: https://learn.microsoft.com/en-us/azure/load-balancer/tutorial-multi-availability-sets-portal

Support for availability set is mentioned for basic load balancer but not for standard load balancer. This gives impression that standard load balancer doesn't support availability set. I've edited it accordingly.