### PR TITLE
Use of User Created Runtime Environments on Hybrid Workers

### DIFF
--- a/articles/automation/manage-runtime-environment.md
+++ b/articles/automation/manage-runtime-environment.md
@@ -53,6 +53,9 @@ To switch to the old experience, follow this step:
 
 
 ## Manage Runtime environment
+> [!NOTE]
+> It is not possible to run Runbooks in a User Created Runtime environment on a Hybrid Worker.
+> Hybrid Workers can only execute Runbooks in a System Created Runtime environment.
 
 ### Create Runtime environment
 

--- a/articles/automation/manage-runtime-environment.md
+++ b/articles/automation/manage-runtime-environment.md
@@ -54,7 +54,7 @@ To switch to the old experience, follow this step:
 
 ## Manage Runtime environment
 > [!NOTE]
-> It is not possible to run Runbooks in a User Created Runtime environment on a Hybrid Worker.
+> Now, It is not possible to run Runbooks in a User Created Runtime environment on a Hybrid Worker.
 > Hybrid Workers can only execute Runbooks in a System Created Runtime environment.
 
 ### Create Runtime environment

--- a/articles/automation/runtime-environment-overview.md
+++ b/articles/automation/runtime-environment-overview.md
@@ -85,7 +85,7 @@ You can't edit these Runtime environments. However, any changes that are made in
 - Deleted Runtime environments cannot be recovered.  
 - This feature is currently supported through Azure portal and [REST API](/rest/api/automation/runtime-environments?view=rest-automation-2023-05-15-preview&preserve-view=true).
 - Management of modules for Azure Automation State Configuration is not supported through Runtime environment experience. You can continue using the old experience for managing modules and packages for Azure Automation State Configuration.
-- It is not possible to run Runbooks in a User Created Runtime environment on a Hybrid Worker. Hybrid Workers can only execute Runbooks in a System Created Runtime environment."
+- Now, It is not possible to run Runbooks in a User Created Runtime environment on a Hybrid Worker. Hybrid Workers can only execute Runbooks in a System Created Runtime environment."
 
 ## Switch between new and old experience
 

--- a/articles/automation/runtime-environment-overview.md
+++ b/articles/automation/runtime-environment-overview.md
@@ -85,6 +85,7 @@ You can't edit these Runtime environments. However, any changes that are made in
 - Deleted Runtime environments cannot be recovered.  
 - This feature is currently supported through Azure portal and [REST API](/rest/api/automation/runtime-environments?view=rest-automation-2023-05-15-preview&preserve-view=true).
 - Management of modules for Azure Automation State Configuration is not supported through Runtime environment experience. You can continue using the old experience for managing modules and packages for Azure Automation State Configuration.
+- It is not possible to run Runbooks in a User Created Runtime environment on a Hybrid Worker. Hybrid Workers can only execute Runbooks in a System Created Runtime environment."
 
 ## Switch between new and old experience
 


### PR DESCRIPTION
Currently, User Created Runtime environments cannot be used on Hybrid Workers.
(This is based on the response from Microsoft Support.)