### PR TITLE
Update description of Application Gateway mTLS auth server variable `client_certificate_verification`

### DIFF
--- a/articles/application-gateway/rewrite-http-headers-url.md
+++ b/articles/application-gateway/rewrite-http-headers-url.md
@@ -149,7 +149,7 @@ Application Gateway supports the following server variables for mutual authentic
 | client_certificate_serial | The serial number of the client certificate for an established SSL connection.  |
 | client_certificate_start_date| The start date of the client certificate. |
 | client_certificate_subject| The "subject DN" string of the client certificate for an established SSL connection. |
-| client_certificate_verification| The result of the client certificate verification. For mTLS passthrough mode: *PASSTHROUGH* if certificate presented, else *NONE*. For mTLS strict mode: *SUCCESS* for valid certificate, else empty. | 
+| client_certificate_verification| The result of the client certificate verification. For mTLS passthrough mode: *PASSTHROUGH* if a certificate is presented, otherwise *NONE*. For mTLS strict mode: *SUCCESS* if a valid certificate is presented, otherwise an empty string. | 
 
 
 ## Common scenarios for header rewrite

--- a/articles/application-gateway/rewrite-http-headers-url.md
+++ b/articles/application-gateway/rewrite-http-headers-url.md
@@ -149,7 +149,7 @@ Application Gateway supports the following server variables for mutual authentic
 | client_certificate_serial | The serial number of the client certificate for an established SSL connection.  |
 | client_certificate_start_date| The start date of the client certificate. |
 | client_certificate_subject| The "subject DN" string of the client certificate for an established SSL connection. |
-| client_certificate_verification| The result of the client certificate verification: *SUCCESS*, *FAILED:\<reason\>*, or *NONE* if a certificate wasn't present. | 
+| client_certificate_verification| The result of the client certificate verification. For mTLS passthrough mode: *PASSTHROUGH* if certificate presented, else *NONE*. For mTLS strict mode: *SUCCESS* for valid certificate, else empty. | 
 
 
 ## Common scenarios for header rewrite

--- a/articles/application-gateway/rewrite-http-headers-url.md
+++ b/articles/application-gateway/rewrite-http-headers-url.md
@@ -149,7 +149,7 @@ Application Gateway supports the following server variables for mutual authentic
 | client_certificate_serial | The serial number of the client certificate for an established SSL connection.  |
 | client_certificate_start_date| The start date of the client certificate. |
 | client_certificate_subject| The "subject DN" string of the client certificate for an established SSL connection. |
-| client_certificate_verification| The result of the client certificate verification. For mTLS passthrough mode: *PASSTHROUGH* if a certificate is presented, otherwise *NONE*. For mTLS strict mode: *SUCCESS* if a valid certificate is presented, otherwise an empty string. | 
+| client_certificate_verification| The result of the client certificate verification. In mTLS passthrough mode: *PASSTHROUGH* when the client presents a certificate, or *NONE* when it doesn't. In mTLS strict mode: *SUCCESS* when the client presents a valid certificate. In strict mode, Application Gateway returns HTTP 400 for a missing or invalid client certificate before it forwards the request, so the backend never receives a value. To review those outcomes, use the `sslClientVerify` property in the [access log](monitor-application-gateway-reference.md#access-log-category). |
 
 
 ## Common scenarios for header rewrite


### PR DESCRIPTION
Update description of Application Gateway mTLS auth server variable `client_certificate_verification` based on the behaviour I've observed (Standard_v2 AGW):
- Passthrough mode: 
	- NONE when no certificate is presented
	- PASSTHROUGH if a certificate is presented
- Strict mode
	- SUCCESS when certificate is valid
	- Empty when certificate is invalid