### PR TITLE
Update tag-support.md

### DIFF
--- a/articles/azure-resource-manager/management/tag-support.md
+++ b/articles/azure-resource-manager/management/tag-support.md
@@ -2367,8 +2367,6 @@ To get the same data as a file of comma-separated values, download [tag-support.
 <a id="network-limitations"></a>
 
 > [!NOTE]
-> For Azure Front Door Service, you can apply tags when creating the resource, but updating or adding tags is not currently supported. Front Door doesn't support the use of # or : in the tag name.
-> 
 > Azure DNS zones and Traffic Manager doesn't support the use of spaces in the tag or a tag that starts with a number. Azure DNS and Traffic Manager tag names do not support special and unicode characters. The value can contain all characters.
 > 
 > Azure IP Groups and Azure Firewall Policies don't support PATCH operations, which means they don't support updating tags through the portal. Instead, use the update commands for those resources. For example, you can update tags for an IP group with the [az network ip-group update](/cli/azure/network/ip-group#az-network-ip-group-update) command.


### PR DESCRIPTION
Removed: "> For Azure Front Door Service, you can apply tags when creating the resource, but updating or adding tags is not currently supported. Front Door doesn't support the use of # or : in the tag name."

Tested this in my lab and this appears to be false on all 3 SKUs: Classic, Standard, Premium. I can show to the Contributor in case there is doubt.

Also tested the Traffic Manager / DNS Zone claim and that appears to be correct.