### PR TITLE
docs: remove duplicate 'the' in IoT Edge downstream device guide

### DIFF
--- a/articles/iot-edge/how-to-connect-downstream-iot-edge-device.md
+++ b/articles/iot-edge/how-to-connect-downstream-iot-edge-device.md
@@ -116,7 +116,7 @@ For example, these commands create a root CA certificate, a parent device certif
     ```bash
     # !!! For test only - do not use in production !!!
     
-    # Create the the root CA test certificate
+    # Create the root CA test certificate
     ./certGen.sh create_root_and_intermediate
     
     # Create the parent (gateway) device test certificate 


### PR DESCRIPTION
## Summary
- Remove duplicate word in IoT Edge downstream device sample comment: "Create the the root CA test certificate" → "Create the root CA test certificate".

## Test plan
- [x] Confirmed the comment reads correctly after the change.