### PR TITLE
Fix bad parameter for Recovering section command

### DIFF
--- a/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
@@ -83,10 +83,10 @@ To upgrade all VMs in a resource group, skipping VMs that do not have Network Se
 
 If a migration fails due to a transient issue, such as a network outage or client system issue, the migration can be re-run to configure the VM and Public IPs in the goal state. At execution, the script outputs a recovery log file, which is used to ensure the VM is properly reconfigured. Review the log file `PublicIPUpgrade.log` created in the location where the script was executed.
 
-To recover from a failed upgrade, pass the recovery log file path to the script with the `-recoverFromFile` parameter and identify the VM to recover with the `-VMName` and `-VMResourceGroup` or `-VMResourceID` parameters, as shown in this example.
+To recover from a failed upgrade, pass the recovery log file path to the script with the `-recoverFromFile` parameter and identify the VM to recover with the `-VMName` and `-ResourceGroupName` or `-VMResourceID` parameters, as shown in this example.
 
 ```powershell
-    Start-VMPublicIPUpgrade -RecoverFromFile ./PublicIPUpgrade_Recovery_2020-01-01-00-00.csv -VMName myVM -VMResourceGroup rg-myrg
+    Start-VMPublicIPUpgrade -RecoverFromFile ./PublicIPUpgrade_Recovery_2020-01-01-00-00.csv -VMName 'myVM' -ResourceGroupName 'rgName'
 ```
 
 ## Common questions


### PR DESCRIPTION
This pull request updates documentation for recovering from a failed upgrade of VMs and Public IPs. The change clarifies parameter names and updates the example script for consistency and accuracy.

Documentation update:

* [`articles/virtual-network/ip-services/public-ip-upgrade-vm.md`](diffhunk://#diff-507a10ea3220b0695002c9a992d02370157fd2af387a9d281fe7b54a999a47e7L86-R89): Updated the parameter name from `-VMResourceGroup` to `-ResourceGroupName` in the recovery instructions and example script to align with the correct naming convention. Also added single quotes around parameter values in the example script for improved readability.

The parameter showed in the example isn't correct for the recovering command :
![image](https://github.com/user-attachments/assets/c379a442-8d62-4932-849e-43d39c13750e)