### PR TITLE
Update a new unsupported feature in synapse workspace deployment

### DIFF
--- a/articles/synapse-analytics/cicd/continuous-integration-delivery.md
+++ b/articles/synapse-analytics/cicd/continuous-integration-delivery.md
@@ -249,7 +249,7 @@ You can choose the operation types based on the use case. Following part is an e
 > [!IMPORTANT]
 > In CI/CD scenarios, the integration runtime type in different environments must be the same. For example, if you have a self-hosted integration runtime in the development environment, the same integration runtime must be self-hosted in other environments, such as in test and production. Similarly, if you're sharing integration runtimes across multiple stages, the integration runtimes must be linked and self-hosted in all environments, such as in development, test, and production.
 >           
-> Currently, the DevOps Service Connection with **Workload Identity Federation (WIF)** is not supported in Synapse Workspace deployment extension. Please switch to secret mode to make the connection successful.
+> Currently, the DevOps Service Connection with **Workload Identity Federation (WIF)** is not supported in Synapse Workspace deployment extension. Switch to secret mode to make the connection successful.
 
 ### Create a release for deployment
 

--- a/articles/synapse-analytics/cicd/continuous-integration-delivery.md
+++ b/articles/synapse-analytics/cicd/continuous-integration-delivery.md
@@ -248,6 +248,8 @@ You can choose the operation types based on the use case. Following part is an e
 
 > [!IMPORTANT]
 > In CI/CD scenarios, the integration runtime type in different environments must be the same. For example, if you have a self-hosted integration runtime in the development environment, the same integration runtime must be self-hosted in other environments, such as in test and production. Similarly, if you're sharing integration runtimes across multiple stages, the integration runtimes must be linked and self-hosted in all environments, such as in development, test, and production.
+>           
+> Currently, the DevOps Service Connection with **Workload Identity Federation (WIF)** is not supported in Synapse Workspace deployment extension. Please switch to secret mode to make the connection successful.
 
 ### Create a release for deployment
 


### PR DESCRIPTION
DevOps has a new service connection feature called workload identity federation. It is not supported in Synapse workspace deployment task. As MSFT engineer, I saw multiple customers face this issue so request to update the doc.