### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/relyingparty.md
+++ b/articles/active-directory-b2c/relyingparty.md
@@ -285,7 +285,7 @@ The **OutputClaim** element contains the following attributes:
 
 With the **SubjectNamingInfo** element, you control the value of the token subject:
 
-- **JWT token** - the `sub` claim. This is a principal about which the token asserts information, such as the user of an application. This value is immutable and cannot be reassigned or reused. It can be used to perform safe authorization checks, such as when the token is used to access a resource. By default, the subject claim is populated with the object ID of the user in the directory. For more information, see [Token, session and single sign-on configuration](session-behavior.md).
+- **JWT** - the `sub` claim. This is a principal about which the token asserts information, such as the user of an application. This value is immutable and cannot be reassigned or reused. It can be used to perform safe authorization checks, such as when the token is used to access a resource. By default, the subject claim is populated with the object ID of the user in the directory. For more information, see [Token, session and single sign-on configuration](session-behavior.md).
 - **SAML token** - the `<Subject><NameID>` element, which identifies the subject element. The NameId format can be modified.
 
 The **SubjectNamingInfo** element contains the following attribute:
@@ -315,7 +315,7 @@ The following example shows how to define an OpenID Connect relying party. The s
   </TechnicalProfile>
 </RelyingParty>
 ```
-The JWT token includes the `sub` claim with the user objectId:
+The JWT includes the `sub` claim with the user objectId:
 
 ```json
 {


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.