### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-signalr/signalr-concept-internals.md
+++ b/articles/azure-signalr/signalr-concept-internals.md
@@ -60,7 +60,7 @@ There are three steps to establish persistent connections between the client and
         ```
         {
             "url":"https://test.service.signalr.net/client/?hub=chat&...",
-            "accessToken":"<a typical JWT token>"
+            "accessToken":"<a typical JWT>"
         }
         ```
     - For ASP.NET SignalR, a typical redirect response looks like:
@@ -68,7 +68,7 @@ There are three steps to establish persistent connections between the client and
         {
             "ProtocolVersion":"2.0",
             "RedirectUrl":"https://test.service.signalr.net/aspnetclient",
-            "AccessToken":"<a typical JWT token>"
+            "AccessToken":"<a typical JWT>"
         }
         ```
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.