### PR TITLE
Update paired region for Brazil South

### DIFF
--- a/articles/reliability/regions-list.md
+++ b/articles/reliability/regions-list.md
@@ -33,7 +33,7 @@ Azure provides the most extensive global footprint of any cloud provider and is 
 | Australia East | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | Australia Southeast | New South Wales | Australia |
 | Australia Southeast | | Australia East | Victoria | Australia |
 |:::image type="content" source="media/icon-region-coming-soon.svg"  alt-text="Icon that shows that this region is coming soon."  border="false"::: Austria East | :::image alt-text="Yes" type="content" source="media/icon-checkmark.svg" border="false"::: | n/a | Vienna| Austria |
-| Brazil South | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | South Central US | Sao Paulo State | Brazil |
+| Brazil South | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | Brazil Southeast | Sao Paulo State | Brazil |
 | :::image type="content" source="media/icon-region-restricted.svg" alt-text="Icon that shows that this region is access restricted to support specific customer scenarios, such as in-country/region disaster recovery" border="false"::: Brazil Southeast | | Brazil South | Rio | Brazil |
 | Canada Central | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | Canada East | Toronto | Canada |
 | Canada East | | Canada Central | Quebec | Canada |

--- a/articles/reliability/regions-list.md
+++ b/articles/reliability/regions-list.md
@@ -33,7 +33,7 @@ Azure provides the most extensive global footprint of any cloud provider and is 
 | Australia East | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | Australia Southeast | New South Wales | Australia |
 | Australia Southeast | | Australia East | Victoria | Australia |
 |:::image type="content" source="media/icon-region-coming-soon.svg"  alt-text="Icon that shows that this region is coming soon."  border="false"::: Austria East | :::image alt-text="Yes" type="content" source="media/icon-checkmark.svg" border="false"::: | n/a | Vienna| Austria |
-| Brazil South | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | Brazil Southeast | Sao Paulo State | Brazil |
+| Brazil South | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: |:::image type="content" source="media/icon-region-restricted.svg" alt-text="Icon that shows that this region is access restricted to support specific customer scenarios, such as in-country/region disaster recovery" border="false"::: Brazil Southeast | Sao Paulo State | Brazil |
 | :::image type="content" source="media/icon-region-restricted.svg" alt-text="Icon that shows that this region is access restricted to support specific customer scenarios, such as in-country/region disaster recovery" border="false"::: Brazil Southeast | | Brazil South | Rio | Brazil |
 | Canada Central | :::image  alt-text="Yes"  type="content" source="media/icon-checkmark.svg"  border="false"::: | Canada East | Toronto | Canada |
 | Canada East | | Canada Central | Quebec | Canada |


### PR DESCRIPTION
Brazil South was listed as paired to South Central US, which is incorrect.