### PR TITLE
Added additional information about the order of precendence for outbo…

### DIFF
--- a/articles/load-balancer/load-balancer-outbound-connections.md
+++ b/articles/load-balancer/load-balancer-outbound-connections.md
@@ -82,6 +82,7 @@ If you have Virtual Machine Scale Sets in the backend, it's recommended to alloc
 
 > [!NOTE]
 > When multiple frontend IPs are configured using outbound rules, outbound connections can come from any of the frontend IPs configured to the backend instance. We don't recommend building any dependencies on which frontend IP can be selected for connections.
+> Where a VM is added to more than one backend pool with different outbound rules and front end configurations, the pool it was added to first is used for outbound connections. This behaviour can mean that VMs in the same two backend pools can have different outbound IPs depending on the order they were added to the pools.
 
 For more information about outbound rules, see [Outbound rules](outbound-rules.md).
 

--- a/articles/load-balancer/load-balancer-outbound-connections.md
+++ b/articles/load-balancer/load-balancer-outbound-connections.md
@@ -82,7 +82,7 @@ If you have Virtual Machine Scale Sets in the backend, it's recommended to alloc
 
 > [!NOTE]
 > When multiple frontend IPs are configured using outbound rules, outbound connections can come from any of the frontend IPs configured to the backend instance. We don't recommend building any dependencies on which frontend IP can be selected for connections.
-> Where a VM is added to more than one backend pool with different outbound rules and front end configurations, the pool it was added to first is used for outbound connections. This behaviour can mean that VMs in the same two backend pools can have different outbound IPs depending on the order they were added to the pools.
+> Where a VM is added to more than one backend pool with different outbound rules and front end configurations, the pool it was added to first is used for outbound connections. This behavior can mean that VMs in the same two backend pools can have different outbound IPs depending on the order they were added to the pools.
 
 For more information about outbound rules, see [Outbound rules](outbound-rules.md).
 


### PR DESCRIPTION
This pull request updates the Azure Load Balancer documentation to clarify outbound connection behavior when a VM is part of multiple backend pools with different outbound rules and frontend IP configurations.

Documentation clarification:

* Added a note explaining that if a VM belongs to more than one backend pool with different outbound rules and frontend IPs, outbound connections will use the pool the VM was added to first. This can result in VMs in the same backend pools having different outbound IPs based on the order of pool addition.…und rules where a VM is added to more than one backend pool.