### PR TITLE
Update configure-language-python.md - adding a note about directory d…

### DIFF
--- a/articles/app-service/configure-language-python.md
+++ b/articles/app-service/configure-language-python.md
@@ -69,7 +69,7 @@ You can run an unsupported version of Python by building your own container imag
 
 ## Customize build automation
 > [!NOTE]
-> When Python applications are deployed with build automation, content will be deployed to and served from `/tmp/<uid>`, not under `/home/site/wwwroot`. This content directory can be access through the `APP_PATH` environment variable. Any additional files created at runtime should be written to a location under `/home` or using [Bring Your Own Storage](https://learn.microsoft.com/en-us/azure/app-service/configure-connect-to-azure-storage?tabs=basic%2Cportal&pivots=container-linux) for persistence. More information on this behavior can be found [here](https://github.com/Azure-App-Service/KuduLite/wiki/Python-Build-Changes).
+> When Python applications are deployed with build automation, content will be deployed to and served from `/tmp/<uid>`, not under `/home/site/wwwroot`. This content directory can be access through the `APP_PATH` environment variable. Any additional files created at runtime should be written to a location under `/home` or using [Bring Your Own Storage](https://learn.microsoft.com/azure/app-service/configure-connect-to-azure-storage?tabs=basic%2Cportal&pivots=container-linux) for persistence. More information on this behavior can be found [here](https://github.com/Azure-App-Service/KuduLite/wiki/Python-Build-Changes).
 
 App Service's build system, called Oryx, performs the following steps when you deploy your app, if the app setting `SCM_DO_BUILD_DURING_DEPLOYMENT` is set to `1`:
 

--- a/articles/app-service/configure-language-python.md
+++ b/articles/app-service/configure-language-python.md
@@ -68,6 +68,8 @@ You can run an unsupported version of Python by building your own container imag
 <a name="access-environment-variables"></a>
 
 ## Customize build automation
+> [!NOTE]
+> When Python applications are deployed with build automation, content will be deployed to and served from `/tmp/<uid>`, not under `/home/site/wwwroot`. This content directory can be access through the `APP_PATH` environment variable. Any additional files created at runtime should be written to a location under `/home` or using [Bring Your Own Storage](https://learn.microsoft.com/en-us/azure/app-service/configure-connect-to-azure-storage?tabs=basic%2Cportal&pivots=container-linux) for persistence. More information on this behavior can be found [here](https://github.com/Azure-App-Service/KuduLite/wiki/Python-Build-Changes).
 
 App Service's build system, called Oryx, performs the following steps when you deploy your app, if the app setting `SCM_DO_BUILD_DURING_DEPLOYMENT` is set to `1`:
 


### PR DESCRIPTION
…ifferences when Oryx is used

Adding a note to call out directory differences of where source code is deployed and served from when Oryx is used/enabled - specifically for Python applications.

This is to avoid confusion in cases where someone may be /tmp/<uid> be the default content location versus the typical /home/site/wwwroot location