### PR TITLE
Update note on subnet delegation requirements

### DIFF
--- a/articles/api-management/integrate-vnet-outbound.md
+++ b/articles/api-management/integrate-vnet-outbound.md
@@ -62,7 +62,7 @@ The subnet needs to be delegated to the **Microsoft.Web/serverFarms** service.
 
 
 > [!NOTE]
-> You might need to register the `Microsoft.Web/serverFarms` resource provider in the subscription so that you can delegate the subnet to the service.
+> You might need to register the `Microsoft.Web/serverFarms` resource provider in the subscription so that you can delegate the subnet to the service, even if you see it on the list of available services in the subnet delegation setup in the portal. 
 
 
 For more information about configuring subnet delegation, see [Add or remove a subnet delegation](../virtual-network/manage-subnet-delegation.md).


### PR DESCRIPTION
Because the Microsoft.Web/serverFarms resource provider shows on the portal even if the service is not registered for the subscription, it might become difficult to troubleshoot. The error message when it is not registered says the setup was not able to set the delegation, instead of saying the resource is not registered. Most of my customers assume it is a permission issue, not a service registration issue.