### PR TITLE
Change edge location selection from Anycast to Unicast

### DIFF
--- a/articles/frontdoor/front-door-traffic-acceleration.md
+++ b/articles/frontdoor/front-door-traffic-acceleration.md
@@ -26,11 +26,11 @@ Front Door optimizes the traffic path from the end user to the backend server. T
 
 ::: zone-end
 
-## Select the Front Door edge location for the request (Anycast)
+## Select the Front Door edge location for the request (Unicast)
 
 Globally, [Front Door has over 150 edge locations](edge-locations-by-region.md), or points of presence (PoPs), located in many countries/regions. Every Front Door PoP can serve traffic for any request.
 
-Traffic routed to the Azure Front Door edge locations uses [Anycast](https://en.wikipedia.org/wiki/Anycast) for both DNS (Domain Name System) and HTTP (Hypertext Transfer Protocol) traffic. Anycast allows for user requests to reach the closest edge location in the fewest network hops. This architecture offers better round-trip times for end users by maximizing the benefits of [Split TCP](#connect-to-the-front-door-edge-location-split-tcp).
+Traffic routed to the Azure Front Door edge locations uses [Unicast](https://en.wikipedia.org/wiki/Unicast) for both DNS (Domain Name System) and HTTP (Hypertext Transfer Protocol) traffic. Unicast allows for user requests to reach the closest edge location in the fewest network hops. This architecture offers better round-trip times for end users by maximizing the benefits of [Split TCP](#connect-to-the-front-door-edge-location-split-tcp).
 
 Front Door organizes its edge locations into primary and fallback *rings*. The outer ring has edge locations that are closer to users, offering lower latencies.  The inner ring has edge locations that can handle the failover for the outer ring edge location in case any issues happen.
 


### PR DESCRIPTION
Updated the edge location selection method from Anycast to Unicast for Azure Front Door traffic routing, inline with the changes being performed in the platform.