### PR TITLE
Fix typo

### DIFF
--- a/articles/automation/automation-runbook-authoring.md
+++ b/articles/automation/automation-runbook-authoring.md
@@ -1,5 +1,5 @@
 ---
-title: Runbook authoring using VS code in Azure Automation
+title: Runbook authoring using VS Code in Azure Automation
 description: This article provides an overview authoring runbooks in Azure Automation using the visual studio code.
 services: automation
 ms.subservice: process-automation


### PR DESCRIPTION
The term `VS code` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.