### PR TITLE
Authorization URL is updated with default value

### DIFF
--- a/includes/api-management-authorization-azure-ad-provider.md
+++ b/includes/api-management-authorization-azure-ad-provider.md
@@ -10,10 +10,9 @@ ms.author: danlep
 | Provider name | Name of credential provider resource in API Management |Yes | N/A | 
 | Identity provider  | Select **Azure Active Directory v1** |Yes | N/A | 
 | Grant type  | The OAuth 2.0 authorization grant type to use<br/><br/>Depending on your scenario, select either **Authorization code** or **Client credentials**. |Yes | Authorization code | 
-|**Authorization URL** | `https://graph.microsoft.com` | Yes | N/A |
+|**Authorization URL** | Authorization URL | No | `https://login.microsoftonline.com` |
 | Client ID | The application (client) ID used to identify the Microsoft Entra app | Yes | N/A |
 | Client secret | The client secret used for the Microsoft Entra app | Yes | N/A |
-| Login URL | The Microsoft Entra login URL  | No | `https://login.windows.net` |
 | Resource URL | The URL of the resource that requires authorization<br/><br/> Example: `https://graph.microsoft.com` | Yes | N/A |
 | Tenant ID | The tenant ID of your Microsoft Entra app | No | common |  
 | Scopes | One or more API permissions for your Microsoft Entra app, separated by the " " character <br/><br/>Example: `ChannelMessage.Read.All User.Read` | No | API permissions set in Microsoft Entra app | 


### PR DESCRIPTION
On the UI, there is no Login Url and Authorization URL is not a required field and is default to login.microsoftonline.com when selecting Azure Active Directory v1 as Identity Provider.