### PR TITLE
Consistency updates of string and array empty() function

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-functions-array.md
+++ b/articles/azure-resource-manager/bicep/bicep-functions-array.md
@@ -158,7 +158,7 @@ The output from the preceding example with the default values is:
 
 `empty(itemToTest)`
 
-Determines if an array, object, or string is empty.
+Determines if an array, object, or string is empty or null.
 
 Namespace: [sys](bicep-functions.md#namespaces-for-functions).
 
@@ -166,11 +166,11 @@ Namespace: [sys](bicep-functions.md#namespaces-for-functions).
 
 | Parameter | Required | Type | Description |
 |:--- |:--- |:--- |:--- |
-| itemToTest |Yes |array, object, or string |The value to check if it's empty. |
+| itemToTest |Yes |array, object, or string |The value to check if it's empty or null. |
 
 ### Return value
 
-Returns **True** if the value is empty; otherwise, **False**.
+Returns **True** if the value is empty or null; otherwise, **False**.
 
 ### Example
 
@@ -180,10 +180,12 @@ The following example checks whether an array, object, and string are empty.
 param testArray array = []
 param testObject object = {}
 param testString string = ''
+param testNullString string?
 
 output arrayEmpty bool = empty(testArray)
 output objectEmpty bool = empty(testObject)
 output stringEmpty bool = empty(testString)
+output stringNull bool = empty(testNullString)
 ```
 
 The output from the preceding example with the default values is:
@@ -193,6 +195,7 @@ The output from the preceding example with the default values is:
 | arrayEmpty | Bool | True |
 | objectEmpty | Bool | True |
 | stringEmpty | Bool | True |
+| stringNull | Bool | True |
 
 ### Quickstart examples
 

--- a/articles/azure-resource-manager/bicep/bicep-functions-string.md
+++ b/articles/azure-resource-manager/bicep/bicep-functions-string.md
@@ -331,7 +331,7 @@ The output from the preceding example with the default values is:
 
 `empty(itemToTest)`
 
-Determines if an array, object, or string is empty.
+Determines if an array, object, or string is empty or null.
 
 Namespace: [sys](bicep-functions.md#namespaces-for-functions).
 
@@ -339,11 +339,11 @@ Namespace: [sys](bicep-functions.md#namespaces-for-functions).
 
 | Parameter | Required | Type | Description |
 |:--- |:--- |:--- |:--- |
-| itemToTest |Yes |array, object, or string |The value to check if it's empty. |
+| itemToTest |Yes |array, object, or string |The value to check if it's empty or null. |
 
 ### Return value
 
-Returns `True` if the value is empty; otherwise, `False`.
+Returns **True** if the value is empty or null; otherwise, **False**.
 
 ### Examples
 
@@ -353,10 +353,12 @@ The following example checks whether an array, object, and string are empty.
 param testArray array = []
 param testObject object = {}
 param testString string = ''
+param testNullString string?
 
 output arrayEmpty bool = empty(testArray)
 output objectEmpty bool = empty(testObject)
 output stringEmpty bool = empty(testString)
+output stringNull bool = empty(testNullString)
 ```
 
 The output from the preceding example with the default values is:
@@ -366,6 +368,7 @@ The output from the preceding example with the default values is:
 | arrayEmpty | Bool | True |
 | objectEmpty | Bool | True |
 | stringEmpty | Bool | True |
+| stringNull | Bool | True |
 
 ## endsWith
 


### PR DESCRIPTION
In this pull request, the documentation of string and array empty() function is updated so it's consistent with the object empty() documentation. See the object empty() docs: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-object#empty

Tagging @mumian 

