### PR TITLE
Clarify : Backup of Azure VMs / AWS EC2 Is Not Supported by MABS

### DIFF
--- a/articles/backup/backup-support-matrix-mabs-dpm.md
+++ b/articles/backup/backup-support-matrix-mabs-dpm.md
@@ -2,7 +2,7 @@
 title: MABS & System Center DPM support matrix
 description: This article summarizes Azure Backup support when you use Microsoft Azure Backup Server (MABS) or System Center DPM to back up on-premises and Azure VM resources.
 ms.service: azure-backup
-ms.date: 07/17/2025
+ms.date: 09/11/2025
 ms.topic: reference
 author: AbhishekMallick-MS
 ms.author: v-mallicka
@@ -55,6 +55,22 @@ For more information:
 **Scenario** | **Agent** | **Location**
 --- | --- | ---
 **Back up on-premises machines/workloads** | DPM/MABS protection agent runs on the machines that you want to back up.<br/><br/> The MARS agent on DPM/MABS server.<br/> The minimum version of the Microsoft Azure Recovery Services agent, or Azure Backup agent, required to enable this feature is 2.0.8719.0.  | DPM/MABS must be running on-premises.
+
+> [!NOTE]
+> ## Backup of Azure VMs / AWS EC2 and others... Is Not Supported by MABS
+> A frequently asked question is whether virtual machines hosted on public cloud platforms such as Azure VMs or AWS EC2 can be backed up using DPM/MABS. The answer is that **these environments are not supported**.
+>
+> Bare Metal Recovery (BMR) with MABS is **only supported for recovery on the same hardware**. Recovery to different hardware or in cloud environments (e.g., Azure VM / AWS EC2) is **not supported**.
+>
+> ### Support Matrix
+>
+> | Scenario | Supported |
+> | --- | --- |
+> | Recover system state after BMR on the same hardware | ✅ Yes |
+> | Recover system state after BMR on different hardware | ❌ No |
+> | Recover system state after non-BMR full restore (same/different hardware) | ❌ No |
+>
+> This limitation is primarily due to the fact that **system state backups contain hardware-dependent information**, making recovery on different environments technically infeasible.
 
 ## Supported deployments
 

--- a/articles/backup/backup-support-matrix-mabs-dpm.md
+++ b/articles/backup/backup-support-matrix-mabs-dpm.md
@@ -62,7 +62,7 @@ For more information:
 > Also, Bare Metal Recovery (BMR) with MABS is supported only for recovery on the same hardware; recovery to different hardware or cloud environments (such as Azure VM or AWS EC2) isn't supported.
 >
 >
-> ### Support Matrix
+> **Support Matrix**
 >
 > | Scenario | Supported |
 > | --- | --- |

--- a/articles/backup/backup-support-matrix-mabs-dpm.md
+++ b/articles/backup/backup-support-matrix-mabs-dpm.md
@@ -57,10 +57,10 @@ For more information:
 **Back up on-premises machines/workloads** | DPM/MABS protection agent runs on the machines that you want to back up.<br/><br/> The MARS agent on DPM/MABS server.<br/> The minimum version of the Microsoft Azure Recovery Services agent, or Azure Backup agent, required to enable this feature is 2.0.8719.0.  | DPM/MABS must be running on-premises.
 
 > [!NOTE]
-> ## Backup of Azure VMs / AWS EC2 and others... Is Not Supported by MABS
-> A frequently asked question is whether virtual machines hosted on public cloud platforms such as Azure VMs or AWS EC2 can be backed up using DPM/MABS. The answer is that **these environments are not supported**.
+> Backup of virtual machines hosted on public cloud platforms such as Azure VMs or AWS EC2 using DPM/MABS is not supported.
+> 
+> Also, Bare Metal Recovery (BMR) with MABS is supported only for recovery on the same hardware; recovery to different hardware or cloud environments (such as Azure VM or AWS EC2) isn't supported.
 >
-> Bare Metal Recovery (BMR) with MABS is **only supported for recovery on the same hardware**. Recovery to different hardware or in cloud environments (e.g., Azure VM / AWS EC2) is **not supported**.
 >
 > ### Support Matrix
 >


### PR DESCRIPTION
Updated the support matrix for MABS and DPM to reflect new limitations on backing up Azure VMs and AWS EC2. Adjusted the date for the article's last update.


This PR adds a critical clarification to the documentation regarding backup limitations for virtual machines hosted on public cloud platforms such as Azure VMs and AWS EC2. While Microsoft Azure Backup Server (MABS) and System Center Data Protection Manager (DPM) offer robust backup capabilities for on-premises workloads, **they do not support backing up cloud-based virtual machines**.

This clarification addresses a frequently asked question and helps prevent misconfiguration or misunderstanding by users who assume that cloud VMs are supported by default. It also outlines the limitations of Bare Metal Recovery (BMR), emphasizing that recovery is only supported on the same hardware.

By explicitly documenting these limitations, we improve transparency, reduce support overhead, and guide users toward appropriate backup solutions for cloud environments.

> ✅ This update is especially helpful for:
> - Customers planning hybrid or multi-cloud backup strategies
> - Support engineers handling backup-related inquiries
> - Architects designing resilient backup workflows across environments