### PR TITLE
Update private-link-configure.md

### DIFF
--- a/articles/application-gateway/private-link-configure.md
+++ b/articles/application-gateway/private-link-configure.md
@@ -37,6 +37,7 @@ You can configure Application Gateway Private Link using multiple methods:
 Before configuring Private Link, ensure you have:
 - An existing Application Gateway
 - A virtual network with a dedicated subnet for Private Link (separate from the Application Gateway subnet)
+- privateLinkServiceNetworkPolicies should be disabled in the dedicated subnet
 - Appropriate permissions to create and configure Private Link resources
 
 ## Define a subnet for Private Link configuration


### PR DESCRIPTION
privateLinkServiceNetworkPolicies should be disabled in the dedicated subnet. This is also a prerequisite. Powershell and Azure CLI example code have command to disable it before adding private link.  Otherwise, clicking add button on Portal does not trigger the change.