### PR TITLE
Update configure-ssl-certificate.md

### DIFF
--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -153,7 +153,8 @@ The service principal app ID or assignee value is the ID for the App Service res
 
 > [!NOTE]
 > Do not delete these access policy permissions from key vault. If you do, App Service will not be able to sync your web app with the latest key vault certificate version.
-
+>
+> If key vault is configured to disable public access, please ensure that Microsoft services have access by checking the 'Allow trusted Microsoft services to bypass this firewall' checkbox. Please see [Key Vault firewall enabled trusted services only](/azure/key-vault/general/network-security?WT.mc_id=Portal-Microsoft_Azure_KeyVault#key-vault-firewall-enabled-trusted-services-only) documentation for more information.
 ---
 
 #### [Azure CLI](#tab/azure-cli/rbac)

--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -154,7 +154,7 @@ The service principal app ID or assignee value is the ID for the App Service res
 > [!NOTE]
 > Do not delete these access policy permissions from key vault. If you do, App Service will not be able to sync your web app with the latest key vault certificate version.
 >
-> If key vault is configured to disable public access, please ensure that Microsoft services have access by checking the 'Allow trusted Microsoft services to bypass this firewall' checkbox. Please see [Key Vault firewall enabled trusted services only](/azure/key-vault/general/network-security?WT.mc_id=Portal-Microsoft_Azure_KeyVault#key-vault-firewall-enabled-trusted-services-only) documentation for more information.
+> If key vault is configured to disable public access, ensure that Microsoft services have access by checking the 'Allow trusted Microsoft services to bypass this firewall' checkbox. See [Key Vault firewall enabled trusted services only](/azure/key-vault/general/network-security?WT.mc_id=Portal-Microsoft_Azure_KeyVault#key-vault-firewall-enabled-trusted-services-only) documentation for more information.
 ---
 
 #### [Azure CLI](#tab/azure-cli/rbac)


### PR DESCRIPTION
Had a case where cx was unable to pull the certificate because that had disabled public access on the key vault and they did not check Allow trusted Microsoft services to bypass this firewall option.  Hoping this will avoid another support case.