### PR TITLE
Update the timeout documentation in task invocation

### DIFF
--- a/articles/dev-box/reference-dev-box-customizations.md
+++ b/articles/dev-box/reference-dev-box-customizations.md
@@ -79,16 +79,16 @@ tasks:
     package: GitHub.GitHubDesktop
 ```
 
-All tasks support the `timeout` parameter, which is optional.
+All tasks support the `timeout` property, which is optional.
 
 Example:
 
 ```
 tasks:
 - name: powershell
+  timeout: 1800 # in seconds
   parameters:
     command: <command>
-    timeout: 1800 # in seconds
 ```
 
 ### Built-in tasks


### PR DESCRIPTION
The timeout documentation in task invocation (imagedefinition.yaml) is wrong. Updated the documentation to reflect the correct way to specify timeout.