### PR TITLE
Update create-confidential-vm-from-compute-gallery.md

### DIFF
--- a/articles/confidential-computing/create-confidential-vm-from-compute-gallery.md
+++ b/articles/confidential-computing/create-confidential-vm-from-compute-gallery.md
@@ -30,7 +30,7 @@ The resulting image version can be used only to create confidential VMs.
 This image version can be replicated within the source region **but cannot be replicated to a different region** or across subscriptions currently.
 
 > [!NOTE]
-> If you want to create an image from a Windows confidential VM that has confidential compute disk encryption enabled with a platform-managed key or a customer-managed key, you can only create a specialized image. This limitation exists because the generalization tool (**sysprep**), might not be able to generalized the encrypted image source. This limitation applies to the OS disk, which is implicitly created along with the Windows confidential VM, and the snapshot created from this OS disk.
+> If you want to create an image from a Windows confidential VM that has confidential compute disk encryption enabled with a platform-managed key or a customer-managed key, you can create a specialized or generalized image.
 
 ### Create a Confidential VM type image using Confidential VM capture
 


### PR DESCRIPTION
The NOTE mentioned -

 Note

If you want to create an image from a Windows confidential VM that has confidential compute disk encryption enabled with a platform-managed key or a customer-managed key, you can only create a specialized image. This limitation exists because the generalization tool (sysprep), might not be able to generalized the encrypted image source. This limitation applies to the OS disk, which is implicitly created along with the Windows confidential VM, and the snapshot created from this OS disk.


This is incorrect, I was able to create both Specialized and Generalized Image in my subscription. There is no such limitation.