### PR TITLE
Update api-management-howto-api-inspector.md

### DIFF
--- a/articles/api-management/api-management-howto-api-inspector.md
+++ b/articles/api-management/api-management-howto-api-inspector.md
@@ -93,7 +93,7 @@ Detailed steps follow.
     POST https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{serviceName}/gateways/managed/listDebugCredentials?api-version=2023-05-01-preview
     ```
     
-    In the request body, pass the full resource ID of the API that you want to trace, and specify `purposes` as `tracing`. By default the token credential returned in the response expires after 1 hour, but you can specify a different value in the payload. For example:
+    In the request body, pass the full resource ID of the API that you want to trace, and specify `purposes` as `tracing`. By default the token credential returned in the response expires after 1 hour, but you can specify a different value in the payload. Note that the expiry time is limited to a maximum of 1 hour. For example:
 
     ```json
     {


### PR DESCRIPTION
The documentation previously mentioned that the credentialsExpireAfter value in the request payload could be customized, but it did not clearly state the upper limit for this value.

Change:
Updated the documentation to clarify that the expiry time for the token credential is limited to a maximum of 1 hour.

Reason:
To prevent confusion and failed requests due to invalid expiry values. The API enforces a strict limit where the credentialsExpireAfter period must be between 00:00 and 01:00 hours inclusively, as shown in the error response below:

{
  "error": {
    "code": "ValidationError",
    "message": "One or more fields contain incorrect values:",
    "details": [
      {
        "code": "ValidationError",
        "target": "credentialsExpireAfter",
        "message": "Period need to be between 00:00 and 01:00 inclusively."
      }
    ]
  }
}

This edit ensures better clarity and aligns the documentation with backend validation behavior.