### PR TITLE
Update Azure Web Application Firewall on Application Gateway for Containers

### DIFF
--- a/articles/application-gateway/for-containers/web-application-firewall.md
+++ b/articles/application-gateway/for-containers/web-application-firewall.md
@@ -36,7 +36,7 @@ The WebApplicationFirewallPolicy resource can also reference the following secti
 
 ### WAF Policy Configuration
 
-The WAF policy must exist before you can assign it. Additionally, the service principal of the Application Load Balancer (ALB) Controller needs the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` on the WAF policy you want to assign. This service principal is named `azure-alb-identity` in the documentation. The permission is part of the `Network Contributor` role or you assign a custom role. 
+The WAF policy must exist before you can assign it. Additionally, the service principal of the Application Load Balancer (ALB) Controller needs the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` on the WAF policy you want to assign. This service principal is named `azure-alb-identity` in the documentation. The permission is part of the `Network Contributor` role or you can assign a custom role. 
 
 ### Example implementations
 
@@ -137,7 +137,9 @@ spec:
 
 ## Common Issues
 
-The most common issues are that either the WAF policy you want to assign does not exist or that the service principal of the ALB does not have enough permissions to attach the WAF policy. Use the following command to check the status of the deployment of the WAF policy:
+The most common issues are that either the WAF policy you want to assign does not exist or that the service principal of the ALB does not have enough permissions to attach the WAF policy. 
+
+Use the following command to check the status of the deployment of the WAF policy:
 
 ```azurecli-interactive
 kubectl get WebApplicationFirewallPolicy -n test-infra

--- a/articles/application-gateway/for-containers/web-application-firewall.md
+++ b/articles/application-gateway/for-containers/web-application-firewall.md
@@ -146,9 +146,9 @@ kubectl get WebApplicationFirewallPolicy -n test-infra
 ```
 You should see the following output:
    
-| NAME            | STATUS  |  AGE  |
-| --------------- | ------- | ----- |
-| waf-policy-0    | True    | 5m16s |
+| NAME            | Deployment  |  AGE  |
+| --------------- | ----------- | ----- |
+| waf-policy-0    | True        | 5m16s |
 
 If the Status is `False` then use the following command to examine the policy assignment:
 

--- a/articles/application-gateway/for-containers/web-application-firewall.md
+++ b/articles/application-gateway/for-containers/web-application-firewall.md
@@ -34,6 +34,10 @@ The WebApplicationFirewallPolicy resource can also reference the following secti
 
 * `Gateway`: `Listener`
 
+### WAF Policy Configuration
+
+The WAF policy must exist before you can assign it. Additionally, the service principal of the Application Load Balancer (ALB) Controller needs the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` on the WAF policy you want to assign. This service principal is named `azure-alb-identity` in the documentation. The permission is part of the `Network Contributor` role or you assign a custom role. 
+
 ### Example implementations
 
 #### Scope a policy to a Gateway resource
@@ -129,6 +133,25 @@ spec:
     namespace: test-infra
   webApplicationFirewall:
     id: /subscriptions/.../Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/waf-policy-1
+```
+
+## Common Issues
+
+The most common issues are that either the WAF policy you want to assign does not exist or that the service principal of the ALB does not have enough permissions to attach the WAF policy. Use the following command to check the status of the deployment of the WAF policy:
+
+```azurecli-interactive
+kubectl get WebApplicationFirewallPolicy -n test-infra
+```
+You should see the following output:
+   
+| NAME            | STATUS  |  AGE  |
+| --------------- | ------- | ----- |
+| waf-policy-0    | True    | 5m16s |
+
+If the Status is `False` then use the following command to examine the policy assignment:
+
+```azurecli-interactive
+kubectl describe WebApplicationFirewallPolicy waf-policy-0 -n test-infra
 ```
 
 ## Limitations

--- a/articles/application-gateway/for-containers/web-application-firewall.md
+++ b/articles/application-gateway/for-containers/web-application-firewall.md
@@ -150,7 +150,7 @@ You should see the following output:
 | --------------- | ----------- | ----- |
 | waf-policy-0    | True        | 5m16s |
 
-If the Status is `False` then use the following command to examine the policy assignment:
+If the Deployment is `False` then use the following command to examine the policy assignment:
 
 ```azurecli-interactive
 kubectl describe WebApplicationFirewallPolicy waf-policy-0 -n test-infra


### PR DESCRIPTION
Following the documentation in its current state will lead to a non functional WAF policy assignment. The documentation is missing two key components:

1. The WAF policy you want assign must already exist
2. The service principal of the ALB Controller needs the right permission on the WAF policy to assign it.

This PR aims to provide more guidance on how to setup everything and what to do in case something went wrong.


## Technical details
Assigning an existing WAF policy as described in the documentation will not work. The statue of the deployment is `False` which can be checked with `kubectl get WebApplicationFirewallPolicy $WafPolicy -n $InfrastructureNamespace`. The state of the WebApplicationFirewallPolicy can be checked with `kubectl describe WebApplicationFirewallPolicy $WafPolicy -n $InfrastructureNamespace`. In the output, you will see an error message that looks something like:

```yaml
RESPONSE 403: 403 Forbidden
ERROR CODE: LinkedAuthorizationFailed
--------------------------------------------------------------------------------
{
  "error": {
    "code": "LinkedAuthorizationFailed",
    "message": "The client '747751ee-7816-4be2-9d18-c75d579ddfae' with object id 'e100d827-3bbf-4332-957c-880818145fc8' has permission to perform action 'Microsoft.ServiceNetworking/trafficControllers/securityPolicies/write' on scope '/subscriptions/e347e896-c1d2-4aea-b63d-2c7f5f6acc7e/resourceGroups/mc_app-gateway-container-rg_app-gateway-container-aks_canadacentral/providers/Microsoft.ServiceNetworking/trafficControllers/alb-b9cf67d1/securityPolicies/sp-87c60681-45cb3d470fd3d292887df0fc9d43ede061f35cbf'; however, it does not have permission to perform action(s) 'microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action' on the linked scope(s) '/subscriptions/e347e896-c1d2-4aea-b63d-2c7f5f6acc7e/resourcegroups/app-gateway-container-rg/providers/microsoft.network/applicationgatewaywebapplicationfirewallpolicies/waf-policy' (respectively) or the linked scope(s) are invalid."
  }
}
```