### PR TITLE
Sentence about tenant-specific object ID

### DIFF
--- a/articles/app-service/configure-ssl-certificate.md
+++ b/articles/app-service/configure-ssl-certificate.md
@@ -141,7 +141,7 @@ By default, the App Service resource provider doesn't have access to your key va
 |--|--|--|
 | **Microsoft Azure App Service** or **Microsoft.Azure.WebSites** | - `abfa0a7c-a6b6-4736-8310-5855508787cd` for public Azure cloud environment <br><br>- `6a02c803-dafd-4136-b4c3-5a6f318b4714` for Azure Government cloud environment | Certificate User |
 
-The service principal app ID or assignee value is the ID for the App Service resource provider. To learn how to authorize key vault permissions for the App Service resource provider using an access policy, see the [provide access to Key Vault keys, certificates, and secrets with an Azure role-based access control documentation](/azure/key-vault/general/rbac-guide?tabs=azure-portal#key-vault-scope-role-assignment).
+The service principal app ID or assignee value is the ID for the App Service resource provider. Note that when granting access using RBAC, the corresponding Object ID of the service principal app ID is tenant-specific. To learn how to authorize key vault permissions for the App Service resource provider using an access policy, see the [provide access to Key Vault keys, certificates, and secrets with an Azure role-based access control documentation](/azure/key-vault/general/rbac-guide?tabs=azure-portal#key-vault-scope-role-assignment).
 
 ### [Access policy permissions](#tab/accesspolicy)
 


### PR DESCRIPTION
Useful sentence to point out the object ID is unique in the tenant and should be used for the role assignment (not the app id).