### PR TITLE
Remove non-resolving OCSP endpoints from APIM VNet docs.

### DIFF
--- a/articles/api-management/virtual-network-reference.md
+++ b/articles/api-management/virtual-network-reference.md
@@ -63,7 +63,7 @@ NSG rules allowing outbound connectivity to Storage, SQL, and Azure Event Hubs s
 
 ## TLS functionality  
 
-To enable TLS/SSL certificate chain building and validation, the API Management service needs outbound network connectivity on ports `80` and `443` to `mscrl.microsoft.com`, `crl.microsoft.com`, `cacerts.digicert.com`, `crl3.digicert.com` and `csp.digicert.com`. 
+To enable TLS/SSL certificate chain building and validation, the API Management service needs outbound network connectivity on ports `80` and `443` to `mscrl.microsoft.com`, `crl.microsoft.com`, `oneocsp.microsoft.com`, `cacerts.digicert.com`, `crl3.digicert.com` and `csp.digicert.com`. 
 
 
 ## DNS access

--- a/articles/api-management/virtual-network-reference.md
+++ b/articles/api-management/virtual-network-reference.md
@@ -63,7 +63,7 @@ NSG rules allowing outbound connectivity to Storage, SQL, and Azure Event Hubs s
 
 ## TLS functionality  
 
-To enable TLS/SSL certificate chain building and validation, the API Management service needs outbound network connectivity on ports `80` and `443` to `ocsp.msocsp.com`, `oneocsp.msocsp.com`, `mscrl.microsoft.com`, `crl.microsoft.com`, `cacerts.digicert.com`, `crl3.digicert.com` and `csp.digicert.com`. 
+To enable TLS/SSL certificate chain building and validation, the API Management service needs outbound network connectivity on ports `80` and `443` to `mscrl.microsoft.com`, `crl.microsoft.com`, `cacerts.digicert.com`, `crl3.digicert.com` and `csp.digicert.com`. 
 
 
 ## DNS access


### PR DESCRIPTION
## Summary

Updates APIM VNet documentation to remove invalid OCSP endpoints and align with current Microsoft CA infrastructure.

## Changes

* Remove `ocsp.msocsp.com` (retired; no longer resolves).
* Replace `oneocsp.msocsp.com` with the correct `oneocsp.microsoft.com`.

## Rationale

Two listed OCSP hosts are no longer functional or documented elsewhere. The Microsoft page “[Azure Certificate Authority details](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-ca-details?tabs=root-and-subordinate-cas-list)” includes a changelog entry (dated 8 October 2024) stating that ocsp.msocsp.com was removed from Microsoft’s CA/CDP/OCSP endpoints list. Cleaning them up prevents incorrect allowlists and reflects current certificate-validation behavior.

## Impact

Improves accuracy of outbound network requirements; no change to APIM functionality.
