### PR TITLE
Add out of memory issue to geo-replication documentation

### DIFF
--- a/articles/azure-cache-for-redis/cache-how-to-active-geo-replication.md
+++ b/articles/azure-cache-for-redis/cache-how-to-active-geo-replication.md
@@ -208,7 +208,9 @@ To monitor the _Geo Replication Healthy_ metric in the Azure portal:
 
 - Use of custom Hash tags – Using custom hashtags in Redis can lead to uneven distribution of data across shards, which might cause performance issues and synchronization problems in geo-replicas therefore avoid using custom hashtags unless the database needs to perform multiple key operations.
 
-- Large Key Size - Large keys can create synchronization issues among geo-replicas. To maintain smooth performance and reliable replication, we recommend keeping key sizes under 500MB when using geo-replication. If individual key size gets close to 2GB the cache faces geo-replication health issues.  
+- Large Key Size - Large keys can create synchronization issues among geo-replicas. To maintain smooth performance and reliable replication, we recommend keeping key sizes under 500MB when using geo-replication. If individual key size gets close to 2GB the cache faces geo-replication health issues.
+
+- Out of Memory - When the nodes are close to their memory limit, they become unable to sync data across caches. This leads to stale data and affect the health of all caches in the replication group. Please make sure you set to proper ttl or eviction policy.
 
 ### Flush caches using Azure CLI or PowerShell
 

--- a/articles/azure-cache-for-redis/cache-how-to-active-geo-replication.md
+++ b/articles/azure-cache-for-redis/cache-how-to-active-geo-replication.md
@@ -210,7 +210,7 @@ To monitor the _Geo Replication Healthy_ metric in the Azure portal:
 
 - Large Key Size - Large keys can create synchronization issues among geo-replicas. To maintain smooth performance and reliable replication, we recommend keeping key sizes under 500MB when using geo-replication. If individual key size gets close to 2GB the cache faces geo-replication health issues.
 
-- Out of Memory - When the nodes are close to their memory limit, they become unable to sync data across caches. This leads to stale data and affects the health of all caches in the replication group. Please make sure you set to proper ttl or eviction policy.
+- Out of Memory - When the nodes are close to their memory limit, they become unable to sync data across caches. This leads to stale data and affects the health of all caches in the replication group. Please make sure you set a proper TTL or eviction policy.
 
 ### Flush caches using Azure CLI or PowerShell
 

--- a/articles/azure-cache-for-redis/cache-how-to-active-geo-replication.md
+++ b/articles/azure-cache-for-redis/cache-how-to-active-geo-replication.md
@@ -210,7 +210,7 @@ To monitor the _Geo Replication Healthy_ metric in the Azure portal:
 
 - Large Key Size - Large keys can create synchronization issues among geo-replicas. To maintain smooth performance and reliable replication, we recommend keeping key sizes under 500MB when using geo-replication. If individual key size gets close to 2GB the cache faces geo-replication health issues.
 
-- Out of Memory - When the nodes are close to their memory limit, they become unable to sync data across caches. This leads to stale data and affect the health of all caches in the replication group. Please make sure you set to proper ttl or eviction policy.
+- Out of Memory - When the nodes are close to their memory limit, they become unable to sync data across caches. This leads to stale data and affects the health of all caches in the replication group. Please make sure you set to proper ttl or eviction policy.
 
 ### Flush caches using Azure CLI or PowerShell
 


### PR DESCRIPTION
Added information about out of memory issues affecting geo-replication health and provided recommendations for setting TTL or eviction policies.