### PR TITLE
Correct role name for PostgreSQL backup permissions

### DIFF
--- a/articles/backup/backup-azure-database-postgresql-flex-overview.md
+++ b/articles/backup/backup-azure-database-postgresql-flex-overview.md
@@ -48,7 +48,7 @@ For successful backup operations, the vault MSI needs the following permissions:
 
 1. *Restore*: Storage Blob Data Contributor role on the target storage account.
 1. *Backup*:
-    1. *PostgreSQL Flexible Server Long Term Retention Backup Role* role on the server.
+    1. *PostgreSQL Flexible Server Long Term Retention Backup Role* on the server.
     1. *Reader* role on the resource group of the server.
 
 ## Understand pricing

--- a/articles/backup/backup-azure-database-postgresql-flex-overview.md
+++ b/articles/backup/backup-azure-database-postgresql-flex-overview.md
@@ -48,7 +48,7 @@ For successful backup operations, the vault MSI needs the following permissions:
 
 1. *Restore*: Storage Blob Data Contributor role on the target storage account.
 1. *Backup*:
-    1. *PostgreSQL Flexible Server Long Term Retention Backup* role on the server.
+    1. *PostgreSQL Flexible Server Long Term Retention Backup Role* role on the server.
     1. *Reader* role on the resource group of the server.
 
 ## Understand pricing


### PR DESCRIPTION
Update role name for PostreSQL server used for LTR backup configuration.