### PR TITLE
Clarify HTTP header size limit descriptions

### DIFF
--- a/includes/front-door-limits.md
+++ b/includes/front-door-limits.md
@@ -70,7 +70,7 @@ In addition to the following limits, there's a [composite limit on the number of
 | Maximum secrets per profile | 100 | 500 |
 | Maximum key groups per profile | 100 | 200 |
 | HTTP header size limit (total header size) | 64 KB | 64 KB|
-| HTTP header size limit (total header size - PLS Origin) | 32 KB | 32 KB|
+| HTTP header size limit (total header size - Private Link Service origin) | 32 KB | 32 KB|
 | Web Application Firewall (WAF) policy per subscription | 100 | 100 |
 | WAF custom rules per policy | 100 | 100 |
 | WAF match conditions per custom rule | 10 | 10 |

--- a/includes/front-door-limits.md
+++ b/includes/front-door-limits.md
@@ -69,7 +69,8 @@ In addition to the following limits, there's a [composite limit on the number of
 | Maximum associations per security policy | 110 | 225 |
 | Maximum secrets per profile | 100 | 500 |
 | Maximum key groups per profile | 100 | 200 |
-| HTTP header size limit (per header) | 64 KB | 64 KB|
+| HTTP header size limit (total header size) | 64 KB | 64 KB|
+| HTTP header size limit (total header size - PLS Origin) | 32 KB | 32 KB|
 | Web Application Firewall (WAF) policy per subscription | 100 | 100 |
 | WAF custom rules per policy | 100 | 100 |
 | WAF match conditions per custom rule | 10 | 10 |

--- a/includes/front-door-limits.md
+++ b/includes/front-door-limits.md
@@ -69,8 +69,8 @@ In addition to the following limits, there's a [composite limit on the number of
 | Maximum associations per security policy | 110 | 225 |
 | Maximum secrets per profile | 100 | 500 |
 | Maximum key groups per profile | 100 | 200 |
-| HTTP header size limit (total header size) | 64 KB | 64 KB|
-| HTTP header size limit (total header size - Private Link Service origin) | 32 KB | 32 KB|
+| HTTP header size limit (total header size) | 64 KB | 64 KB |
+| HTTP header size limit (total header size - Private Link Service origin) | 32 KB | 32 KB |
 | Web Application Firewall (WAF) policy per subscription | 100 | 100 |
 | WAF custom rules per policy | 100 | 100 |
 | WAF match conditions per custom rule | 10 | 10 |


### PR DESCRIPTION
The size limit depends on the Origin (if it is PLS or not) and it counts total header size (it's not per header)