### PR TITLE
Fix RSS trigger failure issue in Logic Apps Quickstart guide

### DIFF
--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -136,12 +136,15 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
 1. Save your workflow. On the designer toolbar, select **Save**.
 
-   This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
+1. On the designer toolbar, select **Code view**. In the code editor, change the line **`"feedUrl": "@{encodeURIComponent(encodeURIComponent(`https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}"`** to the following version:  
+   
+   **`"feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}"`**  
 
-1. On the logic app code view,  
-change "feedUrl": "@{encodeURIComponent(encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}" to  
-       "feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".  
-This is necessary due to a double encoding issue, which must be manually corrected.  
+   This change is necessary to remove double-encoding behavior, which requires manual correction.  
+   
+1. Switch back to the designer.  
+
+   This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
 
 <a name="add-email-action"></a>
 

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -134,7 +134,6 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
    :::image type="content" source="media/quickstart-create-example-consumption-workflow/add-rss-trigger-settings.png" alt-text="Screenshot shows the RSS trigger settings, including RSS URL, frequency, interval, and others." lightbox="media/quickstart-create-example-consumption-workflow/add-rss-trigger-settings.png":::
 
-1. Save your workflow. On the designer toolbar, select **Save**.
 1. On the designer toolbar, select **Code view**.
 
 1. In the code editor, find the line **`"feedUrl": "@{encodeURIComponent(encodeURIComponent(`https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}"`**.

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -148,7 +148,6 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
 1. Save your workflow. On the designer toolbar, select **Save**.
 
-
    This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
 
 <a name="add-email-action"></a>

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -135,7 +135,6 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
    :::image type="content" source="media/quickstart-create-example-consumption-workflow/add-rss-trigger-settings.png" alt-text="Screenshot shows the RSS trigger settings, including RSS URL, frequency, interval, and others." lightbox="media/quickstart-create-example-consumption-workflow/add-rss-trigger-settings.png":::
 
 1. Save your workflow. On the designer toolbar, select **Save**.
-
 1. On the designer toolbar, select **Code view**.
 
 1. In the code editor, find the line **`"feedUrl": "@{encodeURIComponent(encodeURIComponent(`https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}"`**.

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -138,11 +138,11 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
    This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
 
-1. On the logic app code view,
-change "feedUrl": "@{encodeURIComponent(encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}" to
-       "feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".
+1. On the logic app code view,  
+change "feedUrl": "@{encodeURIComponent(encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}" to  
+       "feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".  
 
-This is necessary due to a double encoding issue, which must be manually corrected.
+This is necessary due to a double encoding issue, which must be manually corrected.  
 
 <a name="add-email-action"></a>
 

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -139,9 +139,9 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
    This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
 
 1. On the logic app code view,
-On the Logic App code view,
 change "feedUrl": "@{encodeURIComponent(encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}" to
-"feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".
+       "feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".
+
 This is necessary due to a double encoding issue, which must be manually corrected.
 
 <a name="add-email-action"></a>

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -144,7 +144,10 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
    This change is necessary to remove double-encoding behavior, which requires manual correction.  
    
-1. Switch back to the designer.  
+1. Switch back to the designer.
+
+1. Save your workflow. On the designer toolbar, select **Save**.
+
 
    This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
 

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -141,7 +141,6 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 1. On the logic app code view,  
 change "feedUrl": "@{encodeURIComponent(encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}" to  
        "feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".  
-
 This is necessary due to a double encoding issue, which must be manually corrected.  
 
 <a name="add-email-action"></a>

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -136,7 +136,11 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
 1. Save your workflow. On the designer toolbar, select **Save**.
 
-1. On the designer toolbar, select **Code view**. In the code editor, change the line **`"feedUrl": "@{encodeURIComponent(encodeURIComponent(`https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}"`** to the following version:  
+1. On the designer toolbar, select **Code view**.
+
+1. In the code editor, find the line **`"feedUrl": "@{encodeURIComponent(encodeURIComponent(`https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}"`**.
+
+1. Remove the extra function named **`encodeURIComponent()`** so that you have only one instance, for example: 
    
    **`"feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}"`**  
 

--- a/articles/logic-apps/quickstart-create-example-consumption-workflow.md
+++ b/articles/logic-apps/quickstart-create-example-consumption-workflow.md
@@ -138,6 +138,12 @@ This example uses an RSS trigger that checks an RSS feed, based on the specified
 
    This step instantly publishes your logic app resource and workflow live in the Azure portal. However, the trigger only checks the RSS feed without taking any other actions. So, you need to add an action to specify what you want to happen when the trigger fires.
 
+1. On the logic app code view,
+On the Logic App code view,
+change "feedUrl": "@{encodeURIComponent(encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml'))}" to
+"feedUrl": "@{encodeURIComponent('https://feeds.a.dj.com/rss/RSSMarketsMain.xml')}".
+This is necessary due to a double encoding issue, which must be manually corrected.
+
 <a name="add-email-action"></a>
 
 ## Add an action


### PR DESCRIPTION
This PR updates the Logic Apps Quickstart guide (quickstart-create-example-consumption-workflow.md) to address a known issue with the RSS trigger, where entering a URL in the "RSS Feed URL" field results in double encoding, causing the trigger to fail.

Details
When a URL is entered directly in the RSS trigger's feed URL field, it gets double-encoded
This appears to be a bug in the RSS trigger itself.
To work around this issue, a new step has been added to the Logic App code view, where users can manually correct the double-encoded URL.

