### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-resource-manager/templates/quickstart-create-templates-use-visual-studio-code.md
+++ b/articles/azure-resource-manager/templates/quickstart-create-templates-use-visual-studio-code.md
@@ -20,7 +20,7 @@ If you don't have an Azure subscription, [create a free account](https://azure.m
 > [!TIP]
 > We recommend [Bicep](../bicep/overview.md) because it offers the same capabilities as ARM templates and the syntax is easier to use. To learn more, see [Quickstart: Create Bicep files with Visual Studio Code](../bicep/quickstart-create-bicep-use-visual-studio-code.md).
 
-[!INCLUDE [VSCode ARM Tools extension doesn't support languageVersion 2.0](../../../includes/resource-manager-vscode-language-version-20.md)]
+[!INCLUDE [VS Code ARM Tools extension doesn't support languageVersion 2.0](../../../includes/resource-manager-vscode-language-version-20.md)]
 
 ## Create an ARM template
 


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.