### PR TITLE
Update how-to-signing-integrations.md

### DIFF
--- a/articles/trusted-signing/how-to-signing-integrations.md
+++ b/articles/trusted-signing/how-to-signing-integrations.md
@@ -72,7 +72,7 @@ To install the Trusted Signing Client Tools using PowerShell, start PowerShell *
    ```PowerShell
    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri "https://download.microsoft.com/download/6d9cb638-4d5f-438d-9f21-23f0f4405944/TrustedSigningClientTools.msi" -OutFile .\TrustedSigningClientTools.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I TrustedSigningClientTools.msi /quiet'; Remove-Item .\TrustedSigningClientTools.msi
    ```
- 
+
 ### Summary of manual setup steps
 
 1. [Download and install SignTool](#download-and-install-signtool).
@@ -102,7 +102,7 @@ Another option is to use the latest *nuget.exe* file to download and extract the
 1. Download and extract Windows SDK Build Tools NuGet package by running the following installation command:
 
    ```powershell
-   .\nuget.exe install Microsoft.Windows.SDK.BuildTools -Version 10.0.22621.3233 -x
+   .\nuget.exe install Microsoft.Windows.SDK.BuildTools -x
    ```
    
 ### Download and install .NET 8.0 Runtime
@@ -111,8 +111,8 @@ The components that SignTool uses to interface with Trusted Signing require the 
 
 For example:
 
-- For x64 SignTool.exe: [Download .NET 8.0 Runtime - Windows x64 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-8.0.4-windows-x64-installer)
-- For x86 SignTool.exe: [Download .NET 8.0 Runtime - Windows x86 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-8.0.4-windows-x86-installer)
+- For x64 SignTool.exe: [Download .NET 8.0 Runtime - Windows x64 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-8.0.18-windows-x64-installer)
+- For x86 SignTool.exe: [Download .NET 8.0 Runtime - Windows x86 installer](https://dotnet.microsoft.com/download/dotnet/thank-you/runtime-8.0.18-windows-x86-installer)
 
 ### Download and install the Trusted Signing dlib package
 
@@ -125,8 +125,11 @@ To download and install the Trusted Signing dlib package (a .zip file):
 Another option is to download the [Trusted Signing dlib package](https://www.nuget.org/packages/Microsoft.Trusted.Signing.Client) via NuGet similar like the Windows SDK Build Tools NuGet package:
 
 ```powershell
-.\nuget.exe install Microsoft.Trusted.Signing.Client -Version 1.0.53 -x
+.\nuget.exe install Microsoft.Trusted.Signing.Client -x
 ```
+
+> [!NOTE]
+> We recommend using the latest version of any of the required resources.
 
 ### Create a JSON file
 


### PR DESCRIPTION
This PR simplifies a few instructions where the explicit version was indicated, so that our customers could leverage the latest version.

It also marks the latest .net 8 runtime to ensure our customers install the latest patched version.