### PR TITLE
Update frequently-asked-questions.yml

### DIFF
--- a/articles/network-watcher/frequently-asked-questions.yml
+++ b/articles/network-watcher/frequently-asked-questions.yml
@@ -393,7 +393,7 @@ sections:
       - question: |
           Why do I see additional storage transactions when NSG flow logs and Traffic Analytics are enabled?
         answer: |
-          When NSG flow logs are enabled, flow log records are written to the configured Azure Storage account. To generate Traffic Analytics insights, Azure Network Watcher performs backend read operations on this stored data to process, aggregate, and enrich flow log records. These backend storage interactions are required for analytics functionality and occur even if you do not actively query the data. You can control the overall cost impact by adjusting flow log scope, retention, and whether Traffic Analytics is enabled.
+          When NSG flow logs are enabled, flow log records are written to the configured Azure Storage account. To generate Traffic Analytics insights, Azure Network Watcher performs backend read and write operations on this stored data to process, aggregate, and enrich flow log records. These backend storage interactions are required for analytics functionality and occur even if you do not actively query the data. You can control the overall cost impact by adjusting flow log scope, retention, and whether Traffic Analytics is enabled.
       
       - question: |
           How frequently does traffic analytics process data?


### PR DESCRIPTION
Why do I see additional storage transactions when NSG flow logs and Traffic Analytics are enabled? 
When NSG flow logs are enabled, flow log records are written to the configured Azure Storage account. To generate Traffic Analytics insights, Azure Network Watcher performs backend read and write operations on this stored data to process, aggregate, and enrich flow log records. These backend storage interactions are required for analytics functionality and occur even if you do not actively query the data. You can control the overall cost impact by adjusting flow log scope, retention, and whether Traffic Analytics is enabled.    ====> read and write operations, I see only read operations so added write too.