### PR TITLE
[apim] Remove support for parameterless SymmetricAlgorithm.Create()

### DIFF
--- a/articles/api-management/api-management-policy-expressions.md
+++ b/articles/api-management/api-management-policy-expressions.md
@@ -142,7 +142,7 @@ The following table lists the .NET Framework types and members allowed in policy
 |`System.Security.Cryptography.SHA384Managed`|All|
 |`System.Security.Cryptography.SHA512`|All|
 |`System.Security.Cryptography.SHA512Managed`|All|
-|`System.Security.Cryptography.SymmetricAlgorithm`|All except parameterless Create()|
+|`System.Security.Cryptography.SymmetricAlgorithm`|All except parameterless `Create()`|
 |`System.Security.Cryptography.X509Certificates.PublicKey`|All|
 |`System.Security.Cryptography.X509Certificates.RSACertificateExtensions`|All|
 |`System.Security.Cryptography.X509Certificates.X500DistinguishedName`|`Name`|

--- a/articles/api-management/api-management-policy-expressions.md
+++ b/articles/api-management/api-management-policy-expressions.md
@@ -142,7 +142,7 @@ The following table lists the .NET Framework types and members allowed in policy
 |`System.Security.Cryptography.SHA384Managed`|All|
 |`System.Security.Cryptography.SHA512`|All|
 |`System.Security.Cryptography.SHA512Managed`|All|
-|`System.Security.Cryptography.SymmetricAlgorithm`|All exception parameterless Create()|
+|`System.Security.Cryptography.SymmetricAlgorithm`|All except parameterless Create()|
 |`System.Security.Cryptography.X509Certificates.PublicKey`|All|
 |`System.Security.Cryptography.X509Certificates.RSACertificateExtensions`|All|
 |`System.Security.Cryptography.X509Certificates.X500DistinguishedName`|`Name`|

--- a/articles/api-management/api-management-policy-expressions.md
+++ b/articles/api-management/api-management-policy-expressions.md
@@ -142,7 +142,7 @@ The following table lists the .NET Framework types and members allowed in policy
 |`System.Security.Cryptography.SHA384Managed`|All|
 |`System.Security.Cryptography.SHA512`|All|
 |`System.Security.Cryptography.SHA512Managed`|All|
-|`System.Security.Cryptography.SymmetricAlgorithm`|All|
+|`System.Security.Cryptography.SymmetricAlgorithm`|All exception parameterless Create()|
 |`System.Security.Cryptography.X509Certificates.PublicKey`|All|
 |`System.Security.Cryptography.X509Certificates.RSACertificateExtensions`|All|
 |`System.Security.Cryptography.X509Certificates.X500DistinguishedName`|`Name`|


### PR DESCRIPTION
SymmetricAlgorithm.Create() is not supported in policy expressions