### PR TITLE
Fix incorrect variable name in code example

### DIFF
--- a/articles/communication-services/quickstarts/voice-video-calling/includes/raw-media/raw-media-access-windows.md
+++ b/articles/communication-services/quickstarts/voice-video-calling/includes/raw-media/raw-media-access-windows.md
@@ -571,7 +571,7 @@ This feature gives you access the video frames inside the `IncomingVideoStream` 
     }
     private void OnRawIncomingVideoStreamStateChanged(RawIncomingVideoStream rawIncomingVideoStream)
     {
-        switch (incomingVideoStream.State)
+        switch (rawIncomingVideoStream.State)
         {
             case VideoStreamState.Available:
                 // There is a new IncomingVideoStream


### PR DESCRIPTION
The parameter name in the code example was incorrect. This PR fixed the naming of variables in the example.