### PR TITLE
Fix table rendering issue inside NOTE block and update last modified date

### DIFF
--- a/articles/backup/backup-support-matrix-mabs-dpm.md
+++ b/articles/backup/backup-support-matrix-mabs-dpm.md
@@ -2,7 +2,7 @@
 title: MABS & System Center DPM support matrix
 description: This article summarizes Azure Backup support when you use Microsoft Azure Backup Server (MABS) or System Center DPM to back up on-premises and Azure VM resources.
 ms.service: azure-backup
-ms.date: 09/11/2025
+ms.date: 10/08/2025
 ms.topic: reference
 author: AbhishekMallick-MS
 ms.author: v-mallicka
@@ -60,9 +60,8 @@ For more information:
 > Backup of virtual machines hosted on public cloud platforms such as Azure VMs or AWS EC2 using DPM/MABS is not supported.
 > 
 > Also, Bare Metal Recovery (BMR) with MABS is supported only for recovery on the same hardware; recovery to different hardware or cloud environments (such as Azure VM or AWS EC2) isn't supported.
->
->
-> **Support Matrix**
+
+> **System State Recovery Support Matrix**
 >
 > | Scenario | Supported |
 > | --- | --- |


### PR DESCRIPTION
### Summary
Moved the system state recovery support matrix **outside** the `[!NOTE]` block and updated the **Last updated date**.

### Reason for Change
When a Markdown table is placed **inside** a `[!NOTE]` block, it inherits the NOTE’s purple background color, which makes the table difficult to read and visually inconsistent with other tables in the document.

To improve readability and maintain consistent visual formatting, the table was moved **below** the NOTE block.  
Additionally, the "Last updated" date was updated to reflect this documentation change.

### Result
The NOTE now highlights the key context, while the support matrix is displayed on a standard background for better readability and alignment with the rest of the content.
