### PR TITLE
docs: remove duplicate 'for' in Azure NetApp Files clone FAQ

### DIFF
--- a/articles/azure-netapp-files/faq-clone.md
+++ b/articles/azure-netapp-files/faq-clone.md
@@ -30,7 +30,7 @@ For Auto QoS capacity pools the clone volume throughput limit is defined by the 
 
 For Manual QoS capacity pools you can manually assign a throughput limit to the clone volume independent of the capacity but within the capacity pool allocated limits. You can change the volume throughput limit after short-term volume clone creation if needed. 
 
-## What are the options available for for volume cloning?
+## What are the options available for volume cloning?
 
 Two cloning options are provided: 
 


### PR DESCRIPTION
Tiny docs fix: remove duplicate `for` in the Azure NetApp Files volume cloning FAQ heading.