### PR TITLE
Fix URL

### DIFF
--- a/articles/cdn/cdn-manage-powershell.md
+++ b/articles/cdn/cdn-manage-powershell.md
@@ -90,7 +90,7 @@ DESCRIPTION
     Gets an Azure CDN profile and all related information.
 
 RELATED LINKS
-    https://docs.microsoft.com/powershell/module/az.cdn/get-azcdnprofile
+    https://learn.microsoft.com/powershell/module/az.cdn/get-azcdnprofile
 
 REMARKS
     To see the examples, type: "get-help Get-AzCdnProfile -examples".


### PR DESCRIPTION
Replaced the old docs.microsoft.com link with the updated learn.microsoft.com version to reflect the current documentation domain.