### PR TITLE
Added Q&A to provide guidance for users to reset the cloud shell.

### DIFF
--- a/articles/cloud-shell/faq-troubleshooting.md
+++ b/articles/cloud-shell/faq-troubleshooting.md
@@ -89,6 +89,11 @@ location is the `Azure:` drive, are saved to your `$HOME` folder.
 No. Your user account in Cloud Shell is an unprivileged account. You can't use `sudo` or run any
 command that requires elevated permissions.
 
+### I want to reset current Cloud Shell. How to do?
+
+Switch to the Poweshell option from Azure Portal, and run the `Dismount-CloudDrive` command, which
+will terminate the current session, then reload Azure Portal again.
+
 ## Troubleshoot errors
 
 ### Storage Dialog - Error: 403 RequestDisallowedByPolicy


### PR DESCRIPTION
This pull request includes an update to the `articles/cloud-shell/faq-troubleshooting.md` file to add a new FAQ entry. The most important change is the addition of instructions on how to reset the current Cloud Shell session.

New FAQ entry:

* [`articles/cloud-shell/faq-troubleshooting.md`](diffhunk://#diff-0799276d998234da85b2151cbb5dfb9a607175c17e52287a67e44116025e850fR92-R96): Added instructions on how to reset the current Cloud Shell by switching to the PowerShell option from the Azure Portal and running the `Dismount-CloudDrive` command.