### PR TITLE
fix: remove stale Azure AD rename callout notes from EA billing admin doc

### DIFF
--- a/articles/cost-management-billing/manage/direct-ea-administration.md
+++ b/articles/cost-management-billing/manage/direct-ea-administration.md
@@ -29,8 +29,6 @@ Check out the [EA admin manage enrollment](https://www.youtube.com/watch?v=NUlRr
 
 >[!VIDEO https://www.youtube.com/embed/NUlRrJFF1_U]
 
-Azure Active Directory is now Microsoft Entra ID. For more information, see [New name for Azure AD](https://aka.ms/AzureADNewName).
-
 ## Select a billing scope
 
 Enterprise agreements and the customers accessing the agreements can have multiple enrollments. A user can have access to multiple enrollment scopes (billing account scopes). All the information and activity in the Azure portal are in the context of a billing account scope. It's important that the enterprise administrator first selects a billing scope and then does administrative tasks.
@@ -153,8 +151,6 @@ Check out the [Manage departments in the Azure portal](https://www.youtube.com/w
 
 >[!VIDEO https://www.youtube.com/embed/vs3wIeRDK4Q]
 
-Azure Active Directory is now Microsoft Entra ID. For more information, see [New name for Azure AD](https://aka.ms/AzureADNewName).
-
 ### To create a department
 
 1. Sign in to the [Azure portal](https://portal.azure.com/#blade/Microsoft_Azure_GTM/ModernBillingMenuBlade/AllBillingScopes).
@@ -214,8 +210,6 @@ After a new account is added to the enrollment, the account owner is sent an acc
 Check out the [EA admin manage accounts](https://www.youtube.com/watch?v=VKWAEx6qfPc) video. It's part of the [Enterprise Customer Billing Experience in the Azure portal](https://www.youtube.com/playlist?list=PLeZrVF6SXmsoHSnAgrDDzL0W5j8KevFIm) series of videos.
 
 >[!VIDEO https://www.youtube.com/embed/VKWAEx6qfPc]
-
-Azure Active Directory is now Microsoft Entra ID. For more information, see [New name for Azure AD](https://aka.ms/AzureADNewName).
 
 ### To add an account and account owner
 
@@ -421,8 +415,6 @@ When you create different subscriptions for each application environment, you he
 Check out the [EA admin manage subscriptions](https://www.youtube.com/watch?v=KFfcg2eqPo8) video. It's part of the [Enterprise Customer Billing Experience in the Azure portal](https://www.youtube.com/playlist?list=PLeZrVF6SXmsoHSnAgrDDzL0W5j8KevFIm) series of videos.
 
 >[!VIDEO https://www.youtube.com/embed/KFfcg2eqPo8]
-
-Azure Active Directory is now Microsoft Entra ID. For more information, see [New name for Azure AD](https://aka.ms/AzureADNewName).
 
 > [!WARNING]
 > You will not be able to create new subscriptions or transfer existing subscriptions from an enrollment account if the UPN is deleted from Entra ID. 


### PR DESCRIPTION
## What does this PR change?

Removes four identical transitional callout lines from `direct-ea-administration.md`:

> "Azure Active Directory is now Microsoft Entra ID. For more information, see [New name for Azure AD](https://aka.ms/AzureADNewName)."

These appeared as standalone lines at four separate points in the document (lines 32, 156, 218, and 425).

## Why?

These callout notes were added during the Azure AD → Microsoft Entra ID rename period as temporary reader alerts. The document itself already uses "Microsoft Entra ID" correctly throughout. None of the surrounding sections use the old name.

## References
https://learn.microsoft.com/en-us/entra/fundamentals/new-name