### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-resource-manager/templates/parameters.md
+++ b/articles/azure-resource-manager/templates/parameters.md
@@ -23,7 +23,7 @@ In addition to minValue, maxValue, minLength, maxLength, and allowedValues, [lan
 - [prefixItems](#prefixitems)
 - [properties](#properties)
 
-[!INCLUDE [VSCode ARM Tools extension doesn't support languageVersion 2.0](../../../includes/resource-manager-vscode-language-version-20.md)]
+[!INCLUDE [VS Code ARM Tools extension doesn't support languageVersion 2.0](../../../includes/resource-manager-vscode-language-version-20.md)]
 
 > [!TIP]
 > We recommend [Bicep](../bicep/overview.md) because it offers the same capabilities as ARM templates and the syntax is easier to use. To learn more, see [parameters](../bicep/parameters.md).


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.