### PR TITLE
Docs: Fix consistency and adhere to imperative mood guidelines

### DIFF
--- a/articles/traffic-manager/index.yml
+++ b/articles/traffic-manager/index.yml
@@ -49,7 +49,7 @@ landingContent:
             url: traffic-manager-configure-geographic-routing-method.md
           - text: Configure the weighted traffic routing method
             url: traffic-manager-configure-weighted-routing-method.md
-          - text: Configure priority traffic routing method
+          - text: Configure the priority traffic routing method
             url: traffic-manager-configure-priority-routing-method.md
           - text: Control traffic routing with weighted endpoints
             url: tutorial-traffic-manager-weighted-endpoint-routing.md
@@ -73,7 +73,7 @@ landingContent:
             url: traffic-manager-manage-endpoints.md
           - text: Manage a Traffic Manager profile
             url: traffic-manager-manage-profiles.md
-          - text: Using load-balancing services in Azure
+          - text: Use load-balancing services in Azure
             url: traffic-manager-load-balancing-azure.md
           - text: Point a company Internet domain to an Azure Traffic Manager domain
             url: traffic-manager-point-internet-domain.md


### PR DESCRIPTION
This PR makes two minor corrections to align the landing page with Microsoft's documentation style guidelines:
1. Changed "Using load-balancing..." to imperative mood "Use load-balancing..." for consistency with surrounding how-to links.
2. Added the missing article "the" to "Configure the priority traffic routing method" to match the parallel structure of adjacent list items.