### PR TITLE
Updated region list on elastic-san-regions.md to be in alphabetical order

### DIFF
--- a/includes/elastic-san-regions.md
+++ b/includes/elastic-san-regions.md
@@ -11,35 +11,35 @@
 ---
 The following list contains the regions Elastic SAN is currently available in, and which regions support both zone-redundant storage (ZRS) and locally redundant storage (LRS), or only LRS:
 
-- South Africa North - LRS
-- East Asia - LRS
-- Southeast Asia - LRS
+- Australia East - LRS
 - Brazil South - LRS
 - Canada Central - LRS
+- Central US - LRS
+- East Asia - LRS
+- East US - LRS
+- East US 2 - LRS
 - France Central - LRS & ZRS
 - Germany West Central - LRS
-- Australia East - LRS
-- North Europe - LRS & ZRS
-- West Europe - LRS & ZRS 
-- UK South - LRS
+- India Central - LRS
 - Japan East - LRS
 - Korea Central - LRS
-- Central US - LRS
-- East US - LRS 
+- North Europe - LRS & ZRS
+- Norway East - LRS
+- South Africa North - LRS
 - South Central US - LRS
-- East US 2 - LRS 
-- West US 2 - LRS & ZRS
-- West US 3 - LRS
+- Southeast Asia - LRS
 - Sweden Central - LRS
 - Switzerland North - LRS
-- Norway East - LRS
 - UAE North - LRS
-- India Central - LRS
+- UK South - LRS
+- West Europe - LRS & ZRS
+- West US 2 - LRS & ZRS
+- West US 3 - LRS
 
 Elastic SAN is also available in the following regions, but without Availability Zone support: 
 - Canada East - LRS
-- North Central US - LRS
 - Japan West - LRS
+- North Central US - LRS
 
 To enable these regions, run the following command to register the necessary feature flag: 
 ```azurepowershell


### PR DESCRIPTION
While reviewing the Azure Elastic SAN deploy article, it was difficult to find the regions closest to me. Having the list formatted in alphabetical order will make it easier for anyone to find the region(s) they have interest in and determine if the service is available. 

Updated the regions to be listed in alphabetical order to make it easier for a reader to find their region(s) of interest.