### PR TITLE
Use correct name for per-uri policy

### DIFF
--- a/articles/web-application-firewall/ag/per-site-policies.md
+++ b/articles/web-application-firewall/ag/per-site-policies.md
@@ -257,7 +257,7 @@ $policySettingURI = New-AzApplicationGatewayFirewallPolicySetting `
   -MaxFileUploadInMb 5
 
 $wafPolicyURI = New-AzApplicationGatewayFirewallPolicy `
-  -Name wafpolicySite `
+  -Name wafPolicyURI `
   -ResourceGroup myResourceGroupAG `
   -Location eastus `
   -PolicySetting $PolicySettingURI `


### PR DESCRIPTION
Seems like the name for the policy should be different, otherwise it overwrites the per-site policy.