### PR TITLE
Update test-locally-with-service-bus-emulator.md

### DIFF
--- a/articles/service-bus-messaging/test-locally-with-service-bus-emulator.md
+++ b/articles/service-bus-messaging/test-locally-with-service-bus-emulator.md
@@ -214,7 +214,7 @@ CONFIG_PATH="<Replace with path to Config.json file>"
 ACCEPT_EULA="N"
 
 # 3. MSSQL_SA_PASSWORD to be filled by user as per policy : https://learn.microsoft.com/sql/relational-databases/security/strong-passwords?view=sql-server-linux-ver16 
-MSSQL_SA_PASSWORD: ""
+MSSQL_SA_PASSWORD=""
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
This pull request includes a small change to the `articles/service-bus-messaging/test-locally-with-service-bus-emulator.md` file. The change corrects the syntax for setting the `MSSQL_SA_PASSWORD` environment variable.

* [`articles/service-bus-messaging/test-locally-with-service-bus-emulator.md`](diffhunk://#diff-581d11d8355756bba2ff3643bba41d5e021d11dd07f8623cf953d850bcc771b0L217-R217): Corrected the syntax for setting the `MSSQL_SA_PASSWORD` environment variable by removing the colon and ensuring it is set correctly.