### PR TITLE
Java @BlobTrigger document polling vs eventgrid

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-blob-trigger.md
+++ b/articles/azure-functions/functions-bindings-storage-blob-trigger.md
@@ -64,12 +64,31 @@ For more information about the `BlobTrigger` attribute, see [Attributes](#attrib
 
 This function writes a log when a blob is added or updated in the `myblob` container.
 
+Polling-based:
+
 ```java
 @FunctionName("blobprocessor")
 public void run(
   @BlobTrigger(name = "file",
                dataType = "binary",
                path = "myblob/{name}",
+               connection = "MyStorageAccountAppSetting") byte[] content,
+  @BindingName("name") String filename,
+  final ExecutionContext context
+) {
+  context.getLogger().info("Name: " + filename + " Size: " + content.length + " bytes");
+}
+```
+
+EventGrid:
+
+```java
+@FunctionName("blobprocessor")
+public void run(
+  @BlobTrigger(name = "file",
+               dataType = "binary",
+               path = "myblob/{name}",
+               source = "EventGrid",
                connection = "MyStorageAccountAppSetting") byte[] content,
   @BindingName("name") String filename,
   final ExecutionContext context


### PR DESCRIPTION
In Java, proper annotation usage is essential when switching from `@BlobTrigger` to `@EventGrid` for events in Azure Function Apps. A common mistake when transitioning Blob events from Polling to EventGrid is incorrectly changing the `@BlobTrigger` annotation directly to `@EventGrid`, which leads to an error.

This article addresses this issue and provides a solution, though it lacks specific examples. By including a clear example here, users can avoid referencing multiple documentation sources, ensuring a smoother setup without the risk of overlooking key annotation requirements.