### PR TITLE
[AppService]Update auth configuration instructions for ACR pulls

### DIFF
--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -93,8 +93,7 @@ validation failed" error. To check and enable this setting, run the following co
 az acr config authentication-as-arm show -r <registry-name>
 az acr config authentication-as-arm update -r <registry-name> --status enabled
 ```
-For more information, see [Configure registry acceptance of Microsoft Entra
-authentication scopes](/azure/container-registry/container-registry-disable-authentication-as-arm).
+For more information, see [Configure registry acceptance of Microsoft Entra authentication scopes](/azure/container-registry/container-registry-disable-authentication-as-arm).
 
 1. Enable the [system-assigned managed identity](./overview-managed-identity.md) for the web app by using the [`az webapp identity assign`](/cli/azure/webapp/identity#az-webapp-identity-assign) command:
 

--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -84,7 +84,7 @@ Supply the sign-in credentials for your private registry account in the *\<usern
 Use the following steps to configure your web app to pull from Azure Container Registry by using managed identity. The steps use system-assigned managed identity, but you can also use user-assigned managed identity.
 
 > [!IMPORTANT]
-> Your Azure Container Registry must allow ARM audience tokens for authentication in order to use managed identity to pull images. This is the default configuration, but if it was previously disabled, image pulls fail with an `UNAUTHORIZED` "token validation failed" error. To check and enable this setting, run the following commands:
+> Your Azure Container Registry must allow ARM audience tokens for authentication in order to use managed identity to pull images. If this setting is disabled, image pulls fail with an `UNAUTHORIZED` "token validation failed" error. To check and enable this setting, run the following commands:
 >
 > ```azurecli-interactive
 > az acr config authentication-as-arm show -r <registry-name>

--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -83,17 +83,15 @@ Supply the sign-in credentials for your private registry account in the *\<usern
 
 Use the following steps to configure your web app to pull from Azure Container Registry by using managed identity. The steps use system-assigned managed identity, but you can also use user-assigned managed identity.
 
-[!IMPORTANT]
-Your Azure Container Registry must allow ARM audience tokens for authentication in
-order to use managed identity to pull images. This is the default configuration, but
-if it was previously disabled, image pulls fail with an `UNAUTHORIZED` "token
-validation failed" error. To check and enable this setting, run the following commands:
-
-```azurecli-interactive
-az acr config authentication-as-arm show -r <registry-name>
-az acr config authentication-as-arm update -r <registry-name> --status enabled
-```
-For more information, see [Configure registry acceptance of Microsoft Entra authentication scopes](/azure/container-registry/container-registry-disable-authentication-as-arm).
+> [!IMPORTANT]
+> Your Azure Container Registry must allow ARM audience tokens for authentication in order to use managed identity to pull images. This is the default configuration, but if it was previously disabled, image pulls fail with an `UNAUTHORIZED` "token validation failed" error. To check and enable this setting, run the following commands:
+>
+> ```azurecli-interactive
+> az acr config authentication-as-arm show -r <registry-name>
+> az acr config authentication-as-arm update -r <registry-name> --status enabled
+> ```
+>
+> For more information, see [Configure registry acceptance of Microsoft Entra authentication scopes](/azure/container-registry/container-registry-disable-authentication-as-arm).
 
 1. Enable the [system-assigned managed identity](./overview-managed-identity.md) for the web app by using the [`az webapp identity assign`](/cli/azure/webapp/identity#az-webapp-identity-assign) command:
 

--- a/articles/app-service/configure-custom-container.md
+++ b/articles/app-service/configure-custom-container.md
@@ -83,6 +83,19 @@ Supply the sign-in credentials for your private registry account in the *\<usern
 
 Use the following steps to configure your web app to pull from Azure Container Registry by using managed identity. The steps use system-assigned managed identity, but you can also use user-assigned managed identity.
 
+[!IMPORTANT]
+Your Azure Container Registry must allow ARM audience tokens for authentication in
+order to use managed identity to pull images. This is the default configuration, but
+if it was previously disabled, image pulls fail with an `UNAUTHORIZED` "token
+validation failed" error. To check and enable this setting, run the following commands:
+
+```azurecli-interactive
+az acr config authentication-as-arm show -r <registry-name>
+az acr config authentication-as-arm update -r <registry-name> --status enabled
+```
+For more information, see [Configure registry acceptance of Microsoft Entra
+authentication scopes](/azure/container-registry/container-registry-disable-authentication-as-arm).
+
 1. Enable the [system-assigned managed identity](./overview-managed-identity.md) for the web app by using the [`az webapp identity assign`](/cli/azure/webapp/identity#az-webapp-identity-assign) command:
 
    ```azurecli-interactive


### PR DESCRIPTION
Add note about Azure Container Registry configuration for managed identity to ensure authentication-as-arm is enabled for ACR image pulls
Note is similar to the auth policy requirement for Azure Container Apps : https://learn.microsoft.com/en-us/azure/container-apps/managed-identity-image-pull

