### PR TITLE
Fix typo

### DIFF
--- a/articles/sentinel/data-connectors/crowdstrike-falcon-data-replicator.md
+++ b/articles/sentinel/data-connectors/crowdstrike-falcon-data-replicator.md
@@ -91,7 +91,7 @@ Use the following step-by-step instructions to deploy the Crowdstrike Falcon Dat
 
 **1. Deploy a Function App**
 
-**NOTE:** You will need to [prepare VS code](/azure/azure-functions/functions-create-first-function-python#prerequisites) for Azure function development.
+**NOTE:** You will need to [prepare VS Code](/azure/azure-functions/functions-create-first-function-python#prerequisites) for Azure function development.
 
 1. Download the [Azure Function App](https://aka.ms/sentinel-CrowdstrikeReplicator-functionapp) file. Extract archive to your local development computer.
 2. Start VS Code. Choose File in the main menu and select Open Folder.

--- a/articles/sentinel/data-connectors/crowdstrike-falcon-data-replicator.md
+++ b/articles/sentinel/data-connectors/crowdstrike-falcon-data-replicator.md
@@ -91,7 +91,8 @@ Use the following step-by-step instructions to deploy the Crowdstrike Falcon Dat
 
 **1. Deploy a Function App**
 
-**NOTE:** You will need to [prepare VS Code](/azure/azure-functions/functions-create-first-function-python#prerequisites) for Azure function development.
+>[!NOTE]
+> You will need to [prepare VS Code](/azure/azure-functions/functions-create-first-function-python#prerequisites) for Azure function development.
 
 1. Download the [Azure Function App](https://aka.ms/sentinel-CrowdstrikeReplicator-functionapp) file. Extract archive to your local development computer.
 2. Start VS Code. Choose File in the main menu and select Open Folder.


### PR DESCRIPTION
The term `VS code` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.