### PR TITLE
fix: remove stale Azure AD rename callout and update AAD references to Microsoft Entra

### DIFF
--- a/articles/migrate/create-manage-projects.md
+++ b/articles/migrate/create-manage-projects.md
@@ -190,7 +190,7 @@ Follow the steps to delete a project:
    :::image type="content" source="./media/create-manage-projects/delete-window.png" alt-text="Window appears to delete a project.":::
 
    > [!Note]
-   > You can't delete or manage the associated Azure Active Directory (AAD) app from this Azure Migrate project level. To delete this resource, visit the AAD app details or use the Azure Command Line Interface (AzCLI). `az ad app delete --id <aad app id>`
+   > You can't delete or manage the associated Microsoft Entra app from this Azure Migrate project level. To delete this resource, visit the Microsoft Entra app details or use the Azure Command Line Interface (AzCLI). `az ad app delete --id <aad app id>`
 
 1. When you delete a project, both the project and its metadata about discovered servers are deleted. If you want to keep resources such as **key vaults** or **storage vaults**, you can **deselect them** 
 1. After you finalize the list of resources to delete, select **Next**.

--- a/articles/storage/files/storage-files-identity-ad-ds-overview.md
+++ b/articles/storage/files/storage-files-identity-ad-ds-overview.md
@@ -34,7 +34,7 @@ When you enable AD DS for Azure file shares over SMB, your AD DS-joined machines
 
 ## Videos
 
-To help you set up identity-based authentication for common use cases, we published two videos with step-by-step guidance for the following scenarios. Note that Azure Active Directory is now Microsoft Entra ID. For more info, see [New name for Azure AD](https://aka.ms/azureadnewname).
+To help you set up identity-based authentication for common use cases, we published two videos with step-by-step guidance for the following scenarios.
 
 | Replace on-premises file servers with Azure Files (including setup on private link for files and AD authentication) | Use Azure Files as the profile container for Azure Virtual Desktop (including setup on AD authentication and FSLogix configuration)  |
 |-|-|


### PR DESCRIPTION
## What does this PR change?

Two small fixes across two files, both addressing stale Azure Active Directory naming.

**storage-files-identity-ad-ds-overview.md**
Removes a trailing rename callout sentence from the Videos section intro:
> "Note that Azure Active Directory is now Microsoft Entra ID. For more info, see [New name for Azure AD](https://aka.ms/azureadnewname)."

The surrounding content already uses "Microsoft Entra ID" correctly, making this note redundant.

**migrate/create-manage-projects.md**
Updates a NOTE block that referred to the "Azure Active Directory (AAD) app" and "AAD app details":
Before: > the associated Azure Active Directory (AAD) app
After:  > the associated Microsoft Entra app

The CLI command `az ad app delete` is unchanged as it reflects actual command syntax.

## Why?
Azure Active Directory was renamed to Microsoft Entra ID in July 2023. Both references were stale prose that had not been updated.

## References
https://learn.microsoft.com/en-us/entra/fundamentals/new-name