### PR TITLE
Note that Newtonsoft serialization attributes stop working after migration

### DIFF
--- a/includes/functions-dotnet-migrate-isolated-other-code-changes.md
+++ b/includes/functions-dotnet-migrate-isolated-other-code-changes.md
@@ -10,6 +10,8 @@ ms.author: mahender
 
 By default, the isolated worker model uses *System.Text.Json* for JSON serialization. To customize serializer options or switch to JSON.NET (*Newtonsoft.Json*), see [Customizing JSON serialization](../articles/azure-functions/dotnet-isolated-process-guide.md#customizing-json-serialization).
 
+Because the in-process model used *Newtonsoft.Json*, also check the serialization attributes on any types your functions bind to. *System.Text.Json* ignores attributes such as `[JsonProperty]` and `[JsonIgnore]` from *Newtonsoft.Json*. It binds the affected property to its default value without reporting an error. Either replace them with their *System.Text.Json* equivalents, such as `[JsonPropertyName]`, or configure *Newtonsoft.Json* for the layer that handles the payload.
+
 #### Application Insights log levels and filtering
 
 Logs can be sent to Application Insights from both the Functions host runtime and code in your project. The *host.json* allows you to configure rules for host logging, but to control logs coming from your code, you need to configure filtering rules as part of your *Program.cs*. See [Managing log levels in the isolated worker model](../articles/azure-functions/dotnet-isolated-process-guide.md#managing-log-levels) for details on how to filter these logs.


### PR DESCRIPTION
Follow-up to the `AllowSynchronousIO` clarification in #128726 and the *Migrate to asynchronous HTTP stream I/O* section that was added alongside it. That async guidance is correct as written: replacing `ReadToEnd` with `ReadToEndAsync` keeps the same serializer, so a migrated app keeps behaving identically. This PR covers a step of the migration that isn't behavior-preserving.

## Problem

The in-process model used *Newtonsoft.Json*. The isolated worker model uses *System.Text.Json* by default. Types that a migrated app binds to usually still carry *Newtonsoft.Json* attributes (`[JsonProperty("customer_name")]` being the common one), and *System.Text.Json* doesn't recognize them. It binds the affected property to its default value and reports nothing: HTTP 200, property `null`, no exception and no log entry.

The *JSON serialization* section of this guide covers the serializer switch itself and links to *Customizing JSON serialization* for options and for moving back to JSON.NET. It says nothing about the attributes already sitting on the reader's types. `JsonProperty` and `JsonPropertyName` currently appear nowhere in this guide, its includes, or `dotnet-isolated-process-guide.md`, so a reader whose property silently stops binding has nothing to search for.

Measured on `Microsoft.Azure.Functions.Worker` 2.52.0, `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` 2.1.1, Core Tools 4.13.0, host 4.1051.300.26316: a DTO carrying `[JsonProperty("customer_name")]` binds to `null` on every input path tested while the app stays on *System.Text.Json*, with no diagnostic on any of them.

## Change

One file, one added paragraph, nothing removed: note that *Newtonsoft.Json* serialization attributes carried over from the in-process model are ignored by *System.Text.Json* without an error. The paragraph gives the two ways out: replace them with their *System.Text.Json* equivalents, or configure *Newtonsoft.Json* for the layer that handles the payload.

## Notes for review

The edited file is an include, `includes/functions-dotnet-migrate-isolated-other-code-changes.md`. It renders inside `articles/azure-functions/migrate-dotnet-to-isolated-model.md`, which is also the file changed by my open PR #128730. The two touch different files and don't conflict, but they land on the same rendered page, so you may want to look at them together.

"Configure *Newtonsoft.Json* for the layer that handles the payload" is deliberately unspecific about which layer, because that depends on whether the app uses ASP.NET Core integration. There's a companion change for `articles/azure-functions/dotnet-isolated-process-guide.md` that makes that distinction precise; it's a different file with a different owner, so I'm submitting it separately. Either change stands on its own.