### PR TITLE
Add programmatic health check for Service Bus emulator

### DIFF
--- a/articles/service-bus-messaging/test-locally-with-service-bus-emulator.md
+++ b/articles/service-bus-messaging/test-locally-with-service-bus-emulator.md
@@ -309,7 +309,9 @@ You can verify the containers are running by checking Docker Desktop or using th
 ### Programmatic health check
 
 For automated scenarios (for example, when using Docker Compose), you can verify that the emulator is ready by calling the health endpoint exposed by the emulator:
-`http://localhost:<EMULATOR_HTTP_PORT>/health`
+```http
+http://localhost:<EMULATOR_HTTP_PORT>/health
+```
 
 By default, the `EMULATOR_HTTP_PORT` is `5300`.
 

--- a/articles/service-bus-messaging/test-locally-with-service-bus-emulator.md
+++ b/articles/service-bus-messaging/test-locally-with-service-bus-emulator.md
@@ -306,6 +306,15 @@ Regardless of which setup method you chose, the result is the same: the Service 
 
 You can verify the containers are running by checking Docker Desktop or using the command `docker ps` in a terminal.
 
+### Programmatic health check
+
+For automated scenarios (for example, when using Docker Compose), you can verify that the emulator is ready by calling the health endpoint exposed by the emulator:
+`http://localhost:<EMULATOR_HTTP_PORT>/health`
+
+By default, the `EMULATOR_HTTP_PORT` is `5300`.
+
+This endpoint can be used in scripts or Docker health checks to ensure the emulator is fully initialized before dependent services start.
+
 ## Interact with the emulator
 
 You can create and manage Service Bus entities—such as queues and topics—using the Service Bus [Administration Client](service-bus-management-libraries.md). By default, emulator uses [config.json](https://github.com/Azure/azure-service-bus-emulator-installer/blob/main/ServiceBus-Emulator/Config/Config.json) configuration file. You can also configure entities by making declarative changes to configuration file. To know more, visit [create and manage entities within Service Bus emulator](overview-emulator.md#create-and-manage-entities-within-service-bus-emulator) 


### PR DESCRIPTION
## Description
Added a programmatic health check section for the service bus emulator as it is crucial for any developer thinking of including the emulator in his/her stack.

## Reasoning for the change
This article is the first thing one gets when searching for getting started guideline on service bus emulator. And since at most part of the time, a developer have other services which will depend on this emulator, it becomes important to call out the health check endpoint in this document itself, preventing a waste of time on searching GitHub issues.