### PR TITLE
Update functions-how-to-azure-devops to clear warning message

### DIFF
--- a/articles/azure-functions/functions-how-to-azure-devops.md
+++ b/articles/azure-functions/functions-how-to-azure-devops.md
@@ -118,7 +118,7 @@ steps:
     fi
     npm install 
     npm run build --if-present
-    npm prune --production
+    npm prune --omit=dev
 - task: ArchiveFiles@2
   displayName: "Archive files"
   inputs:
@@ -370,7 +370,7 @@ steps:
     fi
     npm install 
     npm run build --if-present
-    npm prune --production
+    npm prune --omit=dev
 - task: ArchiveFiles@2
   displayName: "Archive files"
   inputs:


### PR DESCRIPTION
Using `prune --production` gives a warning to switch to `--omit=dev` I have done this