### PR TITLE
Fix typo

### DIFF
--- a/articles/automation/whats-new.md
+++ b/articles/automation/whats-new.md
@@ -83,7 +83,7 @@ On **31 August 2024**, Azure Automation will  retire [Automation Update manageme
 
 ### General Availability: Azure Automation supports PowerShell 7.2 runbooks
 
-Azure Automation announces General Availability of PowerShell 7.2 runbooks. This enables you to author runbooks in the long-term supported version of PowerShell using [Azure Automation extension for VS code](how-to/runbook-authoring-extension-for-vscode.md) and execute them on a secure and reliable platform. [Learn more](automation-runbook-types.md).
+Azure Automation announces General Availability of PowerShell 7.2 runbooks. This enables you to author runbooks in the long-term supported version of PowerShell using [Azure Automation extension for VS Code](how-to/runbook-authoring-extension-for-vscode.md) and execute them on a secure and reliable platform. [Learn more](automation-runbook-types.md).
 
 ## October 2023
 


### PR DESCRIPTION
The term `VS code` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.