### PR TITLE
Update shared-query-azure-cli.md

### DIFF
--- a/articles/governance/resource-graph/shared-query-azure-cli.md
+++ b/articles/governance/resource-graph/shared-query-azure-cli.md
@@ -124,14 +124,14 @@ You can verify the shared query works using Azure Resource Graph Explorer. To ch
 1. Select **Resource Graph Explorer**.
 1. Select **Open query**.
 1. Change **Type** to _Shared queries_.
-1. Select the query _Count VMs by OS_.
+1. Select the query _Summarize resources by location_.
 1. Select **Run query** and the view output in the **Results** tab.
 1. Select **Charts** and then select **Map** to view the location map.
 
 You can also run the query from your resource group. 
 
 1. In Azure, go to the resource group, _demoSharedQuery_.
-1. From the **Overview** tab, select the query _Count VMs by OS_.
+1. From the **Overview** tab, select the query _Summarize resources by location_.
 1. Select the **Results** tab.
 1. Select **Charts** and then select **Map** to view the location map.
 


### PR DESCRIPTION
query Count VMs by OS ---> query Summarize resources by location

The name of the query is different from the created one in this article.

![create_shared_query](https://github.com/user-attachments/assets/6cf289d0-c454-4b29-86be-81e14c53429c)

I went through the steps and "Summarize resources by location" appeared on the screen. Not "Count VMs by OS"

![query_name](https://github.com/user-attachments/assets/be91996d-9555-4268-8e80-744b37c9762d)

