### PR TITLE
Update security.md

### DIFF
--- a/articles/role-based-access-control/built-in-roles/security.md
+++ b/articles/role-based-access-control/built-in-roles/security.md
@@ -1326,7 +1326,7 @@ Microsoft Sentinel Responder
 
 ## Security Admin
 
-View and update permissions for Microsoft Defender for Cloud. Same permissions as the Security Reader role and can also update the security policy and dismiss alerts and recommendations.<br><br>For Microsoft Defender for IoT, see [Azure user roles for OT and Enterprise IoT monitoring](/azure/defender-for-iot/organizations/roles-azure).
+View and update permissions for Microsoft Defender for Cloud. Same permissions as the Security Reader role, but can create, update, and delete security connectors, update the security policy, and dismiss alerts and recommendations.<br><br>For Microsoft Defender for IoT, see [Azure user roles for OT and Enterprise IoT monitoring](/azure/defender-for-iot/organizations/roles-azure).
 
 [Learn more](/azure/defender-for-cloud/permissions)
 


### PR DESCRIPTION
Updated the description of the Security Admin role to include the abilities it has to create/update/delete the security connectors in Defender for Cloud. The current description is misleading and sounds like a role that could be assigned to a GRC (Governance, Risk, and Compliance) analyst that is non-technical.