### PR TITLE
Fix wrong lowest 'Maximum scale count' for Flex Consumption

### DIFF
--- a/articles/azure-functions/flex-consumption-plan.md
+++ b/articles/azure-functions/flex-consumption-plan.md
@@ -193,7 +193,7 @@ Keep these other considerations in mind when using Flex Consumption plan:
 + **Regions**: While the Flex Consumption plan is available in many Azure regions, not all regions are currently supported. To learn more, see [View currently supported regions](flex-consumption-how-to.md#view-currently-supported-regions).
 + **Deployments**: Deployment slots aren't currently supported. For zero downtime deployments with Flex Consumption, see [Site update strategies in Flex Consumption](flex-consumption-site-updates.md).
 + **Azure Storage as a local share**: Network File System (NFS) file shares aren't available for Flex Consumption. Only Server Message Block (SMB) and Azure Blobs (read-only) are supported.
-+ **Scale**: The lowest maximum scale is currently `1`. The highest currently supported value is `1000`.
++ **Scale**: The lowest maximum scale is currently `40`. The highest currently supported value is `1000`.
 + **PowerShell Managed dependencies**: Flex Consumption doesn't support [managed dependencies in PowerShell](functions-reference-powershell.md#managed-dependencies-feature). You must instead [upload modules with app content](functions-reference-powershell.md#including-modules-in-app-content).
 + **Certificates**: Loading certificates with the WEBSITE_LOAD_CERTIFICATES app setting, managed certificates, app service certificates, and other platform certificate-based features like endToEndEncryptionEnabled are currently not supported.
 + **Timezones**: `WEBSITE_TIME_ZONE` and `TZ` app settings aren't currently supported when running on Flex Consumption plan.


### PR DESCRIPTION
Currently the documentation states that the lowest `Maximum scale count` is `1` for Flex Consumption while in reality this is `40`.

Another documentation page on Microsoft Learn states this correctly:

https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling?tabs=azure-cli#flex-consumption-plan