### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/custom-policies-series-sign-up-or-sign-in-federation.md
+++ b/articles/active-directory-b2c/custom-policies-series-sign-up-or-sign-in-federation.md
@@ -452,7 +452,7 @@ When the custom policy runs:
 
 - **Orchestration Step 5** - This step runs if the user doesn't already exist (`objectId` doesn't exist), so the `AAD-UserWriteUsingAlternativeSecurityId` Technical Profile executes to write the social account into Microsoft Entra ID.  
 
-- **Orchestration Step 6** - Finally, step 6 assembles and returns the JWT token at the end of the policy’s execution.
+- **Orchestration Step 6** - Finally, step 6 assembles and returns the JWT at the end of the policy’s execution.
 
 ## Step 5 - Update relying party output claims 
 
@@ -466,7 +466,7 @@ In the `ContosoCustomPolicy.XML` file, locate the `RelyingParty` element, and th
     <OutputClaim ClaimTypeReferenceId="objectId" PartnerClaimType="sub"/>
     <OutputClaim ClaimTypeReferenceId="identityProvider" />
 ```
-We've added the identity provider (*identityProvider*) as an output claim, so it will be included in the JWT token returned to the relying party application. 
+We've added the identity provider (*identityProvider*) as an output claim, so it will be included in the JWT returned to the relying party application. 
  
 ## Step 6 - Upload policy
 
@@ -485,7 +485,7 @@ If it's the first time running this policy (social account doesn't already exist
 
 Enter or update **Display Name**, **Given Name** and the **Surname**, and then select **Continue** button.  
 
-After the policy finishes execution, you're redirected to https://jwt.ms, and you see a decoded JWT token. It looks similar to the following JWT token snippet:
+After the policy finishes execution, you're redirected to https://jwt.ms, and you see a decoded JWT. It looks similar to the following JWT snippet:
 
 ```json
 {
@@ -504,7 +504,7 @@ After the policy finishes execution, you're redirected to https://jwt.ms, and yo
 }.[Signature]
 ```
 
-Notice the identity provider, `"idp": "facebook.com"`, has been included in the JWT token. 
+Notice the identity provider, `"idp": "facebook.com"`, has been included in the JWT. 
 
 ## A combined local and social sign-in
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.