### PR TITLE
Fix typo

### DIFF
--- a/articles/cloud-services-extended-support/deploy-sdk.md
+++ b/articles/cloud-services-extended-support/deploy-sdk.md
@@ -33,7 +33,7 @@ To deploy Cloud Services (extended support) by using the SDK:
                 var authenticationContext = new AuthenticationContext("https://login.windows.net/{tenantID}");
                 var credential = new ClientCredential(clientId: "{clientID}", clientSecret: "{clientSecret}");
                 var result = authenticationContext.AcquireTokenAsync(resource: "https://management.core.windows.net/", clientCredential: credential);
-                if (result == null) throw new InvalidOperationException("Failed to obtain the JWT token");
+                if (result == null) throw new InvalidOperationException("Failed to obtain the JWT");
                 AuthenticationToken = result.Result.AccessToken;
             }
             public override async Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.