### PR TITLE
Fix typo in description of plans.md

### DIFF
--- a/articles/container-apps/plans.md
+++ b/articles/container-apps/plans.md
@@ -1,6 +1,6 @@
 ---
 title: Azure Container Apps plan types
-description: Compare different plains available in Azure Container Apps
+description: Compare different plans available in Azure Container Apps
 services: container-apps
 author: craigshoemaker
 ms.service: azure-container-apps


### PR DESCRIPTION
This pull request corrects a typo in the description of the `articles/container-apps/plans.md` file, changing "plains" to "plans" for improved clarity.