### PR TITLE
Update disable-private-endpoint-network-policy.md

### DIFF
--- a/articles/private-link/disable-private-endpoint-network-policy.md
+++ b/articles/private-link/disable-private-endpoint-network-policy.md
@@ -18,10 +18,10 @@ By default, network policies are disabled for a subnet in a virtual network. To 
 
 You can enable network policies either for network security groups only, for user-defined routes only, or for both.
 
-If you enable network security policies for user-defined routes, you can use a custom address prefix equal to or larger than the virtual network address space to invalidate the /32 default route propagated by the private endpoint. This capability can be useful if you want to ensure that private endpoint connection requests go through a firewall or virtual appliance. Otherwise, the /32 default route sends traffic directly to the private endpoint in accordance with the [longest prefix match algorithm](../virtual-network/virtual-networks-udr-overview.md#how-azure-selects-a-route).
+If you enable network security policies for user-defined routes, you can use a custom address prefix equal to or longer than the virtual network address space to invalidate the /32 default route propagated by the private endpoint. This capability can be useful if you want to ensure that private endpoint connection requests go through a firewall or virtual appliance. Otherwise, the /32 default route sends traffic directly to the private endpoint in accordance with the [longest prefix match algorithm](../virtual-network/virtual-networks-udr-overview.md#how-azure-selects-a-route).
 
 > [!IMPORTANT]
-> To invalidate a private endpoint route, user-defined routes must have a prefix equal to or larger than the virtual network address space where the private endpoint is provisioned. For example, a user-defined routes default route (0.0.0.0/0) doesn't invalidate private endpoint routes. Network policies should be enabled in the subnet that hosts the private endpoint.
+> To invalidate a private endpoint route, user-defined routes must have a prefix equal to or longer than the virtual network address space where the private endpoint is provisioned. For example, a user-defined routes default route (0.0.0.0/0) doesn't invalidate private endpoint routes. Network policies should be enabled in the subnet that hosts the private endpoint.
 
 Use the following steps to enable or disable network policy for private endpoints:
 


### PR DESCRIPTION
Replacement of the word "larger" prefix with "longer prefix", which I believe conveys the correct message more concisely.
This should reduce the confusion between a larger prefix, i.e. which is shorter, and a longer or more specific prefix which has more bits.