### PR TITLE
Update to the steps to deploy parsers

### DIFF
--- a/articles/sentinel/normalization-develop-parsers.md
+++ b/articles/sentinel/normalization-develop-parsers.md
@@ -363,9 +363,9 @@ To deploy a large number of parsers, we recommend using parser ARM templates, as
 
 1. Use the [ASIM Yaml to ARM template converter](https://aka.ms/ASimYaml2ARM) to convert your YAML file to an ARM template. 
 
-1. If deploying an update, delete older versions of the functions using the portal or the [function delete PowerShell tool](https://aka.ms/ASimDelFunctionScript). 
-
 1. Deploy your template using the [Azure portal](../azure-resource-manager/templates/quickstart-create-templates-use-the-portal.md#edit-and-deploy-the-template) or [PowerShell](../azure-resource-manager/templates/deploy-powershell.md).
+
+Any existing parsers included in the ARM template being deployed will be overwritten by the new ones. If for any reason you need to clean-up existing parser, you can remove it from the Azure portal or use the [function delete PowerShell tool](https://aka.ms/ASimDelFunctionScript)
 
 You can also combine multiple templates to a single deploy process using [linked templates](../azure-resource-manager/templates/linked-templates.md?tabs=azure-powershell#linked-template)
 


### PR DESCRIPTION
For the most common use cases, there is normally no need to clean-up existing parsers as they will be automatically overwritten by the new ones in the ARM template.

I kept a reference to the "function delete PowerShell tool" since the default ARM template incremental deployment mode will not delete any parsers (but will update them) and customers need to use the “complete” mode which has it’s own challenges: very risky, cannot be used with linked templates and has to be done at the root of the template deployment.