### PR TITLE
Update redirection-configure-camera-webcam-video-capture.md

### DIFF
--- a/articles/virtual-desktop/redirection-configure-camera-webcam-video-capture.md
+++ b/articles/virtual-desktop/redirection-configure-camera-webcam-video-capture.md
@@ -155,7 +155,7 @@ To configure camera, webcam and video capture redirection using host pool RDP pr
 1. To test the configuration, connect to a remote session with a camera, webcam, or video capture peripheral and use it with a supported application for the peripheral, such as Microsoft Teams.
 
 > [!WARNING]
-> Clients that are [optimized with the new VDI solution for Teams](https://learn.microsoft.com/en-us/microsoftteams/vdi-2) using `MsTeamsPluginAvd.dll`, which is bundled with the latest versions of RD Client for Windows and Windows App, will bypass the "Don't redirect any cameras" RDP property and permit the use of client cameras in Microsoft Teams within a remote session.
+> Clients that are [optimized with the new VDI solution for Teams](https://github.com/MicrosoftDocs/OfficeDocs-SkypeForBusiness/blob/public/Teams/vdi-2.md) using `MsTeamsPluginAvd.dll`, which is bundled with the latest versions of RD Client for Windows and Windows App, will bypass the "Don't redirect any cameras" RDP property and permit the use of client cameras in Microsoft Teams within a remote session.
 ::: zone-end
 
 ::: zone pivot="azure-virtual-desktop"

--- a/articles/virtual-desktop/redirection-configure-camera-webcam-video-capture.md
+++ b/articles/virtual-desktop/redirection-configure-camera-webcam-video-capture.md
@@ -153,6 +153,9 @@ To configure camera, webcam and video capture redirection using host pool RDP pr
 1. Select **Save**.
 
 1. To test the configuration, connect to a remote session with a camera, webcam, or video capture peripheral and use it with a supported application for the peripheral, such as Microsoft Teams.
+
+> [!WARNING]
+> Clients that are [optimized with the new VDI solution for Teams](https://learn.microsoft.com/en-us/microsoftteams/vdi-2) using `MsTeamsPluginAvd.dll`, which is bundled with the latest versions of RD Client for Windows and Windows App, will bypass the "Don't redirect any cameras" RDP property and permit the use of client cameras in Microsoft Teams within a remote session.
 ::: zone-end
 
 ::: zone pivot="azure-virtual-desktop"


### PR DESCRIPTION
Within the context of an Azure Virtual Desktop environment where the [New VDI solution for Teams](https://learn.microsoft.com/en-us/microsoftteams/vdi-2) is utilised, client cameras will bypass the "Don't redirect any cameras" RDP property within Microsoft Teams.

While this does make logical sense and may be intentional, I feel that it is worth noting within the property's documentation.