### PR TITLE
Update resource name rules for Microsoft.Compute/galleries

### DIFF
--- a/articles/azure-resource-manager/management/resource-name-rules.md
+++ b/articles/azure-resource-manager/management/resource-name-rules.md
@@ -214,7 +214,7 @@ In the following tables, the term alphanumeric refers to:
 > | cloudservices | resource group | 1-15 <br><br>See note below. | Can't use spaces, control characters, or these characters:<br> `~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \ | ; : . ' " , < > / ?`<br><br>Can't start with underscore. Can't end with period or hyphen. |
 > | diskEncryptionSets | resource group | 1-80 | Alphanumerics, underscores, and hyphens |
 > | disks | resource group | 1-80 | Alphanumerics, underscores, and hyphens |
-> | galleries | resource group | 1-80 | Alphanumerics and periods<br><br>Start and end with alphanumeric. |
+> | galleries | resource group | 1-80 | Alphanumerics, underscores, and periods<br><br>Start and end with alphanumeric. |
 > | galleries / applications | gallery | 1-80 | Alphanumerics, hyphens, and periods<br><br>Start and end with alphanumeric. |
 > | galleries / applications/versions | application | 32-bit integer | Numbers and periods<br/>(Each segment is converted to an int32. So each segment has a max value of 2,147,483,647.) |
 > | galleries / images | gallery | 1-80 | Alphanumerics, underscores, hyphens, and periods<br><br>Start and end with alphanumeric. |


### PR DESCRIPTION
From the Azure portal name validation:
> Azure compute gallery name must contain only English letters, numbers, underscores, and periods. The name cannot begin or end with underscores or periods.