### PR TITLE
Update that AMA Only Supports ARM Templates using v1.0

### DIFF
--- a/articles/azure-resource-manager/managed-applications/publish-bicep-definition.md
+++ b/articles/azure-resource-manager/managed-applications/publish-bicep-definition.md
@@ -32,6 +32,9 @@ To complete the tasks in this article, you need the following items:
 
 ## Create a Bicep file
 
+> [!Note]
+> Azure Managed Applications only supports ARM templates using languageVersion 1.0 and **does not** support languageVersion 2.0. Refer to the [ARM Template documentation](https://learn.microsoft.com/azure/azure-resource-manager/templates/syntax#languageversion-20) to see what features will automatically enable version 2.0.
+
 Every managed application definition includes a file named _mainTemplate.json_. The template defines the Azure resources to deploy and is no different than a regular ARM template. You can develop the template using Bicep and then convert the Bicep file to JSON.
 
 Open Visual Studio Code, create a file with the case-sensitive name _mainTemplate.bicep_ and save it.

--- a/articles/azure-resource-manager/managed-applications/publish-service-catalog-app.md
+++ b/articles/azure-resource-manager/managed-applications/publish-service-catalog-app.md
@@ -33,6 +33,9 @@ To complete this quickstart, you need the following items:
 
 ## Create the ARM template
 
+> [!Note]
+> Azure Managed Applications only supports ARM templates using languageVersion 1.0 and **does not** support languageVersion 2.0. Refer to the [ARM Template documentation](https://learn.microsoft.com/azure/azure-resource-manager/templates/syntax#languageversion-20) to see what features will automatically enable version 2.0.
+
 Every managed application definition includes a file named _mainTemplate.json_. The template defines the Azure resources to deploy and is no different than a regular ARM template.
 
 Open Visual Studio Code, create a file with the case-sensitive name _mainTemplate.json_ and save it.

--- a/articles/azure-resource-manager/managed-applications/publish-service-catalog-bring-your-own-storage.md
+++ b/articles/azure-resource-manager/managed-applications/publish-service-catalog-bring-your-own-storage.md
@@ -34,6 +34,9 @@ To complete this quickstart, you need the following items:
 
 ## Create the ARM template
 
+> [!Note]
+> Azure Managed Applications only supports ARM templates using languageVersion 1.0 and **does not** support languageVersion 2.0. Refer to the [ARM Template documentation](https://learn.microsoft.com/azure/azure-resource-manager/templates/syntax#languageversion-20) to see what features will automatically enable version 2.0.
+
 Every managed application definition includes a file named _mainTemplate.json_. The template defines the Azure resources to deploy and is no different than a regular ARM template.
 
 Open Visual Studio Code, create a file with the case-sensitive name _mainTemplate.json_ and save it.

--- a/articles/azure-resource-manager/managed-applications/reference-main-template-artifact.md
+++ b/articles/azure-resource-manager/managed-applications/reference-main-template-artifact.md
@@ -11,6 +11,9 @@ This article is a reference for a _mainTemplate.json_ artifact in Azure Managed 
 
 ## Deployment template
 
+> [!Note]
+> Azure Managed Applications only supports ARM templates using languageVersion 1.0 and **does not** support languageVersion 2.0. Refer to the [ARM Template documentation](https://learn.microsoft.com/azure/azure-resource-manager/templates/syntax#languageversion-20) to see what features will automatically enable version 2.0.
+
 The following JSON shows an example of _mainTemplate.json_ file for Azure Managed Applications:
 
 ```json


### PR DESCRIPTION
Azure Managed Applications customers are attempting to use Bicep features that result in a new ARM Template version, 2.0, that AMA is not compatible with. This PR attempts to clarify this for all customers anywhere we discuss the mainTemplate.json of the Managed App.