### PR TITLE
Fix wrong import in Table Storage Service Connector Node.js snippets

### DIFF
--- a/articles/service-connector/includes/code-table-me-id.md
+++ b/articles/service-connector/includes/code-table-me-id.md
@@ -137,7 +137,7 @@ ms.reviewer: wchi
 
     ```javascript
     import { DefaultAzureCredential,ClientSecretCredential } from "@azure/identity";
-    const { TableClient } = require("@azure/data-tables");
+    const { TableServiceClient } = require("@azure/data-tables");
     
     const account_url = process.env.AZURE_STORAGETABLE_RESOURCEENDPOINT;
     

--- a/articles/service-connector/includes/code-table-secret.md
+++ b/articles/service-connector/includes/code-table-secret.md
@@ -70,7 +70,7 @@ ms.reviewer: wchi
 1. Get the Azure Table Storage connection string from the environment variable added by Service Connector.
 
     ```javascript
-    const { TableClient } = require("@azure/data-tables");
+    const { TableServiceClient } = require("@azure/data-tables");
 
     const connection_str = process.env.AZURE_STORAGETABLE_CONNECTIONSTRING;
     const serviceClient = TableServiceClient.fromConnectionString(connection_str);


### PR DESCRIPTION
Both the Microsoft Entra ID and connection-string Node.js snippets
import TableClient from @azure/data-tables but then instantiate
TableServiceClient, which is never imported - a ReferenceError as
written. The .NET, Java, and Python versions on the same pages all
correctly use TableServiceClient, confirming that's the intended
class. Fixed both Node.js snippets to import TableServiceClient.