### PR TITLE
PR for merging PowerShell Script for Ingress and Egress Rules for AzureBastionSubnet NSG

### DIFF
--- a/articles/bastion/bastion-nsg.md
+++ b/articles/bastion/bastion-nsg.md
@@ -167,6 +167,7 @@ foreach ($rule in $rules) {
     $nsg.SecurityRules.Add($nsgRule)
     Set-AzNetworkSecurityGroup -NetworkSecurityGroup $nsg
 }
+```
 
 ### Target VM Subnet
 This is the subnet that contains the target virtual machine that you want to RDP/SSH to.

--- a/articles/bastion/bastion-nsg.md
+++ b/articles/bastion/bastion-nsg.md
@@ -54,6 +54,120 @@ Azure Bastion is deployed specifically to ***AzureBastionSubnet***.
 
    :::image type="content" source="./media/bastion-nsg/outbound.png" alt-text="Screenshot shows outbound security rules for Azure Bastion connectivity." lightbox="./media/bastion-nsg/outbound.png":::
 
+### Powershell Script to create the above mentioned Ingress and Egress traffic rules ###
+```
+# Connect to Azure Account
+Connect-AzAccount
+# Get the Network Security Group details
+$resourceGroupName = Read-Host ("Enter the name of the Resource Group")
+$nsgName = Read-Host ("Enter the name of the Network Security Group")
+# Ingress and Egress rules
+$rules = @(
+    @{
+        Name = "AllowHttpsInbound"
+        Priority = 120
+        Direction = "Inbound"
+        Access = "Allow"
+        SourceAddressPrefix = "Internet"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "*"
+        DestinationPortRange = "443"
+        Protocol = "TCP"
+    },
+    @{
+        Name = "AllowGatewayManagerInbound"
+        Priority = 130
+        Direction = "Inbound"
+        Access = "Allow"
+        SourceAddressPrefix = "GatewayManager"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "*"
+        DestinationPortRange = "443"
+        Protocol = "TCP"
+    },
+    @{
+        Name = "AllowAzureLoadBalancerInbound"
+        Priority = 140
+        Direction = "Inbound"
+        Access = "Allow"
+        SourceAddressPrefix = "AzureLoadBalancer"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "*"
+        DestinationPortRange = "443"
+        Protocol = "TCP"
+    },
+    @{
+        Name = "AllowBastionHostCommunication"
+        Priority = 150
+        Direction = "Inbound"
+        Access = "Allow"
+        SourceAddressPrefix = "VirtualNetwork"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "VirtualNetwork"
+        DestinationPortRange = 8080,5701
+        Protocol = "Ah"
+    }
+    @{
+        Name = "AllowSshRdpOutbound"
+        Priority = 100
+        Direction = "Outbound"
+        Access = "Allow"
+        SourceAddressPrefix = "*"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "VirtualNetwork"
+        DestinationPortRange = 22,3389
+        Protocol = "Ah"
+    },
+    @{
+        Name = "AllowAzureCloudOutbound"
+        Priority = 110
+        Direction = "Outbound"
+        Access = "Allow"
+        SourceAddressPrefix = "*"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "AzureCloud"
+        DestinationPortRange = "443"
+        Protocol = "TCP"
+    },
+    @{
+        Name = "AllowBastionCommunication"
+        Priority = 120
+        Direction = "Outbound"
+        Access = "Allow"
+        SourceAddressPrefix = "VirtualNetwork"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "VirtualNetwork"
+        DestinationPortRange = 8080,5701
+        Protocol = "Ah"
+    },
+    @{
+        Name = "AllowHttpOutbound"
+        Priority = 130
+        Direction = "Outbound"
+        Access = "Allow"
+        SourceAddressPrefix = "*"
+        SourcePortRange = "*"
+        DestinationAddressPrefix = "Internet"
+        DestinationPortRange = "80"
+        Protocol = "Ah"
+    }
+ )
+foreach ($rule in $rules) {
+    $nsgRule = New-AzNetworkSecurityRuleConfig -Name $rule.Name `
+        -Priority $rule.Priority `
+        -Direction $rule.Direction `
+        -Access $rule.Access `
+        -SourceAddressPrefix $rule.SourceAddressPrefix `
+        -SourcePortRange $rule.SourcePortRange `
+        -DestinationAddressPrefix $rule.DestinationAddressPrefix `
+        -DestinationPortRange $rule.DestinationPortRange `
+        -Protocol $rule.Protocol
+ # Get the details of the Network Security Group and Add rules to the group
+    $nsg = Get-AzNetworkSecurityGroup -ResourceGroupName $resourceGroupName -Name $nsgName
+    $nsg.SecurityRules.Add($nsgRule)
+    Set-AzNetworkSecurityGroup -NetworkSecurityGroup $nsg
+}
+
 ### Target VM Subnet
 This is the subnet that contains the target virtual machine that you want to RDP/SSH to.
 


### PR DESCRIPTION
Added a powershell script to add the mentioned 8 network security rules (4 inbound and 4 outbound) to the network security group created for AzureBastionSubnet.

This script is tested.

Inbound Rules:
Via Script:
<img width="1461" height="201" alt="image" src="https://github.com/user-attachments/assets/a0434a1d-788b-4eba-83fb-e481a1c6c770" />


Via Documentation:
<img width="1537" height="205" alt="image" src="https://github.com/user-attachments/assets/6fd83b0e-efde-4549-9d72-66933862e108" />


Outbound Rules:
Via Script:
<img width="1458" height="212" alt="image" src="https://github.com/user-attachments/assets/820cd94c-f553-4ccf-a6c3-c1b7e3eac2bd" />

Via Documentation:
<img width="1399" height="158" alt="image" src="https://github.com/user-attachments/assets/213e1966-0893-4ff6-981e-0d7db43e58c4" />


Note: The protocol is "Ah" as the powershell code uses "Ah" for "Any" protocol type.
<img width="1455" height="647" alt="image" src="https://github.com/user-attachments/assets/9e4657d8-ed79-4d2c-8131-1a16074baae1" />
