### PR TITLE
Added limitation of explicit ftps only

### DIFF
--- a/articles/connectors/connectors-create-api-ftp.md
+++ b/articles/connectors/connectors-create-api-ftp.md
@@ -52,7 +52,7 @@ The FTP connector has different versions, based on [logic app type and host envi
 
 * The FTP managed or Azure-hosted connector can create a limited number of connections to the FTP server, based on the connection capacity in the Azure region where your logic app resource exists. If this limit poses a problem in a Consumption logic app workflow, consider creating a Standard logic app workflow and use the FTP built-in connector instead.
 
-* The FTP connector doesn't work with implicit FTPS and supports only explicit FTP over FTPS, which is an extension of TLS.
+* Both the built-in and managed FTP connector support only explicit FTP over FTPS, which is an extension of TLS. Neither connector version supports implicit FTPS.
 
 ## Prerequisites
 

--- a/articles/connectors/connectors-create-api-ftp.md
+++ b/articles/connectors/connectors-create-api-ftp.md
@@ -52,6 +52,8 @@ The FTP connector has different versions, based on [logic app type and host envi
 
 * The FTP managed or Azure-hosted connector can create a limited number of connections to the FTP server, based on the connection capacity in the Azure region where your logic app resource exists. If this limit poses a problem in a Consumption logic app workflow, consider creating a Standard logic app workflow and use the FTP built-in connector instead.
 
+* The FTP connector doesn't work with implicit FTPS and supports only explicit FTP over FTPS, which is an extension of TLS.
+
 ## Prerequisites
 
 * An Azure account and subscription. If you don't have an Azure subscription, [sign up for a free Azure account](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).


### PR DESCRIPTION
Added limitation stating this connector only supports explicit FTPS connections as it is only stated on the managed connector page