### PR TITLE
Update error codes in change feed documentation

### DIFF
--- a/articles/storage/blobs/storage-blob-change-feed.md
+++ b/articles/storage/blobs/storage-blob-change-feed.md
@@ -660,7 +660,7 @@ This section describes known issues and conditions in the current release of the
 - The `LastConsumable` property of the segments.json file does not list the very first segment that the change feed finalizes. This issue occurs only after the first segment is finalized. All subsequent segments after the first hour are accurately captured in the `LastConsumable` property.
 - You currently cannot see the **$blobchangefeed** container when you call the ListContainers API. You can view the contents by calling the ListBlobs API on the $blobchangefeed container directly.
 - Storage account failover of geo-redundant storage accounts with the change feed enabled may result in inconsistencies between the change feed logs and the blob data and/or metadata. For more information about such inconsistencies, see [Change feed and blob data inconsistencies](../common/storage-disaster-recovery-guidance.md#change-feed-and-blob-data-inconsistencies).
-- You might see 404 (Not Found),409 (BlobAlreadyExists) and 412 (Precondition Failed) errors reported on the **$blobchangefeed** containers. You can safely ignore these errors.
+- You might see 404 (Not Found), 409 (BlobAlreadyExists) and 412 (Precondition Failed) errors reported on the **$blobchangefeed** containers. You can safely ignore these errors.
 - BlobDeleted events are not generated when blob versions or snapshots are deleted. A BlobDeleted event is added only when a base (root) blob is deleted.
 - Event records are added only for changes to blobs that result from requests to the Blob Service endpoint (`blob.core.windows.net`). Changes that result from requests to the Data Lake Storage endpoint (`dfs.core.windows.net`) endpoint aren't logged and won't appear in change feed records.
 

--- a/articles/storage/blobs/storage-blob-change-feed.md
+++ b/articles/storage/blobs/storage-blob-change-feed.md
@@ -660,7 +660,7 @@ This section describes known issues and conditions in the current release of the
 - The `LastConsumable` property of the segments.json file does not list the very first segment that the change feed finalizes. This issue occurs only after the first segment is finalized. All subsequent segments after the first hour are accurately captured in the `LastConsumable` property.
 - You currently cannot see the **$blobchangefeed** container when you call the ListContainers API. You can view the contents by calling the ListBlobs API on the $blobchangefeed container directly.
 - Storage account failover of geo-redundant storage accounts with the change feed enabled may result in inconsistencies between the change feed logs and the blob data and/or metadata. For more information about such inconsistencies, see [Change feed and blob data inconsistencies](../common/storage-disaster-recovery-guidance.md#change-feed-and-blob-data-inconsistencies).
-- You might see 404 (Not Found) and 412 (Precondition Failed) errors reported on the **$blobchangefeed** containers. You can safely ignore these errors.
+- You might see 404 (Not Found),409 (BlobAlreadyExists) and 412 (Precondition Failed) errors reported on the **$blobchangefeed** containers. You can safely ignore these errors.
 - BlobDeleted events are not generated when blob versions or snapshots are deleted. A BlobDeleted event is added only when a base (root) blob is deleted.
 - Event records are added only for changes to blobs that result from requests to the Blob Service endpoint (`blob.core.windows.net`). Changes that result from requests to the Data Lake Storage endpoint (`dfs.core.windows.net`) endpoint aren't logged and won't appear in change feed records.
 


### PR DESCRIPTION
Customers observe HTTP 409 responses for PutBlob operations on the $changefeed container, which can lead to confusion. Documenting this behavior would help clarify expectations, reduce misunderstandings, and minimize related support requests.