### PR TITLE
Correct incorrect value in `functions-reference-python.md`: Replace `null` with `None`

### DIFF
--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -1104,7 +1104,7 @@ In Azure Functions, [application settings](functions-app-settings.md), such as s
 | Method | Description |
 | --- | --- |
 | **`os.environ["myAppSetting"]`** | Tries to get the application setting by key name, and raises an error when it's unsuccessful.  |
-| **`os.getenv("myAppSetting")`** | Tries to get the application setting by key name, and returns `null` when it's unsuccessful.  |
+| **`os.getenv("myAppSetting")`** | Tries to get the application setting by key name, and returns `None` when it's unsuccessful.  |
 
 Both of these ways require you to declare `import os`.
 
@@ -1131,7 +1131,7 @@ In Azure Functions, [application settings](functions-app-settings.md), such as s
 | Method | Description |
 | --- | --- |
 | **`os.environ["myAppSetting"]`** | Tries to get the application setting by key name, and raises an error when it's unsuccessful.  |
-| **`os.getenv("myAppSetting")`** | Tries to get the application setting by key name, and returns `null` when it's unsuccessful.  |
+| **`os.getenv("myAppSetting")`** | Tries to get the application setting by key name, and returns `None` when it's unsuccessful.  |
 
 Both of these ways require you to declare `import os`.
 


### PR DESCRIPTION
This is to reflect the appropriate value returned by Python, as Python has no concept of `null` and uses `None` instead. In example:
```py
~ $ python
Python 3.12.6 (main, Sep  8 2024, 13:18:56) [GCC 14.2.1 20240805] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> k = os.getenv("FOO")
>>> print(k)
None
>>> type(k)
<class 'NoneType'>
```