### PR TITLE
Fix documentation inconsistencies in StringCollection transformations.

### DIFF
--- a/articles/active-directory-b2c/stringcollection-transformations.md
+++ b/articles/active-directory-b2c/stringcollection-transformations.md
@@ -28,7 +28,7 @@ Adds a string claim to a new unique values stringCollection claim. Check out the
 
 | Element | TransformationClaimType | Data Type | Notes |
 | ---- | ----------------------- | --------- | ----- |
-| InputClaim | Element | string | The ClaimType to be added to the output claim. |
+| InputClaim | item | string | The ClaimType to be added to the output claim. |
 | InputClaim | collection | stringCollection | The string collection to be added to the output claim. If the collection contains items, the claims transformation copies the items, and adds the item to the end of the output collection claim. |
 | OutputClaim | collection | stringCollection | The ClaimType that is produced after this claims transformation has been invoked, with the value specified in the input claim. |
 
@@ -63,7 +63,7 @@ Adds a string parameter to a new unique values stringCollection claim. Check out
 | Element | TransformationClaimType | Data Type | Notes |
 | ---- | ----------------------- | --------- | ----- |
 | InputClaim | collection | stringCollection | The string collection to be added to the output claim. If the collection contains items, the claims transformation copies the items, and adds the item to the end of the output collection claim. |
-| InputParameter | Element | string | The value to be added to the output claim. |
+| InputParameter | item | string | The value to be added to the output claim. |
 | OutputClaim | collection | stringCollection | The ClaimType that is produced after this claims transformation has been invoked, with the value specified in the input parameter. |
 
 ### Example of AddParameterToStringCollection


### PR DESCRIPTION
This PR corrects documentation bugs in the StringCollection claims transformations where the parameter tables contain incorrect TransformationClaimType values that don't match the XML examples.

- **AddItemToStringCollection** documentation table states TransformationClaimType should be "Element" when the XML example uses "item"
- **AddParameterToStringCollection** documentation table states TransformationClaimType should be "Element" when the XML example uses "item"

Updated documentation tables to reflect the values that match the XML examples.