### PR TITLE
Fix typo

### DIFF
--- a/articles/communication-services/how-tos/call-automation/includes/secure-webhook-endpoint-python.md
+++ b/articles/communication-services/how-tos/call-automation/includes/secure-webhook-endpoint-python.md
@@ -25,9 +25,9 @@ pip install flask pyjwt
 ```
 
 3. Configure your application to validate the JWT and the configuration of your Azure Communication Services resource. You need the `audience` values as it is present in the JWT payload.
-4. Validate the issuer, audience and the JWT token.
+4. Validate the issuer, audience and the JWT.
    - The audience is your Azure Communication Services resource ID you used to set up your Call Automation client. Refer [here](../../../quickstarts/voice-video-calling/get-resource-id.md) about how to get it.
-   - The JSON Web Key Set (JWKS) endpoint in the OpenId configuration contains the keys used to validate the JWT token. When the signature is valid and the token hasn't expired (within 5 minutes of generation), the client can use the token for authorization.
+   - The JSON Web Key Set (JWKS) endpoint in the OpenId configuration contains the keys used to validate the JWT. When the signature is valid and the token hasn't expired (within 5 minutes of generation), the client can use the token for authorization.
 
 This sample code demonstrates how to configure OIDC client to validate webhook payload using JWT
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.