### PR TITLE
Update front-door-route-matching.md

### DIFF
--- a/articles/frontdoor/front-door-route-matching.md
+++ b/articles/frontdoor/front-door-route-matching.md
@@ -135,7 +135,7 @@ The following table shows which routing rule the incoming request gets matched t
 | www\.contoso.com/path/zzz | B |
 
 >[!WARNING]
-> If there are no routing rules for an exact-match frontend host with a catch-all route Path (`/*`), then there will not be a match to any routing rule.
+> If there are no routing rules for an exact-match frontend host without a catch-all route Path (`/*`), then there will not be a match to any routing rule.
 >
 > Example configuration:
 >


### PR DESCRIPTION
Changing to "without". The rule example shows it without a catchall (/\*). If it had the catchall at the root level (e.g. /\*) the example would match.