### PR TITLE
docs: Clarify AOF persistence runs on replica shards only when HA is enabled

### DIFF
--- a/articles/redis/how-to-persistence.md
+++ b/articles/redis/how-to-persistence.md
@@ -32,6 +32,9 @@ You have two options for persistence with Azure Managed Redis: the _Redis databa
 - _RDB persistence_ - When you use RDB persistence, Azure Managed Redis persists a snapshot of your cache in a binary format. The snapshot is saved on a managed disk mounted to the Redis instance. The configurable backup frequency determines how often to persist the snapshot. If a catastrophic event occurs that disables both the primary and replica, the cache is reconstructed automatically using the most recent snapshot. Learn more about the [advantages](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/#rdb-advantages) and [disadvantages](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/#rdb-disadvantages) of RDB persistence.
 - _AOF persistence_ - When you use AOF persistence, Azure Managed Redis saves every write operation to a log. The log is saved once per second on a managed disk mounted to the Redis instance. If a catastrophic event occurs that disables both the primary and replica caches, the cache is reconstructed automatically using the stored write operations. Learn more about the [advantages](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/#aof-advantages) and [disadvantages](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/#aof-disadvantages) of AOF persistence.
 
+> [!NOTE]
+> For caches with high availability (HA) enabled, AOF persistence runs on replica shards only. Primary shards have `appendonly` disabled to avoid write overhead. This means commands such as `WAITAOF` should use `numlocal=0` to avoid errors when the client connects to a primary shard.
+
 > [!IMPORTANT]
 > Azure Managed Redis persistence features are intended to be used to restore data automatically to the same cache after data loss. The RDB/AOF persisted data files can neither be accessed by users nor imported to a new or existing cache. To move data across caches, use the _Import and Export_ feature. For more information, see [Import and Export data in Azure Managed Redis](how-to-import-export-data.md).
 > 
@@ -149,7 +152,7 @@ For more information on performance when using AOF persistence, see [Does AOF pe
 
 ### Does AOF persistence affect throughput, latency, or performance of my cache?
 
-Using AOF persistence does impact throughput. AOF runs on all primary processes, therefore you see higher CPU and Server Load for a cache with AOF persistence than an identical cache without AOF persistence. AOF offers the best consistency with the data in memory because each write and delete is persisted with only a few seconds of delay. The trade-off is that AOF is more compute intensive.
+Using AOF persistence does impact throughput. For caches with high availability enabled, AOF persistence runs on replica shards only, with `appendonly` disabled on primary shards. You might see higher CPU and Server Load for a cache with AOF persistence than an identical cache without AOF persistence. AOF offers the best consistency with the data in memory because each write and delete is persisted with only a few seconds of delay. The trade-off is that AOF is more compute intensive.
 
 ### What happens if I've scaled to a different size and a backup is restored that was made before the scaling operation?
 


### PR DESCRIPTION
## Summary

Clarifies that for Azure Managed Redis caches with high availability (HA) enabled, AOF persistence runs on **replica shards only**, with `appendonly` disabled on primary shards to avoid write overhead.

## Problem

Customers using the `WAITAOF` command with `numlocal > 0` were seeing inconsistent behavior — the command would succeed on replica shards (where AOF is enabled) but fail on primary shards (where AOF is disabled) with:

`ERR WAITAOF cannot be used when numlocal is set but appendonly is disabled`

This was not documented, leading to confusion across multiple customer environments. Additionally, the FAQ incorrectly stated that *"AOF runs on all primary processes"*, which contradicts the actual replica-only behavior.

## Changes

1. **Added a NOTE** under the AOF persistence description clarifying that AOF runs on replica shards only when HA is enabled, and that `WAITAOF` should use `numlocal=0`.
2. **Corrected the FAQ** answer for *"Does AOF persistence affect throughput, latency, or performance?"* to reflect the replica-only behavior instead of the incorrect statement about primary processes.

## Related

- Confirmed by Redis Inc support (CRI Incident 21000000997919)
- Support Request: 2604230040009684