### PR TITLE
Add missing imports for direct ContainerClient construction example

### DIFF
--- a/articles/storage/blobs/storage-blob-client-management.md
+++ b/articles/storage/blobs/storage-blob-client-management.md
@@ -323,6 +323,9 @@ const containerClient = new ContainerClient(
 ## [Python](#tab/python)
 
 ```python
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import ContainerClient
+
 def get_blob_container_client(self, account_name, container_name):
     # Append the container name to the URI
     account_url = f"https://{account_name}.blob.core.windows.net/{container_name}"


### PR DESCRIPTION
The 'create a container client directly without using BlobServiceClient'
Python example instantiates ContainerClient and DefaultAzureCredential,
but neither is imported anywhere on the page (only DefaultAzureCredential
and BlobServiceClient are imported, in the earlier BlobServiceClient
section). Every other Python example on this page explicitly shows an
'Add the following import statements' block before its code; this one
is missing it, so the example raises a NameError as written.