### PR TITLE
Update JSON structure in management group API documentation

### DIFF
--- a/articles/governance/management-groups/create-management-group-rest-api.md
+++ b/articles/governance/management-groups/create-management-group-rest-api.md
@@ -77,7 +77,7 @@ endpoint and request body:
   ```
 
 In the preceding examples, the new management group is created under the root management group. To
-specify a different management group as the parent, use the **properties.parent.id** property.
+specify a different management group as the parent, use the **properties.details.parent.id** property.
 
 - REST API URI
 

--- a/articles/governance/management-groups/create-management-group-rest-api.md
+++ b/articles/governance/management-groups/create-management-group-rest-api.md
@@ -91,8 +91,10 @@ specify a different management group as the parent, use the **properties.parent.
   {
     "properties": {
       "displayName": "Contoso Group",
-      "parent": {
-        "id": "/providers/Microsoft.Management/managementGroups/HoldingGroup"
+      "details": {
+        "parent": {
+          "id": "/providers/Microsoft.Management/managementGroups/HoldingGroup"
+        }
       }
     }
   }


### PR DESCRIPTION
The PUT MG's request body was missing the "details" field. This would have led to the MG being created under the root MG by default. Placing the "parent" JSON under the "details" key ensures the provided parent id is respected.