### PR TITLE
Update route-server-note-nva-peering.md

### DIFF
--- a/includes/route-server-note-nva-peering.md
+++ b/includes/route-server-note-nva-peering.md
@@ -6,4 +6,4 @@ ms.topic: include
 ms.date: 09/16/2024
 ---
 > [!IMPORTANT]
-> We recommend peering each NVA with both route server instances to ensure that virtual network routes are advertised over the NVA connections and achieve high availability.
+> Ensure you peer the NVA with both route server instance IPs to ensure that virtual network routes are advertised over the NVA connections and achieve high availability.

--- a/includes/route-server-note-nva-peering.md
+++ b/includes/route-server-note-nva-peering.md
@@ -6,4 +6,4 @@ ms.topic: include
 ms.date: 09/16/2024
 ---
 > [!IMPORTANT]
-> Ensure you peer the NVA with both route server instance IPs to ensure that virtual network routes are advertised over the NVA connections and achieve high availability.
+> Peer the NVA with both route server instance IPs to ensure virtual network routes are advertised over the NVA connections and achieve high availability.


### PR DESCRIPTION
Changed language from a "Recommend" to an "Ensure"

Failing to peer both IPs results in inconsistent behavior and the failure of routes from the NVA to be advertised to Azure, this should ensure users of the QuickStart know it is a requirement as documented in the Q& A here: https://learn.microsoft.com/en-us/azure/route-server/route-server-faq