### PR TITLE
Adding Warning section about Secure by Default

### DIFF
--- a/articles/virtual-network/ip-services/public-ip-upgrade.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade.md
@@ -21,7 +21,7 @@ Azure public IP addresses are created with a SKU, either Basic or Standard. The 
 In this article, you learn how to upgrade a static Basic SKU public IP address to Standard SKU in the Azure portal, Azure CLI, or Azure PowerShell.
 
 > [!IMPORTANT]
-> Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku)
+> Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#sku)
 
 ## Prerequisites
 

--- a/articles/virtual-network/ip-services/public-ip-upgrade.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade.md
@@ -21,7 +21,7 @@ Azure public IP addresses are created with a SKU, either Basic or Standard. The 
 In this article, you learn how to upgrade a static Basic SKU public IP address to Standard SKU in the Azure portal, Azure CLI, or Azure PowerShell.
 
 > [!IMPORTANT]
-> Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#sku)
+> Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](./public-ip-addresses.md#sku)
 
 ## Prerequisites
 

--- a/articles/virtual-network/ip-services/public-ip-upgrade.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade.md
@@ -20,6 +20,9 @@ Azure public IP addresses are created with a SKU, either Basic or Standard. The 
 
 In this article, you learn how to upgrade a static Basic SKU public IP address to Standard SKU in the Azure portal, Azure CLI, or Azure PowerShell.
 
+> [!WARNING]
+> Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku)
+
 ## Prerequisites
 
 # [Azure portal](#tab/azureportal)

--- a/articles/virtual-network/ip-services/public-ip-upgrade.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade.md
@@ -20,7 +20,7 @@ Azure public IP addresses are created with a SKU, either Basic or Standard. The 
 
 In this article, you learn how to upgrade a static Basic SKU public IP address to Standard SKU in the Azure portal, Azure CLI, or Azure PowerShell.
 
-> [!WARNING]
+> [!IMPORTANT]
 > Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-addresses#sku)
 
 ## Prerequisites

--- a/articles/virtual-network/ip-services/public-ip-upgrade.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade.md
@@ -21,7 +21,7 @@ Azure public IP addresses are created with a SKU, either Basic or Standard. The 
 In this article, you learn how to upgrade a static Basic SKU public IP address to Standard SKU in the Azure portal, Azure CLI, or Azure PowerShell.
 
 > [!IMPORTANT]
-> Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see [Public IP addresses in Azure](./public-ip-addresses.md#sku)
+> Standard SKU IP Addresses are deployed using the [**Secure by default**](public-ip-addresses.md#sku) model. By default, IP addresses will be closed to all internal traffic when used as a front-end. To allow traffic and prevent unexpected downtime, apply a [network security group (NSG)](../../virtual-network/network-security-groups-overview.md#network-security-groups) to public IP address' associated Network Interface (NIC) or subnet.
 
 ## Prerequisites
 


### PR DESCRIPTION
Adding the following warning section so that customers know that making this upgrade does then require an NSG associated to the Interface: 

Be aware that Standard SKU IP Addresses are considered Secure by default and will be closed to all internal traffic. It is recommended to apply an NSG to the Subnet or Network Interface that the Public IP address is assoicated in order to prevent unexpected downtime, see Public IP addresses in Azure