### PR TITLE
media access feature quick start (Hard mute integration with Teams meeting and group call)

### DIFF
--- a/articles/communication-services/how-tos/calling-sdk/includes/capabilities/capabilities-web.md
+++ b/articles/communication-services/how-tos/calling-sdk/includes/capabilities/capabilities-web.md
@@ -81,7 +81,7 @@ capabilitiesFeature.on('capabilitiesChanged', (capabilitiesChangeInfo) => {
 - *muteOthers*: Ability to soft mute remote participant(s) in the meeting 
 - *reaction*: Ability to react in the meeting (beta only)
 - *viewAttendeeNames*: Ability to view attendee names in the meeting
-- *ipAudio*: Ability to controls whether audio can be turned on in meetings and group calls, this is Teams meeting policy setting
-- *ipVideo*: Ability to controls whether outgoing and incoming video can be turned on in meetings and group calls, this is Teams meeting policy setting
+- *ipAudio*: Ability to controls whether audio can be turned on in meetings and group calls, this setting is from Teams meeting policy
+- *ipVideo*: Ability to controls whether outgoing and incoming video can be turned on in meetings and group calls, this setting is from Teams meeting policy
 - *forbidRemoteParticipantsAudio*: Ability to forbid remote participants audio in the meeting
 - *forbidRemoteParticipantsVideo*: Ability to forbid remote participants video in the meeting

--- a/articles/communication-services/how-tos/calling-sdk/includes/capabilities/capabilities-web.md
+++ b/articles/communication-services/how-tos/calling-sdk/includes/capabilities/capabilities-web.md
@@ -81,3 +81,7 @@ capabilitiesFeature.on('capabilitiesChanged', (capabilitiesChangeInfo) => {
 - *muteOthers*: Ability to soft mute remote participant(s) in the meeting 
 - *reaction*: Ability to react in the meeting (beta only)
 - *viewAttendeeNames*: Ability to view attendee names in the meeting
+- *ipAudio*: Ability to controls whether audio can be turned on in meetings and group calls, this is Teams meeting policy setting
+- *ipVideo*: Ability to controls whether outgoing and incoming video can be turned on in meetings and group calls, this is Teams meeting policy setting
+- *forbidRemoteParticipantsAudio*: Ability to forbid remote participants audio in the meeting
+- *forbidRemoteParticipantsVideo*: Ability to forbid remote participants video in the meeting

--- a/articles/communication-services/how-tos/calling-sdk/includes/media-access/media-access-web.md
+++ b/articles/communication-services/how-tos/calling-sdk/includes/media-access/media-access-web.md
@@ -1,0 +1,77 @@
+---
+author: fuyan
+ms.service: azure-communication-services
+ms.topic: include
+ms.date: 10/24/2024
+ms.author: fuyan
+---
+[!INCLUDE [Install SDK](../install-sdk/install-sdk-web.md)]
+
+The media access feature allows organizer or presenters to prevent attendees from unmuting or turn on video themselves during a Microsoft Teams meeting.
+You first need to import calling Features from the Calling SDK:
+
+```js
+import { Features} from "@azure/communication-calling";
+```
+
+Then you can get the feature API object from the call instance:
+
+```js
+const mediaAccessFeature = call.feature(Features.MediaAccess);
+```
+
+### Forbid or permit audio and video for Teams meeting attendees:
+To change the Media access state for an attendee, you can use the `forbidAudio()`, `permitAudio()`,  `forbidVideo()`, and `permitVideo()` methods.
+This is async methods, to verify results can be used `mediaAccessChanged` listeners.
+```js
+const mediaAccessFeature = call.feature(Features.MediaAccsss);
+//forbid audio
+mediaAccessFeature.forbidAudio();
+//permit audio
+mediaAccessFeature.permitAudio();
+//forbid video
+mediaAccessFeature.forbidVideo();
+//permit video
+mediaAccessFeature.permitVideo();
+```
+
+### Forbid orpermit media access for other participants
+This feature allows users with the Organizer and Presenter roles to forbid media access for other participants on Teams calls. In Azure Communication calls, changing the state of other participants is not allowed unless roles have been added.
+
+To use this feature, you can use the following code:
+```js
+const mediaAccessFeature = call.feature(Features.MediaAccess);
+//forbid all attendees audio
+mediaAccessFeature.forbidRemoteParticipantsAudio();
+//or we can provide array of CommunicationIdentifier to specify list of participants
+CommunicationUserIdentifier acsUser = new CommunicationUserIdentifier(<USER_ID>);
+MicrosoftTeamsUserIdentifier teamsUser = new MicrosoftTeamsUserIdentifier(<USER_ID>)
+CommunicationIdentifier participants[] = new CommunicationIdentifier[]{ acsUser, teamsUser };
+mediaAccessFeature.forbidAudio(participants);
+```
+
+### Handle changed states
+With the Raise Hand API, you can subscribe to the `mediaAccessChanged` events to handle changes in the state of participants on a call. These events are triggered by a call instance and provide information about the participant whose state has changed.
+
+To subscribe to these events, you can use the following code:
+```js
+const mediaAccessFeature = call.feature(Features.MediaAccess);
+
+// event : {mediaAccesses: MediaAccess[]}
+const mediaAccessChangedHandler = (event) => {
+    console.log(`Latest media access states ${event.mediaAccesses}`);
+};
+mediaAccessFeature.on('mediaAccessChanged', mediaAccessChangedHandler):
+```
+The `mediaAccessChanged` event contains an object with the `mediaAccesses` property, which represents the participant's media accesses. In the example above, we log a message to the console indicating the latest media accesses for all participants.
+
+To unsubscribe from the events, you can use the `off` method.
+
+### List of all remote participants media access state
+To get information about all remote participants media access state on current call, you can use the `getRemoteParticipantsMediaAccess` api.
+Here's an example of how to use the `getRemoteParticipantsMediaAccess` API:
+```js
+const mediaAccessHandFeature = call.feature(Features.MediaAccess);
+let remoteParticipantsMediaAccess = mediaAccessHandFeature.getRemoteParticipantsMediaAccess();
+```
+

--- a/articles/communication-services/how-tos/calling-sdk/includes/media-access/media-access-web.md
+++ b/articles/communication-services/how-tos/calling-sdk/includes/media-access/media-access-web.md
@@ -21,8 +21,7 @@ const mediaAccessFeature = call.feature(Features.MediaAccess);
 ```
 
 ### Forbid or permit audio and video for Teams meeting attendees:
-To change the Media access state for an attendee, you can use the `forbidAudio()`, `permitAudio()`,  `forbidVideo()`, and `permitVideo()` methods.
-This is async methods, to verify results can be used `mediaAccessChanged` listeners.
+To change the Media access state for an attendee, you can use the `forbidAudio()`, `permitAudio()`,  `forbidVideo()`, and `permitVideo()` methods. These methods are async, to verify results can be used to `mediaAccessChanged` listeners.
 ```js
 const mediaAccessFeature = call.feature(Features.MediaAccsss);
 //forbid audio
@@ -35,8 +34,8 @@ mediaAccessFeature.forbidVideo();
 mediaAccessFeature.permitVideo();
 ```
 
-### Forbid orpermit media access for other participants
-This feature allows users with the Organizer and Presenter roles to forbid media access for other participants on Teams calls. In Azure Communication calls, changing the state of other participants is not allowed unless roles have been added.
+### Forbid and permit media access for other participants
+This feature allows users with the Organizer and Presenter roles to forbid and permit media access for other participants on Teams calls. In Azure Communication calls, changing the state of other participants isn't allowed unless adding the presenter role.
 
 To use this feature, you can use the following code:
 ```js
@@ -51,7 +50,7 @@ mediaAccessFeature.forbidAudio(participants);
 ```
 
 ### Handle changed states
-With the Raise Hand API, you can subscribe to the `mediaAccessChanged` events to handle changes in the state of participants on a call. These events are triggered by a call instance and provide information about the participant whose state has changed.
+With the 'Raise Hand' API, you can subscribe to the `mediaAccessChanged` events to handle changes in the state of participants on a call. These events are from a call instance and provide information about the participant whose state change.
 
 To subscribe to these events, you can use the following code:
 ```js
@@ -63,15 +62,14 @@ const mediaAccessChangedHandler = (event) => {
 };
 mediaAccessFeature.on('mediaAccessChanged', mediaAccessChangedHandler):
 ```
-The `mediaAccessChanged` event contains an object with the `mediaAccesses` property, which represents the participant's media accesses. In the example above, we log a message to the console indicating the latest media accesses for all participants.
+The `mediaAccessChanged` event contains an object with the `mediaAccesses` property, which represents the participant's media accesses.
 
 To unsubscribe from the events, you can use the `off` method.
 
 ### List of all remote participants media access state
-To get information about all remote participants media access state on current call, you can use the `getRemoteParticipantsMediaAccess` api.
+To get information about all remote participants media access state on current call, you can use the `getRemoteParticipantsMediaAccess` API.
 Here's an example of how to use the `getRemoteParticipantsMediaAccess` API:
 ```js
 const mediaAccessHandFeature = call.feature(Features.MediaAccess);
 let remoteParticipantsMediaAccess = mediaAccessHandFeature.getRemoteParticipantsMediaAccess();
 ```
-

--- a/articles/communication-services/how-tos/calling-sdk/media-access.md
+++ b/articles/communication-services/how-tos/calling-sdk/media-access.md
@@ -1,0 +1,50 @@
+---
+title: Media access states
+titleSuffix: An Azure Communication Services how-to guide
+description: Use Azure Communication Services SDKs to send media access state.
+author: fuyan
+ms.author: fuyan
+ms.service: azure-communication-services
+ms.subservice: calling
+ms.topic: how-to 
+ms.date: 10/24/2024
+ms.custom: template-how-to
+zone_pivot_groups: acs-plat-web-ios-android-windows
+
+#Customer intent: As a developer, I want to learn how to send and receive Media access state using SDK.
+---
+
+# Media access states
+::: zone pivot="platform-android"
+[!INCLUDE [Public Preview Disclaimer](../../includes/public-preview-include-document.md)]
+::: zone-end
+
+::: zone pivot="platform-ios"
+[!INCLUDE [Public Preview Disclaimer](../../includes/public-preview-include-document.md)]
+::: zone-end
+
+::: zone pivot="platform-windows"
+[!INCLUDE [Public Preview Disclaimer](../../includes/public-preview-include-document.md)]
+::: zone-end
+During an active call, you may want to send or receive states from other users. Let's learn how. 
+
+## Prerequisites
+
+- An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F). 
+- A deployed Communication Services resource. [Create a Communication Services resource](../../quickstarts/create-communication-resource.md).
+- A user access token to enable the calling client. For more information, see [Create and manage access tokens](../../quickstarts/identity/access-tokens.md).
+- Optional: Complete the quickstart to [add voice calling to your application](../../quickstarts/voice-video-calling/getting-started-with-calling.md)
+
+::: zone pivot="platform-web"
+[!INCLUDE [Media Access Client-side JavaScript](./includes/media-access/media-access-web.md)]
+::: zone-end
+
+Additional resources
+For more information about using the Media Access feature in Teams calls and meetings, see the [Microsoft Teams documentation](https://support.microsoft.com/en-us/office/manage-attendee-audio-and-video-permissions-in-microsoft-teams-meetings-f9db15e1-f46f-46da-95c6-34f9f39e671a).
+
+
+## Next steps
+- [Learn how to manage calls](./manage-calls.md)
+- [Learn how to manage video](./manage-video.md)
+- [Learn how to record calls](./record-calls.md)
+- [Learn how to transcribe calls](./call-transcription.md)

--- a/articles/communication-services/toc.yml
+++ b/articles/communication-services/toc.yml
@@ -359,6 +359,8 @@ items:
         href: how-tos/calling-sdk/capabilities.md
       - name: Pass User-to-User Information (UUI) data in a header
         href: how-tos/calling-sdk/call-context.md     
+      - name: Media Access
+        href: how-tos/calling-sdk/media-access.md
     - name: Call recording
       items:
       - name: Record a call


### PR DESCRIPTION
The media access feature allows organizer or presenters to prevent attendees from unmuting or turn on video themselves during a Microsoft Teams meeting.