### PR TITLE
Update code example in pre-post-events-schedule-maintenance-configuration.md

### DIFF
--- a/articles/update-manager/pre-post-events-schedule-maintenance-configuration.md
+++ b/articles/update-manager/pre-post-events-schedule-maintenance-configuration.md
@@ -86,8 +86,10 @@ In the **Event Subscription Details** section, provide an appropriate name.
     $EventSubscriptionName = "PreEventWebhook"
     
     $PreEventWebhookEndpoint = "<Webhook URL>"
-    
-    New-AzEventGridSystemTopicEventSubscription -ResourceGroupName $ResourceGroupForSystemTopic -SystemTopicName $SystemTopicName -EventSubscriptionName $EventSubscriptionName -Endpoint $PreEventWebhookEndpoint -IncludedEventType $IncludedEventTypes
+
+    $dest = New-AzEventGridWebHookEventSubscriptionDestinationObject -EndpointUrl $PreEventWebhookEndpoint
+   
+    New-AzEventGridSystemTopicEventSubscription -ResourceGroupName $ResourceGroupForSystemTopic -SystemTopicName $SystemTopicName -EventSubscriptionName $EventSubscriptionName -Endpoint $PreEventWebhookEndpoint -IncludedEventType $IncludedEventTypes -Destination $dest
     
     # Azure Function
     
@@ -268,8 +270,10 @@ In the **Event Subscription Details** section, provide an appropriate name.
     $EventSubscriptionName = "PreEventWebhook"
     
     $PreEventWebhookEndpoint = "<Webhook URL>"
+
+    $dest = New-AzEventGridWebHookEventSubscriptionDestinationObject -EndpointUrl $PreEventWebhookEndpoint
     
-    New-AzEventGridSystemTopicEventSubscription -ResourceGroupName $ResourceGroupForSystemTopic -SystemTopicName $SystemTopicName -EventSubscriptionName $EventSubscriptionName -Endpoint $PreEventWebhookEndpoint -IncludedEventType $IncludedEventTypes
+    New-AzEventGridSystemTopicEventSubscription -ResourceGroupName $ResourceGroupForSystemTopic -SystemTopicName $SystemTopicName -EventSubscriptionName $EventSubscriptionName -Endpoint $PreEventWebhookEndpoint -IncludedEventType $IncludedEventTypes -Destination $dest
  
     # Azure Function
     


### PR DESCRIPTION
Fix webhook creation code. Previously was using  New-AzEventGridSystemTopicEventSubscription -Endpoint $PreEventWebhookEndpoint, but -Endpoint is no longer a valid parameter starting in Azure PowerShell 12.3.0 (was supported in Azure PowerShell 11.6.0)  - https://learn.microsoft.com/en-us/powershell/module/az.eventgrid/new-azeventgridsystemtopiceventsubscription