### PR TITLE
Change TLS migration deadline to Jan 31, 2026

### DIFF
--- a/articles/storage/common/transport-layer-security-configure-migrate-to-TLS2.md
+++ b/articles/storage/common/transport-layer-security-configure-migrate-to-TLS2.md
@@ -16,7 +16,7 @@ ms.devlang: csharp
 
 # Migrate to TLS 1.2 for Azure Blob Storage
 
-On **Nov 1, 2025**, Azure Blob Storage will stop supporting versions 1.0 and 1.1 of Transport Layer Security (TLS). TLS 1.2 will become the new minimum TLS version. This change impacts all existing and new blob storage accounts, using TLS 1.0 and 1.1 in all clouds. Storage accounts already using TLS 1.2 aren't impacted by this change.
+On **Jan 31, 2026**, Azure Blob Storage will stop supporting versions 1.0 and 1.1 of Transport Layer Security (TLS). TLS 1.2 will become the new minimum TLS version. This change impacts all existing and new blob storage accounts, using TLS 1.0 and 1.1 in all clouds. Storage accounts already using TLS 1.2 aren't impacted by this change.
 
 To avoid disruptions to applications that connect to your storage account, you must ensure that your account requires clients to send and receive data by using TLS **1.2**, and remove dependencies on TLS version 1.0 and 1.1.
 


### PR DESCRIPTION
According to this Microsoft Tech Community post (https://techcommunity.microsoft.com/blog/azurestorageblog/tls-1-0-and-1-1-support-will-be-removed-for-new--existing-azure-storage-accounts/4026181) , Azure Storage will continue to support TLS 1.0 and 1.1 until January 31, 2026. This timeline has also been confirmed by the Storage PM team.

However, the official documentation (https://learn.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-migrate-to-tls2)
 lists November 1, 2025 as the end date for TLS 1.0 and 1.1 support, which is causing confusion among customers.