### PR TITLE
Container Apps Replica quota limit.

### DIFF
--- a/articles/container-apps/quotas.md
+++ b/articles/container-apps/quotas.md
@@ -23,7 +23,7 @@ You can [request a quota increase in the Azure portal](/azure/quotas/quickstart-
 | Environments | Global | 20 | Unlimited | Up to 20 environments per subscription, across all regions. Adjusted through Managed Environment Count quota (usually 20% more than Managed Environment Count) |
 | Container Apps | Environment | Unlimited | Unlimited | |
 | Revisions | Container app | Unlimited | Unlimited | |
-| Replicas | Revision | Unlimited | Unlimited | Maximum replicas configurable are 300 in Azure portal and 1000 in Azure CLI. There must also be enough cores quota available. |
+| Replicas | Revision | Unlimited | Unlimited | Maximum replicas configurable are 1000 in Azure portal and Azure CLI. There must also be enough cores quota available. |
 | Session pools | Global | Up to 6 | 10,000 | Maximum number of dynamic session pools per subscription. No official Azure quota yet, please raise support case. |
 
 


### PR DESCRIPTION
I could set the Replica minimum and maximum count are 1000 on Azure Portal. Container number of CPU cores and Memory size are default value.

![image](https://github.com/user-attachments/assets/6d45728b-085c-415a-830d-68e612e88b08)

![image](https://github.com/user-attachments/assets/a15e6e47-739c-412f-bf0e-b218606f4e18)

We can see Container Apps Number of Replica count set 100 on azure Portal.
![image](https://github.com/user-attachments/assets/f202baac-b78b-4348-9667-195509f6864d)


