### PR TITLE
Update dotnet-isolated-process-guide.md

### DIFF
--- a/articles/azure-functions/dotnet-isolated-process-guide.md
+++ b/articles/azure-functions/dotnet-isolated-process-guide.md
@@ -978,7 +978,7 @@ var host = new HostBuilder()
     {
         logging.Services.Configure<LoggerFilterOptions>(options =>
         {
-            LoggerFilterRule defaultRule = options.Rules.FirstOrDefault(rule => rule.ProviderName
+            LoggerFilterRule? defaultRule = options.Rules.FirstOrDefault(rule => rule.ProviderName
                 == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
             if (defaultRule is not null)
             {
@@ -1008,7 +1008,7 @@ builder.Services
 
 builder.Logging.Services.Configure<LoggerFilterOptions>(options =>
     {
-        LoggerFilterRule defaultRule = options.Rules.FirstOrDefault(rule => rule.ProviderName
+        LoggerFilterRule? defaultRule = options.Rules.FirstOrDefault(rule => rule.ProviderName
             == "Microsoft.Extensions.Logging.ApplicationInsights.ApplicationInsightsLoggerProvider");
         if (defaultRule is not null)
         {


### PR DESCRIPTION
This is annoying me enough times that I'm going to do a PR.
This will get rid of the warning CS8600: Converting null literal or possible null value to non-nullable type.
The `FirstOrDefault` method returns nullable `LoggerFilterRule?` type.