### PR TITLE
Fix MCA Column Name PricingModel to pricingModel

### DIFF
--- a/articles/cost-management-billing/dataset-schema/cost-usage-details-mca.md
+++ b/articles/cost-management-billing/dataset-schema/cost-usage-details-mca.md
@@ -74,7 +74,7 @@ ms.author: vikdesai
 | 57 |term|Displays the term for the validity of the offer. For example: For reserved instances, it displays 12 months as the Term. For one-time purchases or recurring purchases, Term is one month (SaaS, Marketplace Support). Not applicable for Azure consumption.|
 | 58 |reservationId|Unique identifier for the purchased reservation instance.|
 | 59 |reservationName|Name of the purchased reservation instance.|
-| 60 |PricingModel|Identifier that indicates how the meter is priced. (Values: `On Demand`, `Reservation`, `Spot`, and `SavingsPlan`)|
+| 60 |pricingModel|Identifier that indicates how the meter is priced. (Values: `On Demand`, `Reservation`, `Spot`, and `SavingsPlan`)|
 | 61 |unitPrice|The price for a given product or service inclusive of any negotiated discount that you might have on top of the market price (PayG price column) for your contract. For more information, see [Pricing behavior in cost details](../automate/automation-ingest-usage-details-overview.md#pricing-behavior-in-cost-and-usage-details).|
 | 62 |costAllocationRuleName|Name of the Cost Allocation rule that's applicable to the record.|
 | 63 |benefitId| Unique identifier for the purchased savings plan instance. |


### PR DESCRIPTION
This PR updates the column name `PricingModel` to its correct version `pricingModel` for the MCA file schema, which is actually what is provided in the file when obtained through Exports (small letter p instead of capital P).

This distinction is important to address a use case where one would attempt to append a usage data in the EA format, which is: https://github.com/MicrosoftDocs/azure-docs/blob/97ad00221b46b7bd540d4b47cdf2ed79ad73ef44/articles/cost-management-billing/dataset-schema/cost-usage-details-ea.md?plain=1#L55 

The EA format uses `PricingModel` and appending this to the MCA format to perform a continuous cost analysis across months before and after change to MCA will not be successful.

I do not know if previous versions of the MCA schema did actually use `PricingModel` as I cannot prove this through Exports, so I am only updating the most recent version of the schema