### PR TITLE
Clarify DNS guidance for internal VNet API Management deployments

### DIFF
--- a/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
+++ b/articles/api-management/api-management-howto-integrate-internal-vnet-appgateway.md
@@ -243,7 +243,7 @@ The following example shows how to create an API Management instance in a virtua
         -AdminEmail $apimAdminEmail -VirtualNetwork $apimVirtualNetwork -VpnType "Internal" -Sku "Developer" -PublicIpAddressId $apimPublicIpAddressId.Id
     ```
 
-It can take between 30 and 40 minutes to create and activate an API Management instance in this tier. After the previous command succeeds, see [DNS configuration required to access internal virtual network API Management service](api-management-using-with-internal-vnet.md#dns-configuration) to confirm access to it.
+It can take between 30 and 40 minutes to create and activate an API Management instance in this tier. After the previous command succeeds, see [DNS configuration required to access internal virtual network API Management service](api-management-using-with-internal-vnet.md#dns-configuration-for-internal-virtual-network-scenarios) to confirm access to it.
 
 ## Set up custom domain names in API Management
 

--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -26,7 +26,7 @@ This article explains how to set up VNet connectivity for your API Management in
 * Git 
 
 > [!NOTE]
-> * None of the API Management endpoints are registered on the public DNS. The endpoints remain inaccessible until you [configure DNS](#dns-configuration) for the VNet.
+> * None of the API Management endpoints are registered on the public DNS. The endpoints remain inaccessible until you [configure DNS](#dns-configuration-for-internal-virtual-network-scenarios) for the VNet.
 > * To use the self-hosted gateway in this mode, also enable private connectivity to the self-hosted gateway [configuration endpoint](self-hosted-gateway-overview.md#fqdn-dependencies). 
 
 Use API Management in internal mode to:

--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -111,7 +111,7 @@ DNS must be scoped carefully. Improper zone ownership can break resolution for o
 
 ### Critical DNS design guidance
 
-`azure-api.net` is a publicly owned Azure domain used by multiple Azure services.
+`azure-api.net` is a publicly owned Azure domain used by multiple Azure and Microsoft services.
 
 Creating a Private DNS zone or authoritative forward lookup zone for the apex domain (`azure-api.net`) is not supported and can introduce unintended resolution failures.
 

--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -77,18 +77,6 @@ After successful deployment, you should see your API Management service's **priv
 
 [!INCLUDE [api-management-recommended-nsg-rules](../../includes/api-management-recommended-nsg-rules.md)]
 
-## DNS configuration
-
-In internal VNet mode, you have to manage your own DNS to enable inbound access to your API Management endpoints. 
-
-We recommend:
-
-1. Configure an Azure [DNS private zone](../dns/private-dns-overview.md).
-1. Link the Azure DNS private zone to the VNet into which you've deployed your API Management service. 
-
-Learn how to [set up a private zone in Azure DNS](../dns/private-dns-getstarted-portal.md).
-
-
 > [!NOTE]
 > The API Management service does not listen to requests on its IP addresses. It only responds to requests to the hostname configured on its endpoints. These endpoints include:
 > * API gateway
@@ -115,21 +103,72 @@ If you don't want to access the API Management service with the default host nam
 
 :::image type="content" source="media/api-management-using-with-internal-vnet/api-management-custom-domain-name.png" alt-text="Set up custom domain name":::
 
-### Configure DNS records
+## DNS configuration for internal VNet scenarios
 
-Create records in your DNS server to access the endpoints accessible from within your VNet. Map the endpoint records to the [private virtual IP address](#routing) for your service.
+When API Management is deployed in internal VNet mode, inbound access depends on customer‑managed DNS. The API Management service responds **only** to requests addressed to its configured host names and does not listen directly on its private IP address.
 
-For testing purposes, you might update the hosts file on a virtual machine in a subnet connected to the VNet in which API Management is deployed. Assuming the [private virtual IP address](#routing) for your service is 10.1.0.5, you can map the hosts file as follows. The hosts mapping file is at  `%SystemDrive%\drivers\etc\hosts` (Windows) or `/etc/hosts` (Linux, macOS). 
+**DNS must be scoped carefully. Improper zone ownership can break resolution for other Azure services.**
 
-| Internal virtual IP address | Endpoint configuration |
-| ----- | ----- |
+### Critical DNS design guidance
+
+`azure-api.net` is a **publicly owned Azure domain** used by multiple Azure services.
+
+Creating a **Private DNS zone or authoritative forward lookup zone for the apex domain (`azure-api.net`) is not supported** and can introduce unintended resolution failures.
+
+If a Private DNS zone is created for `azure-api.net`:
+
+- The zone becomes authoritative within the customer DNS scope  
+- Public records published by Azure are no longer resolvable  
+- Other Azure services that rely on `*.azure-api.net` may fail name resolution  
+- Customers must implement complex DNS forwarding to public resolvers to avoid breakage  
+
+**Forwarding or controlling the apex domain is strongly discouraged.**
+
+### Recommended DNS approach
+
+DNS configuration should be limited to **only the exact host names required for the API Management instance**.
+
+Recommended approaches:
+
+- Create **DNS records for the full FQDNs only**, pointing directly to the API Management private virtual IP
+- If using Azure Private DNS, create a zone **scoped to the specific service FQDN**, not the apex public domain
+- Alternatively, use an existing corporate DNS forward lookup zone and define **explicit A records** for each endpoint
+
+Examples of valid scoping:
+
+- `contosointernalvnet.azure-api.net`
+- `contosointernalvnet.portal.azure-api.net`
+- `contosointernalvnet.developer.azure-api.net`
+- `contosointernalvnet.management.azure-api.net`
+- `contosointernalvnet.scm.azure-api.net`
+
+**Do not create a Private DNS Zone or Forward Lookup Zone for `azure-api.net`.**
+
+### DNS records for default host names
+
+For the default API Management host names, create explicit DNS records that map each endpoint FQDN to the service private virtual IP.
+
+Example:
+
+| Private virtual IP | Host name |
+| ------------------ | --------- |
 | 10.1.0.5 | `contosointernalvnet.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.portal.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.developer.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.management.azure-api.net` |
 | 10.1.0.5 | `contosointernalvnet.scm.azure-api.net` |
 
-You can then access all the API Management endpoints from the virtual machine you created.
+These records must be resolvable from all VNets and on‑premises networks that require access to the API Management service.
+
+### Access on custom domain names
+
+If you don't want to access the API Management service with the default host names, set up [custom domain names](configure-custom-domain.md) for all your endpoints, as shown in the following image:
+
+:::image type="content" source="media/api-management-using-with-internal-vnet/api-management-custom-domain-name.png" alt-text="Set up custom domain name":::
+
+### Testing name resolution
+
+For testing purposes, you might update the hosts file on a virtual machine in a subnet connected to the VNet in which API Management is deployed. Assuming the [private virtual IP address](#routing) for your service is 10.1.0.5, you can map the hosts file as follows. The hosts mapping file is at  `%SystemDrive%\drivers\etc\hosts` (Windows) or `/etc/hosts` (Linux, macOS). 
 
 ## Routing
 

--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -103,17 +103,17 @@ If you don't want to access the API Management service with the default host nam
 
 :::image type="content" source="media/api-management-using-with-internal-vnet/api-management-custom-domain-name.png" alt-text="Set up custom domain name":::
 
-## DNS configuration for internal VNet scenarios
+## DNS configuration for internal Virtual Network scenarios
 
-When API Management is deployed in internal VNet mode, inbound access depends on customer‑managed DNS. The API Management service responds **only** to requests addressed to its configured host names and does not listen directly on its private IP address.
+When API Management is deployed in internal VNet mode, inbound access depends on customer‑managed DNS. The API Management service responds only to requests addressed to its configured host names and does not listen directly on its private IP address.
 
-**DNS must be scoped carefully. Improper zone ownership can break resolution for other Azure services.**
+DNS must be scoped carefully. Improper zone ownership can break resolution for other Azure services.
 
 ### Critical DNS design guidance
 
-`azure-api.net` is a **publicly owned Azure domain** used by multiple Azure services.
+`azure-api.net` is a publicly owned Azure domain used by multiple Azure services.
 
-Creating a **Private DNS zone or authoritative forward lookup zone for the apex domain (`azure-api.net`) is not supported** and can introduce unintended resolution failures.
+Creating a Private DNS zone or authoritative forward lookup zone for the apex domain (`azure-api.net`) is not supported and can introduce unintended resolution failures.
 
 If a Private DNS zone is created for `azure-api.net`:
 
@@ -126,13 +126,13 @@ If a Private DNS zone is created for `azure-api.net`:
 
 ### Recommended DNS approach
 
-DNS configuration should be limited to **only the exact host names required for the API Management instance**.
+DNS configuration should be limited to the exact host names required for the API Management instance.
 
 Recommended approaches:
 
-- Create **DNS records for the full FQDNs only**, pointing directly to the API Management private virtual IP
-- If using Azure Private DNS, create a zone **scoped to the specific service FQDN**, not the apex public domain
-- Alternatively, use an existing corporate DNS forward lookup zone and define **explicit A records** for each endpoint
+- Create DNS records for the full FQDNs only, pointing directly to the API Management private virtual IP
+- If using Azure Private DNS, create a zone scoped to the specific service FQDN, not the apex public domain
+- Alternatively, use an existing corporate DNS forward lookup zone and define explicit A records for each endpoint
 
 Examples of valid scoping:
 
@@ -142,7 +142,7 @@ Examples of valid scoping:
 - `contosointernalvnet.management.azure-api.net`
 - `contosointernalvnet.scm.azure-api.net`
 
-**Do not create a Private DNS Zone or Forward Lookup Zone for `azure-api.net`.**
+**Do not create a Private DNS zone or forward lookup zone for `azure-api.net`.**
 
 ### DNS records for default host names
 

--- a/articles/api-management/api-management-using-with-internal-vnet.md
+++ b/articles/api-management/api-management-using-with-internal-vnet.md
@@ -117,10 +117,10 @@ Creating a Private DNS zone or authoritative forward lookup zone for the apex do
 
 If a Private DNS zone is created for `azure-api.net`:
 
-- The zone becomes authoritative within the customer DNS scope  
-- Public records published by Azure are no longer resolvable  
-- Other Azure services that rely on `*.azure-api.net` may fail name resolution  
-- Customers must implement complex DNS forwarding to public resolvers to avoid breakage  
+- The zone becomes authoritative within the customer DNS scope
+- Public records published by Azure are no longer resolvable
+- Other Azure services that rely on `*.azure-api.net` may fail name resolution
+- Customers must implement complex DNS forwarding to public resolvers to avoid breakage
 
 **Forwarding or controlling the apex domain is strongly discouraged.**
 


### PR DESCRIPTION
Summary
Clarifies DNS guidance for API Management in internal VNet mode to avoid recommending ownership of the Azure‑owned azure-api.net public domain.
Details

Replaces the DNS configuration and Configure DNS records sections with consolidated guidance
Removes implicit recommendation to create a Private DNS zone or forward lookup zone for azure-api.net
Explicitly documents risks of apex domain ownership and public DNS resolution conflicts
Clarifies supported DNS scoping using service‑specific FQDNs only

Impact
Documentation-only change. No product behavior or configuration requirements modified.
Review
Content and technical guidance reviewed and approved by Content Dev and APIM EEE