### PR TITLE
Update Azure Queue storage trigger for Azure Functions to fix wrong instructions for local development

### DIFF
--- a/articles/azure-functions/functions-reference.md
+++ b/articles/azure-functions/functions-reference.md
@@ -269,7 +269,9 @@ The environment variables associated with the Azure SDK's [`EnvironmentCredentia
 > [!NOTE]
 > Local development with identity-based connections requires version `4.0.3904` of [Azure Functions Core Tools](functions-run-local.md), or a later version.
 
-When you're running your function project locally, the above configuration tells the runtime to use your local developer identity. The connection attempts to get a token from the following locations, in order:
+When you're running your function project locally with credential set to `managedidentity`, the runtime will attempt to use the managed identity endpoint, which is not available in local development environments. For local development, you should use `defaultazurecredential` instead.
+
+With this configuration, the connection attempts to get a token from the following locations, in order:
 
 - A local cache shared between Microsoft applications
 - The current user context in Visual Studio


### PR DESCRIPTION
The documentation states that: 

_When you're running your function project locally, the above configuration tells the runtime to use your local developer identity. The connection attempts to get a token from the following locations, in order:
- A local cache shared between Microsoft applications
- The current user context in Visual Studio
- The current user context in Visual Studio Code
- The current user context in the Azure CLI_

In the aforementioned section, the "above configuration" most likely refers to this part of the article:  
>
Token Credential | <CONNECTION_NAME_PREFIX>__credential | Defines how a token should be obtained for the connection. This setting should be set to managedidentity if your deployed Azure Function intends to use managed identity authentication. This value is only valid when a managed identity is available in the hosting environment.
-- | -- | --

However, using this value locally doesn't work and the following error message is returned by the azure function runtime: 
`Azure.Identity: ManagedIdentityCredential authentication unavailable. Multiple attempts failed to obtain a token from the managed identity endpoint. Azure.Core: Retry failed after 6 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy. (A socket operation was attempted to an unreachable network. (169.254.169.254:80))`, indicating that the local environment is trying to connect to the managed identity endpoint located at 169.254.169.254:80.

However, using the value `defaultazurecredential` instead of `managedidentity` for the `<CONNECTION_NAME_PREFIX>__credential` property proved to be working as expected and shows the behaviour currently expected from the documentation, i.e., 

_The connection attempts to get a token from the following locations, in order:
- A local cache shared between Microsoft applications
- The current user context in Visual Studio
- The current user context in Visual Studio Code
- The current user context in the Azure CLI_

Thank you in advance for processing.