### PR TITLE
Cost allocation limitation sections

### DIFF
--- a/articles/cost-management-billing/costs/allocate-costs.md
+++ b/articles/cost-management-billing/costs/allocate-costs.md
@@ -126,7 +126,6 @@ Currently, Cost Management supports cost allocation in Cost analysis, budgets, a
 
 The following items are currently unsupported by cost allocation:
 
-- Billing subscriptions area
 - [Cost Management Power BI App](https://appsource.microsoft.com/product/power-bi/costmanagement.azurecostmanagementapp)
 - [Power BI Desktop connector](/power-bi/connect-data/desktop-connect-azure-cost-management)
 
@@ -134,7 +133,7 @@ The [Cost Details](/rest/api/cost-management/generate-cost-details-report/create
 
 However, cost allocation data results might be empty if you're using an unsupported API or if you don't have any cost allocation rules.
 
-If you have cost allocation rules enabled, the unit price for the reserved instance (RI) purchase shows up as 0 in the usage details file. To work around this limitation, you could use the price sheet data. 
+If you have an enterprise agreement (EA) with Microsoft and have cost allocation rules enabled, the unit price for the reserved instance (RI) purchase shows up as 0 in the usage details file. To work around this limitation, you could use the price sheet data for unit price.
 
 Cost allocation to a target doesn't happen if that target doesn't have any costs associated with it.
 


### PR DESCRIPTION
Remove the limitation of unit price = 0 for RI purchases for MCA customers. 