### PR TITLE
Add missing download build artifact step 

### DIFF
--- a/articles/azure-functions/functions-how-to-azure-devops.md
+++ b/articles/azure-functions/functions-how-to-azure-devops.md
@@ -202,7 +202,14 @@ variables:
   # Agent VM image name
   vmImageName: 'ubuntu-latest'
 
-- task: AzureFunctionApp@1 # Add this at the end of your file
+- task: DownloadBuildArtifacts@1 # Add this at the end of your file
+  inputs:
+    buildType: 'current'
+    downloadType: 'single'
+    artifactName: 'drop'
+    itemPattern: '**/*.zip'
+    downloadPath: '$(System.ArtifactsDirectory)'
+- task: AzureFunctionApp@1
   inputs:
     azureSubscription: <Azure service connection>
     appType: functionAppLinux # default is functionApp


### PR DESCRIPTION
Added missing pipeline step that downloads build artifact. This solves "No package found" error in deployment process.

Reference used: [Azure DevOps Function App Deployment "No package found"](https://sterl.org/2023/03/azure-devops-function-app-deployment-no-package-found/)