### PR TITLE
Update data-box-next-gen-quickstart-portal.md

### DIFF
--- a/articles/databox/data-box-next-gen-quickstart-portal.md
+++ b/articles/databox/data-box-next-gen-quickstart-portal.md
@@ -108,7 +108,7 @@ When you receive the Data Box, perform the following steps to cable, connect, an
 
     1. Connect the power cable to the device.
     2. Use the RJ-45 CAT 6 network cable to connect your host computer to the management port (MGMT) on the device. 
-    3. Use the QSFP28 copper cable to connect at least one 100 Gbps (preferred over 10 Gbps or 1 Gbps) network interface, DATA 1 or DATA 2 for data. 
+    3. Use at least one 100 Gbps (preferred over 10 Gbps or 1 Gbps) QSFP28 copper cable to connect to network interface, DATA 1 or DATA 2 for data. 
     4. Turn on the device. The power button is on the front panel of the device.
 
 


### PR DESCRIPTION
Use the QSFP28 copper cable to connect at least one 100 Gbps (preferred over 10 Gbps or 1 Gbps) network interface, DATA 1 or DATA 2 for data. --->
Use at least one 100 Gbps (preferred over 10 Gbps or 1 Gbps) QSFP28 copper cable to connect to network interface, DATA 1 or DATA 2 for data.


The original sentence seems that "100 Gbps (preferred over 10 Gbps or 1 Gbps)" is describing about "network interface, DATA 1 or DATA 2 for data" at a glance.
It (i.e. 100 Gbps preferred over 10 Gbps or 1 Gbps) must be, however, describing about "QSFP28 copper cable", because DATA 1 and DATA 2 is specifically defined as "2 X 100-GbE".  I suggest to change the word order of this sentence, otherwise it's confusing to readers.

If my understanding is not correct, then you can just abandon this PR.