### PR TITLE
Fix disk IOPS and Mbps property naming conventions

### DIFF
--- a/articles/sap/automation/configure-extra-disks.md
+++ b/articles/sap/automation/configure-extra-disks.md
@@ -112,8 +112,8 @@ The three data disks are striped by using LVM. The log disk and the backup disk 
           "count"                 : 1,
           "disk_type"             : "UltraSSD_LRS",
           "size_gb": 512,
-          "disk-iops-read-write"  : 2048,
-          "disk-mbps-read-write"  : 8,
+          "disk_iops_read_write"  : 2048,
+          "disk_mbps_read_write"  : 8,
           "caching"               : "None",
           "write_accelerator"     : false,
           "lun_start"             : 9
@@ -246,8 +246,8 @@ If you need to add disks to an already deployed system, you can add a new block 
           "count"                 : 1,
           "disk_type"             : "UltraSSD_LRS",
           "size_gb": 512,
-          "disk-iops-read-write"  : 2048,
-          "disk-mbps-read-write"  : 8,
+          "disk_iops_read_write"  : 2048,
+          "disk_mbps_read_write"  : 8,
           "caching"               : "None",
           "write_accelerator"     : false,
           "start_lun"             : 9


### PR DESCRIPTION
This pull request makes minor updates to the disk configuration examples in the documentation to ensure consistency in property naming. Specifically, it changes the property names for disk IOPS and throughput from kebab-case to snake_case.

- Documentation consistency:
  * Updated disk configuration property names from `disk-iops-read-write` and `disk-mbps-read-write` to `disk_iops_read_write` and `disk_mbps_read_write` in two code examples within `articles/sap/automation/configure-extra-disks.md`. [[1]](diffhunk://#diff-452d1d24f83ba6877c2b5da4f0acaa3568f51ea842b271e81b308137d36d6e7eL115-R116) [[2]](diffhunk://#diff-452d1d24f83ba6877c2b5da4f0acaa3568f51ea842b271e81b308137d36d6e7eL249-R250)
Use the correct property names when setting disk IOPS and throughtput (MBPS) numbers