### PR TITLE
Update to the default value of duplicate detection window size

### DIFF
--- a/articles/service-bus-messaging/duplicate-detection.md
+++ b/articles/service-bus-messaging/duplicate-detection.md
@@ -37,7 +37,7 @@ The `MessageId` can always be some GUID, but anchoring the identifier to the bus
 
 ## Duplicate detection window size
 
-Apart from just enabling duplicate detection, you can also configure the size of the duplicate detection history time window during which message IDs are retained. This value defaults to 10 minutes for queues and topics, with a minimum value of 20 seconds to maximum value of 7 days.
+Apart from enabling duplicate detection, you can also configure the size of the duplicate detection history time window during which message IDs are retained. This value defaults to 1 minute for queues and topics, with a minimum value of 20 seconds and a maximum value of 7 days.
 
 Enabling duplicate detection and the size of the window directly impact the queue (and topic) throughput, since all recorded message IDs must be matched against the newly submitted message identifier.
 


### PR DESCRIPTION
According to the API doc the default is 1 min rather than 10 mins

I have done some testing as well, it seems to be 1min from my test than 10 mins

https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.administration.createqueueoptions.duplicatedetectionhistorytimewindow?view=azure-dotnet&viewFallbackFrom=net-8.0