### PR TITLE
Fixed binding errors reference link

### DIFF
--- a/articles/azure-functions/functions-triggers-bindings.md
+++ b/articles/azure-functions/functions-triggers-bindings.md
@@ -271,4 +271,4 @@ You can create custom input and output bindings. Bindings must be authored in .N
 - [Binding expressions and patterns](./functions-bindings-expressions-patterns.md)
 - [Register Azure Functions binding extensions](./functions-bindings-register.md)
 - [Manually run a non-HTTP-triggered function](functions-manually-run-non-http.md)
-- [Handling binding errors](./functions-bindings-errors.md)
+- [Handling binding errors](./functions-bindings-error-pages.md)


### PR DESCRIPTION
Fix incorrect “Handling binding errors” reference link to the correct error pages document.
No other changes.