### PR TITLE
Add new Bicep linter rules to sample bicepconfig.json

### DIFF
--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -69,6 +69,9 @@ The following example shows the rules that you can configure.
         "no-hardcoded-location": {
           "level": "off"
         },
+        "no-hardcoded-outputs": {
+          "level": "off"
+        },
         "no-loc-expr-outside-params": {
           "level": "off"
         },
@@ -85,6 +88,9 @@ The following example shows the rules that you can configure.
           "level": "warning"
         },
         "no-unused-params": {
+          "level": "warning"
+        },
+        "no-unused-types": {
           "level": "warning"
         },
         "no-unused-vars": {
@@ -106,6 +112,9 @@ The following example shows the rules that you can configure.
           "level": "warning"
         },
         "secure-params-in-nested-deploy": {
+          "level": "warning"
+        },
+        "secure-params-in-parameters-file": {
           "level": "warning"
         },
         "secure-secrets-in-params": {

--- a/articles/azure-resource-manager/bicep/bicep-config-linter.md
+++ b/articles/azure-resource-manager/bicep/bicep-config-linter.md
@@ -137,6 +137,9 @@ The following example shows the rules that you can configure.
         "use-recent-module-versions": {
           "level": "off"
         },
+        "use-recognized-resource-type": {
+          "level": "warning"
+        },
         "use-resource-id-functions": {
           "level": "off"
         },
@@ -144,9 +147,6 @@ The following example shows the rules that you can configure.
           "level": "warning"
         },
         "use-safe-access": {
-          "level": "warning"
-        },
-        "use-recognized-resource-type": {
           "level": "warning"
         },
         "use-secure-value-for-secure-inputs": {


### PR DESCRIPTION
- Add Bicep linter rules `no-hardcoded-outputs` and `secure-params-in-parameters-file` to sample bicepconfig.json (added in Bicep release [v0.45.6](https://github.com/Azure/bicep/releases#release-v0.45.6))
- Add Bicep linter rule `no-unused-types` to sample bicepconfig.json (added in Bicep release [v0.46.1](https://github.com/Azure/bicep/releases#release-v0.46.1))
- Sort linter rules in sample bicepconfig.json alphabetically

_The Bicep linter rules already have there own pages. They were only missing in the sample bicepconfig.json._