### PR TITLE
Add deprecation notice for MQ managed connector (Consumption)

### DIFF
--- a/articles/connectors/connectors-create-api-mq.md
+++ b/articles/connectors/connectors-create-api-mq.md
@@ -17,6 +17,10 @@ ms.custom:
 
 [!INCLUDE [logic-apps-sku-consumption-standard](../../includes/logic-apps-sku-consumption-standard.md)]
 
+> [!IMPORTANT]
+> **Deprecation notice**: The MQ managed connector for Azure Logic Apps (Consumption) is being deprecated beginning August 2026. We recommend that customers migrate to the [MQ built-in connector](/azure/logic-apps/connectors/built-in/reference/mq/) for Azure Logic Apps (Standard). The existing managed connector will continue to work, but no new features or bug fixes will be added. This change will begin to happen automatically starting August 2026 — please switch to the MQ built-in connector as soon as possible.
+
+
 This guide shows how to access an Azure-hosted or on-premises MQ server from a workflow in Azure Logic Apps using the MQ connector. You can then create automated workflows that receive and send messages stored in your MQ server. For example, your workflow can browse for a single message in a queue and then run other actions.
 
 The MQ connector provides a wrapper around a Microsoft MQ client, which includes all the messaging capabilities to communicate with a remote MQ server across a TCP/IP network. This connector defines the connections, operations, and parameters to call the MQ client.


### PR DESCRIPTION
Adds an IMPORTANT deprecation banner to the top of the "Connect to IBM MQ servers from workflows in Azure Logic Apps" article, directing customers to migrate from the MQ managed connector (Consumption) to the MQ built-in connector (Standard) ahead of the August 2026 retirement.

Aligned with:
- CXP AzComms intake SN-57166 / ICM 836257198 (customer email, sending 2026-07-20)
- Retirement date: 2026-08-17

Mirror of private PR MicrosoftDocs/azure-docs-pr#318355.