### PR TITLE
fix: remove unnecesary space

### DIFF
--- a/articles/azure-functions/durable/durable-functions-configure-managed-identity.md
+++ b/articles/azure-functions/durable/durable-functions-configure-managed-identity.md
@@ -37,7 +37,7 @@ If you don't have an existing Durable Functions project deployed in Azure, we re
 ## Local development 
 
 ### Use Azure Storage emulator
-When developing locally, it's recommended that you use Azurite, which is Azure Storage's local emulator. Configure your app to the emulator by specifying `"AzureWebJobsStorage": "UseDevelopmentStorage = true"` in the local.settings.json.
+When developing locally, it's recommended that you use Azurite, which is Azure Storage's local emulator. Configure your app to the emulator by specifying `"AzureWebJobsStorage": "UseDevelopmentStorage=true"` in the local.settings.json.
 
 ### Identity-based connections for local development
 Strictly speaking, a managed identity is only available to apps when executing on Azure. However, you can still configure a locally running app to use identity-based connection by using your developer credentials to authenticate against Azure resources. Then, when deployed on Azure, the app will utilize your managed identity configuration instead.


### PR DESCRIPTION
I removed unnecessary space from a value for AzureWebJobsStorage. when it stayed as it is, the following error occuerred in my local environmet, However, it was resloved when I removed the space characters. This is a simple fix but many users can avoid wasting time due to the problem.

```
$ func start
Found Python version 3.10.12 (python3).

Azure Functions Core Tools
Core Tools Version:       4.0.6821 Commit hash: N/A +c09a2033faa7ecf51b3773308283af0ca9a99f83 (64-bit)
Function Runtime Version: 4.1036.1.23224

[2025-02-15T01:47:33.113Z] A host error has occurred during startup operation 'b0b67bb3-2dea-4dda-81e0-b75f5e29afa3'.
[2025-02-15T01:47:33.115Z] Microsoft.WindowsAzure.Storage: No valid combination of account information found.
Value cannot be null. (Parameter 'provider')
[2025-02-15T01:47:33.173Z] Host startup operation has been canceled
```