### PR TITLE
Configure monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds a monthly Dependabot check for the repository's GitHub Actions workflow. Minor and patch updates go into one group. Major updates remain separate.

## Validation

- Parsed the YAML and validated it against SchemaStore's Dependabot 2.0 schema.
- Confirmed `/` covers `.github/workflows/stale.yml`.
- Confirmed `.github/dependabot.yml` is the only changed file.
