### PR TITLE
Clarify ingress external/internal behavior on internal VNet environments

### DIFF
--- a/articles/container-apps/connect-apps.md
+++ b/articles/container-apps/connect-apps.md
@@ -58,10 +58,13 @@ The ingress visibility setting controls whether your app is reachable from outsi
 
 | Visibility | FQDN pattern | Reachable from |
 |---|---|---|
-| **External** | `<APP_NAME>.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | Anywhere (public internet) |
-| **Internal** | `<APP_NAME>.internal.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | Same environment only |
+| **External** | `<APP_NAME>.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | The environment's network boundary (public internet or VNet, depending on environment type) **plus** other apps in the same environment |
+| **Internal** | `<APP_NAME>.internal.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | **Only** other apps within the same Container Apps environment |
 
-When you set ingress to **internal**, the FQDN includes an `.internal.` segment. Other container apps in the same environment can still reach the app using this address, but requests from outside the environment receive a `404` response from the environment's proxy. The DNS name resolves to the environment's shared IP, but the proxy rejects the request because the app is internal-only. <!-- Source: Q1 -->
+When you set ingress to **internal**, the FQDN includes an `.internal.` segment. Other container apps in the same environment can still reach the app using this FQDN or the short app name. However, requests from outside the environment—including requests from your own VNet on an internal environment—receive a `404` response from the environment's ingress proxy, because the proxy does not advertise routes for environment-scoped apps to external callers. <!-- Source: Q1 -->
+
+> [!IMPORTANT]
+> On an **internal (VNet-integrated) environment**, setting ingress to **internal** (`external: false`) does *not* mean "accessible from the VNet." It means "accessible only from other container apps within this environment." If your app needs to receive traffic from the VNet (for example, from VMs, databases, or on-premises networks), set ingress to **external** (`external: true`). On an internal environment, external ingress makes the app reachable through the internal load balancer without exposing it to the public internet. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
 
 [!INCLUDE [container-apps-get-fully-qualified-domain-name](../../includes/container-apps-get-fully-qualified-domain-name.md)]
 

--- a/articles/container-apps/connect-apps.md
+++ b/articles/container-apps/connect-apps.md
@@ -58,13 +58,13 @@ The ingress visibility setting controls whether your app is reachable from outsi
 
 | Visibility | FQDN pattern | Reachable from |
 |---|---|---|
-| **External** | `<APP_NAME>.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | The environment's network boundary (public internet or VNet, depending on environment type) **plus** other apps in the same environment |
-| **Internal** | `<APP_NAME>.internal.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | **Only** other apps within the same Container Apps environment |
+| **External** | `<APP_NAME>.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | The environment's network boundary, which is the public internet or your virtual network depending on the environment type, plus other apps in the same environment |
+| **Internal** | `<APP_NAME>.internal.<ENVIRONMENT_UNIQUE_ID>.<REGION>.azurecontainerapps.io` | Only other apps within the same Container Apps environment |
 
-When you set ingress to **internal**, the FQDN includes an `.internal.` segment. Other container apps in the same environment can still reach the app using this FQDN or the short app name. However, requests from outside the environment—including requests from your own VNet on an internal environment—receive a `404` response from the environment's ingress proxy, because the proxy does not advertise routes for environment-scoped apps to external callers. <!-- Source: Q1 -->
+When you set ingress to **internal**, the FQDN includes an `.internal.` segment. Other container apps in the same environment can still reach the app using this address, but requests from outside the environment receive a `404` response from the environment's proxy. The DNS name resolves to the environment's inbound IP address, and the TLS handshake succeeds, but the proxy rejects the request because the app is limited to the environment. <!-- Source: Q1 -->
 
 > [!IMPORTANT]
-> On an **internal (VNet-integrated) environment**, setting ingress to **internal** (`external: false`) does *not* mean "accessible from the VNet." It means "accessible only from other container apps within this environment." If your app needs to receive traffic from the VNet (for example, from VMs, databases, or on-premises networks), set ingress to **external** (`external: true`). On an internal environment, external ingress makes the app reachable through the internal load balancer without exposing it to the public internet. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
+> On an internal environment, requests from your own virtual network count as requests from outside the environment. Setting ingress to **internal** doesn't mean "reachable from the virtual network," it means "reachable only from other container apps in this environment." To let clients in your virtual network reach the app, set ingress to **external**. Because an internal environment has no public endpoint, this setting doesn't expose the app to the internet. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
 
 [!INCLUDE [container-apps-get-fully-qualified-domain-name](../../includes/container-apps-get-fully-qualified-domain-name.md)]
 

--- a/articles/container-apps/ingress-how-to.md
+++ b/articles/container-apps/ingress-how-to.md
@@ -63,6 +63,9 @@ az containerapp ingress enable \
 | Option | Property | Description | Values | Required |
 | --- | --- | --- | --- | --- |
 | `--type` | external | Allow ingress to your app from anywhere, or limit ingress to its internal Container Apps environment. | `external` or `internal` | Yes |
+
+> [!NOTE]
+> On an internal (VNet-integrated) environment, `--type external` does not expose the app to the public internet—it makes the app accessible from the VNet through the internal load balancer. Using `--type internal` restricts the app to other container apps within the same environment only; VNet clients receive HTTP 404. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
 |`--allow-insecure` | allowInsecure | Allow HTTP connections to your app. | | No |
 | `--target-port` | targetPort | The port your container listens to for incoming requests. | Set this value to the port number that your container uses. Your application ingress endpoint is always exposed on port `443`. | Yes |
 |`--exposed-port` | exposedPort | (TCP ingress only) A port for TCP ingress. If `external` is `true`, the value must be unique in the Container Apps environment if ingress is external. | A port number from `1` to `65535`. (can't be `80` or `443`) | No |

--- a/articles/container-apps/ingress-how-to.md
+++ b/articles/container-apps/ingress-how-to.md
@@ -63,13 +63,13 @@ az containerapp ingress enable \
 | Option | Property | Description | Values | Required |
 | --- | --- | --- | --- | --- |
 | `--type` | external | Allow ingress to your app from anywhere, or limit ingress to its internal Container Apps environment. | `external` or `internal` | Yes |
-
-> [!NOTE]
-> On an internal (VNet-integrated) environment, `--type external` does not expose the app to the public internet—it makes the app accessible from the VNet through the internal load balancer. Using `--type internal` restricts the app to other container apps within the same environment only; VNet clients receive HTTP 404. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
 |`--allow-insecure` | allowInsecure | Allow HTTP connections to your app. | | No |
 | `--target-port` | targetPort | The port your container listens to for incoming requests. | Set this value to the port number that your container uses. Your application ingress endpoint is always exposed on port `443`. | Yes |
 |`--exposed-port` | exposedPort | (TCP ingress only) A port for TCP ingress. If `external` is `true`, the value must be unique in the Container Apps environment if ingress is external. | A port number from `1` to `65535`. (can't be `80` or `443`) | No |
 |`--transport` | transport | The transport protocol type. | auto (default) detects HTTP/1 or HTTP/2, `http` for HTTP/1, `http2` for HTTP/2, `tcp` for TCP. | No |
+
+> [!NOTE]
+> On an internal environment, `--type external` doesn't expose your app to the public internet, because the environment has no public endpoint. It makes the app reachable from your virtual network through the environment's internal load balancer. Using `--type internal` limits the app to other container apps in the same environment, and clients elsewhere in your virtual network receive an HTTP 404 response. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
  
 ::: zone-end
 
@@ -88,6 +88,9 @@ You can configure ingress when you create your container app by using the Azure 
 1. Set **Ingress** to **Enabled**.
 1. Configure the ingress settings for your container app.
 1. Select **Limited to Container Apps Environment** for internal ingress or **Accepting traffic from anywhere** for external ingress.
+
+    On an internal environment, **Accepting traffic from anywhere** doesn't expose your app to the public internet. It makes the app reachable from your virtual network through the environment's internal load balancer. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
+
 1. Select the **Ingress Type**: **HTTP** or **TCP** (TCP ingress is only available in environments configured with a virtual network).
 1. If *HTTP* is selected for the **Ingress Type**, select the **Transport**: **Auto**, **HTTP/1** or **HTTP/2**. 
 1. Select **Insecure connections** if you want to allow HTTP connections to your app.

--- a/articles/container-apps/ingress-overview.md
+++ b/articles/container-apps/ingress-overview.md
@@ -42,6 +42,20 @@ When you enable ingress, you can choose between two types of ingress:
 
 Each container app within an environment can be configured with different ingress settings. For example, in a scenario with multiple microservice apps, to increase security you might have a single container app that receives public requests and passes the requests to a background service. In this scenario, you would configure the public-facing container app with external ingress and the internal-facing container app with internal ingress.
 
+### How ingress visibility interacts with the environment type
+
+The per-app ingress visibility setting (`external` or `internal`) controls *which callers can reach the app*. On an internal (VNet-integrated) environment, this distinction is especially important:
+
+| Environment type | `external: true` | `external: false` |
+|---|---|---|
+| **External** (public IP) | Accessible from the **public internet** and from other apps in the environment | Accessible **only from other apps** within the same environment |
+| **Internal** (VNet + internal load balancer) | Accessible from the **VNet via the internal load balancer** and from other apps in the environment. *Not exposed to the public internet.* | Accessible **only from other apps** within the same environment. *VNet clients receive HTTP 404.* |
+
+> [!IMPORTANT]
+> On an internal (VNet-integrated) environment, setting ingress to **external** does *not* expose your app to the public internet. It makes the app accessible from your virtual network through the environment's internal load balancer. Setting ingress to **internal** restricts the app further—it becomes reachable only from other container apps deployed in the same environment. VNet clients that attempt to reach an internal-ingress app receive an HTTP 404 response.
+>
+> If your app needs to receive traffic from the VNet (for example, from VMs, other Azure services, or on-premises networks connected via VPN/ExpressRoute), set ingress to **external**.
+
 ## Protocol types
 
 Container Apps supports two protocols for ingress: HTTP and TCP.

--- a/articles/container-apps/ingress-overview.md
+++ b/articles/container-apps/ingress-overview.md
@@ -44,17 +44,52 @@ Each container app within an environment can be configured with different ingres
 
 ### How ingress visibility interacts with the environment type
 
-The per-app ingress visibility setting (`external` or `internal`) controls *which callers can reach the app*. On an internal (VNet-integrated) environment, this distinction is especially important:
+Two separate settings determine who can reach your container app:
 
-| Environment type | `external: true` | `external: false` |
+- **Environment accessibility level**: Set when you create the environment. An *internal* environment (created with `--internal-only`) has no public endpoint at all. It's reachable only through an internal load balancer in your virtual network. For more information, see [Accessibility level](networking.md#accessibility-level).
+
+- **App ingress visibility**: The per-app `external` property, set with `--type external` or `--type internal`, and shown in the portal as **Ingress traffic**.
+
+The environment's accessibility level defines the outer network boundary. The app's ingress visibility determines whether the app is published at that boundary, or kept inside the environment.
+
+| Environment accessibility level | App ingress external<br>(**Accepting traffic from anywhere**) | App ingress internal<br>(**Limited to Container Apps Environment**) |
 |---|---|---|
-| **External** (public IP) | Accessible from the **public internet** and from other apps in the environment | Accessible **only from other apps** within the same environment |
-| **Internal** (VNet + internal load balancer) | Accessible from the **VNet via the internal load balancer** and from other apps in the environment. *Not exposed to the public internet.* | Accessible **only from other apps** within the same environment. *VNet clients receive HTTP 404.* |
+| **External** | Reachable from the public internet, and from other apps in the environment. | Reachable only from other apps in the same environment. |
+| **Internal** | Reachable from the virtual network through the internal load balancer, and from other apps in the environment. Not reachable from the public internet. | Reachable only from other apps in the same environment. Clients elsewhere in the virtual network receive an HTTP 404 response. |
 
 > [!IMPORTANT]
-> On an internal (VNet-integrated) environment, setting ingress to **external** does *not* expose your app to the public internet. It makes the app accessible from your virtual network through the environment's internal load balancer. Setting ingress to **internal** restricts the app further—it becomes reachable only from other container apps deployed in the same environment. VNet clients that attempt to reach an internal-ingress app receive an HTTP 404 response.
+> The app ingress settings describe the app's relationship to its *environment*, not to the internet. On an internal environment, **Accepting traffic from anywhere** doesn't publish your app to the internet, because the environment has no public endpoint. Instead, it publishes the app at the environment's internal load balancer so that clients in your virtual network can reach it.
 >
-> If your app needs to receive traffic from the VNet (for example, from VMs, other Azure services, or on-premises networks connected via VPN/ExpressRoute), set ingress to **external**.
+> Selecting **Limited to Container Apps Environment** on an internal environment is more restrictive than you might expect. It hides the app from the rest of your virtual network as well as from the internet.
+
+> [!NOTE]
+> An app with internal ingress can still receive traffic from outside the environment if it's referenced as a target in an environment-level HTTP route configuration. For more information, see [Use rule-based routing with Azure Container Apps](rule-based-routing.md).
+
+### Restrict an app to virtual network access only
+
+A common requirement is an app that the public internet can't reach, but that virtual machines, private endpoints, peered networks, and on-premises networks connected through a VPN or Azure ExpressRoute can reach. This configuration requires you to set both the environment accessibility level and the app ingress visibility.
+
+1. Create the environment as internal, so the environment has no public endpoint. Internet isolation comes from this setting, and you can't change it after you create the environment. For more information, see [Use a virtual network with Azure Container Apps](vnet-custom.md).
+
+    ```azurecli
+    az containerapp env create \
+        --name <ENVIRONMENT_NAME> \
+        --resource-group <RESOURCE_GROUP> \
+        --infrastructure-subnet-resource-id <SUBNET_RESOURCE_ID> \
+        --internal-only true
+    ```
+
+1. Set the app's ingress to external, so that the app is published at the environment's internal load balancer and clients in the virtual network can reach it.
+
+    ```azurecli
+    az containerapp ingress enable \
+        --name <APP_NAME> \
+        --resource-group <RESOURCE_GROUP> \
+        --target-port <PORT_NUMBER> \
+        --type external
+    ```
+
+Use internal app ingress only for apps that other container apps in the same environment call, such as a backend service in a microservices application.
 
 ## Protocol types
 

--- a/articles/container-apps/networking.md
+++ b/articles/container-apps/networking.md
@@ -69,7 +69,7 @@ In the [ingress](azure-resource-manager-api-spec.md#propertiesconfiguration) sec
 
 - Enable or disable ingress for your container app.
 
-- Accept traffic to your container app from anywhere or from only within the same Container Apps environment.
+- Accept traffic to your container app from anywhere or from only within the same Container Apps environment. In an internal environment, "anywhere" means anywhere in your virtual network, because the environment has no public endpoint. For more information, see [How ingress visibility interacts with the environment type](ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
 
 - Define traffic-splitting rules between revisions of your application. For more information, see [Traffic splitting](traffic-splitting.md).
 

--- a/articles/container-apps/troubleshooting.md
+++ b/articles/container-apps/troubleshooting.md
@@ -91,6 +91,7 @@ Your container app's ingress settings are enforced through a set of rules that c
 |--|--|
 | Is ingress enabled? | Verify the **Enabled** checkbox is checked. |
 | Do you want to allow external ingress? | Verify that **Ingress Traffic** is set to **Accepting traffic from anywhere**. If your container app doesn't listen for HTTP traffic, set **Ingress Traffic** to **Limited to Container Apps Environment**. |
+| Do clients in your virtual network receive HTTP 404 responses? | If your app runs in an internal environment, verify that **Ingress Traffic** is set to **Accepting traffic from anywhere**. See [Requests from the virtual network return HTTP 404](#requests-from-the-virtual-network-return-http-404). |
 | Does your client use HTTP or TCP to access your container app? | Verify **Ingress type** is set to the correct protocol (**HTTP** or **TCP**). |
 | Does your client support mTLS? | Verify **Client certificate mode** is set to **Require** only if your client supports mTLS. For more information, see [configure client certificate authentication.](./client-certificate-authorization.md) |
 | Does your client use HTTP/1 or HTTP/2? | Verify **Transport** is set to the correct HTTP version (**HTTP/1** or **HTTP/2**). |
@@ -98,6 +99,28 @@ Your container app's ingress settings are enforced through a set of rules that c
 | Is your client IP address denied? | If **IP Security Restrictions Mode** isn't set to **Allow all traffic**, verify your client doesn't have an IP address that is denied. |
 
 For more information, see [Ingress in Azure Container Apps](./ingress-overview.md).
+
+### Requests from the virtual network return HTTP 404
+
+If your container app runs in an internal environment, you might see the following combination of symptoms:
+
+- The app's revision is healthy, and its replicas are running.
+- A client in the virtual network resolves the app's fully qualified domain name (FQDN) successfully, and the TLS handshake succeeds.
+- Every request returns an HTTP 404 response with the message `Container App is stopped or does not exist`, regardless of the request path.
+- The same behavior applies to every app in the environment, including a newly created app that uses a known-good container image.
+
+These symptoms typically indicate that the app's ingress is set to **Limited to Container Apps Environment** rather than a networking, DNS, or application problem. On an internal environment, that setting limits the app to other container apps in the same environment, so requests from elsewhere in the virtual network are rejected.
+
+To make the app reachable from your virtual network, set its ingress to **Accepting traffic from anywhere**. On an internal environment, this setting doesn't expose the app to the public internet, because the environment has no public endpoint.
+
+```azurecli
+az containerapp ingress update \
+    --name <APP_NAME> \
+    --resource-group <RESOURCE_GROUP> \
+    --type external
+```
+
+For more information, see [How ingress visibility interacts with the environment type](./ingress-overview.md#how-ingress-visibility-interacts-with-the-environment-type).
 
 ## Verify networking configuration
 

--- a/articles/container-apps/vnet-custom.md
+++ b/articles/container-apps/vnet-custom.md
@@ -208,7 +208,7 @@ The following table describes the parameters used with `containerapp env create`
 | `logs-workspace-key` | The Log Analytics client secret. Required if using an existing workspace. |
 | `location` | The Azure location where the environment is to deploy. |
 | `infrastructure-subnet-resource-id` | Resource ID of a subnet for infrastructure components and user application containers. |
-| `internal-only` | (Optional) The environment doesn't use a public static IP, only internal IP addresses available in the custom VNet. (Requires an infrastructure subnet resource ID.) |
+| `internal-only` | (Optional) The environment doesn't use a public static IP, only internal IP addresses available in the custom VNet. (Requires an infrastructure subnet resource ID.) After you create an internal environment, set each app's ingress to external so that clients in your virtual network can reach it. For more information, see [Restrict an app to virtual network access only](ingress-overview.md#restrict-an-app-to-virtual-network-access-only). |
 
 # [PowerShell](#tab/powershell)
 


### PR DESCRIPTION
## Summary

Clarifies the counterintuitive meaning of the per-app `ingress.external` setting on **internal (VNet-integrated)** Container Apps environments.

Customers on internal environments commonly set ingress to `internal` (`external: false`) expecting "reachable from my VNet," but instead get **HTTP 404** from the environment proxy. On an internal environment:

- `external: true` -> reachable **from the VNet via the internal load balancer** (still private, not public internet)
- `external: false` -> reachable **only from other apps in the same environment**; VNet clients get 404

## Changes

- **`ingress-overview.md`** - new section *How ingress visibility interacts with the environment type*, with a 2x2 environment-type x ingress-visibility matrix and an `[!IMPORTANT]` callout.
- **`connect-apps.md`** - expanded FQDN reachability table so "External" is described as the *environment's network boundary* rather than always public internet; added an `[!IMPORTANT]` callout for internal environments.
- **`ingress-how-to.md`** - `[!NOTE]` on the `--type` option clarifying that `external` does not mean internet-exposed on an internal environment.

## Motivation

Two customer incidents in 2026 were traced back to this terminology confusion. In both cases the customer spent weeks investigating a suspected platform-side ingress routing bug before the root cause was identified as `ingress.external = false` on an internal environment.
