### PR TITLE
Fix DefaultAzureCredential import issues in Communication Services Python quickstarts

### DIFF
--- a/articles/communication-services/quickstarts/email/includes/add-multiple-senders-python.md
+++ b/articles/communication-services/quickstarts/email/includes/add-multiple-senders-python.md
@@ -31,7 +31,7 @@ Replace the field in the sample code with the subscription ID of the subscriptio
 
 ```python
 from azure.mgmt.communication import CommunicationServiceManagementClient
-from azure.identity import AzureCliCredential
+from azure.identity import DefaultAzureCredential
 
 credential = DefaultAzureCredential()
 subscription_id = "<your-subscription-id>"

--- a/articles/communication-services/quickstarts/identity/includes/access-tokens/access-token-python.md
+++ b/articles/communication-services/quickstarts/identity/includes/access-tokens/access-token-python.md
@@ -75,6 +75,8 @@ client = CommunicationIdentityClient.from_connection_string(connection_string)
 Alternatively, if you already set up a Microsoft Entra application, you can [authenticate by using Microsoft Entra ID](../../../identity/service-principal.md).
 
 ```python
+from azure.identity import DefaultAzureCredential
+
 endpoint = os.environ["COMMUNICATION_SERVICES_ENDPOINT"]
 client = CommunicationIdentityClient(endpoint, DefaultAzureCredential())
 ```


### PR DESCRIPTION
Both quickstarts raise a NameError when followed as written:

- access-tokens/access-token-python.md: the Microsoft Entra ID
  authentication alternative calls DefaultAzureCredential() but never
  imports it anywhere on the page.
- email/add-multiple-senders-python.md: the code imports
  AzureCliCredential but instantiates DefaultAzureCredential(), so the
  imported name is never the one actually used.

Fixed both to import DefaultAzureCredential from azure.identity,
matching the pattern used in 100+ other Python examples across this repo.