### PR TITLE
Clarify Bastion domain controller requirement to include peered virtu…

### DIFF
--- a/articles/bastion/kerberos-authentication-portal.md
+++ b/articles/bastion/kerberos-authentication-portal.md
@@ -20,7 +20,7 @@ This article shows you how to configure Azure Bastion to use Kerberos authentica
 * The Kerberos setting for Azure Bastion can be configured in the Azure portal only and not with native client.
 * VMs migrated from on-premises to Azure aren't currently supported for Kerberos.
 * Cross-realm authentication isn't currently supported for Kerberos.
-* The Domain controller must be an Azure Hosted VM within the same virtual network that bastion is deployed.
+* The domain controller must be an Azure-hosted VM within the same virtual network as Bastion, or in a virtual network that is peered with the Bastion virtual network.
 * Changes to DNS servers don't propagate to Bastion. Bastion redeployment is needed for DNS info to properly propagate. After making any changes to DNS server, you'll need to delete and re-create the Bastion resource.
 * If more DCs (domain controllers) are added, Bastion will only recognize the first DC.
 * If more DCs are added for different domains, the added domains can't successfully authenticate with Kerberos.


### PR DESCRIPTION
Updates the Bastion domain controller requirement to reflect that the domain controller can be hosted in the same virtual network as Bastion or in a peered virtual network, improving accuracy for supported deployment scenarios.