### PR TITLE
fix: replace 'Azure Active Directory' with 'Microsoft Entra ID' in Stream Analytics managed identity doc

### DIFF
--- a/articles/stream-analytics/service-bus-managed-identity.md
+++ b/articles/stream-analytics/service-bus-managed-identity.md
@@ -27,7 +27,7 @@ First, you create a managed identity for your Azure Stream Analytics job. 
 
    :::image type="content" source="media/event-hubs-managed-identity/system-assigned-managed-identity.png" alt-text="Screenshot showing the System assigned managed identity check box.":::  
 
-3. A service principal for the Stream Analytics job's identity is created in Azure Active Directory. The life cycle of the newly created identity is managed by Azure. When the Stream Analytics job is deleted, the associated identity (that is, the service principal) is automatically deleted by Azure.  
+3. A service principal for the Stream Analytics job's identity is created in Microsoft Entra ID. The life cycle of the newly created identity is managed by Azure. When the Stream Analytics job is deleted, the associated identity (that is, the service principal) is automatically deleted by Azure.  
 
    When you save the configuration, the Object ID (OID) of the service principal is listed as the Principal ID as shown in the following image:  
 


### PR DESCRIPTION
## What does this PR change?

Replaces a single instance of the outdated "Azure Active Directory" with the correct post-rename name "Microsoft Entra ID" in the Stream Analytics managed identity article.

**Before:**
> A service principal for the Stream Analytics job's identity is created in Azure Active Directory.

**After:**
> A service principal for the Stream Analytics job's identity is created in Microsoft Entra ID.

## Why?
Azure Active Directory was renamed to Microsoft Entra ID in July 2023. The rest of the article already uses "Microsoft Entra" correctly. This was the one remaining stale reference.

## References
https://learn.microsoft.com/en-us/entra/fundamentals/new-name