### PR TITLE
Fix premium-ingress parameter name and default value

### DIFF
--- a/articles/container-apps/premium-ingress.md
+++ b/articles/container-apps/premium-ingress.md
@@ -93,8 +93,8 @@ The following table describes the parameters you can set when configuring premiu
 
 | Parameter | Description | Default | Minimum | Maximum |
 |--|--|--|--|--|
-| `termination-grace-period` | The time (in seconds) to allow active connections to close before terminating the ingress. | n/a | 0 | 3600  |
-| `request-idle-limit` | The time (in minutes) a request can remain idle before being disconnected. | 4 | 4 | 30 |
+| `termination-grace-period` | The time (in seconds) to allow active connections to close before terminating the ingress. | 500 | 0 | 3600  |
+| `request-idle-timeout` | The time (in minutes) a request can remain idle before being disconnected. | 4 | 4 | 30 |
 | `header-count-limit` | The maximum number of HTTP headers allowed per request. | 100 | 1 | n/a |
 
 


### PR DESCRIPTION
Fixes the parameter table in the premium ingress documentation, based on the issue reported in microsoft/azure-container-apps#1634.

Verified against the official `az containerapp env premium-ingress` CLI reference:

- Renamed `request-idle-limit` to `request-idle-timeout` to match the actual CLI flag.
- Updated `termination-grace-period` default from `n/a` to `500` (the actual CLI default).

The `termination-grace-period` maximum of 3600 was already correct in the current docs.