### PR TITLE
CSS-Networking: Warn public IP's can't be recovered after deletion

### DIFF
--- a/articles/virtual-network/ip-services/public-ip-addresses.md
+++ b/articles/virtual-network/ip-services/public-ip-addresses.md
@@ -79,7 +79,7 @@ Public IPs have two types of assignments:
 
 - **Dynamic** - The IP address **isn't** given to the resource at the time of creation when selecting dynamic. The IP is assigned when you associate the public IP address with a resource. The IP address is released when you stop, or delete the resource. Dynamic public IP addresses are commonly used for when there's no dependency on the IP address. For example, a public IP resource is released from a VM upon stop and then start. Any associated IP address is released if the allocation method is **dynamic**. If you don't want the IP address to change, set the allocation method to **static** to ensure the IP address remains the same.
   
-- **Static** - The resource is assigned an IP address at the time it's created. The IP address is released when the resource is deleted. When you set the allocation method to **static**, you can't specify the actual IP address assigned to the public IP address resource. Azure assigns the IP address from a pool of available IP addresses in the Azure location the resource is created in.
+- **Static** - The resource is assigned an IP address at the time it's created. The IP address is released when the resource is deleted and can't be recovered. When you set the allocation method to **static**, you can't specify the actual IP address assigned to the public IP address resource. Azure assigns the IP address from a pool of available IP addresses in the Azure location the resource is created in.
 
 Static public IP addresses are commonly used in the following scenarios:
 * When you must update firewall rules to communicate with your Azure resources.

--- a/articles/virtual-network/ip-services/virtual-network-public-ip-address.md
+++ b/articles/virtual-network/ip-services/virtual-network-public-ip-address.md
@@ -77,6 +77,9 @@ For more detail on the specific attributes of a public IP address during creatio
 
    - **Delete**: Deletion of public IPs requires that the public IP object isn't associated to any IP configuration or virtual machine network interface. For more information, see the following table.
 
+>[!WARNING]
+   >Once a public IP address is deleted it can not be recovered.
+
 |Resource|Azure portal|Azure PowerShell|Azure CLI|
 |---|---|---|---|
 |[Virtual machine](./remove-public-ip-address-vm.md)|Select **Dissociate** to dissociate the IP address from the NIC configuration, then select **Delete**.|[Set-AzNetworkInterface](/powershell/module/az.network/set-aznetworkinterface) to dissociate the IP address from the NIC configuration; [Remove-AzPublicIpAddress](/powershell/module/az.network/remove-azpublicipaddress) to delete|[az network nic ip-config update](/cli/azure/network/nic/ip-config#az-network-nic-ip-config-update) and with the parameter `--public-ip-address` to remove the IP address from the NIC configuration. Use [az network public-ip delete](/cli/azure/network/public-ip#az-network-public-ip-delete) to delete the public IP. |

--- a/articles/virtual-network/virtual-networks-faq.md
+++ b/articles/virtual-network/virtual-networks-faq.md
@@ -698,6 +698,10 @@ Scenarios that aren't supported include:
 
 See [Frequently asked questions about classic to Azure Resource Manager migration](/azure/virtual-machines/migration-classic-resource-manager-faq).
 
+### Can I recover a deleted public IP address?
+
+No. Once an Azure public IP address is deleted, it cannot be recovered. For more information, see [View, modify settings for, or delete a public IP address](ip-services/virtual-network-public-ip-address.md#view-modify-settings-for-or-delete-a-public-ip-address).
+
 ### How can I report a problem?
 
 You can post questions about migration problems to the [Microsoft Q&A](/answers/topics/azure-virtual-network.html) page. We recommend that you post all your questions on this forum. If you have a support contract, you can also file a support request.


### PR DESCRIPTION
A statement/warning declaring that Azure public IP addresses can't be recovered once the resource is deleted is missing from documentation. Adding to relevant articles.