### PR TITLE
Update storage-files-faq.md

### DIFF
--- a/articles/storage/files/storage-files-faq.md
+++ b/articles/storage/files/storage-files-faq.md
@@ -125,7 +125,23 @@ ms.topic: faq
 **Can I save to an Azure file share using a printer or scanner?**
 
   Azure Files only supports Windows, Linux, and macOS. Accessing an Azure file share directly from a printer or scanner isn't supported. However, if you're already using Azure File Sync, you can print or scan to your Windows file server and then sync the file to an Azure file share.
-   
+
+* <a id="alternate-data-streams"></a>
+**Are alternate data streams supported in Azure Files?**
+
+  Azure Files does not support [alternate data streams](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e2b19412-a925-4360-b009-86e3b8a020c8). Transferring data via SMB will throw a **file already exists** message if an alternate data stream is found. Alternate streams can be checked by using the PowerShell command
+
+```powershell
+  get-item <file path+name> -Stream *
+```
+
+If more than one stream is shown, they can be removed using the following PowerShell command
+
+```powershell
+  Remove-Item <file path+name> -Stream *`
+```
+
+Please note that alternate data streams are preserved on-premises when Azure File Sync is used.
 
 ### Identity-based authentication
 

--- a/articles/storage/files/storage-files-faq.md
+++ b/articles/storage/files/storage-files-faq.md
@@ -129,7 +129,7 @@ ms.topic: faq
 * <a id="alternate-data-streams"></a>
 **Does Azure Files support alternate data streams?**
 
-  Azure Files does not support [alternate data streams](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e2b19412-a925-4360-b009-86e3b8a020c8). Transferring data via SMB will throw a **file already exists** message if an alternate data stream is found. Alternate streams can be checked by using the PowerShell command
+  Azure Files doesn't support [alternate data streams](https://learn.microsoft.com/openspecs/windows_protocols/ms-fscc/e2b19412-a925-4360-b009-86e3b8a020c8). Transferring data via SMB will throw a **file already exists** message if an alternate data stream is found. You can check alternate streams by using the following PowerShell command:
 
 ```powershell
   get-item <file path+name> -Stream *

--- a/articles/storage/files/storage-files-faq.md
+++ b/articles/storage/files/storage-files-faq.md
@@ -135,7 +135,7 @@ ms.topic: faq
   get-item <file path+name> -Stream *
 ```
 
-If more than one stream is shown, they can be removed using the following PowerShell command
+If more than one stream is shown, you can remove them using the following PowerShell command:
 
 ```powershell
   Remove-Item <file path+name> -Stream *`

--- a/articles/storage/files/storage-files-faq.md
+++ b/articles/storage/files/storage-files-faq.md
@@ -127,7 +127,7 @@ ms.topic: faq
   Azure Files only supports Windows, Linux, and macOS. Accessing an Azure file share directly from a printer or scanner isn't supported. However, if you're already using Azure File Sync, you can print or scan to your Windows file server and then sync the file to an Azure file share.
 
 * <a id="alternate-data-streams"></a>
-**Are alternate data streams supported in Azure Files?**
+**Does Azure Files support alternate data streams?**
 
   Azure Files does not support [alternate data streams](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/e2b19412-a925-4360-b009-86e3b8a020c8). Transferring data via SMB will throw a **file already exists** message if an alternate data stream is found. Alternate streams can be checked by using the PowerShell command
 


### PR DESCRIPTION
Adding information about alternate data streams (not supported) which we have in other places but not about the errors thrown with SMB. Please edit as needed.

https://dev.azure.com/Supportability/AzureIaaSVM/_wiki/wikis/AzureIaaSVM/1315074/Copy-Files-File-Explorer-File-Already-Exists-Error_Storage