### PR TITLE
Update Azure Web Application Firewall on Application Gateway for Containers with the Gateway API

### DIFF
--- a/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
@@ -33,7 +33,7 @@ Application Gateway for Containers uses Azure Web Application Firewall to block 
   - Provisioned the Application Gateway for Containers resources via the [`ApplicationLoadBalancer` custom resource](quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md).
 
 - The `WAF Policy`, referenced under `webApplicationFirewall` in the later examples must already exist before the `WebApplicationFirewallPolicy` is applied. Make sure that the policy is enabled as well. For more details about the WAF Policy see the [Azure CLI documentation](/azure/network/application-gateway/waf-policy).
-- The managed identity of the ALB Controller, usually named azure-alb-identity must have the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` assigned on the WAF policy you want to assign. The permission is part of the `Network Contributor` role or you can assign a custom role.
+- The managed identity of the ALB Controller, which is usually named azure-alb-identity, must have the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` assigned on the WAF policy you want to assign. The permission is part of the `Network Contributor` role or you can assign a custom role.
   
 - Apply the following `deployment.yaml` file on your cluster to create a sample web application that demonstrates the header rewrite:
 

--- a/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
@@ -32,7 +32,7 @@ Application Gateway for Containers uses Azure Web Application Firewall to block 
   - Provisioned your [ALB Controller](quickstart-deploy-application-gateway-for-containers-alb-controller.md).
   - Provisioned the Application Gateway for Containers resources via the [`ApplicationLoadBalancer` custom resource](quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md).
 
-- The `WAF Policy`, referenced under `webApplicationFirewall` in the later exampled must already exist before the `WebApplicationFirewallPolicy` is applied. Make sure that the policy is enabled as well. For more details about the WAF Policy see the [Azure CLI documentation](https://learn.microsoft.com/en-us/cli/azure/network/application-gateway/waf-policy?view=azure-cli-latest).
+- The `WAF Policy`, referenced under `webApplicationFirewall` in the later exampled must already exist before the `WebApplicationFirewallPolicy` is applied. Make sure that the policy is enabled as well. For more details about the WAF Policy see the [Azure CLI documentation](/azure/network/application-gateway/waf-policy).
 - The managed identity of the ALB Controller, usually named azure-alb-identity must have the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` assigned on the WAF policy you want to assign. The permission is part of the `Network Contributor` role or you can assign a custom role.
   
 - Apply the following `deployment.yaml` file on your cluster to create a sample web application that demonstrates the header rewrite:

--- a/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
@@ -32,6 +32,9 @@ Application Gateway for Containers uses Azure Web Application Firewall to block 
   - Provisioned your [ALB Controller](quickstart-deploy-application-gateway-for-containers-alb-controller.md).
   - Provisioned the Application Gateway for Containers resources via the [`ApplicationLoadBalancer` custom resource](quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md).
 
+- The `WAF Policy`, referenced under `webApplicationFirewall` in the later exampled must already exist before the `WebApplicationFirewallPolicy` is applied. Make sure that the policy is enabled as well. For more details about the WAF Policy see the [Azure CLI documentation](https://learn.microsoft.com/en-us/cli/azure/network/application-gateway/waf-policy?view=azure-cli-latest).
+- The managed identity of the ALB Controller, usually named azure-alb-identity must have the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` assigned on the WAF policy you want to assign. The permission is part of the `Network Contributor` role or you can assign a custom role.
+  
 - Apply the following `deployment.yaml` file on your cluster to create a sample web application that demonstrates the header rewrite:
 
   ```bash
@@ -331,3 +334,26 @@ curl -k --resolve contoso.com:80:$fqdnIp http://contoso.com/?1=1=1
 ```
 
 Congratulations! You installed an ALB Controller, deployed a back-end application, and used Azure Web Application Firewall functionality to block a malicious request.
+
+## Common Issues
+
+The most common issues are that either the `WAF policy` you want to assign does not exist or that the managed identity of the `ALB` does not have enough permissions to attach the `WAF policy`. 
+
+Use the following command to check the status of the deployment of the `WAF policy`:
+
+```azurecli-interactive
+kubectl get WebApplicationFirewallPolicy -n test-infra
+```
+You should see the following output:
+
+| NAME                 | Deployment  |  AGE  |
+| -------------------- | ----------- | ----- |
+| sample-waf-policy    | True        | 5m16s |
+
+If the Status is `False` then use the following command to examine the policy assignment:
+
+```azurecli-interactive
+kubectl describe WebApplicationFirewallPolicy sample-waf-policy -n test-infra
+```
+
+If everything is setup correctly but you still don't see any results, make sure that the `WAF policy` you assigned is enabled and wheter the `Policy mode` is set to `Detection` or `Prevention`. `Detection` only logs the outcome of the policy but does not enforce it. To enforce it, use `Prevention`.

--- a/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
@@ -356,4 +356,4 @@ If the Status is `False` then use the following command to examine the policy as
 kubectl describe WebApplicationFirewallPolicy sample-waf-policy -n test-infra
 ```
 
-If everything is setup correctly but you still don't see any results, make sure that the `WAF policy` you assigned is enabled and wheter the `Policy mode` is set to `Detection` or `Prevention`. `Detection` only logs the outcome of the policy but does not enforce it. To enforce it, use `Prevention`.
+If everything is setup correctly but you still don't see any results, make sure that the `WAF policy` you assigned is enabled and whether the `Policy mode` is set to `Detection` or `Prevention`. `Detection` only logs the outcome of the policy but does not enforce it. To enforce it, use `Prevention`.

--- a/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-waf-gateway-api.md
@@ -32,7 +32,7 @@ Application Gateway for Containers uses Azure Web Application Firewall to block 
   - Provisioned your [ALB Controller](quickstart-deploy-application-gateway-for-containers-alb-controller.md).
   - Provisioned the Application Gateway for Containers resources via the [`ApplicationLoadBalancer` custom resource](quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md).
 
-- The `WAF Policy`, referenced under `webApplicationFirewall` in the later exampled must already exist before the `WebApplicationFirewallPolicy` is applied. Make sure that the policy is enabled as well. For more details about the WAF Policy see the [Azure CLI documentation](/azure/network/application-gateway/waf-policy).
+- The `WAF Policy`, referenced under `webApplicationFirewall` in the later examples must already exist before the `WebApplicationFirewallPolicy` is applied. Make sure that the policy is enabled as well. For more details about the WAF Policy see the [Azure CLI documentation](/azure/network/application-gateway/waf-policy).
 - The managed identity of the ALB Controller, usually named azure-alb-identity must have the permission `microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action` assigned on the WAF policy you want to assign. The permission is part of the `Network Contributor` role or you can assign a custom role.
   
 - Apply the following `deployment.yaml` file on your cluster to create a sample web application that demonstrates the header rewrite:


### PR DESCRIPTION
Following the documentation in its current state will lead to a non functional WAF policy assignment. The documentation is missing two key components:

1. The WAF policy you want assign must already exist
2. The service principal of the ALB Controller needs the right permission on the WAF policy to assign it.

This PR aims to provide more guidance on how to setup everything and what to do in case something went wrong.


## Technical details
Assigning an existing WAF policy as described in the documentation will not work. The statue of the deployment is `False` which can be checked with `kubectl get WebApplicationFirewallPolicy $WafPolicy -n $InfrastructureNamespace`. The state of the WebApplicationFirewallPolicy can be checked with `kubectl describe WebApplicationFirewallPolicy $WafPolicy -n $InfrastructureNamespace`. In the output, you will see an error message that looks something like:

```yaml
RESPONSE 403: 403 Forbidden
ERROR CODE: LinkedAuthorizationFailed
--------------------------------------------------------------------------------
{
  "error": {
    "code": "LinkedAuthorizationFailed",
    "message": "The client '747751ee-7816-4be2-9d18-c75d579ddfae' with object id 'e100d827-3bbf-4332-957c-880818145fc8' has permission to perform action 'Microsoft.ServiceNetworking/trafficControllers/securityPolicies/write' on scope '/subscriptions/e347e896-c1d2-4aea-b63d-2c7f5f6acc7e/resourceGroups/mc_app-gateway-container-rg_app-gateway-container-aks_canadacentral/providers/Microsoft.ServiceNetworking/trafficControllers/alb-b9cf67d1/securityPolicies/sp-87c60681-45cb3d470fd3d292887df0fc9d43ede061f35cbf'; however, it does not have permission to perform action(s) 'microsoft.network/applicationgatewaywebapplicationfirewallpolicies/join/action' on the linked scope(s) '/subscriptions/e347e896-c1d2-4aea-b63d-2c7f5f6acc7e/resourcegroups/app-gateway-container-rg/providers/microsoft.network/applicationgatewaywebapplicationfirewallpolicies/waf-policy' (respectively) or the linked scope(s) are invalid."
  }
}
```