### PR TITLE
Update static-web-apps/front-door-manual

### DIFF
--- a/articles/static-web-apps/front-door-manual.md
+++ b/articles/static-web-apps/front-door-manual.md
@@ -35,6 +35,7 @@ In this tutorial, you learn to add Azure Front Door to your static web app.
 
 ### Prerequisites
 
+* Registered `Microsoft.Cdn` [resource provider](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types).
 * [Custom domain](./custom-domain.md) configured for your static web app with a time to live (TTL) set to less than 48 hrs.
 * An application deployed with [Azure Static Web Apps](./get-started-portal.md) that uses the Standard hosting plan.
 

--- a/articles/static-web-apps/front-door-manual.md
+++ b/articles/static-web-apps/front-door-manual.md
@@ -35,7 +35,7 @@ In this tutorial, you learn to add Azure Front Door to your static web app.
 
 ### Prerequisites
 
-* Registered `Microsoft.Cdn` [resource provider](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types).
+* Registered `Microsoft.Cdn` [resource provider](/articles/azure-resource-manager/management/resource-providers-and-types.md).
 * [Custom domain](./custom-domain.md) configured for your static web app with a time to live (TTL) set to less than 48 hrs.
 * An application deployed with [Azure Static Web Apps](./get-started-portal.md) that uses the Standard hosting plan.
 


### PR DESCRIPTION
When you enable Enterprise-grade edge on Static Web App, it creates Azure Front Door which requires `Microsoft.Cdn` resource provider.

Without it, it fails without any justification.