### PR TITLE
Fix WEBSITES_ENABLE_APP_SERVICE_STORAGE default value

### DIFF
--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -241,7 +241,20 @@ The only exception is the `C:\home\LogFiles` directory. This directory stores th
 
 We recommend that you write data to `/home` or a [mounted Azure storage path](configure-connect-to-azure-storage.md?tabs=portal&pivots=container-linux). Data that you write outside these paths isn't persistent during restarts. The data is saved to platform-managed host disk space separate from the App Service plans file storage quota.
 
-By default, persistent storage is *disabled* on Linux custom containers. To enable it, set the `WEBSITES_ENABLE_APP_SERVICE_STORAGE` app setting value to `true` by using [Cloud Shell](https://shell.azure.com). In Bash, use the following command:
+By default, persistent storage is *enabled* on Linux custom containers.
+To disable it, set the `WEBSITES_ENABLE_APP_SERVICE_STORAGE` app setting value to `false` by using [Cloud Shell](https://shell.azure.com). In Bash, use the following command:
+
+```azurecli-interactive
+az webapp config appsettings set --resource-group <group-name> --name <app-name> --settings WEBSITES_ENABLE_APP_SERVICE_STORAGE=false
+```
+
+In PowerShell, use the following command:
+
+```azurepowershell-interactive
+Set-AzWebApp -ResourceGroupName <group-name> -Name <app-name> -AppSettings @{"WEBSITES_ENABLE_APP_SERVICE_STORAGE"=false}
+```
+
+To enable it, set the `WEBSITES_ENABLE_APP_SERVICE_STORAGE` app setting value to `true` by using [Cloud Shell](https://shell.azure.com). In Bash, use the following command:
 
 ```azurecli-interactive
 az webapp config appsettings set --resource-group <group-name> --name <app-name> --settings WEBSITES_ENABLE_APP_SERVICE_STORAGE=true


### PR DESCRIPTION
`WEBSITES_ENABLE_APP_SERVICE_STORAGE` seems to be true by default for Linux containers.

I have created Web App on B1 service plan and tested 3 options as follows:

1. SSH to Linux container to run `mount | grep home` with `WEBSITES_ENABLE_APP_SERVICE_STORAGE=false` configuration setting. **Result:** nothing is returned.
2. SSH to Linux container to run `mount | grep home` with `WEBSITES_ENABLE_APP_SERVICE_STORAGE=true` configuration setting. **Result:** the mount point information is returned.
3. SSH to Linux container to run `mount | grep home` without `WEBSITES_ENABLE_APP_SERVICE_STORAGE` configuration setting specified. **Result:** the mount point information is returned.

Web App start/stop is required for changes to take effect when conducting tests.

_I am not sure if it behaves differently on other service plans but I have tested B1 in Switzerland North only._