### PR TITLE
Fix wrong naming due to copy paste: Blob storage data object to Service Bus data object

### DIFF
--- a/articles/service-bus-messaging/includes/event-grid-service-bus.md
+++ b/articles/service-bus-messaging/includes/event-grid-service-bus.md
@@ -222,7 +222,7 @@ An event has the following top-level data:
 | `eventType` | string | One of the registered event types for this event source. |
 | `eventTime` | string | The time the event is generated based on the provider's UTC time. |
 | `id` | string | Unique identifier for the event. |
-| `data` | object | Blob storage event data. |
+| `data` | object | Service Bus event data. |
 | `dataVersion` | string | The schema version of the data object. The publisher defines the schema version. |
 | `metadataVersion` | string | The schema version of the event metadata. Event Grid defines the schema of the top-level properties. Event Grid provides this value. |
 
@@ -237,7 +237,7 @@ An event has the following top-level data:
 | `type` | string | One of the registered event types for this event source. |
 | `time` | string | The time the event is generated based on the provider's UTC time. |
 | `id` | string | Unique identifier for the event. |
-| `data` | object | Blob storage event data. |
+| `data` | object | Service Bus event data. |
 | `specversion` | string | CloudEvents schema specification version. |
 
 ---


### PR DESCRIPTION
Rename data object name from Blob Storage to Service Bus (probably copy paste from another doc)