### PR TITLE
Update concepts-dependency-visualization.md

### DIFF
--- a/articles/migrate/concepts-dependency-visualization.md
+++ b/articles/migrate/concepts-dependency-visualization.md
@@ -30,8 +30,8 @@ There are two options for deploying dependency analysis
 **Option** | **Details** | **Public cloud** | **Azure Government**
 ----  |---- | ---- |----
 **Agentless** | Generally available for VMware VMs, Hyper-V VMs, bare-metal servers, and servers running on other public clouds like AWS, GCP etc. | Supported | Supported
-**Agent-based analysis** | Azure Migrate no longer supports agent-based dependency visualization. However, if you still want to use agent-based dependency visualization, install [Azure Monitor VM Insights](azure/azure-monitor/vm/monitor-vm) on each server that you want to analyze.
-Please note that agent-based dependency analysis is not free, and Log Analytics workspace usage charges will apply. For pricing details, see [Azure Monitor pricing](pricing/details/monitor/). | Supported | Not supported.
+**Agent-based analysis** | Azure Migrate no longer supports agent-based dependency visualization. However, if you still want to use agent-based dependency visualization, install [Azure Monitor VM Insights](/azure/azure-monitor/vm/monitor-vm) on each server that you want to analyze.
+Please note that agent-based dependency analysis is not free, and Log Analytics workspace usage charges will apply. For pricing details, see [Azure Monitor pricing](/pricing/details/monitor/). | Supported | Not supported.
 
 ## Agentless analysis
 
@@ -53,9 +53,9 @@ After discovery of dependency data begins, polling begins:
 
 ## Agent-based analysis
 
-Azure Migrate recommends the use of agentless dependency analysis and no longer provides support for agent based dependency visualization. However, if you still want to use agent-based dependency visualization, you can directly install [Azure Monitor VM Insights](azure/azure-monitor/vm/monitor-vm) on each server that you want to analyze.
+Azure Migrate recommends the use of agentless dependency analysis and no longer provides support for agent based dependency visualization. However, if you still want to use agent-based dependency visualization, you can directly install [Azure Monitor VM Insights](/azure/azure-monitor/vm/monitor-vm) on each server that you want to analyze.
 
-Please note that agent-based dependency analysis is not free, and Log Analytics workspace usage charges will apply. For pricing details, see [Azure Monitor pricing](pricing/details/monitor/).
+Please note that agent-based dependency analysis is not free, and Log Analytics workspace usage charges will apply. For pricing details, see [Azure Monitor pricing](/pricing/details/monitor/).
 
 ## Next steps
 

--- a/articles/migrate/concepts-dependency-visualization.md
+++ b/articles/migrate/concepts-dependency-visualization.md
@@ -30,7 +30,8 @@ There are two options for deploying dependency analysis
 **Option** | **Details** | **Public cloud** | **Azure Government**
 ----  |---- | ---- |----
 **Agentless** | Generally available for VMware VMs, Hyper-V VMs, bare-metal servers, and servers running on other public clouds like AWS, GCP etc. | Supported | Supported
-**Agent-based analysis** | Uses the [Service Map solution](/previous-versions/azure/azure-monitor/vm/service-map) in Azure Monitor, to enable dependency visualization and analysis.<br/><br/> You need to install agents on each source (on-premises or Azure VMware Solution) server that you want to analyze. | Supported | Not supported.
+**Agent-based analysis** | Azure Migrate no longer supports agent-based dependency visualization. However, if you still want to use agent-based dependency visualization, install [Azure Monitor VM Insights](azure/azure-monitor/vm/monitor-vm) on each server that you want to analyze.
+Please note that agent-based dependency analysis is not free, and Log Analytics workspace usage charges will apply. For pricing details, see [Azure Monitor pricing](pricing/details/monitor/). | Supported | Not supported.
 
 ## Agentless analysis
 
@@ -52,34 +53,11 @@ After discovery of dependency data begins, polling begins:
 
 ## Agent-based analysis
 
-For agent-based analysis, Azure Migrate: Discovery and assessment uses the [Service Map](/previous-versions/azure/azure-monitor/vm/service-map) solution in Azure Monitor. You install the [Microsoft Monitoring Agent/Log Analytics agent](/azure/azure-monitor/agents/log-analytics-agent) and the [Dependency agent](/azure/azure-monitor/vm/vminsights-dependency-agent-maintenance), on each server you want to analyze.
+Azure Migrate recommends the use of agentless dependency analysis and no longer provides support for agent based dependency visualization. However, if you still want to use agent-based dependency visualization, you can directly install [Azure Monitor VM Insights](azure/azure-monitor/vm/monitor-vm) on each server that you want to analyze.
 
-### Dependency data
-
-Agent-based analysis provides this data:
-
-- Source server name, process, application name.
-- Destination server name, process, application name, and port.
-- Number of connections, latency, and data transfer information are gathered and available for Log Analytics queries.
-
-## Compare agentless and agent-based
-
-The differences between agentless visualization and agent-based visualization are summarized in the table.
-
-**Requirement** | **Agentless** | **Agent-based**
---- | --- | ---
-**Support** | Generally Available for VMware VMs, Hyper-V VMs, Physical servers, or servers running on other public clouds like AWS and GCP. | In general availability (GA).
-**Agent** | No agents needed on servers you want to analyze. | Agents required on each source (on-premises or Azure VMware Solution) server that you want to analyze.
-**Log Analytics** | Not required. | Azure Migrate uses the [Service Map](/previous-versions/azure/azure-monitor/vm/service-map) solution in [Azure Monitor logs](/azure/azure-monitor/logs/log-query-overview) for dependency analysis.<br/><br/> You associate a Log Analytics workspace with a project. The workspace must reside in the East US, Southeast Asia, or West Europe regions. The workspace must be in a region in which [Service Map is supported](https://azure.microsoft.com/global-infrastructure/services/?products=monitor&regions=all). You can monitor Azure VMs in any region. The VMs themselves aren't limited to the regions supported by the Log Analytics workspace.
-**Process** | Captures TCP connection data. After discovery, it gathers data at intervals of five minutes. | Service Map agents installed on a server gather data about TCP processes, and inbound/outbound connections for each process.
-**Data** | Source server name, process, application name.<br/><br/> Destination server name, process, application name, and port. | Source server name, process, application name.<br/><br/> Destination server name, process, application name, and port.<br/><br/> Number of connections, latency, and data transfer information are gathered and available for Log Analytics queries. 
-**Visualization** | Dependency map of single server can be viewed over a duration of one hour to 30 days. | Dependency map of a single server.<br/><br/> Dependency map of a group of servers.<br/><br/>  Map can be viewed over an hour only.<br/><br/> Add and remove servers in a group from the map view.
-Data export | Last 30 days data can be downloaded in a CSV format. | Data can be queried with Log Analytics.
-
-
+Please note that agent-based dependency analysis is not free, and Log Analytics workspace usage charges will apply. For pricing details, see [Azure Monitor pricing](pricing/details/monitor/).
 
 ## Next steps
 
-- [Set up](how-to-create-group-machine-dependencies.md) agent-based dependency visualization.
 - [Try out](how-to-create-group-machine-dependencies-agentless.md) agentless dependency visualization for servers on VMware.
 - Review [common questions](common-questions-discovery-dependency-analysis.md#what-is-dependency-analysis) about dependency visualization.


### PR DESCRIPTION
Azure migrate no longer supports Agent based dep map. However customer can go ahead and install azure monitor insights on the source but Azure migrate won't be providing any support for them