### PR TITLE
Update immutable-policy-configure-version-scope.md

### DIFF
--- a/articles/storage/blobs/immutable-policy-configure-version-scope.md
+++ b/articles/storage/blobs/immutable-policy-configure-version-scope.md
@@ -80,7 +80,7 @@ az storage account create \
 If version-level immutability support is enabled for the storage account and the account contains one or more containers, then you must delete all containers before you delete the storage account, even if there are no immutability policies in effect for the account or containers.
 
 > [!NOTE]
-> Version-level immutability cannot be disabled after it is enabled on the storage account, although locked policies can be deleted.
+> Version-level immutability cannot be disabled after it is enabled on the storage account, although unlocked policies can be deleted.
 
 ### Enable version-level immutability support on a container
 


### PR DESCRIPTION
As we explained on "Lock a time-based retention policy" section and "Modify or delete an unlocked retention policy" section, it appears that only immutable policies in an "Unlocked" state are eligible for deletion. After a policy is locked, no one is able to delete it.

https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-policy-configure-version-scope?tabs=azure-portal#modify-or-delete-an-unlocked-retention-policy