### PR TITLE
Fix typo: Azure Defender for -> Microsoft Defender for

### DIFF
--- a/articles/defender-for-iot/device-builders/release-notes.md
+++ b/articles/defender-for-iot/device-builders/release-notes.md
@@ -121,7 +121,7 @@ When upgrading the micro agent from version 4.2.* to 4.6.2, you would first need
 
 **Micro agent GA announcement**
 
-Azure Defender for IoT micro agent is now generally available.
+Microsoft Defender for IoT micro agent is now generally available.
 
 ## July 2022
 


### PR DESCRIPTION
Replaced outdated term "Azure Defender for XXX" with the correct service name "Microsoft Defender for XXX".