### PR TITLE
Fix typo

### DIFF
--- a/articles/stream-analytics/visual-studio-code-explore-jobs.md
+++ b/articles/stream-analytics/visual-studio-code-explore-jobs.md
@@ -22,7 +22,7 @@ The Azure Stream Analytics (ASA) extension for Visual Studio Code gives you a se
 1. Open your VS Code and select **Azure** icon on the activity bar. If you haven't installed the ASA extension, follow [this guide](./quick-create-visual-studio-code.md) to install. 
 2. Select **STREAM ANALYTICS** in the explorer to locate the job you want to export. 
 
-![Screenshot of VSCode extension exporting ASA job to Visual Studio Code.](./media/vscode-explore-jobs/export-job.png)
+![Screenshot of VS Code extension exporting ASA job to Visual Studio Code.](./media/vscode-explore-jobs/export-job.png)
 
 ## List job and view job entities
 
@@ -30,13 +30,13 @@ You can use the job view to interact with Azure Stream Analytics jobs from Visua
 
 1. Select the **Azure** icon on Visual Studio Code Activity Bar and then expand **Stream Analytics node**. Your jobs should appear under your subscriptions.
 
-   ![Screenshot of VSCode extension opening Stream Analytics Explorer.](./media/vscode-explore-jobs/open-explorer.png)
+   ![Screenshot of VS Code extension opening Stream Analytics Explorer.](./media/vscode-explore-jobs/open-explorer.png)
 
 2. Expand your job node, you can open and view the job query,  configuration, inputs, outputs and functions. 
 
 3. Right-click your job node, and choose the **Open Job View in Portal** node to open the job view in the Azure portal.
 
-   ![Screenshot of VSCode extension opening job view in portal.](./media/vscode-explore-jobs/open-job-view.png)
+   ![Screenshot of VS Code extension opening job view in portal.](./media/vscode-explore-jobs/open-job-view.png)
 
 ## View job diagram and debug in Job Monitor
 
@@ -44,13 +44,13 @@ You can use job monitor in Visual Studio Code to view and troubleshoot your Azur
 
 ### View job diagram and job summary
 1. Select **Job Monitor**. Your Job Monitor should appear, and job diagram should be loaded automatically.
-   ![Screenshot of VSCode extension opening Job Monitor.](./media/vscode-explore-jobs/open-job-monitor.png)
+   ![Screenshot of VS Code extension opening Job Monitor.](./media/vscode-explore-jobs/open-job-monitor.png)
 
 2. You can view your job diagram and select **Job Summary** to view properties and information of your job. 
-    ![Screenshot of VSCode extension viewing Job Summary.](./media/vscode-explore-jobs/view-jobs-summary.png)
+    ![Screenshot of VS Code extension viewing Job Summary.](./media/vscode-explore-jobs/view-jobs-summary.png)
 
 3. You can select **Test Connection** button to test connection to your input and output.
-    ![Screenshot of VSCode extension testing connection.](./media/vscode-explore-jobs/test-connection.png)
+    ![Screenshot of VS Code extension testing connection.](./media/vscode-explore-jobs/test-connection.png)
 
 4. You can also select **Locate Script** button to view your query.
     ![View Query](./media/vscode-explore-jobs/view-query.png)
@@ -58,10 +58,10 @@ You can use job monitor in Visual Studio Code to view and troubleshoot your Azur
 ### Monitor and debug with Metrics
 
 1. Select the arrow button, you can open the Metrics panel.
-    ![Screenshot of VSCode extension opening Metrics Panel.](./media/vscode-explore-jobs/open-metrics-panel.png)
+    ![Screenshot of VS Code extension opening Metrics Panel.](./media/vscode-explore-jobs/open-metrics-panel.png)
 
 2. You can interact with it and analyze your job with key metrics showing in chart. You can choose to view job-level metrics or nodes level metrics. And you can also decide which metrics you want them to show in the chart.
-    ![Screenshot of VSCode extension viewing job metrics.](./media/vscode-explore-jobs/view-metrics.png)
+    ![Screenshot of VS Code extension viewing job metrics.](./media/vscode-explore-jobs/view-metrics.png)
 
 ### Debug with diagnostic logs and activity logs
 
@@ -69,11 +69,11 @@ You can view your job’s diagnostic logs and activity logs for troubleshooting.
 
 1. Select **Diagnostic Logs** tab.
 
-   ![Screenshot of VSCode extension viewing Diagnostic Logs.](./media/vscode-explore-jobs/view-diagnostic-log.png)
+   ![Screenshot of VS Code extension viewing Diagnostic Logs.](./media/vscode-explore-jobs/view-diagnostic-log.png)
 
 2. Select **Activity Logs** tab 
 
-   ![Screenshot of VSCode extension viewing Activity Logs.](./media/vscode-explore-jobs/view-activity-logs.png)
+   ![Screenshot of VS Code extension viewing Activity Logs.](./media/vscode-explore-jobs/view-activity-logs.png)
 
 ## Next steps
 


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.