### PR TITLE
Update app-consistent recovery points performance guidance for DB

### DIFF
--- a/articles/site-recovery/azure-to-azure-common-questions.md
+++ b/articles/site-recovery/azure-to-azure-common-questions.md
@@ -223,7 +223,8 @@ Because of extra content, app-consistent snapshots are the most involved, and ta
 
 #### Do app-consistent recovery points impact performance?
 
- Because app-consistent recovery points capture all data in memory and process, if they capture frequently, it can affect performance when the workload is already busy. We don't recommend that you capture too often for nondatabase workloads. Even for database workloads, one hour should be enough.
+ Because app-consistent recovery points capture all data in memory and process, if they capture frequently, it can affect performance when the workload is already busy. We don't recommend that you capture too often for nondatabase workloads. As a general rule, a full backup for database workloads (including Azure Site Recovery) every hour is sufficient—if anything, this frequency is on the higher side. Typically, transaction log backups are combined at shorter intervals (for example, every 10 to 15 minutes) to distribute system load while meeting recovery objectives (RPO/RTO/RLO).
+
 
 #### What's the minimum frequency for generating app-consistent recovery points?
 


### PR DESCRIPTION
Clarified performance impact and backup frequency recommendations for app-consistent recovery points.

### Description

This PR updates the backup guidance for database workloads (including Azure Site Recovery).  
The previous text stated only that "one hour should be enough," which could be misinterpreted as implying that hourly full backups alone are always sufficient.  
In reality, **if the Recovery Point Objective (RPO) is one hour, then full backups alone may be acceptable**. However, in many systems shorter RPOs are required, which makes **frequent transaction log backups (e.g., every 10–15 minutes) combined with less frequent full backups the standard approach**.  

### Rationale for Change

- **Clarify the dependency on recovery objectives**: "One hour is enough" is only true when the RPO requirement is one hour. Backup frequency must align with requirements, not arbitrary defaults.  
- **Emphasize the role of transaction log backups**: For shorter RPOs, transaction log backups at short intervals are essential. They balance recovery objectives with system performance.  
- **Tie to business continuity goals (RPO/RTO/RLO)**: Backup strategies should be explicitly aligned with recovery objectives, making the guidance more actionable for architects and operators.  

### Impact

This change clarifies that "one hour should be enough" means **sufficient only if the RPO requirement is one hour**.  
It prevents misinterpretation that hourly full backups alone are always adequate, and instead highlights that log backups are generally required for practical, best-practice database recovery planning.
