### PR TITLE
fix: Removing old preview reference

### DIFF
--- a/articles/bastion/session-recording.md
+++ b/articles/bastion/session-recording.md
@@ -54,7 +54,7 @@ If you've already deployed Bastion, use the following steps to enable session re
 1. In the Azure portal, go to your Bastion resource.
 1. On your Bastion page, in the left pane, select **Configuration**.
 1. On the Configuration page, for Tier, select **Premium** if it isn't already selected. This feature requires the Premium SKU.
-1. Select **Session Recording (Preview)** from the listed features.
+1. Select **Session Recording** from the listed features.
 1. Select **Apply**. Bastion immediately begins updating the settings for your bastion host. Updates take about 10 minutes.
 
 ## Configure storage account container


### PR DESCRIPTION
Bastion preview was removed from the title 2 weeks ago : https://github.com/MicrosoftDocs/azure-docs/commit/dae0a7f1c3321d0f3b0854f1133701de1783292c

However the Preview reference is still further down the documentation.

This PR corrects that simple issue.