### PR TITLE
Remove onboarding section for Oracle Exadata VM Clusters

### DIFF
--- a/articles/oracle/toc.yml
+++ b/articles/oracle/toc.yml
@@ -27,8 +27,6 @@ items:
       href: oracle-db/manage-oracle-transparent-data-encryption-azure-key-vault.md
     - name: Oracle Exadata Database on Dedicated Infrastructure Logs on Azure for Enhanced Observability
       href: oracle-db/oracle-exadata-database-dedicated-infrastructure-logs.md
-    - name: Onboard Oracle Exadata VM Clusters to Microsoft Defender for Cloud using Azure Arc 
-      href: oracle-db/exadata-vm-clusters.md
   - name: Onboarding
     items:
     - name: Onboard Oracle Database@Azure


### PR DESCRIPTION
Removed the section for onboarding Oracle Exadata VM Clusters to Microsoft Defender for Cloud.