### PR TITLE
Fix service tags

### DIFF
--- a/includes/api-management-recommended-nsg-rules.md
+++ b/includes/api-management-recommended-nsg-rules.md
@@ -22,12 +22,12 @@ Configure custom network rules in the API Management subnet to filter traffic to
 |-------|--------------|----------|---------|------------|-----------|-----|--------|-----|
 | Inbound | Internet | * | VirtualNetwork | [80], 443   | TCP            | Allow | Client communication to API Management                   | External only          |
 | Inbound | ApiManagement | * | VirtualNetwork | 3443    | TCP | Allow     | Management endpoint for Azure portal and PowerShell        | External & Internal  |
-| Inbound | AzureLoadBalancer | * | Virtual Network | 6390      | TCP                | Allow | Azure Infrastructure Load Balancer             | External & Internal  |
+| Inbound | AzureLoadBalancer | * | VirtualNetwork | 6390      | TCP                | Allow | Azure Infrastructure Load Balancer             | External & Internal  |
 | Inbound | AzureTrafficManager | * | VirtualNetwork | 443 | TCP | Allow | Azure Traffic Manager routing for multi-region deployment | External only |
 | Outbound | VirtualNetwork | * | Storage | 443                  |  TCP | Allow  | Dependency on Azure Storage for core service functionality                            | External & Internal  |
 | Outbound | VirtualNetwork| * | SQL | 1433                     | TCP           | Allow | Access to Azure SQL endpoints for core service functionality                          | External & Internal  |
 | Outbound | VirtualNetwork | * | AzureKeyVault | 443                     | TCP                | Allow                | Access to Azure Key Vault for core service functionality                         | External & Internal  |
-| Outbound | VirtualNetwork | * | Azure Monitor | 1886, 443                     |  TCP                | Allow         | Publish [Diagnostics Logs and Metrics](../articles/api-management/api-management-howto-use-azure-monitor.md), [Resource Health](/azure/service-health/resource-health-overview), and [Application Insights](../articles/api-management/api-management-howto-app-insights.md)                  | External & Internal  |
+| Outbound | VirtualNetwork | * | AzureMonitor | 1886, 443                     |  TCP                | Allow         | Publish [Diagnostics Logs and Metrics](../articles/api-management/api-management-howto-use-azure-monitor.md), [Resource Health](/azure/service-health/resource-health-overview), and [Application Insights](../articles/api-management/api-management-howto-app-insights.md)                  | External & Internal  |
 
 
 ### [stv1](#tab/stv1)
@@ -40,7 +40,7 @@ Configure custom network rules in the API Management subnet to filter traffic to
 | Inbound | AzureTrafficManager | * | VirtualNetwork | 443 | TCP | Allow | Azure Traffic Manager routing for multi-region deployment | External only |
 | Outbound | VirtualNetwork | * | Storage | 443                  |  TCP | Allow  | Dependency on Azure Storage for core service functionality                            | External & Internal  |
 | Outbound | VirtualNetwork| * | SQL | 1433                     | TCP           | Allow | Access to Azure SQL endpoints for core service functionality                          | External & Internal  |
-| Outbound | VirtualNetwork | * | Azure Monitor | 1886, 443                     |  TCP                | Allow         | Publish [Diagnostics Logs and Metrics](../articles/api-management/api-management-howto-use-azure-monitor.md), [Resource Health](/azure/service-health/resource-health-overview), and [Application Insights](../articles/api-management/api-management-howto-app-insights.md)                  | External & Internal  |
+| Outbound | VirtualNetwork | * | AzureMonitor | 1886, 443                     |  TCP                | Allow         | Publish [Diagnostics Logs and Metrics](../articles/api-management/api-management-howto-use-azure-monitor.md), [Resource Health](/azure/service-health/resource-health-overview), and [Application Insights](../articles/api-management/api-management-howto-app-insights.md)                  | External & Internal  |
 
 
 ---


### PR DESCRIPTION
The current documentation contains erroneous whitespaces - the proper tags are listed here: https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview.

This PR removes the whitespaces.