### PR TITLE
Fix missing tenantId and api-version in Teams Phone extensibility REST API docs

### DIFF
--- a/articles/communication-services/quickstarts/tpe/teams-phone-extensiblity-rest-api.md
+++ b/articles/communication-services/quickstarts/tpe/teams-phone-extensiblity-rest-api.md
@@ -35,8 +35,8 @@ PUT {endpoint}/access/teamsExtension/tenants/{tenantId}/assignments/{objectId}?a
 ### Request body
 
 | Name | In | Required | Type | Description |
-| --- | --- | --- |
-| `request ` | body | true | [TeamsExtensionAssignmentCreateOrUpdateRequest](#teamsextensionassignmentcreateorupdaterequest) | Request for teams account assignment. |
+| --- | --- | --- | --- | --- |
+| `request` | body | true | [TeamsExtensionAssignmentCreateOrUpdateRequest](#teamsextensionassignmentcreateorupdaterequest) | Request for teams account assignment. |
 
 ### Responses
 
@@ -51,14 +51,16 @@ PUT {endpoint}/access/teamsExtension/tenants/{tenantId}/assignments/{objectId}?a
 Get the assignment for a resource access from a Teams user or Teams resource account.
 
 ```http
-GET {endpoint}/access/teamsExtension/assignments/{objectId}?api-version=2025-06-30
+GET {endpoint}/access/teamsExtension/tenants/{tenantId}/assignments/{objectId}?api-version=2025-06-30
 ```
 
 ### URI parameters
 
 | Name | In | Required | Type | Description |
-| --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | `objectId` | path | true | string | Object ID of the principal, that is, the user ID or resource account ID. |
+| `tenantId` | path | true | string | Tenant ID of the tenant that the principal belongs to. |
+| `api-version` | query | true | string | Version of API to invoke. |
 
 ### Responses
 
@@ -72,14 +74,16 @@ GET {endpoint}/access/teamsExtension/assignments/{objectId}?api-version=2025-06-
 Delete the assignment to remove resource access from a Teams user or Teams resource account.
 
 ```http
-DELETE {endpoint}/access/teamsExtension/assignments/{objectId}?api-version=2025-06-30
+DELETE {endpoint}/access/teamsExtension/tenants/{tenantId}/assignments/{objectId}?api-version=2025-06-30
 ```
 
 ### URI parameters
 
 | Name | In | Required | Type | Description |
-| --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | `objectId` | path | true | string | Object ID of the principal, that is, the user ID or resource account ID. |
+| `tenantId` | path | true | string | Tenant ID of the tenant that the principal belongs to. |
+| `api-version` | query | true | string | Version of API to invoke. |
 
 ### Responses
 


### PR DESCRIPTION
## Summary

This PR fixes documentation errors in the Teams Phone extensibility REST API reference page.

### Changes

1. **GET endpoint URL**: Added missing `tenants/{tenantId}/` path segment to match the Create (PUT) endpoint pattern
2. **DELETE endpoint URL**: Added missing `tenants/{tenantId}/` path segment to match the Create (PUT) endpoint pattern  
3. **GET URI parameters table**: Added missing `tenantId` and `api-version` parameters
4. **DELETE URI parameters table**: Added missing `tenantId` and `api-version` parameters
5. **Request body table**: Fixed table separator row (was 3 columns, should be 5 to match header)
6. **Request body field name**: Removed trailing space inside backticks (`request ` → `request`)

### Details

The Create assignment endpoint correctly shows:
\\\
PUT {endpoint}/access/teamsExtension/tenants/{tenantId}/assignments/{objectId}?api-version=2025-06-30
\\\

But the GET and DELETE endpoints were missing `tenants/{tenantId}/` from their URLs and their URI parameter tables did not list `tenantId` or `api-version`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>