### PR TITLE
Update policy-overview.md - Changed AzureAD to Entra

### DIFF
--- a/articles/firewall-manager/policy-overview.md
+++ b/articles/firewall-manager/policy-overview.md
@@ -25,7 +25,7 @@ Policies can be associated with one or more firewalls deployed in either a Virtu
 
 ## Classic rules and policies
 
-Azure Firewall supports both Classic rules and policies, but policies is the recommended configuration. The following table compares policies and classic rules:
+Azure Firewall supports both Classic rules and policies, but policies are the recommended configuration. The following table compares policies and classic rules:
 
 
 | Subject | Policy  | Classic rules |
@@ -70,7 +70,7 @@ With inheritance, any changes to the parent policy are automatically applied dow
 ## Built-in high availability
 
 High availability is built in, so there's nothing you need to configure.
-You can create an Azure Firewall Policy object in any region and link it globally to multiple Azure Firewall instances under the same Azure AD tenant. If the region where you create the Policy goes down and has a paired region, the ARM(Azure Resource Manager) object metadata automatically fails over to the secondary region. During the failover, or if the single-region with no pair remains in a failed state, you can't modify the Azure Firewall Policy object. However, the Azure Firewall instances linked to the Firewall Policy continue to operate. For more information, see [Cross-region replication in Azure: Business continuity and disaster recovery](../reliability/cross-region-replication-azure.md#azure-paired-regions).
+You can create an Azure Firewall Policy object in any region and link it globally to multiple Azure Firewall instances under the same Entra ID tenant. If the region where you create the Policy goes down and has a paired region, the ARM(Azure Resource Manager) object metadata automatically fails over to the secondary region. During the failover, or if the single-region with no pair remains in a failed state, you can't modify the Azure Firewall Policy object. However, the Azure Firewall instances linked to the Firewall Policy continue to operate. For more information, see [Cross-region replication in Azure: Business continuity and disaster recovery](../reliability/cross-region-replication-azure.md#azure-paired-regions).
 
 ## Pricing
 


### PR DESCRIPTION
This pull request includes minor updates to the `articles/firewall-manager/policy-overview.md` file to improve grammar and update terminology for clarity and consistency.

### Grammar correction:
* Corrected a grammatical error by changing "policies is" to "policies are" in the description of Azure Firewall's support for Classic rules and policies. (`articles/firewall-manager/policy-overview.md`, [articles/firewall-manager/policy-overview.mdL28-R28](diffhunk://#diff-2115d6ce82cecb4829d9636a1c44d1b6579bf092fa56310990bb6690111739e6L28-R28))

### Terminology update:
* Updated "Azure AD tenant" to "Entra ID tenant" to reflect the current terminology used for Azure identity services. (`articles/firewall-manager/policy-overview.md`, [articles/firewall-manager/policy-overview.mdL73-R73](diffhunk://#diff-2115d6ce82cecb4829d9636a1c44d1b6579bf092fa56310990bb6690111739e6L73-R73))