### PR TITLE
Update bastion-nsg.md

### DIFF
--- a/articles/bastion/bastion-nsg.md
+++ b/articles/bastion/bastion-nsg.md
@@ -105,7 +105,7 @@ $rules = @(
         SourcePortRange = "*"
         DestinationAddressPrefix = "VirtualNetwork"
         DestinationPortRange = 8080,5701
-        Protocol = "Ah"
+        Protocol = "Tcp"
     }
     @{
         Name = "AllowSshRdpOutbound"
@@ -116,7 +116,7 @@ $rules = @(
         SourcePortRange = "*"
         DestinationAddressPrefix = "VirtualNetwork"
         DestinationPortRange = 22,3389
-        Protocol = "Ah"
+        Protocol = "Tcp"
     },
     @{
         Name = "AllowAzureCloudOutbound"
@@ -138,7 +138,7 @@ $rules = @(
         SourcePortRange = "*"
         DestinationAddressPrefix = "VirtualNetwork"
         DestinationPortRange = 8080,5701
-        Protocol = "Ah"
+        Protocol = "Tcp"
     },
     @{
         Name = "AllowHttpOutbound"
@@ -149,7 +149,7 @@ $rules = @(
         SourcePortRange = "*"
         DestinationAddressPrefix = "Internet"
         DestinationPortRange = "80"
-        Protocol = "Ah"
+        Protocol = "Tcp"
     }
  )
 foreach ($rule in $rules) {


### PR DESCRIPTION
In network security rule 'AH ' is not supported. With this template, the NSG will be created successfully but bastion will not work. Modified the protocol from ah to Tcp is the solution.
Rob Rong | Azure network senior support escalation engineer  