### PR TITLE
Update configure-route-server.md

### DIFF
--- a/articles/route-server/configure-route-server.md
+++ b/articles/route-server/configure-route-server.md
@@ -308,13 +308,13 @@ Use [PowerShell](?tabs=powershell#view-advertised-and-learned-routes) or [Azure 
 Use the [Get-AzRouteServerPeerAdvertisedRoute](/powershell/module/az.network/get-azrouteserverpeeradvertisedroute) cmdlet to view routes advertised by a route server.
 
 ```azurepowershell-interactive
-Get-AzRouteServerPeerAdvertisedRoute -PeerName 'myNVA' -ResourceGroupName 'myResourceGroup' -RouteServerName 'myRouteServer'
+Get-AzRouteServerPeerAdvertisedRoute -PeerName 'myBGPConncetionsName' -ResourceGroupName 'myResourceGroup' -RouteServerName 'myRouteServer'
 ```
 
 Use the [Get-AzRouteServerPeerLearnedRoute](/powershell/module/az.network/get-azrouteserverpeerlearnedroute) cmdlet to view routes learned by a route server.
 
 ```azurepowershell-interactive
-Get-AzRouteServerPeerLearnedRoute -PeerName 'myNVA' -ResourceGroupName 'myResourceGroup' -RouteServerName 'myRouteServer'
+Get-AzRouteServerPeerLearnedRoute -PeerName 'myBGPConncetionsName' -ResourceGroupName 'myResourceGroup' -RouteServerName 'myRouteServer'
 ```
 
 | Parameter | Value |
@@ -330,13 +330,13 @@ Use the [az network routeserver peering list-advertised-routes](/cli/azure/netwo
 
 
 ```azurecli-interactive
-az network routeserver peering list-advertised-routes --name 'myNVA' --resource-group 'myResourceGroup' --routeserver 'myRouteServer' 
+az network routeserver peering list-advertised-routes --name 'myBGPConncetionsName' --resource-group 'myResourceGroup' --routeserver 'myRouteServer' 
 ```
 
 Use the [az network routeserver peering list-learned-routes](/cli/azure/network/routeserver/peering#az-network-routeserver-peering-list-learned-routes) command to view routes learned by a route server.
 
 ```azurecli-interactive
-az network routeserver peering list-learned-routes --name 'myNVA' --resource-group 'myResourceGroup' --routeserver 'myRouteServer' 
+az network routeserver peering list-learned-routes --name 'myBGPConncetionsName' --resource-group 'myResourceGroup' --routeserver 'myRouteServer' 
 ```
 
 | Parameter | Value |


### PR DESCRIPTION
For both PowerShell and Azure CLI the following query provides incorrect information when using the NVA name which is shown in the document. (Paste Document Link) The correct parameter, according to testing is "BGP connection name"
 
Below are testing examples.
 
PowerShell command:
 
Get-AzRouteServerPeerAdvertisedRoute:
 
Get-AzRouteServerPeerAdvertisedRoute -PeerName 'myNVA' -ResourceGroupName 'myResourceGroup' -RouteServerName 'myRouteServer' In this command it requests PeerName then it has myNVA as the variable.  When using the name of the NVA the query returns "bgpconnecitons not found". Changing this to the actual BGP connections name returns the desired results (all the routes the Route Server advertised). Get-AzRouteServerPeerLearnedRoute:
 
Get-AzRouteServerPeerLearnedRoute -PeerName 'myNVA' -ResourceGroupName 'myResourceGroup' -RouteServerName 'myRouteServer'
 
Learned routes from peer follows the same behavior.  When adding the NVA name as the variable it returns "BGP connections not found". Changing this to the actual connection name returns the correct results.
 
 
Azure CLI:
 
az network routeserver peering list-advertised-routes
 
az network routeserver peering list-advertised-routes --name 'myNVA' --resource-group 'myResourceGroup' --routeserver 'myRouteServer'
 
Azure CLI shows the same behavior as stated above.
 
az network routeserver peering list-learned-routes
 
az network routeserver peering list-learned-routes --name 'myNVA' --resource-group 'myResourceGroup' --routeserver 'myRouteServer'