### PR TITLE
Update durable-functions-azure-storage-provider.md

### DIFF
--- a/articles/azure-functions/durable/durable-functions-azure-storage-provider.md
+++ b/articles/azure-functions/durable/durable-functions-azure-storage-provider.md
@@ -243,7 +243,7 @@ As an example, if `durableTask/extendedSessionIdleTimeoutInSeconds` is set to 30
 The specific effects of extended sessions on orchestrator and entity functions are described in the next sections.
 
 > [!NOTE]
-> Extended sessions are currently only supported in .NET languages, like C# or F#. Setting `extendedSessionsEnabled` to `true` for other platforms can lead to runtime issues, such as silently failing to execute activity and orchestration-triggered functions.
+> Extended sessions are currently only supported in .NET languages, like C# (in-process model only) or F#. Setting `extendedSessionsEnabled` to `true` for other platforms can lead to runtime issues, such as silently failing to execute activity and orchestration-triggered functions.
 
 ### Orchestrator function replay
 


### PR DESCRIPTION
There's no equivalent of extended sessions in .NET isolated. Several customers with the setting enabled have seen errors after migrating from in-proc to isolated.