### PR TITLE
Update pay-by-invoice.md

### DIFF
--- a/articles/cost-management-billing/manage/pay-by-invoice.md
+++ b/articles/cost-management-billing/manage/pay-by-invoice.md
@@ -37,7 +37,7 @@ Currently, customers who have a Microsoft Online Subscription Program (pay-as-yo
 To qualify for wire transfer payments, you must:
 
 - Be an established customer for at least six months and have no outstanding balances.
-- Have a subscription cost that exceeds a certain amount. This amount varies by service location.
+- Have a subscription cost that exceeds minimum of $6000 USD each month for at least 3 months in last 12 months window, or should be a key customer(S500/Unified). This amount varies by service location.
 
 > [!IMPORTANT]
 > - You must pay all outstanding charges before switching to payment by wire transfer.


### PR DESCRIPTION
This line below needs to be updated to line after that yellow. 

Line that needs update: Have a subscription cost that exceeds a certain amount. This amount varies by service location.
Change needed: Have a subscription cost that exceeds minimum of $6000 USD each month for at least 3 months in last 12 months window, or should be a key customer(S500/Unified). This amount varies by service location.

 

Reason for change : We ASMS team, reject PI change to Invoice for customers stating that they do not fit the needs for payment method change from Credit to invoice type as their azure spend is less than $6000. This needs to documented clearly so customer can be aware of prerequisites. 

Example case -  2408230010003307 that was rejeted by GTFS team with this criteria

Reference TSG - Section 3.5 ASMS – How to Enable the Invoice Payment Option (microsoft.com)