### PR TITLE
Remove Microsoft Entra security group support from Azure API for FHIR local RBAC

### DIFF
--- a/articles/healthcare-apis/azure-api-for-fhir/configure-local-rbac.md
+++ b/articles/healthcare-apis/azure-api-for-fhir/configure-local-rbac.md
@@ -5,7 +5,7 @@ author: expekesheth
 ms.service: azure-health-data-services
 ms.subservice: fhir
 ms.topic: reference
-ms.date: 11/20/2025
+ms.date: 08/16/2026
 ms.author: kesheth
 ms.devlang: azurecli
 ms.custom:
@@ -61,11 +61,13 @@ In the authority box, enter a valid secondary Microsoft Entra tenant. Once the t
 
 * A Microsoft Entra user.
 * A Microsoft Entra service principal.
-* A Microsoft Entra security group.
+
+> [!NOTE]
+> Assigning access to a Microsoft Entra security group is no longer supported. Grant access directly to individual users or service principals instead. This change keeps Azure API for FHIR aligned with current security practices and limits the access the service needs to your directory. A review of recent usage showed that customers grant access directly to users and service principals, so existing configurations aren't expected to be affected.
 
 You can read the article on how to [find identity object IDs](find-identity-object-ids.md) for more details.
 
-After entering the required Microsoft Entra object IDs, select **Save** and wait for changes to be saved before trying to access the data plane using the assigned users, service principals, or groups. The object IDs are granted with all permissions, an equivalent of the "FHIR Data Contributor" role.
+After entering the required Microsoft Entra object IDs, select **Save** and wait for changes to be saved before trying to access the data plane using the assigned users or service principals. The object IDs are granted with all permissions, an equivalent of the "FHIR Data Contributor" role.
 
 The local RBAC setting is only visible from the authentication blade; it isn't visible from the Access Control (IAM) blade.
 


### PR DESCRIPTION
Removes Microsoft Entra security group as a supported identity type in **Allowed object IDs** for Azure API for FHIR local RBAC, and adds a note explaining that group-based access is no longer supported.

Changes:
- Removed the "A Microsoft Entra security group" bullet from the list of supported object IDs.
- Added a note stating group-based access is no longer supported, with a non-technical explanation (alignment with current security practices, limiting the access the service needs to your directory) and a note that existing configurations aren't expected to be affected.
- Updated the "Save" guidance to refer to users and service principals only.
- Refreshed ms.date.