### PR TITLE
Update expressroute-howto-macsec.md

### DIFF
--- a/articles/expressroute/expressroute-howto-macsec.md
+++ b/articles/expressroute/expressroute-howto-macsec.md
@@ -113,13 +113,17 @@ Every ExpressRoute Direct instance consists of two physical ports. You can activ
 
 
 > [!NOTE]
-> You can configure both XPN and Non-XPN ciphers:
+> You can configure Non-XPN ciphers for 10 gbps ExpressRoute Ports:
 > * GcmAes128
 > * GcmAes256
+>
+> You can configure either Non-XPN or XPN ciphers for 40 gbps and greater ExpressRoute Ports:
+> * GcmAes128
+> * GcmAes256 
 > * GcmAesXpn128
 > * GcmAesXpn256
 >
-> The suggested best practice is to set up encryption with xpn ciphers to prevent sporadic session failures that occur with non-xpn ciphers on high speed links.
+> The suggested best practice is to set up encryption with xpn ciphers to prevent sporadic session failures that occur with non-xpn ciphers on links with 40 gbps or greater bandwidth.
 
 1. Establish the MACsec secrets and cipher and link the user identity with the port to enable the ExpressRoute management code to retrieve the MACsec secrets when required.
 


### PR DESCRIPTION
Updated Note regarding XPN ciphers are not supported on 10gbps express route direct ports AS per cisco and juniper device documentation

Reference :
Juniper: https://www.juniper.net/documentation/en_US/day-one-books/DO_MACsec_UR.pdf Cisco: https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/macsec/configuration/xe-16/macsec-xe-16-book/wan-macsec-mka-support-enhance.html