### PR TITLE
Fix typo

### DIFF
--- a/articles/synapse-analytics/troubleshoot/troubleshoot-synapse-studio.md
+++ b/articles/synapse-analytics/troubleshoot/troubleshoot-synapse-studio.md
@@ -135,7 +135,7 @@ wss://{workspace}.dev.azuresynapse.net/jupyterApi/versions/1/sparkPools/{spark-p
 
 When setting up WebSocket connection, Synapse Studio will include an access token (Microsoft Entra JWT bearer token) in the Sec-WebSocket-Protocol header of the WebSocket request. 
 
-Sometimes, WebSocket request might be blocked, or JWT token in the request header might be redacted in your network environment. This will cause Synapse Notebook unable to establish the connection to our server and run your notebook. 
+Sometimes, WebSocket request might be blocked, or JWT in the request header might be redacted in your network environment. This will cause Synapse Notebook unable to establish the connection to our server and run your notebook. 
 
 ### Action:
 


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.