### PR TITLE
Correct custom numeric format examples

### DIFF
--- a/articles/logic-apps/expression-functions-reference.md
+++ b/articles/logic-apps/expression-functions-reference.md
@@ -2079,7 +2079,7 @@ formatNumber(<number>, <format>, <locale>?)
 Suppose that you want to format the number `1234567890`. This example formats that number as the string "1,234,567,890.00".
 
 ```
-formatNumber(1234567890, '0,0.00', 'en-us')
+formatNumber(1234567890, '#,##0.00', 'en-US')
 ```
 
 *Example 2"
@@ -2087,7 +2087,7 @@ formatNumber(1234567890, '0,0.00', 'en-us')
 Suppose that you want to format the number `1234567890`. This example formats the number to the string "1.234.567.890,00".
 
 ```
-formatNumber(1234567890, '0,0.00', 'is-is')
+formatNumber(1234567890, '#,##0.00', 'is-IS')
 ```
 
 *Example 3*
@@ -2103,7 +2103,7 @@ formatNumber(17.35, 'C2')
 Suppose that you want to format the number `17.35`. This example formats the number to the string "17,35 kr".
 
 ```
-formatNumber(17.35, 'C2', 'is-is')
+formatNumber(17.35, 'C2', 'is-IS')
 ```
 
 ## G


### PR DESCRIPTION
`formatNumber(0.4095, '0,0.00', 'en-US')` => 00.41 ❌
`formatNumber(0.4095, '#,##0.00', 'en-US')` => 0.41 ✅
`formatNumber(1234567890, '#,##0.00', 'en-US'):` => 1,234,567,890.00 ✅
