### PR TITLE
Correct the AllowSynchronousIO condition in the isolated worker guide

### DIFF
--- a/articles/azure-functions/dotnet-isolated-process-guide.md
+++ b/articles/azure-functions/dotnet-isolated-process-guide.md
@@ -764,7 +764,10 @@ builder.Services.AddOpenTelemetry()
 
 builder.Services.AddMvc().AddNewtonsoftJson();
 
-// Only needed if using HttpRequestData/HttpResponseData and a serializer that doesn't support asynchronous IO
+// Only needed when something performs synchronous IO on the request or
+// response stream, for example StreamReader.ReadToEnd() on the body,
+// HttpResponseData.WriteString(), or a serializer without asynchronous IO
+// such as NewtonsoftJsonObjectSerializer
 // builder.Services.Configure<KestrelServerOptions>(options => options.AllowSynchronousIO = true);
 
 builder.Build().Run();
@@ -787,7 +790,10 @@ var host = new HostBuilder()
         services.AddOpenTelemetry().UseAzureMonitorExporter();
         services.AddMvc().AddNewtonsoftJson();
 
-        // Only needed if using HttpRequestData/HttpResponseData and a serializer that doesn't support asynchronous IO
+        // Only needed when something performs synchronous IO on the request or
+        // response stream, for example StreamReader.ReadToEnd() on the body,
+        // HttpResponseData.WriteString(), or a serializer without asynchronous IO
+        // such as NewtonsoftJsonObjectSerializer
         // services.Configure<KestrelServerOptions>(options => options.AllowSynchronousIO = true);
     })
     .Build();


### PR DESCRIPTION
## What this changes

`articles/azure-functions/dotnet-isolated-process-guide.md`, section "JSON serialization with ASP.NET Core integration", in both the `IHostApplicationBuilder` and the `IHostBuilder` tab.

The comment above the `AllowSynchronousIO` line reads:

```
// Only needed if using HttpRequestData/HttpResponseData and a serializer that doesn't support asynchronous IO
```

Both halves of that condition are narrower than the actual behavior. The setting is needed whenever the ASP.NET Core integration is enabled and something performs synchronous IO on the request or response stream. `HttpRequestData` plus a serializer without asynchronous IO is one route to the exception; neither element is required to reach it.

## Prior art

The first half of this is already on record. Listing what exists so the change can be judged on what it adds:

- Azure/azure-functions-dotnet-worker#2184 (opened 2024-01-08, closed 2024-02-14 as completed, `area: http`): the same `Synchronous operations are disallowed` error raised from `HttpResponseData.WriteString()`, with no serializer in play. That disposes of the "and a serializer that doesn't support asynchronous IO" half.
- Azure/azure-functions-dotnet-worker#2459 (opened 2024-05-14, closed 2024-05-15 as not planned): Newtonsoft plus `CreateCheckStatusResponseAsync`, so the response stream rather than the request stream.

Neither covers the other half. The reproduction below raises the same error in an app where `HttpRequestData` and `HttpResponseData` never appear, in the plain `HttpRequest` / `IActionResult` shape an app lands in after migrating from the in-process model.

## Where readers meet this wording

Right after migrating an app from the in-process model. The official in-process HTTP trigger template reads the body asynchronously, but an output binding declared as an `out` parameter, the idiomatic form in that model, rules out `async` (`error CS1988: Async methods cannot have ref, in or out parameters`). What is left is a synchronous read:

```csharp
[FunctionName("Order")]
public static IActionResult Run(
    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "orders")] HttpRequest req,
    [Queue("orders")] out string message,
    ILogger log)
{
    string body = new StreamReader(req.Body).ReadToEnd();
```

The in-process binding model produced that shape. Carried into an isolated worker app with `ConfigureFunctionsWebApplication()`, that line throws on every request. Someone searching the resulting exception lands on this section, reads a comment scoped to `HttpRequestData`/`HttpResponseData` and to serializer choice, and concludes the setting does not apply to their app.

## Reproduction

Verified on 2026-08-22, Windows 11 x64, Azure Functions Core Tools 4.13.0, host runtime 4.1051.300.26316. Reproduced identically on `net8.0` (SDK 8.0.419) and `net10.0` (SDK 10.0.400): same status, same exception, same stack.

Packages:
- `Microsoft.Azure.Functions.Worker` 2.52.0
- `Microsoft.Azure.Functions.Worker.Sdk` 2.1.0
- `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` 2.1.1

`Program.cs`, with no serializer configured anywhere:

```csharp
var builder = FunctionsApplication.CreateBuilder(args);
builder.ConfigureFunctionsWebApplication();
builder.Build().Run();
```

Function: `HttpRequest` in, `IActionResult` out, no `HttpRequestData`, no `HttpResponseData`:

```csharp
[Function("Order")]
public IActionResult Run(
    [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "orders")] HttpRequest req)
{
    string body = new StreamReader(req.Body).ReadToEnd();
    var order = JsonConvert.DeserializeObject<OrderRequest>(body);
    return new OkObjectResult(order);
}
```

`dotnet build`: 0 errors, 0 warnings. `POST /api/orders` returns HTTP 500:

```
System.Private.CoreLib: Exception while executing function: Functions.Order. System.Private.CoreLib: Result: Failure
Type: System.InvalidOperationException
Exception: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead.
Stack:    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.StreamReader.ReadBuffer()
   at System.IO.StreamReader.ReadToEnd()
   at OrderProcessor.OrderFunction.Run(HttpRequest req, ILogger log) in ...\OrderFunction.cs:line 16
   at OrderProcessor.DirectFunctionExecutor.ExecuteAsync(FunctionContext context) in ...\GeneratedFunctionExecutor.g.cs:line 32
   at Microsoft.Azure.Functions.Worker.OutputBindings.OutputBindingsMiddleware.Invoke(FunctionContext context, FunctionExecutionDelegate next) in /_/src/DotNetWorker.Core/OutputBindings/OutputBindingsMiddleware.cs:line 13
   at Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.FunctionsHttpProxyingMiddleware.Invoke(FunctionContext context, FunctionExecutionDelegate next) in /_/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs:line 54
   at Microsoft.Azure.Functions.Worker.FunctionsApplication.InvokeFunctionAsync(FunctionContext context) in /_/src/DotNetWorker.Core/FunctionsApplication.cs:line 83
   at Microsoft.Azure.Functions.Worker.Handlers.InvocationHandler.InvokeAsync(InvocationRequest request) in /_/src/DotNetWorker.Grpc/Handlers/InvocationHandler.cs:line 91.
```

Adding the documented line makes the same request return 200:

```csharp
builder.Services.Configure<KestrelServerOptions>(options => options.AllowSynchronousIO = true);
```

`WorkerOptions.Serializer` is never set in this project, and neither `HttpRequestData` nor `HttpResponseData` appears in it, so neither half of the current condition is met while the setting is still required.

### The response stream behaves the same way

Same host and package versions, still no serializer configured, one function per write path:

| Write path | Parameter binding | Setting unset | Setting on |
|---|---|---|---|
| `Response.Body.Write(byte[], int, int)` | `HttpRequest` | 500 | 200 |
 | `StreamWriter.Write()` then `Flush()` | `HttpRequest` | 500 | 200 |
 | `HttpResponseData.WriteString()` | `HttpRequestData` | 500 | 200 |
 | `Response.WriteAsync()` | `HttpRequest` | 200 | 200 |

The three synchronous paths fail with the write-side wording of the same exception. The `WriteString()` case, which is issue #2184 reproduced on current packages:

```
Exception: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.
Stack:    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at Microsoft.Azure.Functions.Worker.Http.HttpResponseDataExtensions.WriteString(HttpResponseData response, String value, Encoding encoding) in /_/src/DotNetWorker.Core/Http/HttpResponseDataExtensions.cs:line 41
   at SyncWriteRepro.WriteFunctions.SyncWriteResponseData(HttpRequestData req)
   at Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.FunctionsHttpProxyingMiddleware.Invoke(FunctionContext context, FunctionExecutionDelegate next) in /_/extensions/Worker.Extensions.Http.AspNetCore/src/FunctionsMiddleware/FunctionsHttpProxyingMiddleware.cs:line 54
```

The first two rows reach the exception with no `HttpResponseData` in the app at all, so the response type does not decide it either. Setting `AllowSynchronousIO` makes all four return 200 from the same build.

### Counter-check without the integration

The same `WriteString()` call against `Microsoft.Azure.Functions.Worker.Extensions.Http` 3.3.0, with `ConfigureFunctionsWebApplication()` omitted, returns 200 and logs no exception; so does the synchronous read. Kestrel in the pipeline is the precondition. The request type, the response type, and the serializer are incidental to it.

## The proposed wording

```
// Only needed when something performs synchronous IO on the request or
// response stream, for example StreamReader.ReadToEnd() on the body,
// HttpResponseData.WriteString(), or a serializer without asynchronous IO
// such as NewtonsoftJsonObjectSerializer
```

The original case stays listed, with the general condition named first. Applied to both tabs so they stay in sync.

## Related

- Azure/azure-functions-dotnet-worker#2184: same exception, no serializer (prior art, see above).
- Azure/azure-functions-dotnet-worker#2459: same exception on the response stream.
- Azure/azure-functions-dotnet-worker#2131: `WorkerOptions.Serializer` not applying under `ConfigureFunctionsWebApplication`, closed with `AddMvc().AddNewtonsoftJson()`, which is the sample this comment sits in. Not part of this change.