### PR TITLE
Update Let's Encrypt Ingress Docs to Address YAML Format Error

### DIFF
--- a/articles/application-gateway/ingress-controller-letsencrypt-certificate-application-gateway.md
+++ b/articles/application-gateway/ingress-controller-letsencrypt-certificate-application-gateway.md
@@ -95,13 +95,13 @@ Use the following steps to install [cert-manager](https://docs.cert-manager.io) 
         # you prove ownership of a domain by ensuring that a particular
         # file is present at the domain
         solvers:
-          - http01:
+        - http01:
             ingress:
-             #   class: azure/application-gateway
-               ingressTemplate:
-                 metadata:
-                   annotations:
-                     kubernetes.io/ingress.class: azure/application-gateway
+              # class: azure/application-gateway
+              ingressTemplate:
+                metadata:
+                  annotations:
+                    kubernetes.io/ingress.class: azure/application-gateway
     EOF
     ```
 


### PR DESCRIPTION
Addresses an indention error in the example code per CertManager docs for IngressTemplate (https://cert-manager.io/docs/configuration/acme/http01/#ingresstemplate)