### PR TITLE
Update Accelerated Networking Limitations and constraints

### DIFF
--- a/articles/virtual-network/accelerated-networking-overview.md
+++ b/articles/virtual-network/accelerated-networking-overview.md
@@ -39,7 +39,7 @@ Accelerated Networking has the following benefits:
 
 - For best results, enable Accelerated Networking on at least two VMs in the same Azure virtual network. This feature has minimal effect on latency when you communicate across virtual networks or connect on-premises.
 
-- You can't enable Accelerated Networking on a running VM. You can enable Accelerated Networking on a supported VM only when the VM is stopped and deallocated.
+- Network connectivity will be interrupted if the operating system of your virtual machine does not support accelerated networking. Disable accelerated networking if connectivity to your virtual machine is interrupted.
 
 - You can't deploy virtual machines (classic) with Accelerated Networking through Azure Resource Manager.
 


### PR DESCRIPTION
Current Azure Portal now supports enabling Accelerated Networking on running VMs—no deallocation needed, unlike the outdated Learn doc statement: "You can't enable Accelerated Networking on a running VM. You must stop/deallocate first."

I've replaced it with the portal's warning: "Network connectivity will be interrupted if your VM's OS doesn't support accelerated networking. Disable if connectivity drops." This reflects the new Automatic option that detects OS support before enabling.