### PR TITLE
Update template-tutorial-create-first-template.md

### DIFF
--- a/articles/azure-resource-manager/templates/template-tutorial-create-first-template.md
+++ b/articles/azure-resource-manager/templates/template-tutorial-create-first-template.md
@@ -157,7 +157,7 @@ New-AzResourceGroupDeployment `
 To run this deployment command, you need to have the [latest version](/cli/azure/install-azure-cli) of Azure CLI.
 
 ```azurecli
-templateFile="{provide-the-path-to-the-template-file}"
+$templateFile="{provide-the-path-to-the-template-file}"
 az deployment group create \
   --name blanktemplate \
   --resource-group myResourceGroup \


### PR DESCRIPTION
PowerShell and AZ CLI requires a $ before the variable name, it interpreted templateFile="..." as a command rather than a variable assignment. Use $templateFile = "..." instead.