### PR TITLE
Fix typo

### DIFF
--- a/articles/azure-web-pubsub/quickstart-use-sdk.md
+++ b/articles/azure-web-pubsub/quickstart-use-sdk.md
@@ -19,7 +19,7 @@ Azure Web PubSub helps you manage WebSocket clients. This quickstart shows you h
 
 - An Azure subscription, if you don't have one, create a [free account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
 - a Bash and PowerShell command shell. The Python, JavaScript and Java samples require a Bash command shell.
-- A file editor such as VSCode.
+- A file editor such as VS Code.
 - Azure CLI: [install the Azure CLI](/cli/azure/install-azure-cli)
 
 If creating the project on a local machine, you'll need to install the dependencies for the language you're using:


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.