### PR TITLE
fix formatting

### DIFF
--- a/articles/virtual-network/accelerated-networking-overview.md
+++ b/articles/virtual-network/accelerated-networking-overview.md
@@ -159,6 +159,8 @@ Unmanaged=yes
 EOF
 ```
 
+---
+
 #### Network traffic uses the Accelerated Networking data path
 
 For NVIDIA drivers: Verify that the packets are flowing over the VF interface


### PR DESCRIPTION
Fix formatting issue on Accelnet Overview page that caused a section to appear nested in the tabs before it