### PR TITLE
docs: remove non-existent parameter from deploy-azure-pipelines docs

### DIFF
--- a/articles/app-service/deploy-azure-pipelines.md
+++ b/articles/app-service/deploy-azure-pipelines.md
@@ -202,7 +202,6 @@ The following example shows how to deploy to a staging slot, and then swap to a 
 - task: AzureAppServiceManage@0
   inputs:
     azureSubscription: '<service-connection-name>'
-    appType: webAppLinux
     WebAppName: '<app-name>'
     ResourceGroupName: '<name of resource group>'
     SourceSlot: staging


### PR DESCRIPTION
Task `AzureAppServiceManage@0` doesn't seem to have a parameter called `appType`.  Thereby showing an error (`Unexpected property appType`) on the pipeline editor screen