### PR TITLE
Update how-to-create-test-certificates.md

### DIFF
--- a/articles/iot-edge/how-to-create-test-certificates.md
+++ b/articles/iot-edge/how-to-create-test-certificates.md
@@ -241,8 +241,8 @@ The **Edge CA** certificate is also responsible for creating certificates for mo
 
 3. This command creates several certificate and key files. The following certificate and key pair need to be copied over to an IoT Edge device and referenced in the config file:
 
-   * `certs\iot-edge-device-ca-<CA cert name>-full-chain.cert.pem`
-   * `private\iot-edge-device-ca-<CA cert name>.key.pem`
+   * `certs\iot-edge-device-<CA cert name>-full-chain.cert.pem`
+   * `private\iot-edge-device-<CA cert name>.key.pem`
 
 
 # [Linux](#tab/linux)


### PR DESCRIPTION
Updated the file names to show the correct name of files created by `New-CACertsEdgeDevice "<CA cert name>"`. The documentation erroneously adds "-ca" to the file name when that part isn't present in the real file names generated.