### PR TITLE
Update howto-configure-fabric-real-time-intelligence.md

### DIFF
--- a/articles/iot-operations/connect-to-cloud/howto-configure-fabric-real-time-intelligence.md
+++ b/articles/iot-operations/connect-to-cloud/howto-configure-fabric-real-time-intelligence.md
@@ -62,7 +62,7 @@ Azure Key Vault is the recommended way to sync the connection string to the Kube
     | Host                  | The hostname of the Event Stream Custom Endpoint in the format `*.servicebus.windows.net:9093`. Use the bootstrap server address noted previously. |
     | Authentication method | *SASL* is the currently the only supported authentication method. |
     | SASL type             | Choose *Plain* |
-    | Synced secret name    | Enter a name of the Kubernetes secret that contains the connection string. |
+    | Synced secret name    | Enter a name for the syned secret. A Kubernetes secret with this name will be created on the cluster. |
     | Username reference of token secret | Create a new or choose an existing Key Vault reference. The secret value must be exactly the text **$ConnectionString** (literal string, not an environment variable reference). |
     | Password reference of token secret | Create a new or choose an existing Key Vault reference. The secret value must be the Custom Endpoint connection string noted earlier. |
 

--- a/articles/iot-operations/connect-to-cloud/howto-configure-fabric-real-time-intelligence.md
+++ b/articles/iot-operations/connect-to-cloud/howto-configure-fabric-real-time-intelligence.md
@@ -62,7 +62,8 @@ Azure Key Vault is the recommended way to sync the connection string to the Kube
     | Host                  | The hostname of the Event Stream Custom Endpoint in the format `*.servicebus.windows.net:9093`. Use the bootstrap server address noted previously. |
     | Authentication method | *SASL* is the currently the only supported authentication method. |
     | SASL type             | Choose *Plain* |
-    | Synced secret name    | Create or select a Key Vault secret where the secret's value is exactly the text **$ConnectionString** (literal string, not an environment variable reference). |
+    | Synced secret name    | Enter a name of the Kubernetes secret that contains the connection string. |
+    | Username reference of token secret | Create a new or choose an existing Key Vault reference. The secret value must be exactly the text **$ConnectionString** (literal string, not an environment variable reference). |
     | Password reference of token secret | Create a new or choose an existing Key Vault reference. The secret value must be the Custom Endpoint connection string noted earlier. |
 
 1. Select **Apply** to provision the endpoint.


### PR DESCRIPTION
For entering the connectionstring, the username/password must be used.

The '$ConnectionString' literal value must be entered in the username field, not the synced secret name. If this is tried, this will lead to a mask error: 'The name must begin and end with a letter or number, and may contain only letters, numbers, hyphens'.

![image](https://github.com/user-attachments/assets/e6d3f3e4-4580-4222-9ae7-a787b9071758)

Note that these fields are also entered in https://learn.microsoft.com/en-us/azure/iot-operations/connect-to-cloud/howto-configure-kafka-endpoint?tabs=portal#use-connection-string-for-authentication-to-event-hubs but that text is not as clear as seen here.