### PR TITLE
Correct userStateChangedOn superscript

### DIFF
--- a/articles/active-directory-b2c/user-profile-attributes.md
+++ b/articles/active-directory-b2c/user-profile-attributes.md
@@ -85,7 +85,7 @@ Azure AD B2C directory user profile supports the [user resource type](/graph/api
 |usageLocation   |String|Required for users that are assigned licenses due to legal requirement to check for availability of services in countries/regions. Not nullable. A two letter country/region code (ISO standard 3166). For examples, *US*, *JP*, and *GB*.|Yes|No|Persisted, Output|
 |userType        |String|A string value that can be used to classify user types in your directory. Value must be Member. Read-only.|Read only|No|Persisted, Output|
 |userState (externalUserState)<sup>3</sup>|String|For Microsoft Entra B2B account only, and it indicates whether the invitation is PendingAcceptance or Accepted.|No|No|Persisted, Output|
-|userStateChangedOn (externalUserStateChangeDateTime)<sup>2</sup>|DateTime|Shows the timestamp for the latest change to the UserState property.|No|No|Persisted, Output|
+|userStateChangedOn (externalUserStateChangeDateTime)<sup>3</sup>|DateTime|Shows the timestamp for the latest change to the UserState property.|No|No|Persisted, Output|
 
 <sup>1 </sup>Not supported by Microsoft Graph<br><sup>2 </sup>For more information, see [MFA phone number attribute](#mfa-phone-number-attribute)<br><sup>3 </sup>Shouldn't be used with Azure AD B2C
 


### PR DESCRIPTION
This superscript currently refers to a note on MFA phone authentication and should almost certainly refer to the same note as the `userState` attribute above it.