### PR TITLE
Fix URL

### DIFF
--- a/articles/event-grid/auth0-log-stream-blob-storage.md
+++ b/articles/event-grid/auth0-log-stream-blob-storage.md
@@ -48,7 +48,7 @@ This article shows you how to send Auth0 events to Azure Blob Storage via Azure 
       // Event Grid always sends an array of data and may send more
       // than one event in the array. The runtime invokes this function
       // once for each array element, so we are always dealing with one.
-      // See: https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger?tabs=
+      // See: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger?tabs=
       module.exports = async function (context, eventGridEvent) {
           context.log(JSON.stringify(context.bindings));
           context.log(JSON.stringify(context.bindingData));


### PR DESCRIPTION
Replaced the old docs.microsoft.com link with the updated learn.microsoft.com version to reflect the current documentation domain.