### PR TITLE
Add Bash tab for updating Azure IoT Operations media and ONVIF connectors

### DIFF
--- a/articles/iot-operations/includes/deploy-preview-media-connectors.md
+++ b/articles/iot-operations/includes/deploy-preview-media-connectors.md
@@ -12,7 +12,9 @@ To update the version of the media and ONVIF connectors in your Azure IoT Operat
 > [!IMPORTANT]
 > If you don't enable preview features, you see the following error message in the `aio-supervisor-...` pod logs when you try to use the media or ONVIF connectors: `No connector configuration present for AssetEndpointProfile: <AssetEndpointProfileName>`.
 
-```powershell
+# [PowerShell](#tab/powershell)
+
+```azurepowershell
 $clusterName="<YOUR AZURE IOT OPERATIONS CLUSTER NAME>"
 $clusterResourceGroup="<YOUR RESOURCE GROUP NAME>"
 
@@ -22,7 +24,6 @@ $extension = az k8s-extension list `
 --resource-group $clusterResourceGroup `
 --query "[?extensionType == 'microsoft.iotoperations']" `
 | ConvertFrom-Json
-
 
 az k8s-extension update `
 --version $extension.version `
@@ -37,6 +38,41 @@ az k8s-extension update `
 --config connectors.image.tag=1.1.0 `
 --config connectors.values.enablePreviewFeatures=true `
 --yes
+```
+
+# [Bash](#tab/bash)
+
+```azurecli
+CLUSTER_NAME="<YOUR AZURE IOT OPERATIONS CLUSTER NAME>"
+RESOURCE_GROUP="<YOUR RESOURCE GROUP NAME>"
+
+# Get the extension info
+extension=$(az k8s-extension list \
+  --cluster-name "$CLUSTER_NAME" \
+  --cluster-type connectedClusters \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "[?extensionType == 'microsoft.iotoperations']" \
+  --output json)
+
+# Extract version, name, and releaseTrain from the JSON
+version=$(echo "$extension" | jq -r '.[0].version')
+name=$(echo "$extension" | jq -r '.[0].name')
+releaseTrain=$(echo "$extension" | jq -r '.[0].releaseTrain')
+
+# Update the extension
+az k8s-extension update \
+  --version "$version" \
+  --name "$name" \
+  --release-train "$releaseTrain" \
+  --cluster-name "$CLUSTER_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --cluster-type connectedClusters \
+  --auto-upgrade-minor-version false \
+  --config connectors.image.registry=mcr.microsoft.com \
+  --config connectors.image.repository=aio-connectors/helmchart/microsoft-aio-connectors \
+  --config connectors.image.tag=1.1.0 \
+  --config connectors.values.enablePreviewFeatures=true \
+  --yes
 ```
 
 > [!NOTE]


### PR DESCRIPTION
This pull request adds a Bash script tab alongside the existing PowerShell instructions for updating the Azure IoT Operations media and ONVIF connectors.

Why:

* Improves accessibility for users working in Linux/macOS environments or those preferring Bash.
* Aligns the documentation style with other Azure docs that offer multiple platform options (e.g., PowerShell, Bash).
* Makes it easier for customers to copy/paste and run commands in their preferred shell without needing manual translation.

Notes:

* The Bash script uses jq to parse JSON output from az CLI. Users must have jq installed.
* No changes were made to the PowerShell instructions.