### PR TITLE
Replacement PR: Spelling Fixes #125147

### DIFF
--- a/articles/modeling-simulation-workbench/how-to-guide-private-network.md
+++ b/articles/modeling-simulation-workbench/how-to-guide-private-network.md
@@ -7,7 +7,7 @@ ms.service: azure-modeling-simulation-workbench
 ms.topic: how-to
 ms.date: 09/21/2024
 
-#CustomerIntent: As a Workench Owner for Azure Modeling and Simulation Workbench, I want to deploy a connector onto a private virtual network.
+#CustomerIntent: As a Workbench Owner for Azure Modeling and Simulation Workbench, I want to deploy a connector onto a private virtual network.
 ---
 
 # Set up a private networking connector

--- a/articles/operator-service-manager/best-practices-onboard-deploy.md
+++ b/articles/operator-service-manager/best-practices-onboard-deploy.md
@@ -280,7 +280,7 @@ As the first step towards cleaning up a deployed environment, start by deleting 
 - Site
 - CGV
 
-Only once these operator resources are succesfully deleted, should a user proceed to delete other environment resources, such as the NAKS cluster.
+Only once these operator resources are successfully deleted, should a user proceed to delete other environment resources, such as the NAKS cluster.
 
 > [!IMPORTANT]
 > Deleting resources out of order can result in orphaned resources left behind.
@@ -305,7 +305,7 @@ As the first step towards cleaning up an onboarded environment, start by deletin
 ## NfApp Sequential Ordering Behavior
 
 ### Overview
-By default, containerized network function applications (NfApps) are installed or updated based on the sequential order in which they appear in the network function design version (NFDV). For delete, the NfApps are deleted in the reverse order sepcified. Where a publisher needs to define specific ordering of NfApps, different from the default, a dependsOnProfile is used to define a unique sequence for install, update and delete operations.
+By default, containerized network function applications (NfApps) are installed or updated based on the sequential order in which they appear in the network function design version (NFDV). For delete, the NfApps are deleted in the reverse order specified. Where a publisher needs to define specific ordering of NfApps, different from the default, a dependsOnProfile is used to define a unique sequence for install, update and delete operations.
 
 ### How to use dependsOnProfile
 A publisher can use the dependsOnProfile in the NFDV to control the sequence of helm executions for NfApps. Given the following example, on install operation the NfApps will be deployed in the following order: dummyApplication1, dummyApplication2, then dummyApplication. On update operation, the NfApps will be updated in the following order: dummyApplication2, dummyApplication1, then dummyApplication. On delete operation, the NfApps will be deleted in the following order: dummyApplication2, dummyApplication1, then dummyApplication.
@@ -374,10 +374,10 @@ As of today, if dependsOnProfile provided in the NFDV is invalid, the NF operati
 }
 ```
 ## injectArtifactStoreDetails considerations
-In some cases, third-party helm charts maynot be fully compliant with AOSM requirements for registryURL. In this case, the injectArtifactStoreDetails feature can be used to avoid making changes to helm packages.
+In some cases, third-party helm charts may not be fully compliant with AOSM requirements for registryURL. In this case, the injectArtifactStoreDetails feature can be used to avoid making changes to helm packages.
 
 ### How to enable
-To use injectArtifactStoreDetails, set the installOptions parameter in the NF resource roleOrverrides section to true, then use whatever registryURL value is needed to keep the registry URL valid. See following example of injectArtifactStoreDetails parameter enabled.
+To use injectArtifactStoreDetails, set the installOptions parameter in the NF resource roleOverrides section to true, then use whatever registryURL value is needed to keep the registry URL valid. See following example of injectArtifactStoreDetails parameter enabled.
 
 ```bash
 resource networkFunction 'Microsoft.HybridNetwork/networkFunctions@2023-09-01' = {

--- a/articles/operator-service-manager/get-started-with-cluster-registry.md
+++ b/articles/operator-service-manager/get-started-with-cluster-registry.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with Azure Operator Service Manager cluster registry
-description: Azure Operator Service Manager cluster registry provides a locally resilent edge registry service to host Nexus K8s container image artifacts.
+description: Azure Operator Service Manager cluster registry provides a locally resilient edge registry service to host Nexus K8s container image artifacts.
 author: msftadam
 ms.author: adamdor
 ms.date: 10/31/2024
@@ -109,7 +109,7 @@ The following parameters configure the schedule and threshold for the garbage co
 ## High availability and resiliency considerations 
 The AOSM NF extension relies uses a mutating webhook and edge registry to support key features. 
 * Onboarding helm charts without requiring customization of image path.
-* A local cluster registry to accelerate pod operations and enable disconnected-moded support.
+* A local cluster registry to accelerate pod operations and enable disconnected-mode support.
 These essential components need to be highly available and resilient.
 
 ### Summary of changes for HA

--- a/articles/operator-service-manager/get-started-with-private-link.md
+++ b/articles/operator-service-manager/get-started-with-private-link.md
@@ -53,7 +53,7 @@ Before resources can be uploaded securely, the following sequence of operations 
 ### Create publisher and artifact store
 * Create a new publisher resource with identity type set to 'SystemAssigned.'
   - If the publisher was already created without this property, use a reput operation to update.
-* Use the new property 'backingResourcePublicNetworkAcccess' to disable artifact store public access.
+* Use the new property 'backingResourcePublicNetworkAccess' to disable artifact store public access.
   - The property is first added in the 2024-04-15 version.
   - If the ArtifactResource was already created without this property, use a reput operation to update.
 
@@ -120,7 +120,7 @@ az rest --method post --url https://management.azure.com/subscriptions/<Subscrip
 ```
 ```
 # remove private endpoints
-az rest --method post --url https://management.azure.com/subscriptions/<Subscription>/resourceGroups/<ResourceGroup>/providers/Microsoft.HybridNetwork/publishers/<Publisher>/artifactStores/<ArtifactStore>/removeprivateendpoints?api-version=2024-04-15 --body '{ \"manualPrivateEndPointConnections\" : [ { \"id\" : \"/subscriptions/<Subscription>/resourceGroups/<ReourceGroup>/providers/Microsoft.Network/privateEndpoints/peName\" } ] }'
+az rest --method post --url https://management.azure.com/subscriptions/<Subscription>/resourceGroups/<ResourceGroup>/providers/Microsoft.HybridNetwork/publishers/<Publisher>/artifactStores/<ArtifactStore>/removeprivateendpoints?api-version=2024-04-15 --body '{ \"manualPrivateEndPointConnections\" : [ { \"id\" : \"/subscriptions/<Subscription>/resourceGroups/<ResourceGroup>/providers/Microsoft.Network/privateEndpoints/peName\" } ] }'
 ```
 ```
 # list private endpoints

--- a/articles/operator-service-manager/manage-network-function-operator.md
+++ b/articles/operator-service-manager/manage-network-function-operator.md
@@ -157,7 +157,7 @@ The referenced matchCondition implies that the pods getting accepted in kube-sys
 * Default value: "0 0 * * *" -- Runs the job once everyday.
 
 `--config global.networkfunctionextension.clusterRegistry.clusterRegistryGCThreshold=`
-* This configuration specifies the precent threshold value to trigger the cluster registry garbage collection process.
+* This configuration specifies the percent threshold value to trigger the cluster registry garbage collection process.
 * This configuration triggers garbage collection process when cluster registry usage exceeds this value.
 * Default value: 0.
 

--- a/articles/operator-service-manager/quickstart-publish-containerized-network-function-definition.md
+++ b/articles/operator-service-manager/quickstart-publish-containerized-network-function-definition.md
@@ -120,7 +120,7 @@ Execute the following command to publish the Network Function Definition (NFD) a
 >
 >If you get an error saying "**A private publisher resource with the name 'nginx-publisher' already exists in the provided region**", edit the `publisher_name` field in the config file so that it is unique (e.g. add a random string suffix), re-run the `build` command (above), and then re-run this `publish` command.
 >
->If you go on to create a network service design, you will need to use this new pubilsher name in the `resource_element_templates` array.
+>If you go on to create a network service design, you will need to use this new publisher name in the `resource_element_templates` array.
 
 ```azurecli
 az aosm nfd publish -b cnf-cli-output --definition-type cnf

--- a/articles/operator-service-manager/quickstart-publish-virtualized-network-function-definition.md
+++ b/articles/operator-service-manager/quickstart-publish-virtualized-network-function-definition.md
@@ -162,7 +162,7 @@ Execute the following command to publish the Network Function Definition (NFD) a
 >
 >If you get an error saying "**A private publisher resource with the name 'ubuntu-publisher' already exists in the provided region**", edit the `publisher_name` field in the config file so that it is unique (e.g. add a random string suffix), re-run the `build` command (above), and then re-run this `publish` command.
 >
->If you go on to create a network service design, you will need to use this new pubilsher name in the `resource_element_templates` array.
+>If you go on to create a network service design, you will need to use this new publisher name in the `resource_element_templates` array.
 
 ```azurecli
 az aosm nfd publish --build-output-folder vnf-cli-output --definition-type vnf

--- a/articles/operator-service-manager/safe-upgrades-nf-level-rollback.md
+++ b/articles/operator-service-manager/safe-upgrades-nf-level-rollback.md
@@ -14,7 +14,7 @@ ms.service: azure-operator-service-manager
 This guide describes the Azure Operator Service Manager (AOSM) upgrade failure behavior features for container network functions (CNFs). These features, as part of the AOSM safe upgrade practices initiative, offer a choice between faster retries, with pause on failure, versus return to starting point, with rollback on failure.
 
 ## Pause on failure
-Any upgrade using AOSM starts with a site network service (SNS) reput opreation. The reput operation processes the network function applications (NfApps) found in the network function design version (NFDV). The reput operation implements the following default logic:
+Any upgrade using AOSM starts with a site network service (SNS) reput operation. The reput operation processes the network function applications (NfApps) found in the network function design version (NFDV). The reput operation implements the following default logic:
 * NfApps are processed following either updateDependsOn ordering, or in the sequential order they appear.
 * NfApps with parameter "applicationEnabled" set to disable are skipped.
 * NFApps present, but not referenced by the new NFDV are deleted.

--- a/articles/oracle/oracle-db/oracle-database-delegated-subnet-limits.md
+++ b/articles/oracle/oracle-db/oracle-database-delegated-subnet-limits.md
@@ -12,7 +12,7 @@ ms.date: 08/01/2024
 
 In this article, you learn about delegated subnet limits for Oracle Database@Azure.
 
-Oracle Database@Azure infrastructure resources are connected to your Azure virtual network using a virtual NIC from your [delegated subnets](/azure/virtual-network/subnet-delegation-overview) (delegated to `Oracle.Database/networkAttachement`). By default, the Oracle Database@Azure service can use up to five delegated subnets. If you need more delegated subnet capacity, you can request a service limit increase.
+Oracle Database@Azure infrastructure resources are connected to your Azure virtual network using a virtual NIC from your [delegated subnets](/azure/virtual-network/subnet-delegation-overview) (delegated to `Oracle.Database/networkAttachment`). By default, the Oracle Database@Azure service can use up to five delegated subnets. If you need more delegated subnet capacity, you can request a service limit increase.
 
 ## Service limits in the OCI Console
 


### PR DESCRIPTION
This PR replaces https://github.com/MicrosoftDocs/azure-docs/pull/125147

Two files in PR 125147 no longer exist in main:
* articles/orbital/prepare-network.md
* articles/orbital/receive-real-time-telemetry.md

The following file in PR 125147 is omitted in this PR because the typo is fixed in main:
* articles/operator-service-manager/safe-upgrade-practices.md