### PR TITLE
fix: Move Microsoft TLS ECC and RSA Root G2 certs to roots section

### DIFF
--- a/articles/security/fundamentals/azure-certificate-authority-details.md
+++ b/articles/security/fundamentals/azure-certificate-authority-details.md
@@ -43,6 +43,8 @@ To determine when a certificate expires, download the certificate file and view 
 | [DigiCert TLS RSA 4096 Root G5](https://cacerts.digicert.com/DigiCertTLSRSA4096RootG5.crt) | 0x08f9b478a8fa7eda6a333789de7ccf8a<br>A78849DC5D7C758C8CDE399856B3AAD0B2A57135 |
 | [Microsoft ECC Root Certificate Authority 2017](https://www.microsoft.com/pkiops/certs/Microsoft%20ECC%20Root%20Certificate%20Authority%202017.crt) | 0x66f23daf87de8bb14aea0c573101c2ec<br>999A64C37FF47D9FAB95F14769891460EEC4C3C5 |
 | [Microsoft RSA Root Certificate Authority 2017](https://www.microsoft.com/pkiops/certs/Microsoft%20RSA%20Root%20Certificate%20Authority%202017.crt) | 0x1ed397095fd8b4b347701eaabe7f45b3<br>73A5E64A3BFF8316FF0EDCCC618A906E4EAE4D74 |
+| [Microsoft TLS ECC Root G2](https://caissuers.microsoft.com/pkiops/certs/Microsoft%20TLS%20ECC%20Root%20G2%20-%20xsign.crt) | 0x08d3c6d001f26cb5a23f0c7d6a73ffb6 </br> 7FA05ACF9B4AABB0DE0CFAFA297DDF92FDC5F3F5 |
+| [Microsoft TLS RSA Root G2](https://caissuers.microsoft.com/pkiops/certs/Microsoft%20TLS%20RSA%20Root%20G2%20-%20xsign.crt) | 0x0b0c6b2c466917b04773c647d4afc0c8 </br> B5EE89E77326AB2BF1775BD99C19A28947FF8184 |
 
 ### Subordinate Certificate Authorities
 
@@ -74,7 +76,6 @@ To determine when a certificate expires, download the certificate file and view 
 | [Microsoft Azure RSA TLS Issuing CA 07](https://www.microsoft.com/pkiops/certs/Microsoft%20Azure%20RSA%20TLS%20Issuing%20CA%2007.crt) | 0x330000003bf980b0c83783431700000000003b<br>0E5F41B697DAADD808BF55AD080350A2A5DFCA93 |
 | [Microsoft Azure RSA TLS Issuing CA 08](https://www.microsoft.com/pkiops/certs/Microsoft%20Azure%20RSA%20TLS%20Issuing%20CA%2008%20-%20xsign.crt) | 0x0efb7e547edf0ff1069aee57696d7ba0<br>31600991ED5FEC63D355A5484A6DCC787EAD89BC |
 | [Microsoft Azure RSA TLS Issuing CA 08](https://www.microsoft.com/pkiops/certs/Microsoft%20Azure%20RSA%20TLS%20Issuing%20CA%2008.crt) | 0x330000003a5dc2ffc321c16d9b00000000003a<br>512C8F3FB71EDACF7ADA490402E710B10C73026E |
-| [Microsoft TLS ECC Root G2](https://caissuers.microsoft.com/pkiops/certs/Microsoft%20TLS%20ECC%20Root%20G2%20-%20xsign.crt) | 0x08d3c6d001f26cb5a23f0c7d6a73ffb6 </br> 7FA05ACF9B4AABB0DE0CFAFA297DDF92FDC5F3F5 |
 | [Microsoft TLS G2 ECC CA OCSP 02](https://www.microsoft.com/pkiops/certs/Microsoft%20TLS%20G2%20ECC%20CA%20OCSP%2002.crt) | 0x3300000005516a21c89814ccf7000000000005<br>336D3E5451315294F6E1E7CFDA84E51C8B1E4054 |
 | [Microsoft TLS G2 ECC CA OCSP 04](https://www.microsoft.com/pkiops/certs/Microsoft%20TLS%20G2%20ECC%20CA%20OCSP%2004.crt) | 0x3300000008d690fff489d9c4d7000000000008<br>5BFF3CC51FB9C1CCE0D52F754427347545E583C5 |
 | [Microsoft TLS G2 ECC CA OCSP 06](https://www.microsoft.com/pkiops/certs/Microsoft%20TLS%20G2%20ECC%20CA%20OCSP%2006.crt) | 0x33000000066fa24c31c3956fab000000000006<br>9BC57546ACBDB29E388CD1791B43DE4F659B844B |
@@ -87,7 +88,6 @@ To determine when a certificate expires, download the certificate file and view 
 | [Microsoft TLS G2 RSA CA OCSP 12](https://www.microsoft.com/pkiops/certs/Microsoft%20TLS%20G2%20RSA%20CA%20OCSP%2012.crt) | 0x33000000107d59860fd64d7243000000000010<br>D3089DF9F47490887045B91D3FDEF6ED87F02F52 |
 | [Microsoft TLS G2 RSA CA OCSP 14](https://www.microsoft.com/pkiops/certs/Microsoft%20TLS%20G2%20RSA%20CA%20OCSP%2014.crt) | 0x33000000127e739347e75be1a1000000000012<br>55D9B33BDC16DDB3B663F1771F96D4324C118073 |
 | [Microsoft TLS G2 RSA CA OCSP 16](https://www.microsoft.com/pkiops/certs/Microsoft%20TLS%20G2%20RSA%20CA%20OCSP%2016.crt) | 0x330000000e42938f25dc51a99b00000000000e<br>27E6663299D340DFE54571CECCEC01BE74495DC6 |
-| [Microsoft TLS RSA Root G2](https://caissuers.microsoft.com/pkiops/certs/Microsoft%20TLS%20RSA%20Root%20G2%20-%20xsign.crt) | 0x0b0c6b2c466917b04773c647d4afc0c8 </br> B5EE89E77326AB2BF1775BD99C19A28947FF8184 |
 
 # [Certificate Authority chains](#tab/certificate-authority-chains)
 


### PR DESCRIPTION
These certificates sign other certificates listed in the "subordinates" section, and are correctly listed as signing those subordinates in the "certificate authority chains" section.

It's important that these are properly listed as root certificates. These certificates do not ship in the default bundle on some systems and therefore need to be explicitly passed as "roots" whenever their subordinates are validated.