### PR TITLE
Fix hyperlink formatting for Hybris Documentation

### DIFF
--- a/articles/sap/workloads/certifications.md
+++ b/articles/sap/workloads/certifications.md
@@ -54,5 +54,5 @@ References:
 | SAP Data Services 4.2 | | | SAP Note #2288344 |
 | SAP Hybris Commerce Platform  | Windows | SQL Server, Oracle | All NetWeaver certified VM types <br /> [Hybris Documentation](https://help.sap.com/viewer/a74589c3a81a4a95bf51d87258c0ab15/6.7.0.0/en-US/8c71300f866910149b40c88dfc0de431.html) |
 | SAP Hybris Commerce Platform  | SLES 12 or more recent | SAP HANA | All NetWeaver certified VM types <br /> [Hybris Documentation](https://help.sap.com/viewer/a74589c3a81a4a95bf51d87258c0ab15/6.7.0.0/en-US/8c71300f866910149b40c88dfc0de431.html) |
-| SAP Hybris Commerce Platform  | RHEL 7 or more recent | SAP HANA | All NetWeaver certified VM types <br /> [Hybris Documentation]https://help.sap.com/viewer/a74589c3a81a4a95bf51d87258c0ab15/6.7.0.0/en-US/8c71300f866910149b40c88dfc0de431.html) |
+| SAP Hybris Commerce Platform  | RHEL 7 or more recent | SAP HANA | All NetWeaver certified VM types <br /> [Hybris Documentation](https://help.sap.com/viewer/a74589c3a81a4a95bf51d87258c0ab15/6.7.0.0/en-US/8c71300f866910149b40c88dfc0de431.html) |
 | SAP (Hybris) Commerce Platform 1811 and later  | Windows, SLES, or RHEL | SQL Azure DB | All NetWeaver certified VM types <br /> [Hybris Documentation](https://help.sap.com/viewer/a74589c3a81a4a95bf51d87258c0ab15/1811/en-US/8c71300f866910149b40c88dfc0de431.html) |


### PR DESCRIPTION
Hyperlink was missing opening bracket
<img width="904" height="160" alt="image" src="https://github.com/user-attachments/assets/c75d5fe8-155e-4a03-9aeb-8371770499df" />
