### PR TITLE
Fix typo

### DIFF
--- a/articles/sentinel/data-connectors/crowdstrike-falcon-data-replicator-v2.md
+++ b/articles/sentinel/data-connectors/crowdstrike-falcon-data-replicator-v2.md
@@ -95,7 +95,7 @@ Use the following step-by-step instructions to deploy the Crowdstrike Falcon Dat
 **2. Deploy a Function App**
 
 1. Download the [Azure Function App](https://aka.ms/sentinel-CrowdstrikeReplicatorV2-functionapp) file. Extract archive to your local development computer.
-2. Follow the [function app manual deployment instructions](https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/AzureFunctionsManualDeployment.md#function-app-manual-deployment-instructions) to deploy the Azure Functions app using VSCode.
+2. Follow the [function app manual deployment instructions](https://github.com/Azure/Azure-Sentinel/blob/master/DataConnectors/AzureFunctionsManualDeployment.md#function-app-manual-deployment-instructions) to deploy the Azure Functions app using VS Code.
 3. After successful deployment of the function app, follow next steps for configuring it.
 
 


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.