### PR TITLE
Update South US to South Central US in zonal placement

### DIFF
--- a/articles/storage/files/zonal-placement.md
+++ b/articles/storage/files/zonal-placement.md
@@ -44,7 +44,7 @@ Zonal placement is supported for premium storage accounts with LRS redundancy in
 - Qatar Central
 - Poland Central
 - South Africa North
-- South US
+- South Central US
 - Spain Central
 - West US 2
 - West US 3


### PR DESCRIPTION
South US in internal Name and South central US is external Name sort of confusing to the customer