### PR TITLE
Add Azure Red Hat OpenShift as cloud-native option

### DIFF
--- a/articles/sap/workloads/sap-edge-integration-cell-with-azure.md
+++ b/articles/sap/workloads/sap-edge-integration-cell-with-azure.md
@@ -49,6 +49,7 @@ Consider the following Microsoft Learn resources for AKS for a successful deploy
 | **Cloud-Native** | Azure Kubernetes Service (AKS) | Azure Database for PostgreSQL, Azure Redis Cache | Recommended for production; supports autoscaling and HA setups |
 | **On-Premises** | Azure ARC-enabled Kubernetes Service | Azure ARC |  |
 | **Dev/Test** | Azure Kubernetes Service (single node pool) | none | Use SAP's built-in PostgreSQL and Cache option for quickest deployment; not suitable for production |
+| **Cloud-Native** | Azure Red Hat OpenShift (ARO) | Azure Database for PostgreSQL, Azure Cache for Redis | Reference article for OpenShift setup https://access.redhat.com/articles/7084706 |
 
 It's recommended to use Azure PaaS services for a fully platform-managed experience and optimal Service Level Agreement.
 

--- a/articles/sap/workloads/sap-edge-integration-cell-with-azure.md
+++ b/articles/sap/workloads/sap-edge-integration-cell-with-azure.md
@@ -46,7 +46,7 @@ Consider the following Microsoft Learn resources for AKS for a successful deploy
 
 | Deployment Type | Kubernetes Platform | Supporting Azure Services | Notes |
 |-----------------|---------------------|---------------------|-------|
-| **Cloud-Native** | Azure Kubernetes Service (AKS) | Azure Database for PostgreSQL, Azure Redis Cache | Recommended for production; supports autoscaling and HA setups |
+| **Cloud-Native** | Azure Kubernetes Service (AKS) | Azure Database for PostgreSQL, Azure Cache for Redis | Recommended for production; supports autoscaling and HA setups |
 | **On-Premises** | Azure ARC-enabled Kubernetes Service | Azure ARC |  |
 | **Dev/Test** | Azure Kubernetes Service (single node pool) | none | Use SAP's built-in PostgreSQL and Cache option for quickest deployment; not suitable for production |
 | **Cloud-Native** | Azure Red Hat OpenShift (ARO) | Azure Database for PostgreSQL, Azure Cache for Redis | Reference article for OpenShift setup https://access.redhat.com/articles/7084706 |

--- a/articles/sap/workloads/sap-edge-integration-cell-with-azure.md
+++ b/articles/sap/workloads/sap-edge-integration-cell-with-azure.md
@@ -49,7 +49,7 @@ Consider the following Microsoft Learn resources for AKS for a successful deploy
 | **Cloud-Native** | Azure Kubernetes Service (AKS) | Azure Database for PostgreSQL, Azure Cache for Redis | Recommended for production; supports autoscaling and HA setups |
 | **On-Premises** | Azure ARC-enabled Kubernetes Service | Azure ARC |  |
 | **Dev/Test** | Azure Kubernetes Service (single node pool) | none | Use SAP's built-in PostgreSQL and Cache option for quickest deployment; not suitable for production |
-| **Cloud-Native** | Azure Red Hat OpenShift (ARO) | Azure Database for PostgreSQL, Azure Cache for Redis | Reference article for OpenShift setup https://access.redhat.com/articles/7084706 |
+| **Cloud-Native** | Azure Red Hat OpenShift (ARO) | Azure Database for PostgreSQL, Azure Cache for Redis | Reference article for [OpenShift setup](https://access.redhat.com/articles/7084706) |
 
 It's recommended to use Azure PaaS services for a fully platform-managed experience and optimal Service Level Agreement.
 


### PR DESCRIPTION
Added information about Azure Red Hat OpenShift (ARO) as a cloud-native option with a reference article for setup.