### PR TITLE
Update quick-kubernetes-backup-cli.md

### DIFF
--- a/articles/backup/quick-kubernetes-backup-cli.md
+++ b/articles/backup/quick-kubernetes-backup-cli.md
@@ -53,7 +53,7 @@ az dataprotection backup-policy retention-rule set --lifecycles ./retentionrule.
 Once the policy JSON has all the required values, proceed to create a new policy from the policy object.
 
 ```azurecli
-az dataprotection backup-policy create -g testBkpVaultRG --vault-name TestBkpVault -n mypolicy --policy policy.json
+az dataprotection backup-policy create -g testBkpVaultRG --vault-name TestBkpVault -n mypolicy --policy akspolicy.json
 ```
 
 ## Prepare AKS cluster for backup


### PR DESCRIPTION
The naming convention of the `json` is incorrect back on the naming that was save (akspolicy.json) instead of (policy.json)

- The is wrong naming `policy.json` throwing error since the naming convention is different from what was save 


![image](https://github.com/user-attachments/assets/3089fc99-8fec-42de-8571-3f14eb3ebbe2)


<br/>

- The correct is naming convection use to save the json `askpolicy.json` 

```sh
az dataprotection backup-policy create -g testBkpVaultRG --vault-name TestBkpVault -n mypolicy --policy akspolicy.json
```

![image](https://github.com/user-attachments/assets/c689d449-1719-4be3-afc2-a06dc4f62247)

