### PR TITLE
Document reading route parameters in the Python v2 model

### DIFF
--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -218,13 +218,9 @@ def http_trigger(req: func.HttpRequest) -> str:
 
 ### Reading route parameters
 
-When you define a route with parameters in the path — for example, `products/{product_id}` —
-read those parameters from the [HttpRequest] object's `route_params` dictionary inside the
-function body. Don't declare route parameters as additional arguments on the function signature.
-In the Python v2 model, function parameters must correspond to the trigger and any declared
-input or output bindings. Adding an extra argument that doesn't correspond to a declared
-binding, such as a route parameter, can cause the worker indexer to silently drop all
-functions in the app, and the host logs `0 functions found (Custom)` with no traceback.
+You can define route parameters directly in the HTTP route template and read them from the request object.
+
+For example, the route products/{product_id} captures the value from the URL path and makes it available through HttpRequest.route_params.
 
 ```python
 import azure.functions as func
@@ -236,6 +232,9 @@ def get_product(req: func.HttpRequest) -> func.HttpResponse:
     product_id = req.route_params.get("product_id", "")
     return func.HttpResponse(f"Product: {product_id}")
 ```
+
+>[!IMPORTANT]
+>In the Python v2 model, route parameters shouldn't be added as extra function arguments. Read them from `req.route_params` instead.
 
 ### Organizing with blueprints
 

--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -221,10 +221,10 @@ def http_trigger(req: func.HttpRequest) -> str:
 When you define a route with parameters in the path — for example, `products/{product_id}` —
 read those parameters from the [HttpRequest] object's `route_params` dictionary inside the
 function body. Don't declare route parameters as additional arguments on the function signature.
-The Python v2 model expects HTTP-trigger functions to take exactly one `HttpRequest` argument
-plus any declared input or output bindings. Adding an extra argument that doesn't correspond
-to a declared binding causes the worker indexer to silently drop all functions in the app,
-and the host logs `0 functions found (Custom)` with no traceback.
+In the Python v2 model, function parameters must correspond to the trigger and any declared
+input or output bindings. Adding an extra argument that doesn't correspond to a declared
+binding, such as a route parameter, can cause the worker indexer to silently drop all
+functions in the app, and the host logs `0 functions found (Custom)` with no traceback.
 
 ```python
 import azure.functions as func

--- a/articles/azure-functions/functions-reference-python.md
+++ b/articles/azure-functions/functions-reference-python.md
@@ -2,7 +2,7 @@
 title: Python developer reference for Azure Functions
 description: Understand how to develop, validate, and deploy your Python code projects to Azure Functions using the Python library for Azure Functions.
 ms.topic: article
-ms.date: 11/09/2025
+ms.date: 04/26/2026
 ms.devlang: python
 ms.custom:
   - devx-track-python
@@ -214,6 +214,27 @@ The `azure-functions` must be included in your project dependencies. To learn mo
 Use **type annotations** to improve IntelliSense and editor support:
 ```python
 def http_trigger(req: func.HttpRequest) -> str:
+```
+
+### Reading route parameters
+
+When you define a route with parameters in the path — for example, `products/{product_id}` —
+read those parameters from the [HttpRequest] object's `route_params` dictionary inside the
+function body. Don't declare route parameters as additional arguments on the function signature.
+The Python v2 model expects HTTP-trigger functions to take exactly one `HttpRequest` argument
+plus any declared input or output bindings. Adding an extra argument that doesn't correspond
+to a declared binding causes the worker indexer to silently drop all functions in the app,
+and the host logs `0 functions found (Custom)` with no traceback.
+
+```python
+import azure.functions as func
+
+app = func.FunctionApp()
+
+@app.route(route="products/{product_id}", methods=["GET"])
+def get_product(req: func.HttpRequest) -> func.HttpResponse:
+    product_id = req.route_params.get("product_id", "")
+    return func.HttpResponse(f"Product: {product_id}")
 ```
 
 ### Organizing with blueprints


### PR DESCRIPTION
## Summary

Adds a new `### Reading route parameters` subsection to the Python v2 programming
model zone in `functions-reference-python.md`, covering how to read path parameters
from `req.route_params` inside HTTP-trigger functions.

## Why

The article currently mentions in passing that the `HttpRequest` object "contains
request headers, query parameters, route parameters, and the message body," but
never shows how to read route parameters in the v2 model. The natural assumption
— accepting them as additional function arguments, the way many Python web
frameworks do — silently breaks the worker indexer and drops *all* functions in
the app, with `0 functions found (Custom)` in the host logs and no traceback.

This pattern is reported repeatedly in
[azure-functions-python-worker#1262](https://github.com/Azure/azure-functions-python-worker/issues/1262),
and I added a comment on that issue documenting the specific reproduction:
[issue comment](https://github.com/Azure/azure-functions-python-worker/issues/1262#issuecomment-4322820746).

Documenting the correct pattern (and the trap) inline in the language reference
seems to be the cheapest way to spare future contributors the diagnosis cost.

## Changes

- Adds `### Reading route parameters` subsection between the basic HTTP trigger
  example and `### Organizing with blueprints`, within the
  `python-mode-decorators` zone.
- Per the Microsoft Learn style guide ("Avoid notes, tips, and important
  boxes... put that info directly into the article text"), the warning about
  the function-signature trap is written as inline prose, not as an
  `[!IMPORTANT]` callout.
- Bumps `ms.date` to `04/26/2026` per the major-edits contributor guide.

## Validation

The change is text-only inside an existing zone block; no new images, links, or
metadata fields. Should pass the standard build/render validation. Happy to
soften wording if the Azure Functions Python team prefers a less direct framing
of the worker behavior.