### PR TITLE
fixing typo error | Microsoft.Network/applicationGateways/effectiveNetworkSecurityGroups/action

### DIFF
--- a/articles/role-based-access-control/permissions/networking.md
+++ b/articles/role-based-access-control/permissions/networking.md
@@ -453,7 +453,7 @@ Azure service: [Application Gateway](/azure/application-gateway/), [Azure Bastio
 > | Microsoft.Network/applicationGateways/migrateV1ToV2/action | Migrate Application Gateway from v1 sku to v2 sku |
 > | Microsoft.Network/applicationGateways/getMigrationStatus/action | Get Status Of Migrate Application Gateway From V1 sku To V2 sku |
 > | Microsoft.Network/applicationGateways/setSecurityCenterConfiguration/action | Sets Application Gateway Security Center Configuration |
-> | Microsoft.Network/applicationGateways/effectiveNetworkSecurityGroups/action | Get Route Table configured On Application Gateway |
+> | Microsoft.Network/applicationGateways/effectiveNetworkSecurityGroups/action | Get Network Security Group configured On Application Gateway |
 > | Microsoft.Network/applicationGateways/effectiveRouteTable/action | Get Route Table configured On Application Gateway |
 > | Microsoft.Network/applicationGateways/appProtectPolicy/getAppProtectPolicy/action | Get AppProtect policy attached to application gateway resource |
 > | Microsoft.Network/applicationGateways/appProtectPolicy/attachAppProtectPolicy/action | Attaches AppProtect policy to application gateway at global, path and/or listener level |


### PR DESCRIPTION
fixing typo error

Microsoft.Network/applicationGateways/effectiveNetworkSecurityGroups/action mentioned as

Get Route Table configured On Application Gateway instead of Get Network security group configured On Application Gateway