### PR TITLE
Fix memory-to-vCPU ratios in Redis tiers

### DIFF
--- a/articles/redis/quickstart-create-managed-redis.md
+++ b/articles/redis/quickstart-create-managed-redis.md
@@ -17,9 +17,9 @@ Azure Managed Redis provides fully integrated and managed [Redis Enterprise](htt
 
 Three tiers are for in-memory data:
 
-- **Memory Optimized** Ideal for memory-intensive use cases that require a high memory-to-vCPU ratio (1:8) but don't need the highest throughput performance. It provides a lower price point for scenarios where less processing power or throughput is necessary, making it an excellent choice for development and testing environments.
-- **Balanced (Memory + Compute)** Offers a balanced memory-to-vCPU (1:4) ratio, making it ideal for standard workloads. It provides a healthy balance of memory and compute resources.
-- **Compute Optimized** Designed for performance-intensive workloads requiring maximum throughput, with a low memory-to-vCPU (1:2) ratio. It's ideal for applications that demand the highest performance.
+- **Memory Optimized** Ideal for memory-intensive use cases that require a high memory-to-vCPU ratio (8:1) but don't need the highest throughput performance. It provides a lower price point for scenarios where less processing power or throughput is necessary, making it an excellent choice for development and testing environments.
+- **Balanced (Memory + Compute)** Offers a balanced memory-to-vCPU (4:1) ratio, making it ideal for standard workloads. It provides a healthy balance of memory and compute resources.
+- **Compute Optimized** Designed for performance-intensive workloads requiring maximum throughput, with a low memory-to-vCPU (2:1) ratio. It's ideal for applications that demand the highest performance.
 
 One tier stores data both in-memory and on-disk:
 


### PR DESCRIPTION
Correcting the memory-to-vCPU ratios for the tiers in Azure Managed Redis documentation. They were the wrong way around compared to the textual description (e.g. memory-to-vCPU should be "[memoryGB:cpu]" _in that order_, not "[cpu:memoryGB]")