### PR TITLE
Update upgrade-basic-standard-with-powershell.md

### DIFF
--- a/articles/load-balancer/upgrade-basic-standard-with-powershell.md
+++ b/articles/load-balancer/upgrade-basic-standard-with-powershell.md
@@ -117,7 +117,7 @@ Install-Module -Name AzureBasicLoadBalancerUpgrade -Scope CurrentUser -Repositor
 Validate that a Basic Load Balancer is supported for upgrade
 
 ```powershell
-Start-AzBasicLoadBalancerUpgrade -ResourceGroupName <loadBalancerRGName> -BasicLoadBalancerName <basicLBName> -validateScenarioOnly $true
+Start-AzBasicLoadBalancerUpgrade -ResourceGroupName <loadBalancerRGName> -BasicLoadBalancerName <basicLBName> -validateScenarioOnly:$true
 ```
 
 ### Example: upgrade by name

--- a/articles/load-balancer/upgrade-basic-standard-with-powershell.md
+++ b/articles/load-balancer/upgrade-basic-standard-with-powershell.md
@@ -117,7 +117,7 @@ Install-Module -Name AzureBasicLoadBalancerUpgrade -Scope CurrentUser -Repositor
 Validate that a Basic Load Balancer is supported for upgrade
 
 ```powershell
-Start-AzBasicLoadBalancerUpgrade -ResourceGroupName <loadBalancerRGName> -BasicLoadBalancerName <basicLBName> -validateScenarioOnly
+Start-AzBasicLoadBalancerUpgrade -ResourceGroupName <loadBalancerRGName> -BasicLoadBalancerName <basicLBName> -validateScenarioOnly $true
 ```
 
 ### Example: upgrade by name


### PR DESCRIPTION
The -validateScenarioOnly parameter is a SWITCH, defaulted to FALSE. The documentation page has an example of how to use this, but it's missing the $true at the end. I have proposed this correction (line 120 in the file). If a user just copies and pastes from the documentation (which arguably is what the documentation is FOR), expecting to validate the scenario, they will instead go ahead with migrations which can cause potential issues - not to mention any issues/troubles that may rise internally from an engineer unintentionally upgrading the load balancer.