### PR TITLE
docs: add warning for self-hosted IR overwrite during ARM deployment in CI/CD

### DIFF
--- a/articles/data-factory/continuous-integration-delivery-linked-templates.md
+++ b/articles/data-factory/continuous-integration-delivery-linked-templates.md
@@ -37,10 +37,10 @@ When deploying your resources, you specify that the deployment is either an incr
 ## Considerations for shared self-hosted integration runtimes
 
 > [!WARNING]
-> When deploying linked ARM templates to an environment that uses a **linked (shared) self-hosted integration runtime**, the ARM deployment will overwrite the linked IR configuration with a plain self-hosted IR definition that has no registered nodes. This causes the IR to become **Unavailable**, breaking all linked services that depend on it.
+> When deploying linked ARM templates to an environment that uses a **linked (shared) self-hosted integration runtime**, the Resource Manager deployment will overwrite the linked IR configuration with a plain self-hosted IR definition that has no registered nodes. This causes the IR to become **Unavailable**, breaking all linked services that depend on it.
 > This happens because the linked ARM templates generated during publish always export integration runtimes as standalone `Microsoft.DataFactory/factories/integrationRuntimes` resources, with no awareness of linked IR relationships in target environments.
 
-To prevent this, add a step in your CI/CD pipeline to remove IR resource definitions from the linked template files **before** the ARM deployment step. If the target environment uses a different IR name than the source factory, add a rename step after the removal. The shared IR in the target environment remains intact and all linked services continue to resolve correctly after deployment.
+To prevent this, add a step in your CI/CD pipeline to remove IR resource definitions from the linked template files **before** the Resource Manager deployment step. If the target environment uses a different IR name than the source factory, add a rename step after the removal. The shared IR in the target environment remains intact and all linked services continue to resolve correctly after deployment.
 
 ## Related content
 

--- a/articles/data-factory/continuous-integration-delivery-linked-templates.md
+++ b/articles/data-factory/continuous-integration-delivery-linked-templates.md
@@ -34,6 +34,14 @@ If you don't have Git configured, you can access the linked templates via **Expo
 
 When deploying your resources, you specify that the deployment is either an incremental update or a complete update. The difference between these two modes is how Resource Manager handles existing resources in the resource group that aren't in the template. Review [Deployment Modes](../azure-resource-manager/templates/deployment-modes.md).
 
+## Considerations for shared self-hosted integration runtimes
+
+> [!WARNING]
+> When deploying linked ARM templates to an environment that uses a **linked (shared) self-hosted integration runtime**, the ARM deployment will overwrite the linked IR configuration with a plain self-hosted IR definition that has no registered nodes. This causes the IR to become **Unavailable**, breaking all linked services that depend on it.
+> This happens because the linked ARM templates generated during publish always export integration runtimes as standalone `Microsoft.DataFactory/factories/integrationRuntimes` resources, with no awareness of linked IR relationships in target environments.
+
+To prevent this, add a step in your CI/CD pipeline to remove IR resource definitions from the linked template files **before** the ARM deployment step. If the target environment uses a different IR name than the source factory,add a rename step after the removal.The shared IR in the target environment remains intact and all linked services continue to resolve correctly after deployment.
+
 ## Related content
 
 - [Continuous integration and delivery overview](continuous-integration-delivery.md)

--- a/articles/data-factory/continuous-integration-delivery-linked-templates.md
+++ b/articles/data-factory/continuous-integration-delivery-linked-templates.md
@@ -40,7 +40,7 @@ When deploying your resources, you specify that the deployment is either an incr
 > When deploying linked ARM templates to an environment that uses a **linked (shared) self-hosted integration runtime**, the ARM deployment will overwrite the linked IR configuration with a plain self-hosted IR definition that has no registered nodes. This causes the IR to become **Unavailable**, breaking all linked services that depend on it.
 > This happens because the linked ARM templates generated during publish always export integration runtimes as standalone `Microsoft.DataFactory/factories/integrationRuntimes` resources, with no awareness of linked IR relationships in target environments.
 
-To prevent this, add a step in your CI/CD pipeline to remove IR resource definitions from the linked template files **before** the ARM deployment step. If the target environment uses a different IR name than the source factory,add a rename step after the removal.The shared IR in the target environment remains intact and all linked services continue to resolve correctly after deployment.
+To prevent this, add a step in your CI/CD pipeline to remove IR resource definitions from the linked template files **before** the ARM deployment step. If the target environment uses a different IR name than the source factory, add a rename step after the removal. The shared IR in the target environment remains intact and all linked services continue to resolve correctly after deployment.
 
 ## Related content
 


### PR DESCRIPTION
docs: add warning for self-hosted IR overwrite during ARM deployment in CI/CD