### PR TITLE
Adjust compliance status for AI Builder service within IL5 DoD

### DIFF
--- a/articles/azure-government/compliance/azure-services-in-fedramp-auditscope.md
+++ b/articles/azure-government/compliance/azure-services-in-fedramp-auditscope.md
@@ -293,7 +293,7 @@ This article provides a detailed list of Azure, Dynamics 365, Microsoft 365, and
 | Service | FedRAMP High | DoD IL2 | DoD IL4 | DoD IL5 | DoD IL6 |
 | ------- |:------------:|:-------:|:-------:|:-------:|:-------:|
 | [Advisor](/azure/advisor/) | &#x2705; | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
-| [AI Builder](/ai-builder/) | &#x2705; | &#x2705; | &#x2705; | &#x2705;| |
+| [AI Builder](/ai-builder/) | &#x2705; | &#x2705; | &#x2705; | | |
 | [Analysis Services](../../analysis-services/index.yml) | &#x2705; | &#x2705; | &#x2705; | &#x2705; | |
 | [API Management](../../api-management/index.yml) | &#x2705; | &#x2705; | &#x2705; | &#x2705; | &#x2705; |
 | [App Configuration](../../azure-app-configuration/index.yml) | &#x2705; | &#x2705; | &#x2705; | &#x2705; | &#x2705; |


### PR DESCRIPTION
Updated the compliance table for AI Builder to reflect the latest status published within the Business Applications Feature Experience Parity Exceptions and Roadmap in US Government clouds. AI Builder is still "Not Available" in IL5 US DoD.

The referenced document was last updated in January of 2026.

https://aka.ms/bapfunctionalparity
https://learn.microsoft.com/en-us/power-platform/admin/microsoft-dynamics-365-government#dynamics-365-us-government-feature-limitations