### PR TITLE
Update access-tiers-overview.md cold storage minimum supported API version typo

### DIFF
--- a/articles/storage/blobs/access-tiers-overview.md
+++ b/articles/storage/blobs/access-tiers-overview.md
@@ -211,7 +211,7 @@ The cold tier requires the following minimum versions of REST, SDKs, and tools
 
 | Environment | Minimum version |
 |---|---|
-| [REST API](/rest/api/storageservices/blob-service-rest-api)| 2021-21-02 |
+| [REST API](/rest/api/storageservices/blob-service-rest-api)| 2021-12-02 |
 | [.NET](/dotnet/api/azure.storage.blobs) | 12.15.0 |
 | [Java](/java/api/overview/azure/storage-blob-readme) | 12.21.0 |
 | [Python](/python/api/azure-storage-blob/) | 12.15.0 |


### PR DESCRIPTION
Update typo which indicates the minimum storage API version supported to start using Cold storage access tier. The correct API version is 2021-12-02, as documented here: https://learn.microsoft.com/en-us/rest/api/storageservices/version-2021-12-02