### PR TITLE
Fix typo

### DIFF
--- a/articles/api-management/api-management-key-concepts-experiment.md
+++ b/articles/api-management/api-management-key-concepts-experiment.md
@@ -58,7 +58,7 @@ All requests from client applications first reach the API gateway, which then fo
 The API gateway:
   
   * Accepts API calls and routes them to configured backends
-  * Verifies API keys, JWT tokens, certificates, and other credentials
+  * Verifies API keys, JWTs, certificates, and other credentials
   * Enforces usage quotas and rate limits
   * Optionally transforms requests and responses as specified in [policy statements](#policies)
   * If configured, caches responses to improve response latency and minimize the load on backend services


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.