### PR TITLE
Update Dynatrace manage page: document Install Extension permission requirements

### DIFF
--- a/articles/partner-solutions/dynatrace/manage.md
+++ b/articles/partner-solutions/dynatrace/manage.md
@@ -3,7 +3,7 @@ title: Manage settings for your Dynatrace resource via Azure portal
 description: Manage settings, view resources, reconfigure metrics/logs, and more for your Dynatrace resource via Azure portal.
 
 ms.topic: how-to
-ms.date: 10/21/2025
+ms.date: 03/30/2026
 
 ---
 
@@ -61,16 +61,26 @@ You can install Dynatrace OneAgents on virtual machines, App Service extensions,
 
 To monitor resources for virtual machines, select **Dynatrace environment config > Virtual Machines** from the Resource pane.
 
-> [!IMPORTANT]
->
-> - If the virtual machine is stopped, installing the Dynatrace OneAgent is disabled. Dynatrace OneAgent can only be installed on virtual machines that are running.    
-> - If a virtual machine shows that a OneAgent is installed and the option Uninstall extension is disabled, another resource configured the agent. To make changes, go to the other Dynatrace resource in the Azure subscription.
+The **Install Extension** button is enabled when all of the following conditions are met:
+
+- The virtual machine is **Running** (not stopped or deallocated).
+- The Dynatrace OneAgent is **not already installed** on the virtual machine.
+- You have **Owner** or **Contributor** permissions on the subscription where the virtual machine resides. Users with only **Reader** (or lower) permissions can't install the extension.
+
+> [!NOTE]
+> If a virtual machine shows that a OneAgent is installed and the option **Uninstall extension** is disabled, another Dynatrace resource configured the agent. To make changes, go to the other Dynatrace resource in the Azure subscription.
 
 [!INCLUDE [agent](../includes/agent.md)]
 
 #### [App Service](#tab/app-service)
 
 To monitor resources for App Service, select **Dynatrace environment config > App Service** from the Resource pane.
+
+The **Install Extension** button is enabled when all of the following conditions are met:
+
+- The App Service resource is **Running** (not stopped or deallocated).
+- The Dynatrace OneAgent is **not already installed** on the App Service resource.
+- You have **Owner** or **Contributor** permissions on the subscription where the App Service resource resides. Users with only **Reader** (or lower) permissions can't install the extension.
 
 [!INCLUDE [agent](../includes/agent.md)]
 


### PR DESCRIPTION
## Description
Updates the Dynatrace manage documentation to include Install Extension button prerequisites for Virtual Machines and App Service blades.

### Changes:
- **Virtual Machines tab**: Added conditions under which the Install Extension button is enabled (VM running, agent not installed, Owner/Contributor permissions required)
- **App Service tab**: Added same conditions for App Service resources
- Updated ms.date to 03/30/2026

### Related:
- ADO Work Item: [#32931656](https://msazure.visualstudio.com/Liftr/_workitems/edit/32931656)
- ADO Task: [#36968577](https://msazure.visualstudio.com/Liftr/_workitems/edit/36968577) - Update Documentation: Changed permissions for all blades install extension
- IcM Incident: [630877232](https://portal.microsofticm.com/imp/v5/incidents/details/630877232/summary)

The original code required Owner-level permissions for the Install Extension button, which caused it to be greyed out for Contributor users. The code fix (PR #14995861 in Liftr.Services) changed this to require only resource-specific permissions. This PR documents the updated permission requirements.