### PR TITLE
Update static-web-apps-languages-runtimes.md

### DIFF
--- a/includes/static-web-apps-languages-runtimes.md
+++ b/includes/static-web-apps-languages-runtimes.md
@@ -22,7 +22,7 @@ To configure the API language runtime version, set the `apiRuntime` property in 
 | Node.js 16.x | Linux | 4.x | `node:16` | April 30, 2025 |
 | Node.js 18.x | Linux | 4.x | `node:18` | May 31, 2025 |
 | Node.js 20.x | Linux | 4.x | `node:20` | - |
-| Node.js 22.x | Linux | 4.x | `node:20` | - |
+| Node.js 22.x | Linux | 4.x | `node:22` | - |
 | Python 3.8 | Linux | 4.x | `python:3.8` | April 30, 2025 |
 | Python 3.9 | Linux | 4.x | `python:3.9` | - |
 | Python 3.10 | Linux | 4.x | `python:3.10` | - |


### PR DESCRIPTION
Fixed apiRuntime for Node.js 22.x