### PR TITLE
Add HCX Assisted vMotion to HCX migration options

### DIFF
--- a/articles/azure-vmware/architecture-migrate.md
+++ b/articles/azure-vmware/architecture-migrate.md
@@ -19,6 +19,7 @@ VMware HCX offers five options with the HCX Enterprise Edition license when migr
 - Bulk Migration
 - Replication Assisted vMotion
 - OS Assisted Migration
+- HCX Assisted vMotion
 
 The cost of the VMware HCX Enterprise Edition license is included in the cost of the Azure VMware Solution service.
 

--- a/articles/azure-vmware/architecture-migrate.md
+++ b/articles/azure-vmware/architecture-migrate.md
@@ -12,7 +12,7 @@ ms.custom: engagement-fy24
 
 # VMware HCX migration considerations
 
-VMware HCX offers five options with the HCX Enterprise Edition license when migrating VMware vSphere virtual machines to the Azure VMware Solution:
+VMware HCX offers six options with the HCX Enterprise Edition license when migrating VMware vSphere virtual machines to the Azure VMware Solution:
 
 - Cold Migration
 - HCX vMotion


### PR DESCRIPTION
From HCX 4.10 broadcom introuduced this HCX Assited vMotion to support line rate assisted vMotions direct from Host to Host rather than Host to IX to IX to Host. Can we update all our relevant documentation to include this option please. The CSS at microssft is referring to this page with missing HAV and not supporting the customers who want to use HAV