### PR TITLE
ARM templates doco typos

### DIFF
--- a/articles/azure-resource-manager/templates/syntax.md
+++ b/articles/azure-resource-manager/templates/syntax.md
@@ -57,7 +57,7 @@ In the `definitions` section of the template, specify the schemas used for valid
 
 ```json
 "definitions": {
-  "<definition-name": {
+  "<definition-name>": {
     "type": "<data-type-of-definition>",
     "allowedValues": [ "<array-of-allowed-values>" ],
     "minValue": <minimum-value-for-int>,
@@ -287,8 +287,8 @@ You define resources with the following structure:
         "<settings-for-the-resource>",
         "copy": [
             {
-                "name": ,
-                "count": ,
+                "name": "<name-of-copy-loop>",
+                "count": <number-of-iterations>,
                 "input": {}
             }
         ]

--- a/articles/azure-resource-manager/templates/template-functions-deployment.md
+++ b/articles/azure-resource-manager/templates/template-functions-deployment.md
@@ -52,7 +52,7 @@ The following example returns the deployer object.
   "outputs": {
     "developerOutput": {
       "type": "object",
-      "value": "[developer()]"
+      "value": "[deployer()]"
     }
   }
 }


### PR DESCRIPTION
Just a couple suggested typo fixes for the ARM doco's syntax and template-functions-deployment articles.