### PR TITLE
accelerated-networking-overview.md: Add Flatcar Linux

### DIFF
--- a/articles/virtual-network/accelerated-networking-overview.md
+++ b/articles/virtual-network/accelerated-networking-overview.md
@@ -77,6 +77,7 @@ The following Linux and FreeBSD distributions from Azure Marketplace support Acc
 - Oracle Linux 7.4 and later with Red Hat Compatible Kernel (RHCK)
 - Oracle Linux 7.5 and later with UEK version 5
 - FreeBSD 10.4, 11.1, 12.0, or later
+- Flatcar Container Linux 3510 or later
 
 ### Supported VM instances
 


### PR DESCRIPTION
This change updates the list of compatible Linux images that support Azure Accelerated Networking out of the box to include Flatcar Container Linux.

I'm a Flatcar maintainer (see https://github.com/orgs/flatcar/teams/flatcar-maintainers) and I confirm Flatcar supports Accelerated Networking out of the box. We ensure continued support by thorough testing of this feature for each of our releases.