### PR TITLE
Removed the preview tag from the private endpoint on Standard V2

### DIFF
--- a/articles/api-management/api-management-features.md
+++ b/articles/api-management/api-management-features.md
@@ -28,7 +28,7 @@ Each API Management [pricing tier](api-management-key-concepts.md#api-management
 | -------------------------------------------------------------------------------------------- | ----------- | --------- | --------- | --------- | ----- | -------- | ------- | ------- | 
 | Microsoft Entra integration<sup>1</sup>                                                             | No          | Yes       | No    | Yes      | Yes      | Yes      | Yes     | Yes |
 | Virtual network injection support                                                               | No          | Yes       | No    | No       | No       | No       | Yes    | Yes |
-| Private endpoint support for inbound connections                                                               | No          | Yes       | Yes    | No       | Yes      | Yes (preview)       | Yes  | No   |
+| Private endpoint support for inbound connections                                                               | No          | Yes       | Yes    | No       | Yes      | Yes       | Yes  | No   |
 | Outbound virtual network integration support                                                             | No          | No       | No    | No       | No       | Yes       | No    | Yes |
 | Multi-region deployment                                                                      | No          | No        | No    | No       | No       | No       | Yes     | No |
 | Availability zones                                                                           | No          | No        | No    | No       | No       | No       | Yes     | No  |


### PR DESCRIPTION
Based on the announcement on this page private endpoint is GA on standard v2. Updating documentation to match this.

https://techcommunity.microsoft.com/blog/integrationsonazureblog/ga-inbound-private-endpoint-for-standard-v2-tier-of-azure-api-management/4415374