### PR TITLE
Update load balancer frontend reachability test notes

### DIFF
--- a/articles/load-balancer/load-balancer-test-frontend-reachability.md
+++ b/articles/load-balancer/load-balancer-test-frontend-reachability.md
@@ -42,7 +42,7 @@ This section describes testing reachability of a standard load balancer frontend
 Choose either ping or traceroute to test reachability of a standard load balancer frontend from a device outside of Azure.
 
 > [!NOTE]
-> When pinging to a public IPv6 address, there can be a couple of timeouts before the Load Balancer will respond. Also it is common that there appear multiple timeouts after successful responses
+> When using `ping` with a public IPv6 address, there can be a couple of timeouts before the Load Balancer responds. Multiple timeouts after successful responses are also common.
 
 ### [Ping](#tab/ping/windows-outside)
 

--- a/articles/load-balancer/load-balancer-test-frontend-reachability.md
+++ b/articles/load-balancer/load-balancer-test-frontend-reachability.md
@@ -41,6 +41,9 @@ This section describes testing reachability of a standard load balancer frontend
 
 Choose either ping or traceroute to test reachability of a standard load balancer frontend from a device outside of Azure.
 
+> [!NOTE]
+> When pinging to a public IPv6 address, there can be a couple of timeouts before the Load Balancer will respond. Also it is common that there appear multiple timeouts after successful responses
+
 ### [Ping](#tab/ping/windows-outside)
 
 Follow these steps to test reachability of a standard public load balancer frontend using `ping` from a Windows device outside of Azure:


### PR DESCRIPTION
Added note about potential timeouts when pinging a public IPv6 address. Customers need to know this as long as the bug is not fixed. Details: https://learn.microsoft.com/en-us/answers/questions/5893896/(azure)-public-ipv6-icmpv6-packetloss