### PR TITLE
Update private-endpoint-dns.md

### DIFF
--- a/articles/private-link/private-endpoint-dns.md
+++ b/articles/private-link/private-endpoint-dns.md
@@ -119,7 +119,7 @@ For Azure services, use the recommended zone names as described in the following
 >| Azure Database for MySQL - Flexible Server (Microsoft.DBforMySQL/flexibleServers) | mysqlServer | privatelink.mysql.database.azure.com | mysql.database.azure.com |
 >| Azure Database for MariaDB (Microsoft.DBforMariaDB/servers) | mariadbServer | privatelink.mariadb.database.azure.com | mariadb.database.azure.com |
 >| Azure Cache for Redis (Microsoft.Cache/Redis) | redisCache | privatelink.redis.cache.windows.net | redis.cache.windows.net |
->| Azure Cache for Redis Enterprise (Microsoft.Cache/RedisEnterprise) | redisEnterprise | privatelink.redis.azure.net | {instanceName}.{region}.redis.azure.net |
+>| Azure Cache for Redis Enterprise (Microsoft.Cache/RedisEnterprise) | redisEnterprise | privatelink.redisenterprise.cache.azure.net | {instanceName}.{region}.redisenterprise.cache.azure.net |
 
 ### Hybrid + multicloud
 


### PR DESCRIPTION
## Correcting the the Redis Enterprise private DNS name and forwarder

In commit  3e9be7c24548d11edf432635145871fc63df955c the Redis Enterprise private DNS zone name & forwarder was changed. 

The format of the forwarder does need to include the `instanceName` and the `region`; however, the name and forwarder should still contain `redisenterprise.cache`.

When creating a Redis Enterprise cluster through the console `privatelink.redisenterprise.cache.azure.net` is the name given to the private DNS zone.
