### PR TITLE
Remove 'Microsoft Confidential' notice from public doc

### DIFF
--- a/articles/application-gateway/mutual-authentication-arm-template.md
+++ b/articles/application-gateway/mutual-authentication-arm-template.md
@@ -388,4 +388,4 @@ az deployment group create \
 
 ## Security notice
 
-This solution is classified as **Microsoft Confidential**. Please ensure you follow your organization’s security and data handling best practices when deploying and managing this solution.
+Please ensure you follow your organization’s security and data handling best practices when deploying and managing this solution.


### PR DESCRIPTION
This PR removes a “Microsoft Confidential” security notice from a publicly published Azure Docs article.

The content is intended for internal use and is not appropriate for a public-facing document. No other changes were made.