### PR TITLE
Add managed identity authentication option to API Management send-request and send-one-way-request policies

### DIFF
--- a/articles/api-management/send-one-way-request-policy.md
+++ b/articles/api-management/send-one-way-request-policy.md
@@ -28,6 +28,7 @@ The `send-one-way-request` policy sends the provided request to the specified UR
   <set-header>...</set-header>
   <set-body>...</set-body>
   <authentication-certificate thumbprint="thumbprint" />
+  <authentication-managed-identity resource="ResourceID"/>
 </send-one-way-request>
 ```
 
@@ -48,6 +49,7 @@ The `send-one-way-request` policy sends the provided request to the specified UR
 | [set-header](set-header-policy.md)                     | Sets a header in the request. Use multiple `set-header` elements for multiple request headers.                                  | No                              |
 | [set-body](set-body-policy.md)                       | Sets the body of the request.                   | No                              |
 | authentication-certificate | [Certificate to use for client authentication](authentication-certificate-policy.md), specified in a `thumbprint` attribute. | No                              |
+| authentication-managed-identity | [Authenticate with managed identity](https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy) to resource specified in `resource` attribute. | No |
 | [proxy](proxy-policy.md) | Routes request via HTTP proxy. | No |
 
 

--- a/articles/api-management/send-one-way-request-policy.md
+++ b/articles/api-management/send-one-way-request-policy.md
@@ -49,7 +49,7 @@ The `send-one-way-request` policy sends the provided request to the specified UR
 | [set-header](set-header-policy.md)                     | Sets a header in the request. Use multiple `set-header` elements for multiple request headers.                                  | No                              |
 | [set-body](set-body-policy.md)                       | Sets the body of the request.                   | No                              |
 | authentication-certificate | [Certificate to use for client authentication](authentication-certificate-policy.md), specified in a `thumbprint` attribute. | No                              |
-| authentication-managed-identity | [Authenticate with managed identity](https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy) to resource specified in `resource` attribute. | No |
+| authentication-managed-identity | [Authenticate with managed identity](authentication-managed-identity-policy.md) to resource specified in `resource` attribute. | No |
 | [proxy](proxy-policy.md) | Routes request via HTTP proxy. | No |
 
 

--- a/articles/api-management/send-request-policy.md
+++ b/articles/api-management/send-request-policy.md
@@ -29,6 +29,7 @@ The `send-request` policy sends the provided request to the specified URL, waiti
   <set-header>...</set-header>
   <set-body>...</set-body>
   <authentication-certificate thumbprint="thumbprint" />
+  <authentication-managed-identity resource="ResourceID"/>
   <proxy>...</proxy>
 </send-request>
 ```
@@ -51,6 +52,7 @@ The `send-request` policy sends the provided request to the specified URL, waiti
 | [set-header](set-header-policy.md)                     | Sets a header in the request. Use multiple `set-header` elements for multiple request headers.                                  | No                              |
 | [set-body](set-body-policy.md)                       | Sets the body of the request.                   | No                              |
 | authentication-certificate | [Certificate to use for client authentication](authentication-certificate-policy.md), specified in a `thumbprint` attribute. | No                          |
+| authentication-managed-identity | [Authenticate with managed identity](https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy) to resource specified in `resource` attribute. | No                          |
 | [proxy](proxy-policy.md) | Routes request via HTTP proxy. | No |
 
 ## Usage

--- a/articles/api-management/send-request-policy.md
+++ b/articles/api-management/send-request-policy.md
@@ -52,7 +52,7 @@ The `send-request` policy sends the provided request to the specified URL, waiti
 | [set-header](set-header-policy.md)                     | Sets a header in the request. Use multiple `set-header` elements for multiple request headers.                                  | No                              |
 | [set-body](set-body-policy.md)                       | Sets the body of the request.                   | No                              |
 | authentication-certificate | [Certificate to use for client authentication](authentication-certificate-policy.md), specified in a `thumbprint` attribute. | No                          |
-| authentication-managed-identity | [Authenticate with managed identity](https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy) to resource specified in `resource` attribute. | No                          |
+| authentication-managed-identity | [Authenticate with managed identity](authentication-managed-identity-policy.md) to resource specified in `resource` attribute. | No                          |
 | [proxy](proxy-policy.md) | Routes request via HTTP proxy. | No |
 
 ## Usage


### PR DESCRIPTION
Update `send-request` and `send-one-way-request` policy documentation with option to use `authentication-managed-identity` policy for authentication in API Management.

A sample is already included [here](https://learn.microsoft.com/en-us/azure/api-management/authentication-managed-identity-policy#use-managed-identity-in-send-request-policy) on the `authentication-managed-identity` policy page, and I've verified that it works for both policies.