### PR TITLE
Correct ASP.NET Core Route Constraint reference

### DIFF
--- a/articles/azure-functions/functions-bindings-http-webhook-trigger.md
+++ b/articles/azure-functions/functions-bindings-http-webhook-trigger.md
@@ -700,7 +700,7 @@ By default when you create a function for an HTTP trigger, the function is addre
 https://<APP_NAME>.azurewebsites.net/api/<FUNCTION_NAME>
 ```
 
-You can customize this route using the optional `route` property on the HTTP trigger's input binding. You can use any [ASP.NET Core Route Constraint](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/routing#route-constraints) with your parameters. 
+You can customize this route using the optional `route` property on the HTTP trigger's input binding. You can use any [ASP.NET Core Route Constraint](/aspnet/core/fundamentals/routing#route-constraints) with your parameters. 
 
 ::: zone pivot="programming-language-csharp"
 

--- a/articles/azure-functions/functions-bindings-http-webhook-trigger.md
+++ b/articles/azure-functions/functions-bindings-http-webhook-trigger.md
@@ -700,7 +700,7 @@ By default when you create a function for an HTTP trigger, the function is addre
 https://<APP_NAME>.azurewebsites.net/api/<FUNCTION_NAME>
 ```
 
-You can customize this route using the optional `route` property on the HTTP trigger's input binding. You can use any [Web API Route Constraint](https://www.asp.net/web-api/overview/web-api-routing-and-actions/attribute-routing-in-web-api-2#constraints) with your parameters. 
+You can customize this route using the optional `route` property on the HTTP trigger's input binding. You can use any [ASP.NET Core Route Constraint](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/routing#route-constraints) with your parameters. 
 
 ::: zone pivot="programming-language-csharp"
 


### PR DESCRIPTION
Updated link reference for route constraints in HTTP trigger documentation.

Old link was broken