### PR TITLE
Update limits for Security Admin Rules in documentation

### DIFF
--- a/includes/azure-virtual-network-manager-limits.md
+++ b/includes/azure-virtual-network-manager-limits.md
@@ -26,7 +26,7 @@
 | Group Membership | A virtual network can be part of up to two connected groups, expandable to 1000 upon request using [this form](https://forms.office.com/r/xXxYrQt0NQ). |
 | Overlapping IP Spaces | Communication to overlapped IP address is dropped |
 | **Limits for Security Admin Rules** | |
-| IP Prefixes | Max 1,000 IP prefixes combined |
-| Admin Rules | Max 100 admin rules at one level |
+| IP Prefixes | Max 1,000 IP prefixes combined per one Azure Virtual Network Manager resource |
+| Admin Rules | Max 100 admin rules combined per one Azure Virtual Network Manager resource |
 | **Limits for User Defined Routes** | |
 | User Defined Routes per Route Table | Max 1,000 |


### PR DESCRIPTION
Updated the correct limits for IP prefixes and admin rules in Azure Virtual Network Manager. I have confirmed with a PM that the following documents has the latest information. https://learn.microsoft.com/en-us/azure/virtual-network-manager/concept-limitations#limitations-for-security-admin-rules