### PR TITLE
Confusing page with inconsistencies

### DIFF
--- a/articles/azure-functions/run-functions-from-deployment-package.md
+++ b/articles/azure-functions/run-functions-from-deployment-package.md
@@ -66,7 +66,7 @@ The following table indicates the recommended `WEBSITE_RUN_FROM_PACKAGE` values 
 
 ## Use WEBSITE_RUN_FROM_PACKAGE = 1
 
-This section provides information about how to run your function app from a local package.
+This section provides information about how to run your function app from a zipped local package.
 
 ### Considerations for deploying from an on-site package
 
@@ -87,7 +87,7 @@ When you set the `WEBSITE_RUN_FROM_PACKAGE` app setting value to `1`, the zip de
 
 ## Use WEBSITE_RUN_FROM_PACKAGE = URL
 
-This section provides information about how to run your function app from a package deployed to a URL endpoint. This option is the only one supported for running from a Linux-hosted package with a Consumption plan.
+This section provides information about how to run your function app from a zipped package deployed to a URL endpoint. This option is the only one supported for running from a Linux-hosted package with a Consumption plan.
 
 ### Considerations for deploying from a URL
 

--- a/articles/azure-functions/run-functions-from-deployment-package.md
+++ b/articles/azure-functions/run-functions-from-deployment-package.md
@@ -91,7 +91,7 @@ This section provides information about how to run your function app from a zipp
 
 ### Considerations for deploying from a URL
 
-+ Function apps running on Windows experience a slight increase in [cold-start time](event-driven-scaling.md#cold-start) when the application package is deployed to a URL endpoint via `WEBSITE_RUN_FROM_PACKAGE = <URL>`.
++ Function apps running on Windows experience a slight increase in [cold-start time](event-driven-scaling.md#cold-start) when the application package is deployed to a URL endpoint via `WEBSITE_RUN_FROM_PACKAGE = <URL>`. The URL must point to a .ZIP file and include the .ZIP extension.
 + When you specify a URL, you must also [manually sync triggers](functions-deployment-technologies.md#trigger-syncing) after you publish an updated package.
 + The Functions runtime must have permissions to access the package URL.
 + Don't deploy your package to Azure Blob Storage as a public blob. Instead, use a private container with a [shared access signature (SAS)](../storage/common/storage-sas-overview.md) or [use a managed identity](#fetch-a-package-from-azure-blob-storage-using-a-managed-identity) to enable the Functions runtime to access the package.

--- a/articles/azure-functions/run-functions-from-deployment-package.md
+++ b/articles/azure-functions/run-functions-from-deployment-package.md
@@ -5,18 +5,18 @@ ms-service: azure-functions
 ms.topic: conceptual
 ms.date: 06/28/2024
 
-# Customer intent: As a function developer, I want to understand how to run my function app from a deployment package file, so I can make my function app run faster and easier to update.
+# Customer intent: As a function developer, I want to understand how to run my function app from a package, so I can make my function app run faster and easier to update.
 ---
 
-# Run your functions from a package file in Azure
+# Run your functions from a package in Azure
 
-In Azure, you can run your functions directly from a deployment package file in your function app. The other option is to deploy your files in the `c:\home\site\wwwroot` (Windows) or `/home/site/wwwroot` (Linux) directory of your function app.
+In Azure, you can run your functions directly from a .zip file. The other option is to deploy your files in the `c:\home\site\wwwroot` (Windows) or `/home/site/wwwroot` (Linux) directory of your function app.
 
 This article describes the benefits of running your functions from a package. It also shows how to enable this functionality in your function app.
 
-## Benefits of running from a package file
+## Benefits of running from a package
   
-There are several benefits to running functions from a package file:
+There are several benefits to running functions from a package:
 
 + Reduces the risk of file copy locking issues.
 + Can be deployed to a production app (with restart).
@@ -32,8 +32,8 @@ To enable your function app to run from a package, add a `WEBSITE_RUN_FROM_PACKA
 
 | Value  | Description  |
 |---------|---------|
-| **`1`**  | Indicates that the function app runs from a local package file deployed in the `c:\home\data\SitePackages` (Windows) or `/home/data/SitePackages` (Linux) folder of your function app.  |
-|**`<URL>`**  | Sets a URL that is the remote location of the specific package file you want to run. Required for functions apps running on Linux in a Consumption plan.  |
+| **`1`**  | Indicates that the function app runs from a local package deployed in the `c:\home\data\SitePackages` (Windows) or `/home/data/SitePackages` (Linux) folder of your function app.  |
+|**`<URL>`**  | Sets a URL that is the remote location of the specific package you want to run. Required for functions apps running on Linux in a Consumption plan.  |
 
 The following table indicates the recommended `WEBSITE_RUN_FROM_PACKAGE` values for deployment to a specific operating system and hosting plan:
 
@@ -45,11 +45,11 @@ The following table indicates the recommended `WEBSITE_RUN_FROM_PACKAGE` values 
 
 ## General considerations
 
-+ The package file must be .zip formatted. Tar and gzip formats aren't supported.
++ Only .zip is formatted. Tar and gzip formats aren't supported.
 + [Zip deployment](#integration-with-zip-deployment) is recommended.
 + When deploying your function app to Windows, you should set `WEBSITE_RUN_FROM_PACKAGE` to `1` and publish with zip deployment.
 + When you run from a package, the `wwwroot` folder is read-only and you receive an error if you write files to this directory. Files are also read-only in the Azure portal.
-+ The maximum size for a deployment package file is 1 GB.
++ The maximum size for a .zip file is 1 GB.
 + You can't use the local cache when running from a deployment package.
 + If your project needs to use remote build, don't use the `WEBSITE_RUN_FROM_PACKAGE` app setting. Instead, add the `SCM_DO_BUILD_DURING_DEPLOYMENT=true` deployment customization app setting. For Linux, also add the `ENABLE_ORYX_BUILD=true` setting. For more information, see [Remote build](functions-deployment-technologies.md#remote-build).
 
@@ -66,7 +66,7 @@ The following table indicates the recommended `WEBSITE_RUN_FROM_PACKAGE` values 
 
 ## Use WEBSITE_RUN_FROM_PACKAGE = 1
 
-This section provides information about how to run your function app from a local package file.
+This section provides information about how to run your function app from a local package.
 
 ### Considerations for deploying from an on-site package
 
@@ -74,7 +74,7 @@ This section provides information about how to run your function app from a loca
 
 + Using an on-site package is the recommended option for running from the deployment package, except when running on Linux hosted in a Consumption plan.
 + [Zip deployment](#integration-with-zip-deployment) is the recommended way to upload a deployment package to your site.
-+ When not using zip deployment, make sure the `c:\home\data\SitePackages` (Windows) or `/home/data/SitePackages` (Linux) folder has a file named `packagename.txt`. This file contains only the name, without any whitespace, of the package file in this folder that's currently running.
++ When not using zip deployment, make sure the `c:\home\data\SitePackages` (Windows) or `/home/data/SitePackages` (Linux) folder has a file named `packagename.txt`. This file contains only the name, without any whitespace, of the package in this folder that's currently running.
 
 ### Integration with zip deployment
 


### PR DESCRIPTION
I'm afraid this page is confusing. Based on my understanding, the page refers to .zip deployment as "deployment package file" while calling the method of deploying to files to `c:\home\site\wwwroot` as "package". I'm afraid it's confusing to say the least. Worse, it seems to me that the page uses those terms interchangeably. Firstly, I thought it's only me so I asked from Capilot and got this response:

> Here are a few points where the terms and explanations could cause some confusion:
> 
> Terminology: The document sometimes uses terms interchangeably that might confuse newcomers. For example, it refers to a "deployment package" and "zip package" without clearly differentiating or defining them initially. More consistency in terminology could help avoid confusion.
> 
> Steps Clarity: The instructions jump between steps without always providing a clear flow. For example, the transition from creating a package to setting the WEBSITE_RUN_FROM_PACKAGE app setting might be unclear if you're not familiar with the process.
> 
> WEBSITE_RUN_FROM_PACKAGE Setting: The document doesn't make it immediately clear that this setting mounts the package as a read-only file system, which might leave users puzzled if they expect files to appear directly in wwwroot.
> 
> Direct vs. Package Deployment: The document could benefit from a clearer comparison between direct deployment to wwwroot and using a deployment package. Highlighting the pros and cons of each approach in a side-by-side format could be helpful.
> 
> These are a few areas where the documentation could be more user-friendly.

Then I asked from Perplexity AI and I got following response:

> The page you referenced from Microsoft about running functions from a deployment package file in Azure provides detailed information, but there are inconsistencies regarding the term "package file" that could lead to confusion. Here are some observations:
> Inconsistencies in Terminology
> Definition of Package File:
> The term "package file" is primarily used to refer to a .zip file containing the necessary files for the function app. However, throughout the document, it sometimes seems to imply other formats or configurations without clear differentiation, which can cause misunderstanding about what constitutes a valid package file.
> Usage of "Package" vs. "Deployment Package":
> The article alternates between referring to "package file" and "deployment package." While these terms are often interchangeable, the document does not consistently clarify that they refer to the same concept, which may confuse readers who are trying to grasp the specific requirements for deployment.
> Contextual Clarity:
> In sections discussing WEBSITE_RUN_FROM_PACKAGE, the context switches between local and remote package files without explicitly stating when each applies. For example, it mentions using a URL for Linux functions but does not clearly delineate when one should use a local package versus a remote one in other contexts.
> Technical Specifications:
> The document states that the package must be in .zip format and highlights that other formats like tar or gzip are not supported. However, it does not consistently emphasize this requirement throughout all sections discussing package files, which could lead users to mistakenly believe that other formats might be acceptable under certain conditions.

So, it seems it's not only me who has difficulty understanding this page. I tried to make some changes. I would say the two deployment methods need to have easily distinguishable terms. Accordingly I've made an edit. But I'm aware this needs more work. I'm more than happy that we work together to make this page more coherent, consistent and understandable.