### PR TITLE
Private DNS zone name for Azure Cache for Redis Enterprise (Microsoft…

### DIFF
--- a/articles/private-link/private-endpoint-dns.md
+++ b/articles/private-link/private-endpoint-dns.md
@@ -123,7 +123,7 @@ For Azure services, use the recommended zone names as described in the following
 >| Azure Database for MySQL - Flexible Server (Microsoft.DBforMySQL/flexibleServers) | mysqlServer | privatelink.mysql.database.azure.com | mysql.database.azure.com |
 >| Azure Database for MariaDB (Microsoft.DBforMariaDB/servers) | mariadbServer | privatelink.mariadb.database.azure.com | mariadb.database.azure.com |
 >| Azure Cache for Redis (Microsoft.Cache/Redis) | redisCache | privatelink.redis.cache.windows.net | redis.cache.windows.net |
->| Azure Cache for Redis Enterprise (Microsoft.Cache/RedisEnterprise) | redisEnterprise | privatelink.redisenterprise.cache.azure.net | {cachename}.{region}.redisenterprise.cache.azure.net |
+>| Azure Cache for Redis Enterprise (Microsoft.Cache/RedisEnterprise) | redisEnterprise |  privatelink.{regionName}.redisenterprise.cache.azure.net | {cachename}.{region}.redisenterprise.cache.azure.net |
 >| Azure Managed Redis (Microsoft.Cache/RedisEnterprise) | redisEnterprise | privatelink.redis.azure.net | {instanceName}.{region}.redis.azure.net |
 
 ### Hybrid + multicloud


### PR DESCRIPTION
….Cache/RedisEnterprise #126345

In Azure Cache for Redis Enterprise (Microsoft.Cache/RedisEnterprise), I noticed that Private DNS zone name as per this https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-private-link#how-do-i-connect-to-my-cache-with-private-endpoint For Enterprise and Enterprise Flash tier caches, your application should connect to ..redisenterprise.cache.azure.net, there is region is missing. Please review and update the document, and ensure it is corrected before closing, as this is the second time I am creating this PR.

https://github.com/MicrosoftDocs/azure-docs/pull/126345#issuecomment-3024612636