### PR TITLE
Update and correct Microsoft Marketplace references

### DIFF
--- a/articles/index.yml
+++ b/articles/index.yml
@@ -1476,7 +1476,7 @@ additionalContent:
         # Card
         - title: Microsoft Marketplace customer documentation
           summary: Align third-party cloud and AI investments to your Microsoft contract to get the most value while increasing security and governance.
-          url: https://learn.microsoft.com/marketplace/
+          url: /marketplace/
         # Card
         - title: Azure Native ISV Services
           summary: Integrated partner solutions that you can use in Azure to enhance your cloud infrastructure.

--- a/articles/index.yml
+++ b/articles/index.yml
@@ -10,7 +10,7 @@ metadata:
   ms.topic: hub-page
   author: fossygirl
   ms.author: carols
-  ms.date: 06/18/2026
+  ms.date: 07/21/2026
   adobe-target: true
   learn-experiments: true
   featureFlags:
@@ -1467,12 +1467,16 @@ additionalContent:
         - title: Microsoft Azure operated by 21Vianet
           summary: A dedicated cloud located in China and operated by 21Vianet.
           url: /azure/china/
-    - title: Partner solutions
+    - title: Discover Microsoft partner solutions
       items:
         # Card
-        - title: Commercial marketplace
-          summary: An online marketplace of applications and services from independent software vendor (ISV) partners.
-          url: ./marketplace/index.yml
+        - title: Microsoft Marketplace
+          summary: Microsoft Marketplace is your trusted source for cloud solutions, apps, and agents.
+          url: https://marketplace.microsoft.com
+        # Card
+        - title: Microsoft Marketplace customer documentation
+          summary: Align third-party cloud and AI investments to your Microsoft contract to get the most value while increasing security and governance.
+          url: https://learn.microsoft.com/marketplace/
         # Card
         - title: Azure Native ISV Services
           summary: Integrated partner solutions that you can use in Azure to enhance your cloud infrastructure.


### PR DESCRIPTION
Modified partner solutions section with new titles and URLs. Prior azure/marketplace reference went to Partner Center documentation, but should go to Marketplace customer documentation. Also added a card to direct Azure customers to the Microsoft Marketplace storefront where they can explore thousands of partner solutions.