### PR TITLE
Fix typo in roleDefinitions function and update description

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-functions-resource.md
+++ b/articles/azure-resource-manager/bicep/bicep-functions-resource.md
@@ -663,9 +663,9 @@ For more information, see the [JSON template resourceId function](../templates/t
 
 ## roleDefinitions
 
-`roleDefinisions(roleName)`
+`roleDefinitions(roleName)`
 
-Returns information about the specified role definition, including `id` and `roleDefinitionId`. It's a name-based helper for Azure RBAC role assignments. Instead of requiring you to hardcode the GUID of a built-in role definition (like Contributor, Reader, and others), it lets you provide the built-in role’s display name, and the function resolves the corresponding role definition information at deployment time.
+Returns information about the specified role definition, including `id` and `roleDefinitionId`. It's a name-based helper for Azure RBAC role assignments. Instead of requiring you to hardcode the GUID of a custom or built-in role definition (like Contributor, Reader, and others), it lets you provide the custom or built-in role’s display name, and the function resolves the corresponding role definition information at deployment time.
 
 Namespace: [az](bicep-functions.md#namespaces-for-functions).
 


### PR DESCRIPTION
Corrected a typo in the roleDefinitions function name and clarified the description regarding role definitions. I did double check in a live environment that it actually supports custom roles, so that's something to be really emphasized in order to be really clear about what it does. Either like this or omit `built-in` phrasing.