### PR TITLE
fix: specify type for client parameter in http_start for python 3.14

### DIFF
--- a/articles/azure-functions/durable/quickstart-python-vscode.md
+++ b/articles/azure-functions/durable/quickstart-python-vscode.md
@@ -132,7 +132,7 @@ myApp = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 # An HTTP-triggered function with a Durable Functions client binding
 @myApp.route(route="orchestrators/{functionName}")
 @myApp.durable_client_input(client_name="client")
-async def http_start(req: func.HttpRequest, client):
+async def http_start(req: func.HttpRequest, client: str):
     function_name = req.route_params.get('functionName')
     instance_id = await client.start_new(function_name)
     response = client.create_check_status_response(req, instance_id)


### PR DESCRIPTION
This pull request makes a minor update to the function signature for the `http_start` route in the Durable Functions Python quickstart documentation. The change clarifies the type of the `client` parameter.

* Updated the `http_start` function definition to specify that the `client` parameter is of type `str` instead of an unspecified type, improving code clarity and type safety in the example.

## Why

On Python 3.14 the example will fail to run due to this error:

```
>func start

Azure Functions Core Tools
Core Tools Version:       4.7.0+af9404fa5872d8fa5fa2454a7cfeb2ee0cda2832 (64-bit)
Function Runtime Version: 4.1045.200.25556

[2026-03-10T23:42:38.771Z] Durable Functions Distributed Tracing V2 is GA now! Learn how to enable the feature by visiting aka.ms/durable-distributed-tracing. To disable this message, you can configure distributedTracingEnabled to "true" and version to "V2" or "None". Setting it to "None" would in effect disable the feature.
[2026-03-10T23:42:38.991Z] Worker process started and initialized.

Functions:

        http_start:  http://localhost:7071/api/orchestrators/{functionName}

        hello: activityTrigger

        hello_orchestrator: orchestrationTrigger

[2026-03-10T23:42:43.523Z] Executing 'Functions.http_start' (Reason='This function was programmatically called via the host APIs.', Id=2156522f-4e68-4df8-8ed4-467fca8a833e)
[2026-03-10T23:42:43.613Z] Executed 'Functions.http_start' (Failed, Id=2156522f-4e68-4df8-8ed4-467fca8a833e, Duration=111ms)
[2026-03-10T23:42:43.614Z] System.Private.CoreLib: Exception while executing function: Functions.http_start. System.Private.CoreLib: Result: Failure
Type:
Exception: TypeError: unable to decode incoming TypedData: unsupported combination of TypedData field 'string' and expected binding type <class 'azure.functions.durable_functions.DurableClientConverter'>
Stack:   File "C:\Program Files\Microsoft\Azure Functions Core Tools\workers\python\3.14\WINDOWS\X64\azure_functions_runtime\handle_event.py", line 201, in invocation_request
    args[pb.name] = from_incoming_proto(
  File "C:\Program Files\Microsoft\Azure Functions Core Tools\workers\python\3.14\WINDOWS\X64\azure_functions_runtime\bindings\meta.py", line 193, in from_incoming_proto    
    raise TypeError(
.
```

At my company we have to use 3.14 and cannot rollback to older versions. Clarifying the type to `str` for client resolves this error. I believe this to be a non-breaking change for previous python versions.