### PR TITLE
Correct description of resourceLocation property

### DIFF
--- a/articles/governance/policy/concepts/exemption-structure.md
+++ b/articles/governance/policy/concepts/exemption-structure.md
@@ -119,7 +119,7 @@ Exemptions support an optional property `resourceSelectors` that works the same 
 ```
 
 The follow resource selectors `kinds` are supported in the policy exemptions object:
-- resourceLocation: This property is used to select resources based on their type. Can't be used in the same resource selector as resourceWithoutLocation.
+- resourceLocation: This property is used to select resources based on their location. Can't be used in the same resource selector as resourceWithoutLocation.
 - resourceType: This property is used to select resources based on their type.
 - resourceWithoutLocation: This property is used to select resources at the subscription level that don't have a location. Currently only supports subscriptionLevelResources. Can't be used in the same resource selector as resourceLocation.
 - in: The list of allowed values for the specified kind. Can't be used with notIn. Can contain up to 50 values.


### PR DESCRIPTION
Fix incorrect description of `resourceLocation` value for resource selector's `kind` field.

Current description says:
resourceLocation: This property is used to select resources based on their type.

which is incorrect. It should be:
resourceLocation: This property is used to select resources based on their **location**.

<img width="933" height="1033" alt="image" src="https://github.com/user-attachments/assets/035e3889-1c2b-4c59-99b7-c4c86a4fe0fe" />
