### PR TITLE
Fix missing DefaultAzureCredential import in JS access tokens quickstart

### DIFF
--- a/articles/communication-services/quickstarts/identity/includes/access-tokens/access-token-js.md
+++ b/articles/communication-services/quickstarts/identity/includes/access-tokens/access-token-js.md
@@ -102,6 +102,8 @@ const identityClient = new CommunicationIdentityClient(endpoint, tokenCredential
 If you already set up a Microsoft Entra application, you can [authenticate by using Microsoft Entra ID](../../../identity/service-principal.md).
 
 ```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
+
 const endpoint = process.env["COMMUNICATION_SERVICES_ENDPOINT"];
 const tokenCredential = new DefaultAzureCredential();
 const identityClient = new CommunicationIdentityClient(endpoint, tokenCredential);


### PR DESCRIPTION
Same bug as the Python version of this quickstart (already fixed
separately): the Microsoft Entra ID authentication alternative calls
new DefaultAzureCredential() but never imports it anywhere on the
page, raising a ReferenceError. Added the standard
const { DefaultAzureCredential } = require("@azure/identity");
import, matching the pattern used in 7+ other Communication Services
JS quickstarts.