### PR TITLE
Fix parameter name from SourceIpGroup to SourceAddress

### DIFF
--- a/articles/firewall-manager/migrate-to-policy.md
+++ b/articles/firewall-manager/migrate-to-policy.md
@@ -214,7 +214,7 @@ If ($azfw.NatRuleCollections.Count -gt 0)
 				$parsedName = ParseRuleName($rule.Name)
 				If ($rule.SourceAddresses) 
 				{
-					$firewallPolicyNatRule = New-AzFirewallPolicyNatRule -Name $parsedName -SourceIpGroup  $rule.SourceAddresses -TranslatedAddress $rule.TranslatedAddress -TranslatedPort $rule.TranslatedPort -DestinationAddress $rule.DestinationAddresses -DestinationPort $rule.DestinationPorts -Protocol $rule.Protocols
+					$firewallPolicyNatRule = New-AzFirewallPolicyNatRule -Name $parsedName -SourceAddress  $rule.SourceAddresses -TranslatedAddress $rule.TranslatedAddress -TranslatedPort $rule.TranslatedPort -DestinationAddress $rule.DestinationAddresses -DestinationPort $rule.DestinationPorts -Protocol $rule.Protocols
 				}
         elseif ($rule.SourceIpGroups)
         {


### PR DESCRIPTION
The current script is configured to specify the source address of the NAT rule using an IP Group. When this script is executed, it attempts to register the source address of a classic rule using an IP Group; however, since the target resource does not exist, the migration fails. I believe the correct parameter should be "-SourceAddress", so please update the script accordingly.