### PR TITLE
Update toc.yml in AGC docs to valid SO tag URL

### DIFF
--- a/articles/application-gateway/for-containers/toc.yml
+++ b/articles/application-gateway/for-containers/toc.yml
@@ -130,5 +130,5 @@
   - name: Regional availability
     href: https://azure.microsoft.com/global-infrastructure/services/
   - name: Stack Overflow
-    href: https://stackoverflow.com/questions/tagged/azure-application-gateway-for-containers
+    href: https://stackoverflow.com/questions/tagged/azure-app-gateway-for-containers
  


### PR DESCRIPTION
The existing external link to Stack Overflow in the table of contents for AGC docs is referencing the tag [`[azure-application-gateway-for-containers]`](https://stackoverflow.com/tags/azure-application-gateway-for-containers/info) which does not exist and is invalid (exceeds 35 characters).

I've since created the tag [`[azure-app-gateway-for-containers]`](https://stackoverflow.com/questions/tagged/azure-app-gateway-for-containers) and [tag wiki](https://stackoverflow.com/tags/azure-app-gateway-for-containers/info) on SO for AGC related questions and moved over any existing discussions I could find.

This PR updates the link in the ToC to reflect this change.