### PR TITLE
docs: remove duplicate 'to' in private link relocation guide

### DIFF
--- a/articles/azure-resource-manager/management/relocation/relocation-private-link.md
+++ b/articles/azure-resource-manager/management/relocation/relocation-private-link.md
@@ -12,7 +12,7 @@ This article shows you how to relocate [Azure Private Link Service](/azure/priva
 
 [!INCLUDE [relocate-reasons](./includes/service-relocation-reason-include.md)]
 
-To learn how to to reconfigure [private endpoints](/azure/private-link/private-link-overview) for a particular service, see the [appropriate service relocation guide](../move-resources-overview.md).
+To learn how to reconfigure [private endpoints](/azure/private-link/private-link-overview) for a particular service, see the [appropriate service relocation guide](../move-resources-overview.md).
 
 ## Downtime
 


### PR DESCRIPTION
Tiny docs fix: remove duplicate `to` in the private link service relocation guide.