### PR TITLE
Update service limits for email recipient count for SMTP

### DIFF
--- a/articles/communication-services/concepts/service-limits.md
+++ b/articles/communication-services/concepts/service-limits.md
@@ -189,7 +189,6 @@ For more information, see:
 ### Send email to more than 50 recipients
 
 If you want to send emails to more than 50 recipients, make a [support request](../support.md).
-However, sending emails via SMTP to more than 50 recipients is not supported. 
 
 ### Action to take
 
@@ -197,7 +196,6 @@ To increase your email quota, follow the instructions in [Quota increase for ema
 
 > [!NOTE]
 > Email quota increase requests might take up to 72 hours for evaluation and approval, especially for requests that come in on Friday afternoon.
-> The quota increase requests for the number of recipients in email of SMTP is not supported at this time.
 
 ## Chat
 


### PR DESCRIPTION
Remove the note stating that the number of recipients for SMTP cannot exceed 50, as the increment is now supported