### PR TITLE
fix: add missing 'Microsoft' prefix to bare 'Entra' references in share-level permissions doc

### DIFF
--- a/articles/storage/files/storage-files-identity-assign-share-level-permissions.md
+++ b/articles/storage/files/storage-files-identity-assign-share-level-permissions.md
@@ -19,19 +19,19 @@ After you enable an identity source for your storage account, you must configure
 
 ## Choose how to assign share-level permissions
 
-You configure share-level permissions on Azure file shares for Microsoft Entra users, groups, or service principals. Directory-level and file-level permissions are enforced through Windows access control lists (ACLs). Assign share-level permissions to the Entra identity that represents the user, group, or service principal needing access.
+You configure share-level permissions on Azure file shares for Microsoft Entra users, groups, or service principals. Directory-level and file-level permissions are enforced through Windows access control lists (ACLs). Assign share-level permissions to the Microsoft Entra identity that represents the user, group, or service principal needing access.
 
-Most users assign share-level permissions to specific Entra users or groups and use Windows ACLs for granular access control at the directory and file levels. This configuration is the most secure.
+Most users assign share-level permissions to specific Microsoft Entra users or groups and use Windows ACLs for granular access control at the directory and file levels. This configuration is the most secure.
 
 Use a [default share-level permission](#share-level-permissions-for-all-authenticated-identities) to grant role-based access to all authenticated identities in these scenarios:
 
 - You're using Microsoft Entra Kerberos to authenticate cloud-only identities (preview).
-- You can't sync your on-premises Active Directory Domain Services (AD DS) deployment to Microsoft Entra ID. Assigning a default share-level permission works around the sync requirement because you don't need to specify the permission to identities in Entra ID. Then you can use Windows ACLs for granular permission enforcement on your files and directories.
+- You can't sync your on-premises Active Directory Domain Services (AD DS) deployment to Microsoft Entra ID. Assigning a default share-level permission works around the sync requirement because you don't need to specify the permission to identities in Microsoft Entra ID. Then you can use Windows ACLs for granular permission enforcement on your files and directories.
   
   Identities that are tied to an Active Directory but aren't syncing to Microsoft Entra ID can also use the default share-level permission. This condition can include standalone Managed Service Accounts (sMSAs), group Managed Service Accounts (gMSAs), and computer accounts.
-- The on-premises AD DS deployment that you're using is synced to an Entra ID deployment that's different from the one where the file share is deployed.
+- The on-premises AD DS deployment that you're using is synced to a Microsoft Entra ID deployment that's different from the one where the file share is deployed.
   
-  This condition is typical when you're managing multitenant environments. By using a default share-level permission, you bypass the requirement for an Entra ID [hybrid identity](/entra/identity/hybrid/whatis-hybrid-identity). You can still use Windows ACLs on your files and directories for granular permission enforcement.
+  This condition is typical when you're managing multitenant environments. By using a default share-level permission, you bypass the requirement for a Microsoft Entra ID [hybrid identity](/entra/identity/hybrid/whatis-hybrid-identity). You can still use Windows ACLs on your files and directories for granular permission enforcement.
 - You prefer to enforce authentication only by using Windows ACLs at the file and directory levels.
 
 ## Azure RBAC roles for Azure Files
@@ -39,7 +39,7 @@ Use a [default share-level permission](#share-level-permissions-for-all-authenti
 Several built-in Azure role-based access control (RBAC) roles are intended for use with Azure Files. Some of these roles grant share-level permissions to users and groups. If you're using Azure Storage Explorer, you also need the [Reader and Data Access](../../role-based-access-control/built-in-roles.md#reader-and-data-access) role to read and access the Azure file share.
 
 > [!NOTE]
-> Because computer accounts don't have an identity in Entra ID, you can't configure Azure RBAC for them. However, computer accounts can access a file share by using a [default share-level permission](#share-level-permissions-for-all-authenticated-identities).
+> Because computer accounts don't have an identity in Microsoft Entra ID, you can't configure Azure RBAC for them. However, computer accounts can access a file share by using a [default share-level permission](#share-level-permissions-for-all-authenticated-identities).
 
 |**Built-in Azure RBAC role**  |**Description**  |
 |---------|---------|
@@ -53,11 +53,11 @@ Several built-in Azure role-based access control (RBAC) roles are intended for u
 
 <a name='share-level-permissions-for-specific-azure-ad-users-or-groups'></a>
 
-## Share-level permissions for specific Entra users or groups
+## Share-level permissions for specific Microsoft Entra users or groups
 
 If you intend to use a specific Microsoft Entra user or group to access Azure file share resources, that identity must be a [hybrid identity](/entra/identity/hybrid/whatis-hybrid-identity) that exists in both on-premises AD DS and Microsoft Entra ID. Cloud-only identities must use a [default share-level permission](#share-level-permissions-for-all-authenticated-identities).
 
-For example, if you have a user in Active Directory named user1@onprem.contoso.com and you sync to Entra ID as user1@contoso.com by using Microsoft Entra Connect Sync or Microsoft Entra Connect Cloud Sync, the user must have the share-level permissions assigned to user1@contoso.com to access the file share. The same concept applies to groups and service principals.
+For example, if you have a user in Active Directory named user1@onprem.contoso.com and you sync to Microsoft Entra ID as user1@contoso.com by using Microsoft Entra Connect Sync or Microsoft Entra Connect Cloud Sync, the user must have the share-level permissions assigned to user1@contoso.com to access the file share. The same concept applies to groups and service principals.
 
 > [!IMPORTANT]
 > Assign permissions by explicitly declaring actions and data actions instead of using a wildcard (\*) character.
@@ -66,19 +66,19 @@ For example, if you have a user in Active Directory named user1@onprem.contoso.c
 
 For share-level permissions to work, you must take the following actions:
 
-- If your identity source is AD DS or Microsoft Entra Kerberos, sync the users *and* the groups from your local Active Directory deployment to Entra ID by using either [Microsoft Entra Connect Sync](/entra/identity/hybrid/connect/how-to-connect-sync-whatis) or [Microsoft Entra Cloud Sync](/entra/identity/hybrid/cloud-sync/what-is-cloud-sync). Microsoft Entra Cloud Sync is a lightweight agent that you can install from the Microsoft Entra admin center.
+- If your identity source is AD DS or Microsoft Entra Kerberos, sync the users *and* the groups from your local Active Directory deployment to Microsoft Entra ID by using either [Microsoft Entra Connect Sync](/entra/identity/hybrid/connect/how-to-connect-sync-whatis) or [Microsoft Entra Cloud Sync](/entra/identity/hybrid/cloud-sync/what-is-cloud-sync). Microsoft Entra Cloud Sync is a lightweight agent that you can install from the Microsoft Entra admin center.
 - Add Active Directory-synced groups to the RBAC role so they can access your storage account.
 
 > [!TIP]
 > Optional: To migrate SMB server share-level permissions to RBAC permissions, use the `Move-OnPremSharePermissionsToAzureFileShare` PowerShell cmdlet to migrate directory-level and file-level permissions from on-premises to Azure. This cmdlet evaluates the groups of a particular on-premises file share. It then writes the appropriate users and groups to the Azure file share by using the built-in RBAC roles. You provide the information for the on-premises share and the Azure file share when invoking the cmdlet.
 
-To grant share-level permissions, use the Azure portal, Azure PowerShell, or the Azure CLI to assign one of the built-in roles to the Entra ID identity of a user.
+To grant share-level permissions, use the Azure portal, Azure PowerShell, or the Azure CLI to assign one of the built-in roles to the Microsoft Entra ID identity of a user.
 
 Share-level permission changes usually take effect within 30 minutes, but in some cases they can take longer. Wait for permissions to propagate before you connect to the file share by using your credentials.
 
 # [Portal](#tab/azure-portal)
 
-To assign an Azure role to an Entra identity by using the [Azure portal](https://portal.azure.com), follow these steps:
+To assign an Azure role to a Microsoft Entra identity by using the [Azure portal](https://portal.azure.com), follow these steps:
 
 1. In the Azure portal, go to your file share, or [create an SMB file share](storage-how-to-create-file-share.md).
 
@@ -88,15 +88,15 @@ To assign an Azure role to an Entra identity by using the [Azure portal](https:/
 
 1. In the **Add role assignment** pane, select the [appropriate built-in role](#azure-rbac-roles-for-azure-files) from the **Role** list.
 
-1. Keep **Assign access to** at the default setting: **Microsoft Entra user, group, or service principal**. Select the target Entra identity by name or email address.
+1. Keep **Assign access to** at the default setting: **Microsoft Entra user, group, or service principal**. Select the target Microsoft Entra identity by name or email address.
 
-   The selected Entra identity must be a hybrid identity and can't be a cloud-only identity. This requirement means that the same identity is also represented in AD DS.
+   The selected Microsoft Entra identity must be a hybrid identity and can't be a cloud-only identity. This requirement means that the same identity is also represented in AD DS.
 
 1. Select **Save** to complete the role assignment operation.
 
 # [Azure PowerShell](#tab/azure-powershell)
 
-The following PowerShell sample shows how to assign an Azure role to an Entra identity, based on sign-in name. For more information about assigning Azure roles by using PowerShell, see [Add or remove Azure role assignments by using the Azure PowerShell module](../../role-based-access-control/role-assignments-powershell.md).
+The following PowerShell sample shows how to assign an Azure role to a Microsoft Entra identity, based on sign-in name. For more information about assigning Azure roles by using PowerShell, see [Add or remove Azure role assignments by using the Azure PowerShell module](../../role-based-access-control/role-assignments-powershell.md).
 
 Before you run the following sample script, replace placeholder values (including brackets) with your values.
 
@@ -111,7 +111,7 @@ New-AzRoleAssignment -SignInName <user-principal-name> -RoleDefinitionName $File
 
 # [Azure CLI](#tab/azure-cli)
   
-The following Azure CLI command assigns an Azure role to an Entra identity based on sign-in name. For more information about assigning Azure roles by using the Azure CLI, see [Add or remove Azure role assignments by using the Azure CLI](../../role-based-access-control/role-assignments-cli.md).  
+The following Azure CLI command assigns an Azure role to a Microsoft Entra identity based on sign-in name. For more information about assigning Azure roles by using the Azure CLI, see [Add or remove Azure role assignments by using the Azure CLI](../../role-based-access-control/role-assignments-cli.md).  
 
 Before you run the following command, replace placeholder values (including brackets) with your own values.
 
@@ -125,10 +125,10 @@ az role assignment create --role "<role-name>" --assignee <user-principal-name> 
 
 ## Share-level permissions for all authenticated identities
 
-You can add a default share-level permission on your storage account, instead of configuring share-level permissions for Entra users or groups. A default share-level permission assigned to your storage account applies to all file shares contained in the storage account.
+You can add a default share-level permission on your storage account, instead of configuring share-level permissions for Microsoft Entra users or groups. A default share-level permission assigned to your storage account applies to all file shares contained in the storage account.
 
 > [!IMPORTANT]
-> If you set a default share-level permission on the storage account, you don't need to sync your on-premises identities to Entra ID.
+> If you set a default share-level permission on the storage account, you don't need to sync your on-premises identities to Microsoft Entra ID.
 
 When you set a default share-level permission, all authenticated users and groups have the same permission. Authenticated users or groups are identified as the identity that can be authenticated against the AD DS deployment that the storage account is associated with.
 
@@ -183,7 +183,7 @@ az storage account update --name $storageAccountName --resource-group $resourceG
 
 ## What happens if you use both configurations
 
-You can assign permissions to all authenticated Entra users and to specific Entra users or groups. When you use this configuration, a specific user or group gets the higher-level permission between the default share-level permission and the RBAC assignment.
+You can assign permissions to all authenticated Microsoft Entra users and to specific Microsoft Entra users or groups. When you use this configuration, a specific user or group gets the higher-level permission between the default share-level permission and the RBAC assignment.
 
 For example, suppose you grant a user the Storage File Data SMB Reader role on the target file share. You also grant the default share-level permission Storage File Data SMB Share Elevated Contributor to all authenticated users. With this configuration, that particular user has Storage File Data SMB Share Elevated Contributor access to the file share. Higher-level permissions always take precedence.
 
@@ -191,16 +191,16 @@ For example, suppose you grant a user the Storage File Data SMB Reader role on t
 
 This section applies only to storage accounts that use AD DS authentication.
 
-Users who aren't synced to Entra ID can still access Azure file shares through group membership. If a user belongs to an on-premises AD DS group that's synced to Entra ID and has an Azure RBAC role assignment, the user gets the group's permissions, even though they don't appear as a group member in the Microsoft Entra admin center.
+Users who aren't synced to Microsoft Entra ID can still access Azure file shares through group membership. If a user belongs to an on-premises AD DS group that's synced to Microsoft Entra ID and has an Azure RBAC role assignment, the user gets the group's permissions, even though they don't appear as a group member in the Microsoft Entra admin center.
 
 Here's how it works:
 
-- Only the group needs to be synced to Entra ID, not individual users.
+- Only the group needs to be synced to Microsoft Entra ID, not individual users.
 - When a user authenticates, the on-premises domain controller sends a Kerberos ticket that includes all the user's group memberships.
 - Azure Files reads the group security identifiers (SIDs) from the Kerberos ticket.
-- If any of those groups are synced to Entra ID, Azure Files applies the matching RBAC role assignments.
+- If any of those groups are synced to Microsoft Entra ID, Azure Files applies the matching RBAC role assignments.
 
-Because of this process, authorization is based on the groups listed in the Kerberos ticket, not on what appears in the Microsoft Entra admin center. Non-synced users can access file shares through their synced AD DS group memberships without needing individual syncing to Entra ID.
+Because of this process, authorization is based on the groups listed in the Kerberos ticket, not on what appears in the Microsoft Entra admin center. Non-synced users can access file shares through their synced AD DS group memberships without needing individual syncing to Microsoft Entra ID.
 
 ## Next step
 


### PR DESCRIPTION
## What does this PR change?

Adds the missing "Microsoft" prefix to 22 instances of bare "Entra" and "Entra ID" throughout the share-level permissions article, making them consistent with Microsoft's naming guidance for Microsoft Entra ID.

## Examples of changes made
**Before:**
> Assign share-level permissions to the Entra identity
> synced to an Entra ID deployment
> configuring share-level permissions for Entra users or groups

**After:**
> Assign share-level permissions to the Microsoft Entra identity
> synced to a Microsoft Entra ID deployment
> configuring share-level permissions for Microsoft Entra users or groups

## Why?
Per Microsoft's own rename guidance, the correct product name is always "Microsoft Entra ID", never "Entra ID" or "Entra" alone. The rest of the article and surrounding docs already use the full name consistently.

## References
https://learn.microsoft.com/en-us/entra/fundamentals/new-name