### PR TITLE
Document dataType property for function event hub trigger binding

### DIFF
--- a/includes/functions-bindings-event-hubs-trigger.md
+++ b/includes/functions-bindings-event-hubs-trigger.md
@@ -444,6 +444,7 @@ The following table explains the trigger configuration properties that you set i
 |**consumerGroup** |An optional property that sets the [consumer group](../articles/event-hubs/event-hubs-features.md#event-consumers) used to subscribe to events in the hub. If omitted, the `$Default` consumer group is used. |
 |**cardinality** | Set to `many` in order to enable batching.  If omitted or set to `one`, a single message is passed to the function.|
 |**connection** | The name of an app setting or setting collection that specifies how to connect to Event Hubs. See [Connections](#connections).|
+|**dataType** | An optional property that sets the type of the trigger input. Choose `string` or `binary` if the input is not valid JSON. | 
 
 # [Functions 1.x](#tab/functionsv1)
 


### PR DESCRIPTION
Adds the `dataType` property to the table of properties that can be defined when creating an EventHub trigger binding for a Function. The `dataType` property must be set to `string` or `binary` if the event hub input is not valid JSON.

Text is based on the [help label in the Function template](https://github.com/Azure/azure-functions-templates/blob/5814b54831c7416b42c784b21cb5990523b5001a/Functions.Templates/Resources/Resources.resx#L1279)