### PR TITLE
Update static-web-apps-languages-runtimes.md

### DIFF
--- a/includes/static-web-apps-languages-runtimes.md
+++ b/includes/static-web-apps-languages-runtimes.md
@@ -11,18 +11,21 @@ To configure the API language runtime version, set the `apiRuntime` property in 
 | Language runtime version | Operating system | Azure Functions version | `apiRuntime` value | End of support date |
 |--|--|--|--|--|
 | .NET Core 3.1 | Windows | 3.x | `dotnet:3.1` | December 3, 2022 |
-| .NET 6.0 in-process | Windows | 4.x | `dotnet:6.0` | - |
-| .NET 6.0 isolated | Windows | 4.x | `dotnet-isolated:6.0` | - |
-| .NET 7.0 isolated | Windows | 4.x | `dotnet-isolated:7.0` | - |
+| .NET 6.0 in-process | Windows | 4.x | `dotnet:6.0` | April 30, 2025 |
+| .NET 6.0 isolated | Windows | 4.x | `dotnet-isolated:6.0` | April 30, 2025 |
+| .NET 7.0 isolated | Windows | 4.x | `dotnet-isolated:7.0` | April 30, 2025 |
 | .NET 8.0 isolated | Windows | 4.x | `dotnet-isolated:8.0` | - |
+| .NET 9.0 isolated | Windows | 4.x | `dotnet-isolated:9.0` | - |
 | Node.js 12.x | Linux | 3.x | `node:12` | December 3, 2022 |
-| Node.js 14.x | Linux | 4.x | `node:14` | - |
-| Node.js 16.x | Linux | 4.x | `node:16` | - |
-| Node.js 18.x | Linux | 4.x | `node:18` | - |
-| Node.js 20.x (preview) | Linux | 4.x | `node:20` | - |
-| Python 3.8 | Linux | 4.x | `python:3.8` | - |
-| Python 3.9 | Linux | 4.x | `python:3.9` | - |
+| Node.js 14.x | Linux | 4.x | `node:14` | April 30, 2025 |
+| Node.js 16.x | Linux | 4.x | `node:16` | April 30, 2025 |
+| Node.js 18.x | Linux | 4.x | `node:18` | April 30, 2025 |
+| Node.js 20.x | Linux | 4.x | `node:20` | - |
+| Python 3.8 | Linux | 4.x | `python:3.8` | April 30, 2025 |
+| Python 3.9 | Linux | 4.x | `python:3.9` | April 30, 2025 |
 | Python 3.10 | Linux | 4.x | `python:3.10` | - |
+| Python 3.11 | Linux | 4.x | `python:3.11` | - |
+
 
 ### .NET
 

--- a/includes/static-web-apps-languages-runtimes.md
+++ b/includes/static-web-apps-languages-runtimes.md
@@ -12,6 +12,7 @@ To configure the API language runtime version, set the `apiRuntime` property in 
 |--|--|--|--|--|
 | .NET Core 3.1 | Windows | 3.x | `dotnet:3.1` | December 3, 2022 |
 | .NET 6.0 in-process | Windows | 4.x | `dotnet:6.0` | April 30, 2025 |
+| .NET 8.0 in-process | Windows | 4.x | `dotnet:8.0` | - |
 | .NET 6.0 isolated | Windows | 4.x | `dotnet-isolated:6.0` | April 30, 2025 |
 | .NET 7.0 isolated | Windows | 4.x | `dotnet-isolated:7.0` | April 30, 2025 |
 | .NET 8.0 isolated | Windows | 4.x | `dotnet-isolated:8.0` | - |
@@ -19,10 +20,10 @@ To configure the API language runtime version, set the `apiRuntime` property in 
 | Node.js 12.x | Linux | 3.x | `node:12` | December 3, 2022 |
 | Node.js 14.x | Linux | 4.x | `node:14` | April 30, 2025 |
 | Node.js 16.x | Linux | 4.x | `node:16` | April 30, 2025 |
-| Node.js 18.x | Linux | 4.x | `node:18` | April 30, 2025 |
+| Node.js 18.x | Linux | 4.x | `node:18` | May 31, 2025 |
 | Node.js 20.x | Linux | 4.x | `node:20` | - |
 | Python 3.8 | Linux | 4.x | `python:3.8` | April 30, 2025 |
-| Python 3.9 | Linux | 4.x | `python:3.9` | April 30, 2025 |
+| Python 3.9 | Linux | 4.x | `python:3.9` | - |
 | Python 3.10 | Linux | 4.x | `python:3.10` | - |
 | Python 3.11 | Linux | 4.x | `python:3.11` | - |
 


### PR DESCRIPTION
Azure Static Web Apps team is removing support for API backends that are EOL from the functions team