### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-signalr/signalr-reference-data-plane-rest-api.md
+++ b/articles/azure-signalr/signalr-reference-data-plane-rest-api.md
@@ -39,7 +39,7 @@ A typical negotiation response has this format:
 ```json
 {
   "url": "https://<service_name>.service.signalr.net/client/?hub=<hub_name>",
-  "accessToken": "<a typical JWT token>"
+  "accessToken": "<a typical JWT>"
 }
 ```
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.