### PR TITLE
fix: Troubleshoot Azure RBAC limits

### DIFF
--- a/articles/role-based-access-control/includes/query/authorization-same-principal-scope-condition.md
+++ b/articles/role-based-access-control/includes/query/authorization-same-principal-scope-condition.md
@@ -7,7 +7,7 @@ ms.author: rolyon
 ---
 
 ```kusto
-AuthorizationResources
+authorizationresources
 | where type =~ "microsoft.authorization/roleassignments"
 | where id startswith "/subscriptions"
 | extend PrincipalId = tostring(properties.principalId) 
@@ -15,7 +15,7 @@ AuthorizationResources
 | extend RoleDefinitionId = tolower(tostring(properties.roleDefinitionId))
 | extend condition = tostring(properties.condition)
 | join kind = leftouter (
-  AuthorizationResources
+  authorizationresources
   | where type =~ "microsoft.authorization/roledefinitions"
   | extend RoleName = tostring(properties.roleName)
   | extend RoleId = tolower(id)

--- a/articles/role-based-access-control/includes/query/authorization-same-principal-scope.md
+++ b/articles/role-based-access-control/includes/query/authorization-same-principal-scope.md
@@ -7,14 +7,14 @@ ms.author: rolyon
 ---
 
 ```kusto
-AuthorizationResources
+authorizationresources
 | where type =~ "microsoft.authorization/roleassignments"
 | where id startswith "/subscriptions"
 | extend PrincipalId = tostring(properties.principalId) 
 | extend Scope = tolower(properties.scope)
 | extend RoleDefinitionId = tolower(tostring(properties.roleDefinitionId))
 | join kind = leftouter (
-  AuthorizationResources
+  authorizationresources
   | where type =~ "microsoft.authorization/roledefinitions"
   | extend RoleName = tostring(properties.roleName)
   | extend RoleId = tolower(id)

--- a/articles/role-based-access-control/includes/query/authorization-same-role-principal-condition.md
+++ b/articles/role-based-access-control/includes/query/authorization-same-role-principal-condition.md
@@ -21,7 +21,7 @@ authorizationresources
   | extend rdId = tolower(id)
   | project RoleDefinitionName, rdId
 ) on $left.RoleDefinitionId == $right.rdId
-| summarize count_ = count(), Scopes = make_set(tolower(properties.scope)) by RoleDefinitionId_PrincipalId,RoleDefinitionName
+| summarize count_ = count(), Scopes = make_set(tolower(properties.scope)) by RoleDefinitionId_PrincipalId,RoleDefinitionName, condition
 | project RoleDefinitionId = split(RoleDefinitionId_PrincipalId, "_", 0)[0], RoleDefinitionName, PrincipalId = split(RoleDefinitionId_PrincipalId, "_", 1)[0], count_, Scopes, condition
 | where count_ > 1
 | order by count_ desc

--- a/articles/role-based-access-control/includes/query/authorization-unused-custom-roles.md
+++ b/articles/role-based-access-control/includes/query/authorization-unused-custom-roles.md
@@ -7,13 +7,13 @@ ms.author: rolyon
 ---
 
 ```kusto
-AuthorizationResources
+authorizationresources
 | where type =~ "microsoft.authorization/roledefinitions"
 | where tolower(properties.type) == "customrole"
 | extend rdId = tolower(id)
 | extend Scope = tolower(properties.assignableScopes)
 | join kind = leftouter (
-AuthorizationResources
+authorizationresources
   | where type =~ "microsoft.authorization/roleassignments"
   | extend RoleId = tolower(tostring(properties.roleDefinitionId))
   | summarize RoleAssignmentCount = count() by RoleId


### PR DESCRIPTION
Provided fixes for:
- "Solution 2 - Remove Redundant Role Assignments" when using the conditions query. The `condition` column was missing in the `summarize` operator statement. 
- The name 'AuthorizationResources' does not refer to any known table, tabular variable or function. According to the [KQL entity naming rules](https://learn.microsoft.com/en-us/kusto/query/schema-entities/entity-names?view=microsoft-fabric#identifier-naming-rules), a table entity name is case-sensitive.
