### PR TITLE
Clarify eligibility criteria for MPA tool access

### DIFF
--- a/articles/cost-management-billing/manage/mpa-request-ownership.md
+++ b/articles/cost-management-billing/manage/mpa-request-ownership.md
@@ -25,7 +25,7 @@ Supported product (subscriptions, reservations and savings plans) billing owners
 
 This feature is available only to the following partners:
 
-- CSP authorized direct-bill partners that earn an [Azure Solutions Partner designation](https://partner.microsoft.com/partnership/solutions-partner) or enroll in the [Azure Expert MSP](https://partner.microsoft.com/membership/azure-expert-msp) program.
+- CSP authorized direct-bill partners that earn an [Azure Solutions Partner designation](https://partner.microsoft.com/partnership/solutions-partner) or CSP authorized direct-bill partner enrolled in the [Azure Expert MSP](https://partner.microsoft.com/membership/azure-expert-msp) program.
 
 - CSP authorized distributors that earn the [Frontier Distributor designation](https://partner.microsoft.com/asset/collection/frontier-distributor-collection).
 


### PR DESCRIPTION
The current wording can be interpreted as Azure Expert MSP enrollment alone being sufficient for eligibility. We have received inquiries from several partners that are Azure Expert MSPs but not CSP Direct Bill authorized, who assumed they were eligible based on the current text.

Repeating "CSP authorized direct-bill partners" before the Azure Expert MSP clause makes it explicit that both conditions must be met:

The partner must be CSP Direct Bill authorized.
The partner must also be enrolled in the Azure Expert MSP program (or hold an eligible Azure Solutions Partner designation).

This is a small editorial change, but it helps prevent confusion and reduces unnecessary partner inquiries.