### PR TITLE
Add FAQ entry for restoring an archived Container Apps environment

### DIFF
--- a/articles/container-apps/faq.yml
+++ b/articles/container-apps/faq.yml
@@ -76,6 +76,29 @@ sections:
         answer: |
           Azure Container Apps doesn't move or store customer data out of the deployed region.
 
+  - name: Environment management
+    questions:
+      - question: |
+          How do I restore an archived Container Apps environment?
+        answer: |
+          You can restore an archived environment by updating its environment mode to workload profiles using the Azure CLI. The operation can take 15-30 minutes to complete.
+
+          First, add and update the `containerapp` extension to ensure you're using the latest version:
+
+            ```azurecli
+            az extension add --name containerapp
+            az extension update --name containerapp
+            ```
+
+          Then restore the environment by setting its environment mode to `workloadprofiles`:
+
+            ```azurecli
+            az containerapp env update \
+              --environment-mode workloadprofiles \
+              --name $ENV_NAME \
+              --resource-group $RG
+            ```
+
   - name: Quotas
     questions:
       - question: |


### PR DESCRIPTION
Adds a new **Environment management** section to the Container Apps FAQ with a question and answer explaining how to restore an archived environment.

The answer documents the supported workflow:
- Add/update the `containerapp` CLI extension
- Run `az containerapp env update --environment-mode workloadprofiles` to restore the environment (15-30 min)

This addresses a common customer question that wasn't previously documented in the FAQ.