### PR TITLE
Clarify that certificate renewals change both key parts

### DIFF
--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -68,7 +68,7 @@ The free App Service managed certificate is a turn-key solution for helping to s
 >
 > Free certificates are issued by DigiCert. For some domains, you must explicitly allow DigiCert as a certificate issuer by creating a [CAA domain record](https://wikipedia.org/wiki/DNS_Certification_Authority_Authorization) with the value: `0 issue digicert.com`.
 >
-> Azure fully manages the certificates on your behalf, so any aspect of the managed certificate, including the root issuer, can change at anytime. These changes are outside your control. Make sure to avoid hard dependencies and "pinning" practice certificates to the managed certificate or any part of the certificate hierarchy. If you need the certificate pinning behavior, add a certificate to your custom domain using any other available method in this article.
+> Azure fully manages the certificates on your behalf, so any aspect of the managed certificate, including the root issuer, can change at anytime. Certificate renewals change both public and private key parts.  All of these certificate changes are outside your control. Make sure to avoid hard dependencies and "pinning" practice certificates to the managed certificate or any part of the certificate hierarchy. If you need the certificate pinning behavior, add a certificate to your custom domain using any other available method in this article.
 
 The free certificate comes with the following limitations:
 


### PR DESCRIPTION
Make it clear that managed certificate renewals change both the public and private key parts of the certificate.