### PR TITLE
docs: Add explicit User-Assigned Managed Identity (UAMI) example for Service Bus binding

### DIFF
--- a/includes/functions-service-bus-connections.md
+++ b/includes/functions-service-bus-connections.md
@@ -34,6 +34,29 @@ In this mode, the extension requires the following properties:
 | Fully Qualified Namespace | `<CONNECTION_NAME_PREFIX>__fullyQualifiedNamespace` | The fully qualified Service Bus namespace. | <service_bus_namespace>.servicebus.windows.net  |
 
 Additional properties may be set to customize the connection. See [Common properties for identity-based connections](../articles/azure-functions/functions-reference.md#common-properties-for-identity-based-connections).
+
+#### User-assigned managed identity
+
+To use a user-assigned managed identity, add the `credential` and `clientId` properties in addition to the `fullyQualifiedNamespace`:
+
+| Property                  | Environment variable template                       | Description                                | Example value |
+|---------------------------|-----------------------------------------------------|--------------------------------------------|---------|
+| Fully Qualified Namespace | `<CONNECTION_NAME_PREFIX>__fullyQualifiedNamespace` | The fully qualified Service Bus namespace. | `myservicebus.servicebus.windows.net`  |
+| Credential | `<CONNECTION_NAME_PREFIX>__credential` | Must be set to `managedidentity`. | `managedidentity` |
+| Client ID | `<CONNECTION_NAME_PREFIX>__clientId` | The client ID of the user-assigned managed identity. | `00000000-0000-0000-0000-000000000000` |
+
+For example, if your binding configuration specifies `connection = "ServiceBusConnection"`, you would configure the following application settings:
+
+```json
+{
+    "ServiceBusConnection__fullyQualifiedNamespace": "myservicebus.servicebus.windows.net",
+    "ServiceBusConnection__credential": "managedidentity",
+    "ServiceBusConnection__clientId": "00000000-0000-0000-0000-000000000000"
+}
+```
+
+> [!TIP]
+> User-assigned managed identities are recommended for production scenarios where you need fine-grained control over identity permissions across multiple resources.
 > [!NOTE]
 > When using [Azure App Configuration](../articles/azure-app-configuration/quickstart-azure-functions-csharp.md) or [Key Vault](../articles/key-vault/general/overview.md) to provide settings for Managed Identity connections, setting names should use a valid key separator such as `:` or `/` in place of the `__` to ensure names are resolved correctly.
 > 


### PR DESCRIPTION
## Summary

This PR adds a clearer example showing how to configure Service Bus connections using a **User-Assigned Managed Identity (UAMI)** with explicit app settings.

## Problem

The existing documentation mentions `credential` and `clientId` properties for user-assigned managed identities but lacks a concrete JSON example.

## Solution

Added a new **"User-assigned managed identity"** subsection with:
- A table showing the three required properties
- A complete JSON example developers can copy directly
- A tip explaining when UAMI is recommended

## Changes

- `includes/functions-service-bus-connections.md`: Added UAMI configuration example

## Related

- Event Hubs PR: https://github.com/MicrosoftDocs/azure-docs/pull/128219
- Tracking issue: https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/973