### PR TITLE
Document Microsoft.Cache RP registration requirement for cross-subscription private endpoints

### DIFF
--- a/articles/azure-cache-for-redis/cache-private-link.md
+++ b/articles/azure-cache-for-redis/cache-private-link.md
@@ -43,7 +43,7 @@ You can restrict public access to the private endpoint of your cache by disablin
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
-> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache might fail. For more information on how to register `Microsoft.Cache`, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache might fail. For more information on how to register, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
 
 > [!IMPORTANT]
 > Currently, the [portal-based redis console](cache-configure.md#redis-console) is not supported with private link.

--- a/articles/azure-cache-for-redis/cache-private-link.md
+++ b/articles/azure-cache-for-redis/cache-private-link.md
@@ -43,16 +43,7 @@ You can restrict public access to the private endpoint of your cache by disablin
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
-> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, approving the private endpoint connection fails with a `Forbidden` error.
->
-> To register the provider, run:
->
-> ```azurecli
-> az account set --subscription <private-endpoint-subscription-id>
-> az provider register --namespace Microsoft.Cache
-> ```
->
-> Wait until `az provider show --namespace Microsoft.Cache --query registrationState` returns `Registered` before creating or approving the private endpoint. You can also register the provider from the Azure portal under **Subscription** > **Resource providers**. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache (such as approval) might fail. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
 
 > [!IMPORTANT]
 > Currently, the [portal-based redis console](cache-configure.md#redis-console) is not supported with private link.

--- a/articles/azure-cache-for-redis/cache-private-link.md
+++ b/articles/azure-cache-for-redis/cache-private-link.md
@@ -43,7 +43,7 @@ You can restrict public access to the private endpoint of your cache by disablin
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
-> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache (such as approval) might fail. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache might fail. For more information on how to register `Microsoft.Cache`, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
 
 > [!IMPORTANT]
 > Currently, the [portal-based redis console](cache-configure.md#redis-console) is not supported with private link.

--- a/articles/azure-cache-for-redis/cache-private-link.md
+++ b/articles/azure-cache-for-redis/cache-private-link.md
@@ -43,6 +43,18 @@ You can restrict public access to the private endpoint of your cache by disablin
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
+> If the private endpoint is created in a **different subscription** than the Azure Cache for Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, approving the private endpoint connection fails with a `Forbidden` error.
+>
+> To register the provider, run:
+>
+> ```azurecli
+> az account set --subscription <private-endpoint-subscription-id>
+> az provider register --namespace Microsoft.Cache
+> ```
+>
+> Wait until `az provider show --namespace Microsoft.Cache --query registrationState` returns `Registered` before creating or approving the private endpoint. You can also register the provider from the Azure portal under **Subscription** > **Resource providers**. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+
+> [!IMPORTANT]
 > Currently, the [portal-based redis console](cache-configure.md#redis-console) is not supported with private link.
 >
 

--- a/articles/redis/private-link.md
+++ b/articles/redis/private-link.md
@@ -31,16 +31,7 @@ The process is accomplished in two steps:
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
-> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, approving the private endpoint connection fails with a `Forbidden` error.
->
-> To register the provider, run:
->
-> ```azurecli
-> az account set --subscription <private-endpoint-subscription-id>
-> az provider register --namespace Microsoft.Cache
-> ```
->
-> Wait until `az provider show --namespace Microsoft.Cache --query registrationState` returns `Registered` before creating or approving the private endpoint. You can also register the provider from the Azure portal under **Subscription** > **Resource providers**. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache (such as approval) might fail. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
 
 ## Create a virtual network with a subnet
 

--- a/articles/redis/private-link.md
+++ b/articles/redis/private-link.md
@@ -30,6 +30,18 @@ The process is accomplished in two steps:
 
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
+> [!IMPORTANT]
+> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, approving the private endpoint connection fails with a `Forbidden` error.
+>
+> To register the provider, run:
+>
+> ```azurecli
+> az account set --subscription <private-endpoint-subscription-id>
+> az provider register --namespace Microsoft.Cache
+> ```
+>
+> Wait until `az provider show --namespace Microsoft.Cache --query registrationState` returns `Registered` before creating or approving the private endpoint. You can also register the provider from the Azure portal under **Subscription** > **Resource providers**. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+
 ## Create a virtual network with a subnet
 
 First, create a virtual network by using the portal. Use this virtual network when you create a [new cache](#create-an-azure-managed-redis-instance-with-a-private-endpoint-connected-to-a-virtual-network-subnet) or with an [existing cache](#create-an-azure-managed-redis-cache-connected-to-a-private-endpoint-using-azure-powershell).

--- a/articles/redis/private-link.md
+++ b/articles/redis/private-link.md
@@ -31,7 +31,7 @@ The process is accomplished in two steps:
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
-> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache might fail. For more information on how to register `Microsoft.Cache`, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache might fail. For more information on how to register, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
 
 ## Create a virtual network with a subnet
 

--- a/articles/redis/private-link.md
+++ b/articles/redis/private-link.md
@@ -31,7 +31,7 @@ The process is accomplished in two steps:
 - Azure subscription - [create one for free](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn)
 
 > [!IMPORTANT]
-> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache (such as approval) might fail. For more information, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
+> If the private endpoint is created in a **different subscription** than the Azure Managed Redis instance, you must register the `Microsoft.Cache` resource provider in the subscription that contains the private endpoint. Otherwise, subsequent private endpoint operations on the cache might fail. For more information on how to register `Microsoft.Cache`, see [Register an Azure resource provider](/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider).
 
 ## Create a virtual network with a subnet
 


### PR DESCRIPTION
## Summary

Add a prerequisite note to both Private Link articles clarifying that the `Microsoft.Cache` resource provider must be registered in the subscription that contains the private endpoint, when that subscription differs from the cache's subscription.

## Why

Multiple customer incidents (CRIs) have been root-caused to this: approving a private endpoint connection fails with `Forbidden` because `Microsoft.Cache` is not registered in the private endpoint's subscription. The current docs only imply registration on the cache's subscription, so customers hit this repeatedly. Adding a brief note in Prerequisites with a link to the standard "Register an Azure resource provider" guidance prevents the issue without bloating the article.

## Files changed

- `articles/redis/private-link.md` (Azure Managed Redis)
- `articles/azure-cache-for-redis/cache-private-link.md` (Azure Cache for Redis)

## Internal tracking

Microsoft work item: [AB#37173642](https://dev.azure.com/msazure/RedisCache/_workitems/edit/37173642)