### PR TITLE
Add Japan East to the list Application Gateway for Containers: Japan …

### DIFF
--- a/articles/application-gateway/for-containers/overview.md
+++ b/articles/application-gateway/for-containers/overview.md
@@ -105,6 +105,7 @@ Application Gateway for Containers is currently offered in the following regions
 - East US2
 - France Central
 - Germany West Central
+- Japan East
 - Korea Central
 - North Central US
 - North Europe


### PR DESCRIPTION
In the Azure Portal, Japan East is selectable as the deployment region for Application Gateway for Containers, and deployment succeeds. However, the documentation page does not list Japan East under Supported regions. Could you confirm whether Japan East is officially supported/GA, and update the documentation accordingly?