### PR TITLE
Update supported Azure CycleCloud versions

### DIFF
--- a/articles/cyclecloud/service-policy.md
+++ b/articles/cyclecloud/service-policy.md
@@ -4,7 +4,7 @@ description: Complete service policy for Azure CycleCloud. See release types, re
 services: azure cyclecloud
 author: adriankjohnson
 ms.topic: concept-article
-ms.date: 06/19/2026
+ms.date: 07/26/2026
 ms.author: padmalathas
 ---
 
@@ -42,7 +42,7 @@ If your Azure CycleCloud installation is behind by more than two major release u
 
 For example, the two most recently updated major releases are:
 
-* Version 8:  8.7.x, 8.8.x
+* Version 8: 8.8.x, 8.9.x
 
 In this example, all versions listed are supported, and earlier versions are out of support.
 


### PR DESCRIPTION
Update the service policy example from 8.7.x/8.8.x to 8.8.x/8.9.x. The current release notes identify 8.9.1 as the latest release, making 8.9.x the latest and 8.8.x the previous supported release series under the documented policy.

Also refresh the document date.