### PR TITLE
Update tag-support.md

### DIFF
--- a/articles/azure-resource-manager/management/tag-support.md
+++ b/articles/azure-resource-manager/management/tag-support.md
@@ -825,8 +825,8 @@ To get the same data as a file of comma-separated values, download [tag-support.
 > | Resource type | Supports tags | Tag in cost report |
 > | ------------- | ----------- | ----------- |
 > | availabilitySets | Yes | Yes |
-> | capacityReservationGroups | Yes | Yes |
-> | capacityReservationGroups / capacityReservations | Yes | Yes |
+> | capacityReservationGroups | No | No |
+> | capacityReservationGroups / capacityReservations | No | No |
 > | cloudServices | Yes | Yes |
 > | cloudServices / networkInterfaces | No | No |
 > | cloudServices / publicIPAddresses | No | No |


### PR DESCRIPTION
Updating the public doc associated with internal escalation where there was the confirmation that capacityreservations doesn't support tags (please confirm too for capacityreservationgroups). This change is to make the public docs updated until engineering completes work on enabling it with ETA around Feb.