### PR TITLE
Fix: Snapshot+Vault tier also supports Availability Zone restore

### DIFF
--- a/articles/backup/backup-azure-arm-restore-vms.md
+++ b/articles/backup/backup-azure-arm-restore-vms.md
@@ -273,7 +273,7 @@ In the restore process, you'll see the option **Availability Zone.** You'll see 
 
 In summary, the **Availability Zone** will only appear when
  - The source VM is zone pinned and is NOT encrypted
- - The recovery point is present in vault tier only (Snapshots only or snapshot and vault tier are not supported)
+ - The recovery point is present in vault tier (Snapshots only are not supported)
  - The recovery option is to either create a new VM or to restore disks (replace disks option replaces source data and hence the availability zone option is not applicable)
  - Creating VM/disks in the same region when vault's storage redundancy is ZRS (Doesn't work when vault's storage redundancy is GRS even though the source VM is zone pinned)
  - Creating VM/disks in the paired region when vault's storage redundancy is enabled for Cross-Region-Restore AND if the paired region supports zones


### PR DESCRIPTION
The original text stated that "snapshot and vault tier are not supported" 
for Availability Zone restore, which is incorrect.

The actual condition is whether the recovery point exists in the vault tier.
- Snapshot only → vault tier not available → AZ restore NOT supported
- Snapshot + Vault → vault tier available → AZ restore IS supported
- Vault only → vault tier available → AZ restore IS supported

Updated the description to accurately reflect that only "Snapshots only" tier is not supported, as the key requirement is the presence of data in the vault tier.