### PR TITLE
fix: required minimum number of instances

### DIFF
--- a/articles/reliability/reliability-app-service.md
+++ b/articles/reliability/reliability-app-service.md
@@ -27,7 +27,7 @@ When you deploy Azure App Service, you can provision multiple instances in an *A
 
 - Use premium v3/v4 App Service plans.
 
-- [Enable zone redundancy](#availability-zone-support), which requires that you use Premium v3, Premium v4 or Isolated v2 App Service plans and that you have at minimum three instances of the plan. To view more information, make sure that you select the appropriate tier at the top of this page.
+- [Enable zone redundancy](#availability-zone-support), which requires that you use Premium v3, Premium v4 or Isolated v2 App Service plans and that you have at minimum two instances of the plan. To view more information, make sure that you select the appropriate tier at the top of this page.
 
 ::: zone-end
 


### PR DESCRIPTION
Hi there, I corrects a discrepancy in the minimum instance requirement.

A recent update reduced the required minimum number of instances from three to two. While other parts of the document were already updated to reflect this change, this particular line still stated "three".