### PR TITLE
Update redundancy-migration.md

### DIFF
--- a/articles/storage/common/redundancy-migration.md
+++ b/articles/storage/common/redundancy-migration.md
@@ -259,7 +259,7 @@ To track the current migration status of the conversion initiated on your storag
 ```azurecli-interactive
 az storage account migration show \
     --account-name <string> \
-    - g <sting> \
+    - g <string> \
     -n "default"
 ```
 


### PR DESCRIPTION
az storage account migration show \
    --account-name <string> \
    - g <sting> \ -n "default"


Corrected the above spelling :

    - g <string> \