### PR TITLE
Update quick-kubernetes-backup-cli.md

### DIFF
--- a/articles/backup/quick-kubernetes-backup-cli.md
+++ b/articles/backup/quick-kubernetes-backup-cli.md
@@ -27,7 +27,7 @@ Before you configure vaulted backup for AKS cluster, ensure the following prereq
 To create the Backup vault, run the following command:
 
 ```azurecli
-az dataprotection backup-vault create --resource-group $backupvaultresourcegroup --vault-name $backupvault --location $region --type SystemAssigned --storage-settings datastore-type="VaultStore" type="GloballyRedundant"
+az dataprotection backup-vault create --resource-group $backupvaultresourcegroup --vault-name $backupvault --location $region --type SystemAssigned --storage-settings datastore-type="VaultStore" type="GeoRedundant"
 ```
 
 The newly created vault has storage settings set as Globally Redundant, thus backups stored in vault tier will be available in the Azure paired region. Once the vault creation is complete, create a backup policy to protect AKS clusters.


### PR DESCRIPTION
Using GloballyRedundant' throws error below

unrecognized value 'GloballyRedundant' from choices '['GeoRedundant', 'LocallyRedundant', 'ZoneRedundant']'
<br/><br/>

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/d78d6475-9bb3-477f-8919-9cf395e82b8b" />

<br/><br/>


The correct is "**GeoRedundant**" instead of  "**GloballyRedundant**'
