### PR TITLE
Update expressroute-howto-gateway-migration-portal.md

### DIFF
--- a/articles/expressroute/expressroute-howto-gateway-migration-portal.md
+++ b/articles/expressroute/expressroute-howto-gateway-migration-portal.md
@@ -43,7 +43,6 @@ Follow these steps to migrate to a new gateway using the Azure portal:
     |--|--|
     | **Gateway name** | Enter a name for the new gateway. |
     | **Gateway SKU** | Select the SKU for the new gateway. |
-    | **Public IP address** | Select **Add new**, provide a name for the new public IP, choose an availability zone, and select **OK**. |
 
     > [!NOTE]
     > During this process, your existing virtual network gateway is locked, preventing the creation or modification of connections.


### PR DESCRIPTION
Due to the new specifications for ExpressRoute, customers are no longer required to create public IP addresses on their end. Therefore, the relevant statement is no longer necessary and should be removed. I would appreciate it if you could kindly review and confirm.

----------the relevant statement ---------
Public IP address | Select Add new, provide a name for the new public IP, choose an availability zone, and select OK.
---------------------------------------------

Reference：
https://learn.microsoft.com/en-us/azure/expressroute/expressroute-about-virtual-network-gateways#auto-assigned-public-ip