### PR TITLE
add limitation for AGIC 

### DIFF
--- a/articles/application-gateway/ingress-controller-overview.md
+++ b/articles/application-gateway/ingress-controller-overview.md
@@ -48,7 +48,9 @@ The AGIC add-on is still deployed as a pod in the customer's AKS cluster, howeve
   - Since AGIC add-on is a managed service, customers are automatically updated to the latest version of AGIC add-on, unlike AGIC deployed through Helm where the customer must manually update AGIC. 
 
 > [!NOTE]
-> Customers can only deploy one AGIC add-on per AKS cluster, and each AGIC add-on currently can only target one Application Gateway. For deployments that require more than one AGIC per cluster or multiple AGICs targeting one Application Gateway, please continue to use AGIC deployed through Helm. 
+> Customers can only deploy one AGIC add-on per AKS cluster, and each AGIC add-on currently can only target one Application Gateway. For deployments that require more than one AGIC per cluster or multiple AGICs targeting one Application Gateway, please continue to use AGIC deployed through Helm.
+>
+> Both Helm and AGIC add-on doesn't support ExternalName service.
 
 ## Container networking and AGIC
 


### PR DESCRIPTION
add limitation for externalname service:
https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1567#issuecomment-2261029529

I notice several situations that user use externalname service as AGIC backend, although they can set hostname in AG manually but after AGIC pod restart it will revert and the configuration cannot load correctly.