### PR TITLE
Remove cert-manager issuer annotations from ALB config

### DIFF
--- a/articles/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-gateway-api.md
@@ -174,7 +174,6 @@ helm install \
   --version v1.19.3 \
   --namespace cert-manager \
   --create-namespace \
-  --set config.enableGatewayAPI=true \
   --set crds.enabled=true
 ```
 

--- a/articles/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-gateway-api.md
+++ b/articles/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-gateway-api.md
@@ -57,7 +57,6 @@ metadata:
   annotations:
     alb.networking.azure.io/alb-namespace: alb-test-infra
     alb.networking.azure.io/alb-name: alb-test
-    cert-manager.io/issuer: letsencrypt-prod
 spec:
   gatewayClassName: azure-alb-external
   listeners:
@@ -95,7 +94,6 @@ metadata:
   namespace: test-infra
   annotations:
     alb.networking.azure.io/alb-id: $RESOURCE_ID
-    cert-manager.io/issuer: letsencrypt-prod
 spec:
   gatewayClassName: azure-alb-external
   listeners:
@@ -288,7 +286,6 @@ metadata:
   annotations:
     alb.networking.azure.io/alb-namespace: alb-test-infra
     alb.networking.azure.io/alb-name: alb-test
-    cert-manager.io/issuer: letsencrypt-cert
 spec:
   gatewayClassName: azure-alb-external
   listeners:
@@ -335,7 +332,6 @@ metadata:
   namespace: test-infra
   annotations:
     alb.networking.azure.io/alb-id: $RESOURCE_ID
-    cert-manager.io/issuer: letsencrypt-prod
 spec:
   gatewayClassName: azure-alb-external
   listeners:


### PR DESCRIPTION
Removed cert-manager issuer annotations for ALB resources since they only work when used with with a hostname in the listener see:  https://cert-manager.io/docs/usage/gateway/

The follwoing flag is also not needed in this case : "-set config.enableGatewayAPI=true" since the certificate is manualy created

This is article is confusing manual certi creation with the automatic version. I have changed it so it is only having the required settings for manual cert rotation