### PR TITLE
App service tcp dns

### DIFF
--- a/articles/app-service/overview-name-resolution.md
+++ b/articles/app-service/overview-name-resolution.md
@@ -66,9 +66,9 @@ Validate the settings by using this CLI command:
 az resource show --resource-group <group-name> --name <app-name> --query properties.dnsConfiguration --resource-type "Microsoft.Web/sites"
 ```
 
-## Limitations
+## Limitation
 
-- App Service on Windows does not support DNS resolution over TCP.
+App Service on Windows does not support DNS resolution over TCP.
 
 ## Next steps
 

--- a/articles/app-service/overview-name-resolution.md
+++ b/articles/app-service/overview-name-resolution.md
@@ -68,7 +68,7 @@ az resource show --resource-group <group-name> --name <app-name> --query propert
 
 ## Limitations
 
-- App Service does not support falling back to DNS resolution over TCP when it encounters a truncated response over UDP. Configuring App Services to use a DNS server which does not implement EDNS to negotiate UDP responses larger than the standard 512 byte limit may result in DNS resolution failures.
+- App Service on Windows does not support DNS resolution over TCP.
 
 ## Next steps
 

--- a/articles/app-service/overview-name-resolution.md
+++ b/articles/app-service/overview-name-resolution.md
@@ -66,6 +66,10 @@ Validate the settings by using this CLI command:
 az resource show --resource-group <group-name> --name <app-name> --query properties.dnsConfiguration --resource-type "Microsoft.Web/sites"
 ```
 
+## Limitations
+
+- App Service does not support falling back to DNS resolution over TCP when it encounters a truncated response over UDP. Configuring App Services to use a DNS server which does not implmenent EDNS to negotiate UDP responses larger than the standard 512 byte limit may result in DNS resolution failures.
+
 ## Next steps
 
 - [Configure virtual network integration](./configure-vnet-integration-enable.md)

--- a/articles/app-service/overview-name-resolution.md
+++ b/articles/app-service/overview-name-resolution.md
@@ -68,7 +68,7 @@ az resource show --resource-group <group-name> --name <app-name> --query propert
 
 ## Limitations
 
-- App Service does not support falling back to DNS resolution over TCP when it encounters a truncated response over UDP. Configuring App Services to use a DNS server which does not implmenent EDNS to negotiate UDP responses larger than the standard 512 byte limit may result in DNS resolution failures.
+- App Service does not support falling back to DNS resolution over TCP when it encounters a truncated response over UDP. Configuring App Services to use a DNS server which does not implement EDNS to negotiate UDP responses larger than the standard 512 byte limit may result in DNS resolution failures.
 
 ## Next steps
 


### PR DESCRIPTION
We've encountered this limitation recently and I was not able to find this limitation documented anywhere. The limitation was confirmed by Microsoft Support. If this document is not the right place for this could you suggest a better home for documenting this limitation.