### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/custom-policies-series-branch-user-journey.md
+++ b/articles/active-directory-b2c/custom-policies-series-branch-user-journey.md
@@ -229,7 +229,7 @@ Follow the steps in [Test the custom policy](custom-policies-series-validate-use
 
 1. In the first screen, for  **Account Type**, select **Personal Account**. 
 1. For **Access Code**, enter *88888*, and then select **Continue**. 
-1. Enter the rest of the details as required, and then select **Continue**. After the policy finishes execution, you're redirected to `https://jwt.ms`, and you see a decoded JWT token. 
+1. Enter the rest of the details as required, and then select **Continue**. After the policy finishes execution, you're redirected to `https://jwt.ms`, and you see a decoded JWT. 
 1. Repeat step 5, but this time, select **Account Type**, select **Contoso Employee Account**, and then follow the prompts.  
  
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.