### PR TITLE
Updating Custom Image Docs for Clarity, pointing to Terraform Resources

### DIFF
--- a/articles/deployment-environments/how-to-configure-extensibility-model-custom-image.md
+++ b/articles/deployment-environments/how-to-configure-extensibility-model-custom-image.md
@@ -87,7 +87,7 @@ The following example shows a `runner` that references the sample ARM-Bicep cont
     runner: Bicep
     templatePath: azuredeploy.json
 ```
-You can see the sample Bicep container image in the ADE sample repository under the [Runner-Images folder for the ARM-Bicep](https://github.com/Azure/deployment-environments/tree/main/Runner-Images/ARM-Bicep) image, or view the sample Terraform image .
+You can see the sample Bicep container image in the ADE sample repository under the [Runner-Images folder for the ARM-Bicep](https://github.com/Azure/deployment-environments/tree/main/Runner-Images/ARM-Bicep) image.
 
 For more information about how to create environment definitions that use the ADE container images to deploy your Azure resources, see [Add and configure an environment definition](configure-environment-definition.md).
 ::: zone-end

--- a/articles/deployment-environments/how-to-configure-extensibility-model-custom-image.md
+++ b/articles/deployment-environments/how-to-configure-extensibility-model-custom-image.md
@@ -87,7 +87,7 @@ The following example shows a `runner` that references the sample ARM-Bicep cont
     runner: Bicep
     templatePath: azuredeploy.json
 ```
-You can see the sample Bicep container image in the ADE sample repository under the [Runner-Images folder for the ARM-Bicep](https://github.com/Azure/deployment-environments/tree/main/Runner-Images/ARM-Bicep) image.
+You can see the sample Bicep container image in the ADE sample repository under the [Runner-Images folder for the ARM-Bicep](https://github.com/Azure/deployment-environments/tree/main/Runner-Images/ARM-Bicep) image, or view the sample Terraform image .
 
 For more information about how to create environment definitions that use the ADE container images to deploy your Azure resources, see [Add and configure an environment definition](configure-environment-definition.md).
 ::: zone-end
@@ -225,7 +225,7 @@ To install any more packages you need within your image, use the RUN statement.
 
 Within the sample images, operations are determined and executed based on the operation name. Currently, the two operation names supported are *deploy* and *delete*.
 
-To set up your custom image to utilize this structure, specify a folder at the level of your Dockerfile named *scripts*, and specify two files, *deploy.sh*, and *delete.sh*. The deploy shell script runs when your environment is created or redeployed, and the delete shell script runs when your environment is deleted. You can see examples of shell scripts in the repository under the [Runner-Images folder for the ARM-Bicep](https://github.com/Azure/deployment-environments/tree/main/Runner-Images/ARM-Bicep) image.
+To set up your custom image to utilize this structure, specify a folder at the level of your Dockerfile named *scripts*, and specify two files, *deploy.sh*, and *delete.sh*. The deploy shell script runs when your environment is created or redeployed, and the delete shell script runs when your environment is deleted. You can see examples of shell scripts in the repository under the [Runner-Images folder for the ARM-Bicep](https://github.com/Azure/deployment-environments/tree/main/Runner-Images/ARM-Bicep) image, or in the [scripts folder for Terraform](https://github.com/Azure/ade-extensibility-model-terraform/tree/main/scripts).
 
 To ensure these shell scripts are executable, add the following lines to your Dockerfile:
 
@@ -353,6 +353,7 @@ There are three steps to deploy infrastructure via Terraform:
 
 During the core image's entrypoint, any existing state files are pulled into the container and the directory saved under the environment variable ```$ADE_STORAGE```. Additionally, any parameters set for the current environment stored under the variable ```$ADE_OPERATION_PARAMETERS```. In order to access the existing state file, and set your variables within a *.tfvars.json* file, run the following commands:
 ```bash
+set -e #set script to exit on error
 EnvironmentState="$ADE_STORAGE/environment.tfstate"
 EnvironmentPlan="/environment.tfplan"
 EnvironmentVars="/environment.tfvars.json"


### PR DESCRIPTION
Adding a line when building the custom image for Terraform in section 3 to point the user to the sample repository with scripts, and adding a line to the custom image build walkthrough to allow the created shell script to exit on an error.