### PR TITLE
Fix typo: Nodejs -> Node.js

### DIFF
--- a/articles/spring-apps/basic-standard/concept-app-customer-responsibilities.md
+++ b/articles/spring-apps/basic-standard/concept-app-customer-responsibilities.md
@@ -58,7 +58,7 @@ When you deploy your polyglot applications to the Enterprise plan, assign specif
 | .NET   | [.NET and .NET core support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) |
 | Python | [Status of Python versions](https://devguide.python.org/versions/)                                    |
 | Go     | [Go release history](https://go.dev/doc/devel/release)                                                |
-| Node.js | [Nodejs releases](https://nodejs.org/en/about/previous-releases/)                                     |
+| Node.js | [Node.js releases](https://nodejs.org/en/about/previous-releases/)                                     |
 | PHP    | [PHP supported versions](https://www.php.net/supported-versions.php)                                  |
 
 ### Stack image support


### PR DESCRIPTION
Replaced inconsistent or incorrect mentions of "Nodejs" with the official name "Node.js".