### PR TITLE
Add note about importance of checking Application Gateway Activity Logs

### DIFF
--- a/articles/application-gateway/ingress-controller-troubleshoot.md
+++ b/articles/application-gateway/ingress-controller-troubleshoot.md
@@ -316,4 +316,4 @@ aksClusterConfiguration:
 
 ## Review Application Gateway Activity Log
 
-> When troubleshooting Application Gateway Ingress Controller issues, it's good practice to check the Application Gateway's Activity Log in addition to Kubernetes resources. Every time AGIC applies a new configuration, a corresponding entry is recorded in the Activity Log in the Azure portal. Reviewing these entries helps to confirm whether configuration updates were successfully applied and can often reveal gateway-related issues that aren't visible from the Kubernetes side.
+When troubleshooting Application Gateway Ingress Controller issues, it's good practice to check the Application Gateway's Activity Log in addition to Kubernetes resources. Every time AGIC applies a new configuration, a corresponding entry is recorded in the Activity Log in the Azure portal. Reviewing these entries helps to confirm whether configuration updates were successfully applied and can often reveal gateway-related issues that aren't visible from the Kubernetes side.

--- a/articles/application-gateway/ingress-controller-troubleshoot.md
+++ b/articles/application-gateway/ingress-controller-troubleshoot.md
@@ -312,3 +312,8 @@ rbac:
 aksClusterConfiguration:
     apiServerAddress: <aks-api-server-address>
 ```
+
+
+## Review Application Gateway Activity Log
+
+> When troubleshooting Application Gateway Ingress Controller issues, it's good practice to check the Application Gateway's Activity Log in addition to kubernetes resources. Every time AGIC applies a new configuration, a corresponding entry is recorded in the Activity Log in the Azure portal. Reviewing these entries helps to confirm whether configuration updates were successfully applied and can often reveals gateway-related issues that aren't visible from the kubernetes side.

--- a/articles/application-gateway/ingress-controller-troubleshoot.md
+++ b/articles/application-gateway/ingress-controller-troubleshoot.md
@@ -316,4 +316,4 @@ aksClusterConfiguration:
 
 ## Review Application Gateway Activity Log
 
-> When troubleshooting Application Gateway Ingress Controller issues, it's good practice to check the Application Gateway's Activity Log in addition to kubernetes resources. Every time AGIC applies a new configuration, a corresponding entry is recorded in the Activity Log in the Azure portal. Reviewing these entries helps to confirm whether configuration updates were successfully applied and can often reveals gateway-related issues that aren't visible from the kubernetes side.
+> When troubleshooting Application Gateway Ingress Controller issues, it's good practice to check the Application Gateway's Activity Log in addition to Kubernetes resources. Every time AGIC applies a new configuration, a corresponding entry is recorded in the Activity Log in the Azure portal. Reviewing these entries helps to confirm whether configuration updates were successfully applied and can often reveal gateway-related issues that aren't visible from the Kubernetes side.


### PR DESCRIPTION
Most users often overlook checking the Application Gateway Activity Logs. Adding this reminder helps users detect issues early by verifying AGIC configuration updates and operational events.
https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-troubleshoot