### PR TITLE
Add port 53 to the exceptional ports list for application gateway v2

### DIFF
--- a/articles/application-gateway/application-gateway-components.md
+++ b/articles/application-gateway/application-gateway-components.md
@@ -43,7 +43,7 @@ A port is where a listener listens for the client request. You can configure por
 
 | SKU | Supported port range | Exception(s) |
 | ---------- | ---------- | ---------- |
-| V2 | 1 to 64999 | 22 |
+| V2 | 1 to 64999 | 22, 53 |
 | V1 | 1 to 65502 | 3389 |
 
 ### Protocols


### PR DESCRIPTION
Port `53` is another port that doesn't appear to work with application gateway v2.

See https://github.com/dioadconsulting/bicep-application-gateway-tcp-and-port-53

It would be great if the application gateway team could confirm that port `53` is not supported and this change is accurate.