### PR TITLE
Update Container Apps Express FAQ: add environment question and consistency edits

### DIFF
--- a/articles/container-apps/express-faq.yml
+++ b/articles/container-apps/express-faq.yml
@@ -1,32 +1,32 @@
 ### YamlMime:FAQ
 metadata:
-  title: Azure Container Apps express - Frequently asked questions
-  description: Find answers to the frequently asked questions about Azure Container Apps express.
+  title: Azure Container Apps Express - Frequently asked questions
+  description: Find answers to the frequently asked questions about Azure Container Apps Express.
   keywords: azure container apps, express, frequently asked questions, migration
   author: craigshoemaker
   ms.topic: faq
   ms.service: azure-container-apps
-  ms.date: 05/08/2026
+  ms.date: 05/06/2026
   ms.author: cshoe
-title: Azure Container Apps express frequently asked questions (FAQs)
+title: Azure Container Apps Express frequently asked questions (FAQs)
 summary: |
-  This article answers frequently asked questions about Azure Container Apps express.
+  This article lists commonly asked questions about Azure Container Apps Express together with related answers.
 
   > [!IMPORTANT]
-  > Azure Container Apps express is currently in **preview**. Preview features are provided without an SLA and are not recommended for production workloads. Some Container Apps features aren't supported or are limited on express. For more information, see [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
+  > Azure Container Apps Express is currently in **Public Preview**. Preview features are provided without an SLA and are not recommended for production workloads. Some features might not be supported or might have constrained capabilities. For more information, see [Supplemental Terms of Use for Microsoft Azure Previews](https://azure.microsoft.com/support/legal/preview-supplemental-terms/).
 
 sections:
   - name: General
     questions:
       - question: |
-          What is Azure Container Apps express?
+          What is Azure Container Apps Express?
         answer: |
-          Azure Container Apps express is an environment tier for web applications that is currently in **preview**. It helps you deploy quickly with scale from zero and fewer infrastructure choices to manage. You provide a container image, and express handles the environment setup, networking defaults, and scaling behavior for you.
+          Azure Container Apps Express is a streamlined environment tier currently in **Public Preview**, purpose-built for web applications. It delivers the fastest provisioning, instant scale-from-zero, and the simplest developer experience in Azure Container Apps. Express removes infrastructure decisions — there's no environment to manually provision, no networking to configure, and no scaling rules to write. You bring a container image, and Express handles everything else.
 
       - question: |
-          How is Azure Container Apps express different from Azure Container Apps?
+          How is Azure Container Apps Express different from Azure Container Apps?
         answer: |
-          Azure Container Apps requires you to create and configure a managed environment before deploying apps. Express provides production-ready defaults with minimal environment provisioning time. Key differences include:
+          Azure Container Apps requires you to create and configure a managed environment before deploying apps. Express eliminates that step entirely. Key differences include:
 
           - **Provisioning**: Express apps are running in seconds, not minutes.
           - **Cold starts**: Express delivers sub-second scale-from-zero startup times.
@@ -36,62 +36,95 @@ sections:
           For workloads that need VNet isolation, dedicated compute, GPU, or advanced networking, Azure Container Apps continues to offer the full spectrum of compute options through workload profiles.
 
       - question: |
-          Who is express designed for?
+          If Express is meant to simplify Azure Container Apps, why does the environment construct still exist?
         answer: |
-          Express is designed for two main audiences:
+          In Express, the environment's role has shifted. It's no longer infrastructure you provision and configure — it's a lightweight, fully managed grouping for your apps, closer to an *app group* than an infrastructure boundary. Setup time has shrunk to almost zero.
 
-          - **Developers who want to move quickly**: SaaS apps, APIs, web dashboards, prototypes, and startup workloads that need fast deployment.
-          - **Systems that deploy on demand**: Model Context Protocol (MCP) servers, tool-use endpoints, workflow APIs, and user interfaces that benefit from quick startup and teardown.
+          It's preserved in Express for a few reasons:
+
+          - **Consistency**: Existing IaC, SDKs, and CLI commands continue to work unchanged.
+          - **Future features**: Some upcoming capabilities will bind apps in an environment together (for example, VNet attachment).
+          - **Smooth path between tiers**: A shared model makes it easier to move between Express and standard Azure Container Apps.
 
       - question: |
-          What is the relationship between express and Azure Container Apps Sandboxes?
+          Who is Express designed for?
         answer: |
-          Express is built on [Azure Container Apps Sandboxes](https://aka.ms/aca/sandboxes-blog). Sandboxes provide fast startup, isolation, and large-scale execution. You don't need to understand Sandboxes to use express, but they provide the foundation for the express experience.
+          Express is purpose-built for two audiences:
+
+          - **Developers who want to ship fast** — SaaS apps, APIs, web dashboards, prototypes, and startups that want to go from idea to production in minutes.
+          - **Agents that deploy on demand** — MCP servers, tool-use endpoints, multi-step workflow APIs, and human-in-the-loop UIs that need instant provisioning and teardown.
+
+      - question: |
+          What is the relationship between Express and Azure Container Apps Sandboxes?
+        answer: |
+          Under the hood, Express is built entirely on [Azure Container Apps Sandboxes](https://aka.ms/aca/sandboxes-blog) — a foundational platform primitive that delivers sub-second startup from prewarmed pools, strong isolation, and massive scale-out. You don't need to understand Sandboxes to use Express. Express is the opinionated, developer-friendly experience built on top of Sandboxes.
 
   - name: Getting started
     questions:
       - question: |
-          How do I create an express app?
+          How do I create an Express app?
         answer: |
-          You can create an express app using the Azure CLI or the new Azure Container Apps portal at [containerapps.azure.com](https://containerapps.azure.com/).
+          You can create an Express app using the Azure CLI or the new Azure Container Apps portal at [containerapps.azure.com](https://containerapps.azure.com/).
 
-          Using the Azure CLI, first create an express environment, then deploy your app. For more information, see [Deploy an express container app using the Azure CLI](./deploy-express-cli.md).
+          Using the Azure CLI, first create an Express environment, then deploy your app:
+
+          ```azurecli
+          az containerapp env create \
+            --name my-express-env \
+            --resource-group MyResourceGroup \
+            --environment-mode express \
+            --logs-destination none
+
+          az containerapp create \
+            --name my-app \
+            --resource-group MyResourceGroup \
+            --environment my-express-env \
+            --image docker.io/nginx \
+            --target-port 80 \
+            --ingress external \
+            --min-replicas 0 \
+            --max-replicas 1
+          ```
+
+          Your app is live in seconds.
 
       - question: |
-          Do I need to create a managed environment before deploying an express app?
+          Do I need to create a managed environment before deploying an Express app?
         answer: |
-          When using the Azure CLI, you first create an express environment using `az containerapp env create --environment-mode express`, then deploy your app into it. When using the [Azure Container Apps portal](https://containerapps.azure.com/), the environment is created and managed for you automatically.
+          When using the Azure CLI, you first create an Express environment using `az containerapp env create --environment-mode express`, then deploy your app into it. When using the [Azure Container Apps portal](https://containerapps.azure.com/), the environment is created and managed for you automatically.
 
       - question: |
-          What identity and account requirements are needed to use express?
+          What identity and account requirements are needed to use Express?
         answer: |
           Express requires a Microsoft Entra ID-backed account. Personal Microsoft accounts and non-Entra-backed accounts are not supported. Your subscription must also be registered for the Azure Container Apps resource provider. If you encounter a `tenant_not_allowed` error when accessing the portal, verify that your account is backed by a Microsoft Entra tenant.
 
       - question: |
-          Can I use both the Azure CLI and the portal to manage express apps?
+          Can I use both the Azure CLI and the portal to manage Express apps?
         answer: |
-          Yes. You can create and manage express apps through both the [Azure CLI](./deploy-express-cli.md) and the new Azure Container Apps portal at [containerapps.azure.com](https://containerapps.azure.com/).
+          Yes. Express apps can be created and managed through both the Azure CLI (using `az containerapp env create --environment-mode express` and `az containerapp create`) and the new Azure Container Apps portal at [containerapps.azure.com](https://containerapps.azure.com/).
 
   - name: Features and capabilities
     questions:
       - question: |
-          What features are available in express today?
+          What features are available in Express today?
         answer: |
-          Express is in preview. The following features are available:
+          Express is in Public Preview. The following features are available:
 
           - Deploy container images from any registry (anonymous or token-based pull)
           - Automatic scale from zero with no configuration required
-          - Up to 2 min replicas per app. No autoscaling is available yet.
+          - Multi-replica scaling for production traffic
           - Default ingress domain with an immediate public URL
           - Environment variables and secrets management
           - Real-time log streaming
           - Exec access to shell into running containers for debugging
           - New portal experience at [containerapps.azure.com](https://containerapps.azure.com/)
 
+          For the most current list of supported features, see the [Express documentation](https://aka.ms/aca/express).
+
       - question: |
-          What features are not yet available in express?
+          What features are not yet available in Express?
         answer: |
-          Express is in preview and doesn't yet include all Azure Container Apps features. Currently unavailable features include:
+          Express is a Public Preview with a meaningful feature gap compared to Azure Container Apps. Features not yet available include:
 
           - VNet integration
           - Custom domains
@@ -100,108 +133,100 @@ sections:
           - Autoscaling
           - GPU compute
 
-          During preview, feature support changes often. For the latest list of supported and planned features, see the [express documentation](https://aka.ms/aca/express).
+          New features are being shipped on a rapid cadence throughout the preview. The [Express documentation](https://aka.ms/aca/express) includes a current list of supported and upcoming features, updated frequently.
 
       - question: |
-          When will express reach feature parity with Azure Container Apps?
+          When will Express reach feature parity with Azure Container Apps?
         answer: |
-          Express is not designed to support all features of Azure Container Apps. For more information, see [Azure Container Apps express overview](./express-overview.md).
+          Express is shipping new features on a rapid cadence throughout the Public Preview. The goal is for Express to be close to feature-complete by Microsoft Build. The [Express documentation](https://aka.ms/aca/express) includes a current feature support matrix that is updated frequently.
 
   - name: Regions
     questions:
       - question: |
-          Which Azure regions support express?
+          Which Azure regions support Express?
         answer: |
-          Express is available in the following regions during preview:
+          Express is available in the following regions during Public Preview:
 
           - East Asia
           - West Central US
 
+          Region availability is expanding throughout the preview period.
+
       - question: |
-          Why can't I create an express environment in my preferred region?
+          Why can't I create an Express environment in my preferred region?
         answer: |
-          During preview, express is available only in specific regions. The portal and CLI might show unsupported regions. If you receive an `ExpressEnvironmentNotAvailableInRegion` error, choose a supported region and try again.
+          During Public Preview, Express is available in a specific set of regions. The portal and CLI may display regions where Express is not yet supported. If you receive an `ExpressEnvironmentNotAvailableInRegion` error. Region availability is expanding as the preview progresses.
 
   - name: Pricing and billing
     questions:
       - question: |
-          How is express billed?
+          How is Express billed?
         answer: |
-          Express uses the existing Azure Container Apps consumption pricing model, including per-second vCPU and memory billing with scale to zero. There's no separate environment provisioning fee. The same free grant that applies to consumption workloads also applies to express. For pricing details, see the [Azure Container Apps pricing page](https://azure.microsoft.com/pricing/details/container-apps/).
+          Express uses the existing Azure Container Apps consumption pricing model — per-second vCPU and memory billing with scale-to-zero. There is no environment provisioning fee. Customers benefit from the same free grant that applies to consumption workloads today. Express is designed to be the most cost-effective way to run web applications and APIs on Azure Container Apps. For detailed pricing, see the [Azure Container Apps pricing page](https://azure.microsoft.com/pricing/details/container-apps/).
 
       - question: |
-          Is there a free tier for express?
+          Is there a free tier for Express?
         answer: |
-          Yes. Express includes the same free grant that applies to Azure Container Apps consumption workloads. You incur charges only when your usage exceeds the free grant thresholds. Combined with scale-to-zero, express means you pay only for what you use.
+          Yes. Express includes the same generous free grant that applies to Azure Container Apps consumption workloads. You are not charged until your usage exceeds the free grant thresholds. Combined with scale-to-zero, Express ensures you only pay for what you use.
 
   - name: Migration
     questions:
       - question: |
-          Will my existing Azure Container Apps environments be automatically migrated to express?
+          Will my existing Azure Container Apps environments be automatically migrated to Express?
         answer: |
-          Some existing environments are eligible for migration to express. We perform migration in phases, starting with inactive, empty environments (no running apps or jobs) that belong to subscriptions with low Azure Container Apps usage. This approach minimizes disruption.
+          Some existing environments may be eligible for migration to Express. Migration is performed in phases, starting with environments that are inactive, empty (no running apps or jobs), and belong to subscriptions with low Azure Container Apps usage. The criteria are designed to minimize disruption.
 
-          When your environment is selected for migration, you'll receive advance notice with the timeline and any required actions. You can also opt out.
+          If your environment is selected for migration, you will receive a notification in advance with details about the timeline and any action required. You will also be able to opt-out of any migration.
 
       - question: |
           What criteria are used to select environments for migration?
         answer: |
-          We select migration candidates based on multiple factors:
+          Migration candidates are selected based on multiple factors:
 
-          - **Activity level**: We prioritize environments with few or no running applications or jobs.
-          - **Feature usage**: We consider environments that don't use advanced features (such as VNet integration, Dapr, dedicated workload profiles, or session pools).
-          - **Subscription usage**: We migrate low-usage subscriptions before high-usage ones to minimize disruption.
+          - **Activity level**: Environments with no running applications or jobs are prioritized.
+          - **Feature usage**: Environments that don't use advanced features (such as VNet integration, Dapr, dedicated workload profiles, or session pools) are considered first.
+          - **Subscription with low usage**: Low-usage subscriptions are migrated before high-usage ones to minimize revenue risk.
 
-          Environments that use advanced features not yet available in express, or that belong to high-usage subscriptions, are not auto-migrated.
+          Environments that use advanced features not yet available in Express, or that belong to high-usage subscriptions, are not auto-migrated.
 
       - question: |
           What is environment archiving?
         answer: |
-          You can archive an environment if it is not currently needed. Archiving deprovisions the underlying resources, preventing any unwanted billing and freeing up quota. Archived environments can later be restored to a running state. The default domain name won't change but the inbound and outbound IPs will. Archiving is only available if all of the features currently used by the environment can be backed up without data loss. Archiving can also be used to migrate an environment between modes like WorkloadProfiles to Express.
+          Environments that are inactive (no running apps or jobs and no recent activity) may be archived. An archived environment is put to sleep. If you need your environment again, you can restore it.
 
       - question: |
-          Can I self-migrate my environment to express?
+          Can I self-migrate my environment to Express?
         answer: |
-          Yes. You can use the archive and restore workflow to move to express without contacting support. Archive your current environment, then restore it as an express environment. This approach lets you choose when the migration happens.
-
-          For example:
-
-          ```bash
-          az containerapp env update --environment-mode express ...
-          ```
-
-          This command directly migrates an environment to express. The archive and restore functionality is handled internally.
+          Yes. Self-migration is available so you can move to Express on your own terms without contacting support. You can use the archive and restore mechanism to migrate your environment — archive your existing environment and restore it as an Express environment. This gives you full control over the migration process and timing.
 
       - question: |
           Can I opt out of automatic migration?
         answer: |
-          If you receive a migration notice and your environment depends on features that express doesn't yet support, or if migration would disrupt your workloads, contact Azure support to discuss your options. Environments that use unsupported advanced features are not auto-migrated. You can also self-migrate later using the archive and restore workflow.
+          If you receive a migration notification and your environment relies on features not yet available in Express, or if migration would disrupt your workloads, you can reach out to Azure support to discuss your options. Environments using advanced features that are not supported in Express are not auto-migrated. You also have the option to self-migrate at a time that works for you using the archive and restore workflow.
 
       - question: |
-          Will I lose any functionality if my environment is migrated to express?
+          Will I lose any functionality if my environment is migrated to Express?
         answer: |
-          Environments are only auto-migrated where express supports all the features in use. If your environment uses advanced features that are not yet available in express, the app won't proceed through automatic migration.
+          Automatic migration is only performed for environments where Express supports all the features currently in use. If your environment uses advanced features such as VNet integration, Dapr, dedicated workload profiles, or custom domains that are not yet available in Express, it will not be selected for automatic migration.
 
-          If you self-migrate using archive and restore, review the express feature support matrix to confirm that express supports all features your application depends on before proceeding.
-
-          The self-migration flow prevents you from moving an app if a feature in use isn't supported. Instead, you see errors related to what's missing.
+          If you self-migrate using archive and restore, review the Express feature support matrix to confirm that all features your application depends on are available before proceeding.
 
       - question: |
           What happens to my apps and data during migration?
         answer: |
-          During migration, your applications can experience up to 30 minutes of downtime. Automatic migrations are announced in advance. If you self-migrate by using archive and restore, you control the timing of the move.
+          During migration, your applications will experience up to 15 minutes of downtime. The migration process is designed to be transparent and without data loss. You will receive advance notification before any automatic migration takes place. If you self-migrate using archive and restore, you control the process and timing directly.
 
   - name: Production readiness
     questions:
       - question: |
-          Is express ready for production workloads?
+          Is Express ready for production workloads?
         answer: |
-          Express is currently in **preview**. Preview services don't include a Service Level Agreement (SLA). Express works well for development, testing, and prototyping, and for production workloads that don't require features only available in Azure Container Apps with workload profiles, such as VNet integration or managed identity.
+          Express is currently in **Public Preview**. While it provides production-ready defaults (ingress, scaling, secrets, observability), preview services do not come with an SLA guarantee. Express is suitable for development, testing, prototyping, and production workloads that don't require features only available in Azure Container Apps with workload profiles (such as VNet integration or managed identity).
 
       - question: |
-          Does express have an SLA?
+          Does Express have an SLA?
         answer: |
-          Express is in preview and doesn't have an SLA. SLA commitments will emerge as express moves toward General Availability. For workloads that require an SLA today, use Azure Container Apps with workload profiles.
+          Express is in Public Preview and does not currently have an SLA. SLA commitments will be defined as Express moves toward General Availability. For workloads that require an SLA today, use Azure Container Apps with workload profiles.
 
       - question: |
           How do I provide feedback or report issues?


### PR DESCRIPTION
Adds a new Q&A to the Express FAQ addressing a common customer question: 'If Express is meant to simplify Azure Container Apps, why does the environment construct still exist?' The answer reflects guidance from the Container Apps team.

Also includes consistency edits across the FAQ:
- Capitalize 'Express' consistently as a product name
- Refresh phrasing in several answers for clarity

File: articles/container-apps/express-faq.yml