### PR TITLE
Add "Locks Contributor" Built-in Role to Security

### DIFF
--- a/articles/role-based-access-control/built-in-roles.md
+++ b/articles/role-based-access-control/built-in-roles.md
@@ -436,6 +436,7 @@ The following table provides a brief description of each built-in role. Click th
 > | <a name='security-assessment-contributor'></a>[Security Assessment Contributor](./built-in-roles/security.md#security-assessment-contributor) | Lets you push assessments to Microsoft Defender for Cloud | 612c2aa1-cb24-443b-ac28-3ab7272de6f5 |
 > | <a name='security-manager-legacy'></a>[Security Manager (Legacy)](./built-in-roles/security.md#security-manager-legacy) | This is a legacy role. Please use Security Admin instead. | e3d13bf0-dd5a-482e-ba6b-9b8433878d10 |
 > | <a name='security-reader'></a>[Security Reader](./built-in-roles/security.md#security-reader) | View permissions for Microsoft Defender for Cloud. Can view recommendations, alerts, a security policy, and security states, but cannot make changes.<br><br>For Microsoft Defender for IoT, see [Azure user roles for OT and Enterprise IoT monitoring](/azure/defender-for-iot/organizations/roles-azure). | 39bc4728-0917-49c7-9d2c-d95423bc2eb4 |
+> | <a name='locks-contributor'></a>[Locks Contributor](./built-in-roles/security.md#locks-contributor) | Lets you manage locks operations | 28bf596f-4eb7-45ce-b5bc-6cf482fec137 |
 
 ## DevOps
 

--- a/articles/role-based-access-control/built-in-roles/security.md
+++ b/articles/role-based-access-control/built-in-roles/security.md
@@ -1555,6 +1555,48 @@ View permissions for Microsoft Defender for Cloud. Can view recommendations, ale
   "type": "Microsoft.Authorization/roleDefinitions"
 }
 ```
+## Locks Contributor
+
+Lets you manage locks operations
+
+> [!div class="mx-tableFixed"]
+> | Actions | Description |
+> | --- | --- |
+> | [Microsoft.Authorization](../permissions/management-and-governance.md#microsoftauthorization)/locks/read | Gets locks at the specified scope |
+> | [Microsoft.Authorization](../permissions/management-and-governance.md#microsoftauthorization)/locks/write | Add locks at the specified scope |
+> | [Microsoft.Authorization](../permissions/management-and-governance.md#microsoftauthorization)/locks/delete | Delete locks at the specified scope |
+> | **NotActions** |  |
+> | *none* |  |
+> | **DataActions** |  |
+> | *none* |  |
+> | **NotDataActions** |  |
+> | *none* |  |
+
+```json
+{
+  "assignableScopes": [
+    "/"
+  ],
+  "description": "Can Manage Locks Operations.",
+  "id": "/providers/Microsoft.Authorization/roleDefinitions/28bf596f-4eb7-45ce-b5bc-6cf482fec137",
+  "name": "28bf596f-4eb7-45ce-b5bc-6cf482fec137",
+  "permissions": [
+    {
+      "actions": [
+        "Microsoft.Authorization/locks/read",
+        "Microsoft.Authorization/locks/write",
+        "Microsoft.Authorization/locks/delete"
+      ],
+      "notActions": [],
+      "dataActions": [],
+      "notDataActions": []
+    }
+  ],
+  "roleName": "Locks Contributor",
+  "roleType": "BuiltInRole",
+  "type": "Microsoft.Authorization/roleDefinitions"
+}
+```
 
 ## Next steps
 

--- a/articles/role-based-access-control/built-in-roles/security.md
+++ b/articles/role-based-access-control/built-in-roles/security.md
@@ -1557,7 +1557,7 @@ View permissions for Microsoft Defender for Cloud. Can view recommendations, ale
 ```
 ## Locks Contributor
 
-Lets you manage locks operations
+Manage locks operations.
 
 > [!div class="mx-tableFixed"]
 > | Actions | Description |


### PR DESCRIPTION
This PR introduces the addition of the **"Locks Contributor"** built-in role within Security. The role allows users to manage Azure resource locks, providing them with the necessary permissions to perform lock-related operations on resources.

This PR updates the built-in-roles.md and security.md documentation to reflect the addition of the "Locks Contributor" built-in role and its associated permissions.

#### Key Additions:
- **Permissions Added:**
  - **Read** (`Microsoft.Authorization/locks/read`): Allows users to view the properties of locks on resources.
  - **Write** (`Microsoft.Authorization/locks/write`): Enables users to create or modify locks on resources.
  - **Delete** (`Microsoft.Authorization/locks/delete`): Grants the ability to remove locks from resources.

#### Purpose:
The "Locks Contributor" role is for users who need to manage resource locks without giving them full control over the resources themselves. This ensures a more granular level of access.