### PR TITLE
Update routing instructions for Oracle AI Database access

### DIFF
--- a/articles/oracle/oracle-db/oracle-database-network-plan.md
+++ b/articles/oracle/oracle-db/oracle-database-network-plan.md
@@ -158,7 +158,7 @@ When routing traffic to Oracle AI Database@Azure through a Network Virtual Appli
 > Without these routes, outbound traffic may bypass required inspection paths or fail to reach the intended destination.
 
 > [!Note]
-> If you want to configure a route table (UDR route) to control the routing of packets through a network virtual appliance or firewall destined to an Oracle AI Database@Azure instance from a source in the same virtual network or a peered virtual network, the UDR prefix must be more specific or equal to the delegated subnet size of the Oracle AI Database@Azure. If the UDR prefix is less specific than the delegated subnet size, it isn't effective.
+> When routing traffic through a network virtual appliance or firewall from sources in the same virtual network or a peered virtual network, configure the user-defined route (UDR) with a prefix that is equal to or more specific than the delegated subnet size of the Oracle AI Database@Azure instance. Do not use a UDR prefix that is less specific than the delegated subnet size, because such routes won't take effect.
 > 
 > For example, if your delegated subnet is `x.x.x.x/24`, you must configure your UDR to `x.x.x.x/24` (equal) or `x.x.x.x/32` (more specific). If you configure the UDR route to be `x.x.x.x/16`, undefined behaviors such as asymmetric routing can cause a network drop at the firewall.
 

--- a/articles/oracle/oracle-db/oracle-database-network-plan.md
+++ b/articles/oracle/oracle-db/oracle-database-network-plan.md
@@ -158,7 +158,7 @@ When routing traffic to Oracle AI Database@Azure through a Network Virtual Appli
 > Without these routes, outbound traffic may bypass required inspection paths or fail to reach the intended destination.
 
 > [!Note]
-> When routing traffic through a network virtual appliance or firewall from sources in the same virtual network or a peered virtual network, configure the user-defined route (UDR) with a prefix that is equal to or more specific than the delegated subnet size of the Oracle AI Database@Azure instance. Do not use a UDR prefix that is less specific than the delegated subnet size, because such routes won't take effect.
+> When routing traffic through a network virtual appliance or firewall from sources in the same virtual network or a peered virtual network, configure the user-defined route (UDR) with a prefix that is equal to or more specific than the delegated subnet size of the Oracle AI Database@Azure instance. Don't use a UDR prefix that is less specific than the delegated subnet size, because such routes won't take effect.
 > 
 > For example, if your delegated subnet is `x.x.x.x/24`, you must configure your UDR to `x.x.x.x/24` (equal) or `x.x.x.x/32` (more specific). If you configure the UDR route to be `x.x.x.x/16`, undefined behaviors such as asymmetric routing can cause a network drop at the firewall.
 

--- a/articles/oracle/oracle-db/oracle-database-network-plan.md
+++ b/articles/oracle/oracle-db/oracle-database-network-plan.md
@@ -158,9 +158,6 @@ When routing traffic to Oracle AI Database@Azure through a Network Virtual Appli
 > Without these routes, outbound traffic may bypass required inspection paths or fail to reach the intended destination.
 
 > [!Note]
-> To access an Oracle AI Database@Azure instance from an on-premises network via a virtual network gateway (ExpressRoute or VPN) and firewall, configure the route table assigned to the virtual network gateway to include the /32 IPv4 address of the Oracle AI Database@Azure instance listed and point to the firewall as the next hop. Using an aggregate address space that includes the Oracle AI Database@Azure instance IP address doesn't forward the Oracle AI Database@Azure traffic to the firewall.
-
-> [!Note]
 > If you want to configure a route table (UDR route) to control the routing of packets through a network virtual appliance or firewall destined to an Oracle AI Database@Azure instance from a source in the same virtual network or a peered virtual network, the UDR prefix must be more specific or equal to the delegated subnet size of the Oracle AI Database@Azure. If the UDR prefix is less specific than the delegated subnet size, it isn't effective.
 > 
 > For example, if your delegated subnet is `x.x.x.x/24`, you must configure your UDR to `x.x.x.x/24` (equal) or `x.x.x.x/32` (more specific). If you configure the UDR route to be `x.x.x.x/16`, undefined behaviors such as asymmetric routing can cause a network drop at the firewall.


### PR DESCRIPTION
Removed redundant note about accessing Oracle AI Database@Azure instance via virtual network gateway.