### PR TITLE
docs: remove duplicate 'the' in storage task runs alt-text

### DIFF
--- a/articles/storage-actions/storage-tasks/storage-task-runs.md
+++ b/articles/storage-actions/storage-tasks/storage-task-runs.md
@@ -25,7 +25,7 @@ You can see all of the runs attempted by a storage task by opening a list of run
 Navigate to the storage task in the Azure portal and then under **Storage task management**, select **Task runs**.
 
 > [!div class="mx-imgBorder"]
-> ![Screenshot of the the storage task list when opened from a storage task.](../media/storage-tasks/storage-task-runs/storage-task-runs-storage-task-view.png)
+> ![Screenshot of the storage task list when opened from a storage task.](../media/storage-tasks/storage-task-runs/storage-task-runs-storage-task-view.png)
 
 Metrics appear as tiles that you can select to view a list of the task runs which comprise the metric. For example, to view list of task runs where at least one operation failed, select the **Objects on which the operation failed** tile. Then, a filtered list of task runs appear. You can filter this list by time frame. The following table describes each field that appears in this list.
 
@@ -45,7 +45,7 @@ You can see all runs against a specific storage account by opening a list of run
 Navigate to the storage account in the Azure portal and then under **Data management**, select **Storage tasks**.
 
 > [!div class="mx-imgBorder"]
-> ![Screenshot of the the storage task list when opened from a storage account.](../media/storage-tasks/storage-task-runs/storage-task-runs-storage-account-view.png)
+> ![Screenshot of the storage task list when opened from a storage account.](../media/storage-tasks/storage-task-runs/storage-task-runs-storage-account-view.png)
 
 A list of task runs appears. You can filter this list by time frame. The following table describes each field that appears in this list.
 


### PR DESCRIPTION
## Summary
- Remove duplicate word in Storage task runs image alt-text: "the the storage task list" → "the storage task list".

## Test plan
- [x] Confirmed both alt-text lines read correctly after the change.