### PR TITLE
Clarify zone-to-zone disaster recovery limitation for ultra disks

### DIFF
--- a/articles/site-recovery/azure-to-azure-how-to-enable-zone-to-zone-disaster-recovery.md
+++ b/articles/site-recovery/azure-to-azure-how-to-enable-zone-to-zone-disaster-recovery.md
@@ -46,6 +46,8 @@ Learn more about [Azure regions with availability zones](../reliability/availabi
 > Zone-to-zone disaster recovery isn't supported for VMs that have managed disks via zone-redundant storage (ZRS).
 >
 > Regions that don't support Azure availability zones also don't support Azure Site Recovery zone-to-zone replication. For Azure Site Recovery zone-to-zone replication to work, the region must support availability zones.
+>
+> Zone-to-zone disaster recovery is unsupported for VMs with Ultra Disks.
 
 ## Using availability zones for disaster recovery
 


### PR DESCRIPTION
Added note about unsupported configurations for zone-to-zone disaster recovery.