### PR TITLE
Update policy-resources-exemption-query.md

### DIFF
--- a/articles/governance/includes/policy/policy-resources-exemption-query.md
+++ b/articles/governance/includes/policy/policy-resources-exemption-query.md
@@ -51,7 +51,7 @@ PolicyResources
 | extend expiresOnC = todatetime(properties.expiresOn)
 | where isnotnull(expiresOnC)
 | where expiresOnC >= now() and expiresOnC < now(+90d)
-| project name, expiresOnC
+| project properties.displayName, expiresOnC
 ```
 
 # [Azure CLI](#tab/azure-cli)


### PR DESCRIPTION
Hello, the original (project name, expiresOnC) query output is not the name of the exemption that I set on the exemption (on the portal).  However, the modified query output returns the correct value.