### PR TITLE
Recommend .NET 10 in the isolated worker migration guide

### DIFF
--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -54,7 +54,7 @@ On version 4.x of the Functions runtime, your .NET function app targets .NET 8 w
 > [!TIP]
 > **We recommend upgrading to .NET 10 on the isolated worker model.** .NET 10 is the current LTS release and has the longest remaining support window. Support for .NET 8 and .NET 9 ends on November 10, 2026, the same day that support ends for the in-process model, so migrating to either of those versions requires another upgrade shortly afterward.
 
-The examples in this guide target .NET 8 so that only the process model changes during the migration. If you target .NET 10, adapt the examples accordingly.
+The examples in this guide target .NET 8 so that only the process model changes during the migration. If you target .NET 10, set `<TargetFramework>net10.0</TargetFramework>` in your project file and adapt the examples accordingly.
 
 ## Prepare for migration
 

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -52,9 +52,9 @@ On version 4.x of the Functions runtime, your .NET function app targets .NET 8 w
 [!INCLUDE [functions-dotnet-migrate-v4-versions](../../includes/functions-dotnet-migrate-v4-versions.md)]
 
 > [!TIP]
-> **We recommend upgrading to .NET 8 on the isolated worker model.** This provides a quick migration path to the fully released version with the longest support window from .NET.
+> **We recommend upgrading to .NET 10 on the isolated worker model.** .NET 10 is the current LTS release and has the longest remaining support window. Support for .NET 8 and .NET 9 ends on November 10, 2026, the same day that support ends for the in-process model, so migrating to either of those versions requires another upgrade shortly afterward.
 
-This guide doesn't present specific examples for .NET 10 or .NET 9. If you need to target one of those versions, you can adapt the .NET 8 examples.
+The examples in this guide target .NET 8 so that only the process model changes during the migration. If you target .NET 10, set `TargetFramework` to `net10.0` in the project file and follow the same steps.
 
 ## Prepare for migration
 

--- a/articles/azure-functions/migrate-dotnet-to-isolated-model.md
+++ b/articles/azure-functions/migrate-dotnet-to-isolated-model.md
@@ -54,7 +54,7 @@ On version 4.x of the Functions runtime, your .NET function app targets .NET 8 w
 > [!TIP]
 > **We recommend upgrading to .NET 10 on the isolated worker model.** .NET 10 is the current LTS release and has the longest remaining support window. Support for .NET 8 and .NET 9 ends on November 10, 2026, the same day that support ends for the in-process model, so migrating to either of those versions requires another upgrade shortly afterward.
 
-The examples in this guide target .NET 8 so that only the process model changes during the migration. If you target .NET 10, set `TargetFramework` to `net10.0` in the project file and follow the same steps.
+The examples in this guide target .NET 8 so that only the process model changes during the migration. If you target .NET 10, adapt the examples accordingly.
 
 ## Prepare for migration
 


### PR DESCRIPTION
## What this changes

The tip in "Choose your target .NET version" still recommends .NET 8 as the version with the longest support window. The table directly above it (from `includes/functions-dotnet-migrate-v4-versions.md`) lists .NET 10 as LTS with end of support on November 14, 2028, and .NET 8 as LTS with end of support on November 10, 2026. The two statements contradict each other on the same page.

The table was updated when .NET 10 became available, the tip was not. A reader who follows the tip today migrates to a target that loses support on the same day the in-process model does, and has to upgrade again right after finishing the migration.

## Changes in this PR:

- The tip now recommends .NET 10 and states why: it is the current LTS release with the longest remaining support window, while .NET 8 and .NET 9 reach end of support on November 10, 2026, together with the in-process model.
- The sentence about examples now explains why the samples stay on .NET 8 (only the process model changes during the migration) and how to target .NET 10 instead.

The code samples and tabs are intentionally left on `net8.0`. Retargeting them is a separate decision, and keeping the framework version fixed isolates the model change, which is what this guide is about.

No external sources are needed. Every date in the new text is taken from the table on the same page.