### PR TITLE
Update event-schema-blob-storage.md

### DIFF
--- a/articles/event-grid/event-schema-blob-storage.md
+++ b/articles/event-grid/event-schema-blob-storage.md
@@ -101,6 +101,8 @@ These events are triggered when a client creates, replaces, or deletes a blob by
 		"contentType": "image/jpeg",
 		"contentLength": 105891,
 		"blobType": "BlockBlob",
+		"accessTier": "Archive",
+		"previousTier": "Cool",
 		"url": "https://my-storage-account.blob.core.windows.net/testcontainer/Auto.jpg",
 		"sequencer": "000000000000000000000000000089A4000000000018d6ea",
 		"storageDiagnostics": {
@@ -208,6 +210,8 @@ These events are triggered when a client creates, replaces, or deletes a blob by
 		"contentType": "image/jpeg",
 		"contentLength": 105891,
 		"blobType": "BlockBlob",
+		"accessTier": "Archive",
+        	"previousTier": "Cool",
 		"url": "https://my-storage-account.blob.core.windows.net/testcontainer/Auto.jpg",
 		"sequencer": "000000000000000000000000000089A4000000000018d6ea",
 		"storageDiagnostics": {
@@ -1246,6 +1250,8 @@ The data object has the following properties:
 | `contentType` | string | The content type specified for the blob. |
 | `contentLength` | integer | The size of the blob in bytes. |
 | `blobType` | string | The type of blob. Valid values are either "BlockBlob" or "PageBlob". |
+| `accessTier`     | string    | The target tier of the blob. Appears only for the event BlobTierChanged.                                                                                                                                     |
+| `previousTier`   | string    | The source tier of the blob. Appears only for the event BlobTierChanged. If the blob is inferring the tier from the storage account, this field will not appear.                                          |
 | `contentOffset` | number | The offset in bytes of a write operation taken at the point where the event-triggering application completed writing to the file. <br>Appears only for events triggered on blob storage accounts that have a hierarchical namespace.|
 | `destinationUrl` |string | The url of the file that will exist after the operation completes. For example, if a file is renamed, the `destinationUrl` property contains the url of the new file name. <br>Appears only for events triggered on blob storage accounts that have a hierarchical namespace.|
 | `sourceUrl` |string | The url of the file that exists before the operation is done. For example, if a file is renamed, the `sourceUrl` contains the url of the original file name before the rename operation. <br>Appears only for events triggered on blob storage accounts that have a hierarchical namespace. |


### PR DESCRIPTION
Added information for accessTier and previousTier fields in Cloud Event and Event Grid schemas, as these properties are available in SetBlobTier changed event.

Sample json messages showing availability of these fields:

Event grid schema based event data showing both the new fields:
![image](https://github.com/user-attachments/assets/f132deb7-3031-4aae-9071-34b0dfe76483)

Event grid schema based event data showing accessTier field as the blob had inferred data:
<img width="445" alt="image" src="https://github.com/user-attachments/assets/1305e81a-8815-4182-a5dd-d6b0b7615941">

Cloud event schema based event data showing both the new fields:
![image](https://github.com/user-attachments/assets/f353277c-7afc-442b-a8e4-d9689df515cb)

Cloud event schema based event data showing accessTier field as the blob had inferred data:
![image](https://github.com/user-attachments/assets/1544b26e-dabb-4fc9-a0f9-d462cc3d137f)

The StorageBlobTierChangedEventData class in EventGrid .Net SDK already contains properties for these two fields:
https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventgrid.systemevents.storageblobtierchangedeventdata?view=azure-dotnet#properties

![image](https://github.com/user-attachments/assets/55808d64-c30f-441b-9c94-386e8b3801b1)
