### PR TITLE
Updated vpn-gateway-nat-limitations.md to state explicitly that Route…

### DIFF
--- a/includes/vpn-gateway-nat-limitations.md
+++ b/includes/vpn-gateway-nat-limitations.md
@@ -11,7 +11,7 @@
 
 * NAT is supported on the following SKUs: VpnGw2~5, VpnGw2AZ~5AZ.
 * NAT is supported for IPsec/IKE cross-premises connections only. VNet-to-VNet connections or P2S connections aren't supported.
-* NAT rules aren't supported on connections that have Use Policy Based Traffic Selectors enabled.
+* NAT rules aren't supported on connections that have Use Policy Based Traffic Selectors enabled and Policy-based VPNs. NAT rules are supported only on Route-based VPNs.
 * The maximum supported external mapping subnet size for Dynamic NAT is /26.
 * Port mappings can be configured with Static NAT types only. Dynamic NAT scenarios aren't applicable for port mappings.
 * Port mappings can't take ranges at this time. Individual port needs to be entered.


### PR DESCRIPTION
The document stated that connections with "Use Policy Based Traffic Selectors" enabled do not support. I have added further in that statement that Policy-based VPNs do not support NAT rules and only Route-based support NAT rules.