### PR TITLE
Change tag support for accounts in cost report for Video Indexer

### DIFF
--- a/articles/azure-resource-manager/management/tag-support.md
+++ b/articles/azure-resource-manager/management/tag-support.md
@@ -4087,7 +4087,7 @@ To get the same data as a file of comma-separated values, download [tag-support.
 > [!div class="mx-tableFixed"]
 > | Resource type | Supports tags | Tag in cost report |
 > | ------------- | ----------- | ----------- |
-> | accounts | Yes | Yes |
+> | accounts | Yes | No |
 > | accounts / privateEndpointConnections | No | No |
 > | accounts / privateLinkResources | No | No |
 


### PR DESCRIPTION
There's currently a bug that prevents Azure AI Video Indexer from supporting tags in cost reports.  Yehiyam Livneh <ylivneh@microsoft.com>; Einav Pachter <Einav.Pachter@microsoft.com>; Nofar Edan <Nofar.Edan@microsoft.com> have information on this.