### PR TITLE
Removing specific version support to avoid confusion with other pages mentioning "Latest Major Release" as supported.

### DIFF
--- a/articles/backup/back-up-azure-stack-hyperconverged-infrastructure-virtual-machines.md
+++ b/articles/backup/back-up-azure-stack-hyperconverged-infrastructure-virtual-machines.md
@@ -12,7 +12,7 @@ ms.author: v-mallicka
 
 # Back up Azure Local virtual machines with Azure Backup Server
 
-This article describes how to back up virtual machines running on Azure Local, versions *23 H2* and *22 H2*, using Microsoft Azure Backup Server (MABS).
+This article describes how to back up virtual machines running on Azure Local using Microsoft Azure Backup Server (MABS).
  
 ## Supported scenarios
 


### PR DESCRIPTION
Latest Major Release is described as supported [here ](https://learn.microsoft.com/en-us/azure/backup/backup-mabs-protection-matrix#vm-backup:~:text=Lastest%20Major%20Release). 