### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-web-pubsub/howto-connect-mqtt-websocket-client.md
+++ b/articles/azure-web-pubsub/howto-connect-mqtt-websocket-client.md
@@ -59,10 +59,10 @@ This is the default workflow, shown as follows:
 
 1. The client negotiates with your auth server. The auth server contains the authorization middleware, which handles the client request and signs a JWT for the client to connect to the service.
 1. The auth server returns the JWT to the client.
-1. The client tries to connect to the Web PubSub service with the JWT token returned from the auth server. The token can be in either the query string, as `/clients/mqtt/hubs/{hub}?access_token={token}`, or the `Authorization` header, as `Authorization: Bearer {token}`.
+1. The client tries to connect to the Web PubSub service with the JWT returned from the auth server. The token can be in either the query string, as `/clients/mqtt/hubs/{hub}?access_token={token}`, or the `Authorization` header, as `Authorization: Bearer {token}`.
 
 #### Supported claims
-You could also configure properties for the client connection when generating the access token by specifying special claims inside the JWT token:
+You could also configure properties for the client connection when generating the access token by specifying special claims inside the JWT:
 
 | Description | Claim type | Claim value | Notes |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.