### PR TITLE
CSS-Networking: Bastion Document Update troubleshoot.md

### DIFF
--- a/articles/bastion/troubleshoot.md
+++ b/articles/bastion/troubleshoot.md
@@ -82,7 +82,7 @@ Microsoft.Security/locations/jitNetworkAccessPolicies/write | Creates a new just
 
 **Q:** Is file transfer supported with Azure Bastion?
 
-**A:** File transfer isn't supported at this time. We're working on adding support.
+**A:** Azure Bastion offers support for file transfer between your target VM and local computer using Bastion and a native RDP or SSH client. At this time, you can’t upload or download files using PowerShell or via the Azure portal. For more information, see [Upload and download files using the native client](https://learn.microsoft.com/en-us/azure/bastion/vm-upload-download-native).
 
 ## <a name="blackscreen"></a>Black screen in the Azure portal
 

--- a/articles/bastion/troubleshoot.md
+++ b/articles/bastion/troubleshoot.md
@@ -82,7 +82,7 @@ Microsoft.Security/locations/jitNetworkAccessPolicies/write | Creates a new just
 
 **Q:** Is file transfer supported with Azure Bastion?
 
-**A:** Azure Bastion offers support for file transfer between your target VM and local computer using Bastion and a native RDP or SSH client. At this time, you can’t upload or download files using PowerShell or via the Azure portal. For more information, see [Upload and download files using the native client](https://learn.microsoft.com/en-us/azure/bastion/vm-upload-download-native).
+**A:** Azure Bastion offers support for file transfer between your target VM and local computer using Bastion and a native RDP or SSH client. At this time, you can't upload or download files using PowerShell or via the Azure portal. For more information, see [Upload and download files using the native client](./vm-upload-download-native.md).
 
 ## <a name="blackscreen"></a>Black screen in the Azure portal
 


### PR DESCRIPTION
This document https://learn.microsoft.com/en-us/azure/bastion/troubleshoot#filetransfer need to be updated as content "File transfer isn't supported at this time. We're working on adding support." is outdated now. We support file transfer for bastion and its mentioned correctly in other doc https://learn.microsoft.com/en-us/azure/bastion/bastion-faq#file-transfer.

So here we need to replace this 
**"File transfer isn't supported at this time. We're working on adding support."**
with this 
**"Azure Bastion offers support for file transfer between your target VM and local computer using Bastion and a native RDP or SSH client. At this time, you can’t upload or download files using PowerShell or via the Azure portal. For more information, see Upload and download files using the native client."**

Document URL (needs to be updated) - https://learn.microsoft.com/en-us/azure/bastion/troubleshoot#filetransfer

Document URL (already updated) - https://learn.microsoft.com/en-us/azure/bastion/bastion-faq#file-transfer