### PR TITLE
fix: replace 'Azure AD' with 'Microsoft Entra ID' in code comment in Event Hubs management libraries doc

### DIFF
--- a/articles/event-hubs/event-hubs-management-libraries.md
+++ b/articles/event-hubs/event-hubs-management-libraries.md
@@ -58,7 +58,7 @@ namespace event_hub_dotnet_management
 
 		public static async Task Main()
 		{
-			// get a token from Microsoft Entra ID 
+			// get a token from Microsoft Entra ID
 			var token = await GetToken();
 
 			// create an EventHubManagementClient 

--- a/articles/event-hubs/event-hubs-management-libraries.md
+++ b/articles/event-hubs/event-hubs-management-libraries.md
@@ -58,7 +58,7 @@ namespace event_hub_dotnet_management
 
 		public static async Task Main()
 		{
-			// get a token from Azure AD 
+			// get a token from Microsoft Entra ID 
 			var token = await GetToken();
 
 			// create an EventHubManagementClient 


### PR DESCRIPTION
## What does this PR change?

Replaces a stale "Azure AD" reference in a code comment with the correct post-rename name "Microsoft Entra ID".

**Before:**
> // get a token from Azure AD

**After:**
> // get a token from Microsoft Entra ID

## Why?
The surrounding prose in the same article already correctly uses "Microsoft Entra ID" throughout. This code comment was the one remaining stale reference, inconsistent with the rest of the article.

## References
https://learn.microsoft.com/en-us/entra/fundamentals/new-name