### PR TITLE
Adding Note about session recording

### DIFF
--- a/articles/bastion/native-client.md
+++ b/articles/bastion/native-client.md
@@ -28,6 +28,8 @@ If you haven't already deployed Bastion to your VNet, you can deploy with the na
 
    :::image type="content" source="./media/native-client/standard.png" alt-text="Settings for a new bastion host with Standard SKU selected." lightbox="./media/native-client/standard.png":::
 1. Before you create the bastion host, go to the **Advanced** tab and check the box for **Native Client Support**, along with the checkboxes for any other features that you want to deploy.
+>[!NOTE]
+>[Session recording cannot be enabled](session-recording.md#before-you-begin) with Native Client Support.
 
    :::image type="content" source="./media/native-client/new-host.png" alt-text="Screenshot that shows settings for a new bastion host with Native Client Support box selected." lightbox="./media/native-client/new-host.png":::
 


### PR DESCRIPTION
Adding a note that session recording cannot be activated when enabling native client support.
With a link to current consideration and limitations.