### PR TITLE
Document Azure Policy enrollments

### DIFF
--- a/articles/governance/policy/concepts/assignment-structure.md
+++ b/articles/governance/policy/concepts/assignment-structure.md
@@ -1,7 +1,7 @@
 ---
 title: Details of the policy assignment structure
 description: Describes the policy assignment definition used by Azure Policy to relate policy definitions and parameters to resources for evaluation.
-ms.date: 03/04/2025
+ms.date: 06/22/2026
 ms.topic: reference
 ---
 
@@ -130,7 +130,7 @@ The optional `metadata` property stores information about the policy assignment.
 
 ## Resource selectors
 
-The optional `resourceSelectors` property facilitates safe deployment practices (SDP) by enabling you to gradually roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location. When resource selectors are used, Azure Policy only evaluates resources that are applicable to the specifications made in the resource selectors. Resource selectors can also be used to narrow down the scope of [exemptions](exemption-structure.md) in the same way.
+The optional `resourceSelectors` property facilitates safe deployment practices (SDP) by enabling you to gradually roll out policy assignments based on factors like resource location, resource type, or whether a resource has a location. When resource selectors are used, Azure Policy only evaluates resources that are applicable to the specifications made in the resource selectors. Resource selectors can also be used to narrow down the scope of [exemptions](exemption-structure.md) and [enrollments](enrollment-structure.md) in the same way.
 
 In the following example scenario, the new policy assignment is evaluated only if the resource's location is either **East US** or **West US**.
 
@@ -287,8 +287,9 @@ This property has the following values:
 |-|-|-|-|-|-|
 |Enabled |Default |string |Yes |Yes |The policy effect is enforced during resource creation or update. |
 |Disabled |DoNotEnforce |string |Yes |No | The policy effect isn't enforced during resource creation or update. |
+|Enroll |Enroll |string |Yes |Yes for enrolled resources |The policy effect is enforced during resource creation or update only for resources that are enrolled in the assignment. |
 
-If `enforcementMode` isn't specified in a policy or initiative definition, the value _Default_ is used. [Remediation tasks](../how-to/remediate-resources.md) can be started for [deployIfNotExists](./effect-deploy-if-not-exists.md) policies, even when `enforcementMode` is set to _DoNotEnforce_.
+If `enforcementMode` isn't specified in a policy or initiative definition, the value _Default_ is used. [Remediation tasks](../how-to/remediate-resources.md) can be started for [deployIfNotExists](./effect-deploy-if-not-exists.md) policies, even when `enforcementMode` is set to _DoNotEnforce_. For more information about Enroll mode, see [Azure Policy enrollment structure](./enrollment-structure.md).
 
 ## Excluded scopes
 

--- a/articles/governance/policy/concepts/enrollment-structure.md
+++ b/articles/governance/policy/concepts/enrollment-structure.md
@@ -1,0 +1,158 @@
+---
+title: Details of the policy enrollment structure
+description: Describes the policy enrollment resource used by Azure Policy to enroll resources or scopes into an Enroll mode policy assignment.
+ms.date: 06/22/2026
+ms.topic: reference
+---
+
+# Azure Policy enrollment structure
+
+The Azure Policy enrollments feature is used to _enroll_ a resource hierarchy or an individual resource into a policy assignment that's configured with [Enroll enforcement mode](./assignment-structure.md#enforcement-mode). Resources that are enrolled are evaluated by the assignment and have the policy effect enforced during resource creation or update. Resources that are in scope for the assignment but aren't enrolled still have compliance records generated, but the policy effect isn't enforced.
+
+You use JavaScript Object Notation (JSON) to create a policy enrollment. The policy enrollment contains elements for:
+
+- [display name](#display-name-and-description)
+- [description](#display-name-and-description)
+- [policy assignment](#policy-assignment-id)
+- [policy definitions within an initiative](#policy-definition-ids)
+- [resource selectors](#resource-selectors)
+- [assignment scope validation](#assignment-scope-validation-preview)
+
+A policy enrollment is created as a child object on the resource hierarchy or the individual resource that's enrolled. An enrollment can be created at or above the scope of the resource that should be enrolled. Conceptually, an enrollment is the opposite of an exemption: an exemption removes a scope from enforcement, while an enrollment adds a scope to an Enroll mode assignment.
+
+For example, the following JSON shows a policy enrollment for a subscription to an assignment named `resourceShouldBeCompliantInit`. The enrollment applies to two policy definitions in the initiative, the `requiredTags` and `allowedLocations` policy definition reference IDs:
+
+```json
+{
+  "id": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyEnrollments/resourceShouldBeCompliant",
+  "apiVersion": "2025-02-01-preview",
+  "name": "resourceShouldBeCompliant",
+  "type": "Microsoft.Authorization/policyEnrollments",
+  "properties": {
+    "displayName": "Enroll subscription in resource compliance policy",
+    "description": "Enrolls the subscription into the resource compliance initiative assignment.",
+    "policyAssignmentId": "/subscriptions/{mySubscriptionID}/providers/Microsoft.Authorization/policyAssignments/resourceShouldBeCompliantInit",
+    "policyDefinitionReferenceIds": [
+      "requiredTags",
+      "allowedLocations"
+    ],
+    "assignmentScopeValidation": "Default"
+  }
+}
+```
+
+## Display name and description
+
+You use `displayName` and `description` to identify the policy enrollment and provide context for its use with the specific resource or scope. `displayName` has a maximum length of _128_ characters and `description` a maximum length of _512_ characters.
+
+## Policy assignment ID
+
+This field must be the full path name of either a policy assignment or an initiative assignment. The `policyAssignmentId` is a string and not an array. This property defines which assignment the parent resource hierarchy or individual resource is _enrolled_ in.
+
+## Policy definition IDs
+
+If the `policyAssignmentId` is for an initiative assignment, the `policyDefinitionReferenceIds` property might be used to specify which policy definitions in the initiative the enrollment applies to. As the resource might be enrolled into one or more included policy definitions, this property is an _array_. The values must match the values in the initiative definition in the `policyDefinitions.policyDefinitionReferenceId` fields.
+
+## Resource selectors
+
+Enrollments support an optional property `resourceSelectors` that works the same way in enrollments as it does in assignments. The property allows for gradual rollout or rollback of an _enrollment_ to certain subsets of resources in a controlled manner based on resource type, resource location, or whether the resource has a location. More details about how to use resource selectors can be found in the [assignment structure](assignment-structure.md#resource-selectors). The following JSON is an example enrollment that uses resource selectors. In this example, only resources in `eastus` and `westus` are enrolled into the policy assignment:
+
+```json
+{
+  "properties": {
+    "policyAssignmentId": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyAssignments/ResourceLimit",
+    "resourceSelectors": [
+      {
+        "name": "SDPRegions",
+        "selectors": [
+          {
+            "kind": "resourceLocation",
+            "in": [
+              "eastus",
+              "westus"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "systemData": { ...
+  },
+  "id": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyEnrollments/ResourceLimitEnrollment",
+  "type": "Microsoft.Authorization/policyEnrollments",
+  "name": "ResourceLimitEnrollment"
+}
+```
+
+The following resource selector `kinds` are supported in the policy enrollments object:
+
+- `resourceLocation`: This property is used to select resources based on location. Can't be used in the same resource selector as `resourceWithoutLocation`.
+- `resourceType`: This property is used to select resources based on their type.
+- `resourceWithoutLocation`: This property is used to select resources at the subscription level that don't have a location. Currently only supports `subscriptionLevelResources`. Can't be used in the same resource selector as `resourceLocation`.
+- `in`: The list of allowed values for the specified `kind`. Can't be used with `notIn`. Can contain up to 50 values.
+- `notIn`: The list of not-allowed values for the specified `kind`. Can't be used with `in`. Can contain up to 50 values.
+
+A **resource selector** can contain multiple `selectors`. To be applicable to a resource selector, a resource must meet requirements specified by all its selectors. Further, up to 10 `resourceSelectors` can be specified in a single enrollment. In-scope resources are enrolled when they satisfy any one of these resource selectors.
+
+## Assignment scope validation (preview)
+
+In most scenarios, the enrollment scope is validated to ensure it's at or under the policy assignment scope. The optional `assignmentScopeValidation` property can allow an enrollment to bypass this validation and be created outside of the assignment scope. The use of this property is shown in the following example:
+
+```json
+{
+  "properties": {
+    "policyAssignmentId": "/providers/Microsoft.Management/managementGroups/{mgName}/providers/Microsoft.Authorization/policyAssignments/CostManagement",
+    "policyDefinitionReferenceIds": [
+      "limitSku",
+      "limitType"
+    ],
+    "assignmentScopeValidation": "DoNotValidate"
+  },
+  "systemData": { ...
+  },
+  "id": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyEnrollments/DemoExpensiveVM",
+  "type": "Microsoft.Authorization/policyEnrollments",
+  "name": "DemoExpensiveVM"
+}
+```
+
+Allowed values for `assignmentScopeValidation` are `Default` and `DoNotValidate`. If not specified, the default validation process occurs.
+
+## Update an enrollment
+
+The `PATCH` operation for policy enrollments supports only the `assignmentScopeValidation` and `resourceSelectors` properties.
+
+```json
+{
+  "properties": {
+    "assignmentScopeValidation": "Default",
+    "resourceSelectors": [
+      {
+        "name": "SDPRegions",
+        "selectors": [
+          {
+            "kind": "resourceLocation",
+            "in": [
+              "eastus",
+              "westus"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Enrollment creation and management
+
+Enrollments are recommended for scenarios where a policy assignment should be visible across its full scope, but the policy effect should be enforced only for selected resources or scopes. For example, you can create an assignment with `enforcementMode` set to `Enroll`, validate compliance results for the full assignment scope, and then create enrollment resources for the regions, resource groups, subscriptions, or management groups that are ready for enforcement.
+
+An assignment can switch between enforcement modes. Existing enrollments are honored when the assignment is in Enroll mode. If the assignment switches out of Enroll mode and later switches back to Enroll mode, existing enrollments are honored again. If an assignment is deleted and recreated with the same ID, previous enrollments aren't honored by the new assignment.
+
+## Next steps
+
+- Learn about [the policy assignment structure](./assignment-structure.md).
+- Learn about [safe deployment of Azure Policy assignments](../how-to/policy-safe-deployment-practices.md).
+- Learn about [policy exemptions](./exemption-structure.md).
+- Learn how to [get compliance data](../how-to/get-compliance-data.md).

--- a/articles/governance/policy/how-to/policy-safe-deployment-practices.md
+++ b/articles/governance/policy/how-to/policy-safe-deployment-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Safe deployment of Azure Policy assignments
 description: Learn how to apply the safe deployment practices (SDP) framework to your Azure Policy assignments.
-ms.date: 03/04/2025
+ms.date: 06/22/2026
 ms.topic: how-to
 ---
 
@@ -12,6 +12,11 @@ As your environment expands, so does the demand for a controlled continuous depl
 The high-level approach of implementing SDP with Azure Policy is to gradually rollout policy assignments by tiers to detect policy changes that affect the environment in early stages before it affects the critical cloud infrastructure.
 
 Deployment tiers can be organized in diverse ways. In this how-to tutorial, tiers are divided by different Azure regions with _Tier 5_ representing non-critical, low traffic locations, and _Tier 0_ denoting the most critical, highest traffic locations.
+
+You can implement safe deployment with Azure Policy in two ways:
+
+- Use `resourceSelectors` on the policy assignment to gradually expand the resources evaluated by the assignment.
+- Use an assignment with `enforcementMode` set to `Enroll` and create [policy enrollments](../concepts/enrollment-structure.md) to gradually expand where the assignment effect is enforced. This method keeps compliance visibility for the full assignment scope while limiting enforcement to enrolled scopes or resources.
 
 ## Steps for safe deployment of Azure Policy assignments with deny or append effects
 
@@ -233,9 +238,78 @@ locations and validating the expected compliance results and application health.
 }
 ```
 
+## Steps for safe deployment with policy enrollments
+
+Policy enrollments provide another SDP method for assignments that use `enforcementMode` set to `Enroll`. With this method, you create the assignment at the target scope to produce compliance results, and then create or update enrollment resources to turn on enforcement for selected deployment tiers.
+
+1. Create the policy assignment at the highest-level scope inclusive of all deployment tiers and set `enforcementMode` to `Enroll`.
+
+    ```json
+    {
+      "properties": {
+        "policyDefinitionId": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyDefinitions/ResourceLimit",
+        "enforcementMode": "Enroll"
+      }
+    }
+    ```
+
+1. Once the assignment is deployed and the initial compliance scan has completed, validate that the compliance result is as expected across the assignment scope.
+
+1. Create a policy enrollment for the least critical tier. You can use `resourceSelectors` on the enrollment to narrow enforcement to a location, resource type, or resources without a location.
+
+    ```json
+    {
+      "properties": {
+        "policyAssignmentId": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyAssignments/ResourceLimit",
+        "resourceSelectors": [
+          {
+            "name": "SDPRegions",
+            "selectors": [
+              {
+                "kind": "resourceLocation",
+                "in": [
+                  "eastus"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+
+1. Validate that enforcement is taking place as expected for enrolled resources and that application health remains stable.
+
+1. Repeat by expanding the enrollment resource selector values to include the next tier's locations, or by creating additional enrollments for other scopes.
+
+    ```json
+    {
+      "properties": {
+        "policyAssignmentId": "/subscriptions/{subId}/providers/Microsoft.Authorization/policyAssignments/ResourceLimit",
+        "resourceSelectors": [
+          {
+            "name": "SDPRegions",
+            "selectors": [
+              {
+                "kind": "resourceLocation",
+                "in": [
+                  "eastus",
+                  "westus"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+
+1. Repeat this process for all production tiers.
+
 ## Next steps
 
 - Learn how to [programmatically create policies](./programmatically-create.md).
+- Review [Azure Policy enrollment structure](../concepts/enrollment-structure.md).
 - Review [Azure Policy as code workflows](../concepts/policy-as-code.md).
 - Study Microsoft's guidance concerning [safe deployment practices](/devops/operate/safe-deployment-practices).
 - Review [Remediate non-compliant resources with Azure Policy](./remediate-resources.md).

--- a/articles/governance/policy/policy-glossary.md
+++ b/articles/governance/policy/policy-glossary.md
@@ -146,10 +146,11 @@ A JSON-defined object that, when triggered, corrects resources violating policie
 
 ## Resource selectors
 
-The optional `resourceSelectors` property is used for policy assignments or policy exemptions.
+The optional `resourceSelectors` property is used for policy assignments, policy exemptions, or policy enrollments.
 
 - [Policy assignments](./concepts/assignment-structure.md#resource-selectors): Allows you to do a gradual rollout of a policy assignment.
 - [Policy exemptions](./concepts/exemption-structure.md#resource-selectors): Allows you to do a gradual rollout or rollback of an exemption.
+- [Policy enrollments](./concepts/enrollment-structure.md#resource-selectors): Allows you to do a gradual rollout or rollback of an enrollment.
 
 ## Scope
 

--- a/articles/governance/policy/toc.yml
+++ b/articles/governance/policy/toc.yml
@@ -274,6 +274,9 @@
   - name: Exemption structure
     displayName: waiver, mitigated, compliance
     href: ./concepts/exemption-structure.md
+  - name: Enrollment structure
+    displayName: enroll, enrollment, enforcementmode
+    href: ./concepts/enrollment-structure.md
   - name: Applicability
     displayName: policy, applicability, scope
     href: ./concepts/policy-applicability.md


### PR DESCRIPTION
Adds a public Azure Policy enrollment structure article modeled after the exemption structure article. Updates assignment enforcement mode docs to include Enroll mode, safe deployment guidance to describe enrollment-based SDP, the glossary resource selectors entry, and the policy TOC.