### PR TITLE
CSS-Automation: Hybrid worker - add example of environment variable s…

### DIFF
--- a/articles/automation/automation-hrw-run-runbooks.md
+++ b/articles/automation/automation-hrw-run-runbooks.md
@@ -57,7 +57,7 @@ Jobs for Hybrid Runbook Workers run under the local **System** account.
 
 **PowerShell 7.4**
 
-To run PowerShell 7.4 runbooks on a Windows Hybrid Worker, install *PowerShell* on the Hybrid Worker. See [Install PowerShell on Windows](/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5).
+To run PowerShell 7.4 runbooks on a Windows Hybrid Worker, install *PowerShell* on the Hybrid Worker. See [Install PowerShell on Windows](/powershell/scripting/install/installing-powershell-on-windows).
 
 After PowerShell 7.4 installation is complete, create an environment variable with Variable name as powershell_7_4_path and Variable value as path of the executable *PowerShell*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
 

--- a/articles/automation/automation-hrw-run-runbooks.md
+++ b/articles/automation/automation-hrw-run-runbooks.md
@@ -111,7 +111,7 @@ If the *Python* executable file is at the default location *C:\Python27\python.e
 
 To run PowerShell 7.4 runbooks on a Linux Hybrid Worker, install *PowerShell* file on the Hybrid Worker. See [Install PowerShell on Linux](/powershell/scripting/install/installing-powershell-on-linux).
 
-After PowerShell 7.4 installation is complete, create an environment variable with **Variable name** as powershell_7_4_path and **Variable value** as path of the executable *PowerShell* file, for example: `powershell_7_4_path="C:\Program Files\PowerShell\7\pwsh.exe"`
+After PowerShell 7.4 installation is complete, create an environment variable with **Variable name** as powershell_7_4_path and **Variable value** as path of the executable *PowerShell* file, for example: `powershell_7_4_path="/usr/bin/pwsh"`
 
 Restart the Hybrid Runbook Worker after an environment variable is created successfully.
 

--- a/articles/automation/automation-hrw-run-runbooks.md
+++ b/articles/automation/automation-hrw-run-runbooks.md
@@ -109,7 +109,7 @@ If the *Python* executable file is at the default location *C:\Python27\python.e
 
 **PowerShell 7.4**
 
-To run PowerShell 7.4 runbooks on a Linux Hybrid Worker, install *PowerShell* file on the Hybrid Worker. See [Install PowerShell on Linux](/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.5).
+To run PowerShell 7.4 runbooks on a Linux Hybrid Worker, install *PowerShell* file on the Hybrid Worker. See [Install PowerShell on Linux](/powershell/scripting/install/installing-powershell-on-linux).
 
 After PowerShell 7.4 installation is complete, create an environment variable with **Variable name** as powershell_7_4_path and **Variable value** as path of the executable *PowerShell* file, for example: `powershell_7_4_path="C:\Program Files\PowerShell\7\pwsh.exe"`
 

--- a/articles/automation/automation-hrw-run-runbooks.md
+++ b/articles/automation/automation-hrw-run-runbooks.md
@@ -59,13 +59,13 @@ Jobs for Hybrid Runbook Workers run under the local **System** account.
 
 To run PowerShell 7.4 runbooks on a Windows Hybrid Worker, install *PowerShell* on the Hybrid Worker. See [Install PowerShell on Windows](/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.5).
 
-After PowerShell 7.4 installation is complete, create an environment variable with Variable name as powershell_7_4_path and Variable value as location of the executable *PowerShell*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
+After PowerShell 7.4 installation is complete, create an environment variable with Variable name as powershell_7_4_path and Variable value as path of the executable *PowerShell*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
 
 **PowerShell 7.2**
 
 To run PowerShell 7.2 runbooks on a Windows Hybrid Worker, install *PowerShell* on the Hybrid Worker. See [Install PowerShell on Windows](/powershell/scripting/install/installing-powershell-on-windows).
 
-After PowerShell 7.2 installation is complete, create an environment variable with Variable name as powershell_7_2_path and Variable value as location of the executable *PowerShell*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
+After PowerShell 7.2 installation is complete, create an environment variable with Variable name as powershell_7_2_path and Variable value as path of the executable *PowerShell*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
 
 **PowerShell 7.1**
 
@@ -76,7 +76,7 @@ Ensure to add the *PowerShell* file to the PATH environment variable and restart
 
 To run Python 3.10 runbooks on a Windows Hybrid Worker, install *Python* on the Hybrid Worker. See [Install Python on Windows](https://docs.python.org/3/using/windows.html).
 
-After Python 3.10 installation is complete, create an environment variable with Variable name as python_3_10_path and Variable value as location of the executable *Python*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
+After Python 3.10 installation is complete, create an environment variable with Variable name as python_3_10_path and Variable value as path of the executable *Python*. Restart the Hybrid Runbook Worker after environment variable is created successfully.
 
 **Python 3.8**
 
@@ -111,19 +111,23 @@ If the *Python* executable file is at the default location *C:\Python27\python.e
 
 To run PowerShell 7.4 runbooks on a Linux Hybrid Worker, install *PowerShell* file on the Hybrid Worker. See [Install PowerShell on Linux](/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.5).
 
-After PowerShell 7.4 installation is complete, create an environment variable with **Variable name** as powershell_7_4_path and **Variable value** as location of the executable *PowerShell* file. Restart the Hybrid Runbook Worker after an environment variable is created successfully.
+After PowerShell 7.4 installation is complete, create an environment variable with **Variable name** as powershell_7_4_path and **Variable value** as path of the executable *PowerShell* file, for example: `powershell_7_4_path="C:\Program Files\PowerShell\7\pwsh.exe"`
+
+Restart the Hybrid Runbook Worker after an environment variable is created successfully.
 
 **PowerShell 7.2**
 
 To run PowerShell 7.2 runbooks on a Linux Hybrid Worker, install *PowerShell* file on the Hybrid Worker. For more information, see [Install PowerShell on Linux](/powershell/scripting/install/installing-powershell-on-linux).
 
-After PowerShell 7.2 installation is complete, create an environment variable with **Variable name** as *powershell_7_2_path* and **Variable value** as location of the executable *PowerShell* file. Restart the Hybrid Runbook Worker after an environment variable is created successfully.
+After PowerShell 7.2 installation is complete, create an environment variable with **Variable name** as *powershell_7_2_path* and **Variable value** as path of the executable *PowerShell* file. Restart the Hybrid Runbook Worker after an environment variable is created successfully.
 
 **Python 3.10**
 
 To run Python 3.10 runbooks on a Linux Hybrid Worker, install *Python* on the Hybrid Worker. For more information, see [Install Python 3.10 on Linux](https://docs.python.org/3/using/unix.html).
 
-After Python 3.10 installation is complete, create an environment variable with **Variable name** as *python_3_10_path* and **Variable value** as location of the executable *Python* file. Restart the Hybrid Runbook Worker after environment variable is created successfully.
+After Python 3.10 installation is complete, create an environment variable with **Variable name** as *python_3_10_path* and **Variable value** as path of the executable *Python* file,  for example: `python_3_10_path="/usr/bin/python3.10"`
+
+Restart the Hybrid Runbook Worker after environment variable is created successfully.
 
 **Python 3.8**
 


### PR DESCRIPTION
…etup

Updated instructions for setting environment variables for PowerShell and Python installations on Windows and Linux Hybrid Workers to clarify the use of 'path' instead of 'location'. Add example of environment variable setup as some customers could not understand how to set it up correctly.