### PR TITLE
Minor Update: float() Function Examples

### DIFF
--- a/articles/logic-apps/expression-functions-reference.md
+++ b/articles/logic-apps/expression-functions-reference.md
@@ -1956,6 +1956,17 @@ float('10.000,333', 'de-DE')
 
 And returns this result: `10000.333`
 
+*Example 3*
+
+Examples of unexpectedly valid inputs:
+
+```
+float('12,3,4,5678')  //Returns  12345678
+float('1234567,8+')   //Returns  12345678
+float('12345,6,78,-') //Returns -12345678
+float('-12,345,678,') //Returns -12345678
+```
+
 <a name="formatDateTime"></a>
 
 ### formatDateTime

--- a/articles/logic-apps/expression-functions-reference.md
+++ b/articles/logic-apps/expression-functions-reference.md
@@ -1961,10 +1961,12 @@ And returns this result: `10000.333`
 Examples of unexpectedly valid inputs:
 
 ```
-float('12,3,4,5678')  //Returns  12345678
-float('1234567,8+')   //Returns  12345678
-float('12345,6,78,-') //Returns -12345678
-float('-12,345,678,') //Returns -12345678
+float('12,3,4,5678')  //Returns   12345678
+float('1234567,8+')   //Returns   12345678
+float('12345,6,78,-') //Returns  -12345678
+float('-12,345,678,') //Returns  -12345678
+float('12345678.-')   //Returns  -12345678
+float('.12345678')    //Returns 0.12345678
 ```
 
 <a name="formatDateTime"></a>


### PR DESCRIPTION
Examples of unexpectedly accepted inputs by the float() function.
float() ignores `,` and `+`
A trailing `-` causes the number to be treated as negative.

```
float('12,3,4,5678')  Returns   12345678
float('1234567,8+')   Returns   12345678
float('12345,6,78,-') Returns  -12345678
float('-12,345,678,') Returns  -12345678
float('12345678.-')   Returns  -12345678
float('.12345678')    Returns 0.12345678
```