### PR TITLE
Remove left over preview hint for ACA Serverless GPU

### DIFF
--- a/articles/container-apps/gpu-serverless-overview.md
+++ b/articles/container-apps/gpu-serverless-overview.md
@@ -75,7 +75,7 @@ Access to this feature is only available after you have serverless GPU quota. Yo
 
 ## Supported regions
 
-Serverless GPUs are available in preview in the *West US 3*, *Australia East*, and *Sweden Central* regions.
+Serverless GPUs are available in the *West US 3*, *Australia East*, and *Sweden Central* regions.
 
 ## Use serverless GPUs
 


### PR DESCRIPTION
This pull request includes a minor change to the documentation file `articles/container-apps/gpu-serverless-overview.md`. The change removes an outdated preview hint in the description of supported regions for serverless GPUs.