### PR TITLE
Clarify regional VNet peering limitation for Application Gateway for Containers

### DIFF
--- a/articles/application-gateway/for-containers/container-networking.md
+++ b/articles/application-gateway/for-containers/container-networking.md
@@ -47,7 +47,7 @@ Application Gateway for Containers supports Azure Network Policies, Calico, and 
 
 * ALB Controller: You must be running version 1.7.9 or greater to take advantage of CNI Overlay.
 * Subnet Size: The Application Gateway for Containers subnet must be a /24 prefix; only one deployment is supported per subnet. A larger or smaller prefix isn't supported.
-* Regional VNet Peering: Application Gateway for Containers deployed in a virtual network in region A and the AKS cluster nodes in a virtual network in region A isn't supported.
+* Regional VNet Peering: Application Gateway for Containers deployed in a virtual network in region A and the AKS cluster nodes in a separate virtual network in region A isn't supported.
 * Global VNet Peering: Application Gateway for Containers deployed in a virtual network in region A and the AKS cluster nodes in a virtual network in region B isn't supported.
 
 ## CNI and Application Gateway for Containers


### PR DESCRIPTION
The "Regional VNet Peering" limitation currently reads:

> Application Gateway for Containers deployed in a virtual network in region A and the AKS cluster nodes in a virtual network in region A isn't supported.

Taken literally, this says a deployment in region A with the cluster also in region A is unsupported, which contradicts the rest of the page. The intended statement is that the gateway and the cluster nodes must not be in *different* virtual networks within the same region, matching the FAQ entry further down the page ("Can I deploy Application Gateway for Containers in a separate virtual network from my AKS cluster? A: No.").

This change adds the word "separate" so the bullet reads:

> Application Gateway for Containers deployed in a virtual network in region A and the AKS cluster nodes in a separate virtual network in region A isn't supported.

The wording follows the "Global VNet Peering" bullet directly below it and reuses the term "separate virtual network" already used in the FAQ section of the same article. No technical content changes.