### PR TITLE
Fix a typo in integration account creation

### DIFF
--- a/articles/logic-apps/enterprise-integration/create-integration-account.md
+++ b/articles/logic-apps/enterprise-integration/create-integration-account.md
@@ -134,7 +134,7 @@ For this task, you can use the Azure portal, [Azure CLI](/cli/azure/resource#az-
 
    ```azurecli
    az logic integration-account create --resource-group myresourcegroup \
-       --name integration_account_01 --location westus --sku name=Standard
+       --name integration_account_01 --location westus --sku Standard
    ```
 
    Your integration account name can contain only letters, numbers, hyphens (-), underscores (_), parentheses (()), and periods (.).


### PR DESCRIPTION
Removed 'name=' from SKU parameter in CLI command.