### PR TITLE
Fix typo how-to-use-image-templates-web-sdk.md

### DIFF
--- a/articles/azure-maps/how-to-use-image-templates-web-sdk.md
+++ b/articles/azure-maps/how-to-use-image-templates-web-sdk.md
@@ -60,7 +60,7 @@ For the source code for this sample, see [Symbol layer with built-in icon templa
 
 ## Use an image template along a lines path
 
-Once an image template is loaded into the map image sprite, it can be rendered along the path of a line by adding a LineString to a data source and using a symbol layer with a `lineSpacing`option and by referencing the ID of the image resource in the `image` option of th `iconOptions`.
+Once an image template is loaded into the map image sprite, it can be rendered along the path of a line by adding a LineString to a data source and using a symbol layer with a `lineSpacing`option and by referencing the ID of the image resource in the `image` option of the `iconOptions`.
 
 The [Line layer with built-in icon template] demonstrates how to do this. As show in the following screenshot, it renders a red line on the map and uses a symbol layer using the `car` image template with a dodger blue primary color and a white secondary color. For the source code for this sample, see [Line layer with built-in icon template sample code].
 


### PR DESCRIPTION
Fixed a small typo, changing "th" to "the".