### PR TITLE
Fix typo: Azure Defender for -> Microsoft Defender for

### DIFF
--- a/articles/api-management/api-management-key-concepts.md
+++ b/articles/api-management/api-management-key-concepts.md
@@ -136,7 +136,7 @@ API Management integrates with many complementary Azure services to create enter
 * **[Azure Monitor](api-management-howto-use-azure-monitor.md)** for logging, reporting, and alerting on management operations, systems events, and API requests​
 * **[Application Insights](api-management-howto-app-insights.md)** for live metrics, end-to-end tracing, and troubleshooting
 * **[Virtual networks](virtual-network-concepts.md)**, **[private endpoints](private-endpoint.md)**, **[Application Gateway](api-management-howto-integrate-internal-vnet-appgateway.md)**, and **[Azure Front Door](front-door-api-management.md)** for network-level protection​
-* **[Azure Defender for APIs](protect-with-defender-for-apis.md)** and **[Azure DDoS Protection](protect-with-ddos-protection.md)** for runtime protection against malicious attacks​
+* **[Microsoft Defender for APIs](protect-with-defender-for-apis.md)** and **[Azure DDoS Protection](protect-with-ddos-protection.md)** for runtime protection against malicious attacks​
 * **Microsoft Entra ID** for [developer authentication](api-management-howto-aad.md) and [request authorization](api-management-howto-protect-backend-with-aad.md)​
 * **[Event Hubs](api-management-howto-log-event-hubs.md)** for streaming events​
 * **[Azure Redis](api-management-howto-cache-external.md)** for caching responses​ with Azure Cache for Redis or Azure Managed Redis​


### PR DESCRIPTION
Replaced outdated term "Azure Defender for XXX" with the correct service name "Microsoft Defender for XXX".