### PR TITLE
Update redundancy-migration.md

### DIFF
--- a/articles/storage/common/redundancy-migration.md
+++ b/articles/storage/common/redundancy-migration.md
@@ -211,8 +211,8 @@ To change between locally redundant and zone-redundant storage with Azure CLI, c
 
 ```azurecli-interactive
 az storage account migration start  \
-    -- account-name <string> \
-    -- g <string> \
+    --account-name <string> \
+    --resource-group <string> \
     --sku <string> \
     --no-wait
 ```
@@ -260,8 +260,8 @@ To track the current migration status of the conversion initiated on your storag
 ```azurecli-interactive
 az storage account migration show \
     --account-name <string> \
-    - g <string> \
-    -n "default"
+    --resource-group <string> \
+    --name "default"
 ```
 
 ---


### PR DESCRIPTION
There were a couple typos with the cli commands given and also, I guess some flags there have one - and some have two. It may be easier to show the two because then the flag is resource-group instead of just g. Just a suggestion there but the spaces before -'s need to be fixed because the command won't work like that.