### PR TITLE
Document materializing durable task sequences

### DIFF
--- a/articles/durable-task/common/durable-task-code-constraints.md
+++ b/articles/durable-task/common/durable-task-code-constraints.md
@@ -3,7 +3,7 @@ title: Durable orchestrator code constraints
 description: Orchestration replay and code constraints for Azure Durable Functions and Durable Task SDKs.
 author: cgillum
 ms.topic: reference
-ms.date: 02/04/2026
+ms.date: 08/21/2026
 ms.author: azfuncdf
 ms.service: durable-task
 zone_pivot_groups: azure-durable-approach
@@ -672,6 +672,33 @@ This runtime behavior explains why your orchestrator can't use `await` or `yield
 To learn more about how the Durable Task Framework executes orchestrators, see the [Durable Task source code on GitHub](https://github.com/Azure/durabletask). In particular, see [TaskOrchestrationExecutor.cs](https://github.com/Azure/durabletask/blob/master/src/DurableTask.Core/TaskOrchestrationExecutor.cs) and [TaskOrchestrationContext.cs](https://github.com/Azure/durabletask/blob/master/src/DurableTask.Core/TaskOrchestrationContext.cs).
 
 ::: zone-end
+
+### Materialize task sequences in .NET
+
+LINQ queries use deferred execution. If a query's selector calls `CallActivityAsync` or another durable scheduling API, each enumeration of the query creates a new set of durable tasks. For example, don't pass a deferred task sequence to `Task.WhenAll` and then enumerate the same sequence again:
+
+```csharp
+IEnumerable<Task<long>> copyTasks = files.Select(
+    file => context.CallActivityAsync<long>("CopyFile", file));
+
+await Task.WhenAll(copyTasks);
+long totalBytes = copyTasks.Sum(task => task.Result);
+```
+
+The call to `Task.WhenAll` enumerates `copyTasks` once. The call to `Sum` enumerates it again, which calls `CallActivityAsync` again instead of returning the completed tasks from the first enumeration. Reading `Result` from one of these new tasks can then block the orchestrator and cause it to hang.
+
+Materialize the sequence once before waiting for the tasks, and use the results returned by `Task.WhenAll`:
+
+```csharp
+Task<long>[] copyTasks = files
+    .Select(file => context.CallActivityAsync<long>("CopyFile", file))
+    .ToArray();
+
+long[] copiedBytes = await Task.WhenAll(copyTasks);
+long totalBytes = copiedBytes.Sum();
+```
+
+You can also use `ToList()` to materialize the sequence. The important constraint is to reuse the same durable task objects instead of executing the scheduling query more than once. The repeated enumeration, rather than `Result` by itself, creates the new tasks.
 
 ## Next steps
 

--- a/articles/durable-task/common/durable-task-code-constraints.md
+++ b/articles/durable-task/common/durable-task-code-constraints.md
@@ -675,6 +675,8 @@ To learn more about how the Durable Task Framework executes orchestrators, see t
 
 ### Materialize task sequences in .NET
 
+The detailed guidance and examples in this section apply to .NET orchestrators. In other languages, the equivalent mitigation is to eagerly materialize the task list or array before awaiting it and before iterating over it later.
+
 LINQ queries use deferred execution. If a query's selector calls `CallActivityAsync` or another durable scheduling API, each enumeration of the query creates a new set of durable tasks. For example, don't pass a deferred task sequence to `Task.WhenAll` and then enumerate the same sequence again:
 
 ```csharp


### PR DESCRIPTION
## Why

A deferred LINQ query that schedules durable tasks creates a new set of tasks every time it is enumerated. Enumerating it once through `Task.WhenAll` and again while reading results can schedule new work during replay and hang the orchestrator. The existing documentation explains durable task replay but does not cover this failure mode.

## What changed

- Add a .NET-specific subsection to the canonical orchestrator code constraints page.
- Show the unsafe repeated-enumeration pattern and a corrected pattern that materializes the sequence with `ToArray()`.
- Clarify that repeated enumeration, not `Result` by itself, creates the new tasks.
- Update the article date.

The code constraints page is the best location because this is a durable task identity and replay constraint. The fan-out/fan-in article already uses `ToArray()` correctly, but doesn't explain why materialization is required.

## Validation

- Confirmed the warning is absent from current Durable Task documentation and open docs pull requests.
- `git diff --check`
- Verified Markdown code fences and zone directives remain balanced.

Fixes Azure/azure-functions-durable-extension#201