### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-web-pubsub/tutorial-pub-sub-messages.md
+++ b/articles/azure-web-pubsub/tutorial-pub-sub-messages.md
@@ -101,7 +101,7 @@ Clients connect to the Azure Web PubSub service through the standard WebSocket p
 1. First, create a project directory named `subscriber` for this project and install required dependencies:
 
     * The package [Websocket.Client](https://github.com/Marfusios/websocket-client) is a third-party package supporting WebSocket connections. You can use any API/library that supports WebSocket.
-    * The SDK package `Azure.Messaging.WebPubSub` helps to generate the JWT token. 
+    * The SDK package `Azure.Messaging.WebPubSub` helps to generate the JWT. 
 
     ```bash
     mkdir subscriber


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.