### PR TITLE
Contoso Traders cloud testing demo has been archived, new demo? 

### DIFF
--- a/articles/playwright-testing/how-to-test-local-applications.md
+++ b/articles/playwright-testing/how-to-test-local-applications.md
@@ -73,6 +73,6 @@ dotnet test --settings:.runsettings --logger "microsoft-playwright-testing" -- N
 
 ## Related content
 
-- [Run Playwright tests at scale with Microsoft Playwright Testing]
+- [Run Playwright tests at scale with Microsoft Playwright Testing](./quickstart-run-end-to-end-tests.md)
 
 - Learn more about [writing Playwright tests](https://playwright.dev/docs/intro) in the Playwright documentation

--- a/articles/playwright-testing/how-to-test-local-applications.md
+++ b/articles/playwright-testing/how-to-test-local-applications.md
@@ -73,5 +73,6 @@ dotnet test --settings:.runsettings --logger "microsoft-playwright-testing" -- N
 
 ## Related content
 
-- [Run Playwright tests at scale with Microsoft Playwright Testing](./quickstart-run-end-to-end-tests.md)
+- [Run Playwright tests at scale with Microsoft Playwright Testing]
+
 - Learn more about [writing Playwright tests](https://playwright.dev/docs/intro) in the Playwright documentation


### PR DESCRIPTION
Contoso Traders cloud testing demo has been archived, is a new one coming? 

Looking for an updated sample application showcasing Playwright, Azure Load testing and Azure Chaos Studio. Even better if it includes GitHub Copilot for generating test scripts.