### PR TITLE
Revise billing subscription check instructions

### DIFF
--- a/articles/cost-management-billing/reservations/manage-reserved-vm-instance.md
+++ b/articles/cost-management-billing/reservations/manage-reserved-vm-instance.md
@@ -87,7 +87,7 @@ We don’t allow changing the billing subscription after a reservation is purcha
 
 ## Check billing subscription for an Azure Reservation
 
-To check the billing subscription for an Azure reservation, please confirm which Azure subscription is being charged for [an Azure reservation purchase cost](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/view-purchase-refunds).
+To check the billing subscription for an Azure reservation, please confirm which Azure subscription is being charged for [an Azure reservation purchase cost](/azure/cost-management-billing/reservations/view-purchase-refunds).
 
 
 ## Change billing frequency for an Azure Reservation

--- a/articles/cost-management-billing/reservations/manage-reserved-vm-instance.md
+++ b/articles/cost-management-billing/reservations/manage-reserved-vm-instance.md
@@ -87,15 +87,7 @@ We don’t allow changing the billing subscription after a reservation is purcha
 
 ## Check billing subscription for an Azure Reservation
 
-To check the billing subscription for an Azure reservation:
-
-1. Sign in to the [Azure portal](https://portal.azure.com).
-2. Select **All services** > **Reservations**.
-3. Select the reservation.
-4. Select **Renewal**.
-5. Select **Replace this reservation with a new reservation purchase**
-
-This will show you the billing subscription of current reservation along with other details. You can update the details like scope, billing subscription, quantity, term, and billing frequency for the new reservation which will be purchased automatically upon expiry of current reservation.
+To check the billing subscription for an Azure reservation, please confirm which Azure subscription is being charged for [an Azure reservation purchase cost](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/view-purchase-refunds).
 
 
 ## Change billing frequency for an Azure Reservation


### PR DESCRIPTION
This "Renewal" page shows which billing subscription will be used when the reservation is renewed. It is explained by this message "Replace this reservation with a new reservation purchase" . Therefore, it may differ from the billing subscription currently being used for the reservation.

For example, suppose a reservation was initially purchased by Subscription_A with a shared scope, and later its scope was changed to Subscription_B. In this case, the "Renewal" page shows Subscription_B as the billing subscription. However, in this example, the actual billing subscription is still Subscription_A.

To find out which billing subscription is being used, you need to check which subscription the reservation is being charged for by checking the reservation transaction or ACM.