### PR TITLE
Update LRS write request explanation in documentation

### DIFF
--- a/articles/storage/common/storage-redundancy.md
+++ b/articles/storage/common/storage-redundancy.md
@@ -53,7 +53,7 @@ Locally redundant storage (LRS) replicates the data within your storage accounts
 
 LRS is the lowest-cost redundancy option and offers the least durability compared to other options. LRS protects your data against drive, server, and rack failures. However, if a disaster such as fire or flooding occurs within the data center, all replicas of a storage account using LRS might be lost or unrecoverable. If a temporary event, such as a thermal event, occurs within the data center, all replicas might be temporarily unavailable until the event is resolved. To mitigate these risks, Microsoft recommends using [zone-redundant storage](#zone-redundant-storage) (ZRS), [geo-redundant storage](#geo-redundant-storage) (GRS), or [geo-zone-redundant storage](#geo-zone-redundant-storage) (GZRS).
 
-A write request to a storage account that's using LRS happens synchronously. The write operation returns successfully only after the data is written to all three replicas.
+All replicas reflect the same current state — deletions and overwrites are applied to all copies simultaneously. Redundancy protects against hardware failure, not against data-modifying operations.
 
 The following diagram shows how your data is replicated within a single data center with LRS:
 


### PR DESCRIPTION
Clarified the behavior of write requests in LRS and emphasized that redundancy protects against hardware failure, not data-modifying operations. This came from a customer support case where the customer believed because they had LRS enabled we could recover a deleted container for them.