### PR TITLE
Clarify routing rules order in documentation for container apps rule based routing

### DIFF
--- a/articles/container-apps/rule-based-routing.md
+++ b/articles/container-apps/rule-based-routing.md
@@ -131,12 +131,12 @@ ROUTE_CONFIG_NAME="my-route-config"
 
     This configuration defines two routing rules for HTTP traffic.
 
-> [!NOTE]
-> The order of the routing rules matters.
-> 
-> More specific prefixes need to be before less specific prefixes.
-> 
-> For example, if the first rule matches the prefix /api, that will be used even if the second rule uses the prefix /api/v1.
+   > [!NOTE]
+   > The order of the routing rules matters.
+   > 
+   > More specific prefixes need to be before less specific prefixes.
+   > 
+   > For example, if the first rule matches the prefix /api, that will be used even if the second rule uses the prefix /api/v1.
 
     | Property | Description |
     |---|---|

--- a/articles/container-apps/rule-based-routing.md
+++ b/articles/container-apps/rule-based-routing.md
@@ -132,7 +132,7 @@ ROUTE_CONFIG_NAME="my-route-config"
     This configuration defines two routing rules for HTTP traffic.
 
 > [!NOTE]
-> The order of the routing rules matter.
+> The order of the routing rules matters.
 > 
 > More specific prefixes need to be before less specific prefixes.
 > 

--- a/articles/container-apps/rule-based-routing.md
+++ b/articles/container-apps/rule-based-routing.md
@@ -138,7 +138,6 @@ ROUTE_CONFIG_NAME="my-route-config"
 > 
 > For example, if the first rule matches the prefix /api, that will be used even if the second rule uses the prefix /api/v1.
 
-
     | Property | Description |
     |---|---|
     | `description` | Human-readable label for the rule |

--- a/articles/container-apps/rule-based-routing.md
+++ b/articles/container-apps/rule-based-routing.md
@@ -131,6 +131,14 @@ ROUTE_CONFIG_NAME="my-route-config"
 
     This configuration defines two routing rules for HTTP traffic.
 
+> [!NOTE]
+> The order of the routing rules matter.
+> 
+> More specific prefixes need to be before less specific prefixes.
+> 
+> For example, if the first rule matches the prefix /api, that will be used even if the second rule uses the prefix /api/v1.
+
+
     | Property | Description |
     |---|---|
     | `description` | Human-readable label for the rule |


### PR DESCRIPTION
Added a note to clarify that the order of routing rules matter in the configuration.