### PR TITLE
Improve Java Documentation for Blob Storage Events with Event Grid in Azure Functions

### DIFF
--- a/articles/azure-functions/functions-event-grid-blob-trigger.md
+++ b/articles/azure-functions/functions-event-grid-blob-trigger.md
@@ -63,6 +63,13 @@ This article creates a C# app that runs in isolated worker mode, which supports 
 
 When you create a Blob Storage trigger function using Visual Studio Code, you also create a new project. You need to edit the function to consume an event subscription as the source, rather than use the regular polled container.
 
+::: zone pivot="programming-language-java"
+> [!TIP] 
+> Use the `@BlobTrigger` annotation with `source=EventGrid` to handle Blob storage events. Using the `@EventGrid` annotation instead will result in an error.
+::: zone-end
+
+> For details about differences between the two implementations of the Blob storage trigger, as well as other triggering options, see [Working with blobs](./storage-considerations.md#working-with-blobs).
+
 1. In Visual Studio Code, open your function app.
 
 1. Press F1 to open the command palette, enter `Azure Functions: Create Function...`, and select **Create new project**.  


### PR DESCRIPTION
This update enhances the documentation for configuring Blob storage events with Event Grid in Azure Functions for Java.

* Added Tip: Included a note in the Java-specific section, clarifying that the `@BlobTrigger` annotation with `source=EventGrid` should be used for handling Blob events. This addition addresses a common error where users mistakenly switch to the `@EventGrid` annotation, resulting in failures.
* Updated Link: Added a reference to [Working with blobs](https://github.com/MicrosoftDocs/azure-docs/compare/storage-considerations.md#working-with-blobs) for further information on Blob storage trigger options and implementation details.

These improvements provide clearer guidance and examples, helping users avoid common pitfalls when configuring Blob events with Event Grid.