### PR TITLE
Keep dots in category names to override using app settings

### DIFF
--- a/articles/azure-functions/configure-monitoring.md
+++ b/articles/azure-functions/configure-monitoring.md
@@ -466,23 +466,23 @@ To configure these values at App settings level (and avoid redeployment on just 
 | Host.json path | App setting |
 |----------------|-------------|
 | logging.logLevel.default  | AzureFunctionsJobHost__logging__logLevel__default  |
-| logging.logLevel.Host.Aggregator | AzureFunctionsJobHost__logging__logLevel__Host__Aggregator |
+| logging.logLevel.Host.Aggregator | AzureFunctionsJobHost__logging__logLevel__Host.Aggregator |
 | logging.logLevel.Function | AzureFunctionsJobHost__logging__logLevel__Function |
-| logging.logLevel.Function.Function1 | AzureFunctionsJobHost__logging__logLevel__Function__Function1 |
-| logging.logLevel.Function.Function1.User | AzureFunctionsJobHost__logging__logLevel__Function__Function1__User |
+| logging.logLevel.Function.Function1 | AzureFunctionsJobHost__logging__logLevel__Function.Function1 |
+| logging.logLevel.Function.Function1.User | AzureFunctionsJobHost__logging__logLevel__Function.Function1.User |
 
 You can override the settings directly at the Azure portal Function App Configuration pane or by using an Azure CLI or PowerShell script.
 
 # [Azure CLI](#tab/v2)
 
 ```azurecli-interactive
-az functionapp config appsettings set --name MyFunctionApp --resource-group MyResourceGroup --settings "AzureFunctionsJobHost__logging__logLevel__Host__Aggregator=Information"
+az functionapp config appsettings set --name MyFunctionApp --resource-group MyResourceGroup --settings "AzureFunctionsJobHost__logging__logLevel__Host.Aggregator=Information"
 ```
 
 # [PowerShell](#tab/v1)
 
 ```powershell
-Update-AzFunctionAppSetting -Name MyAppName -ResourceGroupName MyResourceGroupName -AppSetting @{"AzureFunctionsJobHost__logging__logLevel__Host__Aggregator" = "Information"}
+Update-AzFunctionAppSetting -Name MyAppName -ResourceGroupName MyResourceGroupName -AppSetting @{"AzureFunctionsJobHost__logging__logLevel__Host.Aggregator" = "Information"}
 ```
 
 ---


### PR DESCRIPTION
If the dots in the category name are replaced with double underscores, we wouldn't end up with the desired category name.

For example, the category name from the following app setting would be `Host:Aggregator`, when `Host.Aggregator` is what we want:

`AzureFunctionsJobHost__logging__logLevel__Host__Aggregator`

The app setting should be:

`AzureFunctionsJobHost__logging__logLevel__Host.Aggregator`