### PR TITLE
Update overview-tls.md as TLS 1.2 is not recommended by Defender anymore

### DIFF
--- a/articles/app-service/overview-tls.md
+++ b/articles/app-service/overview-tls.md
@@ -64,7 +64,7 @@ These suites provide strong encryption and are automatically used when TLS 1.3 i
 
 ### TLS 1.2
 
-TLS 1.2 is the **default and recommended** TLS version for App Service. It provides strong encryption and broad compatibility while meeting compliance standards like PCI DSS. New web apps and SCM endpoints are automatically set to TLS 1.2 unless changed.
+TLS 1.2 is the **default** TLS version for App Service. It provides strong encryption and broad compatibility while meeting compliance standards like PCI DSS. New web apps and SCM endpoints are automatically set to TLS 1.2 unless changed.
 
 Azure App Service uses a secure set of TLS 1.2 cipher suites to ensure encrypted connections and protect against known vulnerabilities. While TLS 1.0 and 1.1 can be enabled for backward compatibility, they are not recommended.
 


### PR DESCRIPTION
TLS 1.2 is not the recommended version anymore according to the latest recommendation from MS Defender for Cloud. 

The rule name is "TLS should be updated to the latest version for web apps" which suggest to use 1.3. Links as below. 

https://learn.microsoft.com/en-us/azure/defender-for-cloud/recommendations-reference-app-services

https://portal.azure.com/#view/Microsoft_Azure_Policy/PolicyDetailAdaptor.ReactView/d[…]n%2FpolicyDefinitions%2Ff0e6e85b-9b9f-4a4b-b67b-f730d42f1b0b