### PR TITLE
doc: Update configure-storage-policy.md

### DIFF
--- a/articles/azure-vmware/configure-storage-policy.md
+++ b/articles/azure-vmware/configure-storage-policy.md
@@ -92,7 +92,7 @@ Run the `Set-VMStoragePolicy` cmdlet to modify vSAN-based storage policies on a 
    | **Field** | **Value** |
    | --- | --- |
    | **VMName** | Name of the target VM. |
-   | **StoragePolicyName** | Name of the storage policy to set. For example, **RAID-FTT-1**. |
+   | **StoragePolicyName** | Name of the storage policy to set. For example, **RAID1 FTT-1**. |
    | **Retain up to**  | Retention period of the cmdlet output. The default value is 60.  |
    | **Specify name for execution**  | Alphanumeric name, for example, **changeVMStoragePolicy**.  |
    | **Timeout**  |  The period after which a cmdlet exits if taking too long to finish.  |
@@ -113,7 +113,7 @@ Run the `Set-LocationStoragePolicy` cmdlet to Modify vSAN based storage policies
    | **Field** | **Value** |
    | --- | --- |
    | **Location** | Name of the target VM. |
-   | **StoragePolicyName** | Name of the storage policy to set. For example, **RAID-FTT-1**. |
+   | **StoragePolicyName** | Name of the storage policy to set. For example, **RAID1 FTT-1**. |
    | **Retain up to**  | Retention period of the cmdlet output. The default value is 60.  |
    | **Specify name for execution**  | Alphanumeric name, for example, **changeVMStoragePolicy**.  |
    | **Timeout**  |  The period after which a cmdlet exits if taking too long to finish.  |
@@ -134,7 +134,7 @@ Run the `Set-ClusterDefaultStoragePolicy` cmdlet to specify default storage poli
    | **Field** | **Value** |
    | --- | --- |
    | **ClusterName** | Name of the cluster. |
-   | **StoragePolicyName** | Name of the storage policy to set. For example, **RAID-FTT-1**. |
+   | **StoragePolicyName** | Name of the storage policy to set. For example, **RAID1 FTT-1**. |
    | **Retain up to**  | Retention period of the cmdlet output. The default value is 60.  |
    | **Specify name for execution**  | Alphanumeric name, for example, **Set-ClusterDefaultStoragePolicy-Exec1**.  |
    | **Timeout**  |  The period after which a cmdlet exits if taking too long to finish.  |
@@ -168,7 +168,7 @@ This function creates a new or overwrites an existing vSphere Storage Policy. No
    | **vSANFailuresToTolerate** | Number of vSAN Hosts failures to Tolerate. <br>- Default is "R1FTT1". <br>- Valid values are "None", "R1FTT1", "R1FTT2", "R1FTT3", "R5FTT1", "R6FTT2", "R1FTT3" <br>- None = No Data Redundancy<br>- R1FTT1 = 1 failure - RAID-1 (Mirroring)<br>- R1FTT2 = 2 failures - RAID-1 (Mirroring)<br>- R1FTT3 = 3 failures - RAID-1 (Mirroring)<br>- R5FTT1 = 1 failure - RAID-5 (Erasure Coding),<br>- R6FTT2 = 2 failures - RAID-6 (Erasure Coding) <br>- No Data Redundancy options aren't covered under Microsoft SLA.|
    | **vSANSiteDisasterTolerance** | Only valid for stretch clusters. <br>-  Default is "None". <br>- Valid Values are "None", "Dual", "Preferred", "Secondary", "NoneStretch"  <br>- None = No Site Redundancy (Recommended Option for Non-Stretch Clusters, NOT recommended for Stretch Clusters)  <br>- Dual = Dual Site Redundancy (Recommended Option for Stretch Clusters)  <br>- Preferred = No site redundancy - keep data on Preferred (stretched cluster)  <br>- Secondary = No site redundancy -  Keep data on Secondary Site (stretched cluster)  <br>- NoneStretch = No site redundancy - Not Recommended (https://kb.vmware.com/s/article/88358)|
    | **Description** | Description of Storage Policy you're creating, free form text. |
-   | **Name** | Name of the storage policy to set. For example, **RAID-FTT-1**. |
+   | **Name** | Name of the storage policy to set. For example, **RAID1 FTT-1**. |
    | **Retain up to**  | Retention period of the cmdlet output. The default value is 60.  |
    | **Specify name for execution**  | Alphanumeric name, for example, **New-AVSStoragePolicy-Exec1**.  |
    | **Timeout**  |  The period after which a cmdlet exits if taking too long to finish.  |


### PR DESCRIPTION
Fixed RAID naming convention in example (RAID-FTT-1 → RAID1 FTT-1)

The previous example used an incorrect naming convention. RAID policies are formatted with the RAID number followed by a space before the FTT configuration, rather than using a hyphen. The correct examples are "RAID1 FTT-1" or "RAID6 FTT-2" instead of "RAID-FTT-1".