### PR TITLE
Fix invalid 'import OpenAI' in Azure OpenAI Microsoft Entra ID Service Connector snippet

### DIFF
--- a/articles/service-connector/includes/code-openai-microsoft-entra-id.md
+++ b/articles/service-connector/includes/code-openai-microsoft-entra-id.md
@@ -102,7 +102,7 @@ ms.reviewer: wchi
 
     ```python
     import os
-    import OpenAI
+    from openai import AzureOpenAI
     from azure.identity import ManagedIdentityCredential, ClientSecretCredential, get_bearer_token_provider
     
     # Uncomment the following lines corresponding to the authentication type you want to use.


### PR DESCRIPTION
'import OpenAI' fails immediately with ModuleNotFoundError - Python
is case-sensitive and there's no top-level 'OpenAI' package, so this
breaks the very first line of active code for every reader following
this guide, before they even reach the AzureOpenAI(...) call further
down.

Fixed to 'from openai import AzureOpenAI', matching the sibling
code-openai-secret.md file in the same directory, which already uses
the correct import for the same client.