### PR TITLE
Update service-bus-partitioning.md

### DIFF
--- a/articles/service-bus-messaging/service-bus-partitioning.md
+++ b/articles/service-bus-messaging/service-bus-partitioning.md
@@ -110,8 +110,6 @@ Service Bus supports automatic message forwarding from, to, or between partition
 ## Partitioned entities limitations
 Currently Service Bus imposes the following limitations on partitioned queues and topics:
 
-- For partitioned premium namespaces, the message size is limited to 1 MB when the messages are sent individually, and the batch size is limited to 1 MB when the messages are sent in a batch. 
-
 - Partitioned queues and topics don't support sending messages that belong to different sessions in a single transaction.
 - Service Bus currently allows up to 100 partitioned queues or topics per namespace for the Basic and Standard SKU. Each partitioned queue or topic counts towards the quota of 10,000 entities per namespace.
 


### PR DESCRIPTION
The 1 MB message size limit for partitioned premium namespaces is not in effect anymore. The size limit is currently the same as for not partitioned namespaces.