### PR TITLE
Add OTel destination guides and destination-table updates for Container Apps

### DIFF
--- a/articles/container-apps/TOC.yml
+++ b/articles/container-apps/TOC.yml
@@ -322,12 +322,6 @@ items:
           href: metrics.md
         - name: Alerts
           href: alerts.md
-    - name: End-to-end tracing and dashboards
-      items:
-        - name: Aspire Dashboard
-          href: aspire-dashboard.md
-        - name: Grafana dashboards
-          href: grafana-dashboards.md
     - name: OpenTelemetry agents
       items:
         - name: Overview
@@ -348,6 +342,12 @@ items:
           href: ../sre-agent/usage.md
         - name: Fix app issues with an SRE agent
           href: ../sre-agent/troubleshoot-azure-container-apps.md
+    - name: Dashboards
+      items:
+        - name: Aspire Dashboard
+          href: aspire-dashboard.md
+        - name: Grafana dashboards
+          href: grafana-dashboards.md
 - name: Scaling & performance
   items:
     - name: Overview

--- a/articles/container-apps/TOC.yml
+++ b/articles/container-apps/TOC.yml
@@ -332,6 +332,8 @@ items:
       items:
         - name: Overview
           href: opentelemetry-agents.md
+        - name: Export to Datadog
+          href: opentelemetry-export-datadog.md
         - name: Export to Dynatrace
           href: opentelemetry-export-dynatrace.md
         - name: Export to Elastic

--- a/articles/container-apps/opentelemetry-agents.md
+++ b/articles/container-apps/opentelemetry-agents.md
@@ -25,7 +25,7 @@ This article shows you how to set up and configure an OpenTelemetry agent for yo
 
 OpenTelemetry agents live within your container app environment. You configure agent settings via an ARM template or Bicep calls to the environment, or through the CLI, or through Terraform (via the [AzAPI provider](https://registry.terraform.io/providers/Azure/azapi/latest/docs)).
 
-Each endpoint type (Azure Monitor Application Insights, DataDog, and OTLP) has specific configuration requirements.
+Each endpoint type (Azure Monitor Application Insights, Datadog, and OTLP) has specific configuration requirements.
 
 ## Prerequisites
 
@@ -52,9 +52,25 @@ The following table shows you what type of data you can send to each destination
 
 | Destination | Logs | Metrics | Traces |
 |---|------|---------|--------|
-| [Azure App Insights](/azure/azure-monitor/app/app-insights-overview) | Yes | No | Yes |
-| [Datadog](https://datadoghq.com/) | Yes | Yes | Yes |
-| [OpenTelemetry](https://opentelemetry.io/) protocol (OTLP) configured endpoint | Yes | Yes | Yes |
+| [Azure Monitor Application Insights](/azure/azure-monitor/app/app-insights-overview) | Yes | No | Yes |
+| [Datadog](./opentelemetry-export-datadog.md) | Yes | Yes | Yes |
+| [Dynatrace](./opentelemetry-export-dynatrace.md) | Yes | Yes | Yes |
+| [New Relic](./opentelemetry-export-new-relic.md) | Yes | Yes | Yes |
+| [Elastic](./opentelemetry-export-elastic.md) | Yes | Yes | Yes |
+| [OpenTelemetry Protocol (OTLP)-compatible endpoint](#otlp-endpoint) | Yes | Yes | Yes |
+
+## Export destination guides
+
+Use the following guides for destination-specific setup and validation details.
+
+| Destination | Guide |
+|---|---|
+| Datadog | [Export OpenTelemetry data to Datadog in Azure Container Apps](./opentelemetry-export-datadog.md) |
+| Dynatrace | [Export OpenTelemetry data to Dynatrace in Azure Container Apps](./opentelemetry-export-dynatrace.md) |
+| New Relic | [Export OpenTelemetry data to New Relic in Azure Container Apps](./opentelemetry-export-new-relic.md) |
+| Elastic | [Export OpenTelemetry data to Elastic in Azure Container Apps](./opentelemetry-export-elastic.md) |
+| Azure Monitor Application Insights | [Azure Monitor Application Insights](#azure-monitor-application-insights) |
+| Other OTLP-compatible endpoints | [OTLP endpoint](#otlp-endpoint) |
 
 ## Azure Monitor Application Insights
 
@@ -167,6 +183,8 @@ resource "azapi_update_resource" "app_insights_open_telemetry_integration" {
 ## Datadog
 
 You don't need to run the Datadog agent in your container app if you enable the managed OpenTelemetry agent for your environment.
+
+For a detailed walkthrough, see [Export telemetry data from Azure Container Apps managed OpenTelemetry agent to Datadog](opentelemetry-export-datadog.md).
 
 The OpenTelemetry agent configuration requires a value for `site` and `key` from your Datadog instance. Gather these values from your Datadog instance according to this table:
 
@@ -537,8 +555,8 @@ To configure an agent, use the `destinations` array to define which agents your 
 |---|---|
 | Select a data type. | You can configure logs, metrics, and/or traces individually. |
 | Enable or disable any data type. | You can choose to send only traces and no other data. |
-| Send one data type to multiple endpoints. | You can send logs to both DataDog and an OTLP-configured endpoint. |
-| Send different data types to different locations. | You can send traces to an OTLP endpoint and metrics to DataDog. |
+| Send one data type to multiple endpoints. | You can send logs to both Datadog and an OTLP-configured endpoint. |
+| Send different data types to different locations. | You can send traces to an OTLP endpoint and metrics to Datadog. |
 | Disable sending all data types. | You can choose to not send any data through the OpenTelemetry agent. |
 
 ### By endpoint
@@ -549,7 +567,7 @@ To configure an agent, use the `destinations` array to define which agents your 
 The following example ARM template shows how to use an OTLP endpoint named `customDashboard`. It sends:
 - traces to app insights and `customDashboard`
 - logs to app insights and `customDashboard`
-- metrics to DataDog and `customDashboard`
+- metrics to Datadog and `customDashboard`
 
 ```json
 {

--- a/articles/container-apps/opentelemetry-export-datadog.md
+++ b/articles/container-apps/opentelemetry-export-datadog.md
@@ -1,0 +1,234 @@
+---
+title: Export OpenTelemetry data to Datadog in Azure Container Apps
+description: Learn how to configure Azure Container Apps to export OpenTelemetry logs, traces, and metrics to Datadog by using the managed OpenTelemetry agent.
+services: container-apps
+author: jefmarti
+ms.service: azure-container-apps
+ms.date: 2026-06-02
+ms.author: cshoe
+ms.topic: how-to
+---
+
+# Export OpenTelemetry data to Datadog in Azure Container Apps
+
+This guide shows how to configure Azure Container Apps to forward logs, traces, and metrics to Datadog by using the managed OpenTelemetry agent.
+
+For more information about the managed OpenTelemetry agent, see [Set up OpenTelemetry agents in Azure Container Apps](opentelemetry-agents).
+
+## What you learn
+
+- Create a Datadog API key for telemetry ingest.
+- Configure a Datadog destination in your Container Apps environment by using Bicep, Azure CLI, or the Azure portal.
+- Apply configuration updates to your existing Container Apps environment and app.
+- Verify telemetry in Datadog.
+
+## Prerequisites
+
+- An Azure subscription where you can create resource groups and deploy Azure Container Apps resources.
+- A Datadog environment and API key.
+- Azure CLI installed and signed in.
+- Azure Container Apps CLI extension installed.
+
+```azurecli
+az extension add --name containerapp --upgrade
+```
+
+## Create a Datadog API key
+
+Create (or use) a Datadog API key with permissions that allow telemetry ingest.
+
+You need the following Datadog values for Container Apps managed OTel configuration:
+
+- `site` (full Datadog site value, for example: `datadoghq.com`, `us3.datadoghq.com`, `us5.datadoghq.com`, `datadoghq.eu`)
+- `key` (Datadog API key)
+
+For Datadog key creation and management, see [Datadog API and application keys](https://docs.datadoghq.com/account_management/api-app-keys/).
+
+## Configure OpenTelemetry destinations
+
+Use one of the following options to configure Datadog as an OpenTelemetry destination in your Container Apps environment.
+
+> [!IMPORTANT]
+> Configuring a managed OpenTelemetry destination does not automatically produce telemetry. Your application must also be instrumented to emit traces, metrics, and logs by using an OpenTelemetry SDK.
+
+# [Bicep](#tab/bicep)
+
+Set CLI variables for the deployment command:
+
+```powershell
+$RESOURCE_GROUP = "<resource-group-name>"
+$DATADOG_SITE = "<datadog-site>" # Example: us3.datadoghq.com, us5.datadoghq.com, datadoghq.eu
+$DATADOG_API_KEY = ""
+$IMAGE = ""
+$ACR_USERNAME = ""
+$ACR_PASSWORD = ""
+```
+
+Use a managed environment resource block like the following:
+
+```bicep
+param datadogSite string
+@secure()
+param datadogApiKey string
+
+var datadogDestinationName = 'dataDog'
+
+resource environment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
+  name: ''
+  location: ''
+  properties: {
+    openTelemetryConfiguration: {
+      destinationsConfiguration: {
+        dataDogConfiguration: {
+          site: datadogSite
+          key: datadogApiKey
+        }
+      }
+      tracesConfiguration: {
+        destinations: [
+          datadogDestinationName
+        ]
+      }
+      logsConfiguration: {
+        destinations: [
+          datadogDestinationName
+        ]
+      }
+      metricsConfiguration: {
+        destinations: [
+          datadogDestinationName
+        ]
+      }
+    }
+  }
+}
+```
+
+Use a container app resource block like the following to set required environment variables:
+
+```bicep
+resource app 'Microsoft.App/containerApps@2024-10-02-preview' = {
+  name: ''
+  location: ''
+  properties: {
+    managedEnvironmentId: environment.id
+    template: {
+      containers: [
+        {
+          name: ''
+          image: ''
+          env: [
+            {
+              name: 'OTEL_SERVICE_NAME'
+              value: ''
+            }
+            {
+              name: 'OTEL_TRACES_EXPORTER'
+              value: 'otlp'
+            }
+            {
+              name: 'OTEL_METRICS_EXPORTER'
+              value: 'otlp'
+            }
+            {
+              name: 'OTEL_LOGS_EXPORTER'
+              value: 'otlp'
+            }
+            {
+              name: 'OTEL_EXPORTER_OTLP_PROTOCOL'
+              value: 'grpc'
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+For production deployments, pass token values through secure Bicep parameters or Key Vault instead of hardcoding secrets.
+
+After you update the template, deploy the Bicep configuration from the repository root:
+
+```powershell
+az deployment group create `
+  --resource-group $RESOURCE_GROUP `
+  --template-file infra/main.bicep `
+  --parameters @infra/main.parameters.json `
+  image=$IMAGE `
+  acrUsername=$ACR_USERNAME `
+  acrPassword=$ACR_PASSWORD `
+  datadogSite="$DATADOG_SITE" `
+  datadogApiKey="$DATADOG_API_KEY"
+```
+
+# [Azure CLI](#tab/cli)
+
+Use CLI to update an existing Container Apps environment:
+
+```powershell
+$RESOURCE_GROUP = "<resource-group-name>"
+$ENVIRONMENT_NAME = "<container-apps-environment-name>"
+$DATADOG_SITE = "<datadog-site>" # Example: us3.datadoghq.com, us5.datadoghq.com, datadoghq.eu
+$DATADOG_API_KEY = ""
+
+az containerapp env telemetry data-dog set `
+  --resource-group $RESOURCE_GROUP `
+  --name $ENVIRONMENT_NAME `
+  --site $DATADOG_SITE `
+  --key $DATADOG_API_KEY `
+  --enable-open-telemetry-traces true `
+  --enable-open-telemetry-metrics true
+```
+
+The current CLI only exposes flags for Datadog traces and metrics. Logs can be enabled by setting `logsConfiguration.destinations` to `dataDog` in the managed environment resource definition. If the portal shows Logs disabled after running the CLI command, update the environment through Bicep or the portal.
+
+Then ensure your app has required OTel env vars:
+
+```powershell
+$APP_NAME = "<container-app-name>"
+
+az containerapp update `
+  --resource-group $RESOURCE_GROUP `
+  --name $APP_NAME `
+  --set-env-vars `
+    OTEL_SERVICE_NAME=$APP_NAME `
+    OTEL_TRACES_EXPORTER=otlp `
+    OTEL_METRICS_EXPORTER=otlp `
+    OTEL_LOGS_EXPORTER=otlp `
+    OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+# [Azure portal](#tab/portal)
+
+Use the Azure portal path shown in the platform docs:
+
+1. Open your Container Apps environment.
+2. In the left menu, under Monitoring, select OTel endpoints.
+3. Select Datadog, and then select Update.
+4. In Update Datadog endpoint, set Site to your Datadog site value.
+5. In Key, paste your Datadog API key.
+6. Select the checkboxes for Logs, Traces, and Metrics.
+7. Save the configuration.
+8. Open your Container App, and then go to Revisions and replicas > Edit and deploy new revision.
+9. Under Environment variables, add or confirm the following values:
+   - `OTEL_SERVICE_NAME` = your app/service name
+   - `OTEL_TRACES_EXPORTER` = `otlp`
+   - `OTEL_METRICS_EXPORTER` = `otlp`
+   - `OTEL_LOGS_EXPORTER` = `otlp`
+   - `OTEL_EXPORTER_OTLP_PROTOCOL` = `grpc`
+10. Deploy the new revision.
+
+In the update panel, if you are not rotating the key, you can leave Key blank to keep the existing value.
+
+---
+
+Your Container App should now be configured to send telemetry to Datadog through the managed OpenTelemetry agent.
+
+## Verify OpenTelemetry data in Datadog
+
+After you complete the configuration, your container app starts sending telemetry to Datadog through the managed OpenTelemetry agent. Use Datadog to confirm that logs, traces, and metrics are arriving from the application and that the data appears under the expected service and environment context.
+
+You can validate the result by checking Datadog experiences and tools that fit your workflow, such as log exploration, distributed tracing, and metric search. The exact query or navigation path might vary depending on the data you want to inspect.
+
+For more information about data exploration in Datadog, see [Datadog observability and telemetry](https://docs.datadoghq.com/).

--- a/articles/container-apps/opentelemetry-export-dynatrace.md
+++ b/articles/container-apps/opentelemetry-export-dynatrace.md
@@ -42,7 +42,7 @@ Create a Dynatrace API token with these scopes:
 - `metrics.ingest`
 - `openTelemetryTrace.ingest`
 
-For token creation steps and permission details, see [Dynatrace token and permission requirements](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/deployment/tokens-permissions).
+For token creation steps and permission details, see [Dynatrace OTLP authentication guidance](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/otlp-api#authentication-export-to-activegate).
 
 
 ## Configure OpenTelemetry destinations
@@ -205,15 +205,20 @@ Your container app is now configured to send telemetry to Dynatrace.
 
 ## Verify OpenTelemetry data in Dynatrace
 
-After you complete the configuration, your container app starts sending telemetry to Dynatrace through the managed OpenTelemetry agent. Use Dynatrace to check that logs, traces, and metrics are arriving from the application and that the data appears under the expected service or environment context.
+After you complete the configuration, your Container App should begin sending telemetry to Dynatrace through the managed OpenTelemetry agent. The fastest way to confirm that metrics, logs, and traces are all arriving from your application is to open the **Services app** in Dynatrace. The Services app provides a single screen where you can validate all three telemetry signals for your service in one place.
 
-You can validate the result by checking the Dynatrace experiences and tools that fit your workflow, such as log exploration, distributed tracing, and metric search. The exact query or navigation path might vary depending on the data you want to inspect.
+To verify your telemetry:
 
-For more information about data exploration in Dynatrace, see [Dynatrace analyze, explore, and automate](https://docs.dynatrace.com/docs/analyze-explore-automate).
+1. Open the [Services app](https://docs.dynatrace.com/docs/observe/application-observability/services/services-app) in Dynatrace.
+1. Locate your Container App service and confirm that metrics, logs, and traces are present for the expected service or environment context.
+
+If you need background on how OpenTelemetry data is ingested into Dynatrace, see the [OpenTelemetry getting started guide](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/getting-started).
+
+If telemetry is missing or doesn't appear as expected, see the [OpenTelemetry troubleshooting guide](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/troubleshooting).
 
 ## Related content
 
 - [Collect and read OpenTelemetry data in Azure Container Apps](./opentelemetry-agents.md)
 - [Dynatrace analyze, explore, and automate](https://docs.dynatrace.com/docs/analyze-explore-automate)
-- [Dynatrace token and permission requirements](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/deployment/tokens-permissions)
+- [Dynatrace OTLP authentication guidance](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/otlp-api#authentication-export-to-activegate)
 


### PR DESCRIPTION
## Summary
- add and link new Datadog export guide for Container Apps managed OpenTelemetry
- update Dynatrace export guide links and verification steps
- expand destination capability table in OpenTelemetry agents doc (Datadog, Dynatrace, New Relic, Elastic, OTLP)
- add an "Export destination guides" table in the OpenTelemetry agents doc
- align Datadog brand casing in prose

## Validation
- quick consistency sweep on destination naming and link targets across related OpenTelemetry docs