### PR TITLE
Fix typo: NodeJS -> Node.js

### DIFF
--- a/articles/communication-services/samples/trusted-auth-sample.md
+++ b/articles/communication-services/samples/trusted-auth-sample.md
@@ -44,7 +44,7 @@ To be able to run this sample, you need:
 - Update the Server (Web API) application with information from the app registrations.
  
 ::: zone pivot="programming-language-javascript"
-[!INCLUDE [NodeJS Auth Hero](./includes/node-auth-hero.md)]
+[!INCLUDE [Node.js Auth Hero](./includes/node-auth-hero.md)]
 ::: zone-end
 
 ::: zone pivot="programming-language-csharp"


### PR DESCRIPTION
Replaced inconsistent or incorrect mentions of "NodeJS" with the official name "Node.js".