### PR TITLE
Add resource group creation step for Event Grid

### DIFF
--- a/articles/event-grid/mqtt-publish-and-subscribe-cli.md
+++ b/articles/event-grid/mqtt-publish-and-subscribe-cli.md
@@ -66,10 +66,16 @@ After a successful installation by using the step CLI, open a Command Prompt win
 
 ## Create a namespace
 
+Create a resource group.
+
+```azurecli-interactive
+az group create --name {Resource Group} --location {Location}
+```
+
 Use this command to create a namespace. Update the command with your resource group and a namespace name.
 
 ```azurecli-interactive
-az eventgrid namespace create --resource-group {Resource Group} --name {Namespace Name} --topic-spaces-configuration "{state:Enabled}"
+az eventgrid namespace create --location {Location} --resource-group {Resource Group} --name {Namespace Name} --topic-spaces-configuration "{state:Enabled}"
 ```
 
 To keep this quickstart simple, create a namespace with minimal properties. For more information about network, security, and settings on other tabs, see [Create and manage namespaces](create-view-manage-namespaces.md).


### PR DESCRIPTION
Added instructions for creating a resource group before creating an Event Grid namespace.

I ran into two errors when trying out this sample article. 

1. First, I got an error that the location parameter needs to be specified.
1. Then, after I supplied the location parameter, it kept telling me that the resource group is not found. 

So, it looks like, the resource group needs be created prior to creating the namespace. 

Second, it looks like the location parameter is needed to make this command work. 

Here are the errors I ran into. 

```
InvalidArgumentValue: Missing required field: --location
```
```
(ResourceGroupNotFound) Resource group 'rg1142' could not be found.
Code: ResourceGroupNotFound
Message: Resource group 'rg1142' could not be found.
```