### PR TITLE
Updated the zip file limits in the run load test with jmeter script doc

### DIFF
--- a/articles/load-testing/how-to-create-and-run-load-test-with-jmeter-script.md
+++ b/articles/load-testing/how-to-create-and-run-load-test-with-jmeter-script.md
@@ -67,7 +67,7 @@ To create a load test using an existing JMeter script in the Azure portal:
     :::image type="content" source="./media/how-to-create-and-run-load-test-with-jmeter-script/create-new-test-test-plan.png" alt-text="Screenshot that shows the Test plan tab." lightbox="./media/how-to-create-and-run-load-test-with-jmeter-script/create-new-test-test-plan.png":::
     
     > [!NOTE]
-    > You can upload additional JMeter configuration files or other files that you reference in the JMX file. For example, if your test script uses CSV data sets, you can upload the corresponding *.csv* file(s). See also how to [read data from a CSV file](./how-to-read-csv-data.md). For files other than the main test script and user properties, if the size of the file is greater than 50 MB, zip the file. The size of the zip file should be below 50 MB. Azure Load Testing automatically unzips the file during the test run. Only five zip artifacts are allowed with a maximum of 1000 files in each zip and an uncompressed total size of 1 GB.
+    > You can upload additional JMeter configuration files or other files that you reference in the JMX file. For example, if your test script uses CSV data sets, you can upload the corresponding *.csv* file(s). See also how to [read data from a CSV file](./how-to-read-csv-data.md). For files other than the main test script and user properties, if the size of the file is greater than 50 MB, zip the file. The size of the zip file should be below 50 MB. Azure Load Testing automatically unzips the file during the test run. Only 100 zip artifacts are allowed with a maximum of 10000 files in each zip and an uncompressed total size of 1 GB.
 
 1. Select **Review + create**. Review all settings, and then select **Create** to create the load test.
 


### PR DESCRIPTION
Updated the new limits for zip files.

Max Zip files count per test to 100
Max entry count per zip file to 10k.