### PR TITLE
disable cgo when building go code

### DIFF
--- a/articles/azure-functions/create-first-function-vs-code-other.md
+++ b/articles/azure-functions/create-first-function-vs-code-other.md
@@ -238,19 +238,20 @@ In this section, you publish your project to Azure in a function app running Lin
     # [macOS](#tab/macos)
 
     ```bash
-    GOOS=linux GOARCH=amd64 go build handler.go
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build handler.go
     ```
 
     # [Linux](#tab/linux)
 
     ```bash
-    GOOS=linux GOARCH=amd64 go build handler.go
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build handler.go
     ```
 
     # [Windows](#tab/windows)
     ```cmd
     set GOOS=linux
     set GOARCH=amd64
+    set CGO_ENABLED=0
     go build handler.go
     ```
 


### PR DESCRIPTION
## Summary
The build settings have been changed so that the executable binary will run regardless of the execution environment.

## Changes Made
- Added `CGO_ENABLED=0` when compiling custom handler for each OS.

## Background
In the current document, the custom handler is built with dynamic link. 
If you continue using this method, an error will occur when you deploy to Azure Functions, and the function will not run.  That's presumably because the dependent C library is not placed in the execution environment. Therefore, I changed it to build the custom handler with static link.

## Additional Notes

<!-- Any additional information or context you want to provide to the reviewers -->
- The need to set `CGO_ENABLED=0` is described in the official Go documentation below.
> The cgo tool is enabled by default for native builds on systems where it is expected to work. It is disabled by default when cross-compiling as well as when the CC environment variable is unset and the default C compiler (typically gcc or clang) cannot be found on the system PATH. You can override the default by setting the CGO_ENABLED environment variable when running the go tool: set it to 1 to enable the use of cgo, and to 0 to disable it. 

https://pkg.go.dev/cmd/cgo