### PR TITLE
Application Gateway for Container - Missing Grafana Permissions

### DIFF
--- a/articles/application-gateway/for-containers/prometheus-grafana.md
+++ b/articles/application-gateway/for-containers/prometheus-grafana.md
@@ -160,7 +160,7 @@ In this section, we visualize a sample logs from Log Analytics Workspace. Refer 
 
 1. In the right top corner, Select **Add + Add Dashboard**.
 2. Select **Add Visualization**.
-3. Search for Azure Monitor under data source + **Add**.
+3. Search for Azure Monitor under data source + **Add**. If you don't see your desired Log Analytics worskpace, assign the `Monitoring Reader' role on the Log Analytics Workspace to the system-assigned managed identity of the Azure Managed Grafana.
 ![A screenshot of Log Data Source.](./media/prometheus-grafana/log-data-source.png)
 4. Change service as **Logs**.
 5. Type: 
@@ -180,7 +180,7 @@ In this section, we visualize a sample logs from Log Analytics Workspace. Refer 
 2. Select **Add Visualization**.
 3. Search for Azure Monitor under data source+ **Add**.
 4. Change service as Metrics.
-5. Select your application gateway for containers instance.
+5. Select your application gateway for containers instance. If you don't see your application gateway for containers, assign the `Monitoring Reader' role on the application gateways for contaiers to the system-assigned managed identity of the Azure Managed Grafana.
 ![[A screenshot of Metrics Log Data Source.](./media/prometheus-grafana/metrics-logs-datasource.png)](./media/prometheus-grafana/metrics-logs-datasource.png#lightbox)
 6. Select metric namespace as microsoft.servicenetworking/trafficcontrollers.
 7. Choose a metric such as **total requests** and type of data visualization.

--- a/articles/application-gateway/for-containers/prometheus-grafana.md
+++ b/articles/application-gateway/for-containers/prometheus-grafana.md
@@ -180,7 +180,7 @@ In this section, we visualize a sample logs from Log Analytics Workspace. Refer 
 2. Select **Add Visualization**.
 3. Search for Azure Monitor under data source+ **Add**.
 4. Change service as Metrics.
-5. Select your application gateway for containers instance. If you don't see your application gateway for containers, assign the `Monitoring Reader' role on the application gateways for contaiers to the system-assigned managed identity of the Azure Managed Grafana.
+5. Select your application gateway for containers instance. If you don't see your application gateway for containers, assign the `Monitoring Reader' role on the application gateways for containers to the system-assigned managed identity of the Azure Managed Grafana.
 ![[A screenshot of Metrics Log Data Source.](./media/prometheus-grafana/metrics-logs-datasource.png)](./media/prometheus-grafana/metrics-logs-datasource.png#lightbox)
 6. Select metric namespace as microsoft.servicenetworking/trafficcontrollers.
 7. Choose a metric such as **total requests** and type of data visualization.

--- a/articles/application-gateway/for-containers/prometheus-grafana.md
+++ b/articles/application-gateway/for-containers/prometheus-grafana.md
@@ -160,7 +160,7 @@ In this section, we visualize a sample logs from Log Analytics Workspace. Refer 
 
 1. In the right top corner, Select **Add + Add Dashboard**.
 2. Select **Add Visualization**.
-3. Search for Azure Monitor under data source + **Add**. If you don't see your desired log analytics workspace, assign the `Monitoring Reader' role on the log analytics workspace to the system-assigned managed identity of the Azure Managed Grafana.
+3. Search for Azure Monitor under data source + **Add**. If you don't see your desired log analytics workspace, assign the `Monitoring Reader` role on the log analytics workspace to the system-assigned managed identity of the Azure Managed Grafana.
 ![A screenshot of Log Data Source.](./media/prometheus-grafana/log-data-source.png)
 4. Change service as **Logs**.
 5. Type: 
@@ -180,7 +180,7 @@ In this section, we visualize a sample logs from Log Analytics Workspace. Refer 
 2. Select **Add Visualization**.
 3. Search for Azure Monitor under data source+ **Add**.
 4. Change service as Metrics.
-5. Select your application gateway for containers instance. If you don't see your application gateway for containers, assign the `Monitoring Reader' role on the application gateways for containers to the system-assigned managed identity of the Azure Managed Grafana.
+5. Select your application gateway for containers instance. If you don't see your application gateway for containers, assign the `Monitoring Reader` role on the application gateways for containers to the system-assigned managed identity of the Azure Managed Grafana.
 ![[A screenshot of Metrics Log Data Source.](./media/prometheus-grafana/metrics-logs-datasource.png)](./media/prometheus-grafana/metrics-logs-datasource.png#lightbox)
 6. Select metric namespace as microsoft.servicenetworking/trafficcontrollers.
 7. Choose a metric such as **total requests** and type of data visualization.

--- a/articles/application-gateway/for-containers/prometheus-grafana.md
+++ b/articles/application-gateway/for-containers/prometheus-grafana.md
@@ -160,7 +160,7 @@ In this section, we visualize a sample logs from Log Analytics Workspace. Refer 
 
 1. In the right top corner, Select **Add + Add Dashboard**.
 2. Select **Add Visualization**.
-3. Search for Azure Monitor under data source + **Add**. If you don't see your desired Log Analytics worskpace, assign the `Monitoring Reader' role on the Log Analytics Workspace to the system-assigned managed identity of the Azure Managed Grafana.
+3. Search for Azure Monitor under data source + **Add**. If you don't see your desired log analytics workspace, assign the `Monitoring Reader' role on the log analytics workspace to the system-assigned managed identity of the Azure Managed Grafana.
 ![A screenshot of Log Data Source.](./media/prometheus-grafana/log-data-source.png)
 4. Change service as **Logs**.
 5. Type: 


### PR DESCRIPTION
Added necessary permissions to access LAW and ALB logs and metrics.

Grafana only has access to the default Log Analytics Workspace. If another LAW is used then Grafana won't see it. After assigning the Monitoring Reader role, Grafana can see the LAW and the user can select it as a data source.
The same for the application gateway for containers, except Grafana never has default access and always needs the Monitoring Reader role (or similar) assigned to read and display the data. 