### PR TITLE
Add export orchestration history documentation for Durable Task Scheduler

### DIFF
--- a/articles/durable-task/common/toc.yml
+++ b/articles/durable-task/common/toc.yml
@@ -114,6 +114,8 @@
         href: ../sdks/durable-task-schedulers-schedules.md
       - name: Large payload support
         href: ../scheduler/durable-task-scheduler-large-payloads.md?pivots=durable-task-sdks
+      - name: Export orchestration history
+        href: ../scheduler/durable-task-scheduler-export-history.md?pivots=durable-task-sdks
       - name: C#
         items:
         - name: Roslyn Analyzer

--- a/articles/durable-task/scheduler/durable-task-scheduler-export-history.md
+++ b/articles/durable-task/scheduler/durable-task-scheduler-export-history.md
@@ -1,0 +1,251 @@
+---
+author: hhunter-ms
+title: Export orchestration history with Durable Task Scheduler (Preview)
+description: Learn how to export orchestration execution history from Durable Task Scheduler to Azure Blob Storage using the Durable Task .NET SDK.
+ms.topic: feature-guide
+ms.date: 04/14/2026
+ms.author: torosent
+ms.service: durable-task
+ms.subservice: durable-task-scheduler
+ms.devlang: csharp
+---
+
+# Export orchestration history with Durable Task Scheduler (Preview)
+
+Export orchestration history lets your app extract execution histories for terminal orchestration instances (completed, failed, or terminated) from [Durable Task Scheduler](durable-task-scheduler.md) and write them to Azure Blob Storage. Use this feature for auditing, compliance, analytics, and long-term archival of orchestration data outside of the scheduler.
+
+This feature is currently available for the [Durable Task .NET SDK](../sdks/durable-task-overview.md). It requires the `Microsoft.DurableTask.ExportHistory` package.
+
+## How it works
+
+Export history uses durable entities and orchestrations internally to manage export jobs reliably:
+
+1. You create an export job through the `ExportHistoryClient`, specifying a time window and export mode.
+1. The SDK creates a durable entity (`ExportJob`) that tracks the job's state and progress.
+1. An internal orchestration lists terminal orchestration instances that match the specified time window and status filters.
+1. For each matching instance, an activity fetches the full execution history from Durable Task Scheduler.
+1. The history is serialized (JSONL with gzip compression by default) and written to Azure Blob Storage.
+1. The job checkpoints its progress, so it can resume if interrupted.
+
+## Export modes
+
+Export history supports two modes:
+
+| Mode | Behavior |
+| --- | --- |
+| **Batch** | Exports instances that reached a terminal state within a fixed time window (`completedTimeFrom` to `completedTimeTo`), then marks the job as completed. |
+| **Continuous** | Tails terminal instances continuously from `completedTimeFrom` onward, with no end time. The job stays active until you delete it. |
+
+## Enable export history
+
+Install the export history package:
+
+```bash
+dotnet add package Microsoft.DurableTask.ExportHistory
+```
+
+Install the Azure Managed client and worker packages for Durable Task Scheduler:
+
+```bash
+dotnet add package Microsoft.DurableTask.Client.AzureManaged
+dotnet add package Microsoft.DurableTask.Worker.AzureManaged
+```
+
+Register export history on both the worker and client:
+
+```csharp
+string connectionString = builder.Configuration.GetValue<string>("DURABLE_TASK_CONNECTION_STRING")
+    ?? throw new InvalidOperationException("Missing DURABLE_TASK_CONNECTION_STRING");
+
+string storageConnectionString = builder.Configuration.GetValue<string>("EXPORT_HISTORY_STORAGE_CONNECTION_STRING")
+    ?? throw new InvalidOperationException("Missing EXPORT_HISTORY_STORAGE_CONNECTION_STRING");
+
+string containerName = builder.Configuration.GetValue<string>("EXPORT_HISTORY_CONTAINER_NAME")
+    ?? throw new InvalidOperationException("Missing EXPORT_HISTORY_CONTAINER_NAME");
+
+// Register the worker with export history support.
+// This registers internal entities, orchestrations, and activities that manage export jobs.
+builder.Services.AddDurableTaskWorker(worker =>
+{
+    worker.UseDurableTaskScheduler(connectionString);
+    worker.UseExportHistory();
+    worker.AddTasks(tasks =>
+    {
+        // Register your own orchestrations and activities here
+    });
+});
+
+// Register the client with export history support.
+// This configures the Azure Blob Storage destination and registers the ExportHistoryClient.
+builder.Services.AddDurableTaskClient(client =>
+{
+    client.UseDurableTaskScheduler(connectionString);
+    client.UseExportHistory(options =>
+    {
+        options.ConnectionString = storageConnectionString;
+        options.ContainerName = containerName;
+
+        // Optional: set a virtual folder path prefix for blob names (for example, "exports/daily").
+        // When set, blobs are written to "{prefix}/{hash}.{ext}" instead of "{hash}.{ext}".
+        options.Prefix = builder.Configuration.GetValue<string>("EXPORT_HISTORY_PREFIX");
+    });
+});
+```
+
+## Create and manage export jobs
+
+After you enable export history, use the `ExportHistoryClient` to create and manage jobs.
+
+### Create a batch export job
+
+A batch export job exports all orchestration instances that reached a terminal state within a fixed time window:
+
+```csharp
+ExportHistoryClient exportClient = app.Services.GetRequiredService<ExportHistoryClient>();
+
+ExportJobCreationOptions options = new(
+    mode: ExportMode.Batch,
+    completedTimeFrom: DateTimeOffset.UtcNow.AddHours(-24),
+    completedTimeTo: DateTimeOffset.UtcNow,
+    destination: new ExportDestination("my-export-container")
+    {
+        // Virtual folder path prefix applied to all blob names for this job
+        Prefix = "exports/daily",
+    });
+
+ExportHistoryJobClient jobClient = await exportClient.CreateJobAsync(options);
+ExportJobDescription description = await jobClient.DescribeAsync();
+```
+
+### Create a continuous export job
+
+A continuous export job tails terminal instances indefinitely from a start time:
+
+```csharp
+ExportJobCreationOptions options = new(
+    mode: ExportMode.Continuous,
+    completedTimeFrom: DateTimeOffset.UtcNow,
+    completedTimeTo: null,
+    destination: null);
+
+ExportHistoryJobClient jobClient = await exportClient.CreateJobAsync(options);
+```
+
+When `destination` is null, the job uses the default container and prefix configured in `ExportHistoryStorageOptions`.
+
+### Get job status
+
+```csharp
+ExportJobDescription? job = await exportClient.GetJobAsync("my-job-id");
+```
+
+The `ExportJobDescription` includes:
+
+| Property | Description |
+| --- | --- |
+| `JobId` | The unique job identifier. |
+| `Status` | Current status: `Pending`, `Active`, `Failed`, or `Completed`. |
+| `CreatedAt` | When the job was created. |
+| `LastModifiedAt` | When the job was last updated. |
+| `ScannedInstances` | Total number of instances scanned so far. |
+| `ExportedInstances` | Total number of instances exported so far. |
+| `LastError` | Last error message, if any. |
+
+### List jobs
+
+```csharp
+ExportJobQuery query = new()
+{
+    Status = ExportJobStatus.Active,
+    CreatedFrom = DateTimeOffset.UtcNow.AddDays(-7),
+    PageSize = 50,
+};
+
+AsyncPageable<ExportJobDescription> jobs = exportClient.ListJobsAsync(query);
+
+await foreach (ExportJobDescription job in jobs)
+{
+    Console.WriteLine($"{job.JobId}: {job.Status} ({job.ExportedInstances} exported)");
+}
+```
+
+### Delete a job
+
+```csharp
+ExportHistoryJobClient jobClient = exportClient.GetJobClient("my-job-id");
+await jobClient.DeleteAsync();
+```
+
+## Export job creation options
+
+The `ExportJobCreationOptions` class controls export job behavior:
+
+| Parameter | Required | Description | Default |
+| --- | --- | --- | --- |
+| `mode` | Yes | `Batch` for a fixed window or `Continuous` for ongoing export. | — |
+| `completedTimeFrom` | Yes (Batch) | Start of the time window (inclusive), based on when instances reached a terminal state. For Continuous mode, defaults to `UtcNow` if not provided. | — |
+| `completedTimeTo` | Yes (Batch) | End of the time window (inclusive). Must be omitted for Continuous mode. Cannot be in the future. | — |
+| `destination` | No | Override the default blob container and prefix for this job. | Uses default from `ExportHistoryStorageOptions` |
+| `jobId` | No | Custom job identifier. | Auto-generated GUID |
+| `format` | No | Export format: JSONL (gzip-compressed) or JSON (uncompressed). | JSONL with gzip |
+| `runtimeStatus` | No | Filter by terminal statuses: `Completed`, `Failed`, `Terminated`. | All terminal statuses |
+| `maxInstancesPerBatch` | No | Number of instances to process per batch (1–1000). | `100` |
+
+## Where exported data goes
+
+Exported history is written to Azure Blob Storage:
+
+- **Container**: default from `EXPORT_HISTORY_CONTAINER_NAME`, or the per-job `destination` override.
+- **Blob name**: derived from a SHA-256 hash of `(completedTimestamp, instanceId)`.
+- **File format**:
+  - Default: `.jsonl.gz` (JSON Lines, gzip-compressed — one history event per line)
+  - Optional: `.json` (uncompressed JSON array of history events)
+- **Blob path with prefix**: when a prefix is configured (for example, `exports/daily`), the blob path becomes `exports/daily/{hash}.{ext}`. Without a prefix, the blob is written directly to the container root as `{hash}.{ext}`.
+
+Each blob includes an `instanceId` metadata tag for traceability.
+
+## Environment variable configuration
+
+Use these environment variables with the Durable Task .NET SDK export history sample.
+
+| Variable | Description | Sample default |
+| --- | --- | --- |
+| `DURABLE_TASK_CONNECTION_STRING` | Durable Task Scheduler connection string | `Endpoint=http://localhost:8080;TaskHub=default;Authentication=None` |
+| `EXPORT_HISTORY_STORAGE_CONNECTION_STRING` | Azure Storage connection string for exported history blobs | `UseDevelopmentStorage=true` |
+| `EXPORT_HISTORY_CONTAINER_NAME` | Blob container for exported history | `export-history` |
+| `EXPORT_HISTORY_PREFIX` | Optional virtual folder path prefix for blob names | unset |
+| `ASPNETCORE_URLS` | Listen URLs for the sample's HTTP host | framework default |
+
+## Azure permissions
+
+When you use Azure resources instead of local emulators, the app identity needs access to Durable Task Scheduler and Blob Storage:
+
+- Grant `Durable Task Data Contributor` on the app's task hub.
+- Grant `Storage Blob Data Contributor` on the storage account that stores exported history blobs.
+
+## Important considerations
+
+- **Concurrent purge operations**: If you purge orchestration instances while an export job is running, the export can be impacted. Instances that are purged before the export reads them will be missing from the exported data. Avoid running purge operations concurrently with active export jobs that cover the same time window.
+
+- **Blob cleanup**: Deleting an export job doesn't remove the exported blobs from Azure Blob Storage. If you need to remove exported data, delete the blobs from the storage account separately.
+
+## Verify that export works
+
+After you create an export job, verify it works by checking for both signals:
+
+- The job status transitions from `Pending` to `Active` and eventually to `Completed` (for Batch mode).
+- Blob entries appear in your configured export container.
+
+For local development, run this Azure CLI command to inspect the container:
+
+```azurecli
+az storage blob list \
+  --connection-string "UseDevelopmentStorage=true" \
+  --container-name export-history \
+  --output table
+```
+
+## Next steps
+
+- [Durable Task .NET SDK export history sample](https://github.com/Azure-Samples/Durable-Task-Scheduler/tree/main/samples/durable-task-sdks/dotnet/ExportHistoryWebApp)
+- [Create an app with the Durable Task SDKs](../sdks/quickstart-portable-durable-task-sdks.md)


### PR DESCRIPTION
## Summary

Adds a new feature guide for exporting orchestration execution history from Durable Task Scheduler to Azure Blob Storage using the .NET Durable Task SDK.

## What's covered

- **Export modes**: Batch (fixed time window) and Continuous (ongoing tail)
- **SDK registration**: \UseExportHistory()\ on both worker and client builders
- **Client API**: \ExportHistoryClient\ for creating, querying, listing, and deleting export jobs
- **Job creation options**: mode, time window, destination, format (JSONL+gzip / JSON), runtime status filter, batch size
- **Exported data layout**: blob naming (SHA-256 hash), file formats, prefix support
- **Environment variables**: \DURABLE_TASK_CONNECTION_STRING\, \EXPORT_HISTORY_STORAGE_CONNECTION_STRING\, \EXPORT_HISTORY_CONTAINER_NAME\, \EXPORT_HISTORY_PREFIX\
- **Azure permissions**: required RBAC roles
- **TOC entry**: added under Durable Task SDKs section

## Source references

- SDK package: [\Microsoft.DurableTask.ExportHistory\](https://github.com/microsoft/durabletask-dotnet/tree/main/src/ExportHistory) in microsoft/durabletask-dotnet
- Sample app: [\ExportHistoryWebApp\](https://github.com/Azure-Samples/Durable-Task-Scheduler/tree/main/samples/durable-task-sdks/dotnet/ExportHistoryWebApp) in Azure-Samples/Durable-Task-Scheduler
- Modeled after the existing [large payload support doc](https://learn.microsoft.com/en-us/azure/durable-task/scheduler/durable-task-scheduler-large-payloads)

## Notes

- Currently .NET Durable Task SDK only (no Durable Functions support yet)
- Feature is in Preview (\1.22.0-preview.1\ package version)