### PR TITLE
Fix typo

### DIFF
--- a/includes/api-management-gateway-role.md
+++ b/includes/api-management-gateway-role.md
@@ -9,7 +9,7 @@ ms.date: 08/04/2022
 Specifically, the gateway:
 
 * Acts as a facade to backend services by accepting API calls and routing them to appropriate backends
-* Verifies [API keys](../articles/api-management/api-management-subscriptions.md) and other credentials such as [JWT tokens and certificates](../articles/api-management/api-management-access-restriction-policies.md) presented with requests
+* Verifies [API keys](../articles/api-management/api-management-subscriptions.md) and other credentials such as [JWTs and certificates](../articles/api-management/api-management-access-restriction-policies.md) presented with requests
 * Enforces [usage quotas and rate limits](../articles/api-management/api-management-access-restriction-policies.md)
 * Optionally transforms requests and responses as specified in [policy statements](../articles/api-management/api-management-howto-policies.md)
 * If configured, [caches responses](../articles/api-management/api-management-howto-cache.md) to improve response latency and minimize the load on backend services


### PR DESCRIPTION
## Description

This PR corrects a redundancy in the terminology. The phrase "JWT token" was redundant since "JWT" already stands for "JSON Web Token."

## Changes

Replaced "JWT token" with "JWT".

## Why this change?

* Clarity: Avoids redundancy and keeps the terminology precise.
* Consistency: Aligns with standard usage in technical documentation.

## No functional changes.

This is a documentation improvement and does not affect any functionality.