### PR TITLE
Updated to explicitly call out no support for LACP or MLAG

### DIFF
--- a/articles/expressroute/expressroute-erdirect-about.md
+++ b/articles/expressroute/expressroute-erdirect-about.md
@@ -96,6 +96,9 @@ ExpressRoute Direct supports large data ingestion scenarios into services such a
     * Must support multiple BGP sessions (VLANs) per port and device
     * IPv4 and IPv6 connectivity. *For IPv6 no extra subinterface will be created. IPv6 address will be added to existing subinterface*. 
     * Optional: [Bidirectional Forwarding Detection (BFD)](./expressroute-bfd.md) support, which is configured by default on all Private Peerings on ExpressRoute circuits
+ 
+> [!NOTE]
+> ExpressRoute Direct does not support Link Aggregation Control Protocol (LACP) or Multi-Chassis Link Aggregation (MLAG)
 
 ## VLAN Tagging
 


### PR DESCRIPTION
The article does not state currently if LACP or MLAG is supported. Text updated to assist with customers designing ExpressRoute Direct services, to ensure its clearly called out (so there are no surprises when they try to connect the services and try to use LACP).