### PR TITLE
CSS-Networking Update configuration-listeners.md

### DIFF
--- a/articles/application-gateway/configuration-listeners.md
+++ b/articles/application-gateway/configuration-listeners.md
@@ -29,7 +29,7 @@ When you create a new listener, you choose between [*basic* and *multi-site*](./
 
 For the v1 SKU, requests are matched according to the order of the rules and the type of listener. If a rule with basic listener comes first in the order, it's processed first and will accept any request for that port and IP combination. To avoid this, configure the rules with multi-site listeners first and push the rule with the basic listener to the last in the list.
 
-For the v2 SKU rule priority defines the order in which listeners are processed. Wildcard and basic listeners should be defined a priority with a number greater than site-specific and multi-site listeners, to ensure site-specific and multi-site listeners execute prior to the wildcard and basic listeners.
+For the v2 SKU, rule priority defines the order in which listeners are processed. Wildcard and basic listeners should be defined a priority with a number greater than site-specific and multi-site listeners, to ensure site-specific and multi-site listeners execute prior to the wildcard and basic listeners.
 
 ## Frontend IP address
 

--- a/articles/application-gateway/configuration-listeners.md
+++ b/articles/application-gateway/configuration-listeners.md
@@ -29,7 +29,7 @@ When you create a new listener, you choose between [*basic* and *multi-site*](./
 
 For the v1 SKU, requests are matched according to the order of the rules and the type of listener. If a rule with basic listener comes first in the order, it's processed first and will accept any request for that port and IP combination. To avoid this, configure the rules with multi-site listeners first and push the rule with the basic listener to the last in the list.
 
-For the v2 SKU, multi-site listeners are processed before basic listeners, unless rule priority is defined. If using rule priority, wildcard listeners should be defined a priority with a number greater than non-wildcard listeners, to ensure non-wildcard listeners execute prior to the wildcard listeners.
+For the v2 SKU rule priority defines the order in which listeners are processed. Wildcard and basic listeners should be defined a priority with a number greater than site-specific and multi-site listeners, to ensure site-specific and multi-site listeners execute prior to the wildcard and basic listeners.
 
 ## Frontend IP address
 


### PR DESCRIPTION
Updating listener order evaluation documentation as it is no longer accurate. Rule priority is a requirement with the modern APIs and as such the logic that multisite listeners are always processed before basic is not accurate any more. Phrasing was updated to reflect the current behavior.