### PR TITLE
Remove Japan West from the documentation

### DIFF
--- a/articles/app-service/app-service-configure-premium-v4-tier.md
+++ b/articles/app-service/app-service-configure-premium-v4-tier.md
@@ -111,7 +111,6 @@ Premium v4 is available in the following regions:
 - Indonesia Central<sup>*</sup>
 - Italy North<sup>*</sup>
 - Japan East
-- Japan West<sup>*</sup>
 - Korea Central<sup>*</sup>
 - Mexico Central
 - North Central US


### PR DESCRIPTION
Removed Japan West from the documentation since the region is not supported.

Command execution results

`az appservice list-locations --sku P1V4 --output table`

> Name
> ----
> Canada Central
> North Europe
> West Europe
> Southeast Asia
> East Asia
> West US
> Japan East
> East US 2
> North Central US
> Australia East
> Central US
> East US
> Central India
> Central US (Stage)
> West Central US
> West US 2
> UK South
> Korea Central
> France Central
> South Africa North
> Switzerland North
> Germany West Central
> UAE North
> Norway East
> West US 3
> Sweden Central
> Poland Central
> Italy North
> Spain Central
> Mexico Central
> Indonesia Central


`az appservice list-locations --sku P1V4 --query "[?name=='Japan West']" -o json
`
> []


Azure CLI is updated to 2.84.0 (latest in this environment).
P1V4-supported regions are listed above, and Japan West is not included.
The explicit filter query also returned an empty array, which confirms that Japan West currently does not support P1V4.