### PR TITLE
Update requests with authorization header caching behavior documentation

### DIFF
--- a/articles/frontdoor/front-door-caching.md
+++ b/articles/frontdoor/front-door-caching.md
@@ -208,7 +208,7 @@ The following request headers don't get forwarded to the origin when caching is 
 - `Accept-Language`
 
 > [!NOTE]
-> Requests that include authorization header will not be cached.
+> Requests that include authorization header will not be cached, unless the response contains a Cache-Control directive that allows caching. The following Cache-Control directives have such an effect: must-revalidate, public, and s-maxage.
 
 ## Response headers
 


### PR DESCRIPTION
AFD supports caching response of request with authorization header as long as the response contains one or more Cache-Control directives that allow this behavior.