### PR TITLE
Update how-to-use-service-connector-in-aks.md TS section with update…

### DIFF
--- a/articles/service-connector/how-to-use-service-connector-in-aks.md
+++ b/articles/service-connector/how-to-use-service-connector-in-aks.md
@@ -269,7 +269,7 @@ Refer to [extension creation errors](/troubleshoot/azure/azure-kubernetes/extens
 
 This error is caused by connectivity problems that occur between the cluster and the firewall in addition to egress blocking problems. 
 To resolve this problem, see [Outbound network and FQDN rules for Azure Kubernetes Service (AKS) clusters](/azure/aks/outbound-rules-control-egress), 
-and add the FQDN required to pull Service Connector Helm chart: `scaksextension.azurecr.io`
+and add the FQDN required to pull Service Connector Helm chart: `mcr.microsoft.com`
 
 **Error messages:**
 


### PR DESCRIPTION
The service connector job in sc-system namespace now uses mcr.microsoft.com instead of scaksextension.azurecr.io

For some time now we've noticed (gladly) the serviceconnector-operator pod images are being pulled by mcr.microsoft.com instead of scaksextension.azurecr.io

Requesting to update documentation to reflect the change.

mcr.microsoft.com is also already present in [Outbound network and FQDN rules for Azure Kubernetes Service (AKS) clusters](/azure/aks/outbound-rules-control-egress) whereas scaksextension.azurecr.io was not.

To reproduce this: follow [docs to create service connector to KeyVault for AKS cluster](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-identity-access?tabs=azure-portal&pivots=access-with-service-connector) and watch the sc-system namespace events, e.g.:

```
$ kubectl get events -n sc-system

LAST SEEN   TYPE     REASON             OBJECT             MESSAGE
11m         Normal   Scheduled          pod/sc-job-gr57x   Successfully assigned sc-system/sc-job-gr57x to aks-nodepool1-40339364-vmss000000
11m         Normal   Pulling            pod/sc-job-gr57x   Pulling image "mcr.microsoft.com/service-connector/prod/image/sc-operator:20251203.5"
11m         Normal   Pulled             pod/sc-job-gr57x   Successfully pulled image "mcr.microsoft.com/service-connector/prod/image/sc-operator:20251203.5" in 2.382s (2.382s including waiting). Image size: 37253044 bytes.
11m         Normal   Created            pod/sc-job-gr57x   Created container: serviceconnector-operator
11m         Normal   Started            pod/sc-job-gr57x   Started container serviceconnector-operator
11m         Normal   SuccessfulCreate   job/sc-job         Created pod: sc-job-gr57x
11m         Normal   Completed          job/sc-job         Job completed
```

