### PR TITLE
Correct value of AZCOPY_CONCURRENCY_VALUE

### DIFF
--- a/articles/storage/common/storage-use-azcopy-optimize.md
+++ b/articles/storage/common/storage-use-azcopy-optimize.md
@@ -80,7 +80,7 @@ File scans on some Linux systems don't execute fast enough to saturate all of th
 
 You can increase throughput by setting the `AZCOPY_CONCURRENCY_VALUE` environment variable. This variable specifies the number of concurrent requests that can occur.
 
-If your computer has fewer than 5 CPUs, then the value of this variable is set to `32`. Otherwise, the default value is equal to 16 multiplied by the number of CPUs. The maximum default value of this variable is `3000`, but you can manually set this value higher or lower.
+If your computer has fewer than 5 CPUs, then the value of this variable is set to `32`. Otherwise, the default value is equal to 16 multiplied by the number of CPUs. The maximum default value of this variable is `300`, but you can manually set this value higher or lower.
 
 | Operating system | Command  |
 |--------|-----------|


### PR DESCRIPTION
AzCopy selects a value between 4 and 300, not 3000: https://github.com/Azure/azure-storage-azcopy/blob/main/ste/concurrency.go#L197-L211