### PR TITLE
Fix supported ACA on Arc regions

### DIFF
--- a/articles/container-apps/azure-arc-overview.md
+++ b/articles/container-apps/azure-arc-overview.md
@@ -38,7 +38,7 @@ The following limitations apply to Azure Container Apps on Azure Arc enabled Kub
 
 | Limitation | Details |
 |---|---|
-| Supported Azure regions | Australia East，Central US, East Asia, East US, North Central US, Southeast Asia, Sweden Central, UK South, West Europe, West US|
+| Supported Azure regions | Australia East, East Asia, East US, North Central US, Southeast Asia, Sweden Central, UK South, West Europe, West US|
 | Cluster networking requirement | Must support [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) service type |
 | Node OS requirement | **Linux** only. | 
 | Feature: Managed identities | [Not available](#are-managed-identities-supported) |

--- a/articles/logic-apps/set-up-standard-workflows-hybrid-deployment-requirements.md
+++ b/articles/logic-apps/set-up-standard-workflows-hybrid-deployment-requirements.md
@@ -53,7 +53,7 @@ The following section describes the limitations for the hybrid deployment option
 | Limitation | Description |
 |------------|-------------|
 | Data logging with a disconnected runtime | In partially connected mode, the Azure Logic Apps runtime can stay disconnected up to 24 hours and still retain data logs. However, any logging data past this duration might be lost. |
-| Supported Azure regions | Hybrid deployment is currently available and supported only in the following Azure regions: <br><br>- Australia East <br>- Central US <br>- East Asia <br>- East US <br>- North Central US <br>- Southeast Asia <br>- Sweden Central <br>- UK South <br>- West Europe <br>- West US |
+| Supported Azure regions | Hybrid deployment is currently available and supported only in the following Azure regions: <br><br>- Australia East <br>- East Asia <br>- East US <br>- North Central US <br>- Southeast Asia <br>- Sweden Central <br>- UK South <br>- West Europe <br>- West US |
 | Supported Azure Arc-enabled Kubernetes clusters | - Azure Arc-enabled Kubernetes clusters <br>- Azure Arc-enabled Kubernetes clusters on Azure Local (formerly Azure Stack HCI) <br>- Azure Arc-enabled Kubernetes clusters on Windows Server |
 | Unsupported capabilities available in single-tenant Azure Logic Apps (Standard) and related Azure services | - Deployment slots <br><br>- Azure Business process tracking <br><br>- Resource health under **Support + troubleshooting** in Azure portal <br><br>- Managed identity authentication for connector operations. For more information, see [Limitations for creating hybrid deployment workflows](create-standard-workflows-hybrid-deployment.md#limitations). |
 


### PR DESCRIPTION
This pull request updates the documentation for supported Azure regions in both Azure Container Apps on Azure Arc and Logic Apps hybrid deployment. The main change is the removal of "Central US" from the list of supported regions, ensuring consistency and accuracy in the documentation.

**Documentation updates for supported Azure regions:**

* [`articles/container-apps/azure-arc-overview.md`](diffhunk://#diff-13eff3230be8530ac631acce83c3a6ae2386b33ed693c32ca96d3a5e35815915L41-R41): Removed "Central US" from the list of supported Azure regions for Azure Container Apps on Azure Arc.
* [`articles/logic-apps/set-up-standard-workflows-hybrid-deployment-requirements.md`](diffhunk://#diff-a9a867563dc3afb01a23e97398a3420413a90b300352c616e676bce9fe51f4f0L56-R56): Removed "Central US" from the list of supported Azure regions for Logic Apps hybrid deployment.