### PR TITLE
[Docs] [Storage] Omit `Set Blob Properties` from list of supported APIs for CPK

### DIFF
--- a/articles/storage/blobs/encryption-customer-provided-keys.md
+++ b/articles/storage/blobs/encryption-customer-provided-keys.md
@@ -55,7 +55,6 @@ The following Blob storage operations support sending customer-provided encrypti
 - [Put Page](/rest/api/storageservices/put-page)
 - [Put Page from URL](/rest/api/storageservices/put-page-from-url)
 - [Append Block](/rest/api/storageservices/append-block)
-- [Set Blob Properties](/rest/api/storageservices/set-blob-properties)
 - [Set Blob Metadata](/rest/api/storageservices/set-blob-metadata)
 - [Get Blob](/rest/api/storageservices/get-blob)
 - [Get Blob Properties](/rest/api/storageservices/get-blob-properties)


### PR DESCRIPTION
As title states, this PR corrects the documentation regarding the `set blob properties` API being supported for customer-provided encryption keys.