### PR TITLE
Update azure-services-resource-providers.md

### DIFF
--- a/articles/azure-resource-manager/management/azure-services-resource-providers.md
+++ b/articles/azure-resource-manager/management/azure-services-resource-providers.md
@@ -236,14 +236,6 @@ The resource providers for management services are:
 | Microsoft.SoftwarePlan | License |
 | Microsoft.Solutions | [Azure Managed Applications](../managed-applications/index.yml) |
 
-## Media resource providers
-
-The resource providers for media services are:
-
-| Resource provider namespace | Azure service |
-| --------------------------- | ------------- |
-| Microsoft.Media | [Media Services](/azure/media-services/) |
-
 ## Migration resource providers
 
 The resource providers for migration services are:


### PR DESCRIPTION
Azure Media Servicers (Microsoft.Media) was deprecated June 30, 2024. The last customers were off platform April 30, 2025. No product team exists at this point.