### PR TITLE
Fix typo in agent-based-migration-architecture.md

### DIFF
--- a/articles/migrate/vmware/agent-based-migration-architecture.md
+++ b/articles/migrate/vmware/agent-based-migration-architecture.md
@@ -27,7 +27,7 @@ Learn more about [selecting and comparing](server-migrate-overview.md?context=/a
 
 ## Agent-based migration
 
-Agent-based migration is used to migrate on-premises VMware VMs and physical servers to Azure. It can also be used to migrate other on-premises virtualized servers, as well as private and public cloud VMs, including AWS instances, and GCP VMs. Agent-based migration in Azure Migrate uses some backend functionality from the [Azure Site Recovery]../../site-recovery/site-recovery-overview.md) service.
+Agent-based migration is used to migrate on-premises VMware VMs and physical servers to Azure. It can also be used to migrate other on-premises virtualized servers, as well as private and public cloud VMs, including AWS instances, and GCP VMs. Agent-based migration in Azure Migrate uses some backend functionality from the [Azure Site Recovery](../../site-recovery/site-recovery-overview.md) service.
 
 
 ## Architectural components


### PR DESCRIPTION
## Why

https://learn.microsoft.com/en-us/azure/migrate/vmware/agent-based-migration-architecture?context=%2Fazure%2Fmigrate%2Fcontext%2Fmigrate-context#replication-process

![image](https://github.com/user-attachments/assets/0e37c4c8-3a5f-4756-bfc2-2f00b7f5849a)

This link does not work.

## What

This pull request includes a minor correction to a markdown link in the `articles/migrate/vmware/agent-based-migration-architecture.md` file. The change fixes a formatting issue in the link to the Azure Site Recovery overview page.

* Fixed a broken markdown link by correcting the closing parenthesis in the reference to the Azure Site Recovery overview page. (`articles/migrate/vmware/agent-based-migration-architecture.md`)