### PR TITLE
fix: Snippets up a level in UI

### DIFF
--- a/articles/static-web-apps/snippets.md
+++ b/articles/static-web-apps/snippets.md
@@ -28,9 +28,7 @@ Common use cases of snippets include:
 
 1. Go to your static web app in the Azure portal.
 
-1. From the *Settings* menu, select **Configuration**.
-
-1. Select the **Snippets** tab.
+1. From the *Settings* menu, select **Snippets**.
 
 1. Select the **Add** button.
 


### PR DESCRIPTION
In the Azure Portal "Snippets" are now a page of their own under the Settings group. They are no longer on the Configuration page

![image](https://github.com/user-attachments/assets/3951a9e1-f815-4e3a-bbee-5543e8c9a466)
