### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-fluid-relay/how-tos/fluid-json-web-token.md
+++ b/articles/azure-fluid-relay/how-tos/fluid-json-web-token.md
@@ -8,7 +8,7 @@ ms.service: azure-fluid
 
 # Azure Fluid Relay token contract
 
-Requests sent to Azure Fluid Relay should contain a JWT token in the authorization header. This token should be [signed by the tenant key](../concepts/authentication-authorization.md).
+Requests sent to Azure Fluid Relay should contain a JWT in the authorization header. This token should be [signed by the tenant key](../concepts/authentication-authorization.md).
 
 ## Claims
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.