### PR TITLE
Fix recovery command

### DIFF
--- a/articles/virtual-network/ip-services/public-ip-upgrade-availability-set.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade-availability-set.md
@@ -83,7 +83,7 @@ If a migration fails due to a transient issue, such as a network outage or clien
 To recover from a failed upgrade, pass the recovery log file path to the script with the `-recoverFromFile` parameter and identify the Availability Set to recover with the `-AvailabilitySetName` parameter, as shown in this example.
 
 ```powershell
-Start-VMPublicIPUpgrade -RecoverFromFile ./AvSetPublicIPUpgrade_Recovery_2020-01-01-00-00.csv -AvailabilitySetName myAvSet -ResourceGroupName rg-myrg
+Start-AzAvSetPublicIPUpgrade -RecoverFromFile ./AvSetPublicIPUpgrade_Recovery_2020-01-01-00-00.csv -AvailabilitySetName myAvSet -ResourceGroupName rg-myrg
 ```
 
 ## Common questions


### PR DESCRIPTION
By source code, Start-AzAvSetPublicIPUpgrade is correct.
https://www.powershellgallery.com/packages/AzureAvSetBasicPublicIPUpgrade/1.0.0
```
        To initate a recovery, follow these steps:
            1. Review the log 'PublicIPUpgrade.log' file to determine which VM was in process during the failure
            2. Determine if the script failed due to a configuration issue that needs to be addressed before retrying the migration. If so, address the error. 
            2. Get the name and resource group or full ID of the Av Set to recover (e.g. '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.Compute/availabilitySets/avset-01')
            3. Execute the script with the following syntax:
            ./Start-AzAvSetPublicIPUpgrade.ps1 -RecoverFromFile ./AvSetPublicIPUpgrade_Recovery_2020-01-01-00-00.csv -AvailiabilitySetName avset-01 -ResourceGroupName rg-01
            
            4. The script will attempt to re-execute each step the migration. 
```
