### PR TITLE
Update Application Gateway docs to say h2c is not supported.

### DIFF
--- a/articles/application-gateway/configuration-listeners.md
+++ b/articles/application-gateway/configuration-listeners.md
@@ -87,6 +87,8 @@ Set-AzApplicationGateway -ApplicationGateway $gw
 
 You can also enable HTTP2 support using the Azure portal by selecting **Enabled** under **HTTP2** in Application gateway > Configuration. 
 
+HTTP/2 without TLS (h2c) is not supported.
+
 ### WebSocket support
 
 WebSocket support is enabled by default. There's no user-configurable setting to enable or disable it. You can use WebSockets with both HTTP and HTTPS listeners.


### PR DESCRIPTION
In my experience using http2 without tls (h2c) with application gateway does not work. Sending a request attempting to upgrade from http1.1 results in a 403 error. Sending a request assuming http2 results in a 400 error. From this, I assume that h2c is not supported. However, neither of the error messages make this clear and I could not find this limitation documented anywhere. If h2c is in fact not supported, I think it would be good to mention this in the docs either here or on a troubleshooting page. 