### PR TITLE
Add NVA flow count sizing guidance near NIU section

### DIFF
--- a/articles/virtual-wan/about-nva-hub.md
+++ b/articles/virtual-wan/about-nva-hub.md
@@ -114,6 +114,25 @@ NVAs in Virtual WAN are deployed to ensure you always are able to achieve at min
 
 If the total amount of traffic that passes through an NVA at a given time goes above the vendor-specific throughput numbers for the chosen scale unit, events that might cause an NVA instance to be unavailable including but not limited to routine Azure platform maintenance activities or software upgrades can result in service or connectivity disruption. To minimize service disruptions, you should choose the scale unit based on your peak traffic profile and vendor-specific throughput numbers for a particular scale unit as opposed to relying on best-case throughput numbers observed during testing.
 
+## NVA sizing and flow count considerations
+
+When sizing NVA deployments in a Virtual WAN hub, consider the VM-level network flow count limits in addition to throughput (NIU) sizing.
+
+Azure VMs have recommended connection limits based on vCPU count. For NVAs, the **effective limit is half the recommended VM connection limit** because forwarding traffic (traffic that enters and exits the appliance) consumes twice the number of flows compared to standard client-server connections.
+
+| VM Size (vCPUs) | Recommended VM Limit | Effective NVA Limit |
+|-----------------|---------------------|---------------------|
+| 8-15            | 500,000             | ~250,000            |
+| 16-31           | 700,000             | ~350,000            |
+| 32-63           | 800,000             | ~400,000            |
+| 64+             | 1,000,000+          | ~500,000+           |
+
+Monitor NVA flow counts using the **Inbound Flows** and **Outbound Flows** metrics in Azure Monitor. If flow counts are consistently approaching the effective NVA limit, consider:
+- Scaling out by adding additional NVA instances to the hub
+- Reviewing your ingress/routing architecture to reduce flows through the NVA
+
+For full connection limit tables and guidance, see [Azure virtual machine network throughput](/azure/virtual-network/virtual-machine-network-throughput#flow-limits-and-active-connections-recommendations).
+
 ### <a name="hubspace"></a> Hub address space
 
 Every Virtual WAN hub is deployed with a hub address space. The minimum recommended hub address space is /23. Certain NVA capabilities have a minimum hub address space requirement. 


### PR DESCRIPTION
The about-nva-hub article covers NIU throughput sizing but has no mention of
  VM-level network flow count limits or the 50% NVA forwarding rule. Customers
  deploying NVAs into Virtual WAN hubs may correctly size for throughput but be
  unaware that the effective flow limit for NVAs is half the documented VM
  connection limit.

  This change adds a new section immediately after the NVA Infrastructure Units
  section with a sizing table, monitoring guidance, and a cross-reference to the
  VM throughput article.

  Customer evidence: Production Sev A incident (May 1, 2026) at a major FSI
  customer. NVA VMs in a VWAN hub restarted at ~400k flows. The customer was
  unaware of the 50% flow limit rule and there was no VWAN-specific guidance
  pointing to this constraint.