### PR TITLE
Update manage-runtime-environment.md

### DIFF
--- a/articles/automation/manage-runtime-environment.md
+++ b/articles/automation/manage-runtime-environment.md
@@ -58,7 +58,7 @@ An Azure Automation account in supported public region (except Central India, Ge
     1. From the **Language** drop-down, select the scripting language for Runtime environment.
         - Choose **PowerShell** for PowerShell scripting language or **Python** for Python scripting language.
     1. Select **Runtime version** for scripting language.
-        - For PowerShell - choose 5.1, 7.2
+        - For PowerShell - choose 5.1, 7.2 or 7.4
         - For Python - choose 3.8, 3.10 (preview)
     1. Provide appropriate **Description**.
     


### PR DESCRIPTION
PowerShell 7.4 is available as an option when creating a new runtime environment but is not noted anywhere in this documentation - so using this PR to add this.

We have been instructed by the PG to advise customers to use a PowerShell 7.4 runtime environment as a suggested solution or workaround in certain Automation Runbook scenarios. So, it would be useful to include PowerShell 7.4 in this documentation.