### PR TITLE
Update test command for Cisco ASA ingestion to account for RFC5452

### DIFF
--- a/articles/sentinel/connect-cef-syslog-ama.md
+++ b/articles/sentinel/connect-cef-syslog-ama.md
@@ -438,7 +438,7 @@ To send demo messages, complete one of the following steps:
     Test Cisco ASA ingestion using the following command:
 
     ```bash
-    echo -n "<164>%ASA-7-106010: Deny inbound TCP src inet:1.1.1.1 dst inet:2.2.2.2" | nc -u -w0 localhost 514
+    echo -n "<164>DummyHost ASA-FW %ASA-7-106010: Deny inbound TCP src inet:1.1.1.1 dst inet:2.2.2.2" | nc -u -w0 localhost 514
     ```
 
     After you run these commands, messages arrive on port 514 and forward to port 28330.


### PR DESCRIPTION
In the bash echo command, we can't force RFC3164, so we're seeing that rsyslog tries to handle the logs as RFC5452, which ends up adding an extra hyphen, which breaks the CEF connector's parsing. I'm making a change to add a couple fields in the example that will allow the log to be handled in RFC5452 format without adding the extra hyphen.