### PR TITLE
Update note on Savings Plans transfer for currency changes

### DIFF
--- a/articles/cost-management-billing/manage/mca-setup-account.md
+++ b/articles/cost-management-billing/manage/mca-setup-account.md
@@ -252,7 +252,7 @@ You see the following image when your Enterprise Agreement enrollment savings pl
 :::image type="content" source="./media/microsoft-customer-agreement-setup-account/savings-plan-repurchase.png" alt-text="Screenshot showing the Savings Plan page." lightbox="./media/microsoft-customer-agreement-setup-account/savings-plan-repurchase.png" :::
 
 >[!NOTE]
-> -If your enrollment is non USD currency, any Azure Savings Plans purchased will not be transferred to the destination billing account.  The Savings Plans will be cancelled in the source enrollment and automatically repurchased in the destination billing account. Note the following:
+> - If your enrollment is non USD currency, any Azure Savings Plans purchased will not be transferred to the destination billing account. The Savings Plans will be cancelled in the source enrollment and automatically repurchased in the destination billing account. Note the following:
 >    - Each newly purchase Savings Plan will be billed Monthly, regardless of the billing frequency of the Savings Plan it is replacing.
 >    - Each newly purchased Savings Plan will be priced as the USD equivalent of the original Savings Plan. For example, assuming a €1: $1.17 rate, a €5/hour Savings Plan would be replaced with a $5.85/hour Savings Plan. 
 >    - Each newly purchased Savings Plans will have a 1-year term, regardless of the term of the Savings Plan it is replacing. As a result, each new Savings Plan will have a different term end date when compared to the Savings Plan being replaced.

--- a/articles/cost-management-billing/manage/mca-setup-account.md
+++ b/articles/cost-management-billing/manage/mca-setup-account.md
@@ -252,7 +252,7 @@ You see the following image when your Enterprise Agreement enrollment savings pl
 :::image type="content" source="./media/microsoft-customer-agreement-setup-account/savings-plan-repurchase.png" alt-text="Screenshot showing the Savings Plan page." lightbox="./media/microsoft-customer-agreement-setup-account/savings-plan-repurchase.png" :::
 
 >[!NOTE]
-> - If your enrollment transfer (e.g. EA to MCA, EA to EA, etc.) involves a change in pricing currency (e.g. EUR to USD), Savings Plans from the source enrollment will not be transferred to the destination enrollment. The Savings Plans will be cancelled in the source enrollment and automatically repurchased in the destination enrollment. Note the following:
+> -If your enrollment is non USD currency, any Azure Savings Plans purchased will not be transferred to the destination billing account.  The Savings Plans will be cancelled in the source enrollment and automatically repurchased in the destination billing account. Note the following:
 >    - Each newly purchase Savings Plan will be billed Monthly, regardless of the billing frequency of the Savings Plan it is replacing.
 >    - Each newly purchased Savings Plan will be priced as the USD equivalent of the original Savings Plan. For example, assuming a €1: $1.17 rate, a €5/hour Savings Plan would be replaced with a $5.85/hour Savings Plan. 
 >    - Each newly purchased Savings Plans will have a 1-year term, regardless of the term of the Savings Plan it is replacing. As a result, each new Savings Plan will have a different term end date when compared to the Savings Plan being replaced.


### PR DESCRIPTION
Clarified note regarding Savings Plans transfer when changing pricing currency.