### PR TITLE
Update manage-accelerated-networking.md

### DIFF
--- a/articles/virtual-network/manage-accelerated-networking.md
+++ b/articles/virtual-network/manage-accelerated-networking.md
@@ -94,8 +94,6 @@ If the VM uses a [supported operating system](./accelerated-networking-overview.
 
 >[!NOTE]
 >- You can enable Accelerated Networking during portal VM creation only for Azure Marketplace supported operating systems. To create and enable Accelerated Networking for a VM with a custom OS image, you must use Azure CLI or PowerShell.
->
->- The Accelerated Networking setting in the portal shows the user-selected state. Accelerated Networking allows choosing **Disabled** in the portal even if the VM size requires Accelerated Networking. VM sizes that require Accelerated Networking enable Accelerated Networking at runtime regardless of the user setting in the portal.
 
 To enable or disable Accelerated Networking for an existing VM through the Azure portal:
 


### PR DESCRIPTION
Moving this comment:
The Accelerated Networking setting in the portal shows the user-selected state. Accelerated Networking allows choosing Disabled in the portal even if the VM size requires Accelerated Networking. VM sizes that require Accelerated Networking enable Accelerated Networking at runtime regardless of the user setting in the portal.

from this page: [Manage accelerated networking for Azure Virtual Machines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-network/manage-accelerated-networking?tabs=portal#enable-accelerated-networking-on-individual-vms-or-vms-in-availability-sets)
To this page/section: [Create an Azure Virtual Machine with Accelerated Networking | Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-network/create-virtual-machine-accelerated-networking?tabs=portal#create-a-vm-and-attach-the-nic)