### PR TITLE
Correct parameter to deploy Event Hub Namespace

### DIFF
--- a/articles/event-hubs/event-hubs-quickstart-powershell.md
+++ b/articles/event-hubs/event-hubs-quickstart-powershell.md
@@ -43,7 +43,7 @@ Run the following command to create an Event Hubs namespace in the resource grou
 
 ```azurepowershell-interactive
 $namespaceName="myNamespace$(Get-Random)"
-New-AzEventHubNamespace -ResourceGroupName $rgName -NamespaceName $namespaceName -Location $region
+New-AzEventHubNamespace -ResourceGroupName $rgName -Name $namespaceName -Location $region
 ```
 
 You see the output similar to the following one. You see the name of the namespace in the `Name` field. 


### PR DESCRIPTION
A parameter cannot be found that matches parameter name 'NamespaceName'. [Reference](https://learn.microsoft.com/en-us/powershell/module/az.eventhub/new-azeventhubnamespace?view=azps-13.4.0)