### PR TITLE
Update bastion-faq.md

### DIFF
--- a/articles/bastion/bastion-faq.md
+++ b/articles/bastion/bastion-faq.md
@@ -128,7 +128,7 @@ In order to make a connection, the following roles are required:
 * Reader role on the virtual machine.
 * Reader role on the NIC with private IP of the virtual machine.
 * Reader role on the Azure Bastion resource.
-* Reader role on the virtual network of the target virtual machine (if the Bastion deployment is in a peered virtual network).
+* Reader role on the virtual network of the target virtual machine.
 
 Additionally, the user must have the rights (if required) to connect to the VM. For example, if the user is connecting to a Windows VM via RDP and isn't a member of the local Administrators group, they must be a member of the Remote Desktop Users group.
 


### PR DESCRIPTION
Could see that Bastion throws the error: "CLIENT.TEXT_CLIENT_STATUS_DEFAULT" even when Bastion and VM are in the same virtual network and the user has all other Reader accesses except the Reader Access on the vnet. Once the user is assigned Reader role on the vnet where Bastion and VM exist, the access work fine.