### PR TITLE
Update automation-manage-send-joblogs-log-analytics.md

### DIFF
--- a/articles/automation/automation-manage-send-joblogs-log-analytics.md
+++ b/articles/automation/automation-manage-send-joblogs-log-analytics.md
@@ -110,7 +110,7 @@ Azure Automation diagnostics create the following types of records in Azure Moni
 | Caller_s |Caller that initiated the operation. Possible values are either an email address or system for scheduled jobs. |
 | Tenant_g | GUID (globally unique identifier) that identifies the tenant for the caller. |
 | JobId_g |GUID that identifies the runbook job. |
-| ResultType |Status of the runbook job. Possible values are:<br>- New<br>- Created<br>- Started<br>- Stopped<br>- Suspended<br>- Failed<br>- Completed |
+| ResultType |Status of the runbook job. Possible values are:<br>- Created<br>- Started<br>- Stopped<br>- Suspended<br>- Failed<br>- Completed |
 | Category | Classification of the type of data. For Automation, the value is JobLogs. |
 | OperationName | Type of operation performed in Azure. For Automation, the value is Job. |
 | Resource | Name of the Automation account |


### PR DESCRIPTION
deleted ResultType:New entries that were not recorded in JobLogs. Although New is recorded in the Status property of the activity log, it is noted as Created in the ResultType column of the Logs of JobLogs category, which contains similar information to the activity log. It is assumed that there was an incorrect mix of information.