### PR TITLE
Update storage-sas-overview.md

### DIFF
--- a/articles/storage/common/storage-sas-overview.md
+++ b/articles/storage/common/storage-sas-overview.md
@@ -37,7 +37,7 @@ Azure Storage supports three types of shared access signatures:
 
 ### User delegation SAS
 
-A user delegation SAS is secured with Microsoft Entra credentials and also by the permissions specified for the SAS. A User Delegation SAS is specific to Blob Storage and cannot be used with other Azure Storage services such as File Storage, Table Storage, or Queue Storage.
+A user delegation SAS is secured with Microsoft Entra credentials and also by the permissions specified for the SAS. A user delegation SAS is supported for Azure Blob Storage and Azure Data Lake Storage. It's not currently supported for Azure Files, Queue Storage, or Table Storage.
 
 For more information about the user delegation SAS, see [Create a user delegation SAS (REST API)](/rest/api/storageservices/create-user-delegation-sas).
 

--- a/articles/storage/common/storage-sas-overview.md
+++ b/articles/storage/common/storage-sas-overview.md
@@ -37,7 +37,7 @@ Azure Storage supports three types of shared access signatures:
 
 ### User delegation SAS
 
-A user delegation SAS is secured with Microsoft Entra credentials and also by the permissions specified for the SAS. A user delegation SAS applies to Blob storage only.
+A user delegation SAS is secured with Microsoft Entra credentials and also by the permissions specified for the SAS. A User Delegation SAS is specific to Blob Storage and cannot be used with other Azure Storage services such as File Storage, Table Storage, or Queue Storage.
 
 For more information about the user delegation SAS, see [Create a user delegation SAS (REST API)](/rest/api/storageservices/create-user-delegation-sas).
 

--- a/articles/storage/common/storage-sas-overview.md
+++ b/articles/storage/common/storage-sas-overview.md
@@ -37,7 +37,7 @@ Azure Storage supports three types of shared access signatures:
 
 ### User delegation SAS
 
-A user delegation SAS is secured with Microsoft Entra credentials and also by the permissions specified for the SAS. A user delegation SAS is supported for Azure Blob Storage and Azure Data Lake Storage. It's not currently supported for Azure Files, Queue Storage, or Table Storage.
+A user delegation SAS is secured with Microsoft Entra credentials and also by the permissions specified for the SAS. A user delegation SAS is supported for Azure Blob Storage and Azure Data Lake Storage. It's not currently supported for Azure Files, Azure Queue Storage, or Azure Table Storage.
 
 For more information about the user delegation SAS, see [Create a user delegation SAS (REST API)](/rest/api/storageservices/create-user-delegation-sas).
 


### PR DESCRIPTION
Azure Storage customers frequently express confusion regarding the statement "A user delegation SAS applies to Blob storage only." and often inquire whether it applies only to Blob Storage and not to File, Table, or Queue Storage. Providing explicit clarification in the documentation would help prevent this confusion and better assist users.