### PR TITLE
Update secure-file-transfer-protocol-known-issues.md

### DIFF
--- a/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
@@ -26,6 +26,7 @@ The following clients are known to be incompatible with SFTP for Azure Blob Stor
 - Kemp
 - paramiko 1.16.0
 - SSH.NET 2016.1.0
+- Renci SSH.NET 2014.6.0
 
 This list isn't exhaustive and might change over time.
 

--- a/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
@@ -25,7 +25,7 @@ The following clients are known to be incompatible with SFTP for Azure Blob Stor
 
 - Kemp
 - paramiko 1.16.0
-- SSH.NET 2016.1.0
+- SSH.NET 2016.1.0 or older
 - Renci SSH.NET 2014.6.0
 
 This list isn't exhaustive and might change over time.


### PR DESCRIPTION
This version is incompatible and unable to authenticate against Azure SFTP with local users. Although this is not an exhaustive list it may be beneficial to call it out.