### PR TITLE
Update storage-blob-scale-targets.md

### DIFF
--- a/includes/storage-blob-scale-targets.md
+++ b/includes/storage-blob-scale-targets.md
@@ -16,7 +16,7 @@ ms.author: normesta
 | Maximum size of an append blob | 50,000 x 4 MiB (approximately 195 GiB) |
 | Maximum size of a page blob | 8 TiB<sup>2</sup> |
 | Maximum number of stored access policies per blob container | 5 |
-| Target request rate for a single page blob | Up to 500 requests per second |
+| Target request rate for a single blob | Up to 500 requests per second |
 | Target throughput for a single page blob | Up to 60 MiB per second<sup>2</sup> |
 | Target throughput for a single block blob | Up to storage account ingress/egress limits<sup>1</sup> |
 


### PR DESCRIPTION
Previously, the target request rate was applied to **all blob types**. However, in the most recent change, it appears to have been restricted to **page blobs only**. At the same time, when reviewing the commit, it seems that the word “page” was added merely to adjust the wording of the line, and the technical background for limiting the target request rate to page blobs is unclear.
Isn’t the target request rate supposed to apply to all blob types, as it did before the change? If the value of 500 requests per second truly applies only to page blobs, then please add information about the target request rates that apply to block blobs and append blobs as well.