### PR TITLE
Fix typo: Azure Defender for -> Microsoft Defender for

### DIFF
--- a/articles/defender-for-iot/includes/banner.md
+++ b/articles/defender-for-iot/includes/banner.md
@@ -9,4 +9,4 @@ ms.topic: include
 
 > [!NOTE]
 >
-> Azure Defender for IoT has been renamed to Microsoft Defender for IoT.
+> Microsoft Defender for IoT has been renamed to Microsoft Defender for IoT.


### PR DESCRIPTION
Replaced outdated term "Azure Defender for XXX" with the correct service name "Microsoft Defender for XXX".