### PR TITLE
Add tip to revert App Service to use system-assigned MI as `keyVaultReferenceIdentity`

### DIFF
--- a/articles/app-service/app-service-key-vault-references.md
+++ b/articles/app-service/app-service-key-vault-references.md
@@ -91,7 +91,7 @@ After you grant permissions to the user-assigned identity, follow these steps:
 This setting applies to all Key Vault references for the app.
 
 > [!TIP]
-> If you want to revert your app to use the system-assigned identity set the value to `SystemAssigned` instead of the Resource Id.
+> If you want to revert your app to use the system-assigned identity, set the value to `SystemAssigned` instead of the Resource ID.
 
 ## <a name = "rotation"></a> Understand rotation
 

--- a/articles/app-service/app-service-key-vault-references.md
+++ b/articles/app-service/app-service-key-vault-references.md
@@ -90,6 +90,9 @@ After you grant permissions to the user-assigned identity, follow these steps:
 
 This setting applies to all Key Vault references for the app.
 
+> [!TIP]
+> If you want to revert your app to use the system-assigned identity set the value to `SystemAssigned` instead of the Resource Id.
+
 ## <a name = "rotation"></a> Understand rotation
 
 If the secret version isn't specified in the reference, the app uses the latest version that exists in the key vault. When newer versions become available, such as with rotation, the app is automatically updated and begins using the latest version within 24 hours.


### PR DESCRIPTION
Changes:

Added a tip how to revert to system-assigned identity, based on this [ARM API docs](https://learn.microsoft.com/en-us/rest/api/appservice/web-apps/create-or-update?view=rest-appservice-2025-03-01&tabs=HTTP) .

Justification: 

It's possible to use key vault secrets as environment variable values in azure app service. 
The documentation covers how to set a user-assigned identity to fetch this secret, but not how to revert back to a system assigned identity.