### PR TITLE
Fix typo

### DIFF
--- a/articles/stream-analytics/visual-studio-code-local-run-live-input.md
+++ b/articles/stream-analytics/visual-studio-code-local-run-live-input.md
@@ -21,32 +21,32 @@ Testing your Stream Analytics query locally against live stream input is a cruci
 ## Define a live stream input
 
 1. Right-click the **Inputs** folder in your Stream Analytics project and select **ASA: Add Input**.
-    ![Screenshot of VSCode extension adding input via drop-down menu.](./media/quick-create-visual-studio-code/add-input-from-inputs-folder.png)
+    ![Screenshot of VS Code extension adding input via drop-down menu.](./media/quick-create-visual-studio-code/add-input-from-inputs-folder.png)
    OR press **Ctrl+Shift+P** to open the command palette and enter **ASA: Add Input**. Then choose the query script for processing the input stream. 
-    ![Screenshot of VSCode extension adding input via command palette.](./media/quick-create-visual-studio-code/add-input.png)
+    ![Screenshot of VS Code extension adding input via command palette.](./media/quick-create-visual-studio-code/add-input.png)
 
 2. Choose a live input source type from the drop-down list, **Select from your Azure Subscriptions** and enter a name for the input source. 
-    ![Screenshot of VSCode extension showing series of steps for Event Hub input configuration.](./media/quick-create-visual-studio-code/add-input-select-subscription.png)
+    ![Screenshot of VS Code extension showing series of steps for Event Hub input configuration.](./media/quick-create-visual-studio-code/add-input-select-subscription.png)
 
 3. You see a new JSON file created under the **Input** folder. Open the file and **Select from your subscriptions** to help you configure your Event Hubs input. 
-    ![Screenshot of VSCode extension showing the input json files.](./media/quick-create-visual-studio-code/configure-input.png)
+    ![Screenshot of VS Code extension showing the input json files.](./media/quick-create-visual-studio-code/configure-input.png)
 
 4. Select **Preview data** to validate if the live input is successfully configured.
-    ![Screenshot of VSCode extension previewing live input data.](./media/quick-create-visual-studio-code/preview-live-input.png)
+    ![Screenshot of VS Code extension previewing live input data.](./media/quick-create-visual-studio-code/preview-live-input.png)
 
 ## Run query locally
 
 Open your query file, select **Run locally** or the **Play** button on the menu bar to open a **Local run option** window for configuring local run mode. 
 
-![Screenshot of VSCode extension selecting "Run locally" in the query editor.](./media/vscode-local-run-live-input/run-locally.png)
+![Screenshot of VS Code extension selecting "Run locally" in the query editor.](./media/vscode-local-run-live-input/run-locally.png)
 
 Choose **Use Live Input and Local Output** to run job locally against live input stream and produce output results to a local folder. Then select **Run** to start running job locally. 
 
-![Screenshot of VSCode extension selecting play mode for local run.](./media/vscode-local-run-live-input/run-live-input-and-local-output.png)
+![Screenshot of VS Code extension selecting play mode for local run.](./media/vscode-local-run-live-input/run-live-input-and-local-output.png)
 
 You can see a **Local test** window is opened and refreshed every 3 seconds. The output results are stored as JSON format in **LocalRunOutputs** folder.
 
-![Screenshot of VSCode extension showing local test window.](./media/vscode-local-run-live-input/local-testing-window.png)
+![Screenshot of VS Code extension showing local test window.](./media/vscode-local-run-live-input/local-testing-window.png)
 
 
 ## Specify input partitions for local testing
@@ -57,7 +57,7 @@ To avoid ingesting all data from Event Hubs, you can specify specific partitions
 2. Under **Select the input partitions** section and choose **Custom**.
 3. Enter the specific partition numbers that you want to ingest data from for your local testing.
 
-![Screenshot of VSCode extension specifying event hub partitions.](./media/vscode-local-run-live-input/specify-partitions.png)
+![Screenshot of VS Code extension specifying event hub partitions.](./media/vscode-local-run-live-input/specify-partitions.png)
 
 By specifying the partitions, you can focus on testing your query logic without worrying about a large volume of data. This feature allows for more efficient and targeted testing of your Stream Analytics job.
 
@@ -68,11 +68,11 @@ Once you have completed testing your query locally, you can submit your Stream A
 2. In the submit options window, you can **update an existing job in Azure** or **create a new job** for the upload.
 3. Provide the necessary details, including your subscription, resource group, and region for the deployment.
 
-![Screenshot of VSCode extension submitting job to Azure.](./media/vscode-local-run-live-input/submit-to-azure.png)
+![Screenshot of VS Code extension submitting job to Azure.](./media/vscode-local-run-live-input/submit-to-azure.png)
 
 Once the submission process is complete, you can view your cloud job in a new window. From there, you can monitor its performance and manage its configurations as needed. You can also open the job in your browser by clicking on the link provided in the OUTPUT panel.
 
-![Screenshot of VSCode extension showing cloud view job.](./media/vscode-local-run-live-input/cloud-view-job.png)
+![Screenshot of VS Code extension showing cloud view job.](./media/vscode-local-run-live-input/cloud-view-job.png)
 
 ## Next steps
 


### PR DESCRIPTION
The term `VSCode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.