### PR TITLE
Update set-variable policy allowed type list with byte arrays

### DIFF
--- a/articles/api-management/set-variable-policy.md
+++ b/articles/api-management/set-variable-policy.md
@@ -43,7 +43,9 @@ Expressions used in the `set-variable` policy must return one of the following b
 
 -   System.Boolean
 -   System.SByte
+-   System.SByte[]
 -   System.Byte
+-   System.Byte[]
 -   System.UInt16
 -   System.UInt32
 -   System.UInt64


### PR DESCRIPTION
Add `System.SByte[]` and `System.Byte[]` to allowed types of the `set-variable` policy.

_For the types `System.SByte` and `System.Byte`, an array is also allowed as the return type. For other types, this is not the case._