### PR TITLE
Updated add-api.md to suit React Vite users as well

### DIFF
--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -278,6 +278,14 @@ Install npm dependencies and build the app into the _build_ folder.
 npm install
 npm run build
 ```
+# [React (Vite)](#tab/react-vite)
+
+Install npm dependencies and build the app into the _dist_ folder.
+
+```bash
+npm install
+npm run dist
+```
 
 # [Vue](#tab/vue)
 
@@ -319,7 +327,14 @@ Run the frontend app and API together by starting the app with the Static Web Ap
     ```bash
     swa start build --api-location api
     ```
+   # [React (Vite)](#tab/react-vite)
 
+    Pass the build output folder (`dist`) and the API folder (`api`) to the CLI.
+
+    ```bash
+    swa start dist --api-location api
+    ```
+    
     # [Vue](#tab/vue)
 
     Pass the build output folder (`dist`) and the API folder (`api`) to the CLI.

--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -327,7 +327,7 @@ Run the frontend app and API together by starting the app with the Static Web Ap
     ```bash
     swa start build --api-location api
     ```
-   # [React (Vite)](#tab/react-vite)
+    # [React (Vite)](#tab/react-vite)
 
     Pass the build output folder (`dist`) and the API folder (`api`) to the CLI.
 

--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -186,7 +186,7 @@ Update the content of the _src/index.html_ file with the following code to fetch
     }
     ```
 
-# [React](#tab/react)
+# [React](#tab/react) or [React (Vite)](#tab/react-vite)
 
 Update the content of _src/App.js_ with the following code to fetch the text from the API function and display it on the screen.
 

--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -278,6 +278,7 @@ Install npm dependencies and build the app into the _build_ folder.
 npm install
 npm run build
 ```
+
 # [React (Vite)](#tab/react-vite)
 
 Install npm dependencies and build the app into the _dist_ folder.
@@ -327,6 +328,7 @@ Run the frontend app and API together by starting the app with the Static Web Ap
     ```bash
     swa start build --api-location api
     ```
+    
     # [React (Vite)](#tab/react-vite)
 
     Pass the build output folder (`dist`) and the API folder (`api`) to the CLI.

--- a/articles/static-web-apps/add-api.md
+++ b/articles/static-web-apps/add-api.md
@@ -284,7 +284,7 @@ Install npm dependencies and build the app into the _dist_ folder.
 
 ```bash
 npm install
-npm run dist
+npm run build
 ```
 
 # [Vue](#tab/vue)


### PR DESCRIPTION
Made changes in 2 places for React Vite users to use dist folder instead of build.  While building and while running with swa command locally.  PLEASE IGNORE MY PREVIOUS COMMIT as this has complete change.