### PR TITLE
Correct "Report Size" description (+ TDX quote format issue observed)

### DIFF
--- a/articles/confidential-computing/guest-attestation-confidential-virtual-machines-design.md
+++ b/articles/confidential-computing/guest-attestation-confidential-virtual-machines-design.md
@@ -92,7 +92,7 @@ Refer to [Azure Confidential VMs attestation guidance & FAQ](https://github.com/
 | Name | Offset (bytes) | Size (bytes) | Description |
 | :--- | :--- | :--- | :--- |
 | Header         | 0    | 32 | The report header (not endorsed by the hardware report). |
-| Report Payload | 32   | 1184 | The hardware report. |
+| Report Payload | 32   | 1184 | The hardware report. The payload size is 1184 (AMD SEV-SNP) or 1024 (Intel TDX). |
 | Runtime Data   | 1216 | variable length | The runtime data includes claims endorsed by the hardware report. |
 
 #### Header
@@ -101,7 +101,7 @@ Refer to [Azure Confidential VMs attestation guidance & FAQ](https://github.com/
 | :--- | :--- | :--- | :--- |
 | Signature    | 0 | 4   | Embedded signature. Expected: 0x414c4348 (`HCLA`). |
 | Version      | 4 | 4   | Format version. Expected: 2.
-| Report Size  | 8 | 4   | Size of the Report Payload. Expected: 1184 (AMD SEV-SNP), 1024 (Intel TDX). |
+| Report Size  | 8 | 4   | Size of the Azure-defined attestation report. |
 | Request Type | 12 | 4  | Azure-specific usage of the attestation report. Expected: 2. |
 | Status       | 16 | 4  | Reserved. |
 | Reserved     | 20 | 12 | Reserved. |


### PR DESCRIPTION
I'd like to point out a potential correction in the description of the "Report Size" field in the Header section of the attestation report format.

Currently, the documentation states that:
> | Report Size  | 8 | 4   | Size of the Report Payload. Expected: 1184 (AMD SEV-SNP), 1024 (Intel TDX). |

However, based on our validation of actual attestation reports, it appears that the "Report Size" field actually indicates the size of the entire Azure-defined attestation report, not just the hardware report. This includes:
- the header
- the hardware report (e.g., SNP or TDX)
- the runtime data

This PR updates the documentation accordingly to reflect the true semantics of this field.

<details>

<summary>Note (Deleted on 25 Aug 2025)</summary>

### ⚠️ Important note (Non-documentation Issue)
While reviewing the report contents, I observed that *the TD Quote embedded in TDX CVM attestation reports appears to be missing the first 4 bytes* (`TDQuoteHeader.Version` and `TDQuoteHeader.AttestationKeyType`), based on a comparison with Intel's official quote format specification. This could potentially indicate a bug in the Azure paravisor or quote generation pipeline. See **"Appendix: TD Quote Deviation"** at the end of this PR description for full technical details.

## Reproduction

### SEV-SNP CVM (DCasv5)
```bash
sudo tpm2_nvread -C o 0x01400001 > ./stored-report.bin
xxd stored-report.bin
```

```
00000000: 4843 4c41 0100 0000 2a09 0000 0200 0000  HCLA....*.......
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 0300 0000 0a00 0000 1f00 0300 0000 0000  ................
...

00000910: 3030 3030 3030 3030 3030 3030 3030 3030  0000000000000000
00000920: 3030 3030 3030 3030 227d 0000 0000 0000  00000000"}......
00000930: 0000 0000 0000 0000 0000 0000 0000 0000  ................
...
00000a20: 0000 0000 0000 0000                      ........
```

The `2a09` (Little Endian) coincides with the end of the Azure Report.

### TDX CVM (DCesv6)
```bash
sudo tpm2_nvread -C o 0x01400001 > ./stored-report.bin
xxd stored-report.bin
```

```
00000000: 4843 4c41 0200 0000 5909 0000 0200 0000  HCLA....Y.......
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 8100 0000 0000 0000 0000 0000 0000 0000  ................
...
00000940: 3030 3030 3030 3030 3030 3030 3030 3030  0000000000000000
00000950: 3030 3030 3030 3022 7d00 0000 0000 0000  0000000"}.......
00000960: 0000 0000 0000 0000 0000 0000 0000 0000  ................
...
00000a20: 0000 0000 0000 0000                      ........
```

The `0x5909` (Little Endian) coincides with the end of the Azure Report.

## Appendix: TD Quote Deviation

While investigating the `"Report Size"` issue, I also discovered a potential error in the actual contents of the Azure-provided attestation report for TDX CVMs.

Specifically, the **first 4 bytes of the embedded TD Quote are missing**. According to Intel's official TDX DCAP documentation ([Intel TDX DCAP: QGL and QVL, pp. 46-47](https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_TDX_DCAP_Quoting_Library_API.pdf)), a valid `TD Quote` should begin with a `TDQuoteHeader` containing at least the following fields:

- `uint16_t Version`
- `uint16_t AttestationKeyType`
- `uint32_t TEEType`

However, in the report retrieved from a DCesv6 VM (starting at byte offset `0x20`):

```
00000000: 4843 4c41 0200 0000 5909 0000 0200 0000  HCLA....Y.......
00000010: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000020: 8100 0000 0000 0000 0000 0000 0000 0000  ................
00000030: 0303 191b 04ff 0005 0000 0000 0000 0000  ................
00000040: 407b dcee 2284 000b d45a b760 938b 05e1  @{.."....Z.`....
00000050: 5a75 f65a 812b d187 7efc 28a4 7fa6 5251  Zu.Z.+..~.(...RQ
00000060: 760d 3f97 3ac5 6a74 3bdc 5389 57c8 a802  v.?.:.jt;.S.W...
00000070: 04c9 a556 0e58 436f f156 13e9 f03b 1e80  ...V.XCo.V...;..
00000080: 826d 4aa3 7545 02c9 aac7 176a 732b b6a4  .mJ.uE.....js+..
00000090: 87e5 2d39 001d cf72 d245 9216 ed76 59e7  ..-9...r.E...vY.
...
```

The contents appear to start directly from the `TEEType` (`0x81000000` in Little Endian = TDX). This suggests that the `Version` and `AttestationKeyType` fields (expected at offsets 0 and 2) are omitted.

This may indicate a bug in the paravisor layer, or a deviation from the expected Intel TDX DCAP quote format.

### Impact on Quote Validation
As a result, attempting to validate the attestation report using [SGX-DCAP-QVL](https://github.com/intel/SGXDataCenterAttestationPrimitives) fails at the quote parsing stage. This is because the quote verifier expects a valid header starting with a known version value (e.g., 0x0400 in LE), which is absent.

This structural mismatch can break:
- Any attestation pipelines relying on Intel's QVL
- Third-party verifiers built using Intel’s quote verification stack
- Format checks in customer-side confidential computing solutions

This behavior may significantly impact customers relying on standard quote verification workflows and should be investigated by the Azure Confidential Computing team.

### Reproduction
```bash
# Pre-requisite: SGX-DCAP-QVL

# Get Azure Attestation Report
sudo tpm2_nvread -C o 0x01400001 > ./stored-report.bin

# Extract TDX Quote
dd if=./stored-report.bin \
	skip=32 \
	bs=1 \
	count=1024 \
	of=./quote.bin \
	status=none

# Use Azure QCNL for verification
sudo cp ./SGXDataCenterAttestationPrimitives/QuoteGeneration/qcnl/linux/sgx_default_qcnl_azure.conf /etc/sgx_default_qcnl.conf

# Verify Quote
./SGXDataCenterAttestationPrimitives/SampleCode/QuoteVerificationSample/app -quote quote.bin
```

```
[APP] Info: ECDSA quote path: quote.bin
[APP] Quote verification with QVL, support both SGX and TDX quote:
[APP] Info: tee_get_quote_supplemental_data_version_and_size successfully returned.
[APP] Info: latest supplemental data major version: 3, minor version: 3, size: 536
[APP] Error: App: tee_verify_quote failed: 0xe01d
```

where

```
 0xe01d = SGX_QL_QUOTE_FORMAT_UNSUPPORTED
```

</details>

### Added on 25 Aug 2025
The note section was based on my misunderstanding. The hardware report field in the HCL report contains the TD Report, not the TD Quote (which I had mistakenly assumed). To obtain the TD Quote, we need to send the stored TD Report to host's TD Quoting Enclave via `169.254.169.254/acc/tdquote`. I apologise for any confusion caused by my incorrect report.
