### PR TITLE
Correct permissions needed to access the image

### DIFF
--- a/articles/dev-box/how-to-configure-azure-compute-gallery.md
+++ b/articles/dev-box/how-to-configure-azure-compute-gallery.md
@@ -91,11 +91,11 @@ When you create a generalized VM to capture to an image, the following issues ca
  
 1. Run `defrag` and `chkdsk` during image creation, then disable the `chkdisk` and `defrag` scheduled tasks. 
 
-## Provide permissions for services to access a gallery
+## Configure permissions to access a gallery
 
-When you use an Azure Compute Gallery image to create a dev box definition, the Windows 365 service validates the image to ensure that it meets the requirements to be provisioned for a dev box. Microsoft Dev Box replicates the image to the regions specified in the attached network connections, so the images are present in the region required for dev box creation.
+When you use an Azure Compute Gallery image to create a dev box definition, Microsoft Dev Box validates the image to ensure that it meets the requirements to be provisioned for a dev box. It also replicates the image to the regions specified in the attached network connections, so the images are present in the region required for dev box creation.
 
-To allow the services to perform these actions, you must provide permissions to your gallery as follows.
+To allow the service to perform these actions, you must provide permissions to your gallery as follows.
 
 ### Add a user-assigned identity to the dev center
 
@@ -118,27 +118,9 @@ To allow the services to perform these actions, you must provide permissions to 
 Microsoft Dev Box behaves differently depending how you attach your gallery:
 
 - When you use the Azure portal to attach the gallery to your dev center, the Dev Box service creates the necessary role assignments automatically after you attach the gallery.
-- When you use the Azure CLI to attach the gallery to your dev center, you must manually create the Windows 365 service principal and the dev center's managed identity role assignments before you attach the gallery.
+- When you use the Azure CLI to attach the gallery to your dev center, you must manually create the dev center's managed identity role assignments before you attach the gallery.
 
-Use the following steps to manually assign each role.
-
-#### Windows 365 service principal
-
-1. Sign in to the [Azure portal](https://portal.azure.com).
-
-1. In the search box, enter **Azure Compute Gallery**. In the list of results, select the gallery that you want to attach to the dev center.
-
-1. On the left menu, select **Access Control (IAM)**.
-
-1. Select **Add** > **Add role assignment**.
-
-1. Assign the following role. For detailed steps, see [Assign Azure roles using the Azure portal](../role-based-access-control/role-assignments-portal.yml).
-
-   | Setting | Value |
-   | --- | --- |
-   | **Role** | Select **Reader**. |
-   | **Assign access to** | Select **User, group, or service principal**. |
-   | **Members** | Search for and select **Windows 365**. |
+Use the following steps to manually assign the role.
 
 #### Managed identity for the dev center
 
@@ -156,7 +138,7 @@ Use the following steps to manually assign each role.
    | **Assign access to** | Select **Managed Identity**. |
    | **Members** | Search for and select the user-assigned managed identity that you created when you [added a user-assigned identity to the dev center](#add-a-user-assigned-identity-to-the-dev-center). |
 
-You can use the same managed identity in multiple dev centers and compute galleries. Any dev center with the managed identity added has the necessary permissions to the images in the gallery that has the Owner role assignment added.
+You can use the same managed identity in multiple dev centers and compute galleries. Any dev center with the managed identity added has the necessary permissions to the images in the gallery that has the Contributor role assignment added.
 
 ## Attach a gallery to a dev center
 


### PR DESCRIPTION
Windows 365 is not used anymore to access the customer's images. Devbox service delegates the DevCenter MSI to Windows 365, so it can use it to access the image (instead of using the Windows 365 application).

Updated the document accordingly.