### PR TITLE
Clarify managed identity usage for Key Vault

### DIFF
--- a/articles/application-gateway/key-vault-certs.md
+++ b/articles/application-gateway/key-vault-certs.md
@@ -64,6 +64,9 @@ Application Gateway integration with Key Vault is a three-step configuration pro
 Application Gateway uses a managed identity to retrieve certificates from Key Vault on your behalf. 
 
 You can either create a new user-assigned managed identity or reuse an existing with the integration. To create a new user-assigned managed identity, see [Create a user-assigned managed identity using the Azure portal](../active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities.md#create-a-user-assigned-managed-identity). 
+> [!Note]
+> Only one managed identity can be used on an Application Gateway.
+
 
 ### Delegate user-assigned managed identity to Key Vault
 

--- a/articles/application-gateway/key-vault-certs.md
+++ b/articles/application-gateway/key-vault-certs.md
@@ -64,7 +64,7 @@ Application Gateway integration with Key Vault is a three-step configuration pro
 Application Gateway uses a managed identity to retrieve certificates from Key Vault on your behalf. 
 
 You can either create a new user-assigned managed identity or reuse an existing with the integration. To create a new user-assigned managed identity, see [Create a user-assigned managed identity using the Azure portal](../active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities.md#create-a-user-assigned-managed-identity). 
-> [!Note]
+> [!NOTE]
 > Only one managed identity can be used on an Application Gateway.
 
 


### PR DESCRIPTION
Added note about singular managed identity usage in Application Gateway as it was not explicit. Requested by Cx on case 2512080040010382. Part of AppGW PACE program.