### PR TITLE
Add instruction about installing 'amg' CLI extension.

### DIFF
--- a/articles/managed-grafana/quickstart-managed-grafana-cli.md
+++ b/articles/managed-grafana/quickstart-managed-grafana-cli.md
@@ -40,7 +40,10 @@ az login
 
 This command prompts your web browser to launch and load an Azure sign-in page.
 
-The CLI experience for Azure Managed Grafana is part of the `amg` extension for the Azure CLI (version 2.30.0 or higher). The extension automatically installs the first time you run the `az grafana` command.
+The CLI experience for Azure Managed Grafana is part of the `amg` extension for the Azure CLI (version 2.30.0 or higher). The extension automatically installs the first time you run the `az grafana` command. If this doesn't work, run:
+```azurecli
+az extension add --name amg
+```
 
 ## Create a resource group
 


### PR DESCRIPTION
The claim that the extension installs automatically when you run `az grafana` seems false. I have azure-cli 2.67.0, which is newer than the min required by the document. 
```cmd
C:\ > az grafana
'grafana' is misspelled or not recognized by the system.

:: Further, it's not self-evident that the extension name is 'amg'. Most would try installing it like this:
az extension add --name grafana
No extension found with name 'grafana'
```