### PR TITLE
Fix required Windows SDK version.

### DIFF
--- a/articles/trusted-signing/how-to-signing-integrations.md
+++ b/articles/trusted-signing/how-to-signing-integrations.md
@@ -40,7 +40,7 @@ To complete the steps in this article, you need:
 
 Trusted Signing Client Tools for SignTool.exe is a library plugin that requires the following components:
 
-1. Windows SDK SignTool.exe (minimum version: 10.0.2261.755)
+1. Windows SDK SignTool.exe (minimum version: 10.0.22621.755)
 1. .NET 8 Runtime
 1. Microsoft Visual C++ Redistributable
 1. Trusted Signing Client Dlib


### PR DESCRIPTION
10.0.2261.755 seems to be a typo. The correct version should be 10.0.22621.755.