### PR TITLE
Add missing information for the OpenID authentication provider for EasyAuth

### DIFF
--- a/articles/app-service/configure-authentication-provider-openid-connect.md
+++ b/articles/app-service/configure-authentication-provider-openid-connect.md
@@ -27,6 +27,9 @@ Your provider requires you to register the details of your application with it. 
 
 You need to collect a *client ID* and a *client secret* for your application. The client secret is an important security credential. Don't share this secret with anyone or distribute it in a client application.
 
+> [!NOTE]
+> You only need to provide a client secret to the configuration if you would like to acquire access tokens for the user through interactive login flow using the authorization code flow. If this is not your case, collecting a secret is not required.
+
 You also need the OIDC metadata for the provider. This metadata is often exposed in a [configuration metadata document](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig), which is the provider's issuer URL suffixed with `/.well-known/openid-configuration`. Get this configuration URL.
 
 If you can't use a configuration metadata document, get the following values separately:
@@ -52,7 +55,7 @@ To add provider information for your OpenID Connect provider, follow these steps
 
    Otherwise, select **Provide endpoints separately**. Put each URL from the identity provider in the appropriate field.
 
-1. Provide the values that you collected earlier for **Client ID** and **Client secret**.
+1. Provide the values that you collected earlier for **Client ID**. If the **Client secret** was also collected, provide it as part of the configuration process.
 
 1. Specify an application setting name for your client secret. Your client secret is stored as an app setting to ensure that secrets are stored in a secure fashion. If you want to manage the secret in Azure Key vault, update that setting later to use [Azure Key Vault references](./app-service-key-vault-references.md).
 
@@ -60,6 +63,8 @@ To add provider information for your OpenID Connect provider, follow these steps
 
 > [!NOTE]
 > The OpenID provider name can't contain a hyphen (-) because an app setting is created based on this name. The app setting doesn't support hyphens. Use an underscore (_) instead.  
+>
+> It also requires that the `aud` scope in your token be the same as the **Client Id** as configured above. It is currently not possible to configure the allowed audiences for this provider at the moment.
 >
 > Azure requires `openid`, `profile`, and `email` scopes. Make sure that you configure your app registration in your ID provider with at least these scopes.
 


### PR DESCRIPTION
As discussed internally, please see the modifications to the documentation