### PR TITLE
Fix typo: Azure Defender for -> Microsoft Defender for

### DIFF
--- a/articles/defender-for-iot/organizations/compliance.md
+++ b/articles/defender-for-iot/organizations/compliance.md
@@ -7,7 +7,7 @@ ms.date: 04/14/2023
 
 # Microsoft Defender for IoT compliance resources
 
-Defender for IoT cloud services, formerly named *Azure Defender for IoT* or *Azure Security for IoT*, are based on Microsoft Azure’s infrastructure, which meets demanding US government and international compliance requirements that produce formal authorizations.
+Defender for IoT cloud services, formerly named *Microsoft Defender for IoT* or *Azure Security for IoT*, are based on Microsoft Azure’s infrastructure, which meets demanding US government and international compliance requirements that produce formal authorizations.
 
 ## Provisional authorizations
  


### PR DESCRIPTION
Replaced outdated term "Azure Defender for XXX" with the correct service name "Microsoft Defender for XXX".