### PR TITLE
Repeated information

### DIFF
--- a/articles/dns/dns-faq-private.yml
+++ b/articles/dns/dns-faq-private.yml
@@ -43,11 +43,6 @@ sections:
           Yes. You must have write operation permission on the virtual networks and the private DNS zone. The write permission can be granted to several Azure roles. For example, the Classic Network Contributor Azure role has write permissions to virtual networks and Private DNS zones Contributor role has write permissions on the private DNS zones. For more information on Azure roles, see [Azure role-based access control (Azure RBAC)](../role-based-access-control/overview.md).
 
       - question: |
-          Can a virtual network that belongs to a different tenant be linked to a private zone?
-        answer: |
-          Yes. You must have write operation permission on the virtual networks and the private DNS zone in both tenants. The write permission can be granted to several Azure roles. For example, the Classic Network Contributor Azure role has write permissions to virtual networks and Private DNS zones Contributor role has write permissions on the private DNS zones. For more information on Azure roles, see [Azure role-based access control (Azure RBAC)](../role-based-access-control/overview.md).
-
-      - question: |
           What causes the automatically registered virtual machine DNS records in a private zone be created or deleted?
         answer: |
           When you start a virtual machine within a linked virtual network with autoregistration enabled, DNS records are automatically created for that virtual machine. When you stop a virtual machine and it is deallocated, the autoregistered DNS records are removed.


### PR DESCRIPTION
This information appears twice in the FAQ.

Can a virtual network that belongs to a different subscription be linked to a private zone? Yes. You must have write operation permission on the virtual networks and the private DNS zone. The write permission can be granted to several Azure roles. For example, the Classic Network Contributor Azure role has write permissions to virtual networks and Private DNS zones Contributor role has write permissions on the private DNS zones. For more information on Azure roles, see Azure role-based access control (Azure RBAC).

Can a virtual network that belongs to a different tenant be linked to a private zone? Yes. You must have write operation permission on the virtual networks and the private DNS zone in both tenants. The write permission can be granted to several Azure roles. For example, the Classic Network Contributor Azure role has write permissions to virtual networks and Private DNS zones Contributor role has write permissions on the private DNS zones. For more information on Azure roles, see Azure role-based access control (Azure RBAC).

Therefore, please remove the duplicate and update the information so it appears only once.