### PR TITLE
Update configuration-infrastructure.md

### DIFF
--- a/articles/application-gateway/configuration-infrastructure.md
+++ b/articles/application-gateway/configuration-infrastructure.md
@@ -67,6 +67,20 @@ When an instance of your Application Gateway issues a DNS query, it uses the val
 
 > [!NOTE]
 > If you use custom DNS servers in the Application Gateway virtual network, the DNS server must be able to resolve public internet names. Application Gateway requires this capability.
+> To ensure the Application Gateway has access to key required services, some domains are configured to be resolved by Azure default DNS, irrespective of any custom DNS setup. The domains are listed below. If you are using PaaS services that fall under the domains listed below with a private endpoint, such as Key Vault and Storage Account, and want the Application Gateway to resolve them to private IPs, please ensure you link the private DNS zone with the Application Gateway's Virtual Network.
+.windows.net
+.chinacloudapi.cn
+.azure.net
+.azure.cn
+.usgovcloudapi.net
+.azure.us
+.eaglex.ic.gov
+.microsoft.scloud
+.nsatc.net
+.msftcloudes.com
+.microsoft.com
+.time.ubuntu.com
+.time.windows.com
 
 ### Virtual network permission
 


### PR DESCRIPTION
Hello there, 

I am from MS support Azure networking team. The customer is having access issue to Key Vault when KV has Private Endpoint configured. Customer has customer DNS server configured and could not understand why his APPGW Vnet must have a vnet link with key vault private DNS zone. He also mentioned none of our public doc mentioned this. 

It is very important to let them know that some of the domains will always be resolved by Azure default DNS. And they must link the private DNS zone with the Vnet if they want to make it work.