### PR TITLE
docs: Add Debian Bullseye EOL migration guidance for Azure Functions

### DIFF
--- a/articles/azure-functions/container-concepts.md
+++ b/articles/azure-functions/container-concepts.md
@@ -74,6 +74,9 @@ The Functions team is committed to publishing monthly updates for these base ima
 
 Choose your base image based on the language stack you're using in your function app. The following table provides examples for each stack. In general, the tag should start with `4-` to indicate the V4 Functions runtime. When new minor versions are released, this tag will be updated to point to the new version. As you periodically rebuild your custom image, you will pull the new versions through that same tag, allowing your app to have the same updates. You shouldn't use tags that specify minor runtime versions, as these will not receive updates, and your app will potentially remain on an unpatched version, no matter how often you rebuild your custom image.
 
+> [!IMPORTANT]
+> **Debian Bullseye EOL (August 31, 2026):** Base images for Java 8/11/17 and Python 3.11 are being migrated from Bullseye to newer OS versions. If you reference these images, your next pull will get the updated OS. See [OS-level migrations](language-support-policy.md#os-level-migrations) for details.
+
 | Language Stack | Example recommended base image tags |
 |----------------|----------------|
 | .NET (isolated worker model) | `mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0` or<br/>`mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0-appservice`<br/><br/>(These examples target .NET 8. Select the appropriate image for the .NET version you need.) |

--- a/articles/azure-functions/language-support-policy.md
+++ b/articles/azure-functions/language-support-policy.md
@@ -97,6 +97,67 @@ Use these resources to better understand and plan for language support-related c
 | **Configuring language versions** | Go version selection is controlled by the Go toolchain you use to build your function app. |
 ::: zone-end
 
+## OS-level migrations
+
+Azure Functions Linux images are built on specific Debian or Ubuntu base OS versions. When a base OS reaches end-of-life, affected language stacks are migrated to a newer supported OS. This ensures continued security updates and compliance.
+
+For **managed plans** (Consumption, Flex Consumption, Elastic Premium, Dedicated):
+- The platform automatically migrates your function app to the newer OS image
+- No action is required from you
+- Your `linuxFxVersion` or function app configuration remains unchanged
+
+For **custom containers**:
+- You must update your Dockerfile to use a newer base image tag
+- The existing tag (e.g., `:4-python3.11`) will be updated to point to the new OS image
+- A legacy OS-suffixed tag (e.g., `:4-python3.11-bullseye`) will remain available temporarily but will not receive security updates
+
+### Current OS migrations
+
+| Stack | Previous OS | New OS | Migration date | Notes |
+|-------|------------|--------|---------------|-------|
+| Python 3.11 | Debian 11 (Bullseye) | Debian 12 (Bookworm) | August 2026 | Platform auto-migrates managed plans |
+| Java 8 | Debian 11 (Bullseye) | Ubuntu 24.04 (Noble) | August 2026 | Platform auto-migrates managed plans |
+| Java 11 | Debian 11 (Bullseye) | Ubuntu 24.04 (Noble) | August 2026 | Platform auto-migrates managed plans |
+| Java 17 | Debian 11 (Bullseye) | Ubuntu 24.04 (Noble) | August 2026 | Platform auto-migrates managed plans |
+
+### Reverting to the previous OS version
+
+After the migration, your function app defaults to the newer OS image. If your app experiences compatibility issues, you can revert to the previous OS by explicitly setting the **environment version** (`envVersion`).
+
+For **Linux Dedicated and Elastic Premium** plans, set the environment version in `linuxFxVersion` using the format:
+
+```
+runtime|version|envVersion
+```
+
+For example, to pin Python 3.11 to the Bullseye-based image:
+
+```
+Python|3.11|2.0
+```
+
+For **Flex Consumption** plans, set the `envVersion` property in `functionAppConfig`:
+
+```json
+{
+  "runtime": "Python",
+  "runtimeVersion": "3.11",
+  "envVersion": "2.0"
+}
+```
+
+The following environment versions are available:
+
+| Stack | envVersion for previous OS (Bullseye) | envVersion for new OS |
+|-------|--------------------------------------|----------------------|
+| Python 3.11 | `2.0` | `3.0` (Bookworm) |
+| Java 8 | `2.0` | `4.0` (Noble) |
+| Java 11 | `2.0` | `4.0` (Noble) |
+| Java 17 | `2.0` | `4.0` (Noble) |
+
+> [!IMPORTANT]
+> The previous OS version (Bullseye) will not receive security updates after August 31, 2026. Use the rollback option only as a temporary measure while you resolve compatibility issues with the newer OS.
+
 ## Frequently asked questions
 
 This section provides you with answers to questions that are frequently asked about language support policies.
@@ -138,3 +199,7 @@ To learn more about how to upgrade your function app's language version, see the
 
 + [Update language stack versions](./update-language-versions.md)
 + [Currently supported language versions](./supported-languages.md#languages-by-runtime-version)
+
+### What happens when the base OS of my function app image reaches end-of-life?
+
+When a base OS (such as Debian Bullseye) reaches end-of-life, Azure Functions migrates affected stacks to a newer OS version. For managed plans, this happens automatically. If your app experiences issues after the migration, you can temporarily revert to the previous OS by setting the `envVersion` in your app configuration (see [Reverting to the previous OS version](#reverting-to-the-previous-os-version)). For custom container deployments, you should update your base image reference. The standard image tag (e.g., `:4-python3.11`) will be updated to the newer OS, while a legacy tag with the OS suffix (e.g., `:4-python3.11-bullseye`) remains available temporarily without security updates. See [OS-level migrations](#os-level-migrations) for current migration details.

--- a/articles/azure-functions/supported-languages.md
+++ b/articles/azure-functions/supported-languages.md
@@ -22,6 +22,9 @@ This article explains the levels of support offered for your preferred language 
 
 The following table shows which languages supported by Functions can run on Linux or Windows. It also indicates whether there's support for editing each language in the Azure portal. The language is based on the **Runtime stack** option you select when you [create your function app in the Azure portal](functions-create-function-app-portal.md#create-a-function-app). This value is the same as the `--worker-runtime` option that you specify when you use the `func init` command in Azure Functions Core Tools.
 
+> [!NOTE]
+> Some language stacks are undergoing a base OS migration as Debian Bullseye reaches end-of-life. See the [language support policy](language-support-policy.md#os-level-migrations) for affected stacks and migration details.
+
 | Language | Runtime stack | Linux | Windows | In-portal editing<sup>1</sup> |
 |:--- |:-- |:--|:--- |:--- |
 | [C# (isolated worker model)](dotnet-isolated-process-guide.md) |.NET|✓ |✓ | |

--- a/includes/functions-supported-languages.md
+++ b/includes/functions-supported-languages.md
@@ -91,6 +91,9 @@ The following table shows the language versions supported for Java function apps
 | **Java 8** | GA | September 2027 |
 
 > [!NOTE]
+> Java 8, 11, and 17 are currently hosted on Debian Bullseye-based images on Linux plans. As Debian Bullseye reaches end-of-life on August 31, 2026, these stacks will be migrated to newer OS images (Ubuntu Noble). The platform handles this migration automatically for managed plans (Linux Dedicated/EP and Flex Consumption). Custom container customers should update their base images. See the [language support policy](../articles/azure-functions/language-support-policy.md) for details.
+
+> [!NOTE]
 > Java 21 is the last Java version supported for Linux Consumption plan apps. Newer Java versions aren't added to Linux Consumption. For more information, see [Migrate Consumption plan apps to the Flex Consumption plan](../articles/azure-functions/migration/migrate-plan-consumption-to-flex.md).
 
 For more information on developing and running Java function apps, see [Azure Functions Java developer guide](../articles/azure-functions/functions-reference-java.md).
@@ -134,6 +137,8 @@ The following table shows the language versions supported for Python function ap
 | Python 3.11 | GA | October 2027 |
 | Python 3.10 | GA | October 2026 |
 
+> [!NOTE]
+> Python 3.11 is currently hosted on Debian Bullseye-based images on Linux plans. As Debian Bullseye reaches end-of-life on August 31, 2026, this stack will be migrated to a newer OS image (Debian Bookworm). The platform handles this migration automatically for managed plans. Custom container customers should update their base images. See the [language support policy](../articles/azure-functions/language-support-policy.md) for details.
 
 > [!NOTE]
 > Python 3.12 is the last Python version supported for Linux Consumption plan apps. Newer Python versions aren't added to Linux Consumption. For more information, see [Migrate Consumption plan apps to the Flex Consumption plan](../articles/azure-functions/migration/migrate-plan-consumption-to-flex.md).


### PR DESCRIPTION
Add documentation for the upcoming Debian Bullseye end-of-life (August 31, 2026) affecting Python 3.11 and Java 8/11/17 on Linux plans.

Changes:
- Add OS-level migrations section to language-support-policy.md with envVersion rollback instructions for Linux Dedicated/EP and Flex Consumption plans
- Add Bullseye EOL notes to Java and Python version tables in functions-supported-languages.md
- Add IMPORTANT callout to container-concepts.md base image section
- Add NOTE to supported-languages.md Language support details section
- Add new FAQ entry about base OS end-of-life handling