### PR TITLE
Update create-customer-subscription.md

### DIFF
--- a/articles/cost-management-billing/manage/create-customer-subscription.md
+++ b/articles/cost-management-billing/manage/create-customer-subscription.md
@@ -43,7 +43,6 @@ Partners with a Microsoft Partner Agreement use the following steps to create a 
     :::image type="content" source="./media/create-customer-subscription/all-billing-subscriptions-add.png" alt-text="Screenshot showing navigation to Add where you create a customer subscription." lightbox="./media/create-customer-subscription/all-billing-subscriptions-add.png" :::
 1. On the Basics tab, enter a subscription name.
 1. Select the partner's billing account.
-1. Select the partner's billing profile.
 1. Select the customer that you're creating the subscription for.
 1. If applicable, select a reseller.
 1. Next to **Plan**, select **Microsoft Azure Plan**.  


### PR DESCRIPTION
The workflow to create a customer subscription for partner does not include selecting a billing profile in the UX. This step in the documentation is misleading, hence we need to remove this step. Selecting billing profile is not an option for Partner subscriptions.

<img width="1615" height="779" alt="image" src="https://github.com/user-attachments/assets/3dc3ff69-5bbd-445a-83b1-ff9fffc12407" />
