### PR TITLE
Clarify NSG enforcement applies when an association is recreated

### DIFF
--- a/articles/application-gateway/for-containers/application-gateway-for-containers-components.md
+++ b/articles/application-gateway/for-containers/application-gateway-for-containers-components.md
@@ -56,6 +56,8 @@ For associations created on or after **April 23, 2026**, Network Security Groups
 > In addition to NSG rules on the association subnet, **Deny all outbound** rules on an NSG applied to the AKS subnet can block traffic from the Application Gateway for Containers ALB controller. To ensure ALB Controller can properly reconcile load balancing intent, ensure outbound traffic is allowed to [these endpoints](application-gateway-for-containers-components.md#alb-controller-outbound-connectivity).
 
 For associations created **before April 23, 2026**, inbound NSG rules can be configured; however, traffic on **ports 80 and 443** is always allowed, regardless of the rules defined.
+> [!NOTE]
+> If the association is deleted and recreated, it is treated as a new association and is subject to the current NSG enforcement model. Ensure the required NSG allow rules (including the _AzureLoadBalancer_ tag) are configured **before** recreating the association to avoid frontend connectivity or health probe issues.
 
 #### User defined routes on the association subnet
 


### PR DESCRIPTION
The "Network Security Groups on the association subnet" section documents the pre/post April 23 2026 states but not the transition. Deleting and recreating an association is treated as a new association, so it becomes subject to the current NSG enforcement model — silently removing the "80/443 always allowed" exemption for pre-April-23 deployments. This can look like a platform fault: the Gateway reports Programmed=True and listeners ResolvedRefs=True, yet the frontend IP times out at TCP.

Adds a NOTE covering the recreate transition and the need to have inbound allow rules (listener ports + AzureLoadBalancer service tag) in place before recreating, to avoid frontend connectivity and health-probe failures.