### PR TITLE
Update backup-azure-backup-vault-troubleshoot.md

### DIFF
--- a/articles/backup/backup-azure-backup-vault-troubleshoot.md
+++ b/articles/backup/backup-azure-backup-vault-troubleshoot.md
@@ -27,6 +27,15 @@ This article provides troubleshooting steps that help you resolve Azure Backup V
 
 **Resolution:** To resolve this error, assign the same or alternate User Identity to the Backup Vault and update the Backup Instance to use the new identity in latter case. Otherwise, enable the System Identity of the Backup Vault, update the Backup Instance and assign all the necessary roles to it. 
 
+#### Error code: UserErrorStorageAccountKeyAccessDisallowed
+
+**Possible Cause:** The associated storage account has "Allow storage account key access" configuration disabled, and the Azure Backup service currently supports only key-based authentication with storage accounts.
+
+**Resolution:** Enable "Allow storage account key access" in the associated storage account by navigating to Storage Account > Settings > Configuration, updating the setting to Enabled, and saving the changes.
+
+<img width="1583" height="546" alt="image" src="https://github.com/user-attachments/assets/3fa478d0-40d7-4c04-915a-888e5dacc125" />
+
+
 ## Related content
 
 - [About Azure Backup Vault](create-manage-backup-vault.md).


### PR DESCRIPTION
add info about storage account key access requirement for Backup Vault. When this is not the case, getting 

Error Code | UserErrorStorageAccountKeyAccessDisallowed
-- | --
Message | The storage account does not support key based authentication
Recommendations | Please ensure that storage account key access is enabled and then retry the operation. For more information, refer to https://aka.ms/aksclusterbackup
DetailedNonLocalisedMessage | Default BSL is not available. InnerErrorMessage: BackupStorageLocation "default" is unavailable: rpc error: code = Unknown desc = GET https://axso4np4nonprod4psvc1.blob.core.windows.net/aks-backup-nonprod -------------------------------------------------------------------------------- RESPONSE 403: 403 Key based authentication is not permitted on this storage account. ERROR CODE: KeyBasedAuthenticationNotPermitted -------------------------------------------------------------------------------- ﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>KeyBasedAuthenticationNotPermitted</Code><Message>Key based authentication is not permitted on this storage account. RequestId:a86e88d4-b01e-0033-1f98-0c7f68000000 Time:2025-08-13T21:24:22.2439178Z</Message></Error> ------------------------------------------------------------------

