### PR TITLE
Update maximum path patterns for routing rules

### DIFF
--- a/includes/front-door-limits.md
+++ b/includes/front-door-limits.md
@@ -63,7 +63,7 @@ ms.custom: include file
 | Maximum bandwidth <sup>1</sup> | 75 Gbps | 75 Gbps |
 | Maximum requests per second per profile <sup>1,</sup> <sup>2</sup> | 100,000 | 100,000 |
 | Maximum concurrent WebSocket connections per profile <sup>3</sup> | 3,000 | 3,000 |
-| Path patterns to match for a routing rule | 25 | 50 |
+| Path patterns to match for a routing rule | 100 | 100 |
 | URLs in a single cache purge call | 100 | 100 |
 | Maximum security policy per profile | 100 | 200 |
 | Maximum associations per security policy | 110 | 225 |


### PR DESCRIPTION
Could you please review this change and confirm the updated limit value is correct?

### Summary
Update the documented limit for "path patterns for routing rules" to 100 for both Standard and Premium.

### Details
The current documentation states Standard 25/Premium 50, but the actual enforced limit is 100 for both tiers. This PR updates the table/text to reflect the current behavior and prevent customer confusion.

### Impact
Documentation-only change. No product behavior change.