### PR TITLE
Update migrate-dotnet-to-isolated-model.md

### DIFF
--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -235,7 +235,30 @@ When you [changed your package references in a previous step](#package-reference
 1. Consult each binding's reference documentation for the types it allows you to bind to. In some cases, you might need to change the type. For output bindings, if the in-process model version used an `IAsyncCollector<T>`, you can replace this with binding to an array of the target type: `T[]`. You can also consider replacing the output binding with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
 
 1. If your function includes an `IBinder` parameter, remove it. Replace the functionality with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
+2. If your function uses cosmos db change feed trigger, then the input documents will be IReadOnlyList<JsonNode> after upgrade instead of IReadOnlyList<Document>.
 
+Before upgrade the input binding will be as below for cosmos change feed trigger
+```csharp
+		  [FunctionName("TestUpdate")]
+    public async Task Run([CosmosDBTrigger(
+        databaseName: "testdb",
+        collectionName: "testcontainer",
+        ConnectionStringSetting = "testCosmosDBConnectionString",
+        LeaseCollectionName = "testauditlease"
+        )]IReadOnlyList<Document> testDocuments)
+```
+
+After upgrade the input binding will be 
+```csharp
+  [Function("TestUpdate")]
+    public async Task Run([CosmosDBTrigger(
+        databaseName: "testdb",
+        collectionName: "testcontainer",
+        ConnectionStringSetting = "testCosmosDBConnectionString",
+        LeaseCollectionName = "testauditlease"
+        )]IReadOnlyList<JsonNode> testDocuments)
+		
+```
 1. Update the function code to work with any new types.
 
 ### local.settings.json file

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -239,7 +239,7 @@ When you [changed your package references in a previous step](#package-reference
 
 Before upgrade the input binding will be as below for cosmos change feed trigger
 ```csharp
-		  [FunctionName("TestUpdate")]
+    [FunctionName("TestUpdate")]
     public async Task Run([CosmosDBTrigger(
         databaseName: "testdb",
         collectionName: "testcontainer",
@@ -250,7 +250,7 @@ Before upgrade the input binding will be as below for cosmos change feed trigger
 
 After upgrade the input binding will be 
 ```csharp
-  [Function("TestUpdate")]
+   [Function("TestUpdate")]
     public async Task Run([CosmosDBTrigger(
         databaseName: "testdb",
         collectionName: "testcontainer",

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -237,7 +237,8 @@ When you [changed your package references in a previous step](#package-reference
 1. If your function includes an `IBinder` parameter, remove it. Replace the functionality with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
 2. If your function uses cosmos db change feed trigger, then the input documents will be IReadOnlyList<JsonNode> after upgrade instead of IReadOnlyList<Document>.
 
-Before upgrade the input binding will be as below for cosmos change feed trigger
+**Before migration:**
+
 ```csharp
     [FunctionName("TestUpdate")]
     public async Task Run([CosmosDBTrigger(

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -235,7 +235,10 @@ When you [changed your package references in a previous step](#package-reference
 1. Consult each binding's reference documentation for the types it allows you to bind to. In some cases, you might need to change the type. For output bindings, if the in-process model version used an `IAsyncCollector<T>`, you can replace this with binding to an array of the target type: `T[]`. You can also consider replacing the output binding with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
 
 1. If your function includes an `IBinder` parameter, remove it. Replace the functionality with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
-1. If your function uses a change feed trigger, post-migration input documents are of type `IReadOnlyList<JsonNode>` instead of `IReadOnlyList<Document>`. You can see the required update in these examples:
+1. If your function uses a change feed trigger, post-migration input documents are of type `IReadOnlyList<JsonNode>` instead of `IReadOnlyList<Document>`.
+JsonNode should be used for cases where you want a generic bag of properties but the trigger now supports any .NET type, not just JsonNode
+
+You can see the required update in these examples:
 
 **Before migration:**
 

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -249,7 +249,8 @@ When you [changed your package references in a previous step](#package-reference
         )]IReadOnlyList<Document> testDocuments)
 ```
 
-After upgrade the input binding will be 
+**After migration**:
+
 ```csharp
    [Function("TestUpdate")]
     public async Task Run([CosmosDBTrigger(

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -235,7 +235,7 @@ When you [changed your package references in a previous step](#package-reference
 1. Consult each binding's reference documentation for the types it allows you to bind to. In some cases, you might need to change the type. For output bindings, if the in-process model version used an `IAsyncCollector<T>`, you can replace this with binding to an array of the target type: `T[]`. You can also consider replacing the output binding with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
 
 1. If your function includes an `IBinder` parameter, remove it. Replace the functionality with a client object for the service it represents, either as the binding type for an input binding if available, or by [injecting a client yourself](./dotnet-isolated-process-guide.md#register-azure-clients).
-2. If your function uses cosmos db change feed trigger, then the input documents will be IReadOnlyList<JsonNode> after upgrade instead of IReadOnlyList<Document>.
+1. If your function uses a change feed trigger, post-migration input documents are of type `IReadOnlyList<JsonNode>` instead of `IReadOnlyList<Document>`. You can see the required update in these examples:
 
 **Before migration:**
 


### PR DESCRIPTION
Add the information about cosmos db change feed trigger input document which will be a IReadOnlyList<JsonNode> instead of IReadOnlyList<Document>