### PR TITLE
Revise OS and kernel version requirements following "accelerated-networking-overview"

### DIFF
--- a/articles/virtual-network/create-virtual-machine-accelerated-networking.md
+++ b/articles/virtual-network/create-virtual-machine-accelerated-networking.md
@@ -732,9 +732,9 @@ Results:
 
 1. From a shell on the remote VM, enter `uname -r` and confirm that the kernel version is one of the following versions, or greater:
 
-   - **Ubuntu 16.04**: 4.11.0-1013.
-   - **SLES SP3**: 4.4.92-6.18.
-   - **RHEL**: 3.10.0-693, 2.6.32-573. RHEL 6.7-6.10 are supported if the Mellanox VF version 4.5+ is installed before Linux Integration Services 4.3+.
+   - **Ubuntu 22.04 / 24.04**: 5.15, 6.8
+   - **SLES 15 SP6 / SP7 / 16**: 6.4.0-150600.23.84, 6.4.0-150700.51, 6.12.0-160000.5
+   - **RHEL**: 5.14.0-570, 6.12.0-55
 
    > [!NOTE]
    > Other kernel versions might be supported. For an updated list, see the compatibility tables for each distribution at [Supported Linux and FreeBSD virtual machines for Hyper-V](/windows-server/virtualization/hyper-v/supported-linux-and-freebsd-virtual-machines-for-hyper-v-on-windows), and confirm that SR-IOV is supported. You can find more details in the release notes for [Linux Integration Services for Hyper-V and Azure](https://www.microsoft.com/download/details.aspx?id=55106). *


### PR DESCRIPTION
Updated supported kernel versions for Ubuntu, SLES, and RHEL. The support information has not been updated for the past three years on Linux. I have revised the descriptions for each distribution to align with the "accelerated-networking-overview" doc.

https://learn.microsoft.com/en-us/azure/virtual-network/accelerated-networking-overview?tabs=NetworkManager#supported-operating-systems

In line with the original description, I also added the kernel versions by comparing them with the following release notes.

https://support.scc.suse.com/s/kb/List-of-SUSE-Linux-Enterprise-Server-kernel-version-and-release-date?language=en_US

https://documentation.ubuntu.com/release-notes/22.04/

https://documentation.ubuntu.com/release-notes/24.04/

https://access.redhat.com/articles/red-hat-enterprise-linux-release-dates