### PR TITLE
Fix typo

### DIFF
--- a/articles/databox-online/azure-stack-edge-gpu-create-iot-edge-module.md
+++ b/articles/databox-online/azure-stack-edge-gpu-create-iot-edge-module.md
@@ -241,7 +241,7 @@ Create a C# solution template that you can customize with your own code.
 
 In the previous section, you created an IoT Edge solution and added code to the FileCopyModule to copy files from local share to the cloud share. Now you need to build the solution as a container image and push it to your container registry.
 
-1. In VSCode, go to Terminal > New Terminal to open a new Visual Studio Code integrated terminal.
+1. In VS Code, go to Terminal > New Terminal to open a new Visual Studio Code integrated terminal.
 2. Sign in to Docker by entering the following command in the integrated terminal.
 
     `docker login <ACR login server> -u <ACR username>`


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.