### PR TITLE
Fix typo: incorrect service name in an article's section heading

### DIFF
--- a/articles/backup/install-mars-agent.md
+++ b/articles/backup/install-mars-agent.md
@@ -64,7 +64,7 @@ To modify the storage replication type, follow these steps:
 > You can't modify the storage replication type after the vault is set up and contains backup items. If you want to do this, you need to re-create the vault.
 >
 
-## Configure Recovery Services vault to save passphrase to Recovery Services vault
+## Configure Recovery Services vault to save passphrase to Key Vault
 
 Azure Backup using the Recovery Services agent (MARS) allows you to back up file or folder and system state data to Azure Recovery Services vault. This data is encrypted using a passphrase provided during the installation and registration of the MARS agent. This passphrase is required to retrieve and restore the backup data and needs to be saved in a secure external location, such as Azure Key Vault.
 

--- a/articles/backup/install-mars-agent.md
+++ b/articles/backup/install-mars-agent.md
@@ -64,11 +64,11 @@ To modify the storage replication type, follow these steps:
 > You can't modify the storage replication type after the vault is set up and contains backup items. If you want to do this, you need to re-create the vault.
 >
 
-## Configure Recovery Services vault to save passphrase to Key Vault
+## Configure Recovery Services vault to save passphrase to Azure Key Vault
 
-Azure Backup using the Recovery Services agent (MARS) allows you to back up file or folder and system state data to Azure Recovery Services vault. This data is encrypted using a passphrase provided during the installation and registration of the MARS agent. This passphrase is required to retrieve and restore the backup data and needs to be saved in a secure external location, such as Azure Key Vault.
+Azure Backup using the Recovery Services agent (MARS) allows you to back up file or folder and system state data to Azure Recovery Services vault. This data is encrypted using a passphrase provided during the installation and registration of the MARS agent. This passphrase is required to retrieve and restore the backup data and needs to be saved in a secure external location, such as Key Vault.
 
-We recommend you to create a Key Vault and provide permissions to your Recovery Services vault to save the passphrase to the Key Vault. [Learn more](save-backup-passphrase-securely-in-azure-key-vault.md).
+We recommend you create a key vault and provide permissions to your Recovery Services vault to save the passphrase to the key vault. [Learn more](save-backup-passphrase-securely-in-azure-key-vault.md).
 
 ### Verify internet access
 


### PR DESCRIPTION
In **Install the Azure Backup MARS Agent** docs ([link](https://learn.microsoft.com/en-us/azure/backup/install-mars-agent#configure-recovery-services-vault-to-save-passphrase-to-recovery-services-vault)), one of the sections has incorrect heading:

![image](https://github.com/user-attachments/assets/794df1d4-dcc8-4ef7-a461-7ee47305beec)


This PR corrects it to:
`Configure Recovery Services vault to save passphrase to Key Vault`