### PR TITLE
Add CA certificate chain-building safety warnings to APIM docs

### DIFF
--- a/articles/api-management/api-management-howto-ca-certificates.md
+++ b/articles/api-management/api-management-howto-ca-certificates.md
@@ -22,6 +22,9 @@ Azure API Management allows you to upload and install CA certificates on the mac
 
 This article shows how to manage CA certificates of an API Management instance in the Azure portal. For example, if you use self-signed client certificates, you can upload custom trusted root certificates to API Management. 
 
+> [!IMPORTANT]
+> **CA certificates are installed into the machine-wide certificate store.** Once installed, a CA certificate immediately participates in TLS certificate chain building for all communications on the API Management infrastructure node — including the API gateway's host certificate chain, custom domain certificate chains, management API, developer portal, and internal services. If the uploaded certificate's issuer key matches certificates used by existing chains, the operating system automatically includes the new CA certificate, which can alter the intermediate certificates presented during TLS handshakes. This can unexpectedly change TLS behavior for host certificates, backend connections, and client certificate validation. **Test CA certificate changes in a non-production environment first**, and review the [safety considerations](#safety-considerations) section before uploading.
+
 [!INCLUDE [api-management-ca-certificate-v2-tiers](../../includes/api-management-ca-certificate-v2-tiers.md)]
 
 CA certificates uploaded to API Management can be used for certificate validation only by the managed API Management gateway. If you use the [self-hosted gateway](self-hosted-gateway-overview.md), you can learn how to [create a custom CA for self-hosted gateway](#create-custom-ca-for-a-self-hosted-gateway) later in this article.
@@ -62,6 +65,40 @@ Use the [Gateway Certificate Authority](/rest/api/apimanagement/current-ga/gatew
 
 1. [Add a certificate](api-management-howto-mutual-certificates.md) .pfx file to your API Management instance.
 1. Use the [Gateway Certificate Authority - Create Or Update](/rest/api/apimanagement/current-ga/gateway-certificate-authority/create-or-update) REST API to associate the certificate with the self-managed gateway.
+
+## Safety considerations
+
+CA certificates uploaded to API Management are installed into the machine-wide certificate store on the underlying infrastructure. It's important to understand the following implications before uploading a CA certificate.
+
+### How certificate chain building works
+
+When a TLS connection is established, the operating system builds a certificate chain from the server (leaf) certificate up to a trusted root. During this process, the system searches the machine certificate store for intermediate and root CA certificates. If a newly uploaded CA certificate's issuer key matches any certificate in a chain being built, the operating system **automatically includes** it — even if that chain is used by a different process or for a different purpose than you intended.
+
+### What can be affected
+
+Because all services on an API Management node share the same machine certificate store, uploading a CA certificate can affect:
+
+- **Host certificate chain** — The default SSL certificate that API Management uses for its built-in hostnames (such as `<service-name>.azure-api.net`) has its own certificate chain. If the uploaded CA certificate's issuer key matches a certificate in the host certificate's chain, the operating system may silently substitute or extend the chain with the new certificate. This can change the intermediate certificate that the gateway presents during TLS handshakes, potentially breaking certificate pinning or thumbprint-based validation performed by clients.
+- **Custom domain certificate chains** — Certificates configured for [custom domain names](configure-custom-domain.md) are also affected because they share the same certificate store.
+- **API gateway** — TLS handshakes for inbound API requests and outbound backend connections.
+- **Management API** — Internal management plane communications.
+- **Developer portal** — Portal-to-backend connectivity.
+- **Internal services** — Certificate validation for service-to-service communication.
+
+### Before you upload
+
+- **Test first** — Upload the CA certificate to a Developer-tier or non-production instance and verify that all services continue to operate correctly.
+- **Verify the issuer** — Check that the certificate's issuer name and key don't conflict with existing certificates used by the API Management instance.
+- **Plan for rollback** — Know how to [delete the CA certificate](#delete-a-ca-certificate) quickly if the upload causes unexpected issues.
+- **Monitor after upload** — After uploading, monitor the API gateway, management API, and developer portal for TLS errors or unexpected certificate validation failures.
+
+### Troubleshooting
+
+If you experience issues after uploading a CA certificate:
+
+- **Unexpected 502 or 503 errors** — The new CA certificate might have changed TLS certificate chains, causing handshake failures. Delete the recently uploaded certificate and verify that operations return to normal.
+- **Certificate validation failures** — Chain building might now include the new CA certificate where it wasn't expected. Check certificate thumbprints and chain composition.
+- **Backend connectivity issues** — Outbound TLS connections to backend services might be using a different certificate chain after the upload.
 
 ## Limits
 

--- a/articles/api-management/api-management-howto-mutual-certificates-for-clients.md
+++ b/articles/api-management/api-management-howto-mutual-certificates-for-clients.md
@@ -50,6 +50,9 @@ We recommend using key vault certificates because the approach helps improve API
    >
    > CA certificates for certificate validation aren't supported in the Consumption tier.
 
+   > [!IMPORTANT]
+   > Uploading CA certificates affects the machine-wide certificate store and can impact TLS communications across the entire API Management node. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading.
+
 [!INCLUDE [api-management-client-certificate-key-vault](../../includes/api-management-client-certificate-key-vault.md)]
 
    > [!NOTE]
@@ -117,7 +120,7 @@ The following policies can be configured to check the issuer and subject of a cl
 >
 > To disable checking certificate revocation list, use `context.Request.Certificate.VerifyNoRevocation()` instead of `context.Request.Certificate.Verify()`.
 >
-> If client certificate is self-signed, root (or intermediate) CA certificates must be [uploaded](api-management-howto-ca-certificates.md) to API Management for `context.Request.Certificate.Verify()` and `context.Request.Certificate.VerifyNoRevocation()` to work.
+> If client certificate is self-signed, root (or intermediate) CA certificates must be [uploaded](api-management-howto-ca-certificates.md) to API Management for `context.Request.Certificate.Verify()` and `context.Request.Certificate.VerifyNoRevocation()` to work. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading CA certificates.
 
 ### Checking the thumbprint
 
@@ -137,7 +140,7 @@ The following policies can be configured to check the thumbprint of a client cer
 >
 > To disable checking certificate revocation list, use `context.Request.Certificate.VerifyNoRevocation()` instead of `context.Request.Certificate.Verify()`.
 >
-> If client certificate is self-signed, root (or intermediate) CA certificates must be [uploaded](api-management-howto-ca-certificates.md) to API Management for `context.Request.Certificate.Verify()` and `context.Request.Certificate.VerifyNoRevocation()` to work.
+> If client certificate is self-signed, root (or intermediate) CA certificates must be [uploaded](api-management-howto-ca-certificates.md) to API Management for `context.Request.Certificate.Verify()` and `context.Request.Certificate.VerifyNoRevocation()` to work. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading CA certificates.
 
 ### Checking a thumbprint against certificates uploaded to API Management
 
@@ -157,7 +160,7 @@ The following example shows how to check the thumbprint of a client certificate 
 > [!NOTE]
 > To disable checking certificate revocation list, use `context.Request.Certificate.VerifyNoRevocation()` instead of `context.Request.Certificate.Verify()`.
 >
-> If client certificate is self-signed, root (or intermediate) CA certificates must be [uploaded](api-management-howto-ca-certificates.md) to API Management for `context.Request.Certificate.Verify()` and `context.Request.Certificate.VerifyNoRevocation()` to work.
+> If client certificate is self-signed, root (or intermediate) CA certificates must be [uploaded](api-management-howto-ca-certificates.md) to API Management for `context.Request.Certificate.Verify()` and `context.Request.Certificate.VerifyNoRevocation()` to work. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading CA certificates.
 
 > [!TIP]
 >

--- a/articles/api-management/api-management-howto-mutual-certificates.md
+++ b/articles/api-management/api-management-howto-mutual-certificates.md
@@ -52,7 +52,10 @@ We recommend that you use key vault certificates because doing so improves API M
 
     > [!NOTE]
     > When a client certificate is used by API Management for **outbound authentication** (for example, when API Management presents the certificate to a backend service), you don't need to upload the root or intermediate CA certificates to the API Management CA store. In this scenario, API Management *presents* the client certificate and doesn't perform certificate chain validation.<br/><br/>
-    > Uploading trusted root or intermediate CA certificates is only required when API Management must *validate* a certificate chain, such as during inbound client certificate authentication. If you do need to upload CA certificates, review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading, because CA certificates affect the machine-wide certificate store.
+    > Uploading trusted root or intermediate CA certificates is only required when API Management must *validate* a certificate chain, such as during inbound client certificate authentication.
+
+    > [!IMPORTANT]
+    > Uploading CA certificates (root or intermediate) affects the **machine-wide** certificate store on the API Management infrastructure node. A newly uploaded intermediate certificate can alter TLS certificate chain building for **all** services on the node — including the API gateway host certificate, custom domain certificates, backend connections, and other internal communications — not just the chain you intend to modify. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading, and test in a non-production environment first.
 
 [!INCLUDE [api-management-client-certificate-key-vault](../../includes/api-management-client-certificate-key-vault.md)]
 

--- a/articles/api-management/api-management-howto-mutual-certificates.md
+++ b/articles/api-management/api-management-howto-mutual-certificates.md
@@ -52,7 +52,7 @@ We recommend that you use key vault certificates because doing so improves API M
 
     > [!NOTE]
     > When a client certificate is used by API Management for **outbound authentication** (for example, when API Management presents the certificate to a backend service), you don't need to upload the root or intermediate CA certificates to the API Management CA store. In this scenario, API Management *presents* the client certificate and doesn't perform certificate chain validation.<br/><br/>
-    > Uploading trusted root or intermediate CA certificates is only required when API Management must *validate* a certificate chain, such as during inbound client certificate authentication.
+    > Uploading trusted root or intermediate CA certificates is only required when API Management must *validate* a certificate chain, such as during inbound client certificate authentication. If you do need to upload CA certificates, review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading, because CA certificates affect the machine-wide certificate store.
 
 [!INCLUDE [api-management-client-certificate-key-vault](../../includes/api-management-client-certificate-key-vault.md)]
 

--- a/articles/api-management/backends.md
+++ b/articles/api-management/backends.md
@@ -121,6 +121,9 @@ To add CA certificate details, follow these steps:
 > [!TIP]
 > You can also configure CA certificate details programmatically by using the API Management REST API. Set the `backendTlsProperties` in the [backend entity](/rest/api/apimanagement/backend/create-or-update?view=rest-apimanagement-2025-03-01-preview&preserve-view=true#backendtlsproperties).
 
+> [!IMPORTANT]
+> CA certificates uploaded to API Management are installed into the machine-wide certificate store. Uploading a CA certificate can affect TLS certificate chain building for **all** services on the API Management node — not only backend connections. The operating system may automatically include the new certificate in chains used by the gateway, custom domains, and other endpoints. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading CA certificates, and test changes in a non-production environment first.
+
 ## Reference backend using set-backend-service policy
 
 After creating a backend, reference the backend identifier (name) in your APIs. Use the [`set-backend-service`](set-backend-service-policy.md) policy to direct an incoming API request to the backend. If you already configured a backend web service for an API, use the `set-backend-service` policy to redirect the request to a backend entity instead. For example:

--- a/articles/api-management/configure-custom-domain.md
+++ b/articles/api-management/configure-custom-domain.md
@@ -80,6 +80,9 @@ If you already have a private certificate from a third-party provider, you can u
 * Contains private key at least 2048 bits long
 * Contains all intermediate certificates and the root certificate in the certificate chain.
 
+> [!NOTE]
+> If you also upload CA certificates (root or intermediate) to the API Management [CA certificate store](api-management-howto-ca-certificates.md), those certificates are installed into the machine-wide certificate store on the underlying infrastructure. This can affect TLS certificate chain building for **all** endpoints on the node, including custom domain certificates. Review the [safety considerations](api-management-howto-ca-certificates.md#safety-considerations) before uploading CA certificates.
+
 # [Key Vault](#tab/key-vault)
 
 We recommend using Azure Key Vault to [manage your certificates](/azure/key-vault/certificates/about-certificates) and setting them to `autorenew`.


### PR DESCRIPTION
## Summary

Adds cross-reference warnings to three API Management articles that mention certificate uploads but previously lacked adequate warnings about the machine-wide certificate store impact on TLS chain building.

## Problem

When a customer uploads an intermediate CA certificate to API Management, it is installed into the **machine-wide Windows certificate store**. This means it can affect **all** certificate chain building on the APIM node — not just the chain the customer intended. Customers need to be aware that uploading an intermediate certificate is not an isolated, safe operation.

The primary CA certificates article (\pi-management-howto-ca-certificates.md\) already has comprehensive safety documentation, but several related articles lacked cross-references to those warnings.

## Changes

### \configure-custom-domain.md\
- Added **NOTE** callout in the PFX requirements section warning that separately uploaded CA certificates affect the machine-wide store and can alter chain building for custom domain certificates.

### \ackends.md\
- Added **IMPORTANT** callout in the *Configure CA certificate* section warning that uploaded CA certs affect TLS chain building for **all** services on the node, not only backend connections.

### \pi-management-howto-mutual-certificates.md\
- Elevated the existing brief inline mention to a standalone **IMPORTANT** callout that explicitly warns about machine-wide store impact and that newly uploaded intermediate certificates can alter chain building for all services on the node.

All warnings cross-reference the [safety considerations](https://learn.microsoft.com/azure/api-management/api-management-howto-ca-certificates#safety-considerations) section and recommend testing in a non-production environment first.