### PR TITLE
Update storage-task-authorization-roles-assign.md

### DIFF
--- a/articles/storage-actions/storage-tasks/storage-task-authorization-roles-assign.md
+++ b/articles/storage-actions/storage-tasks/storage-task-authorization-roles-assign.md
@@ -18,7 +18,7 @@ This article describes the least privileged built-in Azure roles or RBAC actions
 
 ## Permission to manage storage task assignments
 
-To create an assignment, your identity must be assigned either the [Storage Blob Data Owner](../../role-based-access-control/built-in-roles.md#storage-blob-data-owner) role or a custom role that contains the following RBAC actions:
+To create an assignment, your identity must be assigned either the **Storage Actions Task Assignment Contributor** as built-in role or a custom role that contains the following RBAC actions:
 
 - Microsoft.Authorization/roleAssignments/write
 - Microsoft.Authorization/roleAssignments/delete


### PR DESCRIPTION
As discussed in IcM 686054402 and workitem 35040080, the built-in role that includes the listed action permissions required to create a "Storage Task Assignment" is not Storage Blob Data Owner, but rather Storage Task Assignment Contributor.
<img width="991" height="541" alt="2025-10-15_15h33_40" src="https://github.com/user-attachments/assets/15b4c671-2430-4ace-9f30-b32e23dca717" />
<img width="992" height="558" alt="2025-10-15_15h34_19" src="https://github.com/user-attachments/assets/ee46ca38-4d94-474a-bb13-689b391e4c23" />
