### PR TITLE
Update api-management-service-limits.md

### DIFF
--- a/includes/api-management-service-limits.md
+++ b/includes/api-management-service-limits.md
@@ -33,7 +33,7 @@ To request a limit increase, create a support request from the Azure portal. For
 | Maximum number of API operations per service instance | 1,000 | Unlimited | Unlimited | Unlimited | Unlimited |
 | Maximum total request duration | 30 seconds | Unlimited | Unlimited | Unlimited | Unlimited |
 | Maximum request payload size | 1 GiB | Unlimited | Unlimited | Unlimited | Unlimited | 
-| Maximum buffered payload size | 2 MiB | Unlimited | Unlimited | Unlimited | Unlimited |
+| Maximum buffered payload size | 2 MiB | 500 MiB | 500 MiB | 500 MiB | 500 MiB |
 | Maximum request/response payload size in diagnostic logs | 8,192 bytes | 8,192 bytes | 8,192 bytes | 8,192 bytes | 8,192 bytes |
 | Maximum request URL size<sup>2</sup> | 16,384 bytes | Unlimited | Unlimited | Unlimited | Unlimited |
 | Maximum character length of URL path segment | 1,024  | 1,024  | 1,024  | 1,024  | 1,024  |


### PR DESCRIPTION
Modifying the maximum buffered payload size for APIM from Unlimited to 500 MiB for classic developer, basic, standard, premium tiers.