### PR TITLE
Remove BlobFuse v1 deployment section from TOC

### DIFF
--- a/articles/storage/blobs/TOC.yml
+++ b/articles/storage/blobs/TOC.yml
@@ -150,8 +150,6 @@ items:
         href: blobfuse2-what-is.md
       - name: Deploy BlobFuse2 on Linux
         href: blobfuse2-how-to-deploy.md
-      - name: Deploy BlobFuse v1 on Linux
-        href: storage-how-to-mount-container-linux.md
       - name: Health Monitor for BlobFuse2
         href: blobfuse2-health-monitor.md
       - name: Troubleshoot BlobFuse2


### PR DESCRIPTION
Removed the section for deploying BlobFuse v1 on Linux since we are in process of retiring BlobFusev1 by Sept 2026.