### PR TITLE
Update move-resource-group-and-subscription.md with potential cost/charge factors to consider.

### DIFF
--- a/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
+++ b/articles/azure-resource-manager/management/move-resource-group-and-subscription.md
@@ -487,6 +487,10 @@ To resolve this issue, move your resources to a resource group that doesn't have
 
 No, you can't move a resource group to a new subscription. But, you can move all resources in a resource group to a resource group in another subscription. Settings such as tags, role assignments, and policies don't transfer automatically from the original resource group to the destination resource group. You need to apply these settings manually to the new resource group. 
 
+**How much does it cost to move Azure resources to a new resource group or subscription within the same region, and what should I consider?**
+
+#INSERT ANSWER#
+
 ## Next steps
 
 To verify which Azure resources support move operations, see [Move operation support for resources](move-support-resources.md).


### PR DESCRIPTION
This stemmed from a case where cx was requesting cost information regarding moving a storage account from one subscription to another. This documentation is for moving within the same region. There is no publicly available information on what to factor in when considering cost. I can see this being the same as the Azure Resource Mover but I am not sure.

When moving resources across regions and using Azure Resource Mover, there is a documentation on how to and cost. 
- How to: https://learn.microsoft.com/en-us/azure/resource-mover/move-region-within-resource-group?toc=%2Fazure%2Fazure-resource-manager%2Fmanagement%2Ftoc.json
- Frequently asked questions, "What charges do I incur while using Azure Resource Mover?" https://azure.microsoft.com/en-us/pricing/details/resource-mover/

When using AzCopy, there is a how to page and a whole page for Estimating the cost of using AzCopy to transfer blobs.
- How to: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-blobs-copy?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&branch=pr-en-us-259662
- Cost: https://learn.microsoft.com/en-us/azure/storage/blobs/azcopy-cost-estimation

I've written the question on line 490, "How much does it cost to move Azure resources to a new resource group or subscription within the same region, and what should I consider?" to get it started.

Answer is still needed.