### PR TITLE
Typo in auto-generated text: "Configuraions" should be "Configurations"

### DIFF
--- a/articles/role-based-access-control/permissions/compute.md
+++ b/articles/role-based-access-control/permissions/compute.md
@@ -150,7 +150,7 @@ Azure service: [Azure Container Apps](/azure/container-apps/)
 > | microsoft.app/managedenvironments/dotnetcomponents/read | Read Managed Environment .NET Component |
 > | microsoft.app/managedenvironments/dotnetcomponents/write | Create or update Managed Environment .NET Component |
 > | microsoft.app/managedenvironments/dotnetcomponents/delete | Delete Managed Environment .NET Component |
-> | microsoft.app/managedenvironments/httprouteconfigs/read | Get All HTTP Route Configuraions for a Managed Environment. |
+> | microsoft.app/managedenvironments/httprouteconfigs/read | Get All HTTP Route Configurations for a Managed Environment. |
 > | microsoft.app/managedenvironments/httprouteconfigs/write | Create or Update HTTP Route Configuration for a Managed Environment. |
 > | microsoft.app/managedenvironments/httprouteconfigs/delete | Delete an HTTP Route Configuration for a Managed Environment. |
 > | microsoft.app/managedenvironments/javacomponents/read | Read Managed Environment Java Component |


### PR DESCRIPTION
### Summary

There is a typo in the following sentence, which appears in one or more places in this repository:

> Get All HTTP Route Configuraions for a Managed Environment.

### Problem

- The word **"Configuraions"** is a typo.
- The correct spelling is **"Configurations"**.

### Suggested Fix

Please update the sentence as follows:

> Get All HTTP Route Configurations for a Managed Environment.

### Reference

I understand that pull requests for auto-generated files are not accepted, so this issue is intended for your awareness and review of the source content.