### PR TITLE
Update tutorial-ingress-controller-add-on-new.md

### DIFF
--- a/articles/application-gateway/tutorial-ingress-controller-add-on-new.md
+++ b/articles/application-gateway/tutorial-ingress-controller-add-on-new.md
@@ -60,8 +60,6 @@ az aks create -n myCluster -g myResourceGroup --network-plugin azure --enable-ma
 > [!NOTE] 
 > Please ensure the identity used by AGIC has the proper permissions. A list of permissions needed by the identity can be found here: [Configure Infrastructure - Permissions](configuration-infrastructure.md#permissions). If a custom role is not defined with the required permissions, you may use the _Network Contributor_ role.
 
->[!NOTE]
->If you are planning on using AGIC with an AKS cluster using CNI Overlay, specify the parameter `--aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AppGatewayWithOverlayPreview` to configure AGIC to handle connectivity to the CNI Overlay enabled cluster.
 
 ```azurecli-interactive
 # Get application gateway id from AKS addon profile


### PR DESCRIPTION
Removed the below content

"If you are planning on using AGIC with an AKS cluster using CNI Overlay, specify the parameter --aks-custom-headers AKSHTTPCustomFeatures=Microsoft.ContainerService/AppGatewayWithOverlayPreview to configure AGIC to handle connectivity to the CNI Overlay enabled cluster."

As Per PG this is an internal hook and should not be proposed to customer.

From: andliu@microsoft.com Prin PM

AKSHTTPCustomFeatures is an internal test hook, it’s not an feature.

Please do not publish it.

And external customer should not try to use that.

refer the previous PR

https://github.com/MicrosoftDocs/azure-docs/pull/127459