### PR TITLE
Update move-support-resources.md

### DIFF
--- a/articles/azure-resource-manager/management/move-support-resources.md
+++ b/articles/azure-resource-manager/management/move-support-resources.md
@@ -806,9 +806,11 @@ Before starting your move operation, review the [checklist](./move-resource-grou
 > [!div class="mx-tableFixed"]
 > | Resource type | Resource group | Subscription | Region move |
 > | ------------- | ----------- | ---------- | ----------- |
-> | databaseaccounts | **Yes** | Partial | No |
+> | databaseaccounts | **Yes** | **Yes** | No |
+> | mongoClusters | No | No | No |
+> | cassandraClusters | No | No | No |
 
-Moves between subscriptions are supported for APIs that use the RU architecture (Microsoft.DocumentDB/databaseAccounts), but not for those based on the vCore architecture, such as:
+Moves between Resource groups and subscriptions are supported for APIs that use the RU architecture (Microsoft.DocumentDB/databaseAccounts), but not for those based on the vCore architecture, such as:
 
 - MongoDB vCore (Microsoft.DocumentDB/mongoClusters)
 - Azure Managed Instance for Apache Cassandra (Microsoft.DocumentDB/cassandraClusters)


### PR DESCRIPTION
#Microsoft.documentDB

Moves between Resource groups and subscriptions are supported for APIs that use the RU architecture (Microsoft.DocumentDB/databaseAccounts), but not for those based on the vCore architecture, such as:

- MongoDB vCore (Microsoft.DocumentDB/mongoClusters)
- Azure Managed Instance for Apache Cassandra (Microsoft.DocumentDB/cassandraClusters)