### PR TITLE
docs: remove duplicate 'the' in Planetary Computer ingestion overview

### DIFF
--- a/articles/planetary-computer/ingestion-overview.md
+++ b/articles/planetary-computer/ingestion-overview.md
@@ -6,7 +6,7 @@ ms.author: silviadiana
 ms.service: planetary-computer-pro
 ms.topic: concept-article
 ms.date: 05/08/2025
-#customer intent: As a geospatial data producer, I want to understand the the concept of a GeoCatalog ingestion source so that I can ingest petabytes of geospatial assets into my GeoCatalog resource.
+#customer intent: As a geospatial data producer, I want to understand the concept of a GeoCatalog ingestion source so that I can ingest petabytes of geospatial assets into my GeoCatalog resource.
 ms.custom:
   - build-2025
 ---


### PR DESCRIPTION
## Summary
- Remove duplicate word in Planetary Computer ingestion overview customer-intent metadata: "the the concept" → "the concept".

## Test plan
- [x] Confirmed the customer-intent sentence reads correctly after the change.