### PR TITLE
Update session-host-update-configure.md

### DIFF
--- a/articles/virtual-desktop/session-host-update-configure.md
+++ b/articles/virtual-desktop/session-host-update-configure.md
@@ -219,7 +219,7 @@ You can update the session host management policy before you schedule an update,
    Get-AzWvdSessionHostConfiguration @parameters | FL *
    ```
 
-3. *Optional*: If you want to update the session host management policy before scheduling an update, run the following command, using the `Update-AzWvdSessionHostManagement` cmdlet. Alternatively, you can override specific values when scheduling an update, which are used for that update only. For valid time zone values, see [Get-TimeZone PowerShell reference](/powershell/module/microsoft.powershell.management/get-timezone) and use the value from the `StandardName` property.
+3. *Optional*: If you want to update the session host management policy before scheduling an update, run the following command, using the `Update-AzWvdSessionHostManagement` cmdlet. Alternatively, you can override specific values when scheduling an update, which are used for that update only. For valid time zone values, see [Get-TimeZone PowerShell reference](/powershell/module/microsoft.powershell.management/get-timezone) and use the value from the `StandardName` property. We recommend setting UpdateDeleteOriginalVM = $true so that you do not need to clean up session host resources after an update.
 
    ```azurepowershell
    $parameters = @{


### PR DESCRIPTION
Added guidance to mitigate customer challenge of stranded resources after an update. We plan to deprecate the UpdateDeleteOriginalVM property in the future (and always delete the original resources).