### PR TITLE
Fix typo

### DIFF
--- a/articles/sentinel/data-connectors/google-cloud-platform-iam.md
+++ b/articles/sentinel/data-connectors/google-cloud-platform-iam.md
@@ -97,7 +97,8 @@ Use the following step-by-step instructions to deploy the data connector manuall
 
 **1. Deploy a Function App**
 
-> **NOTE:** You will need to [prepare VS Code](/azure/azure-functions/create-first-function-vs-code-python) for Azure function development.
+> [!NOTE]
+> You will need to [prepare VS Code](/azure/azure-functions/create-first-function-vs-code-python) for Azure function development.
 
 1. Download the [Azure Function App](https://aka.ms/sentinel-GCPIAMDataConnector-functionapp) file. Extract archive to your local development computer.
 2. Start VS Code. Choose File in the main menu and select Open Folder.

--- a/articles/sentinel/data-connectors/google-cloud-platform-iam.md
+++ b/articles/sentinel/data-connectors/google-cloud-platform-iam.md
@@ -97,7 +97,7 @@ Use the following step-by-step instructions to deploy the data connector manuall
 
 **1. Deploy a Function App**
 
-> **NOTE:** You will need to [prepare VS code](/azure/azure-functions/create-first-function-vs-code-python) for Azure function development.
+> **NOTE:** You will need to [prepare VS Code](/azure/azure-functions/create-first-function-vs-code-python) for Azure function development.
 
 1. Download the [Azure Function App](https://aka.ms/sentinel-GCPIAMDataConnector-functionapp) file. Extract archive to your local development computer.
 2. Start VS Code. Choose File in the main menu and select Open Folder.


### PR DESCRIPTION
The term `VS code` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.