### PR TITLE
Clarified checkpoint state implications when changing storage accounts or recreating the Event hub.

### DIFF
--- a/articles/azure-functions/functions-reliable-event-processing.md
+++ b/articles/azure-functions/functions-reliable-event-processing.md
@@ -46,6 +46,10 @@ This behavior reveals a few important points:
 - Functions guarantees _at-least-once_ delivery: 
 
     Your code and dependent systems might need to account for the fact that the same event could be processed twice. For more information, see [Designing Azure Functions for identical input](functions-idempotent.md).
+- Checkpoint state is stored on the client side:
+  
+    The checkpoint (processing pointer) is persisted in the storage account configured by the AzureWebJobsStorage setting of the Function App. Changing the storage account used causes the function to start processing from a new position, which may result in events being reprocessed. Similarly, if an Event Hub is deleted and recreated, the event stream position (such as sequence numbers and offsets) is reset, while the existing checkpoints on the storage remain unchanged. In this scenario, the function might not process new events until the checkpoint is manually deleted.
+
 
 ## Handling exceptions
 

--- a/articles/azure-functions/functions-reliable-event-processing.md
+++ b/articles/azure-functions/functions-reliable-event-processing.md
@@ -46,7 +46,7 @@ This behavior reveals a few important points:
 - Functions guarantees _at-least-once_ delivery: 
 
     Your code and dependent systems might need to account for the fact that the same event could be processed twice. For more information, see [Designing Azure Functions for identical input](functions-idempotent.md).
-- Checkpoint state is stored on the client side:
+- Checkpoint state is stored in Azure Storage:
   
     The checkpoint (processing pointer) is persisted in the storage account configured by the AzureWebJobsStorage setting of the Function App. Changing the storage account used causes the function to start processing from a new position, which may result in events being reprocessed. Similarly, if an Event Hub is deleted and recreated, the event stream position (such as sequence numbers and offsets) is reset, while the existing checkpoints on the storage remain unchanged. In this scenario, the function might not process new events until the checkpoint is manually deleted.
 

--- a/articles/azure-functions/functions-reliable-event-processing.md
+++ b/articles/azure-functions/functions-reliable-event-processing.md
@@ -47,8 +47,11 @@ This behavior reveals a few important points:
 
     Your code and dependent systems might need to account for the fact that the same event could be processed twice. For more information, see [Designing Azure Functions for identical input](functions-idempotent.md).
 - Checkpoint state is stored in Azure Storage:
-  
-    The checkpoint (processing pointer) is persisted in the storage account configured by the AzureWebJobsStorage setting of the Function App. Changing the storage account used causes the function to start processing from a new position, which may result in events being reprocessed. Similarly, if an Event Hub is deleted and recreated, the event stream position (such as sequence numbers and offsets) is reset, while the existing checkpoints on the storage remain unchanged. In this scenario, the function might not process new events until the checkpoint is manually deleted.
+
+    The checkpoint (processing pointer) is persisted in the storage account configured by the `AzureWebJobsStorage` setting of the function app. This stored checkpoint reference means: 
+
+   + When you change `AzureWebJobsStorage` to reference a different storage account, the function starts processing from a new position, which can result in events being reprocessed. 
+   + When an event hub is deleted and recreated, the event stream position (such as sequence numbers and offsets) is reset while stored checkpoint references remain unchanged. In this scenario, the function might not process new events until the checkpoint is manually deleted.
 
 
 ## Handling exceptions


### PR DESCRIPTION
This PR aims to clarify checkpoint state storage details and implications of changing storage accounts or recreating the Event hub.

Namely that if an Event Hub is deleted and recreated, the event stream position (such as sequence numbers and offsets) is reset, while existing checkpoints on the Storage Account remain unchanged. In this scenario, the function might not process new events until the checkpoint state is manually reset by either recreating the storage account or just delete the blob files under azure-webjobs-eventhub/[EVENTHUB_NAMESPACE].servicebus.windows.net/[EVENTHUB_NAME]/[CONSUMER_GROUP]/checkpoint..

This scenario was discussed on ICM 51000001001837 and also on this Github issue https://github.com/Azure/azure-sdk-for-net/issues/53741