### PR TITLE
Add instance ID limitation info to durable-task-scheduler.md

### DIFF
--- a/articles/azure-functions/durable/durable-task-scheduler/durable-task-scheduler.md
+++ b/articles/azure-functions/durable/durable-task-scheduler/durable-task-scheduler.md
@@ -152,6 +152,10 @@ Stale orchestration data should be purged periodically to ensure efficient stora
     | Orchestration custom status | 1 MB |
     | Entity state | 1 MB |
 
+- **Orchestration instance ID size:**
+  
+  Currently instance ID length is limited to 100 characters.
+
 - **Feature parity:** 
 
     [Extended sessions](../durable-functions-azure-storage-provider.md#extended-sessions) are not available in the Durable Task Scheduler backend yet.

--- a/articles/azure-functions/durable/durable-task-scheduler/durable-task-scheduler.md
+++ b/articles/azure-functions/durable/durable-task-scheduler/durable-task-scheduler.md
@@ -152,9 +152,9 @@ Stale orchestration data should be purged periodically to ensure efficient stora
     | Orchestration custom status | 1 MB |
     | Entity state | 1 MB |
 
-- **Orchestration instance ID size:**
+- **Orchestration instance ID length:**
   
-  Currently instance ID length is limited to 100 characters.
+  Orchestration instance IDs are limited to a maximum length of 100 UTF-16 code units (approximately 100 characters for ASCII-only IDs).
 
 - **Feature parity:** 
 

--- a/articles/azure-functions/durable/durable-task-scheduler/durable-task-scheduler.md
+++ b/articles/azure-functions/durable/durable-task-scheduler/durable-task-scheduler.md
@@ -154,7 +154,11 @@ Stale orchestration data should be purged periodically to ensure efficient stora
 
 - **Orchestration instance ID length:**
   
-  Orchestration instance IDs are limited to a maximum length of 100 UTF-16 code units (approximately 100 characters for ASCII-only IDs).
+  Orchestration instance IDs are limited to a maximum length of 100 characters.
+
+  * Allowed characters: Printable ASCII only (letters, numbers, symbols like -, _, ., etc. Characters 0x20 through 0x7E)
+  * Minimum length: 1 character (cannot be empty)
+  * Instance IDs starting with @ are reserved for entities
 
 - **Feature parity:** 
 


### PR DESCRIPTION
this is very important when migrating from Azure Storage provider