### PR TITLE
Remove note about assignment_type property

### DIFF
--- a/articles/governance/machine-configuration/how-to/assign-configuration/terraform.md
+++ b/articles/governance/machine-configuration/how-to/assign-configuration/terraform.md
@@ -11,11 +11,6 @@ ms.custom: devx-track-terraform
 
 You can use [Terraform][01] to [deploy][02] machine configuration assignments.
 
-> [!IMPORTANT]
-> The Terraform provider [azurerm_policy_virtual_machine_configuration_assignment][03] hasn't been
-> updated to support the **assignmentType** property so only configurations that perform audits are
-> supported.
-
 ## Assign a custom configuration
 
 The following example assigns a custom configuration.


### PR DESCRIPTION
Per the TF registry example, it is now supported.