### PR TITLE
Update iot-hub-devguide-query-language.md

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-query-language.md
+++ b/articles/iot-hub/iot-hub-devguide-query-language.md
@@ -271,8 +271,8 @@ In routes conditions, the following string functions are supported:
 | UPPER(x) | Returns a string expression after converting lowercase character data to uppercase. |
 | SUBSTRING(string, start [, length]) | Returns part of a string expression starting at the specified character zero-based position and continues to the specified length, or to the end of the string. |
 | INDEX_OF(string, fragment) | Returns the starting position of the first occurrence of the second string expression within the first specified string expression, or -1 if the string isn't found.|
-| STARTSWITH(x, y) | Returns a Boolean indicating whether the first string expression starts with the second. |
-| ENDSWITH(x, y) | Returns a Boolean indicating whether the first string expression ends with the second. |
+| STARTS_WITH(x, y) | Returns a Boolean indicating whether the first string expression starts with the second. |
+| ENDS_WITH(x, y) | Returns a Boolean indicating whether the first string expression ends with the second. |
 | CONTAINS(x,y) | Returns a Boolean indicating whether the first string expression contains the second. |
 
 ## Query examples with the service SDKs


### PR DESCRIPTION
STARTSWITH is not recognized when defining message properties query expressions (https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-routing-query-syntax#message-properties-query-expressions)