### PR TITLE
Remove images with settings that contradict the article

### DIFF
--- a/articles/update-manager/configure-wu-agent.md
+++ b/articles/update-manager/configure-wu-agent.md
@@ -70,15 +70,11 @@ If your machine is patched using Azure Update Manager, and has Automatic updates
 1. Select **Configure Automatic Updates**.
 1. Select or deselect the **Install updates for other Microsoft products** option.
 
-   :::image type="content" source="./media/configure-wu-agent/configure-updates-group-policy-inline.png" alt-text="Screenshot of selection or deselection of install updates for other Microsoft products." lightbox="./media/configure-wu-agent/configure-updates-group-policy-expanded.png":::
-
 For Windows Server 2022:
 
 1. Go to **Computer Configuration** > **Administrative Templates** > **Windows Components** > **Windows Update** > **Configure Automatic Updates**.
 1. Select **Configure Automatic Updates**.
 1. Select or deselect the **Install updates for other Microsoft products** option.
-
-   :::image type="content" source="./media/configure-wu-agent/configure-updates-group-policy-windows.png" alt-text="Screenshot of selection or deselection of install updates for other Microsoft products in Windows Server 2022.":::
 
 ## Make WSUS configuration settings
 


### PR DESCRIPTION
In regards to `Pre-download updates` this article states "Don't use pre-download functionality through AUOptions while using Azure Update Manager default/advanced patching mechanisms" but then later in the article these images were showing settings that would have pre-download enabled.