### PR TITLE
Fix feature evaluation event name.

### DIFF
--- a/articles/azure-app-configuration/feature-flag-telemetry-reference.md
+++ b/articles/azure-app-configuration/feature-flag-telemetry-reference.md
@@ -21,7 +21,7 @@ In this document, you:
 
 ## Feature evaluation
 
-The Feature evaluation event is emitted whenever a feature flag that has telemetry enabled is evaluated in your application. This event, named `EvaluationEvent`, occurs each time your code checks a feature flag's status or gets a variant. The event captures the evaluation result, variant assignment details, and contextual information about why specific decisions were made.
+The Feature evaluation event is emitted whenever a feature flag that has telemetry enabled is evaluated in your application. This event, named `FeatureEvaluation`, occurs each time your code checks a feature flag's status or gets a variant. The event captures the evaluation result, variant assignment details, and contextual information about why specific decisions were made.
 
 This event contains the following fields:
 


### PR DESCRIPTION
The feature evaluation event name is wrong. It should be FeatureEvaluation.

Here is [where it is emitted](https://github.com/microsoft/FeatureManagement-Dotnet/blob/7cb0654442e892829d142604b73d0ee4afa942d4/src/Microsoft.FeatureManagement.Telemetry.ApplicationInsights/ApplicationInsightsEventPublisher.cs#L91), for reference.