### PR TITLE
Add new regions to Managed Grafana availability table

### DIFF
--- a/articles/managed-grafana/high-availability.md
+++ b/articles/managed-grafana/high-availability.md
@@ -46,8 +46,11 @@ Zone redundancy support is enabled in the following regions:
 | Americas         | Europe            | Africa            | Asia Pacific      |
 |------------------|-------------------|-------------------|-------------------|
 | East US          | North Europe      |                   | Australia East    |
-| South Central US |                   |                   | East Asia         |
-| West US 3        |                   |                   |                   |
+| South Central US | France Central    |                   | East Asia         |
+| West US 3        | Norway East       |                   | Central India     |
+| Canada Central   | UK South          |                   | Korea Central     |
+| South Central US |                   |                   |                   |
+
 
 For regions where Azure Managed Grafana is available, see [Products available by region - Azure Managed Grafana](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=managed-grafana&regions=all).
 

--- a/articles/managed-grafana/high-availability.md
+++ b/articles/managed-grafana/high-availability.md
@@ -49,7 +49,6 @@ Zone redundancy support is enabled in the following regions:
 | South Central US | France Central    |                   | East Asia         |
 | West US 3        | Norway East       |                   | Central India     |
 | Canada Central   | UK South          |                   | Korea Central     |
-| South Central US |                   |                   |                   |
 
 
 For regions where Azure Managed Grafana is available, see [Products available by region - Azure Managed Grafana](https://azure.microsoft.com/explore/global-infrastructure/products-by-region/?products=managed-grafana&regions=all).


### PR DESCRIPTION
Updated the availability table for Azure Managed Grafana to include new regions. The list of regions is based on ARM's response when deploying to a region that doesn't support Availability Zones. 

```console
Error: Code=TemplateDeploymentValidationFailed; Message=Validation failed for 'Microsoft.Dashboard/grafana'.
Error: Code=ZoneRedundancyNotSupported; Message=Zone redundancy is currently not supported in this region: swedencentral. Zone redundancy is supported in the following regions: australiaeast, canadacentral, centralindia, eastasia, eastus, eastus2euap, francecentral, koreacentral, northeurope, norwayeast, southcentralus, uksouth, westus3.
```