### PR TITLE
Update priority of custom rule example in WAF limits

### DIFF
--- a/articles/web-application-firewall/ag/application-gateway-waf-request-size-limits.md
+++ b/articles/web-application-firewall/ag/application-gateway-waf-request-size-limits.md
@@ -28,7 +28,7 @@ Only requests with Content-Type of *multipart/form-data* are considered for file
 >[!NOTE]
 >If you're running Core Rule Set 3.2 or later, and you have a high priority custom rule that takes action based on the content of a request's headers, cookies, or URI, this will take precedence over any max request size, or max file upload size, limits. This optimization lets the Web Application Firewall run high priority custom rules that don't require reading the full request first.
 >
->**Example:** If you have a custom rule with priority 0 (the highest priority) set to allow a request with the header xyz, even if the request's size is larger than your maximum request size limit, it will get allowed before the max size limit is enforced
+>**Example:** If you have a custom rule with priority 1 (the highest priority) set to allow a request with the header xyz, even if the request's size is larger than your maximum request size limit, it will get allowed before the max size limit is enforced
 
 >[!NOTE]
 >There's a 4 KB buffer on the file upload limit. The file size restriction won't be enforced until the file upload exceeds your set limit plus this buffer.


### PR DESCRIPTION
This is a typo instead of "0" we need to have "1".  Basically, priority range for App GW custom WAF rule is 1-100, with 1 being the highest and 100 the lowest.

Checked with WAF on-call and got the confirmation.

