### PR TITLE
Fix formatting and warnings in antimalware code samples

### DIFF
--- a/articles/security/fundamentals/antimalware-code-samples.md
+++ b/articles/security/fundamentals/antimalware-code-samples.md
@@ -28,7 +28,8 @@ You can use these samples to deploy and configure the Microsoft Antimalware exte
 ## Deploy Microsoft Antimalware on Azure Resource Manager VMs
 
 > [!NOTE]
-> Before executing this code sample, you must uncomment the variables and provide appropriate values.
+> Before executing this code sample, you must uncomment the variables and provide appropriate values. <br.
+> WARNING: Deploying or updating this extension will replace existing Defender AV settings, including exclusions.
 
 ```powershell
 # Script to add Microsoft Antimalware extension to Azure Resource Manager VMs
@@ -83,7 +84,8 @@ Azure Service Fabric uses Azure virtual machine scale sets to create the Service
 The code sample below shows how you can enable IaaS Antimalware extension using the AzureRmVmss PowerShell cmdlets.
 
 > [!NOTE]
-> Before executing this code sample, you must uncomment the variables and provide appropriate values.
+> Before executing this code sample, you must uncomment the variables and provide appropriate values.<br>
+> WARNING: Deploying or updating this extension will replace existing Defender AV settings, including exclusions.
 
 ```powershell
 # Script to add Microsoft Antimalware extension to VM Scale Set(VMSS) and Service Fabric Cluster(in turn it used VMSS)
@@ -136,7 +138,8 @@ Update-AzureRmVmss -ResourceGroupName $resourceGroupName -Name $vmScaleSetName -
 The code sample below shows how you can add or configure Microsoft Antimalware to Azure Cloud Service using extended support(CS-ES) via PowerShell cmdlets.
 
 > [!NOTE]
-> Before executing this code sample, you must uncomment the variables and provide appropriate values.
+> Before executing this code sample, you must uncomment the variables and provide appropriate values. <br>
+> WARNING: Deploying or updating this extension will replace existing Defender AV settings, including exclusions.
 
 ```powershell
 # Create Antimalware extension object, where file is the AntimalwareSettings


### PR DESCRIPTION
Added a warning about replacing existing Defender AV settings when deploying or updating the extension.
This is based on customer escalation (strategic customer Mediterranean Shipping) and requested by CXP ACE team.