### PR TITLE
Typo in auto-generated text: "incudes" should be "includes"

### DIFF
--- a/includes/policy/reference/bycat/policysets-managed-identity.md
+++ b/includes/policy/reference/bycat/policysets-managed-identity.md
@@ -9,4 +9,4 @@ ms.custom: generated
 
 |Name |Description |Policies |Version |
 |---|---|---|---|
-|[\[Preview\]: Managed Identity Federated Credentials should be of approved types from approved federation sources](https://github.com/Azure/azure-policy/blob/master/built-in-policies/policySetDefinitions/Managed%20Identity/FIC_LimitIssuers.json) |Control use of federated credentials for Managed Identities. This initiative incudes policies to block federated identity credentials altogether, to limit use to specific federation provider types, and to limit federation reationships to approved sources. |3 |1.0.0-preview |
+|[\[Preview\]: Managed Identity Federated Credentials should be of approved types from approved federation sources](https://github.com/Azure/azure-policy/blob/master/built-in-policies/policySetDefinitions/Managed%20Identity/FIC_LimitIssuers.json) |Control use of federated credentials for Managed Identities. This initiative includes policies to block federated identity credentials altogether, to limit use to specific federation provider types, and to limit federation reationships to approved sources. |3 |1.0.0-preview |


### PR DESCRIPTION
### Summary

There is a typo in the following sentence, which appears in one or more places in this repository:

> This initiative incudes policies to block federated identity credentials altogether, to limit use to specific federation provider types, and to limit federation reationships to approved sources.

### Problem

- The word **"incudes"** is a typo.
- The correct spelling is **"includes"**.

### Suggested Fix

Please update the sentence as follows:

> This initiative includes policies to block federated identity credentials altogether, to limit use to specific federation provider types, and to limit federation reationships to approved sources.

### Reference

I understand that pull requests for auto-generated files are not accepted, so this issue is intended for your awareness and review of the source content.