### PR TITLE
docs: swap the DDoS tier descriptions

### DIFF
--- a/articles/ddos-protection/ddos-protection-overview.md
+++ b/articles/ddos-protection/ddos-protection-overview.md
@@ -26,13 +26,13 @@ Azure DDoS Protection protects at layer 3 and layer 4 network layers. For web ap
 
 ## Tiers
 
+### DDoS IP Protection
+
+Azure DDoS IP Protection, combined with application design best practices, provides enhanced DDoS mitigation features to defend against DDoS attacks. It's automatically tuned to help protect your specific Azure resources in a virtual network, on a pay-per-protected-IP model. For more information about enabling DDoS IP Protection, see [Quickstart: Create and configure Azure DDoS IP Protection using Azure PowerShell](manage-ddos-protection-powershell-ip.md).
+
 ### DDoS Network Protection
 
-Azure DDoS Network Protection, combined with application design best practices, provides enhanced DDoS mitigation features to defend against DDoS attacks. It's automatically tuned to help protect your specific Azure resources in a virtual network. For more information about enabling DDoS Network Protection, see [Quickstart: Create and configure Azure DDoS Network Protection using the Azure portal](manage-ddos-protection.md).
-
-### DDoS IP Protection 
-
-DDoS IP Protection is a pay-per-protected IP model. DDoS IP Protection contains the same core engineering features as DDoS Network Protection, but will differ in the following value-added services: DDoS rapid response support, cost protection, and discounts on WAF. For more information about enabling DDoS IP Protection, see [Quickstart: Create and configure Azure DDoS IP Protection using Azure PowerShell](manage-ddos-protection-powershell-ip.md).
+DDoS Network Protection contains the same core engineering features as DDoS IP Protection, but will differ in the following value-added services: DDoS rapid response support, cost protection, and discounts on WAF. For more information about enabling DDoS Network Protection, see [Quickstart: Create and configure Azure DDoS Network Protection using the Azure portal](manage-ddos-protection.md).
 
 
 For more information about the tiers, see [DDoS Protection tier comparison](ddos-protection-sku-comparison.md).


### PR DESCRIPTION
The descriptions for **DDoS IP Protection** and **DDoS Network Protection** appear to be swapped. This update aligns them with the [Azure DDoS Protection Tier Comparison](https://learn.microsoft.com/en-us/azure/ddos-protection/ddos-protection-sku-comparison) and the rest of the file.
