### PR TITLE
APIM virtual network reference - Describe more restricted outbound TCP access to port 12000

### DIFF
--- a/articles/api-management/virtual-network-reference.md
+++ b/articles/api-management/virtual-network-reference.md
@@ -49,7 +49,7 @@ When an API Management service instance is hosted in a VNet, the ports in the fo
 | Outbound | VirtualNetwork | * | Sql | 1433                     |  TCP                | Allow          | **Access to Azure SQL endpoints**                           | External & Internal  |
 | Outbound | VirtualNetwork | * | AzureKeyVault | 443                     |  TCP                | Allow                | **Access to Azure Key Vault**                         | External & Internal  |
 | Outbound | VirtualNetwork | * | EventHub | 5671, 5672, 443          |  TCP                | Allow            | Dependency for [Log to Azure Event Hubs policy](api-management-howto-log-event-hubs.md) and [Azure Monitor](api-management-howto-use-azure-monitor.md) (optional) | External & Internal  |
-| Outbound | VirtualNetwork | * | AzureMonitor | 1886, 443                     |  TCP                | Allow         | **Publish [Diagnostics Logs and Metrics](api-management-howto-use-azure-monitor.md), [Resource Health](/azure/service-health/resource-health-overview), and [Application Insights](api-management-howto-app-insights.md)**                  | External & Internal  |
+| Outbound | VirtualNetwork | * | AzureMonitor | 1886, 443, 12000                |  TCP                | Allow         | **Publish [Diagnostics Logs and Metrics](api-management-howto-use-azure-monitor.md), [Resource Health](/azure/service-health/resource-health-overview), and [Application Insights](api-management-howto-app-insights.md)**                  | External & Internal  |
 | Inbound & Outbound | VirtualNetwork | * | Virtual Network | 6380              | TCP                | Allow     | Access external Azure Cache for Redis service for [caching](api-management-caching-policies.md) policies between machines (optional)        | External & Internal  |
 | Inbound & Outbound | VirtualNetwork | * | VirtualNetwork | 6381 - 6383              |  TCP                | Allow     | Access internal Azure Cache for Redis service for [caching](api-management-caching-policies.md) policies between machines (optional)        | External & Internal  |
 | Inbound & Outbound | VirtualNetwork | * | VirtualNetwork |  4290               | UDP                | Allow     | Sync Counters for [Rate Limit](rate-limit-policy.md) policies between machines (optional)        | External & Internal  |
@@ -111,7 +111,6 @@ When adding virtual machines running Windows to the VNet, allow outbound connect
 The following settings and FQDNs are required to maintain and diagnose API Management's internal compute infrastructure.
 
 * Allow outbound UDP access on port `123` for NTP.
-* Allow outbound TCP access on port `12000` for diagnostics.
 * Allow outbound access on port `443` to the following endpoints for internal diagnostics: `azurewatsonanalysis-prod.core.windows.net`, `*.data.microsoft.com`, `azureprofiler.trafficmanager.net`, `shavamanifestazurecdnprod1.azureedge.net`, `shavamanifestcdnprod1.azureedge.net`.
 * Allow outbound access on port `443` to the following endpoint for internal PKI: `issuer.pki.azure.com`.
 * Allow outbound access on ports `80` and `443` to the following endpoints for Windows Update: `*.update.microsoft.com`, `*.ctldl.windowsupdate.com`, `ctldl.windowsupdate.com`, `download.windowsupdate.com`.


### PR DESCRIPTION
Moved reference to outbound TCP connections on port 12000 to Azure Monitor Service Tags specific outbound rules.

According to the "Virtual network configuration reference: API Management" documentation, there is a requirement to "Allow outbound TCP access on port 12000 for diagnostics" without mentioning a specific destination.
According to [this question/answer](https://learn.microsoft.com/en-us/answers/questions/2280840/internal-apim-calling-out-on-tcp-port-12000-but-th?sharingId=752B055A4C849159), opening this port is only needed for AzureMonitor Service Tags.
