### PR TITLE
docs: Use Azure RBAC role to fetch secrets from Key Vault

### DIFF
--- a/articles/container-apps/manage-secrets.md
+++ b/articles/container-apps/manage-secrets.md
@@ -126,7 +126,7 @@ To reference a secret from Key Vault, you must first enable managed identity in 
 
 To enable managed identity in your container app, see [Managed identities](managed-identity.md).
 
-To grant access to Key Vault secrets, [create an access policy](/azure/key-vault/general/assign-access-policy) in Key Vault for the managed identity you created. Enable the "Get" secret permission on this policy.
+To grant access to Key Vault secrets, grant the Azure RBAC role [Key Vault Secrets User](/azure/role-based-access-control/built-in-roles/security#key-vault-secrets-user) to the managed identity.
 
 # [Azure portal](#tab/azure-portal)
 


### PR DESCRIPTION
I have updated the documentation in accordance with Azure Key Vault best-practices to use Azure RBAC instead of Key Vault access policies.

Moreover, the current link ("[create an access policy](https://learn.microsoft.com/en-us/azure/key-vault/general/assign-access-policy)") aims at a legacy document.

References:
- https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices
- https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-access-policy