### PR TITLE
Update elastic-san-create.md - Optional initial size parameters

### DIFF
--- a/articles/storage/elastic-san/elastic-san-create.md
+++ b/articles/storage/elastic-san/elastic-san-create.md
@@ -53,6 +53,8 @@ Use one of these sets of sample code to create an Elastic SAN that uses locally 
 | `<VolumeName>`                   | The name of the Elastic SAN Volume to be created. |
 | `<Location>`                     | The region where the new resources will be created. |
 | `<Zone>`                         | The availability zone where the Elastic SAN will be created.<br> *Specify the same availability zone as the zone that will host your workload.*<br>*Use only if the Elastic SAN will use locally redundant storage.*<br> *Must be a zone supported in the target location such as `1`, `2`, or `3`.*  |
+| `<BaseSizeTib>`                  | The amount of base units to provision. This is an optional parameter with default value 20. |
+| `<ExtendedCapacitySizeTiB>`      | The amount of capacity-only units to provision. This is an optional parameter with default value 0. |
 | `<AutoScalePolicyEnforcement>`   | The setting that determines whether or not autoscaling is enabled for the Elastic SAN. <br>*This value is optional but if passed in, must be 'Enabled' or 'Disabled'* |
 | `<UnusedSizeTiB>`                | The capacity (in TiB) on your Elastic SAN that you want to keep free and unused. If you use more space than this amount, the scale-up operation is automatically triggered, increasing the size of your SAN. This parameter is optional but is required to enable autoscaling. |
 |`<IncreaseCapacityUnitByTiB>`     | This parameter sets the TiB of additional capacity units that your SAN scales up by when autoscale gets triggered. This parameter is optional but is required to enable autoscaling. |
@@ -109,7 +111,7 @@ $VolumeName = "<VolumeName>"
 $Location   = "<Location>"
 
 # Create the SAN
-New-AzElasticSAN -ResourceGroupName $RgName -Name $EsanName -Location $Location -BaseSizeTib 100 -ExtendedCapacitySizeTiB 20 -SkuName Premium_ZRS
+New-AzElasticSAN -ResourceGroupName $RgName -Name $EsanName -Location $Location -SkuName Premium_ZRS
 ```
 
 # [Azure CLI](#tab/azure-cli)
@@ -124,6 +126,8 @@ Use one of these sets of sample code to create an Elastic SAN that uses locally 
 | `<VolumeName>`                   | The name of the Elastic SAN Volume to be created. |
 | `<Location>`                     | The region where the new resources will be created. |
 | `<Zone>`                         | The availability zone where the Elastic SAN will be created.<br> *Specify the same availability zone as the zone that will host your workload.*<br>*Use only if the Elastic SAN uses locally redundant storage.*<br> *Must be a zone supported in the target location such as `1`, `2`, or `3`.*  |
+| `<BaseSizeTib>`                  | The amount of base units to provision. This is an optional parameter with default value 20. |
+| `<ExtendedCapacitySizeTiB>`      | The amount of capacity-only units to provision. This is an optional parameter with default value 0. |
 | `<AutoScalePolicyEnforcement>`   | The setting that determines whether or not autoscaling is enabled for the Elastic SAN. <br>*This value is optional but if passed in, must be 'Enabled' or 'Disabled'* |
 | `<UnusedSizeTiB>`                | The capacity (in TiB) on your Elastic SAN that you want to keep free and unused. If you use more space than this amount, the scale-up operation is automatically triggered, increasing the size of your SAN. This parameter is optional but is required to enable autoscaling. |
 |`<IncreaseCapacityUnitByTiB>`     | This parameter sets the TiB of additional capacity units that your SAN scales up by when autoscale gets triggered. This parameter is optional but is required to enable autoscaling. |
@@ -145,7 +149,7 @@ Zone=<Zone>
 az login
 
 # Create an Elastic SAN
-az elastic-san create -n $EsanName -g $RgName -l $Location --base-size-tib 100 --extended-capacity-size-tib 20 --sku "{name:Premium_LRS,tier:Premium}" --availability-zones $Zone
+az elastic-san create -n $EsanName -g $RgName -l $Location --sku "{name:Premium_LRS,tier:Premium}" --availability-zones $Zone
 ```
 
 The following command creates an Elastic SAN that uses locally redundant storage with autoscaling enabled.


### PR DESCRIPTION
To help with retention, we've made the BaseSizeTib parameter optional with default value 20, as we've noticed that customers who start with at least 20 TB deployed with us have a higher likelihood of staying with the product. Updating the documentation to reflect that