### PR TITLE
Add brew trust command for Core Tools installation

### DIFF
--- a/includes/functions-install-core-tools.md
+++ b/includes/functions-install-core-tools.md
@@ -38,6 +38,7 @@ The following steps use Homebrew to install the Core Tools on macOS.
 
     ```bash
     brew tap azure/functions
+    brew trust azure/functions
     brew install azure-functions-core-tools@4
     # if upgrading on a machine that has 2.x or 3.x installed:
     brew link --overwrite azure-functions-core-tools@4


### PR DESCRIPTION
## Summary
Adds the `brew trust azure/functions` step before `brew install azure-functions-core-tools@4` in the Homebrew installation instructions for Azure Functions Core Tools on macOS.

## Why
Recent Homebrew versions require explicitly trusting a tap before installing from it, otherwise the install can fail or prompt unexpectedly. This step was missing from the documented sequence.