### PR TITLE
Remove outdated UDR limit information

### DIFF
--- a/articles/virtual-network/virtual-networks-udr-overview.md
+++ b/articles/virtual-network/virtual-networks-udr-overview.md
@@ -78,8 +78,6 @@ You create custom routes by either creating [user-defined](#user-defined) routes
 
 To customize your traffic routes, you shouldn't modify the default routes. You should create custom or user-defined (static) routes, which override the Azure default system routes. In Azure, you create a route table and then associate the route table to zero or more virtual network subnets. Each subnet can have zero or one route table associated to it. To learn about the maximum number of routes that you can add to a route table and the maximum number of UDR tables you can create per Azure subscription, see [Azure limits](../azure-resource-manager/management/azure-subscription-service-limits.md?toc=%2fazure%2fvirtual-network%2ftoc.json#azure-networking-limits).
 
-By default, a route table can contain up to 400 UDRs. With the Azure Virtual Network Manager [routing configuration](../virtual-network-manager/concept-user-defined-route.md), this number can expand to 1,000 UDRs per route table. This increased limit supports more advanced routing setups. An example is directing traffic from on-premises datacenters through a firewall to each spoke virtual network in a hub-and-spoke topology when you have a higher number of spoke virtual networks.
-
 When you create a route table and associate it to a subnet, the table's routes are combined with the subnet's default routes. If there are conflicting route assignments, UDRs override the default routes.
 
 You can specify the following next hop types when you create a UDR:


### PR DESCRIPTION
The article currently states that a route table can contain up to 400 UDRs by default and that the limit can be expanded to 1,000 UDRs per route table with Azure Virtual Network Manager. However, the current Azure limits documentation lists the supported limit as 1,000 user-defined routes per route table, and the Azure Virtual Network Manager documentation also states that UDR management allows up to 1,000 UDRs per route table. Therefore, the distinction between 400 and 1,000 UDRs is no longer accurate.

https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-resource-manager-virtual-networking-limits User-defined routes per route table	1,000

https://learn.microsoft.com/en-us/azure/virtual-network-manager/concept-user-defined-route#impact-of-udr-management-on-routes-and-route-tables • UDR management allows users to create up to 1000 UDRs per route table.

This PR removes the outdated statement to align the article with the current documented limits and avoid confusion.