### PR TITLE
Update documentation for ApplicationLoadBalancer setup

### DIFF
--- a/articles/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md
+++ b/articles/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md
@@ -82,6 +82,9 @@ az role assignment create --assignee-object-id $principalId --assignee-principal
 # Delegate Network Contributor permission for join to association subnet
 az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --scope $ALB_SUBNET_ID --role "4d97b98b-1d4f-4787-a291-c67834d212e7" 
 ```
+> [!Note]
+> When the identity is created via the [Add-on](quickstart-deploy-application-gateway-for-containers-alb-controller-addon.md) the name of the identiy is actually `applicationloadbalancer-<cluster-name>`.
+> Also the _AppGW for Containers Configuration Manager_ role is already assigned.
 
 ## Create ApplicationLoadBalancer Kubernetes resource
 

--- a/articles/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md
+++ b/articles/application-gateway/for-containers/quickstart-create-application-gateway-for-containers-managed-by-alb-controller.md
@@ -83,7 +83,7 @@ az role assignment create --assignee-object-id $principalId --assignee-principal
 az role assignment create --assignee-object-id $principalId --assignee-principal-type ServicePrincipal --scope $ALB_SUBNET_ID --role "4d97b98b-1d4f-4787-a291-c67834d212e7" 
 ```
 > [!Note]
-> When the identity is created via the [Add-on](quickstart-deploy-application-gateway-for-containers-alb-controller-addon.md) the name of the identiy is actually `applicationloadbalancer-<cluster-name>`.
+> When the identity is created via the [Add-on](quickstart-deploy-application-gateway-for-containers-alb-controller-addon.md) the name of the identity is actually `applicationloadbalancer-<cluster-name>`.
 > Also the _AppGW for Containers Configuration Manager_ role is already assigned.
 
 ## Create ApplicationLoadBalancer Kubernetes resource


### PR DESCRIPTION
Adds a note that when the identity is created by the addon instead of helm the name is different and the  _AppGW for Containers Configuration Manager_ role is already assigned