### PR TITLE
Add clarity to returned IPs in split-horizon functionality, wrong picture

### DIFF
--- a/articles/dns/private-dns-scenarios.md
+++ b/articles/dns/private-dns-scenarios.md
@@ -42,7 +42,7 @@ In this scenario, you need a different naming resolution that depends on where t
 
 The following diagram demonstrates this scenario. You have a virtual network A that has two VMs (VNETA-VM1 and VNETA-VM2). Both have a private IP and public IP configured. A public DNS zone called `contoso.com` was created and registers the public IPs for these VMs as DNS records within the zone. A private DNS zone is also created called `contoso.com`. You defined virtual network A as a registration virtual network. Azure then automatically registers the VMs as A records into the Private Zone, pointing to their private IPs.
 
-Now when an internet client does a DNS query for `VNETA-VM1.contoso.com`, Azure will return the public IP record from the public zone. If the same DNS query is issued from another VM (for example: VNETA-VM2) in the same virtual network A, Azure will return the Private IP record from the private zone. 
+Now when an internet client does a DNS query for `VNETA-VM1.contoso.com`, Azure will return the public IP record from the public zone (203.0.113.01). If the same DNS query is issued from another VM (for example: VNETA-VM2) in the same virtual network A, Azure will return the Private IP record from the private zone (10.0.0.1). 
 
 ![Split Brian resolution](./media/private-dns-scenarios/split-brain-resolution.png)
 


### PR DESCRIPTION
In the picture, there is a mistake in the DNS query response. When the Internet client is querying the "VNETA-VM1.contoso.com", it should receive 203.0.113.1. However, in the picture the response shows 56.58.0.1 I added the correct information to the text to increase clarity and accessibility. Please fix the picture as it is not easy through Github!