### PR TITLE
Update how-to-cache-purge-powershell.md

### DIFF
--- a/articles/frontdoor/standard-premium/how-to-cache-purge-powershell.md
+++ b/articles/frontdoor/standard-premium/how-to-cache-purge-powershell.md
@@ -38,7 +38,7 @@ Run [Clear-AzFrontDoorCdnEndpointContent](/powershell/module/az.cdn/clear-azfron
    * Domains/Subdomains with assets you want to purge
 
        > [!IMPORTANT]
-       > Cache purge for wildcard domains is not supported, you have to specify a subdomain for cache purge for a wildcard domain. You can add as many single-level subdomains of the wildcard domain. For example, for the wildcard domain `*.afdxgatest.azfdtest.xyz`, you can add subdomains in the form of `contoso.afdxgatest.azfdtest.xyz` or `cart.afdxgatest.azfdtest.xyz` and so on. For more information, see [Wildcard domains in Azure Front Door](../front-door-wildcard-domain.md).
+       > Cache purge for wildcard domains is not supported, you have to specify a subdomain for cache purge for a wildcard domain. You can add as many single-level subdomains of the wildcard domain, if `-Domain` is omitted, only the endpoint cache will be purged. For example, for the wildcard domain `*.afdxgatest.azfdtest.xyz`, you can add subdomains in the form of `contoso.afdxgatest.azfdtest.xyz` or `cart.afdxgatest.azfdtest.xyz` and so on. For more information, see [Wildcard domains in Azure Front Door](../front-door-wildcard-domain.md).
 
    * The path to the content to be purged.
      * These formats are supported in the lists of paths to purge:


### PR DESCRIPTION
Add clarification to Azure PowerShell usage for Azure Front Door purging

https://learn.microsoft.com/en-us/powershell/module/az.cdn/clear-azfrontdoorcdnendpointcontent?view=azps-12.4.0
The `-Domain` is an optional parameter, however since Azure Front Door using wildcard domains doesn't support purging similar to '*.contoso.com', you must specify a subdomain. Current wording with an 'Optional Parameter' makes it seem as not specifying a `-Domain` would purge the wildcard domain (which isn't supported). Omitting the subdomain would only clear the Endpoint cache of example.azurefd.net as its not clarifying when the operation occurs.