### PR TITLE
Update virtual-network-service-endpoints-overview.md

### DIFF
--- a/articles/virtual-network/virtual-network-service-endpoints-overview.md
+++ b/articles/virtual-network/virtual-network-service-endpoints-overview.md
@@ -89,7 +89,7 @@ Service endpoints provide the following benefits:
 
   ExpressRoute: If you're using [ExpressRoute](../expressroute/expressroute-introduction.md?toc=%2fazure%2fvirtual-network%2ftoc.json) for Microsoft peering from your premises, identify the NAT IP addresses that you're using. The NAT IP addresses are either customer provided or provided by the service provider. To allow access to your service resources, you must allow these public IP addresses in the resource IP firewall setting. For more information about NAT for ExpressRoute Microsoft peering, see [ExpressRoute NAT requirements](../expressroute/expressroute-nat.md?toc=%2fazure%2fvirtual-network%2ftoc.json).
 
-![Securing Azure services to virtual networks](./media/virtual-network-service-endpoints-overview/VNet_Service_Endpoints_Overview.png)
+:::image type="content" source="./media/virtual-network-service-endpoints-overview/VNet_Service_Endpoints_Overview.png" alt-text="Screenshot of diagram showing virtual network service endpoints securing Azure services to virtual networks.":::
 
 ### Configuration
 

--- a/articles/virtual-network/virtual-network-service-endpoints-overview.md
+++ b/articles/virtual-network/virtual-network-service-endpoints-overview.md
@@ -91,8 +91,6 @@ Service endpoints provide the following benefits:
 
 ![Securing Azure services to virtual networks](./media/virtual-network-service-endpoints-overview/VNet_Service_Endpoints_Overview.png)
 
-:::image type="content" source="./media/virtual-network-service-endpoints-overview/VNet_Service_Endpoints_Overview.png" alt-text="Screenshot of diagram showing virtual network service endpoints securing Azure services to virtual networks.":::
-
 ### Configuration
 
 - Configure service endpoints on a subnet in a virtual network. Endpoints work with any type of compute instances running within that subnet.


### PR DESCRIPTION
Removed double images.
The VNet_Service_Endpoints_Overview image was doubled in the article, once using markdown standard, and once using other.
On learn both was rendered the same and two exact images is seen, on github / md render one image and one html blob is seen.