### PR TITLE
Update add-template-to-azure-pipelines.md

### DIFF
--- a/articles/azure-resource-manager/bicep/add-template-to-azure-pipelines.md
+++ b/articles/azure-resource-manager/bicep/add-template-to-azure-pipelines.md
@@ -81,7 +81,7 @@ You can use Azure Resource Group Deployment task or Azure CLI task to deploy a B
     - task: AzureResourceManagerTemplateDeployment@3
       inputs:
         deploymentScope: 'Resource Group'
-        azureSubscription: '${{ parameters.azureServiceConnection }}'
+        azureResourceManagerConnection: '${{ parameters.azureServiceConnection }}'
         action: 'Create Or Update Resource Group'
         resourceGroupName: '$(resourceGroupName)'
         location: '$(location)'


### PR DESCRIPTION
The `AzureResourceManagerTemplateDeployment@3` does not accept an input named `azureSubscription`.
It should be updated to `azureResourceManagerConnection`.

It still accepts the same input as before