### PR TITLE
Update configure-common.md

### DIFF
--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -54,6 +54,9 @@ App settings are always encrypted when they're stored (encrypted at rest).
 
    By default, values for app settings are hidden in the portal for security. To see a hidden value of an app setting, under **Value**, select **Show value**. To see the hidden values of all app settings, select **Show values**.
 
+   > [!NOTE]
+   > Read/Write user permimssions are required to view this section in the Azure Portal. RBAC built-in roles with sufficient permissions are Owner, Contributor, and Website Contributor. The Reader role alone would not be allowed to access this page. 
+
 1. To add a new app setting, select **Add**. To edit a setting, select the setting.
 1. In the dialog, you can [stick the setting to the current slot](deploy-staging-slots.md#which-settings-are-swapped).
 

--- a/articles/app-service/configure-common.md
+++ b/articles/app-service/configure-common.md
@@ -55,7 +55,7 @@ App settings are always encrypted when they're stored (encrypted at rest).
    By default, values for app settings are hidden in the portal for security. To see a hidden value of an app setting, under **Value**, select **Show value**. To see the hidden values of all app settings, select **Show values**.
 
    > [!NOTE]
-   > Read/Write user permimssions are required to view this section in the Azure Portal. RBAC built-in roles with sufficient permissions are Owner, Contributor, and Website Contributor. The Reader role alone would not be allowed to access this page. 
+   > Read/Write user permimssions are required to view this section in the Azure portal. RBAC built-in roles with sufficient permissions are Owner, Contributor, and Website Contributor. The Reader role alone would not be allowed to access this page. 
 
 1. To add a new app setting, select **Add**. To edit a setting, select the setting.
 1. In the dialog, you can [stick the setting to the current slot](deploy-staging-slots.md#which-settings-are-swapped).


### PR DESCRIPTION
As requested from supportability item, added note describing the write RBAC permission required to view this blade regarding App Settings in Azure Portal. 

Before, there was no mention of RBAC. 

After, I have added a few sentence, that Write RBAC is needed, which means Owner/Contributor/Website Contributor for built-in roles. 

This is intentional choice to require higher level permission due to the secret nature of the values displayed here.
Azure Portal UX already shows a banner informing the same if accessed with insufficient permissions. 
![image](https://github.com/user-attachments/assets/449cc266-07aa-47dd-a602-6bb042e092ec)
