### PR TITLE
Maybe it is 'three types of users' instead of 'two types of users'?

### DIFF
--- a/articles/synapse-analytics/metadata/database.md
+++ b/articles/synapse-analytics/metadata/database.md
@@ -68,7 +68,7 @@ If a security principal requires the ability to create objects or drop objects i
 
 ### SQL security model
 
-The Azure Synapse workspace provides a T-SQL endpoint that enables you to query the lake database using the serverless SQL pool. In addition to the data access, SQL interface enables you to control who can access the tables. You need to enable a user to access the shared lake databases using the serverless SQL pool. There are two types of users who can access the lake databases:
+The Azure Synapse workspace provides a T-SQL endpoint that enables you to query the lake database using the serverless SQL pool. In addition to the data access, SQL interface enables you to control who can access the tables. You need to enable a user to access the shared lake databases using the serverless SQL pool. There are three types of users who can access the lake databases:
 
 - Administrators: Assign the **Synapse SQL Administrator** workspace role or **sysadmin** server-level role inside the serverless SQL pool. This role has full control over all databases. The **Synapse Administrator** and **Synapse SQL Administrator** roles also have all permissions on all objects in a serverless SQL pool, by default. 
 - Workspace readers: Grant the server-level permissions **GRANT CONNECT ANY DATABASE** and **GRANT SELECT ALL USER SECURABLES** on serverless SQL pool to a login that will enable the login to access and read any database. This might be a good choice for assigning reader/non-admin access to a user.


### PR DESCRIPTION
'Administrators', 'Workspace readers', and 'Database readers' are bulleted. Therefore, maybe it is 'three types of users' instead of 'two types of users'?