### PR TITLE
Add note about required key-based authentication

### DIFF
--- a/articles/app-service/includes/configure-azure-storage/azure-storage-windows-code-pivot.md
+++ b/articles/app-service/includes/configure-azure-storage/azure-storage-windows-code-pivot.md
@@ -63,6 +63,7 @@ Here are the three options to mount Azure storage to your app:
 - Mapping */mounts*, *mounts/name1/name2*, */*, and */mounts/name.ext/* to custom-mounted storage isn't supported. You can only use */mounts/pathname* for mounting custom storage to your web app.
 - Storage mounts aren't included in [backups](../../manage-backup.md). Be sure to follow best practices to back up Azure Storage accounts.
 - With virtual network integration on your app, the mounted drive uses an RFC1918 IP address and not an IP address from your virtual network.
+- Storage Accounts that have key-based authentication disabled are not supported.
 
 ## Prepare for mounting
 


### PR DESCRIPTION
I noticed that storage accounts with disabled key-based auth are not supported by storage mounts.
There is an open feature request since lying around since two years here: https://feedback.azure.com/d365community/idea/4bf28f50-3f56-ef11-b4ac-000d3a7b1c7e
This limitation is currently missing on the docs.