### PR TITLE
Fix typo in subscriptionResourceID to subscriptionResourceId

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-functions-resource.md
+++ b/articles/azure-resource-manager/bicep/bicep-functions-resource.md
@@ -681,7 +681,7 @@ The identifier is returned in the following format:
 
 You use this function to get the resource ID for resources that are [deployed to the subscription](deploy-to-subscription.md) rather than a resource group. The returned ID differs from the value returned by the [resourceId](#resourceid) function by not including a resource group value.
 
-### subscriptionResourceID example
+### subscriptionResourceId example
 
 The following Bicep file assigns a built-in role. You can deploy it to either a resource group or subscription. It uses the `subscriptionResourceId` function to get the resource ID for built-in roles.
 


### PR DESCRIPTION
This pull request makes a minor documentation update to the Bicep functions article. The change corrects the casing of a section heading for consistency with function naming conventions.

- Documentation update:
  * Changed the section heading from `subscriptionResourceID example` to `subscriptionResourceId example` in `bicep-functions-resource.md` for consistency with the function name.