### PR TITLE
Remove extraneous trailing colons

### DIFF
--- a/articles/automation/automation-webhooks.md
+++ b/articles/automation/automation-webhooks.md
@@ -312,7 +312,7 @@ This example uses the PowerShell cmdlet [Invoke-WebRequest](/powershell/module/m
     $body = ConvertTo-Json -InputObject $Names
     ```
 
-1. For larger sets, you may wish to use a file. Create a file named `names.json` and then paste the following code::
+1. For larger sets, you may wish to use a file. Create a file named `names.json` and then paste the following code:
 
     ```json
     [

--- a/articles/backup/azure-kubernetes-service-backup-troubleshoot.md
+++ b/articles/backup/azure-kubernetes-service-backup-troubleshoot.md
@@ -82,7 +82,7 @@ This error appears due to absence of these FQDN rules because of which configura
 
 **Resolution**: To resolve the issue, you need to create a *CoreDNS-custom override* for the *DP* endpoint to pass through the public network.
 
-1. Get Existing CoreDNS-custom YAML in your cluster (save it on your local for reference later)::
+1. Get Existing CoreDNS-custom YAML in your cluster (save it on your local for reference later):
 
    ```azurecli-interactive
    kubectl get configmap coredns-custom -n kube-system -o yaml

--- a/articles/reliability/reliability-health-data-services-deidentification.md
+++ b/articles/reliability/reliability-health-data-services-deidentification.md
@@ -19,7 +19,7 @@ This article describes reliability support in the de-identification service (pre
 
 [!INCLUDE [introduction to disaster recovery](includes/reliability-disaster-recovery-description-include.md)]
 
-Each de-identification service (preview) is deployed to a single Azure region. If an entire region is not available or performance is significantly degraded::
+Each de-identification service (preview) is deployed to a single Azure region. If an entire region is not available or performance is significantly degraded:
 - ARM control plane functionality is limited to read-only during the outage. Your service metadata (such as resource properties) is always backed up outside of the region by Microsoft. Once the outage is over, you can read and write to the control plane.
 - All data plane requests fail during the outage, such as de-identification or job API requests. No customer data is lost, but there's the potential for job progress metadata to be lost. Once the outage is over, you can read and write to the data plane.
 

--- a/articles/storage/blobs/storage-quickstart-blobs-go.md
+++ b/articles/storage/blobs/storage-quickstart-blobs-go.md
@@ -80,7 +80,7 @@ You can authorize access to data in your storage account using the following ste
     az login
     ```
 
-2. To use `DefaultAzureCredential` in a Go application, install the [azidentity](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity) module using the following command::
+2. To use `DefaultAzureCredential` in a Go application, install the [azidentity](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity) module using the following command:
 
     ```console
     go get github.com/Azure/azure-sdk-for-go/sdk/azidentity


### PR DESCRIPTION
Remove a bunch of extraneous trailing colons and add missing trailing newline for `articles/reliability/reliability-health-data-services-deidentification.md`.