### PR TITLE
Improve clarity in Azure Functions documentation

### DIFF
--- a/articles/azure-functions/functions-develop-local.md
+++ b/articles/azure-functions/functions-develop-local.md
@@ -46,7 +46,7 @@ The local.settings.json file stores app settings and settings used by local deve
 > [!IMPORTANT]  
 > Because the local.settings.json may contain secrets, such as connection strings, you should never store it in a remote repository. Tools that support Functions provide ways to synchronize settings in the local.settings.json file with the [app settings](functions-how-to-use-azure-function-app-settings.md#settings) in the function app to which your project is deployed.
 
-The local settings file has this structure:
+The **local.settings.json** file has this structure:
 
 ```json
 {


### PR DESCRIPTION
In the "Local project files" section, let's refer to the specific "local.settings.json" file by name instead of the generic term "local settings file" for greater clarity.