### PR TITLE
Update authenticate-with-managed-identity.md

### DIFF
--- a/articles/logic-apps/authenticate-with-managed-identity.md
+++ b/articles/logic-apps/authenticate-with-managed-identity.md
@@ -1184,7 +1184,7 @@ This example shows the underlying connection resource definition for a connector
     "location": "[parameters('location')]",
     "kind": "V1",
     "properties": {
-        "alternativeParameterValues":{},
+        "alternativeParameterValues": {},
         "api": {
             "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), '<connector-name>')]"
         },
@@ -1215,8 +1215,8 @@ This example shows the underlying connection resource definition for a connector
 ```json
 {
     "type": "Microsoft.Web/connections",
-    "name": "[variables('connections_<connector-name>_name')]",
     "apiVersion": "[providers('Microsoft.Web','connections').apiVersions[0]]",
+    "name": "[variables('connections_<connector-name>_name')]",
     "location": "[parameters('location')]",
     "kind": "V2",
     "properties": {
@@ -1250,7 +1250,7 @@ This example shows the underlying connection resource definition for a connector
     "location": "[parameters('location')]",
     "kind": "V2",
     "properties": {
-        "alternativeParameterValues":{},
+        "alternativeParameterValues": {},
         "api": {
             "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), '<connector-name>')]"
         },

--- a/articles/logic-apps/authenticate-with-managed-identity.md
+++ b/articles/logic-apps/authenticate-with-managed-identity.md
@@ -1156,7 +1156,7 @@ This example shows the underlying connection resource definition for a connector
     "properties": {
         "alternativeParameterValues": {},
         "api": {
-            "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), 'azureautomation')]"
+            "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), '<connector-name>')]"
         },
         "authenticatedUser": {},
         "connectionState": "Enabled",
@@ -1186,7 +1186,7 @@ This example shows the underlying connection resource definition for a connector
     "properties": {
         "alternativeParameterValues":{},
         "api": {
-            "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), 'azureblob')]"
+            "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), '<connector-name>')]"
         },
         "authenticatedUser": {},
         "connectionState": "Enabled",
@@ -1195,8 +1195,7 @@ This example shows the underlying connection resource definition for a connector
         "parameterValueSet":{
             "name": "managedIdentityAuth",
             "values": {}
-        },
-        "parameterValueType": "Alternative"
+        }
     }
 }
 ```
@@ -1262,8 +1261,7 @@ This example shows the underlying connection resource definition for a connector
         "parameterValueSet":{
             "name": "managedIdentityAuth",
             "values": {}
-        },
-        "parameterValueType": "Alternative"
+        }
     }
 }
 ```

--- a/articles/logic-apps/authenticate-with-managed-identity.md
+++ b/articles/logic-apps/authenticate-with-managed-identity.md
@@ -1192,7 +1192,7 @@ This example shows the underlying connection resource definition for a connector
         "connectionState": "Enabled",
         "customParameterValues": {},
         "displayName": "[variables('connections_<connector-name>_name')]",
-        "parameterValueSet":{
+        "parameterValueSet": {
             "name": "managedIdentityAuth",
             "values": {}
         }
@@ -1258,7 +1258,7 @@ This example shows the underlying connection resource definition for a connector
         "connectionState": "Enabled",
         "customParameterValues": {},
         "displayName": "[variables('connections_<connector-name>_name')]",
-        "parameterValueSet":{
+        "parameterValueSet": {
             "name": "managedIdentityAuth",
             "values": {}
         }


### PR DESCRIPTION
(1) Using `"parameterValueType": "Alternative"` is invalid if you deploy it as a `Multi-authentication` setup. It simply doesn't deploy if you keep the value. Tested on `V2` connector.

(2) Made sure `<connector-name>` is being used consistently throughout the templates.

(3) Some small nit-picking