### PR TITLE
CSS-Networking: Cross-Tenant VNet Peering - Clarify authentication method for directory selection

### DIFF
--- a/articles/virtual-network/create-peering-different-subscriptions.md
+++ b/articles/virtual-network/create-peering-different-subscriptions.md
@@ -673,7 +673,7 @@ You need the **Resource ID** for **vnet-2** from the previous steps to set up th
     | Virtual network deployment model | **Resource Manager** |
     | I know my resource ID | **Select the box** |
     | Resource ID | **Enter the Resource ID for vnet-2** |
-    | Directory | Select the Microsoft Entra ID directory that corresponds with **vnet-2** and **user-2** |
+    | Directory | Select the Microsoft Entra ID directory that corresponds with **vnet-2** and **user-2**, but authenticate using **user-1** |
     | **Remote virtual network peering settings** |   |
     | Allow 'the peered virtual network' to access 'vnet-1' | Leave the default of **Enabled** |
     | Allow 'the peered virtual network' to receive forwarded traffic from 'vnet-1' | **Select the box** |
@@ -849,7 +849,7 @@ You need the **Resource IDs** for **vnet-1** from the previous steps to set up t
     | Virtual network deployment model | **Resource Manager** |
     | I know my resource ID | **Select the box** |
     | Resource ID | **Enter the Resource ID for vnet-1** |
-    | Directory | Select the Microsoft Entra ID directory that corresponds with **vnet-1** and **user-1** |
+    | Directory | Select the Microsoft Entra ID directory that corresponds with **vnet-1** and **user-1**, but authenticate using **user-2** |
     | **Remote virtual network peering settings** |   |
     | Allow 'the peered virtual network' to access 'vnet-1' | Leave the default of **Enabled** |
     | Allow 'the peered virtual network' to receive forwarded traffic from 'vnet-1' | **Select the box** |


### PR DESCRIPTION
Updated the authentication details for Microsoft Entra ID directory selection in the peering configuration. It wasn't quite clear which account you should use when authenticating against the remote tenant, and I worked a case where a customer wasn't able to figure that out on their own. They had to authenticate against the remote tenant using the source tenant's user account. This edit just helps clarify a little.