### PR TITLE
Clarify that PrefetchCount must be greater than or equal to MaxConcurrentCalls

### DIFF
--- a/articles/service-bus-messaging/service-bus-prefetch.md
+++ b/articles/service-bus-messaging/service-bus-prefetch.md
@@ -29,6 +29,8 @@ You can set **prefetch_count** on the [azure.servicebus.ServiceBusReceiver](/pyt
 
 While messages are available in the prefetch buffer, any subsequent receive calls are immediately fulfilled from the buffer. The buffer is replenished in the background as space becomes available. If there are no messages available for delivery, the receive operation empties the buffer and then waits or blocks, as expected.
 
+It's important to note that `PrefetchCount` defines the maximum number of messages that can exist in the local buffer at any time. This also means that it acts as a strict upper limit on how many messages can be processed concurrently. If `MaxConcurrentCalls` is set higher than `PrefetchCount`, the processor will not be able to utilize all concurrent message handlers, as only up to `PrefetchCount` messages can be active in memory at once.
+
 ## Why is Prefetch not the default option?
 Prefetch speeds up the message flow by having a message readily available for local retrieval before the application asks for one. This throughput gain is the result of a trade-off that the application author must make explicitly.
 


### PR DESCRIPTION
This PR updates the final sentence in the paragraph explaining how `PrefetchCount` relates to concurrent message processing.

The original text explained that `PrefetchCount` limits the number of messages that can exist in memory, which indirectly constrains concurrency. However, it did not explicitly state that this limit applies even when `MaxConcurrentCalls` is set higher.

The new wording clarifies that to fully utilize all concurrent message handlers, `PrefetchCount` must always be set greater than or equal to `MaxConcurrentCalls`.

This clarification is based on an issue that caused us several hours of debugging and confusion, and we believe it could help others avoid similar frustration when configuring message processing in Azure Service Bus.
