### PR TITLE
Update general-purpose-version-1-account-migration-overview.md

### DIFF
--- a/articles/storage/common/general-purpose-version-1-account-migration-overview.md
+++ b/articles/storage/common/general-purpose-version-1-account-migration-overview.md
@@ -40,8 +40,7 @@ GPv2 supports all capabilities of GPv1 and adds several enhancements, including 
 
 | Date               | Milestone                                                   |
 |--------------------|-------------------------------------------------------------|
-|**September 2025** |Retirement announced                                        |
-| **March 3 2026**    |Creation of new GPv1 Storage accounts disabled              |
+|**September 2025** |Retirement announced                                        |             |
 |**October 2026** |Full retirement; Any remaining GPv1 Storage accounts will be automigrated to GPv2. Your decision not to migrate an existing GPv1 account will be construed as consent for Microsoft to migrate the account on your behalf. |
 
 The retirement takes effect globally across all Azure regions.


### PR DESCRIPTION
Creation of GPv1 storage accounts is still possible via Azure CLI command.

However, in the document it is mentioned that creation of GPV1 accounts would be disabled by 3rd March.