### PR TITLE
Clarify (de)serialization of custom data types in Python

### DIFF
--- a/articles/azure-functions/durable/durable-functions-bindings.md
+++ b/articles/azure-functions/durable/durable-functions-bindings.md
@@ -95,7 +95,8 @@ Here are some notes about the orchestration trigger:
 > Orchestrator functions should never be declared `async`.
 ::: zone-end
 
-### Trigger usage {#python-trigger-usage}
+<a name="python-trigger-usage"></a> 
+### Trigger usage
 
 The orchestration trigger binding supports both inputs and outputs. Here are some things to know about input and output handling:
 

--- a/articles/azure-functions/durable/durable-functions-bindings.md
+++ b/articles/azure-functions/durable/durable-functions-bindings.md
@@ -95,7 +95,7 @@ Here are some notes about the orchestration trigger:
 > Orchestrator functions should never be declared `async`.
 ::: zone-end
 
-### Trigger usage
+### Trigger usage {#python-trigger-usage}
 
 The orchestration trigger binding supports both inputs and outputs. Here are some things to know about input and output handling:
 

--- a/articles/azure-functions/durable/durable-functions-serialization-and-persistence.md
+++ b/articles/azure-functions/durable/durable-functions-serialization-and-persistence.md
@@ -155,7 +155,7 @@ For full customization of the serialization/deserialization pipeline, consider h
 
 It's recommended to use type annotations to ensure Durable Functions serializes and deserializes your data correctly. While many built-in types are handled automatically, some built-in data types require type annotations to preserve the type during deserialization.
 
-For custom data types, you make JSON serialization and deserialization possible by defining class methods `to_json` and `from_json` on your data type class.
+For custom data types, you make JSON serialization and deserialization possible by defining class methods `to_json` and `from_json` on your data type class. Note that these methods are not called on the return value from the orchestrator function, meaning the return value has to be natively JSON-serializable. For more information, see [Bindings](durable-functions-bindings.md#python-trigger-usage).
 
 # [Java](#tab/java)
 

--- a/articles/azure-functions/durable/durable-functions-serialization-and-persistence.md
+++ b/articles/azure-functions/durable/durable-functions-serialization-and-persistence.md
@@ -155,7 +155,7 @@ For full customization of the serialization/deserialization pipeline, consider h
 
 It's recommended to use type annotations to ensure Durable Functions serializes and deserializes your data correctly. While many built-in types are handled automatically, some built-in data types require type annotations to preserve the type during deserialization.
 
-For custom data types, you must define the JSON serialization and deserialization of a data type by exporting a static `to_json` and `from_json` method from your class.
+For custom data types, you make JSON serialization and deserialization possible by defining class methods `to_json` and `from_json` on your data type class.
 
 # [Java](#tab/java)
 


### PR DESCRIPTION
'Exporting' doesn't exist in Python. The use of the official and established term 'class method' clarifies how the methods for (de)serialization have to be defined.

I think it's also relevant to mention here that the class methods aren't used on the output of the orchestrator function.