### PR TITLE
Overwrite disclaimer

### DIFF
--- a/articles/container-apps/ingress-overview.md
+++ b/articles/container-apps/ingress-overview.md
@@ -64,7 +64,7 @@ HTTP ingress adds headers to pass metadata about the client request to your cont
 | Header | Description | Values |
 |---|---|---|
 | `X-Forwarded-Proto` | Protocol used by the client to connect with the Container Apps service. | `http` or `https` |
-| `X-Forwarded-For` | The IP address of the client that sent the request. |  |
+| `X-Forwarded-For` | The IP address of the client that sent the request. | IP address of the sender. If specified in intital request, it will be overwritten. |
 | `X-Forwarded-Host` | The host name the client used to connect with the Container Apps service. |  |
 | `X-Forwarded-Client-Cert` | The client certificate if `clientCertificateMode` is set. | Semicolon separated list of Hash, Cert, and Chain. For example: `Hash=....;Cert="...";Chain="...";` |
 


### PR DESCRIPTION
When using `http` ingress on `azure container apps`, the `X-Forwarded-For` header gets overwritten.

The disclaimer in the documentation will clearly state that.