### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-resource-manager/templates/syntax.md
+++ b/articles/azure-resource-manager/templates/syntax.md
@@ -508,7 +508,7 @@ In Bicep, see [multi-line strings](../bicep/file.md#multi-line-strings).
 > [!NOTE]
 > Using any `languageVersion` that ends in `-experimental` is not recommended in production environments because experimental functionality could be changed at any time.
 
-[!INCLUDE [VSCode ARM Tools extension doesn't support languageVersion 2.0](../../../includes/resource-manager-vscode-language-version-20.md)]
+[!INCLUDE [VS Code ARM Tools extension doesn't support languageVersion 2.0](../../../includes/resource-manager-vscode-language-version-20.md)]
 
 To use languageVersion 2.0, add `"languageVersion": "2.0"` to your template:
 


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.