### PR TITLE
Update service-limits.md for ACS Chat to introduce new limits

### DIFF
--- a/articles/communication-services/concepts/service-limits.md
+++ b/articles/communication-services/concepts/service-limits.md
@@ -214,9 +214,11 @@ Azure Communication Services supports chat.
 | Operation | Scope | Limit per 10 seconds | Limit per minute |
 | --- | --- | --- | --- |
 | Create chat thread | Per user | 10 | - |
+| Create chat thread | Per resource | - | 3000 |
 | Delete chat thread | Per user | 10 | - |
 | Update chat thread | Per chat thread | 5 | - |
 | Add participants or remove participants | Per chat thread | 10 | 30 |
+| Add participants | Per resource | - | 3000 |
 | Get chat thread or list chat threads | Per user | 50 | - |
 | Get chat message | Per user, per chat thread | 50 | - |
 | Get chat message | Per chat thread | 250 | - |


### PR DESCRIPTION
ACS Chat is going to add a new limit to throttle the usage of create chat thread and add chat participant APIs based on the requests from the same resource Id. Although the throttle limit exists on number of chat thread created per user but since a resource has the ability to create many such users, so we need to put a throttle limit at resource Id level.