### PR TITLE
docs: Generalize Ubuntu Pro guidance beyond EOL scenarios

### DIFF
--- a/articles/update-manager/security-awareness-ubuntu-support.md
+++ b/articles/update-manager/security-awareness-ubuntu-support.md
@@ -16,21 +16,23 @@ ms.date: 02/26/2025
 
 This article provides the details on security vulnerabilities and Ubuntu Pro support in Azure Update Manager.
 
-If you are using an Ubuntu 18.04 LTS image, you should take necessary steps against security vulnerabilities as the operating system reached the [end of its standard support](https://ubuntu.com/18-04/azure) in May 2023. As Canonical has stopped publishing new security or critical updates after May 2023, the risk of systems and data to potential security threats is high. Without software updates, you may experience performance issues or compatibility issues whenever a new hardware or software is released.
+Standard Ubuntu Long-Term Support (LTS) provides security updates for packages in the `Main` repository. However, it does not include security patching from Canonical for the thousands of packages in the `Universe` repository. This can expose systems to security threats even on a fully patched, supported LTS version.
 
-You can either upgrade to [Ubuntu Pro](https://ubuntu.com/azure/pro) or migrate to a newer version of LTS to avoid any future disruption to the patching mechanisms. When you [upgrade to Ubuntu Pro](https://ubuntu.com/blog/enhancing-the-ubuntu-experience-on-azure-introducing-ubuntu-pro-updates-awareness), you can avoid any security or performance issues. 
+For systems where the operating system has reached the [end of its standard support](https://ubuntu.com/about/release-cycle), such as Ubuntu 20.04 LTS, the risk is higher as security updates are no longer provided for the `Main` repository either.
+
+To address potential patching disruptions, you can either **migrate to a newer version of LTS** or **enable Ubuntu Pro**. Migrating to a newer LTS version restores standard support for the `Main` repository. Enabling Ubuntu Pro provides [Expanded Security Maintenance (ESM)](https://ubuntu.com/security/esm), which delivers patches for the `Universe` repository on all LTS versions (`esm-apps`) and extends patching for the `Main` repository on systems that are past their standard support window (`esm-infra`).
 
 
 ## Ubuntu Pro on Azure Update Manager
  
-Azure Update Manager assesses both Azure and Arc-enabled VMs to indicate any action. AUM helps to identify Ubuntu instances that don't have the available security updates and allows an upgrade to Ubuntu Pro from the Azure portal. For example, an Ubuntu server 18.04 LTS instance on Azure Update Manager has information about upgrading to Ubuntu Pro.
+Azure Update Manager assesses both Azure and Arc-enabled VMs to identify available security updates. It will highlight when an Ubuntu VM has vulnerabilities that can be patched by enabling Ubuntu Pro. This applies to vulnerabilities in the `Universe` repository for any LTS version, and to systems past their standard support period. For example, an Ubuntu Server 18.04 LTS instance on Azure Update Manager has information about upgrading to Ubuntu Pro.
 
 :::image type="content" source="./media/security-awareness-ubuntu-support/ubuntu-pro-subscription-inline.png" alt-text="Screenshot of recommendation to subscribe to Ubuntu Pro in Azure Update Manager." lightbox="./media/security-awareness-ubuntu-support/ubuntu-pro-subscription-expanded.png":::
 
 You can continue to use the Azure Update Manager [capabilities](updates-maintenance-schedules.md) to remain secure after migrating to a supported model from Canonical.
 
 > [!NOTE]
-> - [Ubuntu Pro](https://ubuntu.com/azure/pro) will provide the support on 18.04 LTS from Canonical until 2028 through Expanded Security Maintenance (ESM). You can also [upgrade to Ubuntu Pro from Azure Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/canonical.0001-com-ubuntu-pro-bionic?tab=Overview) as well.
+> For detailed information on Ubuntu LTS release cycles, end-of-support dates, and official upgrade paths, see the [Canonical Ubuntu LTS end of standard support guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/workloads/canonical/ubuntu-els-guidance).
 > - Ubuntu offers 20.04 LTS and 22.04 LTS as a migration from 18.04 LTS. [Learn more](https://ubuntu.com/18-04/azure).
 
  

--- a/articles/update-manager/security-awareness-ubuntu-support.md
+++ b/articles/update-manager/security-awareness-ubuntu-support.md
@@ -32,7 +32,7 @@ Azure Update Manager assesses both Azure and Arc-enabled VMs to identify availab
 You can continue to use the Azure Update Manager [capabilities](updates-maintenance-schedules.md) to remain secure after migrating to a supported model from Canonical.
 
 > [!NOTE]
-> For detailed information on Ubuntu LTS release cycles, end-of-support dates, and official upgrade paths, see the [Canonical Ubuntu LTS end of standard support guidance](https://learn.microsoft.com/en-us/azure/virtual-machines/workloads/canonical/ubuntu-els-guidance).
+> For detailed information on Ubuntu LTS release cycles, end-of-support dates, and official upgrade paths, see the [Canonical Ubuntu LTS end of standard support guidance](/azure/virtual-machines/workloads/canonical/ubuntu-els-guidance).
 > - Ubuntu offers 20.04 LTS and 22.04 LTS as a migration from 18.04 LTS. [Learn more](https://ubuntu.com/18-04/azure).
 
  


### PR DESCRIPTION
The previous guidance focused primarily on Ubuntu Pro as a solution for End-of-Life (EOL) systems. This update expands the scope to also cover another key benefit: security patching for the `Universe` repository (`esm-apps`), which applies to all supported LTS versions.

To reflect this, the document is updated to clarify the `Main` vs. `Universe` distinction and show that Azure Update Manager’s recommendations cover both use cases. Redundant lifecycle details are also removed in favor of a link to the primary guidance document.