### PR TITLE
Change Ireland from DASID to PRASID

### DIFF
--- a/articles/communication-services/concepts/sms/concepts.md
+++ b/articles/communication-services/concepts/sms/concepts.md
@@ -94,7 +94,7 @@ To send SMS, you must have a sender ID—this can be a phone number or an alphan
 | Germany          | –         | –          | –     | –              | ✅             | –              |
 | France           | –         | –          | –     | –              | ✅             | –              |
 | Italy            | –         | –          | –     | –              | –              | ✅             |
-| Ireland          | –         | –          | –     | ✅             | ✅             | –              |
+| Ireland          | –         | –          | –     | ✅             | –             | ✅              |
 | Finland          | –         | –          | –     | ✅             | –              | ✅             |
 | Denmark          | –         | –          | –     | ✅             | ✅             | –              |
 | Netherlands      | –         | –          | –     | ✅             | ✅             | –              |


### PR DESCRIPTION
Ireland changed from Dynamic Alpha sender ID to pre-registered sender ID since September 2025

Public Doc: https://www.comreg.ie/industry/electronic-communications/nuisance-communications/sms-sender-id-registry/#1