### PR TITLE
Update support matrix for change tracking inventory

### DIFF
--- a/articles/azure-change-tracking-inventory/change-tracking-inventory-support-matrix.md
+++ b/articles/azure-change-tracking-inventory/change-tracking-inventory-support-matrix.md
@@ -128,7 +128,6 @@ Change Tracking and Inventory using the AMA doesn't support the following capabi
 - Anything other than `HKEY_LOCAL_MACHINE`. You encounter this limitation whenever you add the registry key manually.
 - Network file systems.
 - Different installation methods.
-- The `*.exe` files stored on Windows.
 - The **Max File Size** column and values in the current implementation.
 - Collecting hotfix updates on Windows Server 2016 Core RS3 machines.
 - Any hardening standards for any Linux operating systems or distributions.


### PR DESCRIPTION
Removed the limitation regarding '*.exe' files stored on Windows from the support matrix.  I just tested this and see an exe modified.

<img width="1001" height="700" alt="image" src="https://github.com/user-attachments/assets/d7ee01a1-1581-40ff-b363-3545ac8d109f" />
