### PR TITLE
Add ARM template example for setting app settings in Azure App Service

### DIFF
--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -126,6 +126,44 @@ To make one or more app settings slot specific, use [Set-AzWebAppSlotConfigName]
 Set-AzWebAppSlotConfigName -ResourceGroupName <group-name> -Name <app-name> -AppSettingNames <setting-name1>,<setting-name2>,...
 ```
 
+# [ARM Template](#tab/ARM)
+
+Set one or more app settings by using Azure Resource Manager templates (ARM templates):
+
+```json
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2024-04-01",
+      "name": "[parameters('webAppName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "httpsOnly": true,
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",
+        "siteConfig": {
+          "linuxFxVersion": "[parameters('linuxFxVersion')]",
+          "minTlsVersion": "1.2",
+          "ftpsState": "FtpsOnly",
+		  "appSettings": [
+			{
+			"name": "<setting-name1>", 
+			"value": "<value1>"
+			},
+			{
+			"name": "<setting-name2>", 
+			"value": "<value2>"
+			}
+      ]
+        }
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+      ]
+    },
+```
+
 -----
 
 ### Edit app settings in bulk

--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -147,10 +147,6 @@ Set one or more app settings by using Azure Resource Manager templates (ARM temp
 			{
 			"name": "<setting-name1>", 
 			"value": "<value1>"
-			},
-			{
-			"name": "<setting-name2>", 
-			"value": "<value2>"
 			}
       ]
         }
@@ -237,6 +233,44 @@ az webapp config appsettings set --resource-group <group-name> --name <app-name>
 # [Azure PowerShell](#tab/ps)
 
 It's not possible to edit app settings in bulk by using a JSON file with Azure PowerShell.
+
+# [ARM Template](#tab/ARM)
+
+Set one or more app settings by using Azure Resource Manager templates (ARM templates):
+
+```json
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2024-04-01",
+      "name": "[parameters('webAppName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "httpsOnly": true,
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]",
+        "siteConfig": {
+          "linuxFxVersion": "[parameters('linuxFxVersion')]",
+          "minTlsVersion": "1.2",
+          "ftpsState": "FtpsOnly",
+		  "appSettings": [
+			{
+			"name": "<setting-name1>", 
+			"value": "<value1>"
+			},
+			{
+			"name": "<setting-name2>", 
+			"value": "<value2>"
+			}
+      ]
+        }
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+      ]
+    },
+```
 
 -----
 

--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -160,6 +160,8 @@ Set one or more app settings by using Azure Resource Manager templates (ARM temp
     },
 ```
 
+Please refer to [**Microsoft.Web/sites**](/azure/templates/microsoft.web/sites) for more information.
+
 -----
 
 ### Edit app settings in bulk
@@ -271,6 +273,8 @@ Set one or more app settings by using Azure Resource Manager templates (ARM temp
       ]
     },
 ```
+
+Please refer to [**Microsoft.Web/sites**](/azure/templates/microsoft.web/sites) for more information.
 
 -----
 


### PR DESCRIPTION
This PR is to updated the document [Configure an App Service app](https://learn.microsoft.com/en-us/azure/app-service/configure-common?tabs=portal#configure-app-settings) to include an ARM template example for setting app settings in Azure App Service. 