### PR TITLE
Update 2-create-package.md

### DIFF
--- a/articles/governance/machine-configuration/how-to/develop-custom-package/2-create-package.md
+++ b/articles/governance/machine-configuration/how-to/develop-custom-package/2-create-package.md
@@ -52,7 +52,9 @@ variable sets to `'This was set by machine configuration'`.
 
 ```powershell
 Install-Module -Name PSDscResources
-Import-Module -Name PSDscResources
+```
+
+```powershell
 Configuration MyConfig {
     Import-DscResource -Name 'Environment' -ModuleName 'PSDscResources'
     Environment MachineConfigurationExample {
@@ -70,7 +72,9 @@ This example configuration is for Linux machines. It creates a file at the path 
 
 ```powershell
 Install-Module -Name nxtools
-Import-Module -Name nxtools
+```
+
+```powershell
 Configuration MyConfig {
     Import-DscResource -ModuleName 'nxtools'
     nxFile MyFile {
@@ -88,7 +92,7 @@ With that definition saved in the `MyConfig.ps1` script file, you can run the sc
 configuration.
 
 ```powershell
-& .\MyConfig.ps1
+. .\MyConfig.ps1
 ```
 
 ```output


### PR DESCRIPTION
Trying to install dependencies like nxtools from within the MyConfig.ps1 script is not working. When I run `& .\MyConfig.ps1` I get an error on the `Import-DscResource -ModuleName 'nxtools'` line saying `Could not find the module 'nxtools'`. If I install the module from outside of the script, I can import the module successfully.

I'm separating the PowerShell steps so that users can avoid the problem above.