### PR TITLE
docs: fix code sample to call Build() correctly

### DIFF
--- a/articles/azure-app-configuration/feature-management-dotnet-reference.md
+++ b/articles/azure-app-configuration/feature-management-dotnet-reference.md
@@ -150,7 +150,7 @@ The following example demonstrates how to enable custom feature flag configurati
 IConfiguration configuration = new ConfigurationBuilder()
     .AddJsonFile("appsettings.json")
     .AddJsonFile("appsettings.prod.json")
-    .build();
+    .Build();
 
 services.AddSingleton(configuration);
 services.AddFeatureManagement();


### PR DESCRIPTION
The ConfigurationBuilder example incorrectly used 'build' in lowercase. 
Updated to 'Build()' so the sample compiles and matches the API.