### PR TITLE
Update redundancy-migration.md

### DIFF
--- a/articles/storage/common/redundancy-migration.md
+++ b/articles/storage/common/redundancy-migration.md
@@ -469,9 +469,9 @@ Azure Storage offers several options for configuring replication. These options,
 
 - LRS
 - ZRS
-- GRS 
-- RA-GRS
+- GRS
 - GZRS
+- RA-GRS
 - RA-GZRS
 
 The costs associated with changing how data is replicated in your storage account depend on which [aspects of your redundancy configuration](#options-for-changing-the-replication-type) you change. A combination of data storage and egress bandwidth pricing determines the cost of making a change. For details on pricing, see [Azure Storage Pricing page](https://azure.microsoft.com/pricing/details/storage/blobs/).


### PR DESCRIPTION
The order on the document specified that it was in order of least expensive to most expensive.   GZRS is cheaper than RA-GRS. 

![image](https://github.com/user-attachments/assets/9e4bb249-5b66-48e3-8ea5-81b4ee98e2db)

![image](https://github.com/user-attachments/assets/6faf2f1a-e68d-4662-a654-bd2b5728c064)

![image](https://github.com/user-attachments/assets/2b60c92a-cca8-4415-b54c-44e19abd7ca0)
