### PR TITLE
Isn't the plural 's' unnecessary for 'Link' in 'Azure Private Link Hub'?

### DIFF
--- a/articles/synapse-analytics/security/synapse-private-link-hubs.md
+++ b/articles/synapse-analytics/security/synapse-private-link-hubs.md
@@ -19,7 +19,7 @@ You can securely connect  to Azure Synapse Studio from your Azure virtual networ
 
 There are two steps to connect to Synapse Studio using private links. First, you must create a private link hubs resource. Second, you must create a private endpoint from your Azure virtual network to this private link hub. You can then use private endpoints to securely communicate with Synapse Studio. You must integrate the private endpoints with your DNS solution, either your on-premises solution or Azure Private DNS. 
 
-## Azure Private Links Hubs and Azure Synapse Studio
+## Azure Private Link Hubs and Azure Synapse Studio
 You can use a single Azure Synapse private link hub resource to privately connect to all your Azure Synapse Analytics workspaces using Azure Synapse Studio. The workspaces do not have to be in the same region as the Azure Synapse Private link hub. The Azure Synapse Private link hub resource can also be used for connections to Synapse workspaces in different subscriptions or Microsoft Entra tenants.
 
 You can create your private link hub by searching for *Synapse private link hubs* in the Azure portal and selecting **Azure Synapse Analytics (private link hubs)** from Services. Follow the steps in the guide for how to [connect to workspace resources from a restricted network](./how-to-connect-to-workspace-from-restricted-network.md) for details. Certain URLs must be accessible from the client browser after enabling Azure Synapse private link hub. For more information, see [Connect to workspace resources from a restricted network](how-to-connect-to-workspace-from-restricted-network.md).
@@ -29,7 +29,7 @@ You can create your private link hub by searching for *Synapse private link hubs
 >[!NOTE]
 >Private link hubs are intended for securely loading the static content Synapse Studio over private links. You must create **separate, private endpoints** to the  resources you wish to connect to within the workspace, such as provisioned/dedicated SQL pools, or Spark pools. 
 
-## Azure Private Links Hubs and Azure Virtual Network
+## Azure Private Link Hubs and Azure Virtual Network
 You must connect your Azure virtual network to the Synapse private link hub resource to secure the end-to-end connection to Synapse Studio. For this, you must create a private endpoint from your virtual network to the private link hub you created. You can use the Azure portal for your private link hub and go to the Private endpoint section. Select "+ Private endpoint" to create a new private endpoint that connects to your private link hub.
 
 :::image type="content" source="./media/synapse-private-link-hubs/synapse-private-links-private-endpoint.png" alt-text="Screenshot that shows the private endpoint connections page.":::


### PR DESCRIPTION
Signed-off-by: Makoto Oda <truth_jp_4133@yahoo.co.jp>