### PR TITLE
Update how-to-use-trigger-parameterization.md

### DIFF
--- a/articles/data-factory/how-to-use-trigger-parameterization.md
+++ b/articles/data-factory/how-to-use-trigger-parameterization.md
@@ -70,7 +70,7 @@ Under the `properties` section, add parameter definitions to the `parameters` se
                 "userProperties": [],
                 "typeProperties": {
                     "url": {
-                        "value": "@pipeline().parameters.parameter_2",
+                        "value": "@pipeline().parameters.parameter_1",
                         "type": "Expression"
                     },
                     "method": "GET"


### PR DESCRIPTION
Keeping parameter name consisent across trigger and pipeline.
Earlier we are setting parameter_1 in trigger but using parameter_2 in pipeline's activity.