### PR TITLE
Update durable-functions-perf-and-scale.md

### DIFF
--- a/articles/azure-functions/durable/durable-functions-perf-and-scale.md
+++ b/articles/azure-functions/durable/durable-functions-perf-and-scale.md
@@ -31,7 +31,7 @@ On a premium plan, automatic scaling can help to keep the number of workers (and
 
 ### CPU usage
 
-**Orchestrator functions** execute their logic multiple times due to their replaying behavior, it's therefore important that orchestrator function threads do not perform CPU-intensive tasks, do I/O, or block for any reason. Any work that may require I/O, blocking, or multiple threads should be moved into activity functions.
+**Orchestrator functions** run their logic multiple times due to their replaying behavior. It's therefore important that orchestrator function threads do not perform CPU-intensive tasks, do I/O, or block for any reason. Any work that may require I/O, blocking, or multiple threads should be moved into activity functions.
 
 **Activity functions** have all the same behaviors as regular queue-triggered functions. They can safely do I/O, execute CPU intensive operations, and use multiple threads. Because activity triggers are stateless, they can freely scale out to an unbounded number of VMs.
 

--- a/articles/azure-functions/durable/durable-functions-perf-and-scale.md
+++ b/articles/azure-functions/durable/durable-functions-perf-and-scale.md
@@ -31,7 +31,7 @@ On a premium plan, automatic scaling can help to keep the number of workers (and
 
 ### CPU usage
 
-**Orchestrator functions** are executed on a single thread to ensure that execution can be deterministic across many replays. Because of this single-threaded execution, it's important that orchestrator function threads do not perform CPU-intensive tasks, do I/O, or block for any reason. Any work that may require I/O, blocking, or multiple threads should be moved into activity functions.
+**Orchestrator functions** execute their logic multiple times due to their replaying behavior, it's therefore important that orchestrator function threads do not perform CPU-intensive tasks, do I/O, or block for any reason. Any work that may require I/O, blocking, or multiple threads should be moved into activity functions.
 
 **Activity functions** have all the same behaviors as regular queue-triggered functions. They can safely do I/O, execute CPU intensive operations, and use multiple threads. Because activity triggers are stateless, they can freely scale out to an unbounded number of VMs.
 


### PR DESCRIPTION
When I first read the phrase "Because of this single-threaded execution," I was initially confused about why this would be a bottleneck. My understanding is that each orchestration instance has its own single-threaded execution, meaning that if one instance performs CPU-intensive operations, it shouldn't significantly impact other orchestration instances running on the same worker. These instances can execute concurrently, even alongside long-running ones.

However, after further consideration, I see other valid reasons why CPU-intensive operations should be avoided within orchestration function code:

1) **Replaying:** The replaying behavior of orchestration function code, each time the orchestration handles a new activity response, it re-executes all the orchestration function code. Therefore it executes the CPU intensive, time consuming, operations multiple times, which is obviously detrimental for performance.

Even if replaying would not a problem you would still have to consider

2) **Worker scaling:** A worker listening to orchestration messages cannot scale as easily as a worker for activity messages when using partitioned control queues. So a solution for CPU intensive tasks in orchestration code cannot be to just scale out to more workers as this would also requires more control queues and a higher partition count. 

3) **Concurrency throttle:** A worker can only hold a given number of orchestrations in memory at the time. If a single orchestration takes a long time to execute the orchestration code keeps using up memory. This combined with the use of the maxConcurrenctOrchestratorFunctions throttle has a negative effect on the throughput of the system. 

That said, none of these concerns seem to be directly related to the single-threaded nature of orchestration instances.

If my understanding is incorrect, please let me know.
Otherwise, please accept this change in the pull request.