### PR TITLE
Add Device Update Contributor Role

### DIFF
--- a/articles/iot-hub-device-update/configure-access-control-device-update.md
+++ b/articles/iot-hub-device-update/configure-access-control-device-update.md
@@ -24,6 +24,7 @@ For users to access Azure Device Update for IoT Hub, you must grant them access 
 
 The following roles are available for assigning access to Device Update:
 
+- Device Update Contributor
 - Device Update Administrator
 - Device Update Reader
 - Device Update Content Administrator

--- a/articles/iot-hub-device-update/device-update-control-access.md
+++ b/articles/iot-hub-device-update/device-update-control-access.md
@@ -21,7 +21,7 @@ Device Update supports the following RBAC roles. For more information, see [Conf
 
 |   Role Name   | Description  |
 | :--------- | :---- |
-|  Device Update Contributor | Can manage all Device update resources  |
+|  Device Update Contributor | Can manage all Device Update resources  |
 |  Device Update Administrator | Has access to all Device Update resources  |
 |  Device Update Reader| Can view all updates and deployments |
 |  Device Update Content Administrator | Can view, import, and delete updates  |

--- a/articles/iot-hub-device-update/device-update-control-access.md
+++ b/articles/iot-hub-device-update/device-update-control-access.md
@@ -21,6 +21,7 @@ Device Update supports the following RBAC roles. For more information, see [Conf
 
 |   Role Name   | Description  |
 | :--------- | :---- |
+|  Device Update Contributor | Can manage all Device update resources  |
 |  Device Update Administrator | Has access to all Device Update resources  |
 |  Device Update Reader| Can view all updates and deployments |
 |  Device Update Content Administrator | Can view, import, and delete updates  |


### PR DESCRIPTION
Add Device Update Contributor role to Device Update RBAC docs

# Description
This PR updates Azure Device Update for IoT Hub documentation to include the Device Update Contributor role in RBAC role listings and improve role ordering for discoverability.

# What changed
- Added Device Update Contributor to the role list in [configure-access-control-device-update.md](vscode-file://vscode-app/c:/Users/laonyango/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Added Device Update Contributor to the RBAC roles table in [device-update-control-access.md](vscode-file://vscode-app/c:/Users/laonyango/AppData/Local/Programs/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
- Set the role description to: Can manage all Device update resources.