### PR TITLE
Update api-management-api-import-restrictions.md

### DIFF
--- a/articles/api-management/api-management-api-import-restrictions.md
+++ b/articles/api-management/api-management-api-import-restrictions.md
@@ -52,7 +52,7 @@ If you receive errors while importing your OpenAPI document, make sure you've va
 | **Defined URL parameter** | Must be part of the URL template. |
 | **Available source file URL** | Applied to relative server URLs. |
 | **`\$ref` pointers** | Can't reference external files. |
-
+| **Maximum URL Length** | API URL must be less than 128 characters long. |
 
 #### OpenAPI specifications
 


### PR DESCRIPTION
Added a clarification under URL template requirements stating that the full API URL must be less than 128 characters long. This update aligns with existing backend constraints and helps users avoid import failures due to overly long URLs.

Error Details:  
![image](https://github.com/user-attachments/assets/f6e06627-97c3-47e9-8969-92f5c30f48df)
