### PR TITLE
Add no-unused-types linter rule documentation

### DIFF
--- a/articles/azure-resource-manager/bicep/linter-rule-no-unused-types.md
+++ b/articles/azure-resource-manager/bicep/linter-rule-no-unused-types.md
@@ -1,0 +1,58 @@
+---
+title: Linter rule - no unused types
+description: Linter rule - no unused types
+ms.topic: reference
+ms.custom: devx-track-bicep
+ms.date: 07/10/2026
+---
+
+# Linter rule - no unused types
+
+This rule finds [user-defined data types](./user-defined-data-types.md) that aren't referenced anywhere in the Bicep file.
+
+## Linter rule code
+
+Use the following value in the [Bicep configuration file](bicep-config-linter.md) to customize rule settings:
+
+`no-unused-types`
+
+## Solution
+
+To reduce confusion in your Bicep file, delete any types that are defined but not used. This test finds all types that aren't used anywhere in the file.
+
+The following example fails this test because the `unusedType` type is declared but never used:
+
+```bicep
+type unusedType = {
+  name: string
+  age: int
+}
+
+param location string = resourceGroup().location
+
+output deployedToLocation string = location
+```
+
+You can fix it by removing the unused type declaration, or by referencing the type, for example in a `param` or `output` declaration:
+
+```bicep
+type storageAccountConfigType = {
+  name: string
+  sku: string
+}
+
+param storageAccountConfig storageAccountConfigType = {
+  name: 'mystorageaccount'
+  sku: 'Standard_LRS'
+}
+
+output configuredName string = storageAccountConfig.name
+```
+
+Types that are shared with other Bicep files by using the [`@export()`](./user-defined-data-types.md#export) decorator are excluded from this rule, because they're intended to be consumed elsewhere.
+
+Use **Quick Fix** to remove the unused types.
+
+## Next steps
+
+For more information about the linter, see [Use Bicep linter](./linter.md).

--- a/articles/azure-resource-manager/bicep/linter.md
+++ b/articles/azure-resource-manager/bicep/linter.md
@@ -41,6 +41,7 @@ The default set of linter rules is minimal and taken from [arm-ttk test cases](.
 | <a id='no-unused-existing-resources' />[no-unused-existing-resources](./linter-rule-no-unused-existing-resources.md) | warning |
 | <a id='no-unused-imports' />[no-unused-imports](./linter-rule-no-unused-imports.md) | warning |
 | <a id='no-unused-params' />[no-unused-params](./linter-rule-no-unused-parameters.md) | warning |
+| <a id='no-unused-types' />[no-unused-types](./linter-rule-no-unused-types.md) | warning |
 | <a id='no-unused-vars' />[no-unused-vars](./linter-rule-no-unused-variables.md) | warning |
 | <a id='outputs-should-not-contain-secrets' />[outputs-should-not-contain-secrets](./linter-rule-outputs-should-not-contain-secrets.md) | warning |
 | <a id='prefer-interpolation' />[prefer-interpolation](./linter-rule-prefer-interpolation.md) | warning |

--- a/articles/azure-resource-manager/bicep/toc.yml
+++ b/articles/azure-resource-manager/bicep/toc.yml
@@ -534,6 +534,9 @@ items:
       - name: No unused parameters
         displayName: linter
         href: linter-rule-no-unused-parameters.md
+      - name: No unused types
+        displayName: linter
+        href: linter-rule-no-unused-types.md
       - name: No unused variables
         displayName: linter
         href: linter-rule-no-unused-variables.md


### PR DESCRIPTION
## Description

Adds documentation for the new `no-unused-types` Bicep linter rule, which warns when a user-defined `type` declaration is declared but never referenced.

This documents the rule added in Azure/bicep#20035 (implementation for Azure/bicep#11876).

### Changes
- **New page:** `linter-rule-no-unused-types.md` describing the rule, its config code, and how to fix violations.
- **`linter.md`:** added `no-unused-types` (default: warning) to the default rules table.
- **`toc.yml`:** added the new page to the Bicep table of contents.

> [!NOTE]
> Opening as a **draft** to pair with the code PR (Azure/bicep#20035). The `aka.ms/bicep/linter-diagnostics#no-unused-types` link used by the rule resolves to the new page's `no-unused-types` heading once merged.