### PR TITLE
Fixed Typo in SAP_PSE_Password

### DIFF
--- a/articles/logic-apps/connectors/sap.md
+++ b/articles/logic-apps/connectors/sap.md
@@ -548,7 +548,7 @@ For a Standard workflow that runs in single-tenant Azure Logic Apps, you can ena
 
    1. On your logic app resource menu, under **Settings**, select **Environment variables**.
 
-   1. On the **App settings** tab, check whether the settings named **SAP_PSE** and **SAP__PSE_Password** already exist. If they don't exist, you have to add each setting at the end of the settings list, provide the following required information, and select **Apply** for each setting:
+   1. On the **App settings** tab, check whether the settings named **SAP_PSE** and **SAP_PSE_Password** already exist. If they don't exist, you have to add each setting at the end of the settings list, provide the following required information, and select **Apply** for each setting:
 
       | Name | Value | Description |
       |------|-------|-------------|


### PR DESCRIPTION
There was a typo SAP_PSE_Password. The key has included a double underscore.

Fixed from: SAP__PSE_Password
To: SAP_PSE_Password