### PR TITLE
Enhance CI/CD documentation for Workload Identity Federation

### DIFF
--- a/articles/synapse-analytics/cicd/continuous-integration-delivery.md
+++ b/articles/synapse-analytics/cicd/continuous-integration-delivery.md
@@ -254,10 +254,10 @@ You can choose the operation types based on the use case. Following part is an e
 >           
 > Currently, the DevOps Service Connection with **Workload Identity Federation (WIF)** is not supported in Synapse Workspace deployment extension. Switch to secret mode to make the connection successful.
 > For secure, secret-less alternatives that fully support Workload Identity Federation (WIF),
-> use the [AzureCLI@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2)
-> or [PowerShell](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/powershell-v2)
+> use the [AzureCLI@2](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/azure-cli-v2)
+> or [PowerShell](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/powershell-v2)
 > pipeline tasks with a federated service connection, as described in
-> [Connect to Azure using Workload Identity Federation](https://learn.microsoft.com/en-us/azure/devops/pipelines/library/connect-to-azure?view=azure-devops#workload-identity-federation).
+> [Connect to Azure using Workload Identity Federation](https://learn.microsoft.com/azure/devops/pipelines/library/connect-to-azure?view=azure-devops#workload-identity-federation).
 >
 > These tasks support secret-less authentication and can execute Synapse deployment commands
 > (`az synapse pipeline create`, `az synapse artifact publish`) while maintaining the same deployment flow.

--- a/articles/synapse-analytics/cicd/continuous-integration-delivery.md
+++ b/articles/synapse-analytics/cicd/continuous-integration-delivery.md
@@ -253,6 +253,14 @@ You can choose the operation types based on the use case. Following part is an e
 > In CI/CD scenarios, the integration runtime type in different environments must be the same. For example, if you have a self-hosted integration runtime in the development environment, the same integration runtime must be self-hosted in other environments, such as in test and production. Similarly, if you're sharing integration runtimes across multiple stages, the integration runtimes must be linked and self-hosted in all environments, such as in development, test, and production.
 >           
 > Currently, the DevOps Service Connection with **Workload Identity Federation (WIF)** is not supported in Synapse Workspace deployment extension. Switch to secret mode to make the connection successful.
+> For secure, secret-less alternatives that fully support Workload Identity Federation (WIF),
+> use the [AzureCLI@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/azure-cli-v2)
+> or [PowerShell](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/powershell-v2)
+> pipeline tasks with a federated service connection, as described in
+> [Connect to Azure using Workload Identity Federation](https://learn.microsoft.com/en-us/azure/devops/pipelines/library/connect-to-azure?view=azure-devops#workload-identity-federation).
+>
+> These tasks support secret-less authentication and can execute Synapse deployment commands
+> (`az synapse pipeline create`, `az synapse artifact publish`) while maintaining the same deployment flow.
 
 ### Create a release for deployment
 

--- a/articles/synapse-analytics/cicd/continuous-integration-delivery.md
+++ b/articles/synapse-analytics/cicd/continuous-integration-delivery.md
@@ -253,14 +253,11 @@ You can choose the operation types based on the use case. Following part is an e
 > In CI/CD scenarios, the integration runtime type in different environments must be the same. For example, if you have a self-hosted integration runtime in the development environment, the same integration runtime must be self-hosted in other environments, such as in test and production. Similarly, if you're sharing integration runtimes across multiple stages, the integration runtimes must be linked and self-hosted in all environments, such as in development, test, and production.
 >           
 > Currently, the DevOps Service Connection with **Workload Identity Federation (WIF)** is not supported in Synapse Workspace deployment extension. Switch to secret mode to make the connection successful.
-> For secure, secret-less alternatives that fully support Workload Identity Federation (WIF),
-> use the [AzureCLI@2](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/azure-cli-v2)
-> or [PowerShell](https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/powershell-v2)
-> pipeline tasks with a federated service connection, as described in
-> [Connect to Azure using Workload Identity Federation](https://learn.microsoft.com/azure/devops/pipelines/library/connect-to-azure?view=azure-devops#workload-identity-federation).
+> 
+> For secure, secretless alternatives that fully support Workload Identity Federation (WIF), use the [AzureCLI@2](/azure/devops/pipelines/tasks/reference/azure-cli-v2) or [PowerShell](/azure/devops/pipelines/tasks/reference/powershell-v2)
+> pipeline tasks with a federated service connection, as described in [Connect to Azure using Workload Identity Federation](https://learn.microsoft.com/azure/devops/pipelines/library/connect-to-azure?view=azure-devops).
 >
-> These tasks support secret-less authentication and can execute Synapse deployment commands
-> (`az synapse pipeline create`, `az synapse artifact publish`) while maintaining the same deployment flow.
+> These tasks support secretless authentication and can execute Synapse deployment commands (`az synapse pipeline create`, `az synapse artifact publish`) while maintaining the same deployment flow.
 
 ### Create a release for deployment
 


### PR DESCRIPTION
While the existing note accurately states that WIF is not supported, it does not help enterprise users adhere to Microsoft’s security baseline that favors federated auth over stored secrets. Adding explicit references to the official WIF docs and CLI workaround aligns this page with Microsoft’s own DevOps authentication guidelines and prevents customers from falling back to less secure credentials.

Secondly, when we say something is not supported - we also need to mention the workaround.   I am a  Microsoft FTE ( Satishbal is my alias)