### PR TITLE
Updated cost section

### DIFF
--- a/articles/reliability/reliability-app-service.md
+++ b/articles/reliability/reliability-app-service.md
@@ -103,7 +103,7 @@ Applications that are deployed in a zone-redundant App Service plan continue to 
 
 ::: zone pivot="premium"
 
-When you're using App Service Premium v2 or Premium v3 plans, there's no additional cost associated with enabling availability zones as long as you have three or more instances in your App Service plan. You'll be charged based on your App Service plan SKU, the capacity you specify, and any instances you scale to based on your autoscale criteria. If you enable availability zones but specify a capacity less than three, the platform enforces a minimum instance count of three and charges you for those three instances.
+When you're using App Service Premium v2 or Premium v3 plans, there's no additional cost associated with enabling availability zones as long as you have three or more instances in your App Service plan. You'll be charged based on your App Service plan SKU, the capacity you specify, and any instances you scale to based on your autoscale criteria.
 
 ::: zone-end
 


### PR DESCRIPTION
I beleive this part of the documention is misleading. 
If you create the app service plan using the portal - it will auto scale to three instances.
If you create the app service plan using bicep - it will not auto scale to three instances.

