### PR TITLE
[ACA] [347774] Remove unneeded paragraph.

### DIFF
--- a/articles/container-apps/communicate-between-microservices.md
+++ b/articles/container-apps/communicate-between-microservices.md
@@ -6,7 +6,7 @@ author: craigshoemaker
 ms.service: azure-container-apps
 ms.custom: devx-track-azurecli, devx-track-azurepowershell
 ms.topic: tutorial
-ms.date: 02/03/2025
+ms.date: 02/18/2025
 ms.author: cshoe
 zone_pivot_groups: container-apps-image-build-type
 ---
@@ -35,8 +35,6 @@ In this tutorial, you learn to:
 In the [code to cloud quickstart](./quickstart-code-to-cloud.md), a back end web API is deployed to return a list of music albums. If you didn't deploy the album API microservice, return to [Quickstart: Deploy your code to Azure Container Apps](quickstart-code-to-cloud.md) to continue.
 
 ## Setup
-
-If you're currently authenticated to Azure and have the environment variables that are defined from the quickstart, then skip the following steps and go directly to [Prepare the GitHub repository](#prepare-the-github-repository).
 
 [!INCLUDE [container-apps-code-to-cloud-setup.md](../../includes/container-apps-code-to-cloud-setup.md)]
 


### PR DESCRIPTION
PR review team: please do not review or merge this until craigshoemaker signs off. Thank you!

Removed the following paragraph:
"If you're currently authenticated to Azure and have the environment variables that are defined from the quickstart, then skip the following steps and go directly to [Prepare the GitHub repository](https://learn.microsoft.com/en-us/azure/container-apps/communicate-between-microservices?tabs=bash&pivots=acr-remote#prepare-the-github-repository)."

The user should not skip these steps, because they define additional environment variables (FRONTEND_NAME, GITHUB_USERNAME, ACR_NAME) that are not defined in the referenced quickstart.

The step to run `az login` is potentially redundant, but every quickstart/tutorial starts with this step in any case.