### PR TITLE
Add Durable Task Scheduler to PrivateLink service list

### DIFF
--- a/articles/private-link/private-endpoint-overview.md
+++ b/articles/private-link/private-endpoint-overview.md
@@ -98,6 +98,7 @@ A private-link resource is the destination target of a specified private endpoin
 | Azure Databricks | Microsoft.Databricks/workspaces | databricks_ui_api, browser_authentication |
 | Azure Device Provisioning Service | Microsoft.Devices/provisioningServices | iotDps |
 | Azure Digital Twins | Microsoft.DigitalTwins/digitalTwinsInstances | API |
+| Azure Durable Task Scheduler | Microsoft.DurableTask/schedulers | scheduler |
 | Azure Event Grid | Microsoft.EventGrid/domains | domain |
 | Azure Event Grid | Microsoft.EventGrid/topics  | topic |
 | Azure Event Hub | Microsoft.EventHub/namespaces | namespace |


### PR DESCRIPTION
In the latest Network RP deployment Azure Durable Task Scheduler's private endpoint implementation is now GA.

We should list it as a private link service.

I'm a service owner and the PoC for the private endpoint implementation.