### PR TITLE
Update max queue storage size

### DIFF
--- a/articles/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted.md
+++ b/articles/service-bus-messaging/service-bus-azure-and-service-bus-queues-compared-contrasted.md
@@ -122,7 +122,7 @@ This section compares Storage queues and Service Bus queues from the perspective
 
 | Comparison Criteria | Storage queues | Service Bus queues |
 | --- | --- | --- |
-| Maximum queue size |500 TB<br/><br/>(limited to a [single storage account capacity](../storage/common/storage-introduction.md#queue-storage)) |1 GB to 80 GB<br/><br/>(Premium or Standard tier with partitioning)|
+| Maximum queue size |5 PiB<br/><br/>(limited to a [single storage account capacity](../storage/common/storage-introduction.md#queue-storage)) |1 GB to 80 GB<br/><br/>(Premium or Standard tier with partitioning)|
 | Maximum message size |64 KB<br/><br/>(48 KB when using Base 64 encoding)<br/><br/>Azure supports large messages by combining queues and blobs – at which point you can enqueue up to 200 GB for a single item. |256 KB, 1 MB or 100 MB<br/><br/>(including both header and body, maximum header size: 64 KB).<br/><br/>Depends on the [service tier](service-bus-premium-messaging.md). |
 | Maximum message TTL |Infinite (api-version 2017-07-27 or later) |TimeSpan.MaxValue |
 | Maximum number of queues |Unlimited |10,000 (Standard tier)<br/>1000 / Messaging Unit (Premium tier)<br/>(per service namespace) |


### PR DESCRIPTION
Queue storage documentation says that queue storage supports millions of messages up to the capacity of a storage account. 

"A queue may contain millions of messages, up to the total capacity limit of a storage account."
- https://learn.microsoft.com/en-us/azure/storage/queues/storage-queues-introduction

Storage account documentation says the capacity of storage accounts is 5 PiB. 

"Default maximum storage account capacity |	5 PiB"
- https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account#scale-targets-for-standard-storage-accounts

Yet, this comparison documentation says the max queue storage size is 500 TB.

Trusting the other documentations are accurate, I believe this documentation needs to update the value from 500 TB to 5 PiB. Alternatively, if 500 TB is still the accurate value, more explanation is needed to describe the reasoning.