### PR TITLE
[Docs] [Storage] Add `Append Blob Seal` to list of APIs not supported by ADLS Gen2

### DIFF
--- a/articles/storage/blobs/data-lake-storage-known-issues.md
+++ b/articles/storage/blobs/data-lake-storage-known-issues.md
@@ -55,6 +55,7 @@ These Blob REST APIs aren't supported:
 - [Get Page Ranges](/rest/api/storageservices/get-page-ranges)
 - [Incremental Copy Blob](/rest/api/storageservices/incremental-copy-blob)
 - [Put Page from URL](/rest/api/storageservices/put-page-from-url)
+- [Append Blob Seal](/rest/api/storageservices/append-blob-seal)
 
 Unmanaged VM disks aren't supported in accounts that have a hierarchical namespace. If you want to enable a hierarchical namespace on a storage account, place unmanaged VM disks into a storage account that doesn't have the hierarchical namespace feature enabled.
 


### PR DESCRIPTION
This PR aims to resolve any confusion regarding whether append blob seal API is supported for Datalake. 