### PR TITLE
Update secure-file-transfer-protocol-known-issues.md

### DIFF
--- a/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
@@ -73,9 +73,9 @@ To learn more, see [SFTP permission model](secure-file-transfer-protocol-support
 
 ### Default ACLs and extended ACLs
 
-SFTP doesn't currently support **default ACLs** or **extended ACL entries** (ACL entries beyond the POSIX `user::`, `group::`, and `other::` entries, such as named users or named groups).
+SFTP doesn't currently support **default ACLs** or **extended ACLs** (ACL entries beyond the POSIX `user::`, `group::`, and `other::` entries, such as named users or named groups).
 
-If any directory in the access path (including the user's home directory) has default ACLs or extended ACL entries set, SFTP operations can fail with `Permission denied`, even when the connecting user isn't referenced by those ACL entries.
+If any directory in the access path (including the user's home directory) has default ACLs or extended ACLs set, SFTP operations can fail with `Permission denied`, even when the connecting user isn't referenced by those ACL entries.
 
 ## Other
 

--- a/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
@@ -71,6 +71,12 @@ To learn more, see [SFTP permission model](secure-file-transfer-protocol-support
 
 - There's a 2-minute time out for idle or inactive connections. OpenSSH will appear to stop responding and then disconnect. Some clients reconnect automatically.
 
+### Default ACLs and extended ACLs
+
+SFTP doesn't currently support **default ACLs** or **extended ACL entries** (ACL entries beyond the POSIX `user::`, `group::`, and `other::` entries, such as named users or named groups).
+
+If any directory in the access path (including the user's home directory) has default ACLs or extended ACL entries set, SFTP operations can fail with `Permission denied`, even when the connecting user isn't referenced by those ACL entries.
+
 ## Other
 
 - For performance issues and considerations, see [SSH File Transfer Protocol (SFTP) performance considerations in Azure Blob storage](secure-file-transfer-protocol-performance.md).

--- a/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
+++ b/articles/storage/blobs/secure-file-transfer-protocol-known-issues.md
@@ -76,7 +76,7 @@ To learn more, see [SFTP permission model](secure-file-transfer-protocol-support
 SFTP doesn't currently support **default ACLs** or **extended ACLs** (ACL entries beyond the POSIX `user::`, `group::`, and `other::` entries, such as named users or named groups).
 
 If any directory in the access path (including the user's home directory) has default ACLs or extended ACLs set, SFTP operations can fail with `Permission denied`, even when the connecting user isn't referenced by those ACL entries.
-
+Workaround: Remove default ACLs and any extended ACL entries from all directories in the SFTP access path (including the user's home directory) so that only POSIX `user::`, `group::`, and `other::` entries remain before attempting the SFTP operation again.
 ## Other
 
 - For performance issues and considerations, see [SSH File Transfer Protocol (SFTP) performance considerations in Azure Blob storage](secure-file-transfer-protocol-performance.md).


### PR DESCRIPTION
Adding a known limitation to SFTP docs. Default ACLs and Extended ACLs aren't supported for local users.