### PR TITLE
docs: remove duplicate 'the' in Batch upgrade policy note

### DIFF
--- a/articles/batch/batch-upgrade-policy.md
+++ b/articles/batch/batch-upgrade-policy.md
@@ -29,7 +29,7 @@ When upgrading images, VMs in Azure Batch Pool will follow roughly the same work
 However, if *automaticOSUpgradePolicy.osRollingUpgradeDeferral* is set to 'true' and an upgrade becomes available when a batch node is actively running tasks, the upgrade will be delayed until all tasks have been completed on the node.
 
 > [!Note]
-> If a pool has enabled *osRollingUpgradeDeferral*, its nodes will be displayed as *upgradingos* state during the upgrade process. Please note that the *upgradingos* state will only be shown when you are using the the API version of 2024-02-01 or later. If you're using an old API version to call *GetTVM/ListTVM*, the node will be in a *rebooting* state when upgrading.
+> If a pool has enabled *osRollingUpgradeDeferral*, its nodes will be displayed as *upgradingos* state during the upgrade process. Please note that the *upgradingos* state will only be shown when you are using the API version of 2024-02-01 or later. If you're using an old API version to call *GetTVM/ListTVM*, the node will be in a *rebooting* state when upgrading.
 
 ## Supported OS images
 Only certain OS platform images are currently supported for automatic upgrade. For detailed images list, you can get from [VirtualMachineScaleSet page](/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-automatic-upgrade#supported-os-images).


### PR DESCRIPTION
## Summary
- Remove duplicate word in Batch pool OS rolling upgrade note: "using the the API version" → "using the API version".

## Test plan
- [x] Confirmed the note still reads correctly after the change.