### PR TITLE
Update how-to-end-to-end-tls-ingress-api.md

### DIFF
--- a/articles/application-gateway/for-containers/how-to-end-to-end-tls-ingress-api.md
+++ b/articles/application-gateway/for-containers/how-to-end-to-end-tls-ingress-api.md
@@ -54,6 +54,7 @@ metadata:
   annotations:
     alb.networking.azure.io/alb-name: alb-test
     alb.networking.azure.io/alb-namespace: alb-test-infra
+    alb.networking.azure.io/alb-ingress-extension: https-ingress
 spec:
   ingressClassName: azure-alb-external
   tls:
@@ -100,6 +101,7 @@ metadata:
   annotations:
     alb.networking.azure.io/alb-id: $RESOURCE_ID
     alb.networking.azure.io/alb-frontend: $FRONTEND_NAME
+    alb.networking.azure.io/alb-ingress-extension: https-ingress
 spec:
   ingressClassName: azure-alb-external
   tls:
@@ -137,6 +139,7 @@ metadata:
   annotations:
     alb.networking.azure.io/alb-frontend: FRONTEND_NAME
     alb.networking.azure.io/alb-id: /subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/yyyyyyyy/providers/Microsoft.ServiceNetworking/trafficControllers/zzzzzz
+    alb.networking.azure.io/alb-ingress-extension: https-ingress
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"networking.k8s.io/v1","kind":"Ingress","metadata":{"annotations":{"alb.networking.azure.io/alb-frontend":"FRONTEND_NAME","alb.networking.azure.io/alb-id":"/subscriptions/aaaa0a0a-bb1b-cc2c-dd3d-eeeeee4e4e4e/resourcegroups/yyyyyyyy/providers/Microsoft.ServiceNetworking/trafficControllers/zzzzzz"},"name"
 :"ingress-01","namespace":"test-infra"},"spec":{"ingressClassName":"azure-alb-external","rules":[{"host":"contoso.com","http":{"paths":[{"backend":{"service":{"name":"https-app","port":{"number":443}}},"path":"/","pathType":"Prefix"}]}}],"tls":[{"hosts":["contoso.com"],"secretName":"contoso.com"}]}}


### PR DESCRIPTION
Adding the annotation alb.networking.azure.io/alb-ingress-extension to the ingress configurations as it is missing. This is crucial to make this how to function correctly.