### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/oauth2-technical-profile.md
+++ b/articles/active-directory-b2c/oauth2-technical-profile.md
@@ -210,7 +210,7 @@ Authorization: Basic YWJjZDoxMjM0
 redirect_uri=https%3a%2f%2fcontoso.b2clogin.com%2fontoso.onmicrosoft.com%2foauth2%2fauthresp&code=12345&grant_type=authorization_code
 ```
 
-For identity providers that support private key JWT authentication, configure the `token_endpoint_auth_method` metadata to `private_key_jwt`. With this type of authentication method, the certificate provided to Azure AD B2C is used to generate a signed assertion, which is passed to the identity provider through the `client_assertion` parameter. The `client_assertion_type` set to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`. The `token_signing_algorithm` metadata specifies the signing algorithm of the JWT token. 
+For identity providers that support private key JWT authentication, configure the `token_endpoint_auth_method` metadata to `private_key_jwt`. With this type of authentication method, the certificate provided to Azure AD B2C is used to generate a signed assertion, which is passed to the identity provider through the `client_assertion` parameter. The `client_assertion_type` set to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`. The `token_signing_algorithm` metadata specifies the signing algorithm of the JWT. 
 
 ```xml
 <Item Key="AccessTokenEndpoint">https://contoso.com/oauth2/token</Item>


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.