### PR TITLE
Fix typo

### DIFF
--- a/articles/confidential-computing/skr-flow-confidential-vm-sev-snp.md
+++ b/articles/confidential-computing/skr-flow-confidential-vm-sev-snp.md
@@ -689,7 +689,7 @@ $cert | Format-List *
 # Subject              : CN=vault.azure.net, O=Microsoft Corporation, L=Redmond, S=WA, C=US
 ```
 
-The response's JWT token body looks incredibly similar to the response that you get when invoking the `get` key operation. However, the `release` operation includes the `key_hsm` property, amongst other things.
+The response's JWT body looks incredibly similar to the response that you get when invoking the `get` key operation. However, the `release` operation includes the `key_hsm` property, amongst other things.
 
 ```json
 {


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.