### PR TITLE
Fix case sensitivity in Container Apps extension command

### DIFF
--- a/articles/container-apps/deploy-express-cli.md
+++ b/articles/container-apps/deploy-express-cli.md
@@ -34,7 +34,7 @@ Before you begin, upgrade the Azure Container Apps CLI extension to the required
 1. Add the Container Apps extension.
 
     ```azurecli
-    az extension add -n ContainerApp
+    az extension add -n containerapp
     ```
 
 1. Update the extension to ensure you have the latest version.


### PR DESCRIPTION
extension names are case-sensitive