### PR TITLE
Google no longer a domain registrar

### DIFF
--- a/articles/static-web-apps/custom-domain.md
+++ b/articles/static-web-apps/custom-domain.md
@@ -22,7 +22,7 @@ The following table includes links to articles that demonstrate how to configure
 | Set up a domain with the `www` subdomain | [Azure DNS](custom-domain-azure-dns.md) | [External provider](custom-domain-external.md) |
 | Set up an apex domain | [Azure DNS](apex-domain-azure-dns.md) | [External provider](apex-domain-external.md) |
 
-<sup>1</sup> Some registrars like GoDaddy and Google don't support domain records that affect how you configure your apex domain. Consider using [Azure DNS](custom-domain-azure-dns.md) with these registrars to set up your apex domain.
+<sup>1</sup> Some registrars like GoDaddy don't support domain records that affect how you configure your apex domain. Consider using [Azure DNS](custom-domain-azure-dns.md) with these registrars to set up your apex domain.
 
 > [!NOTE]
 > Adding a custom domain to a [preview environment](preview-environments.md) is not supported. Unicode domains, including Punycode domains and the `xn--` prefix are also not supported.


### PR DESCRIPTION
Google is no longer a domain registrar. They sold this business to Squarespace. 

If you visit http://domains.google.com/ it displays a message informing of this change and advises visitors to contact Squarespace for further help.