### PR TITLE
Update Rate Limits for Email for Azure managed domains

### DIFF
--- a/articles/communication-services/concepts/service-limits.md
+++ b/articles/communication-services/concepts/service-limits.md
@@ -148,8 +148,8 @@ The following table lists limits for [Azure managed domains](../quickstarts/emai
 
 | Operation | Scope | Timeframe (minutes) | Limit (number of emails) | Higher limits available |
 | --- | --- | --- | --- | --- |
-| Send Email | Per Subscription | 1 | 5 | No |
-| Send Email | Per Subscription | 60 | 10 | No |
+| Send Email | Per Subscription | 1 | 30 | No |
+| Send Email | Per Subscription | 60 | 100 | No |
 | Get Email Status | Per Subscription | 1 |10 | No |
 | Get Email Status | Per Subscription | 60 |20 | No |
 


### PR DESCRIPTION
The email rate limits for Azure managed domains have reportedly been increased to 30 emails per minute per subscription and 100 emails per 60 minutes per subscription. This information has been tested and verified.
Azure managed Domain –
<img width="1277" height="377" alt="image (1)" src="https://github.com/user-attachments/assets/57b65d4b-8b0d-4c91-92dd-6bd41036d304" />


Custom Domain –

<img width="1403" height="378" alt="image" src="https://github.com/user-attachments/assets/664612f9-196d-4cd0-bdc2-4c8ba613a022" />

