### PR TITLE
Add instruction to check that the function Authorization Level is Ano…

### DIFF
--- a/includes/functions-create-container-registry.md
+++ b/includes/functions-create-container-registry.md
@@ -165,6 +165,7 @@ func new --name HttpExample --template "HTTP trigger"
 ```
 ::: zone-end  
 To test the function locally, start the local Azure Functions runtime host in the root of the project folder.
+To ensure the function can be called later when hosted in Docker, check that the authorization level is set to AuthorizationLevel.Anonymous, or set it if not already configured.
 ::: zone pivot="programming-language-csharp"  
 ```console
 func start  


### PR DESCRIPTION
While following the tutorial using C#, I encountered an issue where the function couldn't be called and returned a 401 error when ran in docker. Upon investigating, I discovered that the AuthorizationLevel was set to 'Function', whereas the document assumes it should be set to 'Anonymous' when making the call. I have added an instruction for readers to verify that the authorization level is set to AuthorizationLevel.Anonymous and to update it if necessary