### PR TITLE
Fix the function name from DispatchAsync to Counter

### DIFF
--- a/articles/azure-functions/durable/durable-functions-entities.md
+++ b/articles/azure-functions/durable/durable-functions-entities.md
@@ -131,7 +131,7 @@ For more information on the class-based syntax and how to use it, see [Defining 
 
 ```csharp
 [Function(nameof(Counter))]
-public static Task DispatchAsync([EntityTrigger] TaskEntityDispatcher dispatcher)
+public static Task Counter([EntityTrigger] TaskEntityDispatcher dispatcher)
 {
     return dispatcher.DispatchAsync(operation =>
     {


### PR DESCRIPTION
Change the function name to Counter or directly use literal string [Function(nameof(Counter))] to [Function("Counter")].