### PR TITLE
Add missing link for ASimAuthenticationEventLogs

### DIFF
--- a/articles/sentinel/data-transformation.md
+++ b/articles/sentinel/data-transformation.md
@@ -101,7 +101,7 @@ Only the following tables are currently supported for custom log ingestion:
 - [**CommonSecurityLog**](/azure/azure-monitor/reference/tables/commonsecuritylog)
 - [**Syslog**](/azure/azure-monitor/reference/tables/syslog)
 - [**ASimAuditEventLogs**](/azure/azure-monitor/reference/tables/asimauditeventlogs)
-- **ASimAuthenticationEventLogs**
+- [**ASimAuthenticationEventLogs**](/azure/azure-monitor/reference/tables/asimauthenticationeventlogs)
 - [**ASimDnsActivityLogs**](/azure/azure-monitor/reference/tables/asimdnsactivitylogs)
 - [**ASimFileEventLogs**](/azure/azure-monitor/reference/tables/asimfileeventlogs)
 - [**ASimNetworkSessionLogs**](/azure/azure-monitor/reference/tables/asimnetworksessionlogs)


### PR DESCRIPTION
This PR adds the missing documentation link for ASimAuthenticationEventLogs in the relevant section of the article.