### PR TITLE
Update stored procedure activity output parameter guidance

### DIFF
--- a/articles/data-factory/transform-data-using-stored-procedure.md
+++ b/articles/data-factory/transform-data-using-stored-procedure.md
@@ -30,11 +30,15 @@ You can use the Stored Procedure Activity to invoke a stored procedure in one of
 >
 > When copying data from Azure SQL Database or SQL Server or Azure Synapse Analytics, you can configure **SqlSource** in copy activity to invoke a stored procedure to read data from the source database by using the **sqlReaderStoredProcedureName** property. For more information, see the following connector articles: [Azure SQL Database](connector-azure-sql-database.md), [SQL Server](connector-sql-server.md), [Azure Synapse Analytics](connector-azure-sql-data-warehouse.md)          
 
-When the stored procedure has Output parameters, instead of using stored procedure activity, use lookup activity and Script activity. Stored procedure activity does not support calling SPs with Output parameter yet.  
+The Stored Procedure activity doesn’t support output parameters. To run a stored procedure that returns output parameters or results, use a Lookup or Script activity instead.
 
 If you call a stored procedure with output parameters using stored procedure activity, following error occurs.
 
-Execution fail against sql server. Please contact SQL Server team if you need further support. Sql error number: 201. Error Message: Procedure or function 'sp_name' expects parameter '@output_param_name', which was not supplied.
+> [!ERROR]
+> Execution failed against SQL Server. Please contact your SQL Server team for further support.  
+> **SQL error number:** 201  
+> **Error message:** Procedure or function 'sp_name' expects parameter '@output_param_name', which was not supplied.
+
 
  ## Create a Stored Procedure activity with UI
 

--- a/articles/data-factory/transform-data-using-stored-procedure.md
+++ b/articles/data-factory/transform-data-using-stored-procedure.md
@@ -34,7 +34,7 @@ The Stored Procedure activity doesn’t support output parameters. To run a stor
 
 If you call a stored procedure with output parameters using stored procedure activity, following error occurs.
 
-> [!ERROR]
+> [!WARNING]
 > Execution failed against SQL Server. Please contact your SQL Server team for further support.  
 > **SQL error number:** 201  
 > **Error message:** Procedure or function 'sp_name' expects parameter '@output_param_name', which was not supplied.


### PR DESCRIPTION
Clarified that the Stored Procedure activity does not support output parameters and suggested using Lookup or (Not and) Script activity instead. fixed formatting of the error message output to align with ms-learn standards