### PR TITLE
Revise third party application updates section

### DIFF
--- a/articles/update-manager/support-matrix.md
+++ b/articles/update-manager/support-matrix.md
@@ -58,13 +58,7 @@ Use one of the following options to perform the settings change at scale:
 
 ## Third party application updates
 
-#### [Windows](#tab/third-party-win)
-
-Update Manager relies on the locally configured update repository to update supported Windows systems, either WSUS or Windows Update. Tools such as [System Center Updates Publisher](/mem/configmgr/sum/tools/updates-publisher) allow you to import and publish custom updates with WSUS. 
-
-This scenario allows Update Manager to update machines that use Configuration Manager as their update repository with third party software. To learn how to configure Updates Publisher, see [Install Updates Publisher](/mem/configmgr/sum/tools/install-updates-publisher).
-
-#### [Linux](#tab/third-party-lin)
+#### **Linux**
 
 Third party application updates are supported in Azure Update Manager. If you include a specific third party software repository in the Linux package manager repository location, it's scanned when it performs software update operations. 
 The package isn't available for assessment and installation if you remove it.


### PR DESCRIPTION
Removed Windows section and updated Linux application update details.

Windows section referenced to SCUP that is no longer supported per following documentation: https://learn.microsoft.com/en-us/intune/configmgr/sum/tools/updates-publisher

This means that 3rd support is not done with AUM at this moment.