### PR TITLE
Add link to portal page to create an agent

### DIFF
--- a/articles/sre-agent/usage.md
+++ b/articles/sre-agent/usage.md
@@ -47,7 +47,7 @@ To create an agent, you need to grant your agent the correct permissions and acc
 
 Create an agent by associating resource groups that you want to monitor with the agent:
 
-1. Follow the link provided in your onboarding email to access Azure SRE Agent in the Azure portal.
+1. Visit [https://aka.ms/sreagent-portal](https://aka.ms/sreagent-portal) to access Azure SRE Agent in the Azure portal.
 
 1. Select **Create**.
 


### PR DESCRIPTION
We sent an email to 1200 new customers redirecting their setup instructions here, but neglected to give them the link to https://aka.ms/sreagent-portal. This edit adds that link directly on the Learn page instructions.