### PR TITLE
clarify Elastic SAN VG subnet ACLs for multi-nodepool AKS.md

### DIFF
--- a/articles/storage/container-storage/use-container-storage-with-elastic-san.md
+++ b/articles/storage/container-storage/use-container-storage-with-elastic-san.md
@@ -216,8 +216,8 @@ If you don't already have Azure Container Storage installed, [install it](instal
    az network vnet subnet update -g <node-resource-group> --vnet-name <vnet-name> --name <subnet-name> --service-endpoints "Microsoft.Storage"
    ```
 
-> [!IMPORTANT]
-> If your AKS cluster uses multiple node pools in different subnets, **you must include all node pool subnet IDs in the Elastic SAN volume group network ACLs**. Elastic SAN volume groups allow access only from the virtual network subnets explicitly authorized in the volume group rules, and requests from other subnets are blocked by default.
+   > [!IMPORTANT]
+   > If your AKS cluster uses multiple node pools in different subnets, **you must include all node pool subnet IDs in the Elastic SAN volume group network ACLs**. Elastic SAN volume groups allow access only from the virtual network subnets explicitly authorized in the volume group rules, and requests from other subnets are blocked by default.
 
 1. Create the volume group.
 

--- a/articles/storage/container-storage/use-container-storage-with-elastic-san.md
+++ b/articles/storage/container-storage/use-container-storage-with-elastic-san.md
@@ -216,6 +216,9 @@ If you don't already have Azure Container Storage installed, [install it](instal
    az network vnet subnet update -g <node-resource-group> --vnet-name <vnet-name> --name <subnet-name> --service-endpoints "Microsoft.Storage"
    ```
 
+> [!IMPORTANT]
+> If your AKS cluster uses multiple node pools in different subnets, **you must include all node pool subnet IDs in the Elastic SAN volume group network ACLs**. Elastic SAN volume groups allow access only from the virtual network subnets explicitly authorized in the volume group rules, and requests from other subnets are blocked by default.
+
 1. Create the volume group.
 
    ```azurecli


### PR DESCRIPTION
add explicit guidance for multi-subnet AKS node pools when using Elastic SAN (VG network ACLs)