### PR TITLE
Fix tenant ID in key-vault-parameter.md

### DIFF
--- a/articles/azure-resource-manager/bicep/key-vault-parameter.md
+++ b/articles/azure-resource-manager/bicep/key-vault-parameter.md
@@ -118,7 +118,7 @@ The following procedure shows how to create a role with the minimum permission a
       "DataActions": [],
       "NotDataActions": [],
       "AssignableScopes": [
-        "/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e"
+        "/subscriptions/00000000-0000-0000-0000-000000000000"
       ]
     }
     ```


### PR DESCRIPTION
Text stated to replace the 00000000-0000-0000-0000-000000000000 tenant id, but the sample had what seems to be an actual tenant id in there.