### PR TITLE
Update error-storage-account-name.md

### DIFF
--- a/articles/azure-resource-manager/troubleshooting/error-storage-account-name.md
+++ b/articles/azure-resource-manager/troubleshooting/error-storage-account-name.md
@@ -53,14 +53,15 @@ Code=StorageAccountAlreadyTaken
 Message=The storage account named storageckrexph7isnoc is already taken.
 ```
 
-## Cause
+There are two main causes for this error.
 
-Common reasons for an error are because the storage account name uses invalid characters or is a duplicate name. Storage account names must meet the following criteria:
+## Cause 1
 
-- Length between 3 and 24 characters with only lowercase letters and numbers.
-- Must be globally unique across Azure. Storage account names can't be duplicated in Azure.
-
-## Solution
+The storage account name uses invalid characters or is a duplicate name. Storage account names must meet the following criteria:
+   - Length between 3 and 24 characters with only lowercase letters and numbers.
+   - Must be globally unique across Azure. Storage account names can't be duplicated in Azure.
+  
+## Solution 1
 
 You can create a unique name by concatenating a prefix or suffix with a value from the `uniqueString` function.
 
@@ -128,5 +129,14 @@ name: '${storageNamePrefix}${uniqueString(resourceGroup().id)}'
 ```json
 "name": "[concat(parameters('storageNamePrefix'), uniquestring(resourceGroup().id))]"
 ```
+
+## Cause 2
+
+The storage account was recently deleted.
+   - If a request to create the storage account comes from a different subscription and tenant than where it was previously located, it will be denied for security purposes as described here, [Prevent dangling DNS entries and avoid subdomain takeover](https://docs.microsoft.com/en-us/azure/security/fundamentals/subdomain-takeover). 
+  
+## Solution 2
+
+[Create a Support Request](https://learn.microsoft.com/en-us/azure/azure-portal/supportability/how-to-create-azure-support-request#create-a-support-request****) and choose **Create new storage account** for the problem type, and **Failure(s) during new account creation** for the Problem subtype. Please make sure to include the name of the storage account and the approximate time when account creation failed.
 
 ---

--- a/articles/azure-resource-manager/troubleshooting/error-storage-account-name.md
+++ b/articles/azure-resource-manager/troubleshooting/error-storage-account-name.md
@@ -133,10 +133,10 @@ name: '${storageNamePrefix}${uniqueString(resourceGroup().id)}'
 ## Cause 2
 
 The storage account was recently deleted.
-   - If a request to create the storage account comes from a different subscription and tenant than where it was previously located, it will be denied for security purposes as described here, [Prevent dangling DNS entries and avoid subdomain takeover](https://docs.microsoft.com/en-us/azure/security/fundamentals/subdomain-takeover). 
+   - If a request to create the storage account comes from a different subscription and tenant than where it was previously located, it will be denied for security purposes as described here, [Prevent dangling DNS entries and avoid subdomain takeover](https://docs.microsoft.com/azure/security/fundamentals/subdomain-takeover). 
   
 ## Solution 2
 
-[Create a Support Request](https://learn.microsoft.com/en-us/azure/azure-portal/supportability/how-to-create-azure-support-request#create-a-support-request****) and choose **Create new storage account** for the problem type, and **Failure(s) during new account creation** for the Problem subtype. Please make sure to include the name of the storage account and the approximate time when account creation failed.
+[Create a Support Request](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request#create-a-support-request****) and choose **Create new storage account** for the problem type, and **Failure(s) during new account creation** for the Problem subtype. Please make sure to include the name of the storage account and the approximate time when account creation failed.
 
 ---


### PR DESCRIPTION
We have another reason for the error where a storage account name shows that it is already taken and customers should be aware of it. https://supportability.visualstudio.com/AzureIaaSVM/_wiki/wikis/AzureIaaSVM/739673/Storage-Account-name-already-taken_Storage?anchor=different-name-reservation-policy-scenarios