### PR TITLE
Fix generation of storage account name

### DIFF
--- a/articles/dns/dns-traffic-log-how-to.md
+++ b/articles/dns/dns-traffic-log-how-to.md
@@ -239,7 +239,7 @@ Set up a local PowerShell repository and install the Az.DnsResolver PowerShell m
     $domainListName = "domainlist-$($nameSuffix)"
     $securityRuleName = "securityrule-$($nameSuffix)"
     $resolverPolicyLinkName = "dnsresolverpolicylink"
-    $storageAccountName = "stor-$($name)" # Customize this, taking care that the name is not too long
+    $storageAccountName = "stor$($name)" # Customize this, taking care that the name is not too long
     $diagnosticSettingName = "diagnosticsetting-$($nameSuffix)"
     $vnetId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Network/virtualNetworks/$virtualNetworkName"
 

--- a/articles/dns/dns-traffic-log-how-to.md
+++ b/articles/dns/dns-traffic-log-how-to.md
@@ -239,7 +239,8 @@ Set up a local PowerShell repository and install the Az.DnsResolver PowerShell m
     $domainListName = "domainlist-$($nameSuffix)"
     $securityRuleName = "securityrule-$($nameSuffix)"
     $resolverPolicyLinkName = "dnsresolverpolicylink"
-    $storageAccountName = "stor$($name)" # Customize this, taking care that the name is not too long
+    $storageAccountName = "stor$($name.ToLower())"  # Customize this, taking care that the name is not too long
+    $storageAccountName = $storageAccountName.Substring(0, [Math]::Min(24, $storageAccountName.Length)) # Storage account names must be 3-24 characters long
     $diagnosticSettingName = "diagnosticsetting-$($nameSuffix)"
     $vnetId = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.Network/virtualNetworks/$virtualNetworkName"
 


### PR DESCRIPTION
Storage account names only support lowercase letters and digits. Maximum length is 24 characters.