### PR TITLE
Docs: Modify email poller check for version 3.1.0

### DIFF
--- a/articles/communication-services/quickstarts/email/includes/send-email-js.md
+++ b/articles/communication-services/quickstarts/email/includes/send-email-js.md
@@ -187,9 +187,22 @@ async function main() {
 
     const poller = await emailClient.beginSend(message);
 
-    if (!poller.getOperationState().isStarted) {
-      throw "Poller was not started."
-    }
+// NOTE:
+// In @azure/communication-email version 3.1.0,
+// the `isStarted` flag was removed from `poller.getOperationState()`.
+// Instead, the poller state now exposes a `status` field with values
+// such as "running", "succeeded", etc.
+//
+// Previous check: version 3.0.0,
+// if (!poller.getOperationState().isStarted) {
+//   throw "Poller was not started."
+// }
+
+// Updated check for v3.1.0+:
+if (poller.getOperationState().status !== "running") {
+  throw "Poller failed to start.";
+}
+
 
     let timeElapsed = 0;
     while(!poller.isDone()) {

--- a/articles/communication-services/quickstarts/email/includes/send-email-js.md
+++ b/articles/communication-services/quickstarts/email/includes/send-email-js.md
@@ -163,6 +163,9 @@ For simplicity, this article uses connection strings, but in production environm
 ### Send an email message
 
 To send an email message, call the `beginSend` function from the `EmailClient`. This method returns a poller that checks on the status of the operation and retrieves the result once finished.
+> Note:
+> In `@azure/communication-email` v3.1.0 and later, the `isStarted` property was removed from `poller.getOperationState()`. The sample below uses the `status` field instead to validate that the poller has started successfully.
+
 
 ```javascript
 
@@ -187,22 +190,9 @@ async function main() {
 
     const poller = await emailClient.beginSend(message);
 
-// NOTE:
-// In @azure/communication-email version 3.1.0,
-// the `isStarted` flag was removed from `poller.getOperationState()`.
-// Instead, the poller state now exposes a `status` field with values
-// such as "running", "succeeded", etc.
-//
-// Previous check: version 3.0.0,
-// if (!poller.getOperationState().isStarted) {
-//   throw "Poller was not started."
-// }
-
-// Updated check for v3.1.0+:
-if (poller.getOperationState().status !== "running") {
-  throw "Poller failed to start.";
-}
-
+    if (poller.getOperationState().status !== "running") {
+      throw "Poller failed to start.";
+    }
 
     let timeElapsed = 0;
     while(!poller.isDone()) {

--- a/articles/communication-services/quickstarts/email/includes/send-email-js.md
+++ b/articles/communication-services/quickstarts/email/includes/send-email-js.md
@@ -163,7 +163,7 @@ For simplicity, this article uses connection strings, but in production environm
 ### Send an email message
 
 To send an email message, call the `beginSend` function from the `EmailClient`. This method returns a poller that checks on the status of the operation and retrieves the result once finished.
-> Note:
+> [!Note]
 > In `@azure/communication-email` v3.1.0 and later, the `isStarted` property was removed from `poller.getOperationState()`. The sample below uses the `status` field instead to validate that the poller has started successfully.
 
 


### PR DESCRIPTION
Updated the JavaScript SDK email sending sample for `@azure/communication-email` v3.1.0 compatibility.

The `isStarted` property has been removed from `poller.getOperationState()` in newer SDK versions. This change updates the sample to use the new `status` field (`"running"`) for validating poller initialization.
