### PR TITLE
Update about-zone-redundant-vnet-gateways.md

### DIFF
--- a/articles/vpn-gateway/about-zone-redundant-vnet-gateways.md
+++ b/articles/vpn-gateway/about-zone-redundant-vnet-gateways.md
@@ -75,7 +75,7 @@ These SKUs are available in Azure regions that have Azure availability zones. Fo
 ### Can I change/migrate/upgrade my existing virtual network gateways to zone-redundant or zonal gateways?
 
 * VPN gateway - migrating your existing virtual network gateways to zone-redundant or zonal gateways is currently not supported. You can, however, delete your existing gateway and re-create a zone-redundant or zonal gateway.
-* ExpressRoute gateway - migrating your existing ExpressRoute virtual network gateway to a zone-redundant or zonal gateway is currently in public preview. For more information, see [Migrate to an availability zone enabled ExpressRoute virtual network gateway](../expressroute/gateway-migration.md).
+* ExpressRoute gateway - migrating your existing ExpressRoute virtual network gateway to a zone-redundant or zonal gateway is now public. For more information, see [Migrate to an availability zone enabled ExpressRoute virtual network gateway](../expressroute/gateway-migration.md).
 
 ### Can I deploy both VPN and ExpressRoute gateways in same virtual network?
 


### PR DESCRIPTION
Corrected "migrating your existing ExpressRoute virtual network gateway to a zone-redundant or zonal gateway is currently **in public preview**. For more information, see Migrate to an availability zone enabled ExpressRoute virtual network gateway." to "**is now public**"

Reference: Migrate to an availability zone-enabled ExpressRoute virtual network gateway in Azure portal https://learn.microsoft.com/en-us/azure/expressroute/expressroute-howto-gateway-migration-portal

There are no preview requirements.
![image](https://github.com/user-attachments/assets/126fcf58-3823-4791-aefa-a92c37e25a3d)
