### PR TITLE
Fix: update relay-hybrid-connections-http-requests-node-get-started-client.md

### DIFF
--- a/articles/azure-relay/includes/relay-hybrid-connections-http-requests-node-get-started-client.md
+++ b/articles/azure-relay/includes/relay-hybrid-connections-http-requests-node-get-started-client.md
@@ -52,7 +52,7 @@ the package provides functions to construct Relay URIs and tokens.
    }, (res) => {
         let error;
         if (res.statusCode !== 200) {
-            console.error('Request Failed.\n Status Code: ${statusCode}');
+            console.error(`Request Failed.\n Status Code: ${res.statusCode}`);
             res.resume();
         } 
         else {
@@ -89,7 +89,7 @@ the package provides functions to construct Relay URIs and tokens.
     }, (res) => {
         let error;
         if (res.statusCode !== 200) {
-            console.error('Request Failed.\n Status Code: ${statusCode}');
+            console.error(`Request Failed.\n Status Code: ${res.statusCode}`);
             res.resume();
         } 
         else {


### PR DESCRIPTION
fix: use backticks in logs for variable interpolation