### PR TITLE
Update create-virtual-machine-accelerated-networking.md

### DIFF
--- a/articles/virtual-network/create-virtual-machine-accelerated-networking.md
+++ b/articles/virtual-network/create-virtual-machine-accelerated-networking.md
@@ -370,7 +370,12 @@ New-AzBastion @bastionParams -AsJob
 
 ### [Portal](#tab/portal)
 
-Accelerated networking is enabled in the portal during virtual machine creation. Create a virtual machine in the following section.
+Accelerated networking is enabled in the portal during virtual machine creation. Create a virtual machine in the following section. 
+
+>[!NOTE]
+>- The Accelerated Networking setting in the portal shows the user‑selected state. Accelerated Networking allows choosing Disabled in the portal even if the VM size requires Accelerated Networking. VM sizes that require Accelerated Networking enable Accelerated Networking at runtime regardless of the user setting in the portal. Accelerated Networking is a required feature for general purpose VM sizes of v5 or higher.
+
+
 
 ### [PowerShell](#tab/powershell)
 

--- a/articles/virtual-network/create-virtual-machine-accelerated-networking.md
+++ b/articles/virtual-network/create-virtual-machine-accelerated-networking.md
@@ -373,7 +373,7 @@ New-AzBastion @bastionParams -AsJob
 Accelerated networking is enabled in the portal during virtual machine creation. Create a virtual machine in the following section. 
 
 >[!NOTE]
->- The Accelerated Networking setting in the portal shows the user‑selected state. Accelerated Networking allows choosing Disabled in the portal even if the VM size requires Accelerated Networking. VM sizes that require Accelerated Networking enable Accelerated Networking at runtime regardless of the user setting in the portal. Accelerated Networking is a required feature for general purpose VM sizes of v5 or higher.
+>- The Accelerated Networking setting in the portal shows the user-selected state. Accelerated Networking allows choosing Disabled in the portal even if the VM size requires Accelerated Networking. VM sizes that require Accelerated Networking enable Accelerated Networking at runtime regardless of the user setting in the portal. Accelerated Networking is a required feature for general purpose VM sizes of v5 or higher.
 
 
 


### PR DESCRIPTION
Moved this comment:

The Accelerated Networking setting in the portal shows the user-selected state. Accelerated Networking allows choosing Disabled in the portal even if the VM size requires Accelerated Networking. VM sizes that require Accelerated Networking enable Accelerated Networking at runtime regardless of the user setting in the portal.

from this page: [Manage accelerated networking for Azure Virtual Machines | Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-network/manage-accelerated-networking?tabs=portal#enable-accelerated-networking-on-individual-vms-or-vms-in-availability-sets)

To this page/section: [Create an Azure Virtual Machine with Accelerated Networking | Microsoft Learn](https://learn.microsoft.com/en-us/azure/virtual-network/create-virtual-machine-accelerated-networking?tabs=portal#create-a-vm-and-attach-the-nic)

And updated the comment to indicate that customers should generally consider Accelerated Networking as a required feature for general purpose VM sizes of v5 or higher.