### PR TITLE
Add scaling permissions section to Service Bus connections docs

### DIFF
--- a/includes/functions-service-bus-connections.md
+++ b/includes/functions-service-bus-connections.md
@@ -65,3 +65,15 @@ Store this connection string in an app setting with a name that matches the valu
 If the app setting name starts with `AzureWebJobs`, you only need to specify the rest of the name. For example, if you set `connection` to `MyServiceBus`, the Functions runtime looks for an app setting named `AzureWebJobsMyServiceBus`. If you leave `connection` empty, the Functions runtime uses the default Service Bus connection string in the app setting named `AzureWebJobsServiceBus`.
 
 ---
+
+### Scaling permissions
+
+The Service Bus extension uses the Service Bus Administration API (`GetQueueRuntimePropertiesAsync` / `GetSubscriptionRuntimePropertiesAsync`) to retrieve accurate message counts for scale decisions. This API requires additional permissions beyond what is needed to send or receive messages:
+
+- **SAS connection strings**: The SAS policy must include the **Manage** access right.
+- **Identity-based connections**: The identity must be assigned the **Azure Service Bus Data Owner** role, or a custom role that includes `Microsoft.ServiceBus/namespaces/*/read`.
+
+If the connection lacks these permissions, the extension silently falls back to peek-based message estimation, which is less accurate and may result in delayed or incorrect scaling decisions. No error is raised at startup.
+
+> [!TIP]
+> For production workloads that rely on auto-scaling, include the **Manage** claim (SAS) or assign the **Azure Service Bus Data Owner** role (identity-based connections) to ensure accurate scale behavior.


### PR DESCRIPTION
## Summary

Adds a **Scaling permissions** subsection to the shared Service Bus connections include file (`includes/functions-service-bus-connections.md`), documenting the additional permissions required by the Service Bus extension for accurate auto-scaling.

## Details

The Service Bus extension uses the Administration API (`GetQueueRuntimePropertiesAsync` / `GetSubscriptionRuntimePropertiesAsync`) to retrieve message counts for scale decisions. This requires:

- **SAS connection strings**: The **Manage** access right on the SAS policy
- **Identity-based connections**: The **Azure Service Bus Data Owner** role (or a custom role with `Microsoft.ServiceBus/namespaces/*/read`)

If these permissions are missing, the extension silently falls back to peek-based message estimation, which is less accurate and may cause delayed or incorrect scaling. No error is raised at startup.

## Why this change

This is a common production issue where Functions apps don't scale correctly due to missing permissions, with no obvious error to guide troubleshooting. Making this explicit in the connection docs helps developers configure permissions correctly from the start.

## Files changed

- `includes/functions-service-bus-connections.md` — Added **Scaling permissions** subsection