### PR TITLE
Adds dnsConfiguration property to the list of deprecated settings for…

### DIFF
--- a/articles/azure-functions/functions-app-settings.md
+++ b/articles/azure-functions/functions-app-settings.md
@@ -973,6 +973,7 @@ In the [Flex Consumption plan](./flex-consumption-plan.md), these site propertie
 | `WEBSITE_VNET_ROUTE_ALL` |Not used for networking in Flex Consumption|
 | `properties.alwaysOn` |Not valid|
 | `properties.containerSize` |Renamed as `instanceMemoryMB`|
+| `properties.dnsConfiguration` | Custom DNS servers configured in the Azure Virtual Network are automatically used|
 | `properties.ftpsState` | FTPS not supported | 
 | `properties.isReserved` |Not valid|
 | `properties.IsXenon` |Not valid|


### PR DESCRIPTION
Adds dnsConfiguration property to the list of deprecated settings for Flex Consumption.  This property does not need to be configured for Flex Consumption and instead the custom DNS servers should be configured on the VNet directly. 