### PR TITLE
Clarify Google Vertex AI API schema usage

### DIFF
--- a/includes/api-management-llm-models.md
+++ b/includes/api-management-llm-models.md
@@ -14,4 +14,4 @@ This policy works with LLM APIs added to API Management that conform to one of t
 
 * OpenAI Chat Completions or Responses API
 * Anthropic Messages API (currently supported in API Management v2 tiers)
-* Google Vertex AI API
+* Google Vertex AI API (using the OpenAI Chat Completions schema)


### PR DESCRIPTION
Google support both their native generateDontent API and the OpenAI compatible API on their platform.

The mention of Google Vertex AI API leads one to believe it's the native format, not the OpenAI compatible format. But from my testing and scouring the internet, we do not support the generateContent API schema, only the OpenAI schema for Google Gemini models.

Therefore, I'm proposing to add the clarification so that readers are not confused and don't waste time trying to get generateContent working.