### PR TITLE
ARO VNet also needs to be updated in the MachineSet YAML manifest

### DIFF
--- a/articles/openshift/howto-infrastructure-nodes.md
+++ b/articles/openshift/howto-infrastructure-nodes.md
@@ -142,7 +142,7 @@ spec:
           userDataSecret:
             name: worker-user-data 
           vmSize: <Standard_E4s_v5, Standard_E8s_v5, Standard_E16s_v5>
-          vnet: aro-vnet 
+          vnet: <VNET_NAME> 
           zone: <ZONE>
       taints: 
       - key: node-role.kubernetes.io/infra


### PR DESCRIPTION
ARO VNet also needs to be updated in the MachineSet YAML manifest by the user. Modified the manifest so that a placeholder is seen to update the ARO VNet name.