### PR TITLE
docs: Add explicit User-Assigned Managed Identity (UAMI) example for Event Hubs binding

### DIFF
--- a/includes/functions-event-hubs-connections.md
+++ b/includes/functions-event-hubs-connections.md
@@ -35,6 +35,29 @@ In this mode, the extension requires the following properties:
 
 Additional properties may be set to customize the connection. See [Common properties for identity-based connections](../articles/azure-functions/functions-reference.md#common-properties-for-identity-based-connections).
 
+#### User-assigned managed identity
+
+To use a user-assigned managed identity, add the `credential` and `clientId` properties in addition to the `fullyQualifiedNamespace`:
+
+| Property   | Environment variable template     | Description     | Example value     |
+|--------------|----------|-----|----------|
+| Fully Qualified Namespace | `<CONNECTION_NAME_PREFIX>__fullyQualifiedNamespace` | The fully qualified Event Hubs namespace. | `myeventhubns.servicebus.windows.net`|
+| Credential | `<CONNECTION_NAME_PREFIX>__credential` | Must be set to `managedidentity`. | `managedidentity` |
+| Client ID | `<CONNECTION_NAME_PREFIX>__clientId` | The client ID of the user-assigned managed identity. | `00000000-0000-0000-0000-000000000000` |
+
+For example, if your binding configuration specifies `connection = "EventHubConnection"`, you would configure the following application settings:
+
+```json
+{
+    "EventHubConnection__fullyQualifiedNamespace": "myeventhubns.servicebus.windows.net",
+    "EventHubConnection__credential": "managedidentity",
+    "EventHubConnection__clientId": "00000000-0000-0000-0000-000000000000"
+}
+```
+
+> [!TIP]
+> User-assigned managed identities are recommended for production scenarios where you need fine-grained control over identity permissions across multiple resources.
+
 > [!NOTE]
 > When using [Azure App Configuration](../articles/azure-app-configuration/quickstart-azure-functions-csharp.md) or [Key Vault](../articles/key-vault/general/overview.md) to provide settings for Managed Identity connections, setting names should use a valid key separator such as `:` or `/` in place of the `__` to ensure names are resolved correctly.
 > 


### PR DESCRIPTION
## Summary

This PR adds a clearer example showing how to configure Event Hubs connections using a **User-Assigned Managed Identity (UAMI)** with explicit app settings.

## Problem

The existing documentation mentions `credential` and `clientId` properties for user-assigned managed identities but lacks a concrete JSON example. Developers need to piece together information from multiple sources to configure UAMI.

## Solution

Added a new **"User-assigned managed identity"** subsection with:
- A table showing the three required properties (`fullyQualifiedNamespace`, `credential`, `clientId`)
- A complete JSON example developers can copy directly
- A tip explaining when UAMI is recommended over system-assigned identity

## Changes

- `includes/functions-event-hubs-connections.md`: Added UAMI configuration example

## Why This Matters

User-Assigned Managed Identity is recommended for:
- Production deployments requiring fine-grained identity control
- Scenarios with multiple Azure resources sharing an identity
- Zero Trust security architectures

## Related

- GitHub Copilot for Azure skill recipes use this pattern
- Tracking issue: https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/973

---
*This change aligns with Azure security best practices for passwordless authentication.*