### PR TITLE
Remove preview designation for AZ support in ACI

### DIFF
--- a/articles/reliability/reliability-containers.md
+++ b/articles/reliability/reliability-containers.md
@@ -12,9 +12,6 @@ ms.date: 11/29/2022
 
 # Reliability in Azure Container Instances
 
-> [!IMPORTANT]
-> This feature is currently in preview. Previews are made available to you on the condition that you agree to the supplemental terms of use.
-
 This article describes reliability support in Azure Container Instances (ACI) and covers both intra-regional resiliency with [availability zones](#availability-zone-support) and information on Disaster Recovery. For a more detailed overview of reliability in Azure, see [Azure reliability](/azure/architecture/framework/resiliency/overview).
 
 ## Availability zone support
@@ -26,9 +23,6 @@ Azure Container Instances supports *zonal* container group deployments, meaning 
 
 
 ### Prerequisites
-
-> [!IMPORTANT]
-> This feature is currently not available for Azure portal.
 
 - Zonal container group deployments are supported in most regions where ACI is available for Linux and Windows Server 2019 container groups. For details, see [Regions and resource availability](/azure/container-instances/container-instances-region-availability).
 
@@ -178,7 +172,7 @@ To create a Container Instance resource with availability zone enabled, you'll n
     }
     ```
 
-2. Create a resource group with the [az group create][availability-zones-group-create] command:
+2. Create a resource group with the [az group create][az-group-create] command:
 
     ```azurecli
     az group create --name myResourceGroup --location eastus


### PR DESCRIPTION
Remove preview designation since AZ support in Azure Container Instances is now GA.

Update docs to reflect that container groups can now be provisioned with an AZ in Azure Portal.

Update broken link for `az group create` command.