### PR TITLE
Update Rocky Linux version in networking overview

### DIFF
--- a/articles/virtual-network/accelerated-networking-overview.md
+++ b/articles/virtual-network/accelerated-networking-overview.md
@@ -69,7 +69,7 @@ The following Linux and FreeBSD distributions from Azure Marketplace support Acc
 - AlmaLinux 10.0
 - AlmaLinux 9.6
 - Rocky Linux 10.0
-- Rocky Linux 9.6
+- Rocky Linux 9.7
 - SUSE Linux Enterprise Server 16
 - SUSE Linux Enterprise Server 15 SP7
 - SUSE Linux Enterprise Server 15 SP6


### PR DESCRIPTION
Updated Rocky Linux version from 9.6 to 9.7 in the overview.

Rocky Linux 9.6 on kernel version 570.51.1.el9_6 and below do not have a patch that is needed for MANA VF support when a minimum capability check is enforced.