### PR TITLE
Update tutorial-ingress-controller-add-on-existing.md

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-existing.md
@@ -55,9 +55,6 @@ To configure more parameters for the above command, see [az aks create](/cli/azu
 > [!NOTE]
 > A node resource group will be created with the name **MC_resource-group-name_cluster-name_location**.
 
->[!NOTE]
->If you are planning on using AGIC with an AKS cluster using CNI Overlay, specify the parameter `--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AppGatewayWithOverlayPreview` to configure AGIC to handle connectivity to the CNI Overlay enabled cluster.
-
 >[!WARNING]
 >This document assumes Azure CNI is installed in the AKS cluster. If you are planning on using CNI Overlay, you must ensure Application Gateway and the AKS cluster are part of the same virtual network.
 


### PR DESCRIPTION
Removed the below content 

"If you are planning on using AGIC with an AKS cluster using CNI Overlay, specify the parameter --aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AppGatewayWithOverlayPreview to configure AGIC to handle connectivity to the CNI Overlay enabled cluster."

As Per PG this is an internal hook and should not be proposed to customer.

From: andliu@microsoft.com Prin PM

AKSHTTPCustomFeatures is an internal test hook, it’s not an feature.

Please do not publish it.

And external customer should not try to use that.