### PR TITLE
Update quickstart-create-route-server-portal.md

### DIFF
--- a/articles/route-server/quickstart-create-route-server-portal.md
+++ b/articles/route-server/quickstart-create-route-server-portal.md
@@ -85,7 +85,7 @@ In this section, you learn how to configure BGP peering with a network virtual a
 
 ## Complete the configuration on the NVA
 
-To complete the peering setup, you must configure the NVA to establish a BGP session with the route server using its IP addresses and ASN. You can find the IP addresses and ASN of **myRouteServer** in the **Overview** page:
+To complete the peering setup, you must configure the NVA to establish a BGP session with the route server using both of it's IP addresses and ASN. You can find the IP addresses and ASN of **myRouteServer** in the **Overview** page:
 
 :::image type="content" source="./media/route-server-overview.png" alt-text="Screenshot that shows the Overview page of Route Server." lightbox="./media/route-server-overview.png":::
 


### PR DESCRIPTION
Added text to ensure users know both IP's are required a little more explicitly as this is a common issue with ARS deployments.

Failing to peer both IPs results in inconsistent behavior and the failure of routes from the NVA to be advertised to Azure, this should ensure users of the QuickStart know it is a requirement as documented in the Q& A here: https://learn.microsoft.com/en-us/azure/route-server/route-server-faq