### PR TITLE
Need to add explanation of script behavior for AppGW backend pool  - Update public-ip-upgrade-vm.md

### DIFF
--- a/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
@@ -108,7 +108,7 @@ There is no way to evaluate upgrading a Public IP without completing the action.
 
 Yes, the process of upgrading a Zonal Basic SKU Public IP to a Zonal Standard SKU Public IP is identical and works in the script.
 
-### If I specify a NIC associated with a public IP targeted for migration in the AppGW backend pool, will this script remove it from the pool?
+### If I specify a NIC associated with a public IP targeted for migration in the Application Gateway backend pool, will this script remove it from the pool?
 
 Yes, it will be removed. After running the script, you will need to manually reassign the NIC to the Application Gateway backend pool.
 Alternatively, you can avoid this issue by explicitly specifying the private IP address in the backend pool configuration before migration.

--- a/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
@@ -110,7 +110,7 @@ Yes, the process of upgrading a Zonal Basic SKU Public IP to a Zonal Standard SK
 
 ### If I specify a NIC associated with a public IP targeted for migration in the AppGW backend pool, will this script remove it from the pool?
 
-Yes, it will be removed. After running the script, you will need to manually reassign the NIC to the AppGW backend pool.
+Yes, it will be removed. After running the script, you will need to manually reassign the NIC to the Application Gateway backend pool.
 Alternatively, you can avoid this issue by explicitly specifying the private IP address in the backend pool configuration before migration.
 
 ## Use Resource Graph to list VMs with Public IPs requiring upgrade

--- a/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
+++ b/articles/virtual-network/ip-services/public-ip-upgrade-vm.md
@@ -108,6 +108,11 @@ There is no way to evaluate upgrading a Public IP without completing the action.
 
 Yes, the process of upgrading a Zonal Basic SKU Public IP to a Zonal Standard SKU Public IP is identical and works in the script.
 
+### If I specify a NIC associated with a public IP targeted for migration in the AppGW backend pool, will this script remove it from the pool?
+
+Yes, it will be removed. After running the script, you will need to manually reassign the NIC to the AppGW backend pool.
+Alternatively, you can avoid this issue by explicitly specifying the private IP address in the backend pool configuration before migration.
+
 ## Use Resource Graph to list VMs with Public IPs requiring upgrade
 
 ### Query to list virtual machines with Basic SKU public IP addresses


### PR DESCRIPTION
CSS has received multiple cases where customers report that the script does not account for NICs assigned to the AppGW backend pool. If a NIC with a Basic Public IP is upgraded using this script, it will be removed from the AppGW backend pool. Customers must manually reassign the NIC after the script runs — but many are unaware of this until it's too late. Therefore, I strongly recommend adding this Q&A to the MS Learn page to help prevent confusion and reduce support cases.