### PR TITLE
Update footnotes for payload and connection limits

### DIFF
--- a/includes/api-management-gateway-constraints.md
+++ b/includes/api-management-gateway-constraints.md
@@ -20,18 +20,19 @@ ms.custom: Include file
 | Cached response size | 2 MiB | 2 MiB | 2 MiB |
 | Policy document size  | 512 KiB | 512 KiB | 16 KiB |
 | Request payload size | Unlimited | 1 GiB | 1 GiB |
-| Buffered payload size | 500 MiB | 2 MiB | 2 MiB |
+| Buffered payload size | 500 MiB<sup>3</sup> | 2 MiB | 2 MiB |
 | Request/response payload size in diagnostic logs | 8,192 bytes | 8,192 bytes | 8,192 bytes |
-| Request URL size<sup>3</sup> | Unlimited | 16,384 bytes | 16,384 bytes |
+| Request URL size<sup>4</sup> | Unlimited | 16,384 bytes | 16,384 bytes |
 | Length of URL path segment | 1,024 characters | 1,024 characters | 1,024 characters |
 | Length of named value | 4,096 characters | 4,096 characters | 4,096 characters |
 | Size of request or response body in [validate-content policy](/azure/api-management/validate-content-policy) | 100 KiB | 100 KiB | 100 KiB |
 | Size of API schema used by [validation policy](/azure/api-management/validation-policies) | 4 MB | 4 MB | 4 MB |
 | Total request duration | Unlimited | Unlimited | 30 seconds |
-| Active WebSocket connections per unit<sup>4</sup> | 5,000 | 5,000 | N/A |
+| Active WebSocket connections per unit<sup>5</sup> | 5,000 | 5,000 | N/A |
 
 <sup>1</sup> Connections are pooled and reused unless explicitly closed by the backend.<br/>
 <sup>2</sup> Limit is 1,024 in the Developer tier.<br/>
-<sup>3</sup> Includes an up to 2048-bytes long query string.<br/>
-<sup>4</sup> Up to a maximum of 60,000 connections per service instance.
+<sup>3</sup> Buffered payload size is a per-request limit. In Developer and Basic tiers, the total buffering capacity available to the gateway is approximately 300 MB and is shared across concurrent requests.<br/>
+<sup>4</sup> Includes an up to 2048-bytes long query string.<br/>
+<sup>5</sup> Up to a maximum of 60,000 connections per service instance.
 


### PR DESCRIPTION
with EEE, we confirmed that Developer and Basic tiers have a smaller effective buffer capacity than Standard and Premium tiers. It would be helpful to document this limitation so customers can properly design, size, and scale their API Management instances for workloads involving large payload buffering.