### PR TITLE
Update migrate-dotnet-to-isolated-model.md

### DIFF
--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -308,20 +308,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function
 {
-    public class HttpTriggerCSharp
+    public class HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
     {
-        private readonly ILogger<HttpTriggerCSharp> _logger;
-
-        public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
         [Function("HttpTriggerCSharp")]
         public IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req)
         {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
+            logger.LogInformation("C# HTTP trigger function processed a request.");
 
             return new OkObjectResult($"Welcome to Azure Functions, {req.Query["name"]}!");
         }
@@ -339,19 +332,12 @@ using System.Net;
 
 namespace Company.Function
 {
-    public class HttpTriggerCSharp
+    public class HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
     {
-        private readonly ILogger<HttpTriggerCSharp> _logger;
-
-        public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
         [Function("HttpTriggerCSharp")]
         public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req)
         {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
+            logger.LogInformation("C# HTTP trigger function processed a request.");
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");


### PR DESCRIPTION
Convert Example function migrations' code snippets to use primary constructors consistent with .NET 8+