### PR TITLE
Correct resource reference of principalId on Microsoft.ManagedIdentity/userAssignedIdentities

### DIFF
--- a/articles/role-based-access-control/role-assignments-template.md
+++ b/articles/role-based-access-control/role-assignments-template.md
@@ -6,7 +6,7 @@ manager: pmwongera
 ms.service: role-based-access-control
 ms.topic: how-to
 ms.date: 03/30/2025
-ms.author: rolyon
+ms.author: rolyonpri
 ms.custom: devx-track-azurepowershell, devx-track-azurecli, devx-track-arm-template
 ms.devlang: azurecli
 ---
@@ -358,7 +358,7 @@ To use the template, you must specify the following inputs:
             ],
             "properties": {
                 "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')), '2018-11-30').principalId]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')), '2018-11-30').properties.principalId]",
                 "principalType": "ServicePrincipal"
             }
         }

--- a/articles/role-based-access-control/role-assignments-template.md
+++ b/articles/role-based-access-control/role-assignments-template.md
@@ -6,7 +6,7 @@ manager: pmwongera
 ms.service: role-based-access-control
 ms.topic: how-to
 ms.date: 03/30/2025
-ms.author: rolyonpri
+ms.author: rolyon
 ms.custom: devx-track-azurepowershell, devx-track-azurecli, devx-track-arm-template
 ms.devlang: azurecli
 ---


### PR DESCRIPTION
Code example incorrectly references the `principalId`. It's available under `properties.principalId`