### PR TITLE
docs: fix 'enviroment' typo in Data Factory access strategies

### DIFF
--- a/articles/data-factory/data-access-strategies.md
+++ b/articles/data-factory/data-access-strategies.md
@@ -50,7 +50,7 @@ This should work in many scenarios, and we do understand that a unique Static IP
      >     - OData
 
 > [!NOTE]
-> Resource instance network rules for Azure Storage is not supported by user managed enviroment such as self-hosted integration runtime and SSIS integration runtime.
+> Resource instance network rules for Azure Storage is not supported by user managed environment such as self-hosted integration runtime and SSIS integration runtime.
 
 * **Unique Static IP** - You'll need to set up a self-hosted integration runtime to get a Static IP for Data Factory connectors. This mechanism ensures you can block access from all other IP addresses.
 * **[Static IP range](./azure-integration-runtime-ip-addresses.md)** - You can use Azure Integration Runtime's IP addresses to allowlist it in your storage (say S3, Salesforce, etc.). It certainly restricts IP addresses that can connect to the data stores but also relies on Authentication/ Authorization rules.


### PR DESCRIPTION
Tiny docs fix: correct `enviroment` to `environment` in the Data Factory data access strategies note.