### PR TITLE
Add pyproject.toml conversion guidance for App Service

### DIFF
--- a/articles/app-service/configure-language-python.md
+++ b/articles/app-service/configure-language-python.md
@@ -20,7 +20,7 @@ This article describes how [Azure App Service](overview.md) runs Python apps, ho
 The App Service deployment engine automatically activates a virtual environment and runs `pip install -r requirements.txt` for you when you deploy a [Git repository](deploy-local-git.md), or when you deploy a [zip package](deploy-zip.md) [with build automation enabled](deploy-zip.md#enable-build-automation-for-zip-deploy).
 
 > [!NOTE]
-> Currently App Service requires `requirements.txt` in your project's root directory, even if you're using modern Python packaging tools such as `pyproject.toml`.
+> Currently App Service requires `requirements.txt` in your project's root directory even if you have a `pyproject.toml`. See [Generate requirements.txt from pyproject.toml](#generate-requirementstxt-from-pyprojecttoml) for recommended approaches.
 
 This guide provides key concepts and instructions for Python developers who use a built-in Linux container in App Service. If you've never used Azure App Service, first follow the [Python quickstart](quickstart-python.md) and [Flask](tutorial-python-postgresql-app-flask.md), [Django](tutorial-python-postgresql-app-django.md), or [FastAPI](tutorial-python-postgresql-app-fastapi.md) with PostgreSQL tutorial.
 
@@ -100,6 +100,30 @@ For more information on how App Service runs and builds Python apps in Linux, se
 
 > [!NOTE]
 > Always use relative paths in all pre- and post-build scripts because the build container in which Oryx runs is different from the runtime container in which the app runs. Never rely on the exact placement of your app project folder within the container (for example, that it's placed under *site/wwwroot*).
+
+## Generate requirements.txt from pyproject.toml
+
+App Service does not directly support `pyproject.toml` at the moment.  If you're using tools like Poetry or uv, the recommended approach is to generate a compatible `requirements.txt` before deployment in your project's root:
+
+### Using Poetry
+
+Using [Poetry](https://python-poetry.org/) with the [export plugin](https://github.com/python-poetry/poetry-plugin-export):
+
+```sh
+
+poetry export -f requirements.txt --output requirements.txt --without-hashes
+
+```
+
+### Using uv
+
+Using [uv](https://docs.astral.sh/uv/concepts/projects/sync/#exporting-the-lockfile):
+
+```sh
+
+uv export --format requirements-txt --no-hashes --output-file requirements.txt
+
+```
 
 ## Migrate existing applications to Azure
 


### PR DESCRIPTION
Adds guidance for generating `requirements.txt` from `pyproject.toml` for App Service with modern package managers

- Update note clarifying `requirements.txt` is required even with `pyproject.toml`
- Add new section "Generate requirements.txt from pyproject.toml" with:
  - Poetry export command example
  - uv export command example

@btardif These additions provide clearer guidance regarding the requirements.txt requirement