### PR TITLE
Update the Eternal Orchestration Docs for Failed Orchestrations

### DIFF
--- a/articles/azure-functions/durable/durable-functions-eternal-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-eternal-orchestrations.md
@@ -26,7 +26,7 @@ When *continue-as-new* is called, the orchestration instance restarts itself wit
 > [!NOTE]
 > The Durable Task Framework maintains the same instance ID but internally creates a new *execution ID* for the orchestrator function that gets reset by *continue-as-new*. This execution ID is not exposed externally, but it may be useful to know about when debugging orchestration execution.
 
-> [!NOTE]
+> [!IMPORTANT]
 > If during execution the orchestration encounters an uncaught exception, then the orchestration enters a "failed" state and execution will complete. In particular, this means that a call to *continue-as-new*, even in a `finally` block, will *not* restart the orchestration in the case of an uncaught exception.
 
 ## Periodic work example

--- a/articles/azure-functions/durable/durable-functions-eternal-orchestrations.md
+++ b/articles/azure-functions/durable/durable-functions-eternal-orchestrations.md
@@ -26,6 +26,9 @@ When *continue-as-new* is called, the orchestration instance restarts itself wit
 > [!NOTE]
 > The Durable Task Framework maintains the same instance ID but internally creates a new *execution ID* for the orchestrator function that gets reset by *continue-as-new*. This execution ID is not exposed externally, but it may be useful to know about when debugging orchestration execution.
 
+> [!NOTE]
+> If during execution the orchestration encounters an uncaught exception, then the orchestration enters a "failed" state and execution will complete. In particular, this means that a call to *continue-as-new*, even in a `finally` block, will *not* restart the orchestration in the case of an uncaught exception.
+
 ## Periodic work example
 
 One use case for eternal orchestrations is code that needs to do periodic work indefinitely.


### PR DESCRIPTION
There is potentially misleading behavior when calling `continue-as-new` in a finally block. If the orchestration encounters an uncaught exception during execution and enters a "failed" state, then the orchestration just completes rather than restarting. This is true even if the `continue-as-new` call occurs in a `finally` block, which is potentially misleading for customers (see this GitHub [issue](https://github.com/Azure/azure-functions-durable-extension/issues/3190) and this [issue](https://github.com/Azure/durabletask/issues/1261)). This PR updates the documentation to include a note about this.