### PR TITLE
Updated automatic install script for Azure Mobility

### DIFF
--- a/articles/site-recovery/vmware-azure-mobility-install-configuration-mgr.md
+++ b/articles/site-recovery/vmware-azure-mobility-install-configuration-mgr.md
@@ -239,6 +239,13 @@ elif [ -f /etc/redhat-release ]; then
             echo $OS >> /tmp/MobSvc/sccm.log
             cp *RHEL7*.tar.gz /tmp/MobSvc
                 fi
+    elif grep -q 'Red Hat Enterprise Linux release 8.* (Ootpa)' /etc/redhat-release || \
+        grep -q 'CentOS Linux release 8.* (Core)' /etc/redhat-release; then
+        if uname -a | grep -q x86_64; then
+            OS="RHEL8-64"
+            echo $OS >> /tmp/MobSvc/sccm.log
+            cp *RHEL8*.tar.gz /tmp/MobSvc
+                fi
     fi
 elif [ -f /etc/SuSE-release ] && grep -q 'VERSION = 11' /etc/SuSE-release; then
     if grep -q "SUSE Linux Enterprise Server 11" /etc/SuSE-release && grep -q 'PATCHLEVEL = 3' /etc/SuSE-release; then
@@ -273,7 +280,7 @@ fi
 Install()
 {
     echo "Perform Installation." >> /tmp/MobSvc/sccm.log
-    ./install -q -d ${INSTALL_DIR} -r Agent -v VmWare
+    ./install -q -d ${INSTALL_DIR} -r MS -v VmWare -c CSLegacy -a Install
     RET_VAL=$?
     echo "Installation Returncode: $RET_VAL" >> /tmp/MobSvc/sccm.log
     if [ $RET_VAL -eq 0 ]; then
@@ -302,7 +309,7 @@ Configure()
 Upgrade()
 {
     echo "Perform Upgrade." >> /tmp/MobSvc/sccm.log
-    ./install -q -v VmWare
+    ./install -q -v VmWare -r MS -v VmWare -c CSLegacy -a Upgrade
     RET_VAL=$?
     echo "Upgrade Returncode: $RET_VAL" >> /tmp/MobSvc/sccm.log
     if [ $RET_VAL -eq 0 ]; then


### PR DESCRIPTION
* Updates the CLI options for the extracted installer to work properly. It looks like the actual binary .tar.gz used with the installer had been updated with some new install switches breaking compatibility with this script.
* Adds support for RHEL8. This is supported by the Azure Mobility service since the appliance will actually produce a installer .tar.gz with RHEL8 in the filename.

For clarity here are some good references...

RHEL8 is confirmed to be supported due to the referenced RHEL8 lines here: [About the Mobility service for VMware VMs and physical servers > Locate installer files](https://learn.microsoft.com/en-us/azure/site-recovery/vmware-physical-mobility-service-overview#locate-installer-files)

Install script from the file `Microsoft-ASR_UA_9.63.0.0_RHEL7-64_GA_21Oct2024_Release.tar.gz`:
```bash
> /tmp/MobSvc/install --help
install [options]
Options:
  -d <Installation Directory>
  -r <Role of agent MT|MS (MT:MasterTarget, MS:MobilityService>
  -v <Virtual Machine Platform VmWare|Azure|AzureStackHub>
  -l <Install Log Name (absolute path)>
  -e <Install errors json file path (absolute path)>
  -q <Quiet>
  -a <Installation action - Install/Upgrade>
  -c <CSType - CSLegacy/CSPrime>
```

And here is another part of the documentation for the manual process, which was apparently updated when the installer was updated: [About the Mobility service for VMware VMs and physical servers > Linux Machine](https://learn.microsoft.com/en-us/azure/site-recovery/vmware-physical-mobility-service-overview#linux-machine)

This above link indicates the `CSPrime` install method which looks to be more up to date, but this apparently uses a config file generated by the appliance, when the appliance I'm using has only generated me a passphrase. I was able to get up and running with `CSLegacy` and using the passphrase method in this script. You might consider re-evaluating whether the whole script should be moved to use `CSPrime` with some different inputs or not. I used the batch script on this same page for our Windows machines without an issue, and it also still uses the legacy method (implied by the `/PassphraseFilePath` option).