### PR TITLE
Update "Incident Tasks" availability in Defender portal

### DIFF
--- a/articles/sentinel/move-to-defender.md
+++ b/articles/sentinel/move-to-defender.md
@@ -227,7 +227,7 @@ After onboarding Microsoft Sentinel to the Defender portal, the following change
 |**Editing comments**     |  Add comments to incidents in either the Defender or Azure portal, but editing existing comments isn't supported in the Defender portal. Edits made to comments in the Azure portal aren't synchronized to the Defender portal.       |
 |**Programmatic and manual creation of incidents**     |    Incidents created in Microsoft Sentinel through the API, by a Logic App playbook, or manually from the Azure portal, aren't synchronized to the Defender portal. These incidents are still supported in the Azure portal and the API. See [Create your own incidents manually in Microsoft Sentinel](create-incident-manually.md).     |
 | **Reopening closed incidents** | In the Defender portal, you can't set alert grouping in Microsoft Sentinel analytics rules to reopen closed incidents if new alerts are added. <br>Closed incidents aren't reopened in this case, and new alerts trigger new incidents.|
-| **Tasks** | Incident tasks are unavailable in the Defender portal. <br><br>For more information, see [Use tasks to manage incidents in Microsoft Sentinel](incident-tasks.md). |
+| **Tasks** | Incident tasks are available in the Defender portal. <br><br>For more information, see [Streamline incident response using tasks in the Microsoft Defender portal](defender-xdr/split-incidents-into-tasks.md). |
 
 For more information, see [Incidents and alerts in the Microsoft Defender portal](/defender-xdr/incidents-overview) and [Alert correlation and incident merging in the Microsoft Defender portal](/defender-xdr/alerts-incidents-correlation).
 


### PR DESCRIPTION
Incidents Tasks are available in the Defender portal, however, our documentation indicates that tasks aren't available.