### PR TITLE
Update CORS policy documentation for headers

### DIFF
--- a/articles/api-management/cors-policy.md
+++ b/articles/api-management/cors-policy.md
@@ -80,13 +80,13 @@ The `cors` policy adds cross-origin resource sharing (CORS) support to an operat
 
 |Name|Description|Required|Default|
 |----------|-----------------|--------------|-------------|
-|header|Specifies a header name.|At least one `header` element is required in `allowed-headers` if that section is present.|N/A|
+|header|Specifies a header name.|At least one `header` element is required in `allowed-headers` if that section is present.|N/A|The value * indicates all headers.
 
 ### expose-headers elements
 
 |Name|Description|Required|Default|
 |----------|-----------------|--------------|-------------|
-|header|Specifies a header name.|At least one `header` element is required in `expose-headers` if that section is present.|N/A|
+|header|Specifies a header name.|At least one `header` element is required in `expose-headers` if that section is present.|N/A|The value * indicates all headers.
 
 ## Usage
 

--- a/articles/api-management/cors-policy.md
+++ b/articles/api-management/cors-policy.md
@@ -80,13 +80,17 @@ The `cors` policy adds cross-origin resource sharing (CORS) support to an operat
 
 |Name|Description|Required|Default|
 |----------|-----------------|--------------|-------------|
-|header|Specifies a header name.|At least one `header` element is required in `allowed-headers` if that section is present.|N/A|The value * indicates all headers.
+|header|Specifies a header name.|At least one `header` element is required in `allowed-headers` if that section is present.|N/A|
+
+The value `*` indicates all headers.
 
 ### expose-headers elements
 
 |Name|Description|Required|Default|
 |----------|-----------------|--------------|-------------|
-|header|Specifies a header name.|At least one `header` element is required in `expose-headers` if that section is present.|N/A|The value * indicates all headers.
+|header|Specifies a header name.|At least one `header` element is required in `expose-headers` if that section is present.|N/A|
+
+The value `*` indicates all headers.
 
 ## Usage
 


### PR DESCRIPTION
For allowed-headers and expose-headers elements section - Added the statement : The value * indicates all headers.