### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/partner-ping-identity.md
+++ b/articles/active-directory-b2c/partner-ping-identity.md
@@ -95,7 +95,7 @@ You can use basic user flows or advanced Identity Enterprise Framework (IEF) pol
 
    ![Screenshot of the subject sub claim URL on the Token compatibility dialog.](./media/partner-ping/token-setting.png)
 
-In the advanced policies, configuration includes the IssuanceClaimPattern metadata element to AuthorityWithTfp value in the [JWT token issuer technical profile](./jwt-issuer-technical-profile.md).
+In the advanced policies, configuration includes the IssuanceClaimPattern metadata element to AuthorityWithTfp value in the [JWT issuer technical profile](./jwt-issuer-technical-profile.md).
 
 ## Configure PingAccess and PingFederate
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.