### PR TITLE
Add warning for Defender AV settings replacement

### DIFF
--- a/articles/security/fundamentals/antimalware-code-samples.md
+++ b/articles/security/fundamentals/antimalware-code-samples.md
@@ -28,7 +28,8 @@ You can use these samples to deploy and configure the Microsoft Antimalware exte
 ## Deploy Microsoft Antimalware on Azure Resource Manager VMs
 
 > [!NOTE]
-> Before executing this code sample, you must uncomment the variables and provide appropriate values.
+> Before executing this code sample, you must uncomment the variables and provide appropriate values.<br>
+> WARNING: Deploying or updating this extension will replace existing Defender AV settings, including exclusions.
 
 ```powershell
 # Script to add Microsoft Antimalware extension to Azure Resource Manager VMs


### PR DESCRIPTION
Added a warning about replacing existing Defender AV settings when deploying or updating the extension.
This is based on customer escalation (strategic customer Mediterranean Shipping) and requested by CXP ACE team.