### PR TITLE
fix incorrect TCP connection test command for Windows

### DIFF
--- a/articles/batch/simplified-node-communication-pool-no-public-ip.md
+++ b/articles/batch/simplified-node-communication-pool-no-public-ip.md
@@ -166,7 +166,7 @@ If you created node management private endpoint in the virtual network for your 
 
 ```
 # Windows
-Test-TcpConnection -ComputeName <nodeManagementEndpoint> -Port 443
+Test-NetConnection -ComputerName <nodeManagementEndpoint> -Port 443 -InformationLevel Detailed -Verbose
 # Linux
 nc -v <nodeManagementEndpoint> 443
 ```


### PR DESCRIPTION
Updated PowerShell command for testing TCP connection to use Test-NetConnection with additional parameters. Current documentation example has a cmdlet that doesnt exist: 'Test-TcpConnection'