### PR TITLE
Update cache-private-link.md

### DIFF
--- a/articles/azure-cache-for-redis/cache-private-link.md
+++ b/articles/azure-cache-for-redis/cache-private-link.md
@@ -351,7 +351,7 @@ az network private-endpoint delete --name MyPrivateEndpoint --resource-group MyR
 
 For **Basic, Standard, and Premium tier** caches, your application should connect to `<cachename>.redis.cache.windows.net` on port `6380`. A private DNS zone, named `*.privatelink.redis.cache.windows.net`, is automatically created in your subscription. The private DNS zone is vital for establishing the TLS connection with the private endpoint.  We recommend avoiding the use of `<cachename>.privatelink.redis.cache.windows.net` in configuration or connection string.
 
-For **Enterprise and Enterprise Flash** tier caches, your application should connect to `<cachename>.<region>.redisenterprise.cache.azure.net` on port `10000`.
+For **Enterprise and Enterprise Flash** tier caches, your application should connect to `<cachename>.<region>.redisenterprise.cache.azure.net` on port `10000`, and 8500 - 8599 if using OSS Cluster mode. If using Enterprise Cluster mode, only port 10000 is required.
 
 For more information, see [Azure services DNS zone configuration](../private-link/private-endpoint-dns.md).
 


### PR DESCRIPTION
OSS Cluster mode port requirements are not documented except for this MS employee's post here on learn questions: https://learn.microsoft.com/en-us/answers/questions/1661721/what-are-the-port-requirements-for-azure-cache-for The only similar inbound port requirements I found for Redis Cache for Azure is here, but it only lists the premium-tier and it does not mention enterprise skus and their specific requirements: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-premium-vnet#inbound-port-requirements