### PR TITLE
Fix URL

### DIFF
--- a/articles/azure-resource-manager/bicep/scenarios-rbac.md
+++ b/articles/azure-resource-manager/bicep/scenarios-rbac.md
@@ -93,7 +93,7 @@ When you create the role assignment resource, you need to specify a fully qualif
 ```bicep
 param principalId string
 
-@description('This is the built-in Contributor role. See https://docs.microsoft.com/azure/role-based-access-control/built-in-roles#contributor')
+@description('This is the built-in Contributor role. See https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#contributor')
 resource contributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
   scope: subscription()
   name: 'b24988ac-6180-42a0-ab88-20f7382dd24c'


### PR DESCRIPTION
Replaced the old docs.microsoft.com link with the updated learn.microsoft.com version to reflect the current documentation domain.