### PR TITLE
Typo in auto-generated text: "inforamtion" should be "information"

### DIFF
--- a/articles/role-based-access-control/permissions/ai-machine-learning.md
+++ b/articles/role-based-access-control/permissions/ai-machine-learning.md
@@ -714,7 +714,7 @@ Azure service: [Cognitive Services](/azure/cognitive-services/)
 > | Microsoft.CognitiveServices/accounts/ComputerVision/read/analyzeresults/read | Use this interface to retrieve the status and OCR result of a Read operation.  The URL containing the 'operationId' is returned in the Read operation 'Operation-Location' response header.* |
 > | Microsoft.CognitiveServices/accounts/ComputerVision/read/core/asyncbatchanalyze/action | Use this interface to get the result of a Batch Read File operation, employing the state-of-the-art Optical Character |
 > | Microsoft.CognitiveServices/accounts/ComputerVision/read/operations/read | This interface is used for getting OCR results of Read operation. The URL to this interface should be retrieved from <b>"Operation-Location"</b> field returned from Batch Read File interface. |
-> | Microsoft.CognitiveServices/accounts/ComputerVision/retrieval/index-statis/action | Get index statistics inforamtion for the given users. |
+> | Microsoft.CognitiveServices/accounts/ComputerVision/retrieval/index-statis/action | Get index statistics information for the given users. |
 > | Microsoft.CognitiveServices/accounts/ComputerVision/retrieval/suggest/action | Get search suggestions for the user, given the query text that the user has entered so far. |
 > | Microsoft.CognitiveServices/accounts/ComputerVision/retrieval/search/action | Perform a search using the specified search query and parameters. |
 > | Microsoft.CognitiveServices/accounts/ComputerVision/retrieval/indexes:query/action | Search indexes using the specified search query and parameters. |


### PR DESCRIPTION
### Summary

There is a typo in the following sentence, which appears in one or more places in this repository:

> Get index statistics inforamtion for the given users.

### Problem

- The word **"inforamtion"** is a typo.
- The correct spelling is **"information"**.

### Suggested Fix

Please update the sentence as follows:

> Get index statistics information for the given users.

### Reference

I understand that pull requests for auto-generated files are not accepted, so this issue is intended for your awareness and review of the source content.