### PR TITLE
Update app-service-plan-manage.md

### DIFF
--- a/articles/app-service/app-service-plan-manage.md
+++ b/articles/app-service/app-service-plan-manage.md
@@ -52,7 +52,7 @@ You can create an empty App Service plan, or you can create a plan as part of ap
 
 You can move an app to another App Service plan, as long as the source plan and the target plan are in the _same resource group and geographical region and of the same OS type_. Any change in type, such as Windows to Linux or any type that's different from the originating type, isn't supported. 
 
-Any VNET integration configured on the app must be disabled prior to changing App Service Plans. 
+Any VNET integration configured on the app must be disabled prior to changing App Service plans. 
 
 
 > [!NOTE]

--- a/articles/app-service/app-service-plan-manage.md
+++ b/articles/app-service/app-service-plan-manage.md
@@ -50,7 +50,9 @@ You can create an empty App Service plan, or you can create a plan as part of ap
 
 ## Move an app to another App Service plan
 
-You can move an app to another App Service plan, as long as the source plan and the target plan are in the _same resource group and geographical region and of the same OS type_. Any change in type, such as Windows to Linux or any type that's different from the originating type, isn't supported.
+You can move an app to another App Service plan, as long as the source plan and the target plan are in the _same resource group and geographical region and of the same OS type_. Any change in type, such as Windows to Linux or any type that's different from the originating type, isn't supported. 
+
+Any VNET integration configured on the app must be disabled prior to changing App Service Plans. 
 
 
 > [!NOTE]


### PR DESCRIPTION
Add comment documenting existing limitation that VNET integration feature must be disabled in order to change app's App Service Plan.  There is a clear error with this information in the Portal UX when trying this, but no documentation of the limitation.

![image](https://github.com/user-attachments/assets/960e8345-b748-4d95-a3be-52f466c978c2)
