### PR TITLE
Fix double colon in Sentinel SAP systemconfig file structure

### DIFF
--- a/articles/sentinel/sap/reference-systemconfig-json.md
+++ b/articles/sentinel/sap/reference-systemconfig-json.md
@@ -45,7 +45,7 @@ The following code shows the overall structure of the `systemconfig.json` file:
 
     "connector_configuration": {...},
 
-    "abap_table_selector":: {...}
+    "abap_table_selector": {...}
 
 ...
 


### PR DESCRIPTION
Remove extra colon character.