### PR TITLE
Add note on Spark table column limit for SQL queries

### DIFF
--- a/articles/synapse-analytics/metadata/overview.md
+++ b/articles/synapse-analytics/metadata/overview.md
@@ -16,6 +16,10 @@ Azure Synapse Analytics allows the different workspace computational engines to 
 
 The sharing supports the so-called modern data warehouse pattern and gives the workspace SQL engines access to databases and tables created with Spark. It also allows the SQL engines to create their own objects that aren't being shared with the other engines.
 
+> [!IMPORTANT]
+> Tables created in Spark with more than 1,024 columns may appear in Object Explorer but can't be queried from the serverless SQL pool due to incomplete metadata synchronization.
+>
+> **Workaround**: Avoid creating Spark tables with more than 1,024 columns if they need to be queried from the serverless SQL pool. Redesign the schema and recreate the table.
 ## Support the modern data warehouse
 
 The shared metadata model supports the modern data warehouse pattern in the following way:


### PR DESCRIPTION
Added important note about Spark tables with over 1,024 columns and provided a workaround.