### PR TITLE
Update opentelemetry-howto.md

### DIFF
--- a/articles/azure-functions/opentelemetry-howto.md
+++ b/articles/azure-functions/opentelemetry-howto.md
@@ -42,15 +42,6 @@ To enable OpenTelemetry output from the Functions host, update the [host.json fi
 ```json
 {
     "version": "2.0",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            },
-            "enableLiveMetricsFilters": true
-        }
-    },
     "telemetryMode": "openTelemetry"
 }
 ```


### PR DESCRIPTION
The Logging section affects the ApplicationInsights SDK integration but does not apply in OpenTelemetry mode. Removing the section to avoid confusion.