### PR TITLE
Update linux validation tools

### DIFF
--- a/articles/governance/machine-configuration/overview.md
+++ b/articles/governance/machine-configuration/overview.md
@@ -107,7 +107,7 @@ built-in content, machine configuration handles loading these tools automaticall
 | Operating system |                 Validation tool                 |                                                                         Notes                                                                          |
 | ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Windows          | [PowerShell Desired State Configuration][15] v2 | Side-loaded to a folder only used by Azure Policy. Doesn't conflict with Windows PowerShell DSC. PowerShell isn't added to system path.                |
-| Linux            | [PowerShell Desired State Configuration][15] v3 | Side-loaded to a folder only used by Azure Policy. PowerShell isn't added to system path.                                                              |
+| Linux            | [PowerShell Desired State Configuration][15] v2 | Side-loaded to a folder only used by Azure Policy. PowerShell isn't added to system path.                                                              |
 | Linux            | [Chef InSpec][16]                               | Installs Chef InSpec version 2.2.61 in default location and adds it to system path. It installs InSpec's dependencies, including Ruby and Python, too. |
 
 ### Validation frequency


### PR DESCRIPTION
GuestConfiguration Linux uses DSCv2. As of now DSCv3 is not supported scenario.