### PR TITLE
Fix typo

### DIFF
--- a/articles/dev-box/how-to-customize-devbox-azure-image-builder.md
+++ b/articles/dev-box/how-to-customize-devbox-azure-image-builder.md
@@ -223,7 +223,7 @@ To use VM Image Builder with Azure Compute Gallery, make sure you have an existi
            "customize": [
             {
                "type": "PowerShell",
-               "name": "Install Choco and Vscode",
+               "name": "Install Choco and VS Code",
                "inline": [
                   "Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))",
                   "choco install -y vscode"


### PR DESCRIPTION
The term `Vscode` is not the official abbreviation. Per the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/setup-overview), the proper form is `VS Code`.