### PR TITLE
Revert "ACA Resiliency feature learn doc update"

### DIFF
--- a/articles/container-apps/TOC.yml
+++ b/articles/container-apps/TOC.yml
@@ -227,7 +227,7 @@
           href: managed-identity.md
         - name: Azure Container Registry image pull with managed identity
           href: managed-identity-image-pull.md
-- name: Resiliency
+- name: Resiliency (preview)
   items:
     - name: Service discovery resiliency
       href: service-discovery-resiliency.md
@@ -264,7 +264,7 @@
         items:
         - name: Dapr components
           href: dapr-components.md
-        - name: Dapr component resiliency
+        - name: Dapr component resiliency (preview)
           href: dapr-component-resiliency.md
         - name: Scale Dapr apps with KEDA using Bicep
           href: dapr-keda-scaling.md

--- a/articles/container-apps/dapr-component-resiliency.md
+++ b/articles/container-apps/dapr-component-resiliency.md
@@ -1,5 +1,5 @@
 ---
-title: Dapr component resiliency
+title: Dapr component resiliency (preview)
 titleSuffix: Azure Container Apps
 description: Learn how to make your Dapr components resilient in Azure Container Apps.
 services: container-apps
@@ -12,7 +12,7 @@ ms.custom: ignite-fall-2023, ignite-2023, devx-track-azurecli
 # Customer Intent: As a developer, I'd like to learn how to make my container apps resilient using Azure Container Apps.
 ---
 
-# Dapr component resiliency
+# Dapr component resiliency (preview)
 
 Resiliency policies proactively prevent, detect, and recover from your container app failures. In this article, you learn how to apply resiliency policies for applications that use Dapr to integrate with different cloud services, like state stores, pub/sub message brokers, secret stores, and more. 
 

--- a/articles/container-apps/service-discovery-resiliency.md
+++ b/articles/container-apps/service-discovery-resiliency.md
@@ -1,5 +1,5 @@
 ---
-title: Service discovery resiliency
+title: Service discovery resiliency (preview)
 titleSuffix: Azure Container Apps
 description: Learn how to apply container app to container app resiliency when using the application's service name in Azure Container Apps.
 services: container-apps
@@ -12,7 +12,7 @@ ms.custom: ignite-fall-2023, ignite-2023, devx-track-azurecli
 # Customer Intent: As a developer, I'd like to learn how to make my container apps resilient using Azure Container Apps.
 ---
 
-# Service discovery resiliency
+# Service discovery resiliency (preview)
 
 With Azure Container Apps resiliency, you can proactively prevent, detect, and recover from service request failures using simple resiliency policies. In this article, you learn how to configure Azure Container Apps resiliency policies when initiating requests using Azure Container Apps service discovery.
 
@@ -238,7 +238,7 @@ az containerapp resiliency delete --group MyResourceGroup --name MyResiliency --
 
 # [Azure portal](#tab/portal)
 
-Navigate into your container app in the Azure portal. In the left side menu under **Settings**, select **Resiliency** to open the resiliency pane.
+Navigate into your container app in the Azure portal. In the left side menu under **Settings**, select **Resiliency (preview)** to open the resiliency pane.
 
 :::image type="content" source="media/service-discovery-resiliency/resiliency-pane.png" alt-text="Screenshot demonstrating how to access the service discovery resiliency pane.":::
 


### PR DESCRIPTION
Reverts MicrosoftDocs/azure-docs#124741

Change of plans. Resiliency feature is not going GA now, hence reverting this change.