### PR TITLE
Updated Key Vault RBAC permission

### DIFF
--- a/includes/api-management-key-vault-access.md
+++ b/includes/api-management-key-vault-access.md
@@ -24,7 +24,7 @@ ms.author: danlep
 
     1. In the left menu, select **Access control (IAM)**.
     1. On the **Access control (IAM)** page, select **Add role assignment**.
-    1. On the **Role** tab, select **Key Vault Certificate User**.
+    1. On the **Role** tab, select **Key Vault Secrets User**.
     1. On the **Members** tab, select **Managed identity** > **+ Select members**.
     1. On the **Select managed identity** page, select the system-assigned managed identity or a user-assigned managed identity associated with your API Management instance, and then select **Select**.
     1. Select **Review + assign**.


### PR DESCRIPTION
This include appears in the following doc: https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-properties?tabs=azure-portal#configure-access-to-key-vault

This refers to adding Named Values to API Management using Key Vault. As Named Values in key vault can only be secrets the correct RBAC permissions is **Key Vault Secrets User** and not **Key Vault Certificate User**