### PR TITLE
Update dnssec-how-to.md adding App service domain DNSSEC limitation

### DIFF
--- a/articles/dns/dnssec-how-to.md
+++ b/articles/dns/dnssec-how-to.md
@@ -186,6 +186,9 @@ New-AzDnsRecordSet -ResourceGroupName "dns-rg" -ZoneName "adatum.com" -Name "sec
 5. If you don't own the parent zone, send the DS record to the owner of the parent zone with instructions to add it into their zone.
 ---
 
+> [!IMPORTANT]
+> App Service Domain does not support DNSSEC. If you have registered your domain via App Service Domain, then you cannot enable DNSSEC since you cannot register a DS record with a parent zone.
+
 ## Next steps
 
 - Learn how to [unsign a DNS zone](dnssec-unsign.md).


### PR DESCRIPTION
Coming form Azure networking Support engineer jadhavrutuja@microsoft.com. 

I had a case where customer was unable to enable DNSSEC on the domain he created via App Service. App Service Domain PG is currently working on it, but there is no ETA. This information has been confirmed with Yutang.Lin@microsoft.com.