### PR TITLE
Fix NVMe boot disk support details in release notes

### DIFF
--- a/articles/cyclecloud/release-notes/8-8-0.md
+++ b/articles/cyclecloud/release-notes/8-8-0.md
@@ -44,7 +44,7 @@ This release introduces highly requested new features, addresses several key iss
 - **NVMe device support**
     - Azure CycleCloud automatically mounts and formats NVMe storage devices on Linux nodes on machine types with NVMe ephemeral disks.
     - Linux nodes mount NVMe ephemeral disks at `/nvme`.
-    - Machine types with NVMe boot disks, such as the v6, HBv5, and HBv6 machine types, are now supported.
+    - Machine types with NVMe boot disks, such as the HBv5 machine types, are now supported.
  
 - **ARM64 support**
     - Azure CycleCloud and Jetpack support ARM64 nodes and ARM64 images if the cluster type provides ARM64 support. Currently, only the Slurm cluster type provides built-in ARM64 support.


### PR DESCRIPTION
Corrected the mention of supported machine types for NVMe boot disks.