### PR TITLE
Fix links in 'Monitor Azure Cache for Redis' document

### DIFF
--- a/articles/redis/monitor-cache.md
+++ b/articles/redis/monitor-cache.md
@@ -242,7 +242,7 @@ The following screenshot shows an advisor recommendation for an Azure Cache for 
 
 :::image type="content" source="media/monitor-cache/redis-cache-recommendations.png" alt-text="Screenshot that shows Advisor recommendations.":::
 
-To upgrade your cache, select **Upgrade now** to change the pricing tier and [scale]/azure-cache-for-redis/cache-configure.md#scale) your cache. For more information on choosing a pricing tier, see [Choosing the right tier]/azure-cache-for-redis/cache-overview.md#choosing-the-right-tier).
+To upgrade your cache, select **Upgrade now** to change the pricing tier and [scale](../azure-cache-for-redis/cache-configure.md#scale) your cache. For more information on choosing a pricing tier, see [Choosing the right tier](../azure-cache-for-redis/cache-overview.md#choosing-the-right-tier).
 
 ## Related content
 


### PR DESCRIPTION
Fix invalid markdown causing broken links in the 'Monitor Azure Cache for Redis' document. 

Broken links:
![image](https://github.com/user-attachments/assets/896edbe4-0aca-495d-a08d-4c5a736780f5)

Fixed:
![image](https://github.com/user-attachments/assets/35eacc97-04e5-4fcf-a676-cc05204273a7)

