### PR TITLE
Fix typo

### DIFF
--- a/articles/active-directory-b2c/session-behavior.md
+++ b/articles/active-directory-b2c/session-behavior.md
@@ -317,9 +317,9 @@ The following example illustrates the JWT and SAML token issuers with single sig
 <ClaimsProvider>
   <DisplayName>Local Account SignIn</DisplayName>
   <TechnicalProfiles>
-    <!-- JWT Token Issuer -->
+    <!-- JWT Issuer -->
     <TechnicalProfile Id="JwtIssuer">
-      <DisplayName>JWT token Issuer</DisplayName>
+      <DisplayName>JWT Issuer</DisplayName>
       <Protocol Name="OpenIdConnect" />
       <OutputTokenFormat>JWT</OutputTokenFormat>
       ...    


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.