### PR TITLE
Fix typo

### DIFF
--- a/articles/event-grid/authenticate-with-namespaces-using-json-web-tokens.md
+++ b/articles/event-grid/authenticate-with-namespaces-using-json-web-tokens.md
@@ -90,7 +90,7 @@ In this step, you configure custom authentication settings on your Event Grid na
 1. On the **Event Grid Namespace** page, select **Configuration** on the left menu. 
 1. In the **Custom JWT authentication** section, specify values for the following properties:  
     1. Select **Enable custom JWT authentication**. 
-    1. **Token Issuer**: Enter the value of the issuer claims of the JWT tokens, presented by the MQTT clients. 
+    1. **Token Issuer**: Enter the value of the issuer claims of the JWTs, presented by the MQTT clients. 
     1. Select **Add issuer certificate**
     
         :::image type="content" source="./media/authenticate-with-namespaces-using-json-web-tokens/configuration-custom-authentication.png" alt-text="Screenshot that shows the Custom JWT authentication section of the Configuration page for an Event Grid namespace." lightbox="./media/authenticate-with-namespaces-using-json-web-tokens/configuration-custom-authentication.png":::


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.