### PR TITLE
Update expressroute-bfd.md to reflect IPv6 support

### DIFF
--- a/articles/expressroute/expressroute-bfd.md
+++ b/articles/expressroute/expressroute-bfd.md
@@ -34,9 +34,11 @@ In this scenario, BFD can help. BFD provides low-overhead link failure detection
 
 BFD is configured by default under all the newly created ExpressRoute private and Microsoft peering interfaces on the MSEEs. As such, to enable BFD, you only need to configure BFD on both your primary and secondary devices. Configuring BFD is two-step process. You configure the BFD on the interface and then link it to the BGP session.
 
+/*
 > [!NOTE]
 > BFD is only supported on IPv4 peering. 
 >
+*/
 
 An example CE/PE (using Cisco IOS XE) configuration is shown as followed: 
 

--- a/articles/expressroute/expressroute-bfd.md
+++ b/articles/expressroute/expressroute-bfd.md
@@ -34,11 +34,6 @@ In this scenario, BFD can help. BFD provides low-overhead link failure detection
 
 BFD is configured by default under all the newly created ExpressRoute private and Microsoft peering interfaces on the MSEEs. As such, to enable BFD, you only need to configure BFD on both your primary and secondary devices. Configuring BFD is two-step process. You configure the BFD on the interface and then link it to the BGP session.
 
-/*
-> [!NOTE]
-> BFD is only supported on IPv4 peering. 
->
-*/
 
 An example CE/PE (using Cisco IOS XE) configuration is shown as followed: 
 


### PR DESCRIPTION
The article currently states that BFD is supported only for IPv4 on ExpressRoute.   I believe this limitation has been removed, and BFD is now supported for both IPv4 and IPv6.  
This update corrects the documentation to avoid misleading readers.